### PR TITLE
Move benchmark preset expansion into export_benchmark_config

### DIFF
--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -70,6 +70,9 @@ BENCHMARK_PRESET_MATCHERS: Dict[str, PresetMatcher] = {
     "comp-stats":
         lambda _config: False,
 }
+# TODO(#13392): "all" should be called "defaults". Keep it as it is and we will
+# drop it when removing "benchmarks:" git trailer (with announcement).
+META_BENCHMARK_PRESETS = {"all": ["x86_64", "cuda", "comp-stats"]}
 
 
 def filter_and_group_run_configs(
@@ -167,8 +170,15 @@ def _parse_and_strip_list_argument(arg) -> List[str]:
 
 
 def _parse_benchmark_presets(arg) -> List[PresetMatcher]:
+  presets = set(_parse_and_strip_list_argument(arg))
+  for meta_preset, sub_presets in META_BENCHMARK_PRESETS.items():
+    if meta_preset in presets:
+      presets.remove(meta_preset)
+      presets.update(sub_presets)
+
+  presets = sorted(presets)
   matchers = []
-  for preset in _parse_and_strip_list_argument(arg):
+  for preset in presets:
     matcher = BENCHMARK_PRESET_MATCHERS.get(preset)
     if matcher is None:
       raise argparse.ArgumentTypeError(

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -297,10 +297,6 @@ def get_benchmark_presets(trailers: Mapping[str, str], labels: Sequence[str],
       raise ValueError(f"Unknown benchmark preset option: '{preset_option}'.\n"
                        f"Available options: '{BENCHMARK_PRESET_OPTIONS}'.")
 
-  if "all" in preset_options:
-    preset_options = list(
-        option for option in BENCHMARK_PRESET_OPTIONS if option != "all")
-
   return ",".join(preset_options)
 
 


### PR DESCRIPTION
Currently the expansion of "meta" presets (the preset `all`) is done in `configure_ci.py`. I think it should be moved into `export_benchmark_config.py` to make sure these "meta" presets can be passed to the tool locally.

The expansion is also refactored to support more "meta" benchmark presets which might be introduced later (#13392).