### PR TITLE
[spirv] Add pass to erase storage buffer static shape 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -650,6 +650,10 @@ createSPIRVCreateFastSlowPathPass();
 /// Emulates 64-bit integer ops with 32-bit integer ops.
 std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateI64Pass();
 
+/// Turns static shaped storage buffer subspan ops into dynamic shaped ones.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVEraseStorageBufferStaticShapePass();
+
 /// Pass to map MemRef memory spaces to SPIR-V storage classes.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVMapMemRefStorageClassPass();

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -653,6 +653,12 @@ def SPIRVEmulateI64 :
   let constructor = "mlir::iree_compiler::createSPIRVEmulateI64Pass()";
 }
 
+def SPIRVEraseStorageBufferStaticShape :
+    Pass<"iree-spirv-erase-storage-buffer-static-shape", "func::FuncOp"> {
+  let summary = "Turn static shaped storage buffer subspan ops into dynamic shaped ones";
+  let constructor = "mlir::iree_compiler::createSPIRVEraseStorageBufferStaticShapePass()";
+}
+
 def SPIRVMapMemRefStorageClass :
     Pass<"iree-spirv-map-memref-storage-class", "func::FuncOp"> {
   let summary = "Map MemRef memory spaces to SPIR-V storage classes";

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD
@@ -28,6 +28,7 @@ iree_compiler_cc_library(
         "SPIRVCreateFastSlowPath.cpp",
         "SPIRVDistribute.cpp",
         "SPIRVEmulateI64.cpp",
+        "SPIRVEraseStorageBufferStaticShape.cpp",
         "SPIRVLowerExecutableTargetPass.cpp",
         "SPIRVMapMemRefStorageClass.cpp",
         "SPIRVTile.cpp",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     "SPIRVCreateFastSlowPath.cpp"
     "SPIRVDistribute.cpp"
     "SPIRVEmulateI64.cpp"
+    "SPIRVEraseStorageBufferStaticShape.cpp"
     "SPIRVLowerExecutableTargetPass.cpp"
     "SPIRVMapMemRefStorageClass.cpp"
     "SPIRVTile.cpp"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -201,6 +201,8 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
   // because we don't use upstream memref descriptors.
   pm.addNestedPass<func::FuncOp>(createFixupSubspanWithOffsetsPass());
   pm.addPass(createFlattenMemRefSubspanPass());
+  pm.addNestedPass<func::FuncOp>(
+      createSPIRVEraseStorageBufferStaticShapePass());
 }
 
 /// Adds passes to perform the final SPIR-V conversion.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
@@ -1,0 +1,184 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Affine/Utils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-spirv-erase-storage-buffer-static-shape"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+class EraseStorageBufferStaticShapePass final
+    : public SPIRVEraseStorageBufferStaticShapeBase<
+          EraseStorageBufferStaticShapePass> {
+  void runOnOperation() override;
+};
+
+/// Returns true if the given `subspanOp` is from a 1-D static shaped storage
+/// buffer.
+bool is1DStaticShapedStorageBuffer(
+    IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
+  auto type = subspanOp.getType().dyn_cast<MemRefType>();
+  if (!type) return false;
+  auto attr =
+      type.getMemorySpace().dyn_cast_or_null<IREE::HAL::DescriptorTypeAttr>();
+  if (!attr) return false;
+  return type.hasStaticShape() && type.getRank() == 1 &&
+         attr.getValue() == IREE::HAL::DescriptorType::StorageBuffer;
+}
+
+/// Rewrites a subspan op with 1-D static shape into dynamic shape.
+/// e.g.,
+///
+/// ```mlir
+///  hal.interface.binding.subspan set(0) binding(0) offset(%offset)
+///      : memref<16xf32>
+/// ```
+///
+/// is re-written to
+///
+/// ```mlir
+///  hal.interface.binding.subspan set(0) binding(0) offset(%offset)
+///      : memref<?xf32>{%c16}
+/// ```
+IREE::HAL::InterfaceBindingSubspanOp rewriteStorageBufferSubspanOp(
+    RewriterBase &rewriter, IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
+  assert(is1DStaticShapedStorageBuffer(subspanOp));
+  LLVM_DEBUG({
+    llvm::dbgs() << "Rewriting subspan op: ";
+    subspanOp->print(llvm::dbgs(), OpPrintingFlags().assumeVerified());
+    llvm::dbgs() << "\n";
+  });
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(subspanOp);
+
+  auto oldType = subspanOp.getType().cast<MemRefType>();
+  auto newType =
+      MemRefType::get({ShapedType::kDynamic}, oldType.getElementType(),
+                      oldType.getLayout(), oldType.getMemorySpace());
+
+  SmallVector<Value, 1> dynamicDims;
+  assert(subspanOp.getDynamicDims().empty());
+  dynamicDims.push_back(rewriter.create<arith::ConstantIndexOp>(
+      subspanOp.getLoc(), oldType.getNumElements()));
+
+  auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
+      subspanOp.getLoc(), newType, subspanOp.getSetAttr(),
+      subspanOp.getBindingAttr(), subspanOp.getDescriptorTypeAttr(),
+      subspanOp.getByteOffset(), dynamicDims, subspanOp.getAlignmentAttr(),
+      subspanOp.getDescriptorFlagsAttr());
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Rewritten to: ";
+    newOp->print(llvm::dbgs(), OpPrintingFlags().assumeVerified());
+    llvm::dbgs() << "\n";
+  });
+  return newOp;
+}
+
+/// Replace `origValue` with `replacementValue`. The replacement might
+/// require replacing the users of `origValue`. The results of the users
+/// themselves have to be replaced with results of the new users.
+void replaceUsesTransitively(RewriterBase &rewriter, Location loc,
+                             Value origValue, Value replacementValue) {
+  SmallVector<std::pair<Value, Value>> worklist;
+  worklist.push_back({origValue, replacementValue});
+
+  while (!worklist.empty()) {
+    auto [original, replacement] = worklist.pop_back_val();
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "//===------------------------------------------===//\n";
+      llvm::dbgs() << "Replacing: ";
+      original.print(llvm::dbgs(), OpPrintingFlags().assumeVerified());
+      llvm::dbgs() << "\n";
+    });
+
+    llvm::SmallDenseSet<OpOperand *> preservedUses;
+    for (OpOperand &use : original.getUses()) {
+      Operation *user = use.getOwner();
+      // Some uses cannot be replaced.
+      if (isa<func::ReturnOp, scf::YieldOp>(user)) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "\tPreserved user: ";
+          user->print(llvm::dbgs(), OpPrintingFlags().assumeVerified());
+          llvm::dbgs() << "\n";
+        });
+        preservedUses.insert(&use);
+        continue;
+      }
+    }
+
+    // Replace all non-preserved uses.
+    rewriter.replaceUsesWithIf(original, replacement, [&](OpOperand &use) {
+      if (!preservedUses.count(&use)) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "\t\tReplacing use in: ";
+          use.getOwner()->print(llvm::dbgs(),
+                                OpPrintingFlags().assumeVerified());
+          llvm::dbgs() << "\n";
+        });
+        return true;
+      }
+      return false;
+    });
+  }
+}
+
+}  // namespace
+
+void EraseStorageBufferStaticShapePass::runOnOperation() {
+  func::FuncOp funcOp = getOperation();
+
+  // Collect all storage buffer subspan ops with 1-D static shapes. We only need
+  // to handle such cases here--high-D static shapes are expected to be flattend
+  // into 1-D by a previous pass.
+  SmallVector<IREE::HAL::InterfaceBindingSubspanOp> subspanOps;
+  funcOp.walk([&](IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
+    if (is1DStaticShapedStorageBuffer(subspanOp)) {
+      subspanOps.push_back(subspanOp);
+    }
+  });
+
+  IRRewriter rewriter(funcOp.getContext());
+  for (auto subspanOp : subspanOps) {
+    auto newSubspanOp = rewriteStorageBufferSubspanOp(rewriter, subspanOp);
+    replaceUsesTransitively(rewriter, subspanOp.getLoc(), subspanOp,
+                            newSubspanOp);
+  }
+
+  {
+    RewritePatternSet patterns(&getContext());
+    populateRemoveDeadMemAllocPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+}
+
+std::unique_ptr<mlir::OperationPass<func::FuncOp>>
+createSPIRVEraseStorageBufferStaticShapePass() {
+  return std::make_unique<EraseStorageBufferStaticShapePass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "create_fast_slow_path.mlir",
             "distribute_to_invocations.mlir",
             "emulate_i64.mlir",
+            "erase_storage_buffer_static_shape.mlir",
             "illegal_configuration.mlir",
             "lowering_matmul_promotion.mlir",
             "lowering_reduction.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_lit_test_suite(
     "create_fast_slow_path.mlir"
     "distribute_to_invocations.mlir"
     "emulate_i64.mlir"
+    "erase_storage_buffer_static_shape.mlir"
     "illegal_configuration.mlir"
     "lowering_matmul_promotion.mlir"
     "lowering_reduction.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/erase_storage_buffer_static_shape.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/erase_storage_buffer_static_shape.mlir
@@ -1,0 +1,86 @@
+// RUN: iree-opt --split-input-file --iree-spirv-erase-storage-buffer-static-shape %s | FileCheck %s
+
+func.func @storage_buffer_load_store(%offset: index, %i0: index, %i1: index) {
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%offset) flags(ReadOnly) : memref<256xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%offset) : memref<256xf32, #hal.descriptor_type<storage_buffer>>
+  %val = memref.load %0[%i0] : memref<256xf32, #hal.descriptor_type<storage_buffer>>
+  memref.store %val, %1[%i1] : memref<256xf32, #hal.descriptor_type<storage_buffer>>
+  return
+}
+
+// CHECK-LABEL: func.func @storage_buffer_load_store
+//  CHECK-SAME: (%[[OFFSET:.+]]: index, %[[I0:.+]]: index, %[[I1:.+]]: index)
+//       CHECK:   %[[C256:.+]] = arith.constant 256 : index
+//       CHECK:   %[[SPAN0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%[[OFFSET]]) flags(ReadOnly) : memref<?xf32, #hal.descriptor_type<storage_buffer>>{%[[C256]]}
+//       CHECK:   %[[SPAN1:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%[[OFFSET]]) : memref<?xf32, #hal.descriptor_type<storage_buffer>>{%[[C256]]}
+//       CHECK:   %[[LD:.+]] = memref.load %[[SPAN0]][%[[I0]]]
+//       CHECK:   memref.store %[[LD]], %[[SPAN1]][%[[I1]]]
+
+// -----
+
+// Test that we don't rewrite memref for uniform buffers.
+
+func.func @uniform_buffer_load(%offset: index, %i0: index) -> f32 {
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(uniform_buffer) alignment(64) offset(%offset) flags(ReadOnly) : memref<256xf32, #hal.descriptor_type<uniform_buffer>>
+  %val = memref.load %0[%i0] : memref<256xf32, #hal.descriptor_type<uniform_buffer>>
+  return %val : f32
+}
+
+// CHECK-LABEL: func.func @uniform_buffer_load
+//       CHECK:   %[[SPAN0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(uniform_buffer) alignment(64) offset(%{{.+}}) flags(ReadOnly) : memref<256xf32, #hal.descriptor_type<uniform_buffer>>
+//       CHECK:   memref.load %[[SPAN0]]
+
+// -----
+
+// Test that we don't rewrite memref without HAL descriptor types.
+
+func.func @uniform_buffer_load(%offset: index, %i0: index) -> f32 {
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(uniform_buffer) alignment(64) offset(%offset) flags(ReadOnly) : memref<256xf32>
+  %val = memref.load %0[%i0] : memref<256xf32>
+  return %val : f32
+}
+
+// CHECK-LABEL: func.func @uniform_buffer_load
+//       CHECK:   %[[SPAN0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(uniform_buffer) alignment(64) offset(%{{.+}}) flags(ReadOnly) : memref<256xf32>
+//       CHECK:   memref.load %[[SPAN0]]
+
+// -----
+
+func.func @storage_buffer_transfer_read_write(%offset: index, %i0: index, %i1: index) {
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%offset) flags(ReadOnly) : memref<256xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%offset) : memref<256xf32, #hal.descriptor_type<storage_buffer>>
+  %f0 = arith.constant 0.0 : f32
+  %val = vector.transfer_read %0[%i0], %f0 {in_bounds = [true]} : memref<256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+  vector.transfer_write %val, %1[%i1] {in_bounds = [true]} : vector<4xf32>, memref<256xf32, #hal.descriptor_type<storage_buffer>>
+  return
+}
+
+// CHECK-LABEL: func.func @storage_buffer_transfer_read_write(%arg0: index, %arg1: index, %arg2: index) {
+//       CHECK:   vector.transfer_read {{.+}} : memref<?xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//       CHECK:   vector.transfer_write {{.+}} : vector<4xf32>, memref<?xf32, #hal.descriptor_type<storage_buffer>>
+
+// -----
+
+func.func @storage_buffer_subview(%offset : index, %i0: index, %i1: index) -> f32 {
+  %c0 = arith.constant 0 : index
+  %subspan = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%offset) : memref<128xf32, strided<[1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+  %subview = memref.subview %subspan[%i0][16][1] : memref<128xf32, strided<[1], offset: ?>, #hal.descriptor_type<storage_buffer>> to memref<16xf32, strided<[1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+  %value = memref.load %subview[%c0] : memref<16xf32, strided<[1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+  return %value : f32
+}
+
+// CHECK-LABEL: func.func @storage_buffer_subview
+//       CHECK:   memref.subview %{{.+}}[%{{.+}}] [16] [1] : memref<?xf32, strided<[1], offset: ?>, #hal.descriptor_type<storage_buffer>> to memref<16xf32, strided<[1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+
+// -----
+
+func.func @storage_buffer_cast(%offset: index) -> memref<?xf32, #hal.descriptor_type<storage_buffer>> {
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%offset) : memref<16xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = memref.cast %0 : memref<16xf32, #hal.descriptor_type<storage_buffer>> to memref<?xf32, #hal.descriptor_type<storage_buffer>>
+  return %1 : memref<?xf32, #hal.descriptor_type<storage_buffer>>
+}
+
+// CHECK-LABEL: func.func @storage_buffer_cast
+//       CHECK:   %[[C16:.+]] = arith.constant 16 : index
+//       CHECK:   %[[SPAN0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%{{.+}}) : memref<?xf32, #hal.descriptor_type<storage_buffer>>{%[[C16]]}
+//       CHECK:   return %[[SPAN0]]


### PR DESCRIPTION
FlattenMemRefSubspanPass logic is simplified after
https://github.com/openxla/iree/pull/12510 to only consider
static/dynamic shapes, not HAL descriptor types anymore.

For SPIR-V we still want to handle separately according to
whether it's uniform or storage buffer, given that uniform
buffers are required to have static shape, while storage
buffers we want them to be dynamic shaped so that we can
unify multiple subspan ops with the same (set, binding) pair
to one.

So this pass adds another cleanup stage on SPIR-V side
to turn storage buffers into dynamic shaped ones.