### PR TITLE
Update docs to remove iree folder that no longer exists

### DIFF
--- a/build_tools/scripts/integrate/README.md
+++ b/build_tools/scripts/integrate/README.md
@@ -140,7 +140,7 @@ Bazel can help, especially for catching nit-picky strict things:
 
 ```
 bazel build tools:iree-compile
-bazel test iree/compiler/...
+bazel test compiler/...
 ```
 
 Once Bazel is good, remember to run

--- a/docs/developers/get_started/building_with_bazel_linux.md
+++ b/docs/developers/get_started/building_with_bazel_linux.md
@@ -59,7 +59,7 @@ $ python3 configure_bazel.py
 Run all core tests:
 
 ```shell
-$ bazel test -k iree/...
+$ bazel test -k compiler/... runtime/...
 ```
 
 > Tip:<br>

--- a/docs/developers/get_started/building_with_bazel_linux.md
+++ b/docs/developers/get_started/building_with_bazel_linux.md
@@ -59,7 +59,7 @@ $ python3 configure_bazel.py
 Run all core tests:
 
 ```shell
-$ bazel test -k compiler/... runtime/...
+$ bazel test -k //...
 ```
 
 > Tip:<br>

--- a/docs/developers/get_started/building_with_bazel_macos.md
+++ b/docs/developers/get_started/building_with_bazel_macos.md
@@ -60,7 +60,7 @@ $ python3 configure_bazel.py
 Run all core tests that pass on our OSS CI:
 
 ```shell
-$ bazel test -k //iree/... \
+$ bazel test -k //... \
   --test_env=IREE_VULKAN_DISABLE=1 \
   --build_tag_filters="-nokokoro" \
   --test_tag_filters="--nokokoro,-driver=vulkan"

--- a/docs/developers/get_started/building_with_bazel_windows.md
+++ b/docs/developers/get_started/building_with_bazel_windows.md
@@ -77,7 +77,7 @@ clone the repository, initialize its submodules, and configure:
 Run all core tests:
 
 ```powershell
-> bazel test -k iree/...
+> bazel test -k //...
 ```
 
 In general, build artifacts will be under the `bazel-bin` directory at the top


### PR DESCRIPTION
I believe previously it was iree/... but it got refactored to be compiler/ and runtime/ folders so this command needs to be updated.