### PR TITLE
Add a structured op matcher for 2d convolutions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "bufferize_copy_only_dispatches.mlir",
             "canonicalize_interface_load_store.mlir",
             "convert_to_destination_passing_style.mlir",
+            "convolutions.mlir",
             "dead_alloc.mlir",
             "decompose_affine_ops.mlir",
             "decompose_linalg_generic.mlir",
@@ -65,6 +66,7 @@ iree_lit_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
+            "convolution_match_spec.mlir",
             "reductions_codegen_spec.mlir",
             "reductions_match_spec.mlir",
         ],
@@ -73,6 +75,7 @@ iree_lit_test_suite(
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.
     data = [
+        "convolution_match_spec.mlir",
         "reductions_codegen_spec.mlir",
         "reductions_match_spec.mlir",
     ],

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "bufferize_copy_only_dispatches.mlir"
     "canonicalize_interface_load_store.mlir"
     "convert_to_destination_passing_style.mlir"
+    "convolutions.mlir"
     "dead_alloc.mlir"
     "decompose_affine_ops.mlir"
     "decompose_linalg_generic.mlir"
@@ -62,6 +63,7 @@ iree_lit_test_suite(
     FileCheck
     iree-opt
   DATA
+    convolution_match_spec.mlir
     reductions_codegen_spec.mlir
     reductions_match_spec.mlir
 )

--- a/compiler/src/iree/compiler/Codegen/Common/test/convolution_match_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convolution_match_spec.mlir
@@ -1,14 +1,14 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
+^bb0(%arg0: !transform.any_op):
   transform.iree.register_match_callbacks
 
   %fill, %convolution, %trailing =
     transform.iree.match_callback failures(propagate) "convolution"(%arg0)
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
-  transform.iree.emit_remark "fill" at %fill : !pdl.operation
-  transform.iree.emit_remark "convolution" at %convolution : !pdl.operation
-  transform.iree.emit_remark "trailing" at %trailing : !pdl.operation
+  transform.iree.emit_remark "fill" at %fill : !transform.any_op
+  transform.iree.emit_remark "convolution" at %convolution : !transform.any_op
+  transform.iree.emit_remark "trailing" at %trailing : !transform.any_op
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/convolution_match_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convolution_match_spec.mlir
@@ -1,0 +1,14 @@
+// RUN: iree-opt %s
+
+transform.sequence failures(propagate) {
+^bb0(%arg0: !pdl.operation):
+  transform.iree.register_match_callbacks
+
+  %fill, %convolution, %trailing =
+    transform.iree.match_callback failures(propagate) "convolution"(%arg0)
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
+
+  transform.iree.emit_remark "fill" at %fill : !pdl.operation
+  transform.iree.emit_remark "convolution" at %convolution : !pdl.operation
+  transform.iree.emit_remark "trailing" at %trailing : !pdl.operation
+}

--- a/compiler/src/iree/compiler/Codegen/Common/test/convolutions.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convolutions.mlir
@@ -1,0 +1,78 @@
+// RUN: iree-opt %s --iree-transform-dialect-interpreter='transform-file-name=%p/convolution_match_spec.mlir' --split-input-file --verify-diagnostics
+
+!input_tensor_t = tensor<2x16x130x130xf32>
+!weight_tensor_t = tensor<32x16x3x3xf32>
+!output_tensor_t = tensor<2x32x128x128xf32>
+func.func @conv_2d_nchw_fchw_trailing_eltwise(%in: !input_tensor_t, %wei: !weight_tensor_t,
+                             %out: !output_tensor_t) -> !output_tensor_t {
+  // expected-remark @below {{convolution}}
+  %0 = linalg.conv_2d_nchw_fchw
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%in, %wei: !input_tensor_t, !weight_tensor_t)
+    outs(%out: !output_tensor_t) -> !output_tensor_t
+
+  %1 = tensor.empty() : !output_tensor_t
+  // expected-remark @below {{trailing}}
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%1 : !output_tensor_t) outs(%0 : !output_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %3 = math.sqrt %arg3 : f32
+      linalg.yield %3 : f32
+    } -> !output_tensor_t
+  return %2 : !output_tensor_t
+}
+
+// -----
+
+!input_tensor_t = tensor<2x16x130x130xf32>
+!weight_tensor_t = tensor<32x16x3x3xf32>
+!output_tensor_t = tensor<2x32x128x128xf32>
+func.func @conv_2d_nchw_fchw_fill(%in: !input_tensor_t, %wei: !weight_tensor_t) -> !output_tensor_t {
+
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : !output_tensor_t
+  // expected-remark @below {{fill}}
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !output_tensor_t) -> !output_tensor_t
+
+  // expected-remark @below {{convolution}}
+  %2 = linalg.conv_2d_nchw_fchw
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%in, %wei: !input_tensor_t, !weight_tensor_t)
+    outs(%1: !output_tensor_t) -> !output_tensor_t
+  return %2 : !output_tensor_t
+}
+
+// -----
+
+!input_tensor_t = tensor<2x130x130x16xf32>
+!weight_tensor_t = tensor<3x3x16x32xf32>
+!output_tensor_t = tensor<2x128x128x32xf32>
+func.func @conv_2d_nhwc_hwcf(%in: !input_tensor_t, %wei: !weight_tensor_t) -> !output_tensor_t {
+
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : !output_tensor_t
+  // expected-remark @below {{fill}}
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !output_tensor_t) ->   !output_tensor_t
+
+  // expected-remark @below {{convolution}}
+  %2 = linalg.conv_2d_nhwc_hwcf
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%in, %wei: !input_tensor_t, !weight_tensor_t)
+    outs(%1: !output_tensor_t) -> !output_tensor_t
+
+  %3 = tensor.empty() : !output_tensor_t
+  // expected-remark @below {{trailing}}
+  %4 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%2 : !output_tensor_t) outs(%3 : !output_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %5 = math.sqrt %arg3 : f32
+      linalg.yield %5 : f32
+    } -> !output_tensor_t
+  return %4 : !output_tensor_t
+}

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -71,6 +71,12 @@ struct CaptureDims : public CaptureStaticValue<SmallVector<int64_t>> {
   using Base::Base;
 };
 
+/// Captures the convolution dimensions of the target operation.
+struct CaptureConvDims
+    : public CaptureStaticValue<mlir::linalg::detail::ConvolutionDimensions> {
+  using Base::Base;
+};
+
 /// Captures the rank of the operation.
 struct CaptureRank : public CaptureStaticValue<int64_t> {
   using Base::Base;
@@ -366,6 +372,7 @@ public:
   StructuredOpMatcher &rank(CaptureRank capture);
   StructuredOpMatcher &dim(int64_t dimension, CaptureDim capture);
   StructuredOpMatcher &dim(AllDims tag, CaptureDims captures);
+  StructuredOpMatcher &convolutionDims(CaptureConvDims convDims);
 
   //===-------------------------------------------------------------------===//
   // Constraints on input operands.
@@ -761,6 +768,30 @@ void makeSoftmaxMatcher(
     transform_ext::MatcherContext &context,
     transform_ext::StructuredOpMatcher *&maxReductionCapture,
     transform_ext::StructuredOpMatcher *&softmaxRootCapture);
+
+struct MatchedConvolutionCaptures {
+  mlir::linalg::detail::ConvolutionDimensions convolutionDims = {};
+  SmallVector<int64_t> convolutionOpSizes = {};
+  SmallVector<int64_t> trailingOpSizes = {};
+  int64_t convolutionOutputElementalTypeBitWidth = 0;
+  int64_t maybeTrailingOutputElementalTypeBitWidth = 0;
+  int64_t maybeFillElementalTypeBitWidth = 0;
+};
+
+/// Creates a group of matchers for:
+///
+///     trailing(convolution(leading(), fill()))
+///
+/// where fill is a FillOp and trailing is elementwise operations whose presence
+/// is optional. Each matcher will capture the corresponding operation.
+void makeConvolutionMatcher(transform_ext::MatcherContext &context,
+                            StructuredOpMatcher *&convolutionCapture,
+                            StructuredOpMatcher *&fillCapture,
+                            StructuredOpMatcher *&trailingCapture,
+                            MatchedConvolutionCaptures &captures);
+void makeConvolutionMatcher(transform_ext::MatcherContext &context,
+                            StructuredOpMatcher *&convolutionCapture,
+                            MatchedConvolutionCaptures &captures);
 
 } // namespace transform_ext
 } // namespace mlir

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -780,10 +780,10 @@ struct MatchedConvolutionCaptures {
 
 /// Creates a group of matchers for:
 ///
-///     trailing(convolution(leading(), fill()))
+///     trailing(convolution(input, filter, fill()))
 ///
-/// where fill is a FillOp and trailing is elementwise operations whose presence
-/// is optional. Each matcher will capture the corresponding operation.
+/// where fill is a FillOp and trailing is an elementwise operation, both of
+/// which is optional. Each matcher will capture the corresponding operation.
 void makeConvolutionMatcher(transform_ext::MatcherContext &context,
                             StructuredOpMatcher *&convolutionCapture,
                             StructuredOpMatcher *&fillCapture,

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -660,6 +660,64 @@ reductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
   return emitSilenceableFailure(loc) << "failed to match";
 }
 
+/// Match callback for a convolution with optional fill and trailing
+/// elementwise operations. Matches *the first* occurrence of such a convolution
+/// within an op associated with the given handle.
+///
+/// Input handles:
+///
+///   - container op, must be associated with one operation.
+///
+/// Output handles:
+///
+///   - the "fill" op preceding the convolution, if present;
+///   - convolution op;
+///   - trailing elementwise op, if any.
+static DiagnosedSilenceableFailure
+convolutionCallback(transform_ext::MatchCallbackResult &res, Location loc,
+                    const mlir::transform::TransformState &state,
+                    ValueRange handles) {
+  if (handles.size() != 1 || state.getPayloadOps(handles[0]).size() != 1) {
+    return emitSilenceableFailure(loc)
+           << "expected one handle to one operation";
+  }
+
+  transform_ext::StructuredOpMatcher *pattern, *fill, *trailing;
+  transform_ext::MatchedConvolutionCaptures ignore;
+  transform_ext::MatcherContext matcherContext;
+  makeConvolutionMatcher(matcherContext, pattern, fill, trailing, ignore);
+
+  // TODO: need a mechanism for this to go around the entire IR,
+  // potentially with list matches for each group.
+  Operation *root = state.getPayloadOps(handles[0])[0];
+
+  WalkResult walkResult = root->walk([&](Operation *op) {
+    pattern->resetCapture();
+    if (!matchPattern(op, *pattern))
+      return WalkResult::advance();
+
+    // TODO: notify properly.
+    LLVM_DEBUG({
+      DBGS() << "fill:\n";
+      if (fill->getCaptured())
+        DBGS() << fill->getCaptured() << "\n";
+      DBGS() << "pattern: " << pattern->getCaptured() << "\n";
+      DBGS() << "trailing:\n";
+      if (trailing->getCaptured())
+        DBGS() << trailing->getCaptured() << "\n";
+    });
+
+    res.addPotentiallyEmptyPayloadGroup(fill->getCaptured());
+    res.addPayloadGroup({pattern->getCaptured()});
+    res.addPotentiallyEmptyPayloadGroup(trailing->getCaptured());
+    return WalkResult::interrupt();
+  });
+
+  if (walkResult.wasInterrupted())
+    return DiagnosedSilenceableFailure::success();
+  return emitSilenceableFailure(loc) << "failed to match";
+}
+
 DiagnosedSilenceableFailure transform_ext::RegisterMatchCallbacksOp::apply(
     mlir::transform::TransformResults &results,
     mlir::transform::TransformState &state) {
@@ -670,6 +728,7 @@ DiagnosedSilenceableFailure transform_ext::RegisterMatchCallbacksOp::apply(
   registry.registerCallback("_test_value_matcher_callback",
                             testValueMatcherCallback);
   registry.registerCallback("reduction", reductionCallback);
+  registry.registerCallback("convolution", convolutionCallback);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -1102,7 +1102,6 @@ static void matchdivBroadcast(transform_ext::MatcherContext &matcherContext,
       transform_ext::m_StructuredOp<linalg::GenericOp>(matcherContext)
           .singleOpWithCanonicaleArgs<arith::DivFOp>()
           .dim(AllDims(), utils::IteratorType::parallel)
-          // Capture convolution dim classifications.
           .input(NumEqualsTo(2))
           .input(0, IsIdentity())
           .input(1, IsIdentity())


### PR DESCRIPTION
This adds a matcher similar to the existing one for reductions. Currently only matches named 2d convolutions (`linalg.conv_2d_nchw_fchw` and `linalg.conv_2d_nhwc_hwcf`) with an optional fill op for the output and an optional trailing elementwise op. Adds a capture rule for convolution dims based on the dim classifier upstream.