### PR TITLE
[vulkan] NFC: Use EXT subgroup size control symbols

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
@@ -71,7 +71,7 @@ static iree_status_t iree_hal_vulkan_create_pipelines(
       executable_params->constant_count * sizeof(VkSpecializationMapEntry);
   size_t subgroup_control_size =
       pipeline_count *
-      sizeof(VkPipelineShaderStageRequiredSubgroupSizeCreateInfo);
+      sizeof(VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT);
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       logical_device->host_allocator(),
       create_info_size + spec_map_size + subgroup_control_size,
@@ -80,10 +80,10 @@ static iree_status_t iree_hal_vulkan_create_pipelines(
       (VkComputePipelineCreateInfo*)scratch_memory;
   VkSpecializationMapEntry* spec_map_entries =
       (VkSpecializationMapEntry*)(scratch_memory + create_info_size);
-  VkPipelineShaderStageRequiredSubgroupSizeCreateInfo* subgroup_control_entries =
-      (VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*)(scratch_memory +
-                                                             create_info_size +
-                                                             spec_map_size);
+  VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT* subgroup_control_entries =
+      (VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT*)(scratch_memory +
+                                                                create_info_size +
+                                                                spec_map_size);
 
   VkSpecializationInfo spec_info;
   memset(&spec_info, 0, sizeof(spec_info));

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -932,7 +932,7 @@ iree_status_t iree_hal_vulkan_device_create(
     host_query_reset_features.hostQueryReset = VK_TRUE;
   }
 
-  VkPhysicalDeviceSubgroupSizeControlFeatures subgroup_control_features;
+  VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_control_features;
   if (enabled_device_extensions.subgroup_size_control) {
     memset(&subgroup_control_features, 0, sizeof(subgroup_control_features));
     subgroup_control_features.sType =


### PR DESCRIPTION
Non-EXT symbols are just aliases introduced in Vulkan 1.3. The EXT version has better availability, without requiring Vulkan 1.3.