### PR TITLE
Adding flow.tensor.alloc op for unique allocations.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1395,82 +1395,6 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
-// flow.tensor.clone
-//===----------------------------------------------------------------------===//
-
-LogicalResult TensorCloneOp::verify() {
-  if (failed(verifyOpDynamicDims(getOperation(), {getOperand()},
-                                 getArgumentDims())) ||
-      failed(verifyOpDynamicDims(getOperation(), {getResult()},
-                                 getArgumentDims()))) {
-    return failure();
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// flow.tensor.empty
-//===----------------------------------------------------------------------===//
-
-LogicalResult TensorEmptyOp::verify() {
-  if (failed(verifyOpDynamicDims(getOperation(), {getResult()},
-                                 getResultDims()))) {
-    return failure();
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// flow.tensor.load
-//===----------------------------------------------------------------------===//
-
-LogicalResult TensorLoadOp::verify() {
-  if (failed(verifyOpDynamicDims(getOperation(), {getSource()},
-                                 getSourceDims()))) {
-    return failure();
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// flow.tensor.slice
-//===----------------------------------------------------------------------===//
-
-LogicalResult TensorSliceOp::verify() {
-  if (failed(verifyOpDynamicDims(getOperation(), {getSource()},
-                                 getSourceDims())) ||
-      failed(verifyOpDynamicDims(getOperation(), {getResult()},
-                                 getResultDims()))) {
-    return failure();
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// flow.tensor.splat
-//===----------------------------------------------------------------------===//
-
-LogicalResult TensorSplatOp::verify() {
-  if (failed(verifyOpDynamicDims(getOperation(), {getResult()},
-                                 getResultDims()))) {
-    return failure();
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// flow.tensor.store
-//===----------------------------------------------------------------------===//
-
-LogicalResult TensorStoreOp::verify() {
-  if (failed(verifyOpDynamicDims(getOperation(), {getTarget()},
-                                 getTargetDims()))) {
-    return failure();
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // flow.tensor.tie_shape
 //===----------------------------------------------------------------------===//
 
@@ -1523,6 +1447,94 @@ Value TensorReshapeOp::getTiedResult(unsigned resultIndex) {
 
 SmallVector<int64_t, 4> TensorReshapeOp::getTiedResultOperandIndices() {
   return {0};  // source
+}
+
+//===----------------------------------------------------------------------===//
+// flow.tensor.load
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorLoadOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getSource()},
+                                 getSourceDims()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// flow.tensor.store
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorStoreOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getTarget()},
+                                 getTargetDims()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// flow.tensor.alloc
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorAllocOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 getResultDims()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// flow.tensor.empty
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorEmptyOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 getResultDims()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// flow.tensor.splat
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorSplatOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 getResultDims()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// flow.tensor.clone
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorCloneOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getOperand()},
+                                 getArgumentDims())) ||
+      failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 getArgumentDims()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// flow.tensor.slice
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorSliceOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getSource()},
+                                 getSourceDims())) ||
+      failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 getResultDims()))) {
+    return failure();
+  }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1180,6 +1180,42 @@ def FLOW_TensorStoreOp : FLOW_PureOp<"tensor.store", [
   let hasFolder = 1;
 }
 
+def FLOW_TensorAllocOp : FLOW_Op<"tensor.alloc", [
+  Util_ShapeAwareOp,
+  MemoryEffects<[MemAlloc]>,
+]> {
+  let summary = [{an empty tensor allocation with undefined contents}];
+  let description = [{
+    Returns a new transient tensor allocation with undefined contents.
+    Subsequent writes must populate any ranges of the tensor that are later
+    read. The resulting tensor may be long-lived and allocated as part of a
+    dedicated allocation. Prefer using `flow.tensor.empty` whenever possible as
+    this op disables nearly all allocation-related optimizations performed by
+    the compiler. The presence of this op is often an indication of an improper
+    lowering.
+  }];
+
+  let arguments = (ins
+    FLOW_ShapeDynamicDims:$result_dims
+  );
+  let results = (outs
+    FLOW_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    `:` type($result) (`{` $result_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+
+  let extraClassDeclaration = [{
+    ValueRange getOperandDynamicDims(unsigned idx) { return ValueRange{}; }
+    ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
+  }];
+
+  let hasVerifier = 1;
+  let hasCanonicalizer = 1;
+}
+
 def FLOW_TensorEmptyOp : FLOW_PureOp<"tensor.empty", [
   FLOW_StreamableOp,
   Util_ShapeAwareOp,

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -234,9 +234,27 @@ func.func @storeConstScalar() -> tensor<i32> {
 
 // -----
 
+// CHECK-LABEL: @allocDims
+//  CHECK-SAME: (%[[DIM:.+]]: index)
+func.func @allocDims(%dim: index) -> (index, index, index) {
+  // CHECK-NOT: flow.tensor.alloc
+  %0 = flow.tensor.alloc : tensor<4x?x0xf32>{%dim}
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %d0 = tensor.dim %0, %c0 : tensor<4x?x0xf32>
+  %d1 = tensor.dim %0, %c1 : tensor<4x?x0xf32>
+  %d2 = tensor.dim %0, %c2 : tensor<4x?x0xf32>
+  // CHECK: return %c4, %[[DIM]], %c0
+  return %d0, %d1, %d2 : index, index, index
+}
+
+// -----
+
 // CHECK-LABEL: @emptyDims
 //  CHECK-SAME: (%[[DIM:.+]]: index)
 func.func @emptyDims(%dim: index) -> (index, index, index) {
+  // CHECK-NOT: flow.tensor.empty
   %0 = flow.tensor.empty : tensor<4x?x0xf32>{%dim}
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -73,6 +73,15 @@ func.func @tensorStoreDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index, %arg2 : in
 
 // -----
 
+// CHECK-LABEL: @tensorAlloc
+func.func @tensorAlloc(%arg0: index) -> tensor<?x0x1xf32> {
+  // CHECK-NEXT: = flow.tensor.alloc : tensor<?x0x1xf32>{%arg0}
+  %0 = flow.tensor.alloc : tensor<?x0x1xf32>{%arg0}
+  return %0 : tensor<?x0x1xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorEmpty
 func.func @tensorEmpty(%arg0: index) -> tensor<?x0x1xf32> {
   // CHECK-NEXT: = flow.tensor.empty : tensor<?x0x1xf32>{%arg0}

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -640,6 +640,28 @@ Value DeviceQueueAllocaOp::getResultSize(unsigned idx) {
   return getResultSize();
 }
 
+static LogicalResult verifyDeviceQueueFences(Operation *queueOp,
+                                             Value waitFence,
+                                             Value signalFence) {
+  if (waitFence == signalFence) {
+    return queueOp->emitOpError() << "device queue operations cannot wait and "
+                                     "signal on the same fence";
+  }
+  return success();
+}
+
+LogicalResult DeviceQueueAllocaOp::verify() {
+  return verifyDeviceQueueFences(*this, getWaitFence(), getSignalFence());
+}
+
+LogicalResult DeviceQueueDeallocaOp::verify() {
+  return verifyDeviceQueueFences(*this, getWaitFence(), getSignalFence());
+}
+
+LogicalResult DeviceQueueExecuteOp::verify() {
+  return verifyDeviceQueueFences(*this, getWaitFence(), getSignalFence());
+}
+
 //===----------------------------------------------------------------------===//
 // hal.executable
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1465,6 +1465,8 @@ def HAL_DeviceQueueAllocaOp : HAL_Op<"device.queue.alloca", [
     `:` custom<SizeAwareType>(type($result), $result_size)
     attr-dict-with-keyword
   }];
+
+  let hasVerifier = 1;
 }
 
 def HAL_DeviceQueueDeallocaOp : HAL_Op<"device.queue.dealloca"> {
@@ -1495,6 +1497,8 @@ def HAL_DeviceQueueDeallocaOp : HAL_Op<"device.queue.dealloca"> {
     `buffer` `(` $buffer `:` type($buffer) `)`
     attr-dict-with-keyword
   }];
+
+  let hasVerifier = 1;
 }
 
 def HAL_DeviceQueueExecuteOp : HAL_Op<"device.queue.execute"> {
@@ -1524,7 +1528,13 @@ def HAL_DeviceQueueExecuteOp : HAL_Op<"device.queue.execute"> {
     attr-dict-with-keyword
   }];
 
+  let extraClassDeclaration = [{
+    // Returns true if the execution represents a barrier.
+    bool isBarrier() { return getCommandBuffers().empty(); }
+  }];
+
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
 }
 
 def HAL_DeviceQueueFlushOp : HAL_Op<"device.queue.flush"> {
@@ -2524,6 +2534,7 @@ def HAL_FenceJoinOp : HAL_Op<"fence.join", [
     attr-dict-with-keyword
   }];
 
+  let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -2564,6 +2575,8 @@ def HAL_FenceSignalOp : HAL_Op<"fence.signal"> {
     `<` $fence `:` type($fence) `>`
     attr-dict-with-keyword
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def HAL_FenceFailOp : HAL_Op<"fence.fail"> {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -121,6 +121,7 @@ using FunctionLikeNest = MultiOpNest<func::FuncOp, IREE::Util::InitializerOp>;
 
 static void addCleanupPatterns(OpPassManager &passManager) {
   // Standard MLIR cleanup.
+  passManager.addPass(mlir::createCSEPass());
   passManager.addPass(mlir::createCanonicalizerPass());
   passManager.addPass(mlir::createCSEPass());
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -46,6 +46,18 @@ func.func @tensorReshapeWithMultipleUses(%input: tensor<5x24x48xf32>)
 
 // -----
 
+// CHECK-LABEL: @tensorAlloc
+//  CHECK-SAME: (%[[DIM0:.+]]: index)
+func.func @tensorAlloc(%dim0: index) -> tensor<?x0xf32> {
+  // CHECK: %[[ALLOC_SIZE:.+]] = stream.tensor.sizeof tensor<?x0xf32>{%[[DIM0]]}
+  // CHECK: %[[ALLOC:.+]] = stream.resource.alloc uninitialized : !stream.resource<*>{%[[ALLOC_SIZE]]}
+  %0 = flow.tensor.alloc : tensor<?x0xf32>{%dim0}
+  // CHECK: return %[[ALLOC]]
+  return %0 : tensor<?x0xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorEmpty
 //  CHECK-SAME: (%[[DIM0:.+]]: index)
 func.func @tensorEmpty(%dim0: index) -> tensor<?x0xf32> {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -3147,6 +3147,8 @@ def Stream_TimepointChainExternalOp :
     `(` $external_values `:` type($external_values) `)`
     attr-dict-with-keyword
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def Stream_TimepointJoinOp : Stream_PureOp<"timepoint.join", [

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/BUILD.bazel
@@ -27,12 +27,10 @@ iree_lit_test_suite(
             "resource_ops.mlir",
             "tensor_folding.mlir",
             "tensor_ops.mlir",
-            # TODO(#11251): Enable the test.
-            # "timepoint_folding.mlir",
+            "timepoint_folding.mlir",
             "timepoint_ops.mlir",
         ],
         include = ["*.mlir"],
-        exclude = ["timepoint_folding.mlir"],
     ),
     cfg = "//compiler:lit.cfg.py",
     tools = [

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "resource_ops.mlir"
     "tensor_folding.mlir"
     "tensor_ops.mlir"
+    "timepoint_folding.mlir"
     "timepoint_ops.mlir"
   TOOLS
     FileCheck


### PR DESCRIPTION
Each op instance will lower into its own stream.resource.alloc. Since this is a big pessimization it should always be avoided unless absolutely required  - and if required then users should try a different approach if performance-sensitive.

Reverts a30beed741f58ffaff04c52e7abf33f07d80a082.
Fixes #11251.
Fixes #13022.