### PR TITLE
Generalize `iree_uk_cpu_features_list_t` for x86

### DIFF
--- a/runtime/src/iree/builtins/ukernel/tools/benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/benchmark.c
@@ -104,10 +104,18 @@ void iree_uk_benchmark_register(
   iree_string_builder_initialize(iree_allocator_system(), &full_name);
   IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, name));
   if (cpu_features) {
-    for (int i = 0; i < cpu_features->size; ++i) {
+    const char* cpu_features_name =
+        iree_uk_cpu_features_list_get_name(cpu_features);
+    if (cpu_features_name) {
       IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, "_"));
-      IREE_CHECK_OK(iree_string_builder_append_cstring(
-          &full_name, cpu_features->entries[i]));
+      IREE_CHECK_OK(
+          iree_string_builder_append_cstring(&full_name, cpu_features_name));
+    } else {
+      for (int i = 0; i < iree_uk_cpu_features_list_size(cpu_features); ++i) {
+        IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, "_"));
+        IREE_CHECK_OK(iree_string_builder_append_cstring(
+            &full_name, iree_uk_cpu_features_list_entry(cpu_features, i)));
+      }
     }
   }
   iree_benchmark_register(iree_string_builder_view(&full_name), &benchmark_def);

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -102,21 +102,23 @@ int main(int argc, char** argv) {
   iree_uk_benchmark_initialize(&argc, argv);
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_cpu_features_list_t cpu_dotprod =
-      iree_uk_cpu_features_list_1("dotprod");
-  iree_uk_cpu_features_list_t cpu_i8mm = iree_uk_cpu_features_list_1("i8mm");
+  iree_uk_cpu_features_list_t* cpu_dotprod =
+      iree_uk_cpu_features_list_create(1, "dotprod");
+  iree_uk_cpu_features_list_t* cpu_i8mm =
+      iree_uk_cpu_features_list_create(1, "i8mm");
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4,
-                                   &cpu_dotprod);
+                                   cpu_dotprod);
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8,
-                                   &cpu_i8mm);
+                                   cpu_i8mm);
+  iree_uk_cpu_features_list_destroy(cpu_dotprod);
+  iree_uk_cpu_features_list_destroy(cpu_i8mm);
 #else  // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
-
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
   iree_uk_benchmark_run_and_cleanup();

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
@@ -207,12 +207,15 @@ int main(int argc, char** argv) {
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 9, 6, 3, NULL);
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_cpu_features_list_t cpu_dotprod =
-      iree_uk_cpu_features_list_1("dotprod");
-  iree_uk_cpu_features_list_t cpu_i8mm = iree_uk_cpu_features_list_1("i8mm");
+  iree_uk_cpu_features_list_t* cpu_dotprod =
+      iree_uk_cpu_features_list_create(1, "dotprod");
+  iree_uk_cpu_features_list_t* cpu_i8mm =
+      iree_uk_cpu_features_list_create(1, "i8mm");
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4, &cpu_dotprod);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8, &cpu_i8mm);
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4, cpu_dotprod);
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8, cpu_i8mm);
+  iree_uk_cpu_features_list_destroy(cpu_dotprod);
+  iree_uk_cpu_features_list_destroy(cpu_i8mm);
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 }

--- a/runtime/src/iree/builtins/ukernel/tools/util.h
+++ b/runtime/src/iree/builtins/ukernel/tools/util.h
@@ -45,16 +45,21 @@ int iree_uk_type_pair_str(char* buf, int buf_length,
 int iree_uk_type_triple_str(char* buf, int buf_length,
                             const iree_uk_type_triple_t triple);
 
-#define IREE_UK_CPU_FEATURES_LIST_MAX_LENGTH 2
+typedef struct iree_uk_cpu_features_list_t iree_uk_cpu_features_list_t;
 
-typedef struct iree_uk_cpu_features_list_t {
-  int size;
-  const char* entries[IREE_UK_CPU_FEATURES_LIST_MAX_LENGTH];
-} iree_uk_cpu_features_list_t;
-
-iree_uk_cpu_features_list_t iree_uk_cpu_features_list_1(const char* feature1);
-iree_uk_cpu_features_list_t iree_uk_cpu_features_list_2(const char* feature1,
-                                                        const char* feature2);
+iree_uk_cpu_features_list_t* iree_uk_cpu_features_list_create(int count, ...);
+void iree_uk_cpu_features_list_destroy(iree_uk_cpu_features_list_t* list);
+void iree_uk_cpu_features_list_append(iree_uk_cpu_features_list_t* list,
+                                      int count, ...);
+iree_uk_cpu_features_list_t* iree_uk_cpu_features_list_create_extend(
+    iree_uk_cpu_features_list_t* list, int count, ...);
+int iree_uk_cpu_features_list_size(const iree_uk_cpu_features_list_t* list);
+const char* iree_uk_cpu_features_list_entry(
+    const iree_uk_cpu_features_list_t* list, int index);
+void iree_uk_cpu_features_list_set_name(iree_uk_cpu_features_list_t* list,
+                                        const char* name);
+const char* iree_uk_cpu_features_list_get_name(
+    const iree_uk_cpu_features_list_t* list);
 
 void iree_uk_make_cpu_data_for_features(
     const iree_uk_cpu_features_list_t* cpu_features,
@@ -63,5 +68,8 @@ void iree_uk_make_cpu_data_for_features(
 void iree_uk_initialize_cpu_once(void);
 
 bool iree_uk_cpu_supports(const iree_uk_uint64_t* cpu_data_fields);
+
+const char* iree_uk_cpu_first_unsupported_feature(
+    const iree_uk_cpu_features_list_t* cpu_features);
 
 #endif  // IREE_BUILTINS_UKERNEL_TOOLS_UTIL_H_


### PR DESCRIPTION
This is one last prerequisite for x86 ukernels: with x86 we will need to have sets of features that combine together > 5 features, e.g. just base AVX512 is actually a combination of 5 individual features (AVX512{F,BW,CD,VL,DQ}) and is meant to be added on top of AVX2 features (itself the combination AVX+AVX2+FMA).

So this generalizes `iree_uk_cpu_features_list_t` to:
  - Grow more gracefully to several/many features.  Technically it's a heap-backed vector now, but you'll see that the growth logic is very YAGNI : we grow once from capacity 0 to 64 hardcoded, and never again :-) So the code is very simple.  And it's an implementation detail of that grow function if we ever need something better.
  - Support definding cpu feature sets that extend others (e.g. define AVX512 extending AVX2)
  - Support optionally giving cpu feature sets short names instead of enumerating all individual features (otherwise, avx512 test log lines and benchmark names were very verbose and wrapped around multiple lines).

Moreover, this adds reporting of the first unsupported feature when a test gets skipped because of that.