### PR TITLE
[ci] Drop iree-import-tf in build_android_benchmark.sh

### DIFF
--- a/build_tools/cmake/build_android_benchmark.sh
+++ b/build_tools/cmake/build_android_benchmark.sh
@@ -40,7 +40,6 @@ BAZEL_CMD=(bazel --noworkspace_rc --bazelrc=build_tools/bazel/iree-tf.bazelrc)
 BAZEL_BINDIR="$(${BAZEL_CMD[@]} info bazel-bin)"
 "${BAZEL_CMD[@]}" build \
       //iree_tf_compiler:iree-import-tflite \
-      //iree_tf_compiler:iree-import-tf \
       --config=generic_clang \
       --config=remote_cache_bazel_tf_ci
 # So the benchmark build below can find the importer binaries that were built.


### PR DESCRIPTION
To fix the pipeline failure. This target is removed after
https://github.com/openxla/iree/commit/164bad391bee2f94aab05ea1f8dc5ef11a88408e.