### PR TITLE
Explicitely reference enum for fbs file

### DIFF
--- a/runtime/src/iree/schemas/bytecode_module_def.fbs
+++ b/runtime/src/iree/schemas/bytecode_module_def.fbs
@@ -246,7 +246,7 @@ table BytecodeModuleDef {
   // Features required to load and run bytecode from the module.
   // Some functions may have additional requirements for when there are multiple
   // variants selected based on runtime feature detection.
-  requirements:FeatureBits = EXT_32;
+  requirements:FeatureBits = EXT_F32;
 
   // Module-level attributes, if any.
   attrs:[AttrDef];

--- a/runtime/src/iree/schemas/bytecode_module_def.fbs
+++ b/runtime/src/iree/schemas/bytecode_module_def.fbs
@@ -246,7 +246,7 @@ table BytecodeModuleDef {
   // Features required to load and run bytecode from the module.
   // Some functions may have additional requirements for when there are multiple
   // variants selected based on runtime feature detection.
-  requirements:FeatureBits = 0;
+  requirements:FeatureBits = EXT_32;
 
   // Module-level attributes, if any.
   attrs:[AttrDef];


### PR DESCRIPTION
Google3 doesn't it like it when you reference enums by numbers rather than their enum names, so renaming this for google3 integrate process.