### PR TITLE
Add reported peak device memory to benchmark summary

### DIFF
--- a/build_tools/benchmarks/reporting/parse_shark_benchmarks.py
+++ b/build_tools/benchmarks/reporting/parse_shark_benchmarks.py
@@ -41,9 +41,13 @@ _SHARK_LATENCY = "SHARK latency (ms)"
 _IREE_VS_BASELINE = "IREE vs baseline"
 _SHARK_VS_BASELINE = "SHARK vs baseline"
 _IREE_VS_SHARK = "IREE vs SHARK"
+_BASELINE_MEMORY = "Baseline Peak Device Memory (MB)"
+_IREE_MEMORY = "IREE Peak Device Memory (MB)"
+_SHARK_MEMORY = "SHARK Peak Device Memory (MB)"
 
 _PERF_COLUMNS = [_IREE_VS_BASELINE, _SHARK_VS_BASELINE, _IREE_VS_SHARK]
 _LATENCY_COLUMNS = [_BASELINE_LATENCY, _IREE_LATENCY, _SHARK_LATENCY]
+_MEMORY_COLUMNS = [_BASELINE_MEMORY, _IREE_MEMORY, _SHARK_MEMORY]
 
 
 def _generate_table(df_iree, df_shark, df_baseline, title):
@@ -51,7 +55,7 @@ def _generate_table(df_iree, df_shark, df_baseline, title):
   summary = pd.DataFrame(columns=[
       _MODEL, _BASELINE, _DATA_TYPE, _DIALECT, _DEVICE, _BASELINE_LATENCY,
       _IREE_LATENCY, _SHARK_LATENCY, _IREE_VS_BASELINE, _SHARK_VS_BASELINE,
-      _IREE_VS_SHARK
+      _IREE_VS_SHARK, _BASELINE_MEMORY, _IREE_MEMORY, _SHARK_MEMORY
   ])
 
   models = df_iree.model.unique()
@@ -90,16 +94,19 @@ def _generate_table(df_iree, df_shark, df_baseline, title):
                 f" {data_type}, {device}. Using IREE version as baseline. Please"
                 f" update baseline csv.")
             engine = iree_results.engine.iloc[0]
-            baseline_latency = iree_results.loc[iree_results.engine == engine]
-            baseline_latency = baseline_latency.iloc[0]["ms/iter"]
+            baseline_df = iree_results.loc[iree_results.engine == engine]
+            baseline_latency = baseline_df.iloc[0]["ms/iter"]
+            baseline_device_mb = baseline_df.iloc[0]["device_memory_mb"]
           else:
             engine = baseline_results.engine.iloc[0]
-            baseline_latency = baseline_results.loc[baseline_results.engine ==
-                                                    engine]
-            baseline_latency = baseline_latency.iloc[0]["ms/iter"]
+            baseline_df = baseline_results.loc[baseline_results.engine ==
+                                               engine]
+            baseline_latency = baseline_df.iloc[0]["ms/iter"]
+            baseline_device_mb = baseline_df.iloc[0]["device_memory_mb"]
 
-          iree_latency = iree_results.loc[iree_results.engine == "shark_iree_c"]
-          iree_latency = iree_latency.iloc[0]["ms/iter"]
+          iree_df = iree_results.loc[iree_results.engine == "shark_iree_c"]
+          iree_latency = iree_df.iloc[0]["ms/iter"]
+          iree_device_mb = iree_df.iloc[0]["device_memory_mb"]
           iree_vs_baseline = html_utils.format_latency_comparison(
               iree_latency, baseline_latency)
 
@@ -114,9 +121,9 @@ def _generate_table(df_iree, df_shark, df_baseline, title):
               )
               continue
 
-            shark_latency = shark_results.loc[shark_results.engine ==
-                                              "shark_iree_c"]
-            shark_latency = shark_latency.iloc[0]["ms/iter"]
+            shark_df = shark_results.loc[shark_results.engine == "shark_iree_c"]
+            shark_latency = shark_df.iloc[0]["ms/iter"]
+            shark_device_mb = shark_df.iloc[0]["device_memory_mb"]
             shark_vs_baseline = html_utils.format_latency_comparison(
                 shark_latency, baseline_latency)
             iree_vs_shark = html_utils.format_latency_comparison(
@@ -129,10 +136,20 @@ def _generate_table(df_iree, df_shark, df_baseline, title):
             iree_vs_shark = "<missing_comparison>"
 
           summary.loc[len(summary)] = [
-              model, engine, data_type, dialect, device,
-              f"{baseline_latency:.1f}", f"{iree_latency:.1f}",
-              f"{shark_latency:.1f}", iree_vs_baseline, shark_vs_baseline,
-              iree_vs_shark
+              model,
+              engine,
+              data_type,
+              dialect,
+              device,
+              f"{baseline_latency:.1f}",
+              f"{iree_latency:.1f}",
+              f"{shark_latency:.1f}",
+              iree_vs_baseline,
+              shark_vs_baseline,
+              iree_vs_shark,
+              f"{baseline_device_mb:.3f}",
+              f"{iree_device_mb:.3f}",
+              f"{shark_device_mb:.3f}",
           ]
 
   summary = summary.round(2)
@@ -169,6 +186,11 @@ def _generate_table(df_iree, df_shark, df_baseline, title):
                              "width": "150px",
                              "text-align": "right",
                              "color": "#ffffff"
+                         })
+  st = st.set_properties(subset=_MEMORY_COLUMNS,
+                         **{
+                             "width": "100",
+                             "text-align": "right",
                          })
 
   return st.to_html() + "<br/>"


### PR DESCRIPTION
Only IREE supports reporting CPU memory statistics, so baseline CPU comparisons will be added after we add support for measuring it indirectly via `/proc/<pid>/status`. The `Baseline Peak Device Memory (MB)` column will be populated by the numbers TensorFlow and PyTorch report once the various issues affecting GPU support are resolved [https://github.com/nod-ai/SHARK/issues/1197, https://github.com/openxla/iree/issues/12456].

Preview of the change for CPU:
<img width="2045" alt="Screenshot 2023-03-21 at 3 52 19 PM" src="https://user-images.githubusercontent.com/40036383/226760612-e94bb48d-b624-4840-91c9-12bfedbb06d4.png">

Related to https://github.com/openxla/iree/issues/12449.