### PR TITLE
[StableHLO] Re-enable linalg.map lowering tests for non-pointwise ops

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
@@ -2727,8 +2727,9 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
       PadOpConversion,
       PadOpNegativePaddingConversion,
       TorchIndexSelectOpConversion,
-      SelectAndScatterNoOverlapConverter,
-      ReduceRegionReturnOpConversion>(typeConverter, context);
+      SelectAndScatterNoOverlapConverter,  // TODO(#12678): Add tests.
+      ReduceRegionReturnOpConversion       // TODO(#12678): Add tests.
+      >(typeConverter, context);
 
   detail::populatePointwiseStableHloToLinalgConversionPatterns(
       context, typeConverter, patterns, enablePrimitiveOps);
@@ -2740,8 +2741,8 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
       DynamicBroadcastInDimOpToBroadcastConverter,
       IotaToMapConverter<stablehlo::IotaOp>,
       IotaToMapConverter<stablehlo::DynamicIotaOp>,
-      MapOpToMapConverter,
-      ReduceOpToReduceConverter,
+      MapOpToMapConverter,        // TODO(#12678): Add tests.
+      ReduceOpToReduceConverter,  // TODO(#12678): Add tests.
       TransposeOpToTransposeConverter
     >(typeConverter, context);
   } else {
@@ -2751,13 +2752,16 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
       IotaConverter<stablehlo::DynamicIotaOp>,
       HloBroadcastInDimConverter,
       HloDynamicBroadcastInDimConverter,
-      MapOpToGenericConverter,
-      ReduceOpToGenericConverter,
+      MapOpToGenericConverter,     // TODO(#12678): Add tests.
+      ReduceOpToGenericConverter,  // TODO(#12678): Add tests.
       TransposeConverter<stablehlo::TransposeOp>
     >(typeConverter, context);
   }
 
   // clang-format on
+
+  // TODO(#12678): Handle the convolution and reduce_window ops.
+
   detail::populateStableHloDotProdToLinalgConversionPatterns(
       context, typeConverter, patterns);
   linalg::populateEraseUnusedOperandsAndResultsPatterns(*patterns);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg.mlir
@@ -1,6 +1,10 @@
 // RUN: iree-opt %s --iree-stablehlo-to-linalg --split-input-file \
 // RUN:   --canonicalize | FileCheck %s
 
+// RUN: iree-opt %s --iree-stablehlo-to-linalg="enable-primitive-ops=true" \
+// RUN:   --split-input-file --canonicalize | \
+// RUN:   FileCheck %s --check-prefix=CHECK-PRIMITIVE
+
 // CHECK-LABEL: func @bitcast_convert
 func.func @bitcast_convert(%input: tensor<2x2xi32>) -> tensor<2x2xf32> {
   %result = "stablehlo.bitcast_convert"(%input) : (tensor<2x2xi32>) -> tensor<2x2xf32>


### PR DESCRIPTION
Also add TODOs for any lowering patterns not yet ported from mlir-hlo.

Currently, we are at 61/90 (67%) of all StableHLO ops handled by the lowering in mlir-hlo ported to StableHLO and tested.

Issue: https://github.com/openxla/iree/issues/12678