### PR TITLE
ukernels: fold type enums into flags

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_ukernel_ops.mlir
@@ -14,7 +14,7 @@ func.func @mmt4d_f32f32f32(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 257 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -40,7 +40,7 @@ func.func @mmt4d_fill(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>, 
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 0 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -69,7 +69,7 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 258 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -90,7 +90,7 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: i8
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 0 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 2 : i32
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[IN_SIZE1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
@@ -115,7 +115,7 @@ func.func @pack_i8i8(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?x7x8xi8>, %arg2 :
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 65536 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 259 : i32
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[IN_SIZE1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
@@ -140,7 +140,7 @@ func.func @pack_i32i32_transpose_inner(%arg0 : tensor<?x?xi32>, %arg1 : tensor<?
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: f32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 196608 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 769 : i32
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[IN_SIZE1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
@@ -164,7 +164,7 @@ func.func @pack_f32f32_transpose_inner_and_outer(%arg0 : tensor<?x?xf32>, %arg1 
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xi32>
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 65536 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 258 : i32
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[IN_SIZE1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
@@ -188,7 +188,7 @@ func.func @unpack_i32i32_transpose_inner(%arg0 : tensor<?x?x7x8xi32>, %arg1 : te
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 196608 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 769 : i32
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[IN_SIZE1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE0:.+]] = tensor.dim %[[ARG1]], %[[C0]]

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/materialize_encoding.mlir
@@ -40,17 +40,17 @@ func.func @matmul_lowering_i8i8i32_vmvx_ukernel() attributes {
 //  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load[0]
 //  CHECK-DAG:   %[[N:.+]] = hal.interface.constant.load[1]
 //  CHECK-DAG:   %[[K:.+]] = hal.interface.constant.load[2]
-//      CHECK:   %[[LHS_TILE_SIZES:.+]]:2 = vmvx.query_tile_sizes sizes(%[[DYNAMIC]], %[[DYNAMIC]]) flags(1048576) -> index, index
+//      CHECK:   %[[LHS_TILE_SIZES:.+]]:2 = vmvx.query_tile_sizes sizes(%[[DYNAMIC]], %[[DYNAMIC]]) flags(513) -> index, index
 //  CHECK-DAG:   %[[LHS_OUTER_SIZE0:.+]] = affine.apply #[[MAP_CEILDIV]]()[%[[M]], %[[LHS_TILE_SIZES]]#0]
 //  CHECK-DAG:   %[[LHS_OUTER_SIZE1:.+]] = affine.apply #[[MAP_CEILDIV]]()[%[[K]], %[[LHS_TILE_SIZES]]#1]
 //      CHECK:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
 // CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%[[LHS_OUTER_SIZE0]], %[[LHS_OUTER_SIZE1]], %[[LHS_TILE_SIZES]]#0, %[[LHS_TILE_SIZES]]#1}
-//      CHECK:   %[[RHS_TILE_SIZES:.+]]:2 = vmvx.query_tile_sizes sizes(%[[DYNAMIC]], %[[DYNAMIC]]) flags(1114112) -> index, index
+//      CHECK:   %[[RHS_TILE_SIZES:.+]]:2 = vmvx.query_tile_sizes sizes(%[[DYNAMIC]], %[[DYNAMIC]]) flags(514) -> index, index
 //  CHECK-DAG:   %[[RHS_OUTER_SIZE0:.+]] = affine.apply #[[MAP_CEILDIV]]()[%[[N]], %[[RHS_TILE_SIZES]]#0]
 //  CHECK-DAG:   %[[RHS_OUTER_SIZE1:.+]] = affine.apply #[[MAP_CEILDIV]]()[%[[K]], %[[RHS_TILE_SIZES]]#1]
 //      CHECK:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
 // CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%[[RHS_OUTER_SIZE0]], %[[RHS_OUTER_SIZE1]], %[[RHS_TILE_SIZES]]#0, %[[RHS_TILE_SIZES]]#1}
-//      CHECK:   %[[RESULT_TILE_SIZES:.+]]:2 = vmvx.query_tile_sizes sizes(%[[DYNAMIC]], %[[DYNAMIC]]) flags(1179648) -> index, index
+//      CHECK:   %[[RESULT_TILE_SIZES:.+]]:2 = vmvx.query_tile_sizes sizes(%[[DYNAMIC]], %[[DYNAMIC]]) flags(515) -> index, index
 //  CHECK-DAG:   %[[RESULT_OUTER_SIZE0:.+]] = affine.apply #[[MAP_CEILDIV]]()[%[[M]], %[[RESULT_TILE_SIZES]]#0]
 //  CHECK-DAG:   %[[RESULT_OUTER_SIZE1:.+]] = affine.apply #[[MAP_CEILDIV]]()[%[[N]], %[[RESULT_TILE_SIZES]]#1]
 //      CHECK:   %[[OUTS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(2)

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.S
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.S
@@ -12,7 +12,7 @@
 BEGIN_FUNCTION iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64
 
         // Do we accumulate into or clear the accumulator tile?
-        tbnz w4, IREE_UK_FLAG_ACCUMULATE_BIT_POS, 1f
+        tbnz w4, IREE_UK_FLAG_MMT4D_ACCUMULATE_BIT_POS, 1f
 
     0:
         // No-accumulate case. Clear the 8x8 accumulator tile.
@@ -99,7 +99,7 @@ END_FUNCTION iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64
 BEGIN_FUNCTION iree_uk_mmt4d_tile_i8i8i32_8x8x1_arm_64
 
         // Do we accumulate into or clear the accumulator tile?
-        tbnz w4, IREE_UK_FLAG_ACCUMULATE_BIT_POS, 1f
+        tbnz w4, IREE_UK_FLAG_MMT4D_ACCUMULATE_BIT_POS, 1f
 
     0:
         // No-accumulate case. Clear the 8x8 accumulator tile.

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -64,7 +64,7 @@ static iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arm_64_i8i8i32(
 
 iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arm_64(
     const iree_uk_mmt4d_params_t* params) {
-  switch (params->type) {
+  switch (iree_uk_mmt4d_type(params->flags)) {
     case iree_uk_mmt4d_type_f32f32f32:
       return iree_uk_mmt4d_select_tile_func_arm_64_f32f32f32(params);
     case iree_uk_mmt4d_type_i8i8i32:

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.S
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.S
@@ -12,7 +12,7 @@
 BEGIN_FUNCTION iree_uk_mmt4d_tile_i8i8i32_8x8x4_arm_64_dotprod
 
         // Do we accumulate into or clear the accumulator tile?
-        tbnz w4, IREE_UK_FLAG_ACCUMULATE_BIT_POS, 1f
+        tbnz w4, IREE_UK_FLAG_MMT4D_ACCUMULATE_BIT_POS, 1f
 
     0:
         // No-accumulate case. Clear the 8x8 accumulator tile.

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.S
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.S
@@ -18,7 +18,7 @@ BEGIN_FUNCTION iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm
         stp d14, d15, [sp, 48]
 
         // Do we accumulate into or clear the accumulator tile?
-        tbnz w4, IREE_UK_FLAG_ACCUMULATE_BIT_POS, 1f
+        tbnz w4, IREE_UK_FLAG_MMT4D_ACCUMULATE_BIT_POS, 1f
         
     0:
         // No-accumulate case. Clear the 8x8 accumulator tile.

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/pack_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/pack_arm_64.c
@@ -208,7 +208,8 @@ iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_arm_64(
   // At the moment, as sum-reductions are not yet part of pack ops,
   // no arithmetic whatsoever is being done here, so only the element type
   // size matters, not the type itself.
-  int esize = iree_uk_type_size(iree_uk_pack_out_type(params->type));
+  iree_uk_pack_type_t pack_type = iree_uk_pack_type(params->flags);
+  int esize = iree_uk_type_size(iree_uk_pack_out_type(pack_type));
   bool transpose = params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER;
   if (esize == 4 && params->out_size2 == 8 && params->out_size3 == 8) {
     // Currently only used for accumulators, which are never transposed.

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.c
@@ -31,7 +31,8 @@ static void iree_uk_unpack_tile_8x8_x32_arm_64_direct(
 
 iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_arm_64(
     const iree_uk_unpack_params_t* params) {
-  int esize = iree_uk_type_size(iree_uk_unpack_out_type(params->type));
+  iree_uk_unpack_type_t unpack_type = iree_uk_unpack_type(params->flags);
+  int esize = iree_uk_type_size(iree_uk_unpack_out_type(unpack_type));
   bool transpose = params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER;
   // Unpack is currently only used in practice with esize==4 and non-transpose.
   if (esize != 4 || transpose) return 0;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64.c
@@ -92,7 +92,7 @@ static iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_x86_64_i8i8i32(
 
 iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_x86_64(
     const iree_uk_mmt4d_params_t* params) {
-  switch (params->type) {
+  switch (iree_uk_mmt4d_type(params->flags)) {
     case iree_uk_mmt4d_type_f32f32f32:
       return iree_uk_mmt4d_select_tile_func_x86_64_f32f32f32(params);
     case iree_uk_mmt4d_type_i8i8i32:

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
@@ -17,7 +17,7 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   __m256 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  if (flags & IREE_UK_FLAG_ACCUMULATE) {
+  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
     acc1 = _mm256_loadu_ps(out_ptr + 1 * 8);
     acc2 = _mm256_loadu_ps(out_ptr + 2 * 8);
@@ -75,7 +75,7 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(
   __m256i acc_3_0123_7_4567;
   __m256i acc_3_4567_7_0123;
 
-  if (flags & IREE_UK_FLAG_ACCUMULATE) {
+  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567 = iree_uk_avx_loadu_2x128(
         (__m128i*)(out_ptr + 0 * 8 + 0), (__m128i*)(out_ptr + 4 * 8 + 4));
     acc_0_4567_4_0123 = iree_uk_avx_loadu_2x128(

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -25,7 +25,7 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
   _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
   __m512 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
   __m512 acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_ACCUMULATE) {
+  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
     acc1 = _mm512_loadu_ps(out_ptr + 1 * 16);
     acc2 = _mm512_loadu_ps(out_ptr + 2 * 16);
@@ -126,7 +126,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
   __m512i acc_3_89AB_7_CDEF_B_0123_F_4567;
   __m512i acc_3_CDEF_7_89AB_B_4567_F_0123;
 
-  if (flags & IREE_UK_FLAG_ACCUMULATE) {
+  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567_8_89AB_C_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
         out_ptr, 0, 0, 4, 4, 8, 8, 12, 12);
     acc_0_4567_4_0123_8_CDEF_C_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
@@ -34,7 +34,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
   __m512i acc_3_89AB_7_CDEF_B_0123_F_4567;
   __m512i acc_3_CDEF_7_89AB_B_4567_F_0123;
 
-  if (flags & IREE_UK_FLAG_ACCUMULATE) {
+  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567_8_89AB_C_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
         out_ptr, 0, 0, 4, 4, 8, 8, 12, 12);
     acc_0_4567_4_0123_8_CDEF_C_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64.c
@@ -99,7 +99,8 @@ iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_x86_64(
   // At the moment, as sum-reductions are not yet part of pack ops,
   // no arithmetic whatsoever is being done here, so only the element type
   // size matters, not the type itself.
-  int esize = iree_uk_type_size(iree_uk_pack_out_type(params->type));
+  iree_uk_pack_type_t pack_type = iree_uk_pack_type(params->flags);
+  int esize = iree_uk_type_size(iree_uk_pack_out_type(pack_type));
   if (esize == 4 && params->out_size2 == 8 && params->out_size3 == 8) {
     return iree_uk_pack_select_tile_func_x86_64_8x8_x32(params);
   } else if (esize == 4 && params->out_size2 == 16 && params->out_size3 == 16) {

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64.c
@@ -15,7 +15,8 @@ IREE_UK_UNPACK_TILE_FUNC_DECL(
 
 iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_x86_64(
     const iree_uk_unpack_params_t* params) {
-  int esize = iree_uk_type_size(iree_uk_unpack_out_type(params->type));
+  iree_uk_unpack_type_t unpack_type = iree_uk_unpack_type(params->flags);
+  int esize = iree_uk_type_size(iree_uk_unpack_out_type(unpack_type));
   bool transpose = params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER;
   // Unpack is currently only used in practice with esize==4 and non-transpose.
   if (esize != 4 || transpose) return 0;

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -12,9 +12,11 @@
 
 static void iree_uk_mmt4d_validate(const iree_uk_mmt4d_params_t* params) {
 #ifdef IREE_UK_ENABLE_ASSERTS
-  IREE_UK_ASSERT(!(params->flags & ~IREE_UK_FLAG_ACCUMULATE));
-  IREE_UK_ASSERT(params->type == iree_uk_mmt4d_type_f32f32f32 ||
-                 params->type == iree_uk_mmt4d_type_i8i8i32);
+  const iree_uk_uint32_t allflags =
+      IREE_UK_FLAG_MMT4D_TYPE_MASK | IREE_UK_FLAG_MMT4D_ACCUMULATE;
+  IREE_UK_ASSERT(!(params->flags & ~allflags));
+  iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(params->flags);
+  IREE_UK_ASSERT(mmt4d_type != iree_uk_mmt4d_type_none);
   // Some implementations may wish to avoid supporting absurdly wide types. For
   // instance, K is the innermost (i.e. hottest) loop bound, so some 32bit
   // targets may benefit from K being int32, not int64. We still let K be of
@@ -29,7 +31,7 @@ static void iree_uk_mmt4d_validate(const iree_uk_mmt4d_params_t* params) {
   IREE_UK_ASSERT(IREE_UK_VALUE_IN_UNSIGNED_INT_RANGE(params->K0, 15));
   // Ensure iree_uk_mmt4d_tile_generic_max_bytes large enough for this tile.
   IREE_UK_ASSERT(params->M0 * params->N0 *
-                     iree_uk_type_size(iree_uk_mmt4d_out_type(params->type)) <=
+                     iree_uk_type_size(iree_uk_mmt4d_out_type(mmt4d_type)) <=
                  iree_uk_mmt4d_tile_generic_max_bytes);
 #endif  // IREE_UK_ENABLE_ASSERTS
 }
@@ -46,9 +48,10 @@ static void iree_uk_mmt4d_using_tile_func(const iree_uk_mmt4d_params_t* params,
   const iree_uk_int32_t K = params->K;
   const iree_uk_int16_t M0 = params->M0;
   const iree_uk_int16_t N0 = params->N0;
-  const iree_uk_type_t lhs_type = iree_uk_mmt4d_lhs_type(params->type);
-  const iree_uk_type_t rhs_type = iree_uk_mmt4d_rhs_type(params->type);
-  const iree_uk_type_t out_type = iree_uk_mmt4d_out_type(params->type);
+  iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(params->flags);
+  const iree_uk_type_t lhs_type = iree_uk_mmt4d_lhs_type(mmt4d_type);
+  const iree_uk_type_t rhs_type = iree_uk_mmt4d_rhs_type(mmt4d_type);
+  const iree_uk_type_t out_type = iree_uk_mmt4d_out_type(mmt4d_type);
   const iree_uk_int16_t lhs_elem_size_log2 = iree_uk_type_size_log2(lhs_type);
   const iree_uk_int16_t rhs_elem_size_log2 = iree_uk_type_size_log2(rhs_type);
   const iree_uk_int16_t out_elem_size_log2 = iree_uk_type_size_log2(out_type);
@@ -76,7 +79,8 @@ static void iree_uk_mmt4d_using_tile_func(const iree_uk_mmt4d_params_t* params,
 
 // Helper for early-return path when K==0 and we just need to clear the output.
 static void iree_uk_mmt4d_zero_out(const iree_uk_mmt4d_params_t* params) {
-  iree_uk_type_t out_type = iree_uk_mmt4d_out_type(params->type);
+  iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(params->flags);
+  iree_uk_type_t out_type = iree_uk_mmt4d_out_type(mmt4d_type);
   int out_elem_size_log2 = iree_uk_type_size_log2(out_type);
   iree_uk_ssize_t contiguous_size = params->N * params->M0 * params->N0
                                     << out_elem_size_log2;
@@ -99,7 +103,7 @@ static bool iree_uk_mmt4d_early(const iree_uk_mmt4d_params_t* params) {
     return true;
   }
   if (params->K == 0) {
-    if (params->flags & IREE_UK_FLAG_ACCUMULATE) {
+    if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
       // Nothing to do!
     } else {
       iree_uk_mmt4d_zero_out(params);

--- a/runtime/src/iree/builtins/ukernel/mmt4d.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.h
@@ -13,16 +13,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-// TODO(benoitjacob): move to internal, user specifies type in flags.
-typedef enum iree_uk_mmt4d_type_t {
-  iree_uk_mmt4d_type_f32f32f32 =
-      IREE_UK_TIE_3_TYPES_LITERAL(FLOAT_32, FLOAT_32, FLOAT_32),
-  iree_uk_mmt4d_type_i8i8i32 =
-      IREE_UK_TIE_3_TYPES_LITERAL(INT_8, INT_8, INT_32),
-} iree_uk_mmt4d_type_t;
-
 typedef struct iree_uk_mmt4d_params_t {
-  iree_uk_mmt4d_type_t type;
   const void* lhs_buffer;
   iree_uk_ssize_t lhs_offset;
   iree_uk_ssize_t lhs_stride0;

--- a/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
@@ -9,6 +9,25 @@
 
 #include "iree/builtins/ukernel/mmt4d.h"
 
+typedef enum iree_uk_mmt4d_type_t {
+  iree_uk_mmt4d_type_none = 0,
+  iree_uk_mmt4d_type_f32f32f32 =
+      IREE_UK_TIE_3_TYPES_LITERAL(FLOAT_32, FLOAT_32, FLOAT_32),
+  iree_uk_mmt4d_type_i8i8i32 =
+      IREE_UK_TIE_3_TYPES_LITERAL(INT_8, INT_8, INT_32),
+} iree_uk_mmt4d_type_t;
+
+static inline iree_uk_mmt4d_type_t iree_uk_mmt4d_type(iree_uk_uint32_t flags) {
+  switch (flags & IREE_UK_FLAG_MMT4D_TYPE_MASK) {
+    case IREE_UK_FLAG_MMT4D_TYPE_F32F32F32:
+      return iree_uk_mmt4d_type_f32f32f32;
+    case IREE_UK_FLAG_MMT4D_TYPE_I8I8I32:
+      return iree_uk_mmt4d_type_i8i8i32;
+    default:
+      return iree_uk_mmt4d_type_none;
+  }
+}
+
 static inline iree_uk_type_t iree_uk_mmt4d_lhs_type(iree_uk_mmt4d_type_t type) {
   return iree_uk_untie_type(0, type);
 }

--- a/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
@@ -25,7 +25,7 @@ static void iree_uk_mmt4d_tile_i8i8i32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   iree_uk_int32_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_ACCUMULATE) {
+  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
@@ -61,7 +61,7 @@ static void iree_uk_mmt4d_tile_f32f32f32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_ACCUMULATE) {
+  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
@@ -86,7 +86,7 @@ static void iree_uk_mmt4d_tile_f32f32f32_generic(
 
 static iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(
     const iree_uk_mmt4d_params_t* params) {
-  switch (params->type) {
+  switch (iree_uk_mmt4d_type(params->flags)) {
     case iree_uk_mmt4d_type_f32f32f32:
       return iree_uk_mmt4d_tile_f32f32f32_generic;
     case iree_uk_mmt4d_type_i8i8i32:

--- a/runtime/src/iree/builtins/ukernel/pack.c
+++ b/runtime/src/iree/builtins/ukernel/pack.c
@@ -58,12 +58,12 @@ static void iree_uk_pack_tmpbuf_helper_t_init(
 
 static void iree_uk_pack_validate(const iree_uk_pack_params_t* params) {
 #ifdef IREE_UK_ENABLE_ASSERTS
-  const iree_uk_uint32_t allflags =
-      IREE_UK_FLAG_PACK_TRANSPOSE_INNER | IREE_UK_FLAG_PACK_TRANSPOSE_OUTER;
+  const iree_uk_uint32_t allflags = IREE_UK_FLAG_PACK_TRANSPOSE_INNER |
+                                    IREE_UK_FLAG_PACK_TRANSPOSE_OUTER |
+                                    IREE_UK_FLAG_PACK_TYPE_MASK;
   IREE_UK_ASSERT(!(params->flags & ~allflags));
-  IREE_UK_ASSERT(params->type == iree_uk_pack_type_f32f32 ||
-                 params->type == iree_uk_pack_type_i8i8 ||
-                 params->type == iree_uk_pack_type_i32i32);
+  iree_uk_pack_type_t pack_type = iree_uk_pack_type(params->flags);
+  IREE_UK_ASSERT(pack_type != iree_uk_pack_type_none);
   IREE_UK_ASSERT(params->in_stride0 >= 0);
   IREE_UK_ASSERT(params->out_stride0 >= 0);
   IREE_UK_ASSERT(params->in_size0 >= 0);
@@ -96,7 +96,7 @@ static void iree_uk_pack_validate(const iree_uk_pack_params_t* params) {
   // in the validation function so that the subsequent ukernel code can be
   // treated as infallible.
   iree_uk_pack_tmpbuf_helper_t padding_helper;
-  iree_uk_type_t elem_type = iree_uk_pack_in_type(params->type);
+  iree_uk_type_t elem_type = iree_uk_pack_in_type(pack_type);
   iree_uk_ssize_t elem_size = iree_uk_type_size(elem_type);
   iree_uk_pack_tmpbuf_helper_t_init(tile_size0, tile_size1, elem_size,
                                     params->padding_value, &padding_helper);
@@ -190,7 +190,8 @@ static void iree_uk_pad_and_pack_row_using_tile_func(
 static void iree_uk_pack_using_tile_func(const iree_uk_pack_params_t* params,
                                          iree_uk_pack_tile_func_t tile_func) {
   // For now, the input and output element types are always the same.
-  iree_uk_type_t elem_type = iree_uk_pack_in_type(params->type);
+  iree_uk_pack_type_t pack_type = iree_uk_pack_type(params->flags);
+  iree_uk_type_t elem_type = iree_uk_pack_in_type(pack_type);
   iree_uk_ssize_t elem_size = iree_uk_type_size(elem_type);
   iree_uk_ssize_t outer_size0 = params->out_size0;
   iree_uk_ssize_t outer_size1 = params->out_size1;

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -13,15 +13,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-// TODO(benoitjacob): move to internal, user specifies type in flags.
-typedef enum iree_uk_pack_type_t {
-  iree_uk_pack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
-  iree_uk_pack_type_i8i8 = IREE_UK_TIE_2_TYPES_LITERAL(INT_8, INT_8),
-  iree_uk_pack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),
-} iree_uk_pack_type_t;
-
 typedef struct iree_uk_pack_params_t {
-  iree_uk_pack_type_t type;
   const void* in_buffer;
   iree_uk_ssize_t in_offset;
   iree_uk_ssize_t in_stride0;

--- a/runtime/src/iree/builtins/ukernel/pack_internal.h
+++ b/runtime/src/iree/builtins/ukernel/pack_internal.h
@@ -9,6 +9,26 @@
 
 #include "iree/builtins/ukernel/pack.h"
 
+typedef enum iree_uk_pack_type_t {
+  iree_uk_pack_type_none = 0,
+  iree_uk_pack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
+  iree_uk_pack_type_i8i8 = IREE_UK_TIE_2_TYPES_LITERAL(INT_8, INT_8),
+  iree_uk_pack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),
+} iree_uk_pack_type_t;
+
+static inline iree_uk_pack_type_t iree_uk_pack_type(iree_uk_uint32_t flags) {
+  switch (flags & IREE_UK_FLAG_PACK_TYPE_MASK) {
+    case IREE_UK_FLAG_PACK_TYPE_F32F32:
+      return iree_uk_pack_type_f32f32;
+    case IREE_UK_FLAG_PACK_TYPE_I8I8:
+      return iree_uk_pack_type_i8i8;
+    case IREE_UK_FLAG_PACK_TYPE_I32I32:
+      return iree_uk_pack_type_i32i32;
+    default:
+      return iree_uk_pack_type_none;
+  }
+}
+
 static inline iree_uk_type_t iree_uk_pack_in_type(iree_uk_pack_type_t type) {
   return iree_uk_untie_type(0, type);
 }

--- a/runtime/src/iree/builtins/ukernel/query_tile_sizes_internal.h
+++ b/runtime/src/iree/builtins/ukernel/query_tile_sizes_internal.h
@@ -11,12 +11,12 @@
 
 static inline iree_uk_uint32_t iree_uk_query_tile_sizes_operand_role(
     iree_uk_uint32_t flags) {
-  return flags & IREE_UK_FLAG_QUERY_TILE_SIZES_OPERAND_ROLE_MASK_INTERNAL;
+  return flags & IREE_UK_FLAG_QUERY_TILE_SIZES_OPERAND_ROLE_MASK;
 }
 
 static inline iree_uk_uint32_t iree_uk_query_tile_sizes_operation(
     iree_uk_uint32_t flags) {
-  return flags & IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MASK_INTERNAL;
+  return flags & IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MASK;
 }
 
 // Holds matmul tile params as returned from architecture-specific backend code.

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
@@ -13,7 +13,7 @@
 static void iree_mmt4d_reference_innerloop_f32f32f32(
     float* out_ptr, const float* lhs_ptr, const float* rhs_ptr,
     const iree_uk_mmt4d_params_t* params) {
-  float acc = params->flags & IREE_UK_FLAG_ACCUMULATE ? *out_ptr : 0.f;
+  float acc = params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE ? *out_ptr : 0.f;
   for (iree_uk_ssize_t k = 0; k < params->K; ++k) {
     for (iree_uk_ssize_t k0 = 0; k0 < params->K0; ++k0) {
       float lhs_val = lhs_ptr[k * params->M0 * params->K0 + k0];
@@ -27,7 +27,7 @@ static void iree_mmt4d_reference_innerloop_f32f32f32(
 static void iree_mmt4d_reference_innerloop_i8i8i32(
     int32_t* out_ptr, const int8_t* lhs_ptr, const int8_t* rhs_ptr,
     const iree_uk_mmt4d_params_t* params) {
-  int32_t acc = params->flags & IREE_UK_FLAG_ACCUMULATE ? *out_ptr : 0;
+  int32_t acc = params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE ? *out_ptr : 0;
   for (iree_uk_ssize_t k = 0; k < params->K; ++k) {
     for (iree_uk_ssize_t k0 = 0; k0 < params->K0; ++k0) {
       int32_t lhs_val = lhs_ptr[k * params->M0 * params->K0 + k0];
@@ -39,12 +39,13 @@ static void iree_mmt4d_reference_innerloop_i8i8i32(
 }
 
 static void iree_mmt4d_reference(const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(params->flags);
   iree_uk_ssize_t lhs_elem_size =
-      iree_uk_type_size(iree_uk_mmt4d_lhs_type(params->type));
+      iree_uk_type_size(iree_uk_mmt4d_lhs_type(mmt4d_type));
   iree_uk_ssize_t rhs_elem_size =
-      iree_uk_type_size(iree_uk_mmt4d_rhs_type(params->type));
+      iree_uk_type_size(iree_uk_mmt4d_rhs_type(mmt4d_type));
   iree_uk_ssize_t out_elem_size =
-      iree_uk_type_size(iree_uk_mmt4d_out_type(params->type));
+      iree_uk_type_size(iree_uk_mmt4d_out_type(mmt4d_type));
   for (iree_uk_ssize_t i = 0; i < params->M; ++i) {
     for (iree_uk_ssize_t j = 0; j < params->N; ++j) {
       void* out_tile_ptr = ((char*)params->out_buffer) +
@@ -65,13 +66,13 @@ static void iree_mmt4d_reference(const iree_uk_mmt4d_params_t* params) {
               ((char*)lhs_panel_ptr) + i0 * params->K0 * lhs_elem_size;
           const void* rhs_ptr =
               ((char*)rhs_panel_ptr) + j0 * params->K0 * rhs_elem_size;
-          switch (params->type) {
-            case iree_uk_mmt4d_type_f32f32f32:
+          switch (params->flags & IREE_UK_FLAG_MMT4D_TYPE_MASK) {
+            case IREE_UK_FLAG_MMT4D_TYPE_F32F32F32:
               iree_mmt4d_reference_innerloop_f32f32f32(
                   (float*)out_ptr, (const float*)lhs_ptr, (const float*)rhs_ptr,
                   params);
               break;
-            case iree_uk_mmt4d_type_i8i8i32:
+            case IREE_UK_FLAG_MMT4D_TYPE_I8I8I32:
               iree_mmt4d_reference_innerloop_i8i8i32(
                   (int32_t*)out_ptr, (const int8_t*)lhs_ptr,
                   (const int8_t*)rhs_ptr, params);
@@ -99,9 +100,10 @@ static void iree_uk_test_mmt4d_for_shape_params(
       params.K * params.N0 * params.K0 + iree_uk_random_engine_get_0_1(engine);
   params.out_stride0 =
       params.N * params.M0 * params.N0 + iree_uk_random_engine_get_0_1(engine);
-  iree_uk_type_t lhs_type = iree_uk_mmt4d_lhs_type(params.type);
-  iree_uk_type_t rhs_type = iree_uk_mmt4d_rhs_type(params.type);
-  iree_uk_type_t out_type = iree_uk_mmt4d_out_type(params.type);
+  iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(params.flags);
+  iree_uk_type_t lhs_type = iree_uk_mmt4d_lhs_type(mmt4d_type);
+  iree_uk_type_t rhs_type = iree_uk_mmt4d_rhs_type(mmt4d_type);
+  iree_uk_type_t out_type = iree_uk_mmt4d_out_type(mmt4d_type);
   iree_uk_ssize_t lhs_buffer_size =
       iree_uk_2d_buffer_length(lhs_type, params.M, params.lhs_stride0);
   iree_uk_ssize_t rhs_buffer_size =
@@ -191,17 +193,19 @@ static void iree_uk_test_mmt4d_for_tile_params(iree_uk_test_t* test,
     params.N = shape.n;
     params.K = shape.k;
     for (int accumulate = 0; accumulate <= 1; ++accumulate) {
-      params.flags = accumulate ? IREE_UK_FLAG_ACCUMULATE : 0;
+      if (accumulate) params.flags |= IREE_UK_FLAG_MMT4D_ACCUMULATE;
       iree_uk_test_mmt4d_for_shape_params(test, &params);
     }
   }
 }
 
-static void iree_uk_test_mmt4d(iree_uk_mmt4d_type_t type, int M0, int N0,
-                               int K0, const char* cpu_features) {
-  iree_uk_mmt4d_params_t params = {.type = type, .M0 = M0, .N0 = N0, .K0 = K0};
+static void iree_uk_test_mmt4d(iree_uk_uint32_t flags, int M0, int N0, int K0,
+                               const char* cpu_features) {
+  iree_uk_mmt4d_params_t params = {
+      .flags = flags, .M0 = M0, .N0 = N0, .K0 = K0};
   char types_str[32];
-  iree_uk_type_triple_str(types_str, sizeof types_str, type);
+  iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(flags);
+  iree_uk_type_triple_str(types_str, sizeof types_str, mmt4d_type);
   char test_label_str[256];
   snprintf(test_label_str, sizeof test_label_str, "types:%s tile:%dx%dx%d",
            types_str, M0, N0, K0);
@@ -213,21 +217,22 @@ int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird M0, N0, K0 to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 3, 5, 7, NULL);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 9, 6, 3, NULL);
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 3, 5, 7, NULL);
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 9, 6, 3, NULL);
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, NULL);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 1, NULL);
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 4, "dotprod");
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 8, "i8mm");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 8, 1, NULL);
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 1, NULL);
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 4, "dotprod");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 8, "i8mm");
 #elif defined(IREE_UK_ARCH_X86_64)
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 4, 1, NULL);  // SSE
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 8, 8, 1, "avx2_fma");
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_f32f32f32, 16, 16, 1, "avx512_base");
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 4, 2, NULL);  // SSE2
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 8, 8, 2, "avx2_fma");
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2, "avx512_base");
-  iree_uk_test_mmt4d(iree_uk_mmt4d_type_i8i8i32, 16, 16, 2, "avx512_vnni");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 4, 1, NULL);  // SSE
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 8, 1, "avx2_fma");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 16, 16, 1,
+                     "avx512_base");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 4, 2, NULL);  // SSE2
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 2, "avx2_fma");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 16, 16, 2, "avx512_base");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 16, 16, 2, "avx512_vnni");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 }

--- a/runtime/src/iree/builtins/ukernel/unpack.c
+++ b/runtime/src/iree/builtins/ukernel/unpack.c
@@ -38,12 +38,12 @@ static void iree_uk_unpack_tmpbuf_helper_init(
 
 static void iree_uk_unpack_validate(const iree_uk_unpack_params_t* params) {
 #ifdef IREE_UK_ENABLE_ASSERTS
-  const iree_uk_uint32_t allflags =
-      IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER | IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER;
+  const iree_uk_uint32_t allflags = IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER |
+                                    IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER |
+                                    IREE_UK_FLAG_UNPACK_TYPE_MASK;
   IREE_UK_ASSERT(!(params->flags & ~allflags));
-  IREE_UK_ASSERT(params->type == iree_uk_unpack_type_f32f32 ||
-                 params->type == iree_uk_unpack_type_i8i8 ||
-                 params->type == iree_uk_unpack_type_i32i32);
+  iree_uk_unpack_type_t unpack_type = iree_uk_unpack_type(params->flags);
+  IREE_UK_ASSERT(unpack_type != iree_uk_unpack_type_none);
   IREE_UK_ASSERT(params->in_stride0 >= 0);
   IREE_UK_ASSERT(params->out_stride0 >= 0);
   IREE_UK_ASSERT(params->out_size0 >= 0);
@@ -76,7 +76,7 @@ static void iree_uk_unpack_validate(const iree_uk_unpack_params_t* params) {
   // in the validation function so that the subsequent ukernel code can be
   // treated as infallible.
   iree_uk_unpack_tmpbuf_helper_t helper;
-  iree_uk_type_t elem_type = iree_uk_unpack_in_type(params->type);
+  iree_uk_type_t elem_type = iree_uk_unpack_in_type(unpack_type);
   iree_uk_ssize_t elem_size = iree_uk_type_size(elem_type);
   iree_uk_unpack_tmpbuf_helper_init(tile_size0, tile_size1, elem_size, &helper);
 #endif  // IREE_UK_ENABLE_ASSERTS
@@ -131,7 +131,8 @@ static void iree_uk_unpack_using_tile_func(
     const iree_uk_unpack_params_t* params,
     iree_uk_unpack_tile_func_t tile_func) {
   // For now, the input and output element types are always the same.
-  iree_uk_type_t elem_type = iree_uk_unpack_in_type(params->type);
+  iree_uk_unpack_type_t unpack_type = iree_uk_unpack_type(params->flags);
+  iree_uk_type_t elem_type = iree_uk_unpack_in_type(unpack_type);
   iree_uk_ssize_t elem_size = iree_uk_type_size(elem_type);
   iree_uk_ssize_t outer_size0 = params->in_size0;
   iree_uk_ssize_t outer_size1 = params->in_size1;

--- a/runtime/src/iree/builtins/ukernel/unpack.h
+++ b/runtime/src/iree/builtins/ukernel/unpack.h
@@ -13,15 +13,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-// TODO(benoitjacob): move to internal, user specifies type in flags.
-typedef enum iree_uk_unpack_type_t {
-  iree_uk_unpack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
-  iree_uk_unpack_type_i8i8 = IREE_UK_TIE_2_TYPES_LITERAL(INT_8, INT_8),
-  iree_uk_unpack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),
-} iree_uk_unpack_type_t;
-
 typedef struct iree_uk_unpack_params_t {
-  iree_uk_unpack_type_t type;
   const void* in_buffer;
   iree_uk_ssize_t in_offset;
   iree_uk_ssize_t in_stride0;

--- a/runtime/src/iree/builtins/ukernel/unpack_internal.h
+++ b/runtime/src/iree/builtins/ukernel/unpack_internal.h
@@ -9,6 +9,24 @@
 
 #include "iree/builtins/ukernel/unpack.h"
 
+typedef enum iree_uk_unpack_type_t {
+  iree_uk_unpack_type_none = 0,
+  iree_uk_unpack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
+  iree_uk_unpack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),
+} iree_uk_unpack_type_t;
+
+static inline iree_uk_unpack_type_t iree_uk_unpack_type(
+    iree_uk_uint32_t flags) {
+  switch (flags & IREE_UK_FLAG_UNPACK_TYPE_MASK) {
+    case IREE_UK_FLAG_UNPACK_TYPE_F32F32:
+      return iree_uk_unpack_type_f32f32;
+    case IREE_UK_FLAG_UNPACK_TYPE_I32I32:
+      return iree_uk_unpack_type_i32i32;
+    default:
+      return iree_uk_unpack_type_none;
+  }
+}
+
 static inline iree_uk_type_t iree_uk_unpack_in_type(
     iree_uk_unpack_type_t type) {
   return iree_uk_untie_type(0, type);

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -523,8 +523,7 @@ IREE_VMVX_ABI_FIXED_STRUCT(mmt4d, rIIrIIrIIIIIiiii, {
 });
 IREE_VMVX_ABI_DEFINE_SHIM(mmt4d, v);
 
-static iree_status_t iree_vmvx_mmt4d(iree_uk_mmt4d_type_t type,
-                                     int lhs_elem_size, int rhs_elem_size,
+static iree_status_t iree_vmvx_mmt4d(int lhs_elem_size, int rhs_elem_size,
                                      int out_elem_size,
                                      const iree_vm_abi_mmt4d_t* args) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -565,7 +564,6 @@ static iree_status_t iree_vmvx_mmt4d(iree_uk_mmt4d_type_t type,
                            /*size0=*/M,
                            /*size1=*/N * out_tile_size);
   iree_uk_mmt4d_params_t ukernel_params = {
-      .type = type,
       .flags = args->flags,
       .lhs_buffer = lhs,
       .rhs_buffer = rhs,
@@ -587,11 +585,11 @@ static iree_status_t iree_vmvx_mmt4d(iree_uk_mmt4d_type_t type,
 }
 
 IREE_VMVX_ABI_EXPORT(iree_vmvx_mmt4d_f32f32f32, mmt4d, v) {
-  return iree_vmvx_mmt4d(iree_uk_mmt4d_type_f32f32f32, 4, 4, 4, args);
+  return iree_vmvx_mmt4d(4, 4, 4, args);
 }
 
 IREE_VMVX_ABI_EXPORT(iree_vmvx_mmt4d_i8i8i32, mmt4d, v) {
-  return iree_vmvx_mmt4d(iree_uk_mmt4d_type_i8i8i32, 1, 1, 4, args);
+  return iree_vmvx_mmt4d(1, 1, 4, args);
 }
 
 //===----------------------------------------------------------------------===//
@@ -634,8 +632,7 @@ IREE_VMVX_ABI_FIXED_STRUCT(pack_i, rIIIrIIIIIIIIii, {
 });
 IREE_VMVX_ABI_DEFINE_SHIM(pack_i, v);
 
-static iree_status_t iree_vmvx_pack_f(iree_uk_pack_type_t type,
-                                      int in_elem_size, int out_elem_size,
+static iree_status_t iree_vmvx_pack_f(int in_elem_size, int out_elem_size,
                                       const iree_vm_abi_pack_f_t* args) {
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_host_size_t out_tile_size = args->out_size2 * args->out_size3;
@@ -657,7 +654,6 @@ static iree_status_t iree_vmvx_pack_f(iree_uk_pack_type_t type,
   uint32_t padding_value_bits_as_uint32;
   memcpy(&padding_value_bits_as_uint32, &args->padding_value, sizeof(uint32_t));
   iree_uk_pack_params_t ukernel_params = {
-      .type = type,
       .in_buffer = in,
       .out_buffer = out,
       .in_stride0 = args->in_stride0,
@@ -677,8 +673,7 @@ static iree_status_t iree_vmvx_pack_f(iree_uk_pack_type_t type,
   return iree_ok_status();
 }
 
-static iree_status_t iree_vmvx_pack_i(iree_uk_pack_type_t type,
-                                      int in_elem_size, int out_elem_size,
+static iree_status_t iree_vmvx_pack_i(int in_elem_size, int out_elem_size,
                                       const iree_vm_abi_pack_i_t* args) {
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_host_size_t out_tile_size = args->out_size2 * args->out_size3;
@@ -698,7 +693,6 @@ static iree_status_t iree_vmvx_pack_i(iree_uk_pack_type_t type,
                            /*size0=*/args->out_size0,
                            /*size1=*/args->out_size1 * out_tile_size);
   iree_uk_pack_params_t ukernel_params = {
-      .type = type,
       .in_buffer = in,
       .out_buffer = out,
       .in_stride0 = args->in_stride0,
@@ -719,15 +713,15 @@ static iree_status_t iree_vmvx_pack_i(iree_uk_pack_type_t type,
 }
 
 IREE_VMVX_ABI_EXPORT(iree_vmvx_pack_f32f32, pack_f, v) {
-  return iree_vmvx_pack_f(iree_uk_pack_type_f32f32, 4, 4, args);
+  return iree_vmvx_pack_f(4, 4, args);
 }
 
 IREE_VMVX_ABI_EXPORT(iree_vmvx_pack_i8i8, pack_i, v) {
-  return iree_vmvx_pack_i(iree_uk_pack_type_i8i8, 1, 1, args);
+  return iree_vmvx_pack_i(1, 1, args);
 }
 
 IREE_VMVX_ABI_EXPORT(iree_vmvx_pack_i32i32, pack_i, v) {
-  return iree_vmvx_pack_i(iree_uk_pack_type_i32i32, 4, 4, args);
+  return iree_vmvx_pack_i(4, 4, args);
 }
 
 //===----------------------------------------------------------------------===//
@@ -751,8 +745,7 @@ IREE_VMVX_ABI_FIXED_STRUCT(unpack, rIIIrIIIIIIIIi, {
 });
 IREE_VMVX_ABI_DEFINE_SHIM(unpack, v);
 
-static iree_status_t iree_vmvx_unpack(iree_uk_unpack_type_t type,
-                                      int in_elem_size, int out_elem_size,
+static iree_status_t iree_vmvx_unpack(int in_elem_size, int out_elem_size,
                                       const iree_vm_abi_unpack_t* args) {
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_host_size_t out_tile_size = args->in_size2 * args->in_size3;
@@ -772,7 +765,6 @@ static iree_status_t iree_vmvx_unpack(iree_uk_unpack_type_t type,
                            /*size0=*/args->out_size0,
                            /*size1=*/args->out_size1);
   iree_uk_unpack_params_t ukernel_params = {
-      .type = type,
       .in_buffer = in,
       .out_buffer = out,
       .in_stride0 = args->in_stride0,
@@ -792,11 +784,11 @@ static iree_status_t iree_vmvx_unpack(iree_uk_unpack_type_t type,
 }
 
 IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_f32f32, unpack, v) {
-  return iree_vmvx_unpack(iree_uk_unpack_type_f32f32, 4, 4, args);
+  return iree_vmvx_unpack(4, 4, args);
 }
 
 IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack_i32i32, unpack, v) {
-  return iree_vmvx_unpack(iree_uk_unpack_type_i32i32, 4, 4, args);
+  return iree_vmvx_unpack(4, 4, args);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This allows to keep untyped ukernel entry points while minimizing the "bureaucracy" of calling ukernels. Keeping a single untyped entry point for each ukernel also ensures that codegen, VMVX, and ukernel internal tests and benchmarks all call the same single entry point.