### PR TITLE
Handle supported ImportOptions in tf.py and fix Windows compatibility.

### DIFF
--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils.py
@@ -58,9 +58,6 @@ def _get_tf_import_output_kwargs(artifacts_dir: str,
   if needs_temp_saved_model_dir:
     kwargs["saved_model_dir"] = os.path.join(artifacts_dir,
                                              "tfmodule.saved_model")
-  kwargs["save_temp_tf_input"] = os.path.join(artifacts_dir, "tf_input.mlir")
-  kwargs["save_temp_mid_level_input"] = os.path.join(artifacts_dir,
-                                                     "tf_mid_level_input.mlir")
   kwargs["save_temp_iree_input"] = os.path.join(artifacts_dir,
                                                 "iree_input.mlir")
 


### PR DESCRIPTION
This adds back support for `import_only` and `save_temp_iree_input` to our TensorFlow `compile_saved_model` API. I also removed unsupported options (`import_extra_args`, `save_temp_tf_input`, `save_temp_mid_level_input`, and `use_tosa`).

Those flags were dropped in https://github.com/openxla/iree/pull/12758 / https://github.com/openxla/iree/pull/13025 , but they are still useful in Colab notebooks and when debugging tests.

---

Progress on https://github.com/openxla/iree/issues/13148, though some further updates will be needed to our Colab notebooks, such as
```python
# before:
compiler_module = tfc.compile_module(
    EdgeDetectionModule(), import_only=True,
    import_extra_args=["--output-format=mlir-ir"])
print("Edge Detection MLIR: ", compiler_module.decode('utf-8'))

# after:
compiler_module = tfc.compile_module(
    EdgeDetectionModule(), import_only=True)
print("Edge Detection MLIR: ", compiler_module)
```

---

I developed this change on Windows (Yes! Finally, I can use Python that touches TF on Windows without needing to build TF from source!), where I found that this pattern is broken:
```python
 with tempfile.NamedTemporaryFile(mode="w") as temp_file: 
   __main__.import_saved_model(output_path=temp_file.name, 
```
See https://stackoverflow.com/a/23212515 - `NamedTemporaryFile` _creates and opens_ the file, and the file _cannot be opened again_... on Windows (it can be opened again on Unix). I used the trick from https://stackoverflow.com/a/45803022 to work around this:
```python
with tempfile.TemporaryDirectory() as tmpdir:
  # ...

  # Not saving the file, so generate a loose temp file without tfs.
  tf_iree_input = os.path.join(tmpdir, 'tf-iree-input.mlir')
```