### PR TITLE
[StableHLO][NFC] Trim down stablehlo to linalg conversion deps

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
@@ -44,10 +44,11 @@ iree_compiler_cc_library(
 )
 
 iree_compiler_cc_library(
-    name = "StableHLO",
+    name = "StableHLOToLinalg",
     srcs = [
         "LegalizeToLinalgUtils.cpp",
-        "Passes.cpp",
+        "LegalizeToLinalgUtils.h",
+        "MapStableHLOToScalarOp.h",
         "StableHLOToArith.cpp",
         "StableHLOToLinalg.cpp",
         "StableHLOToLinalgConvolution.cpp",
@@ -57,47 +58,45 @@ iree_compiler_cc_library(
         "StableHLOToLinalgReduce.cpp",
         "TypeConversion.cpp",
     ],
-    hdrs = [
-        "LegalizeToLinalgUtils.h",
-        "MapStableHLOToScalarOp.h",
-        "Passes.h",
-    ],
     deps = [
         ":PassHeaders",
-        ":PassesIncGen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:ComplexDialect",
-        "@llvm-project//mlir:ControlFlowDialect",
-        "@llvm-project//mlir:DialectUtils",
-        "@llvm-project//mlir:FuncDialect",
-        "@llvm-project//mlir:FuncTransforms",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:LinalgUtils",
-        "@llvm-project//mlir:MLProgramDialect",
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MemRefDialect",
-        "@llvm-project//mlir:Pass",
-        "@llvm-project//mlir:ReconcileUnrealizedCasts",
         "@llvm-project//mlir:SCFDialect",
-        "@llvm-project//mlir:SCFToControlFlow",
-        "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:ShapeDialect",
-        "@llvm-project//mlir:ShapeToStandard",
         "@llvm-project//mlir:ShapeTransforms",
         "@llvm-project//mlir:SparseTensorDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
-        "@llvm-project//mlir:TensorUtils",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",
-        "@mlir-hlo//stablehlo:broadcast_utils",
         "@mlir-hlo//stablehlo:chlo_ops",
         "@mlir-hlo//stablehlo:stablehlo_ops",
+    ],
+)
+
+iree_compiler_cc_library(
+    name = "StableHLO",
+    srcs = [
+        "Passes.cpp",
+    ],
+    hdrs = [
+        "Passes.h",
+    ],
+    deps = [
+        ":PassHeaders",
+        ":StableHLOToLinalg",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Pass",
     ],
 )

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
@@ -37,14 +37,11 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
-    StableHLO
-  HDRS
-    "LegalizeToLinalgUtils.h"
-    "MapStableHLOToScalarOp.h"
-    "Passes.h"
+    StableHLOToLinalg
   SRCS
     "LegalizeToLinalgUtils.cpp"
-    "Passes.cpp"
+    "LegalizeToLinalgUtils.h"
+    "MapStableHLOToScalarOp.h"
     "StableHLOToArith.cpp"
     "StableHLOToLinalg.cpp"
     "StableHLOToLinalgConvolution.cpp"
@@ -55,7 +52,6 @@ iree_cc_library(
     "TypeConversion.cpp"
   DEPS
     ::PassHeaders
-    ::PassesIncGen
     ChloOps
     LLVMSupport
     MLIRAffineDialect
@@ -63,32 +59,36 @@ iree_cc_library(
     MLIRArithDialect
     MLIRBufferizationDialect
     MLIRComplexDialect
-    MLIRControlFlowDialect
-    MLIRFuncDialect
-    MLIRFuncTransforms
     MLIRIR
     MLIRLinalgDialect
     MLIRLinalgTransforms
     MLIRLinalgUtils
-    MLIRMLProgramDialect
     MLIRMathDialect
     MLIRMemRefDialect
-    MLIRPass
-    MLIRReconcileUnrealizedCasts
     MLIRSCFDialect
-    MLIRSCFToControlFlow
-    MLIRSCFTransforms
     MLIRShapeDialect
     MLIRShapeOpsTransforms
-    MLIRShapeToStandard
     MLIRSparseTensorDialect
     MLIRSupport
     MLIRTensorDialect
-    MLIRTensorUtils
     MLIRTransforms
     MLIRVectorDialect
-    StablehloBroadcastUtils
     StablehloOps
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    StableHLO
+  HDRS
+    "Passes.h"
+  SRCS
+    "Passes.cpp"
+  DEPS
+    ::PassHeaders
+    ::StableHLOToLinalg
+    LLVMSupport
+    MLIRPass
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
@@ -8,11 +8,7 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <memory>
-#include <numeric>
-#include <optional>
 #include <string>
-#include <utility>
 
 #include "iree/compiler/InputConversion/StableHLO/LegalizeToLinalgUtils.h"
 #include "iree/compiler/InputConversion/StableHLO/Passes.h"
@@ -23,7 +19,6 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
@@ -33,7 +28,6 @@
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -45,7 +39,6 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/TypeConversion.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/TypeConversion.cpp
@@ -8,8 +8,6 @@
 
 #include <optional>
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -17,7 +15,6 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
-#include "stablehlo/dialect/StablehloOps.h"
 
 namespace mlir::iree_compiler::stablehlo {
 


### PR DESCRIPTION
Now that lowering to linalg is ported, remove unnecessary build dependencies and includes.

This is in preparation for building a full input processing pipeline and to better understand which dependencies are actually used by each part of the input processing pipeline.

Issue: https://github.com/openxla/iree/issues/12678