### PR TITLE
Avoid more sanitizer test timeouts

### DIFF
--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -111,8 +111,7 @@ static void iree_uk_test_pack_for_tile_params(iree_uk_test_t* test,
       // Non-degenerate cases.
       {1, 1},
       {3, 2},
-      {7, 8},
-      {31, 33},
+      {9, 33},
   };
   typedef enum {
     pad_none,
@@ -129,12 +128,8 @@ static void iree_uk_test_pack_for_tile_params(iree_uk_test_t* test,
           params.cpu_data = iree_uk_test_cpu_data(test);
           outer_shape_t outer_shape = outer_shapes[i];
           if (pad == pad_a_lot) {
-            // Makes the test expensive, and covers a corner case that shouldn't
-            // require large sizes. Try to be economical.
-            if (outer_shape.size0 <= 8 && outer_shape.size1 <= 8) {
-              outer_shape.size0 += 64;
-              outer_shape.size1 += 64;
-            }
+            outer_shape.size0 += 16;
+            outer_shape.size1 += 16;
           }
           params.out_size0 = outer_shape.size0;
           params.out_size1 = outer_shape.size1;

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -110,8 +110,7 @@ static void iree_uk_test_unpack_for_tile_params(iree_uk_test_t* test,
       // Non-degenerate cases.
       {1, 1},
       {3, 2},
-      {7, 8},
-      {31, 33},
+      {9, 33},
   };
   typedef enum {
     pad_none,
@@ -132,12 +131,8 @@ static void iree_uk_test_unpack_for_tile_params(iree_uk_test_t* test,
           params.in_size0 = in_size0;
           params.in_size1 = in_size1;
           if (pad == pad_a_lot) {
-            // Makes the test expensive, and covers a corner case that shouldn't
-            // require large sizes. Try to be economical.
-            if (params.in_size0 <= 8 && params.in_size1 <= 8) {
-              params.in_size0 += 64;
-              params.in_size1 += 64;
-            }
+            params.in_size0 += 16;
+            params.in_size1 += 16;
           }
           iree_uk_ssize_t tile_size0 = params.in_size2;
           iree_uk_ssize_t tile_size1 = params.in_size3;


### PR DESCRIPTION
More CI timeouts with TSAN in `pack_test` reported by @stellaraccident :
  https://github.com/openxla/iree/actions/runs/4580136815/jobs/8088573298?pr=12884

This PR shrinks TSAN test latency on my desktop from 12 seconds to 0.85 second.  I think it preserves the really important test coverage still. The sole substantially large remaining shape `{9, 33}` is larger in dimension 1 because that is the inner loop dim and that's where we want to catch the most bugs. Values are just above a power of two.  And the 64->16 change is because in practice when we do "pad a lot" that is currently incidentally due to our pad-everything-by-16x16 approach to make buffer allocations independent of materialize-encoding, so the 16 value is what we care about in practice.

