### PR TITLE
[StableHLO] Port control flow legalization

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
@@ -45,6 +45,7 @@ iree_compiler_cc_library(
 iree_compiler_cc_library(
     name = "StableHLOLegalization",
     srcs = [
+        "LegalizeControlFlow.cpp",
         "LegalizeShapeComputations.cpp",
         "LegalizeToLinalgUtils.cpp",
         "LegalizeToLinalgUtils.h",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
   NAME
     StableHLOLegalization
   SRCS
+    "LegalizeControlFlow.cpp"
     "LegalizeShapeComputations.cpp"
     "LegalizeToLinalgUtils.cpp"
     "LegalizeToLinalgUtils.h"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/LegalizeControlFlow.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/LegalizeControlFlow.cpp
@@ -1,0 +1,278 @@
+// Copyright 2019 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements logic for lowering StableHLO dialect ops to the SCF dialect.
+
+#include "iree/compiler/InputConversion/StableHLO/Passes.h"
+#include "iree/compiler/InputConversion/StableHLO/Rewriters.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_LEGALIZECONTROLFLOW
+#include "iree/compiler/InputConversion/StableHLO/Passes.h.inc"
+
+namespace {
+// All transformations in this file take stablehlo blocks which end with
+// stablehlo::ReturnOp and lower to SCF ops which end with scf::YieldOp. Inline
+// an entire block with the only change being return -> yield.
+void inlineStableHloRegionIntoSCFRegion(PatternRewriter &rewriter, Region &hlo,
+                                        Region &scf) {
+  // Remove an existing block, then move the region over.
+  if (!scf.empty()) {
+    rewriter.eraseBlock(&scf.back());
+  }
+  rewriter.inlineRegionBefore(hlo, scf, scf.end());
+  // Fix up the terminator.
+  PatternRewriter::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToEnd(&scf.back());
+  Operation *terminator = scf.back().getTerminator();
+  rewriter.replaceOpWithNewOp<scf::YieldOp>(terminator,
+                                            terminator->getOperands());
+}
+
+// stablehlo ops need inputs to be tensors, but scalar values can be a scalar
+// tensor or a 1 element tensor. To handle this, collapse shape before
+// extracting the scalar value when necessary.
+Value extractTensorValue(OpBuilder &b, Value tensor) {
+  Location loc = tensor.getLoc();
+  if (auto rankedTy = dyn_cast<RankedTensorType>(tensor.getType())) {
+    if (rankedTy.getRank() != 0) {
+      tensor = b.create<tensor::CollapseShapeOp>(
+          loc, tensor, SmallVector<ReassociationIndices>());
+    }
+  }
+
+  return b.create<tensor::ExtractOp>(loc, tensor, ValueRange());
+}
+
+struct ScfForBounds {
+  Value lb;
+  Value ub;
+  Value step;
+  unsigned indexArgIndex;
+};
+
+std::optional<ScfForBounds> extractForBounds(mlir::stablehlo::WhileOp op) {
+  Block &cond = op.getCond().front();
+  Block &body = op.getBody().front();
+  if (cond.getOperations().size() != 2) return std::nullopt;
+
+  auto matchBbArg = [](Value v, Block &block) -> std::optional<unsigned> {
+    if (!isa<BlockArgument>(v) || v.getParentBlock() != &block)
+      return std::nullopt;
+    return cast<BlockArgument>(v).getArgNumber();
+  };
+
+  auto compare = dyn_cast<mlir::stablehlo::CompareOp>(cond.front());
+  // If the rhs of the comapare is defined outside the block, it's a constant
+  // within the loop.
+  if (!compare ||
+      compare.getComparisonDirection() !=
+          mlir::stablehlo::ComparisonDirection::LT ||
+      compare.getRhs().getParentBlock() == &cond ||
+      !getElementTypeOrSelf(compare.getLhs().getType())
+           .isSignlessIntOrIndex()) {
+    return std::nullopt;
+  }
+
+  std::optional<unsigned> iterArg = matchBbArg(compare.getLhs(), cond);
+  if (!iterArg) return std::nullopt;
+
+  auto add = dyn_cast_or_null<mlir::stablehlo::AddOp>(
+      body.getTerminator()->getOperand(*iterArg).getDefiningOp());
+  if (!add || matchBbArg(add.getLhs(), body) != iterArg ||
+      add.getRhs().getParentBlock() == &body) {
+    return std::nullopt;
+  }
+
+  ScfForBounds bounds;
+  bounds.ub = compare.getRhs();
+  bounds.step = add.getRhs();
+  bounds.lb = op->getOperand(*iterArg);
+  bounds.indexArgIndex = *iterArg;
+  return bounds;
+}
+
+// Rewrites `stablehlo.while` to `scf.while` or `scf.for`.
+struct WhileOpPattern final : OpConversionPattern<mlir::stablehlo::WhileOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::WhileOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    if (std::optional<ScfForBounds> bounds = extractForBounds(op)) {
+      auto newForOp = rewriter.create<scf::ForOp>(
+          loc, extractTensorValue(rewriter, bounds->lb),
+          extractTensorValue(rewriter, bounds->ub),
+          extractTensorValue(rewriter, bounds->step), adaptor.getOperands());
+
+      rewriter.setInsertionPointToEnd(newForOp.getBody());
+      // Inline while body, and only replace the mhlo.return with an scf.yield.
+      inlineStableHloRegionIntoSCFRegion(rewriter, op.getBody(),
+                                         newForOp.getRegion());
+      BlockArgument indexArg = newForOp.getRegion().insertArgument(
+          unsigned{0}, newForOp.getLowerBound().getType(), loc);
+      BlockArgument oldIndexArg =
+          newForOp.getRegion().getArgument(1 + bounds->indexArgIndex);
+      rewriter.setInsertionPointToStart(&newForOp.getRegion().front());
+      auto indexArgTensor = rewriter.create<tensor::FromElementsOp>(
+          loc, oldIndexArg.getType(), indexArg);
+      oldIndexArg.replaceAllUsesWith(indexArgTensor);
+
+      rewriter.replaceOp(op, newForOp.getResults());
+      return success();
+    }
+
+    auto newWhileOp = rewriter.create<scf::WhileOp>(loc, op.getResultTypes(),
+                                                    adaptor.getOperands());
+
+    // Inline while condition. The block is the same, except the boolean result
+    // needs to be extracted and used with an scf.condition.
+    rewriter.inlineRegionBefore(op.getCond(), newWhileOp.getBefore(),
+                                newWhileOp.getBefore().end());
+    auto conditionReturn = cast<mlir::stablehlo::ReturnOp>(
+        newWhileOp.getBefore().front().getTerminator());
+    rewriter.setInsertionPointToEnd(&newWhileOp.getBefore().front());
+    Value i1 = extractTensorValue(rewriter, conditionReturn->getOperand(0));
+    rewriter.replaceOpWithNewOp<scf::ConditionOp>(
+        conditionReturn, i1, newWhileOp.getBeforeArguments());
+
+    // Inline while body, and only replace the mhlo.return with an scf.yield.
+    inlineStableHloRegionIntoSCFRegion(rewriter, op.getBody(),
+                                       newWhileOp.getAfter());
+
+    rewriter.replaceOp(op, newWhileOp.getResults());
+    return success();
+  }
+};
+
+// Rewrites `stablehlo.if` to `scf.if`.
+struct IfOpPattern final : OpConversionPattern<mlir::stablehlo::IfOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::IfOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto scfIf = rewriter.create<scf::IfOp>(
+        op.getLoc(), op.getResultTypes(),
+        extractTensorValue(rewriter, adaptor.getPred()),
+        /*withElseRegion=*/true);
+    inlineStableHloRegionIntoSCFRegion(rewriter, op.getTrueBranch(),
+                                       scfIf.getThenRegion());
+    inlineStableHloRegionIntoSCFRegion(rewriter, op.getFalseBranch(),
+                                       scfIf.getElseRegion());
+    rewriter.replaceOp(op, scfIf.getResults());
+    return success();
+  }
+};
+
+// Rewrites `stablehlo.case` to a nested `scf.if`.
+struct CaseOpPattern : public OpConversionPattern<mlir::stablehlo::CaseOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  // Recursively create if/else ops to handle each possible value in a case op.
+  scf::IfOp createNestedCases(int currentIdx, mlir::stablehlo::CaseOp op,
+                              OpAdaptor adaptor,
+                              PatternRewriter &outerBuilder) const {
+    Location loc = op.getLoc();
+    Value idxValue = adaptor.getIndex();
+    size_t finalIdx = op.getBranches().size() - 2;
+
+    // Determine if the current index matches the case index.
+    Type scalarType = idxValue.getType();
+    auto shapedType = cast<ShapedType>(scalarType);
+    auto constAttr = DenseElementsAttr::get(
+        shapedType,
+        {cast<Attribute>(outerBuilder.getI32IntegerAttr(currentIdx))});
+    Value currentIdxVal = outerBuilder.create<mlir::stablehlo::ConstantOp>(
+        loc, idxValue.getType(), constAttr);
+
+    auto scfIf = outerBuilder.create<scf::IfOp>(
+        loc, op.getResultTypes(),
+        extractTensorValue(outerBuilder,
+                           outerBuilder.create<mlir::stablehlo::CompareOp>(
+                               loc, idxValue, currentIdxVal,
+                               mlir::stablehlo::ComparisonDirection::EQ)),
+        /*withElseRegion=*/true);
+    inlineStableHloRegionIntoSCFRegion(
+        outerBuilder, op.getBranches()[currentIdx], scfIf.getThenRegion());
+    int nextIdx = currentIdx + 1;
+    // Don't recurse for the final default block.
+    if (currentIdx == static_cast<int64_t>(finalIdx)) {
+      inlineStableHloRegionIntoSCFRegion(
+          outerBuilder, op.getBranches()[nextIdx], scfIf.getElseRegion());
+      return scfIf;
+    }
+
+    PatternRewriter::InsertionGuard guard(outerBuilder);
+    outerBuilder.setInsertionPointToEnd(&scfIf.getElseRegion().back());
+    auto innerIf = createNestedCases(nextIdx, op, adaptor, outerBuilder);
+    outerBuilder.create<scf::YieldOp>(op.getLoc(), innerIf.getResults());
+    return scfIf;
+  }
+
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::CaseOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // Inline the op if there is only a default block.
+    if (op.getBranches().size() == 1) {
+      Block &block = op.getBranches().front().front();
+      OperandRange results = block.getTerminator()->getOperands();
+      // Remove the stablehlo.return terminator, then inline the block.
+      rewriter.eraseOp(block.getTerminator());
+      rewriter.inlineBlockBefore(/*source=*/&block, /*dest=*/op.getOperation(),
+                                 /*argValues=*/{});
+      rewriter.replaceOp(op, results);
+      return success();
+    }
+
+    // Begin recursion with case 0.
+    rewriter.replaceOp(
+        op, createNestedCases(0, op, adaptor, rewriter).getResults());
+    return success();
+  }
+};
+
+struct LegalizeControlFlow final
+    : impl::LegalizeControlFlowBase<LegalizeControlFlow> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<scf::SCFDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    func::FuncOp f = getOperation();
+    MLIRContext *ctx = f.getContext();
+
+    RewritePatternSet patterns(ctx);
+    populateLegalizeControlFlowPatterns(ctx, &patterns);
+
+    mlir::ConversionTarget target(*ctx);
+    target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+    target.addIllegalOp<mlir::stablehlo::IfOp, mlir::stablehlo::WhileOp,
+                        mlir::stablehlo::CaseOp>();
+
+    if (failed(applyPartialConversion(f, target, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+}  // namespace
+
+void populateLegalizeControlFlowPatterns(MLIRContext *context,
+                                         RewritePatternSet *patterns) {
+  patterns->add<WhileOpPattern, IfOpPattern, CaseOpPattern>(context);
+}
+
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
@@ -54,9 +54,9 @@ void registerStableHLOConversionPassPipeline() {
 
 // Prepare HLO for use as an input to the Flow dialect.
 void buildStableHLOInputConversionPassPipelineImpl(OpPassManager &passManager) {
-  // TODO(#12678): Port StableHLO-StableHLO legalization.
   passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
-  // TODO(#12678): Port StableHLO control flow legalization.
+  passManager.addNestedPass<func::FuncOp>(
+      stablehlo::createLegalizeControlFlow());
 
   // Currently we don't handle SCF ops well and have to convert them all to CFG.
   // In the future it would be nice if we could have all of flow be both scf

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.td
@@ -18,6 +18,11 @@ def ConvertStableHloToLinalg :
                         "transpose) when possible, instead of linalg.generic">];
 }
 
+def LegalizeControlFlow :
+    Pass<"iree-stablehlo-legalize-control-flow", "func::FuncOp"> {
+  let summary = "Legalize from StableHLO control flow to SCF control flow";
+}
+
 def LegalizeShapeComputations :
     Pass<"iree-stablehlo-legalize-shape-computations", "func::FuncOp"> {
   let summary = "Legalize StableHLO shape operations to core-mlir operations.";

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Rewriters.h
@@ -17,7 +17,12 @@ void populateStableHloToLinalgConversionPatterns(MLIRContext *context,
                                                  RewritePatternSet *patterns,
                                                  bool enablePrimitiveOps);
 
-// Collection of rewrite patterns for lowering of StableHLO dim operations.
+/// Collection of rewrite patterns for lowering of StableHLO ops to SCF control
+/// flow ops.
+void populateLegalizeControlFlowPatterns(MLIRContext *context,
+                                         RewritePatternSet *patterns);
+
+/// Collection of rewrite patterns for lowering of StableHLO dim operations.
 void populateLegalizeShapeComputationPatterns(MLIRContext *context,
                                               RewritePatternSet *patterns);
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "legalize_control_flow.mlir",
             "legalize_shape_computations.mlir",
             "stablehlo_to_linalg_convolution.mlir",
             "stablehlo_to_linalg_dot_prod.mlir",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "legalize_control_flow.mlir"
     "legalize_shape_computations.mlir"
     "stablehlo_to_linalg.mlir"
     "stablehlo_to_linalg_convolution.mlir"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/legalize_control_flow.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/legalize_control_flow.mlir
@@ -1,0 +1,287 @@
+// RUN: iree-opt --iree-stablehlo-legalize-control-flow %s | FileCheck %s
+
+// CHECK-LABEL: func @while(
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<1xi64>) -> tensor<1xi64> {
+func.func @while(%arg0: tensor<1xi64>) -> tensor<1xi64> {
+
+  // CHECK: %[[VAL_1:.*]] = scf.while (%[[VAL_2:.*]] = %[[VAL_0]]) : (tensor<1xi64>) -> tensor<1xi64> {
+  %0 = "stablehlo.while"(%arg0) ({
+  ^bb0(%arg1: tensor<1xi64>):
+
+    // CHECK: %[[VAL_3:.*]] = stablehlo.compare LT, %[[VAL_2]], %[[VAL_2]] {name = "compare.2"} : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+    // CHECK: %[[RESHAPE:.*]] = stablehlo.reshape %[[VAL_3]] : (tensor<1xi1>) -> tensor<i1>
+    // CHECK: %[[VAL_4:.*]] = tensor.extract %[[RESHAPE]][] : tensor<i1>
+    // CHECK: scf.condition(%[[VAL_4]]) %[[VAL_2]] : tensor<1xi64>
+    %1 = "stablehlo.compare"(%arg1, %arg1) {comparison_direction = #stablehlo<comparison_direction LT>, name = "compare.2"} : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+    %2 = "stablehlo.reshape"(%1) : (tensor<1xi1>) -> tensor<i1>
+    "stablehlo.return"(%2) : (tensor<i1>) -> ()
+
+  // CHECK: } do {
+  // CHECK: ^bb0(%[[VAL_5:.*]]: tensor<1xi64>):
+  },  {
+  ^bb0(%arg1: tensor<1xi64>):
+
+    // CHECK: %[[VAL_6:.*]] = stablehlo.add %[[VAL_5]], %[[VAL_5]] {name = "compare.0"} : tensor<1xi64>
+    // CHECK: scf.yield %[[VAL_6]] : tensor<1xi64>
+    %1 = stablehlo.add %arg1, %arg1 {name = "compare.0"} : tensor<1xi64>
+    "stablehlo.return"(%1) : (tensor<1xi64>) -> ()
+  }) : (tensor<1xi64>) -> tensor<1xi64>
+
+  // CHECK: return %[[VAL_7:.*]] : tensor<1xi64>
+  func.return %0 : tensor<1xi64>
+}
+
+
+// CHECK-LABEL: func @while_multi_operands(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<3xi32>) -> tuple<tensor<i32>, tensor<3xi32>> {
+func.func @while_multi_operands(%arg0: tensor<3xi32>) -> tuple<tensor<i32>, tensor<3xi32>> {
+
+  // CHECK-NEXT: %[[VAL_1:.*]] = stablehlo.constant dense<false> : tensor<i1>
+  // CHECK-NEXT: %[[VAL_2:.*]] = stablehlo.constant dense<0> : tensor<i32>
+  %0 = stablehlo.constant dense<false> : tensor<i1>
+  %1 = stablehlo.constant dense<0> : tensor<i32>
+
+  // CHECK: %[[VAL_3:.*]]:2 = scf.while (%[[VAL_4:.*]] = %[[VAL_2]], %[[VAL_5:.*]] = %[[VAL_0]]) : (tensor<i32>, tensor<3xi32>) -> (tensor<i32>, tensor<3xi32>) {
+  %2:2 = "stablehlo.while"(%1, %arg0) ({
+  ^bb0(%arg1: tensor<i32> , %arg2: tensor<3xi32> ):
+
+    // CHECK-NEXT: %[[VAL_6:.*]] = stablehlo.constant dense<false> : tensor<i1>
+    // CHECK-NEXT: %[[VAL_7:.*]] = stablehlo.constant dense<8> : tensor<i32>
+    // CHECK: %[[VAL_8:.*]] = stablehlo.compare LT, %[[VAL_4]], %[[VAL_7]] : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    // CHECK: %[[VAL_9:.*]] = tensor.extract %[[VAL_8]][] : tensor<i1>
+    // CHECK: scf.condition(%[[VAL_9]]) %[[VAL_4]], %[[VAL_5]] : tensor<i32>, tensor<3xi32>
+    %4 = stablehlo.constant dense<false> : tensor<i1>
+    %5 = stablehlo.constant dense<8> : tensor<i32>
+    %6 = "stablehlo.compare"(%arg1, %5) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    "stablehlo.return"(%6) : (tensor<i1>) -> ()
+  },  {
+
+  // CHECK: } do {
+  // CHECK: ^bb0(%[[VAL_10:.*]]: tensor<i32>, %[[VAL_11:.*]]: tensor<3xi32>):
+  ^bb0(%arg1: tensor<i32>, %arg2: tensor<3xi32>):
+
+    // CHECK-NEXT: %[[VAL_12:.*]] = stablehlo.constant dense<false> : tensor<i1>
+    // CHECK-NEXT: %[[VAL_13:.*]] = stablehlo.constant dense<1> : tensor<i32>
+    // CHECK: %[[VAL_14:.*]] = stablehlo.add %[[VAL_10]], %[[VAL_13]] : tensor<i32>
+    // CHECK: %[[VAL_15:.*]] = stablehlo.convert %[[VAL_10]] : tensor<i32>
+    // CHECK: %[[VAL_16:.*]] = stablehlo.broadcast_in_dim %[[VAL_15]], dims = [] : (tensor<i32>) -> tensor<3xi32>
+    // CHECK: %[[VAL_17:.*]] = stablehlo.add %[[VAL_11]], %[[VAL_16]] : tensor<3xi32>
+    // CHECK: scf.yield %[[VAL_14]], %[[VAL_17]] : tensor<i32>, tensor<3xi32>
+    %4 = stablehlo.constant dense<false> : tensor<i1>
+    %5 = stablehlo.constant dense<1> : tensor<i32>
+    %6 = stablehlo.add %arg1, %5 : tensor<i32>
+    %7 = stablehlo.convert %arg1 : (tensor<i32>) -> tensor<i32>
+    %8 = "stablehlo.broadcast_in_dim"(%7) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<i32>) -> tensor<3xi32>
+    %9 = stablehlo.add %arg2, %8 : tensor<3xi32>
+    "stablehlo.return"(%6, %9) : (tensor<i32>, tensor<3xi32>) -> ()
+  }) : (tensor<i32>, tensor<3xi32>) -> (tensor<i32>, tensor<3xi32>)
+
+  // CHECK: %[[VAL_18:.*]] = stablehlo.tuple %[[VAL_19:.*]]#0, %[[VAL_19]]#1 {xla_shape = "(s32[], s32[3]{0})"} : tuple<tensor<i32>, tensor<3xi32>>
+  // CHECK: return %[[VAL_18]] : tuple<tensor<i32>, tensor<3xi32>>
+  %3 = "stablehlo.tuple"(%2#0, %2#1) {xla_shape = "(s32[], s32[3]{0})"} : (tensor<i32>, tensor<3xi32>) -> tuple<tensor<i32>, tensor<3xi32>>
+  func.return %3 : tuple<tensor<i32>, tensor<3xi32>>
+}
+
+// CHECK-LABEL: func @conditional(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<f32>) -> tensor<f32> {
+func.func @conditional(%arg0: tensor<f32>) -> tensor<f32> {
+
+  // CHECK-NEXT: %[[VAL_1:.*]] = arith.constant dense<1.000000e+01> : tensor<f32>
+  %cst = arith.constant dense<1.000000e+01> : tensor<f32>
+
+  // CHECK: %[[VAL_2:.*]] = stablehlo.compare LT, %[[VAL_0]], %[[VAL_1]] : (tensor<f32>, tensor<f32>) -> tensor<i1>
+  // CHECK: %[[VAL_3:.*]] = tensor.extract %[[VAL_2]][] : tensor<i1>
+  %0 = "stablehlo.compare"(%arg0, %cst) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
+
+  // CHECK: %[[VAL_4:.*]] = scf.if %[[VAL_3]] -> (tensor<f32>) {
+  %1 = "stablehlo.if"(%0) ({
+
+    // CHECK: %[[VAL_5:.*]] = stablehlo.log %[[VAL_0]] : tensor<f32>
+    // CHECK: scf.yield %[[VAL_5]] : tensor<f32>
+    %2 = stablehlo.log %arg0 : (tensor<f32>) -> tensor<f32>
+    "stablehlo.return"(%2) : (tensor<f32>) -> ()
+
+  // CHECK: } else {
+  },  {
+
+    // CHECK: %[[VAL_6:.*]] = stablehlo.exponential %[[VAL_0]] : tensor<f32>
+    // CHECK: scf.yield %[[VAL_6]] : tensor<f32>
+    %2 = stablehlo.exponential %arg0 : (tensor<f32>) -> tensor<f32>
+    "stablehlo.return"(%2) : (tensor<f32>) -> ()
+  }) : (tensor<i1>) -> tensor<f32>
+
+  // CHECK:           return %[[VAL_7:.*]] : tensor<f32>
+  func.return %1 : tensor<f32>
+}
+
+// Check that we recursively lower nested ifs.
+// CHECK-LABEL: func @conditional_nested(
+func.func @conditional_nested(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
+  %cst = arith.constant dense<1.000000e+01> : tensor<f32>
+
+  %cmp1 = "stablehlo.compare"(%arg0, %cst) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
+
+  // CHECK: scf.if
+  %if1 = "stablehlo.if"(%cmp1) ({
+    %cmp2 = "stablehlo.compare"(%arg1, %cst) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
+    %log = stablehlo.log %arg0 : (tensor<f32>) -> tensor<f32>
+
+    // CHECK: scf.if
+    %if2 = "stablehlo.if"(%cmp2) ({
+      "stablehlo.return"(%arg1) : (tensor<f32>) -> ()
+    },  {
+      "stablehlo.return"(%log) : (tensor<f32>) -> ()
+    }) : (tensor<i1>) -> tensor<f32>
+    "stablehlo.return"(%if2) : (tensor<f32>) -> ()
+  },  {
+    %exp = stablehlo.exponential %arg0 : (tensor<f32>) -> tensor<f32>
+    "stablehlo.return"(%exp) : (tensor<f32>) -> ()
+  }) : (tensor<i1>) -> tensor<f32>
+
+  func.return %if1 : tensor<f32>
+}
+
+// Test the two branches case as the common. Following tests verify degenerate
+// behavior.
+// CHECK-LABEL: func @case2(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<i32>,
+// CHECK-SAME:    %[[VAL_1:.*]]: tensor<4xf32>,
+// CHECK-SAME:    %[[VAL_2:.*]]: tensor<4xf32>) -> tensor<4xf32> {
+func.func @case2(%arg0 : tensor<i32>, %arg1 : tensor<4xf32>, %arg2 : tensor<4xf32>) -> tensor<4xf32> {
+
+  // CHECK-NEXT: %[[VAL_3:.*]] = stablehlo.constant dense<0> : tensor<i32>
+  // CHECK: %[[VAL_4:.*]] = stablehlo.compare EQ, %[[VAL_0]], %[[VAL_3]], NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  // CHECK: %[[VAL_5:.*]] = tensor.extract %[[VAL_4]][] : tensor<i1>
+  // CHECK: %[[VAL_6:.*]] = scf.if %[[VAL_5]] -> (tensor<4xf32>) {
+  %1 = "stablehlo.case"(%arg0) ({
+      // CHECK: %[[VAL_7:.*]] = stablehlo.log %[[VAL_1]] : tensor<4xf32>
+      // CHECK: scf.yield %[[VAL_7]] : tensor<4xf32>
+      %2 = stablehlo.log %arg1 : (tensor<4xf32>) -> tensor<4xf32>
+      "stablehlo.return"(%2) : (tensor<4xf32>) -> ()
+
+  // CHECK: } else {
+  }, {
+      // CHECK: %[[VAL_8:.*]] = stablehlo.exponential %[[VAL_2]] : tensor<4xf32>
+      // CHECK: scf.yield %[[VAL_8]] : tensor<4xf32>
+      %3 = stablehlo.exponential %arg2 : (tensor<4xf32>) -> tensor<4xf32>
+      "stablehlo.return"(%3) : (tensor<4xf32>) -> ()
+  }) : (tensor<i32>) -> tensor<4xf32>
+
+  // CHECK: return %[[VAL_9:.*]] : tensor<4xf32>
+  func.return %1 : tensor<4xf32>
+}
+
+
+// CHECK-LABEL: func @case3(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<i32>,
+// CHECK-SAME:    %[[VAL_1:[0-9a-zA-Z]*]]: tensor<4xf32>,
+// CHECK-SAME:    %[[VAL_2:.*]]: tensor<4xf32>,
+// CHECK-SAME:    %[[VAL_3:.*]]: tensor<4xf32>) -> tensor<4xf32> {
+func.func @case3(%arg0 : tensor<i32>, %arg1 : tensor<4xf32>, %arg2 : tensor<4xf32>, %arg3 : tensor<4xf32>) -> tensor<4xf32> {
+
+  // CHECK-NEXT: %[[VAL_4:.*]] = stablehlo.constant dense<0> : tensor<i32>
+  // CHECK: %[[VAL_5:.*]] = stablehlo.compare EQ, %[[VAL_0]], %[[VAL_4]], NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  // CHECK: %[[VAL_6:.*]] = tensor.extract %[[VAL_5]][] : tensor<i1>
+  // CHECK: %[[VAL_7:.*]] = scf.if %[[VAL_6]] -> (tensor<4xf32>) {
+  %1 = "stablehlo.case"(%arg0) ({
+      // CHECK: %[[VAL_8:.*]] = stablehlo.log %[[VAL_1]] : tensor<4xf32>
+      // CHECK: scf.yield %[[VAL_8]] : tensor<4xf32>
+      %2 = stablehlo.log %arg1 : (tensor<4xf32>) -> tensor<4xf32>
+      "stablehlo.return"(%2) : (tensor<4xf32>) -> ()
+
+  // CHECK: } else {
+  // CHECK-NEXT:   %[[VAL_9:.*]] = stablehlo.constant dense<1> : tensor<i32>
+  // CHECK:   %[[VAL_10:.*]] = stablehlo.compare EQ, %[[VAL_0]], %[[VAL_9]], NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  // CHECK:   %[[VAL_11:.*]] = tensor.extract %[[VAL_10]][] : tensor<i1>
+  // CHECK:   %[[VAL_12:.*]] = scf.if %[[VAL_11]] -> (tensor<4xf32>) {
+  }, {
+      // CHECK: %[[VAL_13:.*]] = stablehlo.exponential %[[VAL_2]] : tensor<4xf32>
+      // CHECK: scf.yield %[[VAL_13]] : tensor<4xf32>
+      %3 = stablehlo.exponential %arg2 : (tensor<4xf32>) -> tensor<4xf32>
+      "stablehlo.return"(%3) : (tensor<4xf32>) -> ()
+
+  // CHECK: } else {
+  }, {
+
+      // CHECK: %[[VAL_14:.*]] = stablehlo.floor %[[VAL_3]] : tensor<4xf32>
+      // CHECK: scf.yield %[[VAL_14]] : tensor<4xf32>
+      %3 = stablehlo.floor %arg3 : (tensor<4xf32>) -> tensor<4xf32>
+      "stablehlo.return"(%3) : (tensor<4xf32>) -> ()
+  }) : (tensor<i32>) -> tensor<4xf32>
+  // CHECK:   scf.yield %[[VAL_15:.*]] : tensor<4xf32>
+
+  // CHECK: return %[[VAL_16:.*]] : tensor<4xf32>
+  func.return %1 : tensor<4xf32>
+}
+
+// Case with only one branch is inlined rather than lowering.
+// CHECK-LABEL: func @case0(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<i32>,
+// CHECK-SAME:    %[[VAL_1:.*]]: tensor<4xf32>) -> tensor<4xf32> {
+func.func @case0(%arg0 : tensor<i32>, %arg1 : tensor<4xf32>) -> tensor<4xf32> {
+  %1 = "stablehlo.case"(%arg0) ({
+      // CHECK: %[[VAL_2:.*]] = stablehlo.log %[[VAL_1]] : tensor<4xf32>
+      %2 = stablehlo.log %arg1 : (tensor<4xf32>) -> tensor<4xf32>
+      "stablehlo.return"(%2) : (tensor<4xf32>) -> ()
+  }) : (tensor<i32>) -> tensor<4xf32>
+  // CHECK: return %[[VAL_2]] : tensor<4xf32>
+  func.return %1 : tensor<4xf32>
+}
+
+// Case with only one branch is inlined. Check that we recursively lower.
+// CHECK-LABEL: func @case0_nested(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<i32>,
+// CHECK-SAME:    %[[VAL_1:.*]]: tensor<4xf32>) -> tensor<4xf32> {
+func.func @case0_nested(%arg0 : tensor<i32>, %arg1 : tensor<4xf32>) -> tensor<4xf32> {
+  %1 = "stablehlo.case"(%arg0) ({
+    %2 = "stablehlo.case"(%arg0) ({
+      // CHECK: %[[VAL_2:.*]] = stablehlo.log %[[VAL_1]] : tensor<4xf32>
+      %3 = stablehlo.log %arg1 : (tensor<4xf32>) -> tensor<4xf32>
+      "stablehlo.return"(%3) : (tensor<4xf32>) -> ()
+    }) : (tensor<i32>) -> tensor<4xf32>
+    "stablehlo.return"(%2) : (tensor<4xf32>) -> ()
+  }) : (tensor<i32>) -> tensor<4xf32>
+  // CHECK: return %[[VAL_2]] : tensor<4xf32>
+  func.return %1 : tensor<4xf32>
+}
+
+func.func @while_is_for(%lb: tensor<i32>, %ub: tensor<i32>, %step: tensor<i32>,
+                        %foo: tensor<4xf32>) -> tensor<4xf32> {
+  %0:2 = stablehlo.while(%i = %lb, %arg0 = %foo) : tensor<i32>, tensor<4xf32> cond {
+    %1 = stablehlo.compare LT, %i, %ub : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  } do {
+    %1 = stablehlo.add %i, %step : tensor<i32>
+    stablehlo.return %1, %arg0 : tensor<i32>, tensor<4xf32>
+  }
+  func.return %0#1 : tensor<4xf32>
+}
+
+// CHECK-LABEL: @while_is_for
+// CHECK-SAME: %[[LB:.*]]: tensor<i32>, %[[UB:.*]]: tensor<i32>, %[[STEP:.*]]: tensor<i32>
+// CHECK-SAME: %[[FOO:.*]]: tensor<4xf32>
+// CHECK-DAG:  %[[LB_EXT:.*]] = tensor.extract %[[LB]]
+// CHECK-DAG:  %[[UB_EXT:.*]] = tensor.extract %[[UB]]
+// CHECK-DAG:  %[[STEP_EXT:.*]] = tensor.extract %[[STEP]]
+// CHECK-NEXT: %[[RET:.*]]:2 = scf.for %[[I:.*]] = %[[LB_EXT]] to %[[UB_EXT]] step %[[STEP_EXT]]
+// CHECK-SAME: iter_args(%[[I2:.*]] = %[[LB]], %[[ARG0:.*]] = %[[FOO]])
+// CHECK-NEXT: %[[TENSOR_I:.*]] = tensor.from_elements %[[I]]
+// CHECK-NEXT: %[[NEXT_I2:.*]] = stablehlo.add %[[TENSOR_I]], %[[STEP]]
+// CHECK-NEXT: scf.yield %[[NEXT_I2]], %[[ARG0]]
+// CHECK:      return %[[RET]]#1
+
+func.func @while_is_for_and_unsigned(%lb: tensor<ui32>, %ub: tensor<ui32>,
+                                     %step: tensor<ui32>, %foo: tensor<4xf32>)
+                                     -> tensor<4xf32> {
+  %0:2 = stablehlo.while(%i = %lb, %arg0 = %foo) : tensor<ui32>, tensor<4xf32> cond {
+    %1 = stablehlo.compare LT, %i, %ub : (tensor<ui32>, tensor<ui32>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  } do {
+    %1 = stablehlo.add %i, %step : tensor<ui32>
+    stablehlo.return %1, %arg0 : tensor<ui32>, tensor<4xf32>
+  }
+  func.return %0#1 : tensor<4xf32>
+}
+
+// CHECK-LABEL: @while_is_for_and_unsigned
+// CHECK: scf.while


### PR DESCRIPTION
Port a pass to lower stablehlo control flow ops to SCF dialect ops. This is based on the equivalent MHLO pass from mlir-hlo. For the details, see the initial import: https://github.com/openxla/iree/pull/12957.

Issue: https://github.com/openxla/iree/issues/12678