### PR TITLE
Add --compatible-only option to benchmark tools

### DIFF
--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -70,6 +70,7 @@ class BenchmarkConfig:
   driver_filter: Optional[str] = None
   model_name_filter: Optional[str] = None
   mode_filter: Optional[str] = None
+  use_compatible_filter: bool = True
 
   keep_going: bool = False
   benchmark_min_time: float = 0
@@ -121,16 +122,17 @@ class BenchmarkConfig:
       else:
         root_benchmark_dir = build_dir / BENCHMARK_SUITE_REL_PATH
 
-    return BenchmarkConfig(root_benchmark_dir=root_benchmark_dir,
-                           benchmark_results_dir=per_commit_tmp_dir /
-                           BENCHMARK_RESULTS_REL_PATH,
-                           git_commit_hash=git_commit_hash,
-                           normal_benchmark_tool_dir=real_path_or_none(
-                               args.normal_benchmark_tool_dir),
-                           trace_capture_config=trace_capture_config,
-                           driver_filter=args.driver_filter_regex,
-                           model_name_filter=args.model_name_regex,
-                           mode_filter=args.mode_regex,
-                           keep_going=args.keep_going,
-                           benchmark_min_time=args.benchmark_min_time,
-                           continue_from_previous=args.continue_from_previous)
+    return BenchmarkConfig(
+        root_benchmark_dir=root_benchmark_dir,
+        benchmark_results_dir=per_commit_tmp_dir / BENCHMARK_RESULTS_REL_PATH,
+        git_commit_hash=git_commit_hash,
+        normal_benchmark_tool_dir=real_path_or_none(
+            args.normal_benchmark_tool_dir),
+        trace_capture_config=trace_capture_config,
+        driver_filter=args.driver_filter_regex,
+        model_name_filter=args.model_name_regex,
+        mode_filter=args.mode_regex,
+        use_compatible_filter=not args.disable_compatible_filter,
+        keep_going=args.keep_going,
+        benchmark_min_time=args.benchmark_min_time,
+        continue_from_previous=args.continue_from_previous)

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -70,7 +70,7 @@ class BenchmarkConfig:
   driver_filter: Optional[str] = None
   model_name_filter: Optional[str] = None
   mode_filter: Optional[str] = None
-  use_compatible_filter: bool = True
+  use_compatible_filter: bool = False
 
   keep_going: bool = False
   benchmark_min_time: float = 0
@@ -122,17 +122,17 @@ class BenchmarkConfig:
       else:
         root_benchmark_dir = build_dir / BENCHMARK_SUITE_REL_PATH
 
-    return BenchmarkConfig(
-        root_benchmark_dir=root_benchmark_dir,
-        benchmark_results_dir=per_commit_tmp_dir / BENCHMARK_RESULTS_REL_PATH,
-        git_commit_hash=git_commit_hash,
-        normal_benchmark_tool_dir=real_path_or_none(
-            args.normal_benchmark_tool_dir),
-        trace_capture_config=trace_capture_config,
-        driver_filter=args.driver_filter_regex,
-        model_name_filter=args.model_name_regex,
-        mode_filter=args.mode_regex,
-        use_compatible_filter=not args.disable_compatible_filter,
-        keep_going=args.keep_going,
-        benchmark_min_time=args.benchmark_min_time,
-        continue_from_previous=args.continue_from_previous)
+    return BenchmarkConfig(root_benchmark_dir=root_benchmark_dir,
+                           benchmark_results_dir=per_commit_tmp_dir /
+                           BENCHMARK_RESULTS_REL_PATH,
+                           git_commit_hash=git_commit_hash,
+                           normal_benchmark_tool_dir=real_path_or_none(
+                               args.normal_benchmark_tool_dir),
+                           trace_capture_config=trace_capture_config,
+                           driver_filter=args.driver_filter_regex,
+                           model_name_filter=args.model_name_regex,
+                           mode_filter=args.mode_regex,
+                           use_compatible_filter=args.compatible_only,
+                           keep_going=args.keep_going,
+                           benchmark_min_time=args.benchmark_min_time,
+                           continue_from_previous=args.continue_from_previous)

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -41,7 +41,7 @@ class BenchmarkConfigTest(unittest.TestCase):
         f"--trace_capture_tool={self.trace_capture_tool.name}",
         f"--capture_tarball=capture.tar", f"--driver_filter_regex=a",
         f"--model_name_regex=b", f"--mode_regex=c", f"--keep_going",
-        f"--benchmark_min_time=10",
+        f"--benchmark_min_time=10", f"--compatible_only",
         str(self.build_dir)
     ])
 
@@ -64,7 +64,8 @@ class BenchmarkConfigTest(unittest.TestCase):
         model_name_filter="b",
         mode_filter="c",
         keep_going=True,
-        benchmark_min_time=10)
+        benchmark_min_time=10,
+        use_compatible_filter=True)
     self.assertEqual(config, expected_config)
 
   def test_build_from_args_benchmark_only(self):

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -105,7 +105,8 @@ class BenchmarkDriver(object):
         if benchmark_case.target_arch not in detected_architectures:
           print(f"WARNING: Benchmark '{benchmark_name}' may be incompatible"
                 f" with the detected architectures '{detected_architectures}'"
-                f" on the device. Pass --compatible-only to skip benchmarks.")
+                f" on the device. Pass --compatible-only to skip incompatible"
+                f" benchmarks.")
 
         # Sanity check for the uniqueness of benchmark names.
         if benchmark_name in self._seen_benchmark_names:

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -104,8 +104,8 @@ class BenchmarkDriver(object):
 
         if benchmark_case.target_arch not in detected_architectures:
           print(f"WARNING: Benchmark '{benchmark_name}' may be incompatible"
-                f" with '{self.device_info}'. Pass --compatible-only to skip"
-                f" benchmarks.")
+                f" with the detected architectures '{detected_architectures}'"
+                f" on the device. Pass --compatible-only to skip benchmarks.")
 
         # Sanity check for the uniqueness of benchmark names.
         if benchmark_name in self._seen_benchmark_names:

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -68,20 +68,24 @@ class BenchmarkDriver(object):
 
     use_legacy_name = self.benchmark_suite.legacy_suite
 
-    target_architectures = []
-    cpu_target_arch = self.device_info.get_iree_cpu_arch_name(use_legacy_name)
-    if cpu_target_arch is None:
-      print("WARNING: Detected unsupported CPU architecture in "
-            f'"{self.device_info}", CPU benchmarking is disabled.')
-    else:
-      target_architectures.append(cpu_target_arch)
+    if self.config.use_compatible_filter:
+      compatible_architectures = []
+      cpu_target_arch = self.device_info.get_iree_cpu_arch_name(use_legacy_name)
+      if cpu_target_arch is None:
+        print("WARNING: Detected unsupported CPU architecture in "
+              f'"{self.device_info}", CPU benchmarking is disabled.')
+      else:
+        compatible_architectures.append(cpu_target_arch)
 
-    gpu_target_arch = self.device_info.get_iree_gpu_arch_name(use_legacy_name)
-    if gpu_target_arch is None:
-      print("WARNING: Detected unsupported GPU architecture in "
-            f'"{self.device_info}", GPU benchmarking is disabled.')
+      gpu_target_arch = self.device_info.get_iree_gpu_arch_name(use_legacy_name)
+      if gpu_target_arch is None:
+        print("WARNING: Detected unsupported GPU architecture in "
+              f'"{self.device_info}", GPU benchmarking is disabled.')
+      else:
+        compatible_architectures.append(gpu_target_arch)
     else:
-      target_architectures.append(gpu_target_arch)
+      # No compatible filter on the target architectures.
+      compatible_architectures = None
 
     drivers, loaders = self.__get_available_drivers_and_loaders()
 
@@ -90,7 +94,7 @@ class BenchmarkDriver(object):
           category=category,
           available_drivers=drivers,
           available_loaders=loaders,
-          target_architectures=target_architectures,
+          target_architectures=compatible_architectures,
           driver_filter=self.config.driver_filter,
           mode_filter=self.config.mode_filter,
           model_name_filter=self.config.model_name_filter)

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -103,8 +103,8 @@ class BenchmarkDriver(object):
         benchmark_name = str(benchmark_info)
 
         if benchmark_case.target_arch not in detected_architectures:
-          print(f"WARNING: Benchmark '{benchmark_name}' may be incompatible on"
-                f" '{self.device_info}'. Pass --compatible-only to skip"
+          print(f"WARNING: Benchmark '{benchmark_name}' may be incompatible"
+                f" with '{self.device_info}'. Pass --compatible-only to skip"
                 f" benchmarks.")
 
         # Sanity check for the uniqueness of benchmark names.

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -151,8 +151,41 @@ class BenchmarkDriverTest(unittest.TestCase):
                                benchmark_case_dir=pathlib.Path("case2"),
                                benchmark_tool_name="tool",
                                run_config=run_config_b)
+
+    compile_target_rv64 = iree_definitions.CompileTarget(
+        target_backend=iree_definitions.TargetBackend.LLVM_CPU,
+        target_architecture=common_definitions.DeviceArchitecture.RV64_GENERIC,
+        target_abi=iree_definitions.TargetABI.LINUX_GNU)
+    gen_config_rv64 = iree_definitions.ModuleGenerationConfig.build(
+        imported_model=iree_definitions.ImportedModel.from_model(model_tflite),
+        compile_config=iree_definitions.CompileConfig.build(
+            id="comp_rv64", tags=[], compile_targets=[compile_target_rv64]))
+    device_spec_rv64 = common_definitions.DeviceSpec.build(
+        id="rv64_dev",
+        device_name="rv64_dev",
+        architecture=common_definitions.DeviceArchitecture.RV64_GENERIC,
+        host_environment=common_definitions.HostEnvironment.LINUX_X86_64,
+        device_parameters=[],
+        tags=[])
+    run_config_incompatible = iree_definitions.E2EModelRunConfig.build(
+        module_generation_config=gen_config_rv64,
+        module_execution_config=exec_config_b,
+        target_device_spec=device_spec_rv64,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
+    self.incompatible_case = BenchmarkCase(
+        model_name="model_tflite",
+        model_tags=[],
+        bench_mode=["task"],
+        target_arch="riscv_64-generic",
+        driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
+        benchmark_case_dir=pathlib.Path("incompatible_case"),
+        benchmark_tool_name="tool",
+        run_config=run_config_incompatible)
     self.benchmark_suite = BenchmarkSuite({
-        pathlib.Path("suite/TFLite"): [self.case1, self.case2],
+        pathlib.Path("suite/TFLite"): [
+            self.case1, self.case2, self.incompatible_case
+        ],
     })
 
   def tearDown(self) -> None:
@@ -178,6 +211,15 @@ class BenchmarkDriverTest(unittest.TestCase):
         self.captures_dir / f"{self.case2.run_config}.tracy"
     ])
     self.assertEqual(driver.get_benchmark_errors(), [])
+
+  def test_run_disable_compatible_filter(self):
+    self.config.use_compatible_filter = False
+    driver = FakeBenchmarkDriver(self.device_info, self.config,
+                                 self.benchmark_suite)
+
+    driver.run()
+
+    self.assertEqual(len(driver.get_benchmark_results().benchmarks), 3)
 
   def test_run_with_no_capture(self):
     self.config.trace_capture_config = None

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -79,7 +79,8 @@ class BenchmarkDriverTest(unittest.TestCase):
             traced_benchmark_tool_dir=self.tmp_dir,
             trace_capture_tool=self.tmp_dir / "capture_tool",
             capture_tarball=self.tmp_dir / "captures.tar",
-            capture_tmp_dir=self.captures_dir))
+            capture_tmp_dir=self.captures_dir),
+        use_compatible_filter=True)
 
     self.device_info = DeviceInfo(platform_type=PlatformType.LINUX,
                                   model="Unknown",

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -152,6 +152,11 @@ class Parser(argparse.ArgumentParser):
         "for). In that case, no --benchmark_repetitions flag will be passed."
         " If not specified, a --benchmark_repetitions will be passed "
         "instead.")
+    self.add_argument(
+        "--disable_compatible_filter",
+        action="store_true",
+        help="Disable incompatible benchmark filtering based on the detected "
+        "device information")
     self.add_argument("--execution_benchmark_config",
                       type=_check_file_path,
                       default=None,

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -153,10 +153,11 @@ class Parser(argparse.ArgumentParser):
         " If not specified, a --benchmark_repetitions will be passed "
         "instead.")
     self.add_argument(
-        "--disable_compatible_filter",
+        "--compatible_only",
+        "--compatible-only",
         action="store_true",
-        help="Disable incompatible benchmark filtering based on the detected "
-        "device information")
+        help="Only run compatible benchmarks based on the detected device "
+        "information")
     self.add_argument("--execution_benchmark_config",
                       type=_check_file_path,
                       default=None,

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -72,7 +72,6 @@ elif [[ "${TARGET_DEVICE_NAME}" =~ ^(pixel-4|pixel-6-pro|moto-edge-x30)$ ]]; the
     --pin-cpu-freq \
     --pin-gpu-freq \
     --verbose
-    # TODO(#13198): Disable compatible filter
 else
   echo "${TARGET_DEVICE_NAME} is not supported yet."
   exit 1

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -43,7 +43,6 @@ if [[ "${TARGET_DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
         --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
         --target_device_name="${TARGET_DEVICE_NAME}" \
         --output="${BENCHMARK_RESULTS}" \
-        --disable_compatible_filter \
         --verbose
 elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
   ${DOCKER_WRAPPER} \
@@ -59,7 +58,6 @@ elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
         --output="${BENCHMARK_RESULTS}" \
         --device_model=GCP-c2-standard-16 \
         --cpu_uarch=CascadeLake \
-        --disable_compatible_filter \
         --verbose
 elif [[ "${TARGET_DEVICE_NAME}" =~ ^(pixel-4|pixel-6-pro|moto-edge-x30)$ ]]; then
   ./build_tools/benchmarks/run_benchmarks_on_android.py \

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -43,6 +43,7 @@ if [[ "${TARGET_DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
         --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
         --target_device_name="${TARGET_DEVICE_NAME}" \
         --output="${BENCHMARK_RESULTS}" \
+        --disable_compatible_filter \
         --verbose
 elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
   ${DOCKER_WRAPPER} \
@@ -58,6 +59,7 @@ elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
         --output="${BENCHMARK_RESULTS}" \
         --device_model=GCP-c2-standard-16 \
         --cpu_uarch=CascadeLake \
+        --disable_compatible_filter \
         --verbose
 elif [[ "${TARGET_DEVICE_NAME}" =~ ^(pixel-4|pixel-6-pro|moto-edge-x30)$ ]]; then
   ./build_tools/benchmarks/run_benchmarks_on_android.py \


### PR DESCRIPTION
This option enables the compatible benchmark filtering based on the detected device information. And we disable the compatible filter by default.

With the new benchmark suite, we provide a list of benchmarks to run. And the benchmark tools only run benchmarks of the target device specified by `--target_device_name`. This means the list of benchmarks has been filtered for a specific device. Therefore, by default we can disable the compatible benchmark filtering (based on detected devices) and let users to enable it when needed.

This will give the benchmark tools a simpler behavior (no auto-filtering) and more visible errors (failures) when trying to run incompatible benchmarks.