### PR TITLE
Fix path to MLIR_CMAKE_DIR.

### DIFF
--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -42,8 +42,12 @@ macro(iree_llvm_configure_bundled)
   set(LLVM_CMAKE_DIR "${IREE_BINARY_DIR}/llvm-project/lib/cmake/llvm")
   list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
   # TODO: Fix MLIR upstream so it doesn't spew into the containing project
-  # binary dir.
-  set(MLIR_CMAKE_DIR "${IREE_BINARY_DIR}/lib/cmake/mlir")
+  # binary dir. See mlir/cmake/modules/CMakeLists.txt
+  # (and other LLVM sub-projects).
+  set(MLIR_CMAKE_DIR "${CMAKE_BINARY_DIR}/lib/cmake/mlir")
+  if(NOT EXISTS "${MLIR_CMAKE_DIR}/AddMLIR.cmake")
+    message(SEND_ERROR "Could not find AddMLIR.cmake in ${MLIR_CMAKE_DIR}: LLVM sub-projects may have changed their layout. See the mlir_cmake_builddir variable in mlir/cmake/modules/CMakeLists.txt")
+  endif()
   list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 
   set(LLVM_INCLUDE_DIRS


### PR DESCRIPTION
This fixes an error where AddMLIR cannot be foudn when built with IREE contained inside another project.

It results from an inconsistency in LLVM CMake: llvm/cmake/modules writes its CMake configs to the LLVM lib dir, but sub-projects (like MLIR) write to CMAKE_BINARY_DIR/lib.

Added a check and a descriptive warning since I'd like to fix this at some point.