### PR TITLE
Make handling subspan with offsets and memref return types for CUDA consistent with other backends.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
@@ -37,12 +37,8 @@ struct BufferizeCopyOnlyDispatchesPass
     : public BufferizeCopyOnlyDispatchesBase<BufferizeCopyOnlyDispatchesPass> {
   BufferizeCopyOnlyDispatchesPass() = default;
   BufferizeCopyOnlyDispatchesPass(const BufferizeCopyOnlyDispatchesPass &pass) {
-    this->embedSubspanOffsetIntoMemRefType =
-        pass.embedSubspanOffsetIntoMemRefType;
   }
-  BufferizeCopyOnlyDispatchesPass(bool embedSubspanOffsetIntoMemRefType) {
-    this->embedSubspanOffsetIntoMemRefType = embedSubspanOffsetIntoMemRefType;
-  }
+
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, bufferization::BufferizationDialect,
                     IREE::Flow::FlowDialect, linalg::LinalgDialect,
@@ -109,8 +105,7 @@ void BufferizeCopyOnlyDispatchesPass::runOnOperation() {
   };
 
   addIREEComprehensiveBufferizePasses(bufferizationPipeline, allocationFn,
-                                      deallocationFn, memcpyFn,
-                                      this->embedSubspanOffsetIntoMemRefType);
+                                      deallocationFn, memcpyFn);
   if (failed(runPipeline(bufferizationPipeline, module))) {
     return signalPassFailure();
   }
@@ -125,10 +120,9 @@ void BufferizeCopyOnlyDispatchesPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> createBufferizeCopyOnlyDispatchesPass(
-    bool embedSubspanOffsetIntoMemRefType) {
-  return std::make_unique<BufferizeCopyOnlyDispatchesPass>(
-      embedSubspanOffsetIntoMemRefType);
+std::unique_ptr<OperationPass<ModuleOp>>
+createBufferizeCopyOnlyDispatchesPass() {
+  return std::make_unique<BufferizeCopyOnlyDispatchesPass>();
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -1068,12 +1068,6 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
   options.memCpyFn = memCpyFn;
   options.testAnalysisOnly = getTestAnalysisOnly();
   options.printConflicts = getPrintConflicts();
-  if (getTargetGpu()) {
-    // TODO(#12933): Because of regressions in CUDA backend, there is an
-    // option to keep a legacy mode of not representing the offset in the
-    // type. Remove once the bug is fixed.
-    options.embedSubspanOffsetIntoMemRefType = false;
-  }
   if (failed(runIREEOneShotBufferize(state.getTopLevel(), options)))
     return listener.check(loc, emitDefaultDefiniteFailure(target));
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h
@@ -16,10 +16,8 @@ namespace iree_compiler {
 
 struct IREEOneShotBufferizationOptions
     : public mlir::bufferization::OneShotBufferizationOptions {
-  // TODO(#12933): Because of regressions in CUDA backend, there is an
-  // option to keep a legacy mode of not representing the offset in the
-  // type. Remove once the bug is fixed.
-  bool embedSubspanOffsetIntoMemRefType = true;
+  // For now this has no extra fields. Keeping this anyway in case this is
+  // needed in future.
 };
 
 // Register all interfaces needed for bufferization.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -77,12 +77,8 @@ static void addBufferizePasses(OpPassManager &passManager) {
   BufferizationOptions::AllocationFn allocationFn = gpuAllocationFn;
   BufferizationOptions::DeallocationFn deallocationFn = gpuDeallocationFn;
   BufferizationOptions::MemCpyFn memcpyFn = gpuCopyFn;
-  // TODO(#12933): Because of regressions in CUDA backend, there is an
-  // option to keep a legacy mode of not representing the offset in the
-  // type. Remove once the bug is fixed.
-  addIREEComprehensiveBufferizePasses(
-      passManager, allocationFn, deallocationFn, memcpyFn,
-      /*embedSubspanOffsetIntoMemRefType=*/false);
+  addIREEComprehensiveBufferizePasses(passManager, allocationFn, deallocationFn,
+                                      memcpyFn);
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
   // TODO: Remove the following pass the plumb support for #hal.descriptor_type
@@ -554,9 +550,7 @@ void addGPUTransformDialectPasses(OpPassManager &passManager) {
 }
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
-  addCommonTargetExecutablePreprocessingPasses(
-      pm.nest<ModuleOp>(),
-      /*embedSubspanOffsetIntoMemRefType=*/false);
+  addCommonTargetExecutablePreprocessingPasses(pm.nest<ModuleOp>());
   // TODO: Remove the following pass the plumb support for #hal.descriptor_type
   // memory space through the stack.
   pm.nest<ModuleOp>().addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -17,7 +17,7 @@ hal.executable @abs_ex_dispatch_0 {
       func.func @abs_ex_dispatch_0() {
         %c0 = arith.constant 0 : index
         %c128 = arith.constant 128 : index
-        %0 = hal.interface.binding.subspan set(0) binding(4) type(storage_buffer) offset(%c128) flags(ReadOnly) : memref<16xf32>
+        %0 = hal.interface.binding.subspan set(0) binding(4) type(storage_buffer) offset(%c128) flags(ReadOnly) : memref<16xf32, strided<[1], offset: 32>>
         %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<16xi32>
         %2 = hal.interface.binding.subspan set(1) binding(2) type(storage_buffer) : memref<16xf32>
         %3 = gpu.block_id x
@@ -25,7 +25,7 @@ hal.executable @abs_ex_dispatch_0 {
         %5 = gpu.thread_id x
         %6 = arith.muli %3, %4 : index
         %7 = arith.addi %6, %5 : index
-        %9 = memref.load %0[%7] : memref<16xf32>
+        %9 = memref.load %0[%7] : memref<16xf32, strided<[1], offset: 32>>
         %10 = memref.load %1[%7] : memref<16xi32>
         %11 = arith.sitofp %10 : i32 to f32
         %12 = arith.addf %9, %11 : f32
@@ -39,16 +39,17 @@ hal.executable @abs_ex_dispatch_0 {
 //  CHECK-SAME: (%[[ARG0:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias},
 //  CHECK-SAME:  %[[ARG1:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.readonly},
 //  CHECK-SAME:  %{{.*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias})
-//       CHECK:   %[[C128:.+]] = llvm.mlir.constant(128 : index) : i64
-//       CHECK:   %[[OFF:.+]] = llvm.getelementptr %arg1[%[[C128]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-//       CHECK:   llvm.insertvalue %[[OFF]], %{{.*}}[0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-//       CHECK:   llvm.insertvalue %[[OFF]], %{{.*}}[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-//      CHECK:    nvvm.read.ptx.sreg.tid.x
-//      CHECK:    llvm.fadd
+//       CHECK:   %[[UNDEF:.+]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+//       CHECK:   %[[BASE_PTR_INSERT:.+]] = llvm.insertvalue %arg1, %[[UNDEF]][0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+//       CHECK:   %[[ALIGNED_PTR_INSERT:.+]] = llvm.insertvalue %arg1, %[[BASE_PTR_INSERT]][1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+//       CHECK:   %[[OFFSET:.+]] = llvm.mlir.constant(32 : index) : i64
+//       CHECK:   %[[OFFSET_INSERT:.+]] = llvm.insertvalue %[[OFFSET]], %[[ALIGNED_PTR_INSERT]][2] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+//       CHECK:    nvvm.read.ptx.sreg.tid.x
+//       CHECK:    llvm.fadd
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<push_constants = 1, sets = [
+#pipeline_layout = #hal.pipeline.layout<push_constants = 4, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
     #hal.descriptor_set.binding<4, storage_buffer>
@@ -63,21 +64,21 @@ hal.executable @abs_dynamic {
     builtin.module {
       func.func @abs_dynamic() {
         %c0 = arith.constant 0 : index
-        %c128 = arith.constant 128 : index
-        %s = hal.interface.constant.load[1] : index
-        %0 = hal.interface.binding.subspan set(0) binding(4) type(storage_buffer) offset(%c128) : memref<?xf32>{%s}
-        %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<16xi32>
-        %2 = hal.interface.binding.subspan set(1) binding(2) type(storage_buffer) : memref<16xf32>
-        %3 = gpu.block_id x
-        %4 = gpu.block_dim x
-        %5 = gpu.thread_id x
-        %6 = arith.muli %3, %4 : index
-        %7 = arith.addi %6, %5 : index
-        %9 = memref.load %0[%7] : memref<?xf32>
-        %10 = memref.load %1[%7] : memref<16xi32>
+        %c3 = arith.constant 3 : index
+        %c5 = arith.constant 5 : index
+        %c7 = arith.constant 7 : index
+        %o = hal.interface.constant.load[0] : index
+        %d0 = hal.interface.constant.load[1] : index
+        %d1 = hal.interface.constant.load[2] : index
+        %d2 = hal.interface.constant.load[3] : index
+        %0 = hal.interface.binding.subspan set(0) binding(4) type(storage_buffer) offset(%o) : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>{%d0, %d1, %d2}
+        %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?x?xi32>{%d0, %d1, %d2}
+        %2 = hal.interface.binding.subspan set(1) binding(2) type(storage_buffer) : memref<?x?x?xf32>{%d0, %d1, %d2}
+        %9 = memref.load %0[%c3, %c5, %c7] : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>
+        %10 = memref.load %1[%c3, %c5, %c7] : memref<?x?x?xi32>
         %11 = arith.sitofp %10 : i32 to f32
         %12 = arith.addf %9, %11 : f32
-        memref.store %12, %2[%7] : memref<16xf32>
+        memref.store %12, %2[%c3, %c5, %c7] : memref<?x?x?xf32>
         return
       }
     }
@@ -87,14 +88,33 @@ hal.executable @abs_dynamic {
 //  CHECK-SAME: (%[[ARG0:[a-zA-Z0-9]+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias},
 //  CHECK-SAME:  %[[ARG1:[a-zA-Z0-9]+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias},
 //  CHECK-SAME:  %[[ARG2:[a-zA-Z0-9]+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias},
-//  CHECK-SAME:  %[[ARG3:[a-zA-Z0-9]+]]: i32, %[[ARG4:[a-zA-Z0-9]+]]: i32)
-//       CHECK:   %[[C128:.+]] = llvm.mlir.constant(128 : index) : i64
-//       CHECK:   %{{.*}} = llvm.zext %[[ARG4]] : i32 to i64
-//       CHECK:   %[[OFF:.+]] = llvm.getelementptr %arg1[%[[C128]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-//       CHECK:   llvm.insertvalue %[[OFF]], %{{.*}}[0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-//       CHECK:   llvm.insertvalue %[[OFF]], %{{.*}}[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-//      CHECK:    nvvm.read.ptx.sreg.tid.x
-//      CHECK:    llvm.fadd
+//  CHECK-SAME:  %[[ARG3:[a-zA-Z0-9]+]]: i32,
+//  CHECK-SAME:  %[[ARG4:[a-zA-Z0-9]+]]: i32,
+//  CHECK-SAME:  %[[ARG5:[a-zA-Z0-9]+]]: i32,
+//  CHECK-SAME:  %[[ARG6:[a-zA-Z0-9]+]]: i32)
+//   CHECK-DAG:   %[[OFFSET:.+]] = llvm.zext %[[ARG3]] : i32 to i64
+//   CHECK-DAG:   %[[D0:.+]] = llvm.zext %[[ARG4]] : i32 to i64
+//   CHECK-DAG:   %[[D1:.+]] = llvm.zext %[[ARG5]] : i32 to i64
+//   CHECK-DAG:   %[[D2:.+]] = llvm.zext %[[ARG6]] : i32 to i64
+//       CHECK:   %[[UNDEF:.+]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
+//       CHECK:   %[[BASE_PTR_INSERT:.+]] = llvm.insertvalue %[[ARG1]], %[[UNDEF]][0] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
+//       CHECK:   %[[ALIGNED_PTR_INSERT:.+]] = llvm.insertvalue %[[ARG1]], %[[BASE_PTR_INSERT]][1] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
+//       CHECK:   %[[C4:.+]] = llvm.mlir.constant(4 : i64)
+//       CHECK:   %[[ELEM_OFFSET:.+]] = llvm.udiv %[[OFFSET]], %[[C4]]
+//       CHECK:   %[[OFFSET_INSERT:.+]] = llvm.insertvalue %[[ELEM_OFFSET]], %[[ALIGNED_PTR_INSERT]][2]
+//       CHECK:   %[[D0_INSERT:.+]] = llvm.insertvalue %[[D0]], %[[OFFSET_INSERT]][3, 0]
+//       CHECK:   %[[D1_INSERT:.+]] = llvm.insertvalue %[[D1]], %[[D0_INSERT]][3, 1]
+//       CHECK:   %[[D2_INSERT:.+]] = llvm.insertvalue %[[D2]], %[[D1_INSERT]][3, 2]
+//       CHECK:   %[[STRIDE0:.+]] = llvm.mlir.constant(1 : index)
+//       CHECK:   %[[STRIDE0_INSERT:.+]] = llvm.insertvalue %[[STRIDE0]], %[[D2_INSERT]][4, 2]
+//       CHECK:   %[[D2_EXTRACT:.+]] = llvm.extractvalue %[[STRIDE0_INSERT]][3, 2]
+//       CHECK:   %[[STRIDE0_CONSTANT:.+]] = llvm.mlir.constant(1 : i64)
+//       CHECK:   %[[STRIDE1:.+]] = llvm.mul %[[STRIDE0_CONSTANT]], %[[D2_EXTRACT]]
+//       CHECK:   %[[STRIDE1_INSERT:.+]] = llvm.insertvalue %[[STRIDE1]], %[[STRIDE0_INSERT]][4, 1]
+//       CHECK:   %[[D1_EXTRACT:.+]] = llvm.extractvalue %[[STRIDE1_INSERT]][3, 1]
+//       CHECK:   %[[STRIDE2:.+]] = llvm.mul %[[STRIDE1]], %[[D1_EXTRACT]]
+//       CHECK:   llvm.insertvalue %[[STRIDE2]], %[[STRIDE1_INSERT]][4, 0]
+//       CHECK:   llvm.fadd
 
 // -----
 
@@ -153,7 +173,7 @@ hal.executable @mixed_type {
       func.func @mixed_type() {
         %c0 = arith.constant 0 : index
         %c128 = arith.constant 128 : index
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c128) : memref<16xf32>
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c128) : memref<16xf32, strided<[1], offset: 4>>
         %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) : memref<16xi32>
         %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16xf32>
         %3 = gpu.block_id x
@@ -161,7 +181,7 @@ hal.executable @mixed_type {
         %5 = gpu.thread_id x
         %6 = arith.muli %3, %4 : index
         %7 = arith.addi %6, %5 : index
-        %9 = memref.load %0[%7] : memref<16xf32>
+        %9 = memref.load %0[%7] : memref<16xf32, strided<[1], offset: 4>>
         %10 = memref.load %1[%7] : memref<16xi32>
         %11 = arith.sitofp %10 : i32 to f32
         %12 = arith.addf %9, %11 : f32
@@ -175,10 +195,8 @@ hal.executable @mixed_type {
 // CHECK-LABEL: llvm.func @mixed_type
 //  CHECK-SAME: (%[[ARG0:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias},
 //  CHECK-SAME:  %{{.*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias})
-//       CHECK:   %[[C128:.+]] = llvm.mlir.constant(128 : index) : i64
-//       CHECK:   %[[OFF:.+]] = llvm.getelementptr %arg0[%[[C128]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-//       CHECK:   llvm.insertvalue %[[OFF]], %{{.*}}[0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-//       CHECK:   llvm.insertvalue %[[OFF]], %{{.*}}[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+//       CHECK:   llvm.insertvalue %[[ARG0]], %{{.*}}[0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+//       CHECK:   llvm.insertvalue %[[ARG0]], %{{.*}}[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
 //       CHECK:   nvvm.read.ptx.sreg.tid.x
 //       CHECK:   llvm.fadd
 
@@ -302,18 +320,18 @@ hal.executable @check_not_readonly {
         %c0 = arith.constant 0 : index
         %c128 = arith.constant 128 : index
         %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<16xi32>
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c128) flags(ReadOnly) : memref<16xf32>        
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c128) flags(ReadOnly) : memref<16xf32, strided<[1], offset: 32>>        
         %b11 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) flags(ReadOnly) : memref<16xi32>
-        %b12 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c128) : memref<16xf32>        
+        %b12 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c128) : memref<16xf32, strided<[1], offset: 32>>        
         %b21 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) flags(ReadOnly) : memref<16xi32>
-        %b22 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c128) flags(ReadOnly) : memref<16xf32>        
+        %b22 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c128) flags(ReadOnly) : memref<16xf32, strided<[1], offset: 32>>        
         %2 = hal.interface.binding.subspan set(1) binding(3) type(storage_buffer) : memref<16xf32>
         %3 = gpu.block_id x
         %4 = gpu.block_dim x
         %5 = gpu.thread_id x
         %6 = arith.muli %3, %4 : index
         %7 = arith.addi %6, %5 : index
-        %9 = memref.load %0[%7] : memref<16xf32>
+        %9 = memref.load %0[%7] : memref<16xf32, strided<[1], offset: 32>>
         %10 = memref.load %1[%7] : memref<16xi32>
         %11 = arith.sitofp %10 : i32 to f32
         %12 = arith.addf %9, %11 : f32

--- a/compiler/src/iree/compiler/Codegen/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Passes.cpp
@@ -84,12 +84,10 @@ LogicalResult verifyLoweringConfiguration(
   return success();
 }
 
-void addCommonTargetExecutablePreprocessingPasses(
-    OpPassManager &passManager, bool embedSubspanOffsetIntoMemRefType) {
+void addCommonTargetExecutablePreprocessingPasses(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(createTypePropagationPass());
   passManager.addPass(createBubbleUpOrdinalOpsPass());
-  passManager.addPass(
-      createBufferizeCopyOnlyDispatchesPass(embedSubspanOffsetIntoMemRefType));
+  passManager.addPass(createBufferizeCopyOnlyDispatchesPass());
   passManager.addNestedPass<func::FuncOp>(
       IREE::LinalgExt::createDecomposeSoftmaxPass());
   // Temporary solution to avoid large allocations due to softmax lowering.

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -39,11 +39,7 @@ LogicalResult verifyLoweringConfiguration(
 
 /// Passes that are done on all backends before target-specific code-generation
 /// kicks in.
-// TODO(#12933): Because of regressions in CUDA backend, there is an
-// option to keep a legacy mode of not representing the offset in the
-// type. Remove once the bug is fixed.
-void addCommonTargetExecutablePreprocessingPasses(
-    OpPassManager &passManager, bool embedSubspanOffsetIntoMemRefType = true);
+void addCommonTargetExecutablePreprocessingPasses(OpPassManager &passManager);
 
 /// Post-bufferization passes run to cleanup the IR
 /// (ResolveShapedTypeResultDims, Canonicalization/CSE and
@@ -51,17 +47,13 @@ void addCommonTargetExecutablePreprocessingPasses(
 void addIREEPostBufferizationPasses(OpPassManager &passManager);
 
 using bufferization::BufferizationOptions;
-// TODO(#12933): Because of regressions in CUDA backend, there is an
-// option to keep a legacy mode of not representing the offset in the
-// type. Remove once the bug is fixed.
 void addIREEComprehensiveBufferizePasses(
     OpPassManager &passManager,
     std::optional<BufferizationOptions::AllocationFn> allocationFn =
         std::nullopt,
     std::optional<BufferizationOptions::DeallocationFn> deallocationFn =
         std::nullopt,
-    std::optional<BufferizationOptions::MemCpyFn> memCpyFn = std::nullopt,
-    bool embedSubspanOffsetIntoMemRefType = true);
+    std::optional<BufferizationOptions::MemCpyFn> memCpyFn = std::nullopt);
 
 /// Pass to bubble up ordinal operations to allow workgroup count computation
 /// based on slices to correlate back to workload computation.
@@ -74,11 +66,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createCleanupBufferAllocViewPass();
 /// Pass to bufferize dispatches that are copying from one interface to
 /// another. This will create a `linalg.generic` op which is a copy that can
 /// then be used by backends to handle appropriately.
-// TODO(#12933): Because of regressions in CUDA backend, there is an
-// option to keep a legacy mode of not representing the offset in the
-// type. Remove once the bug is fixed.
-std::unique_ptr<OperationPass<ModuleOp>> createBufferizeCopyOnlyDispatchesPass(
-    bool embedSubspanOffsetIntoMemRefType = true);
+std::unique_ptr<OperationPass<ModuleOp>>
+createBufferizeCopyOnlyDispatchesPass();
 
 // Decomposes linalg generics on tensors into generics containing no more than
 // one op in the body.
@@ -132,16 +121,12 @@ std::unique_ptr<Pass> createIREEExpandStridedMetadataPass();
 /// is specified, the default allocator generates an `std.alloc` instruction
 /// with the allocated MemRefType having no stride map (i.e. default row-major
 /// striding) and default memory space.
-// TODO(#12933): Because of regressions in CUDA backend, there is an
-// option to keep a legacy mode of not representing the offset in the
-// type. Remove once the bug is fixed.
 std::unique_ptr<OperationPass<ModuleOp>> createIREEComprehensiveBufferizePass(
     std::optional<BufferizationOptions::AllocationFn> allocationFn =
         std::nullopt,
     std::optional<BufferizationOptions::DeallocationFn> deallocationFn =
         std::nullopt,
-    std::optional<BufferizationOptions::MemCpyFn> memCpyFn = std::nullopt,
-    bool embedSubspanOffsetIntoMemRefType = true);
+    std::optional<BufferizationOptions::MemCpyFn> memCpyFn = std::nullopt);
 
 std::unique_ptr<OperationPass<func::FuncOp>>
 createHoistStaticallyBoundAllocationsPass();

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -174,12 +174,6 @@ def BufferizeCopyOnlyDispatches :
   let summary =
       "Bufferize dispatches that copy to/from interfaces to convert to a linalg.copy op";
   let constructor = "mlir::iree_compiler::createBufferizeCopyOnlyDispatchesPass()";
-  let options = [
-    Option<"embedSubspanOffsetIntoMemRefType",
-           "embed-subspan-offset-into-memref-type", "bool", /*default=*/"true",
-           "Embeds the offset information on subspan ops into the type."
-           "Is a work-around for #12933">,
-  ];
 }
 
 def EliminateEmptyTensors :
@@ -205,10 +199,6 @@ def IREEComprehensiveBufferize :
     Option<"printConflicts", "print-conflicts", "bool",
             /*default=*/"false",
            "Annotates IR with RaW conflicts. Requires test-analysis-only.">,
-    Option<"embedSubspanOffsetIntoMemRefType",
-           "embed-subspan-offset-into-memref-type", "bool", /*default=*/"true",
-           "Embeds the offset information on subspan ops into the type."
-           "Is a work-around for #12933">,
   ];
 }
 


### PR DESCRIPTION
With https://github.com/iree-org/iree-llvm-fork/commit/e02d4142dca48d9359ad304fec629ea3d7e6924c and https://github.com/iree-org/iree-llvm-fork/commit/68e1aef68e40452b6c176b25e67c13a0359c96ca the regression on CUDA observed with #12874 have been addressed. This removes the work-around that was added for CUDA.

Fixes #12933 