### PR TITLE
Only exclude e2e_matmul_mmt4d_i8_small on RISC-V.

### DIFF
--- a/build_tools/cmake/test_riscv.sh
+++ b/build_tools/cmake/test_riscv.sh
@@ -86,6 +86,11 @@ if [[ "${RISCV_PLATFORM}-${RISCV_ARCH}" == "linux-riscv_32" ]]; then
   )
 fi
 
+test_exclude_args=(
+  # TODO(#12703): Enable the test.
+  "iree/tests/e2e/matmul/e2e_matmul_mmt4d_i8_small_llvm-cpu_local-task"
+)
+
 tests_label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]}"))"
 tests_exclude_regex="($(IFS="|" ; echo "${test_exclude_args[*]}"))"
 test_ctest_args=(

--- a/build_tools/cmake/test_riscv.sh
+++ b/build_tools/cmake/test_riscv.sh
@@ -86,7 +86,7 @@ if [[ "${RISCV_PLATFORM}-${RISCV_ARCH}" == "linux-riscv_32" ]]; then
   )
 fi
 
-test_exclude_args=(
+test_exclude_args+=(
   # TODO(#12703): Enable the test.
   "iree/tests/e2e/matmul/e2e_matmul_mmt4d_i8_small_llvm-cpu_local-task"
 )

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -56,8 +56,7 @@ py_binary(
                                    ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [
-    # TODO: https://github.com/openxla/iree/issues/12703
-    #   "i8",
+    "i8",
     "f32",
 ]]
 

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -44,6 +44,28 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
+    e2e_matmul_mmt4d_i8_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-flow-enable-data-tiling"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:+dotprod"
+    "arm_64:+i8mm"
+)
+
+iree_generated_trace_runner_test(
+  NAME
     e2e_matmul_mmt4d_f32_small
   GENERATOR
     "generate_e2e_matmul_tests.py"


### PR DESCRIPTION
The test only failed on RISC-V. We should not disable it for all the platforms.

https://github.com/openxla/iree/issues/12703