### PR TITLE
Adds LLVMGPUCheckIRBeforeLLVMConversionPass to check shared memory allocation before lowering to LLVM

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -20,6 +20,7 @@ iree_compiler_cc_library(
         "ConvertToROCDL.cpp",
         "ExtractAddressComputationGPUPass.cpp",
         "KernelConfig.cpp",
+        "LLVMGPUCheckIRBeforeLLVMConversion.cpp",
         "LLVMGPUDistribute.cpp",
         "LLVMGPULowerExecutableTarget.cpp",
         "LLVMGPUPackSharedMemoryAlloc.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_library(
     "ConvertToROCDL.cpp"
     "ExtractAddressComputationGPUPass.cpp"
     "KernelConfig.cpp"
+    "LLVMGPUCheckIRBeforeLLVMConversion.cpp"
     "LLVMGPUDistribute.cpp"
     "LLVMGPULowerExecutableTarget.cpp"
     "LLVMGPUPackSharedMemoryAlloc.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCheckIRBeforeLLVMConversion.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Pass/Pass.h"
@@ -54,12 +55,7 @@ static LogicalResult checkGPUAllocationSize(func::FuncOp funcOp) {
   int cumSize = 0;
   for (auto allocOp : allocOps) {
     auto allocType = allocOp.getType().cast<MemRefType>();
-    if (auto attr = allocType.getMemorySpace()
-                        .dyn_cast_or_null<gpu::AddressSpaceAttr>()) {
-      if (attr.getValue() != gpu::GPUDialect::getWorkgroupAddressSpace()) {
-        continue;
-      }
-    } else {
+    if (!hasSharedMemoryAddressSpace(allocType)) {
       continue;
     }
     if (!allocOp.getDynamicSizes().empty()) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCheckIRBeforeLLVMConversion.cpp
@@ -1,0 +1,100 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "llvm/Support/CommandLine.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+static llvm::cl::opt<int> clMaxGPUSharedMemSize(
+    "iree-llvmgpu-shared-mem-allocation-limit",
+    llvm::cl::desc("maximum allowed shared memory size in bytes"),
+    llvm::cl::init(163 * 1024));
+
+namespace {
+struct LLVMGPUCheckIRBeforeLLVMConversionPass
+    : LLVMGPUCheckIRBeforeLLVMConversionBase<
+          LLVMGPUCheckIRBeforeLLVMConversionPass> {
+  void runOnOperation() override;
+};
+}  // namespace
+
+static int shapedTypeStaticSize(ShapedType shapedType) {
+  int allocSize = 1;
+  for (auto dimSize : shapedType.getShape()) {
+    if (ShapedType::isDynamic(dimSize)) continue;
+    allocSize *= dimSize;
+  }
+  if (auto elementType = shapedType.getElementType().dyn_cast<ShapedType>()) {
+    allocSize *= shapedTypeStaticSize(elementType);
+  } else {
+    allocSize *= shapedType.getElementType().getIntOrFloatBitWidth();
+  }
+  return allocSize;
+}
+
+/// Returns success if the total shared memory allocation size is less than the
+/// limit set by clMaxGPUSharedMemSize.
+static LogicalResult checkGPUAllocationSize(func::FuncOp funcOp) {
+  if (funcOp.getBody().empty()) return success();
+
+  SmallVector<memref::AllocOp> allocOps;
+  funcOp.walk([&](memref::AllocOp allocOp) { allocOps.push_back(allocOp); });
+  if (allocOps.empty()) {
+    return success();
+  }
+
+  int cumSize = 0;
+  for (auto allocOp : allocOps) {
+    auto allocType = allocOp.getType().cast<MemRefType>();
+    if (auto attr = allocType.getMemorySpace()
+                        .dyn_cast_or_null<gpu::AddressSpaceAttr>()) {
+      if (attr.getValue() != gpu::GPUDialect::getWorkgroupAddressSpace()) {
+        continue;
+      }
+    } else {
+      continue;
+    }
+    if (!allocOp.getDynamicSizes().empty()) {
+      return allocOp.emitOpError(
+          "dynamic shared memory allocations unsupported.");
+    }
+    int allocSize = shapedTypeStaticSize(allocType);
+    if (allocOp.getAlignment()) {
+      int64_t alignmentInBits = *allocOp.getAlignment() * 8;
+      allocSize =
+          (llvm::divideCeil(allocSize, alignmentInBits) * alignmentInBits);
+    }
+    cumSize += allocSize / 8;
+  }
+  if (cumSize > clMaxGPUSharedMemSize) {
+    return funcOp.emitOpError("exceeded GPU memory limit of ")
+           << clMaxGPUSharedMemSize.getValue() << " bytes for function. Got "
+           << cumSize << " bytes";
+  }
+  return success();
+}
+
+void LLVMGPUCheckIRBeforeLLVMConversionPass::runOnOperation() {
+  auto moduleOp = getOperation();
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+    if (failed(checkGPUAllocationSize(funcOp))) {
+      return signalPassFailure();
+    }
+  }
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createLLVMGPUCheckIRBeforeLLVMConversionPass() {
+  return std::make_unique<LLVMGPUCheckIRBeforeLLVMConversionPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -507,6 +507,9 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   addLowerAndOptimzeAddressComputation(pm);
   // THIS NEEDS TO RUN BEFORE SCF ->CF OFF
 
+  // Run checks on shared memory usage.
+  pm.addPass(createLLVMGPUCheckIRBeforeLLVMConversionPass());
+
   // SCF -> STD
   pm.addNestedPass<func::FuncOp>(createConvertSCFToCFPass());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -98,6 +98,7 @@ LogicalResult verifyGPUMatmulPipeline(
          "Store to workgroup memory currently expected to happen in stage 1 of "
          "software pipeline.");
 
+<<<<<<< HEAD
   // Get Operand/Result types.
   mlir::Type lhsType = op->getOperand(0).getType();
   mlir::Type rhsType = op->getOperand(1).getType();
@@ -112,6 +113,14 @@ LogicalResult verifyGPUMatmulPipeline(
 
   // Tile shapes in number of elements.
   SmallVector<int64_t> tileShape =
+=======
+  // Type inputType = op->getOperand(0).getType();
+  ArrayRef<int64_t> lhsShape =
+      op->getOperand(0).getType().cast<ShapedType>().getShape();
+  ArrayRef<int64_t> rhsShape =
+      op->getOperand(1).getType().cast<ShapedType>().getShape();
+  SmallVector<int64_t> firstLevelTileSizes =
+>>>>>>> 32cb36a47 (remove old shared memeory check)
       loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
   SmallVector<int64_t> threadBlockShape{tileShape};
 
@@ -167,6 +176,7 @@ LogicalResult verifyGPUMatmulPipeline(
            << pipelineName;
   }
 
+<<<<<<< HEAD
   // Verify shared memory usage is within the limit.
   // TODO(KoolJBlack): working on adding check shared memory usage.
 
@@ -243,6 +253,19 @@ LogicalResult verifyGPUMatmulPipeline(
            << " with compilation pipeline " << pipelineName;
   }
 
+=======
+  // Verify shared memory usage of operands after tiling requires <= 64Kb
+  // combined space.
+  // unsigned bytesSize =
+  //     inputType.cast<ShapedType>().getElementType().getIntOrFloatBitWidth() / 8;
+
+  // // Input shape sizes: A [ M x K],  B [ K x N]
+  // unsigned totalSharedMemSizeBytes =
+  //     (firstLevelTileSizes[0] * firstLevelTileSizes[2] +
+  //      firstLevelTileSizes[1] * firstLevelTileSizes[2]) *
+  //     bytesSize;
+
+>>>>>>> 32cb36a47 (remove old shared memeory check)
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -98,7 +98,6 @@ LogicalResult verifyGPUMatmulPipeline(
          "Store to workgroup memory currently expected to happen in stage 1 of "
          "software pipeline.");
 
-<<<<<<< HEAD
   // Get Operand/Result types.
   mlir::Type lhsType = op->getOperand(0).getType();
   mlir::Type rhsType = op->getOperand(1).getType();
@@ -113,14 +112,6 @@ LogicalResult verifyGPUMatmulPipeline(
 
   // Tile shapes in number of elements.
   SmallVector<int64_t> tileShape =
-=======
-  // Type inputType = op->getOperand(0).getType();
-  ArrayRef<int64_t> lhsShape =
-      op->getOperand(0).getType().cast<ShapedType>().getShape();
-  ArrayRef<int64_t> rhsShape =
-      op->getOperand(1).getType().cast<ShapedType>().getShape();
-  SmallVector<int64_t> firstLevelTileSizes =
->>>>>>> 32cb36a47 (remove old shared memeory check)
       loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
   SmallVector<int64_t> threadBlockShape{tileShape};
 
@@ -175,10 +166,6 @@ LogicalResult verifyGPUMatmulPipeline(
            << workgroupSize[kDimZ] << " with compilation pipeline "
            << pipelineName;
   }
-
-<<<<<<< HEAD
-  // Verify shared memory usage is within the limit.
-  // TODO(KoolJBlack): working on adding check shared memory usage.
 
   // Return success for SIMT/CUDA cores.
   if (pipeline.getValue() ==
@@ -253,19 +240,6 @@ LogicalResult verifyGPUMatmulPipeline(
            << " with compilation pipeline " << pipelineName;
   }
 
-=======
-  // Verify shared memory usage of operands after tiling requires <= 64Kb
-  // combined space.
-  // unsigned bytesSize =
-  //     inputType.cast<ShapedType>().getElementType().getIntOrFloatBitWidth() / 8;
-
-  // // Input shape sizes: A [ M x K],  B [ K x N]
-  // unsigned totalSharedMemSizeBytes =
-  //     (firstLevelTileSizes[0] * firstLevelTileSizes[2] +
-  //      firstLevelTileSizes[1] * firstLevelTileSizes[2]) *
-  //     bytesSize;
-
->>>>>>> 32cb36a47 (remove old shared memeory check)
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "attention.mlir",
+            "check_ir_before_llvm_conversion.mlir",
             "conv_pipeline_test.mlir",
             "convert_to_nvvm.mlir",
             "convert_to_rocdl.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "attention.mlir"
+    "check_ir_before_llvm_conversion.mlir"
     "conv_pipeline_test.mlir"
     "convert_to_nvvm.mlir"
     "convert_to_rocdl.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/check_ir_before_llvm_conversion.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/check_ir_before_llvm_conversion.mlir
@@ -1,0 +1,9 @@
+// RUN: iree-opt --iree-llvmgpu-check-ir-before-llvm-conversion %s --verify-diagnostics -split-input-file
+
+module {
+  // expected-error @+1 {{'func.func' op exceeded GPU memory limit of 166912 bytes for function. Got 274432 bytes}}
+  func.func @shared_mem_alloc(%arg0: index) {
+    %alloc = memref.alloc() : memref<274432xi8, #gpu.address_space<workgroup>>
+    return
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -587,6 +587,10 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTensorPadPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createLLVMGPUPackSharedMemoryAlloc();
 
+/// Checks GPU backend specific IR constraints such as shared memory limits.
+std::unique_ptr<OperationPass<ModuleOp>>
+createLLVMGPUCheckIRBeforeLLVMConversionPass();
+
 //------------------------------------------------------------------------------
 // SPIR-V Passes
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -714,6 +714,12 @@ def LLVMGPUTensorPad :
   let constructor = "mlir::iree_compiler::createLLVMGPUTensorPadPass()";
 }
 
+def LLVMGPUCheckIRBeforeLLVMConversion :
+    Pass<"iree-llvmgpu-check-ir-before-llvm-conversion", "ModuleOp"> {
+  let summary = "Checks GPU backend specific IR constraints such as shared memory limits";
+  let constructor = "mlir::iree_compiler::createLLVMGPUCheckIRBeforeLLVMConversionPass()";
+}
+
 //------------------------------------------------------------------------------
 // SPIR-V
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Applies a static shared memory check before llvm conversion. Current limit is set to 163KB based on `sm_86` (maximum we expect to see at any given point). Will followup with target specific checks based on sm. 

Similar to LLVMCPUCheckIRBeforeLLVMConversionPass but unable to reuse due to different allocation types. 