### PR TITLE
Adding streamable custom calls to abi/flow/stream/hal.

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/BUILD.bazel
@@ -15,6 +15,7 @@ package(
 iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
+        "ConvertStreamableOps.cpp",
         "Passes.cpp",
         "WrapEntryPoints.cpp",
     ],

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "Passes.h"
   SRCS
+    "ConvertStreamableOps.cpp"
     "Passes.cpp"
     "WrapEntryPoints.cpp"
   DEPS

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
@@ -1,0 +1,383 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Bindings/Native/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace ABI {
+
+static constexpr int64_t kUnspecifiedDim = -1;
+static constexpr int64_t kTiedDim = -2;
+
+struct StreamableFunc {
+  // Converted func op.
+  IREE::Flow::FuncOp funcOp;
+  // Parsed tied operand indices.
+  SmallVector<int64_t> tiedOperands;
+  // Total number of dynamic result dims required.
+  int requiredResultDims = 0;
+  // Optional custom shape calculation function.
+  SymbolRefAttr resultDimsFunc;
+  // For each result specifies which call arguments the dynamic dimensions are
+  // sourced from. For example, if a result with tensor<?xf32> takes its dim[0]
+  // from call arg 2. Only valid if there's no shape calculation function.
+  // May contain values of kTiedDim if the dimension matches the equivalent
+  // rank dimension of a tied operand.
+  SmallVector<SmallVector<int64_t>> resultDimArgs;
+};
+
+// Returns true if |funcOp| is a valid result dimension calculation function.
+static LogicalResult verifyResultDimsFunc(FunctionType functionType,
+                                          int requiredResultDims,
+                                          FunctionOpInterface calculateFuncOp) {
+  // Check arguments match the function exactly.
+  if (functionType.getNumInputs() != calculateFuncOp.getNumArguments()) {
+    return calculateFuncOp.emitOpError()
+           << "must match the signature of the function using it exactly; "
+              "argument count mismatch";
+  }
+  for (auto [callerType, calleeType] : llvm::zip_equal(
+           functionType.getInputs(), calculateFuncOp.getArgumentTypes())) {
+    if (callerType != calleeType) {
+      return calculateFuncOp.emitOpError()
+             << "must match the signature of the function using it exactly; "
+                "argument type mismatch (expected "
+             << callerType << ", have " << calleeType << ")";
+    }
+  }
+
+  // We only need dynamic dimensions.
+  if (calculateFuncOp.getNumResults() != requiredResultDims) {
+    return calculateFuncOp.emitOpError()
+           << "must return the exact number of dynamic tensor dimensions as "
+              "the function using it (expected "
+           << requiredResultDims << ", have " << calculateFuncOp.getNumResults()
+           << ")";
+  }
+  if (!llvm::all_of(calculateFuncOp.getResultTypes(),
+                    [](Type type) { return type.isIndex(); })) {
+    return calculateFuncOp.emitOpError()
+           << "must return only index types matching the dynamic tensor "
+              "dimensions";
+  }
+
+  return success();
+}
+
+// Converts a func.func with the iree.abi.streamable attribute into a flow.func
+// and fixes all func.call ops to be flow.call across the module.
+static Optional<StreamableFunc> convertStreamableFunc(
+    mlir::ModuleOp moduleOp, func::FuncOp funcOp, SymbolTable &symbolTable) {
+  OpBuilder moduleBuilder(funcOp);
+  auto functionType = funcOp.getFunctionType();
+
+  StreamableFunc streamableFunc;
+
+  // Because streamable ops are asynchronous they must be able to declare their
+  // result shapes before they execute so memory can be allocated.
+  for (auto resultType : functionType.getResults()) {
+    if (auto shapedType = resultType.dyn_cast<ShapedType>()) {
+      streamableFunc.requiredResultDims += shapedType.getNumDynamicDims();
+    }
+  }
+
+  // Check to see if there's a custom result shape calculation function. This
+  // will override any of the logic we try to do for dimension setting.
+  streamableFunc.resultDimsFunc =
+      funcOp->getAttrOfType<SymbolRefAttr>("iree.abi.result_dims");
+  if (streamableFunc.resultDimsFunc) {
+    auto calculateFuncOp =
+        symbolTable.lookupNearestSymbolFrom<FunctionOpInterface>(
+            funcOp, streamableFunc.resultDimsFunc);
+    if (!calculateFuncOp) {
+      funcOp.emitOpError()
+          << "cannot find the referenced result shape calculation function "
+          << streamableFunc.resultDimsFunc;
+      return std::nullopt;
+    }
+    if (failed(verifyResultDimsFunc(functionType,
+                                    streamableFunc.requiredResultDims,
+                                    calculateFuncOp))) {
+      return std::nullopt;
+    }
+  }
+
+  // Exclude the attrs used by this pass but leave the rest. Later stages of
+  // lowering may have some of their own they need to pass-through.
+  SmallVector<NamedAttribute> funcAttrs;
+  for (auto attr : funcOp->getDialectAttrs()) {
+    if (attr.getName() == "iree.abi.streamable" ||
+        attr.getName() == "iree.abi.result_dims") {
+      continue;
+    }
+    funcAttrs.push_back(attr);
+  }
+
+  SmallVector<DictionaryAttr> funcArgAttrs;
+  for (auto [i, argType] : llvm::enumerate(functionType.getInputs())) {
+    // No arg attrs today, just pass-through. Note that we have to handle null.
+    if (auto oldArgAttrs = funcOp.getArgAttrDict(i)) {
+      funcArgAttrs.push_back(oldArgAttrs);
+    } else {
+      funcArgAttrs.push_back(moduleBuilder.getDictionaryAttr({}));
+    }
+  }
+
+  streamableFunc.tiedOperands.resize(functionType.getNumResults(),
+                                     IREE::Util::TiedOpInterface::kUntiedIndex);
+  SmallVector<DictionaryAttr> funcResAttrs;
+  for (auto [i, resultType] : llvm::enumerate(functionType.getResults())) {
+    // Tensor results need to have their dynamic dimensions specified.
+    // If the result is tied we can default to using the operand dims and
+    // otherwise require the user to specify where the dims are. This could get
+    // arbitrarily complex (up to and including calling a function to compute
+    // dims).
+    SmallVector<int64_t> dynamicDimArgs;
+    auto shapedType = resultType.dyn_cast<ShapedType>();
+    if (shapedType) {
+      // Initialize dynamic dim args - we'll verify that they all get covered.
+      dynamicDimArgs.resize(shapedType.getNumDynamicDims(), kUnspecifiedDim);
+    }
+
+    SmallVector<NamedAttribute> newResAttrs;
+    if (auto oldResAttrs = funcOp.getResultAttrDict(i)) {
+      // First check if the result is tied to an argument.
+      // We can use this to source the initial set of dynamic dimensions.
+      if (auto tiedAttr = oldResAttrs.getAs<IntegerAttr>("iree.abi.tied")) {
+        streamableFunc.tiedOperands[i] = tiedAttr.getInt();
+        if (!streamableFunc.resultDimsFunc &&
+            shapedType == functionType.getInput(i)) {
+          // Tied types match and we can infer the shape from that. This may
+          // have false positives (e.g. in the case of ?x? that gets transposed)
+          // but in the more common case of read/write in-place operations this
+          // makes this much easier.
+          dynamicDimArgs.assign(shapedType.getNumDynamicDims(), kTiedDim);
+        }
+      }
+
+      // If the user has manually specified the dimensions then override the
+      // tied dims (if they were set at all).
+      if (auto dimsAttr = oldResAttrs.getAs<ArrayAttr>("iree.abi.dims")) {
+        if (streamableFunc.resultDimsFunc) {
+          funcOp.emitOpError()
+              << "cannot have both an explicit result shape "
+                 "calculation function and arg dims reference (on result "
+              << i << ")";
+          return std::nullopt;
+        }
+        if (dimsAttr.size() != shapedType.getNumDynamicDims()) {
+          funcOp.emitOpError()
+              << "result " << i
+              << " dynamic dimension mismatch; attribute specifies "
+              << dimsAttr.size() << " dimensions but tensor has "
+              << shapedType.getNumDynamicDims() << " dynamic dimensions";
+          return std::nullopt;
+        }
+        for (auto [j, value] :
+             llvm::enumerate(dimsAttr.getAsValueRange<IntegerAttr>())) {
+          dynamicDimArgs[j] = value.getSExtValue();
+        }
+      }
+
+      // Pass-through all other attrs we don't care about.
+      for (auto resAttr : oldResAttrs) {
+        if (resAttr.getName() == "iree.abi.tied" ||
+            resAttr.getName() == "iree.abi.dims") {
+          continue;
+        }
+        newResAttrs.push_back(resAttr);
+      }
+    }
+    funcResAttrs.push_back(moduleBuilder.getDictionaryAttr(newResAttrs));
+
+    // Ensure all result dims are set or we have a calculation function that can
+    // set them.
+    if (!streamableFunc.resultDimsFunc) {
+      for (auto dim : dynamicDimArgs) {
+        if (dim == kUnspecifiedDim) {
+          funcOp.emitOpError()
+              << "missing dynamic dimensions on result " << i
+              << "; must provide via iree.abi.dims, a matching typed tied "
+                 "operand, or with a custom result shape calculation function";
+          return std::nullopt;
+        }
+      }
+    }
+    streamableFunc.resultDimArgs.push_back(std::move(dynamicDimArgs));
+  }
+
+  // Create the new streamable flow.func op at the same place as the original.
+  streamableFunc.funcOp = moduleBuilder.create<IREE::Flow::FuncOp>(
+      funcOp.getLoc(), funcOp.getName(), functionType,
+      moduleBuilder.getIndexArrayAttr(streamableFunc.tiedOperands), funcAttrs,
+      funcArgAttrs, funcResAttrs);
+
+  // Swap out the symbol in the symbol table.
+  symbolTable.erase(funcOp);
+  symbolTable.insert(streamableFunc.funcOp);
+
+  return streamableFunc;
+}
+
+static LogicalResult convertStreamableCall(StreamableFunc &streamableFunc,
+                                           func::CallOp callOp) {
+  OpBuilder builder(callOp);
+
+  // Capture all argument dynamic dimensions.
+  SmallVector<Value> argDims;
+  for (auto arg : callOp.getOperands()) {
+    if (arg.getType().isa<ShapedType>()) {
+      llvm::append_range(argDims, IREE::Util::buildDynamicDimsForValue(
+                                      callOp.getLoc(), arg, builder));
+    }
+  }
+
+  // Capture all result dynamic dimensions.
+  SmallVector<Value> resultDims;
+  if (streamableFunc.resultDimsFunc) {
+    // Call the custom shape calculation function, if specified.
+    // It should return the required number of dynamic dimensions.
+    SmallVector<Type> resultDimTypes(streamableFunc.requiredResultDims,
+                                     builder.getIndexType());
+    auto calculateCallOp = builder.create<func::CallOp>(
+        callOp.getLoc(), streamableFunc.resultDimsFunc, resultDimTypes,
+        callOp.getOperands());
+    llvm::append_range(resultDims, calculateCallOp.getResults());
+  } else {
+    // Get the shape dimensions from existing call arguments or tied operands.
+    for (auto [i, resultType] : llvm::enumerate(callOp.getResultTypes())) {
+      if (auto shapedType = resultType.dyn_cast<ShapedType>()) {
+        const auto &resultDimArgs = streamableFunc.resultDimArgs[i];
+        if (resultDimArgs.empty()) continue;
+        if (resultDimArgs.front() == kTiedDim) {
+          // Source from a tied operand. Types must match exactly.
+          assert(streamableFunc.tiedOperands[i] !=
+                     IREE::Util::TiedOpInterface::kUntiedIndex &&
+                 "tied dims must be from tied operands");
+          auto sourceArg = callOp.getOperand(streamableFunc.tiedOperands[i]);
+          assert(sourceArg.getType() == resultType &&
+                 "only valid to infer result shapes from identically typed "
+                 "tied operands");
+          llvm::append_range(resultDims,
+                             IREE::Util::buildDynamicDimsForValue(
+                                 callOp.getLoc(), sourceArg, builder));
+        } else {
+          // Source from call arguments.
+          for (int64_t j : resultDimArgs) {
+            resultDims.push_back(callOp.getOperand(j));
+          }
+        }
+      }
+    }
+  }
+
+  // Replace the original func.call with the new flow.call.
+  auto streamableCallOp = builder.create<IREE::Flow::CallOp>(
+      callOp.getLoc(), callOp.getCalleeAttr(), callOp.getResultTypes(),
+      resultDims, callOp.getOperands(), argDims,
+      streamableFunc.funcOp.getTiedOperandsAttr());
+  streamableCallOp->setDialectAttrs(callOp->getDialectAttrs());
+  callOp.replaceAllUsesWith(streamableCallOp.getResults());
+  callOp.erase();
+
+  return success();
+}
+
+static LogicalResult convertStreamableCalls(
+    mlir::ModuleOp moduleOp,
+    DenseMap<StringRef, StreamableFunc> &streamableFuncs) {
+  auto walkResult = moduleOp.walk([&](func::CallOp callOp) {
+    auto it = streamableFuncs.find(callOp.getCallee());
+    if (it != streamableFuncs.end()) {
+      if (failed(convertStreamableCall(it->second, callOp))) {
+        return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+  return walkResult.wasInterrupted() ? failure() : success();
+}
+
+class ConvertStreamableOpsPass
+    : public PassWrapper<ConvertStreamableOpsPass, OperationPass<ModuleOp>> {
+ public:
+  ConvertStreamableOpsPass() = default;
+  ConvertStreamableOpsPass(const ConvertStreamableOpsPass &pass) {}
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<func::FuncDialect, mlir::tensor::TensorDialect,
+                    IREE::Flow::FlowDialect>();
+  }
+
+  StringRef getArgument() const override {
+    return "iree-abi-convert-streamable-ops";
+  }
+
+  StringRef getDescription() const override {
+    return "Converts streamable ops in input dialects into their IREE dialect "
+           "forms.";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    // Gather functions that need wrapping.
+    SmallVector<func::FuncOp> originalFuncOps;
+    for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+      // Ignore functions already marked as having their ABI goo handled.
+      if (funcOp->hasAttr("iree.abi.streamable")) {
+        if (!funcOp.isExternal()) {
+          funcOp.emitOpError()
+              << "only external streamable calls are supported today";
+          return signalPassFailure();
+        }
+        originalFuncOps.push_back(funcOp);
+      }
+    }
+
+    SymbolTable symbolTable(moduleOp);
+    DenseMap<StringRef, StreamableFunc> streamableFuncs;
+
+    // Convert all function declarations identified as streamable.
+    for (auto originalFuncOp : originalFuncOps) {
+      auto streamableFuncOr =
+          convertStreamableFunc(moduleOp, originalFuncOp, symbolTable);
+      if (!streamableFuncOr.has_value()) return signalPassFailure();
+      auto streamableFunc = std::move(streamableFuncOr).value();
+      streamableFuncs[streamableFunc.funcOp.getName()] =
+          std::move(streamableFunc);
+    }
+
+    // Convert all calls to those streamable func ops.
+    if (failed(convertStreamableCalls(moduleOp, streamableFuncs))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertStreamableOpsPass() {
+  return std::make_unique<ConvertStreamableOpsPass>();
+}
+
+static PassRegistration<ConvertStreamableOpsPass> pass;
+
+}  // namespace ABI
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/Passes.cpp
@@ -20,6 +20,10 @@ namespace ABI {
 
 void buildTransformPassPipeline(OpPassManager &passManager,
                                 const InvocationOptions &invocationOptions) {
+  // Convert streamable ops prior to wrapping. This lets us use the original
+  // types on function boundaries prior to wrapping.
+  passManager.addPass(createConvertStreamableOpsPass());
+
   // Wraps the entry points in an export function.
   passManager.addPass(
       createWrapEntryPointsPass(invocationOptions.invocationModel));

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/Passes.h
@@ -55,6 +55,9 @@ void registerTransformPassPipeline();
 // IREE native ABI bindings support
 //===----------------------------------------------------------------------===//
 
+// Converts streamable ops in input dialects into their IREE dialect forms.
+std::unique_ptr<OperationPass<ModuleOp>> createConvertStreamableOpsPass();
+
 // Wraps all entry points in a function that is compatible with the
 // expected invocation semantics of bindings following the native IREE ABI.
 std::unique_ptr<OperationPass<ModuleOp>> createWrapEntryPointsPass(
@@ -64,7 +67,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createWrapEntryPointsPass(
 // Register all Passes
 //===----------------------------------------------------------------------===//
 
-inline void registerPasses() { createWrapEntryPointsPass(); }
+inline void registerPasses() {
+  createConvertStreamableOpsPass();
+  createWrapEntryPointsPass();
+}
 
 }  // namespace ABI
 }  // namespace IREE

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "convert_streamable_ops.mlir",
             "wrap_entry_points.mlir",
             "wrap_entry_points_coarse_fences.mlir",
         ],

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "convert_streamable_ops.mlir"
     "wrap_entry_points.mlir"
     "wrap_entry_points_coarse_fences.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/convert_streamable_ops.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/convert_streamable_ops.mlir
@@ -1,0 +1,136 @@
+// RUN: iree-opt --iree-abi-convert-streamable-ops --cse --split-input-file %s --verify-diagnostics | FileCheck %s
+
+// Tests most of the features of the conversion.
+
+// CHECK: flow.func private @import(%arg0: tensor<?x2xi32> {some.arg_attr}, %arg1: tensor<?x4xf32>, %arg2: i32, %arg3: index) -> (%arg0, tensor<?x4xi8> {some.result_attr})
+func.func private @import(tensor<?x2xi32> {some.arg_attr}, tensor<?x4xf32>, i32, index) ->
+    (tensor<?x2xi32> {iree.abi.tied = 0 : index}, tensor<?x4xi8> {iree.abi.dims = [3 : index], some.result_attr}) attributes {
+  iree.abi.streamable
+}
+
+// CHECK: func.func private @caller
+func.func private @caller(%arg0: tensor<?x2xi32>, %arg1: tensor<?x4xf32>, %arg2: i32, %dim0: index) -> (tensor<?x2xi32>, tensor<?x4xi8>) {
+  // CHECK-DAG: %[[ARG0_DIM0:.+]] = tensor.dim %arg0, %c0
+  // CHECK-DAG: %[[ARG1_DIM0:.+]] = tensor.dim %arg1, %c0
+  // CHECK: %[[RETS:.+]]:2 = flow.call @import(%arg0, %arg1, %arg2, %arg3) : (tensor<?x2xi32>{%[[ARG0_DIM0]]}, tensor<?x4xf32>{%[[ARG1_DIM0]]}, i32, index) -> (%arg0{%[[ARG0_DIM0]]}, tensor<?x4xi8>{%arg3})
+  %0:2 = call @import(%arg0, %arg1, %arg2, %dim0) : (tensor<?x2xi32>, tensor<?x4xf32>, i32, index) -> (tensor<?x2xi32>, tensor<?x4xi8>)
+  // CHECK: return %[[RETS]]#0, %[[RETS]]#1
+  return %0#0, %0#1 : tensor<?x2xi32>, tensor<?x4xi8>
+}
+
+// -----
+
+// Verifies if a user doesn't specify untied result dynamic dims we error out.
+
+// expected-error @+1 {{missing dynamic dimensions on result 0}}
+func.func private @importMissingResultDims(tensor<?x?xi32>, index, index) -> tensor<?x?xf32> attributes {
+  iree.abi.streamable
+}
+
+// -----
+
+// Tests that untied results with dynamic dimensions can resolve them.
+// Users need to specify in such cases.
+
+// CHECK: flow.func private @importWithResultDims(%arg0: tensor<?x?xi32>, %arg1: index, %arg2: index) -> tensor<?x?xf32>
+func.func private @importWithResultDims(tensor<?x?xi32>, index, index) -> (tensor<?x?xf32> {iree.abi.dims = [1 : index, 2 : index]}) attributes {
+  iree.abi.streamable
+}
+
+// CHECK: func.func private @callerWithResultDims
+func.func private @callerWithResultDims(%arg0: tensor<?x?xi32>, %arg1: index, %arg2: index) -> tensor<?x?xf32> {
+  // CHECK-DAG: %[[ARG0_DIM0:.+]] = tensor.dim %arg0, %c0
+  // CHECK-DAG: %[[ARG0_DIM1:.+]] = tensor.dim %arg0, %c1
+  // CHECK: %[[RET:.+]] = flow.call @importWithResultDims(%arg0, %arg1, %arg2) : (tensor<?x?xi32>{%[[ARG0_DIM0]], %[[ARG0_DIM1]]}, index, index) -> tensor<?x?xf32>{%arg1, %arg2}
+  %0 = call @importWithResultDims(%arg0, %arg1, %arg2) : (tensor<?x?xi32>, index, index) -> tensor<?x?xf32>
+  // CHECK: return %[[RET]]
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+// Verifies if the user tries specifying result dims and a calculation function
+// we properly error.
+
+func.func private @calculateOverconstrainedResultDims(%arg0: index) -> index {
+  return %arg0 : index
+}
+
+// expected-error @+1 {{cannot have both an explicit result shape calculation function}}
+func.func private @importOverconstrainedResultDims(index) -> (tensor<2x?xf32> {iree.abi.dims = [0 : index]}) attributes {
+  iree.abi.streamable,
+  iree.abi.result_dims = @calculateOverconstrainedResultDims
+}
+
+// -----
+
+// Tests using a shape computation function for computing result dimensions.
+
+// CHECK: func.func private @calculateResultDims
+func.func private @calculateResultDims(%arg0: tensor<1x?xi32>, %arg1: i32, %arg2: tensor<?xf32>) -> (index, index) {
+  // Could do math here, call other imported host functions, etc. Note that
+  // doing anything but tensor.dim on the tensor arguments will cause massive
+  // performance penalties and should always be avoided.
+  //
+  // Note that only dynamic dimensions need to be returned.
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %arg0_dim1 = tensor.dim %arg0, %c1 : tensor<1x?xi32>
+  %arg2_dim0 = tensor.dim %arg2, %c0 : tensor<?xf32>
+  return %arg0_dim1, %arg2_dim0 : index, index
+}
+
+// CHECK: flow.func private @importCustomResultDims(%arg0: tensor<1x?xi32>, %arg1: i32, %arg2: tensor<?xf32>) -> (tensor<2x?xf32>, tensor<?xi8>)
+func.func private @importCustomResultDims(tensor<1x?xi32>, i32, tensor<?xf32>) -> (tensor<2x?xf32>, tensor<?xi8>) attributes {
+  iree.abi.streamable,
+  iree.abi.result_dims = @calculateResultDims
+}
+
+// CHECK: func.func private @callerCustomResultDims
+func.func private @callerCustomResultDims(%arg0: tensor<1x?xi32>, %arg1: i32, %arg2: tensor<?xf32>) -> (tensor<2x?xf32>, tensor<?xi8>) {
+  // CHECK-DAG: %[[ARG0_DIM1:.+]] = tensor.dim %arg0, %c1
+  // CHECK-DAG: %[[ARG2_DIM0:.+]] = tensor.dim %arg2, %c0
+  // CHECK: %[[RET_DIMS:.+]]:2 = call @calculateResultDims(%arg0, %arg1, %arg2) : (tensor<1x?xi32>, i32, tensor<?xf32>) -> (index, index)
+  // CHECK: %[[RETS:.+]]:2 = flow.call @importCustomResultDims(%arg0, %arg1, %arg2) : (tensor<1x?xi32>{%[[ARG0_DIM1]]}, i32, tensor<?xf32>{%[[ARG2_DIM0]]}) -> (tensor<2x?xf32>{%[[RET_DIMS]]#0}, tensor<?xi8>{%[[RET_DIMS]]#1})
+  %0:2 = call @importCustomResultDims(%arg0, %arg1, %arg2) : (tensor<1x?xi32>, i32, tensor<?xf32>) -> (tensor<2x?xf32>, tensor<?xi8>)
+  // CHECK: return %[[RETS]]#0, %[[RETS]]#1
+  return %0#0, %0#1 : tensor<2x?xf32>, tensor<?xi8>
+}
+
+// -----
+
+// Tests that results tied to operands get handled correctly and reuse the
+// argument shapes.
+
+// CHECK: flow.func private @importWithTies(%arg0: tensor<?x?xi32>) -> %arg0
+func.func private @importWithTies(tensor<?x?xi32>) -> (tensor<?x?xi32> {iree.abi.tied = 0 : index}) attributes {
+  iree.abi.streamable
+}
+
+// CHECK: func.func private @callerWithTies
+func.func private @callerWithTies(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
+  // CHECK-DAG: %[[ARG0_DIM0:.+]] = tensor.dim %arg0, %c0
+  // CHECK-DAG: %[[ARG0_DIM1:.+]] = tensor.dim %arg0, %c1
+  // CHECK: %[[RET:.+]] = flow.call @importWithTies(%arg0) : (tensor<?x?xi32>{%[[ARG0_DIM0]], %[[ARG0_DIM1]]}) -> %arg0{%[[ARG0_DIM0]], %[[ARG0_DIM1]]}
+  %0 = call @importWithTies(%arg0) : (tensor<?x?xi32>) -> tensor<?x?xi32>
+  // CHECK: return %[[RET]]
+  return %0 : tensor<?x?xi32>
+}
+
+// -----
+
+// Tests that attrs we don't know about are passed through to the new ops.
+
+// CHECK: flow.func private @importPassThroughAttrs(%arg0: tensor<1xi32> {some.arg_attr}) -> tensor<1xi8> {some.result_attr} attributes {some.import_attr}
+func.func private @importPassThroughAttrs(tensor<1xi32> {some.arg_attr}) -> (tensor<1xi8> {some.result_attr}) attributes {
+  iree.abi.streamable,
+  some.import_attr
+}
+
+// CHECK: func.func private @callerPassThroughArgs
+func.func private @callerPassThroughArgs(%arg0: tensor<1xi32>) -> tensor<1xi8> {
+  // CHECK: %[[RET:.+]] = flow.call @importPassThroughAttrs(%arg0) {some.call_attr} : (tensor<1xi32>) -> tensor<1xi8>
+  %0 = call @importPassThroughAttrs(%arg0) {some.call_attr} : (tensor<1xi32>) -> tensor<1xi8>
+  // CHECK: return %[[RET]]
+  return %0 : tensor<1xi8>
+}

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -10,8 +10,10 @@
 include "iree/compiler/Dialect/Flow/IR/FlowBase.td"
 include "iree/compiler/Dialect/Flow/IR/FlowInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
+include "mlir/IR/FunctionInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -747,6 +749,16 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
     Variadic<AnyType>:$results
   );
 
+  let assemblyFormat = [{
+    $entry_point
+    (`[` $workload^ `]`)? ``
+    `(` $arguments `)` attr-dict `:`
+    custom<ShapedFunctionType>(ref($arguments),
+                               type($arguments), $argument_dims,
+                               type($results), $result_dims,
+                               $tied_operands)
+  }];
+
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins
@@ -784,14 +796,163 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
     }
   }];
 
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Streamable call ops
+//===----------------------------------------------------------------------===//
+
+def FLOW_FuncOp : FLOW_Op<"func", [
+  CallableOpInterface,
+  FunctionOpInterface,
+  IsolatedFromAbove,
+]> {
+  let summary = [{streamable function declaration}];
+  let description = [{
+    Declares a function that can be called as an asynchronous streaming
+    operation via `flow.call`. Today only external functions are allowed.
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    OptionalAttr<StrAttr>:$sym_visibility,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+
+  let regions = (region AnyRegion:$body);
+
   let assemblyFormat = [{
-    $entry_point
-    (`[` $workload^ `]`)? ``
+    custom<SymbolVisibility>($sym_visibility)
+    $sym_name
+    ``
+    custom<ShapedFunctionSignature>($function_type,
+                                    $tied_operands,
+                                    $arg_attrs,
+                                    $res_attrs)
+    attr-dict-with-keyword
+    ($body^)?
+  }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      "StringRef":$name,
+      "FunctionType":$type,
+      CArg<"ArrayAttr", "{}">:$tied_operands,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$resAttrs
+    )>,
+  ];
+
+  let extraClassDeclaration = [{
+    static FuncOp create(Location location, StringRef name, FunctionType type,
+                         ArrayRef<int64_t> tiedOperands = {},
+                         ArrayRef<NamedAttribute> attrs = {},
+                         ArrayRef<DictionaryAttr> argAttrs = {},
+                         ArrayRef<DictionaryAttr> resAttrs = {});
+
+    bool isDeclaration() { return true; }
+
+    ::mlir::Region *getCallableRegion() { return nullptr; }
+    ArrayRef<Type> getCallableResults() { return getFunctionType().getResults(); }
+    ::mlir::ArrayAttr getCallableArgAttrs() { return getArgAttrs().value_or(nullptr); }
+    ::mlir::ArrayAttr getCallableResAttrs() { return getResAttrs().value_or(nullptr); }
+
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+  }];
+}
+
+def FLOW_CallOp : FLOW_Op<"call", [
+  AttrSizedOperandSegments,
+  CallOpInterface,
+  FLOW_StreamableOp,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  DeclareOpInterfaceMethods<Util_TiedOpInterface, [
+    "getTiedOperandsIndexAndLength",
+  ]>,
+  Util_ShapeAwareOp,
+]> {
+  let summary = [{calls a streamable external host function}];
+  let description = [{
+    Calls a function taking/returning tensor values with stream semantics.
+    Tensors have their shapes captured and may be tied to denote in-place
+    operations. Asynchronous calls must have no side-effects.
+
+    Note that returned tensors must have their shapes declared prior to the call
+    as this is what allows the call to be made on the stream. If external host
+    logic is required to compute the shape (avoid at all costs!) a separate
+    func.call can be used outside of the stream to do so. If shapes are
+    unknowable until the operation is performed it should be made as a normal
+    asynchronous host call with 'coarse-fences' instead.
+  }];
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$callee,
+    Variadic<AnyType>:$arguments,
+    FLOW_ShapeDynamicDims:$argument_dims,
+    FLOW_ShapeDynamicDims:$result_dims,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands
+  );
+  let results = (outs
+    Variadic<AnyType>:$results
+  );
+
+  let assemblyFormat = [{
+    $callee
     `(` $arguments `)` attr-dict `:`
     custom<ShapedFunctionType>(ref($arguments),
                                type($arguments), $argument_dims,
                                type($results), $result_dims,
                                $tied_operands)
+  }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      "SymbolRefAttr":$callee,
+      "TypeRange":$resultTypes,
+      "ValueRange":$arguments,
+      "ArrayAttr":$tiedOperands,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
+    OpBuilder<(ins
+      "SymbolRefAttr":$callee,
+      "TypeRange":$resultTypes, "ValueRange":$resultDims,
+      "ValueRange":$arguments, "ValueRange":$argumentDims,
+      "ArrayAttr":$tiedOperands,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
+  ];
+
+  let extraClassDeclaration = [{
+    FunctionType getCalleeType();
+
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return getArguments().begin(); }
+    operand_iterator arg_operand_end() { return getArguments().end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+    }
+
+    // StreamableOpInterface:
+    bool isTransfer() { return false; }
+
+    ValueRange getOperandDynamicDims(unsigned idx) {
+      return IREE::Util::findVariadicDynamicDims(idx, getArguments(), getArgumentDims());
+    }
+    ValueRange getResultDynamicDims(unsigned idx) {
+      return IREE::Util::findVariadicDynamicDims(idx, getResults(), getResultDims());
+    }
   }];
 
   let hasVerifier = 1;

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "call_ops.mlir",
             "dispatch_ops.mlir",
             "dispatch_tensor_folding.mlir",
             "dispatch_workgroups.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "call_ops.mlir"
     "dispatch_ops.mlir"
     "dispatch_tensor_folding.mlir"
     "dispatch_workgroups.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/call_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/call_ops.mlir
@@ -1,0 +1,88 @@
+// RUN: iree-opt --split-input-file %s --verify-diagnostics | FileCheck %s
+
+// CHECK: flow.func private @externArg0()
+flow.func private @externArg0()
+// CHECK-NEXT: flow.func private @externArg1(%arg0: tensor<4x?xi32>)
+flow.func private @externArg1(%arg0: tensor<4x?xi32>)
+// CHECK-NEXT: flow.func private @externArg1Attrs(%arg0: tensor<4x?xi32> {arg.attr})
+flow.func private @externArg1Attrs(%arg0: tensor<4x?xi32> {arg.attr})
+// CHECK-NEXT: flow.func private @externArg2(%arg0: tensor<4x?xi32>, %arg1: i32)
+flow.func private @externArg2(%arg0: tensor<4x?xi32>, %arg1: i32)
+// CHECK-NEXT: flow.func private @externArg2Attrs(%arg0: tensor<4x?xi32> {arg.attr0}, %arg1: i32 {arg.attr1})
+flow.func private @externArg2Attrs(%arg0: tensor<4x?xi32> {arg.attr0}, %arg1: i32 {arg.attr1})
+
+// -----
+
+// CHECK: flow.func private @externRet0()
+flow.func private @externRet0()
+// CHECK-NEXT: flow.func private @externRet1() -> tensor<4x?xi32>
+flow.func private @externRet1() -> tensor<4x?xi32>
+// CHECK-NEXT: flow.func private @externRet1Attrs() -> tensor<4x?xi32> {arg.attr}
+flow.func private @externRet1Attrs() -> tensor<4x?xi32> {arg.attr}
+// CHECK-NEXT: flow.func private @externRet2() -> (tensor<4x?xi32>, i32)
+flow.func private @externRet2() -> (tensor<4x?xi32>, i32)
+// CHECK-NEXT: flow.func private @externRet2Attrs() -> (tensor<4x?xi32> {arg.attr0}, i32 {arg.attr1})
+flow.func private @externRet2Attrs() -> (tensor<4x?xi32> {arg.attr0}, i32 {arg.attr1})
+// CHECK-NEXT: flow.func private @externRetAttributes() -> tensor<4x?xi32> {arg.attr} attributes {some.attr = 123 : index}
+flow.func private @externRetAttributes() -> tensor<4x?xi32> {arg.attr} attributes {some.attr = 123 : index}
+
+// -----
+
+// CHECK: flow.func private @externTied(%arg0: i32, %arg1: tensor<4x?xi32>, %arg2: tensor<4x?xi32>) -> (%arg1, %arg2 as tensor<?x4xf32>)
+flow.func private @externTied(%arg0: i32, %arg1: tensor<4x?xi32>, %arg2: tensor<4x?xi32>) -> (%arg1, %arg2 as tensor<?x4xf32>)
+// CHECK-NEXT: flow.func private @externTiedAttrs(%arg0: i32, %arg1: tensor<4x?xi32>, %arg2: tensor<4x?xi32>) -> (%arg1 {ret.attr0}, %arg2 as tensor<?x4xf32> {ret.attr1})
+flow.func private @externTiedAttrs(%arg0: i32, %arg1: tensor<4x?xi32>, %arg2: tensor<4x?xi32>) -> (%arg1 {ret.attr0}, %arg2 as tensor<?x4xf32> {ret.attr1})
+
+// -----
+
+// Basic extern taking a tensor and returning a new tensor.
+// During lowering the returned tensor will be turned into an output argument.
+flow.func private @basicExtern(%arg0: tensor<?xf32>, %arg1: index) -> (tensor<?xf32>, i32)
+
+// CHECK-LABEL: @basicCall
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<?xf32>)
+func.func @basicCall(%arg0: tensor<?xf32>) -> (tensor<?xf32>, i32) {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[DIM:.+]] = tensor.dim %[[ARG0]], %c0
+  %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+  // CHECK: %[[CALL:.+]]:2 = flow.call @basicExtern(%[[ARG0]], %[[DIM]]) : (tensor<?xf32>{%[[DIM]]}, index) -> (tensor<?xf32>{%[[DIM]]}, i32)
+  %call:2 = flow.call @basicExtern(%arg0, %dim) : (tensor<?xf32>{%dim}, index) -> (tensor<?xf32>{%dim}, i32)
+  // CHECK: return %[[CALL]]#0, %[[CALL]]#1
+  return %call#0, %call#1 : tensor<?xf32>, i32
+}
+
+// -----
+
+// Extern that performs an in-place operation on its argument.
+// No new tensors will be allocated and the call will receive a single argument.
+flow.func private @inplaceExtern(%arg0: tensor<?xf32>, %arg1: index) -> %arg0
+
+// CHECK-LABEL: @inplaceCall
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<?xf32>)
+func.func @inplaceCall(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[DIM:.+]] = tensor.dim %[[ARG0]], %c0
+  %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+  // CHECK: %[[CALL:.+]] = flow.call @inplaceExtern(%[[ARG0]], %[[DIM]]) : (tensor<?xf32>{%[[DIM]]}, index) -> %[[ARG0]]{%[[DIM]]}
+  %call = flow.call @inplaceExtern(%arg0, %dim) : (tensor<?xf32>{%dim}, index) -> %arg0{%dim}
+  // CHECK: return %[[CALL]]
+  return %call : tensor<?xf32>
+}
+
+// -----
+
+// Extern that performs an in-place operation that changes the type as seen by
+// the compiler. Here we change both the dimensions and the element type.
+flow.func private @inplaceTypeChangeExtern(%arg0: tensor<?x4xf32>, %arg1: index) -> %arg0 as tensor<4x?xi32>
+
+// CHECK-LABEL: @inplaceTypeChangeCall
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<?x4xf32>)
+func.func @inplaceTypeChangeCall(%arg0: tensor<?x4xf32>) -> tensor<4x?xi32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[DIM:.+]] = tensor.dim %[[ARG0]], %c0
+  %dim = tensor.dim %arg0, %c0 : tensor<?x4xf32>
+  // CHECK: %[[CALL:.+]] = flow.call @inplaceTypeChangeExtern(%[[ARG0]], %[[DIM]]) : (tensor<?x4xf32>{%[[DIM]]}, index) -> %[[ARG0]] as tensor<4x?xi32>{%[[DIM]]}
+  %call = flow.call @inplaceTypeChangeExtern(%arg0, %dim) : (tensor<?x4xf32>{%dim}, index) -> %arg0 as tensor<4x?xi32>{%dim}
+  // CHECK: return %[[CALL]]
+  return %call : tensor<4x?xi32>
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -419,6 +419,22 @@ class ValueResourceUsage : public AbstractResourceUsage<DFX::ValueElement> {
             getState() ^= resultUsage.getState();
           }
         })
+        .Case([&](IREE::Stream::AsyncCallOp op) {
+          // We treat calls as transfer + dispatch as any particular callee may
+          // use either (or both).
+          removeAssumedBits(NOT_TRANSFER_WRITE | NOT_DISPATCH_WRITE);
+          auto tiedOperand = op.getTiedResultOperand(result);
+          if (tiedOperand) {
+            auto tiedUsage = solver.getElementFor<ValueResourceUsage>(
+                *this, Position::forValue(tiedOperand),
+                DFX::Resolution::REQUIRED);
+            getState() ^= tiedUsage.getState();
+          } else {
+            auto resultUsage = solver.getElementFor<ValueResourceUsage>(
+                *this, Position::forValue(result), DFX::Resolution::REQUIRED);
+            getState() ^= resultUsage.getState();
+          }
+        })
         .Default([&](Operation *op) {});
   }
 
@@ -606,6 +622,17 @@ class ValueResourceUsage : public AbstractResourceUsage<DFX::ValueElement> {
         })
         .Case([&](IREE::Stream::AsyncDispatchOp op) {
           removeAssumedBits(NOT_DISPATCH_READ);
+          for (auto result : op.getOperandTiedResults(operandIdx)) {
+            removeAssumedBits(NOT_MUTATED | NOT_DISPATCH_WRITE);
+            auto resultUsage = solver.getElementFor<ValueResourceUsage>(
+                *this, Position::forValue(result), DFX::Resolution::REQUIRED);
+            getState() ^= resultUsage.getState();
+          }
+        })
+        .Case([&](IREE::Stream::AsyncCallOp op) {
+          // We treat calls as transfer + dispatch as any particular callee may
+          // use either (or both).
+          removeAssumedBits(NOT_TRANSFER_READ | NOT_DISPATCH_READ);
           for (auto result : op.getOperandTiedResults(operandIdx)) {
             removeAssumedBits(NOT_MUTATED | NOT_DISPATCH_WRITE);
             auto resultUsage = solver.getElementFor<ValueResourceUsage>(

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "call_ops.mlir",
             "collective_ops.mlir",
             "dispatch_ops.mlir",
             "executable_ops.mlir",

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "call_ops.mlir"
     "collective_ops.mlir"
     "dispatch_ops.mlir"
     "executable_ops.mlir"

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/call_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/call_ops.mlir
@@ -1,0 +1,55 @@
+// RUN: iree-opt --split-input-file --iree-stream-conversion --canonicalize %s | FileCheck %s
+
+// Basic extern taking a tensor and returning a new tensor.
+// During lowering the returned tensor will be turned into an output argument.
+
+// CHECK: stream.async.func private @basicExtern(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*>
+flow.func private @basicExtern(%arg0: tensor<?xf32>, %arg1: index) -> tensor<?xf32>
+
+// CHECK-LABEL: @basicCall
+// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<*>, %[[SIZE0:.+]]: index, %[[DIM0:.+]]: index)
+func.func @basicCall(%arg0: tensor<?xf32>, %dim0: index) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[RESULT_SIZE:.+]] = stream.tensor.sizeof tensor<?xf32>{%[[DIM0]]}
+  // CHECK: %[[CALL:.+]] = stream.async.call @basicExtern
+  // CHECK-SAME: (%[[ARG0]][%c0 to %[[SIZE0]] for %[[SIZE0]]], %[[DIM0]]) : (!stream.resource<*>{%[[SIZE0]]}, index) -> !stream.resource<*>{%[[RESULT_SIZE]]}
+  %call = flow.call @basicExtern(%arg0, %dim0) : (tensor<?xf32>{%dim0}, index) -> tensor<?xf32>{%dim0}
+  // CHECK: return %[[CALL]], %[[RESULT_SIZE]]
+  return %call : tensor<?xf32>
+}
+
+// -----
+
+// Extern that performs an in-place operation on its argument.
+// No new tensors will be allocated and the call will receive a single argument.
+
+// CHECK: stream.async.func private @inplaceExtern(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*>
+flow.func private @inplaceExtern(%arg0: tensor<?xf32>, %arg1: index) -> tensor<?xf32>
+
+// CHECK-LABEL: @inplaceCall
+// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<*>, %[[SIZE0:.+]]: index, %[[DIM0:.+]]: index)
+func.func @inplaceCall(%arg0: tensor<?xf32>, %dim0: index) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[CALL:.+]] = stream.async.call @inplaceExtern(%[[ARG0]][%c0 to %[[SIZE0]] for %[[SIZE0]]], %[[DIM0]]) : (!stream.resource<*>{%[[SIZE0]]}, index) -> %[[ARG0]]{%[[SIZE0]]}
+  %call = flow.call @inplaceExtern(%arg0, %dim0) : (tensor<?xf32>{%dim0}, index) -> %arg0{%dim0}
+  // CHECK: return %[[CALL]], %[[SIZE0]]
+  return %call : tensor<?xf32>
+}
+
+// -----
+
+// Extern that performs an in-place operation that changes the type as seen by
+// the compiler. Here we change both the dimensions and the element type.
+
+// CHECK: stream.async.func private @inplaceTypeChangeExtern(%arg0: !stream.resource<*>, %arg1: index) -> %arg0
+flow.func private @inplaceTypeChangeExtern(%arg0: tensor<?x4xf32>, %arg1: index) -> %arg0 as tensor<4x?xi32>
+
+// CHECK-LABEL: @inplaceTypeChangeCall
+// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<*>, %[[SIZE0:.+]]: index, %[[DIM0:.+]]: index)
+func.func @inplaceTypeChangeCall(%arg0: tensor<?x4xf32>, %dim0: index) -> tensor<4x?xi32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[CALL:.+]] = stream.async.call @inplaceTypeChangeExtern(%[[ARG0]][%c0 to %[[SIZE0]] for %[[SIZE0]]], %[[DIM0]]) : (!stream.resource<*>{%[[SIZE0]]}, index) -> %[[ARG0]]{%[[SIZE0]]}
+  %call = flow.call @inplaceTypeChangeExtern(%arg0, %dim0) : (tensor<?x4xf32>{%dim0}, index) -> %arg0 as tensor<4x?xi32>{%dim0}
+  // CHECK: return %[[CALL]], %[[SIZE0]]
+  return %call : tensor<4x?xi32>
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -10,8 +10,10 @@
 include "iree/compiler/Dialect/Stream/IR/StreamBase.td"
 include "iree/compiler/Dialect/Stream/IR/StreamInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
+include "mlir/IR/FunctionInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -2006,6 +2008,167 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
 // TODO(benvanik): stream.async.select
 // TODO(benvanik): stream.async.for
 
+def Stream_AsyncFuncOp : Stream_Op<"async.func", [
+  CallableOpInterface,
+  FunctionOpInterface,
+  IsolatedFromAbove,
+  Stream_AsyncPhaseOp,
+]> {
+  let summary = [{streamable function declaration}];
+  let description = [{
+    Declares a function that can be called as an asynchronous streaming
+    operation via `stream.async.call`. Today only external functions are
+    allowed.
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    OptionalAttr<StrAttr>:$sym_visibility,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+
+  let regions = (region AnyRegion:$body);
+
+  let assemblyFormat = [{
+    custom<SymbolVisibility>($sym_visibility)
+    $sym_name
+    ``
+    custom<ShapedFunctionSignature>($function_type,
+                                    $tied_operands,
+                                    $arg_attrs,
+                                    $res_attrs)
+    attr-dict-with-keyword
+    ($body^)?
+  }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      "StringRef":$name,
+      "FunctionType":$type,
+      CArg<"ArrayAttr", "{}">:$tied_operands,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$resAttrs
+    )>,
+  ];
+
+  let extraClassDeclaration = [{
+    static AsyncFuncOp create(Location location, StringRef name,
+                              FunctionType type,
+                              ArrayRef<int64_t> tiedOperands = {},
+                              ArrayRef<DictionaryAttr> argAttrs = {},
+                              ArrayRef<DictionaryAttr> resAttrs = {});
+
+    bool isDeclaration() { return true; }
+
+    ::mlir::Region *getCallableRegion() { return nullptr; }
+    ArrayRef<Type> getCallableResults() { return getFunctionType().getResults(); }
+    ::mlir::ArrayAttr getCallableArgAttrs() { return getArgAttrs().value_or(nullptr); }
+    ::mlir::ArrayAttr getCallableResAttrs() { return getResAttrs().value_or(nullptr); }
+
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+
+    // Returns true if the given result is tied to an argument.
+    bool isResultTied(int resultIndex);
+  }];
+}
+
+def Stream_AsyncCallOp : Stream_Op<"async.call", [
+  AttrSizedOperandSegments,
+  CallOpInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  Stream_AffinityOp,
+  Stream_AsyncPhaseOp,
+  Stream_StreamableOp,
+  DeclareOpInterfaceMethods<Stream_AsyncAccessOp, [
+    "getAsyncAccessRanges",
+  ]>,
+  Util_SizeAwareOp,
+  DeclareOpInterfaceMethods<Util_TiedOpInterface, [
+    "getTiedOperandsIndexAndLength",
+  ]>,
+]> {
+  let summary = [{calls a streamable external host function}];
+  let description = [{
+    Calls a function taking/returning resource values with stream semantics.
+    Asynchronous calls must have no side-effects.
+
+    Note that returned resources must have their sizes declared prior to the
+    call as this is what allows the call to be made on the stream. If external
+    host logic is required to compute the size (avoid at all costs!) a separate
+    func.call can be used outside of the stream to do so. If sizes are
+    unknownable until the operation is performed it should be made as a normal
+    asynchronous host call with 'coarse-fences' instead.
+  }];
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$callee,
+    Variadic<AnyTypeOf<[
+      Stream_AnyStreamResource,
+      Stream_PrimitiveType,
+      AnyType,
+    ]>>:$resource_operands,
+    Variadic<Stream_Size>:$resource_operand_sizes,
+    Variadic<Stream_Offset>:$resource_operand_offsets,
+    Variadic<Stream_Offset>:$resource_operand_ends,
+    Variadic<Stream_Size>:$resource_operand_lengths,
+    Variadic<Stream_Size>:$result_sizes,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    OptionalAttr<Stream_AffinityAttr>:$affinity
+  );
+  let results = (outs
+    Variadic<AnyTypeOf<[
+      Stream_AnyStreamResource,
+      Stream_PrimitiveType,
+    ]>>:$results
+  );
+
+  let assemblyFormat = [{
+    (`on` `(` $affinity^ `)`)?
+    $callee ``
+    custom<DispatchOperands>($resource_operands,
+                             $resource_operand_offsets,
+                             $resource_operand_ends,
+                             $resource_operand_lengths) attr-dict `:`
+    custom<ShapedFunctionType>(ref($resource_operands),
+                               type($resource_operands), $resource_operand_sizes,
+                               type($results), $result_sizes,
+                               $tied_operands)
+  }];
+
+  let extraClassDeclaration = [{
+    FunctionType getCalleeType();
+
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return getResourceOperands().begin(); }
+    operand_iterator arg_operand_end() { return getResourceOperands().end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+    }
+
+    Value getOperandSize(unsigned idx) {
+      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+    }
+    Value getResultSize(unsigned idx) {
+      return findValueSizeInList(idx, getResults(), getResultSizes());
+    }
+  }];
+
+  let hasVerifier = 1;
+
+  let hasCanonicalizer = 1;
+}
+
 def Stream_AsyncExecuteOp : Stream_Op<"async.execute", [
   AttrSizedOperandSegments,
   RecursiveMemoryEffects,
@@ -2521,6 +2684,142 @@ def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
     static SmallVector<unsigned> makeOperandToArgMap(mlir::func::FuncOp funcOp);
     // Builds a map of resource to argument index of the corresponding binding.
     static SmallVector<unsigned> makeResourceToArgMap(mlir::func::FuncOp funcOp);
+  }];
+
+  let hasVerifier = 1;
+
+  let hasCanonicalizer = 1;
+}
+
+def Stream_CmdFuncOp : Stream_Op<"cmd.func", [
+  CallableOpInterface,
+  FunctionOpInterface,
+  IsolatedFromAbove,
+  Stream_CmdPhaseOp,
+]> {
+  let summary = [{streamable function declaration}];
+  let description = [{
+    Declares a function that can be called as an asynchronous streaming
+    operation via `stream.cmd.call`. Today only external functions are
+    allowed.
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<StrAttr>:$sym_visibility,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+
+  let regions = (region AnyRegion:$body);
+
+  let assemblyFormat = [{
+    custom<SymbolVisibility>($sym_visibility)
+    $sym_name ``
+    custom<DispatchFunctionSignature>($function_type,
+                                      $arg_attrs,
+                                      $res_attrs)
+    attr-dict-with-keyword
+    ($body^)?
+  }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      "StringRef":$name,
+      "FunctionType":$type,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$resAttrs
+    )>,
+  ];
+
+  let extraClassDeclaration = [{
+    static CmdFuncOp create(Location location, StringRef name,
+                            FunctionType type,
+                            ArrayRef<DictionaryAttr> argAttrs = {},
+                            ArrayRef<DictionaryAttr> resAttrs = {});
+
+    bool isDeclaration() { return true; }
+
+    ::mlir::Region *getCallableRegion() { return nullptr; }
+    ArrayRef<Type> getCallableResults() { return getFunctionType().getResults(); }
+    ::mlir::ArrayAttr getCallableArgAttrs() { return getArgAttrs().value_or(nullptr); }
+    ::mlir::ArrayAttr getCallableResAttrs() { return getResAttrs().value_or(nullptr); }
+
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+  }];
+}
+
+def Stream_CmdCallOp : Stream_Op<"cmd.call", [
+  AttrSizedOperandSegments,
+  CallOpInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  Stream_CmdPhaseOp,
+  Stream_StreamableOp,
+  Stream_SubviewEffectOp,
+  Util_SizeAwareOp,
+]> {
+  let summary = [{calls a streamable external host function}];
+  let description = [{
+    Calls a function operating on resource values with stream semantics.
+    Asynchronous calls must have no side-effects.
+  }];
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$callee,
+    // TODO(benvanik): rework this to make more sense - it's mostly a copy of
+    // stream.cmd.dispatch mashed together with stream.async.call and it's kind
+    // of confusing.
+    Variadic<AnyTypeOf<[
+      Stream_PrimitiveType,
+      Stream_AnyStreamResource,
+      AnyType,  // for custom types
+    ]>>:$resource_operands,
+    Variadic<Stream_Size>:$resource_operand_sizes,
+    Variadic<Stream_Offset>:$resource_operand_offsets,
+    Variadic<Stream_Size>:$resource_operand_lengths,
+    Variadic<Stream_Size>:$result_sizes,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    Stream_ResourceAccessArrayAttr:$resource_operand_accesses
+  );
+  let results = (outs
+    Variadic<Stream_PrimitiveType>:$results
+  );
+
+  let assemblyFormat = [{
+    $callee ``
+    custom<CmdCallOperands>($resource_operands,
+                            $resource_operand_offsets,
+                            $resource_operand_lengths,
+                            $resource_operand_accesses) attr-dict `:`
+    custom<ShapedFunctionType>(ref($resource_operands),
+                               type($resource_operands),
+                               $resource_operand_sizes,
+                               type($results),
+                               $result_sizes,
+                               $tied_operands)
+  }];
+
+  let extraClassDeclaration = [{
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return getOperands().begin(); }
+    operand_iterator arg_operand_end() { return getOperands().end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+    }
+
+    Value getOperandSize(unsigned idx) {
+      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+    }
+    Value getResultSize(unsigned idx) { return {}; }
   }];
 
   let hasVerifier = 1;

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_ops.mlir
@@ -249,6 +249,19 @@ func.func @asyncDispatchNoWorkload(%arg0: !stream.resource<*>, %arg1: index) -> 
 
 // -----
 
+stream.async.func private @asyncExtern(%arg0: !stream.resource<*>, %arg1: index) -> %arg0
+
+// CHECK-LABEL: @asyncCall
+// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<*>, %[[SIZE0:.+]]: index)
+func.func @asyncCall(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %c0 = arith.constant 0 : index
+  // CHECK: = stream.async.call @asyncExtern(%[[ARG0]][%c0 to %[[SIZE0]] for %[[SIZE0]]], %[[SIZE0]]) : (!stream.resource<*>{%[[SIZE0]]}, index) -> %[[ARG0]]{%[[SIZE0]]}
+  %call = stream.async.call @asyncExtern(%arg0[%c0 to %arg1 for %arg1], %arg1) : (!stream.resource<*>{%arg1}, index) -> %arg0{%arg1}
+  return %call : !stream.resource<*>
+}
+
+// -----
+
 // CHECK-LABEL: @asyncExecute
 func.func @asyncExecute(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.timepoint) -> (!stream.resource<*>, !stream.timepoint) {
   // CHECK: = stream.async.execute await(%arg2) => with(%arg0 as %arg3: !stream.resource<*>{%arg1}) -> %arg0{%arg1} {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -113,6 +113,7 @@ struct Statistics {
   size_t copyCount = 0;
   size_t collectiveCount = 0;
   size_t dispatchCount = 0;
+  size_t callCount = 0;
 
   // Executables:
   size_t executableCount = 0;
@@ -157,7 +158,8 @@ struct Statistics {
             .Case<IREE::Stream::CmdCollectiveOp>(
                 [&](auto op) { ++collectiveCount; })
             .Case<IREE::Stream::CmdDispatchOp>(
-                [&](auto op) { ++dispatchCount; });
+                [&](auto op) { ++dispatchCount; })
+            .Case<IREE::Stream::CmdCallOp>([&](auto op) { ++callCount; });
       });
     }
 
@@ -233,6 +235,7 @@ static void prettyPrintStatistics(const UsageInfo &usageInfo,
   os << llvm::formatv("//  DMA Copies: {0}\n", stats.copyCount);
   os << llvm::formatv("// Collectives: {0}\n", stats.collectiveCount);
   os << llvm::formatv("//  Dispatches: {0}\n", stats.dispatchCount);
+  os << llvm::formatv("// Async Calls: {0}\n", stats.callCount);
 
   os << llvm::formatv(
       "// Executables: {0}, {1}% reuse\n", stats.executableCount,
@@ -386,7 +389,7 @@ static void dumpAggregateCSVTable(const UsageInfo &usageInfo,
   Statistics stats;
   stats.analyze(usageInfo);
 
-  os << R"("Constants","Constant Size","Variables","Variable Size","Awaits","Submissions","Transient Size","Fills","Copies","Dispatches","Executables")";
+  os << R"("Constants","Constant Size","Variables","Variable Size","Awaits","Submissions","Transient Size","Fills","Copies","Dispatches","Async Calls","Executables")";
   os << "\n";
 
   // Globals:
@@ -398,9 +401,9 @@ static void dumpAggregateCSVTable(const UsageInfo &usageInfo,
   os << llvm::formatv("{0},", stats.awaitCount);
 
   // Execution:
-  os << llvm::formatv("{0},{1},{2},{3},{4},", stats.submissionCount,
+  os << llvm::formatv("{0},{1},{2},{3},{4},{5},", stats.submissionCount,
                       stats.transientSize, stats.fillCount, stats.copyCount,
-                      stats.dispatchCount);
+                      stats.dispatchCount, stats.callCount);
 
   // Executables:
   os << llvm::formatv("{0}", stats.executableCount);
@@ -520,7 +523,8 @@ static void dumpAggregateJSONStructure(const UsageInfo &usageInfo,
   os << llvm::formatv(kvPair, "transient-memory-size", stats.transientSize);
   os << llvm::formatv(kvPair, "fill-count", stats.fillCount);
   os << llvm::formatv(kvPair, "copy-count", stats.copyCount);
-  os << llvm::formatv(kvPairNoComma, "dispatch-count", stats.dispatchCount);
+  os << llvm::formatv(kvPair, "dispatch-count", stats.dispatchCount);
+  os << llvm::formatv(kvPairNoComma, "call-count", stats.callCount);
   os << "  },\n";
 
   os << "  \"executable\": {\n";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
@@ -128,7 +128,8 @@ static bool materializeRegionCOW(Region &region) {
                     // TODO(#11249): special case collectives for in-place.
                     // We don't want to clone the send buffer.
                     IREE::Stream::AsyncCollectiveOp,
-                    IREE::Stream::AsyncDispatchOp, IREE::Stream::AsyncExecuteOp,
+                    IREE::Stream::AsyncDispatchOp, IREE::Stream::AsyncCallOp,
+                    IREE::Stream::AsyncExecuteOp,
                     IREE::Stream::AsyncConcurrentOp>(
                   [&](auto op) { return materializeTiedOpCOW(op); })
               .Default(false) ||

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -173,9 +173,8 @@ void buildStreamCmdPassPipeline(OpPassManager &passManager,
                                 const TransformOptions &transformOptions) {
   // Schedule fine-grained allocations and insert placeholders for larger/longer
   // lifetime allocations.
+  passManager.addPass(IREE::Stream::createScheduleAllocationPass());
   FunctionLikeNest(passManager)
-      .addPass(IREE::Stream::createScheduleAllocationPass)
-
       // TODO(benvanik): passes to convert alloc to alloca and thread through
       // streams. Ideally all transient allocs become stream-ordered allocas.
       // createPropagateTransientsPass()

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.h
@@ -131,8 +131,7 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createElideTimepointsPass();
 // Allocation and command issuing
 //===----------------------------------------------------------------------===//
 
-std::unique_ptr<InterfacePass<CallableOpInterface>>
-createScheduleAllocationPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createScheduleAllocationPass();
 
 std::unique_ptr<InterfacePass<CallableOpInterface>> createPackConstantsPass();
 std::unique_ptr<InterfacePass<CallableOpInterface>> createPackAllocationsPass();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -134,7 +134,7 @@ def ElideTimepoints :
 //===----------------------------------------------------------------------===//
 
 def ScheduleAllocation :
-    InterfacePass<"iree-stream-schedule-allocation", "mlir::CallableOpInterface"> {
+    Pass<"iree-stream-schedule-allocation", "mlir::ModuleOp"> {
   let summary = "Allocates resources and converts to explicit stream commands.";
   let constructor = [{
     mlir::iree_compiler::IREE::Stream::createScheduleAllocationPass()

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -358,6 +358,7 @@ static void insertUsageRefinementPatterns(MLIRContext *context,
                   ApplyStreamableOp<IREE::Stream::AsyncLoadOp>,
                   ApplyStreamableOp<IREE::Stream::AsyncStoreOp>,
                   ApplyStreamableOp<IREE::Stream::AsyncDispatchOp>,
+                  ApplyStreamableOp<IREE::Stream::AsyncCallOp>,
                   ApplyStreamableOp<IREE::Stream::AsyncExecuteOp>,
                   ApplyStreamableOp<IREE::Stream::AsyncConcurrentOp>,
                   ApplyStreamableOp<IREE::Stream::YieldOp>>(context, analysis);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/dump_statistics.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/dump_statistics.mlir
@@ -13,8 +13,8 @@
 // CHECK-PRETTY: Executables: 2, 33% reuse
 
 // CHECK-CSV: ; Aggregate Statistics
-// CHECK-CSV: "Constants","Constant Size","Variables","Variable Size","Awaits","Submissions","Transient Size","Fills","Copies","Dispatches","Executables"
-// CHECK-CSV: 1,0,0,0,2,3,0,0,2,3,2
+// CHECK-CSV: "Constants","Constant Size","Variables","Variable Size","Awaits","Submissions","Transient Size","Fills","Copies","Dispatches","Async Calls","Executables"
+// CHECK-CSV: 1,0,0,0,2,3,0,0,2,3,0,2
 // CHECK-CSV: ; Execution
 // CHECK-CSV: "Depth","Command","Symbol","Length","Invocations","Workload","Operands","Resources"
 // CHECK-CSV: 0,"copy",,192,,,,

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
@@ -191,6 +191,21 @@ void printShapedFunctionType(OpAsmPrinter &p, Operation *op,
                              OperandRange operandDims, TypeRange resultTypes,
                              OperandRange resultDims, ArrayAttr tiedOperands);
 
+//===----------------------------------------------------------------------===//
+// custom<ShapedFunctionSignature>
+//===----------------------------------------------------------------------===//
+// (%arg0: type {some.attr = 54 : index}, %arg1: type) -> (type, %arg1 as type)
+
+ParseResult parseShapedFunctionSignature(OpAsmParser &parser,
+                                         TypeAttr &functionTypeAttr,
+                                         ArrayAttr &tiedOperands,
+                                         ArrayAttr &argAttrs,
+                                         ArrayAttr &resultAttrs);
+void printShapedFunctionSignature(OpAsmPrinter &p, Operation *op,
+                                  TypeAttr functionTypeAttr,
+                                  ArrayAttr tiedOperands, ArrayAttr argAttrs,
+                                  ArrayAttr resultAttrs);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
@@ -449,6 +449,70 @@ struct CmdDispatchOpPattern
   }
 };
 
+struct CmdFuncOpPattern : public OpConversionPattern<IREE::Stream::CmdFuncOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      IREE::Stream::CmdFuncOp funcOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> newArgTypes;
+    SmallVector<Type> newResultTypes;
+    if (failed(getTypeConverter()->convertTypes(funcOp.getArgumentTypes(),
+                                                newArgTypes)) ||
+        failed(getTypeConverter()->convertTypes(funcOp.getResultTypes(),
+                                                newResultTypes))) {
+      return rewriter.notifyMatchFailure(funcOp, "failed to convert types");
+    }
+    auto newOp = rewriter.replaceOpWithNewOp<func::FuncOp>(
+        funcOp, funcOp.getName(),
+        rewriter.getFunctionType(newArgTypes, newResultTypes),
+        funcOp.getSymVisibilityAttr(), funcOp.getAllArgAttrs(),
+        funcOp.getAllResultAttrs());
+    newOp->setDialectAttrs(funcOp->getDialectAttrs());
+    return success();
+  }
+};
+
+struct CmdCallOpPattern : public OpConversionPattern<IREE::Stream::CmdCallOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      IREE::Stream::CmdCallOp callOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value> operands;
+    size_t resourceIndex = 0;
+    for (auto [originalOperand, convertedOperand] : llvm::zip_equal(
+             callOp.getResourceOperands(), adaptor.getResourceOperands())) {
+      if (originalOperand.getType().isa<IREE::Stream::ResourceType>()) {
+        // Resource type, add offset/length.
+        auto resourceSize = adaptor.getResourceOperandSizes()[resourceIndex];
+        auto storage = getResourceStorage(callOp.getLoc(), convertedOperand,
+                                          resourceSize, rewriter);
+        operands.push_back(storage.buffer);
+        operands.push_back(adaptor.getResourceOperandOffsets()[resourceIndex]);
+        operands.push_back(adaptor.getResourceOperandLengths()[resourceIndex]);
+        ++resourceIndex;
+      } else {
+        // Primitive/custom type.
+        operands.push_back(convertedOperand);
+      }
+    }
+
+    SmallVector<Type> resultTypes;
+    for (auto result : callOp.getResults()) {
+      SmallVector<Type> convertedTypes;
+      if (failed(getTypeConverter()->convertType(result.getType(),
+                                                 convertedTypes))) {
+        return rewriter.notifyMatchFailure(callOp.getLoc(),
+                                           "unconvertable result type");
+      }
+      llvm::append_range(resultTypes, convertedTypes);
+    }
+
+    rewriter.replaceOpWithNewOp<func::CallOp>(callOp, callOp.getCalleeAttr(),
+                                              resultTypes, operands);
+    return success();
+  }
+};
+
 struct CmdExecuteOpPattern
     : public OpConversionPattern<IREE::Stream::CmdExecuteOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -646,8 +710,9 @@ void populateStreamToHALInlinePatterns(MLIRContext *context,
   patterns
       .insert<CmdFlushOpPattern, CmdInvalidateOpPattern, CmdDiscardOpPattern,
               CmdFillOpPattern, CmdCopyOpPattern, CmdDispatchOpPattern,
-              CmdExecuteOpPattern, CmdSerialOpPattern, CmdConcurrentOpPattern>(
-          typeConverter, context);
+              CmdFuncOpPattern, CmdCallOpPattern, CmdExecuteOpPattern,
+              CmdSerialOpPattern, CmdConcurrentOpPattern>(typeConverter,
+                                                          context);
 
   patterns.insert<GlobalTimepointConversionPattern>(typeConverter, context);
   patterns.insert<TimepointImmediateOpPattern, TimepointImportOpPattern,

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/Conversion.cpp
@@ -54,6 +54,7 @@ class ConversionPass : public ConversionBase<ConversionPass> {
     RewritePatternSet patterns(context);
 
     // Pass-through.
+    typeConverter.addConversion([](Type type) { return type; });
     typeConverter.addConversion([](IndexType type) { return type; });
     typeConverter.addConversion([](IntegerType type) { return type; });
     typeConverter.addConversion([](FloatType type) { return type; });

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Conversion.cpp
@@ -57,6 +57,7 @@ class ConversionPass : public ConversionBase<ConversionPass> {
     RewritePatternSet patterns(context);
 
     // Pass-through.
+    typeConverter.addConversion([](Type type) { return type; });
     typeConverter.addConversion([](IndexType type) { return type; });
     typeConverter.addConversion([](IntegerType type) { return type; });
     typeConverter.addConversion([](FloatType type) { return type; });


### PR DESCRIPTION
New ops: flow.call/stream.async.call/stream.cmd.call + funcs. This allows for externally-defined non-side-effecting streamable calls that end up getting scheduled within command buffers. Users can declare functions with some magic attributes (or directly lower to flow.func/flow.call) to have the ABI handling take care of things.

The intent is that the streamable calls can return non-tensor/resource values but there's larger fixups needed in the stream dialect passes to support this (they currently assume streams only ever return async resources). Future cleanup should derive a common interface between collective, dispatch, and call ops to make it possible to let user ops come through the pipeline.

Workflow-wise a user would setup the streamable calls by forming their func.func/func.call ops with the appropriate attributes, run it through the IREE compiler, and then provide a custom runtime exporting a function with the appropriate signature (iree_hal_command_buffer_t, iree_hal_buffer_t + offset + length for each buffer, etc). If the runtime side is able to use the HAL APIs to perform transfers and dispatches then the modules can be backend-agnostic, while other implementations may want to tightly couple with the HAL device by having special APIs. An example would be something that wanted to schedule CUDA work via CUDA APIs needing to use methods exposed in `iree/hal/drivers/cuda/api.h` to record to streams or graphs. Future work driven by use-cases will be needed to make that ergonomic.