### PR TITLE
Add transform dialect op to reorder transpose

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -807,5 +807,17 @@ transform_dialect::LayoutAnalysisAndDistributionOp::applyToOne(
   return DiagnosedSilenceableFailure::success();
 }
 
+//===---------------------------------------------------------------------===//
+// ReorderTransposeOp
+//===---------------------------------------------------------------------===//
+DiagnosedSilenceableFailure transform_dialect::ReorderTransposeOp::applyToOne(
+    func::FuncOp target, transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  IRRewriter rewriter(getContext());
+  iree_compiler::reorderTranspose(rewriter, cast<func::FuncOp>(target));
+  results.push_back(target);
+  return DiagnosedSilenceableFailure::success();
+}
+
 #define GET_OP_CLASSES
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.cpp.inc"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -521,17 +521,22 @@ def ReorderTransposeOp :
      TransformEachOpTrait,
      TransformOpInterface]> {
   let description = [{
-    Targets the whole func op and does the following:
+    Targets the whole func op and finds transpose ops whose source
+    comes from an elementwise op. For each of those transpose ops,
+    it moves the transpose before the elementwise op by first
+    transposing the operands of the elementwise op and then redoing
+    the elementwise op using the transposed operands. It then
+    replaces all uses of the original transpose op with the result
+    of the new elementwise op.
 
-    Given IR that looks like
-        %0 = arith.subf %a, %b : vector<16x8xf16>
-        %1 = vector.transpose %0 [1, 0] : vector<16x8xf16> to vector<8x16xf16>
+    More specifically, given IR that looks like below,
+      %0 = arith.subf %a, %b : vector<16x8xf16>
+      %1 = vector.transpose %0 [1, 0] : vector<16x8xf16> to vector<8x16xf16>
 
     It moves the transpose before the elementwise op to produce
-        %transposed_a = vector.transpose %a [1, 0] : vector<16x8xf16> to vector<8x16xf16>
-        %transposed_b = vector.transpose %b [1, 0] : vector<16x8xf16> to vector<8x16xf16>
-        %0 = arith.subf %transposed_a, %transposed_b : vector<8x16xf16>
-
+      %transposed_a = vector.transpose %a [1, 0] : vector<16x8xf16> to vector<8x16xf16>
+      %transposed_b = vector.transpose %b [1, 0] : vector<16x8xf16> to vector<8x16xf16>
+      %0 = arith.subf %transposed_a, %transposed_b : vector<8x16xf16>
   }];
 
   let arguments = (ins PDL_Operation:$target);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -514,4 +514,43 @@ def LayoutAnalysisAndDistributionOp :
 
 }
 
+def ReorderTransposeOp :
+  Op<Transform_Dialect, "iree.reorder_transpose",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
+  let description = [{
+    Targets the whole func op and does the following:
+
+    Given IR that looks like
+        %0 = arith.subf %a, %b : vector<16x8xf16>
+        %1 = vector.transpose %0 [1, 0] : vector<16x8xf16> to vector<8x16xf16>
+
+    It moves the transpose before the elementwise op to produce
+        %transposed_a = vector.transpose %a [1, 0] : vector<16x8xf16> to vector<8x16xf16>
+        %transposed_b = vector.transpose %b [1, 0] : vector<16x8xf16> to vector<8x16xf16>
+        %0 = arith.subf %transposed_a, %transposed_b : vector<8x16xf16>
+
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs Variadic<PDL_Operation>:$result);
+
+  let assemblyFormat = [{ $target attr-dict `:` functional-type(operands, results)}];
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
+  ];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::func::FuncOp target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+
+}
+
 #endif // IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMEXTENSIONS_LLVMGPUEXTENSIONS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPULayoutAnalysisAndDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPULayoutAnalysisAndDistribution.cpp
@@ -1041,6 +1041,38 @@ static bool isMatmulTransposeB(vector::ContractionOp contractOp) {
   return maps == infer({{m, k}, {n, k}, {m, n}});
 }
 
+void reorderTranspose(IRRewriter &rewriter, func::FuncOp funcOp) {
+  SmallVector<vector::TransposeOp> transposeOps;
+  funcOp.walk([&](Operation *op) {
+    if (auto transposeOp = dyn_cast<vector::TransposeOp>(op)) {
+      Operation *definingOp = transposeOp.getVector().getDefiningOp();
+      if (OpTrait::hasElementwiseMappableTraits(definingOp)) {
+        transposeOps.push_back(transposeOp);
+      }
+    }
+    return WalkResult::advance();
+  });
+
+  for (auto transposeOp : transposeOps) {
+    OpBuilder::InsertionGuard g(rewriter);
+    Operation *op = transposeOp.getVector().getDefiningOp();
+    rewriter.setInsertionPoint(op);
+    SmallVector<int64_t> perm;
+    transposeOp.getTransp(perm);
+    SmallVector<Value> transposedOperands;
+    for (auto operand : op->getOperands()) {
+      Value transposed =
+          rewriter.create<vector::TransposeOp>(op->getLoc(), operand, perm);
+      transposedOperands.push_back(transposed);
+    }
+    SmallVector<Type> resultTypes{transposedOperands.front().getType()};
+    Operation *newOp =
+        rewriter.create(op->getLoc(), op->getName().getIdentifier(),
+                        transposedOperands, resultTypes, op->getAttrs());
+    rewriter.replaceAllUsesWith(transposeOp.getResult(), newOp->getResult(0));
+  }
+}
+
 void doLayoutAnalysisAndDistribution(IRRewriter &rewriter,
                                      func::FuncOp funcOp) {
   // First walk through all the MMA ops and set their layouts

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPULayoutAnalysisAndDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPULayoutAnalysisAndDistribution.cpp
@@ -1041,38 +1041,6 @@ static bool isMatmulTransposeB(vector::ContractionOp contractOp) {
   return maps == infer({{m, k}, {n, k}, {m, n}});
 }
 
-void reorderTranspose(IRRewriter &rewriter, func::FuncOp funcOp) {
-  SmallVector<vector::TransposeOp> transposeOps;
-  funcOp.walk([&](Operation *op) {
-    if (auto transposeOp = dyn_cast<vector::TransposeOp>(op)) {
-      Operation *definingOp = transposeOp.getVector().getDefiningOp();
-      if (OpTrait::hasElementwiseMappableTraits(definingOp)) {
-        transposeOps.push_back(transposeOp);
-      }
-    }
-    return WalkResult::advance();
-  });
-
-  for (auto transposeOp : transposeOps) {
-    OpBuilder::InsertionGuard g(rewriter);
-    Operation *op = transposeOp.getVector().getDefiningOp();
-    rewriter.setInsertionPoint(op);
-    SmallVector<int64_t> perm;
-    transposeOp.getTransp(perm);
-    SmallVector<Value> transposedOperands;
-    for (auto operand : op->getOperands()) {
-      Value transposed =
-          rewriter.create<vector::TransposeOp>(op->getLoc(), operand, perm);
-      transposedOperands.push_back(transposed);
-    }
-    SmallVector<Type> resultTypes{transposedOperands.front().getType()};
-    Operation *newOp =
-        rewriter.create(op->getLoc(), op->getName().getIdentifier(),
-                        transposedOperands, resultTypes, op->getAttrs());
-    rewriter.replaceAllUsesWith(transposeOp.getResult(), newOp->getResult(0));
-  }
-}
-
 void doLayoutAnalysisAndDistribution(IRRewriter &rewriter,
                                      func::FuncOp funcOp) {
   // First walk through all the MMA ops and set their layouts

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h
@@ -21,6 +21,9 @@ void createAsyncGroups(RewriterBase &rewriter, func::FuncOp funcOp,
 /// Function to do layout analysis and distribution.
 void doLayoutAnalysisAndDistribution(IRRewriter &rewriter, func::FuncOp funcOp);
 
+/// Function to reorder transposes and elementwise ops.
+void reorderTranspose(IRRewriter &rewriter, func::FuncOp funcOp);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 


### PR DESCRIPTION
This patch adds a transform dialect op that moves
a transpose op before its preceding elementwise op.