### PR TITLE
[LLVMCPU] Retire outdated experimental matmul codegen.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -43,10 +43,6 @@ static llvm::cl::opt<bool> clCheckLinalgVectorization(
         "Runs the pass to check if all the Linalg ops are vectorized"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> clEnableHoistPadding(
-    "iree-llvmcpu-enable-hoist-padding",
-    llvm::cl::desc("Flag to enable hoist padding"), llvm::cl::init(false));
-
 // TODO(#10820): Delete the flag. This should be a nop pass to default pipeline
 // while tensor.pad op is lowered to fill + insert_slice before Codegen.
 // However, it causes regressions in terms of compilation time. Skip the passes
@@ -395,7 +391,6 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager,
 
   pad("linalg.fill");
   pad("", /*setAnchorOpToRootOp=*/true);
-  // TODO(hanchung): pack and hoist padding for linalg.generic op.
   pad("linalg.generic");
 
   {
@@ -408,27 +403,11 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager,
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
-  if (!clEnableHoistPadding) {
+  {
     LinalgFusePassOptions options;
     options.padReductionDims = true;
     options.setAnchorOpToRootOp = true;
     nestedModulePM.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
-  } else {
-    {
-      LinalgFusePassOptions options;
-      options.padReductionDims = true;
-      options.setAnchorOpToRootOp = true;
-      options.packPaddings = {1, 1, 0};
-      nestedModulePM.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
-    }
-
-    LinalgFusePassOptions options;
-    options.pad = true;
-    options.setAnchorOpToRootOp = true;
-    options.hoistPaddings = SmallVector<int64_t>{2, 3, 0};
-    nestedModulePM.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
-    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   // Fold dim(pad) away before vectorization.
@@ -745,9 +724,7 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
       createHoistStaticallyBoundAllocationsPass());
 
   // Checking stack allocation before converting to CF dialect is easier.
-  // Do not check allocation if hoist-padding is enabled. It intends to allocate
-  // big stack buffers for better accessing.
-  if (clCheckIRBeforeLLVMConversion && !clEnableHoistPadding) {
+  if (clCheckIRBeforeLLVMConversion) {
     passManager.addPass(createLLVMCPUCheckIRBeforeLLVMConversionPass());
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' --split-input-file %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' --iree-llvmcpu-enable-hoist-padding --split-input-file %s | FileCheck %s --check-prefix=HOIST-PAD
 
 // Check that this dispatch compiles to vectors and that there are no allocas.
 // By proxy checks that destination passing style kicked in correctly
@@ -108,15 +107,6 @@ hal.executable private @preset_config_matmul  {
 }
 // CHECK-LABEL: func.func @preset_config_matmul
 //       CHECK:   vector.outerproduct
-
-// HOIST-PAD-LABEL:   func.func @preset_config_matmul
-// HOIST-PAD-DAG:       %[[BUF1:.+]] = memref.alloca() {{.+}} : memref<3x4x16x32xf32>
-// HOIST-PAD-DAG:       %[[BUF2:.+]] = memref.alloca() {{.+}} : memref<4x8x16xf32>
-// HOIST-PAD-16-DAG:      vector.store {{.+}}, %[[BUF1]]
-// HOIST-PAD-8-DAG:       vector.store {{.+}}, %[[BUF2]]
-// HOIST-PAD-16-DAG:      vector.load %[[BUF1]]
-// HOIST-PAD-8-DAG:       vector.load %[[BUF2]]
-// HOIST-PAD:             vector.outerproduct
 
 // -----
 


### PR DESCRIPTION
Drop the support because hoist padding path is not used and has been outdated.