### PR TITLE
Fix stream.async.dispatch parser.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1572,6 +1572,9 @@ static ParseResult parseDispatchOperands(
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &resourceOffsets,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &resourceEnds,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &resourceLengths) {
+  if (failed(parser.parseLParen())) return failure();
+  // Handle the case of no operands specially.
+  if (succeeded(parser.parseOptionalRParen())) return success();
   do {
     // All entries at least have an %operand.
     resourceOperands.emplace_back();
@@ -1591,6 +1594,7 @@ static ParseResult parseDispatchOperands(
       }
     }
   } while (succeeded(parser.parseOptionalComma()));
+  if (failed(parser.parseRParen())) return failure();
   return success();
 }
 
@@ -1599,6 +1603,7 @@ static void printDispatchOperands(OpAsmPrinter &p, Operation *op,
                                   ValueRange resourceOffsets,
                                   ValueRange resourceEnds,
                                   ValueRange resourceLengths) {
+  p << "(";
   unsigned resourceIndex = 0;
   llvm::interleaveComma(resourceOperands, p, [&](Value operand) {
     p.printOperand(operand);
@@ -1613,6 +1618,7 @@ static void printDispatchOperands(OpAsmPrinter &p, Operation *op,
       ++resourceIndex;
     }
   });
+  p << ")";
 }
 
 LogicalResult AsyncDispatchOp::verify() {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1974,10 +1974,10 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
     (`on` `(` $affinity^ `)`)?
     $entry_point
     (`[` $workload^ `]`)? ``
-    `(` custom<DispatchOperands>($resource_operands,
-                                 $resource_operand_offsets,
-                                 $resource_operand_ends,
-                                 $resource_operand_lengths) `)` attr-dict `:`
+    custom<DispatchOperands>($resource_operands,
+                             $resource_operand_offsets,
+                             $resource_operand_ends,
+                             $resource_operand_lengths) attr-dict `:`
     custom<ShapedFunctionType>(ref($resource_operands),
                                type($resource_operands), $resource_operand_sizes,
                                type($results), $result_sizes,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_ops.mlir
@@ -181,6 +181,16 @@ func.func @asyncDispatch(%arg0: !stream.resource<*>, %arg1: index) -> !stream.re
 
 // -----
 
+// CHECK-LABEL: @asyncDispatchNoInputs
+func.func @asyncDispatchNoInputs(%arg0: index) -> !stream.resource<*> {
+  %c1 = arith.constant 1 : index
+  // CHECK: = stream.async.dispatch @executable::@dispatch[%c1]() : () -> !stream.resource<*>{%arg0}
+  %0 = stream.async.dispatch @executable::@dispatch[%c1]() : () -> !stream.resource<*>{%arg0}
+  return %0 : !stream.resource<*>
+}
+
+// -----
+
 stream.executable private @executable {
   stream.executable.export public @dispatch workgroups(%arg0: index, %arg1: index) -> (index, index, index) {
     stream.return %arg0, %arg1, %arg0 : index, index, index


### PR DESCRIPTION
The previous parser would assume at least one input, but for iota-like ops there can be zero input operands.