### PR TITLE
Some of the recently added tests require sm80

### DIFF
--- a/tests/transform_dialect/cuda/BUILD.bazel
+++ b/tests/transform_dialect/cuda/BUILD.bazel
@@ -28,8 +28,6 @@ iree_lit_test_suite(
     srcs = [
         "mma.mlir",
         "mma_elemwise_layout_analysis.mlir",
-        "mma_reduction_layout_analysis.mlir",
-        "mma_using_layout_analysis.mlir",
         "reduction.mlir",
         "reduction_eltwise.mlir",
         "reduction_v2.mlir",
@@ -64,6 +62,37 @@ iree_lit_test_suite(
         # First few ops of softmax only, acts as a proxy example.
         "softmax_partial_codegen_spec.mlir",
         "vecadd2d_codegen_spec.mlir",
+    ],
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+        "driver=cuda",
+    ],
+    tools = [
+        "//tools:iree-compile",
+        "//tools:iree-opt",
+        "//tools:iree-run-module",
+        "@llvm-project//llvm:FileCheck",
+    ],
+)
+
+iree_lit_test_suite(
+    name = "sm80_lit",
+    srcs = [
+        "mma_reduction_layout_analysis.mlir",
+        "mma_using_layout_analysis.mlir",
+    ],
+    cfg = "//tests:lit.cfg.py",
+    # transform dialect spec files are MLIR files that specify a transformation,
+    # they need to be included as data.
+    data = [
+        "mma_reduction_layout_analysis_codegen_spec.mlir",
+        "mma_reduction_layout_analysis_dispatch_spec.mlir",
+        "mma_using_layout_analysis_codegen_spec.mlir",
     ],
     tags = [
         # CUDA cuInit fails with sanitizer on.

--- a/tests/transform_dialect/cuda/BUILD.bazel
+++ b/tests/transform_dialect/cuda/BUILD.bazel
@@ -71,7 +71,7 @@ iree_lit_test_suite(
         "nomsan",
         "notsan",
         "noubsan",
-        "requires-gpu-nvidia",
+        "requires-gpu-sm80",
         "driver=cuda",
     ],
     tools = [

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -20,8 +20,6 @@ iree_lit_test_suite(
   SRCS
     "mma.mlir"
     "mma_elemwise_layout_analysis.mlir"
-    "mma_reduction_layout_analysis.mlir"
-    "mma_using_layout_analysis.mlir"
     "reduction.mlir"
     "reduction_eltwise.mlir"
     "reduction_v2.mlir"
@@ -56,6 +54,30 @@ iree_lit_test_suite(
     "notsan"
     "noubsan"
     "requires-gpu-nvidia"
+    "driver=cuda"
+)
+
+iree_lit_test_suite(
+  NAME
+    sm80_lit
+  SRCS
+    "mma_reduction_layout_analysis.mlir"
+    "mma_using_layout_analysis.mlir"
+  TOOLS
+    FileCheck
+    iree-compile
+    iree-opt
+    iree-run-module
+  DATA
+    mma_reduction_layout_analysis_codegen_spec.mlir
+    mma_reduction_layout_analysis_dispatch_spec.mlir
+    mma_using_layout_analysis_codegen_spec.mlir
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-sm80"
     "driver=cuda"
 )
 


### PR DESCRIPTION
mma_reduction_layout_analysis.mlir and mma_using_layout_analysis.mlir require gpu sm80 and are failing when we copy them internally without this flag.