### PR TITLE
Split mhlo.optimization_barrier lowering into several util.optimization_barrier ops if there are multiple inputs

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -228,8 +228,11 @@ struct OptimizationBarrierOpConversion
   LogicalResult matchAndRewrite(
       mhlo::OptimizationBarrierOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<IREE::Util::OptimizationBarrierOp>(
-        op, op.getOperands());
+    SmallVector<Value> outputs;
+    for (unsigned i = 0, e = adaptor.getOperands().size(); i < e; ++i) {
+      outputs.push_back(rewriter.create<IREE::Util::OptimizationBarrierOp>(op.getLoc(), adaptor.getOperands()[i]).getResult(0));
+    }
+    rewriter.replaceOp(op, outputs);
     return success();
   }
 };

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -229,11 +229,11 @@ struct OptimizationBarrierOpConversion
       mhlo::OptimizationBarrierOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     SmallVector<Value> outputs;
-    for (unsigned i = 0, e = adaptor.getOperands().size(); i < e; ++i) {
-      outputs.push_back(rewriter
-                            .create<IREE::Util::OptimizationBarrierOp>(
-                                op.getLoc(), adaptor.getOperands()[i])
-                            .getResult(0));
+    for (auto operand : adaptor.getOperands()) {
+      outputs.push_back(
+          rewriter
+              .create<IREE::Util::OptimizationBarrierOp>(op.getLoc(), operand)
+              .getResult(0));
     }
     rewriter.replaceOp(op, outputs);
     return success();

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -230,7 +230,10 @@ struct OptimizationBarrierOpConversion
       ConversionPatternRewriter &rewriter) const override {
     SmallVector<Value> outputs;
     for (unsigned i = 0, e = adaptor.getOperands().size(); i < e; ++i) {
-      outputs.push_back(rewriter.create<IREE::Util::OptimizationBarrierOp>(op.getLoc(), adaptor.getOperands()[i]).getResult(0));
+      outputs.push_back(rewriter
+                            .create<IREE::Util::OptimizationBarrierOp>(
+                                op.getLoc(), adaptor.getOperands()[i])
+                            .getResult(0));
     }
     rewriter.replaceOp(op, outputs);
     return success();

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_linalg.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_linalg.mlir
@@ -30,9 +30,10 @@ func.func @global_types() -> tensor<2xui32> {
 // -----
 
 // CHECK: func.func @optimization_barrier
-// CHECK: %[[BARRIER:.+]] = util.optimization_barrier %arg0 : tensor<3x4xf32
-// CHECK: return %[[BARRIER]]
-func.func @optimization_barrier(%arg0: tensor<3x4xf32>) -> tensor<3x4xf32> {
-  %0 = "mhlo.optimization_barrier"(%arg0) : (tensor<3x4xf32>) -> (tensor<3x4xf32>)
-  return %0 : tensor<3x4xf32>
+// CHECK: %[[RESULT1:.+]] = util.optimization_barrier %arg0 : tensor<3x4xf32
+// CHECK: %[[RESULT2:.+]] = util.optimization_barrier %arg1 : tensor<4xi32>
+// CHECK: return %[[RESULT1]], %[[RESULT2]]
+func.func @optimization_barrier(%arg0: tensor<3x4xf32>, %arg1: tensor<4xi32>) -> (tensor<3x4xf32>, tensor<4xi32>) {
+  %0, %1 = "mhlo.optimization_barrier"(%arg0, %arg1) : (tensor<3x4xf32>, tensor<4xi32>) -> (tensor<3x4xf32>, tensor<4xi32>)
+  return %0, %1 : tensor<3x4xf32>, tensor<4xi32>
 }


### PR DESCRIPTION
`util.optimization_barrier` contains the `SameOperandsAndResultType` verifier, which means that all the operand types must match each other and the result type. Since `mhlo.optimization_barrier` only matches the input-output pairs, this creates a situation where a valid op fails to lower.