### PR TITLE
Add smoke tests to test inline hal compilation flow

### DIFF
--- a/tests/compiler_driver/BUILD.bazel
+++ b/tests/compiler_driver/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "executable_benchmarks.mlir",
             "hal_executable.mlir",
+            "inlinehal_executable.mlir",
             "preprocessing_flags.mlir",
             "smoketest.mlir",
             "streams.mlir",

--- a/tests/compiler_driver/BUILD.bazel
+++ b/tests/compiler_driver/BUILD.bazel
@@ -20,7 +20,8 @@ iree_lit_test_suite(
         [
             "executable_benchmarks.mlir",
             "hal_executable.mlir",
-            "inlinehal_executable.mlir",
+            "inline_dynamic_hal_executable.mlir",
+            "inline_static_hal_executable.mlir",
             "preprocessing_flags.mlir",
             "smoketest.mlir",
             "streams.mlir",

--- a/tests/compiler_driver/CMakeLists.txt
+++ b/tests/compiler_driver/CMakeLists.txt
@@ -16,7 +16,8 @@ iree_lit_test_suite(
   SRCS
     "executable_benchmarks.mlir"
     "hal_executable.mlir"
-    "inlinehal_executable.mlir"
+    "inline_dynamic_hal_executable.mlir"
+    "inline_static_hal_executable.mlir"
     "preprocessing_flags.mlir"
     "smoketest.mlir"
     "streams.mlir"

--- a/tests/compiler_driver/CMakeLists.txt
+++ b/tests/compiler_driver/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "executable_benchmarks.mlir"
     "hal_executable.mlir"
+    "inlinehal_executable.mlir"
     "preprocessing_flags.mlir"
     "smoketest.mlir"
     "streams.mlir"

--- a/tests/compiler_driver/inline_dynamic_hal_executable.mlir
+++ b/tests/compiler_driver/inline_dynamic_hal_executable.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-compile \
+// RUN:   --compile-to=hal \
+// RUN:   --mlir-print-ir-after-all \
+// RUN:   --iree-execution-model=inline-dynamic \
+// RUN:   --iree-hal-target-backends=vmvx %s \
+// RUN:   --o=/dev/null 2>&1 | FileCheck %s
+
+func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+  %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
+  return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
+}
+
+// CHECK-NOT: hal.command_buffer
+// CHECK-NOT: hal.allocator
+// CHECK-NOT: hal.event
+// CHECK-NOT: hal.fence
+// CHECK-NOT: hal.pipeline_layout
+// CHECK-NOT: hal.semaphore

--- a/tests/compiler_driver/inline_dynamic_hal_executable.mlir
+++ b/tests/compiler_driver/inline_dynamic_hal_executable.mlir
@@ -2,8 +2,7 @@
 // RUN:   --compile-to=hal \
 // RUN:   --mlir-print-ir-after-all \
 // RUN:   --iree-execution-model=inline-dynamic \
-// RUN:   --iree-hal-target-backends=vmvx %s \
-// RUN:   --o=/dev/null 2>&1 | FileCheck %s
+// RUN:   --iree-hal-target-backends=vmvx %s | FileCheck %s
 
 func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
   %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>

--- a/tests/compiler_driver/inline_dynamic_hal_executable.mlir
+++ b/tests/compiler_driver/inline_dynamic_hal_executable.mlir
@@ -9,6 +9,7 @@ func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf
   return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
 }
 
+// // Check the IR not registered as iree_hal_module_register_loader_types
 // CHECK-NOT: hal.command_buffer
 // CHECK-NOT: hal.allocator
 // CHECK-NOT: hal.event

--- a/tests/compiler_driver/inline_dynamic_hal_executable.mlir
+++ b/tests/compiler_driver/inline_dynamic_hal_executable.mlir
@@ -9,7 +9,7 @@ func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf
   return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
 }
 
-// // Check the IR not registered as iree_hal_module_register_loader_types
+// Check the IR not registered as iree_hal_module_register_loader_types
 // CHECK-NOT: hal.command_buffer
 // CHECK-NOT: hal.allocator
 // CHECK-NOT: hal.event

--- a/tests/compiler_driver/inline_static_hal_executable.mlir
+++ b/tests/compiler_driver/inline_static_hal_executable.mlir
@@ -1,8 +1,8 @@
 // RUN: iree-compile \
 // RUN:   --compile-to=hal \
 // RUN:   --mlir-print-ir-after-all \
-// RUN:   --iree-execution-model=inline-dynamic \
-// RUN:   --iree-hal-target-backends=llvm-cpu %s \
+// RUN:   --iree-execution-model=inline-static \
+// RUN:   --iree-hal-target-backends=vmvx %s \
 // RUN:   --o=/dev/null 2>&1 | FileCheck %s
 
 func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
@@ -16,3 +16,7 @@ func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf
 // CHECK-NOT: hal.fence
 // CHECK-NOT: hal.pipeline_layout
 // CHECK-NOT: hal.semaphore
+// CHECK-NOT: hal.executable
+
+// TODO(#12586): Check the IR not registered as iree_hal_module_register_common_types
+// XFAIL: *

--- a/tests/compiler_driver/inline_static_hal_executable.mlir
+++ b/tests/compiler_driver/inline_static_hal_executable.mlir
@@ -9,6 +9,7 @@ func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf
   return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
 }
 
+// Check the IR not registered as iree_hal_module_register_inline_types
 // CHECK-NOT: hal.command_buffer
 // CHECK-NOT: hal.allocator
 // CHECK-NOT: hal.event
@@ -17,5 +18,5 @@ func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf
 // CHECK-NOT: hal.semaphore
 // CHECK-NOT: hal.executable
 
-// TODO(#12586): Check the IR not registered as iree_hal_module_register_common_types
+// TODO(#12586): Remove this after tag.
 // XFAIL: *

--- a/tests/compiler_driver/inline_static_hal_executable.mlir
+++ b/tests/compiler_driver/inline_static_hal_executable.mlir
@@ -2,7 +2,7 @@
 // RUN:   --compile-to=hal \
 // RUN:   --mlir-print-ir-after-all \
 // RUN:   --iree-execution-model=inline-static \
-// RUN:   --iree-hal-target-backends=vmvx %s | FileCheck %s
+// RUN:   --iree-hal-target-backends=vmvx-inline %s | FileCheck %s
 
 func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
   %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>

--- a/tests/compiler_driver/inline_static_hal_executable.mlir
+++ b/tests/compiler_driver/inline_static_hal_executable.mlir
@@ -18,5 +18,5 @@ func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf
 // CHECK-NOT: hal.semaphore
 // CHECK-NOT: hal.executable
 
-// TODO(#12586): Remove this after tag.
+// TODO(#12586): Remove this after the issue is fixed.
 // XFAIL: *

--- a/tests/compiler_driver/inline_static_hal_executable.mlir
+++ b/tests/compiler_driver/inline_static_hal_executable.mlir
@@ -2,8 +2,7 @@
 // RUN:   --compile-to=hal \
 // RUN:   --mlir-print-ir-after-all \
 // RUN:   --iree-execution-model=inline-static \
-// RUN:   --iree-hal-target-backends=vmvx %s \
-// RUN:   --o=/dev/null 2>&1 | FileCheck %s
+// RUN:   --iree-hal-target-backends=vmvx %s | FileCheck %s
 
 func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
   %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>

--- a/tests/compiler_driver/inlinehal_executable.mlir
+++ b/tests/compiler_driver/inlinehal_executable.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-compile \
+// RUN:   --mlir-print-ir-after=inline \
+// RUN:   --iree-execution-model=inline-dynamic \
+// RUN:   --iree-hal-target-backends=llvm-cpu %s \
+// RUN:   --o=/dev/null 2>&1 | FileCheck %s
+
+func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+  %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
+  return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
+}
+
+// CHECK-NOT: hal.command_buffer
+// CHECK-NOT: hal.allocator
+// CHECK-NOT: hal.event
+// CHECK-NOT: hal.fence
+// CHECK-NOT: hal.pipeline_layout
+// CHECK-NOT: hal.semaphore
+// CHECK: vm.module public @module {

--- a/tests/compiler_driver/inlinehal_executable.mlir
+++ b/tests/compiler_driver/inlinehal_executable.mlir
@@ -1,5 +1,6 @@
 // RUN: iree-compile \
-// RUN:   --mlir-print-ir-after=inline \
+// RUN:   --compile-to=hal \
+// RUN:   --mlir-print-ir-after-all \
 // RUN:   --iree-execution-model=inline-dynamic \
 // RUN:   --iree-hal-target-backends=llvm-cpu %s \
 // RUN:   --o=/dev/null 2>&1 | FileCheck %s
@@ -15,4 +16,3 @@ func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf
 // CHECK-NOT: hal.fence
 // CHECK-NOT: hal.pipeline_layout
 // CHECK-NOT: hal.semaphore
-// CHECK: vm.module public @module {


### PR DESCRIPTION
Running iree-compile with `--iree-execution-model=inline-{static, dynamic}` and check if there is any hal IR not registered for inline HAL