### PR TITLE
[StableHLO] Port convolution to linalg lowering

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
@@ -50,6 +50,7 @@ iree_compiler_cc_library(
         "Passes.cpp",
         "StableHLOToArith.cpp",
         "StableHLOToLinalg.cpp",
+        "StableHLOToLinalgConvolution.cpp",
         "StableHLOToLinalgDotProd.cpp",
         "StableHLOToLinalgPointwise.cpp",
         "StableHLOToLinalgRandom.cpp",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
@@ -47,6 +47,7 @@ iree_cc_library(
     "Passes.cpp"
     "StableHLOToArith.cpp"
     "StableHLOToLinalg.cpp"
+    "StableHLOToLinalgConvolution.cpp"
     "StableHLOToLinalgDotProd.cpp"
     "StableHLOToLinalgPointwise.cpp"
     "StableHLOToLinalgRandom.cpp"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
@@ -27,6 +27,12 @@ void populatePointwiseStableHloToLinalgConversionPatterns(
     MLIRContext *context, TypeConverter &typeConverter,
     RewritePatternSet *patterns, bool enablePrimitiveOps);
 
+/// Populates the patterns that convert from convolution StableHLO ops to Linalg
+/// on tensors.
+void populateStableHloConvolutionToLinalgConversionPatterns(
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet *patterns);
+
 /// Populates the patterns that convert from dot product StableHLO ops to Linalg
 /// on tensors.
 void populateStableHloDotProdToLinalgConversionPatterns(
@@ -42,8 +48,8 @@ void populateStableHloRandomToLinalgConversionPatterns(
 /// Populates the patterns that convert from reduction StableHLO ops to Linalg
 /// on tensors.
 void populateStableHloReductionToLinalgConversionPatterns(
-    MLIRContext* context, TypeConverter& typeConverter,
-    RewritePatternSet* patterns, bool enablePrimitiveOps);
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet *patterns, bool enablePrimitiveOps);
 
 /// Populates the patterns that convert scalar StableHLO ops to Arith ops.
 void populateScalarHloToArithConversionPatterns(

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
@@ -2480,8 +2480,8 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext* context,
 
   // clang-format on
 
-  // TODO(#12678): Handle the convolution.
-
+  detail::populateStableHloConvolutionToLinalgConversionPatterns(
+      context, typeConverter, patterns);
   detail::populateStableHloDotProdToLinalgConversionPatterns(
       context, typeConverter, patterns);
   detail::populateStableHloRandomToLinalgConversionPatterns(

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgConvolution.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgConvolution.cpp
@@ -1,0 +1,792 @@
+// Copyright 2019 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements logic for lowering StableHLO convolution ops to Linalg dialect.
+
+#include "iree/compiler/InputConversion/StableHLO/LegalizeToLinalgUtils.h"
+#include "iree/compiler/InputConversion/StableHLO/Rewriters.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+namespace {
+/// Apply dilation and padding to the input of a convolution.
+Value applyConvolutionPadding(Location loc, Value input,
+                              DenseIntElementsAttr padding,
+                              DenseIntElementsAttr lhsDilation,
+                              llvm::ArrayRef<int64_t> dimMappings,
+                              OpBuilder &rewriter) {
+  if ((!padding || isSplatValue(padding, 0)) &&
+      (!lhsDilation || isSplatValue(lhsDilation, 1))) {
+    return input;
+  }
+
+  auto inputType = cast<ShapedType>(input.getType());
+  int64_t rank = inputType.getRank();
+
+  // Translate window padding into low/high padding.
+  SmallVector<int64_t, 8> padLow(rank, 0);
+  SmallVector<int64_t, 8> padHigh(rank, 0);
+  if (padding) {
+    // The padding attribute contains two values per dimension, but excludes the
+    // batch and feature dimensions.
+    assert(rank * 2 == padding.size() + 4 &&
+           "There should be 2 padding values per dimension, i.e low and high.");
+    for (int64_t i : llvm::seq<int64_t>(0, padding.size() / 2)) {
+      int64_t dim = dimMappings[i];
+      padLow[dim] = padding.getValues<int64_t>()[i * 2];
+      padHigh[dim] = padding.getValues<int64_t>()[i * 2 + 1];
+    }
+  }
+
+  // Translate input dilation into interior padding.
+  SmallVector<int64_t, 8> padInterior(rank, 0);
+  if (lhsDilation) {
+    assert(rank == lhsDilation.size() + 2);
+    for (int64_t i : llvm::seq<int64_t>(0, lhsDilation.size())) {
+      int64_t dim = dimMappings[i];
+      padInterior[dim] = lhsDilation.getValues<int64_t>()[i] - 1;
+    }
+  }
+
+  IntegerType indexType = rewriter.getIntegerType(64);
+  auto attrType = RankedTensorType::get({rank}, indexType);
+  Value zero = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getZeroAttr(
+               RankedTensorType::get({}, inputType.getElementType())));
+  return rewriter.create<mlir::stablehlo::PadOp>(
+      loc, input, zero, DenseIntElementsAttr::get(attrType, padLow),
+      DenseIntElementsAttr::get(attrType, padHigh),
+      DenseIntElementsAttr::get(attrType, padInterior));
+}
+
+/// If the ConvolutionOp has a window reversal, applies it to the filter.
+Value applyConvolutionReversal(Location loc, OpBuilder &b,
+                               mlir::stablehlo::ConvolutionOp op,
+                               Value filter) {
+  std::optional reversals = op.getWindowReversal();
+  if (!reversals.has_value()) {
+    return filter;
+  }
+  llvm::SmallVector<int64_t> reversedDims;
+  for (auto [idx, reversed] :
+       llvm::enumerate(reversals.value().getValues<bool>())) {
+    if (reversed) {
+      reversedDims.push_back(
+          op.getDimensionNumbers().getKernelSpatialDimensions()[idx]);
+    }
+  }
+
+  return b.create<mlir::stablehlo::ReverseOp>(
+      loc, filter,
+      mlir::DenseIntElementsAttr::get(
+          RankedTensorType::get(reversedDims.size(), b.getI64Type()),
+          reversedDims));
+}
+
+/// Returns true if the given `dimensionNumbers` from a stablehlo.convolution op
+/// follows a canonical form:
+///
+/// * Input dimensions have order: (batch_count, spatial_dims,
+///   input_channel_count).
+/// * Filter dimensions have order: (spatial_dims, input_channel_count,
+///   output_channel_count).
+/// * Output dimensions have order: (batch_count, spatial_dims,
+///   output_channel_count).
+bool hasCanonicalDimensionNumbers(
+    mlir::stablehlo::ConvDimensionNumbersAttr dimensionNumbers) {
+  const int64_t inputSpatialRank =
+      dimensionNumbers.getInputSpatialDimensions().size();
+  // The dimensions for input should follow the order of
+  // batch_count, spatial_dims..., input_feature_count.
+  if (dimensionNumbers.getInputBatchDimension() != 0 ||
+      dimensionNumbers.getInputFeatureDimension() != (inputSpatialRank + 1)) {
+    return false;
+  }
+
+  const int64_t kernelSpatialRank =
+      dimensionNumbers.getKernelSpatialDimensions().size();
+  // The dimensions for filter should follow the order of
+  // spatial_dims..., input_feature_count, num_output_feature_count.
+  if (dimensionNumbers.getKernelInputFeatureDimension() != kernelSpatialRank ||
+      dimensionNumbers.getKernelOutputFeatureDimension() !=
+          (kernelSpatialRank + 1)) {
+    return false;
+  }
+
+  const int64_t outputSpatialRank =
+      dimensionNumbers.getOutputSpatialDimensions().size();
+  // The dimensions for output should follow the order of
+  // batch_count, spatial_dims.., output_feature_count.
+  if (dimensionNumbers.getOutputBatchDimension() != 0 ||
+      dimensionNumbers.getOutputFeatureDimension() != (outputSpatialRank + 1)) {
+    return false;
+  }
+
+  if (inputSpatialRank != outputSpatialRank ||
+      inputSpatialRank != kernelSpatialRank) {
+    return false;
+  }
+
+  const int64_t *inputSpatialDim =
+      dimensionNumbers.getInputSpatialDimensions().data();
+  const int64_t *kernelSpatialDim =
+      dimensionNumbers.getKernelSpatialDimensions().data();
+  const int64_t *outputSpatialDim =
+      dimensionNumbers.getOutputSpatialDimensions().data();
+  // Check spatial dims are ordered correctly.
+  for (int64_t i = 0; i < inputSpatialRank; ++i) {
+    const int64_t dim = i + 1;
+    if ((*inputSpatialDim++) != dim || (*outputSpatialDim++) != dim ||
+        (*kernelSpatialDim++) != i) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/// Converts stablehlo.conv operation to linalg named op. This only covers
+/// normal convolution cases. The op must have canonical dimension numbers.
+/// Depthwise convolution and pointwise convolution are not handled in the
+/// conversion.
+struct NormalConvolutionOpConversion final
+    : OpConversionPattern<mlir::stablehlo::ConvolutionOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::ConvolutionOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    if (!hasCanonicalDimensionNumbers(op.getDimensionNumbers())) {
+      return failure();
+    }
+    if (op.getFeatureGroupCount() != 1u) return failure();
+    if (op.getBatchGroupCount() != 1u) return failure();
+
+    Location loc = op.getLoc();
+    Value input = adaptor.getLhs();
+    Value filter = adaptor.getRhs();
+    filter = applyConvolutionReversal(loc, rewriter, op, filter);
+    auto resultType = dyn_cast_or_null<ShapedType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "type conversion failed");
+    }
+
+    int64_t rank = resultType.getRank();
+
+    // Immediately emit an EmptyOp for output tensors with zero dimension.
+    if (llvm::is_contained(resultType.getShape(), 0)) {
+      rewriter.replaceOpWithNewOp<tensor::EmptyOp>(op, resultType.getShape(),
+                                                   resultType.getElementType());
+      return success();
+    }
+
+    // The output shape is N spatial_dims F.
+    SmallVector<Value, 8> dynSizes;
+    if (resultType.isDynamicDim(0)) {
+      dynSizes.push_back(rewriter.create<tensor::DimOp>(loc, input, 0));
+    }
+    for (int64_t i = 1, e = rank - 1; i < e; ++i) {
+      if (resultType.isDynamicDim(i)) {
+        return rewriter.notifyMatchFailure(
+            op, "expected output spatial dims to be static shapes");
+      }
+    }
+    if (resultType.isDynamicDim(rank - 1)) {
+      dynSizes.push_back(rewriter.create<tensor::DimOp>(loc, filter, rank - 1));
+    }
+    Value emptyTensor = rewriter.create<tensor::EmptyOp>(
+        loc, resultType.getShape(), resultType.getElementType(), dynSizes);
+    Value zeroTensor = fillTensorWithZeros(rewriter, loc, emptyTensor);
+    linalg::LinalgOp res;
+    Attribute strides = op.getWindowStridesAttr();
+    Attribute dilations = op.getRhsDilationAttr();
+
+    // Apply padding and input dilation.
+    llvm::SmallVector<int64_t> spatialDimMapping(rank - 2);
+    std::iota(spatialDimMapping.begin(), spatialDimMapping.end(), 1);
+    input = applyConvolutionPadding(loc, input, op.getPaddingAttr(),
+                                    op.getLhsDilationAttr(), spatialDimMapping,
+                                    rewriter);
+
+    switch (rank) {
+      case 2: {
+        res = rewriter.create<linalg::MatmulOp>(
+            loc, resultType, ValueRange{input, filter}, ValueRange{zeroTensor},
+            linalg::getPrunedAttributeList(op));
+        break;
+      }
+      case 3: {
+        res = rewriter.create<linalg::Conv1DNwcWcfOp>(
+            loc, resultType, ValueRange{input, filter}, ValueRange{zeroTensor},
+            strides, dilations, linalg::getPrunedAttributeList(op));
+        break;
+      }
+      case 4: {
+        res = rewriter.create<linalg::Conv2DNhwcHwcfOp>(
+            loc, resultType, ValueRange{input, filter}, ValueRange{zeroTensor},
+            strides, dilations, linalg::getPrunedAttributeList(op));
+        break;
+      }
+      case 5: {
+        res = rewriter.create<linalg::Conv3DNdhwcDhwcfOp>(
+            loc, resultType, ValueRange{input, filter}, ValueRange{zeroTensor},
+            strides, dilations, linalg::getPrunedAttributeList(op));
+        break;
+      }
+      default: {
+        return rewriter.notifyMatchFailure(op, "expected 1/2/3D conv op");
+      }
+    }
+    rewriter.replaceOp(op, res.getOperation()->getResults());
+    return success();
+  }
+};
+
+/// Handles all possible inputs for the mlir::stablehlo::ConvolutionOp
+struct ConvolutionOpGeneralConversion final
+    : OpConversionPattern<mlir::stablehlo::ConvolutionOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  /// This lowering proceeds with the following steps:
+  /// 1. Handle padding and dilation of the input
+  /// 2. Handle padding and dilation of the window
+  /// 3. Handle reversal of the window
+  /// 4. If feature_group_count != 1:
+  ///    - Reshape the input feature dimension, kernel output feature dimension,
+  ///      and output feature dimension.
+  ///    - Create the AffineExpr for the new dimension
+  ///    - Conceptually, this splits the input feature and both output feature
+  ///      dimensions and computes sets of convolutions with these partial views
+  ///      of the values as if they were multiple convolutions combined in a
+  ///      batch.
+  /// 5: If batch_group_count != 1:
+  ///    - Reshape the input batch dimension, kernel output feature dimension,
+  ///      and output feature dimension.
+  ///    - Create the AffineExpr for the new dimension
+  ///    - Conceptually, this splits the input batch and both output feature
+  ///      dimensions and computes sets of convolutions with these partial views
+  ///      of the values as if they were multiple convolutions combined in a
+  ///      batch.
+  /// 6. For all dimensions not newly created by a reshape, create the
+  ///    appropriate parallel and reduction dimensions to create a convolution.
+  /// 7. Create the linalg.generic that computes the multiply-add
+  /// 8. Reshape the output to the original shape if it was reshaped by the
+  ///    feature or group count attributes.
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::ConvolutionOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    MLIRContext *ctx = op.getContext();
+
+    auto resultType = dyn_cast_or_null<ShapedType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "type conversion failed");
+    }
+
+    auto reshapedResultShape = resultType.getShape().vec();
+    if (!resultType.hasStaticShape()) return failure();
+
+    // Immediately emit an EmptyOp for output tensors with zero dimension.
+    if (llvm::is_contained(reshapedResultShape, 0)) {
+      rewriter.replaceOpWithNewOp<tensor::EmptyOp>(op, reshapedResultShape,
+                                                   resultType.getElementType());
+      return success();
+    }
+
+    mlir::stablehlo::ConvDimensionNumbersAttr dimensionNumbers =
+        op.getDimensionNumbers();
+    int64_t inputBatchDimension = dimensionNumbers.getInputBatchDimension();
+    int64_t inputFeatureDimension = dimensionNumbers.getInputFeatureDimension();
+    ArrayRef<int64_t> inputSpatialDimensions =
+        dimensionNumbers.getInputSpatialDimensions();
+
+    int64_t kernelInputFeatureDimension =
+        dimensionNumbers.getKernelInputFeatureDimension();
+    int64_t kernelOutputFeatureDimension =
+        dimensionNumbers.getKernelOutputFeatureDimension();
+    ArrayRef<int64_t> kernelSpatialDimensions =
+        dimensionNumbers.getKernelSpatialDimensions();
+
+    int64_t outputBatchDimension = dimensionNumbers.getOutputBatchDimension();
+    int64_t outputFeatureDimension =
+        dimensionNumbers.getOutputFeatureDimension();
+    ArrayRef<int64_t> outputSpatialDimensions =
+        dimensionNumbers.getOutputSpatialDimensions();
+
+    size_t featureGroupCount = op.getFeatureGroupCount();
+    size_t batchGroupCount = op.getBatchGroupCount();
+
+    if (op.getFeatureGroupCount() != 1 && op.getBatchGroupCount() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "only one of feature and batch group counts can be non-one");
+    }
+
+    // Decompose the convolution into an initial padding
+    Value modifiedLhs = applyConvolutionPadding(
+        op.getLoc(), adaptor.getLhs(), adaptor.getPaddingAttr(),
+        adaptor.getLhsDilationAttr(),
+        op.getDimensionNumbers().getInputSpatialDimensions(), rewriter);
+    Value modifiedRhs = applyConvolutionPadding(
+        op.getLoc(), adaptor.getRhs(), nullptr, adaptor.getRhsDilationAttr(),
+        op.getDimensionNumbers().getKernelSpatialDimensions(), rewriter);
+    modifiedRhs = applyConvolutionReversal(loc, rewriter, op, modifiedRhs);
+
+    // Non-one values for feature or batch group counts will result in reshaped
+    // inputs and outputs. These mappings are used to keep track of the the new
+    // index after reshaping has possibly inserted new dimensions.
+    auto paddedLhsType = cast<ShapedType>(modifiedLhs.getType());
+    auto paddedRhsType = cast<ShapedType>(modifiedRhs.getType());
+    SmallVector<int64_t> lhsIndexMapping(paddedLhsType.getRank());
+    std::iota(lhsIndexMapping.begin(), lhsIndexMapping.end(), 0);
+    SmallVector<int64_t> rhsIndexMapping(paddedRhsType.getRank());
+    std::iota(rhsIndexMapping.begin(), rhsIndexMapping.end(), 0);
+    SmallVector<int64_t> resultIndexMapping(resultType.getRank());
+    std::iota(resultIndexMapping.begin(), resultIndexMapping.end(), 0);
+    auto updateDimMappingFromOffset =
+        [](llvm::SmallVectorImpl<int64_t> &mapping, int64_t offset) {
+          for (auto &mappingElt : llvm::drop_begin(mapping, offset)) {
+            mappingElt += 1;
+          }
+        };
+
+    // The rest of this code prepares the inputs and a single linalg::GenericOp
+    // to execute the convolution. The final linalg::GenericOp will be iterated
+    // through based on the following eventual maps.
+    SmallVector<AffineExpr, 2> srcExprs(paddedLhsType.getRank());
+    SmallVector<AffineExpr, 2> windowExprs(paddedRhsType.getRank());
+    SmallVector<AffineExpr, 2> dstExprs(reshapedResultShape.size());
+    int64_t nextDim = 0;
+    int64_t rank = resultType.getRank();
+
+    auto reshapeShapeVector = [](llvm::ArrayRef<int64_t> oldShape,
+                                 llvm::SmallVectorImpl<int64_t> &newShape,
+                                 int64_t reshapedDim, int64_t factor) {
+      newShape.reserve(oldShape.size() + 1);
+      for (int64_t i : llvm::seq<int64_t>(0, oldShape.size())) {
+        if (i == reshapedDim) {
+          newShape.push_back(factor);
+          newShape.push_back(oldShape[reshapedDim] / factor);
+        } else {
+          newShape.push_back(oldShape[i]);
+        }
+      }
+    };
+
+    // If batch or feature count groupings exist, represent this through
+    // reshaping the input to have an additional dimension that these groupings
+    // exist along, and reduce in that dimension
+    SmallVector<utils::IteratorType, 3> iterationLoops;
+    if (featureGroupCount != 1) {
+      AffineExpr parallelDim = mlir::getAffineDimExpr(nextDim++, ctx);
+      iterationLoops.push_back(utils::IteratorType::parallel);
+      // Reshape LHS
+      {
+        srcExprs.insert(srcExprs.begin() + inputFeatureDimension, parallelDim);
+        auto prevDimsRef = paddedLhsType.getShape();
+        llvm::SmallVector<int64_t> newShape;
+        reshapeShapeVector(prevDimsRef, newShape, inputFeatureDimension,
+                           featureGroupCount);
+        updateDimMappingFromOffset(lhsIndexMapping, inputFeatureDimension);
+        modifiedLhs = rewriter.create<mlir::stablehlo::ReshapeOp>(
+            loc,
+            RankedTensorType::get(newShape, paddedLhsType.getElementType()),
+            modifiedLhs);
+      }
+
+      // Reshape RHS
+      {
+        windowExprs.insert(windowExprs.begin() + kernelOutputFeatureDimension,
+                           parallelDim);
+        auto prevDimsRef = paddedRhsType.getShape();
+        llvm::SmallVector<int64_t> newShape;
+        reshapeShapeVector(prevDimsRef, newShape, kernelOutputFeatureDimension,
+                           featureGroupCount);
+        updateDimMappingFromOffset(rhsIndexMapping,
+                                   kernelOutputFeatureDimension);
+        modifiedRhs = rewriter.create<mlir::stablehlo::ReshapeOp>(
+            loc,
+            RankedTensorType::get(newShape, paddedRhsType.getElementType()),
+            modifiedRhs);
+      }
+      // Prepare reshaped output shape
+      {
+        dstExprs.insert(dstExprs.begin() + outputFeatureDimension, parallelDim);
+        updateDimMappingFromOffset(resultIndexMapping, outputFeatureDimension);
+        reshapedResultShape.insert(
+            reshapedResultShape.begin() + outputFeatureDimension,
+            featureGroupCount);
+        reshapedResultShape[outputFeatureDimension + 1] /= featureGroupCount;
+      }
+    }
+
+    if (batchGroupCount != 1) {
+      iterationLoops.push_back(utils::IteratorType::parallel);
+      AffineExpr parallelDim = mlir::getAffineDimExpr(nextDim++, ctx);
+      // Reshape LHS
+      {
+        srcExprs.insert(srcExprs.begin() + inputBatchDimension, parallelDim);
+        ArrayRef<int64_t> prevDimsRef = paddedLhsType.getShape();
+        llvm::SmallVector<int64_t> newShape;
+        reshapeShapeVector(prevDimsRef, newShape, inputBatchDimension,
+                           batchGroupCount);
+        updateDimMappingFromOffset(lhsIndexMapping, inputBatchDimension);
+        modifiedLhs = rewriter.create<mlir::stablehlo::ReshapeOp>(
+            op.getLoc(),
+            RankedTensorType::get(newShape, paddedLhsType.getElementType()),
+            modifiedLhs);
+      }
+
+      // Reshape RHS
+      {
+        windowExprs.insert(windowExprs.begin() + kernelOutputFeatureDimension,
+                           parallelDim);
+        ArrayRef<int64_t> prevDimsRef = paddedRhsType.getShape();
+        llvm::SmallVector<int64_t> newShape;
+        reshapeShapeVector(prevDimsRef, newShape, kernelOutputFeatureDimension,
+                           batchGroupCount);
+        updateDimMappingFromOffset(rhsIndexMapping,
+                                   kernelOutputFeatureDimension);
+        modifiedRhs = rewriter.create<mlir::stablehlo::ReshapeOp>(
+            op.getLoc(),
+            RankedTensorType::get(newShape, paddedRhsType.getElementType()),
+            modifiedRhs);
+      }
+      // Prepare reshaped output shape
+      {
+        int64_t outputFeatureDim = resultIndexMapping[outputFeatureDimension];
+        dstExprs.insert(dstExprs.begin() + outputFeatureDim, parallelDim);
+        updateDimMappingFromOffset(resultIndexMapping, outputFeatureDimension);
+        reshapedResultShape.insert(
+            reshapedResultShape.begin() + outputFeatureDim, batchGroupCount);
+        reshapedResultShape[outputFeatureDim + 1] /= batchGroupCount;
+      }
+    }
+
+    // Handle input feature dimension
+    {
+      iterationLoops.push_back(utils::IteratorType::reduction);
+      AffineExpr inputFeatureDim = mlir::getAffineDimExpr(nextDim++, ctx);
+      srcExprs[lhsIndexMapping[inputFeatureDimension]] = inputFeatureDim;
+      windowExprs[rhsIndexMapping[kernelInputFeatureDimension]] =
+          inputFeatureDim;
+    }
+
+    // Handle output feature dimension
+    {
+      iterationLoops.push_back(utils::IteratorType::parallel);
+      AffineExpr outputFeatureDim = mlir::getAffineDimExpr(nextDim++, ctx);
+      dstExprs[resultIndexMapping[outputFeatureDimension]] = outputFeatureDim;
+      windowExprs[rhsIndexMapping[kernelOutputFeatureDimension]] =
+          outputFeatureDim;
+    }
+
+    // Handle spatial Dimensions
+    int64_t numSpatialDims = rank - 2;
+    for (int64_t i = 0; i < numSpatialDims; ++i) {
+      iterationLoops.push_back(utils::IteratorType::parallel);
+      iterationLoops.push_back(utils::IteratorType::reduction);
+      AffineExpr dim0 = mlir::getAffineDimExpr(nextDim++, ctx);
+      AffineExpr dim1 = mlir::getAffineDimExpr(nextDim++, ctx);
+
+      AffineExpr stride = dim0;
+      if (op.getWindowStrides().has_value())
+        stride = stride * op.getWindowStrides().value().getValues<int64_t>()[i];
+      AffineExpr srcExpr = stride + dim1;
+
+      srcExprs[lhsIndexMapping[inputSpatialDimensions[i]]] = srcExpr;
+      dstExprs[resultIndexMapping[outputSpatialDimensions[i]]] = dim0;
+      windowExprs[rhsIndexMapping[kernelSpatialDimensions[i]]] = dim1;
+    }
+
+    // Handle batch dimension
+    {
+      iterationLoops.push_back(utils::IteratorType::parallel);
+      AffineExpr batchDim = mlir::getAffineDimExpr(nextDim++, ctx);
+
+      srcExprs[lhsIndexMapping[inputBatchDimension]] = batchDim;
+      dstExprs[resultIndexMapping[outputBatchDimension]] = batchDim;
+    }
+
+    // Finally, create the computation
+    auto inferredMaps =
+        AffineMap::inferFromExprList({srcExprs, windowExprs, dstExprs});
+
+    Value emptyTensor = rewriter.create<tensor::EmptyOp>(
+        loc, reshapedResultShape, resultType.getElementType());
+    Value zeroTensor = fillTensorWithZeros(rewriter, loc, emptyTensor);
+
+    Value convolved =
+        rewriter
+            .create<linalg::GenericOp>(
+                loc,
+                /*resultTensors=*/
+                llvm::ArrayRef<Type>(zeroTensor.getType()),
+                /*inputs=*/
+                llvm::ArrayRef<Value>({modifiedLhs, modifiedRhs}),
+                /*outputs=*/llvm::ArrayRef<Value>(zeroTensor), inferredMaps,
+                iterationLoops,
+                /*bodyBuild=*/
+                [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange) {
+                  ImplicitLocOpBuilder builder(nestedLoc, nestedBuilder);
+                  linalg::Conv2DOp::regionBuilder(
+                      builder, *builder.getInsertionBlock(), {});
+                },
+                linalg::getPrunedAttributeList(op))
+            .getResult(0);
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(op, resultType,
+                                                            convolved);
+
+    return success();
+  }
+};
+
+/// Converts stablehlo.convolution operation to
+/// linalg.depthwise_conv_2d_input_nhwc_filter_hwcf op or
+/// depthwise_conv_2d_input_nhwc_filter_hwc op.
+struct DepthwiseConvolutionOpConversion final
+    : OpConversionPattern<mlir::stablehlo::ConvolutionOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::ConvolutionOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    if (op.getBatchGroupCount() != 1) return failure();
+    // Fall into the normal convolution cases.
+    if (op.getFeatureGroupCount() == 1) return failure();
+
+    const mlir::stablehlo::ConvDimensionNumbersAttr &dimensionNumbers =
+        op.getDimensionNumbers();
+    const int64_t spatialRank =
+        dimensionNumbers.getInputSpatialDimensions().size();
+    if (spatialRank == 0 || spatialRank > 3) {
+      return rewriter.notifyMatchFailure(op, "only support up to 3D for now");
+    }
+
+    // Make sure that this is depthwise convolution.
+    int64_t inputFeatureDim = dimensionNumbers.getInputFeatureDimension();
+    int64_t inputFeatureCount =
+        cast<ShapedType>(op.getLhs().getType()).getDimSize(inputFeatureDim);
+    if (static_cast<int64_t>(op.getFeatureGroupCount()) != inputFeatureCount) {
+      return rewriter.notifyMatchFailure(op, "not depth-wise convolution");
+    }
+
+    // Make sure that this convolution has a canonical form.
+    if (!hasCanonicalDimensionNumbers(dimensionNumbers)) {
+      return rewriter.notifyMatchFailure(op, "does not have canonical form");
+    }
+
+    Attribute windowStrides;
+    if (op.getWindowStrides()) {
+      windowStrides = op.getWindowStrides().value();
+    } else {
+      windowStrides = SplatElementsAttr::get(
+          VectorType::get({spatialRank}, rewriter.getI64Type()),
+          rewriter.getI64IntegerAttr(1));
+    }
+
+    Attribute rhsDilation;
+    if (op.getRhsDilation()) {
+      rhsDilation = op.getRhsDilation().value();
+    } else {
+      rhsDilation = SplatElementsAttr::get(
+          VectorType::get({spatialRank}, rewriter.getI64Type()),
+          rewriter.getI64IntegerAttr(1));
+    }
+
+    Location loc = op.getLoc();
+    Value input = adaptor.getLhs();
+    Value filter = adaptor.getRhs();
+    auto resultType = dyn_cast_or_null<RankedTensorType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "type conversion failed");
+    }
+    if (!resultType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(op,
+                                         "expected output has static shapes");
+    }
+
+    // Immediately emit an EmptyOp for output tensors with zero dimension.
+    if (llvm::is_contained(resultType.getShape(), 0)) {
+      rewriter.replaceOpWithNewOp<tensor::EmptyOp>(op, resultType.getShape(),
+                                                   resultType.getElementType());
+      return success();
+    }
+
+    // Apply padding and input dilation.
+    llvm::SmallVector<int64_t> spatialDimMapping(spatialRank);
+    std::iota(spatialDimMapping.begin(), spatialDimMapping.end(), 1);
+    input = applyConvolutionPadding(loc, input, op.getPaddingAttr(),
+                                    op.getLhsDilationAttr(), spatialDimMapping,
+                                    rewriter);
+
+    auto filterDims =
+        llvm::to_vector<4>(cast<ShapedType>(op.getRhs().getType()).getShape());
+
+    auto getReassociationIndicesToCollapseLastTwoDims = [](Value v) {
+      SmallVector<ReassociationIndices> reassociations;
+      int64_t rank = cast<ShapedType>(v.getType()).getRank();
+      for (int64_t i = 0; i < rank - 1; ++i) reassociations.emplace_back(1, i);
+      reassociations.back().push_back(rank - 1);
+      return reassociations;
+    };
+
+    int64_t kernelInputFeatureDimension =
+        dimensionNumbers.getKernelInputFeatureDimension();
+    int64_t kernelOutputFeatureDimension =
+        dimensionNumbers.getKernelOutputFeatureDimension();
+    if (filterDims[kernelInputFeatureDimension] *
+            filterDims[kernelOutputFeatureDimension] !=
+        static_cast<int64_t>(op.getFeatureGroupCount())) {
+      // For cases where channel multiplier != 1
+
+      // Reshaping filter shape
+      //   [filter_height, filter_width, 1, kernel-output-feature].
+      // to
+      //   [filter_height, filter_width, feature_group_count,
+      //      kernel-output-feature/feature_group_count ]
+      SmallVector<int64_t> reshapedFilterDims;
+      reshapedFilterDims.assign(filterDims.begin(), filterDims.end());
+      Value reshapedFilter = filter;
+      if (filterDims[kernelInputFeatureDimension] == 1) {
+        reshapedFilterDims[kernelInputFeatureDimension] =
+            op.getFeatureGroupCount();
+        reshapedFilterDims[kernelOutputFeatureDimension] /=
+            op.getFeatureGroupCount();
+        auto reshapedFilterType = RankedTensorType::get(
+            reshapedFilterDims,
+            cast<ShapedType>(op.getRhs().getType()).getElementType());
+
+        reshapedFilter = rewriter.create<mlir::stablehlo::ReshapeOp>(
+            loc, reshapedFilterType, filter);
+      }
+
+      ArrayRef<int64_t> outputDims = resultType.getShape();
+      int64_t channelMultiplier = reshapedFilterDims.back();
+      SmallVector<int64_t> reshapedOutputDims;
+      reshapedOutputDims.assign(outputDims.begin(), outputDims.end());
+      reshapedOutputDims.push_back(channelMultiplier);
+      reshapedOutputDims[reshapedOutputDims.size() - 2] /= channelMultiplier;
+
+      Value emptyTensor = rewriter.create<tensor::EmptyOp>(
+          loc, reshapedOutputDims, resultType.getElementType());
+      Value zeroTensor = fillTensorWithZeros(rewriter, loc, emptyTensor);
+
+      auto reshapedOutputType = RankedTensorType::get(
+          reshapedOutputDims, resultType.getElementType());
+      Value conv;
+      switch (spatialRank) {
+        case 1: {
+          conv = rewriter
+                     .create<linalg::DepthwiseConv1DNwcWcmOp>(
+                         loc, reshapedOutputType,
+                         ValueRange{input, reshapedFilter},
+                         ValueRange{zeroTensor}, windowStrides, rhsDilation,
+                         linalg::getPrunedAttributeList(op))
+                     .getResult(0);
+          break;
+        }
+        case 2: {
+          conv = rewriter
+                     .create<linalg::DepthwiseConv2DNhwcHwcmOp>(
+                         loc, reshapedOutputType,
+                         ValueRange{input, reshapedFilter},
+                         ValueRange{zeroTensor}, windowStrides, rhsDilation,
+                         linalg::getPrunedAttributeList(op))
+                     .getResult(0);
+          break;
+        }
+        case 3: {
+          conv = rewriter
+                     .create<linalg::DepthwiseConv3DNdhwcDhwcmOp>(
+                         loc, reshapedOutputType,
+                         ValueRange{input, reshapedFilter},
+                         ValueRange{zeroTensor}, windowStrides, rhsDilation,
+                         linalg::getPrunedAttributeList(op))
+                     .getResult(0);
+          break;
+        }
+        default:
+          llvm_unreachable("Unhandled case");
+      }
+
+      // Create a Linalg reshape op that converts the output from 5 dimensions
+      // into 4 dimensions (by collapsing the last two dimensions). This is
+      // needed because linalg.depthwise_conv_2d_input_nhwc_filter_hwcf returns
+      // 5 dimensions for the output.
+      rewriter.replaceOpWithNewOp<tensor::CollapseShapeOp>(
+          op, resultType, conv,
+          getReassociationIndicesToCollapseLastTwoDims(conv));
+    } else {
+      // For cases where channel multiplier == 1
+      Value emptyTensor = rewriter.create<tensor::EmptyOp>(
+          loc, resultType.getShape(), resultType.getElementType());
+      Value zeroTensor = fillTensorWithZeros(rewriter, loc, emptyTensor);
+
+      // Create a Linalg reshape op that converts the filter from 4 dimensions
+      // into 3 dimensions (by droping the unit dimension). This is needed
+      // because linalg.depthwise_conv_2d_input_nhwc_filter_hwc expects 3
+      // dimensions for the filter.
+
+      filterDims[filterDims.size() - 2] =
+          static_cast<int64_t>(op.getFeatureGroupCount());
+      filterDims.pop_back();
+
+      RankedTensorType filterShape =
+          RankedTensorType::get(filterDims, op.getType().getElementType());
+
+      Value reshapedFilter = rewriter.create<tensor::CollapseShapeOp>(
+          loc, filterShape, filter,
+          getReassociationIndicesToCollapseLastTwoDims(filter));
+
+      switch (spatialRank) {
+        case 1:
+          rewriter.replaceOpWithNewOp<linalg::DepthwiseConv1DNwcWcOp>(
+              op, resultType, ValueRange{input, reshapedFilter},
+              ValueRange{zeroTensor}, windowStrides, rhsDilation,
+              linalg::getPrunedAttributeList(op));
+          break;
+        case 2:
+          rewriter.replaceOpWithNewOp<linalg::DepthwiseConv2DNhwcHwcOp>(
+              op, resultType, ValueRange{input, reshapedFilter},
+              ValueRange{zeroTensor}, windowStrides, rhsDilation,
+              linalg::getPrunedAttributeList(op));
+          break;
+        case 3:
+          rewriter.replaceOpWithNewOp<linalg::DepthwiseConv3DNdhwcDhwcOp>(
+              op, resultType, ValueRange{input, reshapedFilter},
+              ValueRange{zeroTensor}, windowStrides, rhsDilation,
+              linalg::getPrunedAttributeList(op));
+          break;
+      }
+    }
+
+    return success();
+  }
+};
+
+}  // namespace
+
+namespace detail {
+void populateStableHloConvolutionToLinalgConversionPatterns(
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet *patterns) {
+  // Ensure specialized patterns are higher priority than their generic
+  // versions.
+  patterns
+      ->add<NormalConvolutionOpConversion, DepthwiseConvolutionOpConversion>(
+          typeConverter, context, PatternBenefit(2));
+
+  patterns->add<ConvolutionOpGeneralConversion>(typeConverter, context);
+}
+}  // namespace detail
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "stablehlo_to_linalg_convolution.mlir",
             "stablehlo_to_linalg_dot_prod.mlir",
             "stablehlo_to_linalg_pointwise.mlir",
             "stablehlo_to_linalg_random.mlir",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "stablehlo_to_linalg.mlir"
+    "stablehlo_to_linalg_convolution.mlir"
     "stablehlo_to_linalg_dot_prod.mlir"
     "stablehlo_to_linalg_pointwise.mlir"
     "stablehlo_to_linalg_random.mlir"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg_convolution.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg_convolution.mlir
@@ -1,0 +1,563 @@
+// RUN: iree-opt %s --iree-stablehlo-to-linalg --split-input-file \
+// RUN:   --canonicalize | FileCheck %s
+
+// CHECK-LABEL: @linalg.conv_0d_nc
+func.func @linalg.conv_0d_nc(%arg0: tensor<3x2xf32>, %arg1: tensor<2x3xf32>) -> tensor<3x3xf32> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, f]x[i, o]->[b, f],
+         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [], reverse = []}
+         {
+           batch_group_count = 1 : i64, feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } : (tensor<3x2xf32>, tensor<2x3xf32>) -> tensor<3x3xf32>
+  func.return %0 : tensor<3x3xf32>
+}
+// CHECK-DAG: %[[CST:.+]] = arith.constant 0.000000e+00
+// CHECK-DAG: %[[INIT:.+]] = tensor.empty()
+// CHECK-DAG: %[[FILL:.+]] = linalg.fill ins(%cst{{.*}}outs(%[[INIT]]
+// CHECK: linalg.matmul ins(%arg0, %arg1 : tensor<3x2xf32>, tensor<2x3xf32>) outs(%[[FILL]] : tensor<3x3xf32>)
+
+// -----
+
+// CHECK-LABEL: func @linalg.conv_1d_nwc
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+func.func @linalg.conv_1d_nwc(%arg0: tensor<?x8x?xf32>, %arg1: tensor<2x?x?xf32>)
+  -> tensor<?x7x?xf32> {
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 2,
+      input_spatial_dimensions = [1],
+      kernel_input_feature_dimension = 1,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0],
+      output_batch_dimension = 0,
+      output_feature_dimension = 2,
+      output_spatial_dimensions = [1]
+    >,
+    feature_group_count = 1 : i64,
+    padding = dense<[[0, 0]]> : tensor<1x2xi64>,
+    rhs_dilation = dense<1> : tensor<1xi64>,
+    window_strides = dense<1> : tensor<1xi64>,
+    someattr
+  } : (tensor<?x8x?xf32>, tensor<2x?x?xf32>) -> tensor<?x7x?xf32>
+  func.return %0 : tensor<?x7x?xf32>
+}
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:     %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[DIM0:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x8x?xf32>
+// CHECK:         %[[DIM2:.+]] = tensor.dim %[[ARG1]], %[[C2]] : tensor<2x?x?xf32>
+// CHECK:         %[[INIT:.+]] = tensor.empty(%[[DIM0]], %[[DIM2]])
+// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[ZERO]]{{.*}}outs(%[[INIT]]
+// CHECK:         linalg.conv_1d_nwc_wcf
+// CHECK-SAME:      {dilations = dense<1> : tensor<1xi64>
+// CHECK-SAME:       someattr
+// CHECK-SAME:       strides = dense<1> : tensor<1xi64>}
+// CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]] : tensor<?x8x?xf32>, tensor<2x?x?xf32>)
+// CHECK-SAME:     outs(%[[FILL]] : tensor<?x7x?xf32>) -> tensor<?x7x?xf32>
+
+// -----
+
+// CHECK-LABEL: func @conv_2d_nhwc_hwcf
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+func.func @conv_2d_nhwc_hwcf(%arg0: tensor<?x4x5x?xf32>, %arg1: tensor<3x2x?x?xf32>)
+  -> tensor<?x2x4x?xf32> {
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 2,
+      kernel_output_feature_dimension = 3,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    padding = dense<[[0, 0], [0, 0]]> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<?x4x5x?xf32>, tensor<3x2x?x?xf32>) -> tensor<?x2x4x?xf32>
+  func.return %0 : tensor<?x2x4x?xf32>
+}
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK-DAG:     %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[DIM0:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x4x5x?xf32>
+// CHECK:         %[[DIM3:.+]] = tensor.dim %[[ARG1]], %[[C3]] : tensor<3x2x?x?xf32>
+// CHECK:         %[[INIT:.+]] = tensor.empty(%[[DIM0]], %[[DIM3]])
+// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[ZERO]]{{.*}}outs(%[[INIT]]
+// CHECK:         linalg.conv_2d_nhwc
+// CHECK-SAME:      {dilations = dense<1> : tensor<2xi64>
+// CHECK-SAME:       strides = dense<1> : tensor<2xi64>}
+// CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]] : tensor<?x4x5x?xf32>, tensor<3x2x?x?xf32>)
+// CHECK-SAME:    outs(%[[FILL]] : tensor<?x2x4x?xf32>) -> tensor<?x2x4x?xf32>
+
+// -----
+
+// CHECK-LABEL: func @conv_transpose_2d
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+func.func @conv_transpose_2d(%arg0: tensor<2x9x10x3xf32>,
+                             %arg1: tensor<4x4x3x3xf32>)
+  -> tensor<2x15x25x3xf32> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+    dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+    window = {stride = [1, 1], pad = [[6, 6], [6, 6]],
+              lhs_dilate = [1, 2], rhs_dilate = [2, 2]}
+    {
+      batch_group_count = 1 : i64,
+      feature_group_count = 1 : i64,
+      precision_config = [#stablehlo<precision DEFAULT>,
+                          #stablehlo<precision DEFAULT>]
+    } : (tensor<2x9x10x3xf32>, tensor<4x4x3x3xf32>) -> tensor<2x15x25x3xf32>
+  return %0 : tensor<2x15x25x3xf32>
+}
+// CHECK-DAG:     %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[INIT:.+]] = tensor.empty()
+// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[ZERO]]{{.*}}outs(%[[INIT]]
+// CHECK:         %[[LHS_INIT:.+]] = tensor.empty()
+// CHECK:         %[[LHS_FILL:.+]] = linalg.fill ins(%[[ZERO]]{{.*}}outs(%[[LHS_INIT]]
+// CHECK:         %[[LHS_PAD:.+]] = tensor.insert_slice %[[ARG0]] into %[[LHS_FILL]][0, 6, 6, 0] [2, 9, 10, 3] [1, 1, 2, 1] : tensor<2x9x10x3xf32> into tensor<2x21x31x3xf32>
+// CHECK:         linalg.conv_2d_nhwc_hwcf
+// CHECK-SAME:      {dilations = dense<2> : tensor<2xi64>
+// CHECK-SAME:       strides = dense<1> : tensor<2xi64>}
+// CHECK-SAME:     ins(%[[LHS_PAD]], %[[ARG1]] : tensor<2x21x31x3xf32>, tensor<4x4x3x3xf32>)
+// CHECK-SAME:     outs(%[[FILL]] : tensor<2x15x25x3xf32>) -> tensor<2x15x25x3xf32>
+
+// -----
+
+// Just check that this lowers successfully.
+// CHECK-LABEL: func @conv_different_batch_dim_in_out
+func.func @conv_different_batch_dim_in_out(%arg0: tensor<1x1x1xf64>,
+                                           %arg1: tensor<1x1x1xf64>)
+  -> tensor<1x1x1xf64> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+    dim_numbers = [f, 0, b]x[i, o, 0]->[f, b, 0],
+    window = {stride = [1], pad = [[0, 0]], lhs_dilate = [1],
+             rhs_dilate = [1]}
+    {
+      batch_group_count = 1 : i64,
+      feature_group_count = 1 : i64,
+      precision_config = [#stablehlo<precision HIGHEST>, #stablehlo<precision HIGHEST>]
+    } : (tensor<1x1x1xf64>, tensor<1x1x1xf64>) -> tensor<1x1x1xf64>
+  return %0 : tensor<1x1x1xf64>
+}
+
+// -----
+
+// Just check that this lowers successfully.
+// CHECK-LABEL: func @conv_different_batch_dim_in_out_with_feature_group_count
+func.func @conv_different_batch_dim_in_out_with_feature_group_count(
+    %arg0: tensor<4x6x7x1xf64>, %arg1: tensor<2x6x3x2xf64>)
+  -> tensor<1x2x1x2xf64> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+    dim_numbers = [f, 0, 1, b]x[i, 0, 1, o]->[0, 1, b, f],
+    window = {stride = [1, 1], pad = [[0, 0], [0, -1]],
+              lhs_dilate = [1, 1], rhs_dilate = [1, 2],
+              reverse = [0, 0]}
+    {
+      batch_group_count = 1 : i64,
+      feature_group_count = 2 : i64,
+      precision_config = [#stablehlo<precision HIGHEST>, #stablehlo<precision HIGHEST>]
+    } : (tensor<4x6x7x1xf64>, tensor<2x6x3x2xf64>) -> tensor<1x2x1x2xf64>
+  return %0 : tensor<1x2x1x2xf64>
+}
+
+// -----
+
+// CHECK-LABEL: func @conv_3d_ndhwc_dhwcf
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+func.func @conv_3d_ndhwc_dhwcf(%arg0: tensor<?x8x8x8x?xf32>, %arg1: tensor<2x2x2x?x?xf32>)
+  -> tensor<?x7x7x7x?xf32> {
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 4,
+      input_spatial_dimensions = [1, 2, 3],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 4,
+      kernel_spatial_dimensions = [0, 1, 2],
+      output_batch_dimension = 0,
+      output_feature_dimension = 4,
+      output_spatial_dimensions = [1, 2, 3]
+    >,
+    feature_group_count = 1 : i64,
+    padding = dense<[[0, 0], [0, 0], [0, 0]]> : tensor<3x2xi64>,
+    rhs_dilation = dense<1> : tensor<3xi64>,
+    window_strides = dense<1> : tensor<3xi64>
+  } : (tensor<?x8x8x8x?xf32>, tensor<2x2x2x?x?xf32>) -> tensor<?x7x7x7x?xf32>
+  func.return %0 : tensor<?x7x7x7x?xf32>
+}
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : index
+// CHECK-DAG:     %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[DIM0:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x8x8x8x?xf32>
+// CHECK:         %[[DIM4:.+]] = tensor.dim %[[ARG1]], %[[C4]] : tensor<2x2x2x?x?xf32>
+// CHECK:         %[[INIT:.+]] = tensor.empty(%[[DIM0]], %[[DIM4]])
+// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[ZERO]]{{.*}}outs(%[[INIT]]
+// CHECK:         linalg.conv_3d_ndhwc_dhwcf
+// CHECK-SAME:      {dilations = dense<1> : tensor<3xi64>
+// CHECK-SAME:       strides = dense<1> : tensor<3xi64>}
+// CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]] : tensor<?x8x8x8x?xf32>, tensor<2x2x2x?x?xf32>)
+// CHECK-SAME:    outs(%[[FILL]] : tensor<?x7x7x7x?xf32>) -> tensor<?x7x7x7x?xf32>
+
+// -----
+
+// CHECK-LABEL: func @conv2d_1452x2223_dilated_valid
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+func.func @conv2d_1452x2223_dilated_valid(%arg0: tensor<1x4x5x2xf32>, %arg1: tensor<2x2x2x3xf32>)
+  -> tensor<1x2x4x3xf32> {
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 2,
+      kernel_output_feature_dimension = 3,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    padding = dense<0> : tensor<2x2xi64>,
+    rhs_dilation = dense<[2, 1]> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<1x4x5x2xf32>, tensor<2x2x2x3xf32>) -> tensor<1x2x4x3xf32>
+  func.return %0 : tensor<1x2x4x3xf32>
+}
+// CHECK-DAG:     %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<1x2x4x3xf32>
+// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[INIT]] : tensor<1x2x4x3xf32>) -> tensor<1x2x4x3xf32>
+// CHECK:         linalg.conv_2d_nhwc_hwcf
+// CHECK-SAME:      {dilations = dense<[2, 1]> : tensor<2xi64>
+// CHECK-SAME:       strides = dense<1> : tensor<2xi64>}
+// CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]] : tensor<1x4x5x2xf32>, tensor<2x2x2x3xf32>)
+// CHECK-SAME:    outs(%[[FILL]] : tensor<1x2x4x3xf32>) -> tensor<1x2x4x3xf32>
+
+// -----
+
+// CHECK-LABEL: func @linalg.conv_2D_padding_test1
+// CHECK-SAME: (%[[FILTER:.*]]: tensor<1x33x1x1xf16>, %[[INPUT:.*]]: tensor<400x1024x1024x1xf16>)
+func.func @linalg.conv_2D_padding_test1(%arg0: tensor<1x33x1x1xf16>, %arg1: tensor<400x1024x1024x1xf16>)
+  -> tensor<400x1024x1024x1xf16> {
+  %0 = stablehlo.convolution(%arg1, %arg0)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = { stride = [1, 1], pad = [[0, 0], [16, 16]], rhs_dilate = [1, 1] }
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64
+         } : (tensor<400x1024x1024x1xf16>, tensor<1x33x1x1xf16>) -> (tensor<400x1024x1024x1xf16>)
+  func.return %0 : tensor<400x1024x1024x1xf16>
+}
+// CHECK-DAG: %[[ZERO:.*]] = arith.constant 0.000000e+00 : f16
+// CHECK-NEXT: %[[INIT:.*]] = tensor.empty() : tensor<400x1024x1024x1xf16>
+// CHECK-NEXT: %[[FILL:.*]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[INIT]] : tensor<400x1024x1024x1xf16>) -> tensor<400x1024x1024x1xf16>
+// CHECK-NEXT: %[[PAD:.*]] = tensor.pad %[[INPUT]] low[0, 0, 16, 0] high[0, 0, 16, 0]  {
+// CHECK-NEXT: ^bb0(%{{.*}}: index, %{{.*}}: index, %{{.*}}: index, %{{.*}}: index):
+// CHECK-NEXT:   tensor.yield %[[ZERO]] : f16
+// CHECK-NEXT: } : tensor<400x1024x1024x1xf16> to tensor<400x1024x1056x1xf16>
+// CHECK-NEXT: %[[RESULT:.*]] = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%[[PAD]], %[[FILTER]] : tensor<400x1024x1056x1xf16>, tensor<1x33x1x1xf16>) outs(%[[FILL]] : tensor<400x1024x1024x1xf16>) -> tensor<400x1024x1024x1xf16>
+// CHECK-NEXT: return %[[RESULT]] : tensor<400x1024x1024x1xf16>
+
+// -----
+
+// CHECK-LABEL: func @linalg.conv_2D_padding_test2
+// CHECK-SAME: (%[[FILTER:.*]]: tensor<1x33x1x1xf16>, %[[INPUT:.*]]: tensor<400x1024x1024x1xf16>)
+func.func @linalg.conv_2D_padding_test2(%arg0: tensor<1x33x1x1xf16>, %arg1: tensor<400x1024x1024x1xf16>)
+  -> tensor<400x1040x1024x1xf16> {
+  %0 = stablehlo.convolution(%arg1, %arg0)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[8, 8], [16, 16]], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64
+         } : (tensor<400x1024x1024x1xf16>, tensor<1x33x1x1xf16>) -> (tensor<400x1040x1024x1xf16>)
+  return %0 : tensor<400x1040x1024x1xf16>
+}
+// CHECK-DAG: %[[ZERO:.*]] = arith.constant 0.000000e+00 : f16
+// CHECK: %[[INIT:.*]] = tensor.empty() : tensor<400x1040x1024x1xf16>
+// CHECK: %[[FILL:.*]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[INIT]] : tensor<400x1040x1024x1xf16>) -> tensor<400x1040x1024x1xf16>
+// CHECK-NEXT: %[[PAD:.*]] = tensor.pad %[[INPUT]] low[0, 8, 16, 0] high[0, 8, 16, 0]  {
+// CHECK-NEXT: ^bb0(%{{.*}}: index, %{{.*}}: index, %{{.*}}: index, %{{.*}}: index):
+// CHECK-NEXT:   tensor.yield %[[ZERO]] : f16
+// CHECK-NEXT: } : tensor<400x1024x1024x1xf16> to tensor<400x1040x1056x1xf16>
+// CHECK-NEXT: %[[RESULT:.*]] = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%[[PAD]], %arg0 : tensor<400x1040x1056x1xf16>, tensor<1x33x1x1xf16>) outs(%[[FILL]] : tensor<400x1040x1024x1xf16>) -> tensor<400x1040x1024x1xf16>
+// CHECK-NEXT: return %[[RESULT]] : tensor<400x1040x1024x1xf16>
+
+// -----
+
+// CHECK-LABEL:  func @depthwise_conv
+// CHECK-SAME:   %[[IN:[a-zA-Z0-9_]*]]
+// CHECK-SAME:   %[[FILTER:[a-zA-Z0-9_]*]]
+func.func @depthwise_conv(%arg0: tensor<2x4x5x2xf32>,
+                     %arg1: tensor<2x2x1x6xf32>) -> tensor<2x3x4x6xf32> {
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 2,
+      kernel_output_feature_dimension = 3,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 2 : i64,
+    padding = dense<0> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>,
+    someattr} : (tensor<2x4x5x2xf32>, tensor<2x2x1x6xf32>) -> tensor<2x3x4x6xf32>
+  func.return %0 : tensor<2x3x4x6xf32>
+}
+// CHECK-DAG:       %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:       %[[COLLAPSE:.+]] = tensor.collapse_shape %[[FILTER]] {{\[}}[0, 1, 2, 3]] : tensor<2x2x1x6xf32> into tensor<24xf32>
+// CHECK:       %[[EXPAND:.+]] = tensor.expand_shape %[[COLLAPSE]] {{\[}}[0, 1, 2, 3]] : tensor<24xf32> into tensor<2x2x2x3xf32>
+// CHECK:       %[[INIT:.+]] = tensor.empty() : tensor<2x3x4x2x3xf32>
+// CHECK:       %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[INIT]] : tensor<2x3x4x2x3xf32>) -> tensor<2x3x4x2x3xf32>
+// CHECK:       %[[OUT:.+]] = linalg.depthwise_conv_2d_nhwc_hwcm
+// CHECK-SAME:     {dilations = dense<1> : tensor<2xi64>, someattr, strides = dense<1> : tensor<2xi64>}
+// CHECK-SAME:     ins(%[[IN]], %[[EXPAND]] : tensor<2x4x5x2xf32>, tensor<2x2x2x3xf32>)
+// CHECK-SAME:     outs(%[[FILL]] : tensor<2x3x4x2x3xf32>) -> tensor<2x3x4x2x3xf32>
+// CHECK:       %{{.+}} = tensor.collapse_shape %[[OUT]]
+// CHECK-SAME:     [0], [1], [2], [3, 4]
+// CHECK-SAME:     : tensor<2x3x4x2x3xf32> into tensor<2x3x4x6xf32>
+
+// -----
+
+// CHECK-LABEL:  func @depthwise_conv_with_padding
+// CHECK-SAME:   %[[IN:[a-zA-Z0-9_]*]]
+// CHECK-SAME:   %[[FILTER:[a-zA-Z0-9_]*]]
+func.func @depthwise_conv_with_padding(
+    %arg0: tensor<2x4x5x2xf32>,
+    %arg1: tensor<2x2x1x4xf32>) -> tensor<2x3x6x4xf32> {
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 2,
+      kernel_output_feature_dimension = 3,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 2 : i64,
+    padding = dense<[[0, 0], [1, 1]]> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>,
+    someattr} : (tensor<2x4x5x2xf32>, tensor<2x2x1x4xf32>) -> tensor<2x3x6x4xf32>
+  func.return %0 : tensor<2x3x6x4xf32>
+}
+// CHECK-DAG:    %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[PAD:.*]] = tensor.pad %[[IN]] low[0, 0, 1, 0] high[0, 0, 1, 0] {
+// CHECK:        ^bb0(%{{.*}}: index, %{{.*}}: index, %{{.*}}: index, %{{.*}}: index):
+// CHECK:          tensor.yield %[[ZERO]] : f32
+// CHECK         } : tensor<2x4x5x2xf32> to tensor<2x4x7x2xf32>
+// CHECK:        %[[COLLAPSE:.+]] = tensor.collapse_shape %[[FILTER]]
+// CHECK-SAME:    [0, 1, 2, 3]
+// CHECK-SAME:    : tensor<2x2x1x4xf32> into tensor<16xf32>
+// CHECK:       %[[EXPAND:.+]] = tensor.expand_shape %[[COLLAPSE]]
+// CHECK-SAME:   [0, 1, 2, 3]
+// CHECK-SAME:   tensor<16xf32> into tensor<2x2x2x2xf32>
+// CHECK:        %[[INIT:.+]] = tensor.empty() : tensor<2x3x6x2x2xf32>
+// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[INIT]] : tensor<2x3x6x2x2xf32>) -> tensor<2x3x6x2x2xf32>
+// CHECK:        %[[OUT:.+]] = linalg.depthwise_conv_2d_nhwc_hwcm
+// CHECK-SAME:     {dilations = dense<1> : tensor<2xi64>, someattr, strides = dense<1> : tensor<2xi64>}
+// CHECK-SAME:     ins(%[[PAD]], %[[EXPAND]] : tensor<2x4x7x2xf32>, tensor<2x2x2x2xf32>)
+// CHECK-SAME:     outs(%[[FILL]] : tensor<2x3x6x2x2xf32>) -> tensor<2x3x6x2x2xf32>
+// CHECK:        %{{.+}} = tensor.collapse_shape %[[OUT]]
+// CHECK-SAME:     [0], [1], [2], [3, 4]
+// CHECK-SAME:     : tensor<2x3x6x2x2xf32> into tensor<2x3x6x4xf32>
+
+// -----
+
+// CHECK-LABEL:   func @depthwise_conv_multiplier_1
+// CHECK-SAME:    %[[IN:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[FILTER:[a-zA-Z0-9_]*]]
+func.func @depthwise_conv_multiplier_1(%arg0: tensor<1x113x113x96xf32>,
+                                  %arg1: tensor<3x3x1x96xf32>) -> tensor<1x56x56x96xf32> {
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 2,
+      kernel_output_feature_dimension = 3,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 96 : i64,
+    padding = dense<0> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<2> : tensor<2xi64>} : (tensor<1x113x113x96xf32>, tensor<3x3x1x96xf32>) -> tensor<1x56x56x96xf32>
+  func.return %0 : tensor<1x56x56x96xf32>
+}
+// CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<1x56x56x96xf32>
+// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[INIT]] : tensor<1x56x56x96xf32>) -> tensor<1x56x56x96xf32>
+// CHECK:         %[[RESHAPED_FILTER:.+]] = tensor.collapse_shape %[[FILTER]]
+// CHECK-SAME:     [0], [1], [2, 3]
+// CHECK-SAME:     : tensor<3x3x1x96xf32> into tensor<3x3x96xf32>
+// CHECK:         %{{.+}} = linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK-SAME:      {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
+// CHECK-SAME:       ins(%[[IN]], %[[RESHAPED_FILTER]] : tensor<1x113x113x96xf32>, tensor<3x3x96xf32>)
+// CHECK-SAME:      outs(%[[FILL]] : tensor<1x56x56x96xf32>) -> tensor<1x56x56x96xf32>
+
+// -----
+
+// CHECK-LABEL:   func @depthwise_conv_multiplier_1_with_padding
+// CHECK-SAME:    %[[IN:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[FILTER:[a-zA-Z0-9_]*]]
+func.func @depthwise_conv_multiplier_1_with_padding(
+    %arg0: tensor<1x113x113x96xf32>,
+    %arg1: tensor<3x3x1x96xf32>) -> tensor<1x57x58x96xf32> {
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 2,
+      kernel_output_feature_dimension = 3,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 96 : i64,
+    padding = dense<[[1, 1], [2, 2]]> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<2> : tensor<2xi64>} : (tensor<1x113x113x96xf32>, tensor<3x3x1x96xf32>) -> tensor<1x57x58x96xf32>
+  func.return %0 : tensor<1x57x58x96xf32>
+}
+// CHECK-DAG:     %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[PAD:.*]] = tensor.pad %[[IN]] low[0, 1, 2, 0] high[0, 1, 2, 0]  {
+// CHECK:         ^bb0(%{{.*}}: index, %{{.*}}: index, %{{.*}}: index, %{{.*}}: index):
+// CHECK:           tensor.yield %[[ZERO]] : f32
+// CHECK          } : tensor<1x113x113x96xf32> to tensor<1x115x117x96xf32>
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<1x57x58x96xf32>
+// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[INIT]] : tensor<1x57x58x96xf32>) -> tensor<1x57x58x96xf32>
+// CHECK:         %[[RESHAPED_FILTER:.+]] = tensor.collapse_shape %[[FILTER]]
+// CHECK-SAME:     [0], [1], [2, 3]
+// CHECK-SAME:     : tensor<3x3x1x96xf32> into tensor<3x3x96xf32>
+// CHECK:         %{{.+}} = linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK-SAME:      {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
+// CHECK-SAME:       ins(%[[PAD]], %[[RESHAPED_FILTER]] : tensor<1x115x117x96xf32>, tensor<3x3x96xf32>)
+// CHECK-SAME:       outs(%[[FILL]] : tensor<1x57x58x96xf32>) -> tensor<1x57x58x96xf32>
+
+// -----
+
+// CHECK-LABEL:  func @depthwise_conv1d
+// CHECK-SAME:   %[[IN:[a-zA-Z0-9_]*]]
+// CHECK-SAME:   %[[FILTER:[a-zA-Z0-9_]*]]
+func.func @depthwise_conv1d(%arg0: tensor<1x10x8xf32>,
+                            %arg1: tensor<3x1x16xf32>) -> tensor<1x10x16xf32> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+    dim_numbers = [b, 0, f]x[0, i, o]->[b, 0, f],
+    window = {
+      stride = [1],
+      pad = [[1, 1]],
+      lhs_dilate = [1],
+      rhs_dilate = [1],
+      reverse = [0]} {
+    batch_group_count = 1 : i64,
+    feature_group_count = 8 : i64,
+    someattr} : (tensor<1x10x8xf32>, tensor<3x1x16xf32>) -> tensor<1x10x16xf32>
+  func.return %0 : tensor<1x10x16xf32>
+}
+// CHECK:       %[[CONV:.+]] = linalg.depthwise_conv_1d_nwc_wcm
+// CHECK:       %[[OUT:.+]] = tensor.collapse_shape %[[CONV]]
+// CHECK:       return %[[OUT]]
+
+// -----
+
+// CHECK-LABEL:  func @depthwise_conv1d
+// CHECK-SAME:   %[[IN:[a-zA-Z0-9_]*]]
+// CHECK-SAME:   %[[FILTER:[a-zA-Z0-9_]*]]
+func.func @depthwise_conv1d_m1(%arg0: tensor<1x10x8xf32>,
+                               %arg1: tensor<3x1x8xf32>) -> tensor<1x10x8xf32> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+    dim_numbers = [b, 0, f]x[0, i, o]->[b, 0, f],
+    window = {
+      stride = [1],
+      pad = [[1, 1]],
+      lhs_dilate = [1],
+      rhs_dilate = [1],
+      reverse = [0]} {
+    batch_group_count = 1 : i64,
+    feature_group_count = 8 : i64,
+    someattr} : (tensor<1x10x8xf32>, tensor<3x1x8xf32>) -> tensor<1x10x8xf32>
+  func.return %0 : tensor<1x10x8xf32>
+}
+// CHECK:       %[[CONV:.+]] = linalg.depthwise_conv_1d_nwc_wc
+// CHECK:       return %[[CONV]]
+
+// -----
+
+// CHECK-LABEL:  func @depthwise_conv3d
+// CHECK-SAME:   %[[IN:[a-zA-Z0-9_]*]]
+// CHECK-SAME:   %[[FILTER:[a-zA-Z0-9_]*]]
+func.func @depthwise_conv3d(%arg0: tensor<2x3x5x4x6xf32>,
+                            %arg1: tensor<2x1x3x1x36xf32>)
+                            -> tensor<2x3x13x4x36xf32> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+    dim_numbers = [b, 0, 1, 2, f]x[0, 1, 2, i, o]->[b, 0, 1, 2, f],
+    window = {
+      stride = [2, 1, 3],
+      pad = [[1, 2], [5, 3], [3, 5]],
+      lhs_dilate = [1, 1, 1],
+      rhs_dilate = [1, 1, 1],
+      reverse = [0, 0, 0]} {
+    batch_group_count = 1 : i64,
+    feature_group_count = 6 : i64,
+    someattr} : (tensor<2x3x5x4x6xf32>, tensor<2x1x3x1x36xf32>)
+              -> tensor<2x3x13x4x36xf32>
+  func.return %0 : tensor<2x3x13x4x36xf32>
+}
+// CHECK:       %[[CONV:.+]] = linalg.depthwise_conv_3d_ndhwc_dhwcm
+// CHECK:       %[[OUT:.+]] = tensor.collapse_shape %[[CONV]]
+// CHECK:       return %[[OUT]]
+
+// -----
+
+// CHECK-LABEL:  func @depthwise_conv3d
+// CHECK-SAME:   %[[IN:[a-zA-Z0-9_]*]]
+// CHECK-SAME:   %[[FILTER:[a-zA-Z0-9_]*]]
+func.func @depthwise_conv3d_m1(%arg0: tensor<2x3x5x4x6xf32>,
+                               %arg1: tensor<2x1x3x1x6xf32>)
+                               -> tensor<2x3x13x4x6xf32> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+    dim_numbers = [b, 0, 1, 2, f]x[0, 1, 2, i, o]->[b, 0, 1, 2, f],
+    window = {
+      stride = [2, 1, 3],
+      pad = [[1, 2], [5, 3], [3, 5]],
+      lhs_dilate = [1, 1, 1],
+      rhs_dilate = [1, 1, 1],
+      reverse = [0, 0, 0]} {
+    batch_group_count = 1 : i64,
+    feature_group_count = 6 : i64,
+    someattr} : (tensor<2x3x5x4x6xf32>, tensor<2x1x3x1x6xf32>)
+              -> tensor<2x3x13x4x6xf32>
+  func.return %0 : tensor<2x3x13x4x6xf32>
+}
+// CHECK:       %[[CONV:.+]] = linalg.depthwise_conv_3d_ndhwc_dhwc
+// CHECK:       return %[[CONV]]


### PR DESCRIPTION
This ports the `stablehlo.convolution` op lowering from mlir-hlo. For the details, see the initial import: https://github.com/openxla/iree/pull/12957.

The code is cleaned up to match the existing StableHLO -> linalg conversion patterns. This includes cosmetic changes like placing the patterns and helper functions in a new file, updating the patterns to work on stablehlo ops, replacing some `auto` with the actual type types, etc. The only change to the logic is fixing incorrect type conversion checks.

This is the last op from mlir-hlo's `legalize_to_linalg.cc` that required porting.

Issue: https://github.com/openxla/iree/issues/12678