### PR TITLE
Register all tensor tiling ops

### DIFF
--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -72,7 +72,7 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   shape::ShapeDialect>();
   // clang-format on
   tensor::registerInferTypeOpInterfaceExternalModels(registry);
-  tensor::registerTilingInterfaceExternalModelsForPackUnPackOps(registry);
+  tensor::registerTilingInterfaceExternalModels(registry);
 
 #ifdef IREE_HAVE_C_OUTPUT_FORMAT
   registry.insert<emitc::EmitCDialect>();


### PR DESCRIPTION
Previously, we would single out tensor.pad which would incorrectly make
all transforms in IREE think that this is not an op that supports TilingInterface,
in violation of the upstream semantics.