### PR TITLE
Run Pixel 4 benchmarks in postsubmit on Github CI

### DIFF
--- a/.github/workflows/build_benchmark_tools.yml
+++ b/.github/workflows/build_benchmark_tools.yml
@@ -72,6 +72,11 @@ jobs:
             docker_image: "gcr.io/iree-oss/riscv@sha256:2e71c052d11b2526651af16e64816a30d164efcdfe6fb64623fb4737c37c466a"
             build_script: "./build_tools/cmake/build_riscv.sh"
             tracy_capture: "gs://iree-shared-files/tracy-capture-linux-x86_64-52b6af88"
+          - platform: "android"
+            arch: "armv8.2-a"
+            docker_image: "gcr.io/iree-oss/android@sha256:3f641d25786b1e5e430ee4cacb8bfe57540fda5ecaa7ca2802c179c26e77ce09"
+            build_script: "./build_tools/cmake/build_android.sh"
+            tracy_capture: "gs://iree-shared-files/tracy-capture-linux-arm_64-52b6af88"
     env:
       PLATFORM: ${{ matrix.target.platform }}
       ARCH: ${{ matrix.target.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,13 +799,17 @@ jobs:
         env:
           EXECUTION_BENCHMARK_RESULTS_PATTERN: ${{ steps.download-execution-results.outputs.execution-benchmark-results-pattern }}
           IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}
+        # TODO(#9855): Specify CPU and GPU benchmark results to exclude mobile
+        # results until we migrate the dashboard. The tool ignores the file path
+        # if it doesn't exist.
         run: |
           build_tools/github_actions/docker_run.sh \
             --env "IREE_DASHBOARD_API_TOKEN=${IREE_DASHBOARD_API_TOKEN}" \
             gcr.io/iree-oss/benchmark-report@sha256:7498c6f32f63f13faf085463cc38656d4297519c824e63e1c99c8c258147f6ff \
             ./build_tools/benchmarks/upload_benchmarks_to_dashboard.py \
               --verbose \
-              --benchmark_files="${EXECUTION_BENCHMARK_RESULTS_PATTERN}" \
+              --benchmark_files="${EXECUTION_BENCHMARK_RESULTS_DIR}/benchmark-results-c2-standard-16.json" \
+              --benchmark_files="${EXECUTION_BENCHMARK_RESULTS_DIR}/benchmark-results-a2-highgpu-1g.json" \
               --compile_stats_files="${COMPILE_STATS_RESULTS}"
 
   ############################## Crosscompilation ##############################

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -77,7 +77,10 @@ SKIP_PATH_PATTERNS = [
 RUNNER_ENV_DEFAULT = "prod"
 RUNNER_ENV_OPTIONS = [RUNNER_ENV_DEFAULT, "testing"]
 
-BENCHMARK_PRESET_OPTIONS = ["all", "cuda", "x86_64", "comp-stats"]
+DEFAULT_BENCHMARK_PRESETS = ["cuda", "x86_64", "comp-stats"]
+BENCHMARK_PRESET_OPTIONS = DEFAULT_BENCHMARK_PRESETS + [
+    "experimental-android-cpu"
+]
 
 PR_DESCRIPTION_TEMPLATE = "{title}" "\n\n" "{body}"
 
@@ -274,12 +277,14 @@ def get_benchmark_presets(trailers: Mapping[str, str], labels: Sequence[str],
           f"description has '{SKIP_LLVM_INTEGRATE_BENCHMARK_KEY}' trailer.")
 
   if not is_pr:
-    preset_options = ["all"]
-    print(f"Using benchmark preset 'all' for non-PR run")
+    # TODO(#9855): Only enable android benchmarks in postsubmit before the
+    # migration is finished.
+    preset_options = {"all", "experimental-android-cpu"}
+    print(f"Using benchmark presets '{preset_options}' for non-PR run")
   elif is_llvm_integrate_pr and not skip_llvm_integrate_benchmark:
     # Run all benchmark presets for LLVM integration PRs.
-    preset_options = ["all"]
-    print("Using benchmark preset 'all' for LLVM integration PR")
+    preset_options = {"all"}
+    print(f"Using benchmark preset '{preset_options}' for LLVM integration PR")
   else:
     preset_options = set(
         label.split(":", maxsplit=1)[1]
@@ -289,17 +294,19 @@ def get_benchmark_presets(trailers: Mapping[str, str], labels: Sequence[str],
     if trailer is not None:
       preset_options = preset_options.union(
           option.strip() for option in trailer.split(","))
-    preset_options = sorted(preset_options)
     print(f"Using benchmark preset '{preset_options}' from trailers and labels")
 
+  # TODO(#13392): "all" should be called as "defaults". Keep it as it is and we
+  # will drop it when removing "benchmarks" trailer (with announcement).
+  if "all" in preset_options:
+    preset_options.remove("all")
+    preset_options.update(DEFAULT_BENCHMARK_PRESETS)
+
+  preset_options = sorted(preset_options)
   for preset_option in preset_options:
     if preset_option not in BENCHMARK_PRESET_OPTIONS:
       raise ValueError(f"Unknown benchmark preset option: '{preset_option}'.\n"
                        f"Available options: '{BENCHMARK_PRESET_OPTIONS}'.")
-
-  if "all" in preset_options:
-    preset_options = list(
-        option for option in BENCHMARK_PRESET_OPTIONS if option != "all")
 
   return ",".join(preset_options)
 


### PR DESCRIPTION
This change:

- Support Pixel 4 benchmarks on Github CI
- Run Pixel 4 benchmarks in CI but not upload to results to the dashboard. 

The first commit is based on #13385

benchmarks: experimental-android-cpu, all