### PR TITLE
[Transform] Add op to apply im2col patterns and update the workgroup count region

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -1367,5 +1367,176 @@ void transform_dialect::IREEEraseHALDescriptorTypeFromMemRefOp::getEffects(
   transform::modifiesPayload(effects);
 }
 
+//===---------------------------------------------------------------------===//
+// ConvertConv2DToImg2ColAndAdjustWorkgroupCountOp
+//===---------------------------------------------------------------------===//
+
+// Rewrite the workgroup count compute region based on the specified collapsed
+// dimensions on the output tensor. Only the dims that are expected to be tiled
+// and distributed are adjusted, thus considering only the output is sufficient.
+// TODO: This should be deprecated once workgroup count computation is
+// refactored based on slices.
+static LogicalResult adjustWorkgroupCountComputeRegionForImg2Col(
+    transform::TransformState &state, RewriterBase &rewriter, Location loc,
+    HAL::ExecutableExportOp exportOp, AffineMap outputMap,
+    tensor::CollapseShapeOp collapseOp) {
+  Region &r = exportOp.getWorkgroupCount();
+  if (!r.hasOneBlock()) {
+    return rewriter.notifyMatchFailure(exportOp,
+                                       "expected export op to have a workgroup "
+                                       "count region with a single block");
+  }
+  auto workgroupCountOps =
+      r.front().getOps<IREE::Flow::DispatchWorkgroupCountFromDagRootOp>();
+  if (!llvm::hasSingleElement(workgroupCountOps)) {
+    return rewriter.notifyMatchFailure(
+        exportOp,
+        "expected region to have a single "
+        "flow.dispatch.workgroup_count_from_dag_root op");
+  }
+  auto workgroupCountOp = *workgroupCountOps.begin();
+  auto workload = workgroupCountOp.getOperands();
+
+  // Extend the vector with workload values in range [l, r).
+  auto pushRange = [&](SmallVector<Value> &vec, int l, int r) {
+    for (; l < r; l++) vec.push_back(workload[l]);
+  };
+
+  SmallVector<unsigned> workloadDims;
+  for (AffineExpr result : outputMap.getResults()) {
+    workloadDims.push_back(result.cast<AffineDimExpr>().getPosition());
+  }
+  workloadDims.push_back(workload.size());
+  auto dimCollapseMapping = collapseOp.getReassociationIndices();
+
+  // Adjust the workgroup count computation. This happens by taking the product
+  // of workloads corresponding to groups of collapsed dims. For example,
+  //    workload = [w1, w2, w3, w4, w5, w6, w7, w8]
+  //    dimCollapseMapping = [[0], [1, 2], [3]]
+  //    workloadDims = [1, 3, 4, 5, (8)]
+  // will collapse to
+  //    newWorkload = [w1, w2, w3, w4 * w5, w6, w7, w8]
+  SmallVector<Value> newWorkload;
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(workgroupCountOp);
+  loc = workgroupCountOp.getLoc();
+  for (auto indices : dimCollapseMapping) {
+    // If there is a single index we can just push the corresponding workload
+    // arg.
+    if (indices.size() == 1) {
+      auto index = indices[0];
+      pushRange(newWorkload, workloadDims[index], workloadDims[index + 1]);
+      continue;
+    }
+
+    assert(indices.size());
+    SmallVector<AffineExpr> syms(indices.size());
+    bindSymbolsList(rewriter.getContext(), MutableArrayRef<AffineExpr>{syms});
+    SmallVector<Value> originalSizes;
+    AffineExpr product = syms[0];
+    SmallVector<Value> skipped;
+    for (auto [enIndex, dimIndex] : llvm::enumerate(indices)) {
+      originalSizes.push_back(workload[workloadDims[dimIndex]]);
+      if (enIndex > 0) {
+        // Push any skipped workload values.
+        pushRange(skipped, workloadDims[dimIndex - 1] + 1,
+                  workloadDims[dimIndex]);
+        product = product * syms[enIndex];
+      }
+    }
+
+    // Make+push the collapsed workload value, followed by all values
+    // until the next dim affected by the collapse_shape op.
+    auto m = AffineMap::get(0, indices.size(), product);
+    auto collapsedIndex =
+        makeComposedAffineApply(rewriter, loc, m, originalSizes);
+    newWorkload.push_back(collapsedIndex);
+    newWorkload.append(skipped);
+    pushRange(newWorkload, workloadDims[indices.back()] + 1,
+              workloadDims[indices.back() + 1]);
+  }
+
+  rewriter.replaceOpWithNewOp<IREE::Flow::DispatchWorkgroupCountFromDagRootOp>(
+      workgroupCountOp, newWorkload);
+  return success();
+}
+
+DiagnosedSilenceableFailure
+transform_dialect::ConvertConv2DToImg2ColAndAdjustWorkgroupCountOp::applyToOne(
+    linalg::LinalgOp target, transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  auto funcOp = target->getParentOfType<func::FuncOp>();
+
+  // Get the output map for the target operation before rewriting.
+  AffineMap outputMap = target.getIndexingMapsArray().back();
+
+  IRRewriter rewriter(target->getContext());
+  rewriter.setInsertionPoint(target);
+  // TODO: Extend this to other convolution cases by handling cases beyond
+  // collapse -> matmul -> expand from the patterns for 2D convolutions handled
+  // here.
+  auto maybeTransformed =
+      TypeSwitch<Operation *, FailureOr<std::pair<Operation *, Operation *>>>(
+          target)
+          .Case([&](linalg::Conv2DNhwcHwcfOp op) {
+            return rewriteInIm2Col(rewriter, op);
+          })
+          .Case([&](linalg::Conv2DNchwFchwOp op) {
+            return rewriteInIm2Col(rewriter, op);
+          })
+          .Default([&](Operation *op) {
+            return rewriter.notifyMatchFailure(op, "not supported");
+          });
+  if (failed(maybeTransformed)) return emitDefaultSilenceableFailure(target);
+
+  auto im2col = maybeTransformed->first;
+  auto convReplacement = maybeTransformed->second;
+
+  // Push handles for the im2col operation and the operation that replaces the
+  // original convolution.
+  results.push_back(im2col);
+  // Handle to the operation that replaces the original convolution.
+  results.push_back(convReplacement);
+
+  // If there is no export region, no adjustment needed.
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
+  if (failed(exportOp)) return DiagnosedSilenceableFailure::success();
+
+  // The result of the im2col pattern is expected to be an expand on the matmul
+  // output.
+  auto expandShapeOp = dyn_cast<tensor::ExpandShapeOp>(convReplacement);
+  if (!expandShapeOp)
+    return mlir::emitDefiniteFailure(target,
+                                     "im2col matmul output not expanded");
+
+  auto matmulOp = expandShapeOp.getSrc().getDefiningOp<linalg::LinalgOp>();
+  if (!matmulOp || !isaContractionOpInterface(matmulOp))
+    return mlir::emitDefiniteFailure(target, "im2col matmul not found");
+
+  // If there is no collapse then the workgroup count compute region doesn't
+  // need to be updated.
+  auto outputCollapse = matmulOp.getDpsInitOperand(0)
+                            ->get()
+                            .getDefiningOp<tensor::CollapseShapeOp>();
+  if (!outputCollapse) return DiagnosedSilenceableFailure::success();
+
+  /// Lower the workgroup count region in keeping with the way dispatch
+  /// regions are created by default in IREEs compilation flow.
+  if (failed(adjustWorkgroupCountComputeRegionForImg2Col(
+          state, rewriter, getLoc(), exportOp.value(), outputMap,
+          outputCollapse))) {
+    return mlir::emitDefiniteFailure(convReplacement,
+                                     "failed to adjust workgroup count region");
+  }
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::ConvertConv2DToImg2ColAndAdjustWorkgroupCountOp::build(
+    OpBuilder &builder, OperationState &result, Value target) {
+  result.addOperands(target);
+  MLIRContext *ctx = builder.getContext();
+  result.addTypes({pdl::OperationType::get(ctx), pdl::OperationType::get(ctx)});
+}
+
 #define GET_OP_CLASSES
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.cpp.inc"

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -526,4 +526,41 @@ def TileToForallAndWorkgroupCountRegionOp :
   }];
 }
 
+def ConvertConv2DToImg2ColAndAdjustWorkgroupCountOp : Op<Transform_Dialect,
+    "iree.convert_conv2d_to_img2col_and_adjust_workgroup_count_region",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformOpInterface,
+     TransformEachOpTrait]> {
+  let description = [{
+    Wrapper around `structured.convert_conv2d_to_img2col` for use within IREE.
+
+    In addition to converting the conv2d to img2col, updates the
+    `workgroup_count` region of the export op corresponding to the
+    parent `func.func` of the target to match the changes to the problem
+    shape introduced by the conversion to img2col.
+    Please see the doc of `structured.convert_conv2d_to_img2col` for full
+    description of op semantics.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$img2col_tensor,
+                      TransformHandleTypeInterface:$transformed);
+
+  let assemblyFormat =
+    "$target attr-dict `:` functional-type($target, results)";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
+  ];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::linalg::LinalgOp target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -54,6 +54,7 @@ iree_lit_test_suite(
             "tile_reduction.mlir",
             "transform_buffer_opt.mlir",
             "transform_dialect_apply_pattern_op.mlir",
+            "transform_im2col_workgroup.mlir",
             "transform_ops_invalid.mlir",
             "transpose_canonicalization.mlir",
             "type_propagation.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -50,6 +50,7 @@ iree_lit_test_suite(
     "tile_reduction.mlir"
     "transform_buffer_opt.mlir"
     "transform_dialect_apply_pattern_op.mlir"
+    "transform_im2col_workgroup.mlir"
     "transform_ops_invalid.mlir"
     "transpose_canonicalization.mlir"
     "type_propagation.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_im2col_workgroup.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_im2col_workgroup.mlir
@@ -1,0 +1,87 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+hal.executable @conv2d_nchw_fchw {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @conv2d_nchw_fchw ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @conv2d_nchw_fchw() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f16
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x16x130x130xf16>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32x16x3x3xf16>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x32x128x128xf16>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 16, 130, 130], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x16x130x130xf16>> -> tensor<2x16x130x130xf16>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [32, 16, 3, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<32x16x3x3xf16>> -> tensor<32x16x3x3xf16>
+      %5 = tensor.empty() : tensor<2x32x128x128xf16>
+      %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2x32x128x128xf16>) -> tensor<2x32x128x128xf16>
+      %7 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%3, %4 : tensor<2x16x130x130xf16>, tensor<32x16x3x3xf16>) outs(%6 : tensor<2x32x128x128xf16>) -> tensor<2x32x128x128xf16>
+      flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 32, 128, 128], strides = [1, 1, 1, 1] : tensor<2x32x128x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x32x128x128xf16>>
+      return
+    }
+  }
+}
+}
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 : !pdl.operation failures(propagate) {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.conv_2d_nchw_fchw"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+    %img2col_tensor, %transformed = transform.iree.convert_conv2d_to_img2col_and_adjust_workgroup_count_region %0 : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  }
+}
+
+// CHECK:    #[[MAP:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+// CHECK:    hal.executable.export public @conv2d_nchw_fchw
+// CHECK:      ^bb0(%[[ARG0:.+]]: !hal.device, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index, %[[ARG4:.+]]: index, %[[ARG5:.+]]: index, %[[ARG6:.+]]: index, %[[ARG7:.+]]: index):
+// CHECK:        %[[COLLAPSE:.+]] = affine.apply #[[MAP]]()[%[[ARG3]], %[[ARG4]]]
+// CHECK:        %[[X:.+]], %[[Y:.+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_dag_root %[[ARG1]], %[[ARG2]], %[[COLLAPSE]], %[[ARG5]], %[[ARG6]], %[[ARG7]]
+// CHECK:        hal.return %[[X]], %[[Y]], %[[Z]] : index, index, index
+
+// -----
+
+hal.executable @conv2d_nhwc_hwcf {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @conv2d_nhwc_hwcf ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @conv2d_nhwc_hwcf() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f16
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x130x130x16xf16>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3x3x16x32xf16>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x128x128x32xf16>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 130, 130, 16], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x130x130x16xf16>> -> tensor<2x130x130x16xf16>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 16, 32], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x16x32xf16>> -> tensor<3x3x16x32xf16>
+      %5 = tensor.empty() : tensor<2x128x128x32xf16>
+      %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2x128x128x32xf16>) -> tensor<2x128x128x32xf16>
+      %7 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%3, %4 : tensor<2x130x130x16xf16>, tensor<3x3x16x32xf16>) outs(%6 : tensor<2x128x128x32xf16>) -> tensor<2x128x128x32xf16>
+      flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 128, 128, 32], strides = [1, 1, 1, 1] : tensor<2x128x128x32xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x128x128x32xf16>>
+      return
+    }
+  }
+}
+}
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 : !pdl.operation failures(propagate) {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.conv_2d_nhwc_hwcf"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+    %img2col_tensor, %transformed = transform.iree.convert_conv2d_to_img2col_and_adjust_workgroup_count_region %0 : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  }
+}
+
+// CHECK:    #[[MAP:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+// CHECK:    hal.executable.export public @conv2d_nhwc_hwcf
+// CHECK:      ^bb0(%[[ARG0:.+]]: !hal.device, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index, %[[ARG4:.+]]: index, %[[ARG5:.+]]: index, %[[ARG6:.+]]: index, %[[ARG7:.+]]: index):
+// CHECK:        %[[COLLAPSE:.+]] = affine.apply #[[MAP]]()[%[[ARG2]], %[[ARG3]]]
+// CHECK:        %[[X:.+]], %[[Y:.+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_dag_root %[[ARG1]], %[[COLLAPSE]], %[[ARG4]], %[[ARG5]], %[[ARG6]], %[[ARG7]]
+// CHECK:        hal.return %[[X]], %[[Y]], %[[Z]] : index, index, index


### PR DESCRIPTION
Required for implementing a pipeline for implicit gemm on GPU backends. Im2col converts a convolution to a gather on the input and a gemm. This collapses the image dimensions of the output for 2D convolutions and thus the workgroup count compute region needs to be updated to match the new iteration ranges for the main compute op.

Depends on https://reviews.llvm.org/D144678