### PR TITLE
Handle zero-dim tensors in GPUDistributeSharedMemoryCopyPass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
@@ -74,6 +74,8 @@ static void populateTilingCopyToWorkgroupMemPatterns(
                                        .cast<MemRefType>();
 
         unsigned rank = dstMemRefType.getRank();
+        // Return empty tile size for zero dim tensor.
+        if (rank == 0) return tileSizesVal;
         int copyTileSize =
             copyVectorNumBits / dstMemRefType.getElementTypeBitWidth();
         for (unsigned i = 0; i < rank - 1; i++) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -93,6 +93,8 @@ bool canPerformVectorAccessUsingAllThreads(ArrayRef<int64_t> shape,
                                            int64_t vectorSize) {
   // Verify that each dimension of the shape can be distributed on the
   // threads
+  // For zero dim tensor, consider it's too small to access using all threads.
+  if (shape.size() == 0) return false;
   int64_t threadsAvailable = threadCount;
   for (auto &[index, dim] : llvm::enumerate(llvm::reverse(shape))) {
     int64_t numElementPerThread = index == 0 ? vectorSize : 1;


### PR DESCRIPTION
In GPUDistributeSharedMemoryCopy we assumed the rank of tensor >= 1 in some places. They fail to compile the mem copy generic ops with zero dim tensors (e.g. `tensor<f32>`)

I ran into this issue on TF dynamic shape tests when trying to enable some aggressive fusion by default (#12589). Not sure if this is the right fix, need for comments.

Here is an input example from the failed tests:
```mlir
// -----// IR Dump Before GPUDistributeSharedMemoryCopy (iree-gpu-distribute-shared-memory-copy) //----- //
func.func @reduce_std__2x2x2x2x2x2x2__f32__uniform__axis_None__keepdims_False_dispatch_0_generic_D() {
  %cst = arith.constant -0.000000e+00 : f32
  %c0 = arith.constant 0 : index
  %0 = hal.interface.constant.load[0] : i32
  %1 = arith.index_castui %0 : i32 to index
  %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<f32, #hal.descriptor_type<storage_buffer>>
  memref.assume_alignment %2, 64 : memref<f32, #hal.descriptor_type<storage_buffer>>
  %3 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<f32, #hal.descriptor_type<storage_buffer>>
  memref.assume_alignment %3, 64 : memref<f32, #hal.descriptor_type<storage_buffer>>
  %4 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<?xf32, #hal.descriptor_type<storage_buffer>>{%1}
  memref.assume_alignment %4, 64 : memref<?xf32, #hal.descriptor_type<storage_buffer>>
  linalg.fill {__internal_linalg_transform__ = "tile_reduction"} ins(%cst : f32) outs(%3 : memref<f32, #hal.descriptor_type<storage_buffer>>)
  %alloc = memref.alloc() {alignment = 64 : i64} : memref<f32, #gpu.address_space<workgroup>>
  gpu.barrier
  linalg.generic {indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = []} ins(%3 : memref<f32, #hal.descriptor_type<storage_buffer>>) outs(%alloc : memref<f32, #gpu.address_space<workgroup>>) attrs =  {__internal_linalg_transform__ = "copy_to_workgroup_memory"} {
  ^bb0(%in: f32, %out: f32):
    linalg.yield %in : f32
  }
  gpu.barrier
  linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>], iterator_types = ["reduction"]} ins(%4 : memref<?xf32, #hal.descriptor_type<storage_buffer>>) outs(%alloc : memref<f32, #gpu.address_space<workgroup>>) attrs =  {__internal_linalg_transform__ = "tile_reduction", lowering_config = #iree_codegen.lowering_config<tile_sizes = []>} {
  ^bb0(%in: f32, %out: f32):
    %5 = arith.addf %out, %in : f32
    linalg.yield %5 : f32
  }
  linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>, affine_map<(d0) -> ()>, affine_map<(d0) -> ()>], iterator_types = ["reduction"]} ins(%4, %alloc, %2 : memref<?xf32, #hal.descriptor_type<storage_buffer>>, memref<f32, #gpu.address_space<workgroup>>, memref<f32, #hal.descriptor_type<storage_buffer>>) outs(%3 : memref<f32, #hal.descriptor_type<storage_buffer>>) attrs =  {__internal_linalg_transform__ = "tile_reduction"} {
  ^bb0(%in: f32, %in_0: f32, %in_1: f32, %out: f32):
    %5 = arith.divf %in_0, %in_1 : f32
    %6 = arith.subf %in, %5 : f32
    %7 = arith.mulf %6, %6 : f32
    %8 = arith.addf %out, %7 : f32
    linalg.yield %8 : f32
  }
  linalg.generic {indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = []} ins(%2 : memref<f32, #hal.descriptor_type<storage_buffer>>) outs(%3 : memref<f32, #hal.descriptor_type<storage_buffer>>) attrs =  {__internal_linalg_transform__ = "tile_reduction"} {
  ^bb0(%in: f32, %out: f32):
    %5 = arith.divf %out, %in : f32
    %6 = math.sqrt %5 : f32
    linalg.yield %6 : f32
  }
  return
}
```

benchmarks: all