### PR TITLE
Move flatbuffer schemas into `iree.hal.*` namespaces.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -176,25 +176,26 @@ class MetalSPIRVTargetBackend : public TargetBackend {
 
     // 4. Pack the MTLLibrary and metadata into a FlatBuffer.
     FlatbufferBuilder builder;
-    iree_MetalExecutableDef_start_as_root(builder);
+    iree_hal_metal_ExecutableDef_start_as_root(builder);
 
     auto shaderSourcesRef = builder.createStringVec(llvm::map_range(
         mslShaders, [&](const MetalShader &shader) { return shader.source; }));
 
-    iree_MetalThreadgroupSize_vec_start(builder);
+    iree_hal_metal_ThreadgroupSize_vec_start(builder);
     for (auto &shader : mslShaders) {
-      iree_MetalThreadgroupSize_vec_push_create(
+      iree_hal_metal_ThreadgroupSize_vec_push_create(
           builder, shader.threadgroupSize.x, shader.threadgroupSize.y,
           shader.threadgroupSize.z);
     }
-    auto threadgroupSizesRef = iree_MetalThreadgroupSize_vec_end(builder);
+    auto threadgroupSizesRef = iree_hal_metal_ThreadgroupSize_vec_end(builder);
 
     auto entryPointNamesRef = builder.createStringVec(entryPointNames);
 
-    iree_MetalExecutableDef_entry_points_add(builder, entryPointNamesRef);
-    iree_MetalExecutableDef_threadgroup_sizes_add(builder, threadgroupSizesRef);
-    iree_MetalExecutableDef_shader_sources_add(builder, shaderSourcesRef);
-    iree_MetalExecutableDef_end_as_root(builder);
+    iree_hal_metal_ExecutableDef_entry_points_add(builder, entryPointNamesRef);
+    iree_hal_metal_ExecutableDef_threadgroup_sizes_add(builder,
+                                                       threadgroupSizesRef);
+    iree_hal_metal_ExecutableDef_shader_sources_add(builder, shaderSourcesRef);
+    iree_hal_metal_ExecutableDef_end_as_root(builder);
 
     // 5. Add the binary data to the target executable.
     auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -193,7 +193,7 @@ class ROCMTargetBackend final : public TargetBackend {
     llvmModule->setDataLayout(targetMachine->createDataLayout());
 
     iree_compiler::FlatbufferBuilder builder;
-    iree_ROCMExecutableDef_start_as_root(builder);
+    iree_hal_rocm_ExecutableDef_start_as_root(builder);
 
     // Link module to Device Library
     if (clROCMLinkBC) {
@@ -220,19 +220,19 @@ class ROCMTargetBackend final : public TargetBackend {
         [&](auto op) { return op.getName(); }));
     auto entryPointsRef = builder.createStringVec(entryPointNames);
 
-    iree_ROCMBlockSizeDef_vec_start(builder);
+    iree_hal_rocm_BlockSizeDef_vec_start(builder);
     auto blockSizes = workgroupSizes.begin();
     for (int i = 0, e = entryPointNames.size(); i < e; ++i) {
-      iree_ROCMBlockSizeDef_vec_push_create(builder, (*blockSizes)[0],
-                                            (*blockSizes)[1], (*blockSizes)[2]);
+      iree_hal_rocm_BlockSizeDef_vec_push_create(
+          builder, (*blockSizes)[0], (*blockSizes)[1], (*blockSizes)[2]);
       ++blockSizes;
     }
-    auto blockSizesRef = iree_ROCMBlockSizeDef_vec_end(builder);
+    auto blockSizesRef = iree_hal_rocm_BlockSizeDef_vec_end(builder);
 
-    iree_ROCMExecutableDef_entry_points_add(builder, entryPointsRef);
-    iree_ROCMExecutableDef_block_sizes_add(builder, blockSizesRef);
-    iree_ROCMExecutableDef_hsaco_image_add(builder, hsacoRef);
-    iree_ROCMExecutableDef_end_as_root(builder);
+    iree_hal_rocm_ExecutableDef_entry_points_add(builder, entryPointsRef);
+    iree_hal_rocm_ExecutableDef_block_sizes_add(builder, blockSizesRef);
+    iree_hal_rocm_ExecutableDef_hsaco_image_add(builder, hsacoRef);
+    iree_hal_rocm_ExecutableDef_end_as_root(builder);
 
     // Add the binary data to the target executable.
     executableBuilder.create<iree_compiler::IREE::HAL::ExecutableBinaryOp>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.cpp
@@ -207,23 +207,23 @@ class WebGPUTargetBackend : public TargetBackend {
 
     // Pack the WGSL and metadata into a FlatBuffer.
     FlatbufferBuilder builder;
-    iree_WGSLExecutableDef_start_as_root(builder);
+    iree_hal_wgsl_ExecutableDef_start_as_root(builder);
 
-    iree_WGSLShaderModuleDef_start(builder);
+    iree_hal_wgsl_ShaderModuleDef_start(builder);
     auto wgslRef = builder.createString(wgsl.value());
-    iree_WGSLShaderModuleDef_code_add(builder, wgslRef);
+    iree_hal_wgsl_ShaderModuleDef_code_add(builder, wgslRef);
     // TODO(scotttodd): populate source map
-    auto shaderModuleRef = iree_WGSLShaderModuleDef_end(builder);
+    auto shaderModuleRef = iree_hal_wgsl_ShaderModuleDef_end(builder);
 
-    auto shaderModulesVec = iree_WGSLShaderModuleDef_vec_create(
+    auto shaderModulesVec = iree_hal_wgsl_ShaderModuleDef_vec_create(
         builder, &shaderModuleRef, /*len=*/1);
-    iree_WGSLExecutableDef_shader_modules_add(builder, shaderModulesVec);
+    iree_hal_wgsl_ExecutableDef_shader_modules_add(builder, shaderModulesVec);
 
     auto entryPointsRef = flatbuffers_uint32_vec_create(
         builder, entryPointOrdinals.data(), entryPointOrdinals.size());
-    iree_WGSLExecutableDef_entry_points_add(builder, entryPointsRef);
+    iree_hal_wgsl_ExecutableDef_entry_points_add(builder, entryPointsRef);
 
-    iree_WGSLExecutableDef_end_as_root(builder);
+    iree_hal_wgsl_ExecutableDef_end_as_root(builder);
 
     // Add the binary data to the target executable.
     auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(

--- a/experimental/rocm/native_executable.c
+++ b/experimental/rocm/native_executable.c
@@ -57,16 +57,17 @@ iree_status_t iree_hal_rocm_native_executable_create(
   iree_hal_rocm_native_executable_t* executable = NULL;
 
   // TODO: Verify the flat buffer.
-  iree_ROCMExecutableDef_table_t executable_def =
-      iree_ROCMExecutableDef_as_root(executable_params->executable_data.data);
+  iree_hal_rocm_ExecutableDef_table_t executable_def =
+      iree_hal_rocm_ExecutableDef_as_root(
+          executable_params->executable_data.data);
 
   // Create the kernel module.
   flatbuffers_string_t hsaco_image =
-      iree_ROCMExecutableDef_hsaco_image_get(executable_def);
+      iree_hal_rocm_ExecutableDef_hsaco_image_get(executable_def);
   flatbuffers_string_vec_t entry_points_vec =
-      iree_ROCMExecutableDef_entry_points_get(executable_def);
-  iree_ROCMBlockSizeDef_vec_t block_sizes_vec =
-      iree_ROCMExecutableDef_block_sizes_get(executable_def);
+      iree_hal_rocm_ExecutableDef_entry_points_get(executable_def);
+  iree_hal_rocm_BlockSizeDef_vec_t block_sizes_vec =
+      iree_hal_rocm_ExecutableDef_block_sizes_get(executable_def);
   iree_host_size_t entry_count = flatbuffers_string_vec_len(entry_points_vec);
   iree_host_size_t total_size =
       sizeof(*executable) +

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -51,17 +51,18 @@ iree_status_t iree_hal_cuda_native_executable_create(
   // TODO: verify the flatbuffer.
   // WARNING: THIS IS CURRENTLY INSECURE. This code is not checking any of the
   // data from the flatbuffer.
-  iree_CUDAExecutableDef_table_t executable_def =
-      iree_CUDAExecutableDef_as_root(executable_params->executable_data.data);
+  iree_hal_cuda_ExecutableDef_table_t executable_def =
+      iree_hal_cuda_ExecutableDef_as_root(
+          executable_params->executable_data.data);
 
   flatbuffers_string_t ptx_image =
-      iree_CUDAExecutableDef_ptx_image_get(executable_def);
+      iree_hal_cuda_ExecutableDef_ptx_image_get(executable_def);
   flatbuffers_uint32_vec_t shared_memory_sizes =
-      iree_CUDAExecutableDef_shared_memory_size_get(executable_def);
+      iree_hal_cuda_ExecutableDef_shared_memory_size_get(executable_def);
   flatbuffers_string_vec_t entry_points_vec =
-      iree_CUDAExecutableDef_entry_points_get(executable_def);
-  iree_CUDABlockSizeDef_vec_t block_sizes_vec =
-      iree_CUDAExecutableDef_block_sizes_get(executable_def);
+      iree_hal_cuda_ExecutableDef_entry_points_get(executable_def);
+  iree_hal_cuda_BlockSizeDef_vec_t block_sizes_vec =
+      iree_hal_cuda_ExecutableDef_block_sizes_get(executable_def);
   iree_host_size_t entry_point_count =
       flatbuffers_string_vec_len(entry_points_vec);
 
@@ -164,15 +165,15 @@ iree_status_t iree_hal_cuda_native_executable_create(
       });
 
       IREE_TRACE({
-        if (iree_CUDAExecutableDef_source_locations_is_present(
+        if (iree_hal_cuda_ExecutableDef_source_locations_is_present(
                 executable_def)) {
-          iree_CUDAFileLineLocDef_vec_t source_locs_vec =
-              iree_CUDAExecutableDef_source_locations_get(executable_def);
-          iree_CUDAFileLineLocDef_table_t source_loc =
-              iree_CUDAFileLineLocDef_vec_at(source_locs_vec, i);
+          iree_hal_cuda_FileLineLocDef_vec_t source_locs_vec =
+              iree_hal_cuda_ExecutableDef_source_locations_get(executable_def);
+          iree_hal_cuda_FileLineLocDef_table_t source_loc =
+              iree_hal_cuda_FileLineLocDef_vec_at(source_locs_vec, i);
           flatbuffers_string_t filename =
-              iree_CUDAFileLineLocDef_filename_get(source_loc);
-          uint32_t line = iree_CUDAFileLineLocDef_line_get(source_loc);
+              iree_hal_cuda_FileLineLocDef_filename_get(source_loc);
+          uint32_t line = iree_hal_cuda_FileLineLocDef_line_get(source_loc);
           params->source_filename =
               iree_make_string_view(filename, flatbuffers_string_len(filename));
           params->source_line = line;

--- a/runtime/src/iree/schemas/cuda_executable_def.fbs
+++ b/runtime/src/iree/schemas/cuda_executable_def.fbs
@@ -4,26 +4,26 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-namespace iree;
+namespace iree.hal.cuda;
 
 // 'CUDA Executable'.
 file_identifier "CUDA";
 file_extension "cuda";
 
 // A struct for the kernel block size along each dimensions.
-struct CUDABlockSizeDef {
+struct BlockSizeDef {
   x:uint32;
   y:uint32;
   z:uint32;
 }
 
 // Source code location denoted by a file name and line within that file.
-table CUDAFileLineLocDef {
+table FileLineLocDef {
   filename:string;
   line:int32;
 }
 
-table CUDAExecutableDef {
+table ExecutableDef {
   // A map of entry point ordinals to string names as used in the shader
   // library.
   entry_points:[string];
@@ -32,7 +32,7 @@ table CUDAExecutableDef {
   //
   // Currently the thread group size/block size is decided during code gen but
   // in CUDA it is set by the runtime.
-  block_sizes:[CUDABlockSizeDef];
+  block_sizes:[BlockSizeDef];
   // Size of dynamic shared memory.
   shared_memory_size:[uint32];
 
@@ -44,7 +44,7 @@ table CUDAExecutableDef {
   // A map of entry point ordinals to source locations.
   // This information is optional and may be used by debuggers and profilers to
   // associate executable entry points with the source that generated them.
-  source_locations:[CUDAFileLineLocDef];
+  source_locations:[FileLineLocDef];
 }
 
-root_type CUDAExecutableDef;
+root_type ExecutableDef;

--- a/runtime/src/iree/schemas/metal_executable_def.fbs
+++ b/runtime/src/iree/schemas/metal_executable_def.fbs
@@ -4,14 +4,14 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-namespace iree;
+namespace iree.hal.metal;
 
 // 'Metal Executable'.
 file_identifier "MTLE";
 file_extension "mtle";
 
 // A struct for Metal threadgroup size along each dimension.
-struct MetalThreadgroupSize {
+struct ThreadgroupSize {
   x:uint32;
   y:uint32;
   z:uint32;
@@ -20,7 +20,7 @@ struct MetalThreadgroupSize {
 // A Metal shader library and runtime pipeline state description.
 // This information is used to create MTLLibrary, MTLFunction and pipeline
 // state objects.
-table MetalExecutableDef {
+table ExecutableDef {
   // A map of entry point ordinals to string names as used in the shader
   // library.
   entry_points:[string];
@@ -32,7 +32,7 @@ table MetalExecutableDef {
   // compiling SPIR-V to MSL, we need to persist the information here so that
   // later it can be used for dispatching.
   // TODO(antiagainst): support SPIR-V specialization constant.
-  threadgroup_sizes:[MetalThreadgroupSize];
+  threadgroup_sizes:[ThreadgroupSize];
 
   // Shader content can be provided as either a serialized library or in the
   // form of source code strings.
@@ -43,5 +43,4 @@ table MetalExecutableDef {
   shader_sources:[string];
 }
 
-root_type MetalExecutableDef;
-
+root_type ExecutableDef;

--- a/runtime/src/iree/schemas/rocm_executable_def.fbs
+++ b/runtime/src/iree/schemas/rocm_executable_def.fbs
@@ -4,30 +4,30 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-namespace iree;
+namespace iree.hal.rocm;
 
 // 'ROCM Executable'.
 file_identifier "ROCM";
 file_extension "rocm";
 
 // A struct for the kernel block size along each dimensions.
-struct ROCMBlockSizeDef {
+struct BlockSizeDef {
   x:uint32;
   y:uint32;
   z:uint32;
 }
 
-table ROCMExecutableDef {
+table ExecutableDef {
   // A map of entry point ordinals to string names as used in the shader
   // library.
   entry_points:[string];
 
   // Block sizes for each entry point.
   //
-  block_sizes:[ROCMBlockSizeDef];
+  block_sizes:[BlockSizeDef];
 
   // HSACO string of the module.
   hsaco_image:string;
 }
 
-root_type ROCMExecutableDef;
+root_type ExecutableDef;

--- a/runtime/src/iree/schemas/spirv_executable_def.fbs
+++ b/runtime/src/iree/schemas/spirv_executable_def.fbs
@@ -4,14 +4,14 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-namespace iree;
+namespace iree.hal.spirv;
 
 // 'SPIR-V Executable'.
 file_identifier "SPVE";
 file_extension "spve";
 
 // Source code location denoted by a file name and line within that file.
-table SpirVFileLineLocDef {
+table FileLineLocDef {
   filename:string;
   line:int32;
 }
@@ -19,7 +19,7 @@ table SpirVFileLineLocDef {
 // A SPIR-V shader module and runtime pipeline layout description.
 // This information is used to create the VkShaderModule, VkPipelineLayout, and
 // any required VkDescriptorSetLayouts.
-table SpirVExecutableDef {
+table ExecutableDef {
   // A map of entry point ordinals to string names as used in the shader module.
   entry_points:[string];
 
@@ -32,7 +32,7 @@ table SpirVExecutableDef {
   // A map of entry point ordinals to source locations.
   // This information is optional and may be used by debuggers and profilers to
   // associate executable entry points with the source that generated them.
-  source_locations:[SpirVFileLineLocDef];
+  source_locations:[FileLineLocDef];
 }
 
-root_type SpirVExecutableDef;
+root_type ExecutableDef;

--- a/runtime/src/iree/schemas/wgsl_executable_def.fbs
+++ b/runtime/src/iree/schemas/wgsl_executable_def.fbs
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-namespace iree;
+namespace iree.hal.wgsl;
 
 // 'WGSL Executable'.
 file_identifier "WGSL";
@@ -13,7 +13,7 @@ file_extension "wgsl";
 // Contents of one WGPUShaderModule, possibly with multiple entry points.
 // Entry points have the name "dN" where N is the executable-wide entry point
 // ordinal.
-table WGSLShaderModuleDef {
+table ShaderModuleDef {
   // WGSL source code.
   code:string;
 
@@ -21,13 +21,13 @@ table WGSLShaderModuleDef {
   source_map:string;
 }
 
-table WGSLExecutableDef {
+table ExecutableDef {
   // An ordered list of shader modules, each containing 1+ entry points.
-  shader_modules:[WGSLShaderModuleDef];
+  shader_modules:[ShaderModuleDef];
 
   // A mapping of executable entry point ordinals to the shader module in which
   // they reside.
   entry_points:[int];
 }
 
-root_type WGSLExecutableDef;
+root_type ExecutableDef;


### PR DESCRIPTION
Code changes were all by regex find/replace, e.g. find `iree_CUDA([a-zA-Z]+_)`, replace with `iree_hal_cuda_$1`.