### PR TITLE
Dispatch CUDA workgroups along single dimension

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -419,7 +419,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
     auto linalgTilingOptions =
         linalg::LinalgTilingOptions()
             .setDistributionOptions(getIREELinalgLoopDistributionOptions(
-                tileSizes, distributionMethodValue))
+                tileSizes, distributionMethodValue, maxWorkgroupParallelDims))
             .setInterchange(llvm::to_vector<4>(
                 llvm::map_range(interchange,
                                 [](int64_t v) -> unsigned {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -96,7 +96,7 @@ static void addBufferizePasses(OpPassManager &passManager) {
 static void tileAndDistributeToWorkgroup(
     OpPassManager &pm, bool useWARForCooperativeMatrixCodegen = false) {
   pm.addPass(createTileAndDistributeToWorkgroupsPass(
-      kNumMaxParallelDims,
+      /*maxWorkgroupParallelDims=*/1,
       linalg::DistributionMethod::CyclicNumProcsEqNumIters));
 
   auto &nestedModulePM = pm.nest<ModuleOp>();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
@@ -30,7 +30,6 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 // CHECK-LABEL: hal.executable.export public @forward_dispatch_0_generic_320x320x3x3
 //     CHECK:     workgroup_size = [3 : index, 3 : index, 7 : index]}
-// CHECK-DAG:     %[[C46:.+]] = arith.constant 46 : index
-// CHECK-DAG:     %[[C320:.+]] = arith.constant 320 : index
-// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-//     CHECK:     hal.return %[[C46]], %[[C320]], %[[C1]] : index, index, index
+// CHECK-DAG:     %[[C14720:.*]] = arith.constant 14720 : index
+// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
+//     CHECK:     hal.return %[[C14720]], %[[C1]], %[[C1]] : index, index, index

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -157,7 +157,8 @@ Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from, Value to,
 /// ID/Count operations.
 linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
     const SmallVector<int64_t> &tileSizes,
-    linalg::DistributionMethod distributionMethod);
+    linalg::DistributionMethod distributionMethod,
+    int32_t maxWorkgroupParallelDims = kNumMaxParallelDims);
 
 //===---------------------------------------------------------------------===//
 // Misc. utility functions.


### PR DESCRIPTION
Setting the maxWorkgroupParallelDims option to 1 will dispatch all workgroups along the X dimension only.

Addresses #12642.