### PR TITLE
Fix ukernel/x86 issues discovered by #12818

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64.c
@@ -73,7 +73,6 @@ iree_uk_mmt4d_select_tile_func_x86_64_f32f32f32(
   if (params->M0 == 16 && params->N0 == 16 && params->K0 == 1) {
     return iree_uk_mmt4d_select_tile_func_x86_64_f32f32f32_16x16x1(params);
   }
-
   if (params->M0 == 8 && params->N0 == 8 && params->K0 == 1) {
     return iree_uk_mmt4d_select_tile_func_x86_64_f32f32f32_8x8x1(params);
   }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64_avx512_base.c
@@ -19,8 +19,8 @@ void iree_uk_pack_tile_16x16_x32_x86_64_avx512_base_direct(
   const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
   iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
   for (; outer_size1 > 0; --outer_size1) {
-    iree_uk_copy_8x32xi8_strided_to_strided(out_ptr, in_ptr, 64,
-                                            4 * in_stride0);
+    iree_uk_copy_16x64xi8_strided_to_strided(out_ptr, in_ptr, 64,
+                                             4 * in_stride0);
     out_ptr += 4 * out_stride1;
     in_ptr += 64;
   }

--- a/runtime/src/iree/builtins/ukernel/query_tile_sizes.c
+++ b/runtime/src/iree/builtins/ukernel/query_tile_sizes.c
@@ -8,6 +8,8 @@
 
 #if defined(IREE_UK_ARCH_ARM_64)
 #include "iree/builtins/ukernel/arch/arm_64/query_tile_sizes_arm_64.h"
+#elif defined(IREE_UK_ARCH_X86_64)
+#include "iree/builtins/ukernel/arch/x86_64/query_tile_sizes_x86_64.h"
 #endif
 
 static bool iree_uk_query_tile_sizes_operation_is_matmul(
@@ -45,6 +47,8 @@ static bool iree_uk_query_matmul_tile_sizes_arch(
     iree_uk_matmul_tile_sizes_t* out_matmul_tile_sizes) {
 #if defined(IREE_UK_ARCH_ARM_64)
   return iree_uk_query_matmul_tile_sizes_arm_64(params, out_matmul_tile_sizes);
+#elif defined(IREE_UK_ARCH_X86_64)
+  return iree_uk_query_matmul_tile_sizes_x86_64(params, out_matmul_tile_sizes);
 #endif
   return false;
 }

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -214,8 +214,12 @@ int main(int argc, char** argv) {
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 1, cpu->avx2_fma);
   iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 2, cpu->avx2_fma);
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 8, cpu->avx2_fma);
+  iree_uk_test_pack(iree_uk_pack_type_i32i32, 8, 8, cpu->avx2_fma);
   iree_uk_test_pack(iree_uk_pack_type_f32f32, 16, 1, cpu->avx512_base);
   iree_uk_test_pack(iree_uk_pack_type_i8i8, 16, 2, cpu->avx512_base);
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 16, 16, cpu->avx512_base);
+  iree_uk_test_pack(iree_uk_pack_type_i32i32, 16, 16, cpu->avx512_base);
   // avx512_vnni uses the same tile size and same pack code as avx512_base.
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 


### PR DESCRIPTION
* query_tile_sizes/x86_64 was not wired up. Tests relying on tile size auto-selection were falling back to generic tile size and hence to generic code.
* There was a plain bug in the avx512 pack kernel for 16x16 tiles of 32bit elements --- i.e. accumulator tiles.
* The pack_test was not covering this 16x16 32bit accumulator tile format, which is why the bug was not discovered until the query_tile_sizes fix made e2e VMVX tests (and the new benchmark in #12818) run into it.