### PR TITLE
Update GitHub actions token proxy URL

### DIFF
--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -53,7 +53,7 @@ if (( TESTING!=0 )); then
 fi
 GITHUB_RUNNER_VERSION="${GITHUB_RUNNER_VERSION:-2.303.0}"
 GITHUB_RUNNER_ARCHIVE_DIGEST="${GITHUB_RUNNER_ARCHIVE_DIGEST:-e4a9fb7269c1a156eb5d5369232d0cd62e06bec2fd2b321600e85ac914a9cc73}"
-GITHUB_TOKEN_PROXY_URL="${GITHUB_TOKEN_PROXY_URL:-https://ght-proxy-zbhz5clunq-ue.a.run.app}"
+GITHUB_TOKEN_PROXY_URL="${GITHUB_TOKEN_PROXY_URL:-https://ght-proxy-openxla-zbhz5clunq-ue.a.run.ap}"
 
 if (( TESTING_SELF_DELETER==1 )); then
   INSTANCE_SELF_DELETER_URL="https://instance-self-deleter-testing-zbhz5clunq-uc.a.run.app"


### PR DESCRIPTION
I missed this when updating things for the new setup in
https://github.com/openxla/iree/pull/12413

Part of https://github.com/openxla/iree/issues/12225