### PR TITLE
Add dependency from summary job on `python_release_packages`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1423,6 +1423,7 @@ jobs:
       - test_build_benchmark_suites
 
       # Configurations
+      - python_release_packages
       - asan
       - tsan
       - small_runtime


### PR DESCRIPTION
This was missed in https://github.com/openxla/iree/pull/12346. Without
it, the job will not be blocking.
