### PR TITLE
Properly use TrackingListener in transforms that do not consume their operands

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -112,8 +112,7 @@ struct OptimizeVectorTransferPass
     // TODO(thomasraoux): Remove it once the fix is merged.
     loopInvariantCodeMotion(funcOp);
     linalg::hoistRedundantVectorTransfers(funcOp);
-    IRRewriter rewriter(funcOp->getContext());
-    vector::transferOpflowOpt(rewriter, funcOp);
+    vector::transferOpflowOpt(funcOp);
 
     // Move bitcast inwards from loop region boundaries to increase chances to
     // cancel them.

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
@@ -111,7 +112,8 @@ struct OptimizeVectorTransferPass
     // TODO(thomasraoux): Remove it once the fix is merged.
     loopInvariantCodeMotion(funcOp);
     linalg::hoistRedundantVectorTransfers(funcOp);
-    vector::transferOpflowOpt(funcOp);
+    IRRewriter rewriter(funcOp->getContext());
+    vector::transferOpflowOpt(rewriter, funcOp);
 
     // Move bitcast inwards from loop region boundaries to increase chances to
     // cancel them.

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -21,7 +21,8 @@ namespace iree_compiler {
 
 /// Eliminates tensor.empty ops to avoid buffer allocations.
 LogicalResult eliminateEmptyTensors(
-    Operation *op, const bufferization::OneShotBufferizationOptions &options);
+    RewriterBase &rewriter, Operation *op,
+    const bufferization::OneShotBufferizationOptions &options);
 
 /// Bufferizes the given op with One-Shot Bufferize.
 LogicalResult runIREEOneShotBufferize(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -86,7 +86,7 @@ struct LLVMGPUVectorToGPUPass
         return signalPassFailure();
       }
     }
-    createAsyncGroups(funcOp, targetMmaSync);
+    createAsyncGroups(rewriter, funcOp, targetMmaSync);
 
     if (targetMmaSync) {
       swizzleSharedMemory(funcOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h
@@ -15,7 +15,8 @@ namespace iree_compiler {
 
 /// Helper to convert copy to shared memory to async copy. This creates groups
 /// of consecutive copies and emit wait operation right after.
-void createAsyncGroups(func::FuncOp funcOp, bool useMMASync);
+void createAsyncGroups(RewriterBase &rewriter, func::FuncOp funcOp,
+                       bool useMMASync);
 
 /// Function to do layout analysis and distribution.
 void doLayoutAnalysisAndDistribution(IRRewriter &rewriter, func::FuncOp funcOp);

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
@@ -57,6 +57,21 @@ public:
 #endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
   }
 
+  DiagnosedSilenceableFailure check(Location loc) {
+    if (failed(checkErrorState()))
+      return emitDefiniteFailure(loc, "listener failed");
+    return DiagnosedSilenceableFailure::success();
+  }
+  DiagnosedSilenceableFailure check(Location loc,
+                                    DiagnosedSilenceableFailure &&diag) {
+    LogicalResult listenerState = checkErrorState();
+    if (failed(listenerState)) {
+      (void)diag.checkAndReport();
+      return emitDefiniteFailure(loc, "listener failed");
+    }
+    return std::move(diag);
+  }
+
   void notifyOperationReplaced(Operation *op, ValueRange newValues) override;
 
   void notifyOperationRemoved(Operation *op) override;


### PR DESCRIPTION
#12681 simplified the effects of IREE transforms to avoid always consuming the input handle and thus improve usage.
This was however lacking proper tracking now that the nested handles were not automatically invalidated anymore.
The revision fixes this oversight.

Fixes #12759

This also requires an upstream cherry-pick to properly pass RewriterBase for IR rewrites in VectorTransferOpTransforms: 
 553cebde0669aa98bb0624d9203b008c6e02f40e 