### PR TITLE
Remove awaiting-triage label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: Report an issue
-labels: ["awaiting-triage", "bug 🐞"]
+labels: ["bug 🐞"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: ➕ Feature Request
 description: Ask for a new feature to be added
-labels: ["awaiting-triage", "enhancement ➕"]
+labels: ["enhancement ➕"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
We're switching to use a Project status field for this purpose so the awaiting-triage label is no longer needed. This is step 1 in cleaning it up.