### PR TITLE
[StableHLO] Port patterns to handle scalar op to arith lowering

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
@@ -48,6 +48,7 @@ iree_compiler_cc_library(
     srcs = [
         "LegalizeToLinalgUtils.cpp",
         "Passes.cpp",
+        "StableHLOToArith.cpp",
         "StableHLOToLinalg.cpp",
         "StableHLOToLinalgDotProd.cpp",
         "StableHLOToLinalgPointwise.cpp",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_cc_library(
   SRCS
     "LegalizeToLinalgUtils.cpp"
     "Passes.cpp"
+    "StableHLOToArith.cpp"
     "StableHLOToLinalg.cpp"
     "StableHLOToLinalgDotProd.cpp"
     "StableHLOToLinalgPointwise.cpp"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
@@ -33,6 +33,11 @@ void populateStableHloDotProdToLinalgConversionPatterns(
     MLIRContext* context, TypeConverter& typeConverter,
     RewritePatternSet* patterns);
 
+/// Populates the patterns that convert scalar StableHLO ops to Arith ops.
+void populateScalarHloToArithConversionPatterns(
+    MLIRContext* context, TypeConverter& typeConverter,
+    RewritePatternSet* patterns,
+    llvm::function_ref<bool(Operation*)> filterFn = nullptr);
 }  // namespace detail
 
 }  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToArith.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToArith.cpp
@@ -1,0 +1,123 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements logic for lowering scalar StableHLO ops to arith dialect.
+
+#include "iree/compiler/InputConversion/StableHLO/LegalizeToLinalgUtils.h"
+#include "iree/compiler/InputConversion/StableHLO/Rewriters.h"
+#include "iree/compiler/InputConversion/StableHLO/TypeConversion.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+namespace {
+namespace stablehlo = mlir::stablehlo;
+
+template <typename OpTy>
+struct ScalarHloToArithmeticPattern final : OpConversionPattern<OpTy> {
+  ScalarHloToArithmeticPattern(
+      TypeConverter& typeConverter, MLIRContext* context,
+      llvm::function_ref<bool(Operation*)> filterFn = nullptr,
+      PatternBenefit benefit = 1)
+      : OpConversionPattern<OpTy>(typeConverter, context, benefit),
+        filterFn(filterFn) {}
+
+  LogicalResult matchAndRewrite(
+      OpTy op, typename OpTy::Adaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    if (filterFn && !filterFn(op)) return failure();
+
+    auto isScalar = [](Value v) {
+      return cast<ShapedType>(v.getType()).getRank() == 0;
+    };
+
+    if (!llvm::all_of(adaptor.getOperands(), isScalar))
+      return rewriter.notifyMatchFailure(op, "All operands must be scalar.");
+
+    Location loc = op.getLoc();
+
+    auto resultTy = dyn_cast_or_null<ShapedType>(
+        this->typeConverter->convertType(op->getResultTypes().front()));
+    if (!resultTy) return failure();
+
+    SmallVector<Value> operands;
+    for (Value operand : adaptor.getOperands()) {
+      operands.push_back(
+          rewriter.create<tensor::ExtractOp>(loc, operand, ValueRange()));
+    }
+    Value scalarResult = stablehlo::StableHloOpToStdScalarOp::mapOp(
+        op, resultTy.getElementType(), operands, &rewriter);
+    if (!scalarResult) return failure();
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(op, resultTy,
+                                                        scalarResult);
+    return success();
+  }
+
+ private:
+  llvm::function_ref<bool(Operation*)> filterFn;
+};
+
+}  // namespace
+
+namespace detail {
+void populateScalarHloToArithConversionPatterns(
+    MLIRContext* context, TypeConverter& typeConverter,
+    RewritePatternSet* patterns,
+    llvm::function_ref<bool(Operation*)> filterFn) {
+  // TODO(#12678): Handle the XLA rng op.
+  patterns->add<ScalarHloToArithmeticPattern<stablehlo::AbsOp>,
+                ScalarHloToArithmeticPattern<stablehlo::AddOp>,
+                ScalarHloToArithmeticPattern<stablehlo::AndOp>,
+                ScalarHloToArithmeticPattern<stablehlo::Atan2Op>,
+                ScalarHloToArithmeticPattern<stablehlo::BitcastConvertOp>,
+                ScalarHloToArithmeticPattern<stablehlo::CbrtOp>,
+                ScalarHloToArithmeticPattern<stablehlo::CeilOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ClampOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ClzOp>,
+                ScalarHloToArithmeticPattern<stablehlo::CompareOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ComplexOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ConvertOp>,
+                ScalarHloToArithmeticPattern<stablehlo::CosineOp>,
+                ScalarHloToArithmeticPattern<stablehlo::DivOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ExpOp>,
+                ScalarHloToArithmeticPattern<stablehlo::Expm1Op>,
+                ScalarHloToArithmeticPattern<stablehlo::FloorOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ImagOp>,
+                ScalarHloToArithmeticPattern<stablehlo::IsFiniteOp>,
+                ScalarHloToArithmeticPattern<stablehlo::Log1pOp>,
+                ScalarHloToArithmeticPattern<stablehlo::LogOp>,
+                ScalarHloToArithmeticPattern<stablehlo::LogisticOp>,
+                ScalarHloToArithmeticPattern<stablehlo::MaxOp>,
+                ScalarHloToArithmeticPattern<stablehlo::MinOp>,
+                ScalarHloToArithmeticPattern<stablehlo::MulOp>,
+                ScalarHloToArithmeticPattern<stablehlo::NegOp>,
+                ScalarHloToArithmeticPattern<stablehlo::NotOp>,
+                ScalarHloToArithmeticPattern<stablehlo::OrOp>,
+                ScalarHloToArithmeticPattern<stablehlo::PopulationCountOp>,
+                ScalarHloToArithmeticPattern<stablehlo::PowOp>,
+                ScalarHloToArithmeticPattern<stablehlo::RealOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ReducePrecisionOp>,
+                ScalarHloToArithmeticPattern<stablehlo::RemOp>,
+                ScalarHloToArithmeticPattern<stablehlo::RoundNearestEvenOp>,
+                ScalarHloToArithmeticPattern<stablehlo::RoundOp>,
+                ScalarHloToArithmeticPattern<stablehlo::RsqrtOp>,
+                ScalarHloToArithmeticPattern<stablehlo::SelectOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ShiftLeftOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ShiftRightArithmeticOp>,
+                ScalarHloToArithmeticPattern<stablehlo::ShiftRightLogicalOp>,
+                ScalarHloToArithmeticPattern<stablehlo::SignOp>,
+                ScalarHloToArithmeticPattern<stablehlo::SineOp>,
+                ScalarHloToArithmeticPattern<stablehlo::SqrtOp>,
+                ScalarHloToArithmeticPattern<stablehlo::SubtractOp>,
+                ScalarHloToArithmeticPattern<stablehlo::TanhOp>,
+                ScalarHloToArithmeticPattern<stablehlo::XorOp> >(
+      typeConverter, context, filterFn);
+}
+}  // namespace detail
+
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
@@ -2695,11 +2695,11 @@ struct ConvertStableHloToLinalg
     target.addLegalOp<UnrealizedConversionCastOp>();
 
     auto typeConverter = createStableHloToLinalgTypeConverter();
-    auto func = getOperation();
-    // TODO: Port `populateScalarHloToArithmeticConversionPatterns`.
+    ModuleOp module = getOperation();
+
     populateStableHloToLinalgConversionPatterns(&ctx, *typeConverter, &patterns,
                                                 this->enablePrimitiveOps);
-    if (failed(applyPartialConversion(func, target, std::move(patterns)))) {
+    if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
       signalPassFailure();
     }
   }
@@ -2741,7 +2741,7 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
       DynamicBroadcastInDimOpToBroadcastConverter,
       IotaToMapConverter<stablehlo::IotaOp>,
       IotaToMapConverter<stablehlo::DynamicIotaOp>,
-      MapOpToMapConverter,        // TODO(#12678): Add tests.
+      MapOpToMapConverter,
       ReduceOpToReduceConverter,  // TODO(#12678): Add tests.
       TransposeOpToTransposeConverter
     >(typeConverter, context);
@@ -2752,7 +2752,7 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
       IotaConverter<stablehlo::DynamicIotaOp>,
       HloBroadcastInDimConverter,
       HloDynamicBroadcastInDimConverter,
-      MapOpToGenericConverter,     // TODO(#12678): Add tests.
+      MapOpToGenericConverter,
       ReduceOpToGenericConverter,  // TODO(#12678): Add tests.
       TransposeConverter<stablehlo::TransposeOp>
     >(typeConverter, context);
@@ -2764,6 +2764,8 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
 
   detail::populateStableHloDotProdToLinalgConversionPatterns(
       context, typeConverter, patterns);
+  detail::populateScalarHloToArithConversionPatterns(
+      context, typeConverter, patterns, isInBodyOfLinalgOps);
   linalg::populateEraseUnusedOperandsAndResultsPatterns(*patterns);
 }
 


### PR DESCRIPTION
This lowers scalar StableHLO ops to arith when found in bodies of linalg ops (`linalg.generic`, `linalg.map`).

The code and tests is ported from mlir-hlo, adapted to work on StableHLO, and cleaned up. See the initial import for more context: https://github.com/openxla/iree/pull/12957.

Issue: https://github.com/openxla/iree/issues/12678