### PR TITLE
[codeGen] Added math.exp2 expansion.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/PolynomialApproximationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PolynomialApproximationPass.cpp
@@ -29,6 +29,7 @@ class PolynomialApproximationPass
   void runOnOperation() override {
     RewritePatternSet mathPatterns(&getContext());
     populateExpandTanPattern(mathPatterns);
+    populateExpandExp2FPattern(mathPatterns);
 
     if (clNativeMathPrecision) {
       mathPatterns.add<math::ErfPolynomialApproximation>(&getContext());

--- a/tests/e2e/regression/libm_linking.mlir
+++ b/tests/e2e/regression/libm_linking.mlir
@@ -39,3 +39,11 @@ func.func @floor(%input : tensor<f32>) -> (tensor<f32>) {
   %result = math.floor %input : tensor<f32>
   return %result : tensor<f32>
 }
+
+// CHECK: vm.func private @exp2
+func.func @exp2(%input : tensor<f32>) -> (tensor<f32>) {
+  // May lower to llvm.intr.exp2 (exp2f)
+  %result = math.exp2 %input : tensor<f32>
+  return %result : tensor<f32>
+}
+


### PR DESCRIPTION
IREE Compiler was failing because math.exp2 implementation is not available in the back end. This patch will call the MLIR function to expand exp2(a) to exp(ln(2) *a).

Fixes #12974