### PR TITLE
Update `experimental/web/sample_dynamic/` after runtime changes.

### DIFF
--- a/experimental/web/sample_dynamic/CMakeLists.txt
+++ b/experimental/web/sample_dynamic/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
 # drivers/devices, which include code not compatible with Emscripten.
 target_link_libraries(${_NAME}
   iree_runtime_runtime
+  iree_hal_local_executable_plugin_manager
   iree_hal_local_loaders_system_library_loader
   iree_hal_local_loaders_vmvx_module_loader
   iree_hal_drivers_local_sync_sync_driver

--- a/experimental/web/sample_dynamic/CMakeLists.txt
+++ b/experimental/web/sample_dynamic/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(${_NAME}
 
 target_link_options(${_NAME} PRIVATE
   # https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-ccall-cwrap
-  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_load_program', '_inspect_program', '_unload_program', '_call_function']"
+  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_load_program', '_inspect_program', '_unload_program', '_call_function', '_malloc']"
   "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap']"
   #
   "-sASSERTIONS=1"

--- a/experimental/web/sample_dynamic/device_sync.c
+++ b/experimental/web/sample_dynamic/device_sync.c
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/hal/drivers/local_sync/sync_device.h"
+#include "iree/hal/local/executable_plugin_manager.h"
 #include "iree/hal/local/loaders/system_library_loader.h"
 #include "iree/hal/local/loaders/vmvx_module_loader.h"
 
@@ -15,12 +16,17 @@ iree_status_t create_device_with_loaders(iree_allocator_t host_allocator,
 
   iree_status_t status = iree_ok_status();
 
+  iree_hal_executable_plugin_manager_t* plugin_manager = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_executable_plugin_manager_create(
+        /*capacity=*/0, host_allocator, &plugin_manager);
+  }
+
   iree_hal_executable_loader_t* loaders[2] = {NULL, NULL};
   iree_host_size_t loader_count = 0;
   if (iree_status_is_ok(status)) {
     status = iree_hal_system_library_loader_create(
-        iree_hal_executable_import_provider_null(), host_allocator,
-        &loaders[loader_count++]);
+        plugin_manager, host_allocator, &loaders[loader_count++]);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_vmvx_module_loader_create_isolated(

--- a/experimental/web/sample_dynamic/main.c
+++ b/experimental/web/sample_dynamic/main.c
@@ -288,7 +288,7 @@ static iree_status_t print_outputs_from_call(
         "variant %" PRIhsz " not present", i);
 
     if (iree_vm_variant_is_value(variant)) {
-      switch (variant.type.value_type) {
+      switch (iree_vm_type_def_as_value(variant.type)) {
         case IREE_VM_VALUE_TYPE_I8: {
           IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
               outputs_builder, "i8=%" PRIi8, variant.i8));


### PR DESCRIPTION
This fixes the build after https://github.com/openxla/iree/pull/12625 and https://github.com/openxla/iree/pull/12650.

Sample error logs: https://github.com/openxla/iree/actions/runs/4696278532/jobs/8326230980#step:4:430
```
experimental/web/sample_dynamic/main.c:291:28: error: no member named 'value_type' in 'struct iree_vm_type_def_t'
      switch (variant.type.value_type) {
              ~~~~~~~~~~~~ ^
```

See also https://github.com/openxla/iree/issues/13148