### PR TITLE
Remove legacy benchmarks

### DIFF
--- a/benchmarks/TFLite/linux-x86_64.cmake
+++ b/benchmarks/TFLite/linux-x86_64.cmake
@@ -164,76 +164,6 @@ iree_benchmark_suite(
 #                                                                              #
 ################################################################################
 
-# CPU, LLVM, local-sync, x86_64, full-inference
-iree_benchmark_suite(
-  GROUP_NAME
-    "linux-x86_64"
-
-  MODULES
-    "${DEEPLABV3_FP32_MODULE}"
-    "${MOBILESSD_FP32_MODULE}"
-    "${POSENET_FP32_MODULE}"
-    "${MOBILEBERT_FP32_MODULE}"
-    "${MOBILENET_V2_MODULE}"
-    "${MOBILENET_V3SMALL_MODULE}"
-    "${MOBILEBERT_INT8_MODULE}"
-    "${PERSON_DETECT_INT8_MODULE}"
-    "${EFFICIENTNET_INT8_MODULE}"
-
-  BENCHMARK_MODES
-    "full-inference,experimental-flags"
-  TARGET_BACKEND
-    "llvm-cpu"
-  TARGET_ARCHITECTURE
-    "CPU-x86_64-CascadeLake"
-  COMPILATION_FLAGS
-    ${LINUX_X86_64_CASCADELAKE_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-  BENCHMARK_TOOL
-    iree-benchmark-module
-  CONFIG
-    "iree-llvm-cpu-sync"
-  DRIVER
-    "local-sync"
-)
-
-# CPU, LLVM, local-task, 1 thread, x86_64, full-inference
-iree_benchmark_suite(
-  GROUP_NAME
-    "linux-x86_64"
-
-  MODULES
-    "${DEEPLABV3_FP32_MODULE}"
-    "${MOBILESSD_FP32_MODULE}"
-    "${POSENET_FP32_MODULE}"
-    "${MOBILEBERT_FP32_MODULE}"
-    "${MOBILENET_V2_MODULE}"
-    "${MOBILENET_V3SMALL_MODULE}"
-    "${MOBILEBERT_INT8_MODULE}"
-    "${PERSON_DETECT_INT8_MODULE}"
-    "${EFFICIENTNET_INT8_MODULE}"
-
-  BENCHMARK_MODES
-    "1-thread,full-inference,experimental-flags"
-  TARGET_BACKEND
-    "llvm-cpu"
-  TARGET_ARCHITECTURE
-    "CPU-x86_64-CascadeLake"
-  COMPILATION_FLAGS
-    ${LINUX_X86_64_CASCADELAKE_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-  BENCHMARK_TOOL
-    iree-benchmark-module
-  CONFIG
-    "iree-llvm-cpu"
-  DRIVER
-    "local-task"
-  RUNTIME_FLAGS
-    "--task_topology_max_group_count=1"
-)
-
 # CPU, LLVM, local-task, 4 threads, x86_64, full-inference
 iree_benchmark_suite(
   GROUP_NAME
@@ -268,40 +198,4 @@ iree_benchmark_suite(
     "local-task"
   RUNTIME_FLAGS
     "--task_topology_max_group_count=4"
-)
-
-# CPU, LLVM, local-task, 8 threads, x86_64, full-inference
-iree_benchmark_suite(
-  GROUP_NAME
-    "linux-x86_64"
-
-  MODULES
-    "${DEEPLABV3_FP32_MODULE}"
-    "${MOBILESSD_FP32_MODULE}"
-    "${POSENET_FP32_MODULE}"
-    "${MOBILEBERT_FP32_MODULE}"
-    "${MOBILENET_V2_MODULE}"
-    "${MOBILENET_V3SMALL_MODULE}"
-    "${MOBILEBERT_INT8_MODULE}"
-    "${PERSON_DETECT_INT8_MODULE}"
-    "${EFFICIENTNET_INT8_MODULE}"
-
-  BENCHMARK_MODES
-    "8-thread,full-inference,experimental-flags"
-  TARGET_BACKEND
-    "llvm-cpu"
-  TARGET_ARCHITECTURE
-    "CPU-x86_64-CascadeLake"
-  COMPILATION_FLAGS
-    ${LINUX_X86_64_CASCADELAKE_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-  BENCHMARK_TOOL
-    iree-benchmark-module
-  CONFIG
-    "iree-llvm-cpu"
-  DRIVER
-    "local-task"
-  RUNTIME_FLAGS
-    "--task_topology_max_group_count=8"
 )


### PR DESCRIPTION
Removes x86 CPU benchmarks with experimental flags to be in line with https://github.com/openxla/iree/pull/12791