### PR TITLE
Flip iree-opt-const-expr-hoisting and iree-opt-const-eval on by default.

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -59,11 +59,11 @@ struct InputDialectOptions {
 // Options controlling high level optimizations.
 struct HighLevelOptimizationOptions {
   // Enables const-expr hoisting into globals.
-  bool constExprHoisting = false;
+  bool constExprHoisting = true;
 
   // Enables recursive evaluation of immutable globals using the compiler
   // and runtime.
-  bool constEval = false;
+  bool constEval = true;
 
   // Optimizations to reduce numeric precision where it is safe to do so.
   bool numericPrecisionReduction = false;

--- a/docs/website/docs/reference/optimization-options.md
+++ b/docs/website/docs/reference/optimization-options.md
@@ -14,7 +14,7 @@ These flags can be passed to the:
 
 ## High level program optimizations
 
-### Constant evaluation (`--iree-opt-const-eval` (off))
+### Constant evaluation (`--iree-opt-const-eval` (on))
 
 Performs compile-time evaluation of any global initializers which produce
 the initial values for global constants, storing the global directly in the
@@ -26,7 +26,7 @@ functions, not free-standing operations in the program which may produce
 constant-derived results. See `--iree-opt-const-expr-hoisting` for options to
 optimize these.
 
-### Constant expression hoisting (`--iree-opt-const-expr-hoisting` (off))
+### Constant expression hoisting (`--iree-opt-const-expr-hoisting` (on))
 
 Identifies all trees of constant expressions in the program and uses a
 heuristic to determine which would be profitable to hoist into global


### PR DESCRIPTION
This is https://github.com/openxla/iree/pull/11524, rebased on `main`.

I have evidence that at least `--iree-opt-const-expr-hoisting=true` helps improve compile time considerably for large programs: https://github.com/iree-org/iree/issues/12033. When I was testing both flags together, I saw some incompatibilities - let's see what the CI thinks.