### PR TITLE
Unify the two plugin examples to use the same micro-kernel.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_to_calls.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_to_calls.mlir
@@ -20,6 +20,7 @@ func.func @ukernel_generic_memref_1D(%arg0 : memref<?xf32, strided<[1], offset: 
   return
 }
 //      CHECK: func.func private @test1d(memref<f32>, index, index)
+// CHECK-SAME:     llvm.bareptr = true
 //      CHECK: func.func @ukernel_generic_memref_1D
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: memref<?xf32, strided<[1], offset: ?>>
 //      CHECK:   %[[BASE:.+]], %[[OFFSET:.+]], %[[SIZE:.+]], %[[STRIDES:.+]] = memref.extract_strided_metadata %[[ARG0]]
@@ -165,3 +166,14 @@ func.func @ukernel_mmt4d_i8i8i32(%lhs : memref<?x?x?x?xi8>, %rhs : memref<?x?x?x
 //  CHECK-SAME:       %[[BASE2]], %[[OFFSET2]], %[[STRIDES2]]#0
 //  CHECK-SAME:       %[[M]], %[[N]], %[[K]],
 //  CHECK-SAME:       %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]])
+
+// -----
+
+func.func @ukernel_generic_test_fndef_attrs(%arg0 : memref<?xf32, strided<[1], offset: ?>>) {
+  iree_codegen.ukernel.generic "test1d" outs(%arg0 : memref<?xf32, strided<[1], offset: ?>>)
+      fn_def_attrs{hal.import.fields = ["processor_id", "processor_data"]}
+  return
+}
+//      CHECK: func.func private @test1d(memref<f32>, index, index)
+// CHECK-SAME:     hal.import.fields = ["processor_id", "processor_data"]
+

--- a/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.td
@@ -45,6 +45,13 @@ def IREECodegen_UKernelGenericOp :
     each memref. For memrefs of rank less than the value of
     `strided_outer_dims`, all strides are passed.
 
+    Note that `memref` semantics only guarantee that a `base_pointer + offset`
+    represents the position to read from. So all micro-kernel implementations
+    are expected to take at least a `base_pointer, offset` pair for each
+    operand (input or output) of `memref` type. The `offset` has to be added to
+    the `base_pointer` before dereferencing to read/write data. Also note that
+    the `offset` is in number of elements.
+
     All other operands are expected to be scalar types.
     TODO: `vector` types can be supported as well, but needs better
     ABI specification.
@@ -55,6 +62,7 @@ def IREECodegen_UKernelGenericOp :
     Variadic<AnyType>:$inputs,
     Variadic<AnyRankedTensorOrMemRefType>:$outputs,
     Variadic<AnyType>:$other_operands,
+    OptionalAttr<DictionaryAttr>:$fn_def_attrs,
     OptionalAttr<IndexAttr>:$strided_outer_dims);
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let assemblyFormat = [{
@@ -62,6 +70,7 @@ def IREECodegen_UKernelGenericOp :
     (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     (`outs` `(` $outputs^  `:` type($outputs) `)`)?
     (`(` $other_operands^ `:` type($other_operands) `)`)?
+    ( `fn_def_attrs` $fn_def_attrs^ )?
     (`strided_outer_dims` `(` $strided_outer_dims^ `)`)? (`->` type($results)^)?
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -86,6 +86,7 @@ static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
   auto genericMicroKernelOp = rewriter.create<IREE::Codegen::UKernelGenericOp>(
       loc, outType, "vmvx.mmt4d", ValueRange{lhs, rhs}, out,
       ValueRange{m, n, k, m0, n0, k0, flagsVal},
+      /*fn_def_attrs=*/nullptr,
       /*strided_outer_dims=*/rewriter.getIndexAttr(1));
   return cast<IREE::Codegen::UKernelOpInterface>(
       genericMicroKernelOp.getOperation());
@@ -195,6 +196,7 @@ static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
       loc, outType, "vmvx.pack", in, out,
       ValueRange{in_size0, in_size1, out_size0, out_size1, out_size2, out_size3,
                  paddingVal, flagsVal},
+      /*fn_def_attrs=*/nullptr,
       /*strided_outer_dims=*/rewriter.getIndexAttr(1));
   return cast<IREE::Codegen::UKernelOpInterface>(
       genericMicroKernelOp.getOperation());
@@ -269,6 +271,7 @@ static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
       loc, outType, "vmvx.unpack", in, out,
       ValueRange{in_size0, in_size1, in_size2, in_size3, out_size0, out_size1,
                  flagsVal},
+      /*fn_def_attrs=*/nullptr,
       /*strided_outer_dims=*/rewriter.getIndexAttr(1));
   return cast<IREE::Codegen::UKernelOpInterface>(
       genericMicroKernelOp.getOperation());

--- a/samples/custom_dispatch/cpu/plugin/README.md
+++ b/samples/custom_dispatch/cpu/plugin/README.md
@@ -92,11 +92,25 @@ target_include_directories(...)
 
 ```mlir
 func.func private @simple_mul_workgroup(
-    %binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>,
+    %binding0_baseptr: memref<f32>, %binding0_offset: index,
+    %binding1_baseptr: memref<f32>, %binding2_offset: index,
+    %binding2_baseptr: memref<f32>, %binding2_offset: index,
     %dim: index, %tid: index)
 ...
-func.call @simple_mul_workgroup(%memref0, %memref1, %memref2, %dim, %tid) : (memref<?xf32>, memref<?xf32>, memref<?xf32>, index, index) -> ()
+func.call @simple_mul_workgroup(
+    %memref0_baseptr, %memref0_offset,
+    %memref1_baseptr, %memref1_offset,
+    %memref2_baseptr, %memref2_offset,
+    %dim, %tid)
+    : (memref<f32>, index, memref<f32>, index, memref<f32>, index, index, index) -> ()
 ```
+
+For each of the two inputs and one output, a `<baseptr, offset>` pair is used
+to get the position to read from. It is essential for the implementations of
+these functions to manually perform the `baseptr + offset` before reading the
+data. The `memref` semantics in MLIR only guarantee that the `baseptr + offset`
+represents the valid position to read from. Also note that the `offset` here
+is in number of elements (i.e. number of floats).
 
 4. The user either programmatically registers the plugins via the plugin manager
    or when using IREE tools passes them using the `--executable_plugin=` flag.

--- a/samples/custom_dispatch/cpu/plugin/README.md
+++ b/samples/custom_dispatch/cpu/plugin/README.md
@@ -88,15 +88,16 @@ target_include_directories(...)
 ```
 
 3. The user (or compiler transforms) adds calls to their functions by declaring
-   them.
+   them. For each of the two inputs and one output, a `<baseptr, offset>` pair
+   is used to get the position to read from. It is essential for the
+   implementations of these functions to manually perform the
+   `baseptr + offset` before reading the data. The `memref` semantics in MLIR
+   only guarantee that the `baseptr + offset` represents the valid position to
+   read from. Also note that the `offset` here is in number of elements
+   (i.e. number of floats).
+
 
 ```mlir
-func.func private @simple_mul_workgroup(
-    %binding0_baseptr: memref<f32>, %binding0_offset: index,
-    %binding1_baseptr: memref<f32>, %binding2_offset: index,
-    %binding2_baseptr: memref<f32>, %binding2_offset: index,
-    %dim: index, %tid: index)
-...
 func.call @simple_mul_workgroup(
     %memref0_baseptr, %memref0_offset,
     %memref1_baseptr, %memref1_offset,
@@ -104,14 +105,6 @@ func.call @simple_mul_workgroup(
     %dim, %tid)
     : (memref<f32>, index, memref<f32>, index, memref<f32>, index, index, index) -> ()
 ```
-
-   For each of the two inputs and one output, a `<baseptr, offset>` pair is
-   used to get the position to read from. It is essential for the
-   implementations of these functions to manually perform the
-   `baseptr + offset` before reading the data. The `memref` semantics in
-   MLIR only guarantee that the `baseptr + offset` represents the valid
-   position to read from. Also note that the `offset` here is in number of
-   elements (i.e. number of floats).
 
 4. The user either programmatically registers the plugins via the plugin manager
    or when using IREE tools passes them using the `--executable_plugin=` flag.

--- a/samples/custom_dispatch/cpu/plugin/README.md
+++ b/samples/custom_dispatch/cpu/plugin/README.md
@@ -77,7 +77,7 @@ iree_hal_executable_plugin_query(
 }
 ```
 
-1. Source files are compiled to platform dynamic libraries via normal build
+2. Source files are compiled to platform dynamic libraries via normal build
    system goo. Each platform and architecture the user is targeting will need
    its own libraries. Note that only the header file is required to be included
    and no IREE runtime libraries need to be linked into the plugin.
@@ -87,7 +87,7 @@ add_library(my_plugin SHARED my_plugin.c)
 target_include_directories(...)
 ```
 
-1. The user (or compiler transforms) adds calls to their functions by declaring
+3. The user (or compiler transforms) adds calls to their functions by declaring
    them.
 
 ```mlir
@@ -113,7 +113,7 @@ func.call @simple_mul_workgroup(
    position to read from. Also note that the `offset` here is in number of
    elements (i.e. number of floats).
 
-1. The user either programmatically registers the plugins via the plugin manager
+4. The user either programmatically registers the plugins via the plugin manager
    or when using IREE tools passes them using the `--executable_plugin=` flag.
    Note that imports are resolved in reverse registration order such that
    fallbacks can be supported; a reference plugin can be registered first

--- a/samples/custom_dispatch/cpu/plugin/README.md
+++ b/samples/custom_dispatch/cpu/plugin/README.md
@@ -25,7 +25,7 @@ should be used with careful consideration.
 
 ## Workflow for System Dynamic Libraries
 
-```
+```text
 +----------+    +---------------+      +--------------+
 | plugin.c | -> | plugin.so/dll |-+    | example.mlir |
 +----------+    +---------------+ |    +--------------+
@@ -77,7 +77,7 @@ iree_hal_executable_plugin_query(
 }
 ```
 
-2. Source files are compiled to platform dynamic libraries via normal build
+1. Source files are compiled to platform dynamic libraries via normal build
    system goo. Each platform and architecture the user is targeting will need
    its own libraries. Note that only the header file is required to be included
    and no IREE runtime libraries need to be linked into the plugin.
@@ -87,7 +87,7 @@ add_library(my_plugin SHARED my_plugin.c)
 target_include_directories(...)
 ```
 
-3. The user (or compiler transforms) adds calls to their functions by declaring
+1. The user (or compiler transforms) adds calls to their functions by declaring
    them.
 
 ```mlir
@@ -105,21 +105,22 @@ func.call @simple_mul_workgroup(
     : (memref<f32>, index, memref<f32>, index, memref<f32>, index, index, index) -> ()
 ```
 
-For each of the two inputs and one output, a `<baseptr, offset>` pair is used
-to get the position to read from. It is essential for the implementations of
-these functions to manually perform the `baseptr + offset` before reading the
-data. The `memref` semantics in MLIR only guarantee that the `baseptr + offset`
-represents the valid position to read from. Also note that the `offset` here
-is in number of elements (i.e. number of floats).
+   For each of the two inputs and one output, a `<baseptr, offset>` pair is
+   used to get the position to read from. It is essential for the
+   implementations of these functions to manually perform the
+   `baseptr + offset` before reading the data. The `memref` semantics in
+   MLIR only guarantee that the `baseptr + offset` represents the valid
+   position to read from. Also note that the `offset` here is in number of
+   elements (i.e. number of floats).
 
-4. The user either programmatically registers the plugins via the plugin manager
+1. The user either programmatically registers the plugins via the plugin manager
    or when using IREE tools passes them using the `--executable_plugin=` flag.
    Note that imports are resolved in reverse registration order such that
    fallbacks can be supported; a reference plugin can be registered first
    followed by more specialized plugins that may only handle a subset of
    imports.
 
-```
+```bash
 iree-run-module \
     --device=local-sync \
     --executable_plugin=my_plugins.so \
@@ -131,7 +132,7 @@ iree-run-module \
 
 ## Workflow for Embedded ELF Libraries
 
-```
+```text
 +----------+      +-------------------+       +--------------+
 | plugin.c | -+-> | plugin_aarch64.so | -+    | example.mlir |
 +----------+  |   +-------------------+  |    +--------------+
@@ -175,7 +176,7 @@ for instructions for CMake setup and building from source.
    [system_plugin.c](./system_plugin.c) sources to object files for aarch64 and
    x86_64 or the current target system:
 
-    ```
+    ```bash
     cmake --build ../iree-build/ --target iree-sample-deps
     ```
 
@@ -188,7 +189,7 @@ for instructions for CMake setup and building from source.
 2. Compile the [example module](./example.mlir) to a .vmfb file and pass
    the path to the build directory so the .spv files can be found:
 
-    ```
+    ```bash
     iree-compile \
         samples/custom_dispatch/cpu/plugin/example.mlir \
         -o=/tmp/example.vmfb
@@ -197,7 +198,7 @@ for instructions for CMake setup and building from source.
 3. Run the example program using the plugins for either platform-independent
    embedded ELF files or the system libraries:
 
-    ```
+    ```bash
     iree-run-module \
         --device=llvm-sync \
         --executable_plugin=samples/custom_dispatch/cpu/plugin/standalone_plugin.sos \
@@ -207,7 +208,7 @@ for instructions for CMake setup and building from source.
         /tmp/example.vmfb
     ```
 
-    ```
+    ```bash
     iree-run-module \
         --device=llvm-sync \
         --executable_plugin=samples/custom_dispatch/cpu/plugin/system_plugin.so \

--- a/samples/custom_dispatch/cpu/plugin/standalone_example.mlir
+++ b/samples/custom_dispatch/cpu/plugin/standalone_example.mlir
@@ -42,11 +42,19 @@ module @example {
 
     builtin.module {
       // External function declaration using a user-chosen calling convention.
-      func.func private @simple_mul_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>, %dim: index, %tid: index) attributes {
+      func.func private @simple_mul_workgroup(
+            %binding0: memref<f32>, 
+            %binding0_offset : index,
+            %binding1: memref<f32>,
+            %binding1_offset : index,
+            %binding2: memref<f32>, 
+            %binding2_offset : index,
+            %dim: index, %tid: index) attributes {
         // We can include some additional fields on the parameters struct as
         // needed. Here we request which processor is executing the call and
         // its data fields as defined by runtime/src/iree/schemas/cpu_data.h.
-        hal.import.fields = ["processor_id", "processor_data"]
+        hal.import.fields = ["processor_id", "processor_data"],
+        llvm.bareptr = true
       }
 
       // IREE exported function using stream bindings and operands.
@@ -72,10 +80,22 @@ module @example {
         %memref1 = stream.binding.subspan %binding1[%c0] : !stream.binding -> memref<?xf32>{%dim}
         %memref2 = stream.binding.subspan %binding2[%c0] : !stream.binding -> memref<?xf32>{%dim}
 
+        // The default `memref` lowering contains additional fields that might not be
+        // always required. In this example, we only need the base and offset of the
+        // `memref`s. So extract the base and offset from the memrefs.
+        %base0, %offset0, %size0, %stride0 = memref.extract_strided_metadata %memref0
+            : memref<?xf32> -> memref<f32>, index, index, index
+        %base1, %offset1, %size1, %stride1 = memref.extract_strided_metadata %memref1
+            : memref<?xf32> -> memref<f32>, index, index, index
+        %base2, %offset2, %size2, %stride2 = memref.extract_strided_metadata %memref2
+            : memref<?xf32> -> memref<f32>, index, index, index
+        
         // Call the externally defined C function with an (almost) plain C
         // calling convention (see above for details about the mess memrefs
         // turn into). This will be fetched at runtime from the plugin binary.
-        func.call @simple_mul_workgroup(%memref0, %memref1, %memref2, %dim, %tid) : (memref<?xf32>, memref<?xf32>, memref<?xf32>, index, index) -> ()
+        func.call @simple_mul_workgroup(
+            %base0, %offset0, %base1, %offset1, %base2, %offset2, %dim, %workgroup_id_x)
+            : (memref<f32>, index, memref<f32>, index, memref<f32>, index, index, index) -> ()
 
         // NOTE: this is code generated as normal - other MLIR ops can be used
         // here for looping/control flow, vector operations, linalg, etc.

--- a/samples/custom_dispatch/cpu/plugin/standalone_plugin.c
+++ b/samples/custom_dispatch/cpu/plugin/standalone_plugin.c
@@ -46,40 +46,6 @@
 static int simple_mul_workgroup(void* context, void* params_ptr,
                                 void* reserved) {
   typedef struct {
-    // vvvv simplification pending (buffer + offset)
-    const float* restrict binding0;
-    const float* restrict binding0_aligned;
-    size_t binding0_offset;
-    size_t binding0_size;
-    size_t binding0_stride;
-    const float* restrict binding1;
-    const float* restrict binding1_aligned;
-    size_t binding1_offset;
-    size_t binding1_size;
-    size_t binding1_stride;
-    float* restrict binding2;
-    float* restrict binding2_aligned;
-    size_t binding2_offset;
-    size_t binding2_size;
-    size_t binding2_stride;
-    // ^^^^ simplification pending (buffer + offset)
-    size_t dim;
-    size_t tid;
-    uint32_t processor_id;
-    const uint64_t* restrict processor_data;
-  } params_t;
-  const params_t* params = (const params_t*)params_ptr;
-  size_t end = params->tid + 64;
-  if (end > params->dim) end = params->dim;
-  for (size_t i = params->tid; i < end; ++i) {
-    params->binding2[i] = params->binding0[i] * params->binding1[i];
-  }
-  return 0;
-}
-
-static int simple_mul_workgroup_ukernel(void* context, void* params_ptr,
-                                        void* reserved) {
-  typedef struct {
     const float* restrict binding0;
     size_t binding0_offset;
     const float* restrict binding1;
@@ -88,6 +54,8 @@ static int simple_mul_workgroup_ukernel(void* context, void* params_ptr,
     size_t binding2_offset;
     size_t size;
     size_t tid;
+    uint32_t processor_id;
+    const uint64_t* restrict processor_data;
   } params_t;
   const params_t* params = (const params_t*)params_ptr;
   // The operation `iree_codegen.ukernel.generic` always operates
@@ -145,10 +113,6 @@ static iree_hal_executable_plugin_status_t standalone_plugin_resolve(
     if (iree_hal_executable_plugin_strcmp(symbol_name,
                                           "simple_mul_workgroup") == 0) {
       params->out_fn_ptrs[i] = simple_mul_workgroup;
-      params->out_fn_contexts[i] = NULL;  // no context used, could be self
-    } else if (iree_hal_executable_plugin_strcmp(
-                   symbol_name, "simple_mul_workgroup_ukernel") == 0) {
-      params->out_fn_ptrs[i] = simple_mul_workgroup_ukernel;
       params->out_fn_contexts[i] = NULL;  // no context used, could be self
     } else {
       if (is_optional) {

--- a/samples/custom_dispatch/cpu/plugin/standalone_ukernel.mlir
+++ b/samples/custom_dispatch/cpu/plugin/standalone_ukernel.mlir
@@ -1,3 +1,9 @@
+// This example demonstrates calling dynamically imported functions in the
+// runtime through the use of ukernels. This is calling the same function
+// as `standalone_example.mlir`, but using the `iree_codegen.ukernel.generic`.
+// This is an example of how ukernels can be called from code generated
+// by IREE.
+
 // RUN: iree-compile --iree-hal-target-backends=llvm-cpu %s | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
@@ -37,10 +43,17 @@ func.func @ukernel_example(%arg0 : tensor<?xf32>, %arg1 : tensor<?xf32>) -> tens
     %3 = tensor.extract_slice %dest[%offset] [%size] [1] : tensor<?xf32> to tensor<?xf32>
 
     // Invoke the ukernel.
-    %4 = iree_codegen.ukernel.generic "simple_mul_workgroup_ukernel"
+    %4 = iree_codegen.ukernel.generic "simple_mul_workgroup"
       ins(%1, %2 : tensor<?xf32>, tensor<?xf32>)
       outs(%3 : tensor<?xf32>)
-      (%size, %id : index, index) strided_outer_dims(0) -> tensor<?xf32>
+      (%size, %id : index, index) 
+      // We can include some additional fields on the parameters struct as
+      // needed. Here we request which processor is executing the call and
+      // its data fields as defined by runtime/src/iree/schemas/cpu_data.h.
+      fn_def_attrs {hal.import.fields = ["processor_id", "processor_data"]}
+      // Set the operation to not incorporate any strides. The implementation
+      // expects no stride arguments.
+      strided_outer_dims(0) -> tensor<?xf32>
 
     // Insert the result back into the result at the right position.
     %5 = tensor.insert_slice %4 into %dest[%offset] [%size] [1] : tensor<?xf32> into tensor<?xf32>


### PR DESCRIPTION
As follow up from https://github.com/openxla/iree/pull/13132 this example uses the same micro-kernel both
as a custom dispatch call and as a micro kernel. This requires adding
a new optional attribute to `iree_codegen.ukernel.generic` operations
that carry additional attributes to append to the function definition.
Using these `hal.import.fields` attribute can be set on the function
definitions when lowering to function calls. This is path to send
additional contextual information to the micro-kernel.

Also update the README and op-definition documentation.