### PR TITLE
Add specific CODEOWNERS for /build_tools/python/.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@
 /benchmarks/ @GMNGeoffrey @antiagainst @pzread
 /build_tools/ @GMNGeoffrey @ScottTodd @pzread
 /build_tools/benchmarks/ @GMNGeoffrey @antiagainst @pzread
+/build_tools/python/ @GMNGeoffrey @pzread
 /build_tools/python_deploy/ @stellaraccident
 /build_tools/scripts/ @GMNGeoffrey @ScottTodd
 /build_tools/third_party/ @GMNGeoffrey @ScottTodd @stellaraccident


### PR DESCRIPTION
I don't usually review changes to files under this directory (mostly benchmark suite definitions and supporting scripts), so adding a more specific rule without my name listed.

skip-ci: NFC