### PR TITLE
Introduce a `iree_codegen.get_base_pointer` operation.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.td
@@ -11,6 +11,25 @@ include "iree/compiler/Codegen/Dialect/IREECodegenDialect.td"
 include "iree/compiler/Codegen/Interfaces/UKernelOpInterface.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 
+def IREECodegen_GetBasePointerOp :
+    Op<IREECodegen_Dialect, "get_base_pointer", []> {
+  let summary = "Operation to get the base address of `memref`";
+  let description = [{
+    Similar to `memref.extract_strided_metadata` but only returns
+    the base pointer.
+  }];
+
+  let arguments = (ins
+    AnyMemRef:$source
+  );
+  let results = (outs
+    MemRefRankOf<[AnyType], [0]>:$result
+  );
+  let assemblyFormat = [{
+    attr-dict $source `:` type($source) `->` type($result)
+  }];
+}
+
 class IREECodegen_UKernelOp<string mnemonic, list<Trait> traits = []> : 
   Op<IREECodegen_Dialect, mnemonic, !listconcat(traits,
     [DeclareOpInterfaceMethods<UKernelOpInterface,

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/BUILD
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         ":PassHeaders",
         "//compiler/src/iree/compiler/Codegen:PassHeaders",
         "//compiler/src/iree/compiler/Codegen/Common",
+        "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/LLVMCPU",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/CMakeLists.txt
@@ -73,6 +73,7 @@ iree_cc_library(
     MLIRVectorDialect
     MLIRVectorToSCF
     iree::compiler::Codegen::Common
+    iree::compiler::Codegen::Dialect::IREECodegenDialect
     iree::compiler::Codegen::LLVMCPU
     iree::compiler::Codegen::PassHeaders
     iree::compiler::Codegen::Transforms

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Conversion.cpp
@@ -115,7 +115,7 @@ class ConversionPass : public ConversionBase<ConversionPass> {
   }
 };
 
-} // namespace
+}  // namespace
 
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createConversionPass() {
   return std::make_unique<ConversionPass>();

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Conversion.cpp
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/UKernelOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
@@ -33,6 +35,21 @@ namespace iree_compiler {
 namespace IREE {
 namespace VMVX {
 
+namespace {
+
+// Make `iree_codegen.get_base_pointer` a no-op during VMVX lowering.
+struct ConvertGetBasePointerOp
+    : public OpConversionPattern<IREE::Codegen::GetBasePointerOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      IREE::Codegen::GetBasePointerOp basePointerOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(basePointerOp, adaptor.getSource());
+    return success();
+  }
+};
+
 // Runs conversion with registered input dialects.
 class ConversionPass : public ConversionBase<ConversionPass> {
  public:
@@ -61,6 +78,7 @@ class ConversionPass : public ConversionBase<ConversionPass> {
     // Ensure all input dialects go away.
     ConversionTarget conversionTarget(*context);
     conversionTarget.addIllegalDialect<tensor::TensorDialect>();
+    conversionTarget.addIllegalDialect<IREE::Codegen::IREECodegenDialect>();
     conversionTarget.addLegalDialect<IREE::Util::UtilDialect>();
     conversionTarget.addLegalDialect<IREE::VMVX::VMVXDialect>();
     conversionTarget
@@ -77,6 +95,7 @@ class ConversionPass : public ConversionBase<ConversionPass> {
     populateMemRefToUtilPatterns(context, conversionTarget, typeConverter,
                                  patterns,
                                  IREE::Util::BufferType::get(&getContext()));
+    patterns.insert<ConvertGetBasePointerOp>(typeConverter, context);
 
     // Use the default 64-bit lowering for TOSA's ApplyScale operator:
     //   This lowering widens integer types to 64-bit an performs the non-fused
@@ -95,6 +114,8 @@ class ConversionPass : public ConversionBase<ConversionPass> {
     }
   }
 };
+
+} // namespace
 
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createConversionPass() {
   return std::make_unique<ConversionPass>();


### PR DESCRIPTION
This operation allows getting the base pointer of a `memref`. This is similar to `memref.extract_strided_metadata` but extracts just the base pointer. This is useful for handling `alloca`s and `global`s during lowering to micro kernel that requires the base pointer of these objects. Previously a `builtin.unrealized_conversion_cast` was used to implement this behavior