### PR TITLE
Cleanup MPI error handling.

### DIFF
--- a/runtime/src/iree/hal/utils/libmpi_dynamic_symbols.h
+++ b/runtime/src/iree/hal/utils/libmpi_dynamic_symbols.h
@@ -18,3 +18,7 @@ MPI_PFN_DECL(MPI_Comm_split, IREE_MPI_Comm comm, int color, int key,
 MPI_PFN_DECL(ompi_mpi_byte)
 MPI_PFN_DECL(ompi_mpi_comm_world)
 #endif  // IREE_MPI_TYPES_ARE_POINTERS
+
+// MPI error handling
+MPI_PFN_DECL(MPI_Error_class, int err_code, int* err_class)
+MPI_PFN_DECL(MPI_Error_string, int err_code, char* string, int* resultlen)

--- a/runtime/src/iree/hal/utils/libmpi_test.cc
+++ b/runtime/src/iree/hal/utils/libmpi_test.cc
@@ -65,7 +65,7 @@ class LibmpiTest : public ::testing::Test {
   int world_size = 0;
 };
 
-iree_dynamic_library_t *LibmpiTest::library = NULL;
+iree_dynamic_library_t* LibmpiTest::library = NULL;
 iree_hal_mpi_dynamic_symbols_t LibmpiTest::symbols = {0};
 
 // An MPI "hello world" program to test library loading.

--- a/runtime/src/iree/hal/utils/libmpi_test.cc
+++ b/runtime/src/iree/hal/utils/libmpi_test.cc
@@ -13,40 +13,97 @@
 
 namespace {
 
-TEST(libmpi, DynamicLoadLibraryAndSymbols) {
-  iree_dynamic_library_t* library = NULL;
-  iree_hal_mpi_dynamic_symbols_t symbols = {0};
-  iree_status_t status =
-      iree_hal_mpi_library_load(iree_allocator_system(), &library, &symbols);
-  if (!iree_status_is_ok(status)) {
-    iree_status_fprint(stderr, status);
-    iree_status_ignore(status);
-    std::cerr << "Symbols cannot be loaded, skipping test.";
-    GTEST_SKIP();
+const int MPI_SUCCESS = 0;
+
+class LibmpiTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    iree_status_t status =
+        iree_hal_mpi_library_load(iree_allocator_system(), &library, &symbols);
+
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+    } else {
+      EXPECT_EQ(symbols.MPI_Init(NULL, NULL), MPI_SUCCESS);
+    }
   }
 
-  IREE_EXPECT_OK(
-      MPI_RESULT_TO_STATUS(&symbols, MPI_Init(NULL, NULL), "MPI_Init"));
+  void SetUp() override {
+    if (!library) GTEST_SKIP() << "No MPI library available. Skipping suite.";
+    bool has_symbols = false;
+    unsigned char *syms_ptr = (unsigned char *)&symbols;
+    for (int i = 0; i < sizeof(symbols); i++) {
+      if (*(syms_ptr + i) != 0) {
+        has_symbols = true;
+        break;
+      }
+    }
+    if (!has_symbols)
+      GTEST_SKIP() << "MPI library failed to load symbols. Skipping suite";
 
-  int size = 0;
-  IREE_EXPECT_OK(MPI_RESULT_TO_STATUS(
-      &symbols, MPI_Comm_size(IREE_MPI_COMM_WORLD(&symbols), &size),
-      "MPI_Comm_size"));
+    IREE_EXPECT_OK(MPI_RESULT_TO_STATUS(
+        &symbols, MPI_Comm_size(IREE_MPI_COMM_WORLD(&symbols), &world_size),
+        "MPI_Comm_size"));
 
-  int rank = 0;
-  IREE_EXPECT_OK(MPI_RESULT_TO_STATUS(
-      &symbols, MPI_Comm_rank(IREE_MPI_COMM_WORLD(&symbols), &rank),
-      "MPI_Comm_rank"));
+    IREE_EXPECT_OK(MPI_RESULT_TO_STATUS(
+        &symbols, MPI_Comm_rank(IREE_MPI_COMM_WORLD(&symbols), &rank),
+        "MPI_Comm_rank"));
 
-  EXPECT_LT(rank, size);
+    EXPECT_LT(rank, world_size);
+  }
 
+  void TearDown() override {}
+
+  static void TearDownTestSuite() {
+    if (!library) return;
+
+    IREE_EXPECT_OK(
+        MPI_RESULT_TO_STATUS(&symbols, MPI_Finalize(), "MPI_Finalize"));
+
+    memset(&symbols, 0, sizeof(symbols));
+    if (library) iree_dynamic_library_release(library);
+  }
+
+ protected:
+  static iree_dynamic_library_t *library;
+  static iree_hal_mpi_dynamic_symbols_t symbols;
+  int rank;
+  int world_size;
+};
+
+iree_dynamic_library_t *LibmpiTest::library = NULL;
+iree_hal_mpi_dynamic_symbols_t LibmpiTest::symbols = {0};
+
+// an MPI hello_world program to test library loading
+TEST_F(LibmpiTest, HelloWorld) {
   std::cout << "Hello world! "
-            << "I'm " << rank << " of " << size << std::endl;
+            << "I'm " << rank << " of " << world_size << std::endl;
+}
 
-  IREE_EXPECT_OK(
-      MPI_RESULT_TO_STATUS(&symbols, MPI_Finalize(), "MPI_Finalize"));
+TEST_F(LibmpiTest, MPI_error_to_IREE_status) {
+  iree_status_t status;
+  IREE_EXPECT_OK(iree_hal_mpi_result_to_status(NULL, 0, __FILE__, __LINE__));
 
-  iree_dynamic_library_release(library);
+  const int MPI_ERR_UNKNOWN = 14;
+  status =
+      iree_hal_mpi_result_to_status(NULL, MPI_ERR_UNKNOWN, __FILE__, __LINE__);
+  EXPECT_TRUE(iree_status_is_internal(status));
+  char *buffer = NULL;
+  iree_host_size_t length = 0;
+  iree_allocator_t allocator = iree_allocator_system();
+  if (iree_status_to_string(status, &allocator, &buffer, &length)) {
+    EXPECT_THAT(buffer, testing::HasSubstr("MPI library symbols not loaded"));
+    iree_allocator_free(allocator, buffer);
+  }
+
+  const int MPI_ERR_ACCESS = 20;
+  status = iree_hal_mpi_result_to_status(&symbols, MPI_ERR_ACCESS, __FILE__,
+                                         __LINE__);
+  EXPECT_TRUE(iree_status_is_internal(status));
+  ASSERT_TRUE(iree_status_to_string(status, &allocator, &buffer, &length));
+  EXPECT_THAT(buffer, testing::HasSubstr("MPI_ERR_ACCESS"));
+  iree_allocator_free(allocator, buffer);
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/utils/libmpi_test.cc
+++ b/runtime/src/iree/hal/utils/libmpi_test.cc
@@ -59,7 +59,7 @@ class LibmpiTest : public ::testing::Test {
   }
 
  protected:
-  static iree_dynamic_library_t *library;
+  static iree_dynamic_library_t* library;
   static iree_hal_mpi_dynamic_symbols_t symbols;
   int rank = 0;
   int world_size = 0;


### PR DESCRIPTION
We use MPI_Error_class and MPI_Error_string to print meaningful error messages rather than just printing a numeric error code value.

At the same time, refactor the testing harness to a suite that initializes MPI only once -- otherwise only one test succeeds because orte (the OpenMPI runtime env) does not support calling MPI_Init and MPI_Finalize multiple times.