### PR TITLE
ukernels: let `pack` take `padding_value` by value

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
@@ -530,22 +530,6 @@ vm.import private @unpack.f32f32(
   %flags : i32
 )
 
-vm.import private @unpack.i8i8(
-  %in_buffer : !vm.buffer,
-  %in_offset : i64,
-  %in_stride0 : i64,
-  %out_buffer : !vm.buffer,
-  %out_offset : i64,
-  %out_stride0 : i64,
-  %in_size0 : i64,
-  %in_size1 : i64,
-  %out_size0 : i64,
-  %out_size1 : i64,
-  %out_size2 : i64,
-  %out_size3 : i64,
-  %flags : i32
-)
-
 vm.import private @unpack.i32i32(
   %in_buffer : !vm.buffer,
   %in_offset : i64,

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -33,7 +33,17 @@ typedef struct iree_uk_pack_params_t {
   iree_uk_ssize_t out_size3;
   const void* in_buffer;
   void* out_buffer;
-  const void* padding_value;
+  // The least significant bits of `padding_value`, up to element size, are used
+  // for padding. As this is based solely on bit-significance and not on byte
+  // addresses, this is independent of endianness.
+  //
+  // If the element size is less than 64 bits then the most significant bits
+  // (above element size) are unused.
+  //
+  // If the element size is more than 64 bits then only repeating 64-bit
+  // patterns are supported for padding. This covers most cases as floating
+  // point types encode zero as zero bits.
+  iree_uk_uint64_t padding_value;
   const iree_uk_uint64_t* cpu_data;
 } iree_uk_pack_params_t;
 

--- a/runtime/src/iree/builtins/ukernel/tools/e2e_matmul_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/e2e_matmul_benchmark.c
@@ -190,9 +190,6 @@ static iree_status_t iree_uk_benchmark_e2e_matmul(
       .out_stride = N1 * M0 * N0,
   };
 
-  char padding_value_buf[4] = {0};
-  IREE_UK_ASSERT(sizeof padding_value_buf >= iree_uk_type_size(out_type));
-
   iree_uk_pack_params_t pack_lhs_params = {
       .type = iree_uk_tie_2_types(lhs_type, lhs_type),
       .cpu_data = cpu_data,
@@ -205,7 +202,7 @@ static iree_status_t iree_uk_benchmark_e2e_matmul(
       .out_size3 = K0,
       .in_stride0 = params->K,
       .out_stride0 = mmt4d_params.lhs_stride,
-      .padding_value = padding_value_buf,
+      .padding_value = 0,
   };
 
   iree_uk_pack_params_t pack_rhs_params = {
@@ -221,7 +218,7 @@ static iree_status_t iree_uk_benchmark_e2e_matmul(
       .out_size3 = K0,
       .in_stride0 = params->N,
       .out_stride0 = mmt4d_params.rhs_stride,
-      .padding_value = padding_value_buf,
+      .padding_value = 0,
   };
 
   iree_uk_pack_params_t pack_out_params = {
@@ -236,7 +233,7 @@ static iree_status_t iree_uk_benchmark_e2e_matmul(
       .out_size3 = N0,
       .in_stride0 = params->N,
       .out_stride0 = mmt4d_params.out_stride,
-      .padding_value = padding_value_buf,
+      .padding_value = 0,
   };
 
   iree_uk_unpack_params_t unpack_out_params = {

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -72,7 +72,6 @@ static iree_status_t iree_uk_benchmark_pack(
       iree_uk_2d_buffer_length(out_type, params.out_size0, params.out_stride0);
   void* in_buffer = malloc(in_buffer_size);
   void* out_buffer = malloc(out_buffer_size);
-  void* padding_value_buffer = malloc(out_type_size);
   iree_uk_random_engine_t* engine = iree_uk_benchmark_random_engine(user_data);
   // It's just about plausible that on some platform, for some number type,
   // performance might be different on zero buffers vs random buffers. But it
@@ -81,10 +80,9 @@ static iree_status_t iree_uk_benchmark_pack(
   iree_uk_write_random_buffer(in_buffer, in_buffer_size, in_type, engine);
   iree_uk_write_random_buffer(out_buffer, out_buffer_size, out_type, engine);
   // Test single-byte padding pattern, most common use case as 0.0f is 0 bytes.
-  memset(padding_value_buffer, 0, out_type_size);
   params.in_buffer = in_buffer;
   params.out_buffer = out_buffer;
-  params.padding_value = padding_value_buffer;
+  params.padding_value = 0;
   int64_t total_iterations = 0;
   int64_t batch_count =
       (FLAG_batch_min_traversal_size + FLAG_working_set_size - 1) /
@@ -103,7 +101,6 @@ static iree_status_t iree_uk_benchmark_pack(
                                      total_iterations * out_buffer_size);
   free(in_buffer);
   free(out_buffer);
-  free(padding_value_buffer);
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -184,7 +184,6 @@ int main(int argc, char** argv) {
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
   iree_uk_test_unpack(iree_uk_unpack_type_f32f32, 3, 5, NULL);
-  iree_uk_test_unpack(iree_uk_unpack_type_i8i8, 4, 2, NULL);
   iree_uk_test_unpack(iree_uk_unpack_type_i32i32, 3, 4, NULL);
 
 #if defined(IREE_UK_ARCH_ARM_64)

--- a/runtime/src/iree/builtins/ukernel/tools/util.c
+++ b/runtime/src/iree/builtins/ukernel/tools/util.c
@@ -53,13 +53,19 @@ bool iree_uk_2d_buffers_equal(const void* buf1, const void* buf2,
 #define IREE_PRNG_MULTIPLIER 48271
 #define IREE_PRNG_MODULUS 2147483647
 
-uint32_t iree_uk_random_engine_get(iree_uk_random_engine_t* e) {
+iree_uk_uint32_t iree_uk_random_engine_get_uint32(iree_uk_random_engine_t* e) {
   e->state = (e->state * IREE_PRNG_MULTIPLIER) % IREE_PRNG_MODULUS;
   return e->state;
 }
 
+iree_uk_uint64_t iree_uk_random_engine_get_uint64(iree_uk_random_engine_t* e) {
+  iree_uk_uint64_t result = iree_uk_random_engine_get_uint32(e);
+  result = (result << 32) + iree_uk_random_engine_get_uint32(e);
+  return result;
+}
+
 int iree_uk_random_engine_get_0_65535(iree_uk_random_engine_t* e) {
-  iree_uk_uint32_t v = iree_uk_random_engine_get(e);
+  iree_uk_uint32_t v = iree_uk_random_engine_get_uint32(e);
   // Return the middle two out of the 4 bytes of state. It avoids
   // some mild issues with the least-significant and most-significant bytes.
   return (v >> 8) & 0xffff;

--- a/runtime/src/iree/builtins/ukernel/tools/util.h
+++ b/runtime/src/iree/builtins/ukernel/tools/util.h
@@ -27,6 +27,8 @@ static inline iree_uk_random_engine_t iree_uk_random_engine_init(void) {
   return (iree_uk_random_engine_t){.state = 1};
 }
 
+iree_uk_uint32_t iree_uk_random_engine_get_uint32(iree_uk_random_engine_t* e);
+iree_uk_uint64_t iree_uk_random_engine_get_uint64(iree_uk_random_engine_t* e);
 int iree_uk_random_engine_get_0_65535(iree_uk_random_engine_t* e);
 int iree_uk_random_engine_get_0_1(iree_uk_random_engine_t* e);
 int iree_uk_random_engine_get_minus16_plus15(iree_uk_random_engine_t* e);

--- a/runtime/src/iree/modules/vmvx/exports.inl
+++ b/runtime/src/iree/modules/vmvx/exports.inl
@@ -58,7 +58,6 @@ EXPORT_FN("sub.2d.f32", iree_uk_x32b_subf_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v
 EXPORT_FN("sub.2d.i32", iree_uk_x32b_subi_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 EXPORT_FN("unpack.f32f32", iree_vmvx_unpack_f32f32, unpack, rIIrIIIIIIIIi, v)
 EXPORT_FN("unpack.i32i32", iree_vmvx_unpack_i32i32, unpack, rIIrIIIIIIIIi, v)
-EXPORT_FN("unpack.i8i8", iree_vmvx_unpack_i8i8, unpack, rIIrIIIIIIIIi, v)
 EXPORT_FN("xor.2d.i32", iree_uk_x32b_xori_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 
 

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -793,10 +793,6 @@ IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_f32f32, unpack, v) {
   return iree_vmvx_unpack(iree_uk_unpack_type_f32f32, 4, 4, args);
 }
 
-IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_i8i8, unpack, v) {
-  return iree_vmvx_unpack(iree_uk_unpack_type_i8i8, 1, 1, args);
-}
-
 IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_i32i32, unpack, v) {
   return iree_vmvx_unpack(iree_uk_unpack_type_i32i32, 4, 4, args);
 }

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -654,6 +654,8 @@ static iree_status_t iree_vmvx_pack_f(iree_uk_pack_type_t type,
                            /*stride1=*/1,
                            /*size0=*/args->out_size0,
                            /*size1=*/args->out_size1 * out_tile_size);
+  uint32_t padding_value_bits_as_uint32;
+  memcpy(&padding_value_bits_as_uint32, &args->padding_value, sizeof(uint32_t));
   iree_uk_pack_params_t ukernel_params = {
       .type = type,
       .in_buffer = in,
@@ -666,7 +668,7 @@ static iree_status_t iree_vmvx_pack_f(iree_uk_pack_type_t type,
       .out_size1 = args->out_size1,
       .out_size2 = args->out_size2,
       .out_size3 = args->out_size3,
-      .padding_value = &args->padding_value,
+      .padding_value = padding_value_bits_as_uint32,
       .flags = args->flags,
       .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
   };
@@ -707,7 +709,7 @@ static iree_status_t iree_vmvx_pack_i(iree_uk_pack_type_t type,
       .out_size1 = args->out_size1,
       .out_size2 = args->out_size2,
       .out_size3 = args->out_size3,
-      .padding_value = &args->padding_value,
+      .padding_value = args->padding_value,
       .flags = args->flags,
       .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
   };


### PR DESCRIPTION
It was a void* pointer to achieve type-genericity, but passing by value is more friendly to compilers generating calls to this.

Some care went into not baking in endianness here, particularly in the interface exposed to the compiler, and also within the ukernel implementation. In cases where the element type is smaller than the padding value type, we specify which part of the padding value is used purely in terms of bit-significance and not in terms of byte-address. In the implementation this is implemented with value-casting the padding value to narrower types, instead of memcpy of bytes from the padding value