### PR TITLE
Adding IREE_EXTERNAL_TOOLING_MODULES cmake flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,20 @@ option(IREE_COMPILER_BUILD_SHARED_LIBS "Enables BUILD_SHARED_LIBS CMake mode for
 option(BUILD_SHARED_LIBS "Instructs CMake to build libraries as shared if possible" OFF)
 
 #-------------------------------------------------------------------------------
+# IREE command-line tooling configuration
+#-------------------------------------------------------------------------------
+
+# External user modules linked into IREE tooling (iree-run-module/etc).
+# These are only available in the internal IREE tools and here for testing
+# custom modules in standard workflows. This is not a deployment mechanism and
+# users integrating IREE into their libraries or applications will need to
+# manage the building and registering/resolving the modules themselves.
+#
+# See runtime/src/iree/tooling/modules/CMakeLists.txt for more information on
+# how to declare external modules.
+set(IREE_EXTERNAL_TOOLING_MODULES "" CACHE STRING "")
+
+#-------------------------------------------------------------------------------
 # Compiler plugins
 # IREE compiler plugins can be statically built into the compiler by adding
 # directories to IREE_COMPILER_PLUGIN_PATHS. If directories are relative, they

--- a/runtime/src/iree/hal/local/executable_plugin_manager.c
+++ b/runtime/src/iree/hal/local/executable_plugin_manager.c
@@ -19,7 +19,7 @@
 // as they don't disturb the existing values exposed to the plugin.
 
 #define STATIC_ASSERT_EQ(a, b) \
-  static_assert((a) == (b), "plugin/runtime API mismatch")
+  static_assert((int)(a) == (int)(b), "plugin/runtime API mismatch")
 
 STATIC_ASSERT_EQ(IREE_HAL_EXECUTABLE_PLUGIN_STATUS_OK, IREE_STATUS_OK);
 STATIC_ASSERT_EQ(IREE_HAL_EXECUTABLE_PLUGIN_STATUS_CANCELLED,

--- a/runtime/src/iree/tooling/BUILD.bazel
+++ b/runtime/src/iree/tooling/BUILD.bazel
@@ -88,7 +88,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/modules/hal",
         "//runtime/src/iree/modules/hal/inline",
         "//runtime/src/iree/modules/hal/loader",
-        "//runtime/src/iree/modules/vmvx",
+        "//runtime/src/iree/tooling/modules",
         "//runtime/src/iree/vm",
         "//runtime/src/iree/vm/bytecode:module",
         "//runtime/src/iree/vm/dynamic:module",

--- a/runtime/src/iree/tooling/CMakeLists.txt
+++ b/runtime/src/iree/tooling/CMakeLists.txt
@@ -97,7 +97,7 @@ iree_cc_library(
     iree::modules::hal
     iree::modules::hal::inline
     iree::modules::hal::loader
-    iree::modules::vmvx
+    iree::tooling::modules
     iree::vm
     iree::vm::bytecode::module
     iree::vm::dynamic::module

--- a/runtime/src/iree/tooling/modules/BUILD.bazel
+++ b/runtime/src/iree/tooling/modules/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+iree_runtime_cc_library(
+    name = "modules",
+    srcs = ["resolver.c"],
+    hdrs = ["resolver.h"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/modules/vmvx",
+        "//runtime/src/iree/vm",
+    ],
+)

--- a/runtime/src/iree/tooling/modules/CMakeLists.txt
+++ b/runtime/src/iree/tooling/modules/CMakeLists.txt
@@ -1,0 +1,142 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Link in externally defined modules.
+# This allows users to conditionally enable modules that live outside of the
+# IREE source tree by specifying a few cmake variables.
+#
+# Drivers are expected to have a CMakeLists.txt that is parsed when enabled.
+# If a module is optional it may set an IREE_EXTERNAL_TOOLING_MODULE_{name}_FOUND
+# variable to FALSE and be ignored, such as when dependencies are not found or
+# other user configuration has disabled them.
+#
+# Each module provides a static library target name and a function that is
+# called at runtime to register the module.
+#
+# Required variables:
+#   IREE_EXTERNAL_TOOLING_MODULE_{name}_TARGET: static library target name.
+#   IREE_EXTERNAL_TOOLING_MODULE_{name}_NAME: module name in MLIR.
+#   IREE_EXTERNAL_TOOLING_MODULE_{name}_CREATE: module creation name:
+#      iree_status_t {CREATE}(iree_vm_instance_t* instance,
+#                             iree_allocator_t host_allocator,
+#                             iree_vm_module_t** out_module)
+# Optional variables:
+#   IREE_EXTERNAL_TOOLING_MODULE_{name}_OPTIONAL: true if the module not being
+#      found is not an error.
+#   IREE_EXTERNAL_TOOLING_MODULE_{name}_SOURCE_DIR: source directory with a
+#      CMakeLists.txt included when the module is enabled.
+#   IREE_EXTERNAL_TOOLING_MODULE_{name}_BINARY_DIR: binary directory for cmake
+#      outs.
+#   IREE_EXTERNAL_TOOLING_MODULE_{name}_FOUND: bool to indicate whether the
+#      module was found and valid for use.
+#   IREE_EXTERNAL_TOOLING_MODULE_{name}_REGISTER_TYPES: optional type name:
+#      iree_status_t {REGISTER_TYPES}(iree_vm_instance_t* instance)
+set(IREE_EXTERNAL_TOOLING_MODULES_USED)
+foreach(_MODULE_NAME ${IREE_EXTERNAL_TOOLING_MODULES})
+  string(TOUPPER "IREE_EXTERNAL_TOOLING_MODULES_${_MODULE_NAME}" _MODULE_VAR)
+  string(REGEX REPLACE "-" "_" _MODULE_VAR ${_MODULE_VAR})
+  message(STATUS "Adding IREE external tooling module: ${_MODULE_NAME}")
+
+  set(_MODULE_OPTIONAL ${${_MODULE_VAR}_OPTIONAL})
+  set(_MODULE_SOURCE_DIR ${${_MODULE_VAR}_SOURCE_DIR})
+  set(_MODULE_BINARY_DIR ${${_MODULE_VAR}_BINARY_DIR})
+
+  # Default to found unless the user overrides it in the module source.
+  # This allows the module to decide to disable itself even if the user
+  # requested it.
+  set(${_MODULE_VAR}_FOUND TRUE CACHE BOOL
+      "Whether the external module is valid for use.")
+
+  # Include the module source CMakeLists.txt if required.
+  # Users may have already defined the targets and not need this.
+  if(_MODULE_SOURCE_DIR)
+    if(NOT EXISTS "${_MODULE_SOURCE_DIR}/CMakeLists.txt")
+      message(FATAL_ERROR "External module CMakeLists.txt not found at "
+                          "${_MODULE_SOURCE_DIR}")
+    endif()
+    add_subdirectory(${_MODULE_SOURCE_DIR} ${_MODULE_BINARY_DIR})
+  endif()
+
+  # If found then add to the list of valid modules.
+  if(${${_MODULE_VAR}_FOUND})
+    list(APPEND IREE_EXTERNAL_TOOLING_MODULES_USED ${_MODULE_NAME})
+  else()
+    if(${_MODULE_OPTIONAL})
+      message(STATUS "Optional external module '${_MODULE_NAME}' requested "
+                      "but not found; disabling and continuing")
+    else()
+      message(FATAL_ERROR "External module '${_MODULE_NAME}' not found; may "
+                          "have unavailable dependencies")
+    endif()
+  endif()
+endforeach()
+
+# Produce resolve_external.c that contains a resolver switch for all modules.
+# This will be called by resolver.c after internal modules are tried.
+set(_RESOLVER_EXTERNAL_C_SRC)
+set(_RESOLVER_EXTERNAL_COPTS)
+set(_RESOLVER_EXTERNAL_DEPS)
+if(IREE_EXTERNAL_TOOLING_MODULES_USED)
+  message(STATUS "Registering external tooling modules: ${IREE_EXTERNAL_TOOLING_MODULES_USED}")
+
+  set(_RESOLVER_EXTERNAL_COPTS "-DIREE_HAVE_EXTERNAL_TOOLING_MODULES=1")
+
+  # Build the list of deps and our source code lines.
+  set(_RESOLVER_EXTERNAL_DEPS)
+  set(_RESOLVER_EXTERNAL_DECLS)
+  set(_RESOLVER_EXTERNAL_TYPES)
+  set(_RESOLVER_EXTERNAL_CHECKS)
+  foreach(_MODULE_NAME ${IREE_EXTERNAL_TOOLING_MODULES_USED})
+    string(TOUPPER "IREE_EXTERNAL_TOOLING_MODULE_${_MODULE_NAME}" _MODULE_VAR)
+    string(REGEX REPLACE "-" "_" _MODULE_VAR ${_MODULE_VAR})
+    set(_MODULE_TARGET ${${_MODULE_VAR}_TARGET})
+    set(_MODULE_NAME ${${_MODULE_VAR}_NAME})
+    set(_MODULE_REGISTER_TYPES ${${_MODULE_VAR}_REGISTER_TYPES})
+    set(_MODULE_CREATE ${${_MODULE_VAR}_CREATE})
+    list(APPEND _RESOLVER_EXTERNAL_DEPS ${_MODULE_TARGET})
+    if(_MODULE_REGISTER_TYPES)
+      list(APPEND _RESOLVER_EXTERNAL_DECLS
+          "extern iree_status_t ${_MODULE_REGISTER_TYPES}(iree_vm_instance_t* instance);\n")
+      list(APPEND _RESOLVER_EXTERNAL_REGISTER_TYPES
+          "IREE_RETURN_IF_ERROR(${_MODULE_REGISTER_TYPES}(instance));\n")
+    endif()
+    list(APPEND _RESOLVER_EXTERNAL_DECLS
+        "extern iree_status_t ${_MODULE_CREATE}(iree_vm_instance_t* instance, iree_allocator_t host_allocator, iree_vm_module_t** out_module);\n")
+    list(APPEND _RESOLVER_EXTERNAL_TRY_CREATES
+        "if (iree_string_view_equal(dependency->name, IREE_SV(\"${_MODULE_NAME}\"))) {\n    IREE_RETURN_IF_ERROR(${_MODULE_CREATE}(instance, host_allocator, out_module));\n  }\n")
+  endforeach()
+
+  # Read template file and substitute variables.
+  set(_RESOLVER_EXTERNAL_C_TPL "${CMAKE_CURRENT_SOURCE_DIR}/resolve_external.c.in")
+  set(_RESOLVER_EXTERNAL_C_SRC "${CMAKE_CURRENT_BINARY_DIR}/resolve_external.c")
+  file(READ ${_RESOLVER_EXTERNAL_C_TPL} _RESOLVER_EXTERNAL_TEMPLATE)
+  file(
+    CONFIGURE OUTPUT ${_RESOLVER_EXTERNAL_C_SRC}
+    CONTENT "${_RESOLVER_EXTERNAL_TEMPLATE}"
+  )
+endif()
+
+set(_RESOLVER_INTERNAL_DEPS)
+list(APPEND _RESOLVER_INTERNAL_DEPS iree::modules::vmvx)
+
+iree_cc_library(
+  NAME
+    modules
+  HDRS
+    "resolver.h"
+  SRCS
+    "resolver.c"
+    ${_RESOLVER_EXTERNAL_C_SRC}
+  COPTS
+    ${_RESOLVER_EXTERNAL_COPTS}
+  DEPS
+    iree::base
+    iree::base::tracing
+    iree::vm
+    ${_RESOLVER_INTERNAL_DEPS}
+    ${_RESOLVER_EXTERNAL_DEPS}
+  PUBLIC
+)

--- a/runtime/src/iree/tooling/modules/resolve_external.c.in
+++ b/runtime/src/iree/tooling/modules/resolve_external.c.in
@@ -1,0 +1,22 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/tooling/modules/resolver.h"
+
+${_RESOLVER_EXTERNAL_DECLS}
+
+iree_status_t iree_tooling_register_external_module_types(
+    iree_vm_instance_t* instance) {
+  ${_RESOLVER_EXTERNAL_REGISTER_TYPES}
+  return iree_ok_status();
+}
+
+iree_status_t iree_tooling_try_resolve_external_module_dependency(
+    iree_vm_instance_t* instance, const iree_vm_module_dependency_t* dependency,
+    iree_allocator_t host_allocator, iree_vm_module_t** out_module) {
+  ${_RESOLVER_EXTERNAL_TRY_CREATES}
+  return iree_ok_status();
+}

--- a/runtime/src/iree/tooling/modules/resolver.c
+++ b/runtime/src/iree/tooling/modules/resolver.c
@@ -1,0 +1,74 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/tooling/modules/resolver.h"
+
+#include "iree/base/tracing.h"
+
+#if defined(IREE_HAVE_VMVX_MODULE)
+#include "iree/modules/vmvx/module.h"
+#endif  // IREE_HAVE_VMVX_MODULE
+
+#if defined(IREE_HAVE_EXTERNAL_TOOLING_MODULES)
+// Defined in the generated registry_external.c file:
+extern iree_status_t iree_tooling_register_external_module_types(
+    iree_vm_instance_t* instance);
+extern iree_status_t iree_tooling_try_resolve_external_module_dependency(
+    iree_vm_instance_t* instance, const iree_vm_module_dependency_t* dependency,
+    iree_allocator_t host_allocator, iree_vm_module_t** out_module);
+#else
+static iree_status_t iree_tooling_register_external_module_types(
+    iree_vm_instance_t* instance) {
+  return iree_ok_status();
+}
+static iree_status_t iree_tooling_try_resolve_external_module_dependency(
+    iree_vm_instance_t* instance, const iree_vm_module_dependency_t* dependency,
+    iree_allocator_t host_allocator, iree_vm_module_t** out_module) {
+  *out_module = NULL;
+  return iree_ok_status();
+}
+#endif  // IREE_HAVE_EXTERNAL_TOOLING_MODULES
+
+iree_status_t iree_tooling_register_all_module_types(
+    iree_vm_instance_t* instance) {
+  IREE_RETURN_IF_ERROR(iree_tooling_register_external_module_types(instance));
+  return iree_ok_status();
+}
+
+iree_status_t iree_tooling_resolve_module_dependency(
+    iree_vm_instance_t* instance, const iree_vm_module_dependency_t* dependency,
+    iree_allocator_t host_allocator, iree_vm_module_t** out_module) {
+  IREE_ASSERT_ARGUMENT(instance);
+  IREE_ASSERT_ARGUMENT(dependency);
+  IREE_ASSERT_ARGUMENT(out_module);
+  *out_module = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, dependency->name.data, dependency->name.size);
+
+  iree_vm_module_t* module = NULL;
+  if (iree_string_view_equal(dependency->name, IREE_SV("vmvx"))) {
+    // VMVX module used on the host side for the inline HAL.
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_vmvx_module_create(instance, host_allocator, &module));
+  } else {
+    // Try to resolve the module from externally-defined modules.
+    // If the module is not found this will succeed but module will be NULL.
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_tooling_try_resolve_external_module_dependency(
+                instance, dependency, host_allocator, &module));
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  if (!module && iree_all_bits_set(dependency->flags,
+                                   IREE_VM_MODULE_DEPENDENCY_FLAG_REQUIRED)) {
+    // Required but not found; fail.
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "required module '%.*s' not available in the build",
+                            (int)dependency->name.size, dependency->name.data);
+  }
+  *out_module = module;
+  return iree_ok_status();
+}

--- a/runtime/src/iree/tooling/modules/resolver.h
+++ b/runtime/src/iree/tooling/modules/resolver.h
@@ -1,0 +1,36 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_TOOLING_MODULES_REGISTRY_H_
+#define IREE_TOOLING_MODULES_REGISTRY_H_
+
+#include "iree/base/api.h"
+#include "iree/vm/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Registers all types used by available modules.
+// NOTE: this is only required as a separate step in the tooling as we perform
+// dynamic module resolution and in order to load modules to find their
+// dependencies their dependent types must be registered first. This could be
+// fixed in the future to only resolve types when a module is instantiated in
+// a context instead of when loaded but is TBD.
+iree_status_t iree_tooling_register_all_module_types(
+    iree_vm_instance_t* instance);
+
+// Resolves a module dependency to an initialized module.
+// Returns OK if the dependency is optional and not found.
+iree_status_t iree_tooling_resolve_module_dependency(
+    iree_vm_instance_t* instance, const iree_vm_module_dependency_t* dependency,
+    iree_allocator_t host_allocator, iree_vm_module_t** out_module);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_TOOLING_MODULES_REGISTRY_H_

--- a/runtime/src/iree/tooling/trace_replay.c
+++ b/runtime/src/iree/tooling/trace_replay.c
@@ -438,14 +438,14 @@ static void iree_trace_replay_get_min_max_for_element_type(
 static void iree_trace_replay_generate_fully_specified_pseudorandom_buffer(
     iree_hal_element_type_t element_type, iree_byte_span_t span,
     uint32_t seed) {
+  int32_t min = 0;
+  int32_t max = 0;
+  iree_trace_replay_get_min_max_for_element_type(element_type, &min, &max);
+  uint32_t range = (max - min + 1);
   iree_host_size_t element_byte_count =
       iree_hal_element_dense_byte_count(element_type);
   uint8_t* data_end = span.data + span.data_length;
   uint32_t state = seed;
-  uint32_t range;
-  int32_t min, max;
-  iree_trace_replay_get_min_max_for_element_type(element_type, &min, &max);
-  range = (max - min + 1);
   for (uint8_t* data = span.data; data < data_end; data += element_byte_count) {
     // Generate "uniform" integer-valued numbers in the range [min, max].
     int32_t value =

--- a/samples/custom_module/dynamic/README.md
+++ b/samples/custom_module/dynamic/README.md
@@ -39,7 +39,7 @@ dynamic modules should be carefully considered.
     ```
     # This simple sample doesn't use tensors and can be compiled in host-only
     # mode to avoid the need for the HAL.
-    iree-compile --iree-execution-model=host-only samples/custom_module/basic/test/example.mlir -o=/tmp/example.vmfb
+    iree-compile --iree-hal-target-backends=vmvx samples/custom_module/dynamic/test/example.mlir -o=/tmp/example.vmfb
     ```
 
 3. Build the `iree_samples_custom_module_dynamic_module` CMake target :

--- a/samples/custom_module/static/CMakeLists.txt
+++ b/samples/custom_module/static/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if(NOT IREE_HAL_DRIVER_LOCAL_SYNC)
+  return()
+endif()
+if(NOT "static_sample" IN_LIST IREE_EXTERNAL_TOOLING_MODULES)
+  return()
+endif()
+
+message(WARNING "IREE custom_module/static sample compiled into all tools")
+
+set(_NAME "iree_samples_custom_module_static_module")
+add_library(${_NAME} STATIC module.cc)
+target_link_libraries(${_NAME}
+  iree_base_base
+  iree_hal_hal
+  iree_modules_hal_types
+  iree_vm_vm
+)
+
+# TODO(benvanik): make iree_status_annotate_f always available as a function
+# instead of defining it empty? otherwise optimized builds of the runtime won't
+# export it but external libraries may pull it in.
+target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
+
+add_subdirectory(test)

--- a/samples/custom_module/static/README.md
+++ b/samples/custom_module/static/README.md
@@ -1,0 +1,95 @@
+# Statically-linked custom module sample for IREE tooling
+
+This sample derives from the [basic](./samples/custom_module/basic/) sample to
+show how to build a custom C++ module that can be statically linked into the
+IREE command line tools. This is only useful for debugging/developing/profiling
+custom modules and is not intended as a deployment mechanism. Once a custom
+module has been written it can be statically linked into the user's hosting
+runtime application or library or dynamically linked and loaded as with the
+[dynamic](./samples/custom_module/dynamic/) sample.
+
+The custom module is implemented using a C++ module wrapper layer in
+[`module.cc`](./module.cc) and loaded by the `iree-run-module` tool
+automatically whenever any user module depends on it.
+
+## Background
+
+IREE's VM is used to dynamically link modules of various types together at
+runtime (C, C++, IREE's VM bytecode, etc). Via this mechanism any number of
+modules containing exported functions and types that can be used across modules
+can extend IREE's base functionality. The IREE tooling (`iree-run-module`,
+`iree-benchmark-module`, etc) is _not_ an ML runtime and not intended to be
+deployed but it can be useful to test custom modules using them in order to
+benchmark, profile, or debug outside of user applications. This sample
+demonstrates how to take a generic custom module that's effectively identical to
+both [basic](./samples/custom_module/basic/) and
+[dynamic](./samples/custom_module/dynamic/) samples and link that into the IREE
+tools for those purposes. Note that this is mostly about CMake configuration and
+matching some tooling-specific function signatures and it's possible to share
+the same module code between all various modes with minor differences.
+
+## Instructions
+
+1. Build or install the `iree-compile` binary:
+
+    ```
+    python -m pip install iree-compiler
+    ```
+
+    [See here](https://openxla.github.io/iree/getting-started/)
+    for general instructions on installing the compiler.
+
+3. Compile the [example module](./test/example.mlir) to a .vmfb file:
+
+    ```
+    # This simple sample doesn't use tensors and can be compiled in host-only
+    # mode to avoid the need for the HAL.
+    iree-compile --iree-hal-target-backends=vmvx samples/custom_module/static/test/example.mlir -o=/tmp/example.vmfb
+    ```
+
+3. Configure the IREE tools to include the custom module:
+
+    ```
+    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
+        -DCMAKE_C_FLAGS=-DIREE_VM_EXECUTION_TRACING_FORCE_ENABLE=1 \
+        -DIREE_EXTERNAL_TOOLING_MODULES=static_sample \
+        -DIREE_EXTERNAL_TOOLING_MODULE_STATIC_SAMPLE_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/samples/custom_module/static \
+        -DIREE_EXTERNAL_TOOLING_MODULE_STATIC_SAMPLE_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/samples/custom_module/static \
+        -DIREE_EXTERNAL_TOOLING_MODULE_STATIC_SAMPLE_TARGET=iree_samples_custom_module_static_module \
+        -DIREE_EXTERNAL_TOOLING_MODULE_STATIC_SAMPLE_NAME=custom \
+        -DIREE_EXTERNAL_TOOLING_MODULE_STATIC_SAMPLE_REGISTER_TYPES=register_sample_module_types \
+        -DIREE_EXTERNAL_TOOLING_MODULE_STATIC_SAMPLE_CREATE=create_sample_module
+    cmake --build ../iree-build/ --target iree-run-module
+    ```
+    (here we force runtime execution tracing for demonstration purposes)
+
+    [See here](https://openxla.github.io/iree/building-from-source/getting-started/)
+    for general instructions on building using CMake.
+
+4. Run the example program using the main `iree-run-module` tool:
+
+   ```
+   ../iree-build/tools/iree-run-module \
+      --module=/tmp/example.vmfb \
+      --function=main
+   ```
+
+### Type registration
+
+Custom types defined by the dynamic module must be registered with the
+`iree_vm_instance_t` provided to the creation function.
+
+Any externally defined types such as the builtin VM types
+(`!vm.list`/`iree_vm_list_t`) or the HAL types
+(`!hal.buffer_view`/`iree_hal_buffer_view_t`) must be resolved from the instance
+prior to use. `iree_vm_resolve_builtin_types` and
+`iree_hal_module_resolve_all_types` (or one of the more restricted sets like
+`iree_hal_module_resolve_common_types`) can be used to perform the resolution.
+
+The tooling has a quirk around dynamic module resolution that requires all types
+be registered prior to loading modules. Here that is implemented with the
+`register_sample_module_types` function that is provided to CMake via
+`-DIREE_EXTERNAL_TOOLING_MODULE_STATIC_SAMPLE_REGISTER_TYPES=` to ensure that
+the sample types get registered first. In a real application that manually
+creates modules this would not be required as modules are expected to manage
+type registration alongside their lifetime.

--- a/samples/custom_module/static/module.cc
+++ b/samples/custom_module/static/module.cc
@@ -1,0 +1,232 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstdio>
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/modules/hal/types.h"
+#include "iree/vm/api.h"
+#include "iree/vm/native_module_cc.h"
+
+// NOTE: this module is written in C++ using the native module wrapper and uses
+// template magic to handle marshaling arguments. For a lot of uses this is a
+// much friendlier way of exposing modules to the IREE VM and if performance and
+// code size are not a concern is a fine route to take. Here we do it for
+// brevity but all of the internal IREE modules are implemented in C.
+
+//===----------------------------------------------------------------------===//
+// !custom.string type
+//===----------------------------------------------------------------------===//
+
+// The "string" type we use to store and retain string data.
+// This could be arbitrarily complex or simply wrap another user-defined type.
+// The descriptor that is registered at startup defines how to manage the
+// lifetime of the type (such as which destruction function is called, if any).
+// See ref.h for more information and additional utilities.
+typedef struct iree_sample_string_t {
+  // Must be the first field; used to track the reference count of the object.
+  iree_vm_ref_object_t ref_object;
+  // Allocator the string data was allocated from.
+  // Ideally pools and nested allocators would be used to avoid needing to store
+  // the allocator with every object.
+  iree_allocator_t allocator;
+  // Non-NUL-terminated string value.
+  iree_string_view_t value;
+} iree_sample_string_t;
+
+// Runtime type descriptor for the !custom.string describing how to manage it
+// and destroy it. The type ID is allocated at runtime and does not need to
+// match the compiler ID.
+IREE_VM_DECLARE_TYPE_ADAPTERS(iree_sample_string, iree_sample_string_t);
+IREE_VM_DEFINE_TYPE_ADAPTERS(iree_sample_string, iree_sample_string_t);
+
+// Creates a new !custom.string object with a copy of the given |value|.
+// Applications could use this and any other methods we wanted to expose to
+// interop with the loaded VM modules - such as passing in/out the objects.
+// We don't need this for the demo but creating the sample object, appending it
+// to the invocation input list, and then consuming it in the compiled module
+// is straightforward.
+static iree_status_t iree_sample_string_create(
+    iree_string_view_t value, iree_allocator_t allocator,
+    iree_sample_string_t** out_string) {
+  IREE_ASSERT_ARGUMENT(out_string);
+  // Note that we allocate the string and the string value together.
+  iree_sample_string_t* string = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      allocator, sizeof(*string) + value.size, (void**)&string));
+  string->ref_object.counter = IREE_ATOMIC_VAR_INIT(1);
+  string->allocator = allocator;
+  string->value.data = ((const char*)string) + sizeof(iree_sample_string_t);
+  string->value.size = value.size;
+  memcpy((void*)string->value.data, value.data, string->value.size);
+  *out_string = string;
+  return iree_ok_status();
+}
+
+static void iree_sample_string_destroy(void* ptr) {
+  iree_sample_string_t* string = (iree_sample_string_t*)ptr;
+  iree_allocator_free(string->allocator, ptr);
+}
+
+static iree_vm_ref_type_descriptor_t iree_sample_string_descriptor_storage = {
+    0};
+
+// Registers types provided by the sample module.
+// We must call this before any of our types can be resolved.
+static iree_status_t iree_sample_module_basic_register_types(
+    iree_vm_instance_t* instance) {
+  iree_sample_string_descriptor_storage.destroy = iree_sample_string_destroy;
+  iree_sample_string_descriptor_storage.type_name = IREE_SV("custom.string");
+  iree_sample_string_descriptor_storage.offsetof_counter =
+      offsetof(iree_sample_string_t, ref_object.counter) /
+      IREE_VM_REF_COUNTER_ALIGNMENT;
+  return iree_vm_instance_register_type(instance,
+                                        &iree_sample_string_descriptor_storage,
+                                        &iree_sample_string_registration);
+}
+
+// Unregisters types previously registered.
+// In dynamic modules it's critical that types are unregistered before the
+// library is unloaded.
+static void iree_sample_module_basic_unregister_types(
+    iree_vm_instance_t* instance) {
+  iree_vm_instance_unregister_type(instance,
+                                   &iree_sample_string_descriptor_storage);
+}
+
+//===----------------------------------------------------------------------===//
+// VM module interface implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+using namespace iree;
+
+// Per-context module state.
+// This can contain "globals" and other arbitrary state.
+//
+// Thread-compatible; the runtime will not issue multiple calls at the same
+// time using the same state. If the implementation uses external threads then
+// it must synchronize itself.
+class CustomModuleState final {
+ public:
+  explicit CustomModuleState(iree_allocator_t host_allocator)
+      : host_allocator_(host_allocator) {}
+  ~CustomModuleState() = default;
+
+  // Creates a new string with a copy of the given string data.
+  // No NUL terminator is required.
+  StatusOr<vm::ref<iree_sample_string_t>> StringFromTensor(
+      vm::ref<iree_hal_buffer_view_t> buffer_view) {
+    char string_buffer[512];
+    iree_host_size_t string_length = 0;
+    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_format(
+        buffer_view.get(), 128, IREE_ARRAYSIZE(string_buffer), string_buffer,
+        &string_length));
+
+    vm::ref<iree_sample_string_t> string;
+    IREE_RETURN_IF_ERROR(iree_sample_string_create(
+        iree_make_string_view(string_buffer, string_length), host_allocator_,
+        &string));
+    fprintf(stdout, "CREATE %.*s\n", static_cast<int>(string->value.size),
+            string->value.data);
+    fflush(stdout);
+    return std::move(string);
+  }
+
+  // Prints the contents of the string to stdout.
+  Status StringPrint(const vm::ref<iree_sample_string_t> string) {
+    if (!string) return OkStatus();  // no-op
+    fprintf(stdout, "PRINT %.*s\n", static_cast<int>(string->value.size),
+            string->value.data);
+    fflush(stdout);
+    return OkStatus();
+  }
+
+ private:
+  // Allocator that the caller requested we use for any allocations we need to
+  // perform during operation.
+  iree_allocator_t host_allocator_;
+};
+
+// Function table mapping imported function names to their implementation.
+static const vm::NativeFunction<CustomModuleState> kCustomModuleFunctions[] = {
+    vm::MakeNativeFunction("string.from_tensor",
+                           &CustomModuleState::StringFromTensor),
+    vm::MakeNativeFunction("string.print", &CustomModuleState::StringPrint),
+};
+
+// The module instance that will be allocated and reused across contexts.
+// Any context-specific state must be stored in a state structure such as
+// CustomModuleState.
+//
+// Assumed thread-safe (by construction here, as it's immutable), though if any
+// mutable state is stored here it will need to be synchronized by the
+// implementation.
+class CustomModule final : public vm::NativeModule<CustomModuleState> {
+ public:
+  using vm::NativeModule<CustomModuleState>::NativeModule;
+
+  ~CustomModule() override {
+    iree_sample_module_basic_unregister_types(instance());
+  }
+
+  // Creates per-context state when the module is added to a new context.
+  // May be called from any thread.
+  StatusOr<std::unique_ptr<CustomModuleState>> CreateState(
+      iree_allocator_t host_allocator) override {
+    auto state = std::make_unique<CustomModuleState>(host_allocator);
+    return state;
+  }
+};
+
+}  // namespace
+
+// Registers types exported by the module on |instance|.
+// This is only required when statically linking modules into tooling as dynamic
+// dependency resolution is performed out of order from creation. Normally if
+// there's 'base' and 'derived' modules the 'base' module is expected to have
+// been created and thus registered its types before the 'derived' module but
+// the tooling will try to create 'derived' first. This can be changed in the
+// future by making modules lookup types when instantiated in a context instead
+// of when created but that's TBD.
+extern "C" iree_status_t register_sample_module_types(
+    iree_vm_instance_t* instance) {
+  IREE_RETURN_IF_ERROR(iree_sample_module_basic_register_types(instance));
+  return iree_ok_status();
+}
+
+// Creates a native sample module that can be reused in multiple contexts.
+// The module itself may hold state that can be shared by all instantiated
+// copies but it will require the module to provide synchronization; usually
+// it's safer to just treat the module as immutable and keep state within the
+// instantiated module states instead.
+//
+// Note that while we are using C++ bindings internally we still expose the
+// module as a C instance. This hides the details of our implementation and
+// is required for working across the dynamic library boundary.
+extern "C" iree_status_t create_sample_module(iree_vm_instance_t* instance,
+                                              iree_allocator_t host_allocator,
+                                              iree_vm_module_t** out_module) {
+  // Register sample types used by the module against the instance.
+  // Note that this function must be safe to call multiple times as the module
+  // may be loaded multiple times.
+  IREE_RETURN_IF_ERROR(iree_sample_module_basic_register_types(instance));
+
+  // Create the sample module and return it to the runtime.
+  // NOTE: this isn't using the allocator here and that's bad as it leaves
+  // untracked allocations and pulls in the system allocator that may differ
+  // from the one requested by the user.
+  // TODO(benvanik): std::allocator wrapper around iree_allocator_t so this can
+  // use that instead.
+  auto module = std::make_unique<CustomModule>(
+      "custom", /*version=*/0, instance, host_allocator,
+      iree::span<const vm::NativeFunction<CustomModuleState>>(
+          kCustomModuleFunctions));
+  *out_module = module.release()->interface();
+  return iree_ok_status();
+}

--- a/samples/custom_module/static/test/CMakeLists.txt
+++ b/samples/custom_module/static/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "example.mlir"
+  TOOLS
+    FileCheck
+    iree-compile
+    iree-run-module
+  LABELS
+    "driver=local-sync"
+    "hostonly"
+)

--- a/samples/custom_module/static/test/example.mlir
+++ b/samples/custom_module/static/test/example.mlir
@@ -1,0 +1,43 @@
+// RUN: iree-compile %s --iree-hal-target-backends=vmvx | \
+// RUN: iree-run-module \
+// RUN:     --device=local-sync \
+// RUN:     --module=- \
+// RUN:     --function=main | \
+// RUN: FileCheck %s
+
+module @example {
+  //===--------------------------------------------------------------------===//
+  // Imports
+  //===--------------------------------------------------------------------===//
+  // External function declarations for the methods implemented in the custom
+  // module C++ file. Note that they are prefixed with the `custom.` module
+  // name.
+
+  // Creates a new string with contents from the given tensor.
+  // This is silly. Don't do this :)
+  func.func private @custom.string.from_tensor(tensor<?xi8>) -> !custom.string
+
+  // Prints the contents of the string to stdout.
+  func.func private @custom.string.print(!custom.string)
+
+  //===--------------------------------------------------------------------===//
+  // Sample methods
+  //===--------------------------------------------------------------------===//
+  // Note that there can be any number of publicly-exported methods; this simple
+  // sample just has one to keep things simple.
+
+  // CHECK-LABEL: EXEC @main
+  func.func @main() {
+    // Create string from a byte buffer encoding the characters.
+    %hello_bytes = util.unfoldable_constant dense<[0, 1, 2, 3, 4]> : tensor<5xi8>
+    %hello_arg = tensor.cast %hello_bytes : tensor<5xi8> to tensor<?xi8>
+    // CHECK-NEXT: CREATE 5xi8=0 1 2 3 4
+    %hello_str = call @custom.string.from_tensor(%hello_arg) : (tensor<?xi8>) -> !custom.string
+
+    // Print the string to stdout.
+    // CHECK-NEXT: PRINT 5xi8=0 1 2 3 4
+    call @custom.string.print(%hello_str) : (!custom.string) -> ()
+
+    return
+  }
+}


### PR DESCRIPTION
This allows for custom modules to be linked into IREE tools for the purposes of profiling, benchmarking, and debugging. As the IREE tools are not to be deployed this is considered a development feature.