### PR TITLE
[ci] Adjust int8 EfficientNet flagging threshold for Mali GPUs

### DIFF
--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -82,6 +82,8 @@ BENCHMARK_THRESHOLDS = [
     # suitable anymore.
     BenchmarkThreshold(re.compile(r"^DeepLabV3.*GPU-Mali"), 1 * 10**6,
                        ThresholdUnit.VALUE_NS),
+    BenchmarkThreshold(re.compile(r"^EfficientNet.*int8.*GPU-Mali"), 1 * 10**6,
+                       ThresholdUnit.VALUE_NS),
     BenchmarkThreshold(re.compile(r"^MobileNet.*GPU"), 1 * 10**6,
                        ThresholdUnit.VALUE_NS),
 


### PR DESCRIPTION
This model completes around 10ms; using absolute time difference is better.