### PR TITLE
Improvements Dispatch Generator - MLIR Source Generation and Defining Dispatches

### DIFF
--- a/experimental/dispatch_profiler/generator.py
+++ b/experimental/dispatch_profiler/generator.py
@@ -13,6 +13,8 @@ if __name__ == "__main__":
   parser.add_argument("--build-dir", default=".", \
                       help="IREE top-level build directory is used to generate "\
                         "operations and npy files")
+  parser.add_argument("--verbose", default='False', \
+                      help='Prints verbose output and commands executed.')
   parser.add_argument("--operation_kind", default="all", \
                       help="Specifies the operation kinds to generate.", \
                       choices=["matmul", "conv2d", "all"])
@@ -23,15 +25,16 @@ if __name__ == "__main__":
                       default='linalg',\
                       help="MLIR dialect entry point at which operation is emitter.", \
                       choices=["linalg", "flow", "all"])
-
+  parser.add_argument("--device", default="cuda", \
+                      help="Target backend device to benchmark the operation on. "\
+                        "For example, cuda, vulkan, etc.")
   args = parser.parse_args()
 
   # Manifests dispatches for a group of accompanying operations and configurations.
   manifest = Manifest(args)
 
-  # Collect all the pre-defined dispatches in a manifest for various operations.
-  gpu_matmul_tensor_cores_f16(manifest)
-  #gpu_matmul_tensor_cores_f32(manifest)
+  # Load all the pre-defined dispatches in a manifest.
+  manifest.load()
 
   # Emit the dispatches in MLIR source files.
   manifest.emit(MlirDialect.Linalg)

--- a/experimental/dispatch_profiler/profiler.py
+++ b/experimental/dispatch_profiler/profiler.py
@@ -56,11 +56,9 @@ if __name__ == "__main__":
   parser.add_argument("--dispatches", default='', help="Comma delimited list to "\
                       "filter dispatches by name. A dispatch is a combination of "\
                       "operation and tuning configuration.")
-  parser.add_argument("--mlir-dialect",
-                      default='linalg',
-                      help='MLIR dialect entry "\
-                      "point at which operation is emitter. For example, "\
-                      "linalg*, mhlo, etc.')
+  parser.add_argument("--mlir-dialect", default='linalg', help="MLIR dialect entry "\
+                      "point at which operation is emitter.",
+                      choices=["linalg", "flow", "all"])
   # Compilation-specific options
   parser.add_argument("--device", default="cuda", \
                       help="Target backend device to benchmark the operation on. "\
@@ -119,9 +117,8 @@ if __name__ == "__main__":
   # Manifests metadata for a group of accompanying operations and configurations.
   manifest = Manifest(args)
 
-  # Collect all the avialable operations in a manifest.
-  gpu_matmul_tensor_cores_f16(manifest)
-  #gpu_matmul_tensor_cores_f32(manifest)
+  # Load all the pre-defined dispatches in a manifest.
+  manifest.load()
 
   # Performance report
   perf_report = PerformanceReport(args)


### PR DESCRIPTION
This PR is in series of smaller PRs to iteratively improve IREE dispatch profiler.  The improvements captured in this PR are as follows:
- `EmitSourceMLIR` instead of `EmitMatmulSourceMlir`: Once the `operation` and `configuration` are properly abstracted out, there was very little matmul-specific code for emitting dispatch (operation + configuration). Thus, moved EmitSourceMLIR into its own structure which can be potentially used by new dispatches. 

- Dispatches are **generated** and **profiled** from a predefined shapes, datatypes, and tuning configurations. Both generation and profiling loads the predefined dispatches for a specific data type in a `Manifest` object. The definitions of dispatches are operation- and device-specific. Thus, abstracted out into its own structure `class MatmulGenerator`. Which can be loaded  using `Manifest.load()`. 

- Additionally, `class MatmulGenerator` executes a few simple checks to skip dispatches that a user might naively define but not supported because of architectural constraints (e.g. shared memory capacity) or unsupported codegen path (e.g. unaligned matmuls on CUDA tensor core backend). 