### PR TITLE
let `iree_benchmark_keep_running` take care of batch counts

### DIFF
--- a/runtime/src/iree/builtins/device/tools/libdevice_benchmark.c
+++ b/runtime/src/iree/builtins/device/tools/libdevice_benchmark.c
@@ -9,15 +9,12 @@
 #include "iree/builtins/device/device.h"
 #include "iree/testing/benchmark.h"
 
-// Example flag; not really useful:
-IREE_FLAG(int32_t, batch_count, 64, "Ops to run per benchmark iteration.");
-
 static iree_status_t iree_h2f_ieee_benchmark(
     const iree_benchmark_def_t* benchmark_def,
     iree_benchmark_state_t* benchmark_state) {
-  while (iree_benchmark_keep_running(benchmark_state,
-                                     /*batch_count=*/FLAG_batch_count)) {
-    for (int i = 0; i < FLAG_batch_count; ++i) {
+  int64_t batch_count;
+  while (iree_benchmark_keep_running(benchmark_state, &batch_count)) {
+    for (int i = 0; i < batch_count; ++i) {
       // TODO(benvanik): iree_do_not_optimize barrier.
       iree_h2f_ieee(0x3400 + i);
     }
@@ -28,9 +25,9 @@ static iree_status_t iree_h2f_ieee_benchmark(
 static iree_status_t iree_f2h_ieee_benchmark(
     const iree_benchmark_def_t* benchmark_def,
     iree_benchmark_state_t* benchmark_state) {
-  while (iree_benchmark_keep_running(benchmark_state,
-                                     /*batch_count=*/FLAG_batch_count)) {
-    for (int i = 0; i < FLAG_batch_count; ++i) {
+  int64_t batch_count;
+  while (iree_benchmark_keep_running(benchmark_state, &batch_count)) {
+    for (int i = 0; i < batch_count; ++i) {
       // TODO(benvanik): iree_do_not_optimize barrier.
       iree_f2h_ieee(0.25f + i);
     }

--- a/runtime/src/iree/builtins/ukernel/tools/benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/benchmark.c
@@ -74,7 +74,8 @@ void iree_uk_benchmark_register(
     const char* name,
     iree_status_t (*benchmark_func)(const iree_benchmark_def_t*,
                                     iree_benchmark_state_t*),
-    const void* params, size_t params_size, const char* cpu_features) {
+    const void* params, size_t params_size, const char* cpu_features,
+    const iree_uk_benchmark_options_t* options) {
   // Does this benchmark require an optional CPU feature?
   iree_uk_uint64_t cpu_data_local[IREE_CPU_DATA_FIELD_COUNT] = {0};
   if (cpu_features) {
@@ -98,6 +99,8 @@ void iree_uk_benchmark_register(
       .iteration_count = 0,
       .run = benchmark_func,
       .user_data = user_data,
+      .items_per_iteration = options ? options->items_per_iteration : 0,
+      .bytes_per_iteration = options ? options->bytes_per_iteration : 0,
   };
   iree_string_builder_t full_name;
   iree_string_builder_initialize(iree_allocator_system(), &full_name);

--- a/runtime/src/iree/builtins/ukernel/tools/benchmark.h
+++ b/runtime/src/iree/builtins/ukernel/tools/benchmark.h
@@ -13,13 +13,19 @@
 // Struct for passing around benchmark user data
 typedef struct iree_uk_benchmark_user_data_t iree_uk_benchmark_user_data_t;
 
+typedef struct iree_uk_benchmark_options_t {
+  int64_t items_per_iteration;
+  int64_t bytes_per_iteration;
+} iree_uk_benchmark_options_t;
+
 // High level init/register/run/cleanup entry points. Used in main().
 void iree_uk_benchmark_initialize(int* argc, char** argv);
 void iree_uk_benchmark_register(
     const char* name,
     iree_status_t (*benchmark_func)(const iree_benchmark_def_t*,
                                     iree_benchmark_state_t*),
-    const void* params, size_t params_size, const char* cpu_features);
+    const void* params, size_t params_size, const char* cpu_features,
+    const iree_uk_benchmark_options_t* options);
 void iree_uk_benchmark_run_and_cleanup(void);
 
 // Like malloc, but any buffers allocated through this are freed by

--- a/runtime/src/iree/builtins/ukernel/tools/e2e_matmul_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/e2e_matmul_benchmark.c
@@ -327,18 +327,13 @@ static iree_status_t iree_uk_benchmark_e2e_matmul(
   }
 
   // The benchmark loop.
-  int64_t batch_count = 1;
-  int64_t total_iterations = 0;
-  while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
+  int64_t batch_count;
+  while (iree_benchmark_keep_running(benchmark_state, &batch_count)) {
     for (int i = 0; i < batch_count; ++i) {
       iree_uk_e2e_matmul(&pack_lhs_params, &pack_rhs_params, &pack_out_params,
                          &mmt4d_params, &unpack_out_params);
     }
-    total_iterations += batch_count;
-    batch_count *= 2;
   }
-  iree_benchmark_set_items_processed(benchmark_state,
-                                     total_iterations * 2 * num_mul_adds);
 
   free(rowmajor_lhs_buffer);
   free(rowmajor_rhs_buffer);
@@ -370,8 +365,10 @@ static void iree_uk_benchmark_register_e2e_matmul(const char* type_str, int M,
   iree_uk_mmt4d_type_t type = iree_uk_mmt4d_type_parse(type_str);
   iree_uk_benchmark_e2e_matmul_params_t params = {
       .type = type, .M = M, .K = K, .N = N, .accumulate = accumulate};
+  iree_uk_benchmark_options_t options = {
+      .items_per_iteration = 2 * (int64_t)M * (int64_t)K * (int64_t)N};
   iree_uk_benchmark_register(name, iree_uk_benchmark_e2e_matmul, &params,
-                             sizeof params, cpu_features);
+                             sizeof params, cpu_features, &options);
 }
 
 int main(int argc, char** argv) {

--- a/runtime/src/iree/builtins/ukernel/tools/memcpy_benchmark.h
+++ b/runtime/src/iree/builtins/ukernel/tools/memcpy_benchmark.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 
-void iree_uk_benchmark_register_memcpy(int64_t working_set_size,
-                                       int64_t batch_min_traversal_size);
+void iree_uk_benchmark_register_memcpy(int64_t working_set_size);
 
 #endif  // IREE_BUILTINS_UKERNEL_TOOLS_MEMCPY_BENCHMARK_H_

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -12,7 +12,6 @@
 #include "iree/builtins/ukernel/tools/benchmark.h"
 #include "iree/builtins/ukernel/tools/util.h"
 
-IREE_FLAG(int32_t, batch_count, 1000, "Ops to run per benchmark iteration.");
 IREE_FLAG(int32_t, m_size, 1,
           "M-dimension of mmt4d ops. The overall number of rows of the "
           "accumulator is that times the M0 tile size.");
@@ -66,17 +65,12 @@ static iree_status_t iree_uk_benchmark_mmt4d(
   params.lhs_buffer = lhs_buffer;
   params.rhs_buffer = rhs_buffer;
   params.out_buffer = out_buffer;
-  int64_t total_iterations = 0;
-  while (iree_benchmark_keep_running(benchmark_state,
-                                     /*batch_count=*/FLAG_batch_count)) {
-    for (int i = 0; i < FLAG_batch_count; ++i) {
+  int64_t batch_count;
+  while (iree_benchmark_keep_running(benchmark_state, &batch_count)) {
+    for (int i = 0; i < batch_count; ++i) {
       iree_uk_mmt4d(&params);
     }
-    total_iterations += FLAG_batch_count;
   }
-  iree_benchmark_set_items_processed(
-      benchmark_state, total_iterations * 2 * params.M * params.N * params.K *
-                           params.M0 * params.N0 * params.K0);
   free(lhs_buffer);
   free(rhs_buffer);
   free(out_buffer);
@@ -91,8 +85,11 @@ static void iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_t type, int M0,
   char name[128];
   snprintf(name, sizeof name, "mmt4d_%s_tile_%dx%dx%d", type_str, M0, N0, K0);
   iree_uk_mmt4d_params_t params = {.type = type, .M0 = M0, .N0 = N0, .K0 = K0};
+  iree_uk_benchmark_options_t options = {
+      .items_per_iteration = 2 * (int64_t)FLAG_m_size * (int64_t)FLAG_n_size *
+                             (int64_t)FLAG_k_size * M0 * N0 * K0};
   iree_uk_benchmark_register(name, iree_uk_benchmark_mmt4d, &params,
-                             sizeof params, cpu_features);
+                             sizeof params, cpu_features, &options);
 }
 
 int main(int argc, char** argv) {

--- a/runtime/src/iree/testing/benchmark_nop.c
+++ b/runtime/src/iree/testing/benchmark_nop.c
@@ -14,7 +14,7 @@ int64_t iree_benchmark_get_range(iree_benchmark_state_t* state,
 }
 
 bool iree_benchmark_keep_running(iree_benchmark_state_t* state,
-                                 uint64_t batch_count) {
+                                 int64_t* batch_count) {
   return false;
 }
 
@@ -26,12 +26,6 @@ void iree_benchmark_resume_timing(iree_benchmark_state_t* state) {}
 
 void iree_benchmark_set_label(iree_benchmark_state_t* state,
                               const char* label) {}
-
-void iree_benchmark_set_bytes_processed(iree_benchmark_state_t* state,
-                                        int64_t bytes) {}
-
-void iree_benchmark_set_items_processed(iree_benchmark_state_t* state,
-                                        int64_t items) {}
 
 void iree_benchmark_register(iree_string_view_t name,
                              const iree_benchmark_def_t* benchmark_def) {}

--- a/tools/iree-benchmark-trace-main.c
+++ b/tools/iree-benchmark-trace-main.c
@@ -203,25 +203,27 @@ static iree_status_t iree_replay_benchmark_run_file(
   }
 
   // Call the functions within the trace in order.
-  while (iree_benchmark_keep_running(benchmark_state,
-                                     /*batch_count=*/1)) {
-    // Pause timing that was started automatically. We'll resume/pause around
-    // each call.
-    // TODO(benvanik): see if we can tell benchmark to start paused?
-    iree_benchmark_pause_timing(benchmark_state);
+  int64_t batch_count;
+  while (iree_benchmark_keep_running(benchmark_state, &batch_count)) {
+    for (int64_t i = 0; i < batch_count; ++i) {
+      // Pause timing that was started automatically. We'll resume/pause around
+      // each call.
+      // TODO(benvanik): see if we can tell benchmark to start paused?
+      iree_benchmark_pause_timing(benchmark_state);
 
-    // Clear replay state.
-    iree_trace_replay_reset(&replay);
+      // Clear replay state.
+      iree_trace_replay_reset(&replay);
 
-    // Run all events in the document from start to end.
-    IREE_RETURN_IF_ERROR(
-        iree_replay_benchmark_run_documents(&replay, file, benchmark_state));
+      // Run all events in the document from start to end.
+      IREE_RETURN_IF_ERROR(
+          iree_replay_benchmark_run_documents(&replay, file, benchmark_state));
 
-    // Reset file back to the start.
-    fseek(file, 0, SEEK_SET);
+      // Reset file back to the start.
+      fseek(file, 0, SEEK_SET);
 
-    // Resume before looping because keep_running requires it.
-    iree_benchmark_resume_timing(benchmark_state);
+      // Resume before looping because keep_running requires it.
+      iree_benchmark_resume_timing(benchmark_state);
+    }
   }
 
   iree_trace_replay_deinitialize(&replay);


### PR DESCRIPTION
I don't feel right writing custom logic setting batch counts and accumulating iteration counts and setting number of items processed, in each benchmark.  I thought it would be nice if one could just declare what one wants as part of `iree_benchmark_def_t` and let the implementation take care of details.

This also seems to be improving some existing benchmarks which were hardcoding some specific batch counts, such as 1 (easy but vulnerable to distortions) or 256 (with a comment saying that was to minimize distortion)... this PR implements a simple doubling heuristic which should work well for most cases, but also allows overriding it with a specified `batch_count` or `iteration_count`.

Lifting this to declarative also has the benefit of opening the door to implementing more options such as "minimum interation count" without having to change source code of each benchmark.