### PR TITLE
Update the tensor.pack tests to not fuse inputs and pack ops.

### DIFF
--- a/build_tools/cmake/test_riscv.sh
+++ b/build_tools/cmake/test_riscv.sh
@@ -90,6 +90,7 @@ fi
 test_exclude_args+=(
   # TODO(#12703): Enable the test.
   "iree/tests/e2e/matmul/e2e_matmul_mmt4d_i8_small_llvm-cpu_local-task"
+  "iree/tests/e2e/tensor_ops/check_llvm-cpu_local-task_pack_dynamic_inner_tiles.mlir"
 )
 
 tests_label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]}"))"

--- a/tests/e2e/tensor_ops/pack.mlir
+++ b/tests/e2e/tensor_ops/pack.mlir
@@ -12,7 +12,10 @@ func.func private @generate_2D_source(%height : index, %width : index) -> tensor
       %linearized_i32 = arith.index_cast %linearized : index to i32
       linalg.yield %linearized_i32 : i32
   } -> tensor<?x?xi32>
-  return %source : tensor<?x?xi32>
+  // This blocks the fusion for inputs and testing ops.
+  %0 = util.optimization_barrier %source : tensor<?x?xi32>
+  %1 = flow.tensor.tie_shape %0 : tensor<?x?xi32>{%height, %width}
+  return %1 : tensor<?x?xi32>
 }
 
 func.func @static_pack_simple() {

--- a/tests/e2e/tensor_ops/pack_dynamic_inner_tiles.mlir
+++ b/tests/e2e/tensor_ops/pack_dynamic_inner_tiles.mlir
@@ -12,7 +12,10 @@ func.func private @generate_2D_source(%height : index, %width : index) -> tensor
       %linearized_i32 = arith.index_cast %linearized : index to i32
       linalg.yield %linearized_i32 : i32
   } -> tensor<?x?xi32>
-  return %source : tensor<?x?xi32>
+  // This blocks the fusion for inputs and testing ops.
+  %0 = util.optimization_barrier %source : tensor<?x?xi32>
+  %1 = flow.tensor.tie_shape %0 : tensor<?x?xi32>{%height, %width}
+  return %1 : tensor<?x?xi32>
 }
 
 func.func @fully_dynamic_pack_simple() {


### PR DESCRIPTION
The inputs are generated by a generic op. The fusion could make the generic op and pack op be in the same dispatch, while we want to test the correctness for a single pack op. The commit adds some barrier ops to prevent the case.