### PR TITLE
x86 ukernels for pack/unpack

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.c
@@ -31,13 +31,12 @@ static void iree_uk_unpack_tile_8x8_x32_arm_64_direct(
 
 iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_arm_64(
     const iree_uk_unpack_params_t* params) {
-  // At the moment, as sum-reductions are not yet part of pack ops,
-  // no arithmetic whatsoever is being done here, so only the element type
-  // size matters, not the type itself.
   int esize = iree_uk_type_size(iree_uk_unpack_out_type(params->type));
   bool transpose = params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER;
-  if (esize == 4 && params->in_size2 == 8 && params->in_size3 == 8) {
-    return transpose ? 0 : iree_uk_unpack_tile_8x8_x32_arm_64_direct;
+  // Unpack is currently only used in practice with esize==4 and non-transpose.
+  if (esize != 4 || transpose) return 0;
+  if (params->in_size2 == 8 && params->in_size3 == 8) {
+    return iree_uk_unpack_tile_8x8_x32_arm_64_direct;
   }
   return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
@@ -83,6 +83,8 @@ if(IREE_UK_BUILD_X86_64_AVX2_FMA)
       x86_64_avx2_fma
     SRCS
       "mmt4d_x86_64_avx2_fma.c"
+      "pack_x86_64_avx2_fma.c"
+      "unpack_x86_64_avx2_fma.c"
     COPTS
       "${IREE_UK_COPTS_X86_64_AVX2_FMA}"
     DEPS
@@ -97,6 +99,8 @@ if(IREE_UK_BUILD_X86_64_AVX512_BASE)
       x86_64_avx512_base
     SRCS
       "mmt4d_x86_64_avx512_base.c"
+      "pack_x86_64_avx512_base.c"
+      "unpack_x86_64_avx512_base.c"
     COPTS
       "${IREE_UK_COPTS_X86_64_AVX512_BASE}"
     DEPS
@@ -125,10 +129,14 @@ iree_cc_library(
     x86_64
   HDRS
     "mmt4d_x86_64.h"
+    "pack_x86_64.h"
     "query_tile_sizes_x86_64.h"
+    "unpack_x86_64.h"
   SRCS
     "mmt4d_x86_64.c"
+    "pack_x86_64.c"
     "query_tile_sizes_x86_64.c"
+    "unpack_x86_64.c"
   DEPS
     ::common_x86_64
     iree::base::core_headers

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/common_x86_64.h
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/common_x86_64.h
@@ -93,3 +93,338 @@ static inline void iree_uk_avx512_storeu_4x128_to_16x16xi32(
                                      dst + i2 * 16 + j2, dst + i3 * 16 + j3,
                                      vec512);
 }
+
+static inline void iree_uk_copy_8x32xi8_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  for (int i = 0; i < 8; ++i) {
+    iree_uk_memcpy(out_ptr + i * out_stride, in_ptr + i * in_stride, 32);
+  }
+}
+
+static inline void iree_uk_copy_16x64xi8_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  for (int i = 0; i < 16; ++i) {
+    iree_uk_memcpy(out_ptr + i * out_stride, in_ptr + i * in_stride, 64);
+  }
+}
+
+static inline __m256i iree_uk_avx2_load_8x4xi8_strided(
+    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
+  __m256i indices = _mm256_mullo_epi32(
+      _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7), _mm256_set1_epi32(stride));
+  return _mm256_i32gather_epi32(src, indices, 1);
+}
+
+static inline __m512i iree_uk_avx512_load_16x4xi8_strided(
+    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
+  __m512i indices = _mm512_mullo_epi32(
+      _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+      _mm512_set1_epi32(stride));
+  return _mm512_i32gather_epi32(indices, src, 1);
+}
+
+static inline __m128i iree_uk_avx2_load_8x2xi8_strided(
+    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
+  __m128i result = _mm_setzero_si128();
+  const iree_uk_uint16_t* src_i16 = (const iree_uk_int16_t*)src;
+  result =
+      _mm_insert_epi16(result, *(const iree_uk_int16_t*)(src + 0 * stride), 0);
+  result =
+      _mm_insert_epi16(result, *(const iree_uk_int16_t*)(src + 1 * stride), 1);
+  result =
+      _mm_insert_epi16(result, *(const iree_uk_int16_t*)(src + 2 * stride), 2);
+  result =
+      _mm_insert_epi16(result, *(const iree_uk_int16_t*)(src + 3 * stride), 3);
+  result =
+      _mm_insert_epi16(result, *(const iree_uk_int16_t*)(src + 4 * stride), 4);
+  result =
+      _mm_insert_epi16(result, *(const iree_uk_int16_t*)(src + 5 * stride), 5);
+  result =
+      _mm_insert_epi16(result, *(const iree_uk_int16_t*)(src + 6 * stride), 6);
+  result =
+      _mm_insert_epi16(result, *(const iree_uk_int16_t*)(src + 7 * stride), 7);
+  return result;
+}
+
+static inline __m256i iree_uk_avx2_load_16x2xi8_strided(
+    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
+  __m256i result = _mm256_setzero_si256();
+  const iree_uk_uint16_t* src_i16 = (const iree_uk_int16_t*)src;
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 0 * stride), 0);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 1 * stride), 1);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 2 * stride), 2);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 3 * stride), 3);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 4 * stride), 4);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 5 * stride), 5);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 6 * stride), 6);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 7 * stride), 7);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 8 * stride), 8);
+  result = _mm256_insert_epi16(result,
+                               *(const iree_uk_int16_t*)(src + 9 * stride), 9);
+  result = _mm256_insert_epi16(
+      result, *(const iree_uk_int16_t*)(src + 10 * stride), 10);
+  result = _mm256_insert_epi16(
+      result, *(const iree_uk_int16_t*)(src + 11 * stride), 11);
+  result = _mm256_insert_epi16(
+      result, *(const iree_uk_int16_t*)(src + 12 * stride), 12);
+  result = _mm256_insert_epi16(
+      result, *(const iree_uk_int16_t*)(src + 13 * stride), 13);
+  result = _mm256_insert_epi16(
+      result, *(const iree_uk_int16_t*)(src + 14 * stride), 14);
+  result = _mm256_insert_epi16(
+      result, *(const iree_uk_int16_t*)(src + 15 * stride), 15);
+  return result;
+}
+
+static inline void iree_uk_avx2_copy_8x4xi8_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  __m256i in = iree_uk_avx2_load_8x4xi8_strided(in_ptr, in_stride);
+  _mm256_storeu_si256((__m256i*)out_ptr, in);
+}
+
+static inline void iree_uk_avx512_copy_16x4xi8_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  __m512i in = iree_uk_avx512_load_16x4xi8_strided(in_ptr, in_stride);
+  _mm512_storeu_si512((__m512i*)out_ptr, in);
+}
+
+static inline void iree_uk_avx2_copy_8x2xi8_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  __m128i in = iree_uk_avx2_load_8x2xi8_strided(in_ptr, in_stride);
+  _mm_storeu_si128((__m128i*)out_ptr, in);
+}
+
+static inline void iree_uk_avx2_copy_16x2xi8_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  __m256i in = iree_uk_avx2_load_16x2xi8_strided(in_ptr, in_stride);
+  _mm256_storeu_si256((__m256i*)out_ptr, in);
+}
+
+static inline void
+iree_uk_avx2_copy_8x16xi8_tiled_1x4_transpose_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  __m256i r00004444 =
+      iree_uk_avx_loadu_2x128(in_ptr + 0 * in_stride, in_ptr + 4 * in_stride);
+  __m256i r11115555 =
+      iree_uk_avx_loadu_2x128(in_ptr + 1 * in_stride, in_ptr + 5 * in_stride);
+  __m256i r22226666 =
+      iree_uk_avx_loadu_2x128(in_ptr + 2 * in_stride, in_ptr + 6 * in_stride);
+  __m256i r33337777 =
+      iree_uk_avx_loadu_2x128(in_ptr + 3 * in_stride, in_ptr + 7 * in_stride);
+  __m256i r00224466_0 = _mm256_unpacklo_epi64(r00004444, r22226666);
+  __m256i r00224466_1 = _mm256_unpackhi_epi64(r00004444, r22226666);
+  __m256i r11335577_0 = _mm256_unpacklo_epi64(r11115555, r33337777);
+  __m256i r11335577_1 = _mm256_unpackhi_epi64(r11115555, r33337777);
+  __m256i r01014545_0 = _mm256_unpacklo_epi32(r00224466_0, r11335577_0);
+  __m256i r01014545_1 = _mm256_unpacklo_epi32(r00224466_1, r11335577_1);
+  __m256i r23236767_0 = _mm256_unpackhi_epi32(r00224466_0, r11335577_0);
+  __m256i r23236767_1 = _mm256_unpackhi_epi32(r00224466_1, r11335577_1);
+  __m256i r01234567_0 = _mm256_unpacklo_epi64(r01014545_0, r23236767_0);
+  __m256i r01234567_1 = _mm256_unpackhi_epi64(r01014545_0, r23236767_0);
+  __m256i r01234567_2 = _mm256_unpacklo_epi64(r01014545_1, r23236767_1);
+  __m256i r01234567_3 = _mm256_unpackhi_epi64(r01014545_1, r23236767_1);
+  _mm256_storeu_si256((__m256i*)(out_ptr + 0 * out_stride), r01234567_0);
+  _mm256_storeu_si256((__m256i*)(out_ptr + 1 * out_stride), r01234567_1);
+  _mm256_storeu_si256((__m256i*)(out_ptr + 2 * out_stride), r01234567_2);
+  _mm256_storeu_si256((__m256i*)(out_ptr + 3 * out_stride), r01234567_3);
+}
+
+static inline void
+iree_uk_avx512_copy_16x16xi8_tiled_1x4_transpose_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  __m512i r000044448888CCCC = iree_uk_avx512_loadu_4x128(
+      in_ptr + 0 * in_stride, in_ptr + 4 * in_stride, in_ptr + 8 * in_stride,
+      in_ptr + 12 * in_stride);
+  __m512i r111155559999DDDD = iree_uk_avx512_loadu_4x128(
+      in_ptr + 1 * in_stride, in_ptr + 5 * in_stride, in_ptr + 9 * in_stride,
+      in_ptr + 13 * in_stride);
+  __m512i r22226666AAAAEEEE = iree_uk_avx512_loadu_4x128(
+      in_ptr + 2 * in_stride, in_ptr + 6 * in_stride, in_ptr + 10 * in_stride,
+      in_ptr + 14 * in_stride);
+  __m512i r33337777BBBBFFFF = iree_uk_avx512_loadu_4x128(
+      in_ptr + 3 * in_stride, in_ptr + 7 * in_stride, in_ptr + 11 * in_stride,
+      in_ptr + 15 * in_stride);
+  __m512i r0022446688AACCEE_0 =
+      _mm512_unpacklo_epi64(r000044448888CCCC, r22226666AAAAEEEE);
+  __m512i r0022446688AACCEE_1 =
+      _mm512_unpackhi_epi64(r000044448888CCCC, r22226666AAAAEEEE);
+  __m512i r1133557799BBDDFF_0 =
+      _mm512_unpacklo_epi64(r111155559999DDDD, r33337777BBBBFFFF);
+  __m512i r1133557799BBDDFF_1 =
+      _mm512_unpackhi_epi64(r111155559999DDDD, r33337777BBBBFFFF);
+  __m512i r010145458989CDCD_0 =
+      _mm512_unpacklo_epi32(r0022446688AACCEE_0, r1133557799BBDDFF_0);
+  __m512i r010145458989CDCD_1 =
+      _mm512_unpacklo_epi32(r0022446688AACCEE_1, r1133557799BBDDFF_1);
+  __m512i r23236767ABABEFEF_0 =
+      _mm512_unpackhi_epi32(r0022446688AACCEE_0, r1133557799BBDDFF_0);
+  __m512i r23236767ABABEFEF_1 =
+      _mm512_unpackhi_epi32(r0022446688AACCEE_1, r1133557799BBDDFF_1);
+  __m512i r0123456789ABCDEF_0 =
+      _mm512_unpacklo_epi64(r010145458989CDCD_0, r23236767ABABEFEF_0);
+  __m512i r0123456789ABCDEF_1 =
+      _mm512_unpackhi_epi64(r010145458989CDCD_0, r23236767ABABEFEF_0);
+  __m512i r0123456789ABCDEF_2 =
+      _mm512_unpacklo_epi64(r010145458989CDCD_1, r23236767ABABEFEF_1);
+  __m512i r0123456789ABCDEF_3 =
+      _mm512_unpackhi_epi64(r010145458989CDCD_1, r23236767ABABEFEF_1);
+  _mm512_storeu_si512((__m512i*)(out_ptr + 0 * out_stride),
+                      r0123456789ABCDEF_0);
+  _mm512_storeu_si512((__m512i*)(out_ptr + 1 * out_stride),
+                      r0123456789ABCDEF_1);
+  _mm512_storeu_si512((__m512i*)(out_ptr + 2 * out_stride),
+                      r0123456789ABCDEF_2);
+  _mm512_storeu_si512((__m512i*)(out_ptr + 3 * out_stride),
+                      r0123456789ABCDEF_3);
+}
+
+static inline void
+iree_uk_avx2_copy_8x16xi8_tiled_1x2_transpose_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  __m256i r0000000044444444 =
+      iree_uk_avx_loadu_2x128(in_ptr + 0 * in_stride, in_ptr + 4 * in_stride);
+  __m256i r1111111155555555 =
+      iree_uk_avx_loadu_2x128(in_ptr + 1 * in_stride, in_ptr + 5 * in_stride);
+  __m256i r2222222266666666 =
+      iree_uk_avx_loadu_2x128(in_ptr + 2 * in_stride, in_ptr + 6 * in_stride);
+  __m256i r3333333377777777 =
+      iree_uk_avx_loadu_2x128(in_ptr + 3 * in_stride, in_ptr + 7 * in_stride);
+  __m256i r0000111144445555_0 =
+      _mm256_unpacklo_epi64(r0000000044444444, r1111111155555555);
+  __m256i r0000111144445555_1 =
+      _mm256_unpackhi_epi64(r0000000044444444, r1111111155555555);
+  __m256i r2222333366667777_0 =
+      _mm256_unpacklo_epi64(r2222222266666666, r3333333377777777);
+  __m256i r2222333366667777_1 =
+      _mm256_unpackhi_epi64(r2222222266666666, r3333333377777777);
+  __m256i r0022002244664466_0 =
+      _mm256_unpacklo_epi32(r0000111144445555_0, r2222333366667777_0);
+  __m256i r0022002244664466_1 =
+      _mm256_unpacklo_epi32(r0000111144445555_1, r2222333366667777_1);
+  __m256i r1133113355775577_0 =
+      _mm256_unpackhi_epi32(r0000111144445555_0, r2222333366667777_0);
+  __m256i r1133113355775577_1 =
+      _mm256_unpackhi_epi32(r0000111144445555_1, r2222333366667777_1);
+  __m256i r0101232345456767_0 =
+      _mm256_unpacklo_epi16(r0022002244664466_0, r1133113355775577_0);
+  __m256i r0101232345456767_1 =
+      _mm256_unpackhi_epi16(r0022002244664466_0, r1133113355775577_0);
+  __m256i r0101232345456767_2 =
+      _mm256_unpacklo_epi16(r0022002244664466_1, r1133113355775577_1);
+  __m256i r0101232345456767_3 =
+      _mm256_unpackhi_epi16(r0022002244664466_1, r1133113355775577_1);
+  __m256i r0123012345674567_0 = _mm256_shuffle_epi32(r0101232345456767_0, 0xD8);
+  __m256i r0123012345674567_1 = _mm256_shuffle_epi32(r0101232345456767_1, 0xD8);
+  __m256i r0123012345674567_2 = _mm256_shuffle_epi32(r0101232345456767_2, 0xD8);
+  __m256i r0123012345674567_3 = _mm256_shuffle_epi32(r0101232345456767_3, 0xD8);
+  __m256i r0123456701234567_0 =
+      _mm256_permute4x64_epi64(r0123012345674567_0, 0xD8);
+  __m256i r0123456701234567_1 =
+      _mm256_permute4x64_epi64(r0123012345674567_1, 0xD8);
+  __m256i r0123456701234567_2 =
+      _mm256_permute4x64_epi64(r0123012345674567_2, 0xD8);
+  __m256i r0123456701234567_3 =
+      _mm256_permute4x64_epi64(r0123012345674567_3, 0xD8);
+  iree_uk_avx_storeu_2x128(out_ptr + 0 * out_stride, out_ptr + 1 * out_stride,
+                           r0123456701234567_0);
+  iree_uk_avx_storeu_2x128(out_ptr + 2 * out_stride, out_ptr + 3 * out_stride,
+                           r0123456701234567_1);
+  iree_uk_avx_storeu_2x128(out_ptr + 4 * out_stride, out_ptr + 5 * out_stride,
+                           r0123456701234567_2);
+  iree_uk_avx_storeu_2x128(out_ptr + 6 * out_stride, out_ptr + 7 * out_stride,
+                           r0123456701234567_3);
+}
+
+static inline void
+iree_uk_avx512_copy_16x16xi8_tiled_1x2_transpose_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  __m512i r000044448888CCCC = iree_uk_avx512_loadu_4x128(
+      in_ptr + 0 * in_stride, in_ptr + 4 * in_stride, in_ptr + 8 * in_stride,
+      in_ptr + 12 * in_stride);
+  __m512i r111155559999DDDD = iree_uk_avx512_loadu_4x128(
+      in_ptr + 1 * in_stride, in_ptr + 5 * in_stride, in_ptr + 9 * in_stride,
+      in_ptr + 13 * in_stride);
+  __m512i r22226666AAAAEEEE = iree_uk_avx512_loadu_4x128(
+      in_ptr + 2 * in_stride, in_ptr + 6 * in_stride, in_ptr + 10 * in_stride,
+      in_ptr + 14 * in_stride);
+  __m512i r33337777BBBBFFFF = iree_uk_avx512_loadu_4x128(
+      in_ptr + 3 * in_stride, in_ptr + 7 * in_stride, in_ptr + 11 * in_stride,
+      in_ptr + 15 * in_stride);
+  __m512i r0000111144445555_0 =
+      _mm512_unpacklo_epi64(r000044448888CCCC, r111155559999DDDD);
+  __m512i r0000111144445555_1 =
+      _mm512_unpackhi_epi64(r000044448888CCCC, r111155559999DDDD);
+  __m512i r2222333366667777_0 =
+      _mm512_unpacklo_epi64(r22226666AAAAEEEE, r33337777BBBBFFFF);
+  __m512i r2222333366667777_1 =
+      _mm512_unpackhi_epi64(r22226666AAAAEEEE, r33337777BBBBFFFF);
+  __m512i r0022002244664466_0 =
+      _mm512_unpacklo_epi32(r0000111144445555_0, r2222333366667777_0);
+  __m512i r0022002244664466_1 =
+      _mm512_unpacklo_epi32(r0000111144445555_1, r2222333366667777_1);
+  __m512i r1133113355775577_0 =
+      _mm512_unpackhi_epi32(r0000111144445555_0, r2222333366667777_0);
+  __m512i r1133113355775577_1 =
+      _mm512_unpackhi_epi32(r0000111144445555_1, r2222333366667777_1);
+  __m512i r0101232345456767_0 =
+      _mm512_unpacklo_epi16(r0022002244664466_0, r1133113355775577_0);
+  __m512i r0101232345456767_1 =
+      _mm512_unpackhi_epi16(r0022002244664466_0, r1133113355775577_0);
+  __m512i r0101232345456767_2 =
+      _mm512_unpacklo_epi16(r0022002244664466_1, r1133113355775577_1);
+  __m512i r0101232345456767_3 =
+      _mm512_unpackhi_epi16(r0022002244664466_1, r1133113355775577_1);
+  __m512i r0123012345674567_0 = _mm512_shuffle_epi32(r0101232345456767_0, 0xD8);
+  __m512i r0123012345674567_1 = _mm512_shuffle_epi32(r0101232345456767_1, 0xD8);
+  __m512i r0123012345674567_2 = _mm512_shuffle_epi32(r0101232345456767_2, 0xD8);
+  __m512i r0123012345674567_3 = _mm512_shuffle_epi32(r0101232345456767_3, 0xD8);
+  __m512i r0123456701234567_0 =
+      _mm512_permutex_epi64(r0123012345674567_0, 0xD8);
+  __m512i r0123456701234567_1 =
+      _mm512_permutex_epi64(r0123012345674567_1, 0xD8);
+  __m512i r0123456701234567_2 =
+      _mm512_permutex_epi64(r0123012345674567_2, 0xD8);
+  __m512i r0123456701234567_3 =
+      _mm512_permutex_epi64(r0123012345674567_3, 0xD8);
+  iree_uk_avx512_storeu_4x128(
+      out_ptr + 0 * out_stride, out_ptr + 1 * out_stride + 0,
+      out_ptr + 0 * out_stride + 16, out_ptr + 1 * out_stride + 16,
+      r0123456701234567_0);
+  iree_uk_avx512_storeu_4x128(
+      out_ptr + 2 * out_stride, out_ptr + 3 * out_stride + 0,
+      out_ptr + 2 * out_stride + 16, out_ptr + 3 * out_stride + 16,
+      r0123456701234567_1);
+  iree_uk_avx512_storeu_4x128(
+      out_ptr + 4 * out_stride, out_ptr + 5 * out_stride + 0,
+      out_ptr + 4 * out_stride + 16, out_ptr + 5 * out_stride + 16,
+      r0123456701234567_2);
+  iree_uk_avx512_storeu_4x128(
+      out_ptr + 6 * out_stride, out_ptr + 7 * out_stride + 0,
+      out_ptr + 6 * out_stride + 16, out_ptr + 7 * out_stride + 16,
+      r0123456701234567_3);
+}

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64.h
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64.h
@@ -1,4 +1,4 @@
-// Copyright 2022 The IREE Authors
+// Copyright 2023 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64.c
@@ -1,0 +1,117 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/x86_64/pack_x86_64.h"
+
+#include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
+
+IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x8_x32_x86_64_avx2_fma_direct)
+IREE_UK_PACK_TILE_FUNC_DECL(
+    iree_uk_pack_tile_16x16_x32_x86_64_avx512_base_direct)
+IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x1_x32_x86_64_avx2_fma_direct)
+IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x1_x32_x86_64_avx2_fma_transpose)
+IREE_UK_PACK_TILE_FUNC_DECL(
+    iree_uk_pack_tile_16x1_x32_x86_64_avx512_base_direct)
+IREE_UK_PACK_TILE_FUNC_DECL(
+    iree_uk_pack_tile_16x1_x32_x86_64_avx512_base_transpose)
+IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x2_x8_x86_64_avx2_fma_direct)
+IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x2_x8_x86_64_avx2_fma_transpose)
+IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_16x2_x8_x86_64_avx512_base_direct)
+IREE_UK_PACK_TILE_FUNC_DECL(
+    iree_uk_pack_tile_16x2_x8_x86_64_avx512_base_transpose)
+
+static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64_8x8_x32(
+    const iree_uk_pack_params_t* params) {
+#ifdef IREE_UK_BUILD_X86_64_AVX2_FMA
+  if (iree_uk_cpu_supports_avx2_fma(params->cpu_data)) {
+    bool transpose = params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER;
+    return transpose ? 0 : iree_uk_pack_tile_8x8_x32_x86_64_avx2_fma_direct;
+  }
+#endif
+  return 0;
+}
+
+static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64_16x16_x32(
+    const iree_uk_pack_params_t* params) {
+#ifdef IREE_UK_BUILD_X86_64_AVX512_BASE
+  if (iree_uk_cpu_supports_avx512_base(params->cpu_data)) {
+    bool transpose = params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER;
+    return transpose ? 0
+                     : iree_uk_pack_tile_16x16_x32_x86_64_avx512_base_direct;
+  }
+#endif
+  return 0;
+}
+
+static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64_8x1_x32(
+    const iree_uk_pack_params_t* params) {
+#ifdef IREE_UK_BUILD_X86_64_AVX2_FMA
+  if (iree_uk_cpu_supports_avx2_fma(params->cpu_data)) {
+    bool transpose = params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER;
+    return transpose ? iree_uk_pack_tile_8x1_x32_x86_64_avx2_fma_transpose
+                     : iree_uk_pack_tile_8x1_x32_x86_64_avx2_fma_direct;
+  }
+#endif
+  return 0;
+}
+
+static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64_16x1_x32(
+    const iree_uk_pack_params_t* params) {
+#ifdef IREE_UK_BUILD_X86_64_AVX512_BASE
+  if (iree_uk_cpu_supports_avx512_base(params->cpu_data)) {
+    bool transpose = params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER;
+    return transpose ? iree_uk_pack_tile_16x1_x32_x86_64_avx512_base_transpose
+                     : iree_uk_pack_tile_16x1_x32_x86_64_avx512_base_direct;
+  }
+#endif
+  return 0;
+}
+
+static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64_8x2_x8(
+    const iree_uk_pack_params_t* params) {
+#ifdef IREE_UK_BUILD_X86_64_AVX2_FMA
+  if (iree_uk_cpu_supports_avx2_fma(params->cpu_data)) {
+    bool transpose = params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER;
+    return transpose ? iree_uk_pack_tile_8x2_x8_x86_64_avx2_fma_transpose
+                     : iree_uk_pack_tile_8x2_x8_x86_64_avx2_fma_direct;
+  }
+#endif
+  return 0;
+}
+
+static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64_16x2_x8(
+    const iree_uk_pack_params_t* params) {
+#ifdef IREE_UK_BUILD_X86_64_AVX512_BASE
+  if (iree_uk_cpu_supports_avx512_base(params->cpu_data)) {
+    bool transpose = params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER;
+    return transpose ? iree_uk_pack_tile_16x2_x8_x86_64_avx512_base_transpose
+                     : iree_uk_pack_tile_16x2_x8_x86_64_avx512_base_direct;
+  }
+#endif
+  return 0;
+}
+
+iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64(
+    const iree_uk_pack_params_t* params) {
+  // At the moment, as sum-reductions are not yet part of pack ops,
+  // no arithmetic whatsoever is being done here, so only the element type
+  // size matters, not the type itself.
+  int esize = iree_uk_type_size(iree_uk_pack_out_type(params->type));
+  if (esize == 4 && params->out_size2 == 8 && params->out_size3 == 8) {
+    return iree_uk_pack_select_tile_func_x86_64_8x8_x32(params);
+  } else if (esize == 4 && params->out_size2 == 16 && params->out_size3 == 16) {
+    return iree_uk_pack_select_tile_func_x86_64_16x16_x32(params);
+  } else if (esize == 4 && params->out_size2 == 8 && params->out_size3 == 1) {
+    return iree_uk_pack_select_tile_func_x86_64_8x1_x32(params);
+  } else if (esize == 4 && params->out_size2 == 16 && params->out_size3 == 1) {
+    return iree_uk_pack_select_tile_func_x86_64_16x1_x32(params);
+  } else if (esize == 1 && params->out_size2 == 8 && params->out_size3 == 2) {
+    return iree_uk_pack_select_tile_func_x86_64_8x2_x8(params);
+  } else if (esize == 1 && params->out_size2 == 16 && params->out_size3 == 2) {
+    return iree_uk_pack_select_tile_func_x86_64_16x2_x8(params);
+  }
+  return 0;
+}

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64.h
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64.h
@@ -1,0 +1,18 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_ARCH_X86_64_PACK_X86_64_H_
+#define IREE_BUILTINS_UKERNEL_ARCH_X86_64_PACK_X86_64_H_
+
+#include "iree/builtins/ukernel/pack.h"
+
+// Returns the x86_64 tile function to use for the pack op with given params, or
+// NULL if no suitable x86_64 tile function exists for these params, in which
+// case the caller may fall back to a generic tile function.
+iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64(
+    const iree_uk_pack_params_t* params);
+
+#endif  // IREE_BUILTINS_UKERNEL_ARCH_X86_64_PACK_X86_64_H_

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64_avx2_fma.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64_avx2_fma.c
@@ -1,0 +1,141 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
+#include "iree/builtins/ukernel/arch/x86_64/unpack_x86_64.h"
+
+void iree_uk_pack_tile_8x8_x32_x86_64_avx2_fma_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_copy_8x32xi8_strided_to_strided(out_ptr, in_ptr, 32,
+                                            4 * in_stride0);
+    out_ptr += 4 * out_stride1;
+    in_ptr += 32;
+  }
+}
+
+static void iree_uk_pack_tile_8x4_x8_x86_64_avx2_fma_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 4);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 >= 4; outer_size1 -= 4) {
+    iree_uk_avx2_copy_8x16xi8_tiled_1x4_transpose_strided_to_strided(
+        out_ptr, in_ptr, out_stride1, in_stride0);
+    out_ptr += 4 * out_stride1;
+    in_ptr += 16;
+  }
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_avx2_copy_8x4xi8_strided_to_unstrided(out_ptr, in_ptr, in_stride0);
+    out_ptr += out_stride1;
+    in_ptr += 4;
+  }
+}
+
+void iree_uk_pack_tile_8x1_x32_x86_64_avx2_fma_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 1);
+  iree_uk_pack_tile_8x4_x8_x86_64_avx2_fma_direct(out_tile_ptr, in_tile_ptr,
+                                                  outer_size1, out_stride1 * 4,
+                                                  in_stride0 * 4, 1, 8, 4);
+}
+
+void iree_uk_pack_tile_8x1_x32_x86_64_avx2_fma_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 1);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int32_t* IREE_UK_RESTRICT in_tile_ptr_i32 = in_tile_ptr;
+  iree_uk_int32_t* IREE_UK_RESTRICT out_tile_i32_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_memcpy(out_tile_i32_ptr, in_tile_ptr_i32, 32);
+    out_tile_i32_ptr += out_stride1;
+    in_tile_ptr_i32 += 8;
+  }
+}
+
+void iree_uk_pack_tile_8x2_x8_x86_64_avx2_fma_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 2);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 >= 8; outer_size1 -= 8) {
+    iree_uk_avx2_copy_8x16xi8_tiled_1x2_transpose_strided_to_strided(
+        out_ptr, in_ptr, out_stride1, in_stride0);
+    out_ptr += 8 * out_stride1;
+    in_ptr += 16;
+  }
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_avx2_copy_8x2xi8_strided_to_unstrided(out_ptr, in_ptr, in_stride0);
+    out_ptr += out_stride1;
+    in_ptr += 2;
+  }
+}
+
+void iree_uk_pack_tile_8x2_x8_x86_64_avx2_fma_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 2);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  iree_uk_ssize_t outer_i1 = 0;
+  for (; outer_i1 <= outer_size1 - 4; outer_i1 += 4) {
+    __m256i in0 = _mm256_loadu_si256((const __m256i*)in_ptr);
+    __m256i in1 = _mm256_loadu_si256((const __m256i*)(in_ptr + in_stride0));
+    __m256i out0 = _mm256_unpacklo_epi8(in0, in1);
+    __m256i out1 = _mm256_unpackhi_epi8(in0, in1);
+    iree_uk_avx_storeu_2x128(out_ptr + 0 * out_stride1,
+                             out_ptr + 2 * out_stride1, out0);
+    iree_uk_avx_storeu_2x128(out_ptr + 1 * out_stride1,
+                             out_ptr + 3 * out_stride1, out1);
+    out_ptr += 4 * out_stride1;
+    in_ptr += 32;
+  }
+  for (; outer_i1 < outer_size1; ++outer_i1) {
+    __m128i in0 = _mm_loadu_si64(in_ptr);
+    __m128i in1 = _mm_loadu_si64(in_ptr + in_stride0);
+    __m128i out = _mm_unpacklo_epi8(in0, in1);
+    _mm_storeu_si128((__m128i*)out_ptr, out);
+    out_ptr += out_stride1;
+    in_ptr += 8;
+  }
+}

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64_avx512_base.c
@@ -1,0 +1,148 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
+#include "iree/builtins/ukernel/arch/x86_64/unpack_x86_64.h"
+
+void iree_uk_pack_tile_16x16_x32_x86_64_avx512_base_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 16);
+  IREE_UK_ASSERT(tile_size1 == 16);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_copy_8x32xi8_strided_to_strided(out_ptr, in_ptr, 64,
+                                            4 * in_stride0);
+    out_ptr += 4 * out_stride1;
+    in_ptr += 64;
+  }
+}
+
+static void iree_uk_pack_tile_16x4_x8_x86_64_avx512_base_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 16);
+  IREE_UK_ASSERT(tile_size1 == 4);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 >= 4; outer_size1 -= 4) {
+    iree_uk_avx512_copy_16x16xi8_tiled_1x4_transpose_strided_to_strided(
+        out_ptr, in_ptr, out_stride1, in_stride0);
+    out_ptr += 4 * out_stride1;
+    in_ptr += 16;
+  }
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_avx512_copy_16x4xi8_strided_to_unstrided(out_ptr, in_ptr,
+                                                     in_stride0);
+    out_ptr += out_stride1;
+    in_ptr += 4;
+  }
+}
+
+void iree_uk_pack_tile_16x1_x32_x86_64_avx512_base_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 16);
+  IREE_UK_ASSERT(tile_size1 == 1);
+  iree_uk_pack_tile_16x4_x8_x86_64_avx512_base_direct(
+      out_tile_ptr, in_tile_ptr, outer_size1, out_stride1 * 4, in_stride0 * 4,
+      1, 16, 4);
+}
+
+void iree_uk_pack_tile_16x1_x32_x86_64_avx512_base_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 1);
+  IREE_UK_ASSERT(tile_size1 == 16);
+  const iree_uk_int32_t* IREE_UK_RESTRICT in_tile_ptr_i32 = in_tile_ptr;
+  iree_uk_int32_t* IREE_UK_RESTRICT out_tile_i32_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_memcpy(out_tile_i32_ptr, in_tile_ptr_i32, 64);
+    out_tile_i32_ptr += out_stride1;
+    in_tile_ptr_i32 += 16;
+  }
+}
+
+void iree_uk_pack_tile_16x2_x8_x86_64_avx512_base_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 16);
+  IREE_UK_ASSERT(tile_size1 == 2);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 >= 8; outer_size1 -= 8) {
+    iree_uk_avx512_copy_16x16xi8_tiled_1x2_transpose_strided_to_strided(
+        out_ptr, in_ptr, out_stride1, in_stride0);
+    out_ptr += 8 * out_stride1;
+    in_ptr += 16;
+  }
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_avx2_copy_16x2xi8_strided_to_unstrided(out_ptr, in_ptr, in_stride0);
+    out_ptr += out_stride1;
+    in_ptr += 2;
+  }
+}
+
+void iree_uk_pack_tile_16x2_x8_x86_64_avx512_base_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 2);
+  IREE_UK_ASSERT(tile_size1 == 16);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  iree_uk_ssize_t outer_i1 = 0;
+  for (; outer_i1 <= outer_size1 - 4; outer_i1 += 4) {
+    __m512i in0 = _mm512_loadu_si512((const __m512i*)in_ptr);
+    __m512i in1 = _mm512_loadu_si512((const __m512i*)(in_ptr + in_stride0));
+    __m512i out0 = _mm512_unpacklo_epi8(in0, in1);
+    __m512i out1 = _mm512_unpackhi_epi8(in0, in1);
+    iree_uk_avx512_storeu_4x128(
+        out_ptr + 0 * out_stride1, out_ptr + 1 * out_stride1,
+        out_ptr + 2 * out_stride1, out_ptr + 3 * out_stride1, out0);
+    iree_uk_avx512_storeu_4x128(
+        out_ptr + 0 * out_stride1 + 16, out_ptr + 1 * out_stride1 + 16,
+        out_ptr + 2 * out_stride1 + 16, out_ptr + 3 * out_stride1 + 16, out1);
+    out_ptr += 4 * out_stride1;
+    in_ptr += 64;
+  }
+  for (; outer_i1 < outer_size1; ++outer_i1) {
+    __m256i in0 = _mm256_permute4x64_epi64(
+        _mm256_castsi128_si256(_mm_loadu_si128((const __m128i*)in_ptr)), 0xD8);
+    __m256i in1 = _mm256_permute4x64_epi64(
+        _mm256_castsi128_si256(
+            _mm_loadu_si128((const __m128i*)(in_ptr + in_stride0))),
+        0xD8);
+    __m256i out = _mm256_unpacklo_epi8(in0, in1);
+    _mm256_storeu_si256((__m256i*)out_ptr, out);
+    out_ptr += out_stride1;
+    in_ptr += 16;
+  }
+}

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64.c
@@ -1,0 +1,36 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/x86_64/unpack_x86_64.h"
+
+#include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
+
+IREE_UK_UNPACK_TILE_FUNC_DECL(
+    iree_uk_unpack_tile_8x8_x32_x86_64_avx2_fma_direct)
+IREE_UK_UNPACK_TILE_FUNC_DECL(
+    iree_uk_unpack_tile_16x16_x32_x86_64_avx512_base_direct)
+
+iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_x86_64(
+    const iree_uk_unpack_params_t* params) {
+  int esize = iree_uk_type_size(iree_uk_unpack_out_type(params->type));
+  bool transpose = params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER;
+  // Unpack is currently only used in practice with esize==4 and non-transpose.
+  if (esize != 4 || transpose) return 0;
+  if (params->in_size2 == 8 && params->in_size3 == 8) {
+#ifdef IREE_UK_BUILD_X86_64_AVX2_FMA
+    if (iree_uk_cpu_supports_avx2_fma(params->cpu_data)) {
+      return iree_uk_unpack_tile_8x8_x32_x86_64_avx2_fma_direct;
+    }
+#endif
+  } else if (params->in_size2 == 16 && params->in_size3 == 16) {
+#ifdef IREE_UK_BUILD_X86_64_AVX512_BASE
+    if (iree_uk_cpu_supports_avx512_base(params->cpu_data)) {
+      return iree_uk_unpack_tile_16x16_x32_x86_64_avx512_base_direct;
+    }
+#endif
+  }
+  return 0;
+}

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64.h
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64.h
@@ -1,0 +1,17 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_ARCH_X86_64_UNPACK_X86_64_H_
+#define IREE_BUILTINS_UKERNEL_ARCH_X86_64_UNPACK_X86_64_H_
+
+#include "iree/builtins/ukernel/unpack.h"
+
+// Returns the x86_64 tile function to use for the unpack op with given params,
+// or NULL if none is available, so the caller may fall back to generic code.
+iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_x86_64(
+    const iree_uk_unpack_params_t* params);
+
+#endif  // IREE_BUILTINS_UKERNEL_ARCH_X86_64_UNPACK_X86_64_H_

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64_avx2_fma.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64_avx2_fma.c
@@ -1,0 +1,27 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
+#include "iree/builtins/ukernel/arch/x86_64/unpack_x86_64.h"
+
+void iree_uk_unpack_tile_8x8_x32_x86_64_avx2_fma_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_copy_8x32xi8_strided_to_strided(out_ptr, in_ptr, 4 * out_stride0,
+                                            32);
+    out_ptr += 32;
+    in_ptr += 4 * in_stride1;
+  }
+}

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64_avx512_base.c
@@ -1,0 +1,27 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
+#include "iree/builtins/ukernel/arch/x86_64/unpack_x86_64.h"
+
+void iree_uk_unpack_tile_16x16_x32_x86_64_avx512_base_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 16);
+  IREE_UK_ASSERT(tile_size1 == 16);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_copy_16x64xi8_strided_to_strided(out_ptr, in_ptr, 4 * out_stride0,
+                                             64);
+    out_ptr += 64;
+    in_ptr += 4 * in_stride1;
+  }
+}

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -52,6 +52,14 @@ typedef void (*iree_uk_pack_tile_func_t)(
     iree_uk_ssize_t /*in_stride0*/, iree_uk_ssize_t /*elem_size*/,
     iree_uk_ssize_t /*tile_size0*/, iree_uk_ssize_t /*tile_size1*/);
 
+// Tile kernel declarations. Prototype matches iree_uk_unpack_tile_func_t.
+#define IREE_UK_PACK_TILE_FUNC_DECL(NAME)                             \
+  void NAME(void* IREE_UK_RESTRICT out_tile_ptr,                      \
+            const void* IREE_UK_RESTRICT in_tile_ptr,                 \
+            iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1, \
+            iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size,    \
+            iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
+
 // Main entry point.
 IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params);
 

--- a/runtime/src/iree/builtins/ukernel/pack_tile.c
+++ b/runtime/src/iree/builtins/ukernel/pack_tile.c
@@ -8,6 +8,8 @@
 
 #if defined(IREE_UK_ARCH_ARM_64)
 #include "iree/builtins/ukernel/arch/arm_64/pack_arm_64.h"
+#elif defined(IREE_UK_ARCH_X86_64)
+#include "iree/builtins/ukernel/arch/x86_64/pack_x86_64.h"
 #endif
 
 static void iree_uk_pack_tile_generic_direct(
@@ -69,6 +71,8 @@ static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_arch(
     const iree_uk_pack_params_t* params) {
 #if defined(IREE_UK_ARCH_ARM_64)
   return iree_uk_pack_select_tile_func_arm_64(params);
+#elif defined(IREE_UK_ARCH_X86_64)
+  return iree_uk_pack_select_tile_func_x86_64(params);
 #endif
   return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -153,6 +153,29 @@ int main(int argc, char** argv) {
   iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 4, NULL);
   // Tile size selected with cpu feature "i8mm".
   iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 8, NULL);
+#elif defined(IREE_UK_ARCH_X86_64)
+  iree_uk_cpu_features_list_t* cpu_avx2_fma =
+      iree_uk_cpu_features_list_create(3, "avx", "avx2", "fma");
+  iree_uk_cpu_features_list_set_name(cpu_avx2_fma, "avx2_fma");
+  iree_uk_cpu_features_list_t* cpu_avx512_base =
+      iree_uk_cpu_features_list_create_extend(cpu_avx2_fma, 5, "avx512f",
+                                              "avx512bw", "avx512dq",
+                                              "avx512vl", "avx512cd");
+  iree_uk_cpu_features_list_set_name(cpu_avx512_base, "avx512_base");
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 1, cpu_avx2_fma);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 16, 1,
+                                  cpu_avx512_base);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 8, cpu_avx2_fma);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 16, 16,
+                                  cpu_avx512_base);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 2, cpu_avx2_fma);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 16, 2,
+                                  cpu_avx512_base);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i32i32, 8, 8, cpu_avx2_fma);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i32i32, 16, 16,
+                                  cpu_avx512_base);
+  iree_uk_cpu_features_list_destroy(cpu_avx2_fma);
+  iree_uk_cpu_features_list_destroy(cpu_avx512_base);
 #else   // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -110,17 +110,9 @@ static void iree_uk_test_pack_for_tile_params(iree_uk_test_t* test,
       {1, 0},
       // Non-degenerate cases.
       {1, 1},
-      {2, 3},
-      {3, 4},
-      {4, 5},
-      {5, 6},
-      {6, 7},
+      {3, 2},
       {7, 8},
-      {11, 13},
-      {13, 11},
       {31, 33},
-      {33, 31},
-      {123, 89},
   };
   typedef enum {
     pad_none,
@@ -137,8 +129,12 @@ static void iree_uk_test_pack_for_tile_params(iree_uk_test_t* test,
           params.cpu_data = iree_uk_test_cpu_data(test);
           outer_shape_t outer_shape = outer_shapes[i];
           if (pad == pad_a_lot) {
-            outer_shape.size0 += 64;
-            outer_shape.size0 += 64;
+            // Makes the test expensive, and covers a corner case that shouldn't
+            // require large sizes. Try to be economical.
+            if (outer_shape.size0 <= 8 && outer_shape.size1 <= 8) {
+              outer_shape.size0 += 64;
+              outer_shape.size1 += 64;
+            }
           }
           params.out_size0 = outer_shape.size0;
           params.out_size1 = outer_shape.size1;
@@ -201,16 +197,33 @@ int main(int argc, char** argv) {
   iree_uk_test_pack(iree_uk_pack_type_f32f32, 3, 5, NULL);
   iree_uk_test_pack(iree_uk_pack_type_i8i8, 4, 2, NULL);
   iree_uk_test_pack(iree_uk_pack_type_i32i32, 3, 4, NULL);
-  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 8, NULL);
 
 #if defined(IREE_UK_ARCH_ARM_64)
   iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 1, NULL);
   iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 8, NULL);
   iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 1, NULL);
   iree_uk_test_pack(iree_uk_pack_type_i32i32, 8, 8, NULL);
-  // Tile size selected with cpu feature "dotprod".
+  // Tile size selected with CPU feature dotprod.
+  // Not passing a cpu_features_list because the packing code itself
+  // does not depend on any features.
   iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 4, NULL);
-  // Tile size selected for cpu feature "i8mm".
+  // Tile size selected for CPU feature i8mm. Same comment as for dotprod.
   iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 8, NULL);
+#elif defined(IREE_UK_ARCH_X86_64)
+  iree_uk_cpu_features_list_t* cpu_avx2_fma =
+      iree_uk_cpu_features_list_create(3, "avx", "avx2", "fma");
+  iree_uk_cpu_features_list_set_name(cpu_avx2_fma, "avx2_fma");
+  iree_uk_cpu_features_list_t* cpu_avx512_base =
+      iree_uk_cpu_features_list_create_extend(cpu_avx2_fma, 5, "avx512f",
+                                              "avx512bw", "avx512dq",
+                                              "avx512vl", "avx512cd");
+  iree_uk_cpu_features_list_set_name(cpu_avx512_base, "avx512_base");
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 1, cpu_avx2_fma);
+  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 2, cpu_avx2_fma);
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 16, 1, cpu_avx512_base);
+  iree_uk_test_pack(iree_uk_pack_type_i8i8, 16, 2, cpu_avx512_base);
+  // avx512_vnni uses the same tile size and same pack code as avx512_base.
+  iree_uk_cpu_features_list_destroy(cpu_avx2_fma);
+  iree_uk_cpu_features_list_destroy(cpu_avx512_base);
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 }

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -146,6 +146,25 @@ int main(int argc, char** argv) {
 #if defined(IREE_UK_ARCH_ARM_64)
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 8, 8, NULL);
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8, NULL);
+#elif defined(IREE_UK_ARCH_X86_64)
+  iree_uk_cpu_features_list_t* cpu_avx2_fma =
+      iree_uk_cpu_features_list_create(3, "avx", "avx2", "fma");
+  iree_uk_cpu_features_list_set_name(cpu_avx2_fma, "avx2_fma");
+  iree_uk_cpu_features_list_t* cpu_avx512_base =
+      iree_uk_cpu_features_list_create_extend(cpu_avx2_fma, 5, "avx512f",
+                                              "avx512bw", "avx512dq",
+                                              "avx512vl", "avx512cd");
+  iree_uk_cpu_features_list_set_name(cpu_avx512_base, "avx512_base");
+  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 8, 8,
+                                    cpu_avx2_fma);
+  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8,
+                                    cpu_avx2_fma);
+  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 16, 16,
+                                    cpu_avx512_base);
+  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 16, 16,
+                                    cpu_avx512_base);
+  iree_uk_cpu_features_list_destroy(cpu_avx2_fma);
+  iree_uk_cpu_features_list_destroy(cpu_avx512_base);
 #else   // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.

--- a/runtime/src/iree/builtins/ukernel/unpack.h
+++ b/runtime/src/iree/builtins/ukernel/unpack.h
@@ -53,6 +53,14 @@ typedef void (*iree_uk_unpack_tile_func_t)(
     iree_uk_ssize_t /*in_stride1*/, iree_uk_ssize_t /*elem_size*/,
     iree_uk_ssize_t /*tile_size0*/, iree_uk_ssize_t /*tile_size1*/);
 
+// Tile kernel declarations. Prototype matches iree_uk_unpack_tile_func_t.
+#define IREE_UK_UNPACK_TILE_FUNC_DECL(NAME)                           \
+  void NAME(void* IREE_UK_RESTRICT out_tile_ptr,                      \
+            const void* IREE_UK_RESTRICT in_tile_ptr,                 \
+            iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride0, \
+            iree_uk_ssize_t in_stride1, iree_uk_ssize_t elem_size,    \
+            iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
+
 // Main entry point.
 IREE_UK_EXPORT void iree_uk_unpack(const iree_uk_unpack_params_t* params);
 

--- a/runtime/src/iree/builtins/ukernel/unpack_tile.c
+++ b/runtime/src/iree/builtins/ukernel/unpack_tile.c
@@ -8,6 +8,8 @@
 
 #if defined(IREE_UK_ARCH_ARM_64)
 #include "iree/builtins/ukernel/arch/arm_64/unpack_arm_64.h"
+#elif defined(IREE_UK_ARCH_X86_64)
+#include "iree/builtins/ukernel/arch/x86_64/unpack_x86_64.h"
 #endif
 
 static void iree_uk_unpack_tile_generic_direct(
@@ -71,6 +73,8 @@ static iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_arch(
     const iree_uk_unpack_params_t* params) {
 #if defined(IREE_UK_ARCH_ARM_64)
   return iree_uk_unpack_select_tile_func_arm_64(params);
+#elif defined(IREE_UK_ARCH_X86_64)
+  return iree_uk_unpack_select_tile_func_x86_64(params);
 #endif
   return 0;
 }

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -796,6 +796,7 @@ static iree_status_t iree_vmvx_pack_f(iree_uk_pack_type_t type,
       .out_size3 = args->out_size3,
       .padding_value = &args->padding_value,
       .flags = args->flags,
+      .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
   };
   iree_uk_pack(&ukernel_params);
   IREE_TRACE_ZONE_END(z0);
@@ -837,6 +838,7 @@ static iree_status_t iree_vmvx_pack_i(iree_uk_pack_type_t type,
       .out_size3 = args->out_size3,
       .padding_value = &args->padding_value,
       .flags = args->flags,
+      .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
   };
   iree_uk_pack(&ukernel_params);
   IREE_TRACE_ZONE_END(z0);
@@ -910,6 +912,7 @@ static iree_status_t iree_vmvx_unpack(iree_uk_unpack_type_t type,
       .out_size0 = args->out_size0,
       .out_size1 = args->out_size1,
       .flags = args->flags,
+      .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
   };
   iree_uk_unpack(&ukernel_params);
   IREE_TRACE_ZONE_END(z0);


### PR DESCRIPTION
#12780 was accidentally closed. This is just the same again.  Plus a tweak to make pack/unpack tests not time out with TSan (they actually made more memory accesses than necessary, they are more economical now, and I even caught a bug while rereading this code so coverage is actually improved).