### PR TITLE
Add warpDims argument to buildMapToBlockAndThreads

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -137,9 +137,10 @@ static std::pair<int64_t, int64_t> computeSplitPoint(int64_t upperBound,
 /// Takes a handle to a func.func and returns an updated handle to a
 /// func.func.
 Value mlir::iree_compiler::gpu::buildMapToBlockAndThreads(
-    ImplicitLocOpBuilder &b, Value funcH, ArrayRef<int64_t> blockSize) {
+    ImplicitLocOpBuilder &b, Value funcH, ArrayRef<int64_t> blockSize,
+    ArrayRef<int64_t> warpDims) {
   b.create<ForallToWorkgroupOp>(funcH);
-  b.create<MapNestedForallToGpuThreadsOp>(funcH, blockSize);
+  b.create<MapNestedForallToGpuThreadsOp>(funcH, blockSize, warpDims);
   return funcH;
 }
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h
@@ -40,8 +40,12 @@ int64_t adjustNumberOfWarpsForBlockShuffle(int64_t numWarpsToUse,
 /// Post-bufferization mapping to blocks and threads.
 /// Takes a handle to a func.func and returns an updated handle to a
 /// func.func.
+/// Takes an optional `warpDims` argument to specify the number of warp
+/// dimensions to consider along various dimensions and avoid second-guessing
+/// how the mapping to warps should occur.
 Value buildMapToBlockAndThreads(ImplicitLocOpBuilder& b, Value funcH,
-                                ArrayRef<int64_t> blockSize);
+                                ArrayRef<int64_t> blockSize,
+                                ArrayRef<int64_t> warpDims = {});
 
 /// Post-bufferization vector distribution with rank-reduction.
 /// Takes a handle to a func.func and returns an updated handle to a


### PR DESCRIPTION
This allows strategies to access the mixed SIMT / SIMD mapping model already available upstream and in IREE.