### PR TITLE
Remove stack allocation check flags from experimental benchmarks.

### DIFF
--- a/build_tools/python/benchmark_suites/iree/armv8_a_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/armv8_a_benchmarks.py
@@ -21,8 +21,6 @@ class Android_ARMv8_A_Benchmarks(object):
       tflite_models.MOBILESSD_FP32,
       tflite_models.POSENET_FP32,
       tflite_models.MOBILEBERT_FP32,
-  ]
-  MOBILENET_MODELS = [
       tflite_models.MOBILENET_V2,
       tflite_models.MOBILENET_V3SMALL,
   ]
@@ -46,19 +44,6 @@ class Android_ARMv8_A_Benchmarks(object):
           "--iree-flow-enable-data-tiling",
           "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops",
           "--iree-llvmcpu-enable-pad-consumer-fusion"
-      ])
-  # TODO(#12788) For these benchmarks fusion results in stack allocations
-  # that are not found to be bounded which results in a compilation error.
-  # For now add a flag to ignore that error.
-  MOBILENET_COMPILE_CONFIG = iree_definitions.CompileConfig.build(
-      id=unique_ids.IREE_COMPILE_CONFIG_ANDROID_ARMV8_2_A_GENERIC_MMT4D,
-      tags=["experimental-flags", "mmt4d"],
-      compile_targets=[ARMV8_A_CPU_TARGET],
-      extra_flags=[
-          "--iree-flow-enable-data-tiling",
-          "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops",
-          "--iree-llvmcpu-enable-pad-consumer-fusion",
-          "--iree-llvmcpu-fail-on-out-of-bounds-stack-allocation=false"
       ])
   MMT4D_AND_DOTPROD_COMPILE_CONFIG = iree_definitions.CompileConfig.build(
       id=unique_ids.IREE_COMPILE_CONFIG_ANDROID_ARMV8_2_A_GENERIC_MMT4D_DOTPROD,
@@ -89,19 +74,13 @@ class Android_ARMv8_A_Benchmarks(object):
         iree_definitions.ModuleGenerationConfig.build(
             compile_config=self.DEFAULT_COMPILE_CONFIG,
             imported_model=iree_definitions.ImportedModel.from_model(model))
-        for model in self.NONQUANT_MODELS + self.MOBILENET_MODELS +
-        self.QUANT_MODELS
+        for model in self.NONQUANT_MODELS + self.QUANT_MODELS
     ]
     experimental_gen_confings = [
         iree_definitions.ModuleGenerationConfig.build(
             compile_config=self.MMT4D_COMPILE_CONFIG,
             imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in self.NONQUANT_MODELS
-    ] + [
-        iree_definitions.ModuleGenerationConfig.build(
-            compile_config=self.MOBILENET_COMPILE_CONFIG,
-            imported_model=iree_definitions.ImportedModel.from_model(model))
-        for model in self.MOBILENET_MODELS
     ] + [
         iree_definitions.ModuleGenerationConfig.build(
             compile_config=self.MMT4D_AND_DOTPROD_COMPILE_CONFIG,

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -1914,7 +1914,6 @@ iree_bytecode_module(
     "--iree-flow-enable-data-tiling"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
-    "--iree-llvmcpu-fail-on-out-of-bounds-stack-allocation=false"
   FRIENDLY_NAME
     "MobileNetV2_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d]"
   PUBLIC
@@ -1934,7 +1933,6 @@ iree_bytecode_module(
     "--iree-flow-enable-data-tiling"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
-    "--iree-llvmcpu-fail-on-out-of-bounds-stack-allocation=false"
   FRIENDLY_NAME
     "MobileNetV3Small_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d]"
   PUBLIC
@@ -4611,7 +4609,6 @@ iree_bytecode_module(
     "--iree-flow-enable-data-tiling"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
-    "--iree-llvmcpu-fail-on-out-of-bounds-stack-allocation=false"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
@@ -4635,7 +4632,6 @@ iree_bytecode_module(
     "--iree-flow-enable-data-tiling"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
-    "--iree-llvmcpu-fail-on-out-of-bounds-stack-allocation=false"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"


### PR DESCRIPTION
The stack allocation is bounded. Now they can be inferred by ValueBoundsOpInterface, and we no longer need the flag.

Closes https://github.com/openxla/iree/issues/12788