### PR TITLE
Update script and option to run Android benchmarks in CI

### DIFF
--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -56,12 +56,14 @@ BENCHMARK_PRESET_MATCHERS: Dict[str, PresetMatcher] = {
     "cuda-long":
         lambda config: config.target_device_spec.architecture.architecture ==
         "cuda" and "long-running" in config.tags,
-    "android-cpu":
+    # TODO(#9855): Enable benchmarks on Pixel-6-Pro and XT2201-2.
+    "experimental-android-cpu":
         lambda config:
         (config.target_device_spec.architecture.type == common_definitions.
          ArchitectureType.CPU and config.target_device_spec.host_environment.
-         platform == "android"),
-    "android-gpu":
+         platform == "android" and config.target_device_spec.device_name in
+         ["Pixel-4"]),
+    "experimental-android-gpu":
         lambda config:
         (config.target_device_spec.architecture.type == common_definitions.
          ArchitectureType.GPU and config.target_device_spec.host_environment.

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -59,6 +59,20 @@ elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
         --device_model=GCP-c2-standard-16 \
         --cpu_uarch=CascadeLake \
         --verbose
+elif [[ "${TARGET_DEVICE_NAME}" == "Pixel-4" ]]; then
+  ./build_tools/benchmarks/run_benchmarks_on_android.py \
+    --normal_benchmark_tool_dir="${NORMAL_BENCHMARK_TOOLS_DIR}" \
+    --traced_benchmark_tool_dir="${TRACED_BENCHMARK_TOOLS_DIR}" \
+    --trace_capture_tool="${TRACY_CAPTURE_TOOL}" \
+    --capture_tarball="${BENCHMARK_TRACES}" \
+    --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
+    --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
+    --target_device_name="${TARGET_DEVICE_NAME}" \
+    --output="${BENCHMARK_RESULTS}" \
+    --pin-cpu-freq \
+    --pin-gpu-freq \
+    --verbose
+    # TODO(#13198): Disable compatible filter
 else
   echo "${TARGET_DEVICE_NAME} is not supported yet."
   exit 1


### PR DESCRIPTION
Update `export_benchmark_config.py` and `run_benchmarks.sh` to export config and run android benchmarks in CI.

The update on CI workflow will be in the follow-up #13199