### PR TITLE
CMake IREE_ARCH variable, a canonicalized CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -199,13 +199,13 @@ def iree_generated_trace_runner_test(
         timeout: timeout for the generated tests.
         target_cpu_features_variants: list of target cpu features variants.
             Currently unimplemented, so each entry must be either "default" or
-            start with "aarch64:" so as Bazel builds are currently x86-only,
+            start with "arm_64:" so as Bazel builds are currently x86-only,
             we know that it is correct to ignore this.
         **kwargs: any additional attributes to pass to the underlying tests and test suite.
     """
 
     for target_cpu_features in target_cpu_features_variants:
-        if not (target_cpu_features == "default" or target_cpu_features.startswith("aarch64:")):
+        if not (target_cpu_features == "default" or target_cpu_features.startswith("arm_64:")):
             fail("Entry %s in target_cpu_features_variants: unimplemented" % target_cpu_features)
 
     tests = []

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -160,8 +160,8 @@ function(iree_cc_test)
         TEST_TMPDIR=${_ANDROID_ABS_DIR}/test_tmpdir
     )
     set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
-  elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64" OR
-          CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv32") AND
+  elseif((IREE_ARCH STREQUAL "riscv_64" OR
+          IREE_ARCH STREQUAL "riscv_32") AND
          CMAKE_SYSTEM_NAME STREQUAL "Linux")
     # The test target needs to run within the QEMU emulator for RV64 Linux
     # crosscompile build or on-device.

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -280,7 +280,7 @@ endfunction()
 # the empty string.
 #
 # Other values are parsed as "arch:features", the parsed arch is matched with
-# `CMAKE_SYSTEM_PROCESSOR`, `_ENABLED` is set to "TRUE" if and only if they
+# `IREE_ARCH`, `_ENABLED` is set to "TRUE" if and only if they
 # match, `_TARGET_CPU_FEATURES_SUFFIX` is set to a string based on the
 # features that is appropriate to include in a CMake target or test name, and
 # More than one target cpu feature is currently unsupported.
@@ -308,17 +308,7 @@ _FILTER_ARCH:_TARGET_CPU_FEATURES. Got: ${_INPUT_TARGET_CPU_FEATURES}")
   # TARGET_CPU_FEATURES_VARIANT is of the form _FILTER_ARCH:_TARGET_CPU_FEATURE.
   list(GET _COMPONENTS 0 _FILTER_ARCH)
   list(GET _COMPONENTS 1 _TARGET_CPU_FEATURES)
-  # Canonicalize the architecture name - some architectures have multiple
-  # possible CMAKE_SYSTEM_PROCESSOR values and this has caused failure to select
-  # architecture-specific code paths. For example, if we assume that on AArch64
-  # the value of CMAKE_SYSTEM_PROCESSOR is "aarch64" then we miss Apple where it
-  # is "arm64".
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-    set(_ARCH "aarch64")
-  else()
-    set(_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
-  endif()
-  if(_FILTER_ARCH STREQUAL _ARCH)
+  if(_FILTER_ARCH STREQUAL IREE_ARCH)
     set(_ENABLED "TRUE" PARENT_SCOPE)
     set(_TARGET_CPU_FEATURES "${_TARGET_CPU_FEATURES}" PARENT_SCOPE)
     # TODO: the logic to generate the suffix from the list of target CPU features

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -19,6 +19,75 @@ else()
   set(IREE_HOST_EXECUTABLE_SUFFIX "")
 endif()
 
+
+#-------------------------------------------------------------------------------
+# IREE_ARCH: identifies the target CPU architecture. May be empty when this is
+# ill-defined, such as multi-architecture builds.
+# This should be kept consistent with the C preprocessor token IREE_ARCH defined
+# in target_platform.h.
+#-------------------------------------------------------------------------------
+
+# First, get the raw CMake architecture name, not yet normalized. Even that is
+# non-trivial: it usually is CMAKE_SYSTEM_PROCESSOR, but on some platforms, we
+# have to read other variables instead.
+if(CMAKE_OSX_ARCHITECTURES)
+  list(LENGTH CMAKE_OSX_ARCHITECTURES NUM_ARCHES)
+  if(NOT ${NUM_ARCHES} EQUAL 1)
+    # Leaving _IREE_UNNORMALIZED_ARCH empty disables arch code paths. We will
+    # issue a performance warning about that below.
+  endif()
+  # Only one arch in CMAKE_OSX_ARCHITECTURES, use that.
+  set(_IREE_UNNORMALIZED_ARCH "${CMAKE_OSX_ARCHITECTURES}")
+elseif(CMAKE_GENERATOR MATCHES "^Visual Studio " AND CMAKE_GENERATOR_PLATFORM)
+  # Architecture is given by CMAKE_GENERATOR_PLATFORM.
+  set(_IREE_UNNORMALIZED_ARCH "${CMAKE_GENERATOR_PLATFORM}")
+else()
+  set(_IREE_UNNORMALIZED_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+string(TOLOWER "${_IREE_UNNORMALIZED_ARCH}" _IREE_UNNORMALIZED_ARCH_LOWERCASE)
+
+# Normalize _IREE_UNNORMALIZED_ARCH into IREE_ARCH.
+if (EMSCRIPTEN)
+  # TODO: figure what to do about the wasm target, which masquerades as x86.
+  # This is the one case where the IREE_ARCH CMake variable is currently
+  # inconsistent with the IREE_ARCH C preprocessor token.
+  set (IREE_ARCH "")
+elseif ((_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "aarch64") OR
+        (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "arm64") OR
+        (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "arm64e") OR
+        (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "arm64ec"))
+  set (IREE_ARCH "arm_64")
+elseif ((_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "arm") OR
+        (_IREE_UNNORMALIZED_ARCH_LOWERCASE MATCHES "^armv[5-8]"))
+  set (IREE_ARCH "arm_32")
+elseif ((_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "x86_64") OR
+        (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "amd64") OR
+        (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "x64"))
+  set (IREE_ARCH "x86_64")
+elseif ((_IREE_UNNORMALIZED_ARCH_LOWERCASE MATCHES "^i[3-7]86$") OR
+        (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "x86") OR
+        (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "win32"))
+  set (IREE_ARCH "x86_32")
+elseif (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "riscv64")
+  set (IREE_ARCH "riscv_64")
+elseif (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "riscv32")
+  set (IREE_ARCH "riscv_32")
+elseif (_IREE_UNNORMALIZED_ARCH_LOWERCASE STREQUAL "")
+  set (IREE_ARCH "")
+  message(WARNING "Performance advisory: architecture-specific code paths "
+    "disabled because no target architecture was specified or we didn't know "
+    "which CMake variable to read. Some relevant CMake variables:\n"
+    "CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}\n"
+    "CMAKE_GENERATOR=${CMAKE_GENERATOR}\n"
+    "CMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}\n"
+    "CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}\n"
+    )
+else()
+  set (IREE_ARCH "")
+  message(SEND_ERROR "Unrecognized target architecture ${_IREE_UNNORMALIZED_ARCH_LOWERCASE}")
+endif()
+
 #-------------------------------------------------------------------------------
 # General utilities
 #-------------------------------------------------------------------------------
@@ -427,14 +496,14 @@ function(iree_compile_flags_for_platform OUT_FLAGS IN_FLAGS)
     list(APPEND _FLAGS "--iree-llvmcpu-target-triple=${_TARGET_TRIPLE}")
   endif()
 
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64" AND
+  if(IREE_ARCH STREQUAL "riscv_64" AND
      CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
      NOT IN_FLAGS MATCHES "iree-llvmcpu-target-triple")
     # RV64 Linux crosscompile toolchain can support iree-compile with
     # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
     # llvm-target-triple is not specified.
     list(APPEND _FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
-  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv32" AND
+  elseif(IREE_ARCH STREQUAL "riscv_32" AND
          CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
          NOT IN_FLAGS MATCHES "iree-llvmcpu-target-triple")
     # RV32 Linux crosscompile toolchain can support iree-compile with

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -31,15 +31,19 @@ endif()
 # non-trivial: it usually is CMAKE_SYSTEM_PROCESSOR, but on some platforms, we
 # have to read other variables instead.
 if(CMAKE_OSX_ARCHITECTURES)
+  # Borrowing from:
+  # https://boringssl.googlesource.com/boringssl/+/c5f0e58e653d2d9afa8facc090ce09f8aaa3fa0d/CMakeLists.txt#43
+  # https://github.com/google/XNNPACK/blob/2eb43787bfad4a99bdb613111cea8bc5a82f390d/CMakeLists.txt#L40
   list(LENGTH CMAKE_OSX_ARCHITECTURES NUM_ARCHES)
-  if(NOT ${NUM_ARCHES} EQUAL 1)
-    # Leaving _IREE_UNNORMALIZED_ARCH empty disables arch code paths. We will
-    # issue a performance warning about that below.
+  if(${NUM_ARCHES} EQUAL 1)
+    # Only one arch in CMAKE_OSX_ARCHITECTURES, use that.
+    set(_IREE_UNNORMALIZED_ARCH "${CMAKE_OSX_ARCHITECTURES}")
   endif()
-  # Only one arch in CMAKE_OSX_ARCHITECTURES, use that.
-  set(_IREE_UNNORMALIZED_ARCH "${CMAKE_OSX_ARCHITECTURES}")
+  # Leaving _IREE_UNNORMALIZED_ARCH empty disables arch code paths. We will
+  # issue a performance warning about that below.
 elseif(CMAKE_GENERATOR MATCHES "^Visual Studio " AND CMAKE_GENERATOR_PLATFORM)
-  # Architecture is given by CMAKE_GENERATOR_PLATFORM.
+  # Borrowing from:
+  # https://github.com/google/XNNPACK/blob/2eb43787bfad4a99bdb613111cea8bc5a82f390d/CMakeLists.txt#L50
   set(_IREE_UNNORMALIZED_ARCH "${CMAKE_GENERATOR_PLATFORM}")
 else()
   set(_IREE_UNNORMALIZED_ARCH "${CMAKE_SYSTEM_PROCESSOR}")

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -123,8 +123,8 @@ function(iree_native_test)
         "TEST_TMPDIR=${_ANDROID_ABS_DIR}/test_tmpdir"
     )
     set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
-  elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64" OR
-          CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv32") AND
+  elseif((IREE_ARCH STREQUAL "riscv_64" OR
+          IREE_ARCH STREQUAL "riscv_32") AND
          CMAKE_SYSTEM_NAME STREQUAL "Linux")
     # The test target needs to run within the QEMU emulator for RV64 Linux
     # crosscompile build or on-device.

--- a/build_tools/cmake/iree_run_module_test.cmake
+++ b/build_tools/cmake/iree_run_module_test.cmake
@@ -5,9 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Utility function to return the platform name in crosscompile.
-# TODO: stop leaking CMAKE_SYSTEM_PROCESSOR values. Try to harmonize around
-# IREE_ARCH values, but this will need to be fixed jointly with the callers of
-# iree_run_module_test.
+# TODO(#12692): stop leaking CMAKE_SYSTEM_PROCESSOR values.
 function(iree_get_platform PLATFORM)
   if(ANDROID AND CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
     set(_PLATFORM "android-arm64-v8a")

--- a/build_tools/cmake/iree_run_module_test.cmake
+++ b/build_tools/cmake/iree_run_module_test.cmake
@@ -5,10 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Utility function to return the platform name in crosscompile.
+# TODO: stop leaking CMAKE_SYSTEM_PROCESSOR values. Try to harmonize around
+# IREE_ARCH values, but this will need to be fixed jointly with the callers of
+# iree_run_module_test.
 function(iree_get_platform PLATFORM)
   if(ANDROID AND CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
     set(_PLATFORM "android-arm64-v8a")
-  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  elseif(IREE_ARCH STREQUAL "x86_64")
     set(_PLATFORM "x86_64")
   else()
     set(_PLATFORM "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")

--- a/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
@@ -12,19 +12,8 @@ else()
   set(IREE_UK_ENABLE_ARCH_SPECIFIC_CODE TRUE)
 endif()
 
-# This block is borrowed from boringssl's CMake code here:
-# https://boringssl.googlesource.com/boringssl/+/c5f0e58e653d2d9afa8facc090ce09f8aaa3fa0d/CMakeLists.txt#43
-if(CMAKE_OSX_ARCHITECTURES)
-  list(LENGTH CMAKE_OSX_ARCHITECTURES NUM_ARCHES)
-  if(NOT ${NUM_ARCHES} EQUAL 1)
-    message(WARNING "Performance advisory: architecture-specific code paths disabled because this is a multi-architecture build.")
-    set(IREE_UK_ENABLE_ARCH_SPECIFIC_CODE FALSE)
-  endif()
-  list(GET CMAKE_OSX_ARCHITECTURES 0 CMAKE_SYSTEM_PROCESSOR)
-endif()
-
 if(IREE_UK_ENABLE_ARCH_SPECIFIC_CODE)
-  if((CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
+  if (IREE_ARCH STREQUAL "arm_64")
     set(IREE_UK_ARCH_ARM_64 TRUE)
     add_subdirectory(arm_64)
     list(APPEND IREE_UK_ARCH_DEPS

--- a/samples/custom_dispatch/cpu/embedded/CMakeLists.txt
+++ b/samples/custom_dispatch/cpu/embedded/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # detect what backends are compiled into clang. We could extend this to build
 # for the current cmake target architecture but would also need to modify the
 # MLIR file to have the new target configuration.
-if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)")
+if(NOT IREE_ARCH STREQUAL "x86_64")
   message(STATUS "IREE custom_dispatch/cpu/embedded ignored -- only builds for x86_64 (today)")
   return()
 endif()

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -51,8 +51,8 @@ py_binary(
     ],
     target_cpu_features_variants = ["default"] +
                                    ([
-                                       "aarch64:+dotprod",
-                                       "aarch64:+i8mm",
+                                       "arm_64:+dotprod",
+                                       "arm_64:+i8mm",
                                    ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [
@@ -75,8 +75,8 @@ py_binary(
     ],
     target_cpu_features_variants = ["default"] +
                                    ([
-                                       "aarch64:+dotprod",
-                                       "aarch64:+i8mm",
+                                       "arm_64:+dotprod",
+                                       "arm_64:+i8mm",
                                    ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [
@@ -103,8 +103,8 @@ py_binary(
     ],
     target_cpu_features_variants = ["default"] +
                                    ([
-                                       "aarch64:+dotprod",
-                                       "aarch64:+i8mm",
+                                       "arm_64:+dotprod",
+                                       "arm_64:+i8mm",
                                    ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -60,8 +60,8 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "aarch64:+dotprod"
-    "aarch64:+i8mm"
+    "arm_64:+dotprod"
+    "arm_64:+i8mm"
 )
 
 iree_generated_trace_runner_test(
@@ -102,8 +102,8 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "aarch64:+dotprod"
-    "aarch64:+i8mm"
+    "arm_64:+dotprod"
+    "arm_64:+i8mm"
 )
 
 iree_generated_trace_runner_test(
@@ -145,8 +145,8 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "aarch64:+dotprod"
-    "aarch64:+i8mm"
+    "arm_64:+dotprod"
+    "arm_64:+i8mm"
 )
 
 iree_generated_trace_runner_test(


### PR DESCRIPTION
As suggested by @GMNGeoffrey on #12674.