### PR TITLE
[spirv] Support i8 matmul codegen with integer dot prod ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -31,7 +31,7 @@ static LogicalResult setMaliMatmulConfig(linalg::LinalgOp op,
   if (elementType.getIntOrFloatBitWidth() == 16) {
     threadMNK = {2, 8, 8};
   } else if (elementType.isInteger(8)) {
-    threadMNK = {4, 4, 4};
+    threadMNK = {4, 4, 16};
   } else {
     threadMNK = {6, 4, 4};
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -145,8 +145,6 @@ LogicalResult detectI8ToI32Matmul(vector::ContractionOp contract) {
   if (!mayExtI8ToI32(contract.getLhs()) || !mayExtI8ToI32(contract.getRhs()))
     return failure();
 
-  AffineExpr m, n, k;
-  bindDims(contract.getContext(), m, n, k);
   ArrayRef<Attribute> iteratorTypes = contract.getIteratorTypes().getValue();
   if (iteratorTypes.size() != 3) return failure();
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -18,12 +18,15 @@
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/Conversion/VectorToSPIRV/VectorToSPIRV.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -31,8 +34,10 @@
 #include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/VectorInterfaces.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 using mlir::iree_compiler::IREE::LinalgExt::LinalgVectorizationPattern;
@@ -81,17 +86,106 @@ SmallVector<int64_t> getNativeVectorShapeImpl(VectorTransferOpInterface op) {
   return nativeSize;
 }
 
-SmallVector<int64_t> getNativeVectorShapeImpl(vector::ContractionOp op) {
-  // Find the contract output's innermost dimension. It is guaranteed to be a
-  // parallel dimension due to contract definition. Unroll it with compute
-  // size.
-  AffineMap resultMap = op.getIndexingMapsArray().back();
-  unsigned lastParallelDim =
-      resultMap.getDimPosition(resultMap.getNumResults() - 1);
-  SmallVector<int64_t> nativeSize(op.getIteratorTypes().size(), 1);
+Operation *stripElementBitPatternPreservingParents(Value op) {
+  while (Operation *parent = op.getDefiningOp()) {
+    if (!parent) break;
+
+    if (auto broadcast = dyn_cast<vector::BroadcastOp>(parent)) {
+      op = broadcast.getVector();
+      continue;
+    }
+    if (auto extract = dyn_cast<vector::ExtractOp>(parent)) {
+      op = extract.getVector();
+      continue;
+    }
+    if (auto extract = dyn_cast<vector::ExtractStridedSliceOp>(parent)) {
+      op = extract.getVector();
+      continue;
+    }
+    if (auto extract = dyn_cast<vector::ExtractElementOp>(parent)) {
+      op = extract.getVector();
+      continue;
+    }
+    if (auto transpose = dyn_cast<vector::TransposeOp>(parent)) {
+      op = transpose.getVector();
+      continue;
+    }
+
+    break;
+  }
+
+  return op.getDefiningOp();
+}
+
+bool isExt8To32(Value op) {
+  if (!getElementTypeOrSelf(op.getType()).isInteger(32)) return false;
+
+  // Look through vector operations created by vector unrolling patterns,
+  // hoping to find a zero/sign extension op.
+  Operation *def = stripElementBitPatternPreservingParents(op);
+  Type inTy;
+
+  if (auto ext = dyn_cast_or_null<arith::ExtSIOp>(def)) {
+    inTy = getElementTypeOrSelf(ext.getIn().getType());
+  } else if (auto ext = dyn_cast_or_null<arith::ExtUIOp>(def)) {
+    inTy = getElementTypeOrSelf(ext.getIn().getType());
+  } else {
+    return false;
+  }
+
+  return inTy.isInteger(8);
+}
+
+/// Succeeds when |contract| is an i8 -> i32 matmul.
+LogicalResult detectI8ToI32Matmul(vector::ContractionOp contract) {
+  if (contract.getKind() != vector::CombiningKind::ADD) return failure();
+
+  if (!isExt8To32(contract.getLhs()) || !isExt8To32(contract.getRhs()))
+    return failure();
+
+  AffineExpr m, n, k;
+  bindDims(contract.getContext(), m, n, k);
+  ArrayRef<Attribute> iteratorTypes = contract.getIteratorTypes().getValue();
+  if (iteratorTypes.size() != 3) return failure();
+
+  return success(vector::isParallelIterator(iteratorTypes[0]) &&
+                 vector::isParallelIterator(iteratorTypes[1]) &&
+                 vector::isReductionIterator(iteratorTypes[2]));
+}
+
+/// Returns the index of the reduction dimension.
+unsigned getReductionDim(vector::ContractionOp contract) {
+  AffineMap resultMap = contract.getIndexingMapsArray().back();
+  ArrayRef<Attribute> iteratorTypes = contract.getIteratorTypes().getValue();
+  for (auto [idx, it] : llvm::enumerate(iteratorTypes)) {
+    if (vector::isReductionIterator(it)) {
+      return idx;
+    }
+  }
+
+  // Return the last index as a fallback.
+  return resultMap.getNumDims() - 1;
+}
+
+unsigned getInnermostParallelDim(vector::ContractionOp contract) {
+  AffineMap resultMap = contract.getIndexingMapsArray().back();
+  return resultMap.getDimPosition(resultMap.getNumResults() - 1);
+}
+
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::ContractionOp op,
+                                              bool targetSupportsDotProd) {
+  // Find the contract dimension to unroll. This depends on whether we use the
+  // outer product or inner product lowering. Outer product is the default
+  // strategy.
+  bool lowerToInnerProd =
+      targetSupportsDotProd && succeeded(detectI8ToI32Matmul(op));
+  unsigned unrollDim =
+      lowerToInnerProd ? getReductionDim(op) : getInnermostParallelDim(op);
+  auto iteratorTypes = op.getIteratorTypes().getValue();
+  SmallVector<int64_t> nativeSize(iteratorTypes.size(), 1);
   SmallVector<int64_t, 4> bounds;
   op.getIterationBounds(bounds);
-  nativeSize[lastParallelDim] = getComputeVectorSize(bounds[lastParallelDim]);
+  nativeSize[unrollDim] = getComputeVectorSize(bounds[unrollDim]);
   return nativeSize;
 }
 
@@ -120,7 +214,8 @@ SmallVector<int64_t> getNativeVectorShapeImpl(vector::TransposeOp op) {
   return nativeSize;
 }
 
-std::optional<SmallVector<int64_t>> getNativeVectorShape(Operation *op) {
+std::optional<SmallVector<int64_t>> getNativeVectorShape(
+    Operation *op, bool targetSupportsDotProd) {
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
     if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>()) {
       SmallVector<int64_t> nativeSize(vecType.getRank(), 1);
@@ -130,10 +225,12 @@ std::optional<SmallVector<int64_t>> getNativeVectorShape(Operation *op) {
   }
 
   return TypeSwitch<Operation *, std::optional<SmallVector<int64_t>>>(op)
-      .Case<VectorTransferOpInterface, vector::ContractionOp,
-            vector::MultiDimReductionOp, vector::ReductionOp,
-            vector::TransposeOp>(
+      .Case<VectorTransferOpInterface, vector::MultiDimReductionOp,
+            vector::ReductionOp, vector::TransposeOp>(
           [](auto typedOp) { return getNativeVectorShapeImpl(typedOp); })
+      .Case<vector::ContractionOp>([=](auto contract) {
+        return getNativeVectorShapeImpl(contract, targetSupportsDotProd);
+      })
       .Default([](Operation *) { return std::nullopt; });
 }
 
@@ -150,10 +247,35 @@ void populateVectorizationPatterns(RewritePatternSet &patterns) {
 }
 
 /// Adds patterns to unroll vector ops to SPIR-V native vector size.
-void populateVectorUnrollPatterns(RewritePatternSet &patterns) {
-  auto options =
-      vector::UnrollVectorOptions().setNativeShapeFn(getNativeVectorShape);
+void populateVectorUnrollPatterns(RewritePatternSet &patterns,
+                                  bool targetSupportsDotProd) {
+  auto options = vector::UnrollVectorOptions().setNativeShapeFn(
+      [=](auto op) { return getNativeVectorShape(op, targetSupportsDotProd); });
   vector::populateVectorUnrollPatterns(patterns, options);
+}
+
+/// Returns true when the target environment support integer dot product ops.
+bool supportsIntegerDotProductOps(func::FuncOp fn) {
+  spirv::TargetEnvAttr targetEnvAttr = getSPIRVTargetEnvAttr(fn);
+  if (!targetEnvAttr) {
+    // Alternatively, check if the function op itself has a target env
+    // attribute. This may be preferred in tests.
+    targetEnvAttr =
+        fn->getAttrOfType<spirv::TargetEnvAttr>(spirv::getTargetEnvAttrName());
+    if (!targetEnvAttr) return false;
+  }
+
+  spirv::TargetEnv targetEnv(targetEnvAttr);
+  if (!targetEnv.allows(spirv::Extension::SPV_KHR_integer_dot_product))
+    return false;
+
+  // Query all the dot prod capabilities except for the packed one -- none of
+  // the vectorization patterns need it.
+  if (!targetEnv.allows(spirv::Capability::DotProduct)) return false;
+  if (!targetEnv.allows(spirv::Capability::DotProductInput4x8Bit)) return false;
+  if (!targetEnv.allows(spirv::Capability::DotProductInputAll)) return false;
+
+  return true;
 }
 
 /// Vectorizes Linalg ops on buffer semantics.
@@ -171,6 +293,8 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     func::FuncOp funcOp = getOperation();
+
+    bool emitIntegerDotProdOps = supportsIntegerDotProductOps(funcOp);
 
     // First apply vectorization to generate vectors of the original tensor
     // shape.
@@ -280,11 +404,28 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       llvm::dbgs() << "\n\n";
     });
 
+    // Prepare for SPIR-V integer dot product lowering.
+    if (emitIntegerDotProdOps) {
+      RewritePatternSet patterns(context);
+      vector::populateVectorContractCanonicalizeMatmulToMMT(
+          patterns, detectI8ToI32Matmul);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+
+      LLVM_DEBUG({
+        llvm::dbgs()
+            << "--- After prepare for SPIR-V dot product lowering ---\n";
+        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+        llvm::dbgs() << "\n\n";
+      });
+    }
+
     // Then unroll vectors to native vector size. We try to use 128-bit
     // vectors for memory access and 4/2/1 vector sizes for computation.
     {
       RewritePatternSet patterns(context);
-      populateVectorUnrollPatterns(patterns);
+      populateVectorUnrollPatterns(patterns, emitIntegerDotProdOps);
       if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
@@ -381,6 +522,21 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });
+
+    // Lower vector reduction to SPIR-V integer dot product.
+    if (emitIntegerDotProdOps) {
+      RewritePatternSet patterns(context);
+      populateVectorReductionToSPIRVDotProductPatterns(patterns);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+
+      LLVM_DEBUG({
+        llvm::dbgs() << "--- After lowering to SPIR-V dot product ---\n";
+        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+        llvm::dbgs() << "\n\n";
+      });
+    }
 
     // Next perform hoisting. This would analyze transfer read/write ops into
     // tensors and hoist them out of loop nests. So after it we have

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -35,10 +35,8 @@
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeUtilities.h"
-#include "mlir/IR/Visitors.h"
 #include "mlir/Interfaces/VectorInterfaces.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
@@ -358,7 +358,7 @@ hal.executable @matmul_1024x2048x512xi8 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @matmul_1024x2048x512xi8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
@@ -189,3 +189,114 @@ func.func @matmul_2x8x128_fp16(%a: tensor<2x128xf16>, %b: tensor<128x8xf16>, %x:
 // CHECK:   %[[W0:.+]] = vector.transfer_write %[[ISS1]], %[[Y]][%c0, %c0] {in_bounds = [true]} : vector<8xf16>, tensor<2x8xf16>
 // CHECK:   %[[W1:.+]] = vector.transfer_write %[[ISS3]], %[[W0]][%c1, %c0] {in_bounds = [true]} : vector<8xf16>, tensor<2x8xf16>
 // CHECK:   return %[[W1]]
+
+// -----
+
+// The default i8->i32 matmul codegen uses the outerproduct lowering, as not all
+// SPIR-V targets support integer dot product ops used for efficient innerproduct
+// lowering.
+
+func.func @matmul_4x4x4_i8_to_i32(%lhs: tensor<4x4xi8>, %rhs : tensor<4x4xi8>) -> tensor<4x4xi32> {
+  %c0 = arith.constant 0 : i32
+  %i0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<4x4xi32>
+  %CC = linalg.fill ins(%c0 : i32) outs(%init : tensor<4x4xi32>) -> tensor<4x4xi32>
+  %D = linalg.matmul ins(%lhs, %rhs: tensor<4x4xi8>, tensor<4x4xi8>)
+                     outs(%CC: tensor<4x4xi32>) -> tensor<4x4xi32>
+  return %D : tensor<4x4xi32>
+}
+
+// CHECK-LABEL: func.func @matmul_4x4x4_i8_to_i32
+// CHECK-SAME:    (%[[LHS:.+]]: tensor<4x4xi8>, %[[RHS:.+]]: tensor<4x4xi8>)
+// CHECK-DAG:     %[[CST0:.+]]   = arith.constant 0 : i8
+// CHECK-DAG:     %[[IDX0:.+]]   = arith.constant 0 : index
+// CHECK-DAG:     %[[IDX1:.+]]   = arith.constant 1 : index
+// CHECK-DAG:     %[[IDX2:.+]]   = arith.constant 2 : index
+// CHECK-DAG:     %[[IDX3:.+]]   = arith.constant 3 : index
+// CHECK:         %[[LHS0:.+]]   = vector.transfer_read %[[LHS]][%[[IDX0]], %[[IDX0]]], %[[CST0]]
+// CHECK-NEXT:    %[[LHS1:.+]]   = vector.transfer_read %[[LHS]][%[[IDX1]], %[[IDX0]]], %[[CST0]]
+// CHECK-NEXT:    %[[LHS2:.+]]   = vector.transfer_read %[[LHS]][%[[IDX2]], %[[IDX0]]], %[[CST0]]
+// CHECK-NEXT:    %[[LHS3:.+]]   = vector.transfer_read %[[LHS]][%[[IDX3]], %[[IDX0]]], %[[CST0]]
+// CHECK:         %[[RHS0:.+]]   = vector.transfer_read %[[RHS]][%[[IDX0]], %[[IDX0]]], %[[CST0]]
+// CHECK-NEXT:    %[[RHS1:.+]]   = vector.transfer_read %[[RHS]][%[[IDX1]], %[[IDX0]]], %[[CST0]]
+// CHECK-NEXT:    %[[RHS2:.+]]   = vector.transfer_read %[[RHS]][%[[IDX2]], %[[IDX0]]], %[[CST0]]
+// CHECK-NEXT:    %[[RHS3:.+]]   = vector.transfer_read %[[RHS]][%[[IDX3]], %[[IDX0]]], %[[CST0]]
+// CHECK:         %[[LHS0E:.+]]  = arith.extsi %[[LHS0]] : vector<4xi8> to vector<4xi32>
+// CHECK-NEXT:    %[[LHS1E:.+]]  = arith.extsi %[[LHS1]] : vector<4xi8> to vector<4xi32>
+// CHECK-NEXT:    %[[LHS2E:.+]]  = arith.extsi %[[LHS2]] : vector<4xi8> to vector<4xi32>
+// CHECK-NEXT:    %[[LHS3E:.+]]  = arith.extsi %[[LHS3]] : vector<4xi8> to vector<4xi32>
+// CHECK:         %[[RHS0E:.+]]  = arith.extsi %[[RHS0]] : vector<4xi8> to vector<4xi32>
+// CHECK-NEXT:    %[[RHS1E:.+]]  = arith.extsi %[[RHS1]] : vector<4xi8> to vector<4xi32>
+// CHECK-NEXT:    %[[RHS2E:.+]]  = arith.extsi %[[RHS2]] : vector<4xi8> to vector<4xi32>
+// CHECK-NEXT:    %[[RHS3E:.+]]  = arith.extsi %[[RHS3]] : vector<4xi8> to vector<4xi32>
+// CHECK:         %[[EXT0:.+]]   = vector.extract %[[LHS0E]][0]
+// CHECK-NEXT:    %[[SPLT:.+]]   = vector.splat %[[EXT0]] : vector<4xi32>
+// CHECK-NEXT:    %[[MUL0:.+]]   = arith.muli %[[SPLT]], %[[RHS0E]]
+// CHECK:         %[[EXT1:.+]]   = vector.extract %[[LHS0E]][1]
+// CHECK-NEXT:    %[[SPLT:.+]]   = vector.splat %[[EXT1]] : vector<4xi32>
+// CHECK-NEXT:    %[[MUL1:.+]]   = arith.muli %[[SPLT]], %[[RHS1E]]
+// CHECK-NEXT:    %[[ADD0:.+]]   = arith.addi %[[MUL1]], %[[MUL0]]
+//
+// CHECK:         %[[W0:.+]]     = vector.transfer_write %{{.+}}, %{{.+}}[%[[IDX0]], %[[IDX0]]]
+// CHECK-NEXT:    %[[W1:.+]]     = vector.transfer_write %{{.+}}, %[[W0]][%[[IDX1]], %[[IDX0]]]
+// CHECK-NEXT:    %[[W2:.+]]     = vector.transfer_write %{{.+}}, %[[W1]][%[[IDX2]], %[[IDX0]]]
+// CHECK-NEXT:    %[[W3:.+]]     = vector.transfer_write %{{.+}}, %[[W2]][%[[IDX3]], %[[IDX0]]]
+// CHECK-NEXT:    return %[[W3]] : tensor<4x4xi32>
+
+// -----
+
+// Check that emit SPIR-V integer dot product instructions when supported by
+// the target env. We expect the matmul to follow the inner product lowering.
+
+func.func @matmul_4x4x4_i8_to_i32_dot_prod(%lhs: tensor<4x4xi8>, %rhs : tensor<4x4xi8>) -> tensor<4x4xi32> attributes {
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.5,
+                                         [DotProduct, DotProductInputAll, DotProductInput4x8Bit],
+                                         [SPV_KHR_integer_dot_product]>,
+                                       #spirv.resource_limits<>> } {
+  %c0 = arith.constant 0 : i32
+  %i0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<4x4xi32>
+  %CC = linalg.fill ins(%c0 : i32) outs(%init : tensor<4x4xi32>) -> tensor<4x4xi32>
+  %D = linalg.matmul ins(%lhs, %rhs: tensor<4x4xi8>, tensor<4x4xi8>)
+                     outs(%CC: tensor<4x4xi32>) -> tensor<4x4xi32>
+  return %D : tensor<4x4xi32>
+}
+
+// CHECK-LABEL: func.func @matmul_4x4x4_i8_to_i32
+// CHECK-SAME:    (%[[LHS:.+]]: tensor<4x4xi8>, %[[RHS:.+]]: tensor<4x4xi8>)
+// CHECK-DAG:     %[[C0I8:.+]]   = arith.constant 0 : i8
+// CHECK-DAG:     %[[C0I32:.+]]  = arith.constant 0 : i32
+// CHECK-DAG:     %[[V4I8:.+]]   = arith.constant dense<0> : vector<4xi8>
+// CHECK-DAG:     %[[V4I32:.+]]  = arith.constant dense<0> : vector<4xi32>
+// CHECK-DAG:     %[[V1I32:.+]]  = arith.constant dense<0> : vector<1xi32>
+// CHECK-DAG:     %[[IDX0:.+]]   = arith.constant 0 : index
+// CHECK-DAG:     %[[IDX1:.+]]   = arith.constant 1 : index
+// CHECK-DAG:     %[[IDX2:.+]]   = arith.constant 2 : index
+// CHECK-DAG:     %[[IDX3:.+]]   = arith.constant 3 : index
+// CHECK:         %[[LHS0:.+]]   = vector.transfer_read %[[LHS]][%[[IDX0]], %[[IDX0]]], %[[C0I8]]
+// CHECK-NEXT:    %[[LHS1:.+]]   = vector.transfer_read %[[LHS]][%[[IDX1]], %[[IDX0]]], %[[C0I8]]
+// CHECK-NEXT:    %[[LHS2:.+]]   = vector.transfer_read %[[LHS]][%[[IDX2]], %[[IDX0]]], %[[C0I8]]
+// CHECK-NEXT:    %[[LHS3:.+]]   = vector.transfer_read %[[LHS]][%[[IDX3]], %[[IDX0]]], %[[C0I8]]
+// CHECK:         %[[RHS0:.+]]   = vector.transfer_read %[[RHS]][%[[IDX0]], %[[IDX0]]], %[[C0I8]]
+// CHECK-NEXT:    %[[RHS1:.+]]   = vector.transfer_read %[[RHS]][%[[IDX1]], %[[IDX0]]], %[[C0I8]]
+// CHECK-NEXT:    %[[RHS2:.+]]   = vector.transfer_read %[[RHS]][%[[IDX2]], %[[IDX0]]], %[[C0I8]]
+// CHECK-NEXT:    %[[RHS3:.+]]   = vector.transfer_read %[[RHS]][%[[IDX3]], %[[IDX0]]], %[[C0I8]]
+// CHECK:         %[[EXTR0:.+]]  = vector.extract %[[RHS0]][0]
+// CHECK-NEXT:    %[[INS0:.+]]   = vector.insert %[[EXTR0]], %[[V4I8]] [0]
+// CHECK-NEXT:    %[[EXTR1:.+]]  = vector.extract %[[RHS1]][0]
+// CHECK-NEXT:    %[[INS1:.+]]   = vector.insert %[[EXTR1]], %[[INS0]] [1]
+// CHECK-NEXT:    %[[EXTR2:.+]]  = vector.extract %[[RHS2]][0]
+// CHECK-NEXT:    %[[INS2:.+]]   = vector.insert %[[EXTR2]], %[[INS1]] [2]
+// CHECK-NEXT:    %[[EXTR3:.+]]  = vector.extract %[[RHS3]][0]
+// CHECK-NEXT:    %[[COL0:.+]]   = vector.insert %[[EXTR3]], %[[INS2]] [3]
+// CHECK:         %[[DOT0:.+]]   = spirv.SDotAccSat %[[LHS0]], %[[COL0]], %[[C0I32]]
+// CHECK-NEXT:    %[[RES0:.+]]   = vector.insert %[[DOT0]], %[[V1I32]] [0]
+// CHECK-COUNT-15:                 spirv.SDotAccSat
+//
+// CHECK-COUNT-16:                 vector.insert_strided_slice {{.+}} : vector<1xi32> into vector<4xi32>
+//
+// CHECK:         %[[W0:.+]]     = vector.transfer_write %{{.+}}, %{{.+}}[%[[IDX0]], %[[IDX0]]]
+// CHECK-NEXT:    %[[W1:.+]]     = vector.transfer_write %{{.+}}, %[[W0]][%[[IDX1]], %[[IDX0]]]
+// CHECK-NEXT:    %[[W2:.+]]     = vector.transfer_write %{{.+}}, %[[W1]][%[[IDX2]], %[[IDX0]]]
+// CHECK-NEXT:    %[[W3:.+]]     = vector.transfer_write %{{.+}}, %[[W2]][%[[IDX3]], %[[IDX0]]]
+// CHECK-NEXT:    return %[[W3]] : tensor<4x4xi32>


### PR DESCRIPTION
This configuration is enabled conditionally for targets that support the necessary extension and capabilities.