### PR TITLE
Avoid FunctionalStyleTransformOpTrait where unnecessary to improve u…

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -107,21 +107,18 @@ transform_dialect::ApplyBufferOptimizationsOp::applyToOne(
   vector::transferOpflowOpt(target);
   eraseDeadAllocAndStores(target);
 
-  results.push_back(target);
   return DiagnosedSilenceableFailure::success();
 }
 
 void transform_dialect::ApplyBufferOptimizationsOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   transform::onlyReadsHandle(getTarget(), effects);
-  transform::producesHandle(getResult(), effects);
   transform::modifiesPayload(effects);
 }
 
 void transform_dialect::ApplyBufferOptimizationsOp::build(
     OpBuilder &builder, OperationState &result, Value target) {
   result.addOperands(target);
-  result.addTypes({pdl::OperationType::get(target.getContext())});
 }
 
 //===---------------------------------------------------------------------===//
@@ -130,9 +127,10 @@ void transform_dialect::ApplyBufferOptimizationsOp::build(
 void transform_dialect::ApplyPatternsOp::build(
     OpBuilder &builder, OperationState &result, Value target,
     const ApplyPatternsOpPatterns &patterns) {
-  MLIRContext *ctx = builder.getContext();
   result.addOperands(target);
+
   auto unitAttr = builder.getUnitAttr();
+
 #define ADD_PATTERN(NAME, ATTR) \
   if (patterns.NAME)            \
     result.addAttribute(ApplyPatternsOp::ATTR(result.name), unitAttr);
@@ -169,7 +167,6 @@ void transform_dialect::ApplyPatternsOp::build(
   ADD_PATTERN(unrollVectorsGpuMmaSync, getUnrollVectorsGpuMmaSyncAttrName)
   ADD_PATTERN(unrollVectorsGpuWmma, getUnrollVectorsGpuWmmaAttrName)
 #undef ADD_PATTERN
-  result.addTypes({pdl::OperationType::get(ctx)});
 }
 
 static void addOperands(Operation *op, SetVector<Value> &operandSet) {
@@ -450,14 +447,12 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
     }
   }
 
-  results.push_back(target);
   return DiagnosedSilenceableFailure::success();
 }
 
 void transform_dialect::ApplyPatternsOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   transform::onlyReadsHandle(getTarget(), effects);
-  transform::producesHandle(getResult(), effects);
   transform::modifiesPayload(effects);
 }
 
@@ -471,8 +466,13 @@ DiagnosedSilenceableFailure transform_dialect::HoistStaticAllocOp::applyToOne(
   IRRewriter rewriter(funcOp->getContext());
   mlir::iree_compiler::hoistStaticallyBoundAllocationsInFunc<memref::AllocOp>(
       rewriter, funcOp);
-  results.push_back(funcOp);
   return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::HoistStaticAllocOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1291,47 +1291,37 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
 //===---------------------------------------------------------------------===//
 
 DiagnosedSilenceableFailure
-transform_dialect::IREEEliminateEmptyTensorsOp::apply(
-    transform::TransformResults &results, transform::TransformState &state) {
-  ArrayRef<Operation *> payloads = state.getPayloadOps(getTarget());
-  for (Operation *payload : payloads) {
-    if (failed(eliminateEmptyTensors(payload, getBufferizationOptions()))) {
-      getOperation()->emitError() << "failed to eliminate tensor.empty ops";
-      return DiagnosedSilenceableFailure::definiteFailure();
-    }
+transform_dialect::IREEEliminateEmptyTensorsOp::applyToOne(
+    ::mlir::Operation *target,
+    ::mlir::transform::ApplyToEachResultList &results,
+    ::mlir::transform::TransformState &state) {
+  if (failed(eliminateEmptyTensors(target, getBufferizationOptions()))) {
+    getOperation()->emitError() << "failed to eliminate tensor.empty ops";
+    return DiagnosedSilenceableFailure::definiteFailure();
   }
-  results.set(getOperation()->getOpResult(0), payloads);
   return DiagnosedSilenceableFailure::success();
 }
 
-void transform_dialect::IREEEliminateEmptyTensorsOp::build(
-    OpBuilder &builder, OperationState &result, Value target) {
-  result.addOperands(target);
-  MLIRContext *ctx = builder.getContext();
-  result.addTypes(pdl::OperationType::get(ctx));
+void transform_dialect::IREEEliminateEmptyTensorsOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
 }
 
 //===---------------------------------------------------------------------===//
 // EraseHALDescriptorTypeFromMemRef
 //===---------------------------------------------------------------------===//
 
-void transform_dialect::IREEEraseHALDescriptorTypeFromMemRefOp::build(
-    OpBuilder &builder, OperationState &result, Value target) {
-  result.addOperands(target);
-  MLIRContext *ctx = builder.getContext();
-  result.addTypes(pdl::OperationType::get(ctx));
-}
-
 DiagnosedSilenceableFailure
-transform_dialect::IREEEraseHALDescriptorTypeFromMemRefOp::apply(
-    transform::TransformResults &transformResults,
-    transform::TransformState &state) {
-  ArrayRef<Operation *> targetOps = state.getPayloadOps(getTarget());
-  if (targetOps.size() != 1 || !isa<func::FuncOp>(targetOps.front())) {
+transform_dialect::IREEEraseHALDescriptorTypeFromMemRefOp::applyToOne(
+    ::mlir::Operation *target,
+    ::mlir::transform::ApplyToEachResultList &results,
+    ::mlir::transform::TransformState &state) {
+  if (!isa<func::FuncOp>(target)) {
     return mlir::emitDefiniteFailure(state.getTopLevel(),
                                      "expects a func::FuncOp as the target op");
   }
-  auto funcOp = cast<func::FuncOp>(targetOps.front());
+  auto funcOp = cast<func::FuncOp>(target);
 
   if (failed(eraseHALDescriptorTypeFromMemRef(funcOp))) {
     return mlir::emitDefiniteFailure(
@@ -1339,8 +1329,13 @@ transform_dialect::IREEEraseHALDescriptorTypeFromMemRefOp::apply(
         "failed to erase #hal.descriptor_type as MemRef memory space");
   }
 
-  transformResults.set(getOperation()->getOpResult(0), targetOps.front());
   return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::IREEEraseHALDescriptorTypeFromMemRefOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
 }
 
 #define GET_OP_CLASSES

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -31,14 +31,13 @@ def ApplyBufferOptimizationsOp :
     This operation applies a set of memory optimization on the whole region of
     the operand.
 
-    If the transformation is successful it returns the handle to the
-    same payload as its operand to allow for simpler composition.
+    The transformation does not consume the target handle.
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$result);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let skipDefaultBuilders = 1;
@@ -140,11 +139,13 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
     If the pattern application fails, or if the underlying listener fails to
     capture op handles, the transformation definitely fails.
 
-    Otherwise the transformation is successful and returns the handle to the
-    same payload as its operand to allow for simpler composition.
+    Otherwise the transformation is successful.
+    
+    This operation does not consume the target handle and does not produce any
+    handle.
   }];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
                        UnitAttr:$additional_iree_patterns,
                        UnitAttr:$bubble_collapse,
                        UnitAttr:$bubble_expand,
@@ -168,9 +169,9 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
                        UnitAttr:$tiling_canonicalization,
                        UnitAttr:$unroll_vectors_gpu_mma_sync,
                        UnitAttr:$unroll_vectors_gpu_wmma);
-  let results = (outs PDL_Operation:$result);
+  let results = (outs);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let builders = [
@@ -188,19 +189,21 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
 }
 
 def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
-    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-     TransformOpInterface, TransformEachOpTrait]> {
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
   let summary = "Hoist static allocations";
   let description = [{
     Find static allocations and hoist them to the top level.
 
     #### Return modes
-    This operation applies static alloc hoisting the whole region of the operand.
-    It always return success.
+    This transform applies static alloc hoisting the whole region of the operand.
+
+    It does not consume the target handle and always return success.
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target);
-  let results = (outs TransformHandleTypeInterface:$result);
+  let results = (outs);
 
   let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -240,14 +243,14 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
   }];
 
   let arguments = (
-      ins PDL_Operation:$target,
+      ins TransformHandleTypeInterface:$target,
           UnitAttr:$target_gpu,
           UnitAttr:$test_analysis_only,
           UnitAttr:$print_conflicts
   );
-  let results = (outs PDL_Operation:$result);
+  let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat = "attr-dict $target";
+  let assemblyFormat = "attr-dict $target `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let builders = [
@@ -260,12 +263,12 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
 
 def IREEEliminateEmptyTensorsOp : Op<
     Transform_Dialect, "iree.eliminate_empty_tensors",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
   let description = [{
     This is a pre-processing pass for iree.bufferize. It tries to remove
-    tensor.empty ops by replacing them with a suitable destination tensors,
+    tensor.empty ops by replacing them with suitable destination tensors,
     which can reduce the number of allocations when bufferizing.
 
     This transform is not part of iree.bufferize because additional
@@ -274,24 +277,26 @@ def IREEEliminateEmptyTensorsOp : Op<
 
     #### Return modes
 
-    This transform consumes the target handle and produces a result handle.
+    This transform does not consume the target handle and always return success.
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$result);
-  let assemblyFormat = "attr-dict $target";
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs);
+  let assemblyFormat = "attr-dict $target `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-  let builders = [
-    OpBuilder<(ins "Value":$target)>
-  ];
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
 }
 
 def IREEEraseHALDescriptorTypeFromMemRefOp : Op<Transform_Dialect,
     "iree.erase_hal_descriptor_type_from_memref",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
   let description = [{
     Erase #hal.descriptor_type from MemRef memory space to ignore all IREE
     memory space planning. This is meant to ease transitioning given that
@@ -305,15 +310,21 @@ def IREEEraseHALDescriptorTypeFromMemRefOp : Op<Transform_Dialect,
 
     If any of the pass on any of the FuncOp fails, the transformation
     definitely fails. Otherwise the transformation succeeds.
+
+    This transform does not consume the target handle.
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$result);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs);
 
-  let assemblyFormat = "attr-dict $target";
+  let assemblyFormat = "attr-dict $target `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-  let builders = [OpBuilder<(ins "Value":$target)>];
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
 }
 
 def ForallToWorkgroupOp : Op<Transform_Dialect,
@@ -358,10 +369,10 @@ def ForallToWorkgroupOp : Op<Transform_Dialect,
     properties.
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$transformed);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$transformed);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let builders = [

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -329,10 +329,9 @@ def IREEEraseHALDescriptorTypeFromMemRefOp : Op<Transform_Dialect,
 
 def ForallToWorkgroupOp : Op<Transform_Dialect,
     "iree.forall_to_workgroup",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     TransformOpInterface,
-     TransformEachOpTrait]> {
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
   let description = [{
     Target the whole hal.executable_variant op and rewrite the unique topLevel
     scf.forall to distributed workgroup_id and workgroup_count.
@@ -361,23 +360,19 @@ def ForallToWorkgroupOp : Op<Transform_Dialect,
     topLevel tile_to_forall_op.
 
     If the unique topLevel scf.forall operation contained within the
-    FuncOp referred to by the `target` PDLOperation lowers to workgroup properly,
-    the transform succeeds. Otherwise the transform definitely fails.
+    FuncOp referred to by the `target` transform handle lowers to workgroup 
+    properly, the transform succeeds.
+    
+    Otherwise the transform definitely fails.
 
-    The returned handle points to the same FuncOp operand, consuming it and
-    producing a new SSA value to satisfy chaining and linearity of the IR
-    properties.
+    This transform does not consume its input handle and produces no result.
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target);
-  let results = (outs TransformHandleTypeInterface:$transformed);
+  let results = (outs);
 
   let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-  let builders = [
-    OpBuilder<(ins "Value":$target)>
-  ];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
@@ -18,7 +18,7 @@ transform.sequence failures(propagate) {
     ( mapping = [#gpu.block<x>] )
   
   %func = transform.structured.match ops{["func.func"]} in %arg0 : (!pdl.operation) -> !pdl.operation
-  %func_1 = transform.iree.apply_patterns %func { bubble_expand }
+  transform.iree.apply_patterns %func { bubble_expand } : (!pdl.operation) -> ()
 
   // Excessively eager canonicalization results in `fill`s being "fused" due to
   // swapping with `extract_slice`, which confuses the fusion operation below.
@@ -55,7 +55,7 @@ transform.sequence failures(propagate) {
   
   // Step 3. Rank-reduce.
   // ===========================================================================
-  %func_2 = transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector }
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
 
   // We don't perform any following transformation (vectorization, bufferizaton,
   // mapping) because this schedule is applied to Linalg-only code without the

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_buffer_opt.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_buffer_opt.mlir
@@ -20,6 +20,6 @@ transform.with_pdl_patterns {
   transform.sequence %arg0 : !pdl.operation failures(propagate) {
   ^bb1(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %1 = transform.iree.apply_buffer_optimizations %0
+    transform.iree.apply_buffer_optimizations %0 : (!pdl.operation) -> ()
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
@@ -13,7 +13,7 @@ transform.with_pdl_patterns {
   transform.sequence %arg0 : !pdl.operation failures(propagate) {
   ^bb1(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.apply_patterns %0 { canonicalization }
+    transform.iree.apply_patterns %0 { canonicalization } : (!pdl.operation) -> ()
   }
 }
 
@@ -87,5 +87,5 @@ func.func @bubble_up(%arg0: tensor<32x64xf32>) -> tensor<32x2x32xf32> {
 transform.sequence failures(propagate) {
 ^bb1(%arg1: !pdl.operation):
   %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %0 { bubble_expand }
+  transform.iree.apply_patterns %0 { bubble_expand } : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
@@ -35,8 +35,8 @@ hal.executable private @pad_matmul_static_dispatch_0 {
 
 transform.sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %variant_op_3 = transform.iree.bufferize %variant_op_2
+  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> (!pdl.operation)
   %func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %func
+  transform.iree.erase_hal_descriptor_type_from_memref %func : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_iree_tile_to_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_iree_tile_to_forall.mlir
@@ -60,5 +60,5 @@ transform.sequence failures(propagate) {
   // Late canonicalizations to cleanup and pass the checks.
   // Needs to occur on the whole variant to perform cse on the workgroup_count region
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -53,17 +53,6 @@ void mlir::iree_compiler::registerTransformDialectLLVMGPUExtension(
 // IREE-specific LLVMGPU transformations.
 //===---------------------------------------------------------------------===//
 
-void transform_dialect::MapNestedForallToGpuThreadsOp::build(
-    OpBuilder &builder, OperationState &result, Value target,
-    ArrayRef<int64_t> workgroupSize) {
-  result.addOperands(target);
-  result.addAttribute(
-      MapNestedForallToGpuThreadsOp::getWorkgroupSizeAttrName(result.name),
-      builder.getI64ArrayAttr(workgroupSize));
-  MLIRContext *ctx = builder.getContext();
-  result.addTypes({pdl::OperationType::get(ctx)});
-}
-
 // TODO: if the number of threads was wired like the workgroup_count, we could
 // reuse most of the code and not require a static number of threads.
 // TODO: synchronizations for imperfectly nested stuff.
@@ -87,8 +76,7 @@ transform_dialect::MapNestedForallToGpuThreadsOp::applyToOne(
     return emitDefaultDefiniteFailure(target);
   }
 
-  SmallVector<int64_t> workgroupSize =
-      extractFromI64ArrayAttr(getWorkgroupSize());
+  SmallVector<int64_t> workgroupSize{getWorkgroupDims()};
   // TODO: no magic constant but IREE uses this extensively.
   workgroupSize.resize(/*size=*/3, /*value=*/1);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -16,8 +16,7 @@ include "mlir/IR/OpBase.td"
 
 def MapNestedForallToGpuThreadsOp :
   Op<Transform_Dialect, "iree.map_nested_forall_to_gpu_threads",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      TransformEachOpTrait,
      TransformOpInterface]> {
   let description = [{
@@ -88,11 +87,16 @@ def MapNestedForallToGpuThreadsOp :
     ```
   }];
 
-  let arguments = (ins PDL_Operation:$target,
-                   DefaultValuedAttr<I64ArrayAttr, "{}">:$workgroup_size);
-  let results = (outs PDL_Operation:$result);
+  let arguments = (ins TransformHandleTypeInterface:$target,
+                   DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_dims);
+  let results = (outs);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = [{
+    $target
+    `workgroup_dims` `=` $workgroup_dims
+    attr-dict
+    `:` functional-type($target, results)
+  }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let builders = [
@@ -213,8 +217,7 @@ def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_ex
 }
 
 def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribute",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      TransformEachOpTrait,
      TransformOpInterface]> {
   let description = [{
@@ -304,9 +307,13 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target);
-  let results = (outs TransformHandleTypeInterface:$result);
+  let results = (outs);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
+  let assemblyFormat = [{
+    $target 
+    attr-dict 
+    `:` functional-type($target, results)
+  }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let skipDefaultBuilders = 1;
@@ -322,8 +329,7 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
 }
 
 def VectorToMMAConversionOp : Op<Transform_Dialect, "iree.vector.vector_to_mma_conversion",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      TransformEachOpTrait,
      TransformOpInterface]> {
   let description = [{
@@ -339,18 +345,18 @@ def VectorToMMAConversionOp : Op<Transform_Dialect, "iree.vector.vector_to_mma_c
     This transform consumes the target handle and produces a result handle.
   }];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
                        UnitAttr:$use_mma_sync,
                        UnitAttr:$use_wmma);
-  let results = (outs PDL_Operation:$result);
+  let results = (outs);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = [{
+    $target
+    attr-dict
+    `:` functional-type($target, results)
+  }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "Value":$target)>
-  ];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::Operation *target,
@@ -382,10 +388,6 @@ def PromoteOperandsOp :
 
   let assemblyFormat = [{ $target $indices attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-  let builders = [
-    OpBuilder<(ins "Value":$target, "ArrayRef<int64_t>":$indices)>
-  ];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -419,14 +421,17 @@ def PipelineSharedMemoryCopiesOp : Op<
   }];
 
   let arguments = (
-      ins Transform_ConcreteOpType<"scf.for">:$for_op,
+      ins TransformHandleTypeInterface:$for_op,
           I64Attr:$depth,
           UnitAttr:$peel_epilogue);
-  let results = (outs Transform_ConcreteOpType<"scf.for">:$result);
+  let results = (outs TransformHandleTypeInterface:$result);
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let assemblyFormat = [{ $for_op attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat = [{ 
+    $for_op 
+    attr-dict 
+    `:` functional-type(operands, results)}];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -438,8 +443,7 @@ def PipelineSharedMemoryCopiesOp : Op<
 
 def CreateAsyncGroupsOp :
   Op<Transform_Dialect, "iree.create_async_groups",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      TransformEachOpTrait,
      TransformOpInterface]> {
   let description = [{
@@ -455,16 +459,15 @@ def CreateAsyncGroupsOp :
     changed.
   }];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
                    BoolAttr:$use_mma_sync);
-  let results = (outs Variadic<PDL_Operation>:$result);
+  let results = (outs);
 
-  let assemblyFormat = [{ $target attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat = [{ 
+    $target 
+    attr-dict 
+    `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-  let builders = [
-    OpBuilder<(ins "Value":$target, "bool":$use_mma_sync)>
-  ];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -99,10 +99,6 @@ def MapNestedForallToGpuThreadsOp :
   }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let builders = [
-    OpBuilder<(ins "Value":$target, "ArrayRef<int64_t>":$workgroupSize)>
-  ];
-
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::func::FuncOp target,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
@@ -25,7 +25,7 @@ builtin.module {
   transform.sequence failures(propagate) {
   ^bb1(%variant_op: !pdl.operation):
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %transformed_func = transform.iree.create_async_groups %top_level_func {use_mma_sync = true} : (!pdl.operation) -> (!pdl.operation)
+    transform.iree.create_async_groups %top_level_func {use_mma_sync = true} : (!pdl.operation) -> ()
   }
 }
 
@@ -57,7 +57,7 @@ builtin.module {
   transform.sequence failures(propagate) {
   ^bb1(%variant_op: !pdl.operation):
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %transformed_func = transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!pdl.operation) -> (!pdl.operation)
+    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!pdl.operation) -> ()
   }
 }
 
@@ -87,7 +87,7 @@ builtin.module {
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
     %vector_transfer = transform.structured.match ops{["memref.alloc"]} in %top_level_func : (!pdl.operation) -> !pdl.operation
     // expected-error@below {{transform applied to the wrong op kind}}
-    %transformed_func = transform.iree.create_async_groups %vector_transfer {use_mma_sync = false} : (!pdl.operation) -> (!pdl.operation)
+    transform.iree.create_async_groups %vector_transfer {use_mma_sync = false} : (!pdl.operation) -> ()
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -50,7 +50,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.iree.erase_hal_descriptor_type_from_memref
 //         CHECK:   transform.structured.match ops{["func.func"]} in %{{.*}}
 //         CHECK:   transform.iree.forall_to_workgroup
-//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} {workgroup_size = [64, 1, 1]}
+//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [64, 1, 1]
 //         CHECK:   transform.iree.apply_patterns %{{.*}} {fold_memref_aliases, rank_reducing_vector}
 //         CHECK:   transform.structured.match ops{["scf.if"]} in %{{.*}}
 //         CHECK:   sequence {{.*}} failures(suppress) {
@@ -96,7 +96,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_reduction_128
 //         CHECK:   transform.sequence failures(propagate)
 //         CHECK:   transform.structured.tile_reduction_using_forall %{{.*}} by num_threads = [0, 32], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
-//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}
+//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [32, 1, 1]
 //         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 32 : i64}
 
 // -----
@@ -138,7 +138,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_reduction_D
 //         CHECK:   transform.sequence failures(propagate)
 //         CHECK:   transform.structured.tile_reduction_using_forall %{{.*}} by num_threads = [0, 256], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
-//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} {workgroup_size = [256, 1, 1]}
+//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [256, 1, 1]
 //         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 256 : i64}
 
 // -----
@@ -185,7 +185,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.structured.split %{{.*}} after 32  {dimension = 1 : i64}
 //         CHECK:   transform.structured.tile %{{.*}}[0, 4]
 //         CHECK:   transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
-//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} {workgroup_size = [64, 1, 1]}
+//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [64, 1, 1]
 //     CHECK-NOT:   transform.iree.vector.to_warp_execute_on_lane_0
 
 
@@ -244,5 +244,5 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
 //         CHECK:   transform.structured.tile_to_forall_op %{{.*}}   num_threads [0, 1024] tile_sizes [](mapping = [#gpu.thread<x>])
 //         CHECK:   transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
-//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} {workgroup_size = [1024, 1, 1]}
+//         CHECK:   transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [1024, 1, 1]
 //         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0{{.*}}{warp_size = 1024 : i64}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
@@ -29,9 +29,9 @@ hal.executable private @pad_matmul_static_dispatch_0  {
 
   transform.sequence failures(propagate) {
   ^bb1(%variant_op: !pdl.operation):
-    %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-    %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+    transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+    %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op: (!pdl.operation) -> !pdl.operation
     %func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-    transform.iree.erase_hal_descriptor_type_from_memref %func
+    transform.iree.erase_hal_descriptor_type_from_memref %func : (!pdl.operation) -> ()
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
@@ -1,7 +1,7 @@
 transform.sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %variant_op_3 = transform.iree.bufferize %variant_op_2
+  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> !pdl.operation
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -18,7 +18,8 @@ transform.sequence failures(propagate) {
   %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> (!pdl.operation)
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
-  transform.iree.map_nested_forall_to_gpu_threads %memref_func { workgroup_size = [10, 11] } : (!pdl.operation) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %memref_func 
+    workgroup_dims = [10, 11] : (!pdl.operation) -> ()
 
   // Late canonicalizations to cleanup and pass the checks
   transform.iree.apply_patterns %memref_func

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -13,18 +13,14 @@ transform.sequence failures(propagate) {
   %func = transform.structured.match ops{["func.func"]} in %variant_op
     : (!pdl.operation) -> !pdl.operation
   transform.iree.apply_patterns %func 
-    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse }
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %variant_op_3 = transform.iree.bufferize %variant_op_2
+    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> (!pdl.operation)
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
-
-  // Get the function to which to apply to.
-  %func_2 = transform.structured.match ops{["linalg.matmul"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  %func_3 = transform.get_closest_isolated_parent %func_2 : (!pdl.operation) -> !pdl.operation
-  %func_4 = transform.iree.map_nested_forall_to_gpu_threads %func_3 { workgroup_size = [10, 11]}
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %memref_func { workgroup_size = [10, 11] } : (!pdl.operation) -> ()
 
   // Late canonicalizations to cleanup and pass the checks
-  %func_5 = transform.iree.apply_patterns %func_4
-    { canonicalization, tiling_canonicalization, licm, cse }
+  transform.iree.apply_patterns %memref_func
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
@@ -6,9 +6,9 @@ transform.sequence failures(propagate) {
   %isolated = transform.get_closest_isolated_parent %warp 
     : (!pdl.operation) -> !pdl.operation
   transform.iree.vector.warp_distribute %isolated
-    : (!pdl.operation) -> !pdl.operation
+    : (!pdl.operation) -> ()
 
   // Late canonicalizations to cleanup and pass the checks.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }    
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
@@ -6,5 +6,5 @@ transform.sequence failures(propagate) {
 
   // Late canonicalizations to cleanup and pass the checks.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }     
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_hoist_allocs.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_hoist_allocs.mlir
@@ -18,8 +18,7 @@ transform.sequence failures(propagate) {
 ^bb1(%module: !pdl.operation):
     %func = transform.structured.match ops{["func.func"]} in %module
       : (!pdl.operation) -> !transform.op<"func.func">
-    %func_2 = transform.iree.hoist_static_alloc %func
-      : (!transform.op<"func.func">) -> !transform.op<"func.func">
+    transform.iree.hoist_static_alloc %func : (!transform.op<"func.func">) -> ()
 }
 
 // -----
@@ -50,8 +49,7 @@ transform.sequence failures(propagate) {
 ^bb1(%module: !pdl.operation):
     %func = transform.structured.match ops{["func.func"]} in %module
       : (!pdl.operation) -> !transform.op<"func.func">
-    %func_2 = transform.iree.hoist_static_alloc %func
-      : (!transform.op<"func.func">) -> !transform.op<"func.func">
+    transform.iree.hoist_static_alloc %func : (!transform.op<"func.func">) -> ()
 }
 
 // -----
@@ -83,6 +81,5 @@ transform.sequence failures(propagate) {
 ^bb1(%module: !pdl.operation):
     %func = transform.structured.match ops{["func.func"]} in %module
       : (!pdl.operation) -> !transform.op<"func.func">
-    %func_2 = transform.iree.hoist_static_alloc %func
-      : (!transform.op<"func.func">) -> !transform.op<"func.func">
+    transform.iree.hoist_static_alloc %func : (!transform.op<"func.func">) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_promote_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_promote_operands.mlir
@@ -38,7 +38,7 @@ hal.executable private @pad_matmul_static_dispatch_0  {
 
     // Late canonicalizations to cleanup and pass the checks.
     transform.iree.apply_patterns %variant_op
-      { canonicalization, tiling_canonicalization, licm, cse }     
+      { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_distribute_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_distribute_forall.mlir
@@ -45,12 +45,13 @@ hal.executable private @distribute {
         ^bb0(%variant_op: !pdl.operation):
         %17 = transform.structured.match ops{["func.func"]} in %variant_op 
           : (!pdl.operation) -> !pdl.operation
-        %18 = transform.iree.map_nested_forall_to_gpu_threads %17 {workgroup_size = [256, 1, 1]}
+        transform.iree.map_nested_forall_to_gpu_threads %17 
+          workgroup_dims = [256, 1, 1] : (!pdl.operation) -> ()
 
         // Late canonicalizations to cleanup and pass the checks.
         // Needs to occur on the whole variant to perform cse on the workgroup_count region
         transform.iree.apply_patterns %variant_op
-          { canonicalization, tiling_canonicalization, licm, cse }   
+          { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
       }
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
@@ -50,12 +50,12 @@ func.func @matmul() {
 transform.sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %func_2 = transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma }
-  %func_3 = transform.iree.vector.vector_to_mma_conversion %func_2 { use_wmma }
+  transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!pdl.operation) -> ()
+  transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!pdl.operation) -> ()
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
   // (i.e. all vector.contract are dead).
   // TODO: consider having the vector_to_mma_conversion do the DCE automatically.
-  %func_4 = transform.iree.apply_patterns %func_3 { canonicalization }
+  transform.iree.apply_patterns %func { canonicalization } : (!pdl.operation) -> ()
 }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/workgroup_specialization_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/workgroup_specialization_pipeline_test.mlir
@@ -90,9 +90,9 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 }
 
 // CHECK-LABEL: func.func @vectorized_dispatch_0_generic_102401
-//      CHECK:   %[[cst:.*]] = arith.constant 0.000000e+00 : f32
-//      CHECK:   %[[c256:.*]] = arith.constant 256 : index
-//      CHECK:   %[[c0:.*]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[cst:.*]] = arith.constant 0.000000e+00 : f32
+//  CHECK-DAG:   %[[c256:.*]] = arith.constant 256 : index
+//  CHECK-DAG:   %[[c0:.*]] = arith.constant 0 : index
 //      CHECK:   %[[ARR:.*]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%[[c0]]) : memref<102401xf32>
 //      CHECK:   %[[ARR2:.*]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%[[c0]]) : memref<102401xf32>
 //      CHECK:   %[[BLKX:.*]] = hal.interface.workgroup.id[0] : index

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
@@ -78,11 +78,11 @@ std::pair<Value, Value> mlir::iree_compiler::cpu::buildCommonTrailingStrategy(
   // Need to match again since bufferize invalidated all handles.
   // TODO: assumes a single func::FuncOp to transform, may need hardening.
   funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
-  funcH = b.create<ForallToWorkgroupOp>(funcH);
-  auto pdlOperation = pdl::OperationType::get(b.getContext());
+  b.create<ForallToWorkgroupOp>(funcH);
 
   // Step N. Lower vectors.
   // TODO: Control the lowering to vectors.
+  auto pdlOperation = pdl::OperationType::get(b.getContext());
   funcH = b.create<LowerVectorsOp>(pdlOperation, funcH, lowerVectorsOpts);
   return std::make_pair(variantH, funcH);
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
@@ -133,7 +133,8 @@ Value mlir::iree_compiler::buildCanonicalizationAndEnablingTransforms(
   configuration.cse = true;
   configuration.licm = true;
   configuration.tilingCanonicalization = true;
-  return b.create<ApplyPatternsOp>(variantH, configuration);
+  b.create<ApplyPatternsOp>(variantH, configuration);
+  return variantH;
 }
 
 /// Dynamically selects the first non-empty handle; i.e. if (h1, h2) is:
@@ -307,7 +308,7 @@ Value mlir::iree_compiler::buildBufferize(ImplicitLocOpBuilder &b,
   configuration.foldReassociativeReshapes = true;
   variantH =
       buildCanonicalizationAndEnablingTransforms(b, configuration, variantH);
-  variantH = b.create<IREEEliminateEmptyTensorsOp>(variantH);
+  b.create<IREEEliminateEmptyTensorsOp>(variantH);
   variantH = b.create<IREEBufferizeOp>(variantH, targetGpu);
   Value memrefFunc =
       b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
@@ -451,5 +452,6 @@ Value mlir::iree_compiler::buildMemoryOptimizations(ImplicitLocOpBuilder &b,
   // Apply canonicalizations and enablings twice as they enable each other.
   buildCanonicalizationAndEnablingTransforms(b, configuration, funcH);
   buildCanonicalizationAndEnablingTransforms(b, configuration, funcH);
-  return b.create<ApplyBufferOptimizationsOp>(funcH);
+  b.create<ApplyBufferOptimizationsOp>(funcH);
+  return funcH;
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -139,7 +139,8 @@ static std::pair<int64_t, int64_t> computeSplitPoint(int64_t upperBound,
 Value mlir::iree_compiler::gpu::buildMapToBlockAndThreads(
     ImplicitLocOpBuilder &b, Value funcH, ArrayRef<int64_t> blockSize) {
   funcH = b.create<ForallToWorkgroupOp>(funcH);
-  return b.create<MapNestedForallToGpuThreadsOp>(funcH, blockSize);
+  b.create<MapNestedForallToGpuThreadsOp>(funcH, blockSize);
+  return funcH;
 }
 
 /// Post-bufferization vector distribution with rank-reduction.
@@ -152,7 +153,7 @@ Value mlir::iree_compiler::gpu::buildDistributeVectors(ImplicitLocOpBuilder &b,
   ApplyPatternsOpPatterns patterns;
   patterns.foldMemrefAliases = true;
   patterns.rankReducingVector = true;
-  funcH = b.create<ApplyPatternsOp>(funcH, patterns);
+  b.create<ApplyPatternsOp>(funcH, patterns);
   Value ifH = b.create<MatchOp>(funcH, scf::IfOp::getOperationName());
   // Locally suppress failures for this op only because it doesn't cover the
   // `threadIdx.x == 0 && threadIdx.y == 0` case at the moment.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -138,7 +138,7 @@ static std::pair<int64_t, int64_t> computeSplitPoint(int64_t upperBound,
 /// func.func.
 Value mlir::iree_compiler::gpu::buildMapToBlockAndThreads(
     ImplicitLocOpBuilder &b, Value funcH, ArrayRef<int64_t> blockSize) {
-  funcH = b.create<ForallToWorkgroupOp>(funcH);
+  b.create<ForallToWorkgroupOp>(funcH);
   b.create<MapNestedForallToGpuThreadsOp>(funcH, blockSize);
   return funcH;
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
@@ -25,7 +25,6 @@ using namespace mlir;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
 using iree_compiler::IREE::transform_dialect::ForallToWorkgroupOp;
-using iree_compiler::IREE::transform_dialect::MapNestedForallToGpuThreadsOp;
 using iree_compiler::IREE::transform_dialect::VectorToWarpExecuteOnLane0Op;
 using iree_compiler::IREE::transform_dialect::VectorWarpDistributionOp;
 using transform::FuseIntoContainingOp;

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.cpp
@@ -26,7 +26,6 @@ using namespace mlir;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
 using iree_compiler::IREE::transform_dialect::ForallToWorkgroupOp;
-using iree_compiler::IREE::transform_dialect::MapNestedForallToGpuThreadsOp;
 using iree_compiler::IREE::transform_dialect::ShareForallOperandsOp;
 using iree_compiler::IREE::transform_dialect::VectorToWarpExecuteOnLane0Op;
 using iree_compiler::IREE::transform_dialect::VectorWarpDistributionOp;

--- a/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
@@ -17,7 +17,7 @@ transform.sequence failures(propagate) {
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
-  %memref_func_2 = transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> (!pdl.operation)
+  transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> ()
 
   // CSE is needed on the workgroup_count region to pass this particular test.
   transform.iree.apply_patterns %variant_op_3 { cse } : (!pdl.operation) -> ()

--- a/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
@@ -11,14 +11,14 @@ transform.sequence failures(propagate) {
 
   // Canonicalization/CSE is needed before bufferization otherwise unnecessary
   // allocs will be created.
-  %variant_op_2 = transform.iree.apply_patterns %variant_op 
-    { canonicalization, tiling_canonicalization, cse }
-  %variant_op_3 = transform.iree.bufferize %variant_op_2
+  transform.iree.apply_patterns %variant_op 
+    { canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> (!pdl.operation)
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
-  %memref_func_2 = transform.iree.erase_hal_descriptor_type_from_memref %memref_func
-  %memref_func_3 = transform.iree.forall_to_workgroup %memref_func_2
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+  %memref_func_2 = transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> (!pdl.operation)
 
   // CSE is needed on the workgroup_count region to pass this particular test.
-  transform.iree.apply_patterns %variant_op_3 { cse }
+  transform.iree.apply_patterns %variant_op_3 { cse } : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
@@ -20,5 +20,5 @@ transform.sequence failures(propagate) {
 
   // Step 3. Post-bufferization mapping workgroup.
   // =========================================================
-  %foo = transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> (!pdl.operation)
+  transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
@@ -13,13 +13,12 @@ transform.sequence failures(propagate) {
 
   // Step 2. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %variant_op_3 = transform.iree.bufferize %variant_op_2
+  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> !pdl.operation
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
 
   // Step 3. Post-bufferization mapping workgroup.
   // =========================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func
+  %foo = transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> (!pdl.operation)
 }

--- a/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
@@ -25,7 +25,7 @@ transform.sequence failures(propagate) {
   // able to preserve the handles.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { bubble_expand }
+  transform.iree.apply_patterns %func { bubble_expand } : (!pdl.operation) -> ()
   %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
   %fill_2, %more_parallel_fill_2 = transform.split_handles %fills in [2]
     : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
@@ -59,8 +59,8 @@ transform.sequence failures(propagate) {
   // Step 4. Rank-reduce and vectorize.
   // ===========================================================================
   %func_1 = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %func_2 = transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector }
-  %func_3 = transform.structured.vectorize %func_2
+  transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func_3 = transform.structured.vectorize %func_1
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
@@ -78,7 +78,7 @@ transform.sequence failures(propagate) {
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  %func_7 = transform.iree.apply_patterns %func_6 {  rank_reducing_linalg, rank_reducing_vector }
+  transform.iree.apply_patterns %func_6 {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
@@ -86,5 +86,5 @@ transform.sequence failures(propagate) {
   ^bb0(%arg0: !pdl.operation):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_7
+  transform.iree.vector.warp_distribute %func_6
 }

--- a/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
@@ -27,7 +27,7 @@ transform.sequence failures(propagate) {
   // able to preserve the handles.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { bubble_expand }
+  transform.iree.apply_patterns %func { bubble_expand } : (!pdl.operation) -> ()
   %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
   %fill_2, %more_parallel_fill_2 = transform.split_handles %fills in [2]
     : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
@@ -66,7 +66,7 @@ transform.sequence failures(propagate) {
   // Step 4. Rank-reduce and vectorize.
   // ===========================================================================
   %func_1 = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %func_2 = transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector }
+  %func_2 = transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
   %func_3 = transform.structured.vectorize %func_2
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
@@ -85,7 +85,7 @@ transform.sequence failures(propagate) {
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases }
+  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.

--- a/tests/transform_dialect/cuda/mma.mlir
+++ b/tests/transform_dialect/cuda/mma.mlir
@@ -31,13 +31,13 @@ transform.sequence failures(propagate) {
 ^bb1(%module: !pdl.operation):
   %func = transform.structured.match ops{["func.func"]} in %module
     : (!pdl.operation) -> !pdl.operation
-  %func_2 = transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma }
-  %func_3 = transform.iree.vector.vector_to_mma_conversion %func_2 { use_wmma }
+  transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!pdl.operation) -> ()
+  transform.iree.vector.vector_to_mma_conversion %func { use_wmma }
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
   // (i.e. all vector.contract are dead).
   // TODO: consider having the vector_to_mma_conversion do the DCE automatically.
-  %func_4 = transform.iree.apply_patterns %func_3 { canonicalization }
+  transform.iree.apply_patterns %func { canonicalization } : (!pdl.operation) -> ()
 }
 
 // -----
@@ -71,11 +71,11 @@ transform.sequence failures(propagate) {
 ^bb1(%module: !pdl.operation):
   %func = transform.structured.match ops{["func.func"]} in %module
     : (!pdl.operation) -> !pdl.operation
-  %func_2 = transform.iree.apply_patterns %func { unroll_vectors_gpu_mma_sync }
-  %func_3 = transform.iree.vector.vector_to_mma_conversion %func_2 { use_mma_sync }
+  transform.iree.apply_patterns %func { unroll_vectors_gpu_mma_sync } : (!pdl.operation) -> ()
+  transform.iree.vector.vector_to_mma_conversion %func { use_mma_sync }
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
   // (i.e. all vector.contract are dead).
   // TODO: consider having the vector_to_mma_conversion do the DCE automatically.
-  %func_4 = transform.iree.apply_patterns %func_3 { canonicalization }
+  transform.iree.apply_patterns %func { canonicalization } : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cuda/mma.mlir
+++ b/tests/transform_dialect/cuda/mma.mlir
@@ -32,7 +32,7 @@ transform.sequence failures(propagate) {
   %func = transform.structured.match ops{["func.func"]} in %module
     : (!pdl.operation) -> !pdl.operation
   transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!pdl.operation) -> ()
-  transform.iree.vector.vector_to_mma_conversion %func { use_wmma }
+  transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!pdl.operation) -> ()
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
   // (i.e. all vector.contract are dead).
@@ -72,7 +72,7 @@ transform.sequence failures(propagate) {
   %func = transform.structured.match ops{["func.func"]} in %module
     : (!pdl.operation) -> !pdl.operation
   transform.iree.apply_patterns %func { unroll_vectors_gpu_mma_sync } : (!pdl.operation) -> ()
-  transform.iree.vector.vector_to_mma_conversion %func { use_mma_sync }
+  transform.iree.vector.vector_to_mma_conversion %func { use_mma_sync } : (!pdl.operation) -> ()
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
   // (i.e. all vector.contract are dead).

--- a/tests/transform_dialect/cuda/mma_using_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_using_layout_analysis_codegen_spec.mlir
@@ -17,26 +17,25 @@ transform.sequence failures(propagate) {
   // Step 3. Vectorize
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %func_2 = transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector }
-  %func_3 = transform.structured.vectorize %func_2
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func_3 = transform.structured.vectorize %func
 
   // Step 4. Bufferize
   // ===========================================================================
-   %func_4 = transform.iree.apply_patterns %func_3
-    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse }
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
-  %func_6 = transform.iree.apply_patterns %func_5 { erase_unnecessary_tensor_operands }
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  transform.iree.apply_patterns %func_3
+    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> (!pdl.operation)
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
 
   // Step 6. Post-bufferization vector distribution
   // ===========================================================================
   %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  %func_8 = transform.iree.forall_to_workgroup %func_7
-  %func_9 = transform.iree.map_nested_forall_to_gpu_threads %func_8
-      { workgroup_size = [4, 8, 1] }
+  transform.iree.forall_to_workgroup %func_7 : (!pdl.operation) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_7
+      workgroup_dims = [4, 8, 1] : (!pdl.operation) -> ()
 
   // Step 7. Do layout analysis and lower to mma
   // ===========================================================================

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -30,7 +30,7 @@ transform.sequence failures(propagate) {
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 
   %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op 
     : (!pdl.operation) -> !pdl.operation
@@ -46,14 +46,14 @@ transform.sequence failures(propagate) {
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op 
     : (!pdl.operation) -> !pdl.operation
-  %func_2 = transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector }
-  %func_3 = transform.structured.vectorize %func_2
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func_3 = transform.structured.vectorize %func
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  %func_4 = transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes }
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
@@ -68,7 +68,7 @@ transform.sequence failures(propagate) {
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  %func_8 = transform.iree.apply_patterns %func_7 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases }
+  transform.iree.apply_patterns %func_7 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
@@ -77,7 +77,7 @@ transform.sequence failures(propagate) {
   ^bb0(%arg0: !pdl.operation):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_8
+  transform.iree.vector.warp_distribute %func_7
     : (!pdl.operation) -> !pdl.operation
 
 

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -53,22 +53,22 @@ transform.sequence failures(propagate) {
   // ===========================================================================
   transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!pdl.operation) -> ()
   transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> !pdl.operation
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
   %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
-  %func_6 = transform.iree.forall_to_workgroup %func_5
-  %func_7 = transform.iree.map_nested_forall_to_gpu_threads %func_6
-      { workgroup_size = [32, 2, 1] }
+  transform.iree.forall_to_workgroup %func_5 : (!pdl.operation) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_5
+      workgroup_dims = [32, 2, 1] : (!pdl.operation) -> ()
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_7 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_5 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
@@ -77,11 +77,10 @@ transform.sequence failures(propagate) {
   ^bb0(%arg0: !pdl.operation):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_7
-    : (!pdl.operation) -> !pdl.operation
+  transform.iree.vector.warp_distribute %func_5 : (!pdl.operation) -> ()
 
 
   // Late Canonicalizations.
   transform.iree.apply_patterns %variant_op_3
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
@@ -72,22 +72,22 @@ transform.sequence failures(propagate) {
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
   transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!pdl.operation) -> ()
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  transform.iree.eliminate_empty_tensors %variant_op: (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> (!pdl.operation)
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func: (!pdl.operation) -> ()
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
   %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  %func_6 = transform.iree.forall_to_workgroup %func_5
-  %func_7 = transform.iree.map_nested_forall_to_gpu_threads %func_6
-      { workgroup_size = [32, 2, 1] }
+  transform.iree.forall_to_workgroup %func_5 : (!pdl.operation) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_5
+      workgroup_dims = [32, 2, 1] : (!pdl.operation) -> ()
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_7 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_5 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
@@ -96,8 +96,7 @@ transform.sequence failures(propagate) {
   ^bb0(%arg0: !pdl.operation):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_7
-    : (!pdl.operation) -> !pdl.operation
+  transform.iree.vector.warp_distribute %func_5 : (!pdl.operation) -> ()
 
 
   // Late canonicalizations.

--- a/tests/transform_dialect/cuda/reduction_v2_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v2_codegen_spec.mlir
@@ -35,18 +35,18 @@ transform.sequence failures(propagate) {
   // Step 4. Rank-reduce and vectorize.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %func_2 = transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector }
-  %func_3 = transform.structured.vectorize %func_2
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func_3 = transform.structured.vectorize %func
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
   // Canonicalization/CSE is needed before bufferization otherwise unnecessary
   // allocs will be created.
-  %func_4 = transform.iree.apply_patterns %func_3 
-    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse }
+  transform.iree.apply_patterns %func_3
+    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
   %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
   %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
-  %func_6 = transform.iree.apply_patterns %func_5 { erase_unnecessary_tensor_operands }
+  transform.iree.apply_patterns %func_5 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
   %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
@@ -60,14 +60,14 @@ transform.sequence failures(propagate) {
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  %func_10 = transform.iree.apply_patterns %func_9 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases }
+  transform.iree.apply_patterns %func_9 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-  %func_11 = transform.iree.vector.warp_distribute %func_10
+  transform.iree.vector.warp_distribute %func_9
     : (!pdl.operation) -> !pdl.operation
 
   // Late canonicalizations to cleanup and pass the checks
-  %func_12 = transform.iree.apply_patterns %func_11
-    { canonicalization, tiling_canonicalization, licm, cse }
+  transform.iree.apply_patterns %func_9
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
@@ -16,7 +16,7 @@ transform.sequence failures(propagate) {
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 
   // Step 2. Split the reduction to get meatier parallelism.
   // This also parallelizes to threads.
@@ -37,7 +37,7 @@ transform.sequence failures(propagate) {
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 
   // Step 3. Rank-reduce and vectorize.
   // ===========================================================================
@@ -45,14 +45,14 @@ transform.sequence failures(propagate) {
     : (!pdl.operation) -> !pdl.operation
   // TODO: masked vectorization on block_more_parallel_op_2 if we want 
   // vector<4> to work as intended.
-  %func_2 = transform.iree.apply_patterns %func 
-    { rank_reducing_linalg, rank_reducing_vector }
-  %func_3 = transform.structured.vectorize %func_2
+  transform.iree.apply_patterns %func 
+    { rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func_3 = transform.structured.vectorize %func
 
   // Canonicalizations is necessary to get rid of some tensor.cast that block
   // hoisting.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
   %func_4 = transform.structured.hoist_redundant_tensor_subsets %func_3
     : (!pdl.operation) -> !pdl.operation
 
@@ -61,12 +61,12 @@ transform.sequence failures(propagate) {
   // ===========================================================================
   // Canonicalizations required before bufferization to avoid unnecessary allocs.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }
-  %func_5 = transform.iree.apply_patterns %func_4 { fold_reassociative_reshapes }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_4 { fold_reassociative_reshapes } : (!pdl.operation) -> ()
   %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
   %func_6 = transform.structured.match ops{["func.func"]} in %variant_op_2 
     : (!pdl.operation) -> !pdl.operation
-  %func_7 = transform.iree.apply_patterns %func_6 { erase_unnecessary_tensor_operands }
+  transform.iree.apply_patterns %func_6 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
   %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
@@ -82,15 +82,15 @@ transform.sequence failures(propagate) {
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  %func_m_4 = transform.iree.apply_patterns %func_m_3 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases }
+  transform.iree.apply_patterns %func_m_3 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-  transform.iree.vector.warp_distribute %func_m_4
+  transform.iree.vector.warp_distribute %func_m_3
     : (!pdl.operation) -> !pdl.operation
 
 
   // Late canonicalizations.
   transform.iree.apply_patterns %variant_op_3
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
@@ -63,32 +63,32 @@ transform.sequence failures(propagate) {
   transform.iree.apply_patterns %variant_op
     { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
   transform.iree.apply_patterns %func_4 { fold_reassociative_reshapes } : (!pdl.operation) -> ()
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %func_6 = transform.structured.match ops{["func.func"]} in %variant_op_2 
+  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+  %func_6 = transform.structured.match ops{["func.func"]} in %variant_op
     : (!pdl.operation) -> !pdl.operation
   transform.iree.apply_patterns %func_6 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op
+    : (!pdl.operation) -> !pdl.operation
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
 
   // Step 5. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
   %func_m = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
-  %func_m_2 = transform.iree.forall_to_workgroup %func_m
-  %func_m_3 = transform.iree.map_nested_forall_to_gpu_threads %func_m_2
-      { workgroup_size = [1024, 1, 1] }
+  transform.iree.forall_to_workgroup %func_m : (!pdl.operation) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_m
+      workgroup_dims = [1024, 1, 1] : (!pdl.operation) -> ()
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_m_3 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_m { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-  transform.iree.vector.warp_distribute %func_m_3
-    : (!pdl.operation) -> !pdl.operation
-
+  transform.iree.vector.warp_distribute %func_m
+    : (!pdl.operation) -> ()
 
   // Late canonicalizations.
   transform.iree.apply_patterns %variant_op_3

--- a/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
@@ -71,8 +71,8 @@ transform.sequence failures(propagate) {
   // Step 3. Rank-reduce and vectorize.
   // ==================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %funcx = transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector }
-  transform.structured.vectorize %funcx
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  transform.structured.vectorize %func
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
@@ -91,8 +91,8 @@ transform.sequence failures(propagate) {
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===================================================================
   %end_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  %end_func_2 = transform.iree.apply_patterns %end_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases }
+  transform.iree.apply_patterns %end_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-  transform.iree.vector.warp_distribute %end_func_2
+  transform.iree.vector.warp_distribute %end_func : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cuda/softmax_partial_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_partial_codegen_spec.mlir
@@ -54,8 +54,8 @@ transform.sequence failures(propagate) {
   // Step 3. Rank-reduce and vectorize.
   // ==================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %funcx = transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector }
-  transform.structured.vectorize %funcx
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  transform.structured.vectorize %func
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
@@ -74,8 +74,8 @@ transform.sequence failures(propagate) {
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===================================================================
   %end_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  %end_func_2 = transform.iree.apply_patterns %end_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases }
+  transform.iree.apply_patterns %end_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-  transform.iree.vector.warp_distribute %end_func_2
+  transform.iree.vector.warp_distribute %end_func
 }

--- a/tests/transform_dialect/cuda/softmax_v2_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_v2_codegen_spec.mlir
@@ -33,7 +33,7 @@ transform.sequence failures(propagate) {
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
   
 
   // Step 2. Second level of tiling + fusion parallelizes to threads.
@@ -66,13 +66,13 @@ transform.sequence failures(propagate) {
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 
   // Step 3. Rank-reduce and vectorize.
   // ==================================
   %funcx_2 = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %funcx_3 = transform.iree.apply_patterns %funcx_2 {  rank_reducing_linalg, rank_reducing_vector }
-  transform.structured.vectorize %funcx_3
+  transform.iree.apply_patterns %funcx_2 {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  transform.structured.vectorize %funcx_2
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
@@ -92,15 +92,15 @@ transform.sequence failures(propagate) {
   // ===================================================================
   %end_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
-  %end_func_2 = transform.iree.apply_patterns %end_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases }
+  transform.iree.apply_patterns %end_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
     : (!pdl.operation) -> !pdl.operation
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-  transform.iree.vector.warp_distribute %end_func_2
+  transform.iree.vector.warp_distribute %end_func
     : (!pdl.operation) -> !pdl.operation
 
 
   // Late canonicalizations.
   transform.iree.apply_patterns %variant_op_3
-    { canonicalization, tiling_canonicalization, licm, cse }
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
@@ -9,14 +9,13 @@ transform.sequence failures(propagate) {
   // Step 2. Rank reduce and bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector }
-  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> !pdl.operation
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
 
   // Step 3. Map to GPU thread blocks.
   // ===========================================================================
-  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_2
+  transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> ()
 }

--- a/tests/transform_dialect/cuda/vecadd2d_codegen_spec_partial_tile.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d_codegen_spec_partial_tile.mlir
@@ -9,5 +9,5 @@ transform.sequence failures(propagate) {
   // Late canonicalizations to cleanup and pass the checks.
   // Needs to occur on the whole variant to perform cse on the workgroup_count region
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse }              
+    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation              ) -> ()
 }


### PR DESCRIPTION
…sability

This PR simplifies most transforms that return the same handle that they were passed without modifying the op itself. The chaining behavior results in too much cognitive overhead when manipulating transform scripts as handle names need to constantly be updated as soon as a transform is disabled or moved. Instead, avoid consuming the handle wherever possible.