### PR TITLE
Revise the benchmark logic of continue-from-directory

### DIFF
--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -56,6 +56,8 @@ class BenchmarkConfig:
     benchmark_min_time: min number of seconds to run the benchmark for, if
       specified. Otherwise, the benchmark will be repeated a fixed number of
       times.
+    continue_from_previous: skip the benchmarks if their results are found in
+      the benchmark_results_dir.
   """
 
   root_benchmark_dir: pathlib.Path
@@ -71,6 +73,7 @@ class BenchmarkConfig:
 
   keep_going: bool = False
   benchmark_min_time: float = 0
+  continue_from_previous: bool = False
 
   @staticmethod
   def build_from_args(args: Namespace, git_commit_hash: str):
@@ -129,4 +132,5 @@ class BenchmarkConfig:
                            model_name_filter=args.model_name_regex,
                            mode_filter=args.mode_regex,
                            keep_going=args.keep_going,
-                           benchmark_min_time=args.benchmark_min_time)
+                           benchmark_min_time=args.benchmark_min_time,
+                           continue_from_previous=args.continue_from_previous)

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -336,42 +336,6 @@ class BenchmarkInfo:
 
     return f"{model_part} {mode_tags} with {self.driver_info.pretty_name} @ {device_part}"
 
-  @staticmethod
-  def from_device_info_and_name(device_info: DeviceInfo, name: str):
-    (
-        model_name,
-        model_tags,
-        model_source,
-        mode_tags,
-        _,  # "with"
-        runner,
-        _,  # "@"
-        model,
-        _,  # Device Info
-    ) = name.split()
-    model_source = model_source.strip("()")
-    model_tags = model_tags.strip("[]").split(",")
-
-    if mode_tags.startswith("[") and mode_tags.endswith("]"):
-      bench_mode, compile_tags = mode_tags.strip("[]").split("][")
-      bench_mode = mode_tags.split(",")
-      compile_tags = compile_tags.split(",")
-    else:
-      bench_mode = mode_tags.split(",")
-      compile_tags = None
-
-    driver = IREE_PRETTY_NAME_TO_DRIVER_NAME.get(runner)
-    if not driver:
-      raise ValueError(f"Unrecognized runner: {runner}")
-
-    return BenchmarkInfo(model_name=model_name,
-                         model_tags=model_tags,
-                         model_source=model_source,
-                         bench_mode=bench_mode,
-                         compile_tags=compile_tags,
-                         driver_info=IREE_DRIVERS_INFOS[driver],
-                         device_info=device_info)
-
   def to_json_object(self) -> Dict[str, Any]:
     return {
         "model_name": self.model_name,

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -111,6 +111,12 @@ class BenchmarkDriver(object):
         try:
           self.run_benchmark_case(benchmark_case, results_path, capture_path)
         except Exception as e:
+          # Delete unfinished results if they exist.
+          if results_path is not None:
+            results_path.unlink(missing_ok=True)
+          if capture_path is not None:
+            capture_path.unlink(missing_ok=True)
+
           if not self.config.keep_going:
             raise e
 

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -113,11 +113,8 @@ class BenchmarkDriver(object):
         except Exception as e:
           # Delete unfinished results if they exist.
           # TODO(#11087): Use missing_ok=True once we move to Python 3.8.
-          if results_path is not None:
-            try:
-              results_path.unlink()
-            except FileNotFoundError:
-              pass
+          if results_path is not None and results_path.is_file():
+            results_path.unlink()
           if capture_path is not None:
             try:
               capture_path.unlink()

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -115,11 +115,8 @@ class BenchmarkDriver(object):
           # TODO(#11087): Use missing_ok=True once we move to Python 3.8.
           if results_path is not None and results_path.is_file():
             results_path.unlink()
-          if capture_path is not None:
-            try:
-              capture_path.unlink()
-            except FileNotFoundError:
-              pass
+          if capture_path is not None and capture_path.is_file():
+            capture_path.unlink()
 
           if not self.config.keep_going:
             raise e

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -7,9 +7,9 @@
 import json
 import pathlib
 import time
-from typing import Dict, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Set, Tuple
 from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
-from common.benchmark_config import BENCHMARK_RESULTS_REL_PATH, CAPTURES_REL_PATH, BenchmarkConfig
+from common.benchmark_config import BenchmarkConfig
 from common.benchmark_definition import BenchmarkInfo, BenchmarkResults, BenchmarkRun, DeviceInfo
 
 
@@ -27,8 +27,9 @@ class BenchmarkDriver(object):
     self.benchmark_suite = benchmark_suite
     self.benchmark_grace_time = benchmark_grace_time
     self.verbose = verbose
-    self.finished_benchmarks: Dict[str, Tuple[BenchmarkInfo, pathlib.Path]] = {}
-    self.finished_captures: Dict[str, Tuple[BenchmarkInfo, pathlib.Path]] = {}
+    self.seen_benchmark_names: Set[str] = set()
+    self.finished_benchmarks: List[Tuple[BenchmarkInfo, pathlib.Path]] = []
+    self.finished_captures: List[pathlib.Path] = []
     self.benchmark_errors = []
 
   def run_benchmark_case(self, benchmark_case: BenchmarkCase,
@@ -48,37 +49,6 @@ class BenchmarkDriver(object):
     """
     raise NotImplementedError("Should be overwritten by a subclass.")
 
-  def add_previous_benchmarks_and_captures(
-      self, previous_directory: pathlib.Path) -> None:
-    """Collect names of previous benchmarks and captures that should be skipped
-    and merged into the results.
-    """
-
-    def get_key_value_pair(path: pathlib.Path):
-      name = path.stem
-      info = BenchmarkInfo.from_device_info_and_name(self.device_info, name)
-      return (str(info), (info, path))
-
-    previous_benchmark_filenames = set()
-    previous_capture_filenames = set()
-    previous_benchmarks_dir = previous_directory / BENCHMARK_RESULTS_REL_PATH
-    if previous_benchmarks_dir.is_dir():
-      previous_benchmark_filenames = set(
-          previous_benchmarks_dir / p
-          for p in previous_benchmarks_dir.iterdir()
-          if p.suffix == ".json")
-
-    previous_captures_dir = previous_directory / CAPTURES_REL_PATH
-    if previous_captures_dir.is_dir():
-      previous_capture_filenames = set(previous_captures_dir / p
-                                       for p in previous_captures_dir.iterdir()
-                                       if p.suffix == ".tracy")
-
-    self.finished_benchmarks.update(
-        get_key_value_pair(p) for p in previous_benchmark_filenames)
-    self.finished_captures.update(
-        get_key_value_pair(p) for p in previous_capture_filenames)
-
   def run(self) -> None:
     """Execute the benchmark flow.
 
@@ -89,10 +59,8 @@ class BenchmarkDriver(object):
       4. Collect the benchmark results and captures.
     """
 
-    do_capture = self.config.trace_capture_config is not None
-
     self.config.benchmark_results_dir.mkdir(parents=True, exist_ok=True)
-    if do_capture:
+    if self.config.trace_capture_config is not None:
       self.config.trace_capture_config.capture_tmp_dir.mkdir(parents=True,
                                                              exist_ok=True)
 
@@ -112,20 +80,36 @@ class BenchmarkDriver(object):
           model_name_filter=self.config.model_name_filter)
 
       for benchmark_case in benchmark_cases:
-        (benchmark_info, benchmark_results_filename,
-         capture_filename) = self.__get_benchmark_info_and_output_paths(
-             category, benchmark_case)
+        benchmark_info = self.__get_benchmark_info_from_case(
+            category=category, benchmark_case=benchmark_case)
+        benchmark_name = str(benchmark_info)
+
+        # Sanity check for the uniqueness of benchmark names.
+        if benchmark_name in self.seen_benchmark_names:
+          raise ValueError(
+              f"Found duplicate benchmark {benchmark_name} in the suites.")
+        self.seen_benchmark_names.add(benchmark_name)
+
+        results_path, capture_path = self.__get_output_paths(benchmark_name)
+        # If we continue from the previous results, check and skip if the result
+        # files exist.
+        if self.config.continue_from_previous:
+          if results_path is not None and results_path.exists():
+            self.finished_benchmarks.append((benchmark_info, results_path))
+            results_path = None
+
+          if capture_path is not None and capture_path.exists():
+            self.finished_captures.append(capture_path)
+            capture_path = None
 
         # Skip if no need to benchmark and capture.
-        if not benchmark_results_filename and not capture_filename:
+        if results_path is None and capture_path is None:
           continue
 
-        benchmark_key = str(benchmark_info)
-        print(f"--> Benchmark started: {benchmark_key} <--")
+        print(f"--> Benchmark started: {benchmark_name} <--")
 
         try:
-          self.run_benchmark_case(benchmark_case, benchmark_results_filename,
-                                  capture_filename)
+          self.run_benchmark_case(benchmark_case, results_path, capture_path)
         except Exception as e:
           if not self.config.keep_going:
             raise e
@@ -139,12 +123,10 @@ class BenchmarkDriver(object):
 
         print("Benchmark completed")
 
-        if benchmark_results_filename:
-          self.finished_benchmarks[benchmark_key] = (benchmark_info,
-                                                     benchmark_results_filename)
-        if capture_filename:
-          self.finished_captures[benchmark_key] = (benchmark_info,
-                                                   capture_filename)
+        if results_path:
+          self.finished_benchmarks.append((benchmark_info, results_path))
+        if capture_path:
+          self.finished_captures.append(capture_path)
 
   def get_benchmark_results(self) -> BenchmarkResults:
     """Returns the finished benchmark results."""
@@ -152,13 +134,10 @@ class BenchmarkDriver(object):
     results = BenchmarkResults()
     results.set_commit(self.config.git_commit_hash)
 
-    finished_benchmarks = list(self.finished_benchmarks.items())
-    finished_benchmarks.sort(key=lambda b: b[0])
-
-    for _, value in finished_benchmarks:
-      benchmark_info, path = value
-      with open(path) as f:
-        result_json_object = json.loads(f.read())
+    finished_benchmarks = sorted(self.finished_benchmarks,
+                                 key=lambda pair: str(pair[0]))
+    for benchmark_info, path in finished_benchmarks:
+      result_json_object = json.loads(path.read_text())
       benchmark_run = BenchmarkRun(benchmark_info,
                                    result_json_object["context"],
                                    result_json_object["benchmarks"])
@@ -168,36 +147,30 @@ class BenchmarkDriver(object):
 
   def get_benchmark_result_filenames(self) -> Sequence[pathlib.Path]:
     """Returns the json file paths of finished benchmarks."""
-    return list(path for _, path in self.finished_benchmarks.values())
+    return list(path for _, path in self.finished_benchmarks)
 
   def get_capture_filenames(self) -> Sequence[pathlib.Path]:
     """Returns the tracy file paths of finished captures."""
-    return list(path for _, path in self.finished_captures.values())
+    return self.finished_captures
 
   def get_benchmark_errors(self):
     """Returns the exceptions captured during benchmarking."""
     return self.benchmark_errors
 
-  def __get_benchmark_info_and_output_paths(self, category: str,
-                                            benchmark_case: BenchmarkCase):
-    """Get benchmark info and paths for the results and capture. The path of
-    results/capture is None if the benchmark/capture doesn't need to be run.
+  def __get_output_paths(self, benchmark_name: str):
+    """Get output paths for the results and capture. The path of results/capture
+    is None if the benchmark/capture doesn't need to be run.
     """
-    benchmark_info = self.__get_benchmark_info_from_case(
-        category=category, benchmark_case=benchmark_case)
-    benchmark_name = str(benchmark_info)
 
     benchmark_results_filename = None
-    if (benchmark_name not in self.finished_benchmarks and
-        self.config.normal_benchmark_tool_dir):
+    if self.config.normal_benchmark_tool_dir:
       benchmark_results_filename = self.config.benchmark_results_dir / f"{benchmark_name}.json"
 
     capture_filename = None
-    if (benchmark_name not in self.finished_captures and
-        self.config.trace_capture_config):
+    if self.config.trace_capture_config:
       capture_filename = self.config.trace_capture_config.capture_tmp_dir / f"{benchmark_name}.tracy"
 
-    return (benchmark_info, benchmark_results_filename, capture_filename)
+    return (benchmark_results_filename, capture_filename)
 
   def __get_benchmark_info_from_case(
       self, category: str, benchmark_case: BenchmarkCase) -> BenchmarkInfo:

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -137,7 +137,7 @@ class BenchmarkSuite(object):
         model_name_filter: model name regex.
       Returns:
         A list of matched benchmark cases.
-    """,
+    """
 
     category_dir = self.category_map.get(category)
     if category_dir is None:

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -137,14 +137,11 @@ class Parser(argparse.ArgumentParser):
         help="Base directory in which to store temporary files. A subdirectory"
         " with a name matching the git commit hash will be created.")
     self.add_argument(
-        "--continue_from_directory",
-        "--continue-from-directory",
-        default=None,
-        type=_check_dir_path,
-        help="Path to directory with previous benchmark temporary files. This"
-        " should be for the specific commit (not the general tmp-dir). Previous"
-        " benchmark and capture results from here will not be rerun and will be"
-        " combined with the new runs.")
+        "--continue_from_previous",
+        "--continue-from-previous",
+        action="store_true",
+        help="Previous benchmark and capture results will be used and not "
+        "rerun if they are found in the benchmark results directory.")
     self.add_argument(
         "--benchmark_min_time",
         "--benchmark-min-time",

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -352,11 +352,6 @@ def main(args):
                                             benchmark_grace_time=1.0,
                                             verbose=args.verbose)
 
-  if args.continue_from_directory:
-    # Merge in previous benchmarks and captures.
-    benchmark_driver.add_previous_benchmarks_and_captures(
-        args.continue_from_directory)
-
   if args.pin_cpu_freq:
     set_cpu_frequency_scaling_governor("performance")
     atexit.register(set_cpu_frequency_scaling_governor, "schedutil")


### PR DESCRIPTION
Breaking change to replace `--continue_from_directory` with `--continue_from_previous` in `run_benchmarks_on_*.py`

IIUC the idea of `--continue_from_directory` is to continue and skip finished benchmarks from the previous run. This change replaces it with `--continue_from_previous`, which tries to find the existing benchmark results in the current results directory and reuse them. There are two differences from the `--continue_from_directory`:

1. The tool always tries to find the previous results from the current benchmark results directory, instead of from another directory specified by `--continue_from_directory`. The rationale is that in the case the benchmarking is interrupted, you simply run the same command again. The tool will use the same results directory and it will pick up the previous results.
2. If there are other benchmark results not in the benchmark set the tool is going to run, those results won't be merged into the final results.

Personally I don't use `--continue_from_directory` a lot, but I believe it's still useful in unstable environments (e.g. unreliable adb connections).

However I want to simplify it so I can drop the `BenchmarkInfo.from_device_info_and_name`, which puts a strict restriction on the benchmark names. It requires the benchmark name to encode all benchmark info. IMO it's not an ideal design.