### PR TITLE
Update KernelConfig.cpp to properly tile batch dim for convolutions. 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -916,7 +916,7 @@ static LogicalResult setConvolutionConfig(linalg::LinalgOp linalgOp,
   int64_t residualTilingFactor = bestTilingFactor;
 
   SmallVector<int64_t, 3> workgroupSize(3, 1);  // (X, Y, Z)
-  SmallVector<int64_t> workgroupTileSizes(4, 0);
+  SmallVector<int64_t> workgroupTileSizes(4, 1);
 
   if (isNCHW) {
     // OW -> x, OH -> y, OC -> z


### PR DESCRIPTION
Currently setting the batch dim to 0 causes it to be fully unrolled during vectorization. This change matches Vulkan's current approach by always tiling by 1. 

Fixes #13073