### PR TITLE
[StableHLO] Port rng to linalg lowering

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
@@ -52,6 +52,7 @@ iree_compiler_cc_library(
         "StableHLOToLinalg.cpp",
         "StableHLOToLinalgDotProd.cpp",
         "StableHLOToLinalgPointwise.cpp",
+        "StableHLOToLinalgRandom.cpp",
         "StableHLOToLinalgReduce.cpp",
         "TypeConversion.cpp",
     ],

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     "StableHLOToLinalg.cpp"
     "StableHLOToLinalgDotProd.cpp"
     "StableHLOToLinalgPointwise.cpp"
+    "StableHLOToLinalgRandom.cpp"
     "StableHLOToLinalgReduce.cpp"
     "TypeConversion.cpp"
   DEPS

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
@@ -12,9 +12,9 @@
 namespace mlir::iree_compiler::stablehlo {
 
 /// Populates the patterns that convert from StableHLO to Linalg on tensors.
-void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
-                                                 TypeConverter& typeConverter,
-                                                 RewritePatternSet* patterns,
+void populateStableHloToLinalgConversionPatterns(MLIRContext *context,
+                                                 TypeConverter &typeConverter,
+                                                 RewritePatternSet *patterns,
                                                  bool enablePrimitiveOps);
 
 //===----------------------------------------------------------------------===//
@@ -24,14 +24,20 @@ namespace detail {
 /// Populates the patterns that convert from elementwise StableHLO ops to Linalg
 /// on tensors.
 void populatePointwiseStableHloToLinalgConversionPatterns(
-    MLIRContext* context, TypeConverter& typeConverter,
-    RewritePatternSet* patterns, bool enablePrimitiveOps);
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet *patterns, bool enablePrimitiveOps);
 
 /// Populates the patterns that convert from dot product StableHLO ops to Linalg
 /// on tensors.
 void populateStableHloDotProdToLinalgConversionPatterns(
-    MLIRContext* context, TypeConverter& typeConverter,
-    RewritePatternSet* patterns);
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet *patterns);
+
+/// Populates the patterns that convert from random number generation StableHLO
+/// ops to Linalg on tensors.
+void populateStableHloRandomToLinalgConversionPatterns(
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet *patterns);
 
 /// Populates the patterns that convert from reduction StableHLO ops to Linalg
 /// on tensors.
@@ -41,9 +47,9 @@ void populateStableHloReductionToLinalgConversionPatterns(
 
 /// Populates the patterns that convert scalar StableHLO ops to Arith ops.
 void populateScalarHloToArithConversionPatterns(
-    MLIRContext* context, TypeConverter& typeConverter,
-    RewritePatternSet* patterns,
-    llvm::function_ref<bool(Operation*)> filterFn = nullptr);
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet *patterns,
+    llvm::function_ref<bool(Operation *)> filterFn = nullptr);
 }  // namespace detail
 
 }  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
@@ -2484,6 +2484,8 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
 
   detail::populateStableHloDotProdToLinalgConversionPatterns(
       context, typeConverter, patterns);
+  detail::populateStableHloRandomToLinalgConversionPatterns(
+      context, typeConverter, patterns);
   detail::populateStableHloReductionToLinalgConversionPatterns(
       context, typeConverter, patterns, enablePrimitiveOps);
   detail::populateScalarHloToArithConversionPatterns(

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgRandom.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgRandom.cpp
@@ -4,14 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Implements logic for lowering StableHLO dot product ops to Linalg dialect.
-// These patterns are separated out to their own file to save on the compilation
-// times, given that we instantiate a large number of class templates here.
+// Implements logic for lowering StableHLO random number generation to Linalg
+// dialect.
 
 #include "iree/compiler/InputConversion/StableHLO/LegalizeToLinalgUtils.h"
 #include "iree/compiler/InputConversion/StableHLO/Rewriters.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgRandom.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgRandom.cpp
@@ -1,0 +1,593 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements logic for lowering StableHLO dot product ops to Linalg dialect.
+// These patterns are separated out to their own file to save on the compilation
+// times, given that we instantiate a large number of class templates here.
+
+#include "iree/compiler/InputConversion/StableHLO/LegalizeToLinalgUtils.h"
+#include "iree/compiler/InputConversion/StableHLO/Rewriters.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+namespace {
+namespace stablehlo = mlir::stablehlo;
+
+class ArithOp {
+ public:
+  ArithOp(OpBuilder b, Location l, Value v) : builder(b), loc(l), value(v) {}
+
+  explicit operator Value() { return value; }
+  Value val() { return value; }
+
+  ArithOp constantI(int64_t value, int64_t bits) {
+    Value val = builder.create<arith::ConstantOp>(
+        loc, builder.getIntegerAttr(builder.getIntegerType(bits), value));
+    return ArithOp(builder, loc, val);
+  }
+
+  ArithOp extendUI(int32_t bits) {
+    Value ext = builder.create<arith::ExtUIOp>(
+        loc, builder.getIntegerType(bits), value);
+    return ArithOp(builder, loc, ext);
+  }
+
+  ArithOp truncI(int64_t bits) {
+    if (value.getType().getIntOrFloatBitWidth() == bits) return *this;
+    Value trunc = builder.create<arith::TruncIOp>(
+        loc, builder.getIntegerType(bits), value);
+    return ArithOp(builder, loc, trunc);
+  }
+
+  ArithOp linalgIndex(int32_t index) {
+    Value val = builder.create<linalg::IndexOp>(loc, index);
+    return ArithOp(builder, loc, val);
+  }
+
+  ArithOp indexCast(int32_t bitwidth) {
+    if (isa<IntegerType>(value.getType())) {
+      Value cast = builder.create<arith::IndexCastOp>(
+          loc, builder.getIndexType(), value);
+      return ArithOp(builder, loc, cast);
+    }
+
+    Value cast = builder.create<arith::IndexCastOp>(
+        loc, builder.getIntegerType(bitwidth), value);
+    return ArithOp(builder, loc, cast);
+  }
+
+  ArithOp rotateLeft(int32_t rotation) {
+    int32_t bits = value.getType().getIntOrFloatBitWidth();
+    ArithOp cLeft = constantI(rotation, bits);
+    ArithOp cRight = constantI(bits - rotation, bits);
+    ArithOp rLeft = (*this << cLeft);
+    ArithOp rRight = (*this >> cRight);
+    return rLeft | rRight;
+  }
+
+  ArithOp operator+(ArithOp &rhs) {
+    Value res = builder.create<arith::AddIOp>(loc, value, rhs.value);
+    return ArithOp(builder, loc, res);
+  }
+
+  ArithOp operator|(ArithOp &rhs) {
+    Value res = builder.create<arith::OrIOp>(loc, value, rhs.value);
+    return ArithOp(builder, loc, res);
+  }
+
+  ArithOp operator^(ArithOp &rhs) {
+    Value res = builder.create<arith::XOrIOp>(loc, value, rhs.value);
+    return ArithOp(builder, loc, res);
+  }
+
+  ArithOp operator<<(ArithOp &rhs) {
+    Value shl = builder.create<arith::ShLIOp>(loc, value, rhs.value);
+    return ArithOp(builder, loc, shl);
+  }
+
+  ArithOp operator>>(ArithOp &rhs) {
+    Value shr = builder.create<arith::ShRUIOp>(loc, value, rhs.value);
+    return ArithOp(builder, loc, shr);
+  }
+
+ private:
+  OpBuilder builder;
+  Location loc;
+  Value value;
+};
+
+std::pair<ArithOp, ArithOp> splitI64(ArithOp i64) {
+  auto low = i64.truncI(32);
+  auto c32 = i64.constantI(/*value=*/32, /*bits=*/64);
+  auto high = (i64 >> c32).truncI(32);
+  return {low, high};
+}
+
+ArithOp fuseI32s(ArithOp low, ArithOp high) {
+  auto c32 = high.constantI(/*value=*/32, /*bits=*/64);
+  high = high.extendUI(64) << c32;
+  low = low.extendUI(64);
+  return low | high;
+}
+
+// Implements the ThreeFry counter-based PRNG algorithm.
+// Salmon et al. SC 2011. Parallel random numbers: as easy as 1, 2, 3.
+// http://www.thesalmons.org/john/random123/papers/random123sc11.pdf
+std::pair<ArithOp, ArithOp> runThreeFry2xi32(ArithOp key0, ArithOp key1,
+                                             ArithOp initialState) {
+  ArithOp index = initialState.linalgIndex(0);
+  index = index.indexCast(64);
+  index = index + initialState;
+
+  // Split into the 2xi32 used for threefry.
+  std::pair<ArithOp, ArithOp> input = splitI64(index);
+  ArithOp input0 = input.first;
+  ArithOp input1 = input.second;
+
+  // Magic number and rotation distances specified by the Threefry2x32
+  // algorithm.
+  llvm::SmallVector<int32_t, 8> rotations = {13, 15, 26, 6, 17, 29, 16, 24};
+  ArithOp magic = key0.constantI(/*value=*/0x1bd11bda, /*bits=*/32);
+
+  ArithOp key2 = magic ^ key0 ^ key1;
+  std::array<ArithOp, 3> ks{key0, key1, key2};
+  std::array<ArithOp, 2> x{input0 + key0, input1 + key1};
+
+  // Performs a single round of the Threefry2x32 algorithm, with a rotation
+  // amount 'rotation'.
+  for (int i = 0; i < 5; ++i) {
+    int32_t rot = (4 * i) % rotations.size();
+    int32_t k1 = (i + 1) % ks.size();
+    int32_t k2 = (i + 2) % ks.size();
+
+    for (int j = 0; j < 4; ++j) {
+      x[0] = x[0] + x[1];
+      x[1] = x[1].rotateLeft(rotations[rot + j]);
+      x[1] = x[0] ^ x[1];
+    }
+
+    ArithOp c = x[0].constantI(/*value=*/i + 1, /*bits=*/32);
+    x[0] = x[0] + ks[k1];
+    x[1] = x[1] + ks[k2];
+    x[1] = x[1] + c;
+  }
+
+  return std::pair<ArithOp, ArithOp>(x[0], x[1]);
+}
+
+// Extract and potentially reconstruct the i32 key-pair as necessary.
+std::pair<Value, Value> extractKey32(OpBuilder &builder, Location loc,
+                                     Value store) {
+  auto storeTy = cast<ShapedType>(store.getType());
+  if (storeTy.getRank() != 1) return {nullptr, nullptr};
+
+  Type storeETy = storeTy.getElementType();
+  IntegerType i32Ty = builder.getIntegerType(32);
+  IntegerType i64Ty = builder.getIntegerType(64);
+
+  if (storeTy.getDimSize(0) == 4 && storeETy.isInteger(32)) {
+    Value idx0 = builder.create<arith::ConstantIndexOp>(loc, 0);
+    Value idx1 = builder.create<arith::ConstantIndexOp>(loc, 1);
+    Value key0 = builder.create<tensor::ExtractOp>(loc, store, idx0);
+    Value key1 = builder.create<tensor::ExtractOp>(loc, store, idx1);
+    key0 = builder.create<arith::BitcastOp>(loc, i32Ty, key0);
+    key1 = builder.create<arith::BitcastOp>(loc, i32Ty, key1);
+    return {key0, key1};
+  }
+
+  if (storeTy.getDimSize(0) == 2 && storeETy.isInteger(64)) {
+    Value idx1 = builder.create<arith::ConstantIndexOp>(loc, 0);
+    Value state = builder.create<tensor::ExtractOp>(loc, store, idx1);
+    Value cast = builder.create<arith::BitcastOp>(loc, i64Ty, state);
+    auto pair = splitI64(ArithOp(builder, loc, cast));
+    return std::pair<Value, Value>(pair.first, pair.second);
+  }
+
+  return {nullptr, nullptr};
+}
+
+// Extract and potentially reconstruct the i64 state as necessary.
+Value extractState64(OpBuilder &builder, Location loc, Value store) {
+  auto storeTy = cast<ShapedType>(store.getType());
+  if (storeTy.getRank() != 1) return nullptr;
+
+  Type storeETy = storeTy.getElementType();
+  IntegerType i64Ty = builder.getIntegerType(64);
+
+  if (storeTy.getDimSize(0) == 2 && storeETy.isInteger(64)) {
+    Value idx1 = builder.create<arith::ConstantIndexOp>(loc, 1);
+    Value state = builder.create<tensor::ExtractOp>(loc, store, idx1);
+    Value cast = builder.create<arith::BitcastOp>(loc, i64Ty, state);
+    return cast;
+  }
+
+  if (storeTy.getDimSize(0) == 4 && storeETy.isInteger(32)) {
+    Value idx2 = builder.create<arith::ConstantIndexOp>(loc, 2);
+    Value idx3 = builder.create<arith::ConstantIndexOp>(loc, 3);
+
+    Value low = builder.create<tensor::ExtractOp>(loc, store, idx2);
+    Value high = builder.create<tensor::ExtractOp>(loc, store, idx3);
+
+    ArithOp i64 =
+        fuseI32s(ArithOp(builder, loc, high), ArithOp(builder, loc, low));
+    return builder.create<arith::BitcastOp>(loc, i64Ty, i64.val());
+  }
+
+  return nullptr;
+}
+
+Value setState64(OpBuilder &b, Location loc, Value store, Value state) {
+  auto storeTy = cast<ShapedType>(store.getType());
+  if (storeTy.getRank() != 1) return nullptr;
+
+  Type storeETy = storeTy.getElementType();
+
+  if (storeTy.getDimSize(0) == 2 && storeETy.isInteger(64)) {
+    state = b.create<arith::BitcastOp>(loc, storeETy, state);
+    Value idx1 = b.create<arith::ConstantIndexOp>(loc, 1);
+    return b.create<tensor::InsertOp>(loc, storeTy, state, store,
+                                      ValueRange{idx1});
+  }
+
+  if (storeTy.getDimSize(0) == 4 && storeETy.isInteger(32)) {
+    Value idx2 = b.create<arith::ConstantIndexOp>(loc, 2);
+    Value idx3 = b.create<arith::ConstantIndexOp>(loc, 3);
+    std::pair<ArithOp, ArithOp> states = splitI64(ArithOp(b, loc, state));
+    Value state0 =
+        b.create<arith::BitcastOp>(loc, storeETy, states.first.val());
+    Value state1 =
+        b.create<arith::BitcastOp>(loc, storeETy, states.second.val());
+    Value insert0 = b.create<tensor::InsertOp>(loc, storeTy, state0, store,
+                                               ValueRange{idx2});
+    Value insert1 = b.create<tensor::InsertOp>(loc, storeTy, state1, insert0,
+                                               ValueRange{idx3});
+    return insert1;
+  }
+
+  return nullptr;
+}
+
+Value reshapeToTarget(OpBuilder &builder, Location loc, ShapedType destTy,
+                      Value src) {
+  auto srcTy = cast<ShapedType>(src.getType());
+  // Expand out to the target shape.
+
+  auto reassociationIndices =
+      getReassociationIndicesForCollapse(destTy.getShape(), srcTy.getShape());
+  if (reassociationIndices.has_value()) {
+    src = builder.create<tensor::ExpandShapeOp>(loc, destTy, src,
+                                                reassociationIndices.value());
+  }
+
+  // It is also possible our target is Rank-0, then we would
+  // need to collapse.
+  reassociationIndices =
+      getReassociationIndicesForCollapse(srcTy.getShape(), destTy.getShape());
+  if (reassociationIndices.has_value()) {
+    src = builder.create<tensor::CollapseShapeOp>(loc, destTy, src,
+                                                  reassociationIndices.value());
+  }
+
+  return src;
+}
+
+// Compute the shape for computing three fry.
+std::pair<ShapedType, int64_t> threeFry32Shape(ShapedType resultTy) {
+  if (resultTy.getRank() == 0) {
+    return {resultTy, 0};
+  }
+
+  ArrayRef<int64_t> shape = resultTy.getShape();
+  uint64_t halfDim =
+      std::max_element(shape.begin(), shape.end()) - shape.begin();
+
+  for (int i = 0, s = shape.size(); i < s; i++) {
+    if (shape[i] & 0x1) continue;
+    halfDim = i;
+    break;
+  }
+
+  llvm::SmallVector<int64_t> newShape(shape);
+  newShape[halfDim] = (newShape[halfDim] + 1) / 2;
+  if (halfDim == (newShape.size() - 1)) {
+    newShape.push_back(1);
+  }
+
+  return {RankedTensorType::get(newShape, resultTy.getElementType()), halfDim};
+}
+
+/// This implementation generates a 32-bit tensor of ThreeFry random numbers.
+/// It matches the XLA implementation bit-exact and includes an inefficient
+/// method of concatenating / slicing the pairs of generated numbers.
+///
+/// We should consider dropping the complex slicing and simply generating
+/// 2x the values, then downcast to a 32-bit. It substantially simplifies
+/// the computation and avoids the concat / slice behavior.
+LogicalResult generateLinalgThreeFry32(OpBuilder &builder, Location loc,
+                                       ShapedType resultTy, Value &store,
+                                       Value &result) {
+  Type resultETy = resultTy.getElementType();
+
+  // Extract the stateful values as an i64 and increment the state ahead.
+  Value initialState = extractState64(builder, loc, store);
+  if (!initialState) return failure();
+
+  std::pair<Value, Value> keys = extractKey32(builder, loc, store);
+  if (!keys.first || !keys.second) return failure();
+
+  ArithOp key0(builder, loc, keys.first);
+  ArithOp key1(builder, loc, keys.second);
+
+  // Compute the intermediate type we use to compute three fry values, including
+  // the dimension that was halved.
+  auto pair = threeFry32Shape(resultTy);
+  ShapedType intermediateType = pair.first;
+  int64_t halfDim = pair.second;
+  int64_t count = intermediateType.getNumElements();
+
+  // Compute the number of random i64s generated and increment state.
+  Value countVal =
+      builder.create<arith::ConstantOp>(loc, builder.getI64IntegerAttr(count));
+  Value newState = builder.create<arith::AddIOp>(loc, initialState, countVal);
+
+  // Generate a 1D tensor with for the random values.
+  Value destLeft = builder.create<tensor::EmptyOp>(
+      loc, ArrayRef<int64_t>({count}), resultETy);
+  Value destRight = builder.create<tensor::EmptyOp>(
+      loc, ArrayRef<int64_t>({count}), resultETy);
+
+  ShapedType destTy = destLeft.getType().cast<ShapedType>();
+
+  SmallVector<AffineMap> indexingMaps(2, builder.getMultiDimIdentityMap(1));
+  SmallVector<utils::IteratorType> iterators(1, utils::IteratorType::parallel);
+
+  linalg::GenericOp generic = builder.create<linalg::GenericOp>(
+      loc, TypeRange{destTy, destTy},
+      /*inputs=*/ValueRange(),
+      /*outputs=*/ValueRange{destLeft, destRight},
+      /*indexingMaps=*/indexingMaps, iterators,
+      [&](OpBuilder &b, Location nestedLoc, ValueRange) {
+        // Grab three fry results and write to each array.
+        auto split =
+            runThreeFry2xi32(key0, key1, ArithOp(b, nestedLoc, initialState));
+        auto first = split.first.truncI(resultETy.getIntOrFloatBitWidth());
+        auto second = split.second.truncI(resultETy.getIntOrFloatBitWidth());
+        b.create<linalg::YieldOp>(loc, ValueRange{first.val(), second.val()});
+      });
+
+  if (resultTy.getNumElements() == 1) {
+    result = reshapeToTarget(builder, loc, resultTy, generic.getResult(0));
+    store = setState64(builder, loc, store, newState);
+    return success();
+  }
+
+  // Reshape to the target size and concatenate on the dimension following the
+  // half dimension.
+  Value random0 =
+      reshapeToTarget(builder, loc, intermediateType, generic.getResult(0));
+  Value random1 =
+      reshapeToTarget(builder, loc, intermediateType, generic.getResult(1));
+  Value concatenate = builder.create<stablehlo::ConcatenateOp>(
+      loc, ValueRange{random0, random1},
+      builder.getI64IntegerAttr(halfDim + 1));
+
+  // Collapse the concat dimension back into the parent.
+  llvm::SmallVector<int64_t> collapseShape(resultTy.getShape());
+  collapseShape[halfDim] =
+      collapseShape[halfDim] + (collapseShape[halfDim] & 1);
+  Value reshape = builder.create<stablehlo::ReshapeOp>(
+      loc, resultTy.clone(collapseShape), concatenate);
+
+  // Slice to only the required results.
+  llvm::SmallVector<int64_t> offset(resultTy.getRank(), 0);
+  llvm::SmallVector<int64_t> stride(resultTy.getRank(), 1);
+  Value slice = builder.create<stablehlo::SliceOp>(
+      loc, resultTy, reshape, builder.getI64TensorAttr(offset),
+      builder.getI64TensorAttr(resultTy.getShape()),
+      builder.getI64TensorAttr(stride));
+
+  // Set the new tensor values.
+  store = setState64(builder, loc, store, newState);
+  result = slice;
+
+  return success();
+}
+
+LogicalResult generateLinalgThreeFry64(OpBuilder &builder, Location loc,
+                                       ShapedType resultTy, Value &store,
+                                       Value &result) {
+  Type resultETy = resultTy.getElementType();
+  int64_t count = resultTy.getNumElements();
+
+  // Extract the stateful values as an i64 and increment the state ahead.
+  Value initialState = extractState64(builder, loc, store);
+  if (!initialState) return failure();
+
+  std::pair<Value, Value> keys = extractKey32(builder, loc, store);
+  if (!keys.first || !keys.second) return failure();
+
+  ArithOp key0(builder, loc, keys.first);
+  ArithOp key1(builder, loc, keys.second);
+
+  // Compute the number of random i64s generated and increment state.
+  Value countVal =
+      builder.create<arith::ConstantOp>(loc, builder.getI64IntegerAttr(count));
+  Value newState = builder.create<arith::AddIOp>(loc, initialState, countVal);
+
+  // Generate a 1D tensor with for the random values.
+  Value dest = builder.create<tensor::EmptyOp>(loc, ArrayRef<int64_t>({count}),
+                                               resultETy);
+  ShapedType destTy = dest.getType().cast<ShapedType>();
+
+  SmallVector<AffineMap> indexingMaps(1, builder.getMultiDimIdentityMap(1));
+  SmallVector<utils::IteratorType> iterators(1, utils::IteratorType::parallel);
+
+  auto random = builder.create<linalg::GenericOp>(
+      loc, destTy, /*inputs=*/ValueRange(),
+      /*outputs=*/ValueRange{dest},
+      /*indexingMaps=*/indexingMaps, iterators,
+      [&](OpBuilder &b, Location nestedLoc, ValueRange) {
+        // Generate three fry results, fuse, and return an
+        // i64.
+        auto split =
+            runThreeFry2xi32(key0, key1, ArithOp(b, nestedLoc, initialState));
+        Value result = fuseI32s(split.first, split.second).val();
+        b.create<linalg::YieldOp>(nestedLoc, result);
+      });
+
+  store = setState64(builder, loc, store, newState);
+  result = reshapeToTarget(builder, loc, resultTy, random.getResult(0));
+  return success();
+}
+
+LogicalResult generateLinalgThreeFry(OpBuilder &builder, Location loc,
+                                     ShapedType resultTy, Value &state,
+                                     Value &result) {
+  Type eTy = resultTy.getElementType();
+  unsigned bitwidth = eTy.getIntOrFloatBitWidth();
+
+  if (bitwidth == 64) {
+    return generateLinalgThreeFry64(builder, loc, resultTy, state, result);
+  }
+  if (bitwidth == 32) {
+    return generateLinalgThreeFry32(builder, loc, resultTy, state, result);
+  }
+  if (bitwidth == 16) {
+    return generateLinalgThreeFry32(builder, loc, resultTy, state, result);
+  }
+
+  return failure();
+}
+
+struct RngBitGeneratorConverter final
+    : OpConversionPattern<stablehlo::RngBitGeneratorOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      stablehlo::RngBitGeneratorOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value state = adaptor.getInitialState();
+    auto resultTy = dyn_cast_or_null<ShapedType>(
+        getTypeConverter()->convertType(op.getResult(1).getType()));
+    if (!resultTy) {
+      return rewriter.notifyMatchFailure(op, "type conversion failed");
+    }
+
+    if (op.getRngAlgorithm() == stablehlo::RngAlgorithm::THREE_FRY) {
+      Value random;
+      if (failed(
+              generateLinalgThreeFry(rewriter, loc, resultTy, state, random))) {
+        return failure();
+      }
+      rewriter.replaceOp(op, {state, random});
+      return success();
+    }
+
+    return failure();
+  }
+};
+
+struct RngUniformConversion final : OpConversionPattern<stablehlo::RngOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      stablehlo::RngOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // We only handle uniform distributions.
+    if (op.getRngDistribution() != stablehlo::RngDistribution::UNIFORM) {
+      return failure();
+    }
+    // TODO(raikonenfnu): Handle other element types as well.
+    auto minTy = dyn_cast<ShapedType>(adaptor.getA().getType());
+    auto maxTy = dyn_cast<ShapedType>(adaptor.getB().getType());
+    if (!isa<FloatType>(minTy.getElementType()) ||
+        !isa<FloatType>(maxTy.getElementType())) {
+      return rewriter.notifyMatchFailure(
+          op, "expected min/max for rng op to be FloatType");
+    }
+    auto targetTy = dyn_cast_or_null<ShapedType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+    if (!targetTy) {
+      return rewriter.notifyMatchFailure(
+          op, "expected target shape of rng op to be ShapedType");
+    }
+    auto loc = op.getLoc();
+    Value emptyTensor =
+        getEmptyTensorFor(rewriter, loc, targetTy, op, adaptor.getOperands());
+    // Creates index map using target matrix's rank.
+    auto targetRank = targetTy.getRank();
+    SmallVector<AffineMap, 3> indexingMaps(
+        2, AffineMap::get(targetRank, /*symbolCount=*/0,
+                          SmallVector<AffineExpr>({}), rewriter.getContext()));
+    indexingMaps.push_back(rewriter.getMultiDimIdentityMap(targetRank));
+    const int kInitialSeed = 0;
+
+    // Generic region with LCG Algorithm that make use of element index from:
+    // https://reviews.llvm.org/D101364
+    auto linalgOp = rewriter.create<linalg::GenericOp>(
+        loc, /*resultTensors=*/targetTy,
+        /*inputs=*/
+        ValueRange{adaptor.getOperands()[0], adaptor.getOperands()[1]},
+        /*outputs=*/emptyTensor, indexingMaps,
+        getParallelAndReductionIterators(/*nLoops=*/targetRank,
+                                         /*nReduction=*/0),
+        [&](OpBuilder &b, Location loc, ValueRange args) {
+          llvm::SmallVector<Value> updateVec = {b.create<arith::ConstantOp>(
+              loc, b.getI32IntegerAttr(kInitialSeed))};
+          Value multiplier =
+              b.create<arith::ConstantOp>(loc, b.getI32IntegerAttr(1103515245));
+          Value incrementStep =
+              b.create<arith::ConstantOp>(loc, b.getI32IntegerAttr(12345));
+          // For output matrix with rank N:
+          // temp1 = (cast(I32, index(D.0)) + seed) * mult + incr
+          // ...
+          // tempN = (cast(I32, index(D.(N))) + tempN_1) * mult + incr
+          for (int i = 0; i < targetRank; i++) {
+            Value update = updateVec.back();
+            Value ind = b.create<linalg::IndexOp>(loc, i);
+            Value castInd =
+                b.create<arith::IndexCastOp>(loc, b.getI32Type(), ind);
+            Value addRes = b.create<arith::AddIOp>(loc, castInd, update);
+            Value multRes = b.create<arith::MulIOp>(loc, addRes, multiplier);
+            Value incRes = b.create<arith::AddIOp>(loc, multRes, incrementStep);
+            updateVec.push_back(incRes);
+          }
+          // Scaling = (max - min) * const(F64, 2.3283064E-10)
+          // which is derived from rand(min,max) = rand()/(RAND_MAX/(max-min)).
+          Value epsilon = b.create<arith::ConstantOp>(
+              loc, b.getFloatAttr(args[0].getType(), 2.3283064E-10));
+          Value range = b.create<arith::SubFOp>(loc, args[1], args[0]);
+          Value scale = b.create<arith::MulFOp>(loc, range, epsilon);
+          // Res = cast(T, cast(F64, tempN) * scaling + min)
+          Value updateCast = b.create<arith::UIToFPOp>(
+              loc, targetTy.getElementType(), updateVec.back());
+          Value scaleUpdate = b.create<arith::MulFOp>(loc, updateCast, scale);
+          Value res = b.create<arith::AddFOp>(loc, scaleUpdate, args[0]);
+          b.create<linalg::YieldOp>(loc, res);
+        },
+        linalg::getPrunedAttributeList(op));
+    rewriter.replaceOp(op, linalgOp.getResults());
+    return success();
+  }
+};
+
+}  // namespace
+
+namespace detail {
+void populateStableHloRandomToLinalgConversionPatterns(
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet *patterns) {
+  patterns->add<RngBitGeneratorConverter, RngUniformConversion>(typeConverter,
+                                                                context);
+}
+}  // namespace detail
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "stablehlo_to_linalg_dot_prod.mlir",
             "stablehlo_to_linalg_pointwise.mlir",
+            "stablehlo_to_linalg_random.mlir",
             "stablehlo_to_linalg_reduce.mlir",
             "stablehlo_to_linalg.mlir",
         ],

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "stablehlo_to_linalg.mlir"
     "stablehlo_to_linalg_dot_prod.mlir"
     "stablehlo_to_linalg_pointwise.mlir"
+    "stablehlo_to_linalg_random.mlir"
     "stablehlo_to_linalg_reduce.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg_random.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg_random.mlir
@@ -1,0 +1,327 @@
+// RUN: iree-opt %s --iree-stablehlo-to-linalg --split-input-file \
+// RUN:   --canonicalize | FileCheck %s
+
+// CHECK-LABEL: func @rng_uniform_1d
+func.func @rng_uniform_1d(%min: tensor<f32>, %max: tensor<f32>) -> tensor<10xf32> {
+  %shape = arith.constant dense<[10]>  : tensor<1xi32>
+  %0 = "stablehlo.rng"(%min, %max, %shape) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<1xi32>) -> tensor<10xf32>
+  func.return %0 : tensor<10xf32>
+}
+// CHECK-DAG:  ^{{.+}}(%[[MIN:.+]]: f32, %[[MAX:.+]]: f32, %[[OUT:.+]]: f32
+// CHECK-DAG:    %[[CST0:.+]] = arith.constant 1103515245 : i32
+// CHECK-DAG:    %[[CST1:.+]] = arith.constant 12345 : i32
+// CHECK-DAG:    %[[CST2:.+]] = arith.constant 2.32830644E-10 : f32
+// CHECK-DAG:  %[[IDX0:.+]] = linalg.index 0 : index
+// CHECK-DAG:  %[[IDX0_CAST:.+]] = arith.index_cast %[[IDX0]] : index to i32
+// CHECK-DAG:    %[[VAL1:.+]] = arith.muli %[[IDX0_CAST]], %[[CST0]] : i32
+// CHECK-DAG:    %[[VAL2:.+]] = arith.addi %[[VAL1]], %[[CST1]] : i32
+// CHECK-DAG:    %[[DIFF:.+]] = arith.subf %[[MAX]], %[[MIN]] : f32
+// CHECK-DAG:    %[[FACT:.+]] = arith.mulf %[[DIFF]], %[[CST2]] : f32
+// CHECK-DAG:    %[[VAL2_CAST:.+]] = arith.uitofp %[[VAL2]] : i32 to f32
+// CHECK-DAG:    %[[VAL4:.+]] = arith.mulf %[[VAL2_CAST]], %[[FACT]] : f32
+// CHECK-DAG:    %[[VAL5:.+]] = arith.addf %[[VAL4]], %[[MIN]] : f32
+// CHECK-NEXT:   linalg.yield %[[VAL5]] : f32
+// CHECK-NEXT: -> tensor<10xf32>
+
+// -----
+
+// CHECK-LABEL: func @rng_uniform_2d
+func.func @rng_uniform_2d(%min: tensor<f32>, %max: tensor<f32>) -> tensor<3x3xf32> {
+  %shape = arith.constant dense<[3, 3]>  : tensor<2xi32>
+  %0 = "stablehlo.rng"(%min, %max, %shape) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<2xi32>) -> tensor<3x3xf32>
+  func.return %0 : tensor<3x3xf32>
+}
+// CHECK-DAG:  ^{{.*}}(%[[MIN:.+]]: f32, %[[MAX:.+]]: f32, %[[OUT:.+]]: f32
+// CHECK-DAG:    %[[CST0:.+]] = arith.constant 1103515245 : i32
+// CHECK-DAG:    %[[CST1:.+]] = arith.constant 12345 : i32
+// CHECK-DAG:    %[[CST2:.+]] = arith.constant 2.32830644E-10 : f32
+// CHECK-DAG:  %[[IDX0:.+]] = linalg.index 0 : index
+// CHECK-DAG:  %[[IDX0_CAST:.+]] = arith.index_cast %[[IDX0]] : index to i32
+// CHECK-DAG:  %[[IDX1:.+]] = linalg.index 1 : index
+// CHECK-DAG:  %[[IDX1_CAST:.+]] = arith.index_cast %[[IDX1]] : index to i32
+// CHECK-DAG:    %[[VAL1:.+]] = arith.muli %[[IDX0_CAST]], %[[CST0]] : i32
+// CHECK-DAG:    %[[VAL2:.+]] = arith.addi %[[VAL1]], %[[CST1]] : i32
+// CHECK-DAG:    %[[VAL3:.+]] = arith.addi %[[IDX1_CAST]], %[[VAL2]] : i32
+// CHECK-DAG:    %[[VAL4:.+]] = arith.muli %[[VAL3]], %[[CST0]] : i32
+// CHECK-DAG:    %[[VAL5:.+]] = arith.addi %[[VAL4]], %[[CST1]] : i32
+// CHECK-DAG:    %[[DIFF:.+]] = arith.subf %[[MAX]], %[[MIN]] : f32
+// CHECK-DAG:    %[[FACT:.+]] = arith.mulf %[[DIFF]], %[[CST2]] : f32
+// CHECK-DAG:    %[[VAL5_CAST:.+]] = arith.uitofp %[[VAL5]] : i32 to f32
+// CHECK-DAG:    %[[VAL6:.+]] = arith.mulf %[[VAL5_CAST]], %[[FACT]] : f32
+// CHECK-DAG:    %[[VAL7:.+]] = arith.addf %[[VAL6]], %[[MIN]] : f32
+// CHECK-NEXT:   linalg.yield %[[VAL7]] : f32
+// CHECK-NEXT: -> tensor<3x3xf32>
+
+// -----
+
+// CHECK-LABEL: func @rng_uniform_3d
+func.func @rng_uniform_3d(%min: tensor<f32>, %max: tensor<f32>) -> tensor<2x2x2xf32> {
+  %shape = arith.constant dense<[2, 2, 2]>  : tensor<3xi32>
+  %0 = "stablehlo.rng"(%min, %max, %shape) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<3xi32>) -> tensor<2x2x2xf32>
+  func.return %0 : tensor<2x2x2xf32>
+}
+// CHECK-DAG:  ^{{.*}}(%[[MIN:.+]]: f32, %[[MAX:.+]]: f32, %[[OUT:.+]]: f32
+// CHECK-DAG:    %[[CST0:.+]] = arith.constant 1103515245 : i32
+// CHECK-DAG:    %[[CST1:.+]] = arith.constant 12345 : i32
+// CHECK-DAG:    %[[CST2:.+]] = arith.constant 2.32830644E-10 : f32
+// CHECK-DAG:  %[[IDX0:.+]] = linalg.index 0 : index
+// CHECK-DAG:  %[[IDX0_CAST:.+]] = arith.index_cast %[[IDX0]] : index to i32
+// CHECK-DAG:  %[[IDX1:.+]] = linalg.index 1 : index
+// CHECK-DAG:  %[[IDX1_CAST:.+]] = arith.index_cast %[[IDX1]] : index to i32
+// CHECK-DAG:  %[[IDX2:.+]] = linalg.index 2 : index
+// CHECK-DAG:  %[[IDX2_CAST:.+]] = arith.index_cast %[[IDX2]] : index to i32
+// CHECK-DAG:    %[[VAL1:.+]] = arith.muli %[[IDX0_CAST]], %[[CST0]] : i32
+// CHECK-DAG:    %[[VAL2:.+]] = arith.addi %[[VAL1]], %[[CST1]] : i32
+// CHECK-DAG:    %[[VAL3:.+]] = arith.addi %[[IDX1_CAST]], %[[VAL2]] : i32
+// CHECK-DAG:    %[[VAL4:.+]] = arith.muli %[[VAL3]], %[[CST0]] : i32
+// CHECK-DAG:    %[[VAL5:.+]] = arith.addi %[[VAL4]], %[[CST1]] : i32
+// CHECK-DAG:    %[[VAL6:.+]] = arith.addi %[[IDX2_CAST]], %[[VAL5]] : i32
+// CHECK-DAG:    %[[VAL7:.+]] = arith.muli %[[VAL6]], %[[CST0]] : i32
+// CHECK-DAG:    %[[VAL8:.+]] = arith.addi %[[VAL7]], %[[CST1]] : i32
+// CHECK-DAG:    %[[DIFF:.+]] = arith.subf %[[MAX]], %[[MIN]] : f32
+// CHECK-DAG:    %[[FACT:.+]] = arith.mulf %[[DIFF]], %[[CST2]] : f32
+// CHECK-DAG:    %[[VAL8_CAST:.+]] = arith.uitofp %[[VAL8]] : i32 to f32
+// CHECK-DAG:    %[[VAL6:.+]] = arith.mulf %[[VAL8_CAST]], %[[FACT]] : f32
+// CHECK-DAG:    %[[VAL7:.+]] = arith.addf %[[VAL6]], %[[MIN]] : f32
+// CHECK-NEXT:   linalg.yield %[[VAL7]] : f32
+// CHECK-NEXT: -> tensor<2x2x2xf32>
+
+// -----
+
+// CHECK-LABEL: func @rng_uniform_dynamic_1d
+func.func @rng_uniform_dynamic_1d(%min: tensor<f32>, %max: tensor<f32>, %shape: tensor<1xi32>) -> tensor<?xf32> {
+  %0 = "stablehlo.rng"(%min, %max, %shape) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<1xi32>) -> tensor<?xf32>
+  func.return %0 : tensor<?xf32>
+}
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[EX:.+]] = tensor.extract %{{.*}}[%[[C0]]]
+// CHECK-DAG:    %[[IND:.+]] = arith.index_cast %[[EX]] : i32 to index
+// CHECK-DAG:    %{{.+}} = tensor.empty(%[[IND]]) : tensor<?xf32>
+// CHECK-DAG:  ^{{.*}}(%[[MIN:.+]]: f32, %[[MAX:.+]]: f32, %[[OUT:.+]]: f32
+// CHECK-DAG:    %[[CST0:.+]] = arith.constant 1103515245 : i32
+// CHECK-DAG:    %[[CST1:.+]] = arith.constant 12345 : i32
+// CHECK-DAG:    %[[CST2:.+]] = arith.constant 2.32830644E-10 : f32
+// CHECK-DAG:    %[[IDX0:.+]] = linalg.index 0 : index
+// CHECK-DAG:    %[[IDX0_CAST:.+]] = arith.index_cast %[[IDX0]] : index to i32
+// CHECK-DAG:    %[[VAL1:.+]] = arith.muli %[[IDX0_CAST]], %[[CST0]] : i32
+// CHECK-DAG:    %[[VAL2:.+]] = arith.addi %[[VAL1]], %[[CST1]] : i32
+// CHECK-DAG:    %[[DIFF:.+]] = arith.subf %[[MAX]], %[[MIN]] : f32
+// CHECK-DAG:    %[[FACT:.+]] = arith.mulf %[[DIFF]], %[[CST2]] : f32
+// CHECK-DAG:    %[[VAL2_CAST:.+]] = arith.uitofp %[[VAL2]] : i32 to f32
+// CHECK-DAG:    %[[VAL4:.+]] = arith.mulf %[[VAL2_CAST]], %[[FACT]] : f32
+// CHECK-DAG:    %[[VAL5:.+]] = arith.addf %[[VAL4]], %[[MIN]] : f32
+// CHECK-NEXT:   linalg.yield %[[VAL5]] : f32
+// CHECK-NEXT: -> tensor<?xf32>
+
+// -----
+
+// CHECK-LABEL: func.func @three_fry_i64(
+// CHECK-SAME:  %[[ARG0:.*]]: tensor<2xi64>
+func.func @three_fry_i64(%arg0: tensor<2xi64>) -> (tensor<2xi64>, tensor<8xi64>) {
+  %output_state, %output = "stablehlo.rng_bit_generator"(%arg0) {rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>} : (tensor<2xi64>) -> (tensor<2xi64>, tensor<8xi64>)
+  return %output_state, %output : tensor<2xi64>, tensor<8xi64>
+}
+// CHECK-DAG: %[[VAL_1:.*]] = arith.constant 5 : i32
+// CHECK-DAG: %[[VAL_2:.*]] = arith.constant 4 : i32
+// CHECK-DAG: %[[VAL_3:.*]] = arith.constant 2 : i32
+// CHECK-DAG: %[[VAL_4:.*]] = arith.constant 8 : i32
+// CHECK-DAG: %[[VAL_5:.*]] = arith.constant 24 : i32
+// CHECK-DAG: %[[VAL_6:.*]] = arith.constant 16 : i32
+// CHECK-DAG: %[[VAL_7:.*]] = arith.constant 3 : i32
+// CHECK-DAG: %[[VAL_8:.*]] = arith.constant 29 : i32
+// CHECK-DAG: %[[VAL_9:.*]] = arith.constant 1 : i32
+// CHECK-DAG: %[[VAL_10:.*]] = arith.constant 6 : i32
+// CHECK-DAG: %[[VAL_11:.*]] = arith.constant 26 : i32
+// CHECK-DAG: %[[VAL_12:.*]] = arith.constant 17 : i32
+// CHECK-DAG: %[[VAL_13:.*]] = arith.constant 15 : i32
+// CHECK-DAG: %[[VAL_14:.*]] = arith.constant 19 : i32
+// CHECK-DAG: %[[VAL_15:.*]] = arith.constant 13 : i32
+// CHECK-DAG: %[[VAL_16:.*]] = arith.constant 466688986 : i32
+// CHECK-DAG: %[[VAL_17:.*]] = arith.constant 8 : i64
+// CHECK-DAG: %[[VAL_18:.*]] = arith.constant 32 : i64
+// CHECK-DAG: %[[VAL_19:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[VAL_20:.*]] = arith.constant 1 : index
+
+// CHECK-DAG: %[[VAL_21:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[VAL_20]]] : tensor<2xi64>
+// CHECK-DAG: %[[VAL_22:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[VAL_19]]] : tensor<2xi64>
+// CHECK-DAG: %[[VAL_23:.*]] = arith.trunci %[[VAL_22]] : i64 to i32
+// CHECK-DAG: %[[VAL_24:.*]] = arith.shrui %[[VAL_22]], %[[VAL_18]] : i64
+// CHECK-DAG: %[[VAL_25:.*]] = arith.trunci %[[VAL_24]] : i64 to i32
+// CHECK-DAG: %[[VAL_26:.*]] = arith.addi %[[VAL_21]], %[[VAL_17]] : i64
+// CHECK-DAG: %[[VAL_27:.*]] = tensor.empty() : tensor<8xi64>
+// CHECK-DAG: %[[VAL_28:.*]] = arith.xori %[[VAL_23]], %[[VAL_16]] : i32
+// CHECK-DAG: %[[VAL_29:.*]] = arith.xori %[[VAL_28]], %[[VAL_25]] : i32
+
+// CHECK: %[[GENERIC:.*]] = linalg.generic
+// CHECK-SAME: {indexing_maps = [#map], iterator_types = ["parallel"]}
+// CHECK-SAME: outs(%[[VAL_27]] : tensor<8xi64>)
+
+// CHECK: ^bb0(%[[VAL_31:.*]]: i64):
+
+// CHECK-DAG:   %[[VAL_32:.*]] = linalg.index 0 : index
+// CHECK-DAG:   %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : index to i64
+// CHECK-DAG:   %[[VAL_34:.*]] = arith.addi %[[VAL_33]], %[[VAL_21]] : i64
+// CHECK-DAG:   %[[VAL_35:.*]] = arith.trunci %[[VAL_34]] : i64 to i32
+// CHECK-DAG:   %[[VAL_36:.*]] = arith.shrui %[[VAL_34]], %[[VAL_18]] : i64
+// CHECK-DAG:   %[[VAL_37:.*]] = arith.trunci %[[VAL_36]] : i64 to i32
+
+// CHECK-DAG:   %[[VAL_38:.*]] = arith.addi %[[VAL_35]], %[[VAL_23]] : i32
+// CHECK-DAG:   %[[VAL_39:.*]] = arith.addi %[[VAL_37]], %[[VAL_25]] : i32
+
+// CHECK-DAG:   %[[VAL_40:.*]] = arith.addi %[[VAL_38]], %[[VAL_39]] : i32
+// CHECK-DAG:   %[[VAL_41:.*]] = arith.shli %[[VAL_39]], %[[VAL_15]] : i32
+// CHECK-DAG:   %[[VAL_42:.*]] = arith.shrui %[[VAL_39]], %[[VAL_14]] : i32
+// CHECK-DAG:   %[[VAL_43:.*]] = arith.ori %[[VAL_41]], %[[VAL_42]] : i32
+// CHECK-DAG:   %[[VAL_44:.*]] = arith.xori %[[VAL_40]], %[[VAL_43]] : i32
+
+// CHECK-DAG:   %[[VAL_45:.*]] = arith.addi %[[VAL_40]], %[[VAL_44]] : i32
+// CHECK-DAG:   %[[VAL_46:.*]] = arith.shli %[[VAL_44]], %[[VAL_13]] : i32
+// CHECK-DAG:   %[[VAL_47:.*]] = arith.shrui %[[VAL_44]], %[[VAL_12]] : i32
+// CHECK-DAG:   %[[VAL_48:.*]] = arith.ori %[[VAL_46]], %[[VAL_47]] : i32
+// CHECK-DAG:   %[[VAL_49:.*]] = arith.xori %[[VAL_45]], %[[VAL_48]] : i32
+
+// CHECK-DAG:   %[[VAL_50:.*]] = arith.addi %[[VAL_45]], %[[VAL_49]] : i32
+// CHECK-DAG:   %[[VAL_51:.*]] = arith.shli %[[VAL_49]], %[[VAL_11]] : i32
+// CHECK-DAG:   %[[VAL_52:.*]] = arith.shrui %[[VAL_49]], %[[VAL_10]] : i32
+// CHECK-DAG:   %[[VAL_53:.*]] = arith.ori %[[VAL_51]], %[[VAL_52]] : i32
+// CHECK-DAG:   %[[VAL_54:.*]] = arith.xori %[[VAL_50]], %[[VAL_53]] : i32
+
+// CHECK-DAG:   %[[VAL_55:.*]] = arith.addi %[[VAL_50]], %[[VAL_54]] : i32
+// CHECK-DAG:   %[[VAL_56:.*]] = arith.shli %[[VAL_54]], %[[VAL_10]] : i32
+// CHECK-DAG:   %[[VAL_57:.*]] = arith.shrui %[[VAL_54]], %[[VAL_11]] : i32
+// CHECK-DAG:   %[[VAL_58:.*]] = arith.ori %[[VAL_56]], %[[VAL_57]] : i32
+// CHECK-DAG:   %[[VAL_59:.*]] = arith.xori %[[VAL_55]], %[[VAL_58]] : i32
+
+// CHECK-DAG:   %[[VAL_60:.*]] = arith.addi %[[VAL_55]], %[[VAL_25]] : i32
+// CHECK-DAG:   %[[VAL_61:.*]] = arith.addi %[[VAL_59]], %[[VAL_29]] : i32
+// CHECK-DAG:   %[[VAL_62:.*]] = arith.addi %[[VAL_61]], %[[VAL_9]] : i32
+// CHECK-DAG:   %[[VAL_63:.*]] = arith.addi %[[VAL_60]], %[[VAL_62]] : i32
+// CHECK-DAG:   %[[VAL_64:.*]] = arith.shli %[[VAL_62]], %[[VAL_12]] : i32
+// CHECK-DAG:   %[[VAL_65:.*]] = arith.shrui %[[VAL_62]], %[[VAL_13]] : i32
+// CHECK:   %[[VAL_66:.*]] = arith.ori %[[VAL_64]], %[[VAL_65]] : i32
+
+// CHECK:   linalg.yield %[[YIELDED:.*]] : i64
+
+// Set the updated state.
+// CHECK: %[[VAL_159:.*]] = tensor.insert %[[VAL_26]] into %[[ARG0]]{{\[}}%[[VAL_20]]] : tensor<2xi64>
+
+// CHECK: return %[[VAL_159]], %[[GENERIC:.*]] : tensor<2xi64>, tensor<8xi64>
+
+// -----
+
+// CHECK-LABEL: func.func @three_fry_i32
+// CHECK-SAME:  %[[ARG0:.*]]: tensor<2xi64>
+func.func @three_fry_i32(%arg0: tensor<2xi64>) -> (tensor<2xi64>, tensor<8xi32>) {
+  %output_state, %output = "stablehlo.rng_bit_generator"(%arg0) {rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>} : (tensor<2xi64>) -> (tensor<2xi64>, tensor<8xi32>)
+  return %output_state, %output : tensor<2xi64>, tensor<8xi32>
+}
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i64
+
+// Check we update state correctly:
+// CHECK: %[[STATE:.+]] = tensor.extract %[[ARG0]][%[[C1]]] : tensor<2xi64>
+// CHECK: %[[NEWSTATE:.+]] = arith.addi %[[STATE]], %[[C4]] : i64
+
+// CHECK: %[[DEST0:.+]] = tensor.empty() : tensor<4xi32>
+// CHECK: %[[DEST1:.+]] = tensor.empty() : tensor<4xi32>
+// CHECK: %[[GENERIC:.+]]:2 = linalg.generic
+// CHECK-SAME: indexing_maps = [#map, #map]
+// CHECK-SAME: iterator_types = ["parallel"]}
+// CHECK-SAME: outs(%[[DEST0]], %[[DEST1]] : tensor<4xi32>, tensor<4xi32>)
+
+// CHECK: %expanded = tensor.expand_shape %[[GENERIC]]#0
+// CHECK-SAME{literal}: [[0, 1]] : tensor<4xi32> into tensor<4x1xi32>
+
+// CHECK: %expanded_1 = tensor.expand_shape %[[GENERIC]]#1
+// CHECK-SAME{literal}: [[0, 1]] : tensor<4xi32> into tensor<4x1xi32>
+
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<4x2xi32>
+// CHECK: %[[CONCAT:.+]] = linalg.generic
+// CHECK-SAME: outs(%[[EMPTY]] : tensor<4x2xi32>)
+
+// CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[CONCAT]]
+// CHECK-SAME{literal}: [[0, 1]] : tensor<4x2xi32> into tensor<8xi32>
+// CHECK: %[[INSERTED:.+]] = tensor.insert %[[NEWSTATE]] into %[[ARG0]][%[[C1]]] : tensor<2xi64>
+
+// CHECK: return %[[INSERTED]], %[[COLLAPSE]]
+
+
+// -----
+
+// CHECK-LABEL: func.func @three_fry_odd_i32
+// CHECK-SAME:  %[[ARG0:.*]]: tensor<2xi64>
+func.func @three_fry_odd_i32(%arg0: tensor<2xi64>) -> (tensor<2xi64>, tensor<7x11xi32>) {
+  %output_state, %output = "stablehlo.rng_bit_generator"(%arg0) {rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>} : (tensor<2xi64>) -> (tensor<2xi64>, tensor<7x11xi32>)
+  return %output_state, %output : tensor<2xi64>, tensor<7x11xi32>
+}
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i64
+
+// Check we update state correctly:
+// CHECK: %[[STATE:.+]] = tensor.extract %[[ARG0]][%[[C1]]] : tensor<2xi64>
+// CHECK: %[[NEWSTATE:.+]] = arith.addi %[[STATE]], %[[C42]] : i64
+
+// CHECK: %[[DEST0:.+]] = tensor.empty() : tensor<42xi32>
+// CHECK: %[[DEST1:.+]] = tensor.empty() : tensor<42xi32>
+// CHECK: %[[GENERIC:.+]]:2 = linalg.generic
+// CHECK-SAME: indexing_maps = [#map, #map]
+// CHECK-SAME: iterator_types = ["parallel"]}
+// CHECK-SAME: outs(%[[DEST0]], %[[DEST1]] : tensor<42xi32>, tensor<42xi32>)
+
+// CHECK: %expanded = tensor.expand_shape %[[GENERIC]]#0
+// CHECK-SAME{literal}: [[0, 1]] : tensor<4xi32> into tensor<7x6x1xi32>
+
+// CHECK: %expanded_1 = tensor.expand_shape %[[GENERIC]]#1
+// CHECK-SAME{literal}: [[0, 1]] : tensor<4xi32> into tensor<7x6x1xi32>
+
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<7x6x2xi32>
+// CHECK: %[[CONCAT:.+]] = linalg.generic
+// CHECK-SAME: outs(%[[EMPTY]] : tensor<7x6x2xi32>)
+
+// CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %10
+// CHECK-SAME{literal}: [[0], [1, 2]] : tensor<7x6x2xi32> into tensor<7x12xi32>
+
+// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[COLLAPSE]][0, 0] [7, 11] [1, 1]
+// CHECK: %[[INSERTED:.+]] = tensor.insert %[[NEWSTATE]] into %[[ARG0]][%[[C1]]] : tensor<2xi64>
+// CHECK: return %[[INSERTED]], %[[SLICE]] : tensor<2xi64>, tensor<7x11xi32>
+
+// -----
+
+// CHECK-LABEL: func.func @three_fry_i16
+// CHECK-SAME:  %[[ARG0:.*]]: tensor<2xi64>
+func.func @three_fry_i16(%arg0: tensor<2xi64>) -> (tensor<2xi64>, tensor<8xi16>) {
+  %output_state, %output = "stablehlo.rng_bit_generator"(%arg0) {rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>} : (tensor<2xi64>) -> (tensor<2xi64>, tensor<8xi16>)
+  return %output_state, %output : tensor<2xi64>, tensor<8xi16>
+}
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i64
+
+// Check we update state correctly:
+// CHECK: %[[STATE:.+]] = tensor.extract %[[ARG0]][%[[C1]]] : tensor<2xi64>
+// CHECK: %[[NEWSTATE:.+]] = arith.addi %[[STATE]], %[[C4]] : i64
+
+// CHECK: %[[DEST0:.+]] = tensor.empty() : tensor<4xi16>
+// CHECK: %[[DEST1:.+]] = tensor.empty() : tensor<4xi16>
+// CHECK: %[[GENERIC:.+]]:2 = linalg.generic
+// CHECK-SAME: indexing_maps = [#map, #map]
+// CHECK-SAME: iterator_types = ["parallel"]}
+// CHECK-SAME: outs(%[[DEST0]], %[[DEST1]] : tensor<4xi16>, tensor<4xi16>)
+
+// CHECK: %expanded = tensor.expand_shape %[[GENERIC]]#0
+// CHECK-SAME{literal}: [[0, 1]] : tensor<4xi16> into tensor<4x1xi16>
+
+// CHECK: %expanded_1 = tensor.expand_shape %[[GENERIC]]#1
+// CHECK-SAME{literal}: [[0, 1]] : tensor<4xi16> into tensor<4x1xi16>
+
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<4x2xi16>
+// CHECK: %[[CONCAT:.+]] = linalg.generic
+// CHECK-SAME: outs(%[[EMPTY]] : tensor<4x2xi16>)
+
+// CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[CONCAT]]
+// CHECK-SAME{literal}: [[0, 1]] : tensor<4x2xi16> into tensor<8xi16>
+// CHECK: %[[INSERTED:.+]] = tensor.insert %[[NEWSTATE]] into %[[ARG0]][%[[C1]]] : tensor<2xi64>
+
+// CHECK: return %[[INSERTED]], %[[COLLAPSE]] : tensor<2xi64>, tensor<8xi16>


### PR DESCRIPTION
This ports the `stablehlo.rng` and `stablehlo.rng_bit_generator` op lowering from mlir-hlo. For the details, see the initial import: https://github.com/openxla/iree/pull/12957.

The code is cleaned up to match the existing StableHLO -> linalg conversion patterns. This also fixes incorrect type conversion checks in `RngUniformConversion`.

Issue: https://github.com/openxla/iree/issues/12678