### PR TITLE
Refactor specialization to run after distribution loops are removed

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/WorkgroupSpecializationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/WorkgroupSpecializationPass.cpp
@@ -10,25 +10,21 @@
 //
 // For example, it converts
 //
-// scf.for ...
 //   %tileSizeY = affine.min ...
-//   scf.for ...
-//     %tileSizeX = affine.min ...
-//     the_op with bounded tile sizes (The tensor is of dynamic shape.)
+//   %tileSizeX = affine.min ...
+//   the_op with bounded tile sizes (The tensor is of dynamic shape.)
 //
 // into
 //
-// scf.for
 //   %tileSizeY = affine.min ...
-//   scf.for
-//     %tileSizeX = affine.min ...
-//     %cmp0 = arith.cmpi %worksizeY, %tilesizeY
-//     %cmp1 = arith.cmpi %worksizeX, %tilesizeX
-//     %cond = arith.and %cmp0, %cmp1
-//     scf.if %cond
-//       operation with the static shape with the main tile sizes
-//     else
-//       original nested loops with dynamic shaped op
+//   %tileSizeX = affine.min ...
+//   %cmp0 = arith.cmpi %worksizeY, %tilesizeY
+//   %cmp1 = arith.cmpi %worksizeX, %tilesizeX
+//   %cond = arith.and %cmp0, %cmp1
+//   scf.if %cond
+//     operation with the static shape with the main tile sizes
+//   else
+//     original nested loops with dynamic shaped op
 //
 //===---------------------------------------------------------------------===//
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
@@ -53,61 +49,16 @@ static llvm::cl::opt<bool> clEnableWorkgroupSpecialization(
     "iree-codegen-enable-workgroup-specialization",
     llvm::cl::desc("Enable workgroup specialization."), llvm::cl::init(true));
 
-static bool isBoundedTileSizeOp(Operation *op, int64_t tileSize) {
-  if (!isa<AffineMinOp>(op)) return false;
-
-  AffineMinOp minOp = cast<AffineMinOp>(op);
-  AffineMap map = minOp.getAffineMap();
-
-  // The map is supposed to be the form of <(d0) -> (expr, TILE_SIZE)>
-  if (map.getNumResults() != 2) return false;
-
-  // Check either of the expr is the tile size. Check the RHS first since
-  // a constant appears in RHS after normalization.
-  if (map.getResult(1).isa<AffineConstantExpr>() &&
-      map.getResult(1).cast<AffineConstantExpr>().getValue() == tileSize)
-    return true;
-
-  if (map.getResult(0).isa<AffineConstantExpr>() &&
-      map.getResult(0).cast<AffineConstantExpr>().getValue() == tileSize)
-    return true;
-
-  return false;
-}
-
-static SmallVector<AffineMinOp> getBoundedTileSizeOps(scf::ForOp forOp,
-                                                      int64_t tileSize) {
-  SmallVector<AffineMinOp> minOps;
-
-  for (Operation *user : forOp.getInductionVar().getUsers()) {
-    if (isBoundedTileSizeOp(user, tileSize)) {
-      // check if all operands of the minOp are defined outside. This
-      // guarantees that the bounded tile size op does not depend on
-      // any value in the current loop body.
-      bool definedOutisde =
-          llvm::all_of(user->getOpOperands(), [&](OpOperand &opOperand) {
-            Operation *op = opOperand.get().getDefiningOp();
-            if (op) {
-              return op->getBlock() != forOp.getBody();
-            } else {
-              // It is a block argument, so it is already outside of body.
-              return true;
-            }
-          });
-
-      if (!definedOutisde) continue;
-
-      AffineMinOp minOp = cast<AffineMinOp>(user);
-      minOps.push_back(cast<AffineMinOp>(minOp));
+static std::optional<int64_t> getConstantLowerBound(AffineMinOp affineMinOp) {
+  for (AffineExpr expr : affineMinOp.getMap().getResults()) {
+    if (auto cst = expr.dyn_cast<AffineConstantExpr>()) {
+      return cst.getValue();
     }
   }
-
-  return minOps;
+  return std::nullopt;
 }
 
-// Specialize the tiled distribution loops with the main tile sizes.
-//
-// Input: A vector of LoopTilingAndDistributionInfo
+// Specialize the distributed function with the main tile sizes.
 //
 // Transformed output
 //   cond = (boundedTileSizeY != TileX) && (boundedTileSizeX != TileY) && ...
@@ -117,101 +68,56 @@ static SmallVector<AffineMinOp> getBoundedTileSizeOps(scf::ForOp forOp,
 //     distribution loops with dynamic shapes with the tile size
 //
 // Steps:
-//   1. bail out if the loop bounds are already a multiple of the tile size.
-//   2. create a condition for scf.if
-//   3. clone the body of the innermost loop in the else block.
-//   4. clone the body of the else block into the then block and update the
-//      bounded size ops with the constant tile size during the cloning.
-static void specializeDistributionLoops(
-    SmallVector<LoopTilingAndDistributionInfo> &infoVec) {
-  // get the scf for loop nests and their tile size.
-  SmallVector<scf::ForOp> distLoops;
-  SmallVector<int64_t> tileSizes;
+// 1. Walk the code and collect affine.min that only depend on workgroup.id
+// and have one constant result.
+// 2. Move those at the top of the function
+// 3. Create a condition that ANDs all the affineMin == constant
+// 4. Splice the rest of the block and clone into a specialized if/else
+static void specializeFunction(func::FuncOp funcOp) {
   SmallVector<AffineMinOp> minSizeOps;
-
-  // Distribution info vector has the innermost loop at index 0.
-  for (auto &info : infoVec) {
-    auto forOp = cast<scf::ForOp>(info.loop);
-    distLoops.push_back(forOp);
-    if (!info.tileSize) {
-      return;
+  SmallVector<Operation *> ids;
+  funcOp.walk([&minSizeOps, &ids](Operation *op) {
+    if (auto affineMin = dyn_cast<AffineMinOp>(op)) {
+      for (Value operand : affineMin->getOperands()) {
+        if (!operand.getDefiningOp<IREE::HAL::InterfaceWorkgroupIDOp>()) {
+          return WalkResult::advance();
+        }
+        ids.push_back(operand.getDefiningOp());
+      }
+      if (!getConstantLowerBound(affineMin)) {
+        return WalkResult::advance();
+      }
+      minSizeOps.push_back(affineMin);
     }
-    int64_t tileSize = *info.tileSize;
-    tileSizes.push_back(tileSize);
-    SmallVector<AffineMinOp> boundedTileSizesOps =
-        getBoundedTileSizeOps(forOp, tileSize);
-    if (boundedTileSizesOps.empty()) {
-      // When there is no bounded tile size op, it means that the tensor
-      // size is already a multiple of tile size.
-      minSizeOps.push_back(AffineMinOp());
-    } else if (boundedTileSizesOps.size() != 1) {
-      // Supposed to see only one op for the bounded tile size if any.
-      return;
-    } else {
-      minSizeOps.push_back(boundedTileSizesOps[0]);
-    }
+    return WalkResult::advance();
+  });
+  if (minSizeOps.empty()) {
+    return;
   }
 
-  // Check the eligilbility. Unsupported cases are:
-  //   1. Dynamic cases
-  //   2. UB < Tile size
-  //   3. UB == a multiple of the tile size
-  bool isAlreadyMultiple = true;
-  for (unsigned i = 0, e = distLoops.size(); i != e; ++i) {
-    scf::ForOp loop = distLoops[i];
-    auto ubOp = loop.getUpperBound().getDefiningOp<arith::ConstantIndexOp>();
-    if (!ubOp) {
-      // TODO: handle dynamic cases by adding more code to check the
-      // conditions.
-      return;
-    }
-    int64_t ub = ubOp.value();
-    int64_t tileSize = tileSizes[i];
-    if (ub % tileSize != 0) {
-      isAlreadyMultiple = false;
-    }
-    if (ub < tileSize) {
-      return;
-    }
-  }
+  auto loc = funcOp.getLoc();
+  Block *block = &(*funcOp.getRegion().getBlocks().begin());
 
-  if (isAlreadyMultiple) return;
-
-  scf::ForOp innermostLoop = distLoops[0];
-  auto loc = innermostLoop.getLoc();
-  Block *block = innermostLoop.getBody();
-
-  OpBuilder builder(innermostLoop->getContext());
+  OpBuilder builder(funcOp->getContext());
   OpBuilder::InsertionGuard guard(builder);
-
-  AffineMinOp minOp0 = minSizeOps[0];
-  if (minOp0) {
-    // Make sure the affine.min in the innermost loop is the first
-    // instruction in the body.
-    auto minOp = llvm::dyn_cast_or_null<AffineMinOp>(block->front());
-    if (!minOp || minOp != minOp0) {
-      minOp0->moveBefore(&block->front());
-    }
-    builder.setInsertionPointAfter(&block->front());
-  } else {
-    builder.setInsertionPoint(&block->front());
+  // Move ops at the top of the function. This is always correct as those only
+  // depends on workgroup ids.
+  for (AffineMinOp affineMin : llvm::reverse(minSizeOps)) {
+    affineMin->moveBefore(&block->front());
   }
-
+  for (Operation *id : llvm::reverse(ids)) {
+    id->moveBefore(&block->front());
+  }
+  builder.setInsertionPointAfter(minSizeOps.back());
   // create a condition for scf.if
   Value cond;
   SmallVector<Value> constantOps;  // ConstantIndexOps for tile sizes
-  for (unsigned i = 0, e = distLoops.size(); i != e; ++i) {
+  for (unsigned i = 0, e = minSizeOps.size(); i != e; ++i) {
     AffineMinOp minOp = minSizeOps[i];
-    if (!minOp) {
-      // add a dummy value to indicate that this loop does not have an
-      // op for the bounded tile size.
-      constantOps.push_back(Value());
-      continue;
-    }
-
+    int64_t lowerBound = *getConstantLowerBound(minOp);
     // Generate a compare op that checks the dynamic size is equal to the
     // constant main tile size.
-    Value constant = builder.create<arith::ConstantIndexOp>(loc, tileSizes[i]);
+    Value constant = builder.create<arith::ConstantIndexOp>(loc, lowerBound);
     constantOps.push_back(constant);
     Value cmp = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
                                               minOp, constant);
@@ -255,12 +161,7 @@ struct WorkgroupSpecializationPass
     if (!clEnableWorkgroupSpecialization) return;
 
     func::FuncOp funcOp = getOperation();
-    SmallVector<LoopTilingAndDistributionInfo> infoVec =
-        getTiledAndDistributedLoopInfo(funcOp);
-
-    if (infoVec.empty()) return;
-
-    specializeDistributionLoops(infoVec);
+    specializeFunction(funcOp);
   }
 };
 }  // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/test/workgroup_specialization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/workgroup_specialization.mlir
@@ -1,45 +1,34 @@
 // RUN: iree-opt --iree-codegen-enable-workgroup-specialization --iree-codegen-workgroup-specialization --canonicalize --cse --split-input-file %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [16, 4, 0], [0, 0, 64]]>
-#map0 = affine_map<()[s0] -> (s0 * 64)>
-#map1 = affine_map<(d0) -> (-d0 + 123, 64)>
-#map2 = affine_map<(d0) -> (-d0 + 789, 64)>
-
+#map = affine_map<()[s0] -> (s0 * 64)>
+#map1 = affine_map<()[s0] -> (s0 * -64 + 123, 64)>
+#map2 = affine_map<()[s0] -> (s0 * -64 + 789, 64)>
 func.func @matmul_tensors() {
-  %c123 = arith.constant 123 : index
-  %c789 = arith.constant 789 : index
   %cst = arith.constant 0.000000e+00 : f32
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<123x456xf32>>
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<456x789xf32>>
   %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<123x789xf32>>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
-  %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
-  %workgroup_count_y = hal.interface.workgroup.count[1] : index
-  %3 = affine.apply #map0()[%workgroup_id_y]
-  %4 = affine.apply #map0()[%workgroup_count_y]
-  scf.for %arg0 = %3 to %c123 step %4 {
-    %5 = affine.min #map1(%arg0)
-    %6 = affine.apply #map0()[%workgroup_id_x]
-    %7 = affine.apply #map0()[%workgroup_count_x]
-    scf.for %arg1 = %6 to %c789 step %7 {
-      %8 = affine.min #map2(%arg1)
-      %9 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%5, 456], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<123x456xf32>> -> tensor<?x456xf32>
-      %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [456, %8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<456x789xf32>> -> tensor<456x?xf32>
-      %11 = tensor.empty(%5, %8) : tensor<?x?xf32>
-      %12 = linalg.fill ins(%cst : f32) outs(%11 : tensor<?x?xf32>) -> tensor<?x?xf32>
-      %13 = linalg.matmul {lowering_config = #config} ins(%9, %10 : tensor<?x456xf32>, tensor<456x?xf32>) outs(%12 : tensor<?x?xf32>) -> tensor<?x?xf32>
-      flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%5, %8], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<123x789xf32>>
-    }
-  }
+  %3 = affine.apply #map()[%workgroup_id_y]
+  %4 = affine.min #map1()[%workgroup_id_y]
+  %5 = affine.apply #map()[%workgroup_id_x]
+  %6 = affine.min #map2()[%workgroup_id_x]
+  %7 = flow.dispatch.tensor.load %0, offsets = [%3, 0], sizes = [%4, 456], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<123x456xf32>> -> tensor<?x456xf32>
+  %8 = flow.dispatch.tensor.load %1, offsets = [0, %5], sizes = [456, %6], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<456x789xf32>> -> tensor<456x?xf32>
+  %9 = tensor.empty(%4, %6) : tensor<?x?xf32>
+  %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %11 = linalg.matmul {lowering_config = #config} ins(%7, %8 : tensor<?x456xf32>, tensor<456x?xf32>) outs(%10 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  flow.dispatch.tensor.store %11, %2, offsets = [%3, %5], sizes = [%4, %6], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<123x789xf32>>
   return
 }
 
+
 // CHECK: func.func @matmul_tensors()
-// CHECK:   scf.for
-// CHECK:     scf.for
-// CHECK:       %[[CMP0:.+]] = arith.cmpi eq, %{{.+}}, %c64 : index
-// CHECK:       %[[CMP1:.+]] = arith.cmpi eq, %{{.+}}, %c64 : index
+// CHECK:       %[[C64:.+]] = arith.constant 64 : index
+// CHECK:       %[[CMP0:.+]] = arith.cmpi eq, %{{.+}}, %[[C64]] : index
+// CHECK:       %[[CMP1:.+]] = arith.cmpi eq, %{{.+}}, %[[C64]] : index
 // CHECK:       %[[COND:.+]] = arith.andi %[[CMP0]], %[[CMP1]] : i1
 // CHECK:       scf.if %[[COND]] {
 // CHECK:         linalg.matmul
@@ -51,50 +40,38 @@ func.func @matmul_tensors() {
 // -----
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [16, 4, 0], [0, 0, 64]]>
-#map0 = affine_map<()[s0] -> (s0 * 64)>
-#map1 = affine_map<(d0) -> (-d0 + 123, 64)>
-#map2 = affine_map<(d0) -> (-d0 + 789, 64)>
+#map = affine_map<()[s0] -> (s0 * 64)>
+#map1 = affine_map<()[s0] -> (s0 * -64 + 123, 64)>
+#map2 = affine_map<()[s0] -> (s0 * -64 + 789, 64)>
 #map3 = affine_map<(d0, d1) -> (d0, d1)>
-
 func.func @add_tensors() {
-  %c123 = arith.constant 123 : index
-  %c789 = arith.constant 789 : index
   %cst = arith.constant 0.000000e+00 : f32
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<123x789xf32>>
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<123x789xf32>>
   %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<123x789xf32>>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
-  %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
-  %workgroup_count_y = hal.interface.workgroup.count[1] : index
-  %3 = affine.apply #map0()[%workgroup_id_y]
-  %4 = affine.apply #map0()[%workgroup_count_y]
-  scf.for %arg0 = %3 to %c123 step %4 {
-    %5 = affine.min #map1(%arg0)
-    %6 = affine.apply #map0()[%workgroup_id_x]
-    %7 = affine.apply #map0()[%workgroup_count_x]
-    scf.for %arg1 = %6 to %c789 step %7 {
-      %8 = affine.min #map2(%arg1)
-      %9 = flow.dispatch.tensor.load %0, offsets = [%arg0, %arg1], sizes = [%5, %8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<123x789xf32>> -> tensor<?x?xf32>
-      %10 = flow.dispatch.tensor.load %1, offsets = [%arg0, %arg1], sizes = [%5, %8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<123x789xf32>> -> tensor<?x?xf32>
-      %11 = tensor.empty(%5, %8) : tensor<?x?xf32>
-      %12 = linalg.fill ins(%cst : f32) outs(%11 : tensor<?x?xf32>) -> tensor<?x?xf32>
-      %13 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%9, %10 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%12 : tensor<?x?xf32>) attrs =  {lowering_config = #config} {
-      ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):
-        %14 = arith.addf %arg2, %arg3 : f32
-        linalg.yield %14 : f32
-      } -> tensor<?x?xf32>
-      flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%5, %8], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<123x789xf32>>
-    }
-  }
+  %3 = affine.apply #map()[%workgroup_id_y]
+  %4 = affine.min #map1()[%workgroup_id_y]
+  %5 = affine.apply #map()[%workgroup_id_x]
+  %6 = affine.min #map2()[%workgroup_id_x]
+  %7 = flow.dispatch.tensor.load %0, offsets = [%3, %5], sizes = [%4, %6], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<123x789xf32>> -> tensor<?x?xf32>
+  %8 = flow.dispatch.tensor.load %1, offsets = [%3, %5], sizes = [%4, %6], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<123x789xf32>> -> tensor<?x?xf32>
+  %9 = tensor.empty(%4, %6) : tensor<?x?xf32>
+  %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %11 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%10 : tensor<?x?xf32>) attrs =  {lowering_config = #config} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %12 = arith.addf %in, %in_0 : f32
+    linalg.yield %12 : f32
+  } -> tensor<?x?xf32>
+  flow.dispatch.tensor.store %11, %2, offsets = [%3, %5], sizes = [%4, %6], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<123x789xf32>>
   return
 }
 
 // CHECK: func.func @add_tensors()
-// CHECK:   scf.for
-// CHECK:     scf.for
-// CHECK:       %[[CMP0:.+]] = arith.cmpi eq, %{{.+}}, %c64 : index
-// CHECK:       %[[CMP1:.+]] = arith.cmpi eq, %{{.+}}, %c64 : index
+// CHECK:       %[[C64:.+]] = arith.constant 64 : index
+// CHECK:       %[[CMP0:.+]] = arith.cmpi eq, %{{.+}}, %[[C64]] : index
+// CHECK:       %[[CMP1:.+]] = arith.cmpi eq, %{{.+}}, %[[C64]] : index
 // CHECK:       %[[COND:.+]] = arith.andi %[[CMP0]], %[[CMP1]] : i1
 // CHECK:       scf.if %[[COND]] {
 // CHECK:         linalg.generic
@@ -105,10 +82,13 @@ func.func @add_tensors() {
 
 // -----
 
+#config = #iree_codegen.lowering_config<tile_sizes = [[2, 256, 4]]>
+#map = affine_map<()[s0] -> (s0 * 2)>
+#map1 = affine_map<()[s0] -> (s0 * 256)>
+#map2 = affine_map<()[s0] -> (s0 * -256 + 30522, 256)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+#map4 = affine_map<(d0, d1) -> (d1)>
 func.func @unaligned_partial_loop() {
-  %c2 = arith.constant 2 : index
-  %c128 = arith.constant 128 : index
-  %c30522 = arith.constant 30522 : index
   %c512 = arith.constant 512 : index
   %c786944 = arith.constant 786944 : index
   %c265458176 = arith.constant 265458176 : index
@@ -119,40 +99,29 @@ func.func @unaligned_partial_loop() {
   %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c265458176) : !flow.dispatch.tensor<readonly:tensor<30522xf32>>
   %3 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<128x30522xf32>>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
-  %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
-  %workgroup_count_y = hal.interface.workgroup.count[1] : index
-  %4 = affine.apply affine_map<()[s0] -> (s0 * 2)>()[%workgroup_id_y]
-  %5 = affine.apply affine_map<()[s0] -> (s0 * 2)>()[%workgroup_count_y]
-  scf.for %arg0 = %4 to %c128 step %5 {
-    %6 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%workgroup_id_x]
-    %7 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%workgroup_count_x]
-    scf.for %arg1 = %6 to %c30522 step %7 {
-      %8 = affine.min affine_map<(d0) -> (-d0 + 30522, 256)>(%arg1)
-      %9 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%c2, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x768xf32>> -> tensor<?x768xf32>
-      %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [768, %8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<768x30522xf32>> -> tensor<768x?xf32>
-      %11 = tensor.empty(%8) : tensor<2x?xf32>
-      %12 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[2, 256, 4]]>} ins(%cst : f32) outs(%11 : tensor<2x?xf32>) -> tensor<2x?xf32>
-      %13 = tensor.cast %9 : tensor<?x768xf32> to tensor<2x768xf32>
-      %14 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[2, 256, 4]]>} ins(%13, %10 : tensor<2x768xf32>, tensor<768x?xf32>) outs(%12 : tensor<2x?xf32>) -> tensor<2x?xf32>
-      %15 = flow.dispatch.tensor.load %2, offsets = [%arg1], sizes = [%8], strides = [1] : !flow.dispatch.tensor<readonly:tensor<30522xf32>> -> tensor<?xf32>
-      %16 = tensor.empty(%8) : tensor<2x?xf32>
-      %17 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%14, %15 : tensor<2x?xf32>, tensor<?xf32>) outs(%16 : tensor<2x?xf32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[2, 256, 4]]>} {
-      ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):
-        %19 = arith.addf %arg2, %arg3 : f32
-        linalg.yield %19 : f32
-      } -> tensor<2x?xf32>
-      %18 = tensor.cast %17 : tensor<2x?xf32> to tensor<?x?xf32>
-      flow.dispatch.tensor.store %18, %3, offsets = [%arg0, %arg1], sizes = [%c2, %8], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x30522xf32>>
-    }
-  }
+  %4 = affine.apply #map()[%workgroup_id_y]
+  %5 = affine.apply #map1()[%workgroup_id_x]
+  %6 = affine.min #map2()[%workgroup_id_x]
+  %7 = flow.dispatch.tensor.load %0, offsets = [%4, 0], sizes = [2, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x768xf32>> -> tensor<2x768xf32>
+  %8 = flow.dispatch.tensor.load %1, offsets = [0, %5], sizes = [768, %6], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<768x30522xf32>> -> tensor<768x?xf32>
+  %9 = tensor.empty(%6) : tensor<2x?xf32>
+  %10 = linalg.fill {lowering_config = #config} ins(%cst : f32) outs(%9 : tensor<2x?xf32>) -> tensor<2x?xf32>
+  %11 = linalg.matmul {lowering_config = #config} ins(%7, %8 : tensor<2x768xf32>, tensor<768x?xf32>) outs(%10 : tensor<2x?xf32>) -> tensor<2x?xf32>
+  %12 = flow.dispatch.tensor.load %2, offsets = [%5], sizes = [%6], strides = [1] : !flow.dispatch.tensor<readonly:tensor<30522xf32>> -> tensor<?xf32>
+  %13 = tensor.empty(%6) : tensor<2x?xf32>
+  %14 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel"]} ins(%11, %12 : tensor<2x?xf32>, tensor<?xf32>) outs(%13 : tensor<2x?xf32>) attrs =  {lowering_config = #config} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %15 = arith.addf %in, %in_0 : f32
+    linalg.yield %15 : f32
+  } -> tensor<2x?xf32>
+  flow.dispatch.tensor.store %14, %3, offsets = [%4, %5], sizes = [2, %6], strides = [1, 1] : tensor<2x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x30522xf32>>
   return
 }
 
 // CHECK: func.func @unaligned_partial_loop()
-// CHECK:   scf.for
-// CHECK:     scf.for
-// CHECK:       %[[COND:.+]] = arith.cmpi eq, %{{.+}}, %c256 : index
+// CHECK:       %[[C256:.+]] = arith.constant 256 : index
+// CHECK:       %[[COND:.+]] = arith.cmpi eq, %{{.+}}, %[[C256]] : index
 // CHECK:       scf.if %[[COND]] {
 // CHECK:         linalg.matmul
 // CHECK-SAME:                  ins(%{{.+}}, %{{.+}} : tensor<2x768xf32>, tensor<768x256xf32>) outs(%{{.+}} : tensor<2x256xf32>)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -122,20 +122,19 @@ void addGPUVectorizationPassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createWorkgroupSpecializationPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createRemoveSingleIterationLoopPass());
   // Distribute linalg onto threads within the workgroup.
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUTileTensor(false));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
-
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createRemoveSingleIterationLoopPass());
 
   // Linalg -> vector
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUVectorizationPass());
@@ -160,13 +159,14 @@ void addGPUVectorizationPassPipeline(OpPassManager &pm) {
 void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createWorkgroupSpecializationPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
-
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createRemoveSingleIterationLoopPass());
 
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUTensorAlloc());
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUTileTensor(false));
@@ -340,13 +340,14 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
 void addGPUTransposePassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createWorkgroupSpecializationPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
-
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createRemoveSingleIterationLoopPass());
 
   nestedModulePM.addNestedPass<func::FuncOp>(
       createLLVMGPUTensorAlloc(GPUPromoteSharedMemPattern::TransposeOpPattern));
@@ -424,13 +425,15 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
 void addGPUPackUnPackPasses(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createWorkgroupSpecializationPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createRemoveSingleIterationLoopPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUTileTensor(false));
   nestedModulePM.addNestedPass<func::FuncOp>(
       createVectorizePackUnPackOpsPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/workgroup_specialization_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/workgroup_specialization_pipeline_test.mlir
@@ -93,12 +93,12 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 //  CHECK-DAG:   %[[cst:.*]] = arith.constant 0.000000e+00 : f32
 //  CHECK-DAG:   %[[c256:.*]] = arith.constant 256 : index
 //  CHECK-DAG:   %[[c0:.*]] = arith.constant 0 : index
-//      CHECK:   %[[ARR:.*]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%[[c0]]) : memref<102401xf32>
-//      CHECK:   %[[ARR2:.*]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%[[c0]]) : memref<102401xf32>
 //      CHECK:   %[[BLKX:.*]] = hal.interface.workgroup.id[0] : index
 //      CHECK:   %[[BLKX2:.*]] = affine.min #{{.+}}()[%[[BLKX]]]
 //      CHECK:   %[[CMP:.*]] = arith.cmpi eq, %[[BLKX2]], %[[c256]] : index
 //      CHECK:   scf.if %[[CMP]]
+//      CHECK:   %[[ARR:.*]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%[[c0]]) : memref<102401xf32>
+//      CHECK:   %[[ARR2:.*]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%[[c0]]) : memref<102401xf32>
 //      CHECK:   %[[TIDX:.*]] = gpu.thread_id  x
 //      CHECK:   %[[AFF:.*]] = affine.apply #{{.+}}(%[[TIDX]])[%[[BLKX]]]
 //      CHECK:   vector.transfer_read %[[ARR]][%[[AFF]]], %[[cst]] {in_bounds = [true]} : memref<102401xf32>, vector<4xf32>


### PR DESCRIPTION
This will allow us to remove distribution loops without any interaction with this pass. This also remove dependency to the brittle tiled loop analysis.