### PR TITLE
Track memory statistics in OOBI

### DIFF
--- a/build_tools/benchmarks/common/android_device_utils.py
+++ b/build_tools/benchmarks/common/android_device_utils.py
@@ -10,13 +10,13 @@ import json
 import re
 
 from typing import Sequence
-from .benchmark_definition import (execute_cmd_and_get_output, DeviceInfo,
+from .benchmark_definition import (execute_cmd_and_get_stdout, DeviceInfo,
                                    PlatformType)
 
 
 def get_android_device_model(verbose: bool = False) -> str:
   """Returns the Android device model."""
-  model = execute_cmd_and_get_output(
+  model = execute_cmd_and_get_stdout(
       ["adb", "shell", "getprop", "ro.product.model"], verbose=verbose)
   model = re.sub(r"\W+", "-", model)
   return model
@@ -24,13 +24,13 @@ def get_android_device_model(verbose: bool = False) -> str:
 
 def get_android_cpu_abi(verbose: bool = False) -> str:
   """Returns the CPU ABI for the Android device."""
-  return execute_cmd_and_get_output(
+  return execute_cmd_and_get_stdout(
       ["adb", "shell", "getprop", "ro.product.cpu.abi"], verbose=verbose)
 
 
 def get_android_cpu_features(verbose: bool = False) -> Sequence[str]:
   """Returns the CPU features for the Android device."""
-  cpuinfo = execute_cmd_and_get_output(["adb", "shell", "cat", "/proc/cpuinfo"],
+  cpuinfo = execute_cmd_and_get_stdout(["adb", "shell", "cat", "/proc/cpuinfo"],
                                        verbose=verbose)
   features = []
   for line in cpuinfo.splitlines():
@@ -42,7 +42,7 @@ def get_android_cpu_features(verbose: bool = False) -> Sequence[str]:
 
 def get_android_gpu_name(verbose: bool = False) -> str:
   """Returns the GPU name for the Android device."""
-  vkjson = execute_cmd_and_get_output(["adb", "shell", "cmd", "gpu", "vkjson"],
+  vkjson = execute_cmd_and_get_stdout(["adb", "shell", "cmd", "gpu", "vkjson"],
                                       verbose=verbose)
   vkjson = json.loads(vkjson)
   name = vkjson["devices"][0]["properties"]["deviceName"]
@@ -52,7 +52,7 @@ def get_android_gpu_name(verbose: bool = False) -> str:
   # - Adreno GPUs have raw names like "Adreno (TM) 650".
   name = name.replace("(TM)", "")
 
-  # Replace all consecutive non-word characters with a single hypen.
+  # Replace all consecutive non-word characters with a single hyphen.
   name = re.sub(r"\W+", "-", name)
 
   return name

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -549,10 +549,7 @@ def parse_iree_benchmark_metrics(benchmark_stdout: str,
       host_memory=_get_iree_memory_statistics(benchmark_stderr, "HOST_LOCAL"),
       device_memory=_get_iree_memory_statistics(benchmark_stderr,
                                                 "DEVICE_LOCAL"),
-      raw_data=dict(
-          google_benchmark_json=benchmark_json,
-          benchmark_stderr=benchmark_stderr,
-      ),
+      raw_data=benchmark_json,
   )
 
 

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -473,7 +473,7 @@ def _get_iree_memory_statistics(benchmark_stderr: str,
   for stat in ["peak", "allocated", "freed", "live"]:
     m = re.search(rf".*{device}:.*\s([0-9]+)B {stat}", benchmark_stderr)
     if m is None:
-      raise ValueError(f"Failed to find '{stat}' stat for device '{device}' in "
+      raise ValueError(f"Failed to find stat '{stat}' for device '{device}' in "
                        f"iree-benchmark-module stderr:\n{benchmark_stderr}")
     statistics[stat] = int(m.group(1))
   return BenchmarkMemory.from_json_object(statistics)

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -108,17 +108,6 @@ def execute_cmd(args: Sequence[Any],
     raise exc
 
 
-def execute_cmd_and_get_stdout(args: Sequence[Any],
-                               verbose: bool = False,
-                               **kwargs) -> str:
-  """Executes a command and returns its stdout.
-
-  Same as execute_cmd except captures stdout (and not stderr).
-  """
-  return execute_cmd(args, verbose=verbose, stdout=subprocess.PIPE,
-                     **kwargs).stdout.strip()
-
-
 def execute_cmd_and_get_output(args: Sequence[Any],
                                verbose: bool = False,
                                **kwargs) -> Tuple[str, str]:
@@ -132,6 +121,17 @@ def execute_cmd_and_get_output(args: Sequence[Any],
                     stderr=subprocess.PIPE,
                     **kwargs)
   return exc.stdout.strip(), exc.stderr.strip()
+
+
+def execute_cmd_and_get_stdout(args: Sequence[Any],
+                               verbose: bool = False,
+                               **kwargs) -> str:
+  """Executes a command and returns its stdout.
+
+  Same as execute_cmd except captures stdout (and not stderr).
+  """
+  stdout, _ = execute_cmd_and_get_output(args, verbose=verbose, **kwargs)
+  return stdout
 
 
 def get_git_commit_hash(commit: str) -> str:

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -471,10 +471,10 @@ def _get_iree_memory_statistics(benchmark_stderr: str,
   """Extracts IREE's memory statistics for a given device."""
   # The memory statistics for each device are listed on their own line.
   pattern = (rf"{device}:"
-             rf"\s*(?P<peak>\d+)B peak /"
-             rf"\s*(?P<allocated>\d+)B allocated /"
-             rf"\s*(?P<freed>\d+)B freed /"
-             rf"\s*(?P<live>\d+)B live")
+             r"\s*(?P<peak>\d+)B peak /"
+             r"\s*(?P<allocated>\d+)B allocated /"
+             r"\s*(?P<freed>\d+)B freed /"
+             r"\s*(?P<live>\d+)B live")
   match_ = re.search(pattern, benchmark_stderr)
   return BenchmarkMemory(
       peak=int(match_["peak"]),

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -471,6 +471,8 @@ def _get_iree_memory_statistics(benchmark_stderr: str,
   """Extracts IREE's memory statistics for a given device."""
   statistics = dict(unit="bytes")
   for stat in ["peak", "allocated", "freed", "live"]:
+    # The memory statistics for each device are listed on their own line. E.g.
+    # HOST_LOCAL: 7675392B peak / 7675392B allocated / 0B freed / 7675392B live
     m = re.search(rf".*{device}:.*\s([0-9]+)B {stat}", benchmark_stderr)
     if m is None:
       raise ValueError(f"Failed to find stat '{stat}' for device '{device}' in "

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -597,7 +597,7 @@ class BenchmarkResults(object):
   def to_json_str(self) -> str:
     json_object = {"commit": self.commit, "benchmarks": []}
     json_object["benchmarks"] = [b.to_json_object() for b in self.benchmarks]
-    return json.dumps(json_object, indent=4)
+    return json.dumps(json_object, indent=2)
 
   @staticmethod
   def from_json_str(json_str: str):

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -3,11 +3,11 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-"""Utilities for describing Android benchmarks.
+"""Utilities for describing benchmarks.
 
-This file provides common and structured representation of Android devices,
-benchmark definitions, and benchmark result collections, so that they can be
-shared between different stages of the same benchmark pipeline.
+This file provides common and structured representation of devices, benchmark
+definitions, and benchmark result collections, so that they can be shared
+between different stages of the same benchmark pipeline.
 """
 
 import json
@@ -108,7 +108,7 @@ def execute_cmd(args: Sequence[Any],
     raise exc
 
 
-def execute_cmd_and_get_output(args: Sequence[Any],
+def execute_cmd_and_get_stdout(args: Sequence[Any],
                                verbose: bool = False,
                                **kwargs) -> str:
   """Executes a command and returns its stdout.
@@ -119,8 +119,23 @@ def execute_cmd_and_get_output(args: Sequence[Any],
                      **kwargs).stdout.strip()
 
 
+def execute_cmd_and_get_output(args: Sequence[Any],
+                               verbose: bool = False,
+                               **kwargs) -> Tuple[str, str]:
+  """Executes a command and returns its stdout and stderr
+
+  Same as execute_cmd except captures stdout and stderr.
+  """
+  exc = execute_cmd(args,
+                    verbose=verbose,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    **kwargs)
+  return exc.stdout.strip(), exc.stderr.strip()
+
+
 def get_git_commit_hash(commit: str) -> str:
-  return execute_cmd_and_get_output(['git', 'rev-parse', commit],
+  return execute_cmd_and_get_stdout(['git', 'rev-parse', commit],
                                     cwd=pathlib.Path(__file__).resolve().parent)
 
 
@@ -142,6 +157,7 @@ def get_iree_benchmark_module_arguments(
       "--benchmark_format=json",
       "--benchmark_out_format=json",
       f"--benchmark_out={results_filename}",
+      "--print_statistics=true",
   ]
   if benchmark_min_time:
     cmd.extend([
@@ -335,9 +351,8 @@ class BenchmarkInfo:
     elif driver_info.device_type == 'CPU':
       target_arch = "CPU-" + device_info.get_detailed_cpu_arch_name()
     else:
-      raise ValueError(
-          f"Unrecognized device type '{driver_info.device_type}' of the driver '{driver_info.pretty_name}'"
-      )
+      raise ValueError(f"Unrecognized device type '{driver_info.device_type}' "
+                       f"of the driver '{driver_info.pretty_name}'")
 
     if model_tags:
       tags = ",".join(model_tags)
@@ -347,7 +362,8 @@ class BenchmarkInfo:
     device_part = f"{device_info.model} ({target_arch})"
 
     mode_tags = ",".join(bench_mode)
-    name = f"{model_part} {mode_tags} with {driver_info.pretty_name} @ {device_part}"
+    name = (f"{model_part} {mode_tags} with {driver_info.pretty_name} "
+            f"@ {device_part}")
 
     return cls(name=name,
                model_name=model_name,
@@ -434,6 +450,36 @@ def _get_google_benchmark_latencies(
 
 
 @dataclasses.dataclass(frozen=True)
+class BenchmarkMemory:
+  """Stores memory statistics for a benchmark run."""
+  peak: int
+  allocated: int
+  freed: int
+  live: int
+  unit: str
+
+  def to_json_object(self) -> Dict[str, int]:
+    return dataclasses.asdict(self)
+
+  @staticmethod
+  def from_json_object(json_object: Dict[str, int]):
+    return BenchmarkMemory(**json_object)
+
+
+def _get_iree_memory_statistics(benchmark_stderr: str,
+                                device: str) -> BenchmarkMemory:
+  """Extracts IREE's memory statistics for a given device."""
+  statistics = dict(unit="bytes")
+  for stat in ["peak", "allocated", "freed", "live"]:
+    m = re.search(rf".*{device}:.*\s([0-9]+)B {stat}", benchmark_stderr)
+    if m is None:
+      raise ValueError(f"Failed to find '{stat}' stat for device '{device}' in "
+                       f"iree-benchmark-module stderr:\n{benchmark_stderr}")
+    statistics[stat] = int(m.group(1))
+  return BenchmarkMemory.from_json_object(statistics)
+
+
+@dataclasses.dataclass(frozen=True)
 class BenchmarkMetrics(object):
   """An object describing the results from a single benchmark.
 
@@ -441,45 +487,66 @@ class BenchmarkMetrics(object):
       framework.
   - cpu_time: the cpu time latency statistics returned by the benchmarking
       framework.
+  - host_memory: the host memory statistics returned by the benchmarking
+      framework.
+  - device_memory: the device memory statistics returned by the benchmarking
+      framework.
   - raw_data: additional JSON-compatible raw results returned by the
       benchmarking framework.
   """
   real_time: BenchmarkLatency
   cpu_time: BenchmarkLatency
+  host_memory: BenchmarkMemory
+  device_memory: BenchmarkMemory
   raw_data: Dict[str, Any]
 
   def to_json_object(self) -> Dict[str, Any]:
     return {
         "real_time": self.real_time.to_json_object(),
         "cpu_time": self.cpu_time.to_json_object(),
+        "host_memory": self.host_memory.to_json_object(),
+        "device_memory": self.device_memory.to_json_object(),
         "raw_data": self.raw_data,
     }
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
     return BenchmarkMetrics(
-        BenchmarkLatency.from_json_object(json_object["real_time"]),
-        BenchmarkLatency.from_json_object(json_object["cpu_time"]),
-        json_object["raw_data"],
+        real_time=BenchmarkLatency.from_json_object(json_object["real_time"]),
+        cpu_time=BenchmarkLatency.from_json_object(json_object["cpu_time"]),
+        host_memory=BenchmarkMemory.from_json_object(
+            json_object["host_memory"]),
+        device_memory=BenchmarkMemory.from_json_object(
+            json_object["device_memory"]),
+        raw_data=json_object["raw_data"],
     )
 
 
-def parse_iree_benchmark_metrics(benchmark_stdout: str) -> BenchmarkMetrics:
+def parse_iree_benchmark_metrics(benchmark_stdout: str,
+                                 benchmark_stderr: str) -> BenchmarkMetrics:
   """Extract benchmark metrics from the output of iree-benchmark-module.
 
   Args:
     benchmark_stdout: The stdout of iree-benchmark-module with
       --benchmark_format=json.
+    benchmark_stdout: The stderr of iree-benchmark-module with
+      --print_statistics=true.
 
   Returns:
     A populated BenchmarkMetrics dataclass.
   """
-  iree_benchmark_json = json.loads(benchmark_stdout)
-  real_time, cpu_time = _get_google_benchmark_latencies(iree_benchmark_json)
+  benchmark_json = json.loads(benchmark_stdout)
+  real_time, cpu_time = _get_google_benchmark_latencies(benchmark_json)
   return BenchmarkMetrics(
       real_time=real_time,
       cpu_time=cpu_time,
-      raw_data=iree_benchmark_json,
+      host_memory=_get_iree_memory_statistics(benchmark_stderr, "HOST_LOCAL"),
+      device_memory=_get_iree_memory_statistics(benchmark_stderr,
+                                                "DEVICE_LOCAL"),
+      raw_data=dict(
+          google_benchmark_json=benchmark_json,
+          benchmark_stderr=benchmark_stderr,
+      ),
   )
 
 
@@ -530,7 +597,7 @@ class BenchmarkResults(object):
   def to_json_str(self) -> str:
     json_object = {"commit": self.commit, "benchmarks": []}
     json_object["benchmarks"] = [b.to_json_object() for b in self.benchmarks]
-    return json.dumps(json_object)
+    return json.dumps(json_object, indent=4)
 
   @staticmethod
   def from_json_str(json_str: str):

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -16,7 +16,7 @@ from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
 from common.benchmark_driver import BenchmarkDriver
 from common.benchmark_definition import (IREE_DRIVERS_INFOS, DeviceInfo,
                                          PlatformType, BenchmarkLatency,
-                                         BenchmarkMetrics)
+                                         BenchmarkMemory, BenchmarkMetrics)
 
 
 class FakeBenchmarkDriver(BenchmarkDriver):
@@ -42,6 +42,8 @@ class FakeBenchmarkDriver(BenchmarkDriver):
       fake_benchmark_metrics = BenchmarkMetrics(
           real_time=BenchmarkLatency(0, 0, 0, "ns"),
           cpu_time=BenchmarkLatency(0, 0, 0, "ns"),
+          host_memory=BenchmarkMemory(0, 0, 0, 0, "bytes"),
+          device_memory=BenchmarkMemory(0, 0, 0, 0, "bytes"),
           raw_data={},
       )
       benchmark_results_filename.write_text(

--- a/build_tools/benchmarks/common/linux_device_utils.py
+++ b/build_tools/benchmarks/common/linux_device_utils.py
@@ -9,7 +9,7 @@
 import re
 from typing import Optional, Sequence
 
-from .benchmark_definition import (execute_cmd_and_get_output, DeviceInfo,
+from .benchmark_definition import (execute_cmd_and_get_stdout, DeviceInfo,
                                    PlatformType)
 
 
@@ -29,7 +29,7 @@ def get_linux_cpu_features(lscpu_output: str) -> Sequence[str]:
 
 
 def canonicalize_gpu_name(gpu_name: str) -> str:
-  # Replace all consecutive non-word characters with a single hypen.
+  # Replace all consecutive non-word characters with a single hyphen.
   return re.sub(r"\W+", "-", gpu_name)
 
 
@@ -44,10 +44,10 @@ def get_linux_device_info(device_model: str = "Unknown",
     - cpu_uarch: the CPU microarchitecture, e.g., 'CascadeLake'
     - gpu_id: the target GPU ID, e.g., '0' or 'GPU-<UUID>'
   """
-  lscpu_output = execute_cmd_and_get_output(["lscpu"], verbose)
+  lscpu_output = execute_cmd_and_get_stdout(["lscpu"], verbose)
 
   try:
-    gpu_name = execute_cmd_and_get_output([
+    gpu_name = execute_cmd_and_get_stdout([
         "nvidia-smi", "--query-gpu=name", "--format=csv,noheader",
         f"--id={gpu_id}"
     ], verbose)

--- a/build_tools/benchmarks/generate_benchmark_comment.py
+++ b/build_tools/benchmarks/generate_benchmark_comment.py
@@ -60,7 +60,7 @@ def get_git_total_commit_count(commit: str, verbose: bool = False) -> int:
   """Gets the total commit count in history ending with the given commit."""
   # TODO(#11703): Should use --first-parent here. See issue for the required
   # work.
-  count = benchmark_definition.execute_cmd_and_get_output(
+  count = benchmark_definition.execute_cmd_and_get_stdout(
       ['git', 'rev-list', '--count', commit],
       cwd=THIS_DIRECTORY,
       verbose=verbose)
@@ -115,7 +115,7 @@ def _find_comparable_benchmark_results(
       "git", "rev-list", "--first-parent",
       f"--max-count={MAX_BASE_COMMIT_QUERY_COUNT}", start_commit
   ]
-  output = benchmark_definition.execute_cmd_and_get_output(cmds,
+  output = benchmark_definition.execute_cmd_and_get_stdout(cmds,
                                                            cwd=THIS_DIRECTORY,
                                                            verbose=verbose)
   previous_commits = output.splitlines()
@@ -134,14 +134,14 @@ def _find_comparable_benchmark_results(
 
 def _get_git_commit_hash(ref: str, verbose: bool = False) -> str:
   """Gets the commit hash for the given commit."""
-  return benchmark_definition.execute_cmd_and_get_output(
+  return benchmark_definition.execute_cmd_and_get_stdout(
       ['git', 'rev-parse', ref], cwd=THIS_DIRECTORY, verbose=verbose)
 
 
 def _get_git_merge_base_commit(pr_commit: str,
                                target_branch: str,
                                verbose: bool = False) -> str:
-  return benchmark_definition.execute_cmd_and_get_output(
+  return benchmark_definition.execute_cmd_and_get_stdout(
       args=["git", "merge-base", target_branch, pr_commit],
       cwd=THIS_DIRECTORY,
       verbose=verbose)

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -102,7 +102,7 @@ def adb_execute_and_get_output(
       ANDROID_TMPDIR.
 
   Returns:
-    A string for the command output.
+    Strings for stdout and stderr.
   """
   cmd = ["adb", "shell", "cd", ANDROID_TMPDIR / relative_dir, "&&"]
   cmd.extend(cmd_args)

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -41,15 +41,14 @@ import tarfile
 import shutil
 import json
 
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Tuple
 from common.benchmark_config import BenchmarkConfig
 from common.benchmark_driver import BenchmarkDriver
-from common.benchmark_definition import (DriverInfo, execute_cmd,
-                                         execute_cmd_and_get_output,
-                                         get_git_commit_hash,
-                                         get_iree_benchmark_module_arguments,
-                                         wait_for_iree_benchmark_module_start,
-                                         parse_iree_benchmark_metrics)
+from common.benchmark_definition import (
+    DriverInfo, execute_cmd, execute_cmd_and_get_stdout,
+    execute_cmd_and_get_output, get_git_commit_hash,
+    get_iree_benchmark_module_arguments, wait_for_iree_benchmark_module_start,
+    parse_iree_benchmark_metrics)
 from common.benchmark_suite import (MODEL_FLAGFILE_NAME, BenchmarkCase,
                                     BenchmarkSuite)
 from common.android_device_utils import (get_android_device_model,
@@ -91,7 +90,7 @@ def adb_push_to_tmp_dir(
 def adb_execute_and_get_output(
     cmd_args: Sequence[str],
     relative_dir: pathlib.PurePosixPath = pathlib.PurePosixPath(),
-    verbose: bool = False) -> str:
+    verbose: bool = False) -> Tuple[str, str]:
   """Executes command with adb shell.
 
   Switches to `relative_dir` relative to the android tmp directory before
@@ -133,7 +132,8 @@ def adb_execute(cmd_args: Sequence[str],
 
 def is_magisk_su():
   """Returns true if the Android device has a Magisk SU binary."""
-  return "MagiskSU" in adb_execute_and_get_output(["su", "--help"])
+  stdout, _ = adb_execute_and_get_output(["su", "--help"])
+  return "MagiskSU" in stdout
 
 
 def adb_execute_as_root(cmd_args: Sequence[Any]) -> subprocess.CompletedProcess:
@@ -233,10 +233,10 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
               driver_info=driver_info,
               benchmark_min_time=self.config.benchmark_min_time))
 
-    benchmark_stdout = adb_execute_and_get_output(cmd,
-                                                  android_case_dir,
-                                                  verbose=self.verbose)
-    benchmark_metrics = parse_iree_benchmark_metrics(benchmark_stdout)
+    benchmark_stdout, benchmark_stderr = adb_execute_and_get_output(
+        cmd, android_case_dir, verbose=self.verbose)
+    benchmark_metrics = parse_iree_benchmark_metrics(benchmark_stdout,
+                                                     benchmark_stderr)
     if self.verbose:
       print(benchmark_metrics)
     results_filename.write_text(json.dumps(benchmark_metrics.to_json_object()))
@@ -305,7 +305,7 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
 
 
 def set_cpu_frequency_scaling_governor(governor: str):
-  git_root = execute_cmd_and_get_output(["git", "rev-parse", "--show-toplevel"])
+  git_root = execute_cmd_and_get_stdout(["git", "rev-parse", "--show-toplevel"])
   cpu_script = (pathlib.Path(git_root) / "build_tools" / "benchmarks" /
                 "set_android_scaling_governor.sh")
   android_path = adb_push_to_tmp_dir(cpu_script)
@@ -313,7 +313,7 @@ def set_cpu_frequency_scaling_governor(governor: str):
 
 
 def set_gpu_frequency_scaling_policy(policy: str):
-  git_root = execute_cmd_and_get_output(["git", "rev-parse", "--show-toplevel"])
+  git_root = execute_cmd_and_get_stdout(["git", "rev-parse", "--show-toplevel"])
   device_model = get_android_device_model()
   gpu_name = get_android_gpu_name()
   benchmarks_tool_dir = pathlib.Path(git_root) / "build_tools" / "benchmarks"
@@ -355,12 +355,12 @@ def main(args):
 
   # Clear the benchmark directory on the Android device first just in case
   # there are leftovers from manual or failed runs.
-  execute_cmd_and_get_output(["adb", "shell", "rm", "-rf", ANDROID_TMPDIR],
+  execute_cmd_and_get_stdout(["adb", "shell", "rm", "-rf", ANDROID_TMPDIR],
                              verbose=args.verbose)
 
   if not args.no_clean:
     # Clear the benchmark directory on the Android device.
-    atexit.register(execute_cmd_and_get_output,
+    atexit.register(execute_cmd_and_get_stdout,
                     ["adb", "shell", "rm", "-rf", ANDROID_TMPDIR],
                     verbose=args.verbose)
     # Also clear temporary directory on the host device.
@@ -370,9 +370,9 @@ def main(args):
   # to capture traces along the way, forward port via adb.
   trace_capture_config = benchmark_config.trace_capture_config
   if trace_capture_config:
-    execute_cmd_and_get_output(["adb", "forward", "tcp:8086", "tcp:8086"],
+    execute_cmd_and_get_stdout(["adb", "forward", "tcp:8086", "tcp:8086"],
                                verbose=args.verbose)
-    atexit.register(execute_cmd_and_get_output,
+    atexit.register(execute_cmd_and_get_stdout,
                     ["adb", "forward", "--remove", "tcp:8086"],
                     verbose=args.verbose)
 

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -115,9 +115,10 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
               driver_info=benchmark_case.driver_info,
               benchmark_min_time=self.config.benchmark_min_time))
 
-    benchmark_stdout = execute_cmd_and_get_output(
+    benchmark_stdout, benchmark_stderr = execute_cmd_and_get_output(
         cmd, cwd=benchmark_case.benchmark_case_dir, verbose=self.verbose)
-    benchmark_metrics = parse_iree_benchmark_metrics(benchmark_stdout)
+    benchmark_metrics = parse_iree_benchmark_metrics(benchmark_stdout,
+                                                     benchmark_stderr)
     if self.verbose:
       print(benchmark_metrics)
     results_filename.write_text(json.dumps(benchmark_metrics.to_json_object()))

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -31,7 +31,7 @@ IREE_GITHUB_COMMIT_URL_PREFIX = 'https://github.com/openxla/iree/commit'
 IREE_PROJECT_ID = 'IREE'
 THIS_DIRECTORY = pathlib.Path(__file__).resolve().parent
 
-COMMON_DESCRIIPTION = """
+COMMON_DESCRIPTION = """
 <br>
 For the graph, the x axis is the Git commit index, and the y axis is the
 measured metrics. The unit for the numbers is shown in the "Unit" dropdown.
@@ -78,13 +78,13 @@ def get_model_description(model_name: str, model_source: str) -> Optional[str]:
 
 def get_git_commit_hash(commit: str, verbose: bool = False) -> str:
   """Gets the commit hash for the given commit."""
-  return benchmark_definition.execute_cmd_and_get_output(
+  return benchmark_definition.execute_cmd_and_get_stdout(
       ['git', 'rev-parse', commit], cwd=THIS_DIRECTORY, verbose=verbose)
 
 
 def get_git_total_commit_count(commit: str, verbose: bool = False) -> int:
   """Gets the total commit count in history ending with the given commit."""
-  count = benchmark_definition.execute_cmd_and_get_output(
+  count = benchmark_definition.execute_cmd_and_get_stdout(
       ['git', 'rev-list', '--count', commit],
       cwd=THIS_DIRECTORY,
       verbose=verbose)
@@ -92,11 +92,11 @@ def get_git_total_commit_count(commit: str, verbose: bool = False) -> int:
 
 
 def get_git_commit_info(commit: str, verbose: bool = False) -> Dict[str, str]:
-  """Gets commit information dictory for the given commit."""
+  """Gets commit information dictionary for the given commit."""
   cmd = [
       'git', 'show', '--format=%H:::%h:::%an:::%ae:::%s', '--no-patch', commit
   ]
-  info = benchmark_definition.execute_cmd_and_get_output(cmd,
+  info = benchmark_definition.execute_cmd_and_get_stdout(cmd,
                                                          cwd=THIS_DIRECTORY,
                                                          verbose=verbose)
   segments = info.split(':::')
@@ -139,13 +139,13 @@ def compose_series_payload(project_id: str,
 
 
 def compose_build_payload(project_id: str,
-                          project_github_comit_url: str,
+                          project_github_commit_url: str,
                           build_id: int,
                           commit: str,
                           override: bool = False) -> Dict[str, Any]:
   """Composes the payload dictionary for a build."""
   commit_info = get_git_commit_info(commit)
-  commit_info['url'] = f'{project_github_comit_url}/{commit_info["hash"]}'
+  commit_info['url'] = f'{project_github_commit_url}/{commit_info["hash"]}'
   return {
       'projectId': project_id,
       'build': {
@@ -332,7 +332,7 @@ def main(args):
                                         benchmark_info.model_source)
     if description is None:
       description = ""
-    description += COMMON_DESCRIIPTION
+    description += COMMON_DESCRIPTION
 
     threshold = next(
         (threshold for threshold in benchmark_thresholds.BENCHMARK_THRESHOLDS
@@ -362,7 +362,7 @@ def main(args):
         compile_metrics.compilation_info.model_source)
     if description is None:
       description = ""
-    description += COMMON_DESCRIIPTION
+    description += COMMON_DESCRIPTION
 
     for mapper in benchmark_presentation.COMPILATION_METRICS_TO_TABLE_MAPPERS:
       sample_value, _ = mapper.get_current_and_base_value(compile_metrics)


### PR DESCRIPTION
Tracks the host and device memory statistics provided by `iree-benchmark-module` in OOBI.
Integration with the CI comments and IREE's perf dashboard is left as a follow-up.