### PR TITLE
Add missing canonicalization to LLVMCPUVectorLowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorLowering.cpp
@@ -74,6 +74,17 @@ void LLVMCPUVectorLoweringPass::runOnOperation() {
     llvm::dbgs() << "\n\n";
   });
 
+  // TODO(dcaballe): We should split this pass into smaller/simpler ones and
+  // replace the code below with a full canonicalize pass.
+  {
+    RewritePatternSet patterns(ctx);
+    for (auto *dialect : ctx->getLoadedDialects())
+      dialect->getCanonicalizationPatterns(patterns);
+    for (RegisteredOperationName op : ctx->getRegisteredOperations())
+      op.getCanonicalizationPatterns(patterns, ctx);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  }
+
   {
     RewritePatternSet patterns(ctx);
     vector::populateVectorTransferLoweringPatterns(patterns,
@@ -89,6 +100,17 @@ void LLVMCPUVectorLoweringPass::runOnOperation() {
     funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
     llvm::dbgs() << "\n\n";
   });
+
+  // TODO(dcaballe): We should split this pass into smaller/simpler ones and
+  // replace the code below with a full canonicalize pass.
+  {
+    RewritePatternSet patterns(ctx);
+    for (auto *dialect : ctx->getLoadedDialects())
+      dialect->getCanonicalizationPatterns(patterns);
+    for (RegisteredOperationName op : ctx->getRegisteredOperations())
+      op.getCanonicalizationPatterns(patterns, ctx);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  }
 
   // Lowering for vector.transpose ops.
   {


### PR DESCRIPTION
I found that some canonicalization between the three stages of LLVMCPUVectorLowering are not happening. This patch adds the canonicalization stages that we have between them.

(This is another indicator that we have to split this pass into multiple ones :))