### PR TITLE
Opt in to `-Wc++20-extensions` warning in clang.

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -128,6 +128,7 @@ build:generic_clang --copt=-Wno-user-defined-warnings
 # Explicitly enable some additional warnings.
 # Some of these aren't on by default, or under -Wall, or are subsets of warnings
 # turned off above.
+build:generic_clang --copt=-Wc++20-extensions
 build:generic_clang --copt=-Wctad-maybe-unsupported
 build:generic_clang --copt=-Wfloat-overflow-conversion
 build:generic_clang --copt=-Wfloat-zero-conversion

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -178,6 +178,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     # Explicitly enable some additional warnings.
     # Some of these aren't on by default, or under -Wall, or are subsets of
     # warnings turned off above.
+    "-Wc++20-extensions"  # Enable until we use C++20 across all compilers
     "-Wctad-maybe-unsupported"
     "-Wfloat-overflow-conversion"
     "-Wfloat-zero-conversion"


### PR DESCRIPTION
We're currently using C++17 across all of our supported compilers, but clang backported some C++20 features via extensions. Enabling this warning will make it harder to write code that compiles in clang but not in MSVC (see https://github.com/openxla/iree/pull/13155).

https://releases.llvm.org/11.0.1/tools/clang/docs/DiagnosticsReference.html#wc-20-extensions