### PR TITLE
[NFC] Switch to use upstream methods.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -630,8 +630,7 @@ LogicalResult rewriteForallToWorkgroup(scf::ForallOp forallOp,
   // Ensure we have 3 block sizes, one for each id.
   Value one;
   for (auto attr : {bX, bY, bZ}) {
-    if (std::find(blockMapping.begin(), blockMapping.end(), attr) ==
-        blockMapping.end()) {
+    if (!llvm::is_contained(blockMapping, attr)) {
       blockMapping.push_back(attr);
       one = one ? one : rewriter.create<arith::ConstantIndexOp>(loc, 1);
       numBlocks.push_back(one);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPackSharedMemoryAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPackSharedMemoryAlloc.cpp
@@ -35,12 +35,9 @@ static void addBarrier(func::FuncOp funcOp, Operation *alloc,
         needBarrier = true;
         break;
       }
-      if (isa<memref::AllocOp>(&op)) {
-        if (std::find(aliasGroup.begin(), aliasGroup.end(), &op) ==
-            aliasGroup.end()) {
-          needBarrier = true;
-          break;
-        }
+      if (isa<memref::AllocOp>(&op) && !llvm::is_contained(aliasGroup, &op)) {
+        needBarrier = true;
+        break;
       }
     }
   }

--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD
@@ -79,6 +79,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFToControlFlow",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TensorUtils",
         "@llvm-project//mlir:Transforms",
     ],
 )

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -65,6 +65,7 @@ iree_cc_library(
     MLIRSCFDialect
     MLIRSCFToControlFlow
     MLIRTensorDialect
+    MLIRTensorUtils
     MLIRTransforms
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR

--- a/compiler/src/iree/compiler/InputConversion/MHLO/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/BUILD
@@ -97,6 +97,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ShapeTransforms",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TensorUtils",
         "@llvm-project//mlir:Transforms",
         "@mlir-hlo//:chlo_legalize_to_hlo",
         "@mlir-hlo//:map_chlo_to_hlo_op",

--- a/compiler/src/iree/compiler/InputConversion/MHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/CMakeLists.txt
@@ -82,6 +82,7 @@ iree_cc_library(
     MLIRShapeToStandard
     MLIRSupport
     MLIRTensorDialect
+    MLIRTensorUtils
     MLIRTransforms
     MhloDialect
     MhloPasses

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -448,6 +448,7 @@ struct TopkOpConversion : public OpConversionPattern<chlo::TopKOp> {
     // Define the output types based on the results of CHLO TopK
     SmallVector<OpFoldResult> mixedSizes =
         tensor::createDimValues(rewriter, loc, adaptor.getOperand());
+    mixedSizes.back() = rewriter.getIndexAttr(adaptor.getK());
     Value emptyTensorOutputValues = rewriter.create<mlir::tensor::EmptyOp>(
         loc, mixedSizes, valueElementType);
     Value emptyTensorOutputIndices = rewriter.create<mlir::tensor::EmptyOp>(

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -293,14 +294,10 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
     auto realType = real.getType().cast<ShapedType>();
     auto rank = realType.getRank();
 
-    SmallVector<Value> dynSizes;
-    for (auto en : llvm::enumerate(realType.getShape())) {
-      if (en.value() == ShapedType::kDynamic) {
-        dynSizes.push_back(b.create<tensor::DimOp>(real, en.index()));
-      }
-    }
-    Value emptyTensor = b.create<tensor::EmptyOp>(
-        realType.getShape(), realType.getElementType(), dynSizes);
+    SmallVector<OpFoldResult> mixedSizes =
+        tensor::createDimValues(b, b.getLoc(), real);
+    Value emptyTensor =
+        b.create<tensor::EmptyOp>(mixedSizes, realType.getElementType());
 
     SmallVector<AffineMap> maps;
     maps.push_back(
@@ -382,15 +379,8 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
     auto ty = RankedTensorType::get(shape, operandType.getElementType());
     SmallVector<OpFoldResult> offsets(ty.getRank(), b.getIndexAttr(0));
     SmallVector<OpFoldResult> strides(ty.getRank(), b.getIndexAttr(1));
-    SmallVector<OpFoldResult> sizes;
-    Value operand = adaptor.getOperand();
-    for (auto dim : llvm::enumerate(operandType.getShape().drop_back())) {
-      if (dim.value() != ShapedType::kDynamic) {
-        sizes.push_back(b.getIndexAttr(dim.value()));
-      } else {
-        sizes.push_back(b.createOrFold<tensor::DimOp>(operand, dim.index()));
-      }
-    }
+    SmallVector<OpFoldResult> sizes =
+        tensor::createDimValues(b, b.getLoc(), adaptor.getOperand());
     sizes.push_back(b.getIndexAttr(shape.back()));
     auto real = b.create<tensor::ExtractSliceOp>(ty, results[0], offsets, sizes,
                                                  strides);
@@ -415,15 +405,10 @@ struct ReverseOpConversion : public OpConversionPattern<mhlo::ReverseOp> {
     if (!ty) return failure();
 
     Location loc = op.getLoc();
-    SmallVector<Value> dynSizes;
-    for (auto en : llvm::enumerate(ty.getShape())) {
-      if (en.value() == ShapedType::kDynamic) {
-        dynSizes.push_back(rewriter.create<tensor::DimOp>(
-            loc, adaptor.getOperands()[0], en.index()));
-      }
-    }
-    Value emptyTensor = rewriter.create<tensor::EmptyOp>(
-        loc, ty.getShape(), ty.getElementType(), dynSizes);
+    SmallVector<OpFoldResult> mixedSizes =
+        tensor::createDimValues(rewriter, loc, adaptor.getOperands()[0]);
+    Value emptyTensor =
+        rewriter.create<tensor::EmptyOp>(loc, mixedSizes, ty.getElementType());
     rewriter.replaceOpWithNewOp<IREE::LinalgExt::ReverseOp>(
         op, op->getResultTypes(), adaptor.getOperands(), emptyTensor,
         op.getDimensions());
@@ -461,17 +446,12 @@ struct TopkOpConversion : public OpConversionPattern<chlo::TopKOp> {
 
     // Create and initialize output tensors for LinalgExt TopK results
     // Define the output types based on the results of CHLO TopK
-    SmallVector<Value> dynSizes;
-    for (auto en : llvm::enumerate(inputValuesType.getShape())) {
-      if (en.value() == ShapedType::kDynamic) {
-        dynSizes.push_back(rewriter.create<tensor::DimOp>(
-            loc, adaptor.getOperand(), en.index()));
-      }
-    }
+    SmallVector<OpFoldResult> mixedSizes =
+        tensor::createDimValues(rewriter, loc, adaptor.getOperand());
     Value emptyTensorOutputValues = rewriter.create<mlir::tensor::EmptyOp>(
-        loc, outputValuesType.getShape(), valueElementType, dynSizes);
+        loc, mixedSizes, valueElementType);
     Value emptyTensorOutputIndices = rewriter.create<mlir::tensor::EmptyOp>(
-        loc, outputIndicesType.getShape(), indicesElementType, dynSizes);
+        loc, mixedSizes, indicesElementType);
     // Initialize indices to 0 and values to negative infinity
     Attribute negInfAttr;
     if (auto intType = valueElementType.dyn_cast<IntegerType>()) {

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -381,7 +381,7 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
     SmallVector<OpFoldResult> strides(ty.getRank(), b.getIndexAttr(1));
     SmallVector<OpFoldResult> sizes =
         tensor::createDimValues(b, b.getLoc(), adaptor.getOperand());
-    sizes.push_back(b.getIndexAttr(shape.back()));
+    sizes.back() = b.getIndexAttr(shape.back());
     auto real = b.create<tensor::ExtractSliceOp>(ty, results[0], offsets, sizes,
                                                  strides);
     auto imag = b.create<tensor::ExtractSliceOp>(ty, results[1], offsets, sizes,

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
@@ -17,7 +17,6 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"


### PR DESCRIPTION
- Use llvm::is_contained.
- Use tensor::createDimValues for mixed sizes.