### PR TITLE
benchmark: doubling batch count, set bytes processed

### DIFF
--- a/runtime/src/iree/builtins/ukernel/tools/memcpy_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/memcpy_benchmark.c
@@ -28,24 +28,22 @@ static iree_status_t iree_uk_benchmark_memcpy(
       benchmark_def->user_data;
 
   int64_t total_iterations = 0;
-  int64_t batch_count =
-      (user_data->batch_min_traversal_size + user_data->working_set_size - 1) /
-      user_data->working_set_size;
   iree_uk_ssize_t buffer_size = user_data->working_set_size / 2;
   uint8_t* in_buffer = malloc(buffer_size);
   uint8_t* out_buffer = malloc(buffer_size);
   for (iree_uk_ssize_t i = 0; i < buffer_size; ++i) in_buffer[i] = (i & 0xFF);
-  while (iree_benchmark_keep_running(benchmark_state,
-                                     /*batch_count=*/batch_count)) {
+  int64_t batch_count = 1;
+  while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
     for (int i = 0; i < batch_count; ++i) {
       iree_memcpy_noinline(out_buffer, in_buffer, buffer_size);
     }
     total_iterations += batch_count;
+    batch_count *= 2;
   }
   // Report bytes per second, so that can be easily compared to known memory
   // system performance metrics (e.g. RAM bandwidth, to tell whether this is
   // memory-bound).
-  iree_benchmark_set_items_processed(benchmark_state,
+  iree_benchmark_set_bytes_processed(benchmark_state,
                                      total_iterations * buffer_size);
   assert(!memcmp(in_buffer, out_buffer, buffer_size));
   free(in_buffer);
@@ -53,13 +51,11 @@ static iree_status_t iree_uk_benchmark_memcpy(
   return iree_ok_status();
 }
 
-void iree_uk_benchmark_register_memcpy(int64_t working_set_size,
-                                       int64_t batch_min_traversal_size) {
+void iree_uk_benchmark_register_memcpy(int64_t working_set_size) {
   iree_uk_benchmark_memcpy_user_data_t* user_data =
       iree_uk_benchmark_static_alloc(
           sizeof(iree_uk_benchmark_memcpy_user_data_t));
   user_data->working_set_size = working_set_size;
-  user_data->batch_min_traversal_size = batch_min_traversal_size;
 
   const iree_benchmark_def_t memcpy_benchmark_def = {
       .flags = IREE_BENCHMARK_FLAG_USE_REAL_TIME,

--- a/runtime/src/iree/builtins/ukernel/tools/memcpy_benchmark.h
+++ b/runtime/src/iree/builtins/ukernel/tools/memcpy_benchmark.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 
-void iree_uk_benchmark_register_memcpy(int64_t working_set_size,
-                                       int64_t batch_min_traversal_size);
+void iree_uk_benchmark_register_memcpy(int64_t working_set_size);
 
 #endif  // IREE_BUILTINS_UKERNEL_TOOLS_MEMCPY_BENCHMARK_H_

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -13,7 +13,6 @@
 #include "iree/builtins/ukernel/tools/benchmark.h"
 #include "iree/builtins/ukernel/tools/util.h"
 
-IREE_FLAG(int32_t, batch_count, 1000, "Ops to run per benchmark iteration.");
 IREE_FLAG(int32_t, m_size, 1,
           "M-dimension of mmt4d ops. The overall number of rows of the "
           "accumulator is that times the M0 tile size.");
@@ -69,12 +68,13 @@ static iree_status_t iree_uk_benchmark_mmt4d(
   params.rhs_buffer = rhs_buffer;
   params.out_buffer = out_buffer;
   int64_t total_iterations = 0;
-  while (iree_benchmark_keep_running(benchmark_state,
-                                     /*batch_count=*/FLAG_batch_count)) {
-    for (int i = 0; i < FLAG_batch_count; ++i) {
+  int64_t batch_count = 1;
+  while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
+    for (int i = 0; i < batch_count; ++i) {
       iree_uk_mmt4d(&params);
     }
-    total_iterations += FLAG_batch_count;
+    total_iterations += batch_count;
+    batch_count *= 2;
   }
   iree_benchmark_set_items_processed(
       benchmark_state, total_iterations * 2 * params.M * params.N * params.K *

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -14,9 +14,6 @@
 #include "iree/builtins/ukernel/tools/memcpy_benchmark.h"
 #include "iree/builtins/ukernel/tools/util.h"
 
-IREE_FLAG(int64_t, batch_min_traversal_size, 10000000,
-          "Minimum number of bytes to be traversed in each batch.");
-
 IREE_FLAG(
     int64_t, working_set_size, 10000,
     "Number of bytes to be traversed by the benchmark workload (input and "
@@ -85,20 +82,18 @@ static iree_status_t iree_uk_benchmark_pack(
   params.out_buffer = out_buffer;
   params.padding_value = 0;
   int64_t total_iterations = 0;
-  int64_t batch_count =
-      (FLAG_batch_min_traversal_size + FLAG_working_set_size - 1) /
-      FLAG_working_set_size;
-  while (iree_benchmark_keep_running(benchmark_state,
-                                     /*batch_count=*/batch_count)) {
+  int64_t batch_count = 1;
+  while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
     for (int i = 0; i < batch_count; ++i) {
       iree_uk_pack(&params);
     }
     total_iterations += batch_count;
+    batch_count *= 2;
   }
   // Report bytes per second, so that can be easily compared to known memory
   // system performance metrics (e.g. RAM bandwidth, to tell whether this is
   // memory-bound).
-  iree_benchmark_set_items_processed(benchmark_state,
+  iree_benchmark_set_bytes_processed(benchmark_state,
                                      total_iterations * out_buffer_size);
   free(in_buffer);
   free(out_buffer);
@@ -143,8 +138,7 @@ int main(int argc, char** argv) {
 
   // The memcpy benchmark provides a useful comparison point, as pack is fairly
   // close to memory-bound.
-  iree_uk_benchmark_register_memcpy(FLAG_working_set_size,
-                                    FLAG_batch_min_traversal_size);
+  iree_uk_benchmark_register_memcpy(FLAG_working_set_size);
 
 #if defined(IREE_UK_ARCH_ARM_64)
   iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, NULL);

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -92,7 +92,7 @@ static iree_status_t iree_uk_benchmark_unpack(
   // Report bytes per second, so that can be easily compared to known memory
   // system performance metrics (e.g. RAM bandwidth, to tell whether this is
   // memory-bound).
-  iree_benchmark_set_items_processed(benchmark_state,
+  iree_benchmark_set_bytes_processed(benchmark_state,
                                      total_iterations * out_buffer_size);
   free(in_buffer);
   free(out_buffer);

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -14,9 +14,6 @@
 #include "iree/builtins/ukernel/tools/util.h"
 #include "iree/builtins/ukernel/unpack_internal.h"
 
-IREE_FLAG(int64_t, batch_min_traversal_size, 10000000,
-          "Minimum number of bytes to be traversed in each batch.");
-
 IREE_FLAG(
     int64_t, working_set_size, 10000,
     "Number of bytes to be traversed by the benchmark workload (input and "
@@ -84,15 +81,13 @@ static iree_status_t iree_uk_benchmark_unpack(
   params.in_buffer = in_buffer;
   params.out_buffer = out_buffer;
   int64_t total_iterations = 0;
-  int64_t batch_count =
-      (FLAG_batch_min_traversal_size + FLAG_working_set_size - 1) /
-      FLAG_working_set_size;
-  while (iree_benchmark_keep_running(benchmark_state,
-                                     /*batch_count=*/batch_count)) {
+  int64_t batch_count = 1;
+  while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
     for (int i = 0; i < batch_count; ++i) {
       iree_uk_unpack(&params);
     }
     total_iterations += batch_count;
+    batch_count *= 2;
   }
   // Report bytes per second, so that can be easily compared to known memory
   // system performance metrics (e.g. RAM bandwidth, to tell whether this is
@@ -143,8 +138,7 @@ int main(int argc, char** argv) {
 
   // The memcpy benchmark provides a useful comparison point, as pack is fairly
   // close to memory-bound.
-  iree_uk_benchmark_register_memcpy(FLAG_working_set_size,
-                                    FLAG_batch_min_traversal_size);
+  iree_uk_benchmark_register_memcpy(FLAG_working_set_size);
 
 #if defined(IREE_UK_ARCH_ARM_64)
   iree_uk_benchmark_register_unpack(IREE_UK_FLAG_UNPACK_TYPE_F32F32, 8, 8,


### PR DESCRIPTION
* Drop `batch_count` flags. We don't really need to control batch counts on the command line, we need sane defaults.
* Use a simple doubling strategy for batch counts. This is now implemented locally in each benchmark (1 line of code), in contrast to earlier approach #12917 that tried to standardize this in the benchmark library (that's not really ready for that).
* In memcpy-ish benchmarks that report bytes per second, use the built-in support for reporting bytes per second.