### PR TITLE
Mainloop multistaged pipeline and instruction scheduling for NVIDIA Ampere Tensor Cores (F16 and F32)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -370,7 +370,7 @@ struct MainLoopInfo {
            "Expected only one async.create.group op");
     assert(asyncWaitOps.size() == 1 && "Expected only one async.wait op");
     assert(
-        barrierOps.size() == 1 &&
+        barrierOps.size() == 2 &&
         "Expected only two barrier ops ,i.e., around each Shared Memory copy");
 
     // Collect the dependent operations for cp.async for couarse-grained
@@ -477,7 +477,8 @@ static void getNvidiaAmpereTensorCorePipeline(
 
   // Schedule and pipeline all async.wait and barrier
   ops.push_back(std::make_pair(info.asyncWaitOps[0], numStages - 2));
-  ops.push_back(std::make_pair(info.barrierOps[0], numStages - 2));
+  info.barrierOps[0]->erase();
+  ops.push_back(std::make_pair(info.barrierOps[1], numStages - 2));
   //////////////////////////////////////////////////////////////////////////////
 
   // Coarse-grained instruction pipelining: pipeline Shared Memory loads

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -126,19 +126,34 @@ static void addOpsAndDeps(llvm::SmallDenseSet<Operation*>& filter,
   }
 }
 
-/// Add an op and its dependency to `ops` set and skip operations contained into
-/// filter. This also adds all the ops to filter so that they don't get matched
-/// again.
-static void addOpsAndDepsWithFilter(llvm::SmallDenseSet<Operation*>& filter,
-                                    llvm::SmallDenseSet<Operation*>& skippedOps,
-                                    llvm::SmallDenseSet<Operation*>& ops,
-                                    Operation* op, Block* block) {
-  if (!filter.insert(op).second || skippedOps.count(op)) return;
-  ops.insert(op);
+/// Insert an op and its dependency chain to `dependentOps` set.
+static void insertDependentOps(llvm::SetVector<Operation*>& dependentOps,
+                               Operation* op, Block* block) {
+  dependentOps.insert(op);
   for (Value operand : op->getOperands()) {
     Operation* defOp = operand.getDefiningOp();
     if (defOp && defOp->getBlock() == block)
-      addOpsAndDepsWithFilter(filter, skippedOps, ops, defOp, block);
+      insertDependentOps(dependentOps, defOp, block);
+  }
+}
+
+/// Insert an op and its dependency chain to `dependentOps` set. It skip
+/// operations that are already scheduled (`scheduleOps` list) or ignored
+/// (`filteredOps` list).
+static void insertUnscheduledDependentOps(
+    llvm::SetVector<Operation*>& scheduledOps,
+    llvm::SetVector<Operation*>& filteredOps,
+    llvm::SetVector<Operation*>& dependentOps, Operation* op, Block* block) {
+  if (filteredOps.count(op) || !scheduledOps.insert(op)) return;
+  std::cout << "insertUnscheduledDependentOps ";
+  std::cout << std::flush;
+  op->dump();
+  dependentOps.insert(op);
+  for (Value operand : op->getOperands()) {
+    Operation* defOp = operand.getDefiningOp();
+    if (defOp && defOp->getBlock() == block)
+      insertUnscheduledDependentOps(scheduledOps, filteredOps, dependentOps,
+                                    defOp, block);
   }
 }
 
@@ -279,28 +294,74 @@ struct WarpMmaOp {
   llvm::SetVector<Operation*> mmaOperations;
 };
 
+struct KgroupStagePair {
+  int kgroup;
+  int stage;
+  KgroupStagePair() : kgroup(-1), stage(-1) {}
+  KgroupStagePair(int kgroup, int stage) : kgroup(kgroup), stage(stage) {}
+
+  bool operator==(const KgroupStagePair& other) const {
+    return kgroup == other.kgroup && stage == other.stage;
+  }
+  bool operator!=(const KgroupStagePair& other) const {
+    return !(*this == other);
+  }
+};
 /// Structure to hold the matmul's mainloop information:
 /// Seperates the mmasync operations into kgroups and collects the Shared Memory
 /// loads for each kgroup. This information is used to pipeline the mainloop and
 /// to generate an optimal schedule interleaving Global Memory loads, Shared
 /// Memory loads, and math operations.
 struct MainLoopInfo {
+  using KgroupToWarpMmaMap = std::unordered_map<int, WarpMmaOp>;
+  using OperationDepMap =
+      std::unordered_map<Operation*, llvm::SetVector<Operation*>>;
+
   //
   // Data members
   //
 
   // Mainloop operations GlobalMemory -> SharedMemory
-  SmallVector<Operation*> copyGlobalToSharedOps;
-  SmallVector<Operation*> barrierOps;
-  SmallVector<Operation*> asyncWaitOps;
+  SetVector<Operation*> copyGlobalToSharedOps;
+  SetVector<Operation*> asyncCreateGroupOp;
+  SetVector<Operation*> barrierOps;
+  SetVector<Operation*> asyncWaitOps;
+  int totalPipelineStages;
 
   // Warp-level MMA operations SharedMemory -> Registers -> MMA.
   // Map: kgroupIdx -> WarpMmaOp
-  std::unordered_map<int, WarpMmaOp> warpOperations;
+  KgroupToWarpMmaMap warpOperations;
+  OperationDepMap operationDeps;
+
+  // Map: Operation -> kgroupIdx
+  std::unordered_map<Operation*, int> opToKgroupMap;
+  std::unordered_map<Operation*, KgroupStagePair> opToKgroupStageMap;
+
+  // Set to track the dependencies already seen to a backward slice.
+  llvm::SetVector<Operation*> seenDepOps;
+
+  // Set to track the mma operations in forward slice to count kgroups and
+  // populate the warp-level WarpMmaOp kgroupIdx -> WarpMmaOp map.
+  llvm::SetVector<Operation*> seenMmaOps;
 
   //
   // Methods
   //
+
+  // Populates the dependent operations in ``dependentOps`` for the given a op
+  // recursively that are in the same block and not added to the backward slice
+  // of some other op.
+  void backwardSliceOfDependentOps(llvm::SetVector<Operation*>& dependentOps,
+                                   Operation* op, Block* block) {
+    if (!seenDepOps.insert(op)) return;
+    // Add the unseen op to the dependentOps and recurse on its operands.
+    dependentOps.insert(op);
+    for (Value operand : op->getOperands()) {
+      Operation* defOp = operand.getDefiningOp();
+      if (defOp && defOp->getBlock() == block)
+        backwardSliceOfDependentOps(dependentOps, defOp, block);
+    }
+  }
 
   // Backtrack from the MmaSyncOp operand (mlir::OpOperand) to its defining
   // `mlir::Operation` to find the ldmatrix or ld.shared operations that load
@@ -311,27 +372,28 @@ struct MainLoopInfo {
     if (!op) return;
 
     if (isa<nvgpu::LdMatrixOp>(op)) {
-      if (op->getBlock() == block) loadOperations.insert(op);
+      if (op->getBlock() == block) {
+        loadOperations.insert(op);
+      }
       return;
     }
 
-    // Recurse upwards towards the definition until a load is found.
-    // Assumption here is that only single operand operations are leading up to
-    // LdMatrix.
+    // Recurse upwards towards the definition until a Shared Memory load is
+    // found. Assumption here is that only single operand operations are leading
+    // up to LdMatrix.
     Operation* defOp = op->getOperand(0).getDefiningOp();
 
     backtrackToFindSmemLoad(defOp, loadOperations, block);
   }
 
   // Recursively traverse the chain of mma operations for all kgroups from 0
-  // 0 (start) to numKgroups (ends scf.yield).
-  void vistMmaSyncOp(Operation* op, int kgroupIdx,
-                     llvm::SmallDenseSet<Operation*>& seenMmaSyncOps) {
+  // (start) to numKgroups (ends scf.yield).
+  void vistMmaSyncOp(Operation* op, int kgroupIdx) {
     // if the operation in an `scf.yield`, we reached the end of MmaSyncOp chain
     // return.
-    if (seenMmaSyncOps.count(op) || isa<scf::YieldOp>(op)) return;
+    if (seenMmaOps.count(op) || isa<scf::YieldOp>(op)) return;
 
-    seenMmaSyncOps.insert(op);
+    seenMmaOps.insert(op);
     warpOperations[kgroupIdx].mmaOperations.insert(op);
 
     backtrackToFindSmemLoad(op->getOperand(0).getDefiningOp(),
@@ -342,91 +404,151 @@ struct MainLoopInfo {
                             warpOperations[kgroupIdx].loadOperationsB,
                             op->getBlock());
 
-    vistMmaSyncOp((op->getUses().begin())->getOwner(), ++kgroupIdx,
-                  seenMmaSyncOps);
+    vistMmaSyncOp((op->getUses().begin())->getOwner(), ++kgroupIdx);
+  }
+
+  void setDependentOps(Operation* op, Block* block) {
+    llvm::SetVector<Operation*> dependentOps;
+    backwardSliceOfDependentOps(dependentOps, op, block);
+    operationDeps[op] = std::move(dependentOps);
   }
 
   // ctor
-  MainLoopInfo() {}
+  MainLoopInfo(int totalPipelineStages)
+      : totalPipelineStages(totalPipelineStages) {}
 
-  // Iterate through the mainloop and collect the async.copy, barrier, and
-  // async.wait operations. These operations are used to pipeline the
-  // mainloop. Additionally, collect the mma.sync operations and separate them
-  // into kgroups. These operations are used to generate an optimal
-  // finer-grained schedule for Shared Memory loads, Global Memory loads, and
+  // Iterate through the mainloop and collect the `async.copy`,
+  // `async.wait`, and `barrier` operations. These operations are used to
+  // pipeline the mainloop. Additionally, collect the `mma.sync` operations and
+  // separate them into kgroups. These operations are used to generate an
+  // optimal finer-grained schedule of  Global Memory, Shared Memory loads, and
   // math operations.
   void collect(scf::ForOp forOp) {
-    llvm::SmallDenseSet<Operation*> seenMmaSyncOps;
-    std::cout << "Collecting MainLoopInfo: " << std::endl;
+    int numForLoopInst = 0;
+    std::cout << "ForOp: " << std::endl;
+    forOp.dump();
+    // std::cout << "Collecting MainLoopInfo: " << std::endl;
     for (Operation& op : forOp.getBody()->getOperations()) {
-      op.dump();
-      if (isa<nvgpu::MmaSyncOp>(op)) {
-        vistMmaSyncOp(&op, 0 /*kgroup = 0*/, seenMmaSyncOps);
+      numForLoopInst++;
+      // Collect the async.copy, async.wait, and barrier operations. These are
+      // used for coarse-grained pipelining of the mainloop.
+      if (isa<nvgpu::DeviceAsyncCopyOp>(op)) {
+        copyGlobalToSharedOps.insert(&op);
+        // setDependentOps(&op, forOp.getBody());
       }
-      if (isa<nvgpu::DeviceAsyncCopyOp, nvgpu::DeviceAsyncCreateGroupOp>(op)) {
-        copyGlobalToSharedOps.push_back(&op);
+      if (isa<nvgpu::DeviceAsyncCreateGroupOp>(op)) {
+        asyncCreateGroupOp.insert(&op);
+        // setDependentOps(&op, forOp.getBody());
       }
       if (isa<gpu::BarrierOp>(op)) {
-        barrierOps.push_back(&op);
+        barrierOps.insert(&op);
+        // setDependentOps(&op, forOp.getBody());
       }
       if (isa<nvgpu::DeviceAsyncWaitOp>(op)) {
-        asyncWaitOps.push_back(&op);
+        asyncWaitOps.insert(&op);
+        // setDependentOps(&op, forOp.getBody());
+      }
+      // Collect the warp-level mma.sync and Shared Memory load operations and
+      // separate them into kgroups. These are used for fine-grained instruction
+      // scheduling.
+      if (isa<nvgpu::LdMatrixOp>(op)) {
+        // setDependentOps(&op, forOp.getBody());
+      }
+      if (isa<nvgpu::MmaSyncOp>(op)) {
+        vistMmaSyncOp(&op, 0 /*kgroup = 0*/);
+        // setDependentOps(&op, forOp.getBody());
       }
     }
+    std::cout << "Number of for loop instructions: " << numForLoopInst
+              << std::endl;
 
     // Assert that barrierOps and asyncWaitOps have only 1 occurance in
     // un-pipelined mainloop.
     assert(barrierOps.size() == 1 && "Expected only one barrier op");
     assert(asyncWaitOps.size() == 1 && "Expected only one async.wait op");
 
-#if 0
-    // Obtain the list of all the MmaSyncOps within the mainloop.
-    auto mmaSyncOps = forOp.getBody()->getOps<nvgpu::MmaSyncOp>();
-
-    for (auto mmaSyncOp : mmaSyncOps) {
-      vistMmaSyncOp(mmaSyncOp.getOperation(), 0, visited);
-      // mmaSyncOp.dump();
+    // Fill the reverse map from operation to kgroup, stage.
+    for (auto& warpOp : warpOperations) {
+      for (auto mmaOp : warpOp.second.mmaOperations) {
+        opToKgroupMap[mmaOp] = warpOp.first;
+        opToKgroupStageMap[mmaOp] = {warpOp.first, totalPipelineStages - 1};
+      }
+      for (auto loadOp : warpOp.second.loadOperationsA) {
+        opToKgroupMap[loadOp] = warpOp.first;
+        int stage = totalPipelineStages - 1;
+        if (warpOp.first == 0) {
+          stage = totalPipelineStages - 2;
+        }
+        opToKgroupStageMap[loadOp] = {warpOp.first, stage};
+      }
+      for (auto loadOp : warpOp.second.loadOperationsB) {
+        opToKgroupMap[loadOp] = warpOp.first;
+        int stage = totalPipelineStages - 1;
+        if (warpOp.first == 0) {
+          stage = totalPipelineStages - 2;
+        }
+        opToKgroupStageMap[loadOp] = {warpOp.first, stage};
+      }
     }
-#endif
+
+    // Assign all cp.async a kgroup and stage.
+    for (auto copyOp : copyGlobalToSharedOps) {
+      opToKgroupStageMap[copyOp] = {0, 0};
+    }
+
+    opToKgroupStageMap[asyncCreateGroupOp[0]] = {0, 0};
+
+    opToKgroupStageMap[asyncWaitOps[0]] = {0, totalPipelineStages - 2};
+    opToKgroupStageMap[barrierOps[0]] = {0, totalPipelineStages - 2};
+
+    // Find all the dependent operations for each kgroup, stage in the schedule
+    // order.
   }
 
   // Returns the number of kgroups in the Warp-level MMA operations.
   int getNumKGroups() { return warpOperations.size(); }
 
-  // Dump the Mainloop info collected.
+  void dumpDeps(Operation* op) {
+    std::cout << "Backward slice operations for op leading upto op: ";
+    std::cout << std::flush;
+    op->dump();
+    for (auto depOp : operationDeps[op]) {
+      depOp->dump();
+    }
+  }
+
+  // Debug dump the MainloopInfo.
   void dump() {
     // Debug prints
+    std::cout << ">>> MainLoopInfo::dump() for kGroup *fine-grained* "
+                 "instruction scheduling"
+              << std::endl;
     for (auto warpOp : warpOperations) {
       std::cout << "Load operations for operandA kGroup (" << warpOp.first
                 << ")" << std::endl;
-      for (auto loadOp : warpOp.second.loadOperationsA) {
-        loadOp->dump();
-      }
+
+      for (auto loadOp : warpOp.second.loadOperationsA) dumpDeps(loadOp);
+
       std::cout << "Load operations for operandB kGroup (" << warpOp.first
                 << ")" << std::endl;
-      for (auto loadOp : warpOp.second.loadOperationsB) {
-        loadOp->dump();
-      }
+
+      for (auto loadOp : warpOp.second.loadOperationsB) dumpDeps(loadOp);
+
       std::cout << "Mma Sync kGroup (" << warpOp.first << ")" << std::endl;
-      for (auto mmaOp : warpOp.second.mmaOperations) {
-        mmaOp->dump();
-      }
+      for (auto mmaOp : warpOp.second.mmaOperations) dumpDeps(mmaOp);
     }
 
+    std::cout << ">>> MainLoopInfo::dump() for kGroup *course-grained* "
+                 "software pipelining"
+              << std::endl;
     std::cout << "Copy Global to Shared Memory" << std::endl;
-    for (auto copyOp : copyGlobalToSharedOps) {
-      copyOp->dump();
-    }
+    for (auto copyOp : copyGlobalToSharedOps) dumpDeps(copyOp);
 
-    std::cout << "Barrier" << std::endl;
-    for (auto barrierOp : barrierOps) {
-      barrierOp->dump();
-    }
+    std::cout << "Gpu Barrier" << std::endl;
+    for (auto barrierOp : barrierOps) dumpDeps(barrierOp);
 
-    std::cout << "Async Wait" << std::endl;
-    for (auto asyncWaitOp : asyncWaitOps) {
-      asyncWaitOp->dump();
-    }
+    std::cout << "CpAsync Wait" << std::endl;
+    for (auto asyncWaitOp : asyncWaitOps) dumpDeps(asyncWaitOp);
   }
 };
 
@@ -516,30 +638,30 @@ static void getNvidiaTensorCorePipeline(
       ops.push_back(std::make_pair(&op, depth - 2));
   }
 
-  // Print schedule
-  std::cout << "getNvidiaTensorCorePipeline Schedule" << std::endl;
-  for (auto op : ops) {
-    std::cout << " Stage: " << op.second;
-    std::cout << " Operation: ";
-    op.first->dump();
-    std::cout << std::endl;
+  llvm::SmallDenseSet<Operation*> scheduledOperations;
+  std::cout << std::flush;
+  std::cout << ">>>> Final schedule for the mainloop: Instructions "
+            << ops.size() << std::endl;
+  for (auto& stage_op_pair : ops) {
+    std::cout << " Stage (" << stage_op_pair.second << ") , Operation: ";
+    std::cout << std::flush;
+    stage_op_pair.first->dump();
+    scheduledOperations.insert(stage_op_pair.first);
+    std::cout << std::flush;
   }
-
-  // Create schedule and assign software pipelining stages kgroup-by-kgroup.
 }
 
 /// Schedule operations and assign software pipelining stages.
 static void scheduleOperations(
     std::vector<std::pair<Operation*, unsigned>>& ops,
-    llvm::SmallDenseSet<Operation*> dependentOps, unsigned pipelineDepth) {
-  for (Operation* op : dependentOps) {
-    std::cout << "Stage : " << pipelineDepth << " ";
-    std::cout << "Schedule operation: ";
-    op->dump();
+    llvm::SetVector<Operation*> dependentOps, unsigned pipelineDepth) {
+  // for (Operation* op : dependentOps) {
+  for (auto op_it = dependentOps.rbegin(); op_it != dependentOps.rend();
+       ++op_it) {
+    std::cout << " scheduleOperations: ";
     std::cout << std::flush;
-    std::cout << std::endl;
-    std::cout << std::endl;
-    ops.push_back(std::make_pair(op, pipelineDepth));
+    (*op_it)->dump();
+    ops.push_back(std::make_pair(*op_it, pipelineDepth));
   }
 }
 
@@ -548,90 +670,112 @@ static void scheduleOperations(
 static void getNvidiaTensorCoreScheduleAndPipeline(
     scf::ForOp forOp, std::vector<std::pair<Operation*, unsigned>>& ops,
     unsigned depth) {
-  MainLoopInfo info;
+  MainLoopInfo info(depth);
   info.collect(forOp);
   info.dump();
 
-  // Schedule the mainloop kgroup-by-kgroup.
-  llvm::SmallDenseSet<Operation*> scheduledOps;
-  llvm::SmallDenseSet<Operation*> skippedOps;
+  // Schedule loads for kgroup 1.
+  for (Operation& op : forOp.getBody()->getOperations()) {
+    if (isa<nvgpu::LdMatrixOp>(&op)) {
+      if (info.opToKgroupMap[&op] == 1) {
+        scheduleOperations(ops, info.operationDeps[&op], depth - 1);
+      }
+    }
+  }
 
-  for (int kgroup = 0; kgroup < info.getNumKGroups(); kgroup++) {
-    // Schedule warp-level mma.sync operations.
+  // Schedule math for kgroup 0.
+  for (Operation& op : forOp.getBody()->getOperations()) {
+    if (isa<nvgpu::MmaSyncOp>(&op)) {
+      if (info.opToKgroupMap[&op] == 0) {
+        scheduleOperations(ops, info.operationDeps[&op], depth - 1);
+      }
+    }
+  }
+
+  // Schedule cp.async
+  for (auto& copyOp : info.copyGlobalToSharedOps) {
+    scheduleOperations(ops, info.operationDeps[copyOp], 0);
+  }
+  scheduleOperations(ops, info.operationDeps[info.asyncWaitOps[0]], depth - 2);
+  scheduleOperations(ops, info.operationDeps[info.barrierOps[0]], depth - 2);
+
+  // Schedule loads for kgroup 0.
+  for (Operation& op : forOp.getBody()->getOperations()) {
+    if (isa<nvgpu::LdMatrixOp>(&op)) {
+      if (info.opToKgroupMap[&op] == 0) {
+        scheduleOperations(ops, info.operationDeps[&op], depth - 2);
+      }
+    }
+  }
+
+  // Schedule math for kgroup 1.
+  for (Operation& op : forOp.getBody()->getOperations()) {
+    if (isa<nvgpu::MmaSyncOp>(&op)) {
+      if (info.opToKgroupMap[&op] == 1) {
+        scheduleOperations(ops, info.operationDeps[&op], depth - 1);
+      }
+    }
+  }
+
+#if 0
+  for (int kgroup = 0; kgroup < info.getNumKGroups(); kgroup = kgroup + 2) {
+    // Schedule load operations for kgroup + 1.
+    for (auto& ldmatrixOp : info.warpOperations[kgroup + 1].loadOperationsA) {
+      scheduleOperations(ops, info.operationDeps[ldmatrixOp], depth - 1);
+    }
+
+    for (auto& ldmatrixOp : info.warpOperations[kgroup + 1].loadOperationsB) {
+      scheduleOperations(ops, info.operationDeps[ldmatrixOp], depth - 1);
+    }
+
+    // Schedule mma.sync for kgroup.
     for (auto& mmaOp : info.warpOperations[kgroup].mmaOperations) {
-      skippedOps.insert(info.warpOperations[0].loadOperationsA.begin(),
-                        info.warpOperations[0].loadOperationsA.end());
-      skippedOps.insert(info.warpOperations[0].loadOperationsB.begin(),
-                        info.warpOperations[0].loadOperationsB.end());
-
-      llvm::SmallDenseSet<Operation*> dependentOps;
-
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps, mmaOp,
-                              forOp.getBody());
-      scheduleOperations(ops, dependentOps, depth - 1);
+      scheduleOperations(ops, info.operationDeps[mmaOp], depth - 1);
     }
 
-    skippedOps.clear();
+    // TODO: Distribute cp.async accross kgroup and schedule wait and bar.sync
+    // after the last cp.async.
+    // Schedule *all* cp.async.wait and bar.sync 0 if
+    // it is the kgroup 0.
+    if (kgroup == 0) {
+      for (auto& copyOp : info.copyGlobalToSharedOps) {
+        scheduleOperations(ops, info.operationDeps[copyOp], 0);
+      }
 
-    // Schedule warp-level ldmatrix or ld.shared operations for operandA.
+      scheduleOperations(ops, info.operationDeps[info.asyncWaitOps[0]],
+                         depth - 2);
+      scheduleOperations(ops, info.operationDeps[info.barrierOps[0]],
+                         depth - 2);
+    }
+
+    // Schedule load operations for kgroup.
     for (auto& ldmatrixOp : info.warpOperations[kgroup].loadOperationsA) {
-      llvm::SmallDenseSet<Operation*> dependentOps;
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
-                              ldmatrixOp, forOp.getBody());
-      int pipelineStage = (kgroup == 0) ? (depth - 2) : (depth - 1);
-      scheduleOperations(ops, dependentOps, pipelineStage);
+      int pipelineStage = (kgroup == 0) ? depth - 2 : depth - 1;
+      scheduleOperations(ops, info.operationDeps[ldmatrixOp], pipelineStage);
     }
 
-    // Schedule warp-level ldmatrix or ld.shared operations for operandB.
     for (auto& ldmatrixOp : info.warpOperations[kgroup].loadOperationsB) {
-      llvm::SmallDenseSet<Operation*> dependentOps;
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
-                              ldmatrixOp, forOp.getBody());
-      int pipelineStage = (kgroup == 0) ? (depth - 2) : (depth - 1);
-      scheduleOperations(ops, dependentOps, pipelineStage);
+      int pipelineStage = (kgroup == 0) ? depth - 2 : depth - 1;
+      scheduleOperations(ops, info.operationDeps[ldmatrixOp], pipelineStage);
     }
 
-#if 0  // TODO: Distribute cp.async operations across.
-    // Schedule async copy from Global Memory to Shared Memory.
-    int copyIdxStart =
-        kgroup * (info.copyGlobalToSharedOps.size() / info.getNumKGroups());
-    int copyIdxEnd = (kgroup + 1) *
-                     (info.copyGlobalToSharedOps.size() / info.getNumKGroups());
-
-    for (int idx = copyIdxStart; idx < copyIdxEnd; idx++) {
-      llvm::SmallDenseSet<Operation*> dependentOps;
-      addOpsAndDeps(scheduledOps, dependentOps, info.copyGlobalToSharedOps[idx],
-                    forOp.getBody());
-      scheduleOperations(ops, dependentOps, 0);
+    // Schedule mma.sync for kgroup + 1.
+    for (auto& mmaOp : info.warpOperations[kgroup + 1].mmaOperations) {
+      scheduleOperations(ops, info.operationDeps[mmaOp], depth - 1);
     }
+  }
 #endif
 
-    if (kgroup == info.getNumKGroups() - 1) {
-      // Schedule any remaining cp.async or cp.async.commit_group operations.
-      int idx = 0;
-
-      while (idx < info.copyGlobalToSharedOps.size()) {
-        info.copyGlobalToSharedOps[idx]->dump();
-        llvm::SmallDenseSet<Operation*> dependentOps;
-        addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
-                                info.copyGlobalToSharedOps[idx],
-                                forOp.getBody());
-        scheduleOperations(ops, dependentOps, 0);
-        idx++;
-      }
-      // Schedule cp.async.wait_group and bar.sync 0 for after the last
-      // cp.async.
-      llvm::SmallDenseSet<Operation*> asyncWaitDependentOps;
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, asyncWaitDependentOps,
-                              info.asyncWaitOps[0], forOp.getBody());
-      scheduleOperations(ops, asyncWaitDependentOps, 0);
-
-      llvm::SmallDenseSet<Operation*> barrierDependentOps;
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, barrierDependentOps,
-                              info.barrierOps[0], forOp.getBody());
-
-      scheduleOperations(ops, barrierDependentOps, 0);
-    }
+  llvm::SmallDenseSet<Operation*> scheduledOperations;
+  std::cout << std::flush;
+  std::cout << ">>>> Final schedule for the mainloop: Instructions "
+            << ops.size() << std::endl;
+  for (auto& stage_op_pair : ops) {
+    std::cout << " Stage (" << stage_op_pair.second << ") , Operation: ";
+    std::cout << std::flush;
+    stage_op_pair.first->dump();
+    scheduledOperations.insert(stage_op_pair.first);
+    std::cout << std::flush;
   }
 }
 
@@ -657,8 +801,8 @@ static FailureOr<scf::ForOp> applyPipelining(
                          scf::ForOp forOp,
                          std::vector<std::pair<Operation*, unsigned>>& ops) {
     if (schedule == PipeliningSchedulingStrategy::nvidiaTensorCore) {
-      return getNvidiaTensorCoreScheduleAndPipeline(forOp, ops, maxDepth);
-      // return getNvidiaTensorCorePipeline(forOp, ops, maxDepth);
+      // return getNvidiaTensorCoreScheduleAndPipeline(forOp, ops, maxDepth);
+      return getNvidiaTensorCorePipeline(forOp, ops, maxDepth);
     }
     return getPipelineStages(forOp, ops, maxDepth);
   };

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -501,8 +501,14 @@ static void getNvidiaAmpereTensorCorePipeline(
 
   llvm::SmallDenseSet<Operation*> scheduledOperations;
   std::cout << std::flush;
-  std::cout << ">>>> Final schedule for the mainloop: Instructions "
-            << ops.size() << std::endl;
+  std::cout << ">> Debug prints from getNvidiaAmpereTensorCorePipeline() call "
+            << " in GPUPipelining.cpp " << std::endl;
+  std::cout << " Number of stages: " << numStages << std::endl;
+  std::cout << " Number of kgroups: " << numKgroups << std::endl;
+  std::cout << " Number of mainloop instructions " << ops.size() << std::endl;
+  std::cout << " Mainloop instructions schedule and stage assignment: "
+            << std::endl;
+
   for (auto& stage_op_pair : ops) {
     std::cout << " Stage (" << stage_op_pair.second << ") , Operation: ";
     std::cout << std::flush;

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -437,7 +437,7 @@ struct MainLoopInfo {
 /// stage.
 /// @param numStages the total number of pipeline stages used for pipelining the
 /// mainloop.
-static void getMultiStagedPipelineSchedule(
+static void getNvidiaAmpereTensorCorePipeline(
     scf::ForOp forOp, std::vector<std::pair<Operation*, unsigned>>& ops,
     unsigned numStages) {
   // Analyze the main loop and obtain information for coarse-grained pipelining
@@ -527,7 +527,7 @@ static FailureOr<scf::ForOp> applyPipelining(
                          scf::ForOp forOp,
                          std::vector<std::pair<Operation*, unsigned>>& ops) {
     if (schedule == PipeliningSchedulingStrategy::nvidiaTensorCore) {
-      return getMultiStagedPipelineSchedule(forOp, ops, maxDepth);
+      return getNvidiaAmpereTensorCorePipeline(forOp, ops, maxDepth);
     }
     return getPipelineStages(forOp, ops, maxDepth);
   };

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <iostream>
+
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
@@ -121,6 +123,22 @@ static void addOpsAndDeps(llvm::SmallDenseSet<Operation*>& filter,
     Operation* defOp = operand.getDefiningOp();
     if (defOp && defOp->getBlock() == block)
       addOpsAndDeps(filter, ops, defOp, block);
+  }
+}
+
+/// Add an op and its dependency to `ops` set and skip operations contained into
+/// filter. This also adds all the ops to filter so that they don't get matched
+/// again.
+static void addOpsAndDepsWithFilter(llvm::SmallDenseSet<Operation*>& filter,
+                                    llvm::SmallDenseSet<Operation*>& skippedOps,
+                                    llvm::SmallDenseSet<Operation*>& ops,
+                                    Operation* op, Block* block) {
+  if (!filter.insert(op).second || skippedOps.count(op)) return;
+  ops.insert(op);
+  for (Value operand : op->getOperands()) {
+    Operation* defOp = operand.getDefiningOp();
+    if (defOp && defOp->getBlock() == block)
+      addOpsAndDepsWithFilter(filter, skippedOps, ops, defOp, block);
   }
 }
 
@@ -251,6 +269,167 @@ static bool isAOperand(Operation* op) { return isMMAOperand(op, 0); }
 /// Return true if the op is used as operand B of an mma.sync op.
 static bool isBOperand(Operation* op) { return isMMAOperand(op, 1); }
 
+/// Loads from Shared Memory and the MMA operations on registers for a kgroup.
+struct WarpMmaOp {
+  // Load matrixA from Shared Memory to registers.
+  llvm::SetVector<Operation*> loadOperationsA;
+  // Load matrixB from Shared Memory to registers.
+  llvm::SetVector<Operation*> loadOperationsB;
+  // Warp-level MMA operations on registers.
+  llvm::SetVector<Operation*> mmaOperations;
+};
+
+/// Structure to hold the matmul's mainloop information:
+/// Seperates the mmasync operations into kgroups and collects the Shared Memory
+/// loads for each kgroup. This information is used to pipeline the mainloop and
+/// to generate an optimal schedule interleaving Global Memory loads, Shared
+/// Memory loads, and math operations.
+struct MainLoopInfo {
+  //
+  // Data members
+  //
+
+  // Mainloop operations GlobalMemory -> SharedMemory
+  SmallVector<Operation*> copyGlobalToSharedOps;
+  SmallVector<Operation*> barrierOps;
+  SmallVector<Operation*> asyncWaitOps;
+
+  // Warp-level MMA operations SharedMemory -> Registers -> MMA.
+  // Map: kgroupIdx -> WarpMmaOp
+  std::unordered_map<int, WarpMmaOp> warpOperations;
+
+  //
+  // Methods
+  //
+
+  // Backtrack from the MmaSyncOp operand (mlir::OpOperand) to its defining
+  // `mlir::Operation` to find the ldmatrix or ld.shared operations that load
+  // MmaSyncOp operands.
+  void backtrackToFindSmemLoad(Operation* op,
+                               llvm::SetVector<Operation*>& loadOperations,
+                               Block* block) {
+    if (!op) return;
+
+    if (isa<nvgpu::LdMatrixOp>(op)) {
+      if (op->getBlock() == block) loadOperations.insert(op);
+      return;
+    }
+
+    // Recurse upwards towards the definition until a load is found.
+    // Assumption here is that only single operand operations are leading up to
+    // LdMatrix.
+    Operation* defOp = op->getOperand(0).getDefiningOp();
+
+    backtrackToFindSmemLoad(defOp, loadOperations, block);
+  }
+
+  // Recursively traverse the chain of mma operations for all kgroups from 0
+  // 0 (start) to numKgroups (ends scf.yield).
+  void vistMmaSyncOp(Operation* op, int kgroupIdx,
+                     llvm::SmallDenseSet<Operation*>& seenMmaSyncOps) {
+    // if the operation in an `scf.yield`, we reached the end of MmaSyncOp chain
+    // return.
+    if (seenMmaSyncOps.count(op) || isa<scf::YieldOp>(op)) return;
+
+    seenMmaSyncOps.insert(op);
+    warpOperations[kgroupIdx].mmaOperations.insert(op);
+
+    backtrackToFindSmemLoad(op->getOperand(0).getDefiningOp(),
+                            warpOperations[kgroupIdx].loadOperationsA,
+                            op->getBlock());
+
+    backtrackToFindSmemLoad(op->getOperand(1).getDefiningOp(),
+                            warpOperations[kgroupIdx].loadOperationsB,
+                            op->getBlock());
+
+    vistMmaSyncOp((op->getUses().begin())->getOwner(), ++kgroupIdx,
+                  seenMmaSyncOps);
+  }
+
+  // ctor
+  MainLoopInfo() {}
+
+  // Iterate through the mainloop and collect the async.copy, barrier, and
+  // async.wait operations. These operations are used to pipeline the
+  // mainloop. Additionally, collect the mma.sync operations and separate them
+  // into kgroups. These operations are used to generate an optimal
+  // finer-grained schedule for Shared Memory loads, Global Memory loads, and
+  // math operations.
+  void collect(scf::ForOp forOp) {
+    llvm::SmallDenseSet<Operation*> seenMmaSyncOps;
+    std::cout << "Collecting MainLoopInfo: " << std::endl;
+    for (Operation& op : forOp.getBody()->getOperations()) {
+      op.dump();
+      if (isa<nvgpu::MmaSyncOp>(op)) {
+        vistMmaSyncOp(&op, 0 /*kgroup = 0*/, seenMmaSyncOps);
+      }
+      if (isa<nvgpu::DeviceAsyncCopyOp, nvgpu::DeviceAsyncCreateGroupOp>(op)) {
+        copyGlobalToSharedOps.push_back(&op);
+      }
+      if (isa<gpu::BarrierOp>(op)) {
+        barrierOps.push_back(&op);
+      }
+      if (isa<nvgpu::DeviceAsyncWaitOp>(op)) {
+        asyncWaitOps.push_back(&op);
+      }
+    }
+
+    // Assert that barrierOps and asyncWaitOps have only 1 occurance in
+    // un-pipelined mainloop.
+    assert(barrierOps.size() == 1 && "Expected only one barrier op");
+    assert(asyncWaitOps.size() == 1 && "Expected only one async.wait op");
+
+#if 0
+    // Obtain the list of all the MmaSyncOps within the mainloop.
+    auto mmaSyncOps = forOp.getBody()->getOps<nvgpu::MmaSyncOp>();
+
+    for (auto mmaSyncOp : mmaSyncOps) {
+      vistMmaSyncOp(mmaSyncOp.getOperation(), 0, visited);
+      // mmaSyncOp.dump();
+    }
+#endif
+  }
+
+  // Returns the number of kgroups in the Warp-level MMA operations.
+  int getNumKGroups() { return warpOperations.size(); }
+
+  // Dump the Mainloop info collected.
+  void dump() {
+    // Debug prints
+    for (auto warpOp : warpOperations) {
+      std::cout << "Load operations for operandA kGroup (" << warpOp.first
+                << ")" << std::endl;
+      for (auto loadOp : warpOp.second.loadOperationsA) {
+        loadOp->dump();
+      }
+      std::cout << "Load operations for operandB kGroup (" << warpOp.first
+                << ")" << std::endl;
+      for (auto loadOp : warpOp.second.loadOperationsB) {
+        loadOp->dump();
+      }
+      std::cout << "Mma Sync kGroup (" << warpOp.first << ")" << std::endl;
+      for (auto mmaOp : warpOp.second.mmaOperations) {
+        mmaOp->dump();
+      }
+    }
+
+    std::cout << "Copy Global to Shared Memory" << std::endl;
+    for (auto copyOp : copyGlobalToSharedOps) {
+      copyOp->dump();
+    }
+
+    std::cout << "Barrier" << std::endl;
+    for (auto barrierOp : barrierOps) {
+      barrierOp->dump();
+    }
+
+    std::cout << "Async Wait" << std::endl;
+    for (auto asyncWaitOp : asyncWaitOps) {
+      asyncWaitOp->dump();
+    }
+  }
+};
+
 /// Return a pipelining schedule that gives good performance on Nvidia
 /// Ampere target.
 static void getNvidiaTensorCorePipeline(
@@ -305,7 +484,7 @@ static void getNvidiaTensorCorePipeline(
       stageCompute.empty())
     return;
 
-  // Track dependencies of stage 0 ops.
+  // Add all the dependencies of the operations in the stages.
   llvm::SmallDenseSet<Operation*> deps;
   llvm::SmallDenseSet<Operation*> stageCopyToSharedMemoryDeps;
   llvm::SmallDenseSet<Operation*> stageNMinusOneDeps;
@@ -321,17 +500,138 @@ static void getNvidiaTensorCorePipeline(
   for (Operation* op : stageCompute) {
     addOpsAndDeps(deps, stageNDeps, op, forOp.getBody());
   }
-  // Schedule Last stage followed by stage 0 follwed by prefetch.
+
+  // Schedule Compute and dependent load operations in stage (depth - 1).
   for (Operation& op : forOp.getBody()->getOperations()) {
     if (stageNDeps.count(&op)) ops.push_back(std::make_pair(&op, depth - 1));
   }
+  // Schedule copy to shared memory in stage 0.
   for (Operation& op : forOp.getBody()->getOperations()) {
     if (stageCopyToSharedMemoryDeps.count(&op))
       ops.push_back(std::make_pair(&op, 0));
   }
+  // Schedule prefetch data into register in stage (depth - 2).
   for (Operation& op : forOp.getBody()->getOperations()) {
     if (stageNMinusOneDeps.count(&op))
       ops.push_back(std::make_pair(&op, depth - 2));
+  }
+
+  // Print schedule
+  std::cout << "getNvidiaTensorCorePipeline Schedule" << std::endl;
+  for (auto op : ops) {
+    std::cout << " Stage: " << op.second;
+    std::cout << " Operation: ";
+    op.first->dump();
+    std::cout << std::endl;
+  }
+
+  // Create schedule and assign software pipelining stages kgroup-by-kgroup.
+}
+
+/// Schedule operations and assign software pipelining stages.
+static void scheduleOperations(
+    std::vector<std::pair<Operation*, unsigned>>& ops,
+    llvm::SmallDenseSet<Operation*> dependentOps, unsigned pipelineDepth) {
+  for (Operation* op : dependentOps) {
+    std::cout << "Stage : " << pipelineDepth << " ";
+    std::cout << "Schedule operation: ";
+    op->dump();
+    std::cout << std::flush;
+    std::cout << std::endl;
+    std::cout << std::endl;
+    ops.push_back(std::make_pair(op, pipelineDepth));
+  }
+}
+
+/// Return a pipelining schedule that gives good performance on Nvidia
+/// Ampere target.
+static void getNvidiaTensorCoreScheduleAndPipeline(
+    scf::ForOp forOp, std::vector<std::pair<Operation*, unsigned>>& ops,
+    unsigned depth) {
+  MainLoopInfo info;
+  info.collect(forOp);
+  info.dump();
+
+  // Schedule the mainloop kgroup-by-kgroup.
+  llvm::SmallDenseSet<Operation*> scheduledOps;
+  llvm::SmallDenseSet<Operation*> skippedOps;
+
+  for (int kgroup = 0; kgroup < info.getNumKGroups(); kgroup++) {
+    // Schedule warp-level mma.sync operations.
+    for (auto& mmaOp : info.warpOperations[kgroup].mmaOperations) {
+      skippedOps.insert(info.warpOperations[0].loadOperationsA.begin(),
+                        info.warpOperations[0].loadOperationsA.end());
+      skippedOps.insert(info.warpOperations[0].loadOperationsB.begin(),
+                        info.warpOperations[0].loadOperationsB.end());
+
+      llvm::SmallDenseSet<Operation*> dependentOps;
+
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps, mmaOp,
+                              forOp.getBody());
+      scheduleOperations(ops, dependentOps, depth - 1);
+    }
+
+    skippedOps.clear();
+
+    // Schedule warp-level ldmatrix or ld.shared operations for operandA.
+    for (auto& ldmatrixOp : info.warpOperations[kgroup].loadOperationsA) {
+      llvm::SmallDenseSet<Operation*> dependentOps;
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
+                              ldmatrixOp, forOp.getBody());
+      int pipelineStage = (kgroup == 0) ? (depth - 2) : (depth - 1);
+      scheduleOperations(ops, dependentOps, pipelineStage);
+    }
+
+    // Schedule warp-level ldmatrix or ld.shared operations for operandB.
+    for (auto& ldmatrixOp : info.warpOperations[kgroup].loadOperationsB) {
+      llvm::SmallDenseSet<Operation*> dependentOps;
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
+                              ldmatrixOp, forOp.getBody());
+      int pipelineStage = (kgroup == 0) ? (depth - 2) : (depth - 1);
+      scheduleOperations(ops, dependentOps, pipelineStage);
+    }
+
+#if 0  // TODO: Distribute cp.async operations across.
+    // Schedule async copy from Global Memory to Shared Memory.
+    int copyIdxStart =
+        kgroup * (info.copyGlobalToSharedOps.size() / info.getNumKGroups());
+    int copyIdxEnd = (kgroup + 1) *
+                     (info.copyGlobalToSharedOps.size() / info.getNumKGroups());
+
+    for (int idx = copyIdxStart; idx < copyIdxEnd; idx++) {
+      llvm::SmallDenseSet<Operation*> dependentOps;
+      addOpsAndDeps(scheduledOps, dependentOps, info.copyGlobalToSharedOps[idx],
+                    forOp.getBody());
+      scheduleOperations(ops, dependentOps, 0);
+    }
+#endif
+
+    if (kgroup == info.getNumKGroups() - 1) {
+      // Schedule any remaining cp.async or cp.async.commit_group operations.
+      int idx = 0;
+
+      while (idx < info.copyGlobalToSharedOps.size()) {
+        info.copyGlobalToSharedOps[idx]->dump();
+        llvm::SmallDenseSet<Operation*> dependentOps;
+        addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
+                                info.copyGlobalToSharedOps[idx],
+                                forOp.getBody());
+        scheduleOperations(ops, dependentOps, 0);
+        idx++;
+      }
+      // Schedule cp.async.wait_group and bar.sync 0 for after the last
+      // cp.async.
+      llvm::SmallDenseSet<Operation*> asyncWaitDependentOps;
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, asyncWaitDependentOps,
+                              info.asyncWaitOps[0], forOp.getBody());
+      scheduleOperations(ops, asyncWaitDependentOps, 0);
+
+      llvm::SmallDenseSet<Operation*> barrierDependentOps;
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, barrierDependentOps,
+                              info.barrierOps[0], forOp.getBody());
+
+      scheduleOperations(ops, barrierDependentOps, 0);
+    }
   }
 }
 
@@ -357,7 +657,8 @@ static FailureOr<scf::ForOp> applyPipelining(
                          scf::ForOp forOp,
                          std::vector<std::pair<Operation*, unsigned>>& ops) {
     if (schedule == PipeliningSchedulingStrategy::nvidiaTensorCore) {
-      return getNvidiaTensorCorePipeline(forOp, ops, maxDepth);
+      return getNvidiaTensorCoreScheduleAndPipeline(forOp, ops, maxDepth);
+      // return getNvidiaTensorCorePipeline(forOp, ops, maxDepth);
     }
     return getPipelineStages(forOp, ops, maxDepth);
   };
@@ -431,8 +732,8 @@ FailureOr<scf::ForOp> pipelineSharedMemoryCopy(
 /// Pass options
 /// epiloguePeeling - try enable/disable epilogue peeling.
 /// true  : Peel epilogue (no additional checks required)
-/// false : Try and use unpeeled epilogue (check if predication is supported is
-/// avialable)
+/// false : Try and use unpeeled epilogue (check if predication is supported
+/// is avialable)
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUPipeliningPass(
     bool epiloguePeeling, unsigned depth,
     PipeliningSchedulingStrategy schedule) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/gpu_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/gpu_pipeline.mlir
@@ -491,12 +491,13 @@ func.func @nvidia_tenscore_schedule() {
 //          CHECK-NV:  gpu.barrier
 //  CHECK-NV-COUNT-8:  nvgpu.ldmatrix
 //          CHECK-NV:  scf.for
-//  CHECK-NV-COUNT-8:    nvgpu.ldmatrix
-// CHECK-NV-COUNT-64:    nvgpu.mma.sync
+//  CHECK-NV-COUNT-4:    nvgpu.ldmatrix
+// CHECK-NV-COUNT-32:    nvgpu.mma.sync
 //  CHECK-NV-COUNT-6:    nvgpu.device_async_copy
 //          CHECK-NV:    nvgpu.device_async_create_group
 //          CHECK-NV:    nvgpu.device_async_wait %{{.*}} {numGroups = 1 : i32}
 //          CHECK-NV:    gpu.barrier
 //  CHECK-NV-COUNT-8:    nvgpu.ldmatrix
+// CHECK-NV-COUNT-32:    nvgpu.mma.sync
 //          CHECK-NV:  }
 //          CHECK-NV:  vector.store

--- a/compiler/src/iree/compiler/Codegen/Common/test/gpu_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/gpu_pipeline.mlir
@@ -57,7 +57,7 @@ func.func @_matmul_f16_f16_dispatch_0_fill_3456x1024() {
 
 // -----
 
-func.func @nvidia_tenscore_schedule() {
+func.func @nvidia_tenscore_schedule_f16() {
   %c3 = arith.constant 3 : index
   %c31 = arith.constant 31 : index
   %c2 = arith.constant 2 : index
@@ -482,7 +482,7 @@ func.func @nvidia_tenscore_schedule() {
   return
 }
 
-//  CHECK-NV-LABEL: func.func @nvidia_tenscore_schedule
+//  CHECK-NV-LABEL: func.func @nvidia_tenscore_schedule_f16
 //  CHECK-NV-COUNT-6:  nvgpu.device_async_copy
 //          CHECK-NV:  nvgpu.device_async_create_group
 //  CHECK-NV-COUNT-6:  nvgpu.device_async_copy
@@ -501,3 +501,849 @@ func.func @nvidia_tenscore_schedule() {
 // CHECK-NV-COUNT-32:    nvgpu.mma.sync
 //          CHECK-NV:  }
 //          CHECK-NV:  vector.store
+
+// -----
+func.func @nvidia_tenscore_schedule_f32() {
+  %c31 = arith.constant 31 : index
+  %c2 = arith.constant 2 : index
+  %c7 = arith.constant 7 : index
+  %cst = arith.constant dense<0.000000e+00> : vector<2x1xf32>
+  %c32 = arith.constant 32 : index
+  %cst_0 = arith.constant dense<0.000000e+00> : vector<2x2xf32>
+  %c256 = arith.constant 256 : index
+  %cst_1 = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = gpu.thread_id  x
+  %1 = gpu.thread_id  y
+  %2 = gpu.thread_id  z
+  %alloc = memref.alloc() : memref<128x128xf32, #gpu.address_space<workgroup>>
+  %alloc_2 = memref.alloc() : memref<3x128x32xf32, #gpu.address_space<workgroup>>
+  %alloc_3 = memref.alloc() : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+  %3 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf32>
+  memref.assume_alignment %3, 64 : memref<256x256xf32>
+  %4 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf32>
+  memref.assume_alignment %4, 64 : memref<256x256xf32>
+  %5 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<256x256xf32>
+  memref.assume_alignment %5, 64 : memref<256x256xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %6 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8)>()[%0, %1, %2, %workgroup_id_y]
+  %7 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 16 + s0 floordiv 8)>()[%0, %1, %2]
+  %8 = affine.apply affine_map<()[s0] -> (s0 * 4 - (s0 floordiv 8) * 32)>()[%0]
+  %9 = arith.andi %7, %c7 : index
+  %10 = arith.shli %9, %c2 : index
+  %11 = arith.xori %8, %10 : index
+  %12 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8 + 16)>()[%0, %1, %2, %workgroup_id_y]
+  %13 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 16 + s0 floordiv 8 + 16)>()[%0, %1, %2]
+  %14 = arith.andi %13, %c7 : index
+  %15 = arith.shli %14, %c2 : index
+  %16 = arith.xori %8, %15 : index
+  %17 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8 + 32)>()[%0, %1, %2, %workgroup_id_y]
+  %18 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 16 + s0 floordiv 8 + 32)>()[%0, %1, %2]
+  %19 = arith.andi %18, %c7 : index
+  %20 = arith.shli %19, %c2 : index
+  %21 = arith.xori %8, %20 : index
+  %22 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8 + 48)>()[%0, %1, %2, %workgroup_id_y]
+  %23 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 16 + s0 floordiv 8 + 48)>()[%0, %1, %2]
+  %24 = arith.andi %23, %c7 : index
+  %25 = arith.shli %24, %c2 : index
+  %26 = arith.xori %8, %25 : index
+  %27 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8 + 64)>()[%0, %1, %2, %workgroup_id_y]
+  %28 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 16 + s0 floordiv 8 + 64)>()[%0, %1, %2]
+  %29 = arith.andi %28, %c7 : index
+  %30 = arith.shli %29, %c2 : index
+  %31 = arith.xori %8, %30 : index
+  %32 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8 + 80)>()[%0, %1, %2, %workgroup_id_y]
+  %33 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 16 + s0 floordiv 8 + 80)>()[%0, %1, %2]
+  %34 = arith.andi %33, %c7 : index
+  %35 = arith.shli %34, %c2 : index
+  %36 = arith.xori %8, %35 : index
+  %37 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8 + 96)>()[%0, %1, %2, %workgroup_id_y]
+  %38 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 16 + s0 floordiv 8 + 96)>()[%0, %1, %2]
+  %39 = arith.andi %38, %c7 : index
+  %40 = arith.shli %39, %c2 : index
+  %41 = arith.xori %8, %40 : index
+  %42 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8 + 112)>()[%0, %1, %2, %workgroup_id_y]
+  %43 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 16 + s0 floordiv 8 + 112)>()[%0, %1, %2]
+  %44 = arith.andi %43, %c7 : index
+  %45 = arith.shli %44, %c2 : index
+  %46 = arith.xori %8, %45 : index
+  %47 = affine.apply affine_map<()[s0, s1] -> (s0 * 4 + s1 * 128 - (s0 floordiv 32) * 128)>()[%0, %workgroup_id_x]
+  %48 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32)>()[%0, %1, %2]
+  %49 = affine.apply affine_map<()[s0] -> (s0 * 4 - (s0 floordiv 32) * 128)>()[%0]
+  %50 = arith.andi %48, %c31 : index
+  %51 = arith.shli %50, %c2 : index
+  %52 = arith.xori %49, %51 : index
+  %53 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 4)>()[%0, %1, %2]
+  %54 = arith.andi %53, %c31 : index
+  %55 = arith.shli %54, %c2 : index
+  %56 = arith.xori %49, %55 : index
+  %57 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 8)>()[%0, %1, %2]
+  %58 = arith.andi %57, %c31 : index
+  %59 = arith.shli %58, %c2 : index
+  %60 = arith.xori %49, %59 : index
+  %61 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 12)>()[%0, %1, %2]
+  %62 = arith.andi %61, %c31 : index
+  %63 = arith.shli %62, %c2 : index
+  %64 = arith.xori %49, %63 : index
+  %65 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 16)>()[%0, %1, %2]
+  %66 = arith.andi %65, %c31 : index
+  %67 = arith.shli %66, %c2 : index
+  %68 = arith.xori %49, %67 : index
+  %69 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 20)>()[%0, %1, %2]
+  %70 = arith.andi %69, %c31 : index
+  %71 = arith.shli %70, %c2 : index
+  %72 = arith.xori %49, %71 : index
+  %73 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 24)>()[%0, %1, %2]
+  %74 = arith.andi %73, %c31 : index
+  %75 = arith.shli %74, %c2 : index
+  %76 = arith.xori %49, %75 : index
+  %77 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 28)>()[%0, %1, %2]
+  %78 = arith.andi %77, %c31 : index
+  %79 = arith.shli %78, %c2 : index
+  %80 = arith.xori %49, %79 : index
+  %81 = gpu.lane_id
+  %82 = affine.apply affine_map<(d0)[s0] -> (d0 + s0 * 64 - (d0 floordiv 16) * 16)>(%81)[%1]
+  %83 = affine.apply affine_map<(d0) -> ((d0 floordiv 16) * 4)>(%81)
+  %84 = arith.andi %82, %c7 : index
+  %85 = arith.shli %84, %c2 : index
+  %86 = arith.xori %83, %85 : index
+  %87 = affine.apply affine_map<(d0) -> ((d0 floordiv 16) * 4 + 8)>(%81)
+  %88 = arith.xori %87, %85 : index
+  %89 = affine.apply affine_map<(d0) -> ((d0 floordiv 16) * 4 + 16)>(%81)
+  %90 = arith.xori %89, %85 : index
+  %91 = affine.apply affine_map<(d0) -> ((d0 floordiv 16) * 4 + 24)>(%81)
+  %92 = arith.xori %91, %85 : index
+  %93 = affine.apply affine_map<(d0)[s0] -> (d0 + s0 * 64 - (d0 floordiv 16) * 16 + 16)>(%81)[%1]
+  %94 = arith.andi %93, %c7 : index
+  %95 = arith.shli %94, %c2 : index
+  %96 = arith.xori %83, %95 : index
+  %97 = arith.xori %87, %95 : index
+  %98 = arith.xori %89, %95 : index
+  %99 = arith.xori %91, %95 : index
+  %100 = affine.apply affine_map<(d0)[s0] -> (d0 + s0 * 64 - (d0 floordiv 16) * 16 + 32)>(%81)[%1]
+  %101 = arith.andi %100, %c7 : index
+  %102 = arith.shli %101, %c2 : index
+  %103 = arith.xori %83, %102 : index
+  %104 = arith.xori %87, %102 : index
+  %105 = arith.xori %89, %102 : index
+  %106 = arith.xori %91, %102 : index
+  %107 = affine.apply affine_map<(d0)[s0] -> (d0 + s0 * 64 - (d0 floordiv 16) * 16 + 48)>(%81)[%1]
+  %108 = arith.andi %107, %c7 : index
+  %109 = arith.shli %108, %c2 : index
+  %110 = arith.xori %83, %109 : index
+  %111 = arith.xori %87, %109 : index
+  %112 = arith.xori %89, %109 : index
+  %113 = arith.xori %91, %109 : index
+  %114 = affine.apply affine_map<(d0)[s0] -> (d0 floordiv 4 + (s0 floordiv 32) * 64)>(%81)[%0]
+  %115 = affine.apply affine_map<(d0) -> (d0 mod 4)>(%81)
+  %116 = arith.andi %115, %c31 : index
+  %117 = arith.shli %116, %c2 : index
+  %118 = arith.xori %114, %117 : index
+  %119 = affine.apply affine_map<(d0) -> (d0 mod 4 + 4)>(%81)
+  %120 = arith.andi %119, %c31 : index
+  %121 = arith.shli %120, %c2 : index
+  %122 = arith.xori %114, %121 : index
+  %123 = affine.apply affine_map<(d0) -> (d0 mod 4 + 8)>(%81)
+  %124 = arith.andi %123, %c31 : index
+  %125 = arith.shli %124, %c2 : index
+  %126 = arith.xori %114, %125 : index
+  %127 = affine.apply affine_map<(d0) -> (d0 mod 4 + 12)>(%81)
+  %128 = arith.andi %127, %c31 : index
+  %129 = arith.shli %128, %c2 : index
+  %130 = arith.xori %114, %129 : index
+  %131 = affine.apply affine_map<(d0) -> (d0 mod 4 + 16)>(%81)
+  %132 = arith.andi %131, %c31 : index
+  %133 = arith.shli %132, %c2 : index
+  %134 = arith.xori %114, %133 : index
+  %135 = affine.apply affine_map<(d0) -> (d0 mod 4 + 20)>(%81)
+  %136 = arith.andi %135, %c31 : index
+  %137 = arith.shli %136, %c2 : index
+  %138 = arith.xori %114, %137 : index
+  %139 = affine.apply affine_map<(d0) -> (d0 mod 4 + 24)>(%81)
+  %140 = arith.andi %139, %c31 : index
+  %141 = arith.shli %140, %c2 : index
+  %142 = arith.xori %114, %141 : index
+  %143 = affine.apply affine_map<(d0) -> (d0 mod 4 + 28)>(%81)
+  %144 = arith.andi %143, %c31 : index
+  %145 = arith.shli %144, %c2 : index
+  %146 = arith.xori %114, %145 : index
+  %147 = affine.apply affine_map<(d0)[s0] -> (d0 floordiv 4 + (s0 floordiv 32) * 64 + 8)>(%81)[%0]
+  %148 = arith.xori %147, %117 : index
+  %149 = arith.xori %147, %121 : index
+  %150 = arith.xori %147, %125 : index
+  %151 = arith.xori %147, %129 : index
+  %152 = arith.xori %147, %133 : index
+  %153 = arith.xori %147, %137 : index
+  %154 = arith.xori %147, %141 : index
+  %155 = arith.xori %147, %145 : index
+  %156 = affine.apply affine_map<(d0)[s0] -> (d0 floordiv 4 + (s0 floordiv 32) * 64 + 16)>(%81)[%0]
+  %157 = arith.xori %156, %117 : index
+  %158 = arith.xori %156, %121 : index
+  %159 = arith.xori %156, %125 : index
+  %160 = arith.xori %156, %129 : index
+  %161 = arith.xori %156, %133 : index
+  %162 = arith.xori %156, %137 : index
+  %163 = arith.xori %156, %141 : index
+  %164 = arith.xori %156, %145 : index
+  %165 = affine.apply affine_map<(d0)[s0] -> (d0 floordiv 4 + (s0 floordiv 32) * 64 + 24)>(%81)[%0]
+  %166 = arith.xori %165, %117 : index
+  %167 = arith.xori %165, %121 : index
+  %168 = arith.xori %165, %125 : index
+  %169 = arith.xori %165, %129 : index
+  %170 = arith.xori %165, %133 : index
+  %171 = arith.xori %165, %137 : index
+  %172 = arith.xori %165, %141 : index
+  %173 = arith.xori %165, %145 : index
+  %174 = affine.apply affine_map<(d0)[s0] -> (d0 floordiv 4 + (s0 floordiv 32) * 64 + 32)>(%81)[%0]
+  %175 = arith.xori %174, %117 : index
+  %176 = arith.xori %174, %121 : index
+  %177 = arith.xori %174, %125 : index
+  %178 = arith.xori %174, %129 : index
+  %179 = arith.xori %174, %133 : index
+  %180 = arith.xori %174, %137 : index
+  %181 = arith.xori %174, %141 : index
+  %182 = arith.xori %174, %145 : index
+  %183 = affine.apply affine_map<(d0)[s0] -> (d0 floordiv 4 + (s0 floordiv 32) * 64 + 40)>(%81)[%0]
+  %184 = arith.xori %183, %117 : index
+  %185 = arith.xori %183, %121 : index
+  %186 = arith.xori %183, %125 : index
+  %187 = arith.xori %183, %129 : index
+  %188 = arith.xori %183, %133 : index
+  %189 = arith.xori %183, %137 : index
+  %190 = arith.xori %183, %141 : index
+  %191 = arith.xori %183, %145 : index
+  %192 = affine.apply affine_map<(d0)[s0] -> (d0 floordiv 4 + (s0 floordiv 32) * 64 + 48)>(%81)[%0]
+  %193 = arith.xori %192, %117 : index
+  %194 = arith.xori %192, %121 : index
+  %195 = arith.xori %192, %125 : index
+  %196 = arith.xori %192, %129 : index
+  %197 = arith.xori %192, %133 : index
+  %198 = arith.xori %192, %137 : index
+  %199 = arith.xori %192, %141 : index
+  %200 = arith.xori %192, %145 : index
+  %201 = affine.apply affine_map<(d0)[s0] -> (d0 floordiv 4 + (s0 floordiv 32) * 64 + 56)>(%81)[%0]
+  %202 = arith.xori %201, %117 : index
+  %203 = arith.xori %201, %121 : index
+  %204 = arith.xori %201, %125 : index
+  %205 = arith.xori %201, %129 : index
+  %206 = arith.xori %201, %133 : index
+  %207 = arith.xori %201, %137 : index
+  %208 = arith.xori %201, %141 : index
+  %209 = arith.xori %201, %145 : index
+  %210:32 = scf.for %arg0 = %c0 to %c256 step %c32 iter_args(%arg1 = %cst_0, %arg2 = %cst_0, %arg3 = %cst_0, %arg4 = %cst_0, %arg5 = %cst_0, %arg6 = %cst_0, %arg7 = %cst_0, %arg8 = %cst_0, %arg9 = %cst_0, %arg10 = %cst_0, %arg11 = %cst_0, %arg12 = %cst_0, %arg13 = %cst_0, %arg14 = %cst_0, %arg15 = %cst_0, %arg16 = %cst_0, %arg17 = %cst_0, %arg18 = %cst_0, %arg19 = %cst_0, %arg20 = %cst_0, %arg21 = %cst_0, %arg22 = %cst_0, %arg23 = %cst_0, %arg24 = %cst_0, %arg25 = %cst_0, %arg26 = %cst_0, %arg27 = %cst_0, %arg28 = %cst_0, %arg29 = %cst_0, %arg30 = %cst_0, %arg31 = %cst_0, %arg32 = %cst_0) -> (vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>) {
+    gpu.barrier
+    %390 = affine.apply affine_map<()[s0, s1] -> (s0 + s1 * 4 - (s1 floordiv 8) * 32)>()[%arg0, %0]
+    %391 = affine.apply affine_map<(d0) -> ((d0 floordiv 32) mod 3)>(%arg0)
+    %392 = nvgpu.device_async_copy %3[%6, %390], %alloc_2[%391, %7, %11], 4 {bypassL1} : memref<256x256xf32> to memref<3x128x32xf32, #gpu.address_space<workgroup>>
+    %393 = nvgpu.device_async_copy %3[%12, %390], %alloc_2[%391, %13, %16], 4 {bypassL1} : memref<256x256xf32> to memref<3x128x32xf32, #gpu.address_space<workgroup>>
+    %394 = nvgpu.device_async_copy %3[%17, %390], %alloc_2[%391, %18, %21], 4 {bypassL1} : memref<256x256xf32> to memref<3x128x32xf32, #gpu.address_space<workgroup>>
+    %395 = nvgpu.device_async_copy %3[%22, %390], %alloc_2[%391, %23, %26], 4 {bypassL1} : memref<256x256xf32> to memref<3x128x32xf32, #gpu.address_space<workgroup>>
+    %396 = nvgpu.device_async_copy %3[%27, %390], %alloc_2[%391, %28, %31], 4 {bypassL1} : memref<256x256xf32> to memref<3x128x32xf32, #gpu.address_space<workgroup>>
+    %397 = nvgpu.device_async_copy %3[%32, %390], %alloc_2[%391, %33, %36], 4 {bypassL1} : memref<256x256xf32> to memref<3x128x32xf32, #gpu.address_space<workgroup>>
+    %398 = nvgpu.device_async_copy %3[%37, %390], %alloc_2[%391, %38, %41], 4 {bypassL1} : memref<256x256xf32> to memref<3x128x32xf32, #gpu.address_space<workgroup>>
+    %399 = nvgpu.device_async_copy %3[%42, %390], %alloc_2[%391, %43, %46], 4 {bypassL1} : memref<256x256xf32> to memref<3x128x32xf32, #gpu.address_space<workgroup>>
+    %400 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 + s2 * 2 + s3 * 4 + s1 floordiv 32)>()[%arg0, %0, %1, %2]
+    %401 = nvgpu.device_async_copy %4[%400, %47], %alloc_3[%391, %48, %52], 4 {bypassL1} : memref<256x256xf32> to memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %402 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 + s2 * 2 + s3 * 4 + s1 floordiv 32 + 4)>()[%arg0, %0, %1, %2]
+    %403 = nvgpu.device_async_copy %4[%402, %47], %alloc_3[%391, %53, %56], 4 {bypassL1} : memref<256x256xf32> to memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %404 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 + s2 * 2 + s3 * 4 + s1 floordiv 32 + 8)>()[%arg0, %0, %1, %2]
+    %405 = nvgpu.device_async_copy %4[%404, %47], %alloc_3[%391, %57, %60], 4 {bypassL1} : memref<256x256xf32> to memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %406 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 + s2 * 2 + s3 * 4 + s1 floordiv 32 + 12)>()[%arg0, %0, %1, %2]
+    %407 = nvgpu.device_async_copy %4[%406, %47], %alloc_3[%391, %61, %64], 4 {bypassL1} : memref<256x256xf32> to memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %408 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 + s2 * 2 + s3 * 4 + s1 floordiv 32 + 16)>()[%arg0, %0, %1, %2]
+    %409 = nvgpu.device_async_copy %4[%408, %47], %alloc_3[%391, %65, %68], 4 {bypassL1} : memref<256x256xf32> to memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %410 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 + s2 * 2 + s3 * 4 + s1 floordiv 32 + 20)>()[%arg0, %0, %1, %2]
+    %411 = nvgpu.device_async_copy %4[%410, %47], %alloc_3[%391, %69, %72], 4 {bypassL1} : memref<256x256xf32> to memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %412 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 + s2 * 2 + s3 * 4 + s1 floordiv 32 + 24)>()[%arg0, %0, %1, %2]
+    %413 = nvgpu.device_async_copy %4[%412, %47], %alloc_3[%391, %73, %76], 4 {bypassL1} : memref<256x256xf32> to memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %414 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 + s2 * 2 + s3 * 4 + s1 floordiv 32 + 28)>()[%arg0, %0, %1, %2]
+    %415 = nvgpu.device_async_copy %4[%414, %47], %alloc_3[%391, %77, %80], 4 {bypassL1} : memref<256x256xf32> to memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %416 = nvgpu.device_async_create_group %392, %393, %394, %395, %396, %397, %398, %399, %401, %403, %405, %407, %409, %411, %413, %415
+    nvgpu.device_async_wait %416
+    gpu.barrier
+    %417 = nvgpu.ldmatrix %alloc_2[%391, %82, %86] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %418 = nvgpu.ldmatrix %alloc_2[%391, %82, %88] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %419 = nvgpu.ldmatrix %alloc_2[%391, %82, %90] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %420 = nvgpu.ldmatrix %alloc_2[%391, %82, %92] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %421 = nvgpu.ldmatrix %alloc_2[%391, %93, %96] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %422 = nvgpu.ldmatrix %alloc_2[%391, %93, %97] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %423 = nvgpu.ldmatrix %alloc_2[%391, %93, %98] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %424 = nvgpu.ldmatrix %alloc_2[%391, %93, %99] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %425 = nvgpu.ldmatrix %alloc_2[%391, %100, %103] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %426 = nvgpu.ldmatrix %alloc_2[%391, %100, %104] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %427 = nvgpu.ldmatrix %alloc_2[%391, %100, %105] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %428 = nvgpu.ldmatrix %alloc_2[%391, %100, %106] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %429 = nvgpu.ldmatrix %alloc_2[%391, %107, %110] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %430 = nvgpu.ldmatrix %alloc_2[%391, %107, %111] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %431 = nvgpu.ldmatrix %alloc_2[%391, %107, %112] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %432 = nvgpu.ldmatrix %alloc_2[%391, %107, %113] {numTiles = 4 : i32, transpose = false} : memref<3x128x32xf32, #gpu.address_space<workgroup>> -> vector<4x1xf32>
+    %433 = memref.load %alloc_3[%391, %115, %118] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %434 = vector.insert %433, %cst [0, 0] : f32 into vector<2x1xf32>
+    %435 = memref.load %alloc_3[%391, %119, %122] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %436 = vector.insert %435, %434 [1, 0] : f32 into vector<2x1xf32>
+    %437 = memref.load %alloc_3[%391, %123, %126] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %438 = vector.insert %437, %cst [0, 0] : f32 into vector<2x1xf32>
+    %439 = memref.load %alloc_3[%391, %127, %130] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %440 = vector.insert %439, %438 [1, 0] : f32 into vector<2x1xf32>
+    %441 = memref.load %alloc_3[%391, %131, %134] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %442 = vector.insert %441, %cst [0, 0] : f32 into vector<2x1xf32>
+    %443 = memref.load %alloc_3[%391, %135, %138] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %444 = vector.insert %443, %442 [1, 0] : f32 into vector<2x1xf32>
+    %445 = memref.load %alloc_3[%391, %139, %142] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %446 = vector.insert %445, %cst [0, 0] : f32 into vector<2x1xf32>
+    %447 = memref.load %alloc_3[%391, %143, %146] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %448 = vector.insert %447, %446 [1, 0] : f32 into vector<2x1xf32>
+    %449 = memref.load %alloc_3[%391, %115, %148] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %450 = vector.insert %449, %cst [0, 0] : f32 into vector<2x1xf32>
+    %451 = memref.load %alloc_3[%391, %119, %149] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %452 = vector.insert %451, %450 [1, 0] : f32 into vector<2x1xf32>
+    %453 = memref.load %alloc_3[%391, %123, %150] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %454 = vector.insert %453, %cst [0, 0] : f32 into vector<2x1xf32>
+    %455 = memref.load %alloc_3[%391, %127, %151] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %456 = vector.insert %455, %454 [1, 0] : f32 into vector<2x1xf32>
+    %457 = memref.load %alloc_3[%391, %131, %152] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %458 = vector.insert %457, %cst [0, 0] : f32 into vector<2x1xf32>
+    %459 = memref.load %alloc_3[%391, %135, %153] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %460 = vector.insert %459, %458 [1, 0] : f32 into vector<2x1xf32>
+    %461 = memref.load %alloc_3[%391, %139, %154] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %462 = vector.insert %461, %cst [0, 0] : f32 into vector<2x1xf32>
+    %463 = memref.load %alloc_3[%391, %143, %155] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %464 = vector.insert %463, %462 [1, 0] : f32 into vector<2x1xf32>
+    %465 = memref.load %alloc_3[%391, %115, %157] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %466 = vector.insert %465, %cst [0, 0] : f32 into vector<2x1xf32>
+    %467 = memref.load %alloc_3[%391, %119, %158] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %468 = vector.insert %467, %466 [1, 0] : f32 into vector<2x1xf32>
+    %469 = memref.load %alloc_3[%391, %123, %159] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %470 = vector.insert %469, %cst [0, 0] : f32 into vector<2x1xf32>
+    %471 = memref.load %alloc_3[%391, %127, %160] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %472 = vector.insert %471, %470 [1, 0] : f32 into vector<2x1xf32>
+    %473 = memref.load %alloc_3[%391, %131, %161] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %474 = vector.insert %473, %cst [0, 0] : f32 into vector<2x1xf32>
+    %475 = memref.load %alloc_3[%391, %135, %162] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %476 = vector.insert %475, %474 [1, 0] : f32 into vector<2x1xf32>
+    %477 = memref.load %alloc_3[%391, %139, %163] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %478 = vector.insert %477, %cst [0, 0] : f32 into vector<2x1xf32>
+    %479 = memref.load %alloc_3[%391, %143, %164] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %480 = vector.insert %479, %478 [1, 0] : f32 into vector<2x1xf32>
+    %481 = memref.load %alloc_3[%391, %115, %166] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %482 = vector.insert %481, %cst [0, 0] : f32 into vector<2x1xf32>
+    %483 = memref.load %alloc_3[%391, %119, %167] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %484 = vector.insert %483, %482 [1, 0] : f32 into vector<2x1xf32>
+    %485 = memref.load %alloc_3[%391, %123, %168] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %486 = vector.insert %485, %cst [0, 0] : f32 into vector<2x1xf32>
+    %487 = memref.load %alloc_3[%391, %127, %169] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %488 = vector.insert %487, %486 [1, 0] : f32 into vector<2x1xf32>
+    %489 = memref.load %alloc_3[%391, %131, %170] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %490 = vector.insert %489, %cst [0, 0] : f32 into vector<2x1xf32>
+    %491 = memref.load %alloc_3[%391, %135, %171] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %492 = vector.insert %491, %490 [1, 0] : f32 into vector<2x1xf32>
+    %493 = memref.load %alloc_3[%391, %139, %172] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %494 = vector.insert %493, %cst [0, 0] : f32 into vector<2x1xf32>
+    %495 = memref.load %alloc_3[%391, %143, %173] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %496 = vector.insert %495, %494 [1, 0] : f32 into vector<2x1xf32>
+    %497 = memref.load %alloc_3[%391, %115, %175] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %498 = vector.insert %497, %cst [0, 0] : f32 into vector<2x1xf32>
+    %499 = memref.load %alloc_3[%391, %119, %176] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %500 = vector.insert %499, %498 [1, 0] : f32 into vector<2x1xf32>
+    %501 = memref.load %alloc_3[%391, %123, %177] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %502 = vector.insert %501, %cst [0, 0] : f32 into vector<2x1xf32>
+    %503 = memref.load %alloc_3[%391, %127, %178] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %504 = vector.insert %503, %502 [1, 0] : f32 into vector<2x1xf32>
+    %505 = memref.load %alloc_3[%391, %131, %179] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %506 = vector.insert %505, %cst [0, 0] : f32 into vector<2x1xf32>
+    %507 = memref.load %alloc_3[%391, %135, %180] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %508 = vector.insert %507, %506 [1, 0] : f32 into vector<2x1xf32>
+    %509 = memref.load %alloc_3[%391, %139, %181] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %510 = vector.insert %509, %cst [0, 0] : f32 into vector<2x1xf32>
+    %511 = memref.load %alloc_3[%391, %143, %182] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %512 = vector.insert %511, %510 [1, 0] : f32 into vector<2x1xf32>
+    %513 = memref.load %alloc_3[%391, %115, %184] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %514 = vector.insert %513, %cst [0, 0] : f32 into vector<2x1xf32>
+    %515 = memref.load %alloc_3[%391, %119, %185] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %516 = vector.insert %515, %514 [1, 0] : f32 into vector<2x1xf32>
+    %517 = memref.load %alloc_3[%391, %123, %186] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %518 = vector.insert %517, %cst [0, 0] : f32 into vector<2x1xf32>
+    %519 = memref.load %alloc_3[%391, %127, %187] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %520 = vector.insert %519, %518 [1, 0] : f32 into vector<2x1xf32>
+    %521 = memref.load %alloc_3[%391, %131, %188] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %522 = vector.insert %521, %cst [0, 0] : f32 into vector<2x1xf32>
+    %523 = memref.load %alloc_3[%391, %135, %189] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %524 = vector.insert %523, %522 [1, 0] : f32 into vector<2x1xf32>
+    %525 = memref.load %alloc_3[%391, %139, %190] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %526 = vector.insert %525, %cst [0, 0] : f32 into vector<2x1xf32>
+    %527 = memref.load %alloc_3[%391, %143, %191] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %528 = vector.insert %527, %526 [1, 0] : f32 into vector<2x1xf32>
+    %529 = memref.load %alloc_3[%391, %115, %193] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %530 = vector.insert %529, %cst [0, 0] : f32 into vector<2x1xf32>
+    %531 = memref.load %alloc_3[%391, %119, %194] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %532 = vector.insert %531, %530 [1, 0] : f32 into vector<2x1xf32>
+    %533 = memref.load %alloc_3[%391, %123, %195] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %534 = vector.insert %533, %cst [0, 0] : f32 into vector<2x1xf32>
+    %535 = memref.load %alloc_3[%391, %127, %196] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %536 = vector.insert %535, %534 [1, 0] : f32 into vector<2x1xf32>
+    %537 = memref.load %alloc_3[%391, %131, %197] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %538 = vector.insert %537, %cst [0, 0] : f32 into vector<2x1xf32>
+    %539 = memref.load %alloc_3[%391, %135, %198] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %540 = vector.insert %539, %538 [1, 0] : f32 into vector<2x1xf32>
+    %541 = memref.load %alloc_3[%391, %139, %199] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %542 = vector.insert %541, %cst [0, 0] : f32 into vector<2x1xf32>
+    %543 = memref.load %alloc_3[%391, %143, %200] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %544 = vector.insert %543, %542 [1, 0] : f32 into vector<2x1xf32>
+    %545 = memref.load %alloc_3[%391, %115, %202] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %546 = vector.insert %545, %cst [0, 0] : f32 into vector<2x1xf32>
+    %547 = memref.load %alloc_3[%391, %119, %203] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %548 = vector.insert %547, %546 [1, 0] : f32 into vector<2x1xf32>
+    %549 = memref.load %alloc_3[%391, %123, %204] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %550 = vector.insert %549, %cst [0, 0] : f32 into vector<2x1xf32>
+    %551 = memref.load %alloc_3[%391, %127, %205] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %552 = vector.insert %551, %550 [1, 0] : f32 into vector<2x1xf32>
+    %553 = memref.load %alloc_3[%391, %131, %206] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %554 = vector.insert %553, %cst [0, 0] : f32 into vector<2x1xf32>
+    %555 = memref.load %alloc_3[%391, %135, %207] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %556 = vector.insert %555, %554 [1, 0] : f32 into vector<2x1xf32>
+    %557 = memref.load %alloc_3[%391, %139, %208] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %558 = vector.insert %557, %cst [0, 0] : f32 into vector<2x1xf32>
+    %559 = memref.load %alloc_3[%391, %143, %209] : memref<3x32x128xf32, #gpu.address_space<workgroup>>
+    %560 = vector.insert %559, %558 [1, 0] : f32 into vector<2x1xf32>
+    %561 = nvgpu.mma.sync(%417, %436, %arg1) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %562 = nvgpu.mma.sync(%417, %452, %arg2) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %563 = nvgpu.mma.sync(%417, %468, %arg3) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %564 = nvgpu.mma.sync(%417, %484, %arg4) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %565 = nvgpu.mma.sync(%417, %500, %arg5) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %566 = nvgpu.mma.sync(%417, %516, %arg6) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %567 = nvgpu.mma.sync(%417, %532, %arg7) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %568 = nvgpu.mma.sync(%417, %548, %arg8) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %569 = nvgpu.mma.sync(%421, %436, %arg9) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %570 = nvgpu.mma.sync(%421, %452, %arg10) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %571 = nvgpu.mma.sync(%421, %468, %arg11) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %572 = nvgpu.mma.sync(%421, %484, %arg12) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %573 = nvgpu.mma.sync(%421, %500, %arg13) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %574 = nvgpu.mma.sync(%421, %516, %arg14) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %575 = nvgpu.mma.sync(%421, %532, %arg15) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %576 = nvgpu.mma.sync(%421, %548, %arg16) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %577 = nvgpu.mma.sync(%425, %436, %arg17) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %578 = nvgpu.mma.sync(%425, %452, %arg18) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %579 = nvgpu.mma.sync(%425, %468, %arg19) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %580 = nvgpu.mma.sync(%425, %484, %arg20) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %581 = nvgpu.mma.sync(%425, %500, %arg21) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %582 = nvgpu.mma.sync(%425, %516, %arg22) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %583 = nvgpu.mma.sync(%425, %532, %arg23) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %584 = nvgpu.mma.sync(%425, %548, %arg24) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %585 = nvgpu.mma.sync(%429, %436, %arg25) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %586 = nvgpu.mma.sync(%429, %452, %arg26) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %587 = nvgpu.mma.sync(%429, %468, %arg27) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %588 = nvgpu.mma.sync(%429, %484, %arg28) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %589 = nvgpu.mma.sync(%429, %500, %arg29) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %590 = nvgpu.mma.sync(%429, %516, %arg30) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %591 = nvgpu.mma.sync(%429, %532, %arg31) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %592 = nvgpu.mma.sync(%429, %548, %arg32) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %593 = nvgpu.mma.sync(%418, %440, %561) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %594 = nvgpu.mma.sync(%418, %456, %562) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %595 = nvgpu.mma.sync(%418, %472, %563) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %596 = nvgpu.mma.sync(%418, %488, %564) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %597 = nvgpu.mma.sync(%418, %504, %565) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %598 = nvgpu.mma.sync(%418, %520, %566) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %599 = nvgpu.mma.sync(%418, %536, %567) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %600 = nvgpu.mma.sync(%418, %552, %568) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %601 = nvgpu.mma.sync(%422, %440, %569) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %602 = nvgpu.mma.sync(%422, %456, %570) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %603 = nvgpu.mma.sync(%422, %472, %571) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %604 = nvgpu.mma.sync(%422, %488, %572) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %605 = nvgpu.mma.sync(%422, %504, %573) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %606 = nvgpu.mma.sync(%422, %520, %574) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %607 = nvgpu.mma.sync(%422, %536, %575) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %608 = nvgpu.mma.sync(%422, %552, %576) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %609 = nvgpu.mma.sync(%426, %440, %577) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %610 = nvgpu.mma.sync(%426, %456, %578) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %611 = nvgpu.mma.sync(%426, %472, %579) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %612 = nvgpu.mma.sync(%426, %488, %580) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %613 = nvgpu.mma.sync(%426, %504, %581) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %614 = nvgpu.mma.sync(%426, %520, %582) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %615 = nvgpu.mma.sync(%426, %536, %583) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %616 = nvgpu.mma.sync(%426, %552, %584) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %617 = nvgpu.mma.sync(%430, %440, %585) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %618 = nvgpu.mma.sync(%430, %456, %586) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %619 = nvgpu.mma.sync(%430, %472, %587) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %620 = nvgpu.mma.sync(%430, %488, %588) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %621 = nvgpu.mma.sync(%430, %504, %589) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %622 = nvgpu.mma.sync(%430, %520, %590) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %623 = nvgpu.mma.sync(%430, %536, %591) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %624 = nvgpu.mma.sync(%430, %552, %592) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %625 = nvgpu.mma.sync(%419, %444, %593) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %626 = nvgpu.mma.sync(%419, %460, %594) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %627 = nvgpu.mma.sync(%419, %476, %595) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %628 = nvgpu.mma.sync(%419, %492, %596) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %629 = nvgpu.mma.sync(%419, %508, %597) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %630 = nvgpu.mma.sync(%419, %524, %598) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %631 = nvgpu.mma.sync(%419, %540, %599) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %632 = nvgpu.mma.sync(%419, %556, %600) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %633 = nvgpu.mma.sync(%423, %444, %601) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %634 = nvgpu.mma.sync(%423, %460, %602) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %635 = nvgpu.mma.sync(%423, %476, %603) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %636 = nvgpu.mma.sync(%423, %492, %604) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %637 = nvgpu.mma.sync(%423, %508, %605) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %638 = nvgpu.mma.sync(%423, %524, %606) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %639 = nvgpu.mma.sync(%423, %540, %607) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %640 = nvgpu.mma.sync(%423, %556, %608) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %641 = nvgpu.mma.sync(%427, %444, %609) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %642 = nvgpu.mma.sync(%427, %460, %610) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %643 = nvgpu.mma.sync(%427, %476, %611) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %644 = nvgpu.mma.sync(%427, %492, %612) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %645 = nvgpu.mma.sync(%427, %508, %613) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %646 = nvgpu.mma.sync(%427, %524, %614) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %647 = nvgpu.mma.sync(%427, %540, %615) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %648 = nvgpu.mma.sync(%427, %556, %616) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %649 = nvgpu.mma.sync(%431, %444, %617) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %650 = nvgpu.mma.sync(%431, %460, %618) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %651 = nvgpu.mma.sync(%431, %476, %619) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %652 = nvgpu.mma.sync(%431, %492, %620) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %653 = nvgpu.mma.sync(%431, %508, %621) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %654 = nvgpu.mma.sync(%431, %524, %622) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %655 = nvgpu.mma.sync(%431, %540, %623) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %656 = nvgpu.mma.sync(%431, %556, %624) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %657 = nvgpu.mma.sync(%420, %448, %625) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %658 = nvgpu.mma.sync(%420, %464, %626) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %659 = nvgpu.mma.sync(%420, %480, %627) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %660 = nvgpu.mma.sync(%420, %496, %628) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %661 = nvgpu.mma.sync(%420, %512, %629) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %662 = nvgpu.mma.sync(%420, %528, %630) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %663 = nvgpu.mma.sync(%420, %544, %631) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %664 = nvgpu.mma.sync(%420, %560, %632) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %665 = nvgpu.mma.sync(%424, %448, %633) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %666 = nvgpu.mma.sync(%424, %464, %634) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %667 = nvgpu.mma.sync(%424, %480, %635) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %668 = nvgpu.mma.sync(%424, %496, %636) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %669 = nvgpu.mma.sync(%424, %512, %637) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %670 = nvgpu.mma.sync(%424, %528, %638) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %671 = nvgpu.mma.sync(%424, %544, %639) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %672 = nvgpu.mma.sync(%424, %560, %640) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %673 = nvgpu.mma.sync(%428, %448, %641) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %674 = nvgpu.mma.sync(%428, %464, %642) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %675 = nvgpu.mma.sync(%428, %480, %643) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %676 = nvgpu.mma.sync(%428, %496, %644) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %677 = nvgpu.mma.sync(%428, %512, %645) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %678 = nvgpu.mma.sync(%428, %528, %646) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %679 = nvgpu.mma.sync(%428, %544, %647) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %680 = nvgpu.mma.sync(%428, %560, %648) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %681 = nvgpu.mma.sync(%432, %448, %649) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %682 = nvgpu.mma.sync(%432, %464, %650) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %683 = nvgpu.mma.sync(%432, %480, %651) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %684 = nvgpu.mma.sync(%432, %496, %652) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %685 = nvgpu.mma.sync(%432, %512, %653) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %686 = nvgpu.mma.sync(%432, %528, %654) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %687 = nvgpu.mma.sync(%432, %544, %655) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    %688 = nvgpu.mma.sync(%432, %560, %656) {mmaShape = [16, 8, 8], tf32Enabled} : (vector<4x1xf32>, vector<2x1xf32>, vector<2x2xf32>) -> vector<2x2xf32>
+    scf.yield %657, %658, %659, %660, %661, %662, %663, %664, %665, %666, %667, %668, %669, %670, %671, %672, %673, %674, %675, %676, %677, %678, %679, %680, %681, %682, %683, %684, %685, %686, %687, %688 : vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>, vector<2x2xf32>
+  }
+  %211 = gpu.lane_id
+  %212 = vector.extract %210#31[0] : vector<2x2xf32>
+  %213 = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 floordiv 4 + 48)>()[%1, %211]
+  %214 = affine.apply affine_map<()[s0, s1] -> (s1 * 2 - (s1 floordiv 4) * 8 + (s0 floordiv 32) * 64 + 56)>()[%0, %211]
+  vector.store %212, %alloc[%213, %214] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %215 = vector.extract %210#31[1] : vector<2x2xf32>
+  %216 = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 floordiv 4 + 56)>()[%1, %211]
+  vector.store %215, %alloc[%216, %214] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %217 = vector.extract %210#30[0] : vector<2x2xf32>
+  %218 = affine.apply affine_map<()[s0, s1] -> (s1 * 2 - (s1 floordiv 4) * 8 + (s0 floordiv 32) * 64 + 48)>()[%0, %211]
+  vector.store %217, %alloc[%213, %218] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %219 = vector.extract %210#30[1] : vector<2x2xf32>
+  vector.store %219, %alloc[%216, %218] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %220 = vector.extract %210#29[0] : vector<2x2xf32>
+  %221 = affine.apply affine_map<()[s0, s1] -> (s1 * 2 - (s1 floordiv 4) * 8 + (s0 floordiv 32) * 64 + 40)>()[%0, %211]
+  vector.store %220, %alloc[%213, %221] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %222 = vector.extract %210#29[1] : vector<2x2xf32>
+  vector.store %222, %alloc[%216, %221] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %223 = vector.extract %210#28[0] : vector<2x2xf32>
+  %224 = affine.apply affine_map<()[s0, s1] -> (s1 * 2 - (s1 floordiv 4) * 8 + (s0 floordiv 32) * 64 + 32)>()[%0, %211]
+  vector.store %223, %alloc[%213, %224] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %225 = vector.extract %210#28[1] : vector<2x2xf32>
+  vector.store %225, %alloc[%216, %224] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %226 = vector.extract %210#27[0] : vector<2x2xf32>
+  %227 = affine.apply affine_map<()[s0, s1] -> (s1 * 2 - (s1 floordiv 4) * 8 + (s0 floordiv 32) * 64 + 24)>()[%0, %211]
+  vector.store %226, %alloc[%213, %227] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %228 = vector.extract %210#27[1] : vector<2x2xf32>
+  vector.store %228, %alloc[%216, %227] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %229 = vector.extract %210#26[0] : vector<2x2xf32>
+  %230 = affine.apply affine_map<()[s0, s1] -> (s1 * 2 - (s1 floordiv 4) * 8 + (s0 floordiv 32) * 64 + 16)>()[%0, %211]
+  vector.store %229, %alloc[%213, %230] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %231 = vector.extract %210#26[1] : vector<2x2xf32>
+  vector.store %231, %alloc[%216, %230] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %232 = vector.extract %210#25[0] : vector<2x2xf32>
+  %233 = affine.apply affine_map<()[s0, s1] -> (s1 * 2 - (s1 floordiv 4) * 8 + (s0 floordiv 32) * 64 + 8)>()[%0, %211]
+  vector.store %232, %alloc[%213, %233] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %234 = vector.extract %210#25[1] : vector<2x2xf32>
+  vector.store %234, %alloc[%216, %233] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %235 = vector.extract %210#24[0] : vector<2x2xf32>
+  %236 = affine.apply affine_map<()[s0, s1] -> (s1 * 2 - (s1 floordiv 4) * 8 + (s0 floordiv 32) * 64)>()[%0, %211]
+  vector.store %235, %alloc[%213, %236] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %237 = vector.extract %210#24[1] : vector<2x2xf32>
+  vector.store %237, %alloc[%216, %236] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %238 = vector.extract %210#23[0] : vector<2x2xf32>
+  %239 = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 floordiv 4 + 32)>()[%1, %211]
+  vector.store %238, %alloc[%239, %214] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %240 = vector.extract %210#23[1] : vector<2x2xf32>
+  %241 = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 floordiv 4 + 40)>()[%1, %211]
+  vector.store %240, %alloc[%241, %214] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %242 = vector.extract %210#22[0] : vector<2x2xf32>
+  vector.store %242, %alloc[%239, %218] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %243 = vector.extract %210#22[1] : vector<2x2xf32>
+  vector.store %243, %alloc[%241, %218] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %244 = vector.extract %210#21[0] : vector<2x2xf32>
+  vector.store %244, %alloc[%239, %221] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %245 = vector.extract %210#21[1] : vector<2x2xf32>
+  vector.store %245, %alloc[%241, %221] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %246 = vector.extract %210#20[0] : vector<2x2xf32>
+  vector.store %246, %alloc[%239, %224] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %247 = vector.extract %210#20[1] : vector<2x2xf32>
+  vector.store %247, %alloc[%241, %224] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %248 = vector.extract %210#19[0] : vector<2x2xf32>
+  vector.store %248, %alloc[%239, %227] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %249 = vector.extract %210#19[1] : vector<2x2xf32>
+  vector.store %249, %alloc[%241, %227] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %250 = vector.extract %210#18[0] : vector<2x2xf32>
+  vector.store %250, %alloc[%239, %230] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %251 = vector.extract %210#18[1] : vector<2x2xf32>
+  vector.store %251, %alloc[%241, %230] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %252 = vector.extract %210#17[0] : vector<2x2xf32>
+  vector.store %252, %alloc[%239, %233] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %253 = vector.extract %210#17[1] : vector<2x2xf32>
+  vector.store %253, %alloc[%241, %233] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %254 = vector.extract %210#16[0] : vector<2x2xf32>
+  vector.store %254, %alloc[%239, %236] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %255 = vector.extract %210#16[1] : vector<2x2xf32>
+  vector.store %255, %alloc[%241, %236] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %256 = vector.extract %210#15[0] : vector<2x2xf32>
+  %257 = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 floordiv 4 + 16)>()[%1, %211]
+  vector.store %256, %alloc[%257, %214] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %258 = vector.extract %210#15[1] : vector<2x2xf32>
+  %259 = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 floordiv 4 + 24)>()[%1, %211]
+  vector.store %258, %alloc[%259, %214] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %260 = vector.extract %210#14[0] : vector<2x2xf32>
+  vector.store %260, %alloc[%257, %218] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %261 = vector.extract %210#14[1] : vector<2x2xf32>
+  vector.store %261, %alloc[%259, %218] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %262 = vector.extract %210#13[0] : vector<2x2xf32>
+  vector.store %262, %alloc[%257, %221] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %263 = vector.extract %210#13[1] : vector<2x2xf32>
+  vector.store %263, %alloc[%259, %221] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %264 = vector.extract %210#12[0] : vector<2x2xf32>
+  vector.store %264, %alloc[%257, %224] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %265 = vector.extract %210#12[1] : vector<2x2xf32>
+  vector.store %265, %alloc[%259, %224] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %266 = vector.extract %210#11[0] : vector<2x2xf32>
+  vector.store %266, %alloc[%257, %227] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %267 = vector.extract %210#11[1] : vector<2x2xf32>
+  vector.store %267, %alloc[%259, %227] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %268 = vector.extract %210#10[0] : vector<2x2xf32>
+  vector.store %268, %alloc[%257, %230] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %269 = vector.extract %210#10[1] : vector<2x2xf32>
+  vector.store %269, %alloc[%259, %230] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %270 = vector.extract %210#9[0] : vector<2x2xf32>
+  vector.store %270, %alloc[%257, %233] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %271 = vector.extract %210#9[1] : vector<2x2xf32>
+  vector.store %271, %alloc[%259, %233] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %272 = vector.extract %210#8[0] : vector<2x2xf32>
+  vector.store %272, %alloc[%257, %236] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %273 = vector.extract %210#8[1] : vector<2x2xf32>
+  vector.store %273, %alloc[%259, %236] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %274 = vector.extract %210#7[0] : vector<2x2xf32>
+  %275 = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 floordiv 4)>()[%1, %211]
+  vector.store %274, %alloc[%275, %214] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %276 = vector.extract %210#7[1] : vector<2x2xf32>
+  %277 = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 floordiv 4 + 8)>()[%1, %211]
+  vector.store %276, %alloc[%277, %214] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %278 = vector.extract %210#6[0] : vector<2x2xf32>
+  vector.store %278, %alloc[%275, %218] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %279 = vector.extract %210#6[1] : vector<2x2xf32>
+  vector.store %279, %alloc[%277, %218] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %280 = vector.extract %210#5[0] : vector<2x2xf32>
+  vector.store %280, %alloc[%275, %221] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %281 = vector.extract %210#5[1] : vector<2x2xf32>
+  vector.store %281, %alloc[%277, %221] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %282 = vector.extract %210#4[0] : vector<2x2xf32>
+  vector.store %282, %alloc[%275, %224] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %283 = vector.extract %210#4[1] : vector<2x2xf32>
+  vector.store %283, %alloc[%277, %224] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %284 = vector.extract %210#3[0] : vector<2x2xf32>
+  vector.store %284, %alloc[%275, %227] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %285 = vector.extract %210#3[1] : vector<2x2xf32>
+  vector.store %285, %alloc[%277, %227] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %286 = vector.extract %210#2[0] : vector<2x2xf32>
+  vector.store %286, %alloc[%275, %230] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %287 = vector.extract %210#2[1] : vector<2x2xf32>
+  vector.store %287, %alloc[%277, %230] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %288 = vector.extract %210#1[0] : vector<2x2xf32>
+  vector.store %288, %alloc[%275, %233] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %289 = vector.extract %210#1[1] : vector<2x2xf32>
+  vector.store %289, %alloc[%277, %233] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %290 = vector.extract %210#0[0] : vector<2x2xf32>
+  vector.store %290, %alloc[%275, %236] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  %291 = vector.extract %210#0[1] : vector<2x2xf32>
+  vector.store %291, %alloc[%277, %236] : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+  gpu.barrier
+  %292 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32)>()[%0, %1, %2]
+  %293 = affine.apply affine_map<()[s0] -> (s0 * 4 - (s0 floordiv 32) * 128)>()[%0]
+  %294 = vector.transfer_read %alloc[%292, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %295 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32)>()[%0, %1, %2, %workgroup_id_y]
+  %296 = affine.apply affine_map<()[s0, s1] -> (s0 * 4 + s1 * 128 - (s0 floordiv 32) * 128)>()[%0, %workgroup_id_x]
+  vector.transfer_write %294, %5[%295, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %297 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 4)>()[%0, %1, %2]
+  %298 = vector.transfer_read %alloc[%297, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %299 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 4)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %298, %5[%299, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %300 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 8)>()[%0, %1, %2]
+  %301 = vector.transfer_read %alloc[%300, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %302 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 8)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %301, %5[%302, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %303 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 12)>()[%0, %1, %2]
+  %304 = vector.transfer_read %alloc[%303, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %305 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 12)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %304, %5[%305, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %306 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 16)>()[%0, %1, %2]
+  %307 = vector.transfer_read %alloc[%306, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %308 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 16)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %307, %5[%308, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %309 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 20)>()[%0, %1, %2]
+  %310 = vector.transfer_read %alloc[%309, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %311 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 20)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %310, %5[%311, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %312 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 24)>()[%0, %1, %2]
+  %313 = vector.transfer_read %alloc[%312, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %314 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 24)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %313, %5[%314, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %315 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 28)>()[%0, %1, %2]
+  %316 = vector.transfer_read %alloc[%315, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %317 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 28)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %316, %5[%317, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %318 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 32)>()[%0, %1, %2]
+  %319 = vector.transfer_read %alloc[%318, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %320 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 32)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %319, %5[%320, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %321 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 36)>()[%0, %1, %2]
+  %322 = vector.transfer_read %alloc[%321, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %323 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 36)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %322, %5[%323, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %324 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 40)>()[%0, %1, %2]
+  %325 = vector.transfer_read %alloc[%324, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %326 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 40)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %325, %5[%326, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %327 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 44)>()[%0, %1, %2]
+  %328 = vector.transfer_read %alloc[%327, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %329 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 44)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %328, %5[%329, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %330 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 48)>()[%0, %1, %2]
+  %331 = vector.transfer_read %alloc[%330, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %332 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 48)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %331, %5[%332, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %333 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 52)>()[%0, %1, %2]
+  %334 = vector.transfer_read %alloc[%333, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %335 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 52)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %334, %5[%335, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %336 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 56)>()[%0, %1, %2]
+  %337 = vector.transfer_read %alloc[%336, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %338 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 56)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %337, %5[%338, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %339 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 60)>()[%0, %1, %2]
+  %340 = vector.transfer_read %alloc[%339, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %341 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 60)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %340, %5[%341, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %342 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 64)>()[%0, %1, %2]
+  %343 = vector.transfer_read %alloc[%342, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %344 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 64)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %343, %5[%344, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %345 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 68)>()[%0, %1, %2]
+  %346 = vector.transfer_read %alloc[%345, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %347 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 68)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %346, %5[%347, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %348 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 72)>()[%0, %1, %2]
+  %349 = vector.transfer_read %alloc[%348, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %350 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 72)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %349, %5[%350, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %351 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 76)>()[%0, %1, %2]
+  %352 = vector.transfer_read %alloc[%351, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %353 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 76)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %352, %5[%353, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %354 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 80)>()[%0, %1, %2]
+  %355 = vector.transfer_read %alloc[%354, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %356 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 80)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %355, %5[%356, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %357 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 84)>()[%0, %1, %2]
+  %358 = vector.transfer_read %alloc[%357, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %359 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 84)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %358, %5[%359, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %360 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 88)>()[%0, %1, %2]
+  %361 = vector.transfer_read %alloc[%360, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %362 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 88)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %361, %5[%362, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %363 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 92)>()[%0, %1, %2]
+  %364 = vector.transfer_read %alloc[%363, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %365 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 92)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %364, %5[%365, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %366 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 96)>()[%0, %1, %2]
+  %367 = vector.transfer_read %alloc[%366, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %368 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 96)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %367, %5[%368, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %369 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 100)>()[%0, %1, %2]
+  %370 = vector.transfer_read %alloc[%369, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %371 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 100)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %370, %5[%371, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %372 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 104)>()[%0, %1, %2]
+  %373 = vector.transfer_read %alloc[%372, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %374 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 104)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %373, %5[%374, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %375 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 108)>()[%0, %1, %2]
+  %376 = vector.transfer_read %alloc[%375, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %377 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 108)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %376, %5[%377, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %378 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 112)>()[%0, %1, %2]
+  %379 = vector.transfer_read %alloc[%378, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %380 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 112)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %379, %5[%380, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %381 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 116)>()[%0, %1, %2]
+  %382 = vector.transfer_read %alloc[%381, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %383 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 116)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %382, %5[%383, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %384 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 120)>()[%0, %1, %2]
+  %385 = vector.transfer_read %alloc[%384, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %386 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 120)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %385, %5[%386, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  %387 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 2 + s2 * 4 + s0 floordiv 32 + 124)>()[%0, %1, %2]
+  %388 = vector.transfer_read %alloc[%387, %293], %cst_1 {in_bounds = [true]} : memref<128x128xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+  %389 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 2 + s2 * 4 + s3 * 128 + s0 floordiv 32 + 124)>()[%0, %1, %2, %workgroup_id_y]
+  vector.transfer_write %388, %5[%389, %296] {in_bounds = [true]} : vector<4xf32>, memref<256x256xf32>
+  gpu.barrier
+  return
+}
+
+
+//  CHECK-NV-LABEL: func.func @nvidia_tenscore_schedule_f32
+//  CHECK-NV-COUNT-6:  nvgpu.device_async_copy
+//          CHECK-NV:  nvgpu.device_async_create_group
+//  CHECK-NV-COUNT-6:  nvgpu.device_async_copy
+//          CHECK-NV:  nvgpu.device_async_create_group
+//          CHECK-NV:  nvgpu.device_async_wait %{{.*}} {numGroups = 1 : i32}
+//          CHECK-NV:  gpu.barrier
+//  CHECK-NV-COUNT-4:  nvgpu.ldmatrix
+//  CHECK-NV-COUNT-8:  memref.load
+//          CHECK-NV:  scf.for
+//  CHECK-NV-COUNT-4:    nvgpu.ldmatrix
+//  CHECK-NV-COUNT-16:   memref.load
+// CHECK-NV-COUNT-32:    nvgpu.mma.sync
+//  CHECK-NV-COUNT-4:    nvgpu.ldmatrix
+//  CHECK-NV-COUNT-16:   memref.load
+// CHECK-NV-COUNT-32:    nvgpu.mma.sync
+//  CHECK-NV-COUNT-4:    nvgpu.ldmatrix
+//  CHECK-NV-COUNT-16:   memref.load
+// CHECK-NV-COUNT-32:    nvgpu.mma.sync
+//  CHECK-NV-COUNT-6:    nvgpu.device_async_copy
+//          CHECK-NV:    nvgpu.device_async_create_group
+//          CHECK-NV:    nvgpu.device_async_wait %{{.*}} {numGroups = 1 : i32}
+//          CHECK-NV:    gpu.barrier
+//  CHECK-NV-COUNT-4:    nvgpu.ldmatrix
+//  CHECK-NV-COUNT-16:   memref.load
+// CHECK-NV-COUNT-32:    nvgpu.mma.sync
+//          CHECK-NV:  }
+//          CHECK-NV:  vector.store
+
+// -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -67,13 +67,15 @@ hal.executable @mma_fused_fp16 {
 //  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
 //          CHECK:   nvvm.cp.async.commit.group
 //          CHECK:   nvvm.cp.async.wait.group 2
-//  CHECK-COUNT-4:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
 //          CHECK:   llvm.br
-//  CHECK-COUNT-4:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, shape = #nvvm.shape<m = 16, n = 8, k = 16>} : (vector<2xf16>, vector<2xf16>, vector<2xf16>) -> !llvm.struct<(vector<2xf16>, vector<2xf16>)>
+//  CHECK-COUNT-2:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, shape = #nvvm.shape<m = 16, n = 8, k = 16>} : (vector<2xf16>, vector<2xf16>, vector<2xf16>) -> !llvm.struct<(vector<2xf16>, vector<2xf16>)>
 //  CHECK-COUNT-2:   llvm.inline_asm has_side_effects asm_dialect = att "cp.async.cg.shared.global [$0], [$1], $2, $3;\0A", "r,l,n,r" {{.*}}, {{.*}}, {{.*}}, {{.*}} : (!llvm.ptr<i8, 3>, !llvm.ptr<i8, 1>, i32, i32) -> !llvm.void
 //          CHECK:   nvvm.cp.async.commit.group
 //          CHECK:   nvvm.cp.async.wait.group 2
-//  CHECK-COUNT-4:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, shape = #nvvm.shape<m = 16, n = 8, k = 16>} : (vector<2xf16>, vector<2xf16>, vector<2xf16>) -> !llvm.struct<(vector<2xf16>, vector<2xf16>)>
 //          CHECK:   llvm.br
 //      CHECK-NOT:   nvvm.mma.sync
 //  CHECK-COUNT-4:   llvm.store {{.*}} : !llvm.ptr<vector<2xf16>, 3>
@@ -82,86 +84,3 @@ hal.executable @mma_fused_fp16 {
 
 // -----
 
-
-#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>,
-    #hal.descriptor_set.binding<2, storage_buffer>
-  ]>
-]>
-hal.executable @mma_fused {
-  hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @_large_aligned_dispatch_0() {
-      %c0 = arith.constant 0 : index
-      %cst = arith.constant 0.000000e+00 : f32
-      %c2048 = arith.constant 2048 : index
-      %c512 = arith.constant 512 : index
-      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<2048x1024xf32>>
-      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<1024x512xf32>>
-      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<2048x512xf32>>
-      %di = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<2048x512xf32>>
-      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1024], strides = [1, 1]
-          : !flow.dispatch.tensor<readonly:tensor<2048x1024xf32>> -> tensor<2048x1024xf32>
-      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1]
-          : !flow.dispatch.tensor<readonly:tensor<1024x512xf32>> -> tensor<1024x512xf32>
-      %d = flow.dispatch.tensor.load %di, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
-          : !flow.dispatch.tensor<readonly:tensor<2048x512xf32>> -> tensor<2048x512xf32>
-      %init = tensor.empty() : tensor<2048x512xf32>
-      %f = linalg.fill ins(%cst : f32) outs(%init : tensor<2048x512xf32>) -> tensor<2048x512xf32>
-      %m = linalg.matmul ins(%3, %4 : tensor<2048x1024xf32>, tensor<1024x512xf32>) outs(%f : tensor<2048x512xf32>) -> tensor<2048x512xf32>
-      %init2 = tensor.empty() : tensor<2048x512xf32>
-      %a = linalg.generic {
-          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
-          iterator_types = ["parallel", "parallel"]}
-          ins(%m, %d : tensor<2048x512xf32>, tensor<2048x512xf32>) outs(%init2 : tensor<2048x512xf32>) {
-        ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
-          %19 = arith.addf %arg3, %arg4 : f32
-          linalg.yield %19 : f32
-        } -> (tensor<2048x512xf32>)
-        flow.dispatch.tensor.store %a, %2, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
-          : tensor<2048x512xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x512xf32>>
-      return
-    }
-  }
-}
-}
-
-// mma.sync.1688.f32.tf32 / TensorCore(f32):
-//    CHECK-LABEL: hal.executable public @mma_fused
-//          CHECK:   hal.executable.variant public @cuda
-//      CHECK-NOT:   llvm.store
-//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
-//          CHECK:   nvvm.cp.async.commit.group
-//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
-//          CHECK:   nvvm.cp.async.commit.group
-//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
-//          CHECK:   nvvm.cp.async.commit.group
-//          CHECK:   nvvm.cp.async.wait.group 2
-//  CHECK-COUNT-2:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
-//          CHECK:   llvm.br
-//  CHECK-COUNT-4:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<tf32>, multiplicandBPtxType = #nvvm.mma_type<tf32>, shape = #nvvm.shape<m = 16, n = 8, k = 8>} : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>
-//  CHECK-COUNT-2:   llvm.inline_asm has_side_effects asm_dialect = att "cp.async.cg.shared.global [$0], [$1], $2, $3;\0A", "r,l,n,r" {{.*}}, {{.*}}, {{.*}}, {{.*}} : (!llvm.ptr<i8, 3>, !llvm.ptr<i8, 1>, i32, i32) -> !llvm.void
-//          CHECK:   nvvm.cp.async.commit.group
-//          CHECK:   nvvm.cp.async.wait.group 2
-//  CHECK-COUNT-2:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
-//          CHECK:   llvm.br
-//      CHECK-NOT:   nvvm.mma.sync
-//  CHECK-COUNT-4:   llvm.store {{.*}} : !llvm.ptr<vector<2xf32>, 3>
-//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
-//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
-//    CHECK-COUNT:   nvvm.barrier0
-//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-//    CHECK-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
-//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
-//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-//    CHECK-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
-//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -81,7 +81,6 @@ hal.executable @mma_fused_fp16 {
 //          CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<8xf16>, 3>
 //          CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<8xf16>>
 
-
 // -----
 
 
@@ -147,13 +146,16 @@ hal.executable @mma_fused_f32 {
 //          CHECK:   nvvm.cp.async.commit.group
 //          CHECK:   nvvm.cp.async.wait.group 2
 //  CHECK-COUNT-1:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)> 
 //          CHECK:   llvm.br
 //  CHECK-COUNT-1:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)> 
 //  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<tf32>, multiplicandBPtxType = #nvvm.mma_type<tf32>, shape = #nvvm.shape<m = 16, n = 8, k = 8>} : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>
 //  CHECK-COUNT-2:   llvm.inline_asm has_side_effects asm_dialect = att "cp.async.cg.shared.global [$0], [$1], $2, $3;\0A", "r,l,n,r" {{.*}}, {{.*}}, {{.*}}, {{.*}} : (!llvm.ptr<i8, 3>, !llvm.ptr<i8, 1>, i32, i32) -> !llvm.void
 //          CHECK:   nvvm.cp.async.commit.group
 //          CHECK:   nvvm.cp.async.wait.group 2
 //  CHECK-COUNT-1:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)> 
 //  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<tf32>, multiplicandBPtxType = #nvvm.mma_type<tf32>, shape = #nvvm.shape<m = 16, n = 8, k = 8>} : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>
 //          CHECK:   llvm.br
 //      CHECK-NOT:   nvvm.mma.sync

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -3,7 +3,6 @@
 // Verify that a simple element wise op gets lowered succefully all the way to
 // nvvm/llvm dialect via mma.sync path.
 
-
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
@@ -82,5 +81,91 @@ hal.executable @mma_fused_fp16 {
 //          CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<8xf16>, 3>
 //          CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<8xf16>>
 
+
 // -----
 
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @mma_fused_f32 {
+  hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
+  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @_large_aligned_dispatch_0() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f32
+      %c2048 = arith.constant 2048 : index
+      %c512 = arith.constant 512 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<2048x1024xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<1024x512xf32>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<2048x512xf32>>
+      %di = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<2048x512xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1024], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<2048x1024xf32>> -> tensor<2048x1024xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<1024x512xf32>> -> tensor<1024x512xf32>
+      %d = flow.dispatch.tensor.load %di, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<2048x512xf32>> -> tensor<2048x512xf32>
+      %init = tensor.empty() : tensor<2048x512xf32>
+      %f = linalg.fill ins(%cst : f32) outs(%init : tensor<2048x512xf32>) -> tensor<2048x512xf32>
+      %m = linalg.matmul ins(%3, %4 : tensor<2048x1024xf32>, tensor<1024x512xf32>) outs(%f : tensor<2048x512xf32>) -> tensor<2048x512xf32>
+      %init2 = tensor.empty() : tensor<2048x512xf32>
+      %a = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+          iterator_types = ["parallel", "parallel"]}
+          ins(%m, %d : tensor<2048x512xf32>, tensor<2048x512xf32>) outs(%init2 : tensor<2048x512xf32>) {
+        ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+          %19 = arith.addf %arg3, %arg4 : f32
+          linalg.yield %19 : f32
+        } -> (tensor<2048x512xf32>)
+        flow.dispatch.tensor.store %a, %2, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
+          : tensor<2048x512xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x512xf32>>
+      return
+    }
+  }
+}
+}
+
+// mma.sync.1688.f32.tf32 / TensorCore(f32):
+//    CHECK-LABEL: hal.executable public @mma_fused_f32
+//          CHECK:   hal.executable.variant public @cuda
+//      CHECK-NOT:   llvm.store
+//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
+//          CHECK:   nvvm.cp.async.commit.group
+//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
+//          CHECK:   nvvm.cp.async.commit.group
+//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
+//          CHECK:   nvvm.cp.async.commit.group
+//          CHECK:   nvvm.cp.async.wait.group 2
+//  CHECK-COUNT-1:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//          CHECK:   llvm.br
+//  CHECK-COUNT-1:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<tf32>, multiplicandBPtxType = #nvvm.mma_type<tf32>, shape = #nvvm.shape<m = 16, n = 8, k = 8>} : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>
+//  CHECK-COUNT-2:   llvm.inline_asm has_side_effects asm_dialect = att "cp.async.cg.shared.global [$0], [$1], $2, $3;\0A", "r,l,n,r" {{.*}}, {{.*}}, {{.*}}, {{.*}} : (!llvm.ptr<i8, 3>, !llvm.ptr<i8, 1>, i32, i32) -> !llvm.void
+//          CHECK:   nvvm.cp.async.commit.group
+//          CHECK:   nvvm.cp.async.wait.group 2
+//  CHECK-COUNT-1:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<tf32>, multiplicandBPtxType = #nvvm.mma_type<tf32>, shape = #nvvm.shape<m = 16, n = 8, k = 8>} : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>
+//          CHECK:   llvm.br
+//      CHECK-NOT:   nvvm.mma.sync
+//  CHECK-COUNT-4:   llvm.store {{.*}} : !llvm.ptr<vector<2xf32>, 3>
+//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//    CHECK-COUNT:   nvvm.barrier0
+//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    CHECK-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
+//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    CHECK-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
+//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -280,7 +280,7 @@ void insertBarriersAroundSharedMemoryCopy(func::FuncOp funcOp) {
       Operation *prevOp = copyOp->getPrevNode();
       if (!prevOp || !hasMarker(prevOp, getCopyToWorkgroupMemoryMarker())) {
         builder.setInsertionPoint(copyOp);
-        builder.create<gpu::BarrierOp>(copyOp->getLoc());
+        // builder.create<gpu::BarrierOp>(copyOp->getLoc());
       }
       Operation *nextOp = copyOp->getNextNode();
       if (!nextOp || !hasMarker(nextOp, getCopyToWorkgroupMemoryMarker())) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -280,7 +280,7 @@ void insertBarriersAroundSharedMemoryCopy(func::FuncOp funcOp) {
       Operation *prevOp = copyOp->getPrevNode();
       if (!prevOp || !hasMarker(prevOp, getCopyToWorkgroupMemoryMarker())) {
         builder.setInsertionPoint(copyOp);
-        // builder.create<gpu::BarrierOp>(copyOp->getLoc());
+        builder.create<gpu::BarrierOp>(copyOp->getLoc());
       }
       Operation *nextOp = copyOp->getNextNode();
       if (!nextOp || !hasMarker(nextOp, getCopyToWorkgroupMemoryMarker())) {


### PR DESCRIPTION
This PR creates a coarse-grained multistage pipelining and fine-grained instruction scheduling for optimal performance on NVIDIA Ampere Tensor Cores.

Multi-staging is essential to hide the Global Memory load latency by building longer software pipelines and using the available Shared Memory capacity, especially on NVIDIA A100. Additionally, fine-grained instruction scheduling hides the Shared Memory load latency by prefetching the math operands into registers. The PR adds support for F16 and F32 datatype using `mma.sync` native Tensor Core exposure in the nvptx. 

