### PR TITLE
Always run benchmarks on LLVM integration PR

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -88,6 +88,7 @@ jobs:
           # the JSON strings and later use fromJSON to decode them.
           echo "pr-title=$(jq '.title' ${PR_JSON})" >> "${GITHUB_OUTPUT}"
           echo "pr-body=$(jq '.body' ${PR_JSON})" >> "${GITHUB_OUTPUT}"
+          echo "pr-branch=$(jq '.head.ref' ${PR_JSON})" >> "${GITHUB_OUTPUT}"
           # Use --compact-output to avoid multiline JSON.
           echo "pr-labels=$(jq --compact-output '.labels | map(.name)' \
             ${PR_JSON})" >> "${GITHUB_OUTPUT}"
@@ -96,6 +97,7 @@ jobs:
         env:
           PR_TITLE: ${{ fromJSON(steps.fetch-pr.outputs.pr-title || '""') }}
           PR_BODY: ${{ fromJSON(steps.fetch-pr.outputs.pr-body || '""') }}
+          PR_BRANCH: ${{ fromJSON(steps.fetch-pr.outputs.pr-branch || '""') }}
           PR_LABELS: ${{ steps.fetch-pr.outputs.pr-labels || '[]' }}
           ORIGINAL_PR_TITLE: ${{ github.event.pull_request.title }}
           ORIGINAL_PR_BODY: ${{ github.event.pull_request.body }}

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -79,7 +79,11 @@ BENCHMARK_PRESET_OPTIONS = ["all", "cuda", "x86_64", "comp-stats"]
 
 PR_DESCRIPTION_TEMPLATE = "{title}" "\n\n" "{body}"
 
-# Patterns to detect LLVM integration PRs.
+# Patterns to detect "LLVM integration" PRs, i.e. changes that update the
+# third_party/llvm-project submodule. This should only include PRs
+# intended to be merged and should exclude test/draft PRs as well as
+# PRs that include temporary patches to the submodule during review.
+# See also: https://github.com/openxla/iree/issues/12268
 LLVM_INTEGRATION_PR_TITLE_PATTERN = re.compile("^integrate.+llvm-project",
                                                re.IGNORECASE)
 LLVM_INTEGRATION_BRANCH_PATTERN = re.compile("bump-llvm|llvm-bump",

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -267,9 +267,7 @@ def get_benchmark_presets(is_pr: bool, trailers: Mapping[str, str],
   """
   if not is_pr:
     preset_options = ["all"]
-  elif (LLVM_INTEGRATION_PR_TITLE_PATTERN.search(os.environ["PR_TITLE"]) or
-        LLVM_INTEGRATION_BRANCH_PATTERN.search(os.environ["PR_BRANCH"]) or
-        LLVM_INTEGRATE_LABEL in labels):
+  elif is_llvm_integrate:
     # Always run all benchmark presets for LLVM integration PRs.
     preset_options = ["all"]
   else:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -266,9 +266,11 @@ def get_benchmark_presets(trailers: Mapping[str, str], labels: Sequence[str],
   """
   if not is_pr:
     preset_options = ["all"]
+    print(f"Using benchmark preset 'all' for non-PR run")
   elif is_llvm_integrate_pr:
     # Always run all benchmark presets for LLVM integration PRs.
     preset_options = ["all"]
+    print(f"Using benchmark preset 'all' for LLVM integrate PR")
   else:
     preset_options = set(
         label.split(":", maxsplit=1)[1]
@@ -279,8 +281,7 @@ def get_benchmark_presets(trailers: Mapping[str, str], labels: Sequence[str],
       preset_options = preset_options.union(
           option.strip() for option in trailer.split(","))
     preset_options = sorted(preset_options)
-
-  print(f"Using benchmark preset '{preset_options}'")
+    print(f"Using benchmark preset '{preset_options}' from trailers and labels")
 
   for preset_option in preset_options:
     if preset_option not in BENCHMARK_PRESET_OPTIONS:


### PR DESCRIPTION
Always run benchmarks on LLVM integration PR to prevent unexpected performance impact.

As people have different ways to create their integration PRs, here we use 3 fuzzy logic to match the PR:

- Branch name contains `bump-llvm` or `llvm-bump`
  - Example: https://github.com/openxla/iree/pull/13232, #12894
- PR title matches `^Integrate.+llvm-project` (case-insensitive)
  - Catch the exception #12822
- `llvm-integrate` label is presented
  - Example: #12851

For the PR title matching, I checked the git log in the past year:
```sh
git log --since="2022-04-25" --first-parent --pretty=oneline | cut -d ' ' -f2- | grep --ignore-case -E '^Integrate.+llvm-project'
```
There is no false positive.

This change will trigger benchmark run on every push of an LLVM integration PR, which could be a concern on wasting resources. However it looks like many pushes failed early in CI due to breakages, I think there won't be too many wasteful benchmark runs.

Fix #12268