### PR TITLE
Restructure building-from-source/getting-started page.

### DIFF
--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -225,14 +225,11 @@ export IREE_VULKAN_DISABLE=1
 ### Running samples
 
 ``` shell
-# Build the 'install' target to collect all executables in one directory
-cmake --build ../iree-build/ --target install
-
-# List that directory's contents
-ls ../iree-build/install/bin/
+# Build
+cmake --build ../iree-build/
 
 # Run a standalone sample application
-../iree-build/install/bin/hello_world_embedded
+../iree-build/runtime/src/iree/runtime/demo/hello_world_embedded
 # 4xf32=1 1.1 1.2 1.3
 #  *
 # 4xf32=10 100 1000 10000
@@ -240,6 +237,7 @@ ls ../iree-build/install/bin/
 # 4xf32=10 110 1200 13000
 
 # Try out the developer tools
-../iree-build/install/bin/iree-compile --help
-../iree-build/install/bin/iree-run-module --help
+ls ../iree-build/tools/
+../iree-build/tools/iree-compile --help
+../iree-build/tools/iree-run-module --help
 ```

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -2,17 +2,14 @@
 
 ## Prerequisites
 
-You will need to install [CMake](https://cmake.org/), the
-[Ninja](https://ninja-build.org/) CMake generator, and the clang or MSVC C/C++
-compilers. The tests also requires [Python3](https://www.python.org/) and the
-python package [requests](https://requests.readthedocs.io/en/latest/) to run.
+IREE can be built from source using [CMake](https://cmake.org/). We also
+recommend the [Ninja](https://ninja-build.org/) CMake generator and the
+[clang](https://clang.llvm.org/) or MSVC C/C++ compilers.
 
-???+ Note
-    You are welcome to try different CMake generators and compilers, but IREE
-    devs and CIs exclusively use these and other configurations are "best
-    effort". Additionally, compilation on macOS is "best effort" as well, though
-    we generally expect it to work due to its similarity with Linux. Patches to
-    improve support for these are always welcome.
+??? Note "Note - Other CMake generators and compilers"
+    IREE developers and CIs primarily use Ninja, clang, and MSVC. Other
+    configurations (including the Makefile generator and gcc) are "best effort".
+    Patches to improve support are always welcome.
 
 === "Linux"
 
@@ -23,7 +20,7 @@ python package [requests](https://requests.readthedocs.io/en/latest/) to run.
     3. Install [Ninja](https://ninja-build.org/) (typically "ninja-build"
        package)
 
-    On a relatively recent Debian/Ubuntu:
+    On Debian/Ubuntu:
 
     ``` shell
     sudo apt install cmake ninja-build clang lld
@@ -31,10 +28,9 @@ python package [requests](https://requests.readthedocs.io/en/latest/) to run.
 
 === "macOS"
 
-    1. Install [CMake](https://cmake.org/download/) (typically "cmake" package)
+    1. Install [CMake](https://cmake.org/download/)
 
-    2. Install [Ninja](https://ninja-build.org/) (typically "ninja-build"
-       package)
+    2. Install [Ninja](https://ninja-build.org/)
 
     If using Homebrew:
 
@@ -50,8 +46,7 @@ python package [requests](https://requests.readthedocs.io/en/latest/) to run.
     2. Install CMake from the
        [official downloads page](https://cmake.org/download/)
 
-    3. Install Ninja either from the
-       [official site](https://ninja-build.org/)
+    3. Install Ninja from the [official site](https://ninja-build.org/)
 
     !!! note
         You will need to initialize MSVC by running `vcvarsall.bat` to use it
@@ -59,7 +54,9 @@ python package [requests](https://requests.readthedocs.io/en/latest/) to run.
         [official documentation](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line)
         for details.
 
-## Clone and build
+<!-- TODO(scotttodd): add notes about Docker and/or dev containers  -->
+
+## Quickstart: clone and build
 
 Use [Git](https://git-scm.com/) to clone the IREE repository and initialize its
 submodules:
@@ -70,66 +67,75 @@ cd iree
 git submodule update --init
 ```
 
-Configure then build all targets using CMake:
+The most basic CMake workflow is:
 
-Configure CMake:
+``` shell
+# Configure
+cmake -G Ninja -B ../iree-build/ .
+
+# Build
+cmake --build ../iree-build/
+```
+
+!!! Caution "Caution - slow builds"
+    The compiler build is complex. You will want a powerful machine and to tune
+    the settings following the next section.
+
+    Use case permitting, disabling the compiler build with
+    `-DIREE_BUILD_COMPILER=OFF` will drastically simplify the build.
+
+## Configuration settings
+
+The configure step should be customized for your build environment. These
+settings can improve compile and link times substantially.
+
+<!-- TODO(scotttodd): add notes about CMake presets?  -->
 
 === "Linux"
 
     ``` shell
-    # Recommended for simple development using clang and lld:
-    cmake -GNinja -B ../iree-build/ -S . \
+    # Recommended development options using clang and lld:
+    cmake -G Ninja -B ../iree-build/ -S . \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DIREE_ENABLE_ASSERTIONS=ON \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
         -DIREE_ENABLE_LLD=ON
-
-    # Alternately, with system compiler and your choice of CMake generator:
-    # cmake -B ../iree-build/ -S .
     ```
 
 === "macOS"
 
     ``` shell
-    # Recommended for simple development using clang and lld:
-    cmake -GNinja -B ../iree-build/ -S . \
+    # Recommended development options using clang and lld:
+    cmake -G Ninja -B ../iree-build/ -S . \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DIREE_ENABLE_ASSERTIONS=ON \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
         -DIREE_ENABLE_LLD=ON
-
-    # Alternately, with system compiler and your choice of CMake generator:
-    # cmake -B ../iree-build/ -S .
     ```
 
 === "Windows"
 
     ``` shell
-    cmake -GNinja -B ../iree-build/ -S . \
+    # Recommended development options:
+    cmake -G Ninja -B ../iree-build/ -S . \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DIREE_ENABLE_ASSERTIONS=ON
     ```
 
-Build:
-
-``` shell
-cmake --build ../iree-build/
-```
-
-???+ Tip "Tip - Build types"
+???+ Tip "Tip - CMAKE_BUILD_TYPE values"
     We recommend using the `RelWithDebInfo` build type by default for a good
-    balance of debugging information and performance. The `Debug`, `Release`,
-    and `MinSizeRel` build types are useful in more specific scenarios.
-    In particular, note that several useful LLVM debugging features are only
-    available in `Debug` builds. See the
+    balance of debug info and performance. The `Debug`, `Release`, and
+    `MinSizeRel` build types are useful in more specific cases. Note that
+    several useful LLVM debugging features are only available in `Debug` builds.
+    See the
     [official CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
     for general details.
 
 ???+ Tip "Tip - Faster recompilation with ccache"
-    We recommend using [`ccache`](https://ccache.dev/) together with CMake. To
-    use it, configure CMake with:
+    We recommend using [`ccache`](https://ccache.dev/) with CMake, especially
+    when rebuilding the compiler. To use it, configure CMake with:
 
     ``` shell
     -DCMAKE_C_COMPILER_LAUNCHER=ccache
@@ -138,32 +144,102 @@ cmake --build ../iree-build/
 
     See also our [developer documentation for ccache](https://github.com/openxla/iree/blob/main/docs/developers/developing_iree/ccache.md).
 
-## What's next?
+### Optional components
 
-<!-- TODO(scotttodd): "at this point you can..." -->
+By default, the CMake build includes:
+
+* All compiler targets (`llvm-cpu`, `cuda`, `vulkan-spirv`, etc.)
+* All runtime HAL drivers (`local-task`, `cuda`, `vulkan`, etc.)
+* All compiler input formats (StableHLO, TOSA, etc.)
+* All compiler output formats (VM bytecode, C)
+
+The default build does _not_ include:
+
+* Compiler or runtime bindings (Python, TFLite, etc.)
+* Advanced features like AddressSanitizer or tracing instrumentation
+* Experimental components
+
+These can be changed via the `IREE_` CMake options listed in the root
+[`CMakeLists.txt`](https://github.com/openxla/iree/blob/main/CMakeLists.txt).
+
+### Extensions and project integrations
+
+When using IREE within other projects, you can register compiler plugins and
+runtime HAL drivers. You can also bring your own copy of LLVM and some other
+tools. See the root
+[`CMakeLists.txt`](https://github.com/openxla/iree/blob/main/CMakeLists.txt)
+for details.
+
+## Tests and samples
 
 ### Running tests
 
-Build test dependencies and run tests:
+Tests are run via [ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html).
+To build and run the core project tests:
 
 ``` shell
+# Build default targets
+cmake --build ../iree-build/
+
+# Run tests
+ctest --test-dir ../iree-build/
+```
+
+!!! Caution
+    This has two limitations:
+
+    1. Large tests are excluded from the build by default
+    2. Some tests require hardware like a GPU and will fail on unsupported systems
+
+To build and then run all tests:
+
+``` shell
+# 1. Build default targets
+cmake --build ../iree-build/
+
+# 2. Build test dependencies
+cmake --build ../iree-build/ --target iree-test-deps
+
+# 3. Run tests
+ctest --test-dir ../iree-build/
+
+
+# Or combine all steps using a utility target
 cmake --build ../iree-build --target iree-run-tests
 ```
 
-Internally, this builds dependencies via the `iree-test-deps` target and
-invokes [CTest](https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest).
-
-The parallel testing level can be set via the environment variable
-`CTEST_PARALLEL_LEVEL` when invoking ctest in this fashion. Instructions
-are printed to test with a custom command line.
-
-### Take a look around
-
-Check out the contents of the 'tools' build directory:
+To run only certain tests, we have a
+[helper script](https://github.com/openxla/iree/blob/main/build_tools/cmake/ctest_all.sh)
+that converts environment variables into ctest filters:
 
 ``` shell
-ls ../iree-build/tools/
-../iree-build/tools/iree-compile --help
+# Run default tests
+./build_tools/cmake/ctest_all.sh
+
+# Run tests, turning CUDA on and Vulkan off
+export IREE_CUDA_DISABLE=0
+export IREE_VULKAN_DISABLE=1
+./build_tools/cmake/ctest_all.sh
 ```
 
-<!-- TODO(scotttodd): troubleshooting section? link to github issues? -->
+### Running samples
+
+``` shell
+# Build the 'install' target to collect all executables in one directory
+cmake --build ../iree-build/ --target install
+
+# List that directory's contents
+ls ../iree-build/install/bin/
+
+# Run a standalone sample application
+../iree-build/install/bin/hello_world_embedded
+# 4xf32=1 1.1 1.2 1.3
+#  *
+# 4xf32=10 100 1000 10000
+#  =
+# 4xf32=10 110 1200 13000
+
+# Try out the developer tools
+../iree-build/install/bin/iree-compile --help
+../iree-build/install/bin/iree-run-module --help
+```

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -49,12 +49,12 @@ recommend the [Ninja](https://ninja-build.org/) CMake generator and the
     3. Install Ninja from the [official site](https://ninja-build.org/)
 
     !!! note
-        You will need to initialize MSVC by running `vcvarsall.bat` to use it
-        from the command line. See the
+        Initialize MSVC by running `vcvarsall.bat` to build on the command line.
+        See the
         [official documentation](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line)
         for details.
 
-<!-- TODO(scotttodd): add notes about Docker and/or dev containers  -->
+<!-- TODO(#12921): add notes about Docker and/or dev containers  -->
 
 ## Quickstart: clone and build
 
@@ -79,7 +79,8 @@ cmake --build ../iree-build/
 
 !!! Caution "Caution - slow builds"
     The compiler build is complex. You will want a powerful machine and to tune
-    the settings following the next section.
+    the settings following the next section. In 2023, we've seen builds take
+    around 5-10 minutes on 64-core Linux machines.
 
     Use case permitting, disabling the compiler build with
     `-DIREE_BUILD_COMPILER=OFF` will drastically simplify the build.
@@ -89,7 +90,7 @@ cmake --build ../iree-build/
 The configure step should be customized for your build environment. These
 settings can improve compile and link times substantially.
 
-<!-- TODO(scotttodd): add notes about CMake presets?  -->
+<!-- TODO(#5804): add notes about CMake presets?  -->
 
 === "Linux"
 
@@ -98,6 +99,8 @@ settings can improve compile and link times substantially.
     cmake -G Ninja -B ../iree-build/ -S . \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DIREE_ENABLE_ASSERTIONS=ON \
+        -DIREE_ENABLE_SPLIT_DWARF=ON \
+        -DIREE_ENABLE_THIN_ARCHIVES=ON \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
         -DIREE_ENABLE_LLD=ON
@@ -110,6 +113,8 @@ settings can improve compile and link times substantially.
     cmake -G Ninja -B ../iree-build/ -S . \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DIREE_ENABLE_ASSERTIONS=ON \
+        -DIREE_ENABLE_SPLIT_DWARF=ON \
+        -DIREE_ENABLE_THIN_ARCHIVES=ON \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
         -DIREE_ENABLE_LLD=ON


### PR DESCRIPTION
This restructures the main "how to build from source" page that we have, highlighting how simple "configure, build, test" _can_ be then going into what settings/scripts we recommend and why.

### Hosted pages

| | |
| --- | --- |
| Current page | https://openxla.github.io/iree/building-from-source/getting-started/ | 
| Preview this PR | https://scotttodd.github.io/iree/building-from-source/getting-started/ |

### Summary of changes:

* Add basic configure -> build _then_ explain settings
* Add TODOs for Docker / dev containers and CMake presets
  * https://github.com/openxla/iree/pull/12921
  * https://github.com/openxla/iree/issues/5804
* Discuss optional components (to convey "CUDA is enabled by default")
* Add section on running samples like `hello_world_embedded`
* Refine language throughout

