### PR TITLE
Better Default Tile Configuration for F32 Tensor Cores

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -85,8 +85,6 @@ struct TileWorkgroupSizePair {
   int64_t pipelineDepth;
 };
 
-// Software pipeline depths
-constexpr unsigned softwarePipelineDepthTensorCore = 4;
 // Simt codegen does not do software pipelining.
 constexpr unsigned softwarePipelineDepthSimt = 0;
 }  // namespace
@@ -129,7 +127,7 @@ static void getTensorCoreConfig(
   } else {
     if (parallelDim >= kLargDimThreashold * kLargDimThreashold) {
       tileSizes.push_back(
-          TileWorkgroupSizePair({{128, 256, 32}, {128, 2, 1}, 3}));
+          TileWorkgroupSizePair({{128, 256, 16}, {128, 2, 1}, 4}));
     }
     tileSizes.push_back(TileWorkgroupSizePair({{32, 32, 16}, {64, 2, 1}, 4}));
     tileSizes.push_back(TileWorkgroupSizePair({{16, 32, 16}, {64, 1, 1}, 4}));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -715,8 +715,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 }
 
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 256, 32]{{\]}}
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore pipeline_depth = 3>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 256, 16]{{\]}}
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore pipeline_depth = 4>
 //      CHECK: hal.executable.export public @large_matmul_f32
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-SAME:     workgroup_size = [128 : index, 2 : index, 1 : index]


### PR DESCRIPTION
`128x256_16x4` is a better tile configurations for F32 Tensor Cores using `mma.sync.16m8n8k.*f32.tf32` for a large square matrix `2560x2560x2560`. 

This takes the performance from 115TFLOP/s to 121TFLOP/s . Note that `2560x2560x2560` is the matmul shape that many in the team are exploring for codegen improvement strategies, thus the default tile configurations in KernelConfig.cpp tuned to the the matmul shape in focus. Additionally, one can also explicitly specify the tile configuration as an attribute for every matmul dispatch in mlir.


```
---------------------------------------------------------------- 
Dispatch      : matmul_2560x2560x2560_f32t_f32t_f32t_tile_config_128x256_16x4_tensorcore_mma_sync
Provider      : IREE Codegen
Operation     : matmul_2560x2560x2560_f32t_f32t_f32t
Configuration : tile_config_128x256_16x4_tensorcore_mma_sync
Verification  : SUCCESS
Bytes         : 78643200
Flops         : 33554432000
Runtime(ms)   : 0.277
GFLOP/s       : 121135.13
---------------------------------------------------------------- 
```
