### PR TITLE
ukernels: drop the unused `i8` case in `unpack`.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
@@ -530,22 +530,6 @@ vm.import private @unpack.f32f32(
   %flags : i32
 )
 
-vm.import private @unpack.i8i8(
-  %in_buffer : !vm.buffer,
-  %in_offset : i64,
-  %in_stride0 : i64,
-  %out_buffer : !vm.buffer,
-  %out_offset : i64,
-  %out_stride0 : i64,
-  %in_size0 : i64,
-  %in_size1 : i64,
-  %out_size0 : i64,
-  %out_size1 : i64,
-  %out_size2 : i64,
-  %out_size3 : i64,
-  %flags : i32
-)
-
 vm.import private @unpack.i32i32(
   %in_buffer : !vm.buffer,
   %in_offset : i64,

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -184,7 +184,6 @@ int main(int argc, char** argv) {
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
   iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 3, 5, NULL);
-  iree_uk_test_unpack(iree_uk_unpack_type_i8i8, 4, 2, NULL);
   iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 3, 4, NULL);
 
 #if defined(IREE_UK_ARCH_ARM_64)

--- a/runtime/src/iree/modules/vmvx/exports.inl
+++ b/runtime/src/iree/modules/vmvx/exports.inl
@@ -58,7 +58,6 @@ EXPORT_FN("sub.2d.f32", iree_uk_x32b_subf_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v
 EXPORT_FN("sub.2d.i32", iree_uk_x32b_subi_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 EXPORT_FN("unpack.f32f32", iree_vmvx_unpack_f32f32, unpack, rIIrIIIIIIIIi, v)
 EXPORT_FN("unpack.i32i32", iree_vmvx_unpack_i32i32, unpack, rIIrIIIIIIIIi, v)
-EXPORT_FN("unpack.i8i8", iree_vmvx_unpack_i8i8, unpack, rIIrIIIIIIIIi, v)
 EXPORT_FN("xor.2d.i32", iree_uk_x32b_xori_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 
 

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -793,10 +793,6 @@ IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_f32f32, unpack, v) {
   return iree_vmvx_unpack(iree_uk_unpack_type_f32f32, 4, 4, args);
 }
 
-IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_i8i8, unpack, v) {
-  return iree_vmvx_unpack(iree_uk_unpack_type_i8i8, 1, 1, args);
-}
-
 IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_i32i32, unpack, v) {
   return iree_vmvx_unpack(iree_uk_unpack_type_i32i32, 4, 4, args);
 }


### PR DESCRIPTION
It's unused because we never have `i8` element type in results in data-tiled ops at the moment.