### PR TITLE
BF16 vulkan-spirv support for native execution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -727,8 +727,11 @@ createSPIRVBreakDownLargeVectorPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVCreateFastSlowPathPass();
 
-/// Emulates 64-bit integer ops with 32-bit integer ops.
+/// Emulate 64-bit integer ops with 32-bit integer ops.
 std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateI64Pass();
+
+/// Emulate bfloat 16 ops with 32-bit float ops.
+std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateBf16Pass();
 
 /// Turns static shaped storage buffer subspan ops into dynamic shaped ones.
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -727,10 +727,10 @@ createSPIRVBreakDownLargeVectorPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVCreateFastSlowPathPass();
 
-/// Emulate 64-bit integer ops with 32-bit integer ops.
+/// Emulates 64-bit integer ops with 32-bit integer ops.
 std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateI64Pass();
 
-/// Emulate bfloat 16 ops with 32-bit float ops.
+/// Emulates bfloat 16 ops with 32-bit float ops.
 std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateBf16Pass();
 
 /// Turns static shaped storage buffer subspan ops into dynamic shaped ones.

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -846,8 +846,14 @@ def SPIRVCreateFastSlowPath :
 
 def SPIRVEmulateI64 :
     Pass<"iree-spirv-emulate-i64", "ModuleOp"> {
-  let summary = "Emulate 64-bit integer opts with 32-bit integer ops";
+  let summary = "Emulate 64-bit integer ops with 32-bit integer ops";
   let constructor = "mlir::iree_compiler::createSPIRVEmulateI64Pass()";
+}
+
+def SPIRVEmulateBf16 :
+    Pass<"iree-spirv-emulate-bf16", "ModuleOp"> {
+  let summary = "Emulate bfloat 16 ops with 32-bit float ops";
+  let constructor = "mlir::iree_compiler::createSPIRVEmulateBf16Pass()";
 }
 
 def SPIRVEraseStorageBufferStaticShape :

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -27,6 +27,7 @@ iree_compiler_cc_library(
         "SPIRVBreakDownLargeVector.cpp",
         "SPIRVCreateFastSlowPath.cpp",
         "SPIRVDistribute.cpp",
+        "SPIRVEmulateBf16.cpp",
         "SPIRVEmulateI64.cpp",
         "SPIRVEraseStorageBufferStaticShape.cpp",
         "SPIRVLowerExecutableTargetPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -56,6 +56,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
+        "//compiler/src/iree/compiler/Dialect/Util/Transforms",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
     "SPIRVBreakDownLargeVector.cpp"
     "SPIRVCreateFastSlowPath.cpp"
     "SPIRVDistribute.cpp"
+    "SPIRVEmulateBf16.cpp"
     "SPIRVEmulateI64.cpp"
     "SPIRVEraseStorageBufferStaticShape.cpp"
     "SPIRVLowerExecutableTargetPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -110,6 +110,7 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::Util::IR
+    iree::compiler::Dialect::Util::Transforms
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -21,6 +21,7 @@
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/ComplexToStandard/ComplexToStandard.h"
@@ -227,6 +228,8 @@ static void addSPIRVLoweringPasses(OpPassManager &pm, bool enableFastMath) {
 
   pm.addNestedPass<func::FuncOp>(createSPIRVMapMemRefStorageClassPass());
   pm.addPass(createSPIRVEmulateI64Pass());
+  pm.addPass(IREE::Util::createPromoteArithBF16ToF32Pass());
+  pm.addPass(createSPIRVEmulateBf16Pass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateBf16.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateBf16.cpp
@@ -38,10 +38,7 @@ namespace {
 
 class Bf16EmulationConverter : public TypeConverter {
  public:
-  explicit Bf16EmulationConverter();
-};
-
-Bf16EmulationConverter::Bf16EmulationConverter() {
+  explicit Bf16EmulationConverter() {
   // Allow unknown types.
   addConversion([](Type ty) -> std::optional<Type> { return ty; });
 
@@ -66,6 +63,7 @@ Bf16EmulationConverter::Bf16EmulationConverter() {
     return FunctionType::get(ty.getContext(), inputs, results);
   });
 }
+};
 
 //===----------------------------------------------------------------------===//
 // Rewrite patterns

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateBf16.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateBf16.cpp
@@ -1,0 +1,229 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass to emulate 16-bit brain float operations with
+// 32-bit ones.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-spirv-emulate-bf16"
+
+namespace mlir {
+namespace iree_compiler {
+namespace {
+
+class Bf16EmulationConverter : public TypeConverter {
+ public:
+  explicit Bf16EmulationConverter();
+};
+
+Bf16EmulationConverter::Bf16EmulationConverter() {
+  // Allow unknown types.
+  addConversion([](Type ty) -> std::optional<Type> { return ty; });
+
+  // Scalar case.
+  addConversion([](FloatType ty) -> std::optional<Type> {
+    if (ty.isBF16()) return IntegerType::get(ty.getContext(), 16);
+    return ty;
+  });
+
+  addConversion([this](ShapedType ty) -> std::optional<Type> {
+    return ty.clone(convertType(ty.getElementType()));
+  });
+
+  // Function case.
+  addConversion([this](FunctionType ty) -> std::optional<Type> {
+    SmallVector<Type> inputs;
+    if (failed(convertTypes(ty.getInputs(), inputs))) return std::nullopt;
+
+    SmallVector<Type> results;
+    if (failed(convertTypes(ty.getResults(), results))) return std::nullopt;
+
+    return FunctionType::get(ty.getContext(), inputs, results);
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// Rewrite patterns
+//===----------------------------------------------------------------------===//
+struct ConvertHalInterfaceBindingSubspan final
+    : OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      IREE::HAL::InterfaceBindingSubspanOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type newResultTy = getTypeConverter()->convertType(op.getType());
+    if (!newResultTy)
+      return rewriter.notifyMatchFailure(
+          op->getLoc(),
+          llvm::formatv("failed to legalize memref type: {0}", op.getType()));
+
+    auto newOp =
+        rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
+            op, newResultTy, adaptor.getSet(), adaptor.getBinding(),
+            adaptor.getDescriptorType(), adaptor.getByteOffset(),
+            adaptor.getDynamicDims(), adaptor.getAlignmentAttr(),
+            adaptor.getDescriptorFlagsAttr());
+    LLVM_DEBUG(llvm::dbgs() << "Bf16Emulation: new op: " << newOp << "\n");
+    (void)newOp;
+    return success();
+  }
+};
+
+struct ConvertMemRefAlloc final : OpConversionPattern<memref::AllocOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      memref::AllocOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type newTy = getTypeConverter()->convertType(op.getType());
+    if (!newTy)
+      return rewriter.notifyMatchFailure(
+          op->getLoc(),
+          llvm::formatv("failed to convert memref type: {0}", op.getType()));
+
+    rewriter.replaceOpWithNewOp<memref::AllocOp>(
+        op, newTy, adaptor.getDynamicSizes(), adaptor.getSymbolOperands(),
+        adaptor.getAlignmentAttr());
+    return success();
+  }
+};
+
+struct ConvertMemRefLoad final : OpConversionPattern<memref::LoadOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      memref::LoadOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type newResTy = getTypeConverter()->convertType(op.getType());
+    if (!newResTy)
+      return rewriter.notifyMatchFailure(
+          op->getLoc(), llvm::formatv("failed to convert memref type: {0}",
+                                      op.getMemRefType()));
+
+    rewriter.replaceOpWithNewOp<memref::LoadOp>(
+        op, newResTy, adaptor.getMemref(), adaptor.getIndices(),
+        op.getNontemporal());
+    return success();
+  }
+};
+
+struct ConvertMemRefStore final : OpConversionPattern<memref::StoreOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      memref::StoreOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type newTy = getTypeConverter()->convertType(op.getMemRefType());
+    if (!newTy)
+      return rewriter.notifyMatchFailure(
+          op->getLoc(), llvm::formatv("failed to convert memref type: {0}",
+                                      op.getMemRefType()));
+
+    rewriter.replaceOpWithNewOp<memref::StoreOp>(
+        op, adaptor.getValue(), adaptor.getMemref(), adaptor.getIndices(),
+        op.getNontemporal());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Helper functions
+//===----------------------------------------------------------------------===//
+
+std::optional<Value> materializeArithBitcast(OpBuilder &builder, Type resultTy,
+                                             mlir::ValueRange inputs,
+                                             mlir::Location loc) {
+  return builder.create<arith::BitcastOp>(loc, resultTy, inputs);
+}
+
+static void populateIreeBf16EmulationPatterns(RewritePatternSet &patterns,
+                                              TypeConverter typeConverter) {
+  patterns.add<ConvertHalInterfaceBindingSubspan, ConvertMemRefAlloc,
+               ConvertMemRefLoad, ConvertMemRefStore>(typeConverter,
+                                                      patterns.getContext());
+}
+
+//===----------------------------------------------------------------------===//
+// Main pass
+//===----------------------------------------------------------------------===//
+
+struct SPIRVEmulateBf16Pass final
+    : public SPIRVEmulateBf16Base<SPIRVEmulateBf16Pass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp op = getOperation();
+    MLIRContext *ctx = &getContext();
+
+    Bf16EmulationConverter typeConverter;
+    typeConverter.addTargetMaterialization(materializeArithBitcast);
+    typeConverter.addSourceMaterialization(materializeArithBitcast);
+
+    // Run the main emulation pass.
+    {
+      ConversionTarget target(*ctx);
+      target.addLegalOp<arith::BitcastOp>();
+      target.addDynamicallyLegalOp<func::FuncOp>([&typeConverter](
+                                                     Operation *op) {
+        return typeConverter.isLegal(cast<func::FuncOp>(op).getFunctionType());
+      });
+      target.addDynamicallyLegalDialect<
+          arith::ArithDialect, func::FuncDialect, IREE::HAL::HALDialect,
+          memref::MemRefDialect, vector::VectorDialect>(
+          [&typeConverter](Operation *op) {
+            bool legal = typeConverter.isLegal(op);
+            LLVM_DEBUG(if (!legal) llvm::dbgs()
+                       << "Bf16Emulation: illegal op: " << *op << "\n");
+            return legal;
+          });
+
+      RewritePatternSet patterns(ctx);
+      arith::populateExpandBFloat16Patterns(patterns);
+      populateIreeBf16EmulationPatterns(patterns, typeConverter);
+
+      if (failed(applyPartialConversion(op, target, std::move(patterns))))
+        signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Public interface
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateBf16Pass() {
+  return std::make_unique<SPIRVEmulateBf16Pass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateBf16.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateBf16.cpp
@@ -39,19 +39,19 @@ namespace {
 class Bf16EmulationConverter : public TypeConverter {
  public:
   explicit Bf16EmulationConverter() {
-  // Allow unknown types.
-  addConversion([](Type ty) -> std::optional<Type> { return ty; });
+    // Allow unknown types.
+    addConversion([](Type ty) -> std::optional<Type> { return ty; });
 
-  // Scalar case.
-  addConversion([](FloatType ty) -> std::optional<Type> {
-    if (ty.isBF16()) return IntegerType::get(ty.getContext(), 16);
-    return ty;
-  });
+    // Scalar case.
+    addConversion([](FloatType ty) -> std::optional<Type> {
+      if (ty.isBF16()) return IntegerType::get(ty.getContext(), 16);
+      return ty;
+    });
 
-  addConversion([this](ShapedType ty) -> std::optional<Type> {
-    return ty.clone(convertType(ty.getElementType()));
-  });
-}
+    addConversion([this](ShapedType ty) -> std::optional<Type> {
+      return ty.clone(convertType(ty.getElementType()));
+    });
+  }
 };
 
 //===----------------------------------------------------------------------===//
@@ -150,7 +150,7 @@ std::optional<Value> materializeArithBitcast(OpBuilder &builder, Type resultTy,
 }
 
 static void populateIreeBf16EmulationPatterns(RewritePatternSet &patterns,
-                                              TypeConverter& typeConverter) {
+                                              TypeConverter &typeConverter) {
   patterns.add<ConvertHalInterfaceBindingSubspan, ConvertMemRefAlloc,
                ConvertMemRefLoad, ConvertMemRefStore>(typeConverter,
                                                       patterns.getContext());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "convert_to_spirv.mlir",
             "create_fast_slow_path.mlir",
             "distribute_to_invocations.mlir",
+            "emulate_bf16.mlir",
             "emulate_i64.mlir",
             "erase_storage_buffer_static_shape.mlir",
             "illegal_configuration.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_lit_test_suite(
     "convert_to_spirv.mlir"
     "create_fast_slow_path.mlir"
     "distribute_to_invocations.mlir"
+    "emulate_bf16.mlir"
     "emulate_i64.mlir"
     "erase_storage_buffer_static_shape.mlir"
     "illegal_configuration.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/emulate_bf16.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/emulate_bf16.mlir
@@ -1,0 +1,32 @@
+// RUN: iree-opt --split-input-file \
+// RUN:   --iree-spirv-emulate-bf16 %s | \
+// RUN:   FileCheck %s
+
+// CHECK-LABEL: @bf16_conversion
+func.func @bf16_conversion() {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+
+  // CHECK-DAG: %[[BUF0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<?xi16, #spirv.storage_class<StorageBuffer>>{%c8}
+  // CHECK-DAG: %[[BUF1:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<?xi16, #spirv.storage_class<StorageBuffer>>{%c8}
+  // CHECK-DAG: %[[BUF2:.+]] = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<?xi16, #spirv.storage_class<StorageBuffer>>{%c8}
+  // CHECK-DAG: %[[LOAD0:.+]] = memref.load %[[BUF0]][%arg0] : memref<?xi16, #spirv.storage_class<StorageBuffer>>
+  // CHECK: %[[CAST0:.+]] = arith.bitcast %[[LOAD0]] : i16 to bf16
+  // CHECK-DAG: %[[LOAD1:.+]] = memref.load %[[BUF1]][%arg0] : memref<?xi16, #spirv.storage_class<StorageBuffer>>
+  // CHECK: %[[CAST1:.+]] = arith.bitcast %[[LOAD1]] : i16 to bf16
+  // CHECK: memref.store %{{.+}}, %[[BUF2]][%arg0] : memref<?xi16, #spirv.storage_class<StorageBuffer>>
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<?xbf16, #spirv.storage_class<StorageBuffer>>{%c8}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<?xbf16, #spirv.storage_class<StorageBuffer>>{%c8}    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<?xbf16, #spirv.storage_class<StorageBuffer>>{%c8}
+  %3 = gpu.thread_id  x
+  %4 = gpu.block_dim  x
+  scf.for %arg0 = %3 to %c8 step %4 {
+    %5 = memref.load %0[%arg0] : memref<?xbf16, #spirv.storage_class<StorageBuffer>>
+    %6 = memref.load %1[%arg0] : memref<?xbf16, #spirv.storage_class<StorageBuffer>>
+    %7 = arith.extf %5 : bf16 to f32
+    %8 = arith.extf %6 : bf16 to f32
+    %9 = arith.addf %7, %8 : f32
+    %10 = arith.truncf %9 : f32 to bf16
+    memref.store %10, %2[%arg0] : memref<?xbf16, #spirv.storage_class<StorageBuffer>>
+  }
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/emulate_bf16.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/emulate_bf16.mlir
@@ -15,7 +15,8 @@ func.func @bf16_conversion() {
   // CHECK: %[[CAST1:.+]] = arith.bitcast %[[LOAD1]] : i16 to bf16
   // CHECK: memref.store %{{.+}}, %[[BUF2]][%arg0] : memref<?xi16, #spirv.storage_class<StorageBuffer>>
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<?xbf16, #spirv.storage_class<StorageBuffer>>{%c8}
-  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<?xbf16, #spirv.storage_class<StorageBuffer>>{%c8}    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<?xbf16, #spirv.storage_class<StorageBuffer>>{%c8}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<?xbf16, #spirv.storage_class<StorageBuffer>>{%c8}
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<?xbf16, #spirv.storage_class<StorageBuffer>>{%c8}
   %3 = gpu.thread_id  x
   %4 = gpu.block_dim  x
   scf.for %arg0 = %3 to %c8 step %4 {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/emulate_bf16.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/emulate_bf16.mlir
@@ -1,6 +1,5 @@
 // RUN: iree-opt --split-input-file \
-// RUN:   --iree-spirv-emulate-bf16 %s | \
-// RUN:   FileCheck %s
+// RUN:   --iree-spirv-emulate-bf16 %s | FileCheck %s
 
 // CHECK-LABEL: @bf16_conversion
 func.func @bf16_conversion() {

--- a/tests/e2e/xla_ops/BUILD.bazel
+++ b/tests/e2e/xla_ops/BUILD.bazel
@@ -349,6 +349,7 @@ iree_check_single_backend_test_suite(
             "cosine.mlir",
             "divide.mlir",
             "dot.mlir",
+            "dot_bf16.mlir",
             "dot_general.mlir",
             "dynamic_slice.mlir",
             "dynamic_update_slice.mlir",
@@ -389,7 +390,6 @@ iree_check_single_backend_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
-            "dot_bf16.mlir",  # Missing BF16 support on Vulkan backends
             "exponential_fp16.mlir",
             "fft.mlir",  # TODO(#9583)
             "reverse.mlir",  #TODO(#12415): disabled due to miscompilation on Pixel 6.

--- a/tests/e2e/xla_ops/CMakeLists.txt
+++ b/tests/e2e/xla_ops/CMakeLists.txt
@@ -321,6 +321,7 @@ iree_check_single_backend_test_suite(
     "cosine.mlir"
     "divide.mlir"
     "dot.mlir"
+    "dot_bf16.mlir"
     "dot_general.mlir"
     "dynamic_slice.mlir"
     "dynamic_update_slice.mlir"


### PR DESCRIPTION
Using f32 operations and bf16<->f32 conversions we can natively support bf16 types within the inner reductions. Update the spirv lowerings to natively support bf16 operations within spirv generated code.