### PR TITLE
Enable gather vectorization in LLVMGPU backend #12737

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorization.cpp
@@ -57,6 +57,7 @@ static void populateVectorizationPatterns(RewritePatternSet &patterns,
   });
 
   IREE::LinalgExt::LinalgVectorizationOptions vectorizationOptions;
+  vectorizationOptions.setVectorizeGatherAccesses(true);
   VectorizationPatterns<linalg::FillOp, linalg::GenericOp,
                         linalg::Conv1DNwcWcfOp, linalg::Conv1DNcwFcwOp,
                         linalg::TransposeOp>::insert(patterns,


### PR DESCRIPTION
After enabling the vectorization for the gather op: 

```
// -----// IR Dump After GPUVectorization (iree-codegen-gpu-vectorization) //----- //
func.func @foo_dispatch_0_generic_1x5x1x768_i32xf32() {
  %c0_i32 = arith.constant 0 : i32
  %c64 = arith.constant 64 : index
  %c12 = arith.constant 12 : index
  %c-1 = arith.constant -1 : index
  %c-768 = arith.constant -768 : index
  %cst = arith.constant dense<true> : vector<1x1x1x1xi1>
  %cst_0 = arith.constant dense<0.000000e+00> : vector<1x1x1x1xf32>
  %cst_1 = arith.constant dense<768> : vector<1x1x1x1xindex>
  %c0 = arith.constant 0 : index
  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<50257x768xf32>>
  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x5x1xi32>>
  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<1x5x1x768xf32>>
  %workgroup_id_x = hal.interface.workgroup.id[0] : index
  %3 = affine.apply affine_map<()[s0] -> (s0 floordiv 12)>()[%workgroup_id_x]
  %4 = affine.apply affine_map<()[s0] -> (s0 * 64 - (s0 floordiv 12) * 768)>()[%workgroup_id_x]
  %5 = flow.dispatch.tensor.load %2, offsets = [0, %3, 0, %4], sizes = [1, 1, 1, 64], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<writeonly:tensor<1x5x1x768xf32>> -> tensor<1x1x1x64xf32>
  %6 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [50257, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<50257x768xf32>> -> tensor<50257x768xf32>
  %7 = flow.dispatch.tensor.load %1, offsets = [0, %3, 0], sizes = [1, 1, 1], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x5x1xi32>> -> tensor<1x1x1xi32>
  %8 = scf.forall (%arg0) in (64) shared_outs(%arg1 = %5) -> (tensor<1x1x1x64xf32>) {
    %extracted_slice = tensor.extract_slice %arg1[0, 0, 0, %arg0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x64xf32> to tensor<1x1x1x1xf32>
    %9 = vector.transfer_read %7[%c0, %c0, %c0], %c0_i32 {in_bounds = [true, true, true]} : tensor<1x1x1xi32>, vector<1x1x1xi32>
    %10 = arith.index_cast %9 : vector<1x1x1xi32> to vector<1x1x1xindex>
    %11 = vector.broadcast %10 : vector<1x1x1xindex> to vector<1x1x1x1xindex>
    %12 = vector.broadcast %arg0 : index to vector<1xindex>
    %13 = arith.muli %workgroup_id_x, %c64 : index
    %14 = vector.broadcast %13 : index to vector<1xindex>
    %15 = arith.addi %12, %14 : vector<1xindex>
    %16 = arith.cmpi slt, %workgroup_id_x, %c0 : index
    %17 = arith.subi %c-1, %workgroup_id_x : index
    %18 = arith.select %16, %17, %workgroup_id_x : index
    %19 = arith.divsi %18, %c12 : index
    %20 = arith.subi %c-1, %19 : index
    %21 = arith.select %16, %20, %19 : index
    %22 = arith.muli %21, %c-768 : index
    %23 = vector.broadcast %22 : index to vector<1xindex>
    %24 = arith.addi %15, %23 : vector<1xindex>
    %25 = arith.muli %11, %cst_1 : vector<1x1x1x1xindex>
    %26 = vector.transpose %25, [1, 2, 3, 0] : vector<1x1x1x1xindex> to vector<1x1x1x1xindex>
    %27 = vector.broadcast %24 : vector<1xindex> to vector<1x1x1x1xindex>
    %28 = arith.addi %27, %26 : vector<1x1x1x1xindex>
    %29 = vector.gather %6[%c0, %c0] [%28], %cst, %cst_0 : tensor<50257x768xf32>, vector<1x1x1x1xindex>, vector<1x1x1x1xi1>, vector<1x1x1x1xf32> into vector<1x1x1x1xf32>
    %30 = vector.transfer_write %29, %extracted_slice[%c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x1xf32>, tensor<1x1x1x1xf32>
    scf.forall.in_parallel {
      tensor.parallel_insert_slice %30 into %arg1[0, 0, 0, %arg0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x1x1x64xf32>
    }
  } {mapping = [#gpu.thread<x>]}
  flow.dispatch.tensor.store %8, %2, offsets = [0, %3, 0, %4], sizes = [1, 1, 1, 64], strides = [1, 1, 1, 1] : tensor<1x1x1x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x5x1x768xf32>>
  return
}
```

Issues: https://github.com/openxla/iree/issues/12737

