### PR TITLE
Fix CL options for plugin passes

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
@@ -59,7 +59,8 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
   pluginManager.registerGlobalDialects(registry);
   pluginManager.initializeCLI();
 
-  // Register any command line options.
+  // Register command line options. All passes must be registered at this point
+  // to expose them through the tool.
   MlirOptMainConfig::registerCLOptions(registry);
   registerAsmPrinterCLOptions();
   registerMLIRContextCLOptions();

--- a/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
@@ -59,7 +59,6 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
   pluginManager.registerGlobalDialects(registry);
   pluginManager.initializeCLI();
 
-
   // Register any command line options.
   MlirOptMainConfig::registerCLOptions(registry);
   registerAsmPrinterCLOptions();

--- a/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
@@ -45,6 +45,21 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
 
   InitLLVM y(argc, argv);
 
+  // We support a limited form of the PluginManager, allowing it to perform
+  // global initialization and dialect registration.
+  mlir::iree_compiler::PluginManager pluginManager;
+  if (!pluginManager.loadAvailablePlugins()) {
+    llvm::errs() << "error: Failed to initialize IREE compiler plugins\n";
+    return failure();
+  }
+  // Initialization that applies to all global plugins must be done prior
+  // to CL parsing.
+  pluginManager.globalInitialize();
+  pluginManager.registerPasses();
+  pluginManager.registerGlobalDialects(registry);
+  pluginManager.initializeCLI();
+
+
   // Register any command line options.
   MlirOptMainConfig::registerCLOptions(registry);
   registerAsmPrinterCLOptions();
@@ -62,20 +77,6 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
     interleaveComma(registry.getDialectNames(), os,
                     [&](auto name) { os << name; });
   }
-
-  // We support a limited form of the PluginManager, allowing it to perform
-  // global initialization and dialect registration.
-  mlir::iree_compiler::PluginManager pluginManager;
-  if (!pluginManager.loadAvailablePlugins()) {
-    llvm::errs() << "error: Failed to initialize IREE compiler plugins\n";
-    return failure();
-  }
-  // Initialization that applies to all global plugins must be done prior
-  // to CL parsing.
-  pluginManager.globalInitialize();
-  pluginManager.registerPasses();
-  pluginManager.registerGlobalDialects(registry);
-  pluginManager.initializeCLI();
 
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv, helpHeader);


### PR DESCRIPTION
Plugin passes, e.g. `openxla-nvgpu-convert-hlo-to-cudnn`, must be registered before populating the pass manager CL options. This ensures that the plugin passes are available in the `iree-opt` tool.