### PR TITLE
Stop preserving `"encoding"` attribute on `pack` op.

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -147,20 +147,9 @@ static FailureOr<tensor::PackOp> lowerSetEncodingOpToPackOp(
   auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, resultDims,
                                                   resultType.getElementType());
   std::optional<Value> paddingValue = getPaddingValue(source);
-  auto packOp = rewriter.create<tensor::PackOp>(
+  return rewriter.create<tensor::PackOp>(
       loc, source, emptyOp, materializeEncodingInfo->innerDimsPos,
       *innerTileSizesOfr, paddingValue, materializeEncodingInfo->outerDimsPerm);
-  // As we rewrite the SetEncoding and its old result tensor, which used to hold
-  // the TensorEncodingAttr, into a pack op with a new result tensor which does
-  // not have a TensorEncodingAttr, we lose the information that used to be
-  // stored in that attr. That shouldn't matter, as the purpose of that attr
-  // was to enable exactly this rewrite, but there is a catch: at the moment,
-  // in IREE's TileAndDistributeToWorkgroupsPass.cpp, we need the encoding value
-  // again. See the comment there. So we re-add the attribute on the pack op
-  // itself as a temporary work-around.
-  packOp->setAttr(StringAttr::get(rewriter.getContext(), "encoding"),
-                  EncodingAttr::get(rewriter.getContext(), *encoding));
-  return packOp;
 }
 
 /// Utility method to convert from `set_encoding` op to `pack` operation.


### PR DESCRIPTION
This was added in #11603 with issue #11608 filed about removing it, and that issue was recently fixed by #13038.
