### PR TITLE
Disable caching on GitHub-host MacOS X86_64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,12 +346,13 @@ jobs:
           # halt somewhere around a cache size of 2GB. See
           # https://github.com/actions/cache/issues/1115. Hopefully this is
           # still large enough to be somewhat useful.
-          CCACHE_MAXSIZE: 1.5G
-          CCACHE_COMPRESSLEVEL: 5
+          CCACHE_MAXSIZE: 4G
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
       # Write cache (if configured to) after all other steps are finished.
+      - name: "Recompressing cache (CMake/ccache)"
+        run: ccache --recompress 10
       - name: "Saving cache (CMake/ccache)"
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,8 @@ jobs:
     runs-on: macos-12-xl
     env:
       BUILD_DIR: build-macos
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_GH_CACHE_KEY: ccache_all_macos
     defaults:
       run:
         shell: bash
@@ -310,7 +312,6 @@ jobs:
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
         with:
           python-version: "3.10"
-          cache: "pip"
       - name: "Installing Python packages"
         run: pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
       - name: "Installing requirements"
@@ -324,9 +325,9 @@ jobs:
       - name: "Fetching cache (CMake/ccache)"
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
-          path: ${{ github.workspace }}/.ccache
-          key: ccache_all_macos_${{ github.sha }}
-          restore-keys: ccache_all_macos
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ env.CCACHE_GH_CACHE_KEY }}_${{ github.sha }}
+          restore-keys: ${{ env.CCACHE_GH_CACHE_KEY }}
       # Finally: build and run tests.
       - name: "Building IREE"
         env:
@@ -334,18 +335,15 @@ jobs:
           IREE_WRITE_REMOTE_CCACHE: 0
           IREE_READ_LOCAL_CCACHE: 1
           IREE_WRITE_LOCAL_CCACHE: 1 # DO NOT SUBMIT
-          CCACHE_DIR: ${{ github.workspace }}/.ccache
+          CCACHE_DIR:
           # Cache size and compression level settings are a delicate balance.
           # * A full build cache is around 2-5GB depending on compression level
           # * Upload/download is slow (double compression may or may not help)
           # * We have a limit of 10GB across all cached files per repository
-          # * Cache misses are quite costly:
-          #   * 99% cache hits -> ~5 minutes to build
-          #   * 20% cache hits -> ~15-20 minutes to build
-          # Cache restore on Macs is painfully slow and grinds to a complete
-          # halt somewhere around a cache size of 2GB. See
-          # https://github.com/actions/cache/issues/1115. Hopefully this is
-          # still large enough to be somewhat useful.
+          # * Cache misses are quite costly. Cache restore on Macs is painfully
+          #   slow and grinds to a complete halt somewhere around a cache size
+          #   of 2GB. See https://github.com/actions/cache/issues/1115.
+          #   Hopefully this is still large enough to be somewhat useful.
           CCACHE_MAXSIZE: 4G
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
@@ -356,8 +354,8 @@ jobs:
       - name: "Saving cache (CMake/ccache)"
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
-          path: ${{ github.workspace }}/.ccache
-          key: ccache_all_macos_${{ github.sha }}
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ env.CCACHE_GH_CACHE_KEY }}_${{ github.sha }}
 
   build_test_all_bazel:
     needs: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: ${{ steps.configure.outputs.should-run }}
+      should-run: "false"
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
@@ -295,7 +295,6 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) # DO NOT SUBMIT
     runs-on: macos-12-xl
     env:
       BUILD_DIR: build-macos
@@ -334,7 +333,7 @@ jobs:
           IREE_READ_REMOTE_CCACHE: 0
           IREE_WRITE_REMOTE_CCACHE: 0
           IREE_READ_LOCAL_CCACHE: 1
-          IREE_WRITE_LOCAL_CCACHE: ${{ needs.setup.outputs.write-caches }}
+          IREE_WRITE_LOCAL_CCACHE: 1 # DO NOT SUBMIT
           CCACHE_DIR: ${{ github.workspace }}/.ccache
           # Cache size and compression level settings are a delicate balance.
           # * A full build cache is around 2-5GB depending on compression level

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: "false"
+      should-run: ${{ steps.configure.outputs.should-run }}
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
@@ -220,7 +220,7 @@ jobs:
       - name: "Updating git submodules"
         run: git submodule update --init --jobs 8 --depth 1
       - name: "Setting up Python"
-        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: "3.10" # Needs pybind >= 2.10.1 for Python >= 3.11
       - name: "Installing Python packages"
@@ -295,11 +295,10 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
+    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
     runs-on: macos-12-xl
     env:
       BUILD_DIR: build-macos
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_GH_CACHE_KEY: ccache_all_macos
     defaults:
       run:
         shell: bash
@@ -309,54 +308,30 @@ jobs:
       - name: "Updating git submodules"
         run: git submodule update --init --jobs 8 --depth 1
       - name: "Setting up Python"
-        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: "3.10"
+          cache: "pip"
       - name: "Installing Python packages"
         run: pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
       - name: "Installing requirements"
         # We need coreutils for `realpath` used in scripts.
         # We need bash because the default one on macOS is fairly old and lacks
         # features we use in scripts.
-        run: brew install ninja ccache coreutils bash
-      # Attempt to restore from cache unconditionally.
-      # Note: this will first try to grab a cache entry for this exact commit
-      #       then it will fall back to the latest for any commit.
-      - name: "Fetching cache (CMake/ccache)"
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ${{ env.CCACHE_GH_CACHE_KEY }}_${{ github.sha }}
-          restore-keys: ${{ env.CCACHE_GH_CACHE_KEY }}
+        run: brew install ninja coreutils bash
       # Finally: build and run tests.
       - name: "Building IREE"
         env:
+          # Note: we would love to use caching here but the GitHub Actions cache
+          # is utterly broken. See https://github.com/actions/cache/issues/1115
+          # and https://github.com/openxla/iree/pull/12905
           IREE_READ_REMOTE_CCACHE: 0
           IREE_WRITE_REMOTE_CCACHE: 0
-          IREE_READ_LOCAL_CCACHE: 1
-          IREE_WRITE_LOCAL_CCACHE: 1 # DO NOT SUBMIT
-          # Cache size and compression level settings are a delicate balance.
-          # * A full build cache is around 2-5GB depending on compression level
-          # * Upload/download is slow (double compression may or may not help)
-          # * We have a limit of 10GB across all cached files per repository
-          # * Cache misses are quite costly. Cache restore on Macs is painfully
-          #   slow and grinds to a complete halt somewhere around a cache size
-          #   of 2-3GB. See https://github.com/actions/cache/issues/1115. We get
-          #   about 500MB shaved off from additional compression, so setting
-          #   this to 2.5GB. Hopefully this is still large enough to be somewhat
-          #   useful.
-          CCACHE_MAXSIZE: 2.5G
+          IREE_READ_LOCAL_CCACHE: 0
+          IREE_WRITE_LOCAL_CCACHE: 0
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
-      # Write cache (if configured to) after all other steps are finished.
-      - name: "Recompressing cache (CMake/ccache)"
-        run: ccache --recompress 10
-      - name: "Saving cache (CMake/ccache)"
-        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ${{ env.CCACHE_GH_CACHE_KEY }}_${{ github.sha }}
 
   build_test_all_bazel:
     needs: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,6 @@ jobs:
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
       # Write cache (if configured to) after all other steps are finished.
       - name: "Saving cache (CMake/ccache)"
-        if: needs.setup.outputs.write-caches == '1'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,9 +341,11 @@ jobs:
           # * We have a limit of 10GB across all cached files per repository
           # * Cache misses are quite costly. Cache restore on Macs is painfully
           #   slow and grinds to a complete halt somewhere around a cache size
-          #   of 2GB. See https://github.com/actions/cache/issues/1115.
-          #   Hopefully this is still large enough to be somewhat useful.
-          CCACHE_MAXSIZE: 4G
+          #   of 2-3GB. See https://github.com/actions/cache/issues/1115. We get
+          #   about 500MB shaved off from additional compression, so setting
+          #   this to 2.5GB. Hopefully this is still large enough to be somewhat
+          #   useful.
+          CCACHE_MAXSIZE: 2.5G
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,6 @@ jobs:
           IREE_WRITE_REMOTE_CCACHE: 0
           IREE_READ_LOCAL_CCACHE: 1
           IREE_WRITE_LOCAL_CCACHE: 1 # DO NOT SUBMIT
-          CCACHE_DIR:
           # Cache size and compression level settings are a delicate balance.
           # * A full build cache is around 2-5GB depending on compression level
           # * Upload/download is slow (double compression may or may not help)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: fromJson(needs.setup.outputs.should-run) # DO NOT SUBMIT
     runs-on: macos-12-xl
     env:
       BUILD_DIR: build-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,11 @@ jobs:
           # * Cache misses are quite costly:
           #   * 99% cache hits -> ~5 minutes to build
           #   * 20% cache hits -> ~15-20 minutes to build
-          CCACHE_MAXSIZE: 4G
+          # Cache restore on Macs is painfully slow and grinds to a complete
+          # halt somewhere around a cache size of 2GB. See
+          # https://github.com/actions/cache/issues/1115. Hopefully this is
+          # still large enough to be somewhat useful.
+          CCACHE_MAXSIZE: 1.5G
           CCACHE_COMPRESSLEVEL: 5
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"

--- a/build_tools/cmake/setup_ccache.sh
+++ b/build_tools/cmake/setup_ccache.sh
@@ -38,9 +38,10 @@ fi
 
 if (( IREE_READ_REMOTE_CCACHE == 1 || IREE_READ_LOCAL_CCACHE == 1 )); then
   export IREE_USE_CCACHE=1
-  export CMAKE_C_COMPILER_LAUNCHER=$(which ccache)
-  export CMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)
-  $(which ccache) --zero-stats
+  export CMAKE_C_COMPILER_LAUNCHER="$(which ccache)"
+  export CMAKE_CXX_COMPILER_LAUNCHER="$(which ccache)"
+  ccache --zero-stats
+  ccache --show-stats
 else
   export IREE_USE_CCACHE=0
 fi


### PR DESCRIPTION
The GitHub Actions cache is utterly broken. See
https://github.com/actions/cache/issues/1115 and the many commits in
this PR trying to get it working.

Part of https://github.com/openxla/iree/issues/12727