### PR TITLE
Skip mnist_train_test variants when backends or drivers are disabled.

### DIFF
--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -31,6 +31,17 @@ if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
       "requires-gpu-nvidia"
       "driver=cuda"
   )
+
+  # Mark the CUDA test as WILL_FAIL if it was defined.
+  # TODO(#13007): Thread this through the test rule instead of custom logic.
+  iree_package_path(PKG_PATH)
+  set(CUDA_TEST_NAME ${PKG_PATH}/mnist_train_test_cuda)
+  get_directory_property(TESTS_LIST TESTS)
+  if(${CUDA_TEST_NAME} IN_LIST TESTS_LIST)
+    set_tests_properties(
+      ${CUDA_TEST_NAME}
+      PROPERTIES WILL_FAIL TRUE)
+  endif()
 endif()
 
 if(IREE_TARGET_BACKEND_VULKAN_SPIRV AND IREE_HAL_DRIVER_VULKAN)

--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -32,8 +32,9 @@ if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
       "driver=cuda"
   )
 
-  # Mark the CUDA test as WILL_FAIL if it was defined.
-  # TODO(#13007): Thread this through the test rule instead of custom logic.
+  # The test fails on CUDA with `Mismatched elements: 1 / 100352 (0.000996%)`,
+  # so mark as WILL_FAIL if the test was defined.
+  # TODO(#13007): Plumb WILL_FAIL through the test rule instead of custom logic.
   iree_package_path(PKG_PATH)
   set(CUDA_TEST_NAME ${PKG_PATH}/mnist_train_test_cuda)
   get_directory_property(TESTS_LIST TESTS)

--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -4,52 +4,56 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-include(iree_macros)
-
-iree_py_test(
-  NAME
-    mnist_train_test_cpu
-  SRCS
-    "mnist_train_test.py"
-  ARGS
-    "--target_backend=llvm-cpu"
-    "--driver=local-task"
-  LABELS
-    "driver=local-task"
-)
-
-iree_py_test(
-  NAME
-    mnist_train_test_cuda
-  SRCS
-    "mnist_train_test.py"
-  ARGS
-    "--target_backend=cuda"
-    "--driver=cuda"
-  LABELS
-    "requires-gpu-nvidia"
-    "driver=cuda"
-)
-
-# Mark the CUDA test as WILL_FAIL if it was defined.
-# TODO(#13007): Thread this through the test rule instead of custom logic.
-iree_package_path(PKG_PATH)
-set(CUDA_TEST_NAME ${PKG_PATH}/mnist_train_test_cuda)
-get_directory_property(TESTS_LIST TESTS)
-if(${CUDA_TEST_NAME} IN_LIST TESTS_LIST)
-  set_tests_properties(
-    ${CUDA_TEST_NAME}
-    PROPERTIES WILL_FAIL TRUE)
+if(IREE_TARGET_BACKEND_LLVM_CPU AND IREE_HAL_DRIVER_LOCAL_TASK)
+  iree_py_test(
+    NAME
+      mnist_train_test_cpu
+    SRCS
+      "mnist_train_test.py"
+    ARGS
+      "--target_backend=llvm-cpu"
+      "--driver=local-task"
+    LABELS
+      "driver=local-task"
+  )
 endif()
 
-iree_py_test(
-  NAME
-    mnist_train_test_vulkan
-  SRCS
-    "mnist_train_test.py"
-  ARGS
-    "--target_backend=vulkan-spirv"
-    "--driver=vulkan"
-  LABELS
-    "driver=vulkan"
-)
+if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
+  iree_py_test(
+    NAME
+      mnist_train_test_cuda
+    SRCS
+      "mnist_train_test.py"
+    ARGS
+      "--target_backend=cuda"
+      "--driver=cuda"
+    LABELS
+      "requires-gpu-nvidia"
+      "driver=cuda"
+  )
+
+  # Mark the CUDA test as WILL_FAIL if it was defined.
+  # TODO(#13007): Thread this through the test rule instead of custom logic.
+  iree_package_path(PKG_PATH)
+  set(CUDA_TEST_NAME ${PKG_PATH}/mnist_train_test_cuda)
+  get_directory_property(TESTS_LIST TESTS)
+  if(${CUDA_TEST_NAME} IN_LIST TESTS_LIST)
+    set_tests_properties(
+      ${CUDA_TEST_NAME}
+      PROPERTIES WILL_FAIL TRUE)
+  endif()
+endif()
+
+if(IREE_TARGET_BACKEND_VULKAN_SPIRV AND IREE_HAL_DRIVER_VULKAN)
+  iree_py_test(
+    NAME
+      mnist_train_test_vulkan
+    SRCS
+      "mnist_train_test.py"
+    ARGS
+      "--target_backend=vulkan-spirv"
+      "--driver=vulkan"
+    LABELS
+      "driver=vulkan"
+  )
+endif()

--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -31,17 +31,6 @@ if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
       "requires-gpu-nvidia"
       "driver=cuda"
   )
-
-  # Mark the CUDA test as WILL_FAIL if it was defined.
-  # TODO(#13007): Thread this through the test rule instead of custom logic.
-  iree_package_path(PKG_PATH)
-  set(CUDA_TEST_NAME ${PKG_PATH}/mnist_train_test_cuda)
-  get_directory_property(TESTS_LIST TESTS)
-  if(${CUDA_TEST_NAME} IN_LIST TESTS_LIST)
-    set_tests_properties(
-      ${CUDA_TEST_NAME}
-      PROPERTIES WILL_FAIL TRUE)
-  endif()
 endif()
 
 if(IREE_TARGET_BACKEND_VULKAN_SPIRV AND IREE_HAL_DRIVER_VULKAN)

--- a/tests/e2e/models/mnist_train_test/README.md
+++ b/tests/e2e/models/mnist_train_test/README.md
@@ -8,7 +8,7 @@ To regenerate the model together with the test data use
 python -m venv generate_mnist.venv
 source generate_mnist.venv/bin/activate
 # Add IREE Python to your PYTHONPATH, following
-# https://iree-org.github.io/iree/building-from-source/python-bindings-and-importers
+# https://openxla.github.io/iree/building-from-source/python-bindings-and-importers
 pip install -r generate_test_data_requirements.txt
 python ./generate_test_data.py
 ```

--- a/tests/e2e/models/mnist_train_test/generate_test_data_requirements.txt
+++ b/tests/e2e/models/mnist_train_test/generate_test_data_requirements.txt
@@ -1,4 +1,4 @@
---find-links https://iree-org.github.io/iree/pip-release-links.html
+--find-links https://openxla.github.io/iree/pip-release-links.html
 git+https://github.com/iree-org/iree-jax@26006ef5842a604e28ea71e65e9224ad20f028e9#egg=iree-jax
 jax==0.4.2
 numpy==1.24.2


### PR DESCRIPTION
Follow-up to https://github.com/openxla/iree/pull/12017, which broke some (post-submit) macOS builds: https://github.com/openxla/iree/actions/runs/4662791316/jobs/8253527015#step:7:814
```
 398/1086 Test   #57: iree/tests/e2e/models/mnist_train_test/mnist_train_test_vulkan ***Failed    
ERROR: test_mnist_training (__main__.MnistTrainTest.test_mnist_training)
ValueError: No device found from list ['vulkan']
```