### PR TITLE
Report stream dispatch count in compilation benchmarks

### DIFF
--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -53,7 +53,7 @@ DISPATCH_COMPONENT_PATTERNS = [
 @dataclass(frozen=True)
 class ModuleInfo(object):
   module_path: pathlib.Path
-  stream_stats_path: Optional[pathlib.Path] = None
+  stream_stats_path: pathlib.Path
 
 
 def match_module_cmake_target(module_path: pathlib.PurePath) -> Optional[str]:
@@ -215,7 +215,8 @@ def get_module_map_from_benchmark_suite(
           target_arch=benchmark_case.target_arch,
           compile_tags=tuple(benchmark_case.bench_mode))
       module_map[compilation_info] = ModuleInfo(
-          module_path=(benchmark_case_dir / module_path).resolve())
+          module_path=(benchmark_case_dir / module_path).resolve(),
+          stream_stats_path=None)
 
   return module_map
 
@@ -317,13 +318,10 @@ def main(args: argparse.Namespace):
           f"Module path isn't a module cmake target: {module_path}")
     compilation_time_ms = target_build_time_map[cmake_target]
 
-    if module_info.stream_stats_path is None:
-      ir_stats = None
-    else:
-      stream_stats_json = json.loads(module_info.stream_stats_path.read_text())
-      exec_stats_json = stream_stats_json["stream-aggregate"]["execution"]
-      ir_stats = benchmark_definition.IRStatistics(
-          dispatch_count=exec_stats_json["dispatch-count"])
+    stream_stats_json = json.loads(module_info.stream_stats_path.read_text())
+    exec_stats_json = stream_stats_json["stream-aggregate"]["execution"]
+    ir_stats = benchmark_definition.IRStatistics(
+        dispatch_count=exec_stats_json["dispatch-count"])
 
     compilation_statistics = CompilationStatistics(
         compilation_info=compilation_info,

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -53,7 +53,7 @@ DISPATCH_COMPONENT_PATTERNS = [
 @dataclass(frozen=True)
 class ModuleInfo(object):
   module_path: pathlib.Path
-  stream_stats_path: pathlib.Path
+  stream_stats_path: Optional[pathlib.Path]
 
 
 def match_module_cmake_target(module_path: pathlib.PurePath) -> Optional[str]:
@@ -318,10 +318,15 @@ def main(args: argparse.Namespace):
           f"Module path isn't a module cmake target: {module_path}")
     compilation_time_ms = target_build_time_map[cmake_target]
 
-    stream_stats_json = json.loads(module_info.stream_stats_path.read_text())
-    exec_stats_json = stream_stats_json["stream-aggregate"]["execution"]
-    ir_stats = benchmark_definition.IRStatistics(
-        dispatch_count=exec_stats_json["dispatch-count"])
+    if module_info.stream_stats_path is None:
+      # TODO(#11076): Set dummy data as the legacy benchmark suites don't
+      # support IR statistics. Will be removed during the cleanup.
+      ir_stats = benchmark_definition.IRStatistics(dispatch_count=-1)
+    else:
+      stream_stats_json = json.loads(module_info.stream_stats_path.read_text())
+      exec_stats_json = stream_stats_json["stream-aggregate"]["execution"]
+      ir_stats = benchmark_definition.IRStatistics(
+          dispatch_count=exec_stats_json["dispatch-count"])
 
     compilation_statistics = CompilationStatistics(
         compilation_info=compilation_info,

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -22,9 +22,10 @@ import os
 import re
 import zipfile
 
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import BinaryIO, Dict, List, Optional, TextIO
 
+from common import benchmark_definition
 from common.benchmark_definition import CompilationInfo, CompilationResults, CompilationStatistics, ModuleComponentSizes, get_git_commit_hash
 from common.benchmark_suite import BenchmarkSuite
 from common import benchmark_config
@@ -47,6 +48,12 @@ DISPATCH_COMPONENT_PATTERNS = [
     r".+_cuda_nvptx_fb\.fb",
     r".+_vmvx_bytecode_fb\.fb",
 ]
+
+
+@dataclass(frozen=True)
+class ModuleInfo(object):
+  module_path: pathlib.Path
+  stream_stats_path: Optional[pathlib.Path] = None
 
 
 def match_module_cmake_target(module_path: pathlib.PurePath) -> Optional[str]:
@@ -146,7 +153,7 @@ def get_module_path(flag_file: TextIO) -> Optional[str]:
 def get_module_map_from_compilation_benchmark_config(
     compilation_benchmark_config_data: TextIO,
     e2e_test_artifacts_dir: pathlib.PurePath
-) -> Dict[CompilationInfo, pathlib.Path]:
+) -> Dict[CompilationInfo, ModuleInfo]:
   benchmark_config = json.load(compilation_benchmark_config_data)
   gen_configs = serialization.unpack_and_deserialize(
       data=benchmark_config["generation_configs"],
@@ -169,16 +176,20 @@ def get_module_map_from_compilation_benchmark_config(
         target_arch=f"[{','.join(target_archs)}]",
         compile_tags=tuple(compile_config.tags),
         gen_config_id=gen_config.composite_id)
-    module_dir_path = iree_artifacts.get_module_dir_path(
-        module_generation_config=gen_config, root_path=e2e_test_artifacts_dir)
+    module_dir_path = pathlib.Path(
+        iree_artifacts.get_module_dir_path(module_generation_config=gen_config,
+                                           root_path=e2e_test_artifacts_dir))
     module_path = module_dir_path / iree_artifacts.MODULE_FILENAME
-    module_map[compilation_info] = pathlib.Path(module_path)
+    stream_stats_path = (module_dir_path /
+                         iree_artifacts.SCHEDULING_STATS_FILENAME)
+    module_map[compilation_info] = ModuleInfo(
+        module_path=module_path, stream_stats_path=stream_stats_path)
 
   return module_map
 
 
 def get_module_map_from_benchmark_suite(
-    benchmark_suite_dir: pathlib.Path) -> Dict[CompilationInfo, pathlib.Path]:
+    benchmark_suite_dir: pathlib.Path) -> Dict[CompilationInfo, ModuleInfo]:
   benchmark_suite = BenchmarkSuite.load_from_benchmark_suite_dir(
       benchmark_suite_dir)
   module_map = {}
@@ -203,8 +214,8 @@ def get_module_map_from_benchmark_suite(
           model_source=category,
           target_arch=benchmark_case.target_arch,
           compile_tags=tuple(benchmark_case.bench_mode))
-      module_map[compilation_info] = (benchmark_case_dir /
-                                      module_path).resolve()
+      module_map[compilation_info] = ModuleInfo(
+          module_path=(benchmark_case_dir / module_path).resolve())
 
   return module_map
 
@@ -293,7 +304,8 @@ def main(args: argparse.Namespace):
     target_build_time_map = parse_compilation_time_from_ninja_log(log_file)
 
   compilation_statistics_list = []
-  for compilation_info, module_path in module_map.items():
+  for compilation_info, module_info in module_map.items():
+    module_path = module_info.module_path
     with module_path.open("rb") as module_file:
       module_component_sizes = get_module_component_info(
           module_file,
@@ -304,10 +316,20 @@ def main(args: argparse.Namespace):
       raise RuntimeError(
           f"Module path isn't a module cmake target: {module_path}")
     compilation_time_ms = target_build_time_map[cmake_target]
+
+    if module_info.stream_stats_path is None:
+      ir_stats = None
+    else:
+      stream_stats_json = json.loads(module_info.stream_stats_path.read_text())
+      exec_stats_json = stream_stats_json["stream-aggregate"]["execution"]
+      ir_stats = benchmark_definition.IRStatistics(
+          dispatch_count=exec_stats_json["dispatch-count"])
+
     compilation_statistics = CompilationStatistics(
         compilation_info=compilation_info,
         module_component_sizes=module_component_sizes,
-        compilation_time_ms=compilation_time_ms)
+        compilation_time_ms=compilation_time_ms,
+        ir_stats=ir_stats)
     compilation_statistics_list.append(compilation_statistics)
 
   commit = get_git_commit_hash("HEAD")

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -321,12 +321,12 @@ def main(args: argparse.Namespace):
     if module_info.stream_stats_path is None:
       # TODO(#11076): Set dummy data as the legacy benchmark suites don't
       # support IR statistics. Will be removed during the cleanup.
-      ir_stats = benchmark_definition.IRStatistics(dispatch_count=-1)
+      ir_stats = benchmark_definition.IRStatistics(stream_dispatch_count=-1)
     else:
       stream_stats_json = json.loads(module_info.stream_stats_path.read_text())
       exec_stats_json = stream_stats_json["stream-aggregate"]["execution"]
       ir_stats = benchmark_definition.IRStatistics(
-          dispatch_count=exec_stats_json["dispatch-count"])
+          stream_dispatch_count=exec_stats_json["dispatch-count"])
 
     compilation_statistics = CompilationStatistics(
         compilation_info=compilation_info,

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -144,8 +144,12 @@ class CollectCompilationStatistics(unittest.TestCase):
         target_arch=f"[cpu-x86_64-cascadelake-linux-gnu]",
         compile_tags=tuple(gen_config_a.compile_config.tags),
         gen_config_id=gen_config_a.composite_id)
-    module_a_path = iree_artifacts.get_module_dir_path(
-        gen_config_a, root_dir) / iree_artifacts.MODULE_FILENAME
+    module_dir_a = pathlib.Path(
+        iree_artifacts.get_module_dir_path(gen_config_a, root_dir))
+    module_info_a = collect_compilation_statistics.ModuleInfo(
+        module_path=module_dir_a / iree_artifacts.MODULE_FILENAME,
+        stream_stats_path=module_dir_a /
+        iree_artifacts.SCHEDULING_STATS_FILENAME)
     compile_info_b = common.benchmark_definition.CompilationInfo(
         name=gen_config_b.name,
         model_name=model_a.name,
@@ -154,11 +158,15 @@ class CollectCompilationStatistics(unittest.TestCase):
         target_arch=f"[cpu-riscv_64-generic-linux-gnu]",
         compile_tags=tuple(gen_config_a.compile_config.tags),
         gen_config_id=gen_config_b.composite_id)
-    module_b_path = iree_artifacts.get_module_dir_path(
-        gen_config_b, root_dir) / iree_artifacts.MODULE_FILENAME
+    module_dir_b = pathlib.Path(
+        iree_artifacts.get_module_dir_path(gen_config_b, root_dir))
+    module_info_b = collect_compilation_statistics.ModuleInfo(
+        module_path=module_dir_b / iree_artifacts.MODULE_FILENAME,
+        stream_stats_path=module_dir_b /
+        iree_artifacts.SCHEDULING_STATS_FILENAME)
     self.assertEqual(module_map, {
-        compile_info_a: module_a_path,
-        compile_info_b: module_b_path
+        compile_info_a: module_info_a,
+        compile_info_b: module_info_b
     })
 
 

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -705,21 +705,36 @@ class ModuleComponentSizes(object):
 
 
 @dataclasses.dataclass(frozen=True)
+class IRStatistics(object):
+  dispatch_count: int
+
+  @staticmethod
+  def from_json_object(json_object: Dict[str, Any]):
+    return IRStatistics(**json_object)
+
+
+@dataclasses.dataclass(frozen=True)
 class CompilationStatistics(object):
   compilation_info: CompilationInfo
   # Module file and component sizes.
   module_component_sizes: ModuleComponentSizes
   # Module compilation time in ms.
   compilation_time_ms: int
+  # IR-level statistics
+  ir_stats: Optional[IRStatistics]
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
+    ir_stats_json = json_object.get("ir_stats")
+    ir_stats = None if ir_stats_json is None else IRStatistics.from_json_object(
+        ir_stats_json)
     return CompilationStatistics(
         compilation_info=CompilationInfo.from_json_object(
             json_object["compilation_info"]),
         module_component_sizes=ModuleComponentSizes.from_json_object(
             json_object["module_component_sizes"]),
-        compilation_time_ms=json_object["compilation_time_ms"])
+        compilation_time_ms=json_object["compilation_time_ms"],
+        ir_stats=ir_stats)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -706,7 +706,8 @@ class ModuleComponentSizes(object):
 
 @dataclasses.dataclass(frozen=True)
 class IRStatistics(object):
-  dispatch_count: int
+  # Number of cmd.execute ops in IR.
+  stream_dispatch_count: int
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -706,7 +706,7 @@ class ModuleComponentSizes(object):
 
 @dataclasses.dataclass(frozen=True)
 class IRStatistics(object):
-  # Number of cmd.execute ops in IR.
+  # Number of cmd.dispatch ops in IR.
   stream_dispatch_count: int
 
   @staticmethod

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -721,20 +721,17 @@ class CompilationStatistics(object):
   # Module compilation time in ms.
   compilation_time_ms: int
   # IR-level statistics
-  ir_stats: Optional[IRStatistics]
+  ir_stats: IRStatistics
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
-    ir_stats_json = json_object.get("ir_stats")
-    ir_stats = None if ir_stats_json is None else IRStatistics.from_json_object(
-        ir_stats_json)
     return CompilationStatistics(
         compilation_info=CompilationInfo.from_json_object(
             json_object["compilation_info"]),
         module_component_sizes=ModuleComponentSizes.from_json_object(
             json_object["module_component_sizes"]),
         compilation_time_ms=json_object["compilation_time_ms"],
-        ir_stats=ir_stats)
+        ir_stats=IRStatistics.from_json_object(json_object["ir_stats"]))
 
 
 @dataclasses.dataclass(frozen=True)

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -362,8 +362,7 @@ def collect_all_compilation_metrics(
 
     for compile_stats in file_results.compilation_statistics:
       component_sizes = compile_stats.module_component_sizes
-      total_dispatch_number = (-1 if compile_stats.ir_stats is None else
-                               compile_stats.ir_stats.dispatch_count)
+      total_dispatch_number = compile_stats.ir_stats.dispatch_count
 
       target_name = str(compile_stats.compilation_info)
       if target_name in target_names:

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -20,6 +20,7 @@ from common.benchmark_thresholds import (BENCHMARK_THRESHOLDS,
                                          COMPILATION_TIME_THRESHOLDS,
                                          TOTAL_ARTIFACT_SIZE_THRESHOLDS,
                                          TOTAL_DISPATCH_SIZE_THRESHOLDS,
+                                         TOTAL_DISPATCH_NUMBER_THRESHOLDS,
                                          BenchmarkThreshold, ThresholdUnit)
 
 GetMetricFunc = Callable[[Any], Tuple[int, Optional[int]]]
@@ -39,6 +40,8 @@ TOTAL_DISPATCH_SIZE_METRIC_ID = "9e15f7e6-383c-47ec-bd38-ecba55a5f10a"
 TOTAL_DISPATCH_SIZE_SERIES_SUFFIX = "compilation:module:component-size:total-dispatch-size"
 TOTAL_ARTIFACT_SIZE_METRIC_ID = "2c8a9198-c01c-45b9-a7da-69c82cf749f7"
 TOTAL_ARTIFACT_SIZE_SERIES_SUFFIX = "compilation:module:total-artifact-size"
+TOTAL_DISPATCH_NUMBER_METRIC_ID = "7b72cd9e-43ed-4078-b6d3-20b810f9e4ad"
+TOTAL_DISPATCH_NUMBER_SERIES_SUFFIX = "compilation:ir:total-dispatch-number"
 
 
 @dataclass
@@ -64,9 +67,11 @@ class CompilationMetrics:
   compilation_time_ms: int
   total_dispatch_component_bytes: int
   total_artifact_bytes: int
+  total_dispatch_number: int
   base_compilation_time_ms: Optional[int] = None
   base_total_artifact_bytes: Optional[int] = None
   base_total_dispatch_component_bytes: Optional[int] = None
+  base_total_dispatch_number: Optional[int] = None
 
   def __str__(self) -> str:
     return self.name
@@ -236,11 +241,46 @@ class TotalArtifactSizeToTable(MetricsToTableMapper[CompilationMetrics]):
     return "Total Artifact Sizes"
 
 
+class TotalDispatchNumberToTable(MetricsToTableMapper[CompilationMetrics]):
+  """Helper to map CompilationMetrics to total dispatch number column."""
+
+  def update_base_value(self, compile_metrics: CompilationMetrics,
+                        base_value: Any) -> CompilationMetrics:
+    return dataclasses.replace(compile_metrics,
+                               base_total_dispatch_number=base_value)
+
+  def get_current_and_base_value(
+      self, compile_metrics: CompilationMetrics) -> Tuple[int, Optional[int]]:
+    return (compile_metrics.total_dispatch_number,
+            compile_metrics.base_total_dispatch_number)
+
+  def get_metric_id(self) -> str:
+    return TOTAL_DISPATCH_NUMBER_METRIC_ID
+
+  def get_series_name(self, name: str) -> str:
+    return f"{name} [{TOTAL_DISPATCH_NUMBER_SERIES_SUFFIX}]"
+
+  def get_unit(self) -> str:
+    return "number"
+
+  def get_table_header(self) -> str:
+    return f"Total Dispatch Number ({self.get_unit()})"
+
+  @staticmethod
+  def get_metric_thresholds() -> Sequence[BenchmarkThreshold]:
+    return TOTAL_DISPATCH_NUMBER_THRESHOLDS
+
+  @staticmethod
+  def get_table_title() -> str:
+    return "Total Dispatch Number"
+
+
 COMPILATION_METRICS_TO_TABLE_MAPPERS: List[
     MetricsToTableMapper[CompilationMetrics]] = [
         CompilationTimeToTable(),
         TotalDispatchSizeToTable(),
         TotalArtifactSizeToTable(),
+        TotalDispatchNumberToTable(),
     ]
 
 
@@ -322,6 +362,8 @@ def collect_all_compilation_metrics(
 
     for compile_stats in file_results.compilation_statistics:
       component_sizes = compile_stats.module_component_sizes
+      total_dispatch_number = (-1 if compile_stats.ir_stats is None else
+                               compile_stats.ir_stats.dispatch_count)
 
       target_name = str(compile_stats.compilation_info)
       if target_name in target_names:
@@ -342,7 +384,8 @@ def collect_all_compilation_metrics(
           compilation_time_ms=compile_stats.compilation_time_ms,
           total_artifact_bytes=component_sizes.file_bytes,
           total_dispatch_component_bytes=component_sizes.
-          total_dispatch_component_bytes)
+          total_dispatch_component_bytes,
+          total_dispatch_number=total_dispatch_number)
 
   return compile_metrics
 

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -263,7 +263,7 @@ class StreamIRDispatchCountToTable(MetricsToTableMapper[CompilationMetrics]):
     return "number"
 
   def get_table_header(self) -> str:
-    return f"Stream IR Dispatch Count (# of cmd.execute ops)"
+    return f"Stream IR Dispatch Count (# of cmd.dispatch ops)"
 
   @staticmethod
   def get_metric_thresholds() -> Sequence[BenchmarkThreshold]:
@@ -271,7 +271,7 @@ class StreamIRDispatchCountToTable(MetricsToTableMapper[CompilationMetrics]):
 
   @staticmethod
   def get_table_title() -> str:
-    return "Stream IR Dispatch Count (# of cmd.execute ops)"
+    return "Stream IR Dispatch Count (# of cmd.dispatch ops)"
 
 
 COMPILATION_METRICS_TO_TABLE_MAPPERS: List[

--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -121,5 +121,6 @@ TOTAL_ARTIFACT_SIZE_THRESHOLDS = [
 
 TOTAL_DISPATCH_NUMBER_THRESHOLDS = [
     # Default threshold: 0%.
+    # Any change on number of dispatches should be reported.
     BenchmarkThreshold(re.compile(r".*"), 0, ThresholdUnit.PERCENTAGE),
 ]

--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -119,8 +119,8 @@ TOTAL_ARTIFACT_SIZE_THRESHOLDS = [
     BenchmarkThreshold(re.compile(r".*"), 5, ThresholdUnit.PERCENTAGE),
 ]
 
-TOTAL_DISPATCH_NUMBER_THRESHOLDS = [
+STREAM_IR_DISPATCH_COUNT_THRESHOLDS = [
     # Default threshold: 0%.
-    # Any change on number of dispatches should be reported.
+    # Any change on dispatch count should be reported.
     BenchmarkThreshold(re.compile(r".*"), 0, ThresholdUnit.PERCENTAGE),
 ]

--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -118,3 +118,8 @@ TOTAL_ARTIFACT_SIZE_THRESHOLDS = [
     # Default threshold: 5%.
     BenchmarkThreshold(re.compile(r".*"), 5, ThresholdUnit.PERCENTAGE),
 ]
+
+TOTAL_DISPATCH_NUMBER_THRESHOLDS = [
+    # Default threshold: 0%.
+    BenchmarkThreshold(re.compile(r".*"), 0, ThresholdUnit.PERCENTAGE),
+]


### PR DESCRIPTION
Report dispatch count (number of `cmd.dispatch` op) at stream IR level in the compilation statistics and to the dashboard.

This metric helps us track the changes on number of dispatches called at IR level (doesn't consider the control flow and workgroup size, but it should be enough for now).