### PR TITLE
For float32 kernels, check for "avx" feature, not "avx2"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMaterializeEncodingPass.cpp
@@ -54,8 +54,8 @@ static MatmulTileParams chooseMatmulTileParamsX86_64(
   switch (type) {
     case MatmulType::F32F32F32:
       if (hasFeature(target, "+avx512f")) return {16, 1, 16};
-      if (hasFeature(target, "+avx2")) {
-        // Note: for good performance, most +avx2 users will also want to add
+      if (hasFeature(target, "+avx")) {
+        // Note: for good performance, most +avx users will also want to add
         // +fma, but that's a local instruction selection detail and the tile
         // layout is unaffected, as there are enough registers even with the
         // need for intermediate product registers when +fma is not used.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_encoding.mlir
@@ -274,7 +274,7 @@ func.func @matmul_lowering_f32f32f32_x86_64() attributes {
 // -----
 
 func.func @matmul_lowering_f32f32f32_x86_64_avx2() attributes {
-  hal.executable.target = #hal.executable.target<"xyz", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx2"}>
+  hal.executable.target = #hal.executable.target<"xyz", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx"}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load[0] : index


### PR DESCRIPTION
AVX2 brings support for non-float32 data types, but for float32, AVX is what we need.

Separately we will also check for FMA support in the ukernel impl, and AVX2 is often used as a proxy for AVX+FMA but it's technically not the same even if in practice, CPUs support AVX2 if and only if they support AVX+FMA.  And for those targets that support AVX but not FMA (e.g. Sandy Bridge), thanks to checking for AVX here we will get the right tile size for that case and then codegen should be able to save the day.