### PR TITLE
Add operand to lower_to_llvm transform op

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
@@ -20,23 +20,30 @@ def LowerToLLVMOp : Op<Transform_Dialect, "lower_to_llvm",
     [FunctionalStyleTransformOpTrait,
      MemoryEffectsOpInterface,
      DeclareOpInterfaceMethods<TransformOpInterface>]> {
-  let description = [{Indicates that the entire module should be converted
-  to the LLVM dialect. This is expected to be the last transformation in
-  a sequence.}];
+  let description = [{
+    Indicates that the entire targeted module should be converted
+    to the LLVM dialect. This is expected to be the last transformation in
+    a sequence.
+
+    #### Return modes
+
+    This operation consumes the `target` handle and produces the `transformed`
+    handle.
+  }];
 
   let arguments =
-    (ins DefaultValuedAttr<BoolAttr, "false">:$reassociate_fp_reductions,
+    (ins TransformHandleTypeInterface:$target,
+     DefaultValuedAttr<BoolAttr, "false">:$reassociate_fp_reductions,
      DefaultValuedAttr<BoolAttr, "false">:$enable_index_optimizations,
      DefaultValuedAttr<BoolAttr, "false">:$enable_arm_neon,
      DefaultValuedAttr<BoolAttr, "false">:$enable_arm_sve,
      DefaultValuedAttr<BoolAttr, "false">:$enable_amx,
      DefaultValuedAttr<BoolAttr, "false">:$enable_x86vector,
      DefaultValuedAttr<BoolAttr, "false">:$enable_async);
-
-  let assemblyFormat = "attr-dict";
+  let results = (outs TransformHandleTypeInterface:$transformed);
+  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::transform_ext";
 }
-
 
 def RegisterMatchCallbacksOp :
     Op<Transform_Dialect, "iree.register_match_callbacks",

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
@@ -23,8 +23,8 @@ transform.sequence failures(propagate) {
   // CHECK: vector.lower_contraction %[[FUNC]] {{.*}}
   %6 = transform.structured.match ops{["func.func"]} in %arg0 : (!pdl.operation) -> !pdl.operation
   transform.vector.lower_contraction %6
-    lowering_strategy = "outerproduct" 
+    lowering_strategy = "outerproduct"
       : (!pdl.operation) -> !pdl.operation
   // CHECK: lower_to_llvm
-  lower_to_llvm
+  lower_to_llvm %arg0 : (!pdl.operation) -> !pdl.operation
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -23,18 +23,18 @@ transform.sequence failures(propagate) {
   transform.structured.vectorize %2 { vectorize_padding }
   transform.bufferization.one_shot_bufferize layout{IdentityLayoutMap} %module_op
     {bufferize_function_boundaries = true}
-  %3 = transform.structured.match ops{["func.func"]} in %module_op 
+  %3 = transform.structured.match ops{["func.func"]} in %module_op
     : (!pdl.operation) -> !pdl.operation
 
 
   %func = transform.structured.match ops{["func.func"]} in %module_op
     : (!pdl.operation) -> !pdl.operation
   %func_e_2 = transform.vector.lower_contraction %func
-    lowering_strategy = "outerproduct" 
+    lowering_strategy = "outerproduct"
       : (!pdl.operation) -> !pdl.operation
   %func_e_3 = transform.vector.lower_transpose %func_e_2
-    lowering_strategy = "shuffle" 
+    lowering_strategy = "shuffle"
       : (!pdl.operation) -> !pdl.operation
 
-  lower_to_llvm
+  lower_to_llvm %module_op : (!pdl.operation) -> !pdl.operation
 }


### PR DESCRIPTION
All transform ops should have an explicit target (instead of an implicit "top-level"), so that payload ops are properly invalidated in the transform dialect state.