### PR TITLE
Make python dependency in lit test configurable

### DIFF
--- a/integrations/tensorflow/test/lit.cfg.py
+++ b/integrations/tensorflow/test/lit.cfg.py
@@ -46,16 +46,8 @@ config.excludes = [
     "imagenet_test_data.py",
 ]
 
-PYTHON_EXEC = sys.executable
-
-# Some environments use a version of Python built against an embedded
-# interpreter and lack a sys.executable. In this case, we allow an explicit
-# override from the environment.
-if PYTHON_EXEC is None:
-  PYTHON_EXEC = os.getenv("PYTHON")
-
 config.substitutions.extend([
-    ("%PYTHON", PYTHON_EXEC),
+    ("%PYTHON", os.getenv("PYTHON", sys.executable)),
 ])
 
 # Add our local projects to the PYTHONPATH

--- a/tools/lit.cfg.py
+++ b/tools/lit.cfg.py
@@ -11,6 +11,7 @@
 # pylint: disable=undefined-variable
 
 import os
+import sys
 import tempfile
 
 import lit.formats
@@ -30,3 +31,7 @@ config.environment.update({
 config.test_exec_root = (os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or
                          os.environ.get("TEST_TMPDIR") or
                          os.path.join(tempfile.gettempdir(), "lit"))
+
+config.substitutions.extend([
+    ("%PYTHON", os.getenv("PYTHON", sys.executable)),
+])

--- a/tools/test/iree-run-module-outputs.mlir
+++ b/tools/test/iree-run-module-outputs.mlir
@@ -39,7 +39,7 @@ func.func @default() -> (i32, tensor<f32>, tensor<?x4xi32>) {
 // RUN:                  --output= \
 // RUN:                  --output=@%t \
 // RUN:                  --output=+%t) && \
-// RUN:  python3 %S/echo_npy.py %t | \
+// RUN:  %PYTHON %S/echo_npy.py %t | \
 // RUN: FileCheck --check-prefix=OUTPUT-NUMPY %s
 func.func @numpy() -> (i32, tensor<f32>, tensor<?x4xi32>) {
   // Output skipped:

--- a/tools/test/iree-run-trace.mlir
+++ b/tools/test/iree-run-trace.mlir
@@ -10,7 +10,7 @@
 // RUN:                 --input=4xf32=4,4,4,4 \
 // RUN:                 --output=@%t \
 // RUN:                 --output=+%t) && \
-// RUN:  python3 %S/echo_npy.py %t | \
+// RUN:  %PYTHON %S/echo_npy.py %t | \
 // RUN: FileCheck %s --check-prefix=RUN-TRACE
 //      RUN-TRACE{LITERAL}: [ 0. 4. 8. 12.]
 // RUN-TRACE-NEXT{LITERAL}: [ 0. 12. 24. 36.]


### PR DESCRIPTION
Check if python is configured as an environment variable first and use this. Then fall back to sys.executable.  This allows users to choose which python is used rather than always expecting a python3 executable to be in path.