### PR TITLE
[spirv] Stop requiring identity memref layout for MMA load/store

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -511,11 +511,6 @@ struct ProcessSubgroupMMALoad final
     auto vectorMemrefType =
         adaptor.getSrcMemref().getType().dyn_cast<MemRefType>();
 
-    if (!vectorMemrefType.getLayout().isIdentity()) {
-      return rewriter.notifyMatchFailure(loadOp,
-                                         "non-identity memref unsupported");
-    }
-
     Location loc = loadOp.getLoc();
     auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
                                  adaptor.getIndices(), rewriter, loc);
@@ -548,11 +543,6 @@ struct ProcessSubgroupMMAStore final
         storeOp.getDstMemref().getType().dyn_cast<MemRefType>();
     auto vectorMemrefType =
         adaptor.getDstMemref().getType().dyn_cast<MemRefType>();
-
-    if (!vectorMemrefType.getLayout().isIdentity()) {
-      return rewriter.notifyMatchFailure(storeOp,
-                                         "non-identity memref unsupported");
-    }
 
     Location loc = storeOp.getLoc();
     auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,


### PR DESCRIPTION
After https://github.com/openxla/iree/pull/12874 we started to use the offset in memref to represent `hal.interface.binding.subspan` offsets, so memref don't have identity layout anymore.

Fixes https://github.com/openxla/iree/issues/13051