### PR TITLE
polish ukernel test cpu features

### DIFF
--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -11,6 +11,7 @@
 
 #include "iree/base/target_platform.h"
 #include "iree/base/tracing.h"
+#include "iree/schemas/cpu_data.h"
 
 //===----------------------------------------------------------------------===//
 // Platform-specific processor data queries

--- a/runtime/src/iree/base/internal/cpu.h
+++ b/runtime/src/iree/base/internal/cpu.h
@@ -10,7 +10,6 @@
 #include <stddef.h>
 
 #include "iree/base/api.h"
-#include "iree/schemas/cpu_data.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -8,8 +8,6 @@
 
 #include "iree/builtins/ukernel/mmt4d_internal.h"
 
-#define OUTSIDE_UINT_RANGE(value, bits) (((value) < 0) || ((value) >> (bits)))
-
 static void iree_uk_mmt4d_validate(const iree_uk_mmt4d_params_t* params) {
 #ifdef IREE_UK_ENABLE_ASSERTS
   const iree_uk_uint32_t allflags =

--- a/runtime/src/iree/builtins/ukernel/tools/BUILD.bazel
+++ b/runtime/src/iree/builtins/ukernel/tools/BUILD.bazel
@@ -38,6 +38,18 @@ iree_runtime_cc_library(
     ],
 )
 
+iree_runtime_cc_test(
+    name = "util_test",
+    srcs = ["util_test.c"],
+    deps = [
+        ":test",
+        ":util",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:cpu",
+        "//runtime/src/iree/schemas:cpu_data",
+    ],
+)
+
 iree_runtime_cc_library(
     name = "benchmark",
     srcs = ["benchmark.c"],

--- a/runtime/src/iree/builtins/ukernel/tools/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/tools/CMakeLists.txt
@@ -41,6 +41,19 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    util_test
+  SRCS
+    "util_test.c"
+  DEPS
+    ::test
+    ::util
+    iree::base
+    iree::base::internal::cpu
+    iree::schemas::cpu_data
+)
+
 iree_cc_library(
   NAME
     benchmark

--- a/runtime/src/iree/builtins/ukernel/tools/benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/benchmark.c
@@ -77,7 +77,7 @@ void iree_uk_benchmark_register(
     const void* params, size_t params_size, const char* cpu_features) {
   // Does this benchmark require an optional CPU feature?
   iree_uk_uint64_t cpu_data_local[IREE_CPU_DATA_FIELD_COUNT] = {0};
-  if (cpu_features) {
+  if (strlen(cpu_features)) {
     iree_uk_initialize_cpu_once();
     iree_uk_make_cpu_data_for_features(cpu_features, cpu_data_local);
     if (!iree_uk_cpu_supports(cpu_data_local)) {
@@ -102,7 +102,7 @@ void iree_uk_benchmark_register(
   iree_string_builder_t full_name;
   iree_string_builder_initialize(iree_allocator_system(), &full_name);
   IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, name));
-  if (cpu_features) {
+  if (strlen(cpu_features)) {
     IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, "_"));
     IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, cpu_features));
   }

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -107,9 +107,9 @@ int main(int argc, char** argv) {
 
 #if defined(IREE_UK_ARCH_ARM_64)
   iree_uk_benchmark_register_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 8, 1,
-                                   NULL);
+                                   "");
   iree_uk_benchmark_register_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 1,
-                                   NULL);
+                                   "");
   iree_uk_benchmark_register_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 4,
                                    "dotprod");
   iree_uk_benchmark_register_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 8,
@@ -129,9 +129,9 @@ int main(int argc, char** argv) {
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
   iree_uk_benchmark_register_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 8, 1,
-                                   NULL);
+                                   "");
   iree_uk_benchmark_register_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 1,
-                                   NULL);
+                                   "");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
   iree_uk_benchmark_run_and_cleanup();

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
@@ -235,4 +235,6 @@ int main(int argc, char** argv) {
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 16, 16, 2, "avx512_base");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 16, 16, 2, "avx512_vnni");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
+
+  return EXIT_SUCCESS;  // failures are fatal
 }

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
@@ -217,20 +217,20 @@ int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird M0, N0, K0 to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
-  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 3, 5, 7, NULL);
-  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 9, 6, 3, NULL);
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 3, 5, 7, "");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 9, 6, 3, "");
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 8, 1, NULL);
-  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 1, NULL);
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 8, 1, "");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 1, "");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 4, "dotprod");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 8, "i8mm");
 #elif defined(IREE_UK_ARCH_X86_64)
-  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 4, 1, NULL);  // SSE
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 4, 1, "");  // SSE
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 8, 1, "avx2_fma");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 16, 16, 1,
                      "avx512_base");
-  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 4, 2, NULL);  // SSE2
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 4, 2, "");  // SSE2
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 2, "avx2_fma");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 16, 16, 2, "avx512_base");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 16, 16, 2, "avx512_vnni");

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -147,12 +147,12 @@ int main(int argc, char** argv) {
                                     FLAG_batch_min_traversal_size);
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, NULL);
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, NULL);
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, "");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, "");
   // Tile size selected with cpu feature "dotprod".
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 4, NULL);
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 4, "");
   // Tile size selected with cpu feature "i8mm".
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 8, NULL);
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 8, "");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1,
                                   "avx2_fma");
@@ -173,8 +173,8 @@ int main(int argc, char** argv) {
 #else   // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, NULL);
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, NULL);
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, "");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, "");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
   iree_uk_benchmark_run_and_cleanup();

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -204,21 +204,21 @@ int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 3, 5, NULL);
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 4, 2, NULL);
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 3, 4, NULL);
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 3, 5, "");
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 4, 2, "");
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 3, 4, "");
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, NULL);
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 8, NULL);
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, NULL);
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 8, 8, NULL);
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, "");
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 8, "");
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, "");
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 8, 8, "");
   // Tile size selected with CPU feature dotprod.
   // Not passing a cpu_features_list because the packing code itself
   // does not depend on any features.
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 4, NULL);
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 4, "");
   // Tile size selected for CPU feature i8mm. Same comment as for dotprod.
-  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 8, NULL);
+  iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 8, "");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, "avx2_fma");
   iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 2, "avx2_fma");

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -230,4 +230,6 @@ int main(int argc, char** argv) {
   iree_uk_test_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 16, 16, "avx512_base");
   // avx512_vnni uses the same tile size and same pack code as avx512_base.
 #endif  // defined(IREE_UK_ARCH_ARM_64)
+
+  return EXIT_SUCCESS;  // failures are fatal
 }

--- a/runtime/src/iree/builtins/ukernel/tools/test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/test.c
@@ -101,7 +101,7 @@ void iree_uk_test(const char* name,
   // We might skip the actual test payload requiring CPU features if these are
   // not supported.
   bool skipped = false;
-  if (cpu_features) {
+  if (strlen(cpu_features)) {
     iree_uk_initialize_cpu_once();
     iree_uk_make_cpu_data_for_features(cpu_features, test.cpu_data);
     if (iree_uk_cpu_supports(test.cpu_data)) {

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -147,10 +147,8 @@ int main(int argc, char** argv) {
                                     FLAG_batch_min_traversal_size);
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8,
-                                    NULL);
-  iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 8, 8,
-                                    NULL);
+  iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8, "");
+  iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 8, 8, "");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8,
                                     "avx2_fma");
@@ -163,10 +161,8 @@ int main(int argc, char** argv) {
 #else   // defined(IREE_UK_ARCH_ARM_64)
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
-  iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8,
-                                    NULL);
-  iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 8, 8,
-                                    NULL);
+  iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8, "");
+  iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 8, 8, "");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
 
   iree_uk_benchmark_run_and_cleanup();

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -207,4 +207,6 @@ int main(int argc, char** argv) {
   iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 16, 16, "avx512_base");
   iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 16, 16, "avx512_base");
 #endif  // defined(IREE_UK_ARCH_ARM_64)
+
+  return EXIT_SUCCESS;  // failures are fatal
 }

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -195,12 +195,12 @@ int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
   // in a power-of-two assumption
-  iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 3, 5, NULL);
-  iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 3, 4, NULL);
+  iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 3, 5, "");
+  iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 3, 4, "");
 
 #if defined(IREE_UK_ARCH_ARM_64)
-  iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8, NULL);
-  iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 8, 8, NULL);
+  iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8, "");
+  iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 8, 8, "");
 #elif defined(IREE_UK_ARCH_X86_64)
   iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8, "avx2_fma");
   iree_uk_test_unpack(IREE_UK_FLAG_UNPACK_TYPE_I32I32, 8, 8, "avx2_fma");

--- a/runtime/src/iree/builtins/ukernel/tools/util_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/util_test.c
@@ -69,4 +69,5 @@ static void iree_uk_test_make_cpu_data_for_features(iree_uk_test_t* test,
 int main(int argc, char** argv) {
   iree_uk_test("make_cpu_data_for_features",
                iree_uk_test_make_cpu_data_for_features, NULL, "");
+  return EXIT_SUCCESS;  // failures are fatal
 }

--- a/runtime/src/iree/builtins/ukernel/tools/util_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/util_test.c
@@ -1,0 +1,72 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/tools/util.h"
+
+#include "iree/base/internal/cpu.h"
+#include "iree/builtins/ukernel/tools/test.h"
+#include "iree/schemas/cpu_data.h"
+
+static void iree_uk_test_make_cpu_data_for_features_case(
+    iree_uk_test_t* test, const char* cpu_features,
+    const iree_uk_uint64_t* expected) {
+  iree_uk_uint64_t actual[IREE_CPU_DATA_FIELD_COUNT] = {0};
+  iree_uk_make_cpu_data_for_features(cpu_features, actual);
+  for (int i = 0; i < IREE_CPU_DATA_FIELD_COUNT; ++i) {
+    if (actual[i] != expected[i]) {
+      IREE_UK_TEST_FAIL(test);
+    }
+  }
+}
+
+static void iree_uk_test_make_cpu_data_for_features(iree_uk_test_t* test,
+                                                    const void* params) {
+  (void)params;
+  // Special CPU feature strings understood across architectures.
+  iree_uk_uint64_t expected[IREE_CPU_DATA_FIELD_COUNT] = {0};
+  iree_uk_test_make_cpu_data_for_features_case(test, "", expected);
+  iree_uk_test_make_cpu_data_for_features_case(
+      test, "host", (const iree_uk_uint64_t*)iree_cpu_data_fields());
+
+#if defined(IREE_UK_ARCH_X86_64)
+  // Individual x86-64 features.
+  expected[0] = IREE_CPU_DATA0_X86_64_AVX;
+  iree_uk_test_make_cpu_data_for_features_case(test, "avx", expected);
+  // Comma-separated lists of x86-64 features.
+  expected[0] = IREE_CPU_DATA0_X86_64_AVX | IREE_CPU_DATA0_X86_64_AVX2 |
+                IREE_CPU_DATA0_X86_64_FMA;
+  iree_uk_test_make_cpu_data_for_features_case(test, "avx,avx2,fma", expected);
+  // Named x86-64 feature sets.
+  iree_uk_uint64_t avx2_fma =
+      IREE_CPU_DATA0_X86_64_AVX2 | IREE_CPU_DATA0_X86_64_FMA;
+  iree_uk_uint64_t avx512_base =
+      avx2_fma | IREE_CPU_DATA0_X86_64_AVX512F |
+      IREE_CPU_DATA0_X86_64_AVX512BW | IREE_CPU_DATA0_X86_64_AVX512DQ |
+      IREE_CPU_DATA0_X86_64_AVX512VL | IREE_CPU_DATA0_X86_64_AVX512CD;
+  iree_uk_uint64_t avx512_vnni = avx512_base | IREE_CPU_DATA0_X86_64_AVX512VNNI;
+  expected[0] = avx2_fma;
+  iree_uk_test_make_cpu_data_for_features_case(test, "avx2_fma", expected);
+  expected[0] = avx512_base;
+  iree_uk_test_make_cpu_data_for_features_case(test, "avx512_base", expected);
+  expected[0] = avx512_vnni;
+  iree_uk_test_make_cpu_data_for_features_case(test, "avx512_vnni", expected);
+
+#elif defined(IREE_UK_ARCH_ARM_64)
+  // Individual arm64 features.
+  expected[0] = IREE_CPU_DATA0_ARM_64_DOTPROD;
+  iree_uk_test_make_cpu_data_for_features_case(test, "dotprod", expected);
+  // Comma-separated lists of arm features.
+  expected[0] = IREE_CPU_DATA0_ARM_64_DOTPROD | IREE_CPU_DATA0_ARM_64_I8MM;
+  iree_uk_test_make_cpu_data_for_features_case(test, "dotprod,i8mm", expected);
+  // Named arm64 feature sets: none at the moment.
+
+#endif  // defined(IREE_UK_ARCH_X86_64)
+}
+
+int main(int argc, char** argv) {
+  iree_uk_test("make_cpu_data_for_features",
+               iree_uk_test_make_cpu_data_for_features, NULL, "");
+}


### PR DESCRIPTION
* Support comma-separated lists of features (existing TODO)
* Add `util_test`, test the mapping of cpu feature strings to bits --- had gotten nontrivial enough, and a bug there could silently affect test coverage.
* Use empty string instead of NULL for no CPU features -- we had 2 null-values here, should have only one. That part was #13229.
* Make `base/internal/cpu.h` no longer include `iree/schemas/cpu_data.h` - it doesn't need it anymore and it's best to have users not rely on it to include that for them.