### PR TITLE
Adding support for passing processor_id/data to dynamic imports.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.h
@@ -269,6 +269,9 @@ class HALDispatchABI {
   //   uint32_t processor_id = state->processor_id;
   Value loadProcessorID(Operation *forOp, OpBuilder &builder);
 
+  // Loads a pointer to the processor information data fields.
+  Value loadProcessorData(Operation *forOp, OpBuilder &builder);
+
   // Loads a processor information data field at the given index.
   // May be 0 if the field is not available.
   Value loadProcessorData(Operation *forOp, int64_t index, OpBuilder &builder);
@@ -306,12 +309,18 @@ class HALDispatchABI {
 
   // Emits a call to a dynamically linked import using the given |importName|
   // as a template.
+  //
   // The provided |resultTypes| and |args| are packed in a struct and transit
-  // through memory so that we can expose a single void* argument.
+  // through memory so that we can expose a single void* argument. Optionally
+  // |extraFields| can be specified with an ordered list of field names to be
+  // appended to the end of the struct.
+  //
   // Returns 0 on success and non-zero otherwise.
   SmallVector<Value> wrapAndCallImport(Operation *forOp, StringRef importName,
                                        bool weak, TypeRange resultTypes,
-                                       ValueRange args, OpBuilder &builder);
+                                       ValueRange args,
+                                       ArrayRef<StringRef> extraFields,
+                                       OpBuilder &builder);
 
  private:
   Value getIndexValue(Location loc, int64_t value, OpBuilder &builder);
@@ -327,6 +336,9 @@ class HALDispatchABI {
                        OpBuilder &builder);
   Value loadFieldValue(Operation *forOp, WorkgroupStateField field,
                        OpBuilder &builder);
+
+  Value getExtraField(Operation *forOp, StringRef extraField,
+                      OpBuilder &builder);
 
   mlir::MLIRContext *context;
   LLVMTypeConverter *typeConverter;

--- a/samples/custom_dispatch/cpu/plugin/standalone_example.mlir
+++ b/samples/custom_dispatch/cpu/plugin/standalone_example.mlir
@@ -41,7 +41,12 @@ module @example {
 
     builtin.module {
       // External function declaration using a user-chosen calling convention.
-      func.func private @simple_mul_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>, %dim: index, %tid: index)
+      func.func private @simple_mul_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>, %dim: index, %tid: index) attributes {
+        // We can include some additional fields on the parameters struct as
+        // needed. Here we request which processor is executing the call and
+        // its data fields as defined by runtime/src/iree/schemas/cpu_data.h.
+        hal.import.fields = ["processor_id", "processor_data"]
+      }
 
       // IREE exported function using stream bindings and operands.
       // Compiler passes will be able to optimize across this interface and

--- a/samples/custom_dispatch/cpu/plugin/standalone_plugin.c
+++ b/samples/custom_dispatch/cpu/plugin/standalone_plugin.c
@@ -65,6 +65,8 @@ static int simple_mul_workgroup(void* context, void* params_ptr,
     // ^^^^ simplification pending (buffer + offset)
     size_t dim;
     size_t tid;
+    uint32_t processor_id;
+    const uint64_t* restrict processor_data;
   } params_t;
   const params_t* params = (const params_t*)params_ptr;
   size_t end = params->tid + 64;

--- a/samples/custom_dispatch/cpu/plugin/system_example.mlir
+++ b/samples/custom_dispatch/cpu/plugin/system_example.mlir
@@ -18,6 +18,8 @@
 
 // CHECK-SYSTEM: EXEC @mixed_invocation
 // simple_mul_workgroup
+// CHECK-SYSTEM: processor_id=
+// CHECK-SYSTEM: processor_data[0]=
 // CHECK-SYSTEM: mul[0](2 * 4 = 8)
 // CHECK-SYSTEM: mul[1](2 * 4 = 8)
 // CHECK-SYSTEM: mul[2](2 * 4 = 8)
@@ -51,7 +53,12 @@ module @example {
 
     builtin.module {
       // External function declaration using a user-chosen calling convention.
-      func.func private @simple_mul_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>, %dim: index, %tid: index)
+      func.func private @simple_mul_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>, %dim: index, %tid: index) attributes {
+        // We can include some additional fields on the parameters struct as
+        // needed. Here we request which processor is executing the call and
+        // its data fields as defined by runtime/src/iree/schemas/cpu_data.h.
+        hal.import.fields = ["processor_id", "processor_data"]
+      }
 
       // IREE exported function using stream bindings and operands.
       // Compiler passes will be able to optimize across this interface and

--- a/samples/custom_dispatch/cpu/plugin/system_plugin.c
+++ b/samples/custom_dispatch/cpu/plugin/system_plugin.c
@@ -24,6 +24,7 @@
 // arbitrary threads concurrently. Be very careful and prefer standalone plugins
 // instead except when debugging/profiling.
 
+#include <inttypes.h>
 #include <stdio.h>
 
 // The only header required from IREE:
@@ -83,8 +84,12 @@ static int simple_mul_workgroup(void* context, void* params_ptr,
     // ^^^^ simplification pending (buffer + offset)
     size_t dim;
     size_t tid;
+    uint32_t processor_id;
+    const uint64_t* restrict processor_data;
   } params_t;
   const params_t* params = (const params_t*)params_ptr;
+  fprintf(plugin->file, "processor_id=%u\nprocessor_data[0]=%" PRIX64 "\n",
+          params->processor_id, params->processor_data[0]);
   size_t end = params->tid + 64;
   if (end > params->dim) end = params->dim;
   for (size_t i = params->tid; i < end; ++i) {


### PR DESCRIPTION
Adding an `hal.import.fields` attr with string fields to an import will append those fields on to the call parameter struct. Currently only `processor_id`/`processor_data` are exposed but we can add support for more of the environment/dispatch/workgroup state as needed.

Also added support for overriding the import name with `hal.import.name` to allow for multiple typed imports to call the same imported function.