### PR TITLE
Add `SETUP_INSTALL_RPATH` to `iree-run-mlir`.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -309,6 +309,7 @@ if(IREE_BUILD_COMPILER)
     DATA
       ${IREE_LLD_TARGET}
     HOSTONLY
+    SETUP_INSTALL_RPATH
   )
 
   # Ensure FileCheck and associated binaries get built. Tests don't have


### PR DESCRIPTION
Untested, but we believe this will fix 
```
./bin/iree-run-mlir: error while loading shared libraries: libIREECompiler.so.0: cannot open shared object file: No such file or directory
```

Context: https://github.com/openxla/iree/pull/12715#pullrequestreview-1409628587