### PR TITLE
Make pack/unpack benchmarks have same amount of elements for all benchmarks

### DIFF
--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -47,7 +47,7 @@ static iree_status_t iree_uk_benchmark_pack(
       FLAG_working_set_size / (in_type_size + out_type_size);
   int target_product_of_outer_sizes_0_1 =
       target_matrix_size_in_elems / (out_size2 * out_size3);
-  while (target_product_of_outer_sizes_0_1 >= 4) {
+  while (target_product_of_outer_sizes_0_1 % 4 == 0) {
     target_product_of_outer_sizes_0_1 /= 4;
     out_size0 *= 2;
     out_size1 *= 2;

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -48,7 +48,7 @@ static iree_status_t iree_uk_benchmark_unpack(
       FLAG_working_set_size / (in_type_size + out_type_size);
   int target_product_of_outer_sizes_0_1 =
       target_matrix_size_in_elems / (in_size2 * in_size3);
-  while (target_product_of_outer_sizes_0_1 >= 4) {
+  while (target_product_of_outer_sizes_0_1 % 4 == 0) {
     target_product_of_outer_sizes_0_1 /= 4;
     in_size0 *= 2;
     in_size1 *= 2;


### PR DESCRIPTION
The shape is derived from working_set_size. If the number is not a multiple of 4, The final number of elements could have large variants between avx2 and avx512 configurations.

E.g., I tried benchmarking 384x512xf32, the working_set_size is 1572864 in this case. However, the total elements passed to avx512 is 1.5x of avx2. It misleads the metrics in terms of latency. Now I realize that we should mostly look at bandwidth from the report, not latency. Maybe we should compute the shape correctly, so they will pack the same amount of elements? Or maybe it's just an approximation to get memory bandwidth and we don't really care about the actual number of elements passed to benchmarks?
