### PR TITLE
Enable alias-mutable-bindings setting in FuseDispatchBindings.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -200,7 +200,7 @@ def FuseDispatchBindings :
   }];
   let options = [
     Option<"aliasMutableBindings", "alias-mutable-bindings",
-           "bool", /*default=*/"false",
+           "bool", /*default=*/"true",
            "Fuses bindings that are mutable instead of leaving them split.">
   ];
 }


### PR DESCRIPTION
See https://github.com/openxla/iree/pull/7716 for history here.

This setting appears to be necessary for WebGPU at least (see https://github.com/openxla/iree/pull/11499#issuecomment-1526427462 and [this discussion on Discord](https://discord.com/channels/689900678990135345/867052513935753277/1101251508638580786)).