### PR TITLE
Use 100% as threshold for compilation time

### DIFF
--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -101,7 +101,7 @@ BENCHMARK_THRESHOLDS = [
 COMPILATION_TIME_THRESHOLDS = [
     # Compilation time measurement is very stable right now. Use a large
     # threshold until we make it stable.
-    BenchmarkThreshold(re.compile(r".*"), 50, ThresholdUnit.PERCENTAGE),
+    BenchmarkThreshold(re.compile(r".*"), 100, ThresholdUnit.PERCENTAGE),
 ]
 
 TOTAL_DISPATCH_SIZE_THRESHOLDS = [


### PR DESCRIPTION
Although the noise of compilation time is usually in +-50%, some benchmarks in presubmit are compared to very fast noisy runs as baseline and report false positives. Double the threshold for the compilation time, which is especially unstable, to avoid such problems for now.

We should compare benchmarks to the average baseline instead of a single commit. Filed #13377 to track this issue.

https://perf.iree.dev/serie?IREE?925cdb19f2aa31a1907c81b5a9e179d91280c77b08a039c1cbf146f71683dde9-e54cd682-c079-4c42-b4ad-d92c4bedea13
![image](https://user-images.githubusercontent.com/2104162/235839674-fd651eba-fe27-4660-b623-c82f458d23d4.png)
