### PR TITLE
Use zero-initialization instead of memset

### DIFF
--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -214,8 +214,7 @@ py::str HalBufferView::Repr() {
 //------------------------------------------------------------------------------
 
 void HalDevice::BeginProfiling(const py::kwargs& kwargs) {
-  iree_hal_device_profiling_options_t options;
-  memset(&options, 0, sizeof(options));
+  iree_hal_device_profiling_options_t options = {};
 
   options.mode = IREE_HAL_DEVICE_PROFILING_MODE_QUEUE_OPERATIONS;
   if (kwargs.contains("mode")) {

--- a/runtime/bindings/python/py_module.cc
+++ b/runtime/bindings/python/py_module.cc
@@ -296,8 +296,7 @@ class PyModuleInterface {
           callable(std::move(callable)) {}
 
     iree_status_t ParseCconv() {
-      iree_vm_function_signature_t signature;
-      memset(&signature, 0, sizeof(signature));
+      iree_vm_function_signature_t signature = {};
       signature.calling_convention = {cconv.data(), cconv.size()};
       IREE_RETURN_IF_ERROR(iree_vm_function_call_get_cconv_fragments(
           &signature, &cconv_arguments, &cconv_results));

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -356,8 +356,7 @@ iree_status_t iree_dynamic_library_attach_symbols_from_file(
   // get this (such as registering a LdrDllNotification callback and snooping
   // the values during LoadLibrary or using CreateToolhelp32Snapshot), however
   // EnumerateLoadedModules is in dbghelp which we are using anyway.
-  ModuleEnumCallbackState state;
-  memset(&state, 0, sizeof(state));
+  ModuleEnumCallbackState state = {0};
   state.module_path = library->module_path;
   EnumerateLoadedModules64(GetCurrentProcess(), EnumLoadedModulesCallback,
                            &state);

--- a/runtime/src/iree/base/internal/threading_test.cc
+++ b/runtime/src/iree/base/internal/threading_test.cc
@@ -26,8 +26,7 @@ using iree::Status;
 
 TEST(ThreadTest, Lifetime) {
   // Default parameters:
-  iree_thread_create_params_t params;
-  memset(&params, 0, sizeof(params));
+  iree_thread_create_params_t params = {};
 
   // Our thread: do a bit of math and notify the main test thread when done.
   struct entry_data_t {
@@ -68,8 +67,7 @@ TEST(ThreadTest, Lifetime) {
 }
 
 TEST(ThreadTest, CreateSuspended) {
-  iree_thread_create_params_t params;
-  memset(&params, 0, sizeof(params));
+  iree_thread_create_params_t params = {};
   params.create_suspended = true;
 
   struct entry_data_t {
@@ -120,8 +118,7 @@ TEST(ThreadTest, CreateSuspended) {
 // the system. This is here to test the mechanics of the priority override code
 // on our side and assumes that if we tell the OS something it respects it.
 TEST(ThreadTest, PriorityOverride) {
-  iree_thread_create_params_t params;
-  memset(&params, 0, sizeof(params));
+  iree_thread_create_params_t params = {};
 
   struct entry_data_t {
     iree_atomic_int32_t value;

--- a/runtime/src/iree/base/internal/threading_win32.c
+++ b/runtime/src/iree/base/internal/threading_win32.c
@@ -285,8 +285,7 @@ void iree_thread_request_affinity(iree_thread_t* thread,
                                           affinity_desc_length);
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
-  GROUP_AFFINITY group_affinity;
-  memset(&group_affinity, 0, sizeof(group_affinity));
+  GROUP_AFFINITY group_affinity = {0};
   group_affinity.Group = affinity.group;
   KAFFINITY affinity_mask = 1ull << affinity.id;
   if (affinity.smt) {
@@ -299,8 +298,7 @@ void iree_thread_request_affinity(iree_thread_t* thread,
   // in the scheduler alternating cores within the affinity mask; in theory it's
   // just an SMT ID change and doesn't have any impact on caches but it'd be
   // good to check.
-  PROCESSOR_NUMBER ideal_processor;
-  memset(&ideal_processor, 0, sizeof(ideal_processor));
+  PROCESSOR_NUMBER ideal_processor = {0};
   ideal_processor.Group = affinity.group;
   ideal_processor.Number = affinity.id;
   SetThreadIdealProcessorEx(thread->handle, &ideal_processor, NULL);

--- a/runtime/src/iree/base/internal/wait_handle_test.cc
+++ b/runtime/src/iree/base/internal/wait_handle_test.cc
@@ -526,8 +526,7 @@ TEST(WaitSet, WaitAnyPolling) {
   IREE_ASSERT_OK(
       iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
 
-  iree_wait_handle_t empty_handle;
-  memset(&empty_handle, 0, sizeof(empty_handle));
+  iree_wait_handle_t empty_handle = {};
 
   // Polls when empty should never block and return an empty wake handle.
   // This is so that if the caller touches the wake_handle they at least have
@@ -593,8 +592,7 @@ TEST(WaitSet, WaitAnyTimeout) {
   IREE_ASSERT_OK(
       iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
 
-  iree_wait_handle_t empty_handle;
-  memset(&empty_handle, 0, sizeof(empty_handle));
+  iree_wait_handle_t empty_handle = {};
 
   // Timeouts when empty should never block.
   iree_wait_set_clear(wait_set);

--- a/runtime/src/iree/base/internal/wait_handle_test.cc
+++ b/runtime/src/iree/base/internal/wait_handle_test.cc
@@ -526,7 +526,8 @@ TEST(WaitSet, WaitAnyPolling) {
   IREE_ASSERT_OK(
       iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
 
-  iree_wait_handle_t empty_handle = {};
+  iree_wait_handle_t empty_handle;
+  memset(&empty_handle, 0, sizeof(empty_handle));
 
   // Polls when empty should never block and return an empty wake handle.
   // This is so that if the caller touches the wake_handle they at least have
@@ -592,7 +593,8 @@ TEST(WaitSet, WaitAnyTimeout) {
   IREE_ASSERT_OK(
       iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
 
-  iree_wait_handle_t empty_handle = {};
+  iree_wait_handle_t empty_handle;
+  memset(&empty_handle, 0, sizeof(empty_handle));
 
   // Timeouts when empty should never block.
   iree_wait_set_clear(wait_set);

--- a/runtime/src/iree/base/internal/wait_handle_win32.c
+++ b/runtime/src/iree/base/internal/wait_handle_win32.c
@@ -43,7 +43,8 @@ static iree_status_t iree_wait_primitive_clone(
                             "source wait handle must be a win32 HANDLE");
   }
 
-  iree_wait_primitive_value_t value = {0};
+  iree_wait_primitive_value_t value;
+  memset(&value, 0, sizeof(value));
   HANDLE process = GetCurrentProcess();
   if (!DuplicateHandle(process, (HANDLE)source_handle->value.win32.handle,
                        process, (LPHANDLE)&value.win32.handle, 0, FALSE,
@@ -324,7 +325,8 @@ static iree_status_t iree_wait_multi(iree_wait_set_t* set, bool require_all,
     // One (or more) handles were signaled sucessfully.
     if (out_wake_handle) {
       DWORD wake_index = result - WAIT_OBJECT_0;
-      iree_wait_primitive_value_t wake_value = {0};
+      iree_wait_primitive_value_t wake_value;
+      memset(&wake_value, 0, sizeof(wake_value));
       wake_value.win32.handle = (uintptr_t)set->native_handles[wake_index];
       iree_wait_handle_wrap_primitive(IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE,
                                       wake_value, out_wake_handle);
@@ -439,7 +441,8 @@ iree_status_t iree_wait_one(iree_wait_handle_t* handle,
 iree_status_t iree_event_initialize(bool initial_state,
                                     iree_event_t* out_event) {
   memset(out_event, 0, sizeof(*out_event));
-  iree_wait_primitive_value_t value = {0};
+  iree_wait_primitive_value_t value;
+  memset(&value, 0, sizeof(value));
   value.win32.handle =
       (uintptr_t)CreateEvent(NULL, TRUE, initial_state ? TRUE : FALSE, NULL);
   if (!value.win32.handle) {

--- a/runtime/src/iree/base/internal/wait_handle_win32.c
+++ b/runtime/src/iree/base/internal/wait_handle_win32.c
@@ -43,8 +43,7 @@ static iree_status_t iree_wait_primitive_clone(
                             "source wait handle must be a win32 HANDLE");
   }
 
-  iree_wait_primitive_value_t value;
-  memset(&value, 0, sizeof(value));
+  iree_wait_primitive_value_t value = {0};
   HANDLE process = GetCurrentProcess();
   if (!DuplicateHandle(process, (HANDLE)source_handle->value.win32.handle,
                        process, (LPHANDLE)&value.win32.handle, 0, FALSE,
@@ -325,8 +324,7 @@ static iree_status_t iree_wait_multi(iree_wait_set_t* set, bool require_all,
     // One (or more) handles were signaled sucessfully.
     if (out_wake_handle) {
       DWORD wake_index = result - WAIT_OBJECT_0;
-      iree_wait_primitive_value_t wake_value;
-      memset(&wake_value, 0, sizeof(wake_value));
+      iree_wait_primitive_value_t wake_value = {0};
       wake_value.win32.handle = (uintptr_t)set->native_handles[wake_index];
       iree_wait_handle_wrap_primitive(IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE,
                                       wake_value, out_wake_handle);
@@ -441,8 +439,7 @@ iree_status_t iree_wait_one(iree_wait_handle_t* handle,
 iree_status_t iree_event_initialize(bool initial_state,
                                     iree_event_t* out_event) {
   memset(out_event, 0, sizeof(*out_event));
-  iree_wait_primitive_value_t value;
-  memset(&value, 0, sizeof(value));
+  iree_wait_primitive_value_t value = {0};
   value.win32.handle =
       (uintptr_t)CreateEvent(NULL, TRUE, initial_state ? TRUE : FALSE, NULL);
   if (!value.win32.handle) {

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -374,8 +374,7 @@ static iree_status_t iree_hal_cuda_device_create_channel(
   }
 
   // Ask for the defaults.
-  iree_hal_cuda_nccl_id_t id;
-  memset(&id, 0, sizeof(id));
+  iree_hal_cuda_nccl_id_t id = {0};
   if (device->params.channel_provider.query_group_params) {
     IREE_TRACE_ZONE_BEGIN_NAMED(z0,
                                 "iree_hal_channel_provider_query_group_params");

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
@@ -178,8 +178,7 @@ iree_status_t iree_hal_vulkan_match_available_device_extensions(
 iree_hal_vulkan_instance_extensions_t
 iree_hal_vulkan_populate_enabled_instance_extensions(
     const iree_hal_vulkan_string_list_t* enabled_extensions) {
-  iree_hal_vulkan_instance_extensions_t extensions;
-  memset(&extensions, 0, sizeof(extensions));
+  iree_hal_vulkan_instance_extensions_t extensions = {};
   for (iree_host_size_t i = 0; i < enabled_extensions->count; ++i) {
     const char* extension_name = enabled_extensions->values[i];
     if (strcmp(extension_name, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0) {
@@ -192,8 +191,7 @@ iree_hal_vulkan_populate_enabled_instance_extensions(
 iree_hal_vulkan_device_extensions_t
 iree_hal_vulkan_populate_enabled_device_extensions(
     const iree_hal_vulkan_string_list_t* enabled_extensions) {
-  iree_hal_vulkan_device_extensions_t extensions;
-  memset(&extensions, 0, sizeof(extensions));
+  iree_hal_vulkan_device_extensions_t extensions = {};
   for (iree_host_size_t i = 0; i < enabled_extensions->count; ++i) {
     const char* extension_name = enabled_extensions->values[i];
     if (strcmp(extension_name, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME) == 0) {
@@ -218,8 +216,7 @@ iree_hal_vulkan_populate_enabled_device_extensions(
 iree_hal_vulkan_device_extensions_t
 iree_hal_vulkan_infer_enabled_device_extensions(
     const iree::hal::vulkan::DynamicSymbols* device_syms) {
-  iree_hal_vulkan_device_extensions_t extensions;
-  memset(&extensions, 0, sizeof(extensions));
+  iree_hal_vulkan_device_extensions_t extensions = {};
   if (device_syms->vkCmdPushDescriptorSetKHR) {
     extensions.push_descriptors = true;
   }

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
@@ -85,8 +85,7 @@ static iree_status_t iree_hal_vulkan_create_pipelines(
                                                              create_info_size +
                                                              spec_map_size);
 
-  VkSpecializationInfo spec_info;
-  memset(&spec_info, 0, sizeof(spec_info));
+  VkSpecializationInfo spec_info = {};
   spec_info.mapEntryCount = executable_params->constant_count;
   spec_info.pMapEntries = spec_map_entries;
   spec_info.dataSize = executable_params->constant_count * sizeof(uint32_t);

--- a/runtime/src/iree/hal/drivers/vulkan/tracing.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/tracing.cc
@@ -84,8 +84,7 @@ static VkCommandBuffer iree_hal_vulkan_tracing_begin_command_buffer(
     iree_hal_vulkan_tracing_context_t* context) {
   const auto& syms = context->logical_device->syms();
 
-  VkCommandBufferAllocateInfo command_buffer_info;
-  memset(&command_buffer_info, 0, sizeof(command_buffer_info));
+  VkCommandBufferAllocateInfo command_buffer_info = {};
   command_buffer_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
   command_buffer_info.commandPool = *context->maintenance_command_pool;
   command_buffer_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -95,8 +94,7 @@ static VkCommandBuffer iree_hal_vulkan_tracing_begin_command_buffer(
       &command_buffer_info, &command_buffer));
   if (!command_buffer) return VK_NULL_HANDLE;
 
-  VkCommandBufferBeginInfo begin_info;
-  memset(&begin_info, 0, sizeof(begin_info));
+  VkCommandBufferBeginInfo begin_info = {};
   begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
   begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
   syms->vkBeginCommandBuffer(command_buffer, &begin_info);
@@ -112,8 +110,7 @@ static void iree_hal_vulkan_tracing_submit_command_buffer(
 
   syms->vkEndCommandBuffer(command_buffer);
 
-  VkSubmitInfo submit_info;
-  memset(&submit_info, 0, sizeof(submit_info));
+  VkSubmitInfo submit_info = {};
   submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
   submit_info.commandBufferCount = 1;
   submit_info.pCommandBuffers = &command_buffer;
@@ -317,8 +314,7 @@ static void iree_hal_vulkan_tracing_prepare_query_pool(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Create a query pool with the largest query capacity it can provide.
-  VkQueryPoolCreateInfo pool_info;
-  memset(&pool_info, 0, sizeof(pool_info));
+  VkQueryPoolCreateInfo pool_info = {};
   pool_info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
   pool_info.queryCount = IREE_HAL_VULKAN_TRACING_DEFAULT_QUERY_CAPACITY;
   pool_info.queryType = VK_QUERY_TYPE_TIMESTAMP;

--- a/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
@@ -365,8 +365,7 @@ iree_status_t iree_hal_vulkan_vma_allocator_create(
   allocator->device = device;
 
   const auto& syms = logical_device->syms();
-  VmaVulkanFunctions vulkan_fns;
-  memset(&vulkan_fns, 0, sizeof(vulkan_fns));
+  VmaVulkanFunctions vulkan_fns = {};
   vulkan_fns.vkGetPhysicalDeviceProperties =
       syms->vkGetPhysicalDeviceProperties;
   vulkan_fns.vkGetPhysicalDeviceMemoryProperties =
@@ -389,16 +388,14 @@ iree_status_t iree_hal_vulkan_vma_allocator_create(
   vulkan_fns.vkDestroyImage = syms->vkDestroyImage;
   vulkan_fns.vkCmdCopyBuffer = syms->vkCmdCopyBuffer;
 
-  VmaDeviceMemoryCallbacks device_memory_callbacks;
-  memset(&device_memory_callbacks, 0, sizeof(device_memory_callbacks));
+  VmaDeviceMemoryCallbacks device_memory_callbacks = {};
   IREE_STATISTICS({
     device_memory_callbacks.pfnAllocate = iree_hal_vulkan_vma_allocate_callback;
     device_memory_callbacks.pfnFree = iree_hal_vulkan_vma_free_callback;
     device_memory_callbacks.pUserData = allocator;
   });
 
-  VmaAllocatorCreateInfo create_info;
-  memset(&create_info, 0, sizeof(create_info));
+  VmaAllocatorCreateInfo create_info = {};
   create_info.flags = 0;
   create_info.physicalDevice = physical_device;
   create_info.device = *logical_device;

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -885,8 +885,7 @@ iree_status_t iree_hal_vulkan_device_create(
                                              &physical_device_features);
 
   // Create device and its queues.
-  VkDeviceCreateInfo device_create_info;
-  memset(&device_create_info, 0, sizeof(device_create_info));
+  VkDeviceCreateInfo device_create_info = {};
   device_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
   device_create_info.enabledLayerCount = 0;
   device_create_info.ppEnabledLayerNames = NULL;
@@ -896,8 +895,7 @@ iree_status_t iree_hal_vulkan_device_create(
   device_create_info.pQueueCreateInfos = queue_create_info.data();
   device_create_info.pEnabledFeatures = NULL;
 
-  VkPhysicalDeviceFeatures2 features2;
-  memset(&features2, 0, sizeof(features2));
+  VkPhysicalDeviceFeatures2 features2 = {};
   features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
   device_create_info.pNext = &features2;
   if (physical_device_features.shaderInt64) {
@@ -914,8 +912,7 @@ iree_status_t iree_hal_vulkan_device_create(
     features2.features.robustBufferAccess = VK_TRUE;
   }
 
-  VkPhysicalDeviceTimelineSemaphoreFeatures semaphore_features;
-  memset(&semaphore_features, 0, sizeof(semaphore_features));
+  VkPhysicalDeviceTimelineSemaphoreFeatures semaphore_features = {};
   semaphore_features.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
   semaphore_features.pNext = features2.pNext;

--- a/runtime/src/iree/hal/local/elf/elf_module.c
+++ b/runtime/src/iree/hal/local/elf/elf_module.c
@@ -495,8 +495,7 @@ static iree_status_t iree_elf_module_verify_no_imports(
 static iree_status_t iree_elf_module_apply_relocations(
     iree_elf_module_load_state_t* load_state, iree_elf_module_t* module) {
   // Redirect to the architecture-specific handler.
-  iree_elf_relocation_state_t reloc_state;
-  memset(&reloc_state, 0, sizeof(reloc_state));
+  iree_elf_relocation_state_t reloc_state = {0};
   reloc_state.vaddr_bias = module->vaddr_bias;
   reloc_state.dyn_table = load_state->dyn_table;
   reloc_state.dyn_table_count = load_state->dyn_table_count;

--- a/runtime/src/iree/hal/local/elf/elf_module_test_main.c
+++ b/runtime/src/iree/hal/local/elf/elf_module_test_main.c
@@ -56,8 +56,7 @@ static iree_status_t run_test() {
   iree_const_byte_span_t file_data;
   IREE_RETURN_IF_ERROR(query_arch_test_file_data(&file_data));
 
-  iree_elf_import_table_t import_table;
-  memset(&import_table, 0, sizeof(import_table));
+  iree_elf_import_table_t import_table = {0};
   iree_elf_module_t module;
   IREE_RETURN_IF_ERROR(iree_elf_module_initialize_from_memory(
       file_data, &import_table, iree_allocator_system(), &module));

--- a/runtime/src/iree/hal/local/executable_library_test.c
+++ b/runtime/src/iree/hal/local/executable_library_test.c
@@ -58,8 +58,7 @@ int main(int argc, char** argv) {
   // to specify (no buffer pointer indirection) and more efficient to access
   // (static struct offset address calculation, all fit in a few cache lines,
   // etc). They are limited in capacity, though, so only <=64(ish) are usable.
-  dispatch_tile_a_push_constants_t push_constants;
-  memset(&push_constants, 0, sizeof(push_constants));
+  dispatch_tile_a_push_constants_t push_constants = {0};
   push_constants.f0 = 5.0f;
 
   // Setup the two buffer bindings the entry point is expecting.

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -518,8 +518,7 @@ static iree_status_t iree_hal_vmvx_executable_issue_call(
   // Direct call interface.
   // This only works because we know the exact signature and that these will
   // never block (if they do it'll be handled as if it's an error).
-  iree_vm_function_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_vm_function_call_t call = {0};
   call.function = entry_fn;
   call.arguments = iree_make_byte_span(&call_args, sizeof(call_args));
   call.results = iree_make_byte_span(NULL, 0);

--- a/runtime/src/iree/task/poller.c
+++ b/runtime/src/iree/task/poller.c
@@ -54,8 +54,7 @@ iree_status_t iree_task_poller_initialize(
     status = iree_wait_set_insert(out_poller->wait_set, out_poller->wake_event);
   }
 
-  iree_thread_create_params_t thread_params;
-  memset(&thread_params, 0, sizeof(thread_params));
+  iree_thread_create_params_t thread_params = {0};
   thread_params.name = iree_make_cstring_view("iree-poller");
   thread_params.create_suspended = false;
   // TODO(benvanik): make high so to reduce latency? The sooner we wake the

--- a/runtime/src/iree/task/task.c
+++ b/runtime/src/iree/task/task.c
@@ -754,8 +754,7 @@ void iree_task_dispatch_shard_execute(
   // We perform all our shard statistics work locally here and only push back to
   // the dispatch at the end; this avoids contention from each shard trying to
   // update the statistics together.
-  iree_task_dispatch_statistics_t shard_statistics;
-  memset(&shard_statistics, 0, sizeof(shard_statistics));
+  iree_task_dispatch_statistics_t shard_statistics = {0};
   tile_context.statistics = &shard_statistics;
 
   // Hint as to which processor we are running on.

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -52,8 +52,7 @@ iree_status_t iree_task_worker_initialize(
   iree_atomic_store_int32(&out_worker->state, initial_state,
                           iree_memory_order_release);
 
-  iree_thread_create_params_t thread_params;
-  memset(&thread_params, 0, sizeof(thread_params));
+  iree_thread_create_params_t thread_params = {0};
   thread_params.name = iree_make_cstring_view(topology_group->name);
   thread_params.create_suspended = false;
   thread_params.priority_class = IREE_THREAD_PRIORITY_CLASS_NORMAL;

--- a/runtime/src/iree/testing/benchmark_full.cc
+++ b/runtime/src/iree/testing/benchmark_full.cc
@@ -97,8 +97,7 @@ static void iree_benchmark_run(const char* benchmark_name,
   IREE_TRACE_SCOPE_DYNAMIC(benchmark_name);
   IREE_TRACE_FRAME_MARK();
 
-  iree_benchmark_state_t state;
-  memset(&state, 0, sizeof(state));
+  iree_benchmark_state_t state = {};
   state.impl = &benchmark_state;
   state.host_allocator = iree_allocator_system();
 

--- a/runtime/src/iree/vm/bytecode/dispatch.c
+++ b/runtime/src/iree/vm/bytecode/dispatch.c
@@ -549,8 +549,7 @@ static iree_status_t iree_vm_bytecode_call_import(
   IREE_RETURN_IF_ERROR(iree_vm_bytecode_verify_import(stack, module_state,
                                                       import_ordinal, &import));
 
-  iree_vm_function_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_vm_function_call_t call = {0};
   call.function = import->function;
 
   // Marshal inputs from registers to the ABI arguments buffer.
@@ -586,8 +585,7 @@ static iree_status_t iree_vm_bytecode_call_import_variadic(
   IREE_RETURN_IF_ERROR(iree_vm_bytecode_verify_import(stack, module_state,
                                                       import_ordinal, &import));
 
-  iree_vm_function_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_vm_function_call_t call = {0};
   call.function = import->function;
 
   // Allocate ABI argument/result storage taking into account the variadic

--- a/runtime/src/iree/vm/bytecode/dispatch_async_test.cc
+++ b/runtime/src/iree/vm/bytecode/dispatch_async_test.cc
@@ -73,8 +73,7 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldSequence) {
   uint32_t arg_value = 97;
   uint32_t ret_value = 0;
 
-  iree_vm_function_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_vm_function_call_t call = {};
   call.function = function;
   call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
   call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
@@ -128,8 +127,7 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldDivergent) {
   };
   uint32_t ret_value = 0;
 
-  iree_vm_function_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_vm_function_call_t call = {};
   call.function = function;
   call.arguments = iree_make_byte_span(&arg_values, sizeof(arg_values));
   call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));

--- a/runtime/src/iree/vm/bytecode/module.c
+++ b/runtime/src/iree/vm/bytecode/module.c
@@ -798,8 +798,7 @@ static iree_status_t iree_vm_bytecode_module_begin_call(
       signature_def
           ? iree_vm_FunctionSignatureDef_calling_convention(signature_def)
           : 0;
-  iree_vm_function_signature_t signature;
-  memset(&signature, 0, sizeof(signature));
+  iree_vm_function_signature_t signature = {0};
   signature.calling_convention.data = calling_convention;
   signature.calling_convention.size =
       flatbuffers_string_len(calling_convention);

--- a/runtime/src/iree/vm/bytecode/module_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode/module_benchmark.cc
@@ -103,8 +103,7 @@ static iree_status_t RunFunction(benchmark::State& state,
   IREE_CHECK_OK(
       iree_vm_context_resolve_function(context, function_name, &function));
 
-  iree_vm_function_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_vm_function_call_t call = {};
   call.function = function;
   call.arguments =
       iree_make_byte_span(iree_alloca(i32_args.size() * sizeof(int32_t)),

--- a/runtime/src/iree/vm/context.c
+++ b/runtime/src/iree/vm/context.c
@@ -68,8 +68,7 @@ static iree_status_t iree_vm_context_run_function(
     iree_vm_module_t* module, iree_string_view_t function_name) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_vm_function_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_vm_function_call_t call = {0};
   iree_status_t status = iree_vm_module_lookup_function_by_name(
       module, IREE_VM_FUNCTION_LINKAGE_EXPORT, function_name, &call.function);
   if (iree_status_is_not_found(status)) {
@@ -598,8 +597,7 @@ static iree_status_t iree_vm_context_call_module_notify(
     iree_vm_module_state_t* module_state, iree_vm_signal_t signal) {
   // Single i32 argument with the signal number.
   uint32_t signal_arg = (uint32_t)signal;
-  iree_vm_function_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_vm_function_call_t call = {0};
   call.arguments = iree_make_byte_span(&signal_arg, sizeof(signal_arg));
 
   // Try to find the function. Modules are not required to export it.

--- a/runtime/src/iree/vm/module.c
+++ b/runtime/src/iree/vm/module.c
@@ -229,8 +229,7 @@ iree_vm_module_name(const iree_vm_module_t* module) {
 IREE_API_EXPORT iree_vm_module_signature_t
 iree_vm_module_signature(const iree_vm_module_t* module) {
   if (!module) {
-    iree_vm_module_signature_t empty;
-    memset(&empty, 0, sizeof(empty));
+    iree_vm_module_signature_t empty = {0};
     return empty;
   }
   return module->signature(module->self);
@@ -334,8 +333,7 @@ iree_vm_function_name(const iree_vm_function_t* function) {
 IREE_API_EXPORT iree_vm_function_signature_t
 iree_vm_function_signature(const iree_vm_function_t* function) {
   IREE_ASSERT_ARGUMENT(function);
-  iree_vm_function_signature_t signature;
-  memset(&signature, 0, sizeof(signature));
+  iree_vm_function_signature_t signature = {0};
   IREE_IGNORE_ERROR(function->module->get_function(
       function->module->self, function->linkage, function->ordinal,
       /*out_function=*/NULL,

--- a/samples/static_library/static_library_demo.c
+++ b/samples/static_library/static_library_demo.c
@@ -105,8 +105,7 @@ iree_status_t Run() {
 
   // Lookup the entry point function call.
   const char kMainFunctionName[] = "module.simple_mul";
-  iree_runtime_call_t call;
-  memset(&call, 0, sizeof(call));
+  iree_runtime_call_t call = {0};
   if (iree_status_is_ok(status)) {
     status = iree_runtime_call_initialize_by_name(
         session, iree_make_cstring_view(kMainFunctionName), &call);


### PR DESCRIPTION
Generated by:

For C files, initializing with `= {0}`:
```
git grep --name-only '\bmemset\b' | grep '\.c$' | xargs perl -0777 -i -pe 's/\n[ ]+([a-zA-Z0-9_]+)[ ]([a-zA-Z0-9_]+);\n([ ]+)memset\(\&\g2, 0, sizeof[ (]*(\g1|\g2)[)]*\);/\n$3$1 $2 = {0};/g'
```

For C++ files, initializing with `= {}`:
```
git grep --name-only '\bmemset\b' | grep '\.cc$' | xargs perl -0777 -i -pe 's/\n[ ]+([a-zA-Z0-9_]+)[ ]([a-zA-Z0-9_]+);\n([ ]+)memset\(\&\g2, 0, sizeof[ (]*(\g1|\g2)[)]*\);/\n$3$1 $2 = {};/g'
```
