### PR TITLE
Adding vulkan api.h methods for buffer/semaphore types.

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/native_semaphore.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_semaphore.cc
@@ -310,6 +310,16 @@ static iree_status_t iree_hal_vulkan_native_semaphore_wait(
       semaphore->logical_device, &semaphore_list, timeout, 0);
 }
 
+IREE_API_EXPORT iree_status_t iree_hal_vulkan_semaphore_handle(
+    iree_hal_semaphore_t* base_semaphore, VkSemaphore* out_handle) {
+  IREE_ASSERT_ARGUMENT(base_semaphore);
+  IREE_ASSERT_ARGUMENT(out_handle);
+  iree_hal_vulkan_native_semaphore_t* semaphore =
+      iree_hal_vulkan_native_semaphore_cast(base_semaphore);
+  *out_handle = semaphore->handle;
+  return iree_ok_status();
+}
+
 namespace {
 const iree_hal_semaphore_vtable_t iree_hal_vulkan_native_semaphore_vtable = {
     /*.destroy=*/iree_hal_vulkan_native_semaphore_destroy,

--- a/runtime/src/iree/hal/drivers/vulkan/vma_buffer.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_buffer.cc
@@ -80,7 +80,7 @@ iree_status_t iree_hal_vulkan_vma_buffer_wrap(
   }
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 static void iree_hal_vulkan_vma_buffer_destroy(iree_hal_buffer_t* base_buffer) {
@@ -171,6 +171,19 @@ static iree_status_t iree_hal_vulkan_vma_buffer_flush_range(
   VK_RETURN_IF_ERROR(vmaFlushAllocation(buffer->vma, buffer->allocation,
                                         local_byte_offset, local_byte_length),
                      "vmaFlushAllocation");
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_vulkan_allocated_buffer_handle(
+    iree_hal_buffer_t* allocated_buffer, VkDeviceMemory* out_memory,
+    VkBuffer* out_handle) {
+  IREE_ASSERT_ARGUMENT(allocated_buffer);
+  IREE_ASSERT_ARGUMENT(out_memory);
+  IREE_ASSERT_ARGUMENT(out_handle);
+  iree_hal_vulkan_vma_buffer_t* buffer =
+      iree_hal_vulkan_vma_buffer_cast(allocated_buffer);
+  *out_memory = buffer->allocation_info.deviceMemory;
+  *out_handle = buffer->handle;
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/modules/hal/types.c
+++ b/runtime/src/iree/modules/hal/types.c
@@ -225,3 +225,24 @@ IREE_API_EXPORT iree_status_t iree_vm_list_set_buffer_view_retain(
       iree_vm_ref_wrap_assign(value, iree_hal_buffer_view_type(), &value_ref));
   return iree_vm_list_set_ref_retain(list, i, &value_ref);
 }
+
+IREE_API_EXPORT iree_hal_fence_t* iree_vm_list_get_fence_assign(
+    const iree_vm_list_t* list, iree_host_size_t i) {
+  return (iree_hal_fence_t*)iree_vm_list_get_ref_deref(list, i,
+                                                       iree_hal_fence_type());
+}
+
+IREE_API_EXPORT iree_hal_fence_t* iree_vm_list_get_fence_retain(
+    const iree_vm_list_t* list, iree_host_size_t i) {
+  iree_hal_fence_t* value = iree_vm_list_get_fence_assign(list, i);
+  iree_hal_fence_retain(value);
+  return value;
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_list_set_fence_retain(
+    iree_vm_list_t* list, iree_host_size_t i, iree_hal_fence_t* value) {
+  iree_vm_ref_t value_ref;
+  IREE_RETURN_IF_ERROR(
+      iree_vm_ref_wrap_assign(value, iree_hal_fence_type(), &value_ref));
+  return iree_vm_list_set_ref_retain(list, i, &value_ref);
+}

--- a/runtime/src/iree/modules/hal/types.h
+++ b/runtime/src/iree/modules/hal/types.h
@@ -79,6 +79,13 @@ IREE_API_EXPORT iree_hal_buffer_view_t* iree_vm_list_get_buffer_view_retain(
 IREE_API_EXPORT iree_status_t iree_vm_list_set_buffer_view_retain(
     iree_vm_list_t* list, iree_host_size_t i, iree_hal_buffer_view_t* value);
 
+IREE_API_EXPORT iree_hal_fence_t* iree_vm_list_get_fence_assign(
+    const iree_vm_list_t* list, iree_host_size_t i);
+IREE_API_EXPORT iree_hal_fence_t* iree_vm_list_get_fence_retain(
+    const iree_vm_list_t* list, iree_host_size_t i);
+IREE_API_EXPORT iree_status_t iree_vm_list_set_fence_retain(
+    iree_vm_list_t* list, iree_host_size_t i, iree_hal_fence_t* value);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
These are experimental/temporary but good placeholders for interop.