### PR TITLE
Fix batch_matmul + transpose using nvgpu.mma.sync.1688.f32 (#13075)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -16,6 +16,8 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-utils"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define DBGSNL() (llvm::dbgs() << "\n")
 
 static constexpr unsigned kShuffleBitWidth = 32;
 
@@ -678,8 +680,8 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
         getVectorContractOpOperandIdForVectorReadOp(op);
     if (!operandId) {
       LLVM_DEBUG({
-        llvm::dbgs() << "Failed to get operandId for vector::TransferReadOp:";
-        op->dump();
+        DBGS() << "Failed to get operandId for vector::TransferReadOp: " << *op
+               << "\n";
       });
       return std::nullopt;
     }


### PR DESCRIPTION
This PR fixes the segmentation fault on #13075 for `linalg.batch_matmul` with transpose on the output (see comment [here](https://github.com/openxla/iree/issues/13075#issuecomment-1514852147)). The fix:

- Checks if the op has uses before iterating through first- and second-level use.
- Replaces `op->emitError()` with LLVM debug prints to allow the compilation to go through a fall back path for the `vector.transfer_read` that are not contributing to `vector.contract`
- Add more comments to the `getVectorContractOpOperandIdForVectorReadOp`. 

 