### PR TITLE
[NFC] Update comments and var naming after CodegenStrategy deprecation.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1016,9 +1016,9 @@ static LogicalResult setRootConfig(
                        << vecPreProcStrategy << "\n");
 
   if (usePaddingPipeline) {
-    // It's inspired from Sandbox configuration. Sandbox has
-    // [[288, 128, 512], [12, 32, 1]] setup. We scale 288 to 192 because
-    // 288/12*8=192
+    // It's inspired from https://github.com/iree-org/iree-llvm-sandbox repo.
+    // Sandbox has [[288, 128, 512], [12, 32, 1]] setup. We scale 288 to 192
+    // because 288/12*8=192
     if (numLoops == 3) {
       maxTileSizes[0] = 192;
       maxTileSizes[1] = 128;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.h
@@ -13,30 +13,20 @@
 namespace mlir {
 namespace iree_compiler {
 
-enum class TilingLevel : unsigned {
-  // Tile linalg operations to threads.
-  WorkGroupTiles = 0,
-  // Tile linalg operation on workgroup thread into L1 block tiles.
-  L1Tiles = 1,
-  // Tile linalg operations on L1 block tiles into vector tiles.
-  VectorTiles = 2,
-  NumTileLevels = 3
-};
-
 // TODO(hanchung): Create a pass to handle detailed logic about splitting tiling
 // sizes for parallel dims and reduction dims.
 // We have to fuse the fill + named_op + generic ops along parallel dims
 // firstly. At this stage, we do not apply vectorization. The reduction dim
 // won't get tiled if the case is matmul + generic op. In this case, we have to
-// tile along reduction dim again, which needs them to be Linalg ops form.
-enum class StrategyTilingLevel : unsigned {
-  // Tile linalg operations to threads.
+// tile along reduction dim again, which needs them to be TilingInterface ops.
+enum class TilingLevel : unsigned {
+  // Tile TilingInterface operations to threads.
   WorkGroupTiles = 0,
-  // Tile linalg operation on workgroup thread for parallel dims.
+  // Tile TilingInterface operation on workgroup thread for parallel dims.
   ParallelTiles = 1,
-  // Tile linalg operations on workgroup thread for reduction dims.
+  // Tile TilingInterface operations on workgroup thread for reduction dims.
   ReductionTiles = 2,
-  NumStrategyTileLevels = 3
+  NumTileLevels = 3
 };
 
 LogicalResult initCPULaunchConfig(ModuleOp moduleOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -204,7 +204,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
               CPUDoubleTilingExpert:
             addMultiTilingExpertPassPipeline(
                 executableLoweringPipeline,
-                static_cast<int>(StrategyTilingLevel::NumStrategyTileLevels),
+                static_cast<int>(TilingLevel::NumTileLevels),
                 /*enablePeeling=*/false, enableVectorMasking, lowerToAVX2);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
@@ -216,7 +216,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
               CPUDoubleTilingPeelingExpert:
             addMultiTilingExpertPassPipeline(
                 executableLoweringPipeline,
-                static_cast<int>(StrategyTilingLevel::NumStrategyTileLevels),
+                static_cast<int>(TilingLevel::NumTileLevels),
                 /*enablePeeling=*/true, enableVectorMasking, lowerToAVX2);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -441,8 +441,7 @@ LogicalResult verifyTensorToVectorsPassPipelineConfig(
 void addTensorToVectorsPassPipeline(OpPassManager &passManager,
                                     bool lowerToVectors = true);
 
-/// Populates the passes needed to do two-level tile + vectorize of linalg ops
-/// using the Codegen drivers from sandbox.
+/// Populates the passes needed to do two-level tile + vectorize of linalg ops.
 LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
     Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
     IREE::Codegen::TranslationInfoAttr translationInfo,
@@ -455,7 +454,7 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager,
                                           bool enableVectorMasking);
 
 // Populates the passes needed to do tiling, decomposing, and vectorizing the
-// convolution ops using the Codegen drivers from sandbox.
+// convolution ops.
 LogicalResult verifyConvTileAndDecomposeExpertConfig(
     Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
     IREE::Codegen::TranslationInfoAttr translationInfo,


### PR DESCRIPTION
- Unify TilingLevel enum class.
- Update comments about "Sandbox".