### PR TITLE
Support device detection with new benchmark suite

### DIFF
--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -19,14 +19,16 @@ import dataclasses
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-# A map from CPU ABI to IREE's benchmark target architecture.
-CPU_ABI_TO_TARGET_ARCH_MAP = {
+from e2e_test_framework.definitions import common_definitions
+
+# A map from CPU ABI to IREE's legacy benchmark target architecture.
+LEGACY_CPU_ABI_TO_TARGET_ARCH_MAP = {
     "arm64-v8a": "cpu-arm64-v8a",
-    "x86_64": "cpu-x86_64",
+    "x86_64-CascadeLake": "cpu-x86_64-cascadelake",
 }
 
-# A map from GPU name to IREE's benchmark target architecture.
-GPU_NAME_TO_TARGET_ARCH_MAP = {
+# A map from GPU name to IREE's legacy benchmark target architecture.
+LEGACY_GPU_NAME_TO_TARGET_ARCH_MAP = {
     "adreno-640": "gpu-adreno",
     "adreno-650": "gpu-adreno",
     "adreno-660": "gpu-adreno",
@@ -36,11 +38,28 @@ GPU_NAME_TO_TARGET_ARCH_MAP = {
     "tesla-v100-sxm2-16gb": "gpu-cuda-sm_70",
     "nvidia-a100-sxm4-40gb": "gpu-cuda-sm_80",
     "nvidia-geforce-rtx-3090": "gpu-cuda-sm_80",
-    "unknown": "gpu-unknown",
 }
 
-# A map of canonical microarchitecture names.
-CANONICAL_MICROARCHITECTURE_NAMES = {"CascadeLake", "Zen2"}
+# A map from CPU ABI to IREE's benchmark target architecture.
+CPU_ABI_TO_TARGET_ARCH_MAP = {
+    "arm64-v8a":
+        common_definitions.DeviceArchitecture.ARMV8_2_A_GENERIC,
+    "x86_64-cascadelake":
+        common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
+}
+
+# A map from GPU name to IREE's benchmark target architecture.
+GPU_NAME_TO_TARGET_ARCH_MAP = {
+    "adreno-640": common_definitions.DeviceArchitecture.QUALCOMM_ADRENO,
+    "adreno-650": common_definitions.DeviceArchitecture.QUALCOMM_ADRENO,
+    "adreno-660": common_definitions.DeviceArchitecture.QUALCOMM_ADRENO,
+    "adreno-730": common_definitions.DeviceArchitecture.QUALCOMM_ADRENO,
+    "mali-g77": common_definitions.DeviceArchitecture.ARM_VALHALL,
+    "mali-g78": common_definitions.DeviceArchitecture.ARM_VALHALL,
+    "tesla-v100-sxm2-16gb": common_definitions.DeviceArchitecture.CUDA_SM70,
+    "nvidia-a100-sxm4-40gb": common_definitions.DeviceArchitecture.CUDA_SM80,
+    "nvidia-geforce-rtx-3090": common_definitions.DeviceArchitecture.CUDA_SM80,
+}
 
 
 @dataclasses.dataclass
@@ -224,28 +243,27 @@ class DeviceInfo:
     params = ", ".join(params)
     return f"{self.platform_type.value} device <{params}>"
 
-  def get_iree_cpu_arch_name(self) -> str:
-    arch = CPU_ABI_TO_TARGET_ARCH_MAP.get(self.cpu_abi.lower())
-    if not arch:
-      raise ValueError(f"Unrecognized CPU ABI: '{self.cpu_abi}'; "
-                       "need to update the map")
-
+  def get_iree_cpu_arch_name(self,
+                             use_legacy_name: bool = False) -> Optional[str]:
+    name = self.cpu_abi.lower()
     if self.cpu_uarch:
-      if self.cpu_uarch not in CANONICAL_MICROARCHITECTURE_NAMES:
-        raise ValueError(
-            f"Unrecognized CPU microarchitecture: '{self.cpu_uarch}'; "
-            "need to update the map")
+      name += f"-{self.cpu_uarch.lower()}"
 
-      arch = f'{arch}-{self.cpu_uarch.lower()}'
+    if use_legacy_name:
+      return LEGACY_CPU_ABI_TO_TARGET_ARCH_MAP.get(name)
 
-    return arch
+    arch = CPU_ABI_TO_TARGET_ARCH_MAP.get(name)
+    return None if arch is None else str(arch)
 
-  def get_iree_gpu_arch_name(self) -> str:
-    arch = GPU_NAME_TO_TARGET_ARCH_MAP.get(self.gpu_name.lower())
-    if not arch:
-      raise ValueError(f"Unrecognized GPU name: '{self.gpu_name}'; "
-                       "need to update the map")
-    return arch
+  def get_iree_gpu_arch_name(self,
+                             use_legacy_name: bool = False) -> Optional[str]:
+    name = self.gpu_name.lower()
+
+    if use_legacy_name:
+      return LEGACY_GPU_NAME_TO_TARGET_ARCH_MAP.get(name)
+
+    arch = GPU_NAME_TO_TARGET_ARCH_MAP.get(name)
+    return None if arch is None else str(arch)
 
   def get_detailed_cpu_arch_name(self) -> str:
     """Returns the detailed architecture name."""

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -22,13 +22,13 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 from e2e_test_framework.definitions import common_definitions
 
 # A map from CPU ABI to IREE's legacy benchmark target architecture.
-LEGACY_CPU_ABI_TO_TARGET_ARCH_MAP = {
+CPU_ABI_TO_LEGACY_TARGET_ARCH_MAP = {
     "arm64-v8a": "cpu-arm64-v8a",
     "x86_64-CascadeLake": "cpu-x86_64-cascadelake",
 }
 
 # A map from GPU name to IREE's legacy benchmark target architecture.
-LEGACY_GPU_NAME_TO_TARGET_ARCH_MAP = {
+GPU_NAME_TO_LEGACY_TARGET_ARCH_MAP = {
     "adreno-640": "gpu-adreno",
     "adreno-650": "gpu-adreno",
     "adreno-660": "gpu-adreno",
@@ -250,9 +250,11 @@ class DeviceInfo:
       name += f"-{self.cpu_uarch.lower()}"
 
     if use_legacy_name:
-      return LEGACY_CPU_ABI_TO_TARGET_ARCH_MAP.get(name)
+      return CPU_ABI_TO_LEGACY_TARGET_ARCH_MAP.get(name)
 
     arch = CPU_ABI_TO_TARGET_ARCH_MAP.get(name)
+    # TODO(#11076): Return common_definitions.DeviceArchitecture instead after
+    # removing the legacy path.
     return None if arch is None else str(arch)
 
   def get_iree_gpu_arch_name(self,
@@ -260,7 +262,7 @@ class DeviceInfo:
     name = self.gpu_name.lower()
 
     if use_legacy_name:
-      return LEGACY_GPU_NAME_TO_TARGET_ARCH_MAP.get(name)
+      return GPU_NAME_TO_LEGACY_TARGET_ARCH_MAP.get(name)
 
     arch = GPU_NAME_TO_TARGET_ARCH_MAP.get(name)
     return None if arch is None else str(arch)

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -24,7 +24,7 @@ from e2e_test_framework.definitions import common_definitions
 # A map from CPU ABI to IREE's legacy benchmark target architecture.
 CPU_ABI_TO_LEGACY_TARGET_ARCH_MAP = {
     "arm64-v8a": "cpu-arm64-v8a",
-    "x86_64-CascadeLake": "cpu-x86_64-cascadelake",
+    "x86_64-cascadeLake": "cpu-x86_64-cascadelake",
 }
 
 # A map from GPU name to IREE's legacy benchmark target architecture.

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -68,17 +68,20 @@ class BenchmarkDriver(object):
 
     use_legacy_name = self.benchmark_suite.legacy_suite
 
+    target_architectures = []
     cpu_target_arch = self.device_info.get_iree_cpu_arch_name(use_legacy_name)
     if cpu_target_arch is None:
       print("WARNING: Detected unsupported CPU architecture in "
             f'"{self.device_info}", CPU benchmarking is disabled.')
-      cpu_target_arch = "unknown"
+    else:
+      target_architectures.append(cpu_target_arch)
 
     gpu_target_arch = self.device_info.get_iree_gpu_arch_name(use_legacy_name)
     if gpu_target_arch is None:
       print("WARNING: Detected unsupported GPU architecture in "
             f'"{self.device_info}", GPU benchmarking is disabled.')
-      gpu_target_arch = "unknown"
+    else:
+      target_architectures.append(gpu_target_arch)
 
     drivers, loaders = self.__get_available_drivers_and_loaders()
 
@@ -87,8 +90,7 @@ class BenchmarkDriver(object):
           category=category,
           available_drivers=drivers,
           available_loaders=loaders,
-          cpu_target_arch_filter=f"^{cpu_target_arch}$",
-          gpu_target_arch_filter=f"^{gpu_target_arch}$",
+          target_architectures=target_architectures,
           driver_filter=self.config.driver_filter,
           mode_filter=self.config.mode_filter,
           model_name_filter=self.config.model_name_filter)

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -66,8 +66,20 @@ class BenchmarkDriver(object):
       self.config.trace_capture_config.capture_tmp_dir.mkdir(parents=True,
                                                              exist_ok=True)
 
-    cpu_target_arch = self.device_info.get_iree_cpu_arch_name()
-    gpu_target_arch = self.device_info.get_iree_gpu_arch_name()
+    use_legacy_name = self.benchmark_suite.legacy_suite
+
+    cpu_target_arch = self.device_info.get_iree_cpu_arch_name(use_legacy_name)
+    if cpu_target_arch is None:
+      print("WARNING: Detected unsupported CPU architecture in "
+            f'"{self.device_info}", CPU benchmarking is disabled.')
+      cpu_target_arch = "unknown"
+
+    gpu_target_arch = self.device_info.get_iree_gpu_arch_name(use_legacy_name)
+    if gpu_target_arch is None:
+      print("WARNING: Detected unsupported GPU architecture in "
+            f'"{self.device_info}", GPU benchmarking is disabled.')
+      gpu_target_arch = "unknown"
+
     drivers, loaders = self.__get_available_drivers_and_loaders()
 
     for category, _ in self.benchmark_suite.list_categories():

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -17,13 +17,14 @@ from common.benchmark_driver import BenchmarkDriver
 from common.benchmark_definition import (IREE_DRIVERS_INFOS, DeviceInfo,
                                          PlatformType, BenchmarkLatency,
                                          BenchmarkMemory, BenchmarkMetrics)
+from e2e_test_framework.definitions import common_definitions, iree_definitions
 
 
 class FakeBenchmarkDriver(BenchmarkDriver):
 
   def __init__(self,
                *args,
-               raise_exception_on_case: Optional[str] = None,
+               raise_exception_on_case: Optional[BenchmarkCase] = None,
                **kwargs):
     super().__init__(*args, **kwargs)
     self.raise_exception_on_case = raise_exception_on_case
@@ -32,8 +33,7 @@ class FakeBenchmarkDriver(BenchmarkDriver):
   def run_benchmark_case(self, benchmark_case: BenchmarkCase,
                          benchmark_results_filename: Optional[pathlib.Path],
                          capture_filename: Optional[pathlib.Path]) -> None:
-    if (self.raise_exception_on_case is not None and
-        self.raise_exception_on_case in str(benchmark_case.benchmark_case_dir)):
+    if self.raise_exception_on_case == benchmark_case:
       raise Exception("fake exception")
 
     self.run_benchmark_cases.append(benchmark_case)
@@ -83,27 +83,74 @@ class BenchmarkDriverTest(unittest.TestCase):
 
     self.device_info = DeviceInfo(platform_type=PlatformType.LINUX,
                                   model="Unknown",
-                                  cpu_abi="arm64-v8a",
-                                  cpu_uarch=None,
-                                  cpu_features=["sha2"],
-                                  gpu_name="Mali-G78")
+                                  cpu_abi="x86_64",
+                                  cpu_uarch="CascadeLake",
+                                  cpu_features=[],
+                                  gpu_name="unknown")
 
-    case1 = BenchmarkCase(model_name="DeepNet",
-                          model_tags=[],
-                          bench_mode=["1-thread", "full-inference"],
-                          target_arch="CPU-ARM64-v8A",
-                          driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-                          benchmark_case_dir=pathlib.Path("case1"),
-                          benchmark_tool_name="tool")
-    case2 = BenchmarkCase(model_name="DeepNetv2",
-                          model_tags=["f32"],
-                          bench_mode=["full-inference"],
-                          target_arch="CPU-ARM64-v8A",
-                          driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
-                          benchmark_case_dir=pathlib.Path("case2"),
-                          benchmark_tool_name="tool")
+    model_tflite = common_definitions.Model(
+        id="tflite",
+        name="model_tflite",
+        tags=[],
+        source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
+        source_url="",
+        entry_function="predict",
+        input_types=["1xf32"])
+    device_spec = common_definitions.DeviceSpec.build(
+        id="dev",
+        device_name="test_dev",
+        architecture=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
+        host_environment=common_definitions.HostEnvironment.LINUX_X86_64,
+        device_parameters=[],
+        tags=[])
+    compile_target = iree_definitions.CompileTarget(
+        target_backend=iree_definitions.TargetBackend.LLVM_CPU,
+        target_architecture=(
+            common_definitions.DeviceArchitecture.X86_64_CASCADELAKE),
+        target_abi=iree_definitions.TargetABI.LINUX_GNU)
+    gen_config = iree_definitions.ModuleGenerationConfig.build(
+        imported_model=iree_definitions.ImportedModel.from_model(model_tflite),
+        compile_config=iree_definitions.CompileConfig.build(
+            id="comp_a", tags=[], compile_targets=[compile_target]))
+    exec_config_a = iree_definitions.ModuleExecutionConfig.build(
+        id="exec_a",
+        tags=["sync"],
+        loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
+        driver=iree_definitions.RuntimeDriver.LOCAL_SYNC)
+    run_config_a = iree_definitions.E2EModelRunConfig.build(
+        module_generation_config=gen_config,
+        module_execution_config=exec_config_a,
+        target_device_spec=device_spec,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
+    exec_config_b = iree_definitions.ModuleExecutionConfig.build(
+        id="exec_b",
+        tags=["task"],
+        loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
+        driver=iree_definitions.RuntimeDriver.LOCAL_TASK)
+    run_config_b = iree_definitions.E2EModelRunConfig.build(
+        module_generation_config=gen_config,
+        module_execution_config=exec_config_b,
+        target_device_spec=device_spec,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
+    self.case1 = BenchmarkCase(
+        model_name="model_tflite",
+        model_tags=[],
+        bench_mode=["sync"],
+        target_arch="x86_64-cascadelake",
+        driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
+        benchmark_tool_name="tool",
+        run_config=run_config_a)
+    self.case2 = BenchmarkCase(model_name="model_tflite",
+                               model_tags=[],
+                               bench_mode=["task"],
+                               target_arch="x86_64-cascadelake",
+                               driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
+                               benchmark_tool_name="tool",
+                               run_config=run_config_b)
     self.benchmark_suite = BenchmarkSuite({
-        pathlib.Path("suite/TFLite"): [case1, case2],
+        pathlib.Path("suite/TFLite"): [self.case1, self.case2],
     })
 
   def tearDown(self) -> None:
@@ -121,16 +168,12 @@ class BenchmarkDriverTest(unittest.TestCase):
     self.assertEqual(
         driver.get_benchmark_results().benchmarks[0].metrics.raw_data, {})
     self.assertEqual(driver.get_benchmark_result_filenames(), [
-        self.benchmark_results_dir /
-        "DeepNet (TFLite) 1-thread,full-inference with IREE-LLVM-CPU @ Unknown (CPU-ARMv8-A).json",
-        self.benchmark_results_dir /
-        "DeepNetv2 [f32] (TFLite) full-inference with IREE-LLVM-CPU-Sync @ Unknown (CPU-ARMv8-A).json"
+        self.benchmark_results_dir / f"{self.case1.run_config}.json",
+        self.benchmark_results_dir / f"{self.case2.run_config}.json"
     ])
     self.assertEqual(driver.get_capture_filenames(), [
-        self.captures_dir /
-        "DeepNet (TFLite) 1-thread,full-inference with IREE-LLVM-CPU @ Unknown (CPU-ARMv8-A).tracy",
-        self.captures_dir /
-        "DeepNetv2 [f32] (TFLite) full-inference with IREE-LLVM-CPU-Sync @ Unknown (CPU-ARMv8-A).tracy"
+        self.captures_dir / f"{self.case1.run_config}.tracy",
+        self.captures_dir / f"{self.case2.run_config}.tracy"
     ])
     self.assertEqual(driver.get_benchmark_errors(), [])
 
@@ -149,7 +192,7 @@ class BenchmarkDriverTest(unittest.TestCase):
     driver = FakeBenchmarkDriver(self.device_info,
                                  self.config,
                                  self.benchmark_suite,
-                                 raise_exception_on_case="case1")
+                                 raise_exception_on_case=self.case1)
 
     driver.run()
 
@@ -157,15 +200,10 @@ class BenchmarkDriverTest(unittest.TestCase):
     self.assertEqual(len(driver.get_benchmark_result_filenames()), 1)
 
   def test_run_with_previous_benchmarks_and_captures(self):
-    benchmark_filename = (
-        self.benchmark_results_dir /
-        "DeepNet (TFLite) 1-thread,full-inference with IREE-LLVM-CPU @ Unknown (CPU-ARMv8-A).json"
-    )
+    benchmark_filename = (self.benchmark_results_dir /
+                          f"{self.case1.run_config}.json")
     benchmark_filename.touch()
-    capture_filename = (
-        self.captures_dir /
-        "DeepNet (TFLite) 1-thread,full-inference with IREE-LLVM-CPU @ Unknown (CPU-ARMv8-A).tracy"
-    )
+    capture_filename = self.captures_dir / f"{self.case1.run_config}.tracy"
     capture_filename.touch()
     config = dataclasses.replace(self.config, continue_from_previous=True)
     driver = FakeBenchmarkDriver(device_info=self.device_info,

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -156,9 +156,9 @@ class BenchmarkSuite(object):
       driver_name = driver_info.driver_name
       matched_available_driver = (available_drivers is None or
                                   driver_name in available_drivers)
-      matched_drivler_filter = driver_filter is None or re.match(
+      matched_driver_filter = driver_filter is None or re.match(
           driver_filter, driver_name) is not None
-      matched_driver = matched_available_driver and matched_drivler_filter
+      matched_driver = matched_available_driver and matched_driver_filter
 
       matched_loader = not driver_info.loader_name or available_loaders is None or (
           driver_info.loader_name in available_loaders)

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -221,9 +221,7 @@ class BenchmarkSuite(object):
             f"Can't map execution config to driver info: {module_exec_config}.")
       driver_info = IREE_DRIVERS_INFOS[driver_info_key]
 
-      arch_info = target_device_spec.architecture
-      target_arch = f"{arch_info.type.value}-{arch_info.architecture}-{arch_info.microarchitecture}"
-
+      target_arch = str(target_device_spec.architecture)
       model = module_gen_config.imported_model.model
 
       benchmark_case = BenchmarkCase(model_name=model.name,

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -92,15 +92,19 @@ EXECUTION_CONFIG_TO_DRIVER_INFO_KEY_MAP: Dict[Tuple[
 class BenchmarkSuite(object):
   """Represents the benchmarks in benchmark suite directory."""
 
-  def __init__(self, suite_map: Dict[pathlib.Path, List[BenchmarkCase]]):
+  def __init__(self,
+               suite_map: Dict[pathlib.Path, List[BenchmarkCase]],
+               legacy_suite: bool = False):
     """Construct a benchmark suite.
 
     Args:
       suites: the map of benchmark cases keyed by category directories.
+      legacy_suite: true if this is a legacy benchmark suite.
     """
     self.suite_map = suite_map
     self.category_map = dict((category_dir.name, category_dir)
                              for category_dir in self.suite_map.keys())
+    self.legacy_suite = legacy_suite
 
   def list_categories(self) -> List[Tuple[str, pathlib.Path]]:
     """Returns all categories and their directories.
@@ -172,16 +176,18 @@ class BenchmarkSuite(object):
       model_name_with_tags = benchmark_case.model_name
       if len(benchmark_case.model_tags) > 0:
         model_name_with_tags += f"-{','.join(benchmark_case.model_tags)}"
-      if benchmark_case.run_config is not None:
-        # For the new run option, we drop the obscure old semantic and only
-        # search on model name and its tags.
-        model_and_case_name = model_name_with_tags
-      elif benchmark_case.benchmark_case_dir is not None:
+      if self.legacy_suite:
+        if benchmark_case.benchmark_case_dir is None:
+          raise ValueError(
+              "Either run_config or benchmark_case_dir must be set.")
         # For backward compatibility, model_name_filter matches against the string:
         #   <model name with tags>/<benchmark case name>
         model_and_case_name = f"{model_name_with_tags}/{benchmark_case.benchmark_case_dir.name}"
       else:
-        raise ValueError("Either run_config or benchmark_case_dir must be set.")
+        # For the new run option, we drop the obscure old semantic and only
+        # search on model name and its tags.
+        model_and_case_name = model_name_with_tags
+
       matched_model_name = (model_name_filter is None or re.match(
           model_name_filter, model_and_case_name) is not None)
 
@@ -273,4 +279,4 @@ class BenchmarkSuite(object):
                         benchmark_case_dir=benchmark_case_dir,
                         benchmark_tool_name=tool_name))
 
-    return BenchmarkSuite(suite_map=suite_map)
+    return BenchmarkSuite(suite_map=suite_map, legacy_suite=True)

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -117,13 +117,15 @@ class BenchmarkSuite(object):
     category_list.sort(key=lambda category: category[0])
     return category_list
 
+  # TODO(#11076): target_architectures should be a list of
+  # common_definitions.DeviceArchitecture instead of string, after removing the
+  # legacy path.
   def filter_benchmarks_for_category(
       self,
       category: str,
       available_drivers: Optional[Sequence[str]] = None,
       available_loaders: Optional[Sequence[str]] = None,
-      cpu_target_arch_filter: Optional[str] = None,
-      gpu_target_arch_filter: Optional[str] = None,
+      target_architectures: Optional[Sequence[str]] = None,
       driver_filter: Optional[str] = None,
       mode_filter: Optional[str] = None,
       model_name_filter: Optional[str] = None) -> Sequence[BenchmarkCase]:
@@ -134,8 +136,8 @@ class BenchmarkSuite(object):
           match any driver.
         available_loaders: list of executable loaders supported by the tools.
           None means to match any loader.
-        cpu_target_arch_filter: CPU target architecture filter regex.
-        gpu_target_arch_filter: GPU target architecture filter regex.
+        target_architectures: list of target architectures to be included. None
+          means no filter.
         driver_filter: driver filter regex.
         mode_filter: benchmark mode regex.
         model_name_filter: model name regex.
@@ -162,13 +164,11 @@ class BenchmarkSuite(object):
           driver_info.loader_name in available_loaders)
 
       target_arch = benchmark_case.target_arch.lower()
-      matched_cpu_arch = (cpu_target_arch_filter is not None and re.match(
-          cpu_target_arch_filter, target_arch) is not None)
-      matched_gpu_arch = (gpu_target_arch_filter is not None and re.match(
-          gpu_target_arch_filter, target_arch) is not None)
-      matched_arch = (matched_cpu_arch or matched_gpu_arch or
-                      (cpu_target_arch_filter is None and
-                       gpu_target_arch_filter is None))
+      if target_architectures is None:
+        matched_arch = True
+      else:
+        matched_arch = target_arch in target_architectures
+
       bench_mode = ','.join(benchmark_case.bench_mode)
       matched_mode = (mode_filter is None or
                       re.match(mode_filter, bench_mode) is not None)

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -70,7 +70,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
         gpu_target_arch_filter="gpu-mali",
         driver_filter="vulkan",
         mode_filter=".*full-inference.*",
-        model_name_filter="deepnet.*/case2")
+        model_name_filter="deepnet.*")
     all_benchmarks = suite.filter_benchmarks_for_category(
         category="TFLite",
         available_drivers=None,

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -58,8 +58,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
         category="TFLite",
         available_drivers=["local-task", "vulkan"],
         available_loaders=["embedded-elf"],
-        cpu_target_arch_filter="cpu-armv8",
-        gpu_target_arch_filter="gpu-mali",
+        target_architectures=["cpu-armv8", "gpu-mali"],
         driver_filter=None,
         mode_filter=".*full-inference.*",
         model_name_filter="deepnet.*")
@@ -67,16 +66,14 @@ class BenchmarkSuiteTest(unittest.TestCase):
         category="TFLite",
         available_drivers=["local-task", "vulkan"],
         available_loaders=["embedded-elf"],
-        cpu_target_arch_filter="cpu-unknown",
-        gpu_target_arch_filter="gpu-mali",
+        target_architectures=["gpu-mali"],
         driver_filter="vulkan",
         mode_filter=".*full-inference.*",
         model_name_filter="deepnet.*")
     all_benchmarks = suite.filter_benchmarks_for_category(
         category="TFLite",
         available_drivers=None,
-        cpu_target_arch_filter=None,
-        gpu_target_arch_filter=None,
+        target_architectures=None,
         driver_filter=None,
         mode_filter=None,
         model_name_filter=None)
@@ -94,8 +91,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
         category="PyTorch",
         available_drivers=[],
         available_loaders=[],
-        cpu_target_arch_filter="ARMv8",
-        gpu_target_arch_filter="Mali-G78")
+        target_architectures=["ARMv8", "Mali-G78"])
 
     self.assertEqual(benchmarks, [])
 
@@ -128,8 +124,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
               category="PyTorch",
               available_drivers=["vulkan"],
               available_loaders=[],
-              cpu_target_arch_filter="cpu-armv8",
-              gpu_target_arch_filter="gpu-mali"), [case2])
+              target_architectures=["cpu-armv8", "gpu-mali"]), [case2])
 
   def test_load_from_run_configs(self):
     model_tflite = common_definitions.Model(
@@ -234,7 +229,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
     self.assertEqual(
         suite.filter_benchmarks_for_category(
             category="exported_tf_v2",
-            cpu_target_arch_filter="riscv_32-generic",
+            target_architectures=["riscv_32-generic"],
             model_name_filter="model_tf.*fp32",
             mode_filter="defaults"),
         [
@@ -250,7 +245,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
     self.assertEqual(
         suite.filter_benchmarks_for_category(
             category="exported_tf_v2",
-            cpu_target_arch_filter="cpu-riscv_32-generic",
+            target_architectures=["cpu-riscv_32-generic"],
             mode_filter="experimental"), [])
 
   @staticmethod

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -13,6 +13,7 @@ from typing import Sequence
 from common.benchmark_definition import IREE_DRIVERS_INFOS
 from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
 from e2e_test_framework.definitions import common_definitions, iree_definitions
+from e2e_test_artifacts import iree_artifacts
 
 
 class BenchmarkSuiteTest(unittest.TestCase):
@@ -216,7 +217,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             BenchmarkCase(model_name=model_tflite.name,
                           model_tags=model_tflite.tags,
                           bench_mode=exec_config_a.tags,
-                          target_arch="cpu-riscv_32-generic",
+                          target_arch="riscv_32-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,
@@ -224,7 +225,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             BenchmarkCase(model_name=model_tflite.name,
                           model_tags=model_tflite.tags,
                           bench_mode=exec_config_b.tags,
-                          target_arch="cpu-riscv_64-generic",
+                          target_arch="riscv_64-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,
@@ -233,14 +234,14 @@ class BenchmarkSuiteTest(unittest.TestCase):
     self.assertEqual(
         suite.filter_benchmarks_for_category(
             category="exported_tf_v2",
-            cpu_target_arch_filter="cpu-riscv_32-generic",
+            cpu_target_arch_filter="riscv_32-generic",
             model_name_filter="model_tf.*fp32",
             mode_filter="defaults"),
         [
             BenchmarkCase(model_name=model_tf.name,
                           model_tags=model_tf.tags,
                           bench_mode=exec_config_a.tags,
-                          target_arch="cpu-riscv_32-generic",
+                          target_arch="riscv_32-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,

--- a/build_tools/benchmarks/diff_local_benchmarks.py
+++ b/build_tools/benchmarks/diff_local_benchmarks.py
@@ -11,8 +11,13 @@ Example usage:
                                    --target=/path/to/target_benchmarks.json
 """
 
-import argparse
 import pathlib
+import sys
+
+# Add build_tools python dir to the search path.
+sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
+
+import argparse
 
 from typing import Optional
 

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -15,10 +15,15 @@ Example usage:
   python3 upload_benchmarks.py /path/to/benchmark/json/file
 """
 
+import pathlib
+import sys
+
+# Add build_tools python dir to the search path.
+sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
+
 import argparse
 import json
 import os
-import pathlib
 import requests
 
 from typing import Any, Dict, Optional, Union


### PR DESCRIPTION
IREE benchmark tool automatically detects the device info of benchmark device and filter the benchmarks. This change maps the detected info to device architecture enum of new benchmark suite.

For unknown architecture, instead of failing directly, print a warning and skip the benchmarks. This allows users to use the tools with partially unknown hardware (e.g. If users want to run GPU benchmarks but don't care about the CPU benchmarks, we shouldn't fail simply because their CPU is not in the supported list). This is actually the current intended behavior for x86_64 (if `uarch` is unknown, we don't fail but no CPU benchmarks will be run) but without any warning.

In the case that we should fail if hardware is mismatched to the benchmarks (e.g. on CI), the force mode option will be added in a follow-up change (#13198).

As a side effect, some tests are updated to test with new benchmark suite as we change some code to use new path by default.

This enables the detection of mobile phones' CPU/GPU for Android benchmark tool with new benchmark suite #13176

First 3 commits are the major changes. Each commit message describes their goals.