### PR TITLE
Extra checks for reifyResultShapes and fix PackOp/UnPackOp impl

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorPad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorPad.cpp
@@ -85,11 +85,10 @@ static FailureOr<SmallVector<Value>> rewriteAsPaddedOp(
   // Slice out the original shape from the padded result to pass on to
   // consumers. The original linalg op is used to provide the dims for the reify
   // result shapes.
-  SmallVector<SmallVector<OpFoldResult>> reifiedResultShapes;
-  if (failed(cast<ReifyRankedShapedTypeOpInterface>(linalgOp.getOperation())
-                 .reifyResultShapes(rewriter, reifiedResultShapes))) {
+  ReifiedRankedShapedTypeDims reifiedResultShapes;
+  if (failed(reifyResultShapes(rewriter, linalgOp.getOperation(),
+                               reifiedResultShapes)))
     return failure();
-  }
 
   SmallVector<Value> paddedSubviewResults;
   paddedSubviewResults.reserve(paddedOp->getNumResults());
@@ -147,10 +146,9 @@ static FailureOr<Value> rewriteAsPaddedOp(IRRewriter &rewriter,
 
   // Slice out the original shape from the padded result to pass on to
   // consumers.
-  SmallVector<SmallVector<OpFoldResult>> reifiedResultShapes;
-  if (failed(op.reifyResultShapes(rewriter, reifiedResultShapes))) {
+  ReifiedRankedShapedTypeDims reifiedResultShapes;
+  if (failed(reifyResultShapes(rewriter, op, reifiedResultShapes)))
     return failure();
-  }
 
   Value paddedSubviewResults;
   int64_t rank = paddedOp.getDestRank();

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/BUILD
@@ -29,6 +29,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:TensorDialect",

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     MLIRArithUtils
     MLIRFuncDialect
     MLIRIR
+    MLIRInferTypeOpInterface
     MLIRLinalgDialect
     MLIRMemRefTransforms
     MLIRTensorDialect

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -66,7 +66,7 @@ static SmallVector<Range> getLoopRangesImpl(tensor::ExtractSliceOp sliceOp,
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
   ReifiedRankedShapedTypeDims resultDims;
-  LogicalResult status = sliceOp.reifyResultShapes(builder, resultDims);
+  LogicalResult status = reifyResultShapes(builder, sliceOp, resultDims);
   (void)status;
   assert(succeeded(status) && "reifyResultShapes failed");
   return llvm::to_vector(llvm::map_range(resultDims[0], [&](OpFoldResult v) {

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtInterfaces.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtInterfaces.cpp
@@ -51,6 +51,9 @@ LogicalResult LinalgExtOp::reifyResultShapes(
     OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
   Operation *op = getOperation();
   for (auto output : getOutputs()) {
+    // Only tensor outputs have a tied result.
+    if (!output.getType().isa<TensorType>())
+      continue;
     SmallVector<OpFoldResult> dims;
     Type outputType = output.getType();
     if (auto rankedTensorType = outputType.dyn_cast<RankedTensorType>()) {


### PR DESCRIPTION
Using `mlir::reifyResultShapes` (D145777) for extra error checking and less code.

This uncovered an incorrect implementation of `PackOp::reifyResultShapes` and `UnPackOp::refiyResultShapes`, which is also fixed in this commit.
