### PR TITLE
[spirv] Tile reduction to avoid code bloat

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1110,7 +1110,8 @@ static int getReductionTilingFactor(int64_t dimSize) {
   for (int i = 0; i < primeNumbers.size(); ++i) {
     if (dimSize % primeNumbers[i] == 0) return primeNumbers[i];
   }
-  return 0;
+
+  return 1;  // Otherwise just tile with size 1.
 }
 
 static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1105,10 +1105,10 @@ static int getReductionTilingFactor(int64_t dimSize) {
   // Try to find the smallest prime factor as the tiling factor. As a trade off
   // between generated code size and compilation time, only look at prime
   // numbers less than 50 right now.
-  const std::array<int, 15> primeNumbers = {2,  3,  5,  7,  11, 13, 17, 19,
-                                            23, 29, 31, 37, 41, 43, 47};
-  for (int i = 0; i < primeNumbers.size(); ++i) {
-    if (dimSize % primeNumbers[i] == 0) return primeNumbers[i];
+  static constexpr std::array<int, 15> primeNumbers = {
+      2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47};
+  for (int n : primeNumbers) {
+    if (dimSize % n == 0) return n;
   }
 
   return 1;  // Otherwise just tile with size 1.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1097,6 +1097,22 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
 // Everything Default Configuration
 //===----------------------------------------------------------------------===//
 
+/// Returns a small tiling factor for the given reduction `dimSize`.
+/// Returns 0 to avoid tiling.
+static int getReductionTilingFactor(int64_t dimSize) {
+  if (dimSize % 4 == 0) return 4;
+
+  // Try to find the smallest prime factor as the tiling factor. As a trade off
+  // between generated code size and compilation time, only look at prime
+  // numbers less than 50 right now.
+  const std::array<int, 15> primeNumbers = {2,  3,  5,  7,  11, 13, 17, 19,
+                                            23, 29, 31, 37, 41, 43, 47};
+  for (int i = 0; i < primeNumbers.size(); ++i) {
+    if (dimSize % primeNumbers[i] == 0) return primeNumbers[i];
+  }
+  return 0;
+}
+
 static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
                                         Operation *op,
                                         bool allowVectorization = true) {
@@ -1294,17 +1310,15 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
   tileSizes.push_back(threadTileSizes);
 
   if (vectorizable) {
-    // Try to tile all reductions by size 4 if possible. This gives us a chance
-    // to perform vector4 load if an input has its innnermost dimension being
-    // reduction. It also avoids generating too many instructions when unrolling
-    // vector later. Similarly, also try to tile other untiled parallel
-    // dimensions by 4 to avoid instruction bloat.
+    // Try to tile all reductions by some small factor, preferrably 4, when
+    // possible. This gives us a chance to perform vector4 load if an input has
+    // its innnermost dimension being reduction. It also avoids generating too
+    // many instructions when unrolling vector later.
     SmallVector<int64_t> loopTileSizes(linalgOp.getNumLoops(), 0);
     for (const auto &[i, iter] :
          llvm::enumerate(linalgOp.getIteratorTypesArray())) {
-      if (loopBounds[i] % 4 != 0) continue;
       if (linalg::isReductionIterator(iter) || workgroupTileSizes[i] == 0) {
-        loopTileSizes[i] = 4;
+        loopTileSizes[i] = getReductionTilingFactor(loopBounds[i]);
       }
     }
     if (llvm::any_of(loopTileSizes, [](int64_t s) { return s != 0; })) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -531,7 +531,7 @@ hal.executable @four_dim_elementwise {
   ]>
 ]>
 
-hal.executable private @odd_reduction_dimension_size {
+hal.executable private @odd_reduction_dimension_size_501 {
   hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader], []>, Unknown:IntegratedGPU, #spirv.resource_limits<
         max_compute_shared_memory_size = 32768,
@@ -539,9 +539,9 @@ hal.executable private @odd_reduction_dimension_size {
         max_compute_workgroup_size = [512, 512, 512],
         subgroup_size = 32>>
     }> {
-    hal.executable.export public @odd_reduction_dimension_size ordinal(0) layout(#pipeline_layout)
+    hal.executable.export public @odd_reduction_dimension_size_501 ordinal(0) layout(#pipeline_layout)
     builtin.module {
-      func.func @odd_reduction_dimension_size() {
+      func.func @odd_reduction_dimension_size_501() {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0xFF800000 : f32
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<512x501xf32>>
@@ -576,8 +576,66 @@ hal.executable private @odd_reduction_dimension_size {
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128], [4],  [0, 3]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
-// CHECK-LABEL: hal.executable.export public @odd_reduction_dimension_size
+// CHECK-LABEL: hal.executable.export public @odd_reduction_dimension_size_501
 //  CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     lowering_config = #[[$CONFIG]]
 
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+
+hal.executable private @odd_reduction_dimension_size_2809 {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader], []>, Unknown:IntegratedGPU, #spirv.resource_limits<
+        max_compute_shared_memory_size = 32768,
+        max_compute_workgroup_invocations = 512,
+        max_compute_workgroup_size = [512, 512, 512],
+        subgroup_size = 32>>
+    }> {
+    hal.executable.export public @odd_reduction_dimension_size_2809 ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @odd_reduction_dimension_size_2809() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0xFF800000 : f32
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<512x2809xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<512x2809xf32>>
+        %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 2809], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x2809xf32>> -> tensor<512x2809xf32>
+        %3 = tensor.empty() : tensor<512x2809xf32>
+        %4 = tensor.empty() : tensor<512xf32>
+        %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<512xf32>) -> tensor<512xf32>
+        %6 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+          iterator_types = ["parallel", "reduction"]
+        } ins(%2 : tensor<512x2809xf32>) outs(%5 : tensor<512xf32>) {
+        ^bb0(%in: f32, %out: f32):
+          %8 = arith.maxf %out, %in : f32
+          linalg.yield %8 : f32
+        } -> tensor<512xf32>
+        %7 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>],
+          iterator_types = ["parallel", "parallel"]
+        } ins(%2, %6 : tensor<512x2809xf32>, tensor<512xf32>) outs(%3 : tensor<512x2809xf32>) {
+        ^bb0(%in: f32, %in_0: f32, %out: f32):
+          %8 = arith.subf %in, %in_0 : f32
+          %9 = math.exp %8 : f32
+          linalg.yield %9 : f32
+        } -> tensor<512x2809xf32>
+        flow.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [512, 2809], strides = [1, 1] : tensor<512x2809xf32> -> !flow.dispatch.tensor<writeonly:tensor<512x2809xf32>>
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128], [4],  [0, 1]{{\]}}>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
+// CHECK-LABEL: hal.executable.export public @odd_reduction_dimension_size_2809
+//  CHECK-SAME:   translation_info = #[[$TRANSLATION]]
+//       CHECK:   linalg.generic
+//  CHECK-SAME:     lowering_config = #[[$CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -521,3 +521,63 @@ hal.executable @four_dim_elementwise {
 //  CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     lowering_config = #[[$CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+
+hal.executable private @odd_reduction_dimension_size {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader], []>, Unknown:IntegratedGPU, #spirv.resource_limits<
+        max_compute_shared_memory_size = 32768,
+        max_compute_workgroup_invocations = 512,
+        max_compute_workgroup_size = [512, 512, 512],
+        subgroup_size = 32>>
+    }> {
+    hal.executable.export public @odd_reduction_dimension_size ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @odd_reduction_dimension_size() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0xFF800000 : f32
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<512x501xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<512x501xf32>>
+        %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 501], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x501xf32>> -> tensor<512x501xf32>
+        %3 = tensor.empty() : tensor<512x501xf32>
+        %4 = tensor.empty() : tensor<512xf32>
+        %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<512xf32>) -> tensor<512xf32>
+        %6 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+          iterator_types = ["parallel", "reduction"]
+        } ins(%2 : tensor<512x501xf32>) outs(%5 : tensor<512xf32>) {
+        ^bb0(%in: f32, %out: f32):
+          %8 = arith.maxf %out, %in : f32
+          linalg.yield %8 : f32
+        } -> tensor<512xf32>
+        %7 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>],
+          iterator_types = ["parallel", "parallel"]
+        } ins(%2, %6 : tensor<512x501xf32>, tensor<512xf32>) outs(%3 : tensor<512x501xf32>) {
+        ^bb0(%in: f32, %in_0: f32, %out: f32):
+          %8 = arith.subf %in, %in_0 : f32
+          %9 = math.exp %8 : f32
+          linalg.yield %9 : f32
+        } -> tensor<512x501xf32>
+        flow.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [512, 501], strides = [1, 1] : tensor<512x501xf32> -> !flow.dispatch.tensor<writeonly:tensor<512x501xf32>>
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128], [4],  [0, 3]{{\]}}>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
+// CHECK-LABEL: hal.executable.export public @odd_reduction_dimension_size
+//  CHECK-SAME:   translation_info = #[[$TRANSLATION]]
+//       CHECK:   linalg.generic
+//  CHECK-SAME:     lowering_config = #[[$CONFIG]]
+


### PR DESCRIPTION
Previously we only tile reduction dimensions for multiples of 4 when going down the vectorization pipeline. This causes code bloat and long compilation time for odd dimension sizes which gets fully unrolled. Improve the logic to try to find the smallest prime number for tiling such cases too, before we have the solution of general packing and padding.