### PR TITLE
Reduce runtime configurations for x86 CPU experimental benchmarks

### DIFF
--- a/build_tools/python/benchmark_suites/iree/x86_64_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/x86_64_benchmarks.py
@@ -36,42 +36,73 @@ class Linux_x86_64_Benchmarks(object):
           "--iree-llvmcpu-enable-pad-consumer-fusion"
       ])
 
-  def generate(
-      self
+  def _generate_default(
+      self, device_specs: List[common_definitions.DeviceSpec]
   ) -> Tuple[List[iree_definitions.ModuleGenerationConfig],
              List[iree_definitions.E2EModelRunConfig]]:
-    """Generates IREE compile and run configs."""
-
     gen_configs = [
         iree_definitions.ModuleGenerationConfig.build(
             compile_config=self.CASCADELAKE_COMPILE_CONFIG,
             imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in model_groups.SMALL + model_groups.LARGE
     ]
-    # TODO(#11174): Excludes ResNet50
-    excluded_models_for_experiments = [tf_models.RESNET50_TF_FP32]
-    gen_configs += [
-        iree_definitions.ModuleGenerationConfig.build(
-            compile_config=self.CASCADELAKE_FUSE_PADDING_COMPILE_CONFIG,
-            imported_model=iree_definitions.ImportedModel.from_model(model))
-        for model in model_groups.SMALL + model_groups.LARGE
-        if model not in excluded_models_for_experiments
-    ]
+
     default_execution_configs = [
         module_execution_configs.ELF_LOCAL_SYNC_CONFIG
     ] + [
         module_execution_configs.get_elf_local_task_config(thread_num)
         for thread_num in [1, 4, 8]
     ]
-    cascadelake_devices = device_collections.DEFAULT_DEVICE_COLLECTION.query_device_specs(
-        architecture=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
-        host_environment=common_definitions.HostEnvironment.LINUX_X86_64)
+
     run_configs = benchmark_suites.iree.utils.generate_e2e_model_run_configs(
         module_generation_configs=gen_configs,
         module_execution_configs=default_execution_configs,
-        device_specs=cascadelake_devices)
+        device_specs=device_specs)
 
     return (gen_configs, run_configs)
+
+  def _generate_experimental(
+      self, device_specs: List[common_definitions.DeviceSpec]
+  ) -> Tuple[List[iree_definitions.ModuleGenerationConfig],
+             List[iree_definitions.E2EModelRunConfig]]:
+    # TODO(#11174): Excludes ResNet50
+    excluded_models_for_experiments = [tf_models.RESNET50_TF_FP32]
+    gen_configs = [
+        iree_definitions.ModuleGenerationConfig.build(
+            compile_config=self.CASCADELAKE_FUSE_PADDING_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
+        for model in model_groups.SMALL + model_groups.LARGE
+        if model not in excluded_models_for_experiments
+    ]
+    # We run the fuse padding compiler config under 4 threads only.
+    default_execution_configs = [
+        module_execution_configs.get_elf_local_task_config(4)
+    ]
+
+    run_configs = benchmark_suites.iree.utils.generate_e2e_model_run_configs(
+        module_generation_configs=gen_configs,
+        module_execution_configs=default_execution_configs,
+        device_specs=device_specs)
+
+    return (gen_configs, run_configs)
+
+  def generate(
+      self
+  ) -> Tuple[List[iree_definitions.ModuleGenerationConfig],
+             List[iree_definitions.E2EModelRunConfig]]:
+    """Generates IREE compile and run configs."""
+
+    cascadelake_devices = device_collections.DEFAULT_DEVICE_COLLECTION.query_device_specs(
+        architecture=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
+        host_environment=common_definitions.HostEnvironment.LINUX_X86_64)
+
+    default_gen_configs, default_run_configs = self._generate_default(
+        cascadelake_devices)
+    experimental_gen_configs, experimental_run_configs = self._generate_experimental(
+        cascadelake_devices)
+
+    return (default_gen_configs + experimental_gen_configs,
+            default_run_configs + experimental_run_configs)
 
 
 def generate() -> Tuple[List[iree_definitions.ModuleGenerationConfig],


### PR DESCRIPTION
Currently we are running 2 sets of benchmarks for x86 CPU: one with default flags and another with experimental flags (fuse padding). For experimental flags, we do not need to run under all runtime configs (thread 1, 4, 8 and sync). This change updates the experimental benchmarks to use 4 threads.

Reduces x86 CPU benchmarks from ~50mins to ~30mins.