### PR TITLE
Move the tiling logic out of DecomposePackUnPackOps pass.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -26,6 +26,40 @@ namespace mlir {
 namespace iree_compiler {
 namespace {
 
+/// A warpper pattern that calls linalg::lowerPack on tensor::PackOp. It lowers
+/// a tensor.pack op to tensor.pad + tensor.expand_shape + linalg.transpose ops.
+struct LowerPackPattern : public OpRewritePattern<tensor::PackOp> {
+  using OpRewritePattern<tensor::PackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::PackOp op,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<linalg::LowerPackResult> res = linalg::lowerPack(rewriter, op);
+    if (failed(res)) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot lower to pad + expand + transpose");
+    }
+    return success();
+  }
+};
+
+/// A warpper pattern that calls linalg::lowerUnPack on tensor::UnPackOp. It
+/// lowers a tensor.unpack op to tensor.empty + linalg.transpose +
+/// tensor.collapse_shape + tensor.extract_slice ops.
+struct LowerUnPackPattern : public OpRewritePattern<tensor::UnPackOp> {
+  using OpRewritePattern<tensor::UnPackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::UnPackOp op,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<linalg::LowerUnPackOpResult> res =
+        linalg::lowerUnPack(rewriter, op);
+    if (failed(res)) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot lower to empty + transpose + reshape + extract_slice");
+    }
+    return success();
+  }
+};
+
 struct DecomposePackUnPackOpsPass
     : public DecomposePackUnPackOpsBase<DecomposePackUnPackOpsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -41,6 +75,23 @@ struct DecomposePackUnPackOpsPass
 void DecomposePackUnPackOpsPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   auto funcOp = getOperation();
+  {
+    RewritePatternSet patterns(ctx);
+    // Generalization patterns for outer unit dims have higher prirority because
+    // they do not generate reshape ops.
+    patterns.add<linalg::GeneralizeOuterUnitDimsPackOpPattern,
+                 linalg::GeneralizeOuterUnitDimsUnPackOpPattern>(
+        ctx,
+        /*benefit=*/10);
+    patterns.add<LowerPackPattern, LowerUnPackPattern>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+
+  // TODO(hanchung): Below is a fallback solution for tensor.pack/unpack
+  // decomposition. They will be retired after lowerPack and lowerUnPack handle
+  // all the cases.
 
   // Apply tiling to make outer dims be all 1s.
   {
@@ -97,34 +148,41 @@ void DecomposePackUnPackOpsPass::runOnOperation() {
       if (failed(tilingResult)) return signalPassFailure();
       rewriter.replaceOp(op, tilingResult->replacements);
     });
+
+    LLVM_DEBUG({
+      llvm::dbgs()
+          << "--- After applying tiling that makes outer dims be all 1s ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
   }
 
-  LLVM_DEBUG({
-    llvm::dbgs()
-        << "--- After applying tiling that makes outer dims be all 1s ---\n";
-    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-    llvm::dbgs() << "\n\n";
-  });
-
-  // Generalize pack and unpack ops and canonicalize tiled ops.
+  // Canonicalize tiled ops.
   {
     RewritePatternSet patterns(ctx);
     linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
     memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
-    patterns.add<linalg::GeneralizeOuterUnitDimsPackOpPattern,
-                 linalg::GeneralizeOuterUnitDimsUnPackOpPattern>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    ctx->getOrLoadDialect<tensor::TensorDialect>()->getCanonicalizationPatterns(
+        patterns);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }
 
   LLVM_DEBUG({
-    llvm::dbgs()
-        << "--- After generalizing tensor.pack and tensor.unpack ops ---\n";
+    llvm::dbgs() << "--- After canonicalizing tiled ops ---\n";
     funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
     llvm::dbgs() << "\n\n";
   });
+
+  {
+    RewritePatternSet patterns(ctx);
+    patterns.add<linalg::GeneralizeOuterUnitDimsPackOpPattern,
+                 linalg::GeneralizeOuterUnitDimsUnPackOpPattern>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_pack_unpack_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_pack_unpack_ops.mlir
@@ -53,39 +53,15 @@ func.func @KCRS_to_KCRSsr(%arg0: tensor<1x1x128x64xf32>, %arg1: tensor<1x1x4x8x8
   %0 = tensor.pack %arg0 inner_dims_pos = [3, 2] inner_tiles = [8, 32] into %arg1 : tensor<1x1x128x64xf32> -> tensor<1x1x4x8x8x32xf32>
   return %0 : tensor<1x1x4x8x8x32xf32>
 }
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0) -> (d0 * 32)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (d0 * 8)>
 // CHECK:       func.func @KCRS_to_KCRSsr
 // CHECK-SAME:    %[[IN:[A-Za-z0-9]+]]:
 // CHECK-SAME:    %[[OUT:[A-Za-z0-9]+]]:
-// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : index
-// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
-// CHECK:         %[[RES0:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[C4]] step %[[C1]]
-// CHECK-SAME:      iter_args(%[[ITER0:.+]] = %[[OUT]])
-// CHECK:           %[[RES1:.+]] = scf.for %[[J:.+]] = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK-SAME:        iter_args(%[[ITER1:.+]] = %[[ITER0]])
-// CHECK-DAG:         %[[IDX2:.+]] = affine.apply #[[MAP0]](%[[I]])
-// CHECK-DAG:         %[[IDX3:.+]] = affine.apply #[[MAP1]](%[[J]])
-// CHECK:             %[[IN_SLICE:.+]] = tensor.extract_slice %[[IN]]
-// CHECK-SAME:          [0, 0, %[[IDX2]], %[[IDX3]]] [1, 1, 32, 8] [1, 1, 1, 1]
-// CHECK:             %[[ITER_SLICE:.+]] = tensor.extract_slice %[[ITER1]]
-// CHECK-SAME:          [0, 0, %[[I]], %[[J]], 0, 0] [1, 1, 1, 1, 8, 32] [1, 1, 1, 1, 1, 1]
-// CHECK-SAME:          tensor<1x1x4x8x8x32xf32> to tensor<1x1x1x1x8x32xf32>
-// CHECK:             %[[TILE:.+]] = tensor.extract_slice %[[IN_SLICE]]
-// CHECK-SAME:          [0, 0, 0, 0] [1, 1, 32, 8] [1, 1, 1, 1]
-// CHECK-SAME:          tensor<1x1x32x8xf32> to tensor<32x8xf32>
-// CHECK:             %[[EMPTY:.+]] = tensor.empty() : tensor<8x32xf32>
-// CHECK:             %[[TRANS:.+]] = linalg.transpose ins(%[[TILE]] : tensor<32x8xf32>) outs(%[[EMPTY]] : tensor<8x32xf32>) permutation = [1, 0]
-// CHECK:             %[[INSERT0:.+]] = tensor.insert_slice %[[TRANS]] into %[[ITER_SLICE]][0, 0, 0, 0, 0, 0] [1, 1, 1, 1, 8, 32] [1, 1, 1, 1, 1, 1]
-// CHECK:             %[[INSERT1:.+]] = tensor.insert_slice %[[INSERT0]] into %[[ITER1]]
-// CHECK-SAME:          [0, 0, %[[I]], %[[J]], 0, 0]
-// CHECK:             scf.yield %[[INSERT1]]
-// CHECK:           }
-// CHECK:           scf.yield %[[RES1]]
-// CHECK:         }
-// CHECK:         return %[[RES0]]
+// CHECK:         %[[EXPAND:.+]] = tensor.expand_shape %[[IN]] {{\[}}[0], [1], [2, 3], [4, 5]] : tensor<1x1x128x64xf32> into tensor<1x1x4x32x8x8xf32>
+// CHECK:          %[[TRANSP:.+]] = linalg.transpose
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<1x1x4x32x8x8xf32>)
+// CHECK-SAME:       outs(%[[OUT]] : tensor<1x1x4x8x8x32xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 5, 3]
+// CHECK:         return %[[TRANSP]]
 
 // -----
 
@@ -93,45 +69,22 @@ func.func @pad_and_pack(%arg0: tensor<13x15xf32>, %arg1: tensor<2x8x8x2xf32>, %a
   %0 = tensor.pack %arg0 padding_value(%arg2 : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 2] into %arg1 : tensor<13x15xf32> -> tensor<2x8x8x2xf32>
   return %0 : tensor<2x8x8x2xf32>
 }
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0) -> (d0 * 8)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (d0 * -8 + 13, 8)>
-// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0) -> (d0 * 2)>
-// CHECK-DAG:   #[[MAP3:.+]] = affine_map<(d0) -> (d0 * -2 + 15, 2)>
-// CHECK-DAG:   #[[MAP4:.+]] = affine_map<(d0) -> (-d0 + 8)>
-// CHECK-DAG:   #[[MAP5:.+]] = affine_map<(d0) -> (-d0 + 2)>
 // CHECK:       func.func @pad_and_pack
 // CHECK-SAME:    %[[IN:[A-Za-z0-9]+]]:
 // CHECK-SAME:    %[[OUT:[A-Za-z0-9]+]]:
 // CHECK-SAME:    %[[PAD_VAL:[A-Za-z0-9]+]]:
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
-// CHECK:         %[[RES0:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
-// CHECK-SAME:      iter_args(%[[ITER0:.+]] = %[[OUT]])
-// CHECK:           %[[RES1:.+]] = scf.for %[[J:.+]] = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK-SAME:        iter_args(%[[ITER1:.+]] = %[[ITER0]])
-// CHECK-DAG:         %[[IDX0:.+]] = affine.apply #[[MAP0]](%[[I]])
-// CHECK-DAG:         %[[SZ0:.+]] = affine.min #[[MAP1]](%[[I]])
-// CHECK-DAG:         %[[IDX1:.+]] = affine.apply #[[MAP2]](%[[J]])
-// CHECK-DAG:         %[[SZ1:.+]] = affine.min #[[MAP3]](%[[J]])
-// CHECK:             %[[TILE:.+]] = tensor.extract_slice %[[IN]][%[[IDX0]], %[[IDX1]]] [%[[SZ0]], %[[SZ1]]]
-// CHECK:             %[[ITER_SLICE:.+]] = tensor.extract_slice %[[ITER1]]
-// CHECK-SAME:          [%[[I]], %[[J]], 0, 0] [1, 1, 8, 2] [1, 1, 1, 1]
-// CHECK:             %[[H0:.+]] = affine.apply #[[MAP4]](%[[SZ0]])
-// CHECK:             %[[H1:.+]] = affine.apply #[[MAP5]](%[[SZ1]])
-// CHECK:             %[[PAD:.+]] = tensor.pad %[[TILE]] low[%[[C0]], %[[C0]]] high[%[[H0]], %[[H1]]]
-// CHECK:               tensor.yield %[[PAD_VAL]]
-// CHECK:             %[[EMPTY:.+]] = tensor.empty() : tensor<8x2xf32>
-// CHECK:             %[[TRANS:.+]] = linalg.transpose ins(%[[PAD]] : tensor<8x2xf32>) outs(%[[EMPTY:.+]] : tensor<8x2xf32>) permutation = [0, 1]
-// CHECK:             %[[INSERT0:.+]] = tensor.insert_slice %[[TRANS]] into %[[ITER_SLICE]][0, 0, 0, 0] [1, 1, 8, 2] [1, 1, 1, 1]
-// CHECK:             %[[INSERT1:.+]] = tensor.insert_slice %[[INSERT0]] into %[[ITER1]]
-// CHECK-SAME:          [%[[I]], %[[J]], 0, 0]
-// CHECK:             scf.yield %[[INSERT1]]
-// CHECK:           }
-// CHECK:           scf.yield %[[RES1]]
-// CHECK:         }
-// CHECK:         return %[[RES0]]
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         %[[PAD:.+]] = tensor.pad %[[IN]] low[%[[C0]], %[[C0]]] high[%[[C3]], %[[C1]]]
+// CHECK:           tensor.yield %[[PAD_VAL]]
+// CHECK:         } : tensor<13x15xf32> to tensor<16x16xf32>
+// CHECK:         %[[EXPAND:.+]] = tensor.expand_shape %[[PAD]] {{\[}}[0, 1], [2, 3]] : tensor<16x16xf32> into tensor<2x8x8x2xf32>
+// CHECK:         %[[TRANS:.+]] = linalg.transpose
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<2x8x8x2xf32>)
+// CHECK-SAME:      outs(%[[OUT:.+]] : tensor<2x8x8x2xf32>)
+// CHECK-SAME:      permutation = [0, 2, 1, 3]
+// CHECK:         return %[[TRANSP]]
 
 // -----
 
@@ -139,34 +92,15 @@ func.func @KC_to_CKck(%arg0: tensor<128x256xf32>, %arg1: tensor<32x4x32x8xf32>) 
   %0 = tensor.pack %arg0 outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 8] into %arg1 : tensor<128x256xf32> -> tensor<32x4x32x8xf32>
   return %0 : tensor<32x4x32x8xf32>
 }
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0) -> (d0 * 32)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (d0 * 8)>
 // CHECK:       func.func @KC_to_CKck
 // CHECK-SAME:    %[[IN:[A-Za-z0-9]+]]:
 // CHECK-SAME:    %[[OUT:[A-Za-z0-9]+]]:
-// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : index
-// CHECK-DAG:     %[[C32:.+]] = arith.constant 32 : index
-// CHECK:         %[[RES0:.+]] = scf.for %[[C:.+]] = %[[C0]] to %[[C32]] step %[[C1]]
-// CHECK-SAME:      iter_args(%[[ITER0:.+]] = %[[OUT]])
-// CHECK:           %[[RES1:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C4]] step %[[C1]]
-// CHECK-SAME:        iter_args(%[[ITER1:.+]] = %[[ITER0]])
-// CHECK-DAG:         %[[IN_K:.+]] = affine.apply #[[MAP0]](%[[K]])
-// CHECK-DAG:         %[[IN_C:.+]] = affine.apply #[[MAP1]](%[[C]])
-// CHECK:             %[[TILE:.+]] = tensor.extract_slice %[[IN]][%[[IN_K]], %[[IN_C]]] [32, 8] [1, 1]
-// CHECK:             %[[ITER_SLICE:.+]] = tensor.extract_slice %[[ITER1]]
-// CHECK-SAME:          [%[[C]], %[[K]], 0, 0] [1, 1, 32, 8] [1, 1, 1, 1]
-// CHECK:             %[[EMPTY:.+]] = tensor.empty() : tensor<32x8xf32>
-// CHECK:             %[[TRANS:.+]] = linalg.transpose ins(%[[TILE]] : tensor<32x8xf32>) outs(%[[EMPTY:.+]] : tensor<32x8xf32>) permutation = [0, 1]
-// CHECK:             %[[INSERT:.+]] = tensor.insert_slice %[[TRANS]] into %[[ITER_SLICE]][0, 0, 0, 0] [1, 1, 32, 8] [1, 1, 1, 1]
-// CHECK:             %[[INSERT1:.+]] = tensor.insert_slice %[[INSERT0]] into %[[ITER1]]
-// CHECK-SAME:          [%[[C]], %[[K]], 0, 0] [1, 1, 32, 8] [1, 1, 1, 1]
-// CHECK:             scf.yield %[[INSERT1]]
-// CHECK:           }
-// CHECK:           scf.yield %[[RES1]]
-// CHECK:         }
-// CHECK:         return %[[RES0]]
+// CHECK:         %[[EXPAND:.+]] = tensor.expand_shape %[[IN]] {{\[}}[0, 1], [2, 3]] : tensor<128x256xf32> into tensor<4x32x32x8xf32>
+// CHECK:         %[[TRANSP:.+]] = linalg.transpose
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<4x32x32x8xf32>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<32x4x32x8xf32>)
+// CHECK-SAME:      permutation = [2, 0, 1, 3]
+// CHECK:         return %[[TRANSP]]
 
 // -----
 
@@ -219,47 +153,17 @@ func.func @KCRSsr_to_KCRS(%arg0: tensor<13x12x4x8x8x32xf32>, %arg1: tensor<13x12
   %0 = tensor.unpack %arg0 inner_dims_pos = [3, 2] inner_tiles = [8, 32] into %arg1 : tensor<13x12x4x8x8x32xf32> -> tensor<13x12x128x64xf32>
   return %0 : tensor<13x12x128x64xf32>
 }
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0) -> (d0 floordiv 32)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (d0 floordiv 8)>
 // CHECK:       func.func @KCRSsr_to_KCRS
 // CHECK-SAME:    %[[IN:[A-Za-z0-9]+]]:
 // CHECK-SAME:    %[[OUT:[A-Za-z0-9]+]]:
-// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:     %[[C12:.+]] = arith.constant 12 : index
-// CHECK-DAG:     %[[C13:.+]] = arith.constant 13 : index
-// CHECK-DAG:     %[[C32:.+]] = arith.constant 32 : index
-// CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : index
-// CHECK-DAG:     %[[C128:.+]] = arith.constant 128 : index
-// CHECK:         %[[RES0:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C13]] step %[[C1]]
-// CHECK-SAME:      iter_args(%[[ITER0:.+]] = %[[OUT]])
-// CHECK:         %[[RES1:.+]] = scf.for %[[C:.+]] = %[[C0]] to %[[C12]] step %[[C1]]
-// CHECK-SAME:      iter_args(%[[ITER1:.+]] = %[[ITER0]])
-// CHECK:         %[[RES2:.+]] = scf.for %[[R:.+]] = %[[C0]] to %[[C128]] step %[[C32]]
-// CHECK-SAME:      iter_args(%[[ITER2:.+]] = %[[ITER1]])
-// CHECK:           %[[RES3:.+]] = scf.for %[[S:.+]] = %[[C0]] to %[[C64]] step %[[C8]]
-// CHECK-SAME:        iter_args(%[[ITER3:.+]] = %[[ITER2]])
-// CHECK-DAG:         %[[IN_R:.+]] = affine.apply #[[MAP0]](%[[R]])
-// CHECK-DAG:         %[[IN_S:.+]] = affine.apply #[[MAP1]](%[[S]])
-// CHECK-DAG:         %[[IN_SLICE:.+]] = tensor.extract_slice %[[IN]]
-// CHECK-SAME:          [%[[K]], %[[C]], %[[IN_R]], %[[IN_S]], 0, 0] [1, 1, 1, 1, 8, 32] [1, 1, 1, 1, 1, 1]
-// CHECK-DAG:         %[[ITER3_SLICE:.+]] = tensor.extract_slice %[[ITER3]]
-// CHECK-SAME:          [%[[K]], %[[C]], %[[R]], %[[S]]] [1, 1, 32, 8] [1, 1, 1, 1]
-// CHECK-DAG:         %[[TILE:.+]] = tensor.extract_slice %[[IN_SLICE]]
-// CHECK-SAME:          [0, 0, 0, 0, 0, 0] [1, 1, 1, 1, 8, 32] [1, 1, 1, 1, 1, 1]
-// CHECK:             %[[EMPTY:.+]] = tensor.empty() : tensor<32x8xf32>
-// CHECK:             %[[TRANS:.+]] = linalg.transpose ins(%[[TILE]] : tensor<8x32xf32>) outs(%[[EMPTY]] : tensor<32x8xf32>) permutation = [1, 0]
-// CHECK:             %[[INSERT0:.+]] = tensor.insert_slice %[[TRANS]] into %[[ITER3_SLICE]][0, 0, 0, 0] [1, 1, 32, 8] [1, 1, 1, 1]
-// CHECK:             %[[INSERT1:.+]] = tensor.insert_slice %[[INSERT0]]
-// CHECK-SAME:          into %[[ITER3]][%[[K]], %[[C]], %[[R]], %[[S]]] [1, 1, 32, 8] [1, 1, 1, 1]
-// CHECK:             scf.yield %[[INSERT1]]
-// CHECK:           }
-// CHECK:           scf.yield %[[RES3]]
-// CHECK:         }
-// CHECK:         scf.yield %[[RES2]]
-// CHECK:         scf.yield %[[RES1]]
-// CHECK:         return %[[RES0]]
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<13x12x4x32x8x8xf32>
+// CHECK:         %[[TRANSP:.+]] = linalg.transpose
+// CHECK-SAME:      ins(%[[IN]] : tensor<13x12x4x8x8x32xf32>)
+// CHECK-SAME:      outs(%[[EMPTY]] : tensor<13x12x4x32x8x8xf32>)
+// CHECK-SAME:      permutation = [0, 1, 2, 5, 3, 4]
+// CHECK:         %[[COLLAPSE:.+]] = tensor.collapse_shape %[[TRANSP]]
+// CHECK-SAME:      {{\[}}[0], [1], [2, 3], [4, 5]] : tensor<13x12x4x32x8x8xf32> into tensor<13x12x128x64xf32>
+// CHECK:         return %[[COLLAPSE]]
 
 // -----
 
@@ -267,44 +171,19 @@ func.func @unpack_and_extract_slice(%arg0: tensor<2x8x8x2xf32>, %arg1: tensor<13
   %0 = tensor.unpack %arg0 inner_dims_pos = [0, 1] inner_tiles = [8, 2] into %arg1 : tensor<2x8x8x2xf32> -> tensor<13x15xf32>
   return %0 : tensor<13x15xf32>
 }
-// CHECK-DAG:  #[[MAP0:.+]] = affine_map<(d0) -> (-d0 + 13, 8)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0) -> (-d0 + 15, 2)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 floordiv 8)>
-// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0) -> (d0 floordiv 2)>
 // CHECK:      func.func @unpack_and_extract_slice
 // CHECK-SAME:   %[[IN:[A-Za-z0-9]+]]:
 // CHECK-SAME:   %[[OUT:[A-Za-z0-9]+]]:
-// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:    %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:    %[[C13:.+]] = arith.constant 13 : index
-// CHECK-DAG:    %[[C15:.+]] = arith.constant 15 : index
-// CHECK:        %[[RES0:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[C13]] step %[[C8]]
-// CHECK-SAME:     iter_args(%[[ITER0:.+]] = %[[OUT]])
-// CHECK-DAG:      %[[OUT_I_SZ:.+]] = affine.min #[[MAP0]](%[[I]])
-// CHECK:          %[[RES1:.+]] = scf.for %[[J:.+]] = %[[C0]] to %[[C15]] step %[[C2]]
-// CHECK-SAME:       iter_args(%[[ITER1:.+]] = %[[ITER0]])
-// CHECK-DAG:        %[[OUT_J_SZ:.+]] = affine.min #[[MAP1]](%[[J]])
-// CHECK-DAG:        %[[IN_I:.+]] = affine.apply #[[MAP2]](%[[I]])
-// CHECK-DAG:        %[[IN_J:.+]] = affine.apply #[[MAP3]](%[[J]])
-// CHECK-DAG:        %[[IN_SLICE]] = tensor.extract_slice %[[IN]]
-// CHECK-SAME:         [%[[IN_I]], %[[IN_J]], 0, 0] [1, 1, 8, 2] [1, 1, 1, 1]
-// CHECK-DAG:        %[[ITER1_SLICE1:.+]] = tensor.extract_slice %[[ITER1]]
-// CHECK-SAME:         [%[[I]], %[[J]]] [%[[OUT_I_SZ]], %[[OUT_J_SZ]]] [1, 1]
-// CHECK:            %[[TILE:.+]] = tensor.extract_slice %[[IN_SLICE]][0, 0, 0, 0] [1, 1, 8, 2] [1, 1, 1, 1]
-// CHECK:            %[[EMPTY:.+]] = tensor.empty() : tensor<8x2xf32>
-// CHECK:            %[[TRANS:.+]] = linalg.transpose ins(%[[TILE]] : tensor<8x2xf32>) outs(%[[EMPTY]] : tensor<8x2xf32>) permutation = [0, 1]
-// CHECK:            %[[TRANS_SLICE:.+]] = tensor.extract_slice %[[TRANS]][0, 0] [%[[OUT_I_SZ]], %[[OUT_J_SZ]]] [1, 1]
-// CHECK:            %[[INSERT1:.+]] = tensor.insert_slice %[[TRANS_SLICE]]
-// CHECK-SAME:         into %[[ITER1_SLICE1]][0, 0] [%[[OUT_I_SZ]], %[[OUT_J_SZ]]] [1, 1]
-// CHECK:            %[[INSERT2:.+]] = tensor.insert_slice %[[INSERT1]]
-// CHECK-SAME:         into %[[ITER1]][%[[I]], %[[J]]] [%[[OUT_I_SZ]], %[[OUT_J_SZ]]] [1, 1]
-// CHECK:            scf.yield %[[INSERT2]]
-// CHECK:          }
-// CHECK:          scf.yield %[[RES1]]
-// CHECK:        }
-// CHECK:        return %[[RES0]]
-
+// CHECK:          %[[EMPTY:.+]] = tensor.empty() : tensor<2x8x8x2xf32>
+// CHECK:          %[[TRANSP:.+]] = linalg.transpose
+// CHECK-SAME:       ins(%[[IN]] : tensor<2x8x8x2xf32>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<2x8x8x2xf32>)
+// CHECK-SAME:       permutation = [0, 2, 1, 3]
+// CHECK:          %[[COLLAPSE:.+]] = tensor.collapse_shape %[[TRANSP]]
+// CHECK-SAME:       {{\[}}[0, 1], [2, 3]] : tensor<2x8x8x2xf32> into tensor<16x16xf32>
+// CHECK:          %[[RES:.+]] = tensor.extract_slice %[[COLLAPSE]]
+// CHECK-SAME:       [0, 0] [13, 15] [1, 1] : tensor<16x16xf32> to tensor<13x15xf32>
+// CHECK:          return %[[RES]]
 // -----
 
 func.func @CKck_to_KC(%arg0: tensor<32x4x32x8xf32>, %arg1: tensor<128x256xf32>) -> tensor<128x256xf32> {
@@ -337,3 +216,53 @@ func.func @CKck_to_KC(%arg0: tensor<32x4x32x8xf32>, %arg1: tensor<128x256xf32>) 
 // CHECK:          scf.yield %[[RES1]]
 // CHECK:        }
 // CHECK:        return %[[RES0]]
+
+// -----
+
+func.func @pack_matmul_DYN_LHS(%src: tensor<?x?xf32>, %dest: tensor<?x?x16x1xf32>) -> tensor<?x?x16x1xf32> {
+  %pack = tensor.pack %src inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %dest : tensor<?x?xf32> -> tensor<?x?x16x1xf32>
+  return %pack : tensor<?x?x16x1xf32>
+}
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0) -> (d0 * 16)>
+// CHECK:      func.func @pack_matmul_DYN_LHS
+// CHECK-SAME:   %[[IN:[A-Za-z0-9]+]]:
+// CHECK-SAME:   %[[OUT:[A-Za-z0-9]+]]:
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:    %[[D0:.+]] = tensor.dim %[[OUT]], %c0 : tensor<?x?x16x1xf32>
+// CHECK-DAG:    %[[D1:.+]] = tensor.dim %[[OUT]], %c1 : tensor<?x?x16x1xf32>
+// CHECK:        %[[RES0:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[D0]] step %[[C1]]
+// CHECK-SAME:     iter_args(%[[ITER0:.+]] = %[[OUT]])
+// CHECK:          %[[RES1:.+]] = scf.for %[[J:.+]] = %[[C0]] to %[[D1]] step %[[C1]]
+// CHECK:            %[[IN_I:.+]] = affine.apply #[[MAP]](%[[I]])
+// CHECK:            %[[IN_TILE:.+]] = tensor.extract_slice %[[IN]][%[[IN_I]], %[[J]]] [16, 1] [1, 1]
+// CHECK:            %[[EMPTY:.+]] = tensor.empty() : tensor<16x1xf32>
+// CHECK:            %[[TRANSP:.+]] = linalg.transpose
+// CHECK-SAME:         ins(%[[IN_TILE]] : tensor<16x1xf32>)
+// CHECK-SAME:         outs(%[[EMPTY]] : tensor<16x1xf32>)
+// CHECK-SAME:         permutation = [0, 1]
+
+// -----
+
+func.func @pack_matmul_DYN_RHS(%src: tensor<?x?xf32>, %dest: tensor<?x?x16x1xf32>) -> tensor<?x?x16x1xf32> {
+  %pack = tensor.pack %src outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [16, 1] into %dest : tensor<?x?xf32> -> tensor<?x?x16x1xf32>
+  return %pack : tensor<?x?x16x1xf32>
+}
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0) -> (d0 * 16)>
+// CHECK:      func.func @pack_matmul_DYN_RHS
+// CHECK-SAME:   %[[IN:[A-Za-z0-9]+]]:
+// CHECK-SAME:   %[[OUT:[A-Za-z0-9]+]]:
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:    %[[D0:.+]] = tensor.dim %[[OUT]], %c0 : tensor<?x?x16x1xf32>
+// CHECK-DAG:    %[[D1:.+]] = tensor.dim %[[OUT]], %c1 : tensor<?x?x16x1xf32>
+// CHECK:        %[[RES0:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[D0]] step %[[C1]]
+// CHECK-SAME:     iter_args(%[[ITER0:.+]] = %[[OUT]])
+// CHECK:          %[[RES1:.+]] = scf.for %[[J:.+]] = %[[C0]] to %[[D1]] step %[[C1]]
+// CHECK:            %[[IN_I:.+]] = affine.apply #[[MAP]](%[[I]])
+// CHECK:            %[[IN_TILE:.+]] = tensor.extract_slice %[[IN]][%[[J]], %[[IN_I]]] [1, 16] [1, 1]
+// CHECK:            %[[EMPTY:.+]] = tensor.empty() : tensor<16x1xf32>
+// CHECK:            %[[TRANSP:.+]] = linalg.transpose
+// CHECK-SAME:         ins(%[[IN_TILE]] : tensor<1x16xf32>)
+// CHECK-SAME:         outs(%[[EMPTY]] : tensor<16x1xf32>)
+// CHECK-SAME:         permutation = [1, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1130,7 +1130,7 @@ static SmallVector<int64_t> getLinalgExtDefaultWorkgroupTileSizes(
 static LogicalResult setRootConfig(func::FuncOp entryPointFn,
                                    tensor::PackOp op) {
   assert(!getLoweringConfig(op) && "expected lowering_config is not set");
-  SmallVector<int64_t> tileSizes = getLinalgExtDefaultWorkgroupTileSizes(
+  SmallVector<int64_t> distTileSizes = getLinalgExtDefaultWorkgroupTileSizes(
       cast<TilingInterface>(op.getOperation()));
 
   // The default function aims to returns the number of workload per workgroup,
@@ -1139,12 +1139,15 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
   SmallVector<int64_t> innerTiles = op.getStaticTiles();
   ArrayRef<int64_t> dimPos = op.getInnerDimsPos();
   for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
-    if (tileSizes[pos] == 0 || ShapedType::isDynamic(size)) continue;
-    tileSizes[pos] = tileSizes[pos] / size;
-    tileSizes[pos] = std::max<int64_t>(tileSizes[pos], 1);
+    if (distTileSizes[pos] == 0 || ShapedType::isDynamic(size)) continue;
+    distTileSizes[pos] = distTileSizes[pos] / size;
+    distTileSizes[pos] = std::max<int64_t>(distTileSizes[pos], 1);
   }
 
-  TileSizesListType tileSizesList = {tileSizes};
+  SmallVector<int64_t> tileSizes(op.getSourceRank(), 1);
+  TileSizesListType tileSizesList = {distTileSizes};
+  tileSizesList.push_back(tileSizes);
+
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, op, tileSizesList,
       DispatchLoweringPassPipeline::CPUDataTiling);
@@ -1154,18 +1157,25 @@ static LogicalResult setUnPackOpRootConfig(
     func::FuncOp entryPointFn, tensor::UnPackOp op,
     DispatchLoweringPassPipeline pipeline =
         DispatchLoweringPassPipeline::CPUDataTiling) {
-  SmallVector<int64_t> tileSizes = getLinalgExtDefaultWorkgroupTileSizes(
+  SmallVector<int64_t> distTileSizes = getLinalgExtDefaultWorkgroupTileSizes(
       cast<TilingInterface>(op.getOperation()));
 
-  // Fixup for making tileSizes be multiple of inner_tile_sizes.
+  // Fixup for making distTileSizes be multiple of inner_tile_sizes.
   SmallVector<int64_t> innerTiles = op.getStaticTiles();
   ArrayRef<int64_t> dimPos = op.getInnerDimsPos();
   for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
-    if (tileSizes[pos] == 0 || ShapedType::isDynamic(size)) continue;
-    tileSizes[pos] = llvm::alignTo(tileSizes[pos], size);
+    if (distTileSizes[pos] == 0 || ShapedType::isDynamic(size)) continue;
+    distTileSizes[pos] = llvm::alignTo(distTileSizes[pos], size);
   }
 
-  TileSizesListType tileSizesList = {tileSizes};
+  SmallVector<int64_t> tileSizes(op.getDestRank(), 1);
+  for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
+    tileSizes[pos] = ShapedType::isDynamic(size) ? 1 : size;
+  }
+
+  TileSizesListType tileSizesList = {distTileSizes};
+  tileSizesList.push_back(tileSizes);
+
   return setOpConfigAndEntryPointFnTranslation(entryPointFn, op, tileSizesList,
                                                pipeline);
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -586,6 +586,8 @@ void addCPUDataTilingPipeline(OpPassManager &passManager) {
   addTileAndDistributePasses(passManager);
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMCPUTilePass(static_cast<int64_t>(TilingLevel::ParallelTiles)));
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createDecomposePackUnPackOpsPass());
 
   LLVMCPUVectorizationPassOptions options;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -362,7 +362,7 @@ hal.executable private @pack  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 64]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 64], [1, 1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDataTiling>
 //      CHECK: hal.executable.export public @pack
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -407,7 +407,7 @@ hal.executable private @unpack_outer_dynamic  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [32, 16]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDataTiling>
 //      CHECK: hal.executable.export public @unpack_outer_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
@@ -219,7 +219,7 @@ hal.executable private @unpack_outer_dynamic  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [32, 16]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
 //      CHECK: hal.executable.export public @unpack_outer_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
@@ -1522,7 +1522,7 @@ hal.executable private @pack  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 64]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 64], [1, 1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDataTiling>
 //      CHECK: hal.executable.export public @pack
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
It is not necessary to make outer dims be all unit dims before decomposition. It exposes the tiling sizes to configuration, and will unblock other codegen paths in IREE, e.g., specialized transpose lowering on AVX2 and AVX512, etc.

The lowerPack and lowerUnPack patterns are required for fusion cases. The outer dims could be non unit in fusion because the tiling sizes are driven by other Linalg ops. In this context, it relies on lowerPack and lowerUnpack to decompose the tensor.pack/unpack ops. It can also be used in specialized transpose lowering.