### PR TITLE
Dump names in benchmark helper output

### DIFF
--- a/build_tools/benchmarks/benchmark_helper.py
+++ b/build_tools/benchmarks/benchmark_helper.py
@@ -70,7 +70,6 @@ def _dump_cmds_of_generation_config(
         model=imported_model.model)
     import_cmd_str = _convert_to_cmd_string(import_cmds)
 
-  # TODO(#12215): Print benchmark name to make them searchable by keywords.
   # Insert a blank line after each command to help read with line wrap.
   return [
       "Compile Module:", compile_cmd_str, "", "Import Model:", import_cmd_str,
@@ -89,7 +88,6 @@ def _dump_cmds_from_run_config(
 
   run_cmds = [run_config.tool.value, f"--module={module_path}"]
   run_cmds += run_config.materialize_run_flags()
-  # TODO(#12215): Include benchmark name to make them searchable by keywords.
   # Insert a blank line after the command to help read with line wrap.
   lines = ["Run Module:", _convert_to_cmd_string(run_cmds), ""]
   lines += _dump_cmds_of_generation_config(gen_config=gen_config,
@@ -116,6 +114,7 @@ def _dump_cmds_handler(e2e_test_artifacts_dir: pathlib.Path,
         lines.append("################")
         lines.append("")
         lines.append(f"Execution Benchmark ID: {run_config.composite_id}")
+        lines.append(f"Name: {run_config}")
         lines.append(f"Target Device: {target_device}")
         lines.append("")
         lines += _dump_cmds_from_run_config(run_config=run_config,
@@ -133,6 +132,7 @@ def _dump_cmds_handler(e2e_test_artifacts_dir: pathlib.Path,
       lines.append("################")
       lines.append("")
       lines.append(f"Compilation Benchmark ID: {gen_config.composite_id}")
+      lines.append(f"Name: {gen_config}")
       lines.append("")
       lines += _dump_cmds_of_generation_config(gen_config=gen_config,
                                                root_path=e2e_test_artifacts_dir)

--- a/docs/developers/developing_iree/benchmark_suites.md
+++ b/docs/developers/developing_iree/benchmark_suites.md
@@ -173,7 +173,18 @@ build_tools/benchmarks/benchmark_helper.py dump-cmds \
   --benchmark_id="<benchmark_id>"
 ```
 
-> TODO(#12215): Dump should also include searchable benchmark names.
+### Get Full List of Benchmarks
+
+The commands below output the full list of execution and compilation benchmarks,
+including the benchmark names and their flags:
+
+```sh
+build_tools/benchmarks/export_benchmark_config.py execution > exec_config.json
+build_tools/benchmarks/export_benchmark_config.py compilation > comp_config.json
+build_tools/benchmarks/benchmark_helper.py dump-cmds \
+  --execution_benchmark_config=exec_config.json \
+  --compilation_benchmark_config=comp_config.json
+```
 
 ## Fetching Benchmark Artifacts from CI
 


### PR DESCRIPTION
Dump benchmark names in the benchmark helper output to help people search benchmarks with keywords.

Example output:
```
################

Execution Benchmark ID: 015af8c7c74743569726f8fecf3c5af66eb516b1e4c27b9c53444e5eb68254f9
Name: DeepLabV3_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags] local_task(embedded_elf)[1-thread,full-inference,default-flags] with zeros @ c2-standard-16[cpu]
Target Device: c2-standard-16

Run Module:
iree-benchmark-module --module=iree_DeepLabV3_fp32_module_87aead729018ce5f114501cecefb6315086eb2a21ae1b30984b1794f619871c6/module.vmfb --function=main --input=1x257x257x3xf32=0 --device_allocator=caching --task_topology_max_group_count=1 --device=local-task

Compile Module:
iree-compile iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir -o iree_DeepLabV3_fp32_module_87aead729018ce5f114501cecefb6315086eb2a21ae1b30984b1794f619871c6/module.vmfb --iree-hal-target-backends=llvm-cpu --iree-input-type=tosa --iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu --iree-llvmcpu-target-cpu=cascadelake

Import Model:
iree-import-tflite model_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.tflite -o iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir --output-format=mlir-bytecode

################

Compilation Benchmark ID: e7bd41e564750501f39ac9690c18d1a2e77dc7999da710d0c0bf80751dda84a0
Name: MobileNetV3Small_fp32(tflite) [vmvx-generic-vmvx-vmvx][default-flags,compile-stats]

Compile Module:
iree-compile iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir -o iree_MobileNetV3Small_fp32_module_e7bd41e564750501f39ac9690c18d1a2e77dc7999da710d0c0bf80751dda84a0/module.vmfb --iree-hal-target-backends=vmvx --iree-input-type=tosa --iree-vm-emit-polyglot-zip=true --iree-llvmcpu-debug-symbols=false

Import Model:
iree-import-tflite model_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.tflite -o iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir --output-format=mlir-bytecode
```