### PR TITLE
Disable fusion with consumers without projected permutation maps

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -73,6 +73,15 @@ static bool areFusableOps(MLIRContext *context, Operation *producerOp,
     return true;
   }
 
+  // Don't fuse if all of the consumer maps aren't projected permutations.
+  if (auto linalgConsumerOp = dyn_cast<linalg::LinalgOp>(consumerOp)) {
+    if (!llvm::all_of(
+            linalgConsumerOp.getIndexingMapsArray(),
+            [](AffineMap map) { return map.isProjectedPermutation(); })) {
+      return false;
+    }
+  }
+
   // If producer has a single user, always fuse
   if (producerOp->hasOneUse()) return true;
 


### PR DESCRIPTION
This avoids fusing convolution-like generics with leading elementwise operations, as per [this discussion on Discord](https://discord.com/channels/689900678990135345/689906000043573354/1086818672204595200).