### PR TITLE
Fix XLA import path

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -48,15 +48,17 @@ void registerMHLOConversionPassPipeline() {
       [](OpPassManager &passManager) {
         buildMHLOInputConversionPassPipeline(passManager);
       });
-  PassPipelineRegistration<> xla("iree-mhlo-xla-cleanup-pipeline",
-                                 "Runs the post-XLA import cleanup pipeline",
-                                 [](OpPassManager &passManager) {
-                                   buildXLACleanupPassPipeline(passManager);
-                                 });
+  PassPipelineRegistration<> xla(
+      "iree-xla-input-transformation-pipeline",
+      "Runs the XLA IREE flow dialect transformation pipeline",
+      [](OpPassManager &passManager) {
+        buildXLAInputConversionPassPipeline(passManager);
+      });
 }
 
 // Prepare HLO for use as an input to the Flow dialect.
-void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
+static void buildMHLOInputConversionPassPipelineImpl(OpPassManager &passManager,
+                                                     bool detuple) {
   passManager.addPass(mlir::mhlo::createStablehloLegalizeToHloPass());
   passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
   passManager.addNestedPass<func::FuncOp>(
@@ -66,6 +68,7 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
   // In the future it would be nice if we could have all of flow be both scf
   // and cfg compatible.
   passManager.addNestedPass<func::FuncOp>(createTopLevelSCFToCFGPass());
+  if (detuple) passManager.addPass(createFlattenTuplesInCFGPass());
 
   passManager.addNestedPass<func::FuncOp>(createMHLOToMHLOPreprocessingPass());
   passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
@@ -119,11 +122,12 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createVerifyCompilerMHLOInputLegality());
 }
 
-void buildXLACleanupPassPipeline(OpPassManager &passManager) {
-  passManager.addNestedPass<func::FuncOp>(
-      mhlo::createLegalizeControlFlowPass());
-  passManager.addPass(createFlattenTuplesInCFGPass());
-  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
+void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
+  buildMHLOInputConversionPassPipelineImpl(passManager, /*detuple=*/false);
+}
+
+void buildXLAInputConversionPassPipeline(OpPassManager &passManager) {
+  buildMHLOInputConversionPassPipelineImpl(passManager, /*detuple=*/true);
 }
 
 namespace {

--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.h
@@ -22,11 +22,8 @@ namespace MHLO {
 // Performs input legalization for specific combination of input dialects.
 void buildMHLOInputConversionPassPipeline(OpPassManager &passManager);
 
-// Performs some cleanup activities on programs that may have originated from
-// an XLA import (or made to interop with it) followed by MHLO input
-// converstion. This involves:
-//   - Convert XLA control flow to SCF
-//   - Canonicalize
+// Performs input legalization on programs that may have originated from an XLA
+// import (or made to interop with it).
 void buildXLAInputConversionPassPipeline(OpPassManager &passManager);
 
 void registerMHLOConversionPassPipelines();

--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.h
@@ -23,15 +23,11 @@ namespace MHLO {
 void buildMHLOInputConversionPassPipeline(OpPassManager &passManager);
 
 // Performs some cleanup activities on programs that may have originated from
-// an XLA import (or made to interop with it). This involves:
+// an XLA import (or made to interop with it) followed by MHLO input
+// converstion. This involves:
 //   - Convert XLA control flow to SCF
-//   - Convert SCF control flow to CFG
-//   - Flatten tuples in CFG
 //   - Canonicalize
-// It is unfortunate to lose SCF so early in the process but CFG provides a
-// large simplification to tuple heavy programs, and this compromise is taken
-// in the name of compatibility.
-void buildXLACleanupPassPipeline(OpPassManager &passManager);
+void buildXLAInputConversionPassPipeline(OpPassManager &passManager);
 
 void registerMHLOConversionPassPipelines();
 

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -53,8 +53,7 @@ void buildIREEVMTransformPassPipeline(
       MHLO::buildMHLOInputConversionPassPipeline(passManager);
       break;
     case InputDialectOptions::Type::xla:
-      MHLO::buildXLACleanupPassPipeline(passManager);
-      MHLO::buildMHLOInputConversionPassPipeline(passManager);
+      MHLO::buildXLAInputConversionPassPipeline(passManager);
       break;
 #endif  // IREE_HAVE_MHLO_INPUT
 #ifdef IREE_HAVE_TORCH_INPUT


### PR DESCRIPTION
The pipeline wasn't following the route documented post refactoring,
which led to tuples not being handled correctly: the flatten tuple pass
required CF form to operate on and not SCF form.

We can make this a bit more automatic (and we have the tracking bug to
avoid even specifying type here).

This is for the legacy import path.