### PR TITLE
Adding better diagnostics on input shape mismatch.

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
@@ -8,14 +8,14 @@
 //  CHECK-SAME:   iree.abi.stub
 //  CHECK-SAME: } {
 //  CHECK-NEXT:   %[[ARG0_DIM0:.+]] = hal.buffer_view.dim<%[[ARG0]] : !hal.buffer_view>[0] : index
-//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
+//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
 //  CHECK-NEXT:   %[[ARG1_DIM0:.+]] = hal.buffer_view.dim<%[[ARG1]] : !hal.buffer_view>[0] : index
-//  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import %[[ARG1]] : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG1_DIM0]]}
+//  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import %[[ARG1]] "input 1" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG1_DIM0]]}
 //  CHECK-NEXT:   %[[RET_TENSORS:.+]]:2 = call @_dynamicEntry(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]])
 //       CHECK:   %[[RET0_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#0, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 "output 0" : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
 //       CHECK:   %[[RET1_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#1, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 "output 1" : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
 //  CHECK-NEXT:   return %[[RET0_VIEW]], %[[RET1_VIEW]] : !hal.buffer_view, !hal.buffer_view
 //  CHECK-NEXT: }
 
@@ -38,12 +38,12 @@ func.func @dynamicEntry(%arg0: tensor<?x8x8x3xf32>, %arg1: tensor<?x8x8x3xf32>) 
 //  CHECK-SAME:   iree.abi.stub
 //  CHECK-SAME: } {
 //  CHECK-NEXT:   %[[ARG0_DIM0:.+]] = hal.buffer_view.dim<%[[ARG0]] : !hal.buffer_view>[0] : index
-//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
+//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
 //  CHECK-NEXT:   %[[RET_TENSORS:.+]]:2 = call @_outputStorage(%[[ARG0_TENSOR]], %[[RET1_STORAGE]])
 //       CHECK:   %[[RET0_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#0, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 "output 0" : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
 //       CHECK:   %[[RET1_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#1, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 into %[[RET1_STORAGE]] : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 "output 1" into %[[RET1_STORAGE]] : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
 //  CHECK-NEXT:   return %[[RET0_VIEW]], %[[RET1_VIEW]] : !hal.buffer_view, !hal.buffer_view
 //  CHECK-NEXT: }
 

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points_coarse_fences.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points_coarse_fences.mlir
@@ -8,12 +8,12 @@
 //  CHECK-SAME:   iree.abi.stub
 //  CHECK-SAME:   iree.reflection = {iree.abi.model = "coarse-fences"}
 //  CHECK-SAME: } {
-//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] : !hal.buffer_view -> tensor<4xf32>
-//  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG1]] : !hal.buffer_view -> tensor<4xf32>
+//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<4xf32>
+//  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG1]] "input 1" : !hal.buffer_view -> tensor<4xf32>
 //  CHECK-NEXT:   %[[RESULT_TENSORS:.+]]:2 = call @_asyncEntry(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]])
 //  CHECK-NEXT:   %[[READY_TENSORS:.+]]:2 = hal.tensor.barrier join(%[[RESULT_TENSORS]]#0, %[[RESULT_TENSORS]]#1 : tensor<4xf32>, tensor<4xf32>) => %[[SIGNAL]] : !hal.fence
-//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[READY_TENSORS]]#0 : tensor<4xf32> -> !hal.buffer_view
-//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[READY_TENSORS]]#1 : tensor<4xf32> -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[READY_TENSORS]]#0 "output 0" : tensor<4xf32> -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[READY_TENSORS]]#1 "output 1" : tensor<4xf32> -> !hal.buffer_view
 //  CHECK-NEXT:   return %[[RET0_VIEW]], %[[RET1_VIEW]] : !hal.buffer_view, !hal.buffer_view
 //  CHECK-NEXT: }
 
@@ -56,7 +56,7 @@ func.func @primitiveArgOnly(%arg0: i32) {
 
 // CHECK-LABEL: func.func @tensorArgOnly
 //  CHECK-SAME: (%[[ARG0:.+]]: !hal.buffer_view, %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence)
-//       CHECK:   %[[ARG0_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] : !hal.buffer_view -> tensor<4xf32>
+//       CHECK:   %[[ARG0_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<4xf32>
 //  CHECK-NEXT:   call @_tensorArgOnly(%[[ARG0_TENSOR]])
 //  CHECK-NEXT:   hal.fence.signal<%[[SIGNAL]] : !hal.fence>
 //  CHECK-NEXT:   return

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -224,7 +224,7 @@ class WrapEntryPointsPass
       auto dynamicDims = inputDynamicDims.loadDynamicDims(recalculateBuilder);
       auto castOp = recalculateBuilder.create<IREE::HAL::TensorImportOp>(
           loc, inputValue.getType(), inputPlaceholder, inputValue.getType(),
-          dynamicDims, /*wait_fence=*/Value{});
+          dynamicDims, /*wait_fence=*/Value{}, /*name=*/nullptr);
       inputValue.replaceAllUsesWith(castOp.getTarget());
     }
     while (entryBlock.getNumArguments() > 0) {
@@ -519,7 +519,7 @@ class WrapEntryPointsPass
       callOperands.push_back(entryBuilder.create<IREE::HAL::TensorImportOp>(
           arg.getLoc(), inputDynamicDims.tensorType, arg,
           TypeAttr::get(inputDynamicDims.tensorType), dynamicDims,
-          /*wait_fence=*/Value{}));
+          /*wait_fence=*/Value{}, /*name=*/nullptr));
     }
     auto callOp = entryBuilder.create<mlir::func::CallOp>(
         entryFuncOp.getLoc(), entryFuncOp, callOperands);
@@ -535,7 +535,7 @@ class WrapEntryPointsPass
       }
       callResults.push_back(entryBuilder.create<IREE::HAL::TensorExportOp>(
           result.getLoc(), bufferType, result, outputDynamicDims.tensorType,
-          dynamicDims, /*target_storage=*/nullptr));
+          dynamicDims, /*target_storage=*/nullptr, /*name=*/nullptr));
       for (auto [dynamicDim, globalOp] :
            llvm::zip_equal(dynamicDims, outputDynamicDims.globalOps)) {
         entryBuilder.create<IREE::Util::GlobalStoreOp>(

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -78,7 +78,7 @@ static IREE::Util::GlobalOp createBufferLikeGlobalOp(
       loc, tensorType, zeroOp, /*result_dims=*/ValueRange{});
   // hal.tensor.export
   auto bufferExportOp = initializerBuilder.create<IREE::HAL::TensorExportOp>(
-      loc, globalOp.getType(), splatOp.getResult());
+      loc, globalOp.getType(), splatOp.getResult(), /*name=*/nullptr);
   // util.optimization_barrier (try to prevent optimizations across the export)
   auto barrierOp = initializerBuilder.create<IREE::Util::OptimizationBarrierOp>(
       loc, bufferExportOp.getTarget());

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -159,12 +159,13 @@ LogicalResult ReturnOp::verify() {
 //===----------------------------------------------------------------------===//
 
 void TensorImportOp::build(OpBuilder &builder, OperationState &result,
-                           Type resultType, Value source) {
-  build(builder, result, resultType, source, /*waitFence=*/Value{});
+                           Type resultType, Value source, StringAttr name) {
+  build(builder, result, resultType, source, /*waitFence=*/Value{}, name);
 }
 
 void TensorImportOp::build(OpBuilder &builder, OperationState &result,
-                           Type resultType, Value source, Value waitFence) {
+                           Type resultType, Value source, Value waitFence,
+                           StringAttr name) {
   auto shapedType = resultType.cast<ShapedType>();
   assert((source.getType().isa<IREE::HAL::BufferViewType>() ||
           shapedType.hasStaticShape()) &&
@@ -178,7 +179,7 @@ void TensorImportOp::build(OpBuilder &builder, OperationState &result,
         builder.getIndexAttr(i)));
   }
   build(builder, result, resultType, source, TypeAttr::get(shapedType),
-        dynamicDims, waitFence);
+        dynamicDims, waitFence, name);
 }
 
 Value TensorImportOp::getTiedResult(unsigned resultIndex) {
@@ -251,11 +252,11 @@ LogicalResult TensorImportOp::verify() {
 }
 
 void TensorExportOp::build(OpBuilder &builder, OperationState &result,
-                           Type resultType, Value source) {
+                           Type resultType, Value source, StringAttr name) {
   auto dynamicDims =
       IREE::Util::buildDynamicDimsForValue(result.location, source, builder);
   build(builder, result, resultType, source, TypeAttr::get(source.getType()),
-        dynamicDims, /*target_storage=*/nullptr);
+        dynamicDims, /*target_storage=*/nullptr, name);
 }
 
 Value TensorExportOp::getTiedResult(unsigned resultIndex) {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -80,7 +80,8 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
     AnyTypeOf<[HAL_Buffer, HAL_BufferView]>:$source,
     TypeAttr:$target_encoding,
     HAL_ShapeDynamicDims:$target_dims,
-    Optional<HAL_Fence>:$wait_fence
+    Optional<HAL_Fence>:$wait_fence,
+    OptionalAttr<StrAttr>:$name
   );
   let results = (outs
     AnyTensor:$target
@@ -88,21 +89,24 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
 
   let assemblyFormat = [{
     (`wait` `(` $wait_fence^ `)` `=` `` `>`)?
-    $source `:` type($source)
-    `->`
+    $source
+    ($name^)?
+    `:` type($source) `->`
     custom<TypeAlias>($target_encoding, type($target)) (`{` $target_dims^ `}`)?
-    attr-dict-with-keyword
+    attr-dict
   }];
 
   let builders = [
     OpBuilder<(ins
       "Type":$resultType,
-      "Value":$source
+      "Value":$source,
+      "StringAttr":$name
     )>,
     OpBuilder<(ins
       "Type":$resultType,
       "Value":$source,
-      "Value":$waitFence
+      "Value":$waitFence,
+      "StringAttr":$name
     )>,
   ];
 
@@ -146,7 +150,8 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
     AnyTensor:$source,
     TypeAttr:$source_encoding,
     HAL_ShapeDynamicDims:$source_dims,
-    Optional<HAL_Buffer>:$target_storage
+    Optional<HAL_Buffer>:$target_storage,
+    OptionalAttr<StrAttr>:$name
   );
   let results = (outs
     AnyTypeOf<[HAL_Buffer, HAL_BufferView]>:$target
@@ -154,18 +159,20 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
 
   let assemblyFormat = [{
     $source
+    ($name^)?
     (`into` $target_storage^)?
     `:`
     custom<TypeAlias>($source_encoding, type($source)) (`{` $source_dims^ `}`)?
     `->`
     type($target)
-    attr-dict-with-keyword
+    attr-dict
   }];
 
   let builders = [
     OpBuilder<(ins
       "Type":$resultType,
-      "Value":$source
+      "Value":$source,
+      "StringAttr":$name
     )>,
   ];
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
@@ -2,8 +2,8 @@
 
 // CHECK-LABEL: @tensorImportStatic
 func.func @tensorImportStatic(%arg0: !hal.buffer_view) -> tensor<5xi32> {
-  // CHECK: hal.tensor.import %arg0 : !hal.buffer_view -> tensor<5xi32>
-  %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<5xi32>
+  // CHECK: hal.tensor.import %arg0 "hello" : !hal.buffer_view -> tensor<5xi32>
+  %0 = hal.tensor.import %arg0 "hello" : !hal.buffer_view -> tensor<5xi32>
   return %0 : tensor<5xi32>
 }
 
@@ -29,8 +29,8 @@ func.func @tensorImportAsync(%arg0: !hal.buffer_view, %arg1: !hal.fence) -> tens
 
 // CHECK-LABEL: @tensorExportDynamic
 func.func @tensorExportDynamic(%arg0: tensor<?x3xi32>, %arg1: index) -> !hal.buffer_view {
-  // CHECK: hal.tensor.export %arg0 : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
-  %0 = hal.tensor.export %arg0 : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
+  // CHECK: hal.tensor.export %arg0 "goodbye" : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
+  %0 = hal.tensor.export %arg0 "goodbye" : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -43,10 +43,8 @@ struct ConvertTensorImportOp
       // mistake and it's better to know of a shape mismatch than just buffer
       // byte length difference.
       if (auto tensorType = targetType.dyn_cast<RankedTensorType>()) {
-        // TODO(benvanik): get a name for the tensor (argument name/etc).
-        auto message = rewriter.getStringAttr("tensor");
         if (failed(buildEncodingAssertions(op.getLoc(), adaptor.getSource(),
-                                           message, tensorType,
+                                           op.getNameAttr(), tensorType,
                                            op.getTargetDims(), rewriter))) {
           return rewriter.notifyMatchFailure(op, "unsupported tensor type");
         }
@@ -129,8 +127,8 @@ struct ConvertTensorImportOp
     }
 
     builder.create<IREE::HAL::BufferViewAssertOp>(
-        loc, bufferView, message, expectedElementType, expectedEncodingType,
-        shapeDims);
+        loc, bufferView, message ? message : builder.getStringAttr("tensor"),
+        expectedElementType, expectedEncodingType, shapeDims);
     return success();
   }
 };

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -99,13 +99,13 @@ class BufferViewToTensorPattern
       // specified and we reify them here with the specific builder that does
       // the work.
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorImportOp>(
-          srcOp, resultType, adaptor.getSource());
+          srcOp, resultType, adaptor.getSource(), /*name=*/nullptr);
     } else {
       // Dynamic dims explicitly provided (or wrong, in which case the verifier
       // will get it).
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorImportOp>(
           srcOp, resultType, adaptor.getSource(), TypeAttr::get(resultType),
-          adaptor.getTargetDims(), /*wait_fence=*/Value{});
+          adaptor.getTargetDims(), /*wait_fence=*/Value{}, /*name=*/nullptr);
     }
     return success();
   }
@@ -126,14 +126,14 @@ class TensorToBufferViewPattern
       // specified and we reify them here with the specific builder that does
       // the work.
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorExportOp>(
-          srcOp, resultType, adaptor.getSource());
+          srcOp, resultType, adaptor.getSource(), /*name=*/nullptr);
     } else {
       // Dynamic dims explicitly provided (or wrong, in which case the verifier
       // will get it).
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorExportOp>(
           srcOp, resultType, adaptor.getSource(),
           TypeAttr::get(adaptor.getSource().getType()), adaptor.getSourceDims(),
-          /*target_storage=*/nullptr);
+          /*target_storage=*/nullptr, /*name=*/nullptr);
     }
     return success();
   }

--- a/runtime/src/iree/modules/hal/utils/buffer_diagnostics.c
+++ b/runtime/src/iree/modules/hal/utils/buffer_diagnostics.c
@@ -43,7 +43,8 @@ iree_status_t iree_hal_modules_buffer_assert(
   iree_hal_memory_type_t actual_memory_type =
       iree_hal_buffer_memory_type(buffer);
   if (!iree_all_bits_set(actual_memory_type, required_memory_types)) {
-#if IREE_HAL_MODULE_STRING_UTIL_ENABLE
+#if ((IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0) && \
+    IREE_HAL_MODULE_STRING_UTIL_ENABLE
     iree_bitfield_string_temp_t temp0, temp1;
     iree_string_view_t actual_memory_type_str =
         iree_hal_memory_type_format(actual_memory_type, &temp0);
@@ -72,7 +73,8 @@ iree_status_t iree_hal_modules_buffer_assert(
   iree_hal_buffer_usage_t actual_buffer_usage =
       iree_hal_buffer_allowed_usage(buffer);
   if (!iree_all_bits_set(actual_buffer_usage, required_buffer_usage)) {
-#if IREE_HAL_MODULE_STRING_UTIL_ENABLE
+#if ((IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0) && \
+    IREE_HAL_MODULE_STRING_UTIL_ENABLE
     iree_bitfield_string_temp_t temp0, temp1;
     iree_string_view_t allowed_usage_str =
         iree_hal_buffer_usage_format(actual_buffer_usage, &temp0);
@@ -168,7 +170,8 @@ iree_status_t iree_hal_modules_buffer_view_assert(
       iree_hal_buffer_view_element_type(buffer_view);
   if (!iree_hal_element_types_are_compatible(actual_element_type,
                                              expected_element_type)) {
-#if IREE_HAL_MODULE_STRING_UTIL_ENABLE
+#if ((IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0) && \
+    IREE_HAL_MODULE_STRING_UTIL_ENABLE
     char actual_element_type_str[32];
     iree_host_size_t actual_element_type_str_length = 0;
     char expected_element_type_str[32];
@@ -204,9 +207,11 @@ iree_status_t iree_hal_modules_buffer_view_assert(
   if (actual_shape_rank != expected_shape_rank) {
     shape_status = iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "%.*s shape rank mismatch; expected %" PRIhsz " but have %" PRIhsz,
+        "%.*s shape rank mismatch; expected %" PRIhsz "%s but have %" PRIhsz
+        "%s",
         (int)message_str.size, message_str.data, expected_shape_rank,
-        actual_shape_rank);
+        expected_shape_rank == 0 ? " (scalar)" : "", actual_shape_rank,
+        actual_shape_rank == 0 ? " (scalar)" : "");
   }
   if (iree_status_is_ok(shape_status)) {
     for (iree_host_size_t i = 0; i < actual_shape_rank; ++i) {
@@ -222,7 +227,8 @@ iree_status_t iree_hal_modules_buffer_view_assert(
     }
   }
 
-#if IREE_HAL_MODULE_STRING_UTIL_ENABLE
+#if ((IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0) && \
+    IREE_HAL_MODULE_STRING_UTIL_ENABLE
   if (!iree_status_is_ok(shape_status)) {
     char actual_shape_str[32];
     iree_host_size_t actual_shape_str_length = 0;
@@ -235,7 +241,7 @@ iree_status_t iree_hal_modules_buffer_view_assert(
         expected_shape_rank, expected_shape_dims, sizeof(expected_shape_str),
         expected_shape_str, &expected_shape_str_length));
     shape_status = iree_status_annotate_f(
-        shape_status, "expected shape %.*s, actual shape %.*s",
+        shape_status, "expected shape `%.*s`, actual shape `%.*s`",
         (int)expected_shape_str_length, expected_shape_str,
         (int)actual_shape_str_length, actual_shape_str);
   }

--- a/tests/compiler_driver/preprocessing_flags.mlir
+++ b/tests/compiler_driver/preprocessing_flags.mlir
@@ -13,9 +13,9 @@ func.func @test(%arg0 : tensor<10x20xf32>, %arg1 : tensor<20x30xf32>, %arg2 : te
 //       CHECK: PadLinalgOps (iree-preprocessing-pad-linalg-ops)
 // CHECK-LABEL: module
 //  CHECK-NEXT:   func.func @test(
-//   CHECK-DAG:     %[[ARG0:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} : !hal.buffer_view -> tensor<10x20xf32>
-//   CHECK-DAG:     %[[ARG1:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} : !hal.buffer_view -> tensor<20x30xf32>
-//   CHECK-DAG:     %[[ARG2:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} : !hal.buffer_view -> tensor<10x30xf32>
+//   CHECK-DAG:     %[[ARG0:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input 0" : !hal.buffer_view -> tensor<10x20xf32>
+//   CHECK-DAG:     %[[ARG1:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input 1" : !hal.buffer_view -> tensor<20x30xf32>
+//   CHECK-DAG:     %[[ARG2:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input 2" : !hal.buffer_view -> tensor<10x30xf32>
 //   CHECK-DAG:     %[[PAD0:.+]] = tensor.pad %[[ARG0]] low[0, 0] high[6, 12]
 //   CHECK-DAG:     %[[PAD1:.+]] = tensor.pad %[[ARG1]] low[0, 0] high[12, 2]
 //   CHECK-DAG:     %[[PAD2:.+]] = tensor.pad %[[ARG2]] low[0, 0] high[6, 2]

--- a/tools/test/compile_to_phase.mlir
+++ b/tools/test/compile_to_phase.mlir
@@ -4,7 +4,7 @@
 
 // RUN: iree-compile --compile-to=abi %s | FileCheck %s --check-prefix=ABI-PHASE
 // ABI-PHASE: func.func @abs(%[[ARG0:.+]]: !hal.buffer_view)
-// ABI-PHASE: %[[INPUT:.+]] = hal.tensor.import %[[ARG0]] : !hal.buffer_view -> tensor<f32>
+// ABI-PHASE: %[[INPUT:.+]] = hal.tensor.import %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<f32>
 // ABI-PHASE: math.absf %[[INPUT]] : tensor<f32>
 
 // RUN: iree-compile --compile-to=flow %s | FileCheck %s --check-prefix=FLOW-PHASE


### PR DESCRIPTION
The messages are now clearer when scalar tensors are used and we infer arg/result names to pass down instead of just using 'tensor'. This produces messages like:
```
buffer_diagnostics.c:225: INVALID_ARGUMENT; input 1 shape dimension 0 mismatch; expected 4 but have 409; expected shape `4`, actual shape `409`; while invoking native function hal.buffer_view.assert; while calling import;
```

I haven't done a survey to see if there's anything closer to frontends we can use to get better names but we at least have something now and a placeholder of where such name inference could live.