### PR TITLE
Fix the VNNI tile size for using VPDPWSSD

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMaterializeEncodingPass.cpp
@@ -65,8 +65,10 @@ static MatmulTileParams chooseMatmulTileParamsX86_64(
       return {8, 1, 4};
     case MatmulType::I8I8I32:
       if (hasFeature(target, "+avx512vnni")) {
-        // Aim to use VPDPWSSD.
-        return {16, 4, 16};
+        // Aim to use VPDPWSSD. This is the same tile size as with VPMADDWD
+        // as the only difference is that VPDPWSSD accumulates. VPDPBUSD would
+        // call for {16, 4, 16} but we can't use it because of its unsigned LHS.
+        return {16, 2, 16};
       }
       if (hasFeature(target, "+avx512bw")) {
         // Aim to use VPMADDWD (zmm).

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_encoding.mlir
@@ -733,7 +733,7 @@ func.func @matmul_lowering_i8i8i32_x86_64_avx512vnni() attributes {
   return
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
-//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 2)>
 //      CHECK: func @matmul_lowering_i8i8i32_x86_64_avx512vnni()
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load[0]
@@ -742,16 +742,16 @@ func.func @matmul_lowering_i8i8i32_x86_64_avx512vnni() attributes {
 //  CHECK-DAG:   %[[TILED_M:.+]] = affine.apply #[[MAP0]]()[%[[M]]]
 //  CHECK-DAG:   %[[TILED_K:.+]] = affine.apply #[[MAP1]]()[%[[K]]]
 //      CHECK:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
-// CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x16x4xi8>>{%[[TILED_M]], %[[TILED_K]]}
+// CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x16x2xi8>>{%[[TILED_M]], %[[TILED_K]]}
 //      CHECK:   %[[TILED_N:.+]] = affine.apply #[[MAP0]]()[%[[N]]]
 //      CHECK:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
-// CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x16x4xi8>>{%[[TILED_N]], %[[TILED_K]]}
+// CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x16x2xi8>>{%[[TILED_N]], %[[TILED_K]]}
 //      CHECK:   %[[OUTS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(2)
 // CHECK-SAME:       !flow.dispatch.tensor<readwrite:tensor<?x?x16x16xi32>>{%[[TILED_M]], %[[TILED_N]]}
 //      CHECK:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
-// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_K]], 16, 4], strides = [1, 1, 1, 1]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_K]], 16, 2], strides = [1, 1, 1, 1]
 //      CHECK:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
-// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_N]], %[[TILED_K]], 16, 4], strides = [1, 1, 1, 1]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_N]], %[[TILED_K]], 16, 2], strides = [1, 1, 1, 1]
 //      CHECK:   %[[OUTS:.+]] = flow.dispatch.tensor.load %[[OUTS_BINDING]]
 // CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 16, 16], strides = [1, 1, 1, 1]
 //      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d


### PR DESCRIPTION
VNNI offers 2 separate instructions that we might consider using:
 * VPDPWSSD is a `i32 += i16*i16 + i16*i16` dot product (2D)
 * VPDPBUSD is a `i32 += ui8*i8 + ui8*i8 + ui8*i8 + ui8*i8` dot product (4D)
 
The unsigned LHS in VPDPBUSD makes it nearly unusable for our purposes, so we have to use VPDPWSSD.

The comment was already saying we were going to use VPDPWSSD, but it was selecting the tile size for VPDPBUSD.