### PR TITLE
use empty string not NULL for no CPU features

### DIFF
--- a/runtime/src/iree/builtins/ukernel/tools/benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/benchmark.c
@@ -77,7 +77,7 @@ void iree_uk_benchmark_register(
     const void* params, size_t params_size, const char* cpu_features) {
   // Does this benchmark require an optional CPU feature?
   iree_uk_uint64_t cpu_data_local[IREE_CPU_DATA_FIELD_COUNT] = {0};
-  if (cpu_features) {
+  if (strlen(cpu_features)) {
     iree_uk_initialize_cpu_once();
     iree_uk_make_cpu_data_for_features(cpu_features, cpu_data_local);
     if (!iree_uk_cpu_supports(cpu_data_local)) {
@@ -102,7 +102,7 @@ void iree_uk_benchmark_register(
   iree_string_builder_t full_name;
   iree_string_builder_initialize(iree_allocator_system(), &full_name);
   IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, name));
-  if (cpu_features) {
+  if (strlen(cpu_features)) {
     IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, "_"));
     IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, cpu_features));
   }

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -102,8 +102,8 @@ int main(int argc, char** argv) {
   iree_uk_benchmark_initialize(&argc, argv);
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
-  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
+  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, "");
+  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, "");
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4,
                                    "dotprod");
   iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8, "i8mm");
@@ -121,8 +121,8 @@ int main(int argc, char** argv) {
 #else  // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
-  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
-  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
+  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, "");
+  iree_uk_benchmark_register_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, "");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
   iree_uk_benchmark_run_and_cleanup();

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
@@ -202,19 +202,19 @@ int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird M0, N0, K0 to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 3, 5, 7, NULL);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 9, 6, 3, NULL);
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 3, 5, 7, "");
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 9, 6, 3, "");
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, "");
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, "");
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4, "dotprod");
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8, "i8mm");
 #elif defined(IREE_UK_ARCH_X86_64)
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 4, 1, NULL);  // SSE
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 4, 1, "");  // SSE
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, "avx2_fma");
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 16, 16, 1, "avx512_base");
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 4, 2, NULL);  // SSE2
+  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 4, 2, "");  // SSE2
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 2, "avx2_fma");
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2, "avx512_base");
   iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2, "avx512_vnni");

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -147,12 +147,12 @@ int main(int argc, char** argv) {
                                     FLAG_batch_min_traversal_size);
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 1, NULL);
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 1, NULL);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 1, "");
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 1, "");
   // Tile size selected with cpu feature "dotprod".
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 4, NULL);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 4, "");
   // Tile size selected with cpu feature "i8mm".
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 8, NULL);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 8, "");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 1, "avx2_fma");
   iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 16, 1,
@@ -168,8 +168,8 @@ int main(int argc, char** argv) {
 #else   // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 1, NULL);
-  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 1, NULL);
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_f32f32, 8, 1, "");
+  iree_uk_benchmark_register_pack(iree_uk_pack_type_i8i8, 8, 1, "");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
   iree_uk_benchmark_run_and_cleanup();

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -188,21 +188,21 @@ int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
-  iree_uk_test_pack(iree_uk_pack_type_f32f32, 3, 5, NULL);
-  iree_uk_test_pack(iree_uk_pack_type_i8i8, 4, 2, NULL);
-  iree_uk_test_pack(iree_uk_pack_type_i32i32, 3, 4, NULL);
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 3, 5, "");
+  iree_uk_test_pack(iree_uk_pack_type_i8i8, 4, 2, "");
+  iree_uk_test_pack(iree_uk_pack_type_i32i32, 3, 4, "");
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 1, NULL);
-  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 8, NULL);
-  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 1, NULL);
-  iree_uk_test_pack(iree_uk_pack_type_i32i32, 8, 8, NULL);
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 1, "");
+  iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 8, "");
+  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 1, "");
+  iree_uk_test_pack(iree_uk_pack_type_i32i32, 8, 8, "");
   // Tile size selected with CPU feature dotprod.
   // Not passing a cpu_features_list because the packing code itself
   // does not depend on any features.
-  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 4, NULL);
+  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 4, "");
   // Tile size selected for CPU feature i8mm. Same comment as for dotprod.
-  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 8, NULL);
+  iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 8, "");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_test_pack(iree_uk_pack_type_f32f32, 8, 1, "avx2_fma");
   iree_uk_test_pack(iree_uk_pack_type_i8i8, 8, 2, "avx2_fma");

--- a/runtime/src/iree/builtins/ukernel/tools/test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/test.c
@@ -101,7 +101,7 @@ void iree_uk_test(const char* name,
   // We might skip the actual test payload requiring CPU features if these are
   // not supported.
   bool skipped = false;
-  if (cpu_features) {
+  if (strlen(cpu_features)) {
     iree_uk_initialize_cpu_once();
     iree_uk_make_cpu_data_for_features(cpu_features, test.cpu_data);
     if (iree_uk_cpu_supports(test.cpu_data)) {

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -144,8 +144,8 @@ int main(int argc, char** argv) {
                                     FLAG_batch_min_traversal_size);
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 8, 8, NULL);
-  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8, NULL);
+  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 8, 8, "");
+  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8, "");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 8, 8,
                                     "avx2_fma");
@@ -158,8 +158,8 @@ int main(int argc, char** argv) {
 #else   // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
-  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 8, 8, NULL);
-  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8, NULL);
+  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_f32f32, 8, 8, "");
+  iree_uk_benchmark_register_unpack(iree_uk_unpack_type_i32i32, 8, 8, "");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
   iree_uk_benchmark_run_and_cleanup();

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -182,13 +182,13 @@ int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
-  iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 3, 5, NULL);
-  iree_uk_test_unpack(iree_uk_unpack_type_i8i8, 4, 2, NULL);
-  iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 3, 4, NULL);
+  iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 3, 5, "");
+  iree_uk_test_unpack(iree_uk_unpack_type_i8i8, 4, 2, "");
+  iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 3, 4, "");
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 8, 8, NULL);
-  iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 8, 8, NULL);
+  iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 8, 8, "");
+  iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 8, 8, "");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 8, 8, "avx2_fma");
   iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 8, 8, "avx2_fma");

--- a/runtime/src/iree/builtins/ukernel/tools/util.c
+++ b/runtime/src/iree/builtins/ukernel/tools/util.c
@@ -148,8 +148,6 @@ int iree_uk_type_triple_str(char* buf, int buf_length,
 
 void iree_uk_make_cpu_data_for_features(const char* cpu_features,
                                         iree_uk_uint64_t* out_cpu_data_fields) {
-  // The caller should have checked for NULL prior to calling this function.
-  IREE_UK_ASSERT(cpu_features != NULL);
   const size_t data_fields_byte_size =
       IREE_CPU_DATA_FIELD_COUNT * sizeof(out_cpu_data_fields[0]);
   memset(out_cpu_data_fields, 0, data_fields_byte_size);


### PR DESCRIPTION
CPU features are currently passed as a nullable string, where NULL means no CPU features. But the empty string also means that. It's not great to have two null states. So this makes this a non-nullable string, and the way to get no CPU features is to have an empty string.