### PR TITLE
Rename managed windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
   build_test_all_windows:
     needs: setup
     if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
-    runs-on: managed-windows-cpu
+    runs-on: windows-2022-64core
     defaults:
       run:
         shell: bash
@@ -416,7 +416,7 @@ jobs:
   build_test_runtime_windows:
     needs: setup
     if: fromJson(needs.setup.outputs.should-run)
-    runs-on: managed-windows-cpu
+    runs-on: windows-2022-64core
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This follows the naming convention for GitHub-managed runners and the
one the Google Enterprise account has adopted for custom managed
runners of using the standard name with '-Xcore' appended.

For managed runners we don't need to differentiate presubmit/postsubmit
and similar trust-related stuff because they're all isolated ephemeral
runners with no special permissions.