### PR TITLE
Using FindThreads instead of hardcode `-lpthread`.

### DIFF
--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -115,6 +115,16 @@ function(iree_cc_library)
     list(APPEND _RULE_DEPS ${IREE_IMPLICIT_DEFS_CC_DEPS})
   endif()
 
+  # Find and add threads as dependency.
+  if(NOT ANDROID AND IREE_ENABLE_THREADING)
+    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+    find_package(Threads)
+    list(APPEND _RULE_DEPS Threads::Threads)
+  else()
+    # Android provides its own pthreads support with no linking required.
+  endif()
+
   if(NOT _RULE_IS_INTERFACE)
     add_library(${_OBJECTS_NAME} OBJECT)
     if(_RULE_SHARED OR BUILD_SHARED_LIBS)

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -115,16 +115,6 @@ function(iree_cc_library)
     list(APPEND _RULE_DEPS ${IREE_IMPLICIT_DEFS_CC_DEPS})
   endif()
 
-  # Find and add threads as dependency.
-  if(NOT ANDROID AND IREE_ENABLE_THREADING)
-    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-    find_package(Threads)
-    list(APPEND _RULE_DEPS Threads::Threads)
-  else()
-    # Android provides its own pthreads support with no linking required.
-  endif()
-
   if(NOT _RULE_IS_INTERFACE)
     add_library(${_OBJECTS_NAME} OBJECT)
     if(_RULE_SHARED OR BUILD_SHARED_LIBS)
@@ -203,6 +193,7 @@ function(iree_cc_library)
     target_link_libraries(${_NAME}
       PUBLIC
         ${_RULE_DEPS}
+        ${IREE_THREADS_DEPS}
     )
 
     iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -334,15 +334,6 @@ if(CMAKE_CXX_FLAGS AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
-if(NOT ANDROID AND IREE_ENABLE_THREADING)
-  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  find_package(Threads REQUIRED)
-  link_libraries(Threads::Threads)
-else()
-  # Android provides its own pthreads support with no linking required.
-endif()
-
 # Emscripten needs -pthread specified in link _and_ compile options when using
 # atomics, shared memory, or pthreads. If we bring our own threading impl and
 # try to omit this, we get this error:

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -335,10 +335,10 @@ if(CMAKE_CXX_FLAGS AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 endif()
 
 if(NOT ANDROID AND IREE_ENABLE_THREADING)
-  iree_select_compiler_opts(_IREE_PTHREADS_LINKOPTS
-    CLANG_OR_GCC
-      "-lpthread"
-  )
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+  find_package(Threads REQUIRED)
+  link_libraries(Threads::Threads)
 else()
   # Android provides its own pthreads support with no linking required.
 endif()
@@ -370,7 +370,6 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
   CLANG_OR_GCC
     # Required by all modern software, effectively:
     "-lm"
-    ${_IREE_PTHREADS_LINKOPTS}
     ${_IREE_LOGGING_LINKOPTS}
   MSVC
     "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -334,6 +334,17 @@ if(CMAKE_CXX_FLAGS AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
+# Find and add threads as dependency.
+if(NOT ANDROID AND IREE_ENABLE_THREADING)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+  find_package(Threads)
+  set(IREE_THREADS_DEPS Threads::Threads)
+else()
+  # Android provides its own pthreads support with no linking required.
+endif()
+
+
 # Emscripten needs -pthread specified in link _and_ compile options when using
 # atomics, shared memory, or pthreads. If we bring our own threading impl and
 # try to omit this, we get this error:


### PR DESCRIPTION
To fix #13114 

From what I have read in `iree_copts.cmake`, if it is not targeting android and thread is enabled, link to pthread by default for all of the libraries. So I just `link_libraries(Threads::Threads)`, assuming there is no libraries don't like accepting pthread and want to override the default. It compiles successfully on my machine.

Here is the generated compile command:
```
ccache /usr/bin/c++ -O3 -DNDEBUG -lm CMakeFiles/iree_samples_simple_embedding_simple_embedding_vmvx_sync.dir/device_vmvx_sync.c.o CMakeFiles/iree_samples_simple_embedding_simple_embedding_vmvx_sync.dir/simple_embedding.c.o -o ../../../../dist/misc/bin/simple_embedding_vmvx_sync  ../../../../dist/misc/lib/libiree_samples_simple_embedding_simple_embedding_test_bytecode_module_vmvx_c.a ../../../../dist/misc/lib/libiree_base_base.a ../../../../dist/misc/lib/libiree_hal_hal.a ../../../../dist/misc/lib/libiree_hal_drivers_local_sync_sync_driver.a ../../../../dist/misc/lib/libiree_hal_local_local.a ../../../../dist/misc/lib/libiree_hal_local_loaders_vmvx_module_loader.a ../../../../dist/misc/lib/libiree_modules_hal_hal.a ../../../../dist/misc/lib/libiree_vm_bytecode_module.a ../../../../dist/misc/lib/libiree_base_internal_fpu_state.a ../../../../dist/misc/lib/libiree_hal_utils_buffer_transfer.a ../../../../dist/misc/lib/libiree_hal_utils_deferred_command_buffer.a ../../../../dist/misc/lib/libiree_hal_utils_resource_set.a ../../../../dist/misc/lib/libiree_base_internal_arena.a ../../../../dist/misc/lib/libiree_base_internal_atomic_slist.a ../../../../dist/misc/lib/libiree_hal_utils_semaphore_base.a ../../../../dist/misc/lib/libiree_vm_bytecode_utils_utils.a ../../../../dist/misc/lib/libflatcc_parsing.a -lm ../../../../dist/misc/lib/libiree_hal_local_executable_loader.a ../../../../dist/misc/lib/libiree_hal_local_executable_environment.a ../../../../dist/misc/lib/libiree_modules_vmvx_vmvx.a ../../../../dist/misc/lib/libiree_base_internal_cpu.a ../../../../dist/misc/lib/libiree_builtins_ukernel_ukernel.a ../../../../dist/misc/lib/libiree_builtins_ukernel_arch_x86_64_x86_64.a ../../../../dist/misc/lib/libiree_builtins_ukernel_arch_x86_64_x86_64_avx2_fma.a ../../../../dist/misc/lib/libiree_builtins_ukernel_arch_x86_64_x86_64_avx512_base.a ../../../../dist/misc/lib/libiree_builtins_ukernel_arch_x86_64_x86_64_avx512_vnni.a ../../../../dist/misc/lib/libiree_modules_hal_utils_buffer_diagnostics.a ../../../../dist/misc/lib/libiree_modules_hal_types.a ../../../../dist/misc/lib/libiree_hal_hal.a ../../../../dist/misc/lib/libiree_base_internal_path.a ../../../../dist/misc/lib/libiree_vm_impl.a ../../../../dist/misc/lib/libiree_base_internal_synchronization.a ../../../../dist/misc/lib/libiree_base_base.a ../../../../dist/misc/lib/libiree_base_tracing.a -lpthread
```

Kind of a crazy big junk but the important thing is `-lpthread` is correctly placed at the back of the command, after `libiree_base_internal_synchronization.a`. 

I also did not change anything regarding webassembly and riscv as I'm not sure whether FindThreads will also deal with linking for those two platform or not. 