### PR TITLE
Simplify handling of CPU features in ukernel tests

### DIFF
--- a/runtime/src/iree/builtins/ukernel/tools/benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/benchmark.c
@@ -74,8 +74,7 @@ void iree_uk_benchmark_register(
     const char* name,
     iree_status_t (*benchmark_func)(const iree_benchmark_def_t*,
                                     iree_benchmark_state_t*),
-    const void* params, size_t params_size,
-    const iree_uk_cpu_features_list_t* cpu_features) {
+    const void* params, size_t params_size, const char* cpu_features) {
   // Does this benchmark require an optional CPU feature?
   iree_uk_uint64_t cpu_data_local[IREE_CPU_DATA_FIELD_COUNT] = {0};
   if (cpu_features) {
@@ -104,19 +103,8 @@ void iree_uk_benchmark_register(
   iree_string_builder_initialize(iree_allocator_system(), &full_name);
   IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, name));
   if (cpu_features) {
-    const char* cpu_features_name =
-        iree_uk_cpu_features_list_get_name(cpu_features);
-    if (cpu_features_name) {
-      IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, "_"));
-      IREE_CHECK_OK(
-          iree_string_builder_append_cstring(&full_name, cpu_features_name));
-    } else {
-      for (int i = 0; i < iree_uk_cpu_features_list_size(cpu_features); ++i) {
-        IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, "_"));
-        IREE_CHECK_OK(iree_string_builder_append_cstring(
-            &full_name, iree_uk_cpu_features_list_entry(cpu_features, i)));
-      }
-    }
+    IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, "_"));
+    IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, cpu_features));
   }
   iree_benchmark_register(iree_string_builder_view(&full_name), &benchmark_def);
   iree_string_builder_deinitialize(&full_name);

--- a/runtime/src/iree/builtins/ukernel/tools/benchmark.h
+++ b/runtime/src/iree/builtins/ukernel/tools/benchmark.h
@@ -19,8 +19,7 @@ void iree_uk_benchmark_register(
     const char* name,
     iree_status_t (*benchmark_func)(const iree_benchmark_def_t*,
                                     iree_benchmark_state_t*),
-    const void* params, size_t params_size,
-    const iree_uk_cpu_features_list_t* cpu_features);
+    const void* params, size_t params_size, const char* cpu_features);
 void iree_uk_benchmark_run_and_cleanup(void);
 
 // Like malloc, but any buffers allocated through this are freed by

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -83,9 +83,9 @@ static iree_status_t iree_uk_benchmark_mmt4d(
   return iree_ok_status();
 }
 
-static void iree_uk_benchmark_register_mmt4d(
-    iree_uk_mmt4d_type_t type, int M0, int N0, int K0,
-    const iree_uk_cpu_features_list_t* cpu_features) {
+static void iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_t type, int M0,
+                                             int N0, int K0,
+                                             const char* cpu_features) {
   char type_str[32];
   iree_uk_type_triple_str(type_str, sizeof type_str, type);
   char name[128];
@@ -100,26 +100,24 @@ int main(int argc, char** argv) {
 
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_UNDEFINED_OK, &argc, &argv);
   iree_uk_benchmark_initialize(&argc, argv);
-  iree_uk_standard_cpu_features_t* cpu = iree_uk_standard_cpu_features_create();
 
 #if defined(IREE_UK_ARCH_ARM_64)
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4,
-                                   cpu->dotprod);
-  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8,
-                                   cpu->i8mm);
+                                   "dotprod");
+  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8, "i8mm");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1,
-                                   cpu->avx2_fma);
+                                   "avx2_fma");
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 16, 16, 1,
-                                   cpu->avx512_base);
+                                   "avx512_base");
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 2,
-                                   cpu->avx2_fma);
+                                   "avx2_fma");
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2,
-                                   cpu->avx512_base);
+                                   "avx512_base");
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2,
-                                   cpu->avx512_vnni);
+                                   "avx512_vnni");
 #else  // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
@@ -127,6 +125,5 @@ int main(int argc, char** argv) {
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
-  iree_uk_standard_cpu_features_destroy(cpu);
   iree_uk_benchmark_run_and_cleanup();
 }

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
@@ -186,9 +186,8 @@ static void iree_uk_test_mmt4d_for_tile_params(iree_uk_test_t* test,
   }
 }
 
-static void iree_uk_test_mmt4d(
-    iree_uk_mmt4d_type_t type, int M0, int N0, int K0,
-    const iree_uk_cpu_features_list_t* cpu_features) {
+static void iree_uk_test_mmt4d(iree_uk_mmt4d_type_t type, int M0, int N0,
+                               int K0, const char* cpu_features) {
   iree_uk_mmt4d_params_t params = {.type = type, .M0 = M0, .N0 = N0, .K0 = K0};
   char types_str[32];
   iree_uk_type_triple_str(types_str, sizeof types_str, type);
@@ -200,8 +199,6 @@ static void iree_uk_test_mmt4d(
 }
 
 int main(int argc, char** argv) {
-  iree_uk_standard_cpu_features_t* cpu = iree_uk_standard_cpu_features_create();
-
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird M0, N0, K0 to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
@@ -211,17 +208,15 @@ int main(int argc, char** argv) {
 #if defined(IREE_UK_ARCH_ARM_64)
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4, cpu->dotprod);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8, cpu->i8mm);
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4, "dotprod");
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8, "i8mm");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 4, 1, NULL);  // SSE
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, cpu->avx2_fma);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 16, 16, 1, cpu->avx512_base);
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, "avx2_fma");
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 16, 16, 1, "avx512_base");
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 4, 2, NULL);  // SSE2
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 2, cpu->avx2_fma);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2, cpu->avx512_base);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2, cpu->avx512_vnni);
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 2, "avx2_fma");
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2, "avx512_base");
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2, "avx512_vnni");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
-
-  iree_uk_standard_cpu_features_destroy(cpu);
 }

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -106,9 +106,9 @@ static iree_status_t iree_uk_benchmark_pack(
   return iree_ok_status();
 }
 
-static void iree_uk_benchmark_register_pack(
-    iree_uk_pack_type_t type, int tile_size0, int tile_size1,
-    const iree_uk_cpu_features_list_t* cpu_features) {
+static void iree_uk_benchmark_register_pack(iree_uk_pack_type_t type,
+                                            int tile_size0, int tile_size1,
+                                            const char* cpu_features) {
   char type_str[32];
   iree_uk_type_pair_str(type_str, sizeof type_str, type);
   iree_uk_pack_params_t params = {
@@ -140,7 +140,6 @@ int main(int argc, char** argv) {
 
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_UNDEFINED_OK, &argc, &argv);
   iree_uk_benchmark_initialize(&argc, argv);
-  iree_uk_standard_cpu_features_t* cpu = iree_uk_standard_cpu_features_create();
 
   // The memcpy benchmark provides a useful comparison point, as pack is fairly
   // close to memory-bound.
@@ -155,21 +154,17 @@ int main(int argc, char** argv) {
   // Tile size selected with cpu feature "i8mm".
   iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 8, NULL);
 #elif defined(IREE_UK_ARCH_X86_64)
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 1,
-                                  cpu->avx2_fma);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 1, "avx2_fma");
   iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 16, 1,
-                                  cpu->avx512_base);
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 8,
-                                  cpu->avx2_fma);
+                                  "avx512_base");
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 8, "avx2_fma");
   iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 16, 16,
-                                  cpu->avx512_base);
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 2, cpu->avx2_fma);
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 16, 2,
-                                  cpu->avx512_base);
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_i32i32, 8, 8,
-                                  cpu->avx2_fma);
+                                  "avx512_base");
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 2, "avx2_fma");
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 16, 2, "avx512_base");
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i32i32, 8, 8, "avx2_fma");
   iree_uk_benchmark_register_pack(iree_uk_pack_type_i32i32, 16, 16,
-                                  cpu->avx512_base);
+                                  "avx512_base");
 #else   // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
@@ -177,6 +172,5 @@ int main(int argc, char** argv) {
   iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 1, NULL);
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
-  iree_uk_standard_cpu_features_destroy(cpu);
   iree_uk_benchmark_run_and_cleanup();
 }

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -177,8 +177,7 @@ static void iree_uk_test_pack_for_tile_params(iree_uk_test_t* test,
 }
 
 static void iree_uk_test_pack(iree_uk_pack_type_t type, int tile_size0,
-                              int tile_size1,
-                              const iree_uk_cpu_features_list_t* cpu_features) {
+                              int tile_size1, const char* cpu_features) {
   iree_uk_pack_params_t params = {
       .type = type, .out_size2 = tile_size0, .out_size3 = tile_size1};
   char types_str[32];
@@ -191,8 +190,6 @@ static void iree_uk_test_pack(iree_uk_pack_type_t type, int tile_size0,
 }
 
 int main(int argc, char** argv) {
-  iree_uk_standard_cpu_features_t* cpu = iree_uk_standard_cpu_features_create();
-
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
@@ -212,16 +209,14 @@ int main(int argc, char** argv) {
   // Tile size selected for CPU feature i8mm. Same comment as for dotprod.
   iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 8, NULL);
 #elif defined(IREE_UK_ARCH_X86_64)
-  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 1, cpu->avx2_fma);
-  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 2, cpu->avx2_fma);
-  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 8, cpu->avx2_fma);
-  iree_uk_test_pack(iree_uk_pack_type_i32i32, 8, 8, cpu->avx2_fma);
-  iree_uk_test_pack(iree_uk_pack_type_f32f32, 16, 1, cpu->avx512_base);
-  iree_uk_test_pack(iree_uk_pack_type_i8i8, 16, 2, cpu->avx512_base);
-  iree_uk_test_pack(iree_uk_pack_type_f32f32, 16, 16, cpu->avx512_base);
-  iree_uk_test_pack(iree_uk_pack_type_i32i32, 16, 16, cpu->avx512_base);
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 1, "avx2_fma");
+  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 2, "avx2_fma");
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 8, "avx2_fma");
+  iree_uk_test_pack(iree_uk_pack_type_i32i32, 8, 8, "avx2_fma");
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 16, 1, "avx512_base");
+  iree_uk_test_pack(iree_uk_pack_type_i8i8, 16, 2, "avx512_base");
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 16, 16, "avx512_base");
+  iree_uk_test_pack(iree_uk_pack_type_i32i32, 16, 16, "avx512_base");
   // avx512_vnni uses the same tile size and same pack code as avx512_base.
 #endif  // defined(IREE_UK_ARCH_ARM_64)
-
-  iree_uk_standard_cpu_features_destroy(cpu);
 }

--- a/runtime/src/iree/builtins/ukernel/tools/test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/test.c
@@ -22,7 +22,7 @@ typedef enum {
 
 struct iree_uk_test_t {
   const char* name;
-  const iree_uk_cpu_features_list_t* cpu_features;
+  const char* cpu_features;
   iree_uk_uint64_t cpu_data[IREE_CPU_DATA_FIELD_COUNT];
   iree_time_t time_start;
   iree_uk_random_engine_t random_engine;
@@ -59,18 +59,7 @@ static void iree_uk_test_log_status(const iree_uk_test_t* test,
                                     iree_uk_test_status_t status) {
   fprintf(stderr, "%s %s", iree_uk_test_status_header(status), test->name);
   if (test->cpu_features) {
-    fprintf(stderr, ", cpu_features:");
-    const char* cpu_features_name =
-        iree_uk_cpu_features_list_get_name(test->cpu_features);
-    if (cpu_features_name) {
-      fprintf(stderr, "%s", cpu_features_name);
-    } else {
-      for (int i = 0; i < iree_uk_cpu_features_list_size(test->cpu_features);
-           ++i) {
-        fprintf(stderr, "%s%s", i ? "," : "",
-                iree_uk_cpu_features_list_entry(test->cpu_features, i));
-      }
-    }
+    fprintf(stderr, ", cpu_features:%s", test->cpu_features);
   }
   if (status != IREE_UK_TEST_STATUS_RUN) {
     fprintf(stderr, " (%" PRIi64 " ms)",
@@ -91,8 +80,7 @@ static void iree_uk_test_log_error(const iree_uk_test_t* test,
 
 void iree_uk_test(const char* name,
                   void (*test_func)(iree_uk_test_t*, const void*),
-                  const void* params,
-                  const iree_uk_cpu_features_list_t* cpu_features) {
+                  const void* params, const char* cpu_features) {
   iree_uk_test_t test = {
       .name = name,
       .cpu_features = cpu_features,
@@ -123,7 +111,7 @@ void iree_uk_test(const char* name,
       skipped = true;
       char msg[128];
       snprintf(msg, sizeof msg, "CPU does not support required feature %s",
-               iree_uk_cpu_first_unsupported_feature(cpu_features));
+               iree_uk_cpu_first_unsupported_feature(test.cpu_data));
       iree_uk_test_log_info(&test, "🦕", msg);
     }
   }

--- a/runtime/src/iree/builtins/ukernel/tools/test.h
+++ b/runtime/src/iree/builtins/ukernel/tools/test.h
@@ -25,8 +25,7 @@ typedef struct iree_uk_test_t iree_uk_test_t;
 // baseline kernels used when CPU features are unavailable.
 void iree_uk_test(const char* name,
                   void (*test_func)(iree_uk_test_t*, const void*),
-                  const void* params,
-                  const iree_uk_cpu_features_list_t* cpu_features);
+                  const void* params, const char* cpu_features);
 
 // Fail the current test.
 // This is currently always a fatal error: that is generally the most useful

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -102,9 +102,9 @@ static iree_status_t iree_uk_benchmark_unpack(
   return iree_ok_status();
 }
 
-static void iree_uk_benchmark_register_unpack(
-    iree_uk_unpack_type_t type, int tile_size0, int tile_size1,
-    const iree_uk_cpu_features_list_t* cpu_features) {
+static void iree_uk_benchmark_register_unpack(iree_uk_unpack_type_t type,
+                                              int tile_size0, int tile_size1,
+                                              const char* cpu_features) {
   char type_str[32];
   iree_uk_type_pair_str(type_str, sizeof type_str, type);
   iree_uk_unpack_params_t params = {
@@ -137,7 +137,6 @@ int main(int argc, char** argv) {
 
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_UNDEFINED_OK, &argc, &argv);
   iree_uk_benchmark_initialize(&argc, argv);
-  iree_uk_standard_cpu_features_t* cpu = iree_uk_standard_cpu_features_create();
 
   // The memcpy benchmark provides a useful comparison point, as pack is fairly
   // close to memory-bound.
@@ -149,13 +148,13 @@ int main(int argc, char** argv) {
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8, NULL);
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 8, 8,
-                                    cpu->avx2_fma);
+                                    "avx2_fma");
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8,
-                                    cpu->avx2_fma);
+                                    "avx2_fma");
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 16, 16,
-                                    cpu->avx512_base);
+                                    "avx512_base");
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 16, 16,
-                                    cpu->avx512_base);
+                                    "avx512_base");
 #else   // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
@@ -163,6 +162,5 @@ int main(int argc, char** argv) {
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8, NULL);
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
-  iree_uk_standard_cpu_features_destroy(cpu);
   iree_uk_benchmark_run_and_cleanup();
 }

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -170,9 +170,8 @@ static void iree_uk_test_unpack_for_tile_params(iree_uk_test_t* test,
   }
 }
 
-static void iree_uk_test_unpack(
-    iree_uk_unpack_type_t type, int tile_size0, int tile_size1,
-    const iree_uk_cpu_features_list_t* cpu_features) {
+static void iree_uk_test_unpack(iree_uk_unpack_type_t type, int tile_size0,
+                                int tile_size1, const char* cpu_features) {
   iree_uk_unpack_params_t params = {
       .type = type, .in_size2 = tile_size0, .in_size3 = tile_size1};
   char types_str[32];
@@ -185,8 +184,6 @@ static void iree_uk_test_unpack(
 }
 
 int main(int argc, char** argv) {
-  iree_uk_standard_cpu_features_t* cpu = iree_uk_standard_cpu_features_create();
-
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
@@ -198,11 +195,9 @@ int main(int argc, char** argv) {
   iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 8, 8, NULL);
   iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 8, 8, NULL);
 #elif defined(IREE_UK_ARCH_X86_64)
-  iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 8, 8, cpu->avx2_fma);
-  iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 8, 8, cpu->avx2_fma);
-  iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 16, 16, cpu->avx512_base);
-  iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 16, 16, cpu->avx512_base);
+  iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 8, 8, "avx2_fma");
+  iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 8, 8, "avx2_fma");
+  iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 16, 16, "avx512_base");
+  iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 16, 16, "avx512_base");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
-
-  iree_uk_standard_cpu_features_destroy(cpu);
 }

--- a/runtime/src/iree/builtins/ukernel/tools/util.h
+++ b/runtime/src/iree/builtins/ukernel/tools/util.h
@@ -45,46 +45,14 @@ int iree_uk_type_pair_str(char* buf, int buf_length,
 int iree_uk_type_triple_str(char* buf, int buf_length,
                             const iree_uk_type_triple_t triple);
 
-typedef struct iree_uk_cpu_features_list_t iree_uk_cpu_features_list_t;
-
-iree_uk_cpu_features_list_t* iree_uk_cpu_features_list_create(int count, ...);
-void iree_uk_cpu_features_list_destroy(iree_uk_cpu_features_list_t* list);
-void iree_uk_cpu_features_list_append(iree_uk_cpu_features_list_t* list,
-                                      int count, ...);
-iree_uk_cpu_features_list_t* iree_uk_cpu_features_list_create_extend(
-    iree_uk_cpu_features_list_t* list, int count, ...);
-int iree_uk_cpu_features_list_size(const iree_uk_cpu_features_list_t* list);
-const char* iree_uk_cpu_features_list_entry(
-    const iree_uk_cpu_features_list_t* list, int index);
-void iree_uk_cpu_features_list_set_name(iree_uk_cpu_features_list_t* list,
-                                        const char* name);
-const char* iree_uk_cpu_features_list_get_name(
-    const iree_uk_cpu_features_list_t* list);
-
-void iree_uk_make_cpu_data_for_features(
-    const iree_uk_cpu_features_list_t* cpu_features,
-    iree_uk_uint64_t* out_cpu_data_fields);
+void iree_uk_make_cpu_data_for_features(const char* cpu_features,
+                                        iree_uk_uint64_t* out_cpu_data_fields);
 
 void iree_uk_initialize_cpu_once(void);
 
 bool iree_uk_cpu_supports(const iree_uk_uint64_t* cpu_data_fields);
 
 const char* iree_uk_cpu_first_unsupported_feature(
-    const iree_uk_cpu_features_list_t* cpu_features);
-
-typedef struct iree_uk_standard_cpu_features_t {
-#if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_cpu_features_list_t* dotprod;
-  iree_uk_cpu_features_list_t* i8mm;
-#elif defined(IREE_UK_ARCH_X86_64)
-  iree_uk_cpu_features_list_t* avx2_fma;
-  iree_uk_cpu_features_list_t* avx512_base;
-  iree_uk_cpu_features_list_t* avx512_vnni;
-#endif
-} iree_uk_standard_cpu_features_t;
-
-iree_uk_standard_cpu_features_t* iree_uk_standard_cpu_features_create(void);
-void iree_uk_standard_cpu_features_destroy(
-    iree_uk_standard_cpu_features_t* cpu);
+    const iree_uk_uint64_t* cpu_data_fields);
 
 #endif  // IREE_BUILTINS_UKERNEL_TOOLS_UTIL_H_


### PR DESCRIPTION
When I first wrote ukernel tests and benchmarks, the only target was ARM64 where there are few non-baseline architecture features to consider, and we only needed to consider one at a time.

Then when I added x86-64 ukernels, suddently we had to deal with sets of 5-10 CPU features to enable for each test. For example, what is commonly called AVX-512, really "the Skylake flavor of AVX-512", consists of 5 separate features: `avx512f`, `avx512bw`, `avx512cd`, `avx512vl`, `avx512dq`.  (The naming convention is that of GCC/Clang/LLVM compatible compilers target attributes).  Then these sets of features come on top of each other, e.g. avx512 comes on top of avx2.  Most applications aren't so careful to track individual features like that that are in practice almost always simultaneously supported or unsupported, but we need to be more careful as this is eventually making its way into a compiler.

So when I added x86-64 ukernels, I hesitated a bit about how much to over-engineer this... since this is plain C code, it's not like we can "just use a `std::vector<std::string>`".  I eventually implemented my own thing like that: `iree_uk_cpu_features_list_t`. Really a vector of `const char*`. The alternative was to just use a single `const char*` string and say that multiple features could be represented as a comma-separated string. But then I remembered about the "don't parse" principle.

Then I realized that having lists of 8 CPU features was too verbose to print in benchmark names and in tests. So I introduced a set of common feature sets with shorthand names, like "avx512_base".

Then I realized that those shorthand names were all I needed in practice, as all tests and benchmarks needed to test the same few feature sets.  (partly by construction: I designed x86 ukernels to factor all through a few such feature sets).

Then I realized that meant that just a const char* was all I needed actually.  There was no parsing of comma-separated lists as we only needed to parse these set names.

And if we ever want to support arbitrary combinations, we can always support parsing comma-separated. The other thing I realized writing this PR is that doing so would be very localized within 1 function, so actually not bad.

This PR also adds a special feature set with the name "host".  It is implemented as runtime feature detection of the host CPU.  It is needed by subsequent PR introducing the e2e matmul benchmark where it's the sensible default.