### PR TITLE
`ukernel/arch/arm_64`: simplify build, allow non-GCC-compatible toolchains

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
@@ -17,10 +17,7 @@ if(IREE_UK_ENABLE_ARCH_SPECIFIC_CODE)
     set(IREE_UK_ARCH_ARM_64 TRUE)
     add_subdirectory(arm_64)
     list(APPEND IREE_UK_ARCH_DEPS
-      "iree::builtins::ukernel::arch::arm_64::mmt4d_arm_64"
-      "iree::builtins::ukernel::arch::arm_64::pack_arm_64"
-      "iree::builtins::ukernel::arch::arm_64::query_tile_sizes_arm_64"
-      "iree::builtins::ukernel::arch::arm_64::unpack_arm_64"
+      "iree::builtins::ukernel::arch::arm_64"
     )
   endif()
 endif()  # IREE_UK_ENABLE_ARCH_SPECIFIC_CODE

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
@@ -4,8 +4,19 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-check_cxx_compiler_flag("-march=armv8.2-a+dotprod" IREE_UK_BUILD_ARM_64_DOTPROD)
-check_cxx_compiler_flag("-march=armv8.2-a+i8mm" IREE_UK_BUILD_ARM_64_I8MM)
+iree_select_compiler_opts(IREE_UK_COPTS_ARM_64_DOTPROD
+  CLANG_OR_GCC
+    "-march=armv8.2-a+dotprod"
+)
+
+iree_select_compiler_opts(IREE_UK_COPTS_ARM_64_I8MM
+  CLANG_OR_GCC
+    "-march=armv8.2-a+i8mm"
+)
+
+check_cxx_compiler_flag("${IREE_UK_COPTS_ARM_64_DOTPROD}" IREE_UK_BUILD_ARM_64_DOTPROD)
+check_cxx_compiler_flag("${IREE_UK_COPTS_ARM_64_I8MM}" IREE_UK_COPTS_ARM_64_I8MM)
+
 configure_file(config.h.in config.h)
 
 iree_cc_library(
@@ -25,27 +36,22 @@ iree_cc_library(
 if(IREE_UK_BUILD_ARM_64_DOTPROD)
   iree_cc_library(
     NAME
-      mmt4d_arm_64_dotprod
-    HDRS
-      "mmt4d_arm_64.h"
+      arm_64_dotprod
     SRCS
       "mmt4d_arm_64_dotprod.S"
     COPTS
-      "-march=armv8.2-a+dotprod"
+      "${IREE_UK_COPTS_ARM_64_DOTPROD}"
     DEPS
       ::assembly
       iree::builtins::ukernel::exported_bits
-
   )
-  list(APPEND IREE_UK_MMT4D_ARM_64_DEPS "iree::builtins::ukernel::arch::arm_64::mmt4d_arm_64_dotprod")
+  list(APPEND IREE_UK_ARM_64_DEPS "iree::builtins::ukernel::arch::arm_64::arm_64_dotprod")
 endif()
 
 if(IREE_UK_BUILD_ARM_64_I8MM)
   iree_cc_library(
     NAME
-      mmt4d_arm_64_i8mm
-    HDRS
-      "mmt4d_arm_64.h"
+      arm_64_i8mm
     SRCS
       "mmt4d_arm_64_i8mm.S"
     COPTS
@@ -54,65 +60,27 @@ if(IREE_UK_BUILD_ARM_64_I8MM)
       ::assembly
       iree::builtins::ukernel::exported_bits
   )
-  list(APPEND IREE_UK_MMT4D_ARM_64_DEPS "iree::builtins::ukernel::arch::arm_64::mmt4d_arm_64_i8mm")
+  list(APPEND IREE_UK_ARM_64_DEPS "iree::builtins::ukernel::arch::arm_64::arm_64_i8mm")
 endif()
 
 iree_cc_library(
   NAME
-    mmt4d_arm_64
+    arm_64
   HDRS
     "mmt4d_arm_64.h"
+    "pack_arm_64.h"
+    "query_tile_sizes_arm_64.h"
+    "unpack_arm_64.h"
   SRCS
     "mmt4d_arm_64.c"
     "mmt4d_arm_64.S"
-  DEPS
-    iree::base::core_headers
-    iree::schemas::cpu_data
-    iree::builtins::ukernel::headers
-    ${IREE_UK_MMT4D_ARM_64_DEPS}
-  PUBLIC
-)
-
-iree_cc_library(
-  NAME
-    pack_arm_64
-  HDRS
-    "pack_arm_64.h"
-  SRCS
     "pack_arm_64.c"
-  DEPS
-    ::common_arm_neon
-    iree::base::core_headers
-    iree::schemas::cpu_data
-    iree::builtins::ukernel::headers
-  PUBLIC
-)
-
-iree_cc_library(
-  NAME
-  query_tile_sizes_arm_64
-  HDRS
-    "query_tile_sizes_arm_64.h"
-  SRCS
     "query_tile_sizes_arm_64.c"
-  DEPS
-    iree::base::core_headers
-    iree::schemas::cpu_data
-    iree::builtins::ukernel::headers
-  PUBLIC
-)
-
-iree_cc_library(
-  NAME
-    unpack_arm_64
-  HDRS
-    "unpack_arm_64.h"
-  SRCS
     "unpack_arm_64.c"
   DEPS
-    ::common_arm_neon
     iree::base::core_headers
     iree::schemas::cpu_data
     iree::builtins::ukernel::headers
+    ${IREE_UK_ARM_64_DEPS}
   PUBLIC
 )


### PR DESCRIPTION
This is the last big rehearsal before x86 ukernels and I wanted to backport to `arm_64/` things I had noticed there while thinking about x86:
 - This was set up to have a separate cc_library for each ukernel, for each ISA variant. That was a bit too much; the simplification resulting from having only one cc_library per ISA variant outweighs the benefits of keeping ukernels separate. They are still in separate source (.c or .S) files, so there isn't any readability impact.
 - This was hardcoding the GCC-compatible compiler flag for each ISA variant. As a result, if one ever tried to build this with MSVC, this would just disable all these code paths as the flag wasn't supported by the compiler (see the `check_cxx_compiler_flag`). Now we are using `iree_select_compiler_opts` so we currently leave the flag blank on MSVC and we can add the right MSVC flag as needed.