### PR TITLE
Document how to update tensorflow importers in CI

### DIFF
--- a/build_tools/python/benchmark_suites/iree/README.md
+++ b/build_tools/python/benchmark_suites/iree/README.md
@@ -15,6 +15,21 @@ configrations. To run the benchmark suites, see
 To add a new source model, see
 [Adding a new model](/build_tools/python/e2e_test_framework/models/README.md#adding-a-new-model)
 
+## Updating TF/TFLite Importer in CI
+
+For TF/TFLite source models, benchmark CI uses `iree-import-tf/tflite` to import
+models into MLIR files. CI installs pinned binary releases of these tools. To
+bump the tool version, you can change:
+
+-   `iree-import-tflite`:
+    -   Update the `iree-tools-tflite` version in
+        [build_tools/cmake/setup_tf_python.sh](build_tools/cmake/setup_tf_python.sh).
+-   `iree-import-tf`: It is a wrapper of Tensorflow Python API.
+    -   Update the Tensorflow version pinned in
+        [integrations/tensorflow/test/requirements.txt](integrations/tensorflow/test/requirements.txt).
+    -   Follow [build_tools/docker/README.md](build_tools/docker/README.md) to
+        rebuild the docker images.
+
 ## Benchmark Suites Design
 
 > TODO(#12215): Explain the design and the end-to-end flow.

--- a/build_tools/python/benchmark_suites/iree/README.md
+++ b/build_tools/python/benchmark_suites/iree/README.md
@@ -17,11 +17,11 @@ To add a new source model, see
 
 ## Updating TF/TFLite Importer in Benchmark CI
 
-For TF and TFLite source models, the benchmark CI installs
-`iree-import-tf/tflite` from
-[integrations/tensorflow/python_projects](integrations/tensorflow/python_projects)
+For TF and TFLite source models, benchmark CI installs `iree-import-tf/tflite`
+from
+[integrations/tensorflow/python_projects](/integrations/tensorflow/python_projects)
 to import models. See
-[Updating Tenserflow Importers in CI](integrations/tensorflow/README.md#updating-tenserflow-importers-in-ci)
+[Updating Tensorflow Importers in CI](/integrations/tensorflow/README.md#updating-tensorflow-importers-in-ci)
 to learn about the update procedure.
 
 ## Benchmark Suites Design

--- a/build_tools/python/benchmark_suites/iree/README.md
+++ b/build_tools/python/benchmark_suites/iree/README.md
@@ -18,17 +18,24 @@ To add a new source model, see
 ## Updating TF/TFLite Importer in CI
 
 For TF/TFLite source models, benchmark CI uses `iree-import-tf/tflite` to import
-models into MLIR files. CI installs pinned binary releases of these tools. To
-bump the tool version, you can change:
+models into MLIR files. These tools are just wrappers which call Tensorflow
+Python API to do conversion. CI installs a pinned version of Tensorflow in its
+docker images. To bump the Tenserflow version, you need to:
 
--   `iree-import-tflite`:
-    -   Update the `iree-tools-tflite` version in
-        [build_tools/cmake/setup_tf_python.sh](build_tools/cmake/setup_tf_python.sh).
--   `iree-import-tf`: It is a wrapper of Tensorflow Python API.
-    -   Update the Tensorflow version pinned in
-        [integrations/tensorflow/test/requirements.txt](integrations/tensorflow/test/requirements.txt).
-    -   Follow [build_tools/docker/README.md](build_tools/docker/README.md) to
-        rebuild the docker images.
+1.  Update the Tensorflow pinned version in
+    [integrations/tensorflow/test/requirements.txt](integrations/tensorflow/test/requirements.txt).
+2.  Follow [build_tools/docker/README.md](build_tools/docker/README.md) to
+    rebuild the `frontends` docker image and its descendants.
+
+Here is the command to rebuild and update the docker images:
+
+```sh
+python3 build_tools/docker/manage_images.py --image frontends
+```
+
+To modify the import tools themselves, you can directly change their code in
+[integrations/tensorflow/python_projects](integrations/tensorflow/python_projects)
+without updating the dockers.
 
 ## Benchmark Suites Design
 

--- a/build_tools/python/benchmark_suites/iree/README.md
+++ b/build_tools/python/benchmark_suites/iree/README.md
@@ -15,27 +15,14 @@ configrations. To run the benchmark suites, see
 To add a new source model, see
 [Adding a new model](/build_tools/python/e2e_test_framework/models/README.md#adding-a-new-model)
 
-## Updating TF/TFLite Importer in CI
+## Updating TF/TFLite Importer in Benchmark CI
 
-For TF/TFLite source models, benchmark CI uses `iree-import-tf/tflite` to import
-models into MLIR files. These tools are just wrappers which call Tensorflow
-Python API to do conversion. CI installs a pinned version of Tensorflow in its
-docker images. To bump the Tenserflow version, you need to:
-
-1.  Update the Tensorflow pinned version in
-    [integrations/tensorflow/test/requirements.txt](integrations/tensorflow/test/requirements.txt).
-2.  Follow [build_tools/docker/README.md](build_tools/docker/README.md) to
-    rebuild the `frontends` docker image and its descendants.
-
-Here is the command to rebuild and update the docker images:
-
-```sh
-python3 build_tools/docker/manage_images.py --image frontends
-```
-
-To modify the import tools themselves, you can directly change their code in
+For TF and TFLite source models, the benchmark CI installs
+`iree-import-tf/tflite` from
 [integrations/tensorflow/python_projects](integrations/tensorflow/python_projects)
-without updating the dockers.
+to import models. See
+[Updating Tenserflow Importers in CI](integrations/tensorflow/README.md#updating-tenserflow-importers-in-ci)
+to learn about the update procedure.
 
 ## Benchmark Suites Design
 

--- a/integrations/tensorflow/README.md
+++ b/integrations/tensorflow/README.md
@@ -51,19 +51,20 @@ lit -v -D DISABLE_FEATURES=llvmcpu -D FEATURES=vulkan test/
 lit -v $(find test -name '*softplus*')
 ```
 
-## Updating Tenserflow Importers in CI
+## Updating Tensorflow Importers in CI
 
-CI uses Tenserflow importers to run integration tests and benchmarks. They might
-need an update in CI if you want new features/bugfixes from the frontends.
+CI uses Tensorflow importers to run integration tests and benchmarks. They might
+need an update in CI if you want new features or bugfixes from the frontends.
 
-Tenserflow importers are wrappers which call Tensorflow Python API to do
+Tensorflow importers are wrappers which call Tensorflow Python API to do
 conversion. CI installs a pinned version of Tensorflow in the docker images. To
-bump the Tenserflow version, you need to:
+bump the Tensorflow version, you need to:
 
-1.  Update the Tensorflow pinned version in
-    [integrations/tensorflow/test/requirements.txt](integrations/tensorflow/test/requirements.txt).
-2.  Follow [build_tools/docker/README.md](build_tools/docker/README.md) to
-    rebuild the `frontends` docker image and its descendants.
+1.  Update the pinned version of Tensorflow in
+    [integrations/tensorflow/test/requirements.txt](/integrations/tensorflow/test/requirements.txt).
+2.  Follow
+    [Adding or Updating an Image](/build_tools/docker/README.md#adding-or-updating-an-image)
+    to rebuild the `frontends` docker image and its descendants.
 
 Here is the command to rebuild and update the docker images:
 
@@ -72,5 +73,5 @@ python3 build_tools/docker/manage_images.py --image frontends
 ```
 
 To modify the import tools themselves, you can directly change their code in
-[integrations/tensorflow/python_projects](integrations/tensorflow/python_projects)
+[integrations/tensorflow/python_projects](/integrations/tensorflow/python_projects)
 without updating the dockers.

--- a/integrations/tensorflow/README.md
+++ b/integrations/tensorflow/README.md
@@ -50,3 +50,27 @@ lit -v -D DISABLE_FEATURES=llvmcpu -D FEATURES=vulkan test/
 # Individual test directories, files or globs can be run individually.
 lit -v $(find test -name '*softplus*')
 ```
+
+## Updating Tenserflow Importers in CI
+
+CI uses Tenserflow importers to run integration tests and benchmarks. They might
+need an update in CI if you want new features/bugfixes from the frontends.
+
+Tenserflow importers are wrappers which call Tensorflow Python API to do
+conversion. CI installs a pinned version of Tensorflow in the docker images. To
+bump the Tenserflow version, you need to:
+
+1.  Update the Tensorflow pinned version in
+    [integrations/tensorflow/test/requirements.txt](integrations/tensorflow/test/requirements.txt).
+2.  Follow [build_tools/docker/README.md](build_tools/docker/README.md) to
+    rebuild the `frontends` docker image and its descendants.
+
+Here is the command to rebuild and update the docker images:
+
+```sh
+python3 build_tools/docker/manage_images.py --image frontends
+```
+
+To modify the import tools themselves, you can directly change their code in
+[integrations/tensorflow/python_projects](integrations/tensorflow/python_projects)
+without updating the dockers.


### PR DESCRIPTION
Add the docs to explain how to update the tensorflow importers in CI for the integration tests and benchmarks.

It mainly focuses on bumping the tensorflow version used by the importers in CI.