### PR TITLE
Add transform dialect op to insert extract strided slice ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -810,11 +810,14 @@ transform_dialect::LayoutAnalysisAndDistributionOp::applyToOne(
 //===---------------------------------------------------------------------===//
 // ReorderTransposeOp
 //===---------------------------------------------------------------------===//
-DiagnosedSilenceableFailure transform_dialect::ReorderTransposeOp::applyToOne(
+DiagnosedSilenceableFailure
+transform_dialect::LayoutPreprocessingOp::applyToOne(
     func::FuncOp target, transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
   IRRewriter rewriter(getContext());
   iree_compiler::reorderTranspose(rewriter, cast<func::FuncOp>(target));
+  iree_compiler::createExtractSliceAfterReductionBroadcastTranspose(
+      rewriter, cast<func::FuncOp>(target));
   results.push_back(target);
   return DiagnosedSilenceableFailure::success();
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -514,18 +514,21 @@ def LayoutAnalysisAndDistributionOp :
 
 }
 
-def ReorderTransposeOp :
-  Op<Transform_Dialect, "iree.reorder_transpose",
+def LayoutPreprocessingOp :
+  Op<Transform_Dialect, "iree.layout_preprocessing",
     [FunctionalStyleTransformOpTrait,
      MemoryEffectsOpInterface,
      TransformEachOpTrait,
      TransformOpInterface]> {
   let description = [{
-    Targets the whole func op and finds transpose ops whose source
-    comes from an elementwise op. For each of those transpose ops,
-    it moves the transpose before the elementwise op by first
-    transposing the operands of the elementwise op and then redoing
-    the elementwise op using the transposed operands. It then
+    Targets the whole func op and does a series of preprocessing
+    transforms for layout analysis. The transforms are listed
+    below.
+
+    1. Finds transpose ops whose source comes from an elementwise op.
+    For each of those transpose ops, it moves the transpose before the
+    elementwise op by first transposing the operands of the elementwise op
+    and then redoing the elementwise op using the transposed operands. It then
     replaces all uses of the original transpose op with the result
     of the new elementwise op.
 
@@ -537,6 +540,13 @@ def ReorderTransposeOp :
       %transposed_a = vector.transpose %a [1, 0] : vector<16x8xf16> to vector<8x16xf16>
       %transposed_b = vector.transpose %b [1, 0] : vector<16x8xf16> to vector<8x16xf16>
       %0 = arith.subf %transposed_a, %transposed_b : vector<8x16xf16>
+
+    2. Searches for reductions + inner broadcasts (broadcast + transpose) where
+       the final shape is smaller than that of the original reduction source. It
+       then creates new broadcast + transpose ops so that the final shape after
+       the transpose is the same as that of the reduction source. Finally, it
+       adds an extract strided slice op to extract the relevant slice.
+
   }];
 
   let arguments = (ins PDL_Operation:$target);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_CODEGEN_LLVMGPU_UTILS_LLVMGPUUTILS_H_
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
@@ -23,6 +24,21 @@ void doLayoutAnalysisAndDistribution(IRRewriter &rewriter, func::FuncOp funcOp);
 
 /// Function to reorder transposes and elementwise ops.
 void reorderTranspose(IRRewriter &rewriter, func::FuncOp funcOp);
+
+/// Function to create extract slice after reduction + broadcast + transpose
+/// when the broadcast size is less than that of the reduction source.
+void createExtractSliceAfterReductionBroadcastTranspose(IRRewriter &rewriter,
+                                                        func::FuncOp funcOp);
+
+/// Find broadcast and transpose ops that use the given reduction op.
+SmallVector<std::tuple<vector::BroadcastOp, vector::TransposeOp>>
+getReductionBroadcastPairs(vector::MultiDimReductionOp reductionOp);
+
+/// Checks to see if the result of the reduction, broadcast and transpose op
+/// has dimensions that are the same or smaller shape than the reduction source.
+bool compatibleBroadcastReductionShapes(vector::MultiDimReductionOp reductionOp,
+                                        vector::BroadcastOp broadcastOp,
+                                        vector::TransposeOp transposeOp);
 
 }  // namespace iree_compiler
 }  // namespace mlir


### PR DESCRIPTION
In order to enforce uniformity among reduction + broadcast + transpose ops, we find ops whose final shape is <= that of the reduction source and modify them to broadcast + transpose to the original shape. Then we insert an extract strided slice to extract the relevant slice.