### PR TITLE
[StableHLO] Port shape computation legalization

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
@@ -34,7 +34,6 @@ iree_compiler_cc_library(
         "Passes.h",
         "Passes.h.inc",
         "Rewriters.h",
-        "TypeConversion.h",
     ],
     deps = [
         ":PassesIncGen",
@@ -44,8 +43,9 @@ iree_compiler_cc_library(
 )
 
 iree_compiler_cc_library(
-    name = "StableHLOToLinalg",
+    name = "StableHLOLegalization",
     srcs = [
+        "LegalizeShapeComputations.cpp",
         "LegalizeToLinalgUtils.cpp",
         "LegalizeToLinalgUtils.h",
         "MapStableHLOToScalarOp.h",
@@ -57,6 +57,7 @@ iree_compiler_cc_library(
         "StableHLOToLinalgRandom.cpp",
         "StableHLOToLinalgReduce.cpp",
         "TypeConversion.cpp",
+        "TypeConversion.h",
     ],
     deps = [
         ":PassHeaders",
@@ -66,6 +67,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:ComplexDialect",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransforms",
@@ -95,7 +97,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":PassHeaders",
-        ":StableHLOToLinalg",
+        ":StableHLOLegalization",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
@@ -27,7 +27,6 @@ iree_cc_library(
     "Passes.h"
     "Passes.h.inc"
     "Rewriters.h"
-    "TypeConversion.h"
   DEPS
     ::PassesIncGen
     MLIRPass
@@ -37,8 +36,9 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
-    StableHLOToLinalg
+    StableHLOLegalization
   SRCS
+    "LegalizeShapeComputations.cpp"
     "LegalizeToLinalgUtils.cpp"
     "LegalizeToLinalgUtils.h"
     "MapStableHLOToScalarOp.h"
@@ -50,6 +50,7 @@ iree_cc_library(
     "StableHLOToLinalgRandom.cpp"
     "StableHLOToLinalgReduce.cpp"
     "TypeConversion.cpp"
+    "TypeConversion.h"
   DEPS
     ::PassHeaders
     ChloOps
@@ -59,6 +60,7 @@ iree_cc_library(
     MLIRArithDialect
     MLIRBufferizationDialect
     MLIRComplexDialect
+    MLIRFuncDialect
     MLIRIR
     MLIRLinalgDialect
     MLIRLinalgTransforms
@@ -86,7 +88,7 @@ iree_cc_library(
     "Passes.cpp"
   DEPS
     ::PassHeaders
-    ::StableHLOToLinalg
+    ::StableHLOLegalization
     LLVMSupport
     MLIRLinalgTransforms
     MLIRMLProgramDialect

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/LegalizeShapeComputations.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/LegalizeShapeComputations.cpp
@@ -1,0 +1,197 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements logic for lowering StableHLO dialect to scalar shape operations.
+
+#include "iree/compiler/InputConversion/StableHLO/MapStableHLOToScalarOp.h"
+#include "iree/compiler/InputConversion/StableHLO/Passes.h"
+#include "iree/compiler/InputConversion/StableHLO/Rewriters.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_LEGALIZESHAPECOMPUTATIONS
+#include "iree/compiler/InputConversion/StableHLO/Passes.h.inc"
+
+namespace {
+
+// We assume that if one of the operands is a FromElements operation that means
+// it is a shape computation.
+bool opIsShapeComputation(Operation *op) {
+  bool foundFromElements = false;
+  for (Value operand : op->getOperands()) {
+    auto shapedTy = cast<ShapedType>(operand.getType());
+    if (!shapedTy.hasRank() || shapedTy.getRank() > 1) {
+      return false;
+    }
+    if (auto fromElements = operand.getDefiningOp<tensor::FromElementsOp>()) {
+      foundFromElements = true;
+      continue;
+    }
+  }
+  return foundFromElements;
+}
+
+template <typename OpTy>
+struct HloElementwiseConverter : OpRewritePattern<OpTy> {
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const final {
+    if (!opIsShapeComputation(op)) return failure();
+
+    auto resultTy = cast<ShapedType>(op.getType());
+
+    Location loc = op.getLoc();
+    SmallVector<Value> operands;
+    for (int i = 0, s = resultTy.getNumElements(); i < s; ++i) {
+      SmallVector<Value> extracts;
+      for (Value operand : op->getOperands()) {
+        ShapedType operandTy = cast<ShapedType>(operand.getType());
+        if (operandTy.getRank() == 0) {
+          Value extract =
+              rewriter.create<tensor::ExtractOp>(loc, operand, ValueRange({}));
+          extracts.push_back(extract);
+        } else {
+          Value idx = rewriter.create<arith::ConstantIndexOp>(loc, i);
+          Value extract = rewriter.create<tensor::ExtractOp>(loc, operand, idx);
+          extracts.push_back(extract);
+        }
+      }
+
+      Value scalarOp = mlir::stablehlo::StableHloOpToStdScalarOp::mapOp(
+          op, resultTy.getElementType(), extracts, &rewriter);
+      operands.push_back(scalarOp);
+    }
+
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(op, resultTy, operands);
+    return success();
+  }
+};
+
+struct ConcatenateConverter final
+    : OpRewritePattern<mlir::stablehlo::ConcatenateOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ConcatenateOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!opIsShapeComputation(op)) return failure();
+
+    Location loc = op.getLoc();
+    auto resultTy = cast<ShapedType>(op.getType());
+    llvm::SmallVector<Value> elements;
+    elements.reserve(resultTy.getNumElements());
+
+    for (Value operand : op->getOperands()) {
+      ShapedType operandTy = operand.getType().cast<ShapedType>();
+      if (operandTy.getRank() == 0) {
+        Value extract =
+            rewriter.create<tensor::ExtractOp>(loc, operand, ValueRange({}));
+        elements.push_back(extract);
+      } else {
+        for (int i = 0, s = operandTy.getNumElements(); i < s; ++i) {
+          Value idx = rewriter.create<arith::ConstantIndexOp>(loc, i);
+          Value extract = rewriter.create<tensor::ExtractOp>(loc, operand, idx);
+          elements.push_back(extract);
+        }
+      }
+    }
+
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(op, resultTy, elements);
+    return success();
+  }
+};
+
+struct GetDimSizeConverter final
+    : OpRewritePattern<mlir::stablehlo::GetDimensionSizeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::GetDimensionSizeOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Type resultTy = op.getType();
+    Type elementTy = getElementTypeOrSelf(resultTy);
+    IntegerAttr dimAttr = rewriter.getIndexAttr(op.getDimension());
+    auto dimConst = rewriter.create<arith::ConstantOp>(loc, dimAttr);
+
+    Value dimOp = rewriter.create<tensor::DimOp>(loc, rewriter.getIndexType(),
+                                                 op.getOperand(), dimConst);
+
+    // Cast to the correct element type and convert to a tensor.
+    Value cast = rewriter.create<arith::IndexCastOp>(loc, elementTy, dimOp);
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(op, resultTy, cast);
+    return success();
+  }
+};
+
+struct ReshapeConverter : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ReshapeOp op,
+                                PatternRewriter &rewriter) const override {
+    Value operand = op.getOperand();
+    auto shapedTy = cast<ShapedType>(operand.getType());
+    if (!shapedTy.hasRank() || shapedTy.getRank() > 1) return failure();
+
+    auto resultTy = cast<ShapedType>(op.getType());
+
+    auto fromElements = op.getOperand().getDefiningOp<tensor::FromElementsOp>();
+    if (!fromElements) return failure();
+
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(
+        op, resultTy, fromElements.getOperands());
+    return success();
+  }
+};
+
+struct LegalizeShapeComputations final
+    : impl::LegalizeShapeComputationsBase<LegalizeShapeComputations> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, math::MathDialect, func::FuncDialect,
+                    tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext &ctx = this->getContext();
+    RewritePatternSet patterns(&ctx);
+
+    func::FuncOp func = this->getOperation();
+    populateLegalizeShapeComputationPatterns(&ctx, &patterns);
+    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns)))) {
+      this->signalPassFailure();
+    }
+  }
+};
+}  // namespace
+
+void populateLegalizeShapeComputationPatterns(MLIRContext *context,
+                                              RewritePatternSet *patterns) {
+  patterns->add<HloElementwiseConverter<mlir::stablehlo::AbsOp>,
+                HloElementwiseConverter<mlir::stablehlo::AddOp>,
+                HloElementwiseConverter<mlir::stablehlo::AndOp>,
+                HloElementwiseConverter<mlir::stablehlo::CeilOp>,
+                HloElementwiseConverter<mlir::stablehlo::ConvertOp>,
+                HloElementwiseConverter<mlir::stablehlo::DivOp>,
+                HloElementwiseConverter<mlir::stablehlo::FloorOp>,
+                HloElementwiseConverter<mlir::stablehlo::MaxOp>,
+                HloElementwiseConverter<mlir::stablehlo::MinOp>,
+                HloElementwiseConverter<mlir::stablehlo::MulOp>,
+                HloElementwiseConverter<mlir::stablehlo::NegOp>,
+                HloElementwiseConverter<mlir::stablehlo::RoundOp>,
+                HloElementwiseConverter<mlir::stablehlo::RsqrtOp>,
+                HloElementwiseConverter<mlir::stablehlo::SqrtOp>,
+                HloElementwiseConverter<mlir::stablehlo::SubtractOp>,
+                ConcatenateConverter, GetDimSizeConverter, ReshapeConverter>(
+      context);
+}
+
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
@@ -99,9 +99,10 @@ void buildStableHLOInputConversionPassPipelineImpl(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(mlir::createCSEPass());
 
   // Convert to Linalg. After this point, StableHLO will be eliminated.
-  // TODO(#12678): Port StableHLO shape computation legalization.
+  passManager.addNestedPass<func::FuncOp>(
+      stablehlo::createLegalizeShapeComputations());
   // TODO(#12678): Port StableHLO to LinalgExt lowering.
-  passManager.addPass(createConvertStableHloToLinalg());
+  passManager.addPass(stablehlo::createConvertStableHloToLinalg());
   // Ensure conversion completed.
   passManager.addPass(createReconcileUnrealizedCastsPass());
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.td
@@ -18,4 +18,9 @@ def ConvertStableHloToLinalg :
                         "transpose) when possible, instead of linalg.generic">];
 }
 
+def LegalizeShapeComputations :
+    Pass<"iree-stablehlo-legalize-shape-computations", "func::FuncOp"> {
+  let summary = "Legalize StableHLO shape operations to core-mlir operations.";
+}
+
 #endif // IREE_COMPILER_INPUTCONVERSION_STABLEHLO_PASSES

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
@@ -17,6 +17,10 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext *context,
                                                  RewritePatternSet *patterns,
                                                  bool enablePrimitiveOps);
 
+// Collection of rewrite patterns for lowering of StableHLO dim operations.
+void populateLegalizeShapeComputationPatterns(MLIRContext *context,
+                                              RewritePatternSet *patterns);
+
 //===----------------------------------------------------------------------===//
 // Fine-grained patterns used by the implementation.
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "legalize_shape_computations.mlir",
             "stablehlo_to_linalg_convolution.mlir",
             "stablehlo_to_linalg_dot_prod.mlir",
             "stablehlo_to_linalg_pointwise.mlir",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "legalize_shape_computations.mlir"
     "stablehlo_to_linalg.mlir"
     "stablehlo_to_linalg_convolution.mlir"
     "stablehlo_to_linalg_dot_prod.mlir"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/legalize_shape_computations.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/legalize_shape_computations.mlir
@@ -1,0 +1,67 @@
+// RUN: iree-opt --iree-stablehlo-legalize-shape-computations \
+// RUN:          --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func @get_dimension_size
+func.func @get_dimension_size(%arg0: tensor<?x?xf32>) -> (tensor<i32>) {
+  %1 = "stablehlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<?x?xf32>) -> tensor<i32>
+  func.return %1 : tensor<i32>
+}
+
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK-DAG: %[[IDX:.+]] = arith.index_cast %[[DIM]]
+// CHECK-DAG: %[[FROM:.+]] = tensor.from_elements %[[IDX]]
+// CHECK: return %[[FROM]] : tensor<i32>
+
+// -----
+
+// CHECK-LABEL: func @reshape_dimension_size
+func.func @reshape_dimension_size(%arg0: tensor<?x?xf32>) -> (tensor<1xi32>) {
+  %0 = "stablehlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<?x?xf32>) -> tensor<i32>
+  %1 = "stablehlo.reshape"(%0) : (tensor<i32>) -> tensor<1xi32>
+  func.return %1 : tensor<1xi32>
+}
+
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK-DAG: %[[IDX:.+]] = arith.index_cast %[[DIM]]
+// CHECK-DAG: %[[FROM:.+]] = tensor.from_elements %[[IDX]]
+// CHECK: return %[[FROM]] : tensor<1xi32>
+
+// -----
+
+// CHECK-LABEL: func @multiply_dimension_size
+func.func @multiply_dimension_size(%arg0: tensor<?x?xf32>) -> (tensor<i32>) {
+  %0 = stablehlo.constant dense<2> : tensor<i32>
+  %1 = "stablehlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<?x?xf32>) -> tensor<i32>
+  %2 = "stablehlo.multiply"(%0, %1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+  func.return %2 : tensor<i32>
+}
+
+
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK-DAG: %[[IDX:.+]] = arith.index_cast %[[DIM]]
+// CHECK-DAG: %[[MUL:.+]] = arith.muli %[[IDX]], %[[C2]]
+// CHECK-DAG: %[[RES:.+]] = tensor.from_elements %[[MUL]]
+// CHECK: return %[[RES]]
+
+// -----
+
+// CHECK-LABEL: func @concat_dimension_size
+func.func @concat_dimension_size(%arg0: tensor<?x?xf32>) -> (tensor<2xi32>) {
+  %0 = "stablehlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<?x?xf32>) -> tensor<i32>
+  %1 = "stablehlo.reshape"(%0) : (tensor<i32>) -> tensor<1xi32>
+  %2 = stablehlo.constant dense<2> : tensor<1xi32>
+  %3 = "stablehlo.concatenate"(%1, %2) {dimension = 0 : i64} : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  func.return %3 : tensor<2xi32>
+}
+
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK-DAG: %[[IDX:.+]] = arith.index_cast %[[DIM]]
+// CHECK-DAG: %[[RES:.+]] = tensor.from_elements %[[IDX]], %[[C2]]
+// CHECK: return %[[RES]]
+


### PR DESCRIPTION
Ports a pass to lower shape computations to core-mlir ops. This is based on the equivalent MHLO pass from mlir-hlo. For the details, see the initial import: https://github.com/openxla/iree/pull/12957.

Issue: https://github.com/openxla/iree/issues/12678