### PR TITLE
Support `num_replicas` and `num_partitions`

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertCollectiveOps.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertCollectiveOps.cpp
@@ -366,9 +366,43 @@ static int32_t getNumPartitions(ModuleOp moduleOp) {
 
 }  // namespace
 
-/// Converts mhlo.replica_id to flow.channel.default + flow.channel.rank.
-/// TODO(okkwon): this assumes that there is no partition so that there is a 1:1
-/// mapping between the replica ID and the process ID.
+/// Converts mhlo.partition_id to (flow.channel.rank % numPartitions)
+struct PartitionIdOpConversion
+    : public OpConversionPattern<mhlo::PartitionIdOp> {
+  using OpConversionPattern<mhlo::PartitionIdOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mhlo::PartitionIdOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    // PartitionId = rank % numPartitions
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    int32_t numPartitions = getNumPartitions(moduleOp);
+    Value value;
+    if (numPartitions <= 1) {
+      value = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    } else {
+      auto channel = rewriter.create<IREE::Flow::ChannelDefaultOp>(
+          loc, /*group=*/StringAttr{});
+      Value rank = rewriter.create<IREE::Flow::ChannelRankOp>(loc, channel);
+      auto cst =
+          rewriter.create<arith::ConstantIndexOp>(loc,
+                                                  /*value=*/numPartitions);
+      value = rewriter.create<arith::RemUIOp>(loc, rank, cst);
+    }
+    auto resultType = op.getType().cast<RankedTensorType>();  // tensor<ui32>
+    auto elemType = resultType.getElementType();
+    // index -> ui32
+    auto rankElem = rewriter.create<arith::IndexCastUIOp>(loc, elemType, value);
+    // tensor<ui32>
+    auto rankTensor = rewriter.create<tensor::FromElementsOp>(
+        loc, resultType, rankElem.getResult());
+    rewriter.replaceOp(op, rankTensor.getResult());
+    return success();
+  }
+};
+
+/// Converts mhlo.replica_id to floor_div(flow.channel.rank, numPartitions)
 struct ReplicaIdOpConversion : public OpConversionPattern<mhlo::ReplicaIdOp> {
   using OpConversionPattern<mhlo::ReplicaIdOp>::OpConversionPattern;
 
@@ -378,7 +412,17 @@ struct ReplicaIdOpConversion : public OpConversionPattern<mhlo::ReplicaIdOp> {
     auto loc = op.getLoc();
     auto channel = rewriter.create<IREE::Flow::ChannelDefaultOp>(
         loc, /*group=*/StringAttr{});
-    auto rank = rewriter.create<IREE::Flow::ChannelRankOp>(loc, channel);
+    Value rank = rewriter.create<IREE::Flow::ChannelRankOp>(loc, channel);
+
+    // ReplicaId = floor_div(rank, numPartitions)
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    int32_t numPartitions = getNumPartitions(moduleOp);
+    auto cst = rewriter.create<arith::ConstantIndexOp>(loc,
+                                                       /*value=*/numPartitions);
+    if (numPartitions > 1) {
+      rank = rewriter.create<arith::DivUIOp>(loc, rank, cst);
+    }
+
     auto resultType = op.getType().cast<RankedTensorType>();  // tensor<ui32>
     auto elemType = resultType.getElementType();
     // index -> ui32
@@ -760,6 +804,7 @@ void populateMHLOCollectiveOpsConversionPatterns(MLIRContext *context,
   patterns.insert<AllGatherOpConversion>(typeConverter, context);
   patterns.insert<AllReduceOpConversion>(typeConverter, context);
   patterns.insert<AllToAllOpConversion>(typeConverter, context);
+  patterns.insert<PartitionIdOpConversion>(typeConverter, context);
   patterns.insert<ReduceScatterOpConversion>(typeConverter, context);
   patterns.insert<ReplicaIdOpConversion>(typeConverter, context);
 }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_collective_ops.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_collective_ops.mlir
@@ -345,3 +345,81 @@ func.func @reduce_scatter_dim_0_optional_attrs(%input : tensor<4x2xf32>) -> tens
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>} : (tensor<4x2xf32>) -> tensor<2x2xf32>
   return %out : tensor<2x2xf32>
 }
+
+// -----
+
+// flattened_ids: channel_id > 0 && use_global_device_ids = true
+module @jit_fn attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 8 : i32 } {
+  // CHECK-LABEL: @flattened_ids
+  // CHECK-SAME: ([[ARG0:%.+]]: tensor<2304xf32>)
+  func.func @flattened_ids(%input : tensor<2304xf32>) -> tensor<2304xf32> {
+    // CHECK: [[CHANNEL:%.+]] = flow.channel.default : !flow.channel
+    // CHECK: [[EMPTY:%.+]] = tensor.empty() : tensor<2304xf32>
+    // CHECK: [[ALLREDUCE:%.+]] = flow.collective.all_reduce sum, f32, [[EMPTY]], [[ARG0]], [[CHANNEL]] : (tensor<2304xf32>, tensor<2304xf32>, !flow.channel) -> [[EMPTY]] as tensor<2304xf32>
+    // CHECK: return [[ALLREDUCE]] : tensor<2304xf32>
+    %out = "mhlo.all_reduce"(%input) ({
+      ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+        %sum = mhlo.add %arg0, %arg1 : tensor<f32>
+        mhlo.return %sum : tensor<f32>
+      }) {channel_handle = #mhlo.channel_handle<handle = 1, type = 1>,
+          replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>,
+          use_global_device_ids} : (tensor<2304xf32>) -> tensor<2304xf32>
+    return %out : tensor<2304xf32>
+  }
+}
+
+// -----
+
+// cross-replica: channel_id <= 0 && use_global_device_ids = false
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @cross_replica
+  func.func @cross_replica(%input : tensor<2304xf32>) -> tensor<2304xf32> {
+    // Cross replica should form groups (0,2,4,6),(1,3,5,7), where each number represents a cell below.
+    // +---+---+
+    // | 0 | 1 |
+    // | 2 | 3 |
+    // | 4 | 5 |
+    // | 6 | 7 |
+    // +---+---+
+    //                          rank:   0    1    2    3    4    5    6    7
+    // CHECK: util.switch index from [%c0, %c1, %c0, %c1, %c0, %c1, %c0, %c1] at %channel_rank else %c-1 : index
+    // CHECK: util.switch index from [%c0, %c0, %c1, %c1, %c2, %c2, %c3, %c3] at %channel_rank else %c-1 : index
+    %out = "mhlo.all_reduce"(%input) ({
+      ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+        %sum = mhlo.add %arg0, %arg1 : tensor<f32>
+        mhlo.return %sum : tensor<f32>
+      }) {channel_handle = #mhlo.channel_handle<handle = 0, type = 1>,
+          replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
+         } : (tensor<2304xf32>) -> tensor<2304xf32>
+    return %out : tensor<2304xf32>
+  }
+}
+
+// -----
+
+// cross_replica_and_partition: channel_id > 0 && use_global_device_ids = false
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @cross_replica_and_partition
+  func.func @cross_replica_and_partition(%input : tensor<2304xf32>) -> tensor<2304xf32> {
+    // Cross replica_and_partition should form groups (0,2,1,3),(4,6,5,7), where each number represents a cell below.
+    // Note that the rank is assigned in a partiton first, e.g., rank 0 and 1 are assigned to cell 0 and 2, respectively.
+    // +---+---+
+    // | 0   1 |
+    // | 2   3 |
+    // |---+---|
+    // | 4   5 |
+    // | 6   7 |
+    // +---+---+
+    //                          rank:   0    1    2    3    4    5    6    7
+    // CHECK: util.switch index from [%c0, %c0, %c0, %c0, %c1, %c1, %c1, %c1] at %channel_rank else %c-1 : index
+    // CHECK: util.switch index from [%c0, %c2, %c1, %c3, %c0, %c2, %c1, %c3] at %channel_rank else %c-1 : index
+    %out = "mhlo.all_reduce"(%input) ({
+      ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+        %sum = mhlo.add %arg0, %arg1 : tensor<f32>
+        mhlo.return %sum : tensor<f32>
+      }) {channel_handle = #mhlo.channel_handle<handle = 1, type = 1>,
+          replica_groups = dense<[[0, 1], [2, 3]]> : tensor<2x2xi64>
+         } : (tensor<2304xf32>) -> tensor<2304xf32>
+    return %out : tensor<2304xf32>
+  }
+}

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/convert_collectives.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/convert_collectives.mlir
@@ -345,3 +345,81 @@ func.func @reduce_scatter_dim_0_optional_attrs(%input : tensor<4x2xf32>) -> tens
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>} : (tensor<4x2xf32>) -> tensor<2x2xf32>
   return %out : tensor<2x2xf32>
 }
+
+// -----
+
+// flattened_ids: channel_id > 0 && use_global_device_ids = true
+module @jit_fn attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 8 : i32 } {
+  // CHECK-LABEL: @flattened_ids
+  // CHECK-SAME: ([[ARG0:%.+]]: tensor<2304xf32>)
+  func.func @flattened_ids(%input : tensor<2304xf32>) -> tensor<2304xf32> {
+    // CHECK: [[CHANNEL:%.+]] = flow.channel.default : !flow.channel
+    // CHECK: [[EMPTY:%.+]] = tensor.empty() : tensor<2304xf32>
+    // CHECK: [[ALLREDUCE:%.+]] = flow.collective.all_reduce sum, f32, [[EMPTY]], [[ARG0]], [[CHANNEL]] : (tensor<2304xf32>, tensor<2304xf32>, !flow.channel) -> [[EMPTY]] as tensor<2304xf32>
+    // CHECK: return [[ALLREDUCE]] : tensor<2304xf32>
+    %out = "stablehlo.all_reduce"(%input) ({
+      ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+        %sum = stablehlo.add %arg0, %arg1 : tensor<f32>
+        stablehlo.return %sum : tensor<f32>
+      }) {channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>,
+          replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>,
+          use_global_device_ids} : (tensor<2304xf32>) -> tensor<2304xf32>
+    return %out : tensor<2304xf32>
+  }
+}
+
+// -----
+
+// cross-replica: channel_id <= 0 && use_global_device_ids = false
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @cross_replica
+  func.func @cross_replica(%input : tensor<2304xf32>) -> tensor<2304xf32> {
+    // Cross replica should form groups (0,2,4,6),(1,3,5,7), where each number represents a cell below.
+    // +---+---+
+    // | 0 | 1 |
+    // | 2 | 3 |
+    // | 4 | 5 |
+    // | 6 | 7 |
+    // +---+---+
+    //                          rank:   0    1    2    3    4    5    6    7
+    // CHECK: util.switch index from [%c0, %c1, %c0, %c1, %c0, %c1, %c0, %c1] at %channel_rank else %c-1 : index
+    // CHECK: util.switch index from [%c0, %c0, %c1, %c1, %c2, %c2, %c3, %c3] at %channel_rank else %c-1 : index
+    %out = "stablehlo.all_reduce"(%input) ({
+      ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+        %sum = stablehlo.add %arg0, %arg1 : tensor<f32>
+        stablehlo.return %sum : tensor<f32>
+      }) {channel_handle = #stablehlo.channel_handle<handle = 0, type = 1>,
+          replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
+         } : (tensor<2304xf32>) -> tensor<2304xf32>
+    return %out : tensor<2304xf32>
+  }
+}
+
+// -----
+
+// cross_replica_and_partition: channel_id > 0 && use_global_device_ids = false
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @cross_replica_and_partition
+  func.func @cross_replica_and_partition(%input : tensor<2304xf32>) -> tensor<2304xf32> {
+    // Cross replica_and_partition should form groups (0,2,1,3),(4,6,5,7), where each number represents a cell below.
+    // Note that the rank is assigned in a partiton first, e.g., rank 0 and 1 are assigned to cell 0 and 2, respectively.
+    // +---+---+
+    // | 0   1 |
+    // | 2   3 |
+    // |---+---|
+    // | 4   5 |
+    // | 6   7 |
+    // +---+---+
+    //                          rank:   0    1    2    3    4    5    6    7
+    // CHECK: util.switch index from [%c0, %c0, %c0, %c0, %c1, %c1, %c1, %c1] at %channel_rank else %c-1 : index
+    // CHECK: util.switch index from [%c0, %c2, %c1, %c3, %c0, %c2, %c1, %c3] at %channel_rank else %c-1 : index
+    %out = "stablehlo.all_reduce"(%input) ({
+      ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+        %sum = stablehlo.add %arg0, %arg1 : tensor<f32>
+        stablehlo.return %sum : tensor<f32>
+      }) {channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>,
+          replica_groups = dense<[[0, 1], [2, 3]]> : tensor<2x2xi64>
+         } : (tensor<2304xf32>) -> tensor<2304xf32>
+    return %out : tensor<2304xf32>
+  }
+}

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/convert_collectives.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/convert_collectives.mlir
@@ -14,6 +14,50 @@ func.func @replica_id() -> tensor<ui32> {
 
 // -----
 
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @replica_id_with_partitions
+  func.func @replica_id_with_partitions() -> tensor<ui32> {
+    // CHECK-DAG: %[[CHANNEL:.+]] = flow.channel.default : !flow.channel
+    // CHECK-DAG: %[[RANK:.+]] = flow.channel.rank %[[CHANNEL]] : index
+    // CHECK-DAG: %[[DIV2:.+]] = arith.divui %[[RANK]], %c2 : index
+    // CHECK-DAG: %[[CAST:.+]] = arith.index_castui %[[DIV2]] : index to i32
+    // CHECK-DAG: %[[TENSOR:.+]] = tensor.from_elements %[[CAST]] : tensor<i32>
+    // CHECK-DAG: return %[[TENSOR]] : tensor<i32>
+    %id = stablehlo.replica_id : tensor<ui32>
+    return %id : tensor<ui32>
+  }
+}
+
+// -----
+
+// Returns 0 since num_partitions is not set.
+
+// CHECK-LABEL: @partition_id
+func.func @partition_id() -> tensor<ui32> {
+  // CHECK-DAG: %[[CST0:.+]] = arith.constant dense<0> : tensor<i32>
+  // CHECK-DAG: return %[[CST0]] : tensor<i32>
+  %id = stablehlo.partition_id : tensor<ui32>
+  return %id : tensor<ui32>
+}
+
+// -----
+
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @partition_id_with_partitions
+  func.func @partition_id_with_partitions() -> tensor<ui32> {
+    // CHECK-DAG: %[[CHANNEL:.+]] = flow.channel.default : !flow.channel
+    // CHECK-DAG: %[[RANK:.+]] = flow.channel.rank %[[CHANNEL]] : index
+    // CHECK-DAG: %[[REM2:.+]] = arith.remui %[[RANK]], %c2 : index
+    // CHECK-DAG: %[[CAST:.+]] = arith.index_castui %[[REM2]] : index to i32
+    // CHECK-DAG: %[[TENSOR:.+]] = tensor.from_elements %[[CAST]] : tensor<i32>
+    // CHECK-DAG: return %[[TENSOR]] : tensor<i32>
+    %id = stablehlo.partition_id : tensor<ui32>
+    return %id : tensor<ui32>
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @all_reduce_sum
 // CHECK-SAME: (%[[ARG0:.+]]: tensor<2304xf32>)
 func.func @all_reduce_sum(%input : tensor<2304xf32>) -> tensor<2304xf32> {


### PR DESCRIPTION
Support `num_replicas` and `num_partitions` through cross_replica and cross_partition for all_reduce, all_gather, and reduce_scatter, replica_id, and partition_id.

Based on the channel ID and use_global_device_ids, the communication mode can be different in the 2D grid.

See https://github.com/openxla/stablehlo/blob/main/docs/spec.md#collective-ops for more information.

Note that stablehlo still uses `mhlo.num_replicas` and `mhlo.num_partitions` to embed the info in the module.