### PR TITLE
Do not fuse producer-consumer if they have no common outer parallel loops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -246,6 +246,7 @@ static llvm::SmallBitVector getOuterParallelLoops(Operation *op) {
 /// identity.
 static bool isIdentityMapWithZeros(AffineMap map) {
   if (map.getNumSymbols() != 0) return false;
+  if (map.isEmpty()) return false;
   unsigned dimsSeen = 0;
   for (auto result : map.getResults()) {
     bool isValidExpr = TypeSwitch<AffineExpr, bool>(result)


### PR DESCRIPTION
Producer-consumer fusion tries to fuse producer with consumer when they have common outer-parallel loops.  This is done through use of affine_maps, but missed a case where the affine_map is empty which should be treated as a case with no common outer parallel loops (it was treated as a having common outer parallel loops).

Fixes #12431 