### PR TITLE
Fix mobilenet_v2_int8 model input typo

### DIFF
--- a/build_tools/python/e2e_test_framework/models/tflite_models.py
+++ b/build_tools/python/e2e_test_framework/models/tflite_models.py
@@ -139,4 +139,4 @@ MOBILENET_V2_INT8 = common_definitions.Model(
     source_url=
     "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v2_1.0_224_quantized.tflite",
     entry_function="main",
-    input_types=["1x224x224xui8"])
+    input_types=["1x224x224x3xui8"])


### PR DESCRIPTION
mobilenet_v2_int8 model should have the input of `1x224x224x3xui8`. Fix the typo from PR https://github.com/openxla/iree/pull/12690