### PR TITLE
Re-enable vectorization of gathers

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -331,8 +331,7 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager,
   {
     LLVMCPUVectorizationPassOptions options;
     options.enableVectorMasking = enableVectorMasking;
-    // TODO(#13036): Re-enable once debugged.
-    options.vectorizeGatherAccesses = false;
+    options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createLLVMCPUVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -370,8 +369,7 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager,
     LLVMCPUVectorizationPassOptions options;
     options.enableVectorMasking = enableVectorMasking;
     options.vectorizePadding = true;
-    // TODO(#13036): Re-enable once debugged.
-    options.vectorizeGatherAccesses = false;
+    options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createLLVMCPUVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -468,8 +466,7 @@ void addMultiTilingExpertPassPipeline(OpPassManager &passManager,
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
     LLVMCPUVectorizationPassOptions options;
     options.enableVectorMasking = enableVectorMasking;
-    // TODO(#13036): Re-enable once debugged.
-    options.vectorizeGatherAccesses = false;
+    options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createLLVMCPUVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -526,8 +523,7 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager,
     LLVMCPUVectorizationPassOptions options;
     options.enableVectorMasking = enableVectorMasking;
     options.vectorizePadding = true;
-    // TODO(#13036): Re-enable once debugged.
-    options.vectorizeGatherAccesses = false;
+    options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createLLVMCPUVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());


### PR DESCRIPTION
The vectorisation of gathers was disable due to assertion failures (see #13036). This was fixed in https://reviews.llvm.org/D148537, hence re-enabling.