### PR TITLE
Use our private copy of Vulkan header files explicitly.

### DIFF
--- a/build_tools/third_party/vulkan_headers/BUILD.overlay
+++ b/build_tools/third_party/vulkan_headers/BUILD.overlay
@@ -12,6 +12,6 @@ package(default_visibility = ["//visibility:public"])
 # headers to disable additional validation.
 cc_library(
     name = "vulkan_headers",
-    includes = ["include"],
-    textual_hdrs = glob(["include/vulkan/*.h"]),
+    hdrs = glob(["include/vulkan/*.h"]),
+    include_prefix = "third_party/vulkan_headers",
 )

--- a/runtime/src/iree/hal/drivers/vulkan/api.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/api.cc
@@ -15,8 +15,6 @@
 #include "iree/hal/drivers/vulkan/dynamic_symbols.h"
 #include "iree/hal/drivers/vulkan/util/ref_ptr.h"
 
-using namespace iree::hal::vulkan;
-
 // TODO(benvanik): move these into the appropriate files and delete this .cc.
 
 //===----------------------------------------------------------------------===//
@@ -31,7 +29,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_syms_create(
   *out_syms = nullptr;
 
   iree::ref_ptr<iree::hal::vulkan::DynamicSymbols> syms;
-  IREE_RETURN_IF_ERROR(DynamicSymbols::Create(
+  IREE_RETURN_IF_ERROR(iree::hal::vulkan::DynamicSymbols::Create(
       [&vkGetInstanceProcAddr_fn](const char* function_name) {
         // Only resolve vkGetInstanceProcAddr, rely on syms->LoadFromInstance()
         // and/or syms->LoadFromDevice() for further loading.
@@ -54,14 +52,15 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_syms_create_from_system_loader(
   *out_syms = nullptr;
 
   iree::ref_ptr<iree::hal::vulkan::DynamicSymbols> syms;
-  IREE_RETURN_IF_ERROR(DynamicSymbols::CreateFromSystemLoader(&syms));
+  IREE_RETURN_IF_ERROR(
+      iree::hal::vulkan::DynamicSymbols::CreateFromSystemLoader(&syms));
   *out_syms = reinterpret_cast<iree_hal_vulkan_syms_t*>(syms.release());
   return iree_ok_status();
 }
 
 IREE_API_EXPORT void iree_hal_vulkan_syms_retain(iree_hal_vulkan_syms_t* syms) {
   IREE_ASSERT_ARGUMENT(syms);
-  auto* handle = reinterpret_cast<DynamicSymbols*>(syms);
+  auto* handle = reinterpret_cast<iree::hal::vulkan::DynamicSymbols*>(syms);
   if (handle) {
     handle->AddReference();
   }
@@ -70,7 +69,7 @@ IREE_API_EXPORT void iree_hal_vulkan_syms_retain(iree_hal_vulkan_syms_t* syms) {
 IREE_API_EXPORT void iree_hal_vulkan_syms_release(
     iree_hal_vulkan_syms_t* syms) {
   IREE_ASSERT_ARGUMENT(syms);
-  auto* handle = reinterpret_cast<DynamicSymbols*>(syms);
+  auto* handle = reinterpret_cast<iree::hal::vulkan::DynamicSymbols*>(syms);
   if (handle) {
     handle->ReleaseReference();
   }

--- a/runtime/src/iree/hal/drivers/vulkan/api.h
+++ b/runtime/src/iree/hal/drivers/vulkan/api.h
@@ -11,9 +11,10 @@
 
 #include <stdint.h>
 
-// clang-format off: must be included before all other headers.
-#include "iree/hal/drivers/vulkan/vulkan_headers.h"
-// clang-format on
+// Declare Vulkan symbols that are used, keeping implementation symbols private.
+typedef struct VkInstance_T* VkInstance;
+typedef struct VkPhysicalDevice_T* VkPhysicalDevice;
+typedef struct VkDevice_T* VkDevice;
 
 #include <stdint.h>
 

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -6,6 +6,10 @@
 
 #include "iree/hal/drivers/vulkan/registration/driver_module.h"
 
+// clang-format off: must be included before all other headers.
+#include "iree/hal/drivers/vulkan/vulkan_headers.h"
+// clang-format on
+
 #include <cinttypes>
 #include <cstddef>
 

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -6,10 +6,6 @@
 
 #include "iree/hal/drivers/vulkan/registration/driver_module.h"
 
-// clang-format off: must be included before all other headers.
-#include "iree/hal/drivers/vulkan/vulkan_headers.h"
-// clang-format on
-
 #include <cinttypes>
 #include <cstddef>
 

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.h
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.h
@@ -7,6 +7,10 @@
 #ifndef IREE_HAL_DRIVERS_VULKAN_REGISTRATION_DRIVER_MODULE_H_
 #define IREE_HAL_DRIVERS_VULKAN_REGISTRATION_DRIVER_MODULE_H_
 
+// clang-format off: must be included before all other headers.
+#include "iree/hal/drivers/vulkan/vulkan_headers.h"
+// clang-format on
+
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_headers.h
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_headers.h
@@ -41,10 +41,10 @@
 #define VK_USE_PLATFORM_WIN32_KHR 1
 #endif  // IREE_PLATFORM_*
 
-#include <vulkan/vulkan.h>  // IWYU pragma: export
+#include "third_party/vulkan_headers/include/vulkan/vulkan.h"  // IWYU pragma: export
 
 #ifdef IREE_PLATFORM_APPLE
-#include <vulkan/vulkan_beta.h>  // IWYU pragma: export
+#include "third_party/vulkan_headers/include/vulkan/vulkan_beta.h"  // IWYU pragma: export
 #endif
 
 #endif  // IREE_HAL_DRIVERS_VULKAN_VULKAN_HEADERS_H_


### PR DESCRIPTION
With this, we should no longer need https://github.com/openxla/iree/pull/13344.

See also [this discussion on Discord](https://discord.com/channels/689900678990135345/689959648501039106/1102623805639245995).