### PR TITLE
Removing a verifier check on equality between threadblock K shape and problem K shape

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -143,9 +143,6 @@ LogicalResult verifyGPUMatmulPipeline(
     rhsShape = rhsShape.drop_front();
   }
 
-  // Number of software pipeline stages/depth.
-  int64_t softwarePipelineDepth = translationInfo.getSoftwarePipelineDepth();
-
   //
   // Begin verification for CUDA and Tensor Core pipelines.
   //
@@ -206,18 +203,6 @@ LogicalResult verifyGPUMatmulPipeline(
                                  lhsType.cast<ShapedType>().getElementType(),
                                  instructionShape))) {
     return failure();
-  }
-
-  // Verify the matmul problem shape K has a multiple of thread block K tiles.
-  if (softwarePipelineDepth > 1 && threadBlockShape[kK] == matmulShape[kK]) {
-    return op->emitError("Matmul problem shape K ")
-           << matmulShape[kK]
-           << " is not in the multiple of thread block K tiles needed for "
-              "software pipelining ("
-           << threadBlockShape[kK] << ")"
-           << " * "
-           << "(" << softwarePipelineDepth << ")"
-           << " with compilation pipeline " << pipelineName;
   }
 
   // Verify that matmul problem shape can be tiled with the thread block shape.


### PR DESCRIPTION
This PR removes a check from verifier.cpp that is filtering a configuration that, I think, we can support. Please review the following for more details:

We pushed a few fixes to batch matmul and trying out t5 model matmul shapes (`batch_matmul_16x512x512x64_f16t_f16t_f16t`). Without this PR, I am unable to run a functionally supported and top-performing tile config (`tile_config_64x64_64x5_tensorcore_mmasync`) because threadblock::kK == problem_shape_k (`64 == 64`).

batch matmul sweeps here
```bash
---------------------------------------------------------------- 
Dispatch      : batch_matmul_16x512x512x64_f16t_f16t_f16t_tile_config_256x128_32x3_tensorcore_mmasync
Provider      : IREE Codegen
OpKind        : OperationKind.BatchMatmul
Operation     : batch_matmul_16x512x512x64_f16t_f16t_f16t
Configuration : tile_config_256x128_32x3_tensorcore_mmasync
Arguments     : --batch_count=16, --M=512, --N=512, --K=64, --lhs=f16t, --rhs=f16t,
                --result=f16t, --split_k_mode=N/A, --split_k_slices=N/A
Verification  : SUCCESS
Runtime(ms)   : 0.021
GFLOPs        : 25565.28
---------------------------------------------------------------- 
Dispatch      : batch_matmul_16x512x512x64_f16t_f16t_f16t_tile_config_128x256_32x3_tensorcore_mmasync
Provider      : IREE Codegen
OpKind        : OperationKind.BatchMatmul
Operation     : batch_matmul_16x512x512x64_f16t_f16t_f16t
Configuration : tile_config_128x256_32x3_tensorcore_mmasync
Arguments     : --batch_count=16, --M=512, --N=512, --K=64, --lhs=f16t, --rhs=f16t,
                --result=f16t, --split_k_mode=N/A, --split_k_slices=N/A
Verification  : SUCCESS
Runtime(ms)   : 0.02
GFLOPs        : 26843.55
---------------------------------------------------------------- 
Dispatch      : batch_matmul_16x512x512x64_f16t_f16t_f16t_tile_config_128x128_64x4_tensorcore_mmasync
Provider      : IREE Codegen
OpKind        : OperationKind.BatchMatmul
Operation     : batch_matmul_16x512x512x64_f16t_f16t_f16t
Configuration : tile_config_128x128_64x4_tensorcore_mmasync
Arguments     : --batch_count=16, --M=512, --N=512, --K=64, --lhs=f16t, --rhs=f16t,
                --result=f16t, --split_k_mode=N/A, --split_k_slices=N/A
Verification  : SUCCESS
Runtime(ms)   : 0.014
GFLOPs        : 38347.92
---------------------------------------------------------------- 
Dispatch      : batch_matmul_16x512x512x64_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync
Provider      : IREE Codegen
OpKind        : OperationKind.BatchMatmul
Operation     : batch_matmul_16x512x512x64_f16t_f16t_f16t
Configuration : tile_config_128x128_32x5_tensorcore_mmasync
Arguments     : --batch_count=16, --M=512, --N=512, --K=64, --lhs=f16t, --rhs=f16t,
                --result=f16t, --split_k_mode=N/A, --split_k_slices=N/A
Verification  : SUCCESS
Runtime(ms)   : 0.016
GFLOPs        : 33554.43
---------------------------------------------------------------- 
Dispatch      : batch_matmul_16x512x512x64_f16t_f16t_f16t_tile_config_128x64_32x5_tensorcore_mmasync
Provider      : IREE Codegen
OpKind        : OperationKind.BatchMatmul
Operation     : batch_matmul_16x512x512x64_f16t_f16t_f16t
Configuration : tile_config_128x64_32x5_tensorcore_mmasync
Arguments     : --batch_count=16, --M=512, --N=512, --K=64, --lhs=f16t, --rhs=f16t,
                --result=f16t, --split_k_mode=N/A, --split_k_slices=N/A
Verification  : SUCCESS
Runtime(ms)   : 0.015
GFLOPs        : 35791.39
---------------------------------------------------------------- 
Dispatch      : batch_matmul_16x512x512x64_f16t_f16t_f16t_tile_config_64x64_64x5_tensorcore_mmasync
Provider      : IREE Codegen
OpKind        : OperationKind.BatchMatmul
Operation     : batch_matmul_16x512x512x64_f16t_f16t_f16t
Configuration : tile_config_64x64_64x5_tensorcore_mmasync
Arguments     : --batch_count=16, --M=512, --N=512, --K=64, --lhs=f16t, --rhs=f16t,
                --result=f16t, --split_k_mode=N/A, --split_k_slices=N/A
Verification  : SUCCESS
Runtime(ms)   : 0.013
GFLOPs        : 41297.76
---------------------------------------------------------------- 
```