### PR TITLE
Add GlobalOpInterface to ml_program::Global.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/BUILD.bazel
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgStructuredOpsIncGen",
+        "@llvm-project//mlir:MLProgramDialect",
         "@llvm-project//mlir:TensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
     MLIRArithDialect
     MLIRLinalgDialect
     MLIRLinalgStructuredOpsIncGenLib
+    MLIRMLProgramDialect
     MLIRTensorDialect
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/ConvertPrimitiveType.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/ConvertPrimitiveType.cpp
@@ -176,8 +176,8 @@ struct ConvertTypesPass : public Base {
 
     // Operations are legal if they don't contain any illegal type.
     target.markUnknownOpDynamicallyLegal([&](Operation *op) {
-      if (auto globalOp = dyn_cast<IREE::Util::GlobalOp>(op)) {
-        return typeConverter.isLegal(globalOp.getType());
+      if (auto globalOp = dyn_cast<IREE::Util::GlobalOpInterface>(op)) {
+        return typeConverter.isLegal(globalOp.getGlobalType());
       } else if (auto funcOp = dyn_cast<func::FuncOp>(op)) {
         for (Type type : funcOp.getFunctionType().getInputs()) {
           if (!typeConverter.isLegal(type)) return false;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
@@ -234,14 +234,14 @@ func.func @arith.extsi(%arg0: i32) -> i64 {
 // Check: ml_program is also handled.
 
 // CHECK: global.*i32
-"ml_program.global"() {sym_name = "_vocab$0", sym_visibility = "private", type = tensor<2x2xi64>, value = dense<1> : tensor<2x2xi64>} : () -> ()
+"ml_program.global"() {sym_name = "_v", sym_visibility = "private", type = tensor<2x2xi64>, value = dense<1> : tensor<2x2xi64>} : () -> ()
 func.func @run() -> tensor<2x2xi64> {
-  %0 = "ml_program.global_load"() {global = @_vocab$0} : () -> tensor<2x2xi64>
-  %1 = call @jit__run$main(%0) : (tensor<2x2xi64>) -> tensor<2x2xi64>
+  %0 = "ml_program.global_load"() {global = @_v} : () -> tensor<2x2xi64>
+  %1 = call @f(%0) : (tensor<2x2xi64>) -> tensor<2x2xi64>
   return %1 : tensor<2x2xi64>
 }
 
-func.func private @jit__run$main(%arg0: tensor<2x2xi64> {mhlo.sharding = ""}) -> tensor<2x2xi64> {
+func.func private @f(%arg0: tensor<2x2xi64>) -> tensor<2x2xi64> {
   return %arg0 : tensor<2x2xi64>
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
@@ -233,7 +233,8 @@ func.func @arith.extsi(%arg0: i32) -> i64 {
 
 // Check: ml_program is also handled.
 
-// CHECK: global.*i32
+// CHECK: ml_program.global
+// CHECK-SAME: i32
 "ml_program.global"() {sym_name = "_v", sym_visibility = "private", type = tensor<2x2xi64>, value = dense<1> : tensor<2x2xi64>} : () -> ()
 func.func @run() -> tensor<2x2xi64> {
   %0 = "ml_program.global_load"() {global = @_v} : () -> tensor<2x2xi64>

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
@@ -228,3 +228,20 @@ func.func @arith.extsi(%arg0: i32) -> i64 {
   %0 = arith.extsi %arg0 : i32 to i64
   return %0 : i64
 }
+
+// -----
+
+// Check: ml_program is also handled.
+
+// CHECK: global.*i32
+"ml_program.global"() {sym_name = "_vocab$0", sym_visibility = "private", type = tensor<2x2xi64>, value = dense<1> : tensor<2x2xi64>} : () -> ()
+func.func @run() -> tensor<2x2xi64> {
+  %0 = "ml_program.global_load"() {global = @_vocab$0} : () -> tensor<2x2xi64>
+  %1 = call @jit__run$main(%0) : (tensor<2x2xi64>) -> tensor<2x2xi64>
+  return %1 : tensor<2x2xi64>
+}
+
+func.func private @jit__run$main(%arg0: tensor<2x2xi64> {mhlo.sharding = ""}) -> tensor<2x2xi64> {
+  return %arg0 : tensor<2x2xi64>
+}
+


### PR DESCRIPTION
This enables treating global ops uniformly in type demotion pass (need to 
follow up why it lasts until then).

Fixes #12252
