### PR TITLE
Use benchmark name from benchmark config object

### DIFF
--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -152,7 +152,7 @@ def get_module_map_from_compilation_benchmark_config(
           (f"{arch.type.value}-{arch.architecture}-{arch.microarchitecture}-"
            f"{compile_target.target_abi.value}"))
     compilation_info = CompilationInfo(
-        benchmark_name=gen_config.name,
+        name=gen_config.name,
         model_name=model.name,
         model_tags=tuple(model.tags),
         model_source=model.source_type.value,

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -152,6 +152,7 @@ def get_module_map_from_compilation_benchmark_config(
           (f"{arch.type.value}-{arch.architecture}-{arch.microarchitecture}-"
            f"{compile_target.target_abi.value}"))
     compilation_info = CompilationInfo(
+        benchmark_name=gen_config.name,
         model_name=model.name,
         model_tags=tuple(model.tags),
         model_source=model.source_type.value,
@@ -186,7 +187,7 @@ def get_module_map_from_benchmark_suite(
       if module_path is None:
         raise RuntimeError(
             f"Can't find the module file in the flagfile: {flag_file_path}")
-      compilation_info = CompilationInfo(
+      compilation_info = CompilationInfo.build_with_legacy_name(
           model_name=benchmark_case.model_name,
           model_tags=tuple(benchmark_case.model_tags),
           model_source=category,

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -137,7 +137,7 @@ class CollectCompilationStatistics(unittest.TestCase):
         e2e_test_artifacts_dir=root_dir)
 
     compile_info_a = common.benchmark_definition.CompilationInfo(
-        benchmark_name=gen_config_a.name,
+        name=gen_config_a.name,
         model_name=model_a.name,
         model_tags=tuple(model_a.tags),
         model_source=model_a.source_type.value,
@@ -147,7 +147,7 @@ class CollectCompilationStatistics(unittest.TestCase):
     module_a_path = iree_artifacts.get_module_dir_path(
         gen_config_a, root_dir) / iree_artifacts.MODULE_FILENAME
     compile_info_b = common.benchmark_definition.CompilationInfo(
-        benchmark_name=gen_config_b.name,
+        name=gen_config_b.name,
         model_name=model_a.name,
         model_tags=tuple(model_a.tags),
         model_source=model_a.source_type.value,

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -137,6 +137,7 @@ class CollectCompilationStatistics(unittest.TestCase):
         e2e_test_artifacts_dir=root_dir)
 
     compile_info_a = common.benchmark_definition.CompilationInfo(
+        benchmark_name=gen_config_a.name,
         model_name=model_a.name,
         model_tags=tuple(model_a.tags),
         model_source=model_a.source_type.value,
@@ -146,6 +147,7 @@ class CollectCompilationStatistics(unittest.TestCase):
     module_a_path = iree_artifacts.get_module_dir_path(
         gen_config_a, root_dir) / iree_artifacts.MODULE_FILENAME
     compile_info_b = common.benchmark_definition.CompilationInfo(
+        benchmark_name=gen_config_b.name,
         model_name=model_a.name,
         model_tags=tuple(model_a.tags),
         model_source=model_a.source_type.value,

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -319,7 +319,12 @@ class BenchmarkInfo:
   def build_with_legacy_name(cls, model_name: str, model_tags: Sequence[str],
                              model_source: str, bench_mode: Sequence[str],
                              driver_info: DriverInfo, device_info: DeviceInfo):
-    """Build legacy name for legacy benchmark suites."""
+    """Build legacy name by combining the components of the BenchmarkInfo.
+
+    This is the legacy way to construct the name and still used as primary key
+    in the legacy benchmark system. It's deprecated and the new benchmark suites
+    use a human-defined name which can be more concise.
+    """
     # TODO(#11076): Remove when we drop the legacy path in
     # BenchmarkDriver.__get_benchmark_info_from_case
 
@@ -487,7 +492,12 @@ class CompilationInfo(object):
   def build_with_legacy_name(cls, model_name: str, model_tags: Sequence[str],
                              model_source: str, target_arch: str,
                              compile_tags: Sequence[str]):
-    """Build legacy name for legacy benchmark suites."""
+    """Build legacy name by combining the components of the CompilationInfo.
+
+    This is the legacy way to construct the name and still used as primary key
+    in the legacy benchmark system. It's deprecated and the new benchmark suites
+    use a human-defined name which can be more concise.
+    """
     # TODO(#11076): Remove when we drop
     # collect_compilation_statistics.get_module_map_from_benchmark_suite
     if model_tags:

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -194,7 +194,7 @@ class BenchmarkDriver(object):
 
     run_tags = run_config.module_execution_config.tags
     compile_tags = run_config.module_generation_config.compile_config.tags
-    return BenchmarkInfo(benchmark_name=run_config.name,
+    return BenchmarkInfo(name=run_config.name,
                          model_name=benchmark_case.model_name,
                          model_tags=benchmark_case.model_tags,
                          model_source=category,

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -181,25 +181,28 @@ class BenchmarkDriver(object):
 
   def __get_benchmark_info_from_case(
       self, category: str, benchmark_case: BenchmarkCase) -> BenchmarkInfo:
-    if benchmark_case.run_config is None:
+    run_config = benchmark_case.run_config
+    if run_config is None:
       # TODO(#11076): Remove legacy path.
-      return BenchmarkInfo(model_name=benchmark_case.model_name,
-                           model_tags=benchmark_case.model_tags,
-                           model_source=category,
-                           bench_mode=benchmark_case.bench_mode,
-                           driver_info=benchmark_case.driver_info,
-                           device_info=self.device_info)
+      return BenchmarkInfo.build_with_legacy_name(
+          model_name=benchmark_case.model_name,
+          model_tags=benchmark_case.model_tags,
+          model_source=category,
+          bench_mode=benchmark_case.bench_mode,
+          driver_info=benchmark_case.driver_info,
+          device_info=self.device_info)
 
-    run_tags = benchmark_case.run_config.module_execution_config.tags
-    compile_tags = benchmark_case.run_config.module_generation_config.compile_config.tags
-    return BenchmarkInfo(model_name=benchmark_case.model_name,
+    run_tags = run_config.module_execution_config.tags
+    compile_tags = run_config.module_generation_config.compile_config.tags
+    return BenchmarkInfo(benchmark_name=run_config.name,
+                         model_name=benchmark_case.model_name,
                          model_tags=benchmark_case.model_tags,
                          model_source=category,
                          bench_mode=run_tags,
                          compile_tags=compile_tags,
                          driver_info=benchmark_case.driver_info,
                          device_info=self.device_info,
-                         run_config_id=benchmark_case.run_config.composite_id)
+                         run_config_id=run_config.composite_id)
 
   def __get_available_drivers_and_loaders(
       self) -> Tuple[Sequence[str], Sequence[str]]:


### PR DESCRIPTION
For running new benchmark suite, use the benchmark name from benchmark config instead of generating from `BenchmarkInfo` and `CompilationInfo`. This allows us to use the new benchmark suite as the SoT of all benchmark configurations.

Perf dashboard is using benchmark id as primary key for new benchmark suites, so this change won't break the series. Android benchmarks still use the legacy name as key and this change doesn't touch it.