### PR TITLE
Expand the CUDA header file pattern for building with CUDA 12.x.

### DIFF
--- a/build_tools/third_party/cuda/BUILD.template
+++ b/build_tools/third_party/cuda/BUILD.template
@@ -37,6 +37,7 @@ cc_library(
     hdrs = glob([
         "include/**/*.h",
         "include/**/*.hpp",
+        "include/nv/**/*",
     ]),
     includes = ["include"],
 )


### PR DESCRIPTION
CUDA 12.0 adds header files that are extensionless. This expands the `hdrs` pattern to capture the missing header files.