### PR TITLE
Plumb source MLIR locs to SPIR-V and CUDA executables.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -587,8 +587,9 @@ class CUDATargetBackend final : public TargetBackend {
                                                   workgroupLocalMemoriesRef);
     iree_CUDAExecutableDef_ptx_image_add(builder, gpuImageRef);
     if (!sourceLocationRefs.empty()) {
-      iree_CUDAExecutableDef_source_locations_create(
-          builder, sourceLocationRefs.data(), sourceLocationRefs.size());
+      auto sourceLocationsRef =
+          builder.createOffsetVecDestructive(sourceLocationRefs);
+      iree_CUDAExecutableDef_source_locations_add(builder, sourceLocationsRef);
     }
     iree_CUDAExecutableDef_end_as_root(builder);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -413,9 +413,9 @@ class CUDATargetBackend final : public TargetBackend {
     FlatbufferBuilder builder;
     iree_CUDAExecutableDef_start_as_root(builder);
 
-    SmallVector<std::string, 8> entryPointNames;
+    SmallVector<std::string> entryPointNames;
     std::string ptxImage;
-    SmallVector<iree_CUDAFileLineLocDef_ref_t, 8> sourceLocationRefs;
+    SmallVector<iree_CUDAFileLineLocDef_ref_t> sourceLocationRefs;
     if (variantOp.isExternal()) {
       if (!variantOp.getObjects().has_value()) {
         return variantOp.emitOpError()

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.h"
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/Utils/FlatbufferUtils.h"
+#include "iree/compiler/Utils/ModuleUtils.h"
 #include "iree/compiler/Utils/StringUtils.h"
 #include "iree/compiler/Utils/ToolUtils.h"
 #include "iree/schemas/cuda_executable_def_builder.h"
@@ -409,8 +410,12 @@ class CUDATargetBackend final : public TargetBackend {
       workgroupLocalMemories.push_back(workgroupLocalMemory);
     }
 
-    SmallVector<std::string> entryPointNames;
+    FlatbufferBuilder builder;
+    iree_CUDAExecutableDef_start_as_root(builder);
+
+    SmallVector<std::string, 8> entryPointNames;
     std::string ptxImage;
+    SmallVector<iree_CUDAFileLineLocDef_ref_t, 8> sourceLocationRefs;
     if (variantOp.isExternal()) {
       if (!variantOp.getObjects().has_value()) {
         return variantOp.emitOpError()
@@ -486,6 +491,15 @@ class CUDATargetBackend final : public TargetBackend {
         setMetadataValueI32("maxntidx", workgroupSize[0]);
         setMetadataValueI32("maxntidy", workgroupSize[1]);
         setMetadataValueI32("maxntidz", workgroupSize[2]);
+
+        // Optional source location information for debugging/profiling.
+        if (options.debugLevel >= 1) {
+          if (auto loc = findFirstFileLoc(exportOp.getLoc())) {
+            auto filenameRef = builder.createString(loc->getFilename());
+            sourceLocationRefs.push_back(iree_CUDAFileLineLocDef_create(
+                builder, filenameRef, loc->getLine()));
+          }
+        }
       }
 
       std::unique_ptr<llvm::TargetMachine> targetMachine;
@@ -554,10 +568,6 @@ class CUDATargetBackend final : public TargetBackend {
     }
 
     std::string gpuImage = produceGpuImage(ptxImage);
-
-    FlatbufferBuilder builder;
-    iree_CUDAExecutableDef_start_as_root(builder);
-
     auto gpuImageRef = flatbuffers_uint8_vec_create(
         builder, reinterpret_cast<const uint8_t *>(gpuImage.c_str()),
         gpuImage.size());
@@ -576,6 +586,10 @@ class CUDATargetBackend final : public TargetBackend {
     iree_CUDAExecutableDef_shared_memory_size_add(builder,
                                                   workgroupLocalMemoriesRef);
     iree_CUDAExecutableDef_ptx_image_add(builder, gpuImageRef);
+    if (!sourceLocationRefs.empty()) {
+      iree_CUDAExecutableDef_source_locations_create(
+          builder, sourceLocationRefs.data(), sourceLocationRefs.size());
+    }
     iree_CUDAExecutableDef_end_as_root(builder);
 
     // Add the binary data to the target executable.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -320,10 +320,9 @@ class LLVMCPUTargetBackend final : public TargetBackend {
       std::string sourceFile = "";
       int sourceLine = 0;
       if (options.debugLevel >= 1) {
-        // TODO(scotttodd): Copy findFirstFileLoc() from VulkanSPIRVTarget?
-        if (auto loc = exportOp.getLoc().dyn_cast<FileLineColLoc>()) {
-          sourceFile = loc.getFilename().str();
-          sourceLine = loc.getLine();
+        if (auto loc = findFirstFileLoc(exportOp.getLoc())) {
+          sourceFile = loc->getFilename().str();
+          sourceLine = loc->getLine();
         }
       }
       libraryBuilder.addExport(

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -197,8 +197,9 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     }
     iree_SpirVExecutableDef_code_add(builder, spvCodeRef);
     if (!sourceLocationRefs.empty()) {
-      iree_SpirVExecutableDef_source_locations_create(
-          builder, sourceLocationRefs.data(), sourceLocationRefs.size());
+      auto sourceLocationsRef =
+          builder.createOffsetVecDestructive(sourceLocationRefs);
+      iree_SpirVExecutableDef_source_locations_add(builder, sourceLocationsRef);
     }
     iree_SpirVExecutableDef_end_as_root(builder);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Dialect/Vulkan/IR/VulkanDialect.h"
 #include "iree/compiler/Dialect/Vulkan/Utils/TargetEnvironment.h"
 #include "iree/compiler/Utils/FlatbufferUtils.h"
+#include "iree/compiler/Utils/ModuleUtils.h"
 #include "iree/schemas/spirv_executable_def_builder.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
@@ -158,14 +159,15 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     auto spvCodeRef = flatbuffers_uint32_vec_create(builder, spvBinary.data(),
                                                     spvBinary.size());
 
-    // The sequencer and runtime use ordinals instead of names. We provide the
-    // list of entry point names here that are then passed in
-    // VkShaderModuleCreateInfo.
+    // The runtime uses ordinals instead of names. We provide the list of entry
+    // point names here that are then passed in VkShaderModuleCreateInfo.
     SmallVector<StringRef, 8> entryPointNames;
     SmallVector<uint32_t, 8> subgroupSizes;
+    SmallVector<iree_SpirVFileLineLocDef_ref_t, 8> sourceLocationRefs;
     bool hasAnySubgroupSizes = false;
     spvModuleOp.walk([&](spirv::EntryPointOp exportOp) {
       entryPointNames.push_back(exportOp.getFn());
+
       auto fn = spvModuleOp.lookupSymbol<spirv::FuncOp>(exportOp.getFn());
       auto abi = fn->getAttrOfType<spirv::EntryPointABIAttr>(
           spirv::getEntryPointABIAttrName());
@@ -174,6 +176,15 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
         hasAnySubgroupSizes = true;
       } else {
         subgroupSizes.push_back(0);
+      }
+
+      // Optional source location information for debugging/profiling.
+      if (options.debugLevel >= 1) {
+        if (auto loc = findFirstFileLoc(exportOp.getLoc())) {
+          auto filenameRef = builder.createString(loc->getFilename());
+          sourceLocationRefs.push_back(iree_SpirVFileLineLocDef_create(
+              builder, filenameRef, loc->getLine()));
+        }
       }
     });
     auto entryPointsRef = builder.createStringVec(entryPointNames);
@@ -185,6 +196,10 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
       iree_SpirVExecutableDef_subgroup_sizes_add(builder, subgroupSizesRef);
     }
     iree_SpirVExecutableDef_code_add(builder, spvCodeRef);
+    if (!sourceLocationRefs.empty()) {
+      iree_SpirVExecutableDef_source_locations_create(
+          builder, sourceLocationRefs.data(), sourceLocationRefs.size());
+    }
     iree_SpirVExecutableDef_end_as_root(builder);
 
     // Add the binary data to the target executable.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -161,9 +161,9 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
 
     // The runtime uses ordinals instead of names. We provide the list of entry
     // point names here that are then passed in VkShaderModuleCreateInfo.
-    SmallVector<StringRef, 8> entryPointNames;
-    SmallVector<uint32_t, 8> subgroupSizes;
-    SmallVector<iree_SpirVFileLineLocDef_ref_t, 8> sourceLocationRefs;
+    SmallVector<StringRef> entryPointNames;
+    SmallVector<uint32_t> subgroupSizes;
+    SmallVector<iree_SpirVFileLineLocDef_ref_t> sourceLocationRefs;
     bool hasAnySubgroupSizes = false;
     spvModuleOp.walk([&](spirv::EntryPointOp exportOp) {
       entryPointNames.push_back(exportOp.getFn());

--- a/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
@@ -17,7 +17,7 @@
 namespace mlir {
 namespace iree_compiler {
 
-static std::optional<FileLineColLoc> findFirstFileLoc(Location baseLoc) {
+std::optional<FileLineColLoc> findFirstFileLoc(Location baseLoc) {
   if (auto loc = baseLoc.dyn_cast<FusedLoc>()) {
     for (auto &childLoc : loc.getLocations()) {
       auto childResult = findFirstFileLoc(childLoc);

--- a/compiler/src/iree/compiler/Utils/ModuleUtils.h
+++ b/compiler/src/iree/compiler/Utils/ModuleUtils.h
@@ -16,6 +16,9 @@
 namespace mlir {
 namespace iree_compiler {
 
+// Finds the first file location in |baseLoc|, if one exists.
+std::optional<FileLineColLoc> findFirstFileLoc(Location baseLoc);
+
 // Guesses the name of the module from the source locations attached unless a
 // name is already specified. If no source locations are found then
 // |defaultName| is returned.

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -162,6 +162,22 @@ iree_status_t iree_hal_cuda_native_executable_create(
             iree_make_string_view(string_table_buffer, entry_name_length);
         string_table_buffer += entry_name_length;
       });
+
+      IREE_TRACE({
+        if (iree_CUDAExecutableDef_source_locations_is_present(
+                executable_def)) {
+          iree_CUDAFileLineLocDef_vec_t source_locs_vec =
+              iree_CUDAExecutableDef_source_locations_get(executable_def);
+          iree_CUDAFileLineLocDef_table_t source_loc =
+              iree_CUDAFileLineLocDef_vec_at(source_locs_vec, i);
+          flatbuffers_string_t filename =
+              iree_CUDAFileLineLocDef_filename_get(source_loc);
+          uint32_t line = iree_CUDAFileLineLocDef_line_get(source_loc);
+          params->source_filename =
+              iree_make_string_view(filename, flatbuffers_string_len(filename));
+          params->source_line = line;
+        }
+      });
     }
   }
 

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.h
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.h
@@ -25,6 +25,8 @@ typedef struct iree_hal_cuda_kernel_params_t {
   uint32_t block_size[3];
   uint32_t shared_memory_size;
   IREE_TRACE(iree_string_view_t function_name;)
+  IREE_TRACE(iree_string_view_t source_filename;)
+  IREE_TRACE(uint32_t source_line;)
 } iree_hal_cuda_kernel_params_t;
 
 // Creates an executable from a PTX module. The module may contain several

--- a/runtime/src/iree/hal/drivers/cuda/stream_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/stream_command_buffer.c
@@ -492,9 +492,9 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_dispatch(
 
   IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(
       command_buffer->tracing_context, command_buffer->stream,
-      kernel_params.function_name.data, kernel_params.function_name.size,
-      /*line=*/0, /*func_name=*/NULL, 0, kernel_params.function_name.data,
-      kernel_params.function_name.size);
+      kernel_params.source_filename.data, kernel_params.source_filename.size,
+      kernel_params.source_line, /*func_name=*/NULL, 0,
+      kernel_params.function_name.data, kernel_params.function_name.size);
 
   // Patch the push constants in the kernel arguments.
   iree_host_size_t num_constants =

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
@@ -31,8 +31,8 @@ typedef struct iree_hal_vulkan_entry_point_t {
   iree_string_view_t name;
 
   // Optional debug information.
-  IREE_TRACE(iree_string_view_t source_filename;)
-  IREE_TRACE(uint32_t source_line;)
+  iree_string_view_t source_filename;
+  uint32_t source_line;
 } iree_hal_vulkan_entry_point_t;
 
 static iree_status_t iree_hal_vulkan_create_shader_module(
@@ -344,23 +344,21 @@ iree_status_t iree_hal_vulkan_native_executable_create(
     }
   }
 
-  IREE_TRACE({
-    if (iree_status_is_ok(status) &&
-        iree_SpirVExecutableDef_source_locations_is_present(executable_def)) {
-      iree_SpirVFileLineLocDef_vec_t source_locs_vec =
-          iree_SpirVExecutableDef_source_locations_get(executable_def);
-      for (iree_host_size_t i = 0; i < entry_point_count; ++i) {
-        iree_SpirVFileLineLocDef_table_t source_loc =
-            iree_SpirVFileLineLocDef_vec_at(source_locs_vec, i);
-        flatbuffers_string_t filename =
-            iree_SpirVFileLineLocDef_filename_get(source_loc);
-        uint32_t line = iree_SpirVFileLineLocDef_line_get(source_loc);
-        executable->entry_points[i].source_filename =
-            iree_make_string_view(filename, flatbuffers_string_len(filename));
-        executable->entry_points[i].source_line = line;
-      }
+  if (iree_status_is_ok(status) &&
+      iree_SpirVExecutableDef_source_locations_is_present(executable_def)) {
+    iree_SpirVFileLineLocDef_vec_t source_locs_vec =
+        iree_SpirVExecutableDef_source_locations_get(executable_def);
+    for (iree_host_size_t i = 0; i < entry_point_count; ++i) {
+      iree_SpirVFileLineLocDef_table_t source_loc =
+          iree_SpirVFileLineLocDef_vec_at(source_locs_vec, i);
+      flatbuffers_string_t filename =
+          iree_SpirVFileLineLocDef_filename_get(source_loc);
+      uint32_t line = iree_SpirVFileLineLocDef_line_get(source_loc);
+      executable->entry_points[i].source_filename =
+          iree_make_string_view(filename, flatbuffers_string_len(filename));
+      executable->entry_points[i].source_line = line;
     }
-  });
+  }
 
   if (iree_status_is_ok(status)) {
     *out_executable = (iree_hal_executable_t*)executable;

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
@@ -31,8 +31,8 @@ typedef struct iree_hal_vulkan_entry_point_t {
   iree_string_view_t name;
 
   // Optional debug information.
-  iree_string_view_t source_filename;
-  uint32_t source_line;
+  IREE_TRACE(iree_string_view_t source_filename;)
+  IREE_TRACE(uint32_t source_line;)
 } iree_hal_vulkan_entry_point_t;
 
 static iree_status_t iree_hal_vulkan_create_shader_module(
@@ -344,21 +344,23 @@ iree_status_t iree_hal_vulkan_native_executable_create(
     }
   }
 
-  if (iree_status_is_ok(status) &&
-      iree_SpirVExecutableDef_source_locations_is_present(executable_def)) {
-    iree_SpirVFileLineLocDef_vec_t source_locs_vec =
-        iree_SpirVExecutableDef_source_locations_get(executable_def);
-    for (iree_host_size_t i = 0; i < entry_point_count; ++i) {
-      iree_SpirVFileLineLocDef_table_t source_loc =
-          iree_SpirVFileLineLocDef_vec_at(source_locs_vec, i);
-      flatbuffers_string_t filename =
-          iree_SpirVFileLineLocDef_filename_get(source_loc);
-      uint32_t line = iree_SpirVFileLineLocDef_line_get(source_loc);
-      executable->entry_points[i].source_filename =
-          iree_make_string_view(filename, flatbuffers_string_len(filename));
-      executable->entry_points[i].source_line = line;
+  IREE_TRACE({
+    if (iree_status_is_ok(status) &&
+        iree_SpirVExecutableDef_source_locations_is_present(executable_def)) {
+      iree_SpirVFileLineLocDef_vec_t source_locs_vec =
+          iree_SpirVExecutableDef_source_locations_get(executable_def);
+      for (iree_host_size_t i = 0; i < entry_point_count; ++i) {
+        iree_SpirVFileLineLocDef_table_t source_loc =
+            iree_SpirVFileLineLocDef_vec_at(source_locs_vec, i);
+        flatbuffers_string_t filename =
+            iree_SpirVFileLineLocDef_filename_get(source_loc);
+        uint32_t line = iree_SpirVFileLineLocDef_line_get(source_loc);
+        executable->entry_points[i].source_filename =
+            iree_make_string_view(filename, flatbuffers_string_len(filename));
+        executable->entry_points[i].source_line = line;
+      }
     }
-  }
+  });
 
   if (iree_status_is_ok(status)) {
     *out_executable = (iree_hal_executable_t*)executable;
@@ -398,9 +400,15 @@ void iree_hal_vulkan_native_executable_entry_point_source_location(
   }
   iree_hal_vulkan_entry_point_t entry_point =
       executable->entry_points[entry_ordinal];
+
   out_source_location->func_name = entry_point.name;
-  out_source_location->file_name = entry_point.source_filename;
-  out_source_location->line = entry_point.source_line;
+
+  out_source_location->file_name = out_source_location->func_name;
+  out_source_location->line = 0;
+  IREE_TRACE({
+    out_source_location->file_name = entry_point.source_filename;
+    out_source_location->line = entry_point.source_line;
+  });
 }
 
 iree_status_t iree_hal_vulkan_native_executable_pipeline_for_entry_point(

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
@@ -31,8 +31,8 @@ typedef struct iree_hal_vulkan_entry_point_t {
   iree_string_view_t name;
 
   // Optional debug information.
-  iree_string_view_t source_filename;
-  uint32_t source_line;
+  IREE_TRACE(iree_string_view_t source_filename;)
+  IREE_TRACE(uint32_t source_line;)
 } iree_hal_vulkan_entry_point_t;
 
 static iree_status_t iree_hal_vulkan_create_shader_module(
@@ -344,21 +344,23 @@ iree_status_t iree_hal_vulkan_native_executable_create(
     }
   }
 
-  if (iree_status_is_ok(status) &&
-      iree_SpirVExecutableDef_source_locations_is_present(executable_def)) {
-    iree_SpirVFileLineLocDef_vec_t source_locs_vec =
-        iree_SpirVExecutableDef_source_locations_get(executable_def);
-    for (iree_host_size_t i = 0; i < entry_point_count; ++i) {
-      iree_SpirVFileLineLocDef_table_t source_loc =
-          iree_SpirVFileLineLocDef_vec_at(source_locs_vec, i);
-      flatbuffers_string_t filename =
-          iree_SpirVFileLineLocDef_filename_get(source_loc);
-      uint32_t line = iree_SpirVFileLineLocDef_line_get(source_loc);
-      executable->entry_points[i].source_filename =
-          iree_make_string_view(filename, flatbuffers_string_len(filename));
-      executable->entry_points[i].source_line = line;
+  IREE_TRACE({
+    if (iree_status_is_ok(status) &&
+        iree_SpirVExecutableDef_source_locations_is_present(executable_def)) {
+      iree_SpirVFileLineLocDef_vec_t source_locs_vec =
+          iree_SpirVExecutableDef_source_locations_get(executable_def);
+      for (iree_host_size_t i = 0; i < entry_point_count; ++i) {
+        iree_SpirVFileLineLocDef_table_t source_loc =
+            iree_SpirVFileLineLocDef_vec_at(source_locs_vec, i);
+        flatbuffers_string_t filename =
+            iree_SpirVFileLineLocDef_filename_get(source_loc);
+        uint32_t line = iree_SpirVFileLineLocDef_line_get(source_loc);
+        executable->entry_points[i].source_filename =
+            iree_make_string_view(filename, flatbuffers_string_len(filename));
+        executable->entry_points[i].source_line = line;
+      }
     }
-  }
+  });
 
   if (iree_status_is_ok(status)) {
     *out_executable = (iree_hal_executable_t*)executable;

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
@@ -29,6 +29,10 @@ using namespace iree::hal::vulkan;
 typedef struct iree_hal_vulkan_entry_point_t {
   VkPipeline pipeline;
   iree_string_view_t name;
+
+  // Optional debug information.
+  iree_string_view_t source_filename;
+  uint32_t source_line;
 } iree_hal_vulkan_entry_point_t;
 
 static iree_status_t iree_hal_vulkan_create_shader_module(
@@ -340,6 +344,22 @@ iree_status_t iree_hal_vulkan_native_executable_create(
     }
   }
 
+  if (iree_status_is_ok(status) &&
+      iree_SpirVExecutableDef_source_locations_is_present(executable_def)) {
+    iree_SpirVFileLineLocDef_vec_t source_locs_vec =
+        iree_SpirVExecutableDef_source_locations_get(executable_def);
+    for (iree_host_size_t i = 0; i < entry_point_count; ++i) {
+      iree_SpirVFileLineLocDef_table_t source_loc =
+          iree_SpirVFileLineLocDef_vec_at(source_locs_vec, i);
+      flatbuffers_string_t filename =
+          iree_SpirVFileLineLocDef_filename_get(source_loc);
+      uint32_t line = iree_SpirVFileLineLocDef_line_get(source_loc);
+      executable->entry_points[i].source_filename =
+          iree_make_string_view(filename, flatbuffers_string_len(filename));
+      executable->entry_points[i].source_line = line;
+    }
+  }
+
   if (iree_status_is_ok(status)) {
     *out_executable = (iree_hal_executable_t*)executable;
   } else {
@@ -376,11 +396,11 @@ void iree_hal_vulkan_native_executable_entry_point_source_location(
   if (entry_ordinal >= executable->entry_point_count) {
     return;
   }
-  out_source_location->func_name = executable->entry_points[entry_ordinal].name;
-
-  // TODO(benvanik): plumb through file name/line for the MLIR function.
-  out_source_location->file_name = out_source_location->func_name;
-  out_source_location->line = 0;
+  iree_hal_vulkan_entry_point_t entry_point =
+      executable->entry_points[entry_ordinal];
+  out_source_location->func_name = entry_point.name;
+  out_source_location->file_name = entry_point.source_filename;
+  out_source_location->line = entry_point.source_line;
 }
 
 iree_status_t iree_hal_vulkan_native_executable_pipeline_for_entry_point(

--- a/runtime/src/iree/schemas/cuda_executable_def.fbs
+++ b/runtime/src/iree/schemas/cuda_executable_def.fbs
@@ -17,6 +17,12 @@ struct CUDABlockSizeDef {
   z:uint32;
 }
 
+// Source code location denoted by a file name and line within that file.
+table CUDAFileLineLocDef {
+  filename:string;
+  line:int32;
+}
+
 table CUDAExecutableDef {
   // A map of entry point ordinals to string names as used in the shader
   // library.
@@ -32,8 +38,13 @@ table CUDAExecutableDef {
 
   // PTX string of the module.
   ptx_image:string;
-  
+
   // TODO(thomasraoux): Add potential cuBin binary specialized for some targets.
+
+  // A map of entry point ordinals to source locations.
+  // This information is optional and may be used by debuggers and profilers to
+  // associate executable entry points with the source that generated them.
+  source_locations:[CUDAFileLineLocDef];
 }
 
 root_type CUDAExecutableDef;

--- a/runtime/src/iree/schemas/spirv_executable_def.fbs
+++ b/runtime/src/iree/schemas/spirv_executable_def.fbs
@@ -10,6 +10,12 @@ namespace iree;
 file_identifier "SPVE";
 file_extension "spve";
 
+// Source code location denoted by a file name and line within that file.
+table SpirVFileLineLocDef {
+  filename:string;
+  line:int32;
+}
+
 // A SPIR-V shader module and runtime pipeline layout description.
 // This information is used to create the VkShaderModule, VkPipelineLayout, and
 // any required VkDescriptorSetLayouts.
@@ -22,6 +28,11 @@ table SpirVExecutableDef {
 
   // SPIR-V code words.
   code:[uint32];
+
+  // A map of entry point ordinals to source locations.
+  // This information is optional and may be used by debuggers and profilers to
+  // associate executable entry points with the source that generated them.
+  source_locations:[SpirVFileLineLocDef];
 }
 
 root_type SpirVExecutableDef;


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/13142 (CUDA + Vulkan, no Metal or ROCm)

As with https://github.com/openxla/iree/pull/9994 for the `llvm-cpu` compiler target, the `vulkan-spirv` and `cuda` targets now include MLIR source locations in the SPIR-V/CUDA executables they produce. Source locations are only included with `--iree-hal-executable-debug-level=1` (or higher, default is 2). If you use `--iree-hal-dump-executable-sources-to={path}`, the source locations will be snapshotted and point to those dumped source files; otherwise they will be the original source locations in your input program.

## Vulkan examples

To use in Tracy, see `iree_hal_vulkan_direct_command_buffer` at the top:
![image](https://user-images.githubusercontent.com/4010439/235252527-513850e0-abb8-43d8-887e-d1dda6230f24.png)

Zoom until you can see individual dispatches, then click one -> "Source":
![image](https://user-images.githubusercontent.com/4010439/235252685-8a69b85e-ba42-4e9e-b37e-6cd6ef988902.png)

Or from "Statistics", hover over (or right click) each source location: 
![image](https://user-images.githubusercontent.com/4010439/235253183-602a088a-fd56-4137-a637-015a5465faba.png)

## CUDA examples

![image](https://user-images.githubusercontent.com/4010439/235266608-4966b0ba-99a6-4ff1-be41-34a08347c6d0.png)
