### PR TITLE
Dedup workload values and bubble up ordinal ops at Flow level.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/bubble_up_ordinal_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bubble_up_ordinal_ops.mlir
@@ -2,12 +2,12 @@
 
 func.func @castui(%arg0: i32) -> index {
   %0 = arith.index_castui %arg0 : i32 to index
-  %1 = flow.dispatch.workload.ordinal %0 4 : index
+  %1 = flow.dispatch.workload.ordinal %0, 4 : index
   %2 = "foo.op"(%1) : (index) -> (index)
   return %2 : index
 }
 // CHECK-LABEL: func @castui(
 //  CHECK-SAME:     %[[ARG0:.+]]: i32)
 //       CHECK:   %[[CAST:.+]] = arith.index_castui %[[ARG0]] : i32 to index
-//       CHECK:   %[[ORDINAL:.+]] = flow.dispatch.workload.ordinal %[[CAST]] 4
+//       CHECK:   %[[ORDINAL:.+]] = flow.dispatch.workload.ordinal %[[CAST]], 4
 //       CHECK:   "foo.op"(%[[ORDINAL]])

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -28,9 +28,9 @@ hal.executable private @matmul_tensors {
         %cl_0 = hal.interface.constant.load[0] : index
         %cl_1 = hal.interface.constant.load[1] : index
         %cl_2 = hal.interface.constant.load[2] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
         %3 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
             : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%0, %2}
         %4 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
@@ -126,8 +126,8 @@ hal.executable private @add {
       func.func @add() {
         %cl_0 = hal.interface.constant.load[0] : index
         %cl_1 = hal.interface.constant.load[1] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
         %2 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
             : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%0, %1}
         %3 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
@@ -202,10 +202,10 @@ hal.executable private @add4D {
         %cl_1 = hal.interface.constant.load[1] : index
         %cl_2 = hal.interface.constant.load[2] : index
         %cl_3 = hal.interface.constant.load[3] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
-        %3 = flow.dispatch.workload.ordinal %cl_3 3  : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
+        %3 = flow.dispatch.workload.ordinal %cl_3, 3  : index
         %4 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32)
             : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3}
         %5 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(32)
@@ -282,10 +282,10 @@ hal.executable private @add_distribute4D {
         %cl_1 = hal.interface.constant.load[1] : index
         %cl_2 = hal.interface.constant.load[2] : index
         %cl_3 = hal.interface.constant.load[3] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
-        %3 = flow.dispatch.workload.ordinal %cl_3 3 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
+        %3 = flow.dispatch.workload.ordinal %cl_3, 3 : index
         %4 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32)
             : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3}
         %5 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(32)
@@ -403,10 +403,10 @@ hal.executable private @add_distribute4D_zero_tile_size {
         %cl_1 = hal.interface.constant.load[1] : index
         %cl_2 = hal.interface.constant.load[2] : index
         %cl_3 = hal.interface.constant.load[3] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
-        %3 = flow.dispatch.workload.ordinal %cl_3 3 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
+        %3 = flow.dispatch.workload.ordinal %cl_3, 3 : index
         %4 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32)
             : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3}
         %5 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(32)
@@ -478,10 +478,10 @@ hal.executable private @batch_matmul_tensors {
         %cl_1 = hal.interface.constant.load[1] : index
         %cl_2 = hal.interface.constant.load[2] : index
         %cl_3 = hal.interface.constant.load[3] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
-        %3 = flow.dispatch.workload.ordinal %cl_3 3 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
+        %3 = flow.dispatch.workload.ordinal %cl_3, 3 : index
         %4 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32)
             : !flow.dispatch.tensor<readonly:tensor<?x?x?xf32>>{%0, %1, %3}
         %5 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(32)
@@ -618,16 +618,16 @@ hal.executable public @copy_op {
         %cl_7 = hal.interface.constant.load[7] : index
         %cl_8 = hal.interface.constant.load[8] : index
         %cl_9 = hal.interface.constant.load[9] : index
-        %source_size_y = flow.dispatch.workload.ordinal %cl_0 0: index
-        %source_size_x = flow.dispatch.workload.ordinal %cl_1 1: index
-        %dest_size_y = flow.dispatch.workload.ordinal %cl_2 2: index
-        %dest_size_x = flow.dispatch.workload.ordinal %cl_3 3: index
-        %source_offset_y = flow.dispatch.workload.ordinal %cl_4 4: index
-        %source_offset_x = flow.dispatch.workload.ordinal %cl_5 5: index
-        %dest_offset_y = flow.dispatch.workload.ordinal %cl_6 6: index
-        %dest_offset_x = flow.dispatch.workload.ordinal %cl_7 7: index
-        %slice_size_y = flow.dispatch.workload.ordinal %cl_8 8: index
-        %slice_size_x = flow.dispatch.workload.ordinal %cl_9 9: index
+        %source_size_y = flow.dispatch.workload.ordinal %cl_0, 0: index
+        %source_size_x = flow.dispatch.workload.ordinal %cl_1, 1: index
+        %dest_size_y = flow.dispatch.workload.ordinal %cl_2, 2: index
+        %dest_size_x = flow.dispatch.workload.ordinal %cl_3, 3: index
+        %source_offset_y = flow.dispatch.workload.ordinal %cl_4, 4: index
+        %source_offset_x = flow.dispatch.workload.ordinal %cl_5, 5: index
+        %dest_offset_y = flow.dispatch.workload.ordinal %cl_6, 6: index
+        %dest_offset_x = flow.dispatch.workload.ordinal %cl_7, 7: index
+        %slice_size_y = flow.dispatch.workload.ordinal %cl_8, 8: index
+        %slice_size_x = flow.dispatch.workload.ordinal %cl_9, 9: index
         %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xi32>{%source_size_y, %source_size_x}
         %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xi32>{%dest_size_y, %dest_size_x}
         %source_subview = memref.subview %source[%source_offset_y, %source_offset_x] [%slice_size_y, %slice_size_x] [1, 1] : memref<?x?xi32> to memref<?x?xi32, strided<[?, ?], offset : ?>>
@@ -825,9 +825,9 @@ hal.executable private @outs_fusion {
         %cl_0 = hal.interface.constant.load[0] : index
         %cl_1 = hal.interface.constant.load[1] : index
         %cl_2 = hal.interface.constant.load[2] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
         %3 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
             : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%0, %2}
         %4 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
@@ -914,15 +914,15 @@ hal.executable private @conv {
         %cl_6 = hal.interface.constant.load[6] : index
         %cl_7 = hal.interface.constant.load[7] : index
         %cl_8 = hal.interface.constant.load[8] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
-        %3 = flow.dispatch.workload.ordinal %cl_3 3 : index
-        %4 = flow.dispatch.workload.ordinal %cl_4 4 : index
-        %5 = flow.dispatch.workload.ordinal %cl_5 5 : index
-        %6 = flow.dispatch.workload.ordinal %cl_6 6 : index
-        %7 = flow.dispatch.workload.ordinal %cl_7 7 : index
-        %8 = flow.dispatch.workload.ordinal %cl_8 8 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
+        %3 = flow.dispatch.workload.ordinal %cl_3, 3 : index
+        %4 = flow.dispatch.workload.ordinal %cl_4, 4 : index
+        %5 = flow.dispatch.workload.ordinal %cl_5, 5 : index
+        %6 = flow.dispatch.workload.ordinal %cl_6, 6 : index
+        %7 = flow.dispatch.workload.ordinal %cl_7, 7 : index
+        %8 = flow.dispatch.workload.ordinal %cl_8, 8 : index
         %9 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
             : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3}
         %10 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
@@ -1331,8 +1331,8 @@ hal.executable private @gemm_unit_N {
         %c0 = arith.constant 0 : index
         %cl_0 = hal.interface.constant.load[0] : index
         %cl_1 = hal.interface.constant.load[1] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
         %2 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32) offset(%c0)
             : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%0, %1}
         %3 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(32) offset(%c0)
@@ -1464,10 +1464,10 @@ hal.executable private @generic_unit_dims {
         %cl_1 = hal.interface.constant.load[1] : index
         %cl_2 = hal.interface.constant.load[2] : index
         %cl_3 = hal.interface.constant.load[3] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
-        %3 = flow.dispatch.workload.ordinal %cl_3 3 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
+        %3 = flow.dispatch.workload.ordinal %cl_3, 3 : index
         %4 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
             : !flow.dispatch.tensor<readonly:tensor<1x?x1x1x?x?x1x?xf32>>{%0, %1, %2, %3}
         %5 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
@@ -1537,7 +1537,7 @@ hal.executable private @reduce_to_scalar {
     builtin.module {
       func.func @reduce_to_scalar() {
         %cl_0 = hal.interface.constant.load[0] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
         %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
             : !flow.dispatch.tensor<readonly:tensor<?xf32>>{%0}
         %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
@@ -1724,9 +1724,9 @@ hal.executable private @matmul_interchange {
         %cl_0 = hal.interface.constant.load[0] : index
         %cl_1 = hal.interface.constant.load[1] : index
         %cl_2 = hal.interface.constant.load[2] : index
-        %0 = flow.dispatch.workload.ordinal %cl_0 0 : index
-        %1 = flow.dispatch.workload.ordinal %cl_1 1 : index
-        %2 = flow.dispatch.workload.ordinal %cl_2 2 : index
+        %0 = flow.dispatch.workload.ordinal %cl_0, 0 : index
+        %1 = flow.dispatch.workload.ordinal %cl_1, 1 : index
+        %2 = flow.dispatch.workload.ordinal %cl_2, 2 : index
         %3 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
             : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%0, %2}
         %4 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
@@ -1791,11 +1791,11 @@ hal.executable private @no_compute {
         %2 = arith.index_cast %cl_2 : i32 to index
         %3 = arith.index_cast %cl_3 : i32 to index
         %4 = arith.index_cast %cl_4 : i32 to index
-        %5 = flow.dispatch.workload.ordinal %0 0 : index
-        %6 = flow.dispatch.workload.ordinal %1 1 : index
-        %7 = flow.dispatch.workload.ordinal %2 2 : index
-        %8 = flow.dispatch.workload.ordinal %3 3 : index
-        %9 = flow.dispatch.workload.ordinal %4 4 : index
+        %5 = flow.dispatch.workload.ordinal %0, 0 : index
+        %6 = flow.dispatch.workload.ordinal %1, 1 : index
+        %7 = flow.dispatch.workload.ordinal %2, 2 : index
+        %8 = flow.dispatch.workload.ordinal %3, 3 : index
+        %9 = flow.dispatch.workload.ordinal %4, 4 : index
         %10 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : memref<?x?x?xf32>{%5, %6, %7}
         memref.assume_alignment %10, 64 : memref<?x?x?xf32>
         %11 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : memref<1x?x?xf32>{%8, %9}
@@ -2050,10 +2050,10 @@ hal.executable private @clone_index_computations {
         %1 = arith.index_castui %cl_1 : i32 to index
         %2 = arith.index_castui %cl_2 : i32 to index
         %3 = arith.index_castui %cl_3 : i32 to index
-        %4 = flow.dispatch.workload.ordinal %0 0 : index
-        %5 = flow.dispatch.workload.ordinal %1 1 : index
-        %6 = flow.dispatch.workload.ordinal %2 2 : index
-        %7 = flow.dispatch.workload.ordinal %3 3 : index
+        %4 = flow.dispatch.workload.ordinal %0, 0 : index
+        %5 = flow.dispatch.workload.ordinal %1, 1 : index
+        %6 = flow.dispatch.workload.ordinal %2, 2 : index
+        %7 = flow.dispatch.workload.ordinal %3, 3 : index
         %8 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0)
             : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%4, %5}
         %9 = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%6]
@@ -2113,10 +2113,10 @@ hal.executable private @dynamic_unpack {
         %1 = arith.index_castui %cl_1 : i32 to index
         %2 = arith.index_castui %cl_2 : i32 to index
         %3 = arith.index_castui %cl_3 : i32 to index
-        %4 = flow.dispatch.workload.ordinal %0 0 : index
-        %5 = flow.dispatch.workload.ordinal %1 1 : index
-        %6 = flow.dispatch.workload.ordinal %2 2 : index
-        %7 = flow.dispatch.workload.ordinal %3 3 : index
+        %4 = flow.dispatch.workload.ordinal %0, 0 : index
+        %5 = flow.dispatch.workload.ordinal %1, 1 : index
+        %6 = flow.dispatch.workload.ordinal %2, 2 : index
+        %7 = flow.dispatch.workload.ordinal %3, 3 : index
         %8 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<?x?x32x16xi32>>{%4, %5}
         %9 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c131072) : !flow.dispatch.tensor<writeonly:tensor<?x?xi32>>{%6, %7}
         %10 = flow.dispatch.tensor.load %8, offsets = [0, 0, 0, 0], sizes = [%4, %5, 32, 16], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x32x16xi32>>{%4, %5} -> tensor<?x?x32x16xi32>
@@ -2161,10 +2161,10 @@ hal.executable private @dynamic_unpack_dynamic_tile {
         %1 = arith.index_castui %cl_1 : i32 to index
         %2 = arith.index_castui %cl_2 : i32 to index
         %3 = arith.index_castui %cl_3 : i32 to index
-        %4 = flow.dispatch.workload.ordinal %0 0 : index
-        %5 = flow.dispatch.workload.ordinal %1 1 : index
-        %6 = flow.dispatch.workload.ordinal %2 2 : index
-        %7 = flow.dispatch.workload.ordinal %3 3 : index
+        %4 = flow.dispatch.workload.ordinal %0, 0 : index
+        %5 = flow.dispatch.workload.ordinal %1, 1 : index
+        %6 = flow.dispatch.workload.ordinal %2, 2 : index
+        %7 = flow.dispatch.workload.ordinal %3, 3 : index
         %8 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi32>>{%4, %5, %c32, %c16}
         %9 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c131072) : !flow.dispatch.tensor<writeonly:tensor<?x?xi32>>{%6, %7}
         %10 = flow.dispatch.tensor.load %8, offsets = [0, 0, 0, 0], sizes = [%4, %5, %c32, %c16], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi32>>{%4, %5, %c32, %c16} -> tensor<?x?x?x?xi32>

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -186,6 +186,29 @@ static SmallVector<Value, 4> refreshDimsOnTypeChange(
 // flow.dispatch.workgroups
 //===----------------------------------------------------------------------===//
 
+/// Helper method to take a list of values to be deduped and returns
+/// - list of deduped values.
+/// - mapping for a value from its position in the original list to
+///   the deduped list.
+static std::tuple<SmallVector<Value>, llvm::MapVector<int, int>>
+dedupAndGetOldToNewPosMapping(ValueRange values) {
+  llvm::MapVector<int, int> oldPosToNewPos;
+  SmallVector<Value> uniquedList;
+  int numUnique = 0;
+  llvm::MapVector<Value, int> oldValueToNewPos;
+  for (auto [index, val] : llvm::enumerate(values)) {
+    if (oldValueToNewPos.count(val)) {
+      oldPosToNewPos[index] = oldValueToNewPos[val];
+      continue;
+    }
+    oldPosToNewPos[index] = numUnique;
+    oldValueToNewPos[val] = numUnique;
+    uniquedList.push_back(val);
+    numUnique++;
+  }
+  return {uniquedList, oldPosToNewPos};
+}
+
 struct ReplaceDispatchResultIfZeroElements
     : public OpRewritePattern<DispatchWorkgroupsOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -208,6 +231,135 @@ struct ReplaceDispatchResultIfZeroElements
   }
 };
 
+/// Deduplicate redundant workload values of a dispatch.workgroups op. This
+/// requires modifying the `count` region of the op to match the new workloads.
+struct ElideRedundantWorkloadValues
+    : public OpRewritePattern<DispatchWorkgroupsOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(DispatchWorkgroupsOp op,
+                                PatternRewriter &rewriter) const override {
+    ValueRange workload = op.getWorkload();
+    auto [newWorkload, oldWorkloadPosToNewWorkloadPos] =
+        dedupAndGetOldToNewPosMapping(workload);
+    if (newWorkload.size() == workload.size()) {
+      // Nothing to do.
+      return failure();
+    }
+
+    // Create a new flow.dispatch.workgroup op with new workloads.
+    Location loc = op.getLoc();
+    auto newWorkgroupsOp = rewriter.create<DispatchWorkgroupsOp>(
+        loc, newWorkload, op.getResultTypes(), op.getResultDims(),
+        op.getArguments(), op.getArgumentDims(),
+        op.getTiedOperandsAsIntegerList(),
+        getPrunedAttributeList(op, /*elidedAttrs=*/{}));
+
+    // Move the body over.
+    Region &body = op.getWorkgroupBody();
+    if (!body.empty()) {
+      Region &newBody = newWorkgroupsOp.getWorkgroupBody();
+      rewriter.inlineRegionBefore(body, newBody, newBody.begin());
+    }
+
+    // Move the workgroup count region over.
+    Region &count = op.getWorkgroupCount();
+    if (!count.empty()) {
+      Region &newCount = newWorkgroupsOp.getWorkgroupCount();
+      rewriter.inlineRegionBefore(count, newCount, newCount.begin());
+
+      // Create a new entry basic block with as many arguments as the workload
+      // and then merge this block with the original entry block.
+      auto newWorkloadTypes = llvm::to_vector(
+          llvm::map_range(newWorkload, [](Value v) { return v.getType(); }));
+      auto newWorkloadLocs = llvm::to_vector(
+          llvm::map_range(newWorkload, [](Value v) { return v.getLoc(); }));
+      Block *oldCountBlock = &newCount.front();
+      Block *newCountBlock = rewriter.createBlock(
+          &newCount.front(), newWorkloadTypes, newWorkloadLocs);
+      auto newCountBlockArgs = newCountBlock->getArguments();
+      SmallVector<Value> replacements;
+      replacements.resize(oldCountBlock->getNumArguments());
+      for (auto [index, val] : llvm::enumerate(oldCountBlock->getArguments())) {
+        replacements[index] =
+            newCountBlockArgs[oldWorkloadPosToNewWorkloadPos.lookup(index)];
+      }
+      rewriter.mergeBlocks(oldCountBlock, newCountBlock, replacements);
+    }
+
+    // Replace the old workgroups op with the new workgroups op.
+    rewriter.replaceOp(op, newWorkgroupsOp.getResults());
+    return success();
+  }
+};
+
+/// Deduplicate operands of the `dispatch.workgroup_count_from_slice` op. This
+/// requires updating the `flow.dispatch.workload.ordinal` operation in
+/// the body of the `dispatch.workgroups` op to match the new positions
+/// of the operands in the `dispatch.workgroup_count_from_slice`.
+struct ElideRedundantOperandsOfWorkgroupCountFromSliceOp
+    : OpRewritePattern<DispatchWorkgroupsOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(DispatchWorkgroupsOp op,
+                                PatternRewriter &rewriter) const override {
+    Region &count = op.getWorkgroupCount();
+    if (count.empty()) {
+      return failure();
+    }
+
+    assert(
+        llvm::hasSingleElement(count) &&
+        "expected dispatch.workgroup op count region to have a single block");
+
+    // Check for `dispatch.workgroup_count_from_slice` operations in the count
+    // region.
+    Block &countBody = count.front();
+    auto countFromSliceOps =
+        countBody.getOps<DispatchWorkgroupCountFromSliceOp>();
+    if (countFromSliceOps.empty()) {
+      return failure();
+    }
+    assert(llvm::hasSingleElement(countFromSliceOps) &&
+           "expected only one dispatch.workgroup_count_from_slice op in count "
+           "region");
+    auto countFromSliceOp = *countFromSliceOps.begin();
+
+    // Deduplicate the operands and get a mapping from old position to new
+    // position.
+    auto [newOrdinals, oldOrdinalPosToNewOrdinalPos] =
+        dedupAndGetOldToNewPosMapping(countFromSliceOp.getOperands());
+    if (newOrdinals.size() == countFromSliceOp.getNumOperands()) {
+      return failure();
+    }
+
+    // Replace the old `dispatch.workgroup_count_from_slice` with a new op
+    // with deduped operands.
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(countFromSliceOp);
+    rewriter.replaceOpWithNewOp<DispatchWorkgroupCountFromSliceOp>(
+        countFromSliceOp, newOrdinals);
+
+    // Adjust the flow.dispatch.workload.ordinal ops in the body to use
+    // the new ordinal numbers.
+    Region &body = op.getWorkgroupBody();
+    SmallVector<DispatchWorkloadOrdinalOp> ordinalOps;
+    body.walk([&](DispatchWorkloadOrdinalOp ordinalOp) {
+      ordinalOps.push_back(ordinalOp);
+    });
+
+    for (auto ordinalOp : ordinalOps) {
+      int oldOrdinalPos = ordinalOp.getOrdinal().getSExtValue();
+      rewriter.setInsertionPoint(ordinalOp);
+      rewriter.replaceOpWithNewOp<DispatchWorkloadOrdinalOp>(
+          ordinalOp, ordinalOp.getOperand(),
+          rewriter.getIndexAttr(
+              oldOrdinalPosToNewOrdinalPos.lookup(oldOrdinalPos)));
+    }
+    rewriter.updateRootInPlace(op, []() {});
+    return success();
+  }
+};
+
 void DispatchWorkgroupsOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   // Disable constant inlining as we have done it during dispatch region
@@ -216,7 +368,9 @@ void DispatchWorkgroupsOp::getCanonicalizationPatterns(
   closureOptions.maxInlinedConstantBytes = 0;
   results.insert<IREE::Util::ClosureOptimizationPattern<DispatchWorkgroupsOp>>(
       context, closureOptions);
-  results.insert<ReplaceDispatchResultIfZeroElements>(context);
+  results.insert<ElideRedundantWorkloadValues,
+                 ElideRedundantOperandsOfWorkgroupCountFromSliceOp,
+                 ReplaceDispatchResultIfZeroElements>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -257,6 +411,24 @@ struct BubbleUpOrdinalOp : public OpRewritePattern<DispatchWorkloadOrdinalOp> {
     return success();
   }
 };
+
+/// Fold away following sequence of `flow.dispatch.workload.ordinal`.
+///
+/// ```mlir
+/// %1 = flow.dispatch.workload.ordinal %0 2
+/// %2 = flow.dispatch.workload.ordinal %1 2
+/// ```
+///
+/// This can happen when the operands get deduped.
+OpFoldResult DispatchWorkloadOrdinalOp::fold(FoldAdaptor operands) {
+  if (auto producerOrdinalOp = dyn_cast_or_null<DispatchWorkloadOrdinalOp>(
+          getOperand().getDefiningOp())) {
+    if (producerOrdinalOp.getOrdinal() == getOrdinal()) {
+      return producerOrdinalOp.getOperand();
+    }
+  }
+  return {};
+}
 
 void DispatchWorkloadOrdinalOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1122,6 +1122,14 @@ DispatchWorkgroupsOp::getTiedOperandsIndexAndLength() {
   return getODSOperandIndexAndLength(1);
 }
 
+SmallVector<int64_t> DispatchWorkgroupsOp::getTiedOperandsAsIntegerList() {
+  ArrayAttr attr = getTiedOperandsAttr();
+  if (!attr) return {};
+  return llvm::to_vector(llvm::map_range(attr, [](Attribute intAttr) {
+    return intAttr.cast<IntegerAttr>().getInt();
+  }));
+}
+
 //===----------------------------------------------------------------------===//
 // flow.dispatch.workgroup.*
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -215,6 +215,9 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
     /// signature. In case an output is tied to an input, the return list
     /// overlaps with `getInputBlockArguments`.
     SmallVector<BlockArgument> getOutputBlockArguments();
+
+    /// Returns the tiedOperands attribute as a list of integers.
+    SmallVector<int64_t> getTiedOperandsAsIntegerList();
   }];
 
   let hasVerifier = 1;
@@ -1539,6 +1542,8 @@ def FLOW_DispatchWorkloadOrdinalOp :
   }];
 
   let hasCanonicalizer = 1;
+
+  let hasFolder = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1538,7 +1538,7 @@ def FLOW_DispatchWorkloadOrdinalOp :
   }];
 
   let assemblyFormat = [{
-    attr-dict $operand $ordinal `:` type($operand)
+    attr-dict $operand `,` $ordinal `:` type($operand)
   }];
 
   let hasCanonicalizer = 1;

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1537,6 +1537,8 @@ def FLOW_DispatchWorkloadOrdinalOp :
   let assemblyFormat = [{
     attr-dict $operand $ordinal `:` type($operand)
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
@@ -27,7 +27,7 @@ func.func @dontInlineReadWrite(%arg0: tensor<1x4xf32>) -> tensor<4x8xf32> {
 // CHECK-LABEL: func.func @remove_unused_result
 func.func @remove_unused_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
   %c1 = arith.constant 1 : index
-  //      CHECK: flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> tensor<i32> =
+  //      CHECK: flow.dispatch.workgroups[%c1]() : () -> tensor<i32> =
   // CHECK-NEXT:   (%{{.+}}: !flow.dispatch.tensor<writeonly:tensor<i32>>)
   //      CHECK: flow.dispatch.tensor.store
   //  CHECK-NOT: flow.dispatch.tensor.store
@@ -52,7 +52,7 @@ func.func @remove_unused_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) ->
 // CHECK-LABEL: func.func @remove_unused_dynamic_result
 func.func @remove_unused_dynamic_result(%dim: index) -> (tensor<i32>) {
   %c1 = arith.constant 1 : index
-  //      CHECK: flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> tensor<i32> =
+  //      CHECK: flow.dispatch.workgroups[%c1]() : () -> tensor<i32> =
   // CHECK-NEXT:   (%{{.+}}: !flow.dispatch.tensor<writeonly:tensor<i32>>)
   //  CHECK-NOT: flow.dispatch.tie_shape
   //      CHECK: flow.dispatch.tensor.store
@@ -81,7 +81,7 @@ func.func @remove_unused_dynamic_result(%dim: index) -> (tensor<i32>) {
 // CHECK-LABEL: func.func @remove_unused_read_write_result
 func.func @remove_unused_read_write_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
   %c1 = arith.constant 1 : index
-  //      CHECK: flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> tensor<i32> =
+  //      CHECK: flow.dispatch.workgroups[%c1]() : () -> tensor<i32> =
   // CHECK-NEXT:   (%{{.+}}: !flow.dispatch.tensor<writeonly:tensor<i32>>)
   //      CHECK: flow.dispatch.tensor.store %{{.+}},
   //  CHECK-NOT: flow.dispatch.tensor.store
@@ -106,7 +106,7 @@ func.func @remove_unused_read_write_result(%arg0 : tensor<9xi32>, %arg1 : tensor
 // CHECK-LABEL: func.func @keep_used_read_write_result
 func.func @keep_used_read_write_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
   %c1 = arith.constant 1 : index
-  //      CHECK: flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> (tensor<i32>, tensor<i32>) =
+  //      CHECK: flow.dispatch.workgroups[%c1]() : () -> (tensor<i32>, tensor<i32>) =
   // CHECK-NEXT:   (%{{.+}}: !flow.dispatch.tensor<writeonly:tensor<i32>>, %{{.+}}: !flow.dispatch.tensor<readwrite:tensor<i32>>)
   %0:2 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0, %arg1) : (tensor<9xi32>, tensor<9xi32>) -> (tensor<i32>, tensor<i32>) =
       (%arg0: !flow.dispatch.tensor<readonly:tensor<9xi32>>, %arg1: !flow.dispatch.tensor<readonly:tensor<9xi32>>, %arg2: !flow.dispatch.tensor<writeonly:tensor<i32>>, %arg3: !flow.dispatch.tensor<readwrite:tensor<i32>>) {
@@ -175,4 +175,85 @@ func.func @bubble_up_ordinal_ops(%arg0 : index, %arg1 : index) -> tensor<?x?xf32
     flow.return
   }  
   return %result : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @dedup_workgroup_count_from_slice_operands(
+func.func @dedup_workgroup_count_from_slice_operands(
+  %arg0 : index, %arg1 : index, %arg2 : index) -> tensor<?x?x?x?x?xf32> {
+  %result = flow.dispatch.workgroups [%arg0, %arg1, %arg2](%arg0, %arg1, %arg2)
+      : (index, index, index) -> tensor<?x?x?x?x?xf32>{%arg0, %arg1, %arg2, %arg2, %arg0} =
+      (%b0 : index, %b1 : index, %b2 : index, %b3 : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>) {
+    //      CHECK: flow.dispatch.workgroups
+    // CHECK-NEXT:   (%[[B0:[a-zA-Z0-9]+]]: index, %[[B1:[a-zA-Z0-9]+]]: index, %[[B2:[a-zA-Z0-9]+]]: index
+    //  CHECK-DAG:   %[[WL0:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0
+    //  CHECK-DAG:   %[[WL1:.+]] = flow.dispatch.workload.ordinal %[[B1]] 1
+    //  CHECK-DAG:   %[[WL2:.+]] = flow.dispatch.workload.ordinal %[[B2]] 2
+    //  CHECK-DAG:   %[[WL3:.+]] = flow.dispatch.workload.ordinal %[[B2]] 2
+    //  CHECK-DAG:   %[[WL4:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0
+    //      CHECK:   tensor.empty(%[[WL0]], %[[WL1]], %[[WL2]], %[[WL3]], %[[WL4]])
+    %wl0 = flow.dispatch.workload.ordinal %b0 0 : index
+    %wl1 = flow.dispatch.workload.ordinal %b1 1 : index
+    %wl2 = flow.dispatch.workload.ordinal %b2 2 : index
+    %wl3 = flow.dispatch.workload.ordinal %b2 3 : index
+    %wl4 = flow.dispatch.workload.ordinal %b0 4 : index
+    %out_binding = flow.dispatch.tie_shape %b3
+        : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>{%wl0, %wl1, %wl2, %wl3, %wl4}
+    %tensor = tensor.empty(%wl0, %wl1, %wl2, %wl3, %wl4) : tensor<?x?x?x?x?xf32>
+    flow.dispatch.tensor.store %tensor, %out_binding,
+        offsets = [0, 0, 0, 0, 0], sizes = [%wl0, %wl1, %wl2, %wl3, %wl4], strides = [1, 1, 1, 1, 1]
+        : tensor<?x?x?x?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>{%wl0, %wl1, %wl2, %wl3, %wl4}
+    flow.return
+  } count(%b0 : index, %b1 : index, %b2 : index) -> (index, index, index) {
+    //     CHECK: count(%[[B0:[a-zA-Z0-9]+]]: index, %[[B1:[a-zA-Z0-9]+]]: index, %[[B2:[a-zA-Z0-9]+]]: index)
+    //     CHECK: flow.dispatch.workgroup_count_from_slice %[[B0]], %[[B1]], %[[B2]]
+    // CHECK-NOT: %[[B2]]
+    // CHECK-NOT: %[[B0]]
+    %x, %y, %z = flow.dispatch.workgroup_count_from_slice %b0, %b1, %b2, %b2, %b0
+    flow.return %x, %y, %z : index, index, index
+  }
+  return %result :tensor<?x?x?x?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @dedup_workload(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index)
+func.func @dedup_workload(
+  %arg0 : index, %arg1 : index, %arg2 : index) -> tensor<?x?x?x?x?xf32> {
+  %result = flow.dispatch.workgroups [%arg0, %arg1, %arg2, %arg2, %arg0](%arg0, %arg1, %arg2)
+      : (index, index, index) -> tensor<?x?x?x?x?xf32>{%arg0, %arg1, %arg2, %arg2, %arg0} =
+      (%b0 : index, %b1 : index, %b2 : index, %b3 : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>) {
+    //      CHECK: flow.dispatch.workgroups[%[[ARG0]], %[[ARG1]], %[[ARG2]]]
+    // CHECK-NEXT:   (%[[B0:[a-zA-Z0-9]+]]: index, %[[B1:[a-zA-Z0-9]+]]: index, %[[B2:[a-zA-Z0-9]+]]: index
+    //  CHECK-DAG:   %[[WL0:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0
+    //  CHECK-DAG:   %[[WL1:.+]] = flow.dispatch.workload.ordinal %[[B1]] 1
+    //  CHECK-DAG:   %[[WL2:.+]] = flow.dispatch.workload.ordinal %[[B2]] 2
+    //  CHECK-DAG:   %[[WL3:.+]] = flow.dispatch.workload.ordinal %[[B2]] 2
+    //  CHECK-DAG:   %[[WL4:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0
+    //      CHECK:   tensor.empty(%[[WL0]], %[[WL1]], %[[WL2]], %[[WL3]], %[[WL4]])
+    %wl0 = flow.dispatch.workload.ordinal %b0 0 : index
+    %wl1 = flow.dispatch.workload.ordinal %b1 1 : index
+    %wl2 = flow.dispatch.workload.ordinal %b2 2 : index
+    %wl3 = flow.dispatch.workload.ordinal %b2 3 : index
+    %wl4 = flow.dispatch.workload.ordinal %b0 4 : index
+    %out_binding = flow.dispatch.tie_shape %b3
+        : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>{%wl0, %wl1, %wl2, %wl3, %wl4}
+    %tensor = tensor.empty(%wl0, %wl1, %wl2, %wl3, %wl4) : tensor<?x?x?x?x?xf32>
+    flow.dispatch.tensor.store %tensor, %out_binding,
+        offsets = [0, 0, 0, 0, 0], sizes = [%wl0, %wl1, %wl2, %wl3, %wl4], strides = [1, 1, 1, 1, 1]
+        : tensor<?x?x?x?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>{%wl0, %wl1, %wl2, %wl3, %wl4}
+    flow.return
+  } count(%b0 : index, %b1 : index, %b2 : index, %b3 : index, %b4 : index) -> (index, index, index) {
+    //     CHECK: count(%[[B0:[a-zA-Z0-9]+]]: index, %[[B1:[a-zA-Z0-9]+]]: index, %[[B2:[a-zA-Z0-9]+]]: index)
+    //     CHECK: flow.dispatch.workgroup_count_from_slice %[[B0]], %[[B1]], %[[B2]]
+    // CHECK-NOT: %[[B2]]
+    // CHECK-NOT: %[[B0]]
+    %x, %y, %z = flow.dispatch.workgroup_count_from_slice %b0, %b1, %b2, %b3, %b4
+    flow.return %x, %y, %z : index, index, index
+  }
+  return %result :tensor<?x?x?x?x?xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
@@ -158,8 +158,8 @@ func.func @bubble_up_ordinal_ops(%arg0 : index, %arg1 : index) -> tensor<?x?xf32
     // CHECK-NEXT:     %[[B0:[a-zA-Z0-9]+]]: index,
     // CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: index,
     // CHECK-SAME:     %[[B2:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
-    //  CHECK-DAG:   %[[WL0:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0 : index
-    //  CHECK-DAG:   %[[WL1:.+]] = flow.dispatch.workload.ordinal %[[B1]] 1 : index
+    //  CHECK-DAG:   %[[WL0:.+]] = flow.dispatch.workload.ordinal %[[B0]], 0 : index
+    //  CHECK-DAG:   %[[WL1:.+]] = flow.dispatch.workload.ordinal %[[B1]], 1 : index
     //      CHECK:   %[[BINDING:.+]] = flow.dispatch.tie_shape %[[B2]]
     // CHECK-SAME:       !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[WL0]], %[[WL1]]}
     //      CHECK:   %[[EMPTY:.+]] = tensor.empty(%[[WL0]], %[[WL1]])
@@ -167,8 +167,8 @@ func.func @bubble_up_ordinal_ops(%arg0 : index, %arg1 : index) -> tensor<?x?xf32
     // CHECK-SAME:       sizes = [%[[WL0]], %[[WL1]]]
     // CHECK-SAME:       !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[WL0]], %[[WL1]]}
     %binding = flow.dispatch.tie_shape %b2 : !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%b0, %b1}
-    %wl0 = flow.dispatch.workload.ordinal %b0 0 : index
-    %wl1 = flow.dispatch.workload.ordinal %b1 1 : index
+    %wl0 = flow.dispatch.workload.ordinal %b0, 0 : index
+    %wl1 = flow.dispatch.workload.ordinal %b1, 1 : index
     %empty = tensor.empty(%wl0, %wl1) : tensor<?x?xf32>
     flow.dispatch.tensor.store %empty, %binding, offsets = [0, 0], sizes = [%wl0, %wl1], strides = [1, 1]
         : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%wl0, %wl1}
@@ -187,17 +187,15 @@ func.func @dedup_workgroup_count_from_slice_operands(
       (%b0 : index, %b1 : index, %b2 : index, %b3 : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>) {
     //      CHECK: flow.dispatch.workgroups
     // CHECK-NEXT:   (%[[B0:[a-zA-Z0-9]+]]: index, %[[B1:[a-zA-Z0-9]+]]: index, %[[B2:[a-zA-Z0-9]+]]: index
-    //  CHECK-DAG:   %[[WL0:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0
-    //  CHECK-DAG:   %[[WL1:.+]] = flow.dispatch.workload.ordinal %[[B1]] 1
-    //  CHECK-DAG:   %[[WL2:.+]] = flow.dispatch.workload.ordinal %[[B2]] 2
-    //  CHECK-DAG:   %[[WL3:.+]] = flow.dispatch.workload.ordinal %[[B2]] 2
-    //  CHECK-DAG:   %[[WL4:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0
-    //      CHECK:   tensor.empty(%[[WL0]], %[[WL1]], %[[WL2]], %[[WL3]], %[[WL4]])
-    %wl0 = flow.dispatch.workload.ordinal %b0 0 : index
-    %wl1 = flow.dispatch.workload.ordinal %b1 1 : index
-    %wl2 = flow.dispatch.workload.ordinal %b2 2 : index
-    %wl3 = flow.dispatch.workload.ordinal %b2 3 : index
-    %wl4 = flow.dispatch.workload.ordinal %b0 4 : index
+    //  CHECK-DAG:   %[[WL0:.+]] = flow.dispatch.workload.ordinal %[[B0]], 0
+    //  CHECK-DAG:   %[[WL1:.+]] = flow.dispatch.workload.ordinal %[[B1]], 1
+    //  CHECK-DAG:   %[[WL2:.+]] = flow.dispatch.workload.ordinal %[[B2]], 2
+    //      CHECK:   tensor.empty(%[[WL0]], %[[WL1]], %[[WL2]], %[[WL2]], %[[WL0]])
+    %wl0 = flow.dispatch.workload.ordinal %b0, 0 : index
+    %wl1 = flow.dispatch.workload.ordinal %b1, 1 : index
+    %wl2 = flow.dispatch.workload.ordinal %b2, 2 : index
+    %wl3 = flow.dispatch.workload.ordinal %b2, 3 : index
+    %wl4 = flow.dispatch.workload.ordinal %b0, 4 : index
     %out_binding = flow.dispatch.tie_shape %b3
         : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>{%wl0, %wl1, %wl2, %wl3, %wl4}
     %tensor = tensor.empty(%wl0, %wl1, %wl2, %wl3, %wl4) : tensor<?x?x?x?x?xf32>
@@ -229,17 +227,15 @@ func.func @dedup_workload(
       (%b0 : index, %b1 : index, %b2 : index, %b3 : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>) {
     //      CHECK: flow.dispatch.workgroups[%[[ARG0]], %[[ARG1]], %[[ARG2]]]
     // CHECK-NEXT:   (%[[B0:[a-zA-Z0-9]+]]: index, %[[B1:[a-zA-Z0-9]+]]: index, %[[B2:[a-zA-Z0-9]+]]: index
-    //  CHECK-DAG:   %[[WL0:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0
-    //  CHECK-DAG:   %[[WL1:.+]] = flow.dispatch.workload.ordinal %[[B1]] 1
-    //  CHECK-DAG:   %[[WL2:.+]] = flow.dispatch.workload.ordinal %[[B2]] 2
-    //  CHECK-DAG:   %[[WL3:.+]] = flow.dispatch.workload.ordinal %[[B2]] 2
-    //  CHECK-DAG:   %[[WL4:.+]] = flow.dispatch.workload.ordinal %[[B0]] 0
-    //      CHECK:   tensor.empty(%[[WL0]], %[[WL1]], %[[WL2]], %[[WL3]], %[[WL4]])
-    %wl0 = flow.dispatch.workload.ordinal %b0 0 : index
-    %wl1 = flow.dispatch.workload.ordinal %b1 1 : index
-    %wl2 = flow.dispatch.workload.ordinal %b2 2 : index
-    %wl3 = flow.dispatch.workload.ordinal %b2 3 : index
-    %wl4 = flow.dispatch.workload.ordinal %b0 4 : index
+    //  CHECK-DAG:   %[[WL0:.+]] = flow.dispatch.workload.ordinal %[[B0]], 0
+    //  CHECK-DAG:   %[[WL1:.+]] = flow.dispatch.workload.ordinal %[[B1]], 1
+    //  CHECK-DAG:   %[[WL2:.+]] = flow.dispatch.workload.ordinal %[[B2]], 2
+    //      CHECK:   tensor.empty(%[[WL0]], %[[WL1]], %[[WL2]], %[[WL2]], %[[WL0]])
+    %wl0 = flow.dispatch.workload.ordinal %b0, 0 : index
+    %wl1 = flow.dispatch.workload.ordinal %b1, 1 : index
+    %wl2 = flow.dispatch.workload.ordinal %b2, 2 : index
+    %wl3 = flow.dispatch.workload.ordinal %b2, 3 : index
+    %wl4 = flow.dispatch.workload.ordinal %b0, 4 : index
     %out_binding = flow.dispatch.tie_shape %b3
         : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>{%wl0, %wl1, %wl2, %wl3, %wl4}
     %tensor = tensor.empty(%wl0, %wl1, %wl2, %wl3, %wl4) : tensor<?x?x?x?x?xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -29,12 +29,12 @@ func.func @tile_matmul_alone(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
 // CHECK-SAME:       %[[ARG9:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:       %[[ARG10:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:       %[[ARG11:[a-zA-Z0-9_]+]]: index
-//  CHECK-DAG:     %[[ARG6_W:.+]] = flow.dispatch.workload.ordinal %[[ARG6]] 0
-//  CHECK-DAG:     %[[ARG7_W:.+]] = flow.dispatch.workload.ordinal %[[ARG7]] 1
-//  CHECK-DAG:     %[[ARG8_W:.+]] = flow.dispatch.workload.ordinal %[[ARG8]] 2
-//  CHECK-DAG:     %[[ARG9_W:.+]] = flow.dispatch.workload.ordinal %[[ARG9]] 3
-//  CHECK-DAG:     %[[ARG10_W:.+]] = flow.dispatch.workload.ordinal %[[ARG10]] 4
-//  CHECK-DAG:     %[[ARG11_W:.+]] = flow.dispatch.workload.ordinal %[[ARG11]] 5
+//  CHECK-DAG:     %[[ARG6_W:.+]] = flow.dispatch.workload.ordinal %[[ARG6]], 0
+//  CHECK-DAG:     %[[ARG7_W:.+]] = flow.dispatch.workload.ordinal %[[ARG7]], 1
+//  CHECK-DAG:     %[[ARG8_W:.+]] = flow.dispatch.workload.ordinal %[[ARG8]], 2
+//  CHECK-DAG:     %[[ARG9_W:.+]] = flow.dispatch.workload.ordinal %[[ARG9]], 3
+//  CHECK-DAG:     %[[ARG10_W:.+]] = flow.dispatch.workload.ordinal %[[ARG10]], 4
+//  CHECK-DAG:     %[[ARG11_W:.+]] = flow.dispatch.workload.ordinal %[[ARG11]], 5
 //  CHECK-DAG:     %[[LHS:.+]] = flow.dispatch.tensor.load %[[ARG3]]
 // CHECK-SAME:         offsets = [0, 0], sizes = [%[[ARG6_W]], %[[ARG7_W]]], strides = [1, 1]
 //  CHECK-DAG:     %[[RHS:.+]] = flow.dispatch.tensor.load %[[ARG4]]
@@ -84,9 +84,9 @@ func.func @generic_op_alone(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x
 // CHECK-NEXT:       %[[ARG0_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>, %[[ARG1_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:tensor<?xf32>>,
 // CHECK-SAME:       %[[ARG0_D0_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG0_D1_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG1_D0_CAPTURE:[a-zA-Z0-9_]+]]: index,
 // CHECK-SAME:       %[[RET0_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
-//  CHECK-DAG:     %[[ARG0_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]] 0
-//  CHECK-DAG:     %[[ARG0_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]] 1
-//  CHECK-DAG:     %[[ARG1_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D0_CAPTURE]] 2
+//  CHECK-DAG:     %[[ARG0_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]], 0
+//  CHECK-DAG:     %[[ARG0_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]], 1
+//  CHECK-DAG:     %[[ARG1_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D0_CAPTURE]], 2
 //  CHECK-DAG:     %[[LOAD2:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]], {{.*}} : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[ARG0_D0_W]], %[[ARG0_D1_W]]}
 //  CHECK-DAG:     %[[LOAD3:.+]] = flow.dispatch.tensor.load %[[ARG1_CAPTURE]], {{.*}} : !flow.dispatch.tensor<readonly:tensor<?xf32>>{%[[ARG1_D0_W]]}
 //  CHECK-DAG:     %[[INIT:.+]] = tensor.empty
@@ -128,10 +128,10 @@ func.func @fuse_matmul_with_fill(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> 
 //  CHECK-SAME:          %[[ARG1_DIM1_CAPTURE:[a-zA-Z0-9_]+]]: index,
 //  CHECK-SAME:          %[[RET0_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>) {
 //   CHECK-DAG:        %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-//   CHECK-DAG:        %[[ARG0_DIM0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_DIM0_CAPTURE]] 0
-//   CHECK-DAG:        %[[ARG0_DIM1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_DIM1_CAPTURE]] 1
-//   CHECK-DAG:        %[[ARG1_DIM0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_DIM0_CAPTURE]] 2
-//   CHECK-DAG:        %[[ARG1_DIM1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_DIM1_CAPTURE]] 3
+//   CHECK-DAG:        %[[ARG0_DIM0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_DIM0_CAPTURE]], 0
+//   CHECK-DAG:        %[[ARG0_DIM1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_DIM1_CAPTURE]], 1
+//   CHECK-DAG:        %[[ARG1_DIM0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_DIM0_CAPTURE]], 2
+//   CHECK-DAG:        %[[ARG1_DIM1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_DIM1_CAPTURE]], 3
 //   CHECK-DAG:        %[[LHS:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]], {{.*}} : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[ARG0_DIM0_W]], %[[ARG0_DIM1_W]]}
 //   CHECK-DAG:        %[[RHS:.+]] = flow.dispatch.tensor.load %[[ARG1_CAPTURE]], {{.*}} : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[ARG1_DIM0_W]], %[[ARG1_DIM1_W]]}
 //   CHECK-DAG:        %[[INIT:.+]] = tensor.empty
@@ -424,14 +424,14 @@ func.func @subtensor_insert(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>,
 // CHECK-SAME:       %[[ARG0_D1_CAPTURE:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[ARG1_D0_CAPTURE:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[ARG1_D1_CAPTURE:[a-zA-Z0-9]+]]: index
-//  CHECK-DAG:     %[[ARG2_W:.+]] = flow.dispatch.workload.ordinal %[[ARG2_CAPTURE]] 0
-//  CHECK-DAG:     %[[ARG3_W:.+]] = flow.dispatch.workload.ordinal %[[ARG3_CAPTURE]] 1
-//  CHECK-DAG:     %[[ARG4_W:.+]] = flow.dispatch.workload.ordinal %[[ARG4_CAPTURE]] 2
-//  CHECK-DAG:     %[[ARG5_W:.+]] = flow.dispatch.workload.ordinal %[[ARG5_CAPTURE]] 3
-//  CHECK-DAG:     %[[ARG0_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]] 4
-//  CHECK-DAG:     %[[ARG0_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]] 5
-//  CHECK-DAG:     %[[ARG1_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D0_CAPTURE]] 6
-//  CHECK-DAG:     %[[ARG1_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D1_CAPTURE]] 7
+//  CHECK-DAG:     %[[ARG2_W:.+]] = flow.dispatch.workload.ordinal %[[ARG2_CAPTURE]], 0
+//  CHECK-DAG:     %[[ARG3_W:.+]] = flow.dispatch.workload.ordinal %[[ARG3_CAPTURE]], 1
+//  CHECK-DAG:     %[[ARG4_W:.+]] = flow.dispatch.workload.ordinal %[[ARG4_CAPTURE]], 2
+//  CHECK-DAG:     %[[ARG5_W:.+]] = flow.dispatch.workload.ordinal %[[ARG5_CAPTURE]], 3
+//  CHECK-DAG:     %[[ARG0_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]], 4
+//  CHECK-DAG:     %[[ARG0_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]], 5
+//  CHECK-DAG:     %[[ARG1_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D0_CAPTURE]], 6
+//  CHECK-DAG:     %[[ARG1_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D1_CAPTURE]], 7
 //      CHECK:     %[[SRC:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]]
 // CHECK-SAME:         offsets = [0, 0], sizes = [%[[ARG0_D0_W]], %[[ARG0_D1_W]]]
 //      CHECK:     flow.dispatch.tensor.store %[[SRC]], %[[ARG1_CAPTURE]]
@@ -891,12 +891,12 @@ func.func @sort_3d(%arg0: tensor<?x?x?xi32>, %arg1 : tensor<?x?x?xf32>)
 // CHECK-SAME:        %[[ARG1_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readwrite:tensor<?x?x?xf32>>,
 // CHECK-SAME:        %[[ARG0_D0_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG0_D1_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG0_D2_CAPTURE:[a-zA-Z0-9_]+]]: index,
 // CHECK-SAME:        %[[ARG1_D0_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG1_D1_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG1_D2_CAPTURE:[a-zA-Z0-9_]+]]: index) {
-//  CHECK-DAG:     %[[ARG0_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]] 0
-//  CHECK-DAG:     %[[ARG0_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]] 1
-//  CHECK-DAG:     %[[ARG0_D2_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D2_CAPTURE]] 2
-//  CHECK-DAG:     %[[ARG1_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D0_CAPTURE]] 3
-//  CHECK-DAG:     %[[ARG1_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D1_CAPTURE]] 4
-//  CHECK-DAG:     %[[ARG1_D2_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D2_CAPTURE]] 5
+//  CHECK-DAG:     %[[ARG0_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]], 0
+//  CHECK-DAG:     %[[ARG0_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]], 1
+//  CHECK-DAG:     %[[ARG0_D2_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D2_CAPTURE]], 2
+//  CHECK-DAG:     %[[ARG1_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D0_CAPTURE]], 3
+//  CHECK-DAG:     %[[ARG1_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D1_CAPTURE]], 4
+//  CHECK-DAG:     %[[ARG1_D2_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D2_CAPTURE]], 5
 //      CHECK:     %[[OUT1:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]]
 // CHECK-SAME:         offsets = [0, 0, 0], sizes = [%[[ARG0_D0_W]], %[[ARG0_D1_W]], %[[ARG0_D2_W]]]
 //      CHECK:     %[[OUT2:.+]] = flow.dispatch.tensor.load %[[ARG1_CAPTURE]]
@@ -1062,12 +1062,12 @@ func.func @extract_slice(%arg0 : tensor<?x?xf32>, %arg1 : index, %arg2 : index,
 // CHECK-SAME:     %[[ARG3_CAPTURE:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:     %[[ARG4_CAPTURE:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
-//  CHECK-DAG:     %[[ARG1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_CAPTURE]] 0
-//  CHECK-DAG:     %[[ARG2_W:.+]] = flow.dispatch.workload.ordinal %[[ARG2_CAPTURE]] 1
-//  CHECK-DAG:     %[[ARG5_W:.+]] = flow.dispatch.workload.ordinal %[[ARG5_CAPTURE]] 2
-//  CHECK-DAG:     %[[ARG6_W:.+]] = flow.dispatch.workload.ordinal %[[ARG6_CAPTURE]] 3
-//  CHECK-DAG:     %[[ARG3_W:.+]] = flow.dispatch.workload.ordinal %[[ARG3_CAPTURE]] 6
-//  CHECK-DAG:     %[[ARG4_W:.+]] = flow.dispatch.workload.ordinal %[[ARG4_CAPTURE]] 7
+//  CHECK-DAG:     %[[ARG1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_CAPTURE]], 0
+//  CHECK-DAG:     %[[ARG2_W:.+]] = flow.dispatch.workload.ordinal %[[ARG2_CAPTURE]], 1
+//  CHECK-DAG:     %[[ARG5_W:.+]] = flow.dispatch.workload.ordinal %[[ARG5_CAPTURE]], 2
+//  CHECK-DAG:     %[[ARG6_W:.+]] = flow.dispatch.workload.ordinal %[[ARG6_CAPTURE]], 3
+//  CHECK-DAG:     %[[ARG3_W:.+]] = flow.dispatch.workload.ordinal %[[ARG3_CAPTURE]], 6
+//  CHECK-DAG:     %[[ARG4_W:.+]] = flow.dispatch.workload.ordinal %[[ARG4_CAPTURE]], 7
 //      CHECK:     %[[SLICE:.+]] = flow.dispatch.tensor.load %[[INPUT]]
 // CHECK-SAME:         offsets = [%[[ARG1_W]], %[[ARG2_W]]], sizes = [%[[ARG3_W]], %[[ARG4_W]]], strides = [%[[ARG5_W]], %[[ARG6_W]]]
 //      CHECK:     flow.dispatch.tensor.store %[[SLICE]], %[[OUTPUT]],
@@ -1370,19 +1370,19 @@ func.func @generic_tensor_insert(%arg0 : tensor<?x?xf32>,
 // CHECK-SAME:        %[[SOURCE_D1_CAPTURE:[a-zA-Z0-9]+]]: index,
 // CHECK-SAME:        %[[DEST_D0_CAPTURE:[a-zA-Z0-9]+]]: index,
 // CHECK-SAME:        %[[DEST_D1_CAPTURE:[a-zA-Z0-9]+]]: index)
-//  CHECK-DAG:     %[[SOURCE_OFFSET_Y_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_OFFSET_Y_CAPTURE]] 0
-//  CHECK-DAG:     %[[SOURCE_OFFSET_X_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_OFFSET_X_CAPTURE]] 1
-//  CHECK-DAG:     %[[SLICE_SIZE_W:.+]] = flow.dispatch.workload.ordinal %[[SLICE_SIZE_CAPTURE]] 2
-//  CHECK-DAG:     %[[SOURCE_STRIDE_Y_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_STRIDE_Y_CAPTURE]] 3
-//  CHECK-DAG:     %[[SOURCE_STRIDE_X_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_STRIDE_X_CAPTURE]] 4
-//  CHECK-DAG:     %[[DEST_OFFSET_Y_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_OFFSET_Y_CAPTURE]] 5
-//  CHECK-DAG:     %[[DEST_OFFSET_X_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_OFFSET_X_CAPTURE]] 6
-//  CHECK-DAG:     %[[DEST_STRIDE_Y_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_STRIDE_Y_CAPTURE]] 7
-//  CHECK-DAG:     %[[DEST_STRIDE_X_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_STRIDE_X_CAPTURE]] 8
-//  CHECK-DAG:     %[[SOURCE_D0_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_D0_CAPTURE]] 9
-//  CHECK-DAG:     %[[SOURCE_D1_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_D1_CAPTURE]] 10
-//  CHECK-DAG:     %[[DEST_D0_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_D0_CAPTURE]] 11
-//  CHECK-DAG:     %[[DEST_D1_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_D1_CAPTURE]] 12
+//  CHECK-DAG:     %[[SOURCE_OFFSET_Y_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_OFFSET_Y_CAPTURE]], 0
+//  CHECK-DAG:     %[[SOURCE_OFFSET_X_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_OFFSET_X_CAPTURE]], 1
+//  CHECK-DAG:     %[[SLICE_SIZE_W:.+]] = flow.dispatch.workload.ordinal %[[SLICE_SIZE_CAPTURE]], 2
+//  CHECK-DAG:     %[[SOURCE_STRIDE_Y_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_STRIDE_Y_CAPTURE]], 3
+//  CHECK-DAG:     %[[SOURCE_STRIDE_X_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_STRIDE_X_CAPTURE]], 4
+//  CHECK-DAG:     %[[DEST_OFFSET_Y_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_OFFSET_Y_CAPTURE]], 5
+//  CHECK-DAG:     %[[DEST_OFFSET_X_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_OFFSET_X_CAPTURE]], 6
+//  CHECK-DAG:     %[[DEST_STRIDE_Y_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_STRIDE_Y_CAPTURE]], 7
+//  CHECK-DAG:     %[[DEST_STRIDE_X_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_STRIDE_X_CAPTURE]], 8
+//  CHECK-DAG:     %[[SOURCE_D0_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_D0_CAPTURE]], 9
+//  CHECK-DAG:     %[[SOURCE_D1_W:.+]] = flow.dispatch.workload.ordinal %[[SOURCE_D1_CAPTURE]], 10
+//  CHECK-DAG:     %[[DEST_D0_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_D0_CAPTURE]], 11
+//  CHECK-DAG:     %[[DEST_D1_W:.+]] = flow.dispatch.workload.ordinal %[[DEST_D1_CAPTURE]], 12
 //      CHECK:     %[[SLICE:.+]] = flow.dispatch.tensor.load %[[SOURCE_CAPTURE]]
 // CHECK-SAME:         offsets = [%[[SOURCE_OFFSET_Y_W]], %[[SOURCE_OFFSET_X_W]]]
 // CHECK-SAME:         sizes = [1, %[[SLICE_SIZE_W]]]
@@ -1436,9 +1436,9 @@ func.func @multi_use_producer_fusion(%arg0 : tensor<?x8xf32>, %arg1 : tensor<8x?
 // CHECK-SAME:       %[[D2_CAPTURE:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[RESULT0:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
 // CHECK-SAME:       %[[RESULT1:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
-//  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[D0_CAPTURE]] 0
-//  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[D1_CAPTURE]] 1
-//  CHECK-DAG:     %[[D2_W:.+]] = flow.dispatch.workload.ordinal %[[D2_CAPTURE]] 2
+//  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[D0_CAPTURE]], 0
+//  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[D1_CAPTURE]], 1
+//  CHECK-DAG:     %[[D2_W:.+]] = flow.dispatch.workload.ordinal %[[D2_CAPTURE]], 2
 //  CHECK-DAG:     %[[LHS:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]]
 //  CHECK-DAG:     %[[RHS:.+]] = flow.dispatch.tensor.load %[[ARG1_CAPTURE]]
 //  CHECK-DAG:     %[[BIAS:.+]] = flow.dispatch.tensor.load %[[ARG2_CAPTURE]]
@@ -1858,8 +1858,8 @@ func.func @set_encoding_op(%arg0 : tensor<?x?xf32>)
 // CHECK-SAME:     %[[INDEXARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:     %[[INDEXARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:     %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>
-//  CHECK-DAG:     %[[W0:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 0
-//  CHECK-DAG:     %[[W1:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 1
+//  CHECK-DAG:     %[[W0:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]], 0
+//  CHECK-DAG:     %[[W1:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]], 1
 //      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
 // CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[W0]], %[[W1]]}
 //      CHECK:     %[[ENCODING:.+]] = iree_linalg_ext.set_encoding %[[LOAD]]
@@ -1891,8 +1891,8 @@ func.func @unset_encoding_op(%arg0 : tensor<?x?xf32, #iree_linalg_ext.encoding<M
 // CHECK-SAME:       %[[INDEXARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[INDEXARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
-//  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 0
-//  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 1
+//  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]], 0
+//  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]], 1
 //      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
 // CHECK-SAME:         sizes = [%[[D0_W]], %[[D1_W]]]
 // CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>{%[[D0_W]], %[[D1_W]]}
@@ -1942,10 +1942,10 @@ func.func @pad_and_set_encoding_op(%arg0 : tensor<?x?xf32>)
 // CHECK-SAME:       %[[PADDED_D0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[PADDED_D1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>
-//  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 0
-//  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 1
-//  CHECK-DAG:     %[[PADDED_D0_W:.+]] = flow.dispatch.workload.ordinal %[[PADDED_D0]] 2
-//  CHECK-DAG:     %[[PADDED_D1_W:.+]] = flow.dispatch.workload.ordinal %[[PADDED_D1]] 3
+//  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]], 0
+//  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]], 1
+//  CHECK-DAG:     %[[PADDED_D0_W:.+]] = flow.dispatch.workload.ordinal %[[PADDED_D0]], 2
+//  CHECK-DAG:     %[[PADDED_D1_W:.+]] = flow.dispatch.workload.ordinal %[[PADDED_D1]], 3
 //      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
 // CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[D0_W]], %[[D1_W]]}
 //      CHECK:     %[[HIGHPAD1:.+]] = affine.apply #[[MAP1]]()[%[[D1_W]]]
@@ -1988,10 +1988,10 @@ func.func @unset_encoding_and_slice(
 // CHECK-SAME:       %[[INDEXARG2:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[INDEXARG3:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
-//  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 0
-//  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 1
-//  CHECK-DAG:     %[[ARG0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG2]] 2
-//  CHECK-DAG:     %[[ARG1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG3]] 3
+//  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]], 0
+//  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]], 1
+//  CHECK-DAG:     %[[ARG0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG2]], 2
+//  CHECK-DAG:     %[[ARG1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG3]], 3
 //      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
 // CHECK-SAME:         sizes = [%[[D0_W]], %[[D1_W]]]
 // CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>{%[[D0_W]], %[[D1_W]]}

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -79,7 +79,7 @@ func.func @generic_op_alone(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x
 //  CHECK-DAG:   %[[ARG0_D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[ARG0_D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[ARG1_D0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
-//      CHECK:   flow.dispatch.workgroups[%[[ARG0_D0]], %[[ARG0_D1]], %[[ARG1_D0]], %[[ARG0_D0]], %[[ARG0_D1]]]
+//      CHECK:   flow.dispatch.workgroups[%[[ARG0_D0]], %[[ARG0_D1]], %[[ARG1_D0]]]
 // CHECK-SAME:       (%[[ARG0]], %[[ARG1]], %[[ARG0_D0]], %[[ARG0_D1]], %[[ARG1_D0]])
 // CHECK-NEXT:       %[[ARG0_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>, %[[ARG1_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:tensor<?xf32>>,
 // CHECK-SAME:       %[[ARG0_D0_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG0_D1_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG1_D0_CAPTURE:[a-zA-Z0-9_]+]]: index,
@@ -87,15 +87,13 @@ func.func @generic_op_alone(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x
 //  CHECK-DAG:     %[[ARG0_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]] 0
 //  CHECK-DAG:     %[[ARG0_D1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]] 1
 //  CHECK-DAG:     %[[ARG1_D0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_D0_CAPTURE]] 2
-//  CHECK-DAG:     %[[ARG0_D0_W_0:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]] 3
-//  CHECK-DAG:     %[[ARG0_D1_W_0:.+]] = flow.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]] 4
 //  CHECK-DAG:     %[[LOAD2:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]], {{.*}} : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[ARG0_D0_W]], %[[ARG0_D1_W]]}
 //  CHECK-DAG:     %[[LOAD3:.+]] = flow.dispatch.tensor.load %[[ARG1_CAPTURE]], {{.*}} : !flow.dispatch.tensor<readonly:tensor<?xf32>>{%[[ARG1_D0_W]]}
 //  CHECK-DAG:     %[[INIT:.+]] = tensor.empty
 //      CHECK:     %[[RESULT:.+]] = linalg.generic
 // CHECK-SAME:         ins(%[[LOAD2]], %[[LOAD3]] : tensor<?x?xf32>, tensor<?xf32>)
 // CHECK-SAME:         outs(%[[INIT]] : tensor<?x?xf32>)
-//      CHECK:     flow.dispatch.tensor.store %[[RESULT]], %[[RET0_CAPTURE]], {{.*}} -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[ARG0_D0_W_0]], %[[ARG0_D1_W_0]]}
+//      CHECK:     flow.dispatch.tensor.store %[[RESULT]], %[[RET0_CAPTURE]], {{.*}} -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[ARG0_D0_W]], %[[ARG0_D1_W]]}
 
 // -----
 
@@ -120,7 +118,7 @@ func.func @fuse_matmul_with_fill(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> 
 //   CHECK-DAG:     %[[ARG0_DIM1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //   CHECK-DAG:     %[[ARG1_DIM0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //   CHECK-DAG:     %[[ARG1_DIM1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
-//  CHECK-NEXT:     flow.dispatch.workgroups[%[[ARG0_DIM0]], %[[ARG0_DIM1]], %[[ARG1_DIM0]], %[[ARG1_DIM1]], %[[ARG0_DIM0]], %[[ARG1_DIM1]]]
+//  CHECK-NEXT:     flow.dispatch.workgroups[%[[ARG0_DIM0]], %[[ARG0_DIM1]], %[[ARG1_DIM0]], %[[ARG1_DIM1]]]
 //  CHECK-SAME:         (%[[ARG0]], %[[ARG1]], %[[ARG0_DIM0]], %[[ARG0_DIM1]], %[[ARG1_DIM0]], %[[ARG1_DIM1]])
 //  CHECK-NEXT:         (%[[ARG0_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>,
 //  CHECK-SAME:          %[[ARG1_CAPTURE:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>,
@@ -134,8 +132,6 @@ func.func @fuse_matmul_with_fill(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> 
 //   CHECK-DAG:        %[[ARG0_DIM1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG0_DIM1_CAPTURE]] 1
 //   CHECK-DAG:        %[[ARG1_DIM0_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_DIM0_CAPTURE]] 2
 //   CHECK-DAG:        %[[ARG1_DIM1_W:.+]] = flow.dispatch.workload.ordinal %[[ARG1_DIM1_CAPTURE]] 3
-//   CHECK-DAG:        %[[ARG0_DIM0_W_0:.+]] = flow.dispatch.workload.ordinal %[[ARG0_DIM0_CAPTURE]] 4
-//   CHECK-DAG:        %[[ARG1_DIM1_W_0:.+]] = flow.dispatch.workload.ordinal %[[ARG1_DIM1_CAPTURE]] 5
 //   CHECK-DAG:        %[[LHS:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]], {{.*}} : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[ARG0_DIM0_W]], %[[ARG0_DIM1_W]]}
 //   CHECK-DAG:        %[[RHS:.+]] = flow.dispatch.tensor.load %[[ARG1_CAPTURE]], {{.*}} : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[ARG1_DIM0_W]], %[[ARG1_DIM1_W]]}
 //   CHECK-DAG:        %[[INIT:.+]] = tensor.empty
@@ -145,7 +141,7 @@ func.func @fuse_matmul_with_fill(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> 
 //       CHECK:        %[[RESULT:.+]] = linalg.matmul
 //  CHECK-SAME:            ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>)
 //  CHECK-SAME:            outs(%[[FILL]] : tensor<?x?xf32>)
-//       CHECK:        flow.dispatch.tensor.store %[[RESULT]], %[[RET0_CAPTURE]], {{.*}} -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[ARG0_DIM0_W_0]], %[[ARG1_DIM1_W_0]]}
+//       CHECK:        flow.dispatch.tensor.store %[[RESULT]], %[[RET0_CAPTURE]], {{.*}} -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[ARG0_DIM0_W]], %[[ARG1_DIM1_W]]}
 //       CHECK:        flow.return
 
 // -----
@@ -240,11 +236,11 @@ func.func @always_fuse_cast
 //  CHECK-DAG:   %[[N1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[N2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[RESULT1:.+]] = flow.dispatch.workgroups[%[[M]], %[[K]], %[[N1]], %[[M]], %[[N1]]]
+//      CHECK:   %[[RESULT1:.+]] = flow.dispatch.workgroups[%[[M]], %[[K]], %[[N1]]]
 // CHECK-SAME:     (%[[ARG0]], %[[ARG1]], %[[M]], %[[K]], %[[N1]])
 //      CHECK:     tensor.cast
 //      CHECK:     flow.return
-//      CHECK:   %[[RESULT2:.+]] = flow.dispatch.workgroups[%[[M]], %[[K]], %[[N2]], %[[M]], %[[N2]]]
+//      CHECK:   %[[RESULT2:.+]] = flow.dispatch.workgroups[%[[M]], %[[K]], %[[N2]]]
 // CHECK-SAME:     (%[[ARG0]], %[[ARG2]], %[[M]], %[[K]], %[[N2]])
 //      CHECK:     tensor.cast
 //      CHECK:     flow.return
@@ -341,7 +337,7 @@ func.func @keep_original_producer_uses(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>,
 //  CHECK-DAG: %[[ARG2_D1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
 //  CHECK-DAG: %[[ARG0_D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG: %[[ARG1_D0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
-//      CHECK: %[[origCC:.+]]:2 = flow.dispatch.workgroups[%[[ARG2_D0]], %[[ARG2_D1]], %[[ARG0_D0]], %[[ARG0_D1]], %[[ARG1_D0]], %[[ARG1_D1]], %[[ARG2_D0]], %[[ARG2_D1]]]
+//      CHECK: %[[origCC:.+]]:2 = flow.dispatch.workgroups[%[[ARG2_D0]], %[[ARG2_D1]], %[[ARG0_D0]], %[[ARG0_D1]], %[[ARG1_D0]], %[[ARG1_D1]]]
 //      CHECK:   %[[ARG2_CAPTURE:.+]]: !flow.dispatch.tensor<readwrite:tensor<?x?xf32>>
 // CHECK-SAME:   %[[RESULT_CAPTURE:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
 //      CHECK:   %[[LOAD:.+]] = flow.dispatch.tensor.load %[[ARG2_CAPTURE]]
@@ -1027,7 +1023,7 @@ func.func @dynamic_slice(%arg0 : i32, %arg1 : i32, %arg2 : tensor<?xi32>,
 //   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG3]], %[[C0]]
 //   CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG3]], %[[C1]]
-//       CHECK:   flow.dispatch.workgroups[%[[D0]], %[[D0]], %[[D1]], %[[D2]]]
+//       CHECK:   flow.dispatch.workgroups[%[[D0]], %[[D1]], %[[D2]]]
 //  CHECK-SAME:       tensor<?xi32>{%[[D0]]}
 //  CHECK-SAME:       tensor<?x?xi32>{%[[D1]], %[[D2]]}
 //  CHECK-NEXT:     !flow.dispatch.tensor<readonly:tensor<?xi32>>
@@ -1430,7 +1426,7 @@ func.func @multi_use_producer_fusion(%arg0 : tensor<?x8xf32>, %arg1 : tensor<8x?
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C0]]
-//      CHECK:   %[[DISPATCH:.+]]:2 = flow.dispatch.workgroups[%[[D0]], %[[D1]], %[[D2]], %[[D0]], %[[D1]]]
+//      CHECK:   %[[DISPATCH:.+]]:2 = flow.dispatch.workgroups[%[[D0]], %[[D1]], %[[D2]]]
 // CHECK-SAME:       (%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[D0]], %[[D1]], %[[D2]])
 // CHECK-NEXT:       %[[ARG0_CAPTURE:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:tensor<?x8xf32>>
 // CHECK-SAME:       %[[ARG1_CAPTURE:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:tensor<8x?xf32>>
@@ -1443,12 +1439,10 @@ func.func @multi_use_producer_fusion(%arg0 : tensor<?x8xf32>, %arg1 : tensor<8x?
 //  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[D0_CAPTURE]] 0
 //  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[D1_CAPTURE]] 1
 //  CHECK-DAG:     %[[D2_W:.+]] = flow.dispatch.workload.ordinal %[[D2_CAPTURE]] 2
-//  CHECK-DAG:     %[[D0_W_0:.+]] = flow.dispatch.workload.ordinal %[[D0_CAPTURE]] 3
-//  CHECK-DAG:     %[[D1_W_0:.+]] = flow.dispatch.workload.ordinal %[[D1_CAPTURE]] 4
 //  CHECK-DAG:     %[[LHS:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]]
 //  CHECK-DAG:     %[[RHS:.+]] = flow.dispatch.tensor.load %[[ARG1_CAPTURE]]
 //  CHECK-DAG:     %[[BIAS:.+]] = flow.dispatch.tensor.load %[[ARG2_CAPTURE]]
-//  CHECK-DAG:     %[[INIT:.+]] = tensor.empty(%[[D0_W_0]], %[[D1_W_0]])
+//  CHECK-DAG:     %[[INIT:.+]] = tensor.empty(%[[D0_W]], %[[D1_W]])
 //      CHECK:     %[[FILL:.+]] = linalg.fill
 // CHECK-SAME:         outs(%[[INIT]] :
 //      CHECK:     %[[MATMUL:.+]] = linalg.matmul
@@ -1859,24 +1853,22 @@ func.func @set_encoding_op(%arg0 : tensor<?x?xf32>)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
-//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D0]], %[[D1]], %[[D0]], %[[D1]]](%[[ARG0]], %[[D0]], %[[D1]])
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D0]], %[[D1]]](%[[ARG0]], %[[D0]], %[[D1]])
 // CHECK-NEXT:     %[[INARG:.+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>
 // CHECK-SAME:     %[[INDEXARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:     %[[INDEXARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:     %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>
 //  CHECK-DAG:     %[[W0:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 0
 //  CHECK-DAG:     %[[W1:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 1
-//  CHECK-DAG:     %[[W2:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 2
-//  CHECK-DAG:     %[[W3:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 3
 //      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
 // CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[W0]], %[[W1]]}
 //      CHECK:     %[[ENCODING:.+]] = iree_linalg_ext.set_encoding %[[LOAD]]
 //      CHECK:     flow.dispatch.tensor.store %[[ENCODING]], %[[OUTARG]]
-// CHECK-SAME:         sizes = [%[[W2]], %[[W3]]]
-// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>{%[[W2]], %[[W3]]}
+// CHECK-SAME:         sizes = [%[[W0]], %[[W1]]]
+// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>{%[[W0]], %[[W1]]}
 //      CHECK:     flow.return
-//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:[a-zA-Z0-9]+]]: index, %[[WL2:[a-zA-Z0-9]+]]: index, %[[WL3:[a-zA-Z0-9]+]]: index)
-//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_slice %[[WL0]], %[[WL1]], %[[WL2]], %[[WL3]]
+//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:[a-zA-Z0-9]+]]: index)
+//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_slice %[[WL0]], %[[WL1]]
 //      CHECK:     flow.return %[[X]], %[[Y]], %[[Z]]
 //      CHECK:   return %[[DISPATCH]]
 
@@ -1894,24 +1886,22 @@ func.func @unset_encoding_op(%arg0 : tensor<?x?xf32, #iree_linalg_ext.encoding<M
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
-//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D0]], %[[D1]], %[[D0]], %[[D1]]](%[[ARG0]], %[[D0]], %[[D1]])
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D0]], %[[D1]]](%[[ARG0]], %[[D0]], %[[D1]])
 // CHECK-NEXT:       %[[INARG:.+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>
 // CHECK-SAME:       %[[INDEXARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[INDEXARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
 //  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 0
 //  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 1
-//  CHECK-DAG:     %[[D0_W_0:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 2
-//  CHECK-DAG:     %[[D1_W_0:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 3
 //      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
 // CHECK-SAME:         sizes = [%[[D0_W]], %[[D1_W]]]
 // CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>{%[[D0_W]], %[[D1_W]]}
 //      CHECK:     %[[ENCODING:.+]] = iree_linalg_ext.unset_encoding %[[LOAD]]
 //      CHECK:     flow.dispatch.tensor.store %[[ENCODING]], %[[OUTARG]]
-// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[D0_W_0]], %[[D1_W_0]]}
+// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[D0_W]], %[[D1_W]]}
 //      CHECK:     flow.return
-//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:[a-zA-Z0-9]+]]: index, %[[WL2:[a-zA-Z0-9]+]]: index, %[[WL3:[a-zA-Z0-9]+]]: index)
-//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_slice %[[WL0]], %[[WL1]], %[[WL2]], %[[WL3]]
+//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:[a-zA-Z0-9]+]]: index)
+//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_slice %[[WL0]], %[[WL1]]
 //      CHECK:     flow.return %[[X]], %[[Y]], %[[Z]]
 //      CHECK:   return %[[DISPATCH]]
 
@@ -1945,7 +1935,7 @@ func.func @pad_and_set_encoding_op(%arg0 : tensor<?x?xf32>)
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[WLIN0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
 //  CHECK-DAG:   %[[WLIN1:.+]] = affine.apply #[[MAP0]]()[%[[D1]]]
-//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D1]], %[[D0]], %[[D0]], %[[D1]], %[[WLIN0]], %[[WLIN1]]](%[[D1]], %[[D0]], %[[ARG0]], %[[WLIN0]], %[[WLIN1]])
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D1]], %[[D0]], %[[WLIN0]], %[[WLIN1]]](%[[D1]], %[[D0]], %[[ARG0]], %[[WLIN0]], %[[WLIN1]])
 // CHECK-NEXT:       %[[INDEXARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[INDEXARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:       %[[INARG:.+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>
@@ -1954,12 +1944,10 @@ func.func @pad_and_set_encoding_op(%arg0 : tensor<?x?xf32>)
 // CHECK-SAME:       %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>
 //  CHECK-DAG:     %[[D1_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 0
 //  CHECK-DAG:     %[[D0_W:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 1
-//  CHECK-DAG:     %[[D0_W_0:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]] 2
-//  CHECK-DAG:     %[[D1_W_1:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]] 3
-//  CHECK-DAG:     %[[PADDED_D0_W:.+]] = flow.dispatch.workload.ordinal %[[PADDED_D0]] 4
-//  CHECK-DAG:     %[[PADDED_D1_W:.+]] = flow.dispatch.workload.ordinal %[[PADDED_D1]] 5
+//  CHECK-DAG:     %[[PADDED_D0_W:.+]] = flow.dispatch.workload.ordinal %[[PADDED_D0]] 2
+//  CHECK-DAG:     %[[PADDED_D1_W:.+]] = flow.dispatch.workload.ordinal %[[PADDED_D1]] 3
 //      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
-// CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[D0_W_0]], %[[D1_W_1]]}
+// CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[D0_W]], %[[D1_W]]}
 //      CHECK:     %[[HIGHPAD1:.+]] = affine.apply #[[MAP1]]()[%[[D1_W]]]
 //      CHECK:     %[[HIGHPAD0:.+]] = affine.apply #[[MAP1]]()[%[[D0_W]]]
 //      CHECK:     %[[PADDED:.+]] = tensor.pad %[[LOAD]] low[0, 0] high[%[[HIGHPAD0]], %[[HIGHPAD1]]]
@@ -1968,9 +1956,9 @@ func.func @pad_and_set_encoding_op(%arg0 : tensor<?x?xf32>)
 // CHECK-SAME:         sizes = [%[[PADDED_D0_W]], %[[PADDED_D1_W]]]
 // CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>{%[[PADDED_D0_W]], %[[PADDED_D1_W]]}
 //      CHECK:     flow.return
-//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:[a-zA-Z0-9]+]]: index, %[[WL2:[a-zA-Z0-9]+]]: index,
-// CHECK-SAME:       %[[WL3:[a-zA-Z0-9]+]]: index, %[[WL4:[a-zA-Z0-9]+]]: index, %[[WL5:[a-zA-Z0-9]+]]: index)
-//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_slice %[[WL0]], %[[WL1]], %[[WL2]], %[[WL3]], %[[WL4]], %[[WL5]]
+//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:[a-zA-Z0-9]+]]: index,
+// CHECK-SAME:         %[[WL2:[a-zA-Z0-9]+]]: index, %[[WL3:[a-zA-Z0-9]+]]: index)
+//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_slice %[[WL0]], %[[WL1]], %[[WL2]], %[[WL3]]
 //      CHECK:     flow.return %[[X]], %[[Y]], %[[Z]]
 //      CHECK:   return %[[DISPATCH]]
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
@@ -294,10 +294,10 @@ func.func @main(%arg0: tensor<?x?xf32>, %arg1: index, %arg2: index, %arg3: tenso
   %1 = flow.tensor.tie_shape %arg3 : tensor<?x?xf32>{%arg4, %arg5}
   %2 = flow.dispatch.workgroups[%arg1, %arg2, %arg4, %arg5](%0, %1, %arg1, %arg2, %arg4, %arg5) : (tensor<?x?xf32>{%arg1, %arg2}, tensor<?x?xf32>{%arg4, %arg5}, index, index, index, index) -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>{%arg4, %arg5} =
       (%arg6: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>, %arg7: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>, %arg8: index, %arg9: index, %arg10: index, %arg11: index, %arg12: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>) {
-    %arg8_0 = flow.dispatch.workload.ordinal %arg8 0 : index
-    %arg9_0 = flow.dispatch.workload.ordinal %arg9 1 : index
-    %arg10_0 = flow.dispatch.workload.ordinal %arg10 2 : index
-    %arg11_0 = flow.dispatch.workload.ordinal %arg11 3 : index
+    %arg8_0 = flow.dispatch.workload.ordinal %arg8, 0 : index
+    %arg9_0 = flow.dispatch.workload.ordinal %arg9, 1 : index
+    %arg10_0 = flow.dispatch.workload.ordinal %arg10, 2 : index
+    %arg11_0 = flow.dispatch.workload.ordinal %arg11, 3 : index
     %4 = flow.dispatch.tie_shape %arg6 : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%arg8_0, %arg9_0}
     %5 = flow.dispatch.tie_shape %arg7 : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%arg10_0, %arg11_0}
     %6 = flow.dispatch.tie_shape %arg12 : !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>>{%arg10_0, %arg11_0}


### PR DESCRIPTION
With #13038 the number of workgroups is computed using slice of the
computation within the dispatch. To do so, values captured by the
`flow.dispatch.workgroups` form the workload. The body of the
`flow.dispatch.workgroups` gets canonicalized to remove redundantly
captured operands, but this canonicalization does not dedup the values
captured as workload. This PR dedups the workload values as well.
This done through two patterns
1) A pattern to dedup the workload values themselves and updates the
   `count` region of `flow.dispatch.workgroups` op.
2) If the `count` region contains a
   `flow.dispatch.workgroup_count_from_slice` op, then operands of
   that are deduped as well. This also requires an update to the
   `flow.dispatch.workgroup.ordinal

It is better for all uses of the arguments corresponding to those
operands captured as workload values to go through the
`flow.dispatch.workload.ordinal`. This ensures that dynamic values get
deduped effectively, providing more contexts to the backends. Ideally
backend transformations shouldnt rely on this being the case, but can
help with optimizations.

Fixes #13321.