### PR TITLE
[TransformExtensions] Fix the vector_to_mma_conversion op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -713,7 +713,7 @@ transform_dialect::VectorToMMAConversionOp::applyToOne(
   nvgpu::populateMmaSyncF32ToTF32Patterns(f32ToTF32patterns,
                                           nvgpu::MmaSyncF32Lowering::TF32);
   if (failed(applyPatternsAndFoldGreedily(
-          getOperation(), std::move(f32ToTF32patterns), config))) {
+          funcOp, std::move(f32ToTF32patterns), config))) {
     target->emitOpError("vector to mma F32ToTF32 patterns failed to apply");
     return listener.check(loc, emitDefaultDefiniteFailure(target));
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -712,8 +712,8 @@ transform_dialect::VectorToMMAConversionOp::applyToOne(
   RewritePatternSet f32ToTF32patterns(funcOp.getContext());
   nvgpu::populateMmaSyncF32ToTF32Patterns(f32ToTF32patterns,
                                           nvgpu::MmaSyncF32Lowering::TF32);
-  if (failed(applyPatternsAndFoldGreedily(
-          funcOp, std::move(f32ToTF32patterns), config))) {
+  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(f32ToTF32patterns),
+                                          config))) {
     target->emitOpError("vector to mma F32ToTF32 patterns failed to apply");
     return listener.check(loc, emitDefaultDefiniteFailure(target));
   }

--- a/tests/transform_dialect/cuda/mma.mlir
+++ b/tests/transform_dialect/cuda/mma.mlir
@@ -60,7 +60,7 @@ func.func @mma_sync(%a: memref<16x16xf32>, %b: memref<16x16xf32>, %c: memref<16x
   %vc = vector.transfer_read %c[%c0, %c0], %cst: memref<16x16xf32>, vector<16x16xf32>
 
   // CHECK-NOT: vector.contract
-  //     CHECK: nvgpu.mma.sync
+  //     CHECK: nvgpu.mma.sync{{.*}} tf32Enabled}
   %vres = vector.contract #matmat_trait %va, %vb, %vc
     : vector<16x16xf32>, vector<16x16xf32> into vector<16x16xf32>
   vector.transfer_write %vres, %c[%c0, %c0]: vector<16x16xf32>, memref<16x16xf32>


### PR DESCRIPTION
Apply the F32 to TF32 pattern to the function.

Prior to this patch we were applying the last set of patterns (`nvgpu::populateMmaSyncF32ToTF32Patterns`) of
`VectorToMMAConversionOp` to the transform op itself instead of the input handle.

This was easy to miss because the only thing that changes with this pattern is the presence of the `tf32Enabled` attribute on f32 mma.sync operations.
However, not having this attribute will prevent the conversion from nvgpu to nvvm leading to failed legalization.