### PR TITLE
Fix __str__ for enums in python 3.11

### DIFF
--- a/build_tools/python/e2e_test_framework/definitions/common_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/common_definitions.py
@@ -26,13 +26,6 @@ class _ArchitectureInfo(object):
   microarchitecture: str = ""
   vendor: str = ""
 
-  def __str__(self):
-    parts = [
-        part for part in (self.vendor, self.architecture,
-                          self.microarchitecture) if len(part) != 0
-    ]
-    return "-".join(parts)
-
 
 class DeviceArchitecture(_ArchitectureInfo, Enum):
   """Predefined architecture/microarchitecture."""
@@ -58,6 +51,16 @@ class DeviceArchitecture(_ArchitectureInfo, Enum):
   # CUDA GPUs
   CUDA_SM70 = (ArchitectureType.GPU, "cuda", "sm_70")
   CUDA_SM80 = (ArchitectureType.GPU, "cuda", "sm_80")
+
+  # Starting from 3.11, enum members are defined before the subclasses (doesn't
+  # follow MRO). So __str__ is defined here instead of in _ArchitectureInfo to
+  # override the default one.
+  def __str__(self):
+    parts = [
+        part for part in (self.vendor, self.architecture,
+                          self.microarchitecture) if len(part) != 0
+    ]
+    return "-".join(parts)
 
 
 @dataclass(frozen=True)

--- a/build_tools/python/e2e_test_framework/definitions/common_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/common_definitions.py
@@ -52,8 +52,9 @@ class DeviceArchitecture(_ArchitectureInfo, Enum):
   CUDA_SM70 = (ArchitectureType.GPU, "cuda", "sm_70")
   CUDA_SM80 = (ArchitectureType.GPU, "cuda", "sm_80")
 
-  # Starting from 3.11, enum members are defined before the subclasses (doesn't
-  # follow MRO). So __str__ is defined here instead of in _ArchitectureInfo to
+  # Starting from 3.11, enum members are defined before the subclasses (don't
+  # follow MRO, see https://docs.python.org/3/whatsnew/3.11.html#enum).
+  # Therefore __str__ is defined here instead of in _ArchitectureInfo to
   # override the default one.
   def __str__(self):
     parts = [

--- a/build_tools/python/e2e_test_framework/definitions/common_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/common_definitions.py
@@ -57,11 +57,8 @@ class DeviceArchitecture(_ArchitectureInfo, Enum):
   # Therefore __str__ is defined here instead of in _ArchitectureInfo to
   # override the default one.
   def __str__(self):
-    parts = [
-        part for part in (self.vendor, self.architecture,
-                          self.microarchitecture) if len(part) != 0
-    ]
-    return "-".join(parts)
+    parts = [self.vendor, self.architecture, self.microarchitecture]
+    return "-".join(part for part in parts if part != "")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Python 3.11 changes the behaviors on Enum and the `__str__` in the parent class now can't override the default one from `enum.Enum`. Move the `__str__` into enum class itself to properly override the default one.

It's a little bit unclear to me why it doesn't follow MRO to use the `__str__` in the first parent class, but seems like this is the reason:
> Changed [Enum](https://docs.python.org/3/library/enum.html#enum.Enum) and [Flag](https://docs.python.org/3/library/enum.html#enum.Flag) so that members are now defined before [__init_subclass__()](https://docs.python.org/3/reference/datamodel.html#object.__init_subclass__) is called; [dir()](https://docs.python.org/3/library/functions.html#dir) now includes methods, etc., from mixed-in data types.

This change should solve the test failures on macos arm64 (which is using python 3.11 to run tests).

References:
- https://docs.python.org/3/whatsnew/3.11.html#enum
- https://blog.pecar.me/python-enum