### PR TITLE
[docs] Fix the cmake command for the tracy convenience targets

### DIFF
--- a/docs/developers/developing_iree/profiling_with_tracy.md
+++ b/docs/developers/developing_iree/profiling_with_tracy.md
@@ -108,7 +108,7 @@ A CMake-based build system for Tracy is maintained as part of IREE. In your IREE
 desktop build directory, set the following CMake option:
 
 ```shell
-$ cmake -DIREE_BUILD_TRACY=ON .
+$ cmake -DIREE_BUILD_TRACY=ON -DIREE_ENABLE_LLD=ON .
 ```
 
 That enables building the Tracy server tools, `iree-tracy-profiler` and


### PR DESCRIPTION
Building tracy convenience targets without using lld will result in a link error.
Explicitly add LLD on the cmake command to remind people that this is the only linker that we officially support.

Fixes https://github.com/openxla/iree/issues/11970