### PR TITLE
[ci] Use 10% as flagging threshold for Mali GPU int8 mobilebert

### DIFF
--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -75,6 +75,9 @@ BENCHMARK_THRESHOLDS = [
 
     # Fluctuating benchmarks on mobile GPUs.
     BenchmarkThreshold(
+        re.compile(r"^MobileBertSquad.*int8.*full-inference.*GPU-Mali"), 10,
+        ThresholdUnit.PERCENTAGE),
+    BenchmarkThreshold(
         re.compile(r"^MobileNetV3Small.*full-inference.*GPU-Mali"), 2 * 10**6,
         ThresholdUnit.VALUE_NS),
 


### PR DESCRIPTION
This is fluctuating roughly in 10% range: https://perf.iree.dev/serie?IREE?MobileBertSquad%20%5Bint8%5D%20(TFLite)%20full-inference,default-flags%20with%20IREE-Vulkan%20@%20Pixel-6-Pro%20(GPU-Mali-G78)