### PR TITLE
Make boot disks bigger instead of futzing with ramdisk and local ssd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 cmake_minimum_required(VERSION 3.21...3.24)
 
+# DO NOT SUBMIT: Change that affects CI
+
 # LLVM requires CMP0116 for tblgen: https://reviews.llvm.org/D101083
 # CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
 # New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.21...3.24)
 
-# DO NOT SUBMIT: Change that affects CI
-
 # LLVM requires CMP0116 for tblgen: https://reviews.llvm.org/D101083
 # CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
 # New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html

--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -15,23 +15,6 @@ SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
 source "${SCRIPT_DIR}/functions.sh"
 
 mkdir /runner-root
-
-RUNNER_TYPE="$(get_attribute github-runner-type)"
-
-# On the CPU machines we use a ramdisk because they have 360GB of RAM, but the
-# GPU machines only have 80GB. We don't use local SSD on the CPU machines
-# because they require a minimum of 16 local SSD if any, which is quite wasteful
-# (increases cost by about 20%).
-if [[ "${RUNNER_TYPE}" == gpu ]]; then
-  echo "Formatting and mounting local SSD for working directory"
-  mkfs.ext4 -F /dev/nvme0n1
-  # Options suggested from https://cloud.google.com/compute/docs/disks/optimizing-local-ssd-performance#disable_flush
-  mount --options discard,defaults,nobarrier /dev/nvme0n1 /runner-root
-else
-  echo "Mounting tmpfs for working directory"
-  mount --types tmpfs --options size=100g tmpfs /runner-root
-fi
-
 cp -r "${SCRIPT_DIR}" /runner-root/config
 chown -R runner:runner /runner-root/
 


### PR DESCRIPTION
We keep running into disk space issues on the runners, especially with larger framework-level models for benchmarking. I originally used a ram disk because it was simple and fast, but with the current disk requirements it's no longer simple and we're getting into the territory of using too much RAM even on the runners that have tons of it. Local ssd isn't a great option because with the n1-standard-96 machines we use for builds, we'd have to attach 16 of them if we attach any. They also require more configuration. Just making the boot disk big enough for everything is simpler than what we have now, is easy to scale as far as we should reasonably need to scale it, doesn't cost much, and doesn't appear to have noticeable impact on build times.

Tested: deployed to test environment and ran CI for this pr on the test runners, then manually compared CI job times with a recent postsubmit run. 


runner-env: testing
