### PR TITLE
[StableHLO] Port compiler input verification pass

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/BUILD.bazel
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         "StableHLOToLinalgReduce.cpp",
         "TypeConversion.cpp",
         "TypeConversion.h",
+        "VerifyCompilerInputLegality.cpp",
     ],
     deps = [
         ":PassHeaders",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_cc_library(
     "StableHLOToLinalgReduce.cpp"
     "TypeConversion.cpp"
     "TypeConversion.h"
+    "VerifyCompilerInputLegality.cpp"
   DEPS
     ::PassHeaders
     ChloOps

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
@@ -111,7 +111,7 @@ void buildStableHLOInputConversionPassPipelineImpl(OpPassManager &passManager) {
   // canonicalization. See comments in the above pass and find a better way.
   passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
-  // TODO(#12678): Port StableHLO input legality verification pass.
+  passManager.addPass(stablehlo::createVerifyCompilerStableHloInputLegality());
 }
 }  // namespace
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.td
@@ -31,7 +31,12 @@ def LegalizeControlFlow :
 
 def LegalizeShapeComputations :
     Pass<"iree-stablehlo-legalize-shape-computations", "func::FuncOp"> {
-  let summary = "Legalize StableHLO shape operations to core-mlir operations.";
+  let summary = "Legalize StableHLO shape operations to core-mlir operations";
+}
+
+def VerifyCompilerStableHloInputLegality :
+    Pass<"iree-stablehlo-verify-compiler-input-legality", "ModuleOp"> {
+  let summary = "Verifies that only supported IR constructs are passed to the compiler";
 }
 
 #endif // IREE_COMPILER_INPUTCONVERSION_STABLEHLO_PASSES

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/VerifyCompilerInputLegality.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/VerifyCompilerInputLegality.cpp
@@ -1,0 +1,73 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/InputConversion/StableHLO/PassDetail.h"
+#include "iree/compiler/InputConversion/StableHLO/Passes.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/ChloOps.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_VERIFYCOMPILERSTABLEHLOINPUTLEGALITY
+#include "iree/compiler/InputConversion/StableHLO/Passes.h.inc"
+
+namespace {
+
+struct VerifyCompilerStableHloInputLegality final
+    : impl::VerifyCompilerStableHloInputLegalityBase<
+          VerifyCompilerStableHloInputLegality> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ConversionTarget conversionTarget(*context);
+    RewritePatternSet conversionPatterns(context);
+
+    // Note that we would prefer allow-lists of what we positively support.
+    // However, it is so common to sneak input-level ops into the pipeline
+    // that we explicitly deny the dialects we know about.
+    conversionTarget.addIllegalDialect<mlir::stablehlo::StablehloDialect>();
+    conversionTarget.addIllegalDialect<mlir::chlo::ChloDialect>();
+    conversionTarget.addIllegalDialect<mlir::shape::ShapeDialect>();
+
+    // NOTE: It is not fully illegal to tunnel input dialect ops through to
+    // backends that expect them. When such situations arise, the container
+    // op should be marked recursively legal here.
+    SmallVector<Diagnostic> failures;
+    {
+      ScopedDiagnosticHandler diag(context,
+                                   [&](Diagnostic &d) -> LogicalResult {
+                                     failures.push_back(std::move(d));
+                                     return success();
+                                   });
+      if (succeeded(applyPartialConversion(getOperation(), conversionTarget,
+                                           std::move(conversionPatterns)))) {
+        return;
+      }
+    }
+
+    // Error fall-through. Attach all reported issues as notes.
+    InFlightDiagnostic errorDiag =
+        emitError(getOperation().getLoc())
+        << "one or more illegal operations were found in the compiler input "
+           "(are you missing an --iree-input-type= flag, or did you mean to "
+           "pre-process through an IREE importer frontend?)";
+    for (Diagnostic &failureDiag : failures) {
+      Diagnostic &note = errorDiag.attachNote(failureDiag.getLocation());
+      for (auto &arg : failureDiag.getArguments()) {
+        note.append(arg);
+      }
+    }
+
+    signalPassFailure();
+  }
+};
+
+}  // namespace
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/VerifyCompilerInputLegality.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/VerifyCompilerInputLegality.cpp
@@ -8,8 +8,6 @@
 #include "iree/compiler/InputConversion/StableHLO/Passes.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/IR/MLIRContext.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "stablehlo/dialect/ChloOps.h"
 #include "stablehlo/dialect/StablehloOps.h"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "stablehlo_to_linalg_random.mlir",
             "stablehlo_to_linalg_reduce.mlir",
             "stablehlo_to_linalg.mlir",
+            "verify_compiler_input_legality.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     "stablehlo_to_linalg_pointwise.mlir"
     "stablehlo_to_linalg_random.mlir"
     "stablehlo_to_linalg_reduce.mlir"
+    "verify_compiler_input_legality.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/verify_compiler_input_legality.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/verify_compiler_input_legality.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt --split-input-file --iree-mhlo-verify-compiler-input-legality --verify-diagnostics %s
+// RUN: iree-opt --split-input-file --iree-stablehlo-verify-compiler-input-legality \
+// RUN:   --verify-diagnostics %s
 
 // expected-error@+1 {{one or more illegal operations were found in the compiler input}}
 module {
@@ -12,9 +13,9 @@ func.func @illegal_chlo(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4x
 // -----
 // expected-error@+1 {{one or more illegal operations were found in the compiler input}}
 module {
-func.func @illegal_mhlo(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
-  // expected-note@+1 {{failed to legalize operation 'mhlo.add' that was explicitly marked illegal}}
-  %0 = mhlo.add %arg0, %arg1 : tensor<4xf32>
+func.func @illegal_stablehlo(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // expected-note@+1 {{failed to legalize operation 'stablehlo.add' that was explicitly marked illegal}}
+  %0 = stablehlo.add %arg0, %arg1 : tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 }


### PR DESCRIPTION
The pass checks that there are no outstanding `stablehlo`/`chlo`/`shape` dialect ops in the IR.

This is based on an equivalent IREE pass for MHLO.

Also update the MHLO pass to check for shape ops.

Issue: https://github.com/openxla/iree/issues/12678