### PR TITLE
Do not error on NCCL library load failure during CUDA driver creation

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
@@ -76,7 +76,8 @@ static iree_status_t iree_hal_cuda_driver_create_internal(
     // and otherwise defer reporting.
     status = iree_hal_cuda_nccl_dynamic_symbols_initialize(host_allocator,
                                                            &driver->syms);
-    if (iree_status_is_unavailable(status)) {
+    if (iree_status_is_unavailable(status) ||
+        iree_status_is_not_found(status)) {
       status = iree_status_ignore(status);
     }
   }

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
@@ -153,7 +153,7 @@ iree_status_t iree_hal_cuda_nccl_dynamic_symbols_initialize(
     if (nccl_version < NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, 0) ||
         major != NCCL_MAJOR) {
       status = iree_make_status(
-          IREE_STATUS_INTERNAL,
+          IREE_STATUS_NOT_FOUND,
           "NCCL version %d.%d found but at least version %d.%d is required",
           major, minor, NCCL_MAJOR, NCCL_MINOR);
     }


### PR DESCRIPTION
If a library symbol is not found or the NCCL library version does not match the requirements do not fail during CUDA driver creation.