### PR TITLE
[StableHLO][spirv][vulkan] Enable dot_bf16 e2e test on vulkan

### DIFF
--- a/tests/e2e/stablehlo_ops/BUILD.bazel
+++ b/tests/e2e/stablehlo_ops/BUILD.bazel
@@ -167,6 +167,7 @@ iree_check_single_backend_test_suite(
             "cosine.mlir",
             "divide.mlir",
             "dot.mlir",
+            "dot_bf16.mlir",
             "dot_general.mlir",
             "dynamic_slice.mlir",
             "dynamic_update_slice.mlir",
@@ -205,7 +206,6 @@ iree_check_single_backend_test_suite(
         include = ["*.mlir"],
         exclude = [
             "concatenate.mlir",  # TODO(#12678): Investigate this failure.
-            "dot_bf16.mlir",  # Missing BF16 support on Vulkan backends.
             "reverse.mlir",  # TODO(#12415): disabled due to miscompilation on Pixel 6.
         ],
     ),

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -150,6 +150,7 @@ iree_check_single_backend_test_suite(
     "cosine.mlir"
     "divide.mlir"
     "dot.mlir"
+    "dot_bf16.mlir"
     "dot_general.mlir"
     "dynamic_slice.mlir"
     "dynamic_update_slice.mlir"


### PR DESCRIPTION
This is supported after https://github.com/openxla/iree/pull/13292.

Issue: https://github.com/openxla/iree/issues/12678