### PR TITLE
[CUDA] Add a function to get CUDA context wrapper from the CUDA device

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -6,6 +6,8 @@
 
 #include "iree/hal/drivers/cuda/cuda_device.h"
 
+#include <iree/base/assert.h>
+#include <iree/base/status.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -184,14 +186,18 @@ iree_status_t iree_hal_cuda_device_create(
   return status;
 }
 
-bool iree_hal_is_cuda_device(iree_hal_device_t* base_device) {
-  return iree_hal_resource_is(base_device, &iree_hal_cuda_device_vtable);
-}
+iree_status_t iree_hal_cuda_device_get_context(iree_hal_device_t* base_device,
+                                               CUcontext* out_context) {
+  IREE_ASSERT_ARGUMENT(out_context);
 
-iree_hal_cuda_context_wrapper_t* iree_hal_cuda_device_context_wrapper(
-    iree_hal_device_t* base_device) {
+  if (!iree_hal_resource_is(base_device, &iree_hal_cuda_device_vtable)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "HAL device is not a CUDA device");
+  }
+
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
-  return &device->context_wrapper;
+  *out_context = device->context_wrapper.cu_context;
+  return iree_ok_status();
 }
 
 static void iree_hal_cuda_device_destroy(iree_hal_device_t* base_device) {

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -184,6 +184,16 @@ iree_status_t iree_hal_cuda_device_create(
   return status;
 }
 
+bool iree_hal_is_cuda_device(iree_hal_device_t* base_device) {
+  return iree_hal_resource_is(base_device, &iree_hal_cuda_device_vtable);
+}
+
+iree_hal_cuda_context_wrapper_t* iree_hal_cuda_device_context_wrapper(
+    iree_hal_device_t* base_device) {
+  iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
+  return &device->context_wrapper;
+}
+
 static void iree_hal_cuda_device_destroy(iree_hal_device_t* base_device) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   iree_allocator_t host_allocator = iree_hal_device_host_allocator(base_device);

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -6,8 +6,6 @@
 
 #include "iree/hal/drivers/cuda/cuda_device.h"
 
-#include <iree/base/assert.h>
-#include <iree/base/status.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.h
@@ -10,7 +10,6 @@
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/cuda/api.h"
-#include "iree/hal/drivers/cuda/context_wrapper.h"
 #include "iree/hal/drivers/cuda/dynamic_symbols.h"
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.h
@@ -10,6 +10,7 @@
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/cuda/api.h"
+#include "iree/hal/drivers/cuda/context_wrapper.h"
 #include "iree/hal/drivers/cuda/dynamic_symbols.h"
 
 #ifdef __cplusplus
@@ -22,6 +23,14 @@ iree_status_t iree_hal_cuda_device_create(
     const iree_hal_cuda_device_params_t* params,
     iree_hal_cuda_dynamic_symbols_t* syms, CUdevice device,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device);
+
+// Returns `true` if `base_device` is an instance of a HAL CUDA device.
+bool iree_hal_is_cuda_device(iree_hal_device_t* base_device);
+
+// Returns a pointer to context wrapper owned by the `base_device`. Undefined
+// if `base_device` is not a HAL CUDA device.
+iree_hal_cuda_context_wrapper_t* iree_hal_cuda_device_context_wrapper(
+    iree_hal_device_t* base_device);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.h
@@ -7,8 +7,6 @@
 #ifndef IREE_HAL_DRIVERS_CUDA_CUDA_DEVICE_H_
 #define IREE_HAL_DRIVERS_CUDA_CUDA_DEVICE_H_
 
-#include <cuda.h>
-
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/cuda/api.h"

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.h
@@ -7,6 +7,8 @@
 #ifndef IREE_HAL_DRIVERS_CUDA_CUDA_DEVICE_H_
 #define IREE_HAL_DRIVERS_CUDA_CUDA_DEVICE_H_
 
+#include <cuda.h>
+
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/cuda/api.h"
@@ -24,13 +26,10 @@ iree_status_t iree_hal_cuda_device_create(
     iree_hal_cuda_dynamic_symbols_t* syms, CUdevice device,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device);
 
-// Returns `true` if `base_device` is an instance of a HAL CUDA device.
-bool iree_hal_is_cuda_device(iree_hal_device_t* base_device);
-
-// Returns a pointer to context wrapper owned by the `base_device`. Undefined
-// if `base_device` is not a HAL CUDA device.
-iree_hal_cuda_context_wrapper_t* iree_hal_cuda_device_context_wrapper(
-    iree_hal_device_t* base_device);
+// Returns a CUDA context bound to the given `base_device` if it is a HAL CUDA
+// device. Returns error if `base_device` is not a HAL CUDA device.
+iree_status_t iree_hal_cuda_device_get_context(iree_hal_device_t* base_device,
+                                               CUcontext* out_context);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
For `openxla-nvgpu` project when we create a custom VM module we need to check if we are running with CUDA device, and get access to `CUdevice` and `CUcontext`