### PR TITLE
Improvements to IREE Dispatch Profiler

### DIFF
--- a/experimental/dispatch_profiler/generator.py
+++ b/experimental/dispatch_profiler/generator.py
@@ -3,7 +3,7 @@ import argparse
 from library import *
 from matmul import *
 from manifest import *
-from options import add_generator_arguments
+from options import parse_generator_arguments
 
 ###############################################################################
 
@@ -12,8 +12,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Generates MLIR operations for "\
                      "verification and profiling of IREE compiled dispatches.")
 
-  add_generator_arguments(parser)
-  args = parser.parse_args()
+  args = parse_generator_arguments(parser)
 
   # Manifests dispatches for a group of accompanying operations and configurations.
   manifest = Manifest(args)

--- a/experimental/dispatch_profiler/generator.py
+++ b/experimental/dispatch_profiler/generator.py
@@ -3,6 +3,7 @@ import argparse
 from library import *
 from matmul import *
 from manifest import *
+from options import add_generator_arguments
 
 ###############################################################################
 
@@ -10,24 +11,8 @@ if __name__ == "__main__":
 
   parser = argparse.ArgumentParser(description="Generates MLIR operations for "\
                      "verification and profiling of IREE compiled dispatches.")
-  parser.add_argument("--build-dir", default=".", \
-                      help="IREE top-level build directory is used to generate "\
-                        "operations and npy files")
-  parser.add_argument("--verbose", default='False', \
-                      help='Prints verbose output and commands executed.')
-  parser.add_argument("--operation_kind", default="all", \
-                      help="Specifies the operation kinds to generate.", \
-                      choices=["matmul", "conv2d", "all"])
-  parser.add_argument("--dispatches", default='', help="Comma delimited list to "\
-                      "filter dispatches by name. A dispatch is a combination of "\
-                      "operation and tuning configuration.")
-  parser.add_argument("--mlir-dialect",\
-                      default='linalg',\
-                      help="MLIR dialect entry point at which operation is emitter.", \
-                      choices=["linalg", "flow", "all"])
-  parser.add_argument("--device", default="cuda", \
-                      help="Target backend device to benchmark the operation on. "\
-                        "For example, cuda, vulkan, etc.")
+
+  add_generator_arguments(parser)
   args = parser.parse_args()
 
   # Manifests dispatches for a group of accompanying operations and configurations.

--- a/experimental/dispatch_profiler/library.py
+++ b/experimental/dispatch_profiler/library.py
@@ -83,6 +83,17 @@ CompilationModeNames = {
 }
 
 
+class CompilationConfigType(enum.Enum):
+  Default = auto()
+  Custom = auto()
+
+
+CompilationConfigTypeName = {
+    CompilationConfigType.Default: 'default',
+    CompilationConfigType.Custom: 'custom',
+}
+
+
 # Enumerations for data types and layouts
 ###################################################################################################
 class DataType(enum.Enum):

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -361,11 +361,13 @@ class MatmulOperationLauncher:
     # Base iree-compile commandline
     cmd = [self.iree_compile_path, self.source_mlir_file, "-o", f"{vmfb_file}"]
 
-    # Device specific flags.
+    # General compilation options
     cmd += [f"--iree-hal-target-backends={self.args.device}"]
     cmd += [f"--iree-hal-cuda-llvm-target-arch={self.args.cuda_arch}"]
+    if self.args.split_k_slices != "":
+      cmd += [f"--iree-flow-split-matmul-reduction={self.args.split_k_slices}"]
 
-    # Misc flags.
+    # Compilation options for profiling
     cmd += [
         f"--iree-hal-benchmark-dispatch-repeat-count={benchmark_dispatch_repeat_count}"
     ]
@@ -498,8 +500,11 @@ class MatmulGenerator:
         LLVMGPUMatmulTensorCoreMmaSync,  # Tensor Core (MMA.SYNC)
     ]
 
+    self.problem_shapes = [[128, 256, 8192]]
+    """
     self.problem_shapes = [[128, 128, 256], [256, 512, 128], [1024, 512, 2048],
                            [2560, 2560, 2560], [3456, 1024, 2048]]
+    """
 
     # List of pre-definied matmul dispatch collections.
     self.dispatches_collection_list = []

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -366,6 +366,10 @@ class MatmulOperationLauncher:
     cmd += [f"--iree-hal-cuda-llvm-target-arch={self.args.cuda_arch}"]
     if self.args.split_k_slices != "":
       cmd += [f"--iree-flow-split-matmul-reduction={self.args.split_k_slices}"]
+    if self.args.use_mma_sync:
+      cmd += [f"--iree-codegen-llvmgpu-use-mma-sync"]
+    if self.args.use_wmma:
+      cmd += [f"--iree-codegen-llvmgpu-use-wmma"]
 
     # Compilation options for profiling
     cmd += [

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -303,10 +303,9 @@ class MatmulOperationLauncher:
     # Variables from top-level argparse.
     self.generated_path = os.path.join(args.build_dir, 'generated',
                                        args.mlir_dialect)
-    self.device = args.device
+    self.args = args
     self.benchmark_dispatch_repeat_count = args.batch_size
     self.batch_size = args.batch_size
-    self.benchmark_repetitions = args.benchmark_repetitions
     self.verbose = False if args.verbose in ['False', 'false', '0'] else True
 
     # Additional paths.
@@ -346,8 +345,8 @@ class MatmulOperationLauncher:
     cmd = [self.iree_compile_path, self.source_mlir_file, "-o", f"{vmfb_file}"]
 
     # Device specific flags.
-    cmd += [f"--iree-hal-target-backends={self.device}"]
-    cmd += [f"--iree-hal-cuda-llvm-target-arch=sm_80"]
+    cmd += [f"--iree-hal-target-backends={self.args.device}"]
+    cmd += [f"--iree-hal-cuda-llvm-target-arch={self.args.cuda_arch}"]
 
     # Misc flags.
     cmd += [
@@ -392,7 +391,7 @@ class MatmulOperationLauncher:
     # Commandline `iree-run-module` for verification.
     cmd = [
         self.iree_run_module_path, f'--module={self.vmfb_verify_file}',
-        f'--device={self.device}'
+        f'--device={self.args.device}'
     ]
 
     # Operation-specific verification command-line.
@@ -430,11 +429,11 @@ class MatmulOperationLauncher:
     # Commandline `iree-benchmark-module` for profiling.
     cmd = [
         self.iree_benchmark_module_path, f'--module={self.vmfb_benchmark_file}',
-        f'--device={self.device}'
+        f'--device={self.args.device}'
     ]
 
     # Profiling specific flags.
-    cmd += [f'--benchmark_repetitions={self.benchmark_repetitions}']
+    cmd += [f'--benchmark_repetitions={self.args.benchmark_repetitions}']
     cmd += [f'--batch_size={self.batch_size}']
 
     # Operation-specific profiling command-line.

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -326,7 +326,6 @@ class MatmulOperationLauncher:
     self.args = args
     self.benchmark_dispatch_repeat_count = args.batch_size
     self.batch_size = args.batch_size
-    self.verbose = False if args.verbose in ['False', 'false', '0'] else True
 
     # Additional paths.
     self.matmul_path = os.path.join(self.generated_path, 'matmul')
@@ -337,8 +336,6 @@ class MatmulOperationLauncher:
     # path to iree-compile tool. (for compiling the input mlir file to vmfb)
     self.iree_compile_path = os.path.join(args.build_dir, 'tools',
                                           'iree-compile')
-    self.force_compile = False if args.force_compile in ['False', 'false', '0'
-                                                        ] else True
 
     # path to iree-benchmark-module tool. (for performance benchmarking and profiling)
     self.iree_benchmark_module_path = os.path.join(args.build_dir, 'tools',
@@ -373,13 +370,13 @@ class MatmulOperationLauncher:
         f"--iree-hal-benchmark-dispatch-repeat-count={benchmark_dispatch_repeat_count}"
     ]
 
-    if not os.path.exists(vmfb_file) or self.force_compile:
+    if not os.path.exists(vmfb_file) or self.args.force_compile:
       print(
           f">> Compilation command for {CompilationModeNames[compilation_mode]} : {' '.join(cmd)}"
       )
       subprocess.check_output(cmd)
 
-    elif self.verbose:
+    elif self.args.verbose:
       print("Skipping compilation of matmul operation: " + vmfb_file +
             " since it already exists.")
 
@@ -422,7 +419,7 @@ class MatmulOperationLauncher:
     cmd.append(f'--expected_output=@{expected_result_npy_file}')
 
     # Print the command if verbose.
-    if self.verbose:
+    if self.args.verbose:
       print(">> Verification command: " + ' '.join(cmd))
 
     # Launch verification.
@@ -436,7 +433,7 @@ class MatmulOperationLauncher:
           cmd_output)
     verification_result = m.group('verification_result')
 
-    if self.verbose or verification_result != "SUCCESS":
+    if self.args.verbose or verification_result != "SUCCESS":
       print(cmd_output)
 
     return verification_result
@@ -462,7 +459,7 @@ class MatmulOperationLauncher:
     cmd += [f'--input={self.operation.rhs_npy_shape()}']
 
     # Print the command if verbose.
-    if self.verbose:
+    if self.args.verbose:
       print(">> Profiling command: " + ' '.join(cmd))
 
     # Launch profiling.

--- a/experimental/dispatch_profiler/options.py
+++ b/experimental/dispatch_profiler/options.py
@@ -116,23 +116,52 @@ def add_performance_report_arguments(parser):
 
 
 ###############################################################################
-# Create a parser and add all the arguments for a script function:
-# add_generator_arguments() for generator.py
-# add_profiler_arguments() for profiler.py
+# Parser all the arguments for a script function:
+# parse_generator_arguments() for generator.py
+# parse_profiler_arguments() for profiler.py
 ###############################################################################
 
 
-def add_generator_arguments(parser):
-  """Adds all the arguments for the *generator.py* script."""
+def parse_generator_arguments(parser):
+  """Adds and parse all the arguments for the *generator.py* script."""
   add_typical_arguments(parser)
   add_iree_compile_arguments(parser)
+  args = parser.parse_args()
+  return args
 
 
-def add_profiler_arguments(parser):
-  """Adds all the arguments for the *profiler.py* script."""
+def parse_profiler_arguments(parser):
+  """Adds and parse all the arguments for the *profiler.py* script."""
   add_typical_arguments(parser)
   add_compilation_arguments(parser)
   add_iree_compile_arguments(parser)
   add_verification_arguments(parser)
   add_profiling_arguments(parser)
   add_performance_report_arguments(parser)
+  args = parser.parse_args()
+
+  # Boolenize the string arguments from command line.
+  # We can use boolean flag and store_true action of from argparse.ArgumentParser, but
+  # we are making a choice to have all string-based arguments for uniformity of
+  # the commandline. All boolean arguments are specified as `argument=<true|false>`.
+  args.verbose = False if args.verbose in ['False', 'false', '0'] else True
+  args.default_config = False if args.default_config in ['False', 'false', '0'
+                                                        ] else True
+  args.append = False if args.append in ['False', 'false', '0'] else True
+  args.verification_enabled = False if args.verification_enabled in [
+      'False', 'false', '0'
+  ] else True
+  args.profiling_enabled = False if args.profiling_enabled in [
+      'False', 'false', '0'
+  ] else True
+  args.force_compile = False if args.force_compile in ['False', 'false', '0'
+                                                      ] else True
+  args.compile_only = False if args.compile_only in ['False', 'false', '0'
+                                                    ] else True
+
+  # Overrite verification and profiling if compile_only is set.
+  if args.compile_only:
+    args.verification_enabled = False
+    args.profiling_enabled = False
+
+  return args

--- a/experimental/dispatch_profiler/options.py
+++ b/experimental/dispatch_profiler/options.py
@@ -35,6 +35,10 @@ def add_typical_arguments(parser):
                       "point at which operation is emitter.",
                       choices=["linalg", "flow", "all"])
 
+  parser.add_argument("--default-config", default='False', help="When true adds a "\
+                      "dispatch without a pre-defined tuning configuration and uses "\
+                      " default configuration from KernelsConfig.cpp.")
+
 
 def add_compilation_arguments(parser):
   """Adds compilation (NOT part of iree-compile) command line arguments to the parser."""

--- a/experimental/dispatch_profiler/options.py
+++ b/experimental/dispatch_profiler/options.py
@@ -1,0 +1,134 @@
+import argparse
+
+###############################################################################
+#                    Options ohh! too main options
+###############################################################################
+# This file organizes the plenty of options that once can pass to the profiler
+# tool scripts for generating, compiling, verifying, and profiling IREE-compiled
+# MLIR operations.
+#
+# The options are organized into groups: typical, compilation, iree-compile,
+# verification, profiling, performance-reporting. Note that there is a function
+# of each group.
+###############################################################################
+
+
+def add_typical_arguments(parser):
+  """Adds typical command line arguments to the parser."""
+  parser.add_argument("--build-dir", default=".", \
+                      help="IREE top-level build directory is used to generate "\
+                      "operations and npy files.This should be same that used "\
+                      "to call generated.py")
+
+  parser.add_argument("--operation-kind", "--op-kind", dest="operation_kind",
+                      default="all", help="Specifies the "\
+                      "operation kinds to generate.", choices=["matmul", "conv2d", "all"])
+
+  parser.add_argument("--verbose", default='False', \
+                      help='Prints verbose output and commands executed.')
+
+  parser.add_argument("--dispatches", default='', help="Comma delimited list to "\
+                      "filter dispatches by name. A dispatch is a combination of "\
+                      "operation and tuning configuration.")
+
+  parser.add_argument("--mlir-dialect", default='linalg', help="MLIR dialect entry "\
+                      "point at which operation is emitter.",
+                      choices=["linalg", "flow", "all"])
+
+
+def add_compilation_arguments(parser):
+  """Adds compilation (NOT part of iree-compile) command line arguments to the parser."""
+
+  compilation_parser = parser.add_argument_group(
+      'Compilation', 'Compilation related options.')
+
+  compilation_parser.add_argument("--force-compile", default='False', \
+                      type=str, help="Force re-compilation of the operation even "\
+                      "if .vmfb file is present.")
+  compilation_parser.add_argument("--compile-only", default='False', \
+                      type=str, help="Compiles the operation "\
+                        "without running verification and profiling.")
+
+
+def add_iree_compile_arguments(parser):
+  """Adds iree-compile command line arguments to the parser."""
+  iree_compile_parser = parser.add_argument_group(
+      'iree-compile', 'iree-compile related options.')
+
+  iree_compile_parser.add_argument("--iree-hal-target-backends", "--device", \
+                      dest="device", default="cuda", \
+                      help="Target backends for executable compilation. ", \
+                      choices=["cuda", "vulkan", "cpu"])
+  iree_compile_parser.add_argument("--iree-hal-cuda-llvm-target-arch", "--cuda-arch", \
+                      dest="cuda_arch", default='sm_80', \
+                      help="Target architecture for the CUDA backend. ", \
+                      choices=["sm_50", "sm_60", "sm_75", "sm_80", "sm_86"])
+  iree_compile_parser.add_argument('--iree-hal-benchmark-dispatch-repeat-count', '--batch-size',  \
+                      dest="batch_size", default=100,
+                      help="Number of times dispatch is launched in a loop to amortize the "\
+                      "launch overhead. This argument is used for iree-compile and iree-benchamrk-module. "\
+                      "The value used for iree-compile and iree-benchamrk-module should be the same.")
+
+
+def add_verification_arguments(parser):
+  """Adds verification related arguments to the parser."""
+  verification_parser = parser.add_argument_group(
+      'Verification', 'Verification related options.')
+
+  verification_parser.add_argument("--verification-enabled", "--verify", default='True', \
+                      type=str, help="Verify the operation.")
+  verification_parser.add_argument("--verification-providers", default='numpy', \
+                      choices=["numpy", "triton"], help="Comma delimited list of verification providers.")
+
+
+def add_profiling_arguments(parser):
+  """Adds profiling related arguments to the parser."""
+  profiling_parser = parser.add_argument_group(
+      'Profiling', 'Profiling (iree-benchmark-module) related options.')
+
+  profiling_parser.add_argument("--profiling-enabled", "--benchmark", default='True', \
+                      type=str, help="Benchmark the operation.")
+  profiling_parser.add_argument("--benchmark-repetitions", default=5,
+                      type=int, help="Number of times benchmark is repeated "\
+                      "and min, max, median, and average runtimes/gflops are "\
+                      "reported.")
+
+
+def add_performance_report_arguments(parser):
+  """Adds performance report related arguments to the parser."""
+
+  performance_report_parser = parser.add_argument_group(
+      'Performance Report', 'Performance report related options.')
+
+  performance_report_parser.add_argument("--output", default='', \
+                      help="Path to output file for csv readable results.")
+  performance_report_parser.add_argument("--append", default='false', \
+                      help="If true, result is appended to possibly existing file. "\
+                        "Otherwise, any existing file is overwritten.")
+
+  performance_report_parser.add_argument("--tags", default='', \
+                      help="Inserts leading columns in output table and uniform "\
+                        "values for each column. Useful for generating pivot tables.")
+
+
+###############################################################################
+# Create a parser and add all the arguments for a script function:
+# add_generator_arguments() for generator.py
+# add_profiler_arguments() for profiler.py
+###############################################################################
+
+
+def add_generator_arguments(parser):
+  """Adds all the arguments for the *generator.py* script."""
+  add_typical_arguments(parser)
+  add_iree_compile_arguments(parser)
+
+
+def add_profiler_arguments(parser):
+  """Adds all the arguments for the *profiler.py* script."""
+  add_typical_arguments(parser)
+  add_compilation_arguments(parser)
+  add_iree_compile_arguments(parser)
+  add_verification_arguments(parser)
+  add_profiling_arguments(parser)
+  add_performance_report_arguments(parser)

--- a/experimental/dispatch_profiler/options.py
+++ b/experimental/dispatch_profiler/options.py
@@ -20,38 +20,41 @@ def add_typical_arguments(parser):
                       "operations and npy files.This should be same that used "\
                       "to call generated.py")
 
-  parser.add_argument("--operation-kind", "--op-kind", dest="operation_kind",
-                      default="all", help="Specifies the "\
-                      "operation kinds to generate.", choices=["matmul", "conv2d", "all"])
+  parser.add_argument("--operation-kind","--op-kind", \
+                      dest="operation_kind", default="all", \
+                      help="Specifies the operation kinds to generate.", \
+                      choices=["matmul", "conv2d", "all"])
 
-  parser.add_argument("--verbose", default='False', \
+  parser.add_argument("--verbose", action='store_true', \
                       help='Prints verbose output and commands executed.')
 
-  parser.add_argument("--dispatches", default='', help="Comma delimited list to "\
-                      "filter dispatches by name. A dispatch is a combination of "\
-                      "operation and tuning configuration.")
+  parser.add_argument("--dispatches", default='',
+                      help="Comma delimited list to filter dispatches by name. "\
+                      "A dispatch is a combination of operation and tuning "\
+                      "configuration.")
 
-  parser.add_argument("--mlir-dialect", default='linalg', help="MLIR dialect entry "\
-                      "point at which operation is emitter.",
+  parser.add_argument("--mlir-dialect", default='linalg', \
+                      help="MLIR dialect entry point at which operation is emitter.",
                       choices=["linalg", "flow", "all"])
 
-  parser.add_argument("--default-config", default='False', help="When true adds a "\
-                      "dispatch without a pre-defined tuning configuration and uses "\
-                      " default configuration from KernelsConfig.cpp.")
+  parser.add_argument("--default-config", action='store_true',
+                      help="When true adds a dispatch without a pre-defined "\
+                      "tuning configuration and uses default configuration "\
+                      "from KernelsConfig.cpp.")
 
 
 def add_compilation_arguments(parser):
-  """Adds compilation (NOT part of iree-compile) command line arguments to the parser."""
+  """Adds compilation (not part of iree-compile) command line arguments to the parser."""
 
   compilation_parser = parser.add_argument_group(
       'Compilation', 'Compilation related options.')
 
-  compilation_parser.add_argument("--force-compile", default='False', \
-                      type=str, help="Force re-compilation of the operation even "\
+  compilation_parser.add_argument("--force-compile", action='store_true', \
+                      help="Force re-compilation of the operation even "\
                       "if .vmfb file is present.")
-  compilation_parser.add_argument("--compile-only", default='False', \
-                      type=str, help="Compiles the operation "\
-                        "without running verification and profiling.")
+  compilation_parser.add_argument("--compile-only", action='store_true', \
+                      help="Compiles the operation "\
+                      "without running verification and profiling.")
 
 
 def add_iree_compile_arguments(parser):
@@ -59,22 +62,34 @@ def add_iree_compile_arguments(parser):
   iree_compile_parser = parser.add_argument_group(
       'iree-compile', 'iree-compile related options.')
 
-  iree_compile_parser.add_argument("--iree-hal-target-backends", "--device", \
+  iree_compile_parser.add_argument(
+                      "--iree-hal-target-backends", "--device", \
                       dest="device", default="cuda", \
                       help="Target backends for executable compilation. ", \
                       choices=["cuda", "vulkan", "cpu"])
-  iree_compile_parser.add_argument("--iree-hal-cuda-llvm-target-arch", "--cuda-arch", \
+  iree_compile_parser.add_argument(
+                      "--iree-hal-cuda-llvm-target-arch", "--cuda-arch", \
                       dest="cuda_arch", default='sm_80', \
                       help="Target architecture for the CUDA backend. ", \
                       choices=["sm_50", "sm_60", "sm_75", "sm_80", "sm_86"])
-  iree_compile_parser.add_argument('--iree-hal-benchmark-dispatch-repeat-count', '--batch-size',  \
+  iree_compile_parser.add_argument(
+                      '--iree-hal-benchmark-dispatch-repeat-count', '--batch-size', \
                       dest="batch_size", default=100,
-                      help="Number of times dispatch is launched in a loop to amortize the "\
-                      "launch overhead. This argument is used for iree-compile and iree-benchamrk-module. "\
-                      "The value used for iree-compile and iree-benchamrk-module should be the same.")
-  iree_compile_parser.add_argument('--iree-flow-split-matmul-reduction', '--split-k-slices', \
+                      help="Number of times dispatch is launched in a loop to "\
+                      "amortize the launch overhead. This argument is used for "\
+                      "iree-compile and iree-benchamrk-module. The value used by "\
+                      "iree-compile and iree-benchamrk-module should be the same.")
+  iree_compile_parser.add_argument(
+                      '--iree-flow-split-matmul-reduction', '--split-k-slices', \
                       dest="split_k_slices", default="", \
                       help="Number of slices to split the reduction K-dimension.")
+  iree_compile_parser.add_argument(
+                     '--iree-codegen-llvmgpu-use-mma-sync', '--use-mma-sync', \
+                      dest="use_mma_sync", action='store_true', \
+                      help="Use mma.sync instructions.")
+  iree_compile_parser.add_argument('--iree-codegen-llvmgpu-use-wmma', '--use-wmma', \
+                      dest="use_wmma", action='store_true', \
+                      help="Use wmma instructions.")
 
 
 def add_verification_arguments(parser):
@@ -82,10 +97,13 @@ def add_verification_arguments(parser):
   verification_parser = parser.add_argument_group(
       'Verification', 'Verification related options.')
 
-  verification_parser.add_argument("--verification-enabled", "--verify", default='True', \
+  verification_parser.add_argument(
+                      "--verification-enabled", "--verify", default='True', \
                       type=str, help="Verify the operation.")
-  verification_parser.add_argument("--verification-providers", default='numpy', \
-                      choices=["numpy", "triton"], help="Comma delimited list of verification providers.")
+  verification_parser.add_argument(
+                     "--verification-providers", default='numpy', \
+                      choices=["numpy", "triton"],
+                      help="Comma delimited list of verification providers.")
 
 
 def add_profiling_arguments(parser):
@@ -93,9 +111,11 @@ def add_profiling_arguments(parser):
   profiling_parser = parser.add_argument_group(
       'Profiling', 'Profiling (iree-benchmark-module) related options.')
 
-  profiling_parser.add_argument("--profiling-enabled", "--benchmark", default='True', \
+  profiling_parser.add_argument(
+                      "--profiling-enabled", "--benchmark", default='True', \
                       type=str, help="Benchmark the operation.")
-  profiling_parser.add_argument("--benchmark-repetitions", default=5,
+  profiling_parser.add_argument(
+                      "--benchmark-repetitions", default=5,
                       type=int, help="Number of times benchmark is repeated "\
                       "and min, max, median, and average runtimes/gflops are "\
                       "reported.")
@@ -109,9 +129,9 @@ def add_performance_report_arguments(parser):
 
   performance_report_parser.add_argument("--output", default='', \
                       help="Path to output file for csv readable results.")
-  performance_report_parser.add_argument("--append", default='false', \
+  performance_report_parser.add_argument("--append", action='store_true', \
                       help="If true, result is appended to possibly existing file. "\
-                        "Otherwise, any existing file is overwritten.")
+                      "Otherwise, any existing file is overwritten.")
 
   performance_report_parser.add_argument("--tags", default='', \
                       help="Inserts leading columns in output table and uniform "\
@@ -144,25 +164,16 @@ def parse_profiler_arguments(parser):
   args = parser.parse_args()
 
   # Boolenize the string arguments from command line.
-  # We can use boolean flag and store_true action of from argparse.ArgumentParser, but
-  # we are making a choice to have all string-based arguments for uniformity of
-  # the commandline. All boolean arguments are specified as `argument=<true|false>`.
-  args.verbose = False if args.verbose in ['False', 'false', '0'] else True
-  args.default_config = False if args.default_config in ['False', 'false', '0'
-                                                        ] else True
-  args.append = False if args.append in ['False', 'false', '0'] else True
+  # This boolean arguments are specified as `argument=<true|false>` as it makes
+  # it easier to read and convey the meaning.
   args.verification_enabled = False if args.verification_enabled in [
       'False', 'false', '0'
   ] else True
   args.profiling_enabled = False if args.profiling_enabled in [
       'False', 'false', '0'
   ] else True
-  args.force_compile = False if args.force_compile in ['False', 'false', '0'
-                                                      ] else True
-  args.compile_only = False if args.compile_only in ['False', 'false', '0'
-                                                    ] else True
 
-  # Overrite verification and profiling if compile_only is set.
+  # Overwrite verification and profiling if compile_only is set.
   if args.compile_only:
     args.verification_enabled = False
     args.profiling_enabled = False

--- a/experimental/dispatch_profiler/options.py
+++ b/experimental/dispatch_profiler/options.py
@@ -72,6 +72,9 @@ def add_iree_compile_arguments(parser):
                       help="Number of times dispatch is launched in a loop to amortize the "\
                       "launch overhead. This argument is used for iree-compile and iree-benchamrk-module. "\
                       "The value used for iree-compile and iree-benchamrk-module should be the same.")
+  iree_compile_parser.add_argument('--iree-flow-split-matmul-reduction', '--split-k-slices', \
+                      dest="split_k_slices", default="", \
+                      help="Number of slices to split the reduction K-dimension.")
 
 
 def add_verification_arguments(parser):

--- a/experimental/dispatch_profiler/performance_report.py
+++ b/experimental/dispatch_profiler/performance_report.py
@@ -61,7 +61,6 @@ class PerformanceReport:
 
     # Data members extracted from the args.
     self.output_file_path = args.output
-    self.append = True if args.append in ['True', 'true', '1'] else False
 
     # List of PerformanceResult.
     self.perf_result_vector = []
@@ -74,7 +73,7 @@ class PerformanceReport:
 
     # If the args.output set, open the file and write the header.
     if self.output_file_path != '':
-      open_mode = 'a' if self.append else 'w'
+      open_mode = 'a' if self.args.append else 'w'
       self.csv_file = open(self.output_file_path, open_mode)
 
       # Create and write the header.

--- a/experimental/dispatch_profiler/profiler.py
+++ b/experimental/dispatch_profiler/profiler.py
@@ -4,6 +4,7 @@ from library import *
 from matmul import *
 from manifest import *
 from performance_report import *
+from options import add_profiler_arguments
 
 ###############################################################################
 # Map of operation kinds to their dispatch launchers.
@@ -42,60 +43,7 @@ if __name__ == "__main__":
                                     "for IREE-compiled MLIR operations.")
   ###############################################################################
 
-  # General profiler options
-  parser.add_argument("--build-dir", default=".", \
-                      help="IREE top-level build directory is used to generate "\
-                        "operations and npy files.This should be same that used "\
-                        "to call generated.py")
-  parser.add_argument("--operation_kind", default="all", help="Specifies the "\
-                      "operation kinds to generate.", choices=["matmul", "conv2d", "all"])
-  parser.add_argument("--verbose", default='False', \
-                      help='Prints verbose output and commands executed.')
-
-  # Generator-specific options
-  parser.add_argument("--dispatches", default='', help="Comma delimited list to "\
-                      "filter dispatches by name. A dispatch is a combination of "\
-                      "operation and tuning configuration.")
-  parser.add_argument("--mlir-dialect", default='linalg', help="MLIR dialect entry "\
-                      "point at which operation is emitter.",
-                      choices=["linalg", "flow", "all"])
-  # Compilation-specific options
-  parser.add_argument("--device", default="cuda", \
-                      help="Target backend device to benchmark the operation on. "\
-                        "For example, cuda, vulkan, etc.")
-  parser.add_argument("--force-compile", default='False', \
-                      type=str, help="Force re-compilation of the operation even "\
-                      "if .vmfb file is present.")
-  parser.add_argument("--compile-only", default='False', \
-                      type=str, help="Compiles the operation "\
-                        "without running verification and profiling.")
-
-  # Profiling-specific options
-  parser.add_argument("--profiling-enabled", "--benchmark", default='True', \
-                      type=str, help="Benchmark the operation.")
-  parser.add_argument('--batch-size', '--benchmark-dispatch-repeat-count', \
-                      default=100, help="Number of times dispatch is launched "\
-                        "in a loop to amortize the launch overhead.")
-  parser.add_argument("--benchmark-repetitions", default=5,
-                      type=int, help="Number of times benchmark is repeated "\
-                      "and min, max, median, and average runtimes/gflops are "\
-                      "reported.")
-
-  # Verification-specific options
-  parser.add_argument("--verification-enabled", default='True',
-                      type=str, help="Verify the operation against reference numpy "\
-                      "implementation.")
-
-  # Performance reporting options
-  parser.add_argument("--output", default='', \
-                      help="Path to output file for csv readable results.")
-  parser.add_argument("--append", default='false', \
-                      help="If true, result is appended to possibly existing file. "\
-                        "Otherwise, any existing file is overwritten.")
-
-  parser.add_argument("--tags", default='', \
-                      help="Inserts leading columns in output table and uniform "\
-                        "values for each column. Useful for generating pivot tables.")
+  add_profiler_arguments(parser)
 
   # Parse the command line arguments.
   args = parser.parse_args()

--- a/experimental/dispatch_profiler/profiler.py
+++ b/experimental/dispatch_profiler/profiler.py
@@ -41,11 +41,8 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="IREE Python profiler tool for "\
                                    "verifcation and performance profiling tool "\
                                     "for IREE-compiled MLIR operations.")
-  ###############################################################################
 
   args = parse_profiler_arguments(parser)
-
-  print(args)
   ###############################################################################
 
   # Manifests metadata for a group of accompanying operations and configurations.

--- a/experimental/dispatch_profiler/profiler.py
+++ b/experimental/dispatch_profiler/profiler.py
@@ -4,7 +4,7 @@ from library import *
 from matmul import *
 from manifest import *
 from performance_report import *
-from options import add_profiler_arguments
+from options import parse_profiler_arguments
 
 ###############################################################################
 # Map of operation kinds to their dispatch launchers.
@@ -43,24 +43,10 @@ if __name__ == "__main__":
                                     "for IREE-compiled MLIR operations.")
   ###############################################################################
 
-  add_profiler_arguments(parser)
+  args = parse_profiler_arguments(parser)
 
-  # Parse the command line arguments.
-  args = parser.parse_args()
+  print(args)
   ###############################################################################
-
-  # Boolenize the string arguments from command line.
-  verification_enabled = False if args.verification_enabled in [
-      'False', 'false', '0'
-  ] else True
-  profiling_enabled = False if args.profiling_enabled in [
-      'False', 'false', '0'
-  ] else True
-  compile_only = False if args.compile_only in ['False', 'false', '0'] else True
-  # Overrite verification and profiling if compile_only is set.
-  if compile_only:
-    verification_enabled = False
-    profiling_enabled = False
 
   # Manifests metadata for a group of accompanying operations and configurations.
   manifest = Manifest(args)
@@ -83,23 +69,23 @@ if __name__ == "__main__":
       for configuration in operation_collection.configuration_list:
 
         # Compile the operation dispatches for verification and profiling.
-        if compile_only:
+        if args.compile_only:
           operation_launcher.compile(CompilationMode.Verify)
           operation_launcher.compile(CompilationMode.Profile)
 
         else:
           # Initialize verification and profiling results.
-          verification_result = 'Not verified' if not verification_enabled else 'Failed'
+          verification_result = 'Not verified' if not args.verification_enabled else 'Failed'
           runtime = -1.0
 
           # Launch the operation dispatches for verification and profiling.
-          if verification_enabled:
+          if args.verification_enabled:
             verification_result = operation_launcher.verify(configuration)
-          if profiling_enabled:
+          if args.profiling_enabled:
             runtime = operation_launcher.profile(configuration)
 
           # Save and print the performance result.
-          if verification_enabled or profiling_enabled:
+          if args.verification_enabled or args.profiling_enabled:
             # Create and print a performance result.
             result = PerformanceResult(operation_collection.operation,
                                        configuration, verification_result,


### PR DESCRIPTION
Improvements to IREE dispatch profiler as we work on split-k and coverage for matmul.

- Added capacity to handle default configuration being picked from KernelConfig.
- Added split-k run capability. For now, only wmma split-k path works. 
- Organized command line arguments better. 