### PR TITLE
Add typed ukernel entry points taking buffers as base+offset.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
@@ -1042,9 +1042,6 @@ struct LinalgExtUnpackConversion
     if (inElType.isF32() && outElType.isF32()) {
       return true;
     }
-    if (inElType.isSignlessInteger(8) && inElType.isSignlessInteger(8)) {
-      return true;
-    }
     if (inElType.isSignlessInteger(32) && inElType.isSignlessInteger(32)) {
       return true;
     }

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
@@ -439,21 +439,6 @@ func.func @pack_f32f32_transpose_inner_and_outer_dims(%arg0 : memref<34x47xf32>,
   func.return
 }
 
-// CHECK-LABEL: @unpack_i8i8
-//   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:4, %[[STRIDES0:.*]]:4 = vmvx.get_buffer_descriptor %arg0
-//   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:2, %[[STRIDES1:.*]]:2 = vmvx.get_buffer_descriptor %arg1
-//       CHECK: vmvx.unpack
-//  CHECK-SAME:   in(%[[BB0]] offset %[[OFFSET0]] stride0 %[[STRIDES0]]#0 : !util.buffer)
-//  CHECK-SAME:   out(%[[BB1]] offset %[[OFFSET1]] stride0 %[[STRIDES1]]#0 : !util.buffer)
-//  CHECK-SAME:   in_shape(%[[SIZES0]]#0, %[[SIZES0]]#1, %[[SIZES0]]#2, %[[SIZES0]]#3)
-//  CHECK-SAME:   out_shape(%[[SIZES1]]#0, %[[SIZES1]]#1)
-//  CHECK-SAME:   flags(0)
-func.func @unpack_i8i8(%arg0 : memref<5x6x7x8xi8>, %arg1 : memref<34x47xi8>) {
-  iree_linalg_ext.unpack %arg0 inner_dims_pos = [0, 1] inner_tiles = [7, 8] into %arg1
-      : (memref<5x6x7x8xi8> memref<34x47xi8>)
-  func.return
-}
-
 // CHECK-LABEL: @unpack_i32i32_transpose_inner_dims
 //   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:4, %[[STRIDES0:.*]]:4 = vmvx.get_buffer_descriptor %arg0
 //   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:2, %[[STRIDES1:.*]]:2 = vmvx.get_buffer_descriptor %arg1

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/unpack.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/unpack.mlir
@@ -53,29 +53,3 @@ func.func @unpack_i32i32(
              flags(65536) : (i32, i32)
   func.return
 }
-
-// CHECK-LABEL: @unpack_i8i8
-func.func @unpack_i8i8(
-    // IN buffer/offset/stride0
-    %arg0 : !util.buffer, %arg1 : index, %arg2 : index,
-    // OUT buffer/offset/stride0
-    %arg3 : !util.buffer, %arg4 : index, %arg5 : index,
-    // IN size0/size1/size2/size3
-    %arg6 : index, %arg7 : index,  %arg8 : index, %arg9 : index,
-    // OUT size0/size1
-    %arg10 : index, %arg11 : index
-    ) {
-  //  CHECK-DAG: %[[FLAGS:.*]] = vm.const.i32.zero
-  //      CHECK: vm.call @vmvx.unpack.i8i8(
-  // CHECK-SAME: %arg0, %arg1, %arg2,
-  // CHECK-SAME: %arg3, %arg4, %arg5,
-  // CHECK-SAME: %arg6, %arg7, %arg8,
-  // CHECK-SAME: %arg9, %arg10, %arg11,
-  // CHECK-SAME: %[[FLAGS]]) : (!vm.buffer, i64, i64, !vm.buffer, i64, i64, i64, i64, i64, i64, i64, i64, i32) -> ()
-  vmvx.unpack in(%arg0 offset %arg1 stride0 %arg2 : !util.buffer)
-             out(%arg3 offset %arg4 stride0 %arg5 : !util.buffer)
-             in_shape(%arg6, %arg7, %arg8, %arg9)
-             out_shape(%arg10, %arg11)
-             flags(0) : (i8, i8)
-  func.return
-}

--- a/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
@@ -566,22 +566,6 @@ vm.import private @unpack.f32f32(
   %flags : i32
 )
 
-vm.import private @unpack.i8i8(
-  %in_buffer : !vm.buffer,
-  %in_offset : i64,
-  %in_stride0 : i64,
-  %out_buffer : !vm.buffer,
-  %out_offset : i64,
-  %out_stride0 : i64,
-  %in_size0 : i64,
-  %in_size1 : i64,
-  %out_size0 : i64,
-  %out_size1 : i64,
-  %out_size2 : i64,
-  %out_size3 : i64,
-  %flags : i32
-)
-
 vm.import private @unpack.i32i32(
   %in_buffer : !vm.buffer,
   %in_offset : i64,

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -121,3 +121,47 @@ IREE_UK_EXPORT void iree_uk_mmt4d(const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_func_t tile_func = iree_uk_mmt4d_select_tile_func(params);
   iree_uk_mmt4d_using_tile_func(params, tile_func);
 }
+
+IREE_UK_EXPORT void iree_uk_mmt4d_f32f32f32(
+    const iree_uk_mmt4d_f32f32f32_params_t* params) {
+  iree_uk_mmt4d_params_t p = {
+      .type = iree_uk_mmt4d_type_f32f32f32,
+      .lhs_buffer = params->lhs_buffer_base + params->lhs_buffer_offset,
+      .rhs_buffer = params->rhs_buffer_base + params->rhs_buffer_offset,
+      .out_buffer = params->out_buffer_base + params->out_buffer_offset,
+      .lhs_stride = params->lhs_stride,
+      .rhs_stride = params->rhs_stride,
+      .out_stride = params->out_stride,
+      .M = params->M,
+      .N = params->N,
+      .K = params->K,
+      .M0 = params->M0,
+      .N0 = params->N0,
+      .K0 = params->K0,
+      .flags = params->flags,
+      .cpu_data = params->cpu_data,
+  };
+  iree_uk_mmt4d(&p);
+}
+
+IREE_UK_EXPORT void iree_uk_mmt4d_i8i8i32(
+    const iree_uk_mmt4d_i8i8i32_params_t* params) {
+  iree_uk_mmt4d_params_t p = {
+      .type = iree_uk_mmt4d_type_i8i8i32,
+      .lhs_buffer = params->lhs_buffer_base + params->lhs_buffer_offset,
+      .rhs_buffer = params->rhs_buffer_base + params->rhs_buffer_offset,
+      .out_buffer = params->out_buffer_base + params->out_buffer_offset,
+      .lhs_stride = params->lhs_stride,
+      .rhs_stride = params->rhs_stride,
+      .out_stride = params->out_stride,
+      .M = params->M,
+      .N = params->N,
+      .K = params->K,
+      .M0 = params->M0,
+      .N0 = params->N0,
+      .K0 = params->K0,
+      .flags = params->flags,
+      .cpu_data = params->cpu_data,
+  };
+  iree_uk_mmt4d(&p);
+}

--- a/runtime/src/iree/builtins/ukernel/pack.c
+++ b/runtime/src/iree/builtins/ukernel/pack.c
@@ -236,3 +236,66 @@ IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params) {
   iree_uk_pack_tile_func_t tile_func = iree_uk_pack_select_tile_func(params);
   iree_uk_pack_using_tile_func(params, tile_func);
 }
+
+IREE_UK_EXPORT void iree_uk_pack_f32f32(
+    const iree_uk_pack_f32f32_params_t* params) {
+  iree_uk_pack_params_t p = {
+      .type = iree_uk_pack_type_f32f32,
+      .in_buffer = params->in_buffer_base + params->in_buffer_offset,
+      .out_buffer = params->out_buffer_base + params->out_buffer_offset,
+      .in_stride0 = params->in_stride0,
+      .out_stride0 = params->out_stride0,
+      .in_size0 = params->in_size0,
+      .in_size1 = params->in_size1,
+      .out_size0 = params->out_size0,
+      .out_size1 = params->out_size1,
+      .out_size2 = params->out_size2,
+      .out_size3 = params->out_size3,
+      .padding_value = &params->padding_value,
+      .flags = params->flags,
+      .cpu_data = params->cpu_data,
+  };
+  iree_uk_pack(&p);
+}
+
+IREE_UK_EXPORT void iree_uk_pack_i8i8(
+    const iree_uk_pack_i8i8_params_t* params) {
+  iree_uk_pack_params_t p = {
+      .type = iree_uk_pack_type_i8i8,
+      .in_buffer = params->in_buffer_base + params->in_buffer_offset,
+      .out_buffer = params->out_buffer_base + params->out_buffer_offset,
+      .in_stride0 = params->in_stride0,
+      .out_stride0 = params->out_stride0,
+      .in_size0 = params->in_size0,
+      .in_size1 = params->in_size1,
+      .out_size0 = params->out_size0,
+      .out_size1 = params->out_size1,
+      .out_size2 = params->out_size2,
+      .out_size3 = params->out_size3,
+      .padding_value = &params->padding_value,
+      .flags = params->flags,
+      .cpu_data = params->cpu_data,
+  };
+  iree_uk_pack(&p);
+}
+
+IREE_UK_EXPORT void iree_uk_pack_i32i32(
+    const iree_uk_pack_i32i32_params_t* params) {
+  iree_uk_pack_params_t p = {
+      .type = iree_uk_pack_type_i32i32,
+      .in_buffer = params->in_buffer_base + params->in_buffer_offset,
+      .out_buffer = params->out_buffer_base + params->out_buffer_offset,
+      .in_stride0 = params->in_stride0,
+      .out_stride0 = params->out_stride0,
+      .in_size0 = params->in_size0,
+      .in_size1 = params->in_size1,
+      .out_size0 = params->out_size0,
+      .out_size1 = params->out_size1,
+      .out_size2 = params->out_size2,
+      .out_size3 = params->out_size3,
+      .padding_value = &params->padding_value,
+      .flags = params->flags,
+      .cpu_data = params->cpu_data,
+  };
+  iree_uk_pack(&p);
+}

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -13,11 +13,102 @@
 extern "C" {
 #endif  // __cplusplus
 
+//===----------------------------------------------------------------------===//
+// Typed entry points, taking base+offset pairs for each buffer.
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_uk_pack_f32f32_params_t {
+  const float* in_buffer_base;
+  iree_uk_ssize_t in_buffer_offset;
+  iree_uk_ssize_t in_stride0;
+  float* out_buffer_base;
+  iree_uk_ssize_t out_buffer_offset;
+  iree_uk_ssize_t out_stride0;
+  iree_uk_ssize_t in_size0;
+  iree_uk_ssize_t in_size1;
+  iree_uk_ssize_t out_size0;
+  iree_uk_ssize_t out_size1;
+  iree_uk_ssize_t out_size2;
+  iree_uk_ssize_t out_size3;
+  float padding_value;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_pack_f32f32_params_t;
+
+typedef struct iree_uk_pack_i8i8_params_t {
+  const iree_uk_int8_t* in_buffer_base;
+  iree_uk_ssize_t in_buffer_offset;
+  iree_uk_ssize_t in_stride0;
+  iree_uk_int8_t* out_buffer_base;
+  iree_uk_ssize_t out_buffer_offset;
+  iree_uk_ssize_t out_stride0;
+  iree_uk_ssize_t in_size0;
+  iree_uk_ssize_t in_size1;
+  iree_uk_ssize_t out_size0;
+  iree_uk_ssize_t out_size1;
+  iree_uk_ssize_t out_size2;
+  iree_uk_ssize_t out_size3;
+  iree_uk_int8_t padding_value;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_pack_i8i8_params_t;
+
+typedef struct iree_uk_pack_i32i32_params_t {
+  const iree_uk_int32_t* in_buffer_base;
+  iree_uk_ssize_t in_buffer_offset;
+  iree_uk_ssize_t in_stride0;
+  iree_uk_int32_t* out_buffer_base;
+  iree_uk_ssize_t out_buffer_offset;
+  iree_uk_ssize_t out_stride0;
+  iree_uk_ssize_t in_size0;
+  iree_uk_ssize_t in_size1;
+  iree_uk_ssize_t out_size0;
+  iree_uk_ssize_t out_size1;
+  iree_uk_ssize_t out_size2;
+  iree_uk_ssize_t out_size3;
+  iree_uk_int32_t padding_value;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_pack_i32i32_params_t;
+
+IREE_UK_EXPORT void iree_uk_pack_f32f32(
+    const iree_uk_pack_f32f32_params_t* params);
+IREE_UK_EXPORT void iree_uk_pack_i8i8(const iree_uk_pack_i8i8_params_t* params);
+IREE_UK_EXPORT void iree_uk_pack_i32i32(
+    const iree_uk_pack_i32i32_params_t* params);
+
+//===----------------------------------------------------------------------===//
+// Untyped entry point, taking raw pointers without offsets.
+//===----------------------------------------------------------------------===//
+
 typedef enum iree_uk_pack_type_t {
   iree_uk_pack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
   iree_uk_pack_type_i8i8 = IREE_UK_TIE_2_TYPES_LITERAL(INT_8, INT_8),
   iree_uk_pack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),
 } iree_uk_pack_type_t;
+
+typedef struct iree_uk_pack_params_t {
+  iree_uk_pack_type_t type;
+  const void* in_buffer;
+  iree_uk_ssize_t in_stride0;
+  void* out_buffer;
+  iree_uk_ssize_t out_stride0;
+  iree_uk_ssize_t in_size0;
+  iree_uk_ssize_t in_size1;
+  iree_uk_ssize_t out_size0;
+  iree_uk_ssize_t out_size1;
+  iree_uk_ssize_t out_size2;
+  iree_uk_ssize_t out_size3;
+  const void* padding_value;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_pack_params_t;
+
+IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params);
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
 
 static inline iree_uk_type_t iree_uk_pack_in_type(iree_uk_pack_type_t type) {
   return iree_uk_untie_type(0, type);
@@ -27,24 +118,6 @@ static inline iree_uk_type_t iree_uk_pack_out_type(iree_uk_pack_type_t type) {
   return iree_uk_untie_type(1, type);
 }
 
-// Parameters for a pack operation.
-typedef struct iree_uk_pack_params_t {
-  iree_uk_pack_type_t type;
-  iree_uk_uint32_t flags;
-  iree_uk_ssize_t in_stride0;
-  iree_uk_ssize_t out_stride0;
-  iree_uk_ssize_t in_size0;
-  iree_uk_ssize_t in_size1;
-  iree_uk_ssize_t out_size0;
-  iree_uk_ssize_t out_size1;
-  iree_uk_ssize_t out_size2;
-  iree_uk_ssize_t out_size3;
-  const void* in_buffer;
-  void* out_buffer;
-  const void* padding_value;
-  const iree_uk_uint64_t* cpu_data;
-} iree_uk_pack_params_t;
-
 typedef void (*iree_uk_pack_tile_func_t)(
     void* IREE_UK_RESTRICT /*out_tile_ptr*/,
     const void* IREE_UK_RESTRICT /*in_tile_ptr*/,
@@ -52,16 +125,13 @@ typedef void (*iree_uk_pack_tile_func_t)(
     iree_uk_ssize_t /*in_stride0*/, iree_uk_ssize_t /*elem_size*/,
     iree_uk_ssize_t /*tile_size0*/, iree_uk_ssize_t /*tile_size1*/);
 
-// Tile kernel declarations. Prototype matches iree_uk_unpack_tile_func_t.
+// Tile function declarations. Prototype matches iree_uk_unpack_tile_func_t.
 #define IREE_UK_PACK_TILE_FUNC_DECL(NAME)                             \
   void NAME(void* IREE_UK_RESTRICT out_tile_ptr,                      \
             const void* IREE_UK_RESTRICT in_tile_ptr,                 \
             iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1, \
             iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size,    \
             iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
-
-// Main entry point.
-IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/builtins/ukernel/query_tile_sizes.h
+++ b/runtime/src/iree/builtins/ukernel/query_tile_sizes.h
@@ -13,7 +13,10 @@
 extern "C" {
 #endif  // __cplusplus
 
-// Parameters for a query_tile_sizes operation.
+//===----------------------------------------------------------------------===//
+// Public entry points
+//===----------------------------------------------------------------------===//
+
 typedef struct iree_uk_query_tile_sizes_2d_params_t {
   iree_uk_uint32_t flags;
   iree_uk_ssize_t size0;
@@ -25,6 +28,14 @@ typedef struct iree_uk_query_tile_sizes_2d_out_params_t {
   iree_uk_ssize_t tile_size0;
   iree_uk_ssize_t tile_size1;
 } iree_uk_query_tile_sizes_2d_out_params_t;
+
+IREE_UK_EXPORT void iree_uk_query_tile_sizes_2d(
+    const iree_uk_query_tile_sizes_2d_params_t* params,
+    iree_uk_query_tile_sizes_2d_out_params_t* out_params);
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
 
 static inline iree_uk_uint32_t iree_uk_query_tile_sizes_operand_role(
     iree_uk_uint32_t flags) {
@@ -41,11 +52,6 @@ static inline iree_uk_uint32_t iree_uk_query_tile_sizes_operation(
 typedef struct iree_uk_matmul_tile_sizes_t {
   int M, K, N;
 } iree_uk_matmul_tile_sizes_t;
-
-// Main entry point.
-IREE_UK_EXPORT void iree_uk_query_tile_sizes_2d(
-    const iree_uk_query_tile_sizes_2d_params_t* params,
-    iree_uk_query_tile_sizes_2d_out_params_t* out_params);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -55,6 +55,67 @@ static void iree_pack_reference(const iree_uk_pack_params_t* params) {
   }
 }
 
+static void iree_pack_actual(const iree_uk_pack_params_t* params,
+                             bool typed_entry_point) {
+  if (!typed_entry_point) {
+    iree_uk_pack(params);
+  } else if (params->type == iree_uk_pack_type_f32f32) {
+    iree_uk_pack_f32f32_params_t p = {
+        .in_buffer_base = ((const float*)params->in_buffer) - 1,
+        .in_buffer_offset = 1,
+        .out_buffer_base = ((float*)params->out_buffer) - 2,
+        .out_buffer_offset = 2,
+        .in_stride0 = params->in_stride0,
+        .out_stride0 = params->out_stride0,
+        .in_size0 = params->in_size0,
+        .in_size1 = params->in_size1,
+        .out_size0 = params->out_size0,
+        .out_size1 = params->out_size1,
+        .out_size2 = params->out_size2,
+        .out_size3 = params->out_size3,
+        .padding_value = *(const float*)params->padding_value,
+        .flags = params->flags,
+        .cpu_data = params->cpu_data};
+    iree_uk_pack_f32f32(&p);
+  } else if (params->type == iree_uk_pack_type_i8i8) {
+    iree_uk_pack_i8i8_params_t p = {
+        .in_buffer_base = ((const iree_uk_int8_t*)params->in_buffer) - 1,
+        .in_buffer_offset = 1,
+        .out_buffer_base = ((iree_uk_int8_t*)params->out_buffer) - 2,
+        .out_buffer_offset = 2,
+        .in_stride0 = params->in_stride0,
+        .out_stride0 = params->out_stride0,
+        .in_size0 = params->in_size0,
+        .in_size1 = params->in_size1,
+        .out_size0 = params->out_size0,
+        .out_size1 = params->out_size1,
+        .out_size2 = params->out_size2,
+        .out_size3 = params->out_size3,
+        .padding_value = *(const iree_uk_int8_t*)params->padding_value,
+        .flags = params->flags,
+        .cpu_data = params->cpu_data};
+    iree_uk_pack_i8i8(&p);
+  } else if (params->type == iree_uk_pack_type_i32i32) {
+    iree_uk_pack_i32i32_params_t p = {
+        .in_buffer_base = ((const iree_uk_int32_t*)params->in_buffer) - 1,
+        .in_buffer_offset = 1,
+        .out_buffer_base = ((iree_uk_int32_t*)params->out_buffer) - 2,
+        .out_buffer_offset = 2,
+        .in_stride0 = params->in_stride0,
+        .out_stride0 = params->out_stride0,
+        .in_size0 = params->in_size0,
+        .in_size1 = params->in_size1,
+        .out_size0 = params->out_size0,
+        .out_size1 = params->out_size1,
+        .out_size2 = params->out_size2,
+        .out_size3 = params->out_size3,
+        .padding_value = *(const iree_uk_int32_t*)params->padding_value,
+        .flags = params->flags,
+        .cpu_data = params->cpu_data};
+    iree_uk_pack_i32i32(&p);
+  }
+}
+
 static void iree_uk_test_pack_for_shape_params(
     iree_uk_test_t* test, const iree_uk_pack_params_t* src_params) {
   iree_uk_pack_params_t params;
@@ -87,7 +148,7 @@ static void iree_uk_test_pack_for_shape_params(
                               out_type, engine);
 
   iree_pack_reference(&reference_params);
-  iree_uk_pack(&actual_params);
+  iree_pack_actual(&actual_params, iree_uk_random_engine_get_0_1(engine));
 
   if (memcmp(actual_params.out_buffer, reference_params.out_buffer,
              out_buffer_size)) {

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -52,6 +52,47 @@ static void iree_unpack_reference(const iree_uk_unpack_params_t* params) {
   }
 }
 
+static void iree_unpack_actual(const iree_uk_unpack_params_t* params,
+                               bool typed_entry_point) {
+  if (!typed_entry_point) {
+    iree_uk_unpack(params);
+  } else if (params->type == iree_uk_unpack_type_f32f32) {
+    iree_uk_unpack_f32f32_params_t p = {
+        .in_buffer_base = ((const float*)params->in_buffer) - 1,
+        .in_buffer_offset = 1,
+        .out_buffer_base = ((float*)params->out_buffer) - 2,
+        .out_buffer_offset = 2,
+        .in_stride0 = params->in_stride0,
+        .out_stride0 = params->out_stride0,
+        .in_size0 = params->in_size0,
+        .in_size1 = params->in_size1,
+        .in_size2 = params->in_size2,
+        .in_size3 = params->in_size3,
+        .out_size0 = params->out_size0,
+        .out_size1 = params->out_size1,
+        .flags = params->flags,
+        .cpu_data = params->cpu_data};
+    iree_uk_unpack_f32f32(&p);
+  } else if (params->type == iree_uk_unpack_type_i32i32) {
+    iree_uk_unpack_i32i32_params_t p = {
+        .in_buffer_base = ((const iree_uk_int32_t*)params->in_buffer) - 1,
+        .in_buffer_offset = 1,
+        .out_buffer_base = ((iree_uk_int32_t*)params->out_buffer) - 2,
+        .out_buffer_offset = 2,
+        .in_stride0 = params->in_stride0,
+        .out_stride0 = params->out_stride0,
+        .in_size0 = params->in_size0,
+        .in_size1 = params->in_size1,
+        .in_size2 = params->in_size2,
+        .in_size3 = params->in_size3,
+        .out_size0 = params->out_size0,
+        .out_size1 = params->out_size1,
+        .flags = params->flags,
+        .cpu_data = params->cpu_data};
+    iree_uk_unpack_i32i32(&p);
+  }
+}
+
 static void iree_uk_test_unpack_for_shape_params(
     iree_uk_test_t* test, const iree_uk_unpack_params_t* src_params) {
   iree_uk_unpack_params_t params;
@@ -85,7 +126,7 @@ static void iree_uk_test_unpack_for_shape_params(
                               out_type, engine);
 
   iree_unpack_reference(&reference_params);
-  iree_uk_unpack(&actual_params);
+  iree_unpack_actual(&actual_params, iree_uk_random_engine_get_0_1(engine));
 
   if (!iree_uk_2d_buffers_equal(
           actual_params.out_buffer, reference_params.out_buffer, out_type,
@@ -183,7 +224,6 @@ int main(int argc, char** argv) {
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
   iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 3, 5, NULL);
-  iree_uk_test_unpack(iree_uk_unpack_type_i8i8, 4, 2, NULL);
   iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 3, 4, NULL);
 
 #if defined(IREE_UK_ARCH_ARM_64)

--- a/runtime/src/iree/builtins/ukernel/unpack.c
+++ b/runtime/src/iree/builtins/ukernel/unpack.c
@@ -44,7 +44,6 @@ static void iree_uk_unpack_validate(const iree_uk_unpack_params_t* params) {
       IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER | IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER;
   IREE_UK_ASSERT(!(params->flags & ~allflags));
   IREE_UK_ASSERT(params->type == iree_uk_unpack_type_f32f32 ||
-                 params->type == iree_uk_unpack_type_i8i8 ||
                  params->type == iree_uk_unpack_type_i32i32);
   IREE_UK_ASSERT(params->in_stride0 >= 0);
   IREE_UK_ASSERT(params->out_stride0 >= 0);
@@ -196,4 +195,44 @@ IREE_UK_EXPORT void iree_uk_unpack(const iree_uk_unpack_params_t* params) {
   // Select a target-specific tile_func and use that with generic outer loops.
   iree_uk_unpack_tile_func_t func = iree_uk_unpack_select_tile_func(params);
   iree_uk_unpack_using_tile_func(params, func);
+}
+
+IREE_UK_EXPORT void iree_uk_unpack_f32f32(
+    const iree_uk_unpack_f32f32_params_t* params) {
+  iree_uk_unpack_params_t p = {
+      .type = iree_uk_unpack_type_f32f32,
+      .in_buffer = params->in_buffer_base + params->in_buffer_offset,
+      .out_buffer = params->out_buffer_base + params->out_buffer_offset,
+      .in_stride0 = params->in_stride0,
+      .out_stride0 = params->out_stride0,
+      .in_size0 = params->in_size0,
+      .in_size1 = params->in_size1,
+      .in_size2 = params->in_size2,
+      .in_size3 = params->in_size3,
+      .out_size0 = params->out_size0,
+      .out_size1 = params->out_size1,
+      .flags = params->flags,
+      .cpu_data = params->cpu_data,
+  };
+  iree_uk_unpack(&p);
+}
+
+IREE_UK_EXPORT void iree_uk_unpack_i32i32(
+    const iree_uk_unpack_i32i32_params_t* params) {
+  iree_uk_unpack_params_t p = {
+      .type = iree_uk_unpack_type_i32i32,
+      .in_buffer = params->in_buffer_base + params->in_buffer_offset,
+      .out_buffer = params->out_buffer_base + params->out_buffer_offset,
+      .in_stride0 = params->in_stride0,
+      .out_stride0 = params->out_stride0,
+      .in_size0 = params->in_size0,
+      .in_size1 = params->in_size1,
+      .in_size2 = params->in_size2,
+      .in_size3 = params->in_size3,
+      .out_size0 = params->out_size0,
+      .out_size1 = params->out_size1,
+      .flags = params->flags,
+      .cpu_data = params->cpu_data,
+  };
+  iree_uk_unpack(&p);
 }

--- a/runtime/src/iree/builtins/ukernel/unpack.h
+++ b/runtime/src/iree/builtins/ukernel/unpack.h
@@ -13,11 +13,79 @@
 extern "C" {
 #endif  // __cplusplus
 
+//===----------------------------------------------------------------------===//
+// Typed entry points, taking base+offset pairs for each buffer.
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_uk_unpack_f32f32_params_t {
+  const float* in_buffer_base;
+  iree_uk_ssize_t in_buffer_offset;
+  iree_uk_ssize_t in_stride0;
+  float* out_buffer_base;
+  iree_uk_ssize_t out_buffer_offset;
+  iree_uk_ssize_t out_stride0;
+  iree_uk_ssize_t in_size0;
+  iree_uk_ssize_t in_size1;
+  iree_uk_ssize_t in_size2;
+  iree_uk_ssize_t in_size3;
+  iree_uk_ssize_t out_size0;
+  iree_uk_ssize_t out_size1;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_unpack_f32f32_params_t;
+
+typedef struct iree_uk_unpack_i32i32_params_t {
+  const iree_uk_int32_t* in_buffer_base;
+  iree_uk_ssize_t in_buffer_offset;
+  iree_uk_ssize_t in_stride0;
+  iree_uk_int32_t* out_buffer_base;
+  iree_uk_ssize_t out_buffer_offset;
+  iree_uk_ssize_t out_stride0;
+  iree_uk_ssize_t in_size0;
+  iree_uk_ssize_t in_size1;
+  iree_uk_ssize_t in_size2;
+  iree_uk_ssize_t in_size3;
+  iree_uk_ssize_t out_size0;
+  iree_uk_ssize_t out_size1;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_unpack_i32i32_params_t;
+
+IREE_UK_EXPORT void iree_uk_unpack_f32f32(
+    const iree_uk_unpack_f32f32_params_t* params);
+IREE_UK_EXPORT void iree_uk_unpack_i32i32(
+    const iree_uk_unpack_i32i32_params_t* params);
+
+//===----------------------------------------------------------------------===//
+// Untyped entry point, taking raw pointers without offsets.
+//===----------------------------------------------------------------------===//
+
 typedef enum iree_uk_unpack_type_t {
   iree_uk_unpack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
-  iree_uk_unpack_type_i8i8 = IREE_UK_TIE_2_TYPES_LITERAL(INT_8, INT_8),
   iree_uk_unpack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),
 } iree_uk_unpack_type_t;
+
+typedef struct iree_uk_unpack_params_t {
+  iree_uk_unpack_type_t type;
+  const void* in_buffer;
+  iree_uk_ssize_t in_stride0;
+  void* out_buffer;
+  iree_uk_ssize_t out_stride0;
+  iree_uk_ssize_t in_size0;
+  iree_uk_ssize_t in_size1;
+  iree_uk_ssize_t in_size2;
+  iree_uk_ssize_t in_size3;
+  iree_uk_ssize_t out_size0;
+  iree_uk_ssize_t out_size1;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_unpack_params_t;
+
+IREE_UK_EXPORT void iree_uk_unpack(const iree_uk_unpack_params_t* params);
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
 
 static inline iree_uk_type_t iree_uk_unpack_in_type(
     iree_uk_unpack_type_t type) {
@@ -28,23 +96,6 @@ static inline iree_uk_type_t iree_uk_unpack_out_type(
     iree_uk_unpack_type_t type) {
   return iree_uk_untie_type(1, type);
 }
-
-// Parameters for a unpack operation.
-typedef struct iree_uk_unpack_params_t {
-  iree_uk_unpack_type_t type;
-  iree_uk_uint32_t flags;
-  iree_uk_ssize_t in_stride0;
-  iree_uk_ssize_t out_stride0;
-  iree_uk_ssize_t in_size0;
-  iree_uk_ssize_t in_size1;
-  iree_uk_ssize_t in_size2;
-  iree_uk_ssize_t in_size3;
-  iree_uk_ssize_t out_size0;
-  iree_uk_ssize_t out_size1;
-  const void* in_buffer;
-  void* out_buffer;
-  const iree_uk_uint64_t* cpu_data;
-} iree_uk_unpack_params_t;
 
 typedef void (*iree_uk_unpack_tile_func_t)(
     void* IREE_UK_RESTRICT /*out_tile_ptr*/,
@@ -60,9 +111,6 @@ typedef void (*iree_uk_unpack_tile_func_t)(
             iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride0, \
             iree_uk_ssize_t in_stride1, iree_uk_ssize_t elem_size,    \
             iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
-
-// Main entry point.
-IREE_UK_EXPORT void iree_uk_unpack(const iree_uk_unpack_params_t* params);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/modules/vmvx/exports.inl
+++ b/runtime/src/iree/modules/vmvx/exports.inl
@@ -60,8 +60,6 @@ EXPORT_FN("sub.2d.f32", iree_uk_x32b_subf_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v
 EXPORT_FN("sub.2d.i32", iree_uk_x32b_subi_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 EXPORT_FN("unpack.f32f32", iree_vmvx_unpack_f32f32, unpack, rIIrIIIIIIIIi, v)
 EXPORT_FN("unpack.i32i32", iree_vmvx_unpack_i32i32, unpack, rIIrIIIIIIIIi, v)
-EXPORT_FN("unpack.i8i8", iree_vmvx_unpack_i8i8, unpack, rIIrIIIIIIIIi, v)
 EXPORT_FN("xor.2d.i32", iree_uk_x32b_xori_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
-
 
 // clang-format on

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -923,10 +923,6 @@ IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_f32f32, unpack, v) {
   return iree_vmvx_unpack(iree_uk_unpack_type_f32f32, args);
 }
 
-IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_i8i8, unpack, v) {
-  return iree_vmvx_unpack(iree_uk_unpack_type_i8i8, args);
-}
-
 IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_i32i32, unpack, v) {
   return iree_vmvx_unpack(iree_uk_unpack_type_i32i32, args);
 }


### PR DESCRIPTION
Also removing the unused case of `unpack_i8i8`. `i8` is not currently used for results, only for inputs.