### PR TITLE
[StableHLO] Port dot general to dot preprocessing

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
@@ -60,6 +60,7 @@ iree_gentbl_cc_library(
 iree_compiler_cc_library(
     name = "Preprocessing",
     srcs = [
+        "DotGeneralToDot.cpp",
         "EinsumToDotGeneral.cpp",
         "GatherToTorchIndexSelect.cpp",
         "LowerComplex.cpp",
@@ -80,6 +81,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:ShapeDialect",
+        "@llvm-project//mlir:SparseTensorDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_cc_library(
     "Passes.h"
     "Rewriters.h"
   SRCS
+    "DotGeneralToDot.cpp"
     "EinsumToDotGeneral.cpp"
     "GatherToTorchIndexSelect.cpp"
     "LowerComplex.cpp"
@@ -69,6 +70,7 @@ iree_cc_library(
     MLIRMathDialect
     MLIRPass
     MLIRShapeDialect
+    MLIRSparseTensorDialect
     MLIRSupport
     MLIRTensorDialect
     MLIRTransforms

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
@@ -1,0 +1,333 @@
+// Copyright 2019 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements logic for lowering the StableHLO general dot op to the dot op.
+
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h"
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_DOTGENERALTODOT
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h.inc"
+
+namespace {
+Value transposeReshape(Value arg, Location loc,
+                       llvm::ArrayRef<int64_t> leftDims,
+                       llvm::ArrayRef<int64_t> rightDims,
+                       llvm::ArrayRef<int64_t> argShape,
+                       PatternRewriter &rewriter) {
+  Type elementType = getElementTypeOrSelf(arg.getType());
+
+  int64_t leftSize = 1;
+  for (int64_t dim : leftDims) {
+    leftSize = (ShapedType::isDynamic(argShape[dim]) || leftSize < 0)
+                   ? ShapedType::kDynamic
+                   : leftSize * argShape[dim];
+  }
+
+  int64_t rightSize = 1;
+  for (int64_t dim : rightDims) {
+    rightSize = (ShapedType::isDynamic(argShape[dim]) || rightSize < 0)
+                    ? ShapedType::kDynamic
+                    : rightSize * argShape[dim];
+  }
+
+  // Generate the transpose permutation attribute.
+  auto transposePermutation =
+      llvm::to_vector<5>(llvm::concat<const int64_t>(leftDims, rightDims));
+
+  TensorType transposePermutationType =
+      RankedTensorType::get({static_cast<int64_t>(transposePermutation.size())},
+                            rewriter.getIntegerType(64));
+
+  auto transposePermutationAttr =
+      DenseIntElementsAttr::get(transposePermutationType,
+                                llvm::ArrayRef(transposePermutation))
+          .cast<DenseIntElementsAttr>();
+
+  // Compute the resulting shape.
+  llvm::SmallVector<int64_t, 5> transposedShape;
+  for (int64_t val : transposePermutation) {
+    transposedShape.push_back(argShape[val]);
+  }
+
+  // If there are only a single pair of contracting dimensions and the output
+  // rank is two we can skip a needless reshape.
+  bool noReshape = transposedShape.size() == 2 && leftDims.size() == 1 &&
+                   rightDims.size() == 1;
+
+  // Construct transpose. If no reshape is needed, we are done.
+  auto transposeType = RankedTensorType::get(transposedShape, elementType);
+  Value transposeResult = rewriter.create<mlir::stablehlo::TransposeOp>(
+      loc, transposeType, arg, transposePermutationAttr);
+  if (noReshape) return transposeResult;
+
+  // Return the final result.
+  auto reshapedType = RankedTensorType::get({leftSize, rightSize}, elementType);
+
+  if (reshapedType.hasStaticShape()) {
+    return rewriter.create<mlir::stablehlo::ReshapeOp>(loc, reshapedType,
+                                                       transposeResult);
+  }
+
+  SmallVector<Value> reshapeDims;
+  auto multiplyDynamicDims = [&](llvm::ArrayRef<int64_t> dims) -> Value {
+    Value dynamicSize = rewriter.create<mlir::stablehlo::GetDimensionSizeOp>(
+        loc, arg, rewriter.getI64IntegerAttr(dims.front()));
+    Value dynamicSizeReshaped = rewriter.create<mlir::stablehlo::ReshapeOp>(
+        loc, RankedTensorType::get({1}, rewriter.getI32Type()), dynamicSize);
+    for (auto idx : dims.drop_front()) {
+      Value dim = rewriter.create<mlir::stablehlo::GetDimensionSizeOp>(
+          loc, arg, rewriter.getI64IntegerAttr(idx));
+      Value dimReshaped = rewriter.create<mlir::stablehlo::ReshapeOp>(
+          loc, RankedTensorType::get({1}, rewriter.getI32Type()), dim);
+      dynamicSizeReshaped = rewriter.create<mlir::stablehlo::MulOp>(
+          loc, dynamicSizeReshaped, dimReshaped);
+    }
+    return dynamicSizeReshaped;
+  };
+
+  if (leftSize < 0) {
+    reshapeDims.push_back(multiplyDynamicDims(leftDims));
+  } else {
+    reshapeDims.push_back(rewriter.create<mlir::stablehlo::ConstantOp>(
+        loc, rewriter.getI32TensorAttr(leftSize)));
+  }
+
+  if (rightSize < 0) {
+    reshapeDims.push_back(multiplyDynamicDims(rightDims));
+  } else {
+    reshapeDims.push_back(rewriter.create<mlir::stablehlo::ConstantOp>(
+        loc, rewriter.getI32TensorAttr(rightSize)));
+  }
+
+  Value reshapeDimsTensor = rewriter.create<mlir::stablehlo::ConcatenateOp>(
+      loc, RankedTensorType::get({2}, rewriter.getI32Type()), reshapeDims,
+      rewriter.getI64IntegerAttr(0));
+  return rewriter.create<mlir::stablehlo::DynamicReshapeOp>(
+      loc, reshapedType, transposeResult, reshapeDimsTensor);
+}
+
+Value processDotArg(Value arg, Location loc, ArrayRef<int64_t> contractDimsAttr,
+                    bool outerDimsFirst, PatternRewriter &rewriter) {
+  auto shape = arg.getType().cast<ShapedType>().getShape();
+
+  llvm::SmallVector<bool, 5> isOuterDim;
+  isOuterDim.resize(shape.size(), true);
+
+  // Compute the contract dimension ordering.
+  llvm::SmallVector<int64_t, 5> contractDims;
+  for (auto dim : contractDimsAttr) {
+    contractDims.push_back(dim);
+    isOuterDim[dim] = false;
+  }
+
+  // Compute the outer dimension orderings.
+  llvm::SmallVector<int64_t, 5> outerDims;
+  for (const auto &it : llvm::enumerate(isOuterDim)) {
+    if (it.value()) {
+      outerDims.push_back(it.index());
+    }
+  }
+
+  if (outerDimsFirst) {
+    return transposeReshape(arg, loc, outerDims, contractDims, shape, rewriter);
+  }
+
+  return transposeReshape(arg, loc, contractDims, outerDims, shape, rewriter);
+}
+
+struct GeneralDotConvert final
+    : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
+  using OpRewritePattern::OpRewritePattern;
+  // Attempts to lower a General Dot operator to a standard Dot operator.
+  // General dots include batching dimensions and can have collapsing
+  // dimensions along any axis. Inserting correctly arrange transpose and
+  // reshape operators organizes the tensors and allows the General Dot to be
+  // replaced with the standard Dot operator.
+  //
+  // Note: This requires an empty list of batch dimensions.
+  LogicalResult matchAndRewrite(mlir::stablehlo::DotGeneralOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    auto dotNumbers = op.getDotDimensionNumbers();
+    if (!dotNumbers.getLhsBatchingDimensions().empty() ||
+        !dotNumbers.getRhsBatchingDimensions().empty()) {
+      return failure();
+    }
+
+    ArrayAttr precisionConfig;
+    auto opPrecisionConfig = op.getPrecisionConfig();
+    if (opPrecisionConfig.has_value()) precisionConfig = *opPrecisionConfig;
+
+    auto resultTy = cast<ShapedType>(op.getType());
+
+    ArrayRef<int64_t> lhsContractingDims =
+        dotNumbers.getLhsContractingDimensions();
+    ArrayRef<int64_t> rhsContractingDims =
+        dotNumbers.getRhsContractingDimensions();
+
+    TypedValue<TensorType> lhs = op.getLhs();
+    TypedValue<TensorType> rhs = op.getRhs();
+
+    RankedTensorType lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+    RankedTensorType rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+    if (!lhsTy || !rhsTy) return failure();
+
+    // The StableHLO dot operator directly supports a vector dot product
+    // (two vectors reduce into a scalar) as well as a matrix vector
+    // product (a matrix and vector reduce into a vector) without any
+    // need for reshaping. We handle those special cases first, before
+    // entering the general logic that reduces into a matrix.
+    if (lhsTy.hasStaticShape() && rhsTy.hasStaticShape() &&
+        lhsContractingDims.size() == 1 && rhsContractingDims.size() == 1) {
+      if (lhsTy.getRank() == 1 && rhsTy.getRank() == 1) {
+        // Vector-vector, reduces into scalar.
+        assert(lhsContractingDims[0] == 0 && rhsContractingDims[0] == 0);
+        ShapedType newTy = RankedTensorType::get({}, resultTy.getElementType());
+        rewriter.replaceOpWithNewOp<mlir::stablehlo::DotOp>(op, newTy, lhs, rhs,
+                                                            precisionConfig);
+        return success();
+      }
+      if (lhsTy.getRank() == 2 && rhsTy.getRank() == 1 &&
+          lhsContractingDims[0] == 1) {
+        // Matrix-vector, reduces into vector.
+        assert(rhsContractingDims[0] == 0);
+        ShapedType newTy = RankedTensorType::get({lhsTy.getShape()[0]},
+                                                 resultTy.getElementType());
+        rewriter.replaceOpWithNewOp<mlir::stablehlo::DotOp>(op, newTy, lhs, rhs,
+                                                            precisionConfig);
+        return success();
+      }
+      if (lhsTy.getRank() == 2 && rhsTy.getRank() == 2 &&
+          lhsContractingDims[0] == 1 && rhsContractingDims[0] == 0) {
+        // Matrix-matrix, reduces into matrix. Note that for dense cases, this
+        // rewriting rule simply provides a shortcut for what is to follow
+        // (modulo optimizing the trivial transpose/reshape operations). For
+        // sparse cases, however, this rewriting preserves the output sparsity
+        // that was explicitly given for the general dot operation.
+        Value newDotOp = rewriter.create<mlir::stablehlo::DotOp>(
+            loc, resultTy, lhs, rhs, precisionConfig);
+        if (auto enc = sparse_tensor::getSparseTensorEncoding(resultTy)) {
+          newDotOp.setType(RankedTensorType::get(
+              resultTy.getShape(), resultTy.getElementType(), enc));
+        }
+        rewriter.replaceOp(op, newDotOp);
+        return success();
+      }
+    }
+
+    // For any sparse situation, don't use any of the following rules, since
+    // transposing and reshaping is not without cost. Instead, rely on the
+    // default linalg lowering that follows later in the pipeline.
+    if (sparse_tensor::hasAnySparseOperandOrResult(op)) return failure();
+
+    // Compute the, possibly, transposed-reshaped operands.
+    lhs = cast<mlir::TypedValue<mlir::TensorType>>(processDotArg(
+        lhs, loc, lhsContractingDims, /*outerDimsFirst=*/true, rewriter));
+    rhs = cast<mlir::TypedValue<mlir::TensorType>>(processDotArg(
+        rhs, loc, rhsContractingDims, /*outerDimsFirst=*/false, rewriter));
+
+    // Accept only static shaped types.
+    auto lhsShapeType = dyn_cast_or_null<ShapedType>(lhs.getType());
+    auto rhsShapeType = dyn_cast_or_null<ShapedType>(rhs.getType());
+    if (!lhsShapeType || !rhsShapeType) return failure();
+
+    // Generate new dot operator on expanded types.
+    ShapedType newTy = RankedTensorType::get(
+        {lhsShapeType.getShape()[0], rhsShapeType.getShape()[1]},
+        resultTy.getElementType());
+    Value newDotOp = rewriter.create<mlir::stablehlo::DotOp>(
+        loc, newTy, lhs, rhs, precisionConfig);
+    if (static_cast<int64_t>(lhsContractingDims.size()) ==
+            lhsTy.getRank() - 1 &&
+        static_cast<int64_t>(rhsContractingDims.size()) ==
+            rhsTy.getRank() - 1) {
+      rewriter.replaceOp(op, newDotOp);
+      return success();
+    }
+
+    // We can avoid all the computation below if we know the static shape.
+    if (resultTy.hasStaticShape()) {
+      rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(op, resultTy,
+                                                              newDotOp);
+      return success();
+    }
+
+    llvm::SmallVector<int64_t> staticDims;
+    llvm::SmallVector<Value> dynDims;
+
+    auto getDynamicDims = [&](Value arg,
+                              llvm::ArrayRef<int64_t> contractingDims) {
+      RankedTensorType ty = arg.getType().cast<RankedTensorType>();
+      int index = 0;
+      for (int64_t contractingDim : contractingDims) {
+        for (; index < contractingDim; ++index) {
+          staticDims.push_back(ty.getDimSize(index));
+          Value dynDim = rewriter.create<mlir::stablehlo::GetDimensionSizeOp>(
+              loc, arg, rewriter.getI64IntegerAttr(index));
+          Value dynDimReshaped = rewriter.create<mlir::stablehlo::ReshapeOp>(
+              loc, RankedTensorType::get({1}, rewriter.getI32Type()), dynDim);
+          dynDims.push_back(dynDimReshaped);
+        }
+        index++;
+      }
+
+      for (; index < ty.getRank(); ++index) {
+        staticDims.push_back(ty.getDimSize(index));
+        Value dynDim = rewriter.create<mlir::stablehlo::GetDimensionSizeOp>(
+            loc, arg, rewriter.getI64IntegerAttr(index));
+        Value dynDimReshaped = rewriter.create<mlir::stablehlo::ReshapeOp>(
+            loc, RankedTensorType::get({1}, rewriter.getI32Type()), dynDim);
+        dynDims.push_back(dynDimReshaped);
+      }
+    };
+
+    getDynamicDims(op.getLhs(), lhsContractingDims);
+    getDynamicDims(op.getRhs(), rhsContractingDims);
+
+    Value reshapeDimsTensor = rewriter.create<mlir::stablehlo::ConcatenateOp>(
+        loc,
+        RankedTensorType::get({static_cast<int64_t>(dynDims.size())},
+                              rewriter.getI32Type()),
+        dynDims, rewriter.getI64IntegerAttr(0));
+
+    Value result = rewriter.create<mlir::stablehlo::DynamicReshapeOp>(
+        loc, RankedTensorType::get(staticDims, resultTy.getElementType()),
+        newDotOp, reshapeDimsTensor);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct DotGeneralToDot final : impl::DotGeneralToDotBase<DotGeneralToDot> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    populatePreprocessingDotGeneralToDotPatterns(&getContext(), &patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+void populatePreprocessingDotGeneralToDotPatterns(mlir::MLIRContext *context,
+                                                  RewritePatternSet *patterns) {
+  patterns->add<GeneralDotConvert>(context);
+}
+
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
@@ -9,9 +9,14 @@
 
 include "mlir/Pass/PassBase.td"
 
+def DotGeneralToDot :
+    Pass<"iree-stablehlo-preprocessing-dot-general-to-dot", "func::FuncOp"> {
+  let summary = "Lowers general dot to a non-batched dot when possible";
+}
+
 def EinsumToDotGeneral :
     Pass<"iree-stablehlo-preprocessing-einsum-to-dot-general", "func::FuncOp"> {
-  let summary = "Legalizes einsum ops to dot_general ops";
+  let summary = "Legalizes einsum ops to general dot ops";
 }
 
 def GatherToTorchIndexSelect :

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h
@@ -15,6 +15,11 @@ namespace mlir::iree_compiler::stablehlo {
 // General StableHLO/CHLO preprocessing patterns.
 //===----------------------------------------------------------------------===//
 
+/// Collection of rewrite patterns for lowering of StableHLO dot general
+/// operations.
+void populatePreprocessingDotGeneralToDotPatterns(MLIRContext *context,
+                                                  RewritePatternSet *patterns);
+
 /// Collection of rewrite patterns for lowering of StableHLO einsum operations.
 void populatePreprocessingEinsumToDotGeneralPatterns(
     MLIRContext *context, RewritePatternSet *patterns);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "complex_lowering.mlir",
+            "dot_general_to_dot.mlir",
             "einsum_to_dot_general.mlir",
             "gather_to_torch_index_select.mlir",
             "unfuse_batch_norm.mlir",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "complex_lowering.mlir"
+    "dot_general_to_dot.mlir"
     "einsum_to_dot_general.mlir"
     "gather_to_torch_index_select.mlir"
     "unfuse_batch_norm.mlir"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/dot_general_to_dot.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/dot_general_to_dot.mlir
@@ -1,0 +1,182 @@
+// RUN: iree-opt --iree-stablehlo-preprocessing-dot-general-to-dot \
+// RUN:   --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @testDebatch1
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<1x1x2xf32>, [[ARG1:%.+]]: tensor<2x3xf32>)
+func.func @testDebatch1(%arg0: tensor<1x1x2xf32>, %arg1: tensor<2x3xf32>) -> tensor<1x1x3xf32> {
+  // CHECK-DAG: [[T0:%.+]] = stablehlo.transpose [[ARG0]], dims = [0, 1, 2]
+  // CHECK-DAG: [[R0:%.+]] = stablehlo.reshape [[T0]] : (tensor<1x1x2xf32>) -> tensor<1x2xf32>
+  // CHECK-DAG: [[T1:%.+]] = stablehlo.transpose [[ARG1]], dims = [0, 1]
+  // CHECK:     [[R1:%.+]] = stablehlo.dot [[R0]], [[T1]], precision = [DEFAULT, DEFAULT] : (tensor<1x2xf32>, tensor<2x3xf32>) -> tensor<1x3xf32>
+  // CHECK:     [[R2:%.+]] = stablehlo.reshape [[R1]] : (tensor<1x3xf32>) -> tensor<1x1x3xf32>
+  // CHECK:     return [[R2]]
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_contracting_dimensions = [2],
+      rhs_contracting_dimensions = [0]
+    >,
+   precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x1x2xf32>, tensor<2x3xf32>) -> tensor<1x1x3xf32>
+
+  func.return %0 : tensor<1x1x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @testDebatch2
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<2x3xf32>, [[ARG1:%.+]]: tensor<1x1x2xf32>)
+func.func @testDebatch2(%arg0: tensor<2x3xf32>, %arg1: tensor<1x1x2xf32>) -> tensor<3x1x1xf32> {
+  // CHECK-DAG: [[R0:%.+]] = stablehlo.transpose [[ARG0]], dims = [1, 0] : (tensor<2x3xf32>) -> tensor<3x2xf32>
+  // CHECK-DAG: [[R1:%.+]] = stablehlo.transpose [[ARG1]], dims = [2, 0, 1] : (tensor<1x1x2xf32>) -> tensor<2x1x1xf32>
+  // CHECK-DAG: [[R2:%.+]] = stablehlo.reshape [[R1]] : (tensor<2x1x1xf32>) -> tensor<2x1xf32>
+  // CHECK:     [[R3:%.+]] = stablehlo.dot [[R0]], [[R2]], precision = [DEFAULT, DEFAULT] : (tensor<3x2xf32>, tensor<2x1xf32>) -> tensor<3x1xf32>
+  // CHECK:     [[R4:%.+]] = stablehlo.reshape [[R3]] : (tensor<3x1xf32>) -> tensor<3x1x1xf32>
+
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_contracting_dimensions = [0],
+      rhs_contracting_dimensions = [2]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x3xf32>, tensor<1x1x2xf32>) -> tensor<3x1x1xf32>
+  func.return %0 : tensor<3x1x1xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @testBatchPassthrough
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<2x2x3xf32>, [[ARG1:%.+]]: tensor<2x1x2xf32>)
+func.func @testBatchPassthrough(%arg0: tensor<2x2x3xf32>, %arg1: tensor<2x1x2xf32>) -> tensor<2x3x1xf32> {
+  // CHECK-NEXT:  stablehlo.dot_general [[ARG0]], [[ARG1]]
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [1],
+      rhs_batching_dimensions = [0],
+      rhs_contracting_dimensions = [2]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x2x3xf32>, tensor<2x1x2xf32>) -> tensor<2x3x1xf32>
+  func.return %0 : tensor<2x3x1xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @testVec
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<32xf32>, [[ARG1:%.+]]: tensor<32xf32>)
+func.func @testVec(%arg0: tensor<32xf32>, %arg1: tensor<32xf32>) -> tensor<f32> {
+  // CHECK-NEXT: [[R:%.+]] = stablehlo.dot [[ARG0]], [[ARG1]]
+  // CHECK-NEXT: return [[R]]
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_contracting_dimensions = [0],
+      rhs_contracting_dimensions = [0]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<32xf32>, tensor<32xf32>) -> tensor<f32>
+  func.return %0 : tensor<f32>
+}
+
+// -----
+
+// CHECK-LABEL: @testMatVec
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<20x32xf32>, [[ARG1:%.+]]: tensor<32xf32>)
+func.func @testMatVec(%arg0: tensor<20x32xf32>, %arg1: tensor<32xf32>) -> tensor<20xf32> {
+  // CHECK-NEXT: [[R:%.+]] = stablehlo.dot [[ARG0]], [[ARG1]]
+  // CHECK-NEXT: return [[R]]
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_contracting_dimensions = [1],
+      rhs_contracting_dimensions = [0]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<20x32xf32>, tensor<32xf32>) -> tensor<20xf32>
+  func.return %0 : tensor<20xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @testMatVec
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<32x20xf32>, [[ARG1:%.+]]: tensor<32xf32>)
+func.func @testMatVec(%arg0: tensor<32x20xf32>, %arg1: tensor<32xf32>) -> tensor<20xf32> {
+  // CHECK-DAG:  [[T0:%.+]] = stablehlo.transpose [[ARG0]], dims = [1, 0]
+  // CHECK-DAG:  [[T1:%.+]] = stablehlo.transpose [[ARG1]], dims = [0]
+  // CHECK-DAG:  [[R1:%.+]] = stablehlo.reshape [[T1]] : (tensor<32xf32>) -> tensor<32x1xf32>
+  // CHECK-NEXT: [[M:%.+]]  = stablehlo.dot [[T0]], [[R1]]
+  // CHECK-NEXT: [[R:%.+]]  = stablehlo.reshape [[M]]
+  // CHECK-NEXT: return [[R]]
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_contracting_dimensions = [0],
+      rhs_contracting_dimensions = [0]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<32x20xf32>, tensor<32xf32>) -> tensor<20xf32>
+  func.return %0 : tensor<20xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @dot_general_to_dot_dynamic
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<128x4x?x32xf32>, [[ARG1:%.+]]: tensor<8x?x128x4xf32>)
+func.func @dot_general_to_dot_dynamic(%arg0: tensor<128x4x?x32xf32>, %arg1: tensor<8x?x128x4xf32>) -> tensor<?x32x8x?xf32> {
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [],
+      lhs_contracting_dimensions = [0, 1],
+      rhs_batching_dimensions = [],
+      rhs_contracting_dimensions = [2, 3],
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<128x4x?x32xf32>, tensor<8x?x128x4xf32>) -> tensor<?x32x8x?xf32>
+  func.return %0 : tensor<?x32x8x?xf32>
+}
+// CHECK:     %[[C512:.+]] = stablehlo.constant dense<512> : tensor<1xi32>
+// CHECK-DAG:                stablehlo.get_dimension_size [[ARG0]], dim = 2
+// CHECK-DAG:                stablehlo.get_dimension_size [[ARG0]], dim = 3
+// CHECK-DAG:                stablehlo.get_dimension_size [[ARG1]], dim = 0
+// CHECK-DAG:                stablehlo.get_dimension_size [[ARG1]], dim = 0
+// CHECK-DAG:                stablehlo.get_dimension_size [[ARG1]], dim = 1
+// CHECK-DAG: %[[T0:.+]]   = stablehlo.transpose [[ARG0]], dims = [2, 3, 0, 1]
+// CHECK-DAG: %[[R0:.+]]   = stablehlo.dynamic_reshape %[[T0]], {{%.+}} : (tensor<?x32x128x4xf32>, tensor<2xi32>) -> tensor<?x512xf32>
+// CHECK-DAG: %[[T1:.+]]   = stablehlo.transpose [[ARG1]], dims = [2, 3, 0, 1]
+// CHECK-DAG: %[[R1:.+]]   = stablehlo.dynamic_reshape %[[T1]], {{%.+}} : (tensor<128x4x8x?xf32>, tensor<2xi32>) -> tensor<512x?xf32>
+// CHECK-DAG: %[[DOT:.+]]  = stablehlo.dot %[[R0]], %[[R1]], precision = [DEFAULT, DEFAULT] : (tensor<?x512xf32>, tensor<512x?xf32>) -> tensor<?x?xf32>
+// CHECK:     %[[R2:.+]]   = stablehlo.dynamic_reshape %[[DOT]], {{%.+}} : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x32x8x?xf32>
+// CHECK-NEXT: return %[[R2]] : tensor<?x32x8x?xf32>
+
+// -----
+
+// CHECK-LABEL: func @dot_no_rhs_batch
+// CHECK-SAME:    ([[ARG0:%.+]]: tensor<1x512x768xf32>, [[ARG1:%.+]]: tensor<768x12x64xf32>)
+func.func @dot_no_rhs_batch(%arg0: tensor<1x512x768xf32>, %arg1: tensor<768x12x64xf32>) -> tensor<1x512x12x64xf32> {
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_contracting_dimensions = [2],
+      rhs_contracting_dimensions = [0]>
+    } : (tensor<1x512x768xf32>, tensor<768x12x64xf32>) -> tensor<1x512x12x64xf32>
+  func.return %0 : tensor<1x512x12x64xf32>
+}
+// CHECK-DAG:  %[[T0:.+]]       = stablehlo.transpose [[ARG0]], dims = [0, 1, 2] : (tensor<1x512x768xf32>) -> tensor<1x512x768xf32>
+// CHECK-DAG:  %[[T1:.+]]       = stablehlo.transpose [[ARG1]], dims = [0, 1, 2] : (tensor<768x12x64xf32>) -> tensor<768x12x64xf32>
+// CHECK-DAG:  %[[RESHAPEL:.+]] = stablehlo.reshape %[[T0]] : (tensor<1x512x768xf32>) -> tensor<512x768xf32>
+// CHECK-DAG:  %[[RESHAPER:.+]] = stablehlo.reshape %[[T1]] : (tensor<768x12x64xf32>) -> tensor<768x768xf32>
+// CHECK:      %[[DOT:.+]]      = stablehlo.dot %[[RESHAPEL]], %[[RESHAPER]] : (tensor<512x768xf32>, tensor<768x768xf32>) -> tensor<512x768xf32>
+// CHECK:      %[[OUT:.+]]      = stablehlo.reshape %[[DOT]] : (tensor<512x768xf32>) -> tensor<1x512x12x64xf32>
+// CHECK-NEXT: return %[[OUT]] : tensor<1x512x12x64xf32>
+
+// -----
+
+// CHECK-LABEL: @testPrefElem
+func.func @testPrefElem(%arg0: tensor<1x1x2xf32>, %arg1: tensor<2x3xf32>) -> tensor<1x1x3xf64> {
+  // CHECK: stablehlo.dot {{%.*}}, {{%.*}} precision = [DEFAULT, DEFAULT] : (tensor<1x2xf32>, tensor<2x3xf32>) -> tensor<1x3xf64>
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_contracting_dimensions = [2],
+      rhs_contracting_dimensions = [0]
+    >,
+   precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x1x2xf32>, tensor<2x3xf32>) -> tensor<1x1x3xf64>
+
+  func.return %0 : tensor<1x1x3xf64>
+}


### PR DESCRIPTION
These are ported from mlir-hlo. See the initial import for more context: https://github.com/openxla/iree/pull/12957.

The changes compared to the mlir-hlo code are:
-  Code was ported to work on StableHLO ops.
-  Tests were ported to use stablehlo ops and match against how these are printed.
-  Test CHECKs were largely re-written to account for the lack of stablehlo folds and canonicalization patterns.

Issue: https://github.com/openxla/iree/issues/12678