### PR TITLE
Removing iree_hal_command_buffer_dyn_cast from the HAL.

### DIFF
--- a/experimental/rocm/direct_command_buffer.c
+++ b/experimental/rocm/direct_command_buffer.c
@@ -104,17 +104,8 @@ static void iree_hal_rocm_direct_command_buffer_destroy(
 
 bool iree_hal_rocm_direct_command_buffer_isa(
     iree_hal_command_buffer_t* command_buffer) {
-  return iree_hal_command_buffer_dyn_cast(
-      command_buffer, &iree_hal_rocm_direct_command_buffer_vtable);
-}
-
-static void* iree_hal_rocm_direct_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
-  if (vtable == &iree_hal_rocm_direct_command_buffer_vtable) {
-    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
-    return command_buffer;
-  }
-  return NULL;
+  return iree_hal_resource_is(&command_buffer->resource,
+                              &iree_hal_rocm_direct_command_buffer_vtable);
 }
 
 static iree_status_t iree_hal_rocm_direct_command_buffer_begin(
@@ -397,7 +388,6 @@ static iree_status_t iree_hal_rocm_direct_command_buffer_execute_commands(
 static const iree_hal_command_buffer_vtable_t
     iree_hal_rocm_direct_command_buffer_vtable = {
         .destroy = iree_hal_rocm_direct_command_buffer_destroy,
-        .dyn_cast = iree_hal_rocm_direct_command_buffer_dyn_cast,
         .begin = iree_hal_rocm_direct_command_buffer_begin,
         .end = iree_hal_rocm_direct_command_buffer_end,
         .begin_debug_group =

--- a/runtime/src/iree/hal/command_buffer.c
+++ b/runtime/src/iree/hal/command_buffer.c
@@ -222,13 +222,6 @@ IREE_API_EXPORT iree_status_t iree_hal_command_buffer_create(
   return status;
 }
 
-IREE_API_EXPORT void* iree_hal_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
-  IREE_ASSERT_ARGUMENT(command_buffer);
-  if (iree_hal_resource_is(command_buffer, vtable)) return command_buffer;
-  return _VTABLE_DISPATCH(command_buffer, dyn_cast)(command_buffer, vtable);
-}
-
 IREE_API_EXPORT iree_hal_command_buffer_mode_t
 iree_hal_command_buffer_mode(const iree_hal_command_buffer_t* command_buffer) {
   IREE_ASSERT_ARGUMENT(command_buffer);

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -506,9 +506,6 @@ IREE_API_EXPORT void iree_hal_command_buffer_retain(
 IREE_API_EXPORT void iree_hal_command_buffer_release(
     iree_hal_command_buffer_t* command_buffer);
 
-IREE_API_EXPORT void* iree_hal_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable);
-
 // Returns a bitmask indicating the behavior of the command buffer.
 IREE_API_EXPORT iree_hal_command_buffer_mode_t
 iree_hal_command_buffer_mode(const iree_hal_command_buffer_t* command_buffer);
@@ -796,9 +793,6 @@ IREE_API_EXPORT iree_status_t iree_hal_create_transfer_command_buffer(
 
 typedef struct iree_hal_command_buffer_vtable_t {
   void(IREE_API_PTR* destroy)(iree_hal_command_buffer_t* command_buffer);
-
-  void*(IREE_API_PTR* dyn_cast)(iree_hal_command_buffer_t* command_buffer,
-                                const void* vtable);
 
   iree_status_t(IREE_API_PTR* begin)(iree_hal_command_buffer_t* command_buffer);
   iree_status_t(IREE_API_PTR* end)(iree_hal_command_buffer_t* command_buffer);

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -188,19 +188,13 @@ iree_status_t iree_hal_cuda_device_create(
   return status;
 }
 
-bool iree_hal_cuda_device_isa(iree_hal_device_t* base_device) {
-  return iree_hal_resource_is(base_device, &iree_hal_cuda_device_vtable);
-}
-
 CUcontext iree_hal_cuda_device_context(iree_hal_device_t* base_device) {
-  if (!iree_hal_cuda_device_isa(base_device)) return NULL;
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   return device->context_wrapper.cu_context;
 }
 
 iree_hal_cuda_dynamic_symbols_t* iree_hal_cuda_device_dynamic_symbols(
     iree_hal_device_t* base_device) {
-  if (!iree_hal_cuda_device_isa(base_device)) return NULL;
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   return device->context_wrapper.syms;
 }

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.h
@@ -23,9 +23,6 @@ iree_status_t iree_hal_cuda_device_create(
     iree_hal_cuda_dynamic_symbols_t* syms, CUdevice device,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device);
 
-// Returns true if |device| is a CUDA device.
-bool iree_hal_cuda_device_isa(iree_hal_device_t* device);
-
 // Returns a CUDA context bound to the given |device| if it is a CUDA device
 // and otherwise returns NULL.
 //

--- a/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.c
@@ -158,26 +158,16 @@ static void iree_hal_cuda_graph_command_buffer_destroy(
 
 CUgraphExec iree_hal_cuda_graph_command_buffer_handle(
     iree_hal_command_buffer_t* base_command_buffer) {
+  if (!iree_hal_cuda_graph_command_buffer_isa(base_command_buffer)) return NULL;
   iree_hal_cuda_graph_command_buffer_t* command_buffer =
-      (iree_hal_cuda_graph_command_buffer_t*)iree_hal_command_buffer_dyn_cast(
-          base_command_buffer, &iree_hal_cuda_graph_command_buffer_vtable);
-  IREE_ASSERT_TRUE(command_buffer);
+      iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
   return command_buffer->exec;
 }
 
 bool iree_hal_cuda_graph_command_buffer_isa(
     iree_hal_command_buffer_t* command_buffer) {
-  return iree_hal_command_buffer_dyn_cast(
-      command_buffer, &iree_hal_cuda_graph_command_buffer_vtable);
-}
-
-static void* iree_hal_cuda_graph_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
-  if (vtable == &iree_hal_cuda_graph_command_buffer_vtable) {
-    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
-    return command_buffer;
-  }
-  return NULL;
+  return iree_hal_resource_is(&command_buffer->resource,
+                              &iree_hal_cuda_graph_command_buffer_vtable);
 }
 
 // Flushes any pending batched collective operations.
@@ -683,7 +673,6 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_execute_commands(
 static const iree_hal_command_buffer_vtable_t
     iree_hal_cuda_graph_command_buffer_vtable = {
         .destroy = iree_hal_cuda_graph_command_buffer_destroy,
-        .dyn_cast = iree_hal_cuda_graph_command_buffer_dyn_cast,
         .begin = iree_hal_cuda_graph_command_buffer_begin,
         .end = iree_hal_cuda_graph_command_buffer_end,
         .begin_debug_group =

--- a/runtime/src/iree/hal/drivers/cuda/stream_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/stream_command_buffer.c
@@ -123,17 +123,8 @@ static void iree_hal_cuda_stream_command_buffer_destroy(
 
 bool iree_hal_cuda_stream_command_buffer_isa(
     iree_hal_command_buffer_t* command_buffer) {
-  return iree_hal_command_buffer_dyn_cast(
-      command_buffer, &iree_hal_cuda_stream_command_buffer_vtable);
-}
-
-static void* iree_hal_cuda_stream_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
-  if (vtable == &iree_hal_cuda_stream_command_buffer_vtable) {
-    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
-    return command_buffer;
-  }
-  return NULL;
+  return iree_hal_resource_is(&command_buffer->resource,
+                              &iree_hal_cuda_stream_command_buffer_vtable);
 }
 
 // Flushes any pending batched collective operations.
@@ -543,7 +534,6 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_execute_commands(
 static const iree_hal_command_buffer_vtable_t
     iree_hal_cuda_stream_command_buffer_vtable = {
         .destroy = iree_hal_cuda_stream_command_buffer_destroy,
-        .dyn_cast = iree_hal_cuda_stream_command_buffer_dyn_cast,
         .begin = iree_hal_cuda_stream_command_buffer_begin,
         .end = iree_hal_cuda_stream_command_buffer_end,
         .begin_debug_group =

--- a/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
@@ -182,17 +182,8 @@ static void iree_hal_task_command_buffer_destroy(
 
 bool iree_hal_task_command_buffer_isa(
     iree_hal_command_buffer_t* command_buffer) {
-  return iree_hal_command_buffer_dyn_cast(command_buffer,
-                                          &iree_hal_task_command_buffer_vtable);
-}
-
-static void* iree_hal_task_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
-  if (vtable == &iree_hal_task_command_buffer_vtable) {
-    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
-    return command_buffer;
-  }
-  return NULL;
+  return iree_hal_resource_is(&command_buffer->resource,
+                              &iree_hal_task_command_buffer_vtable);
 }
 
 //===----------------------------------------------------------------------===//
@@ -357,8 +348,7 @@ iree_status_t iree_hal_task_command_buffer_issue(
     iree_hal_task_queue_state_t* queue_state, iree_task_t* retire_task,
     iree_arena_allocator_t* arena, iree_task_submission_t* pending_submission) {
   iree_hal_task_command_buffer_t* command_buffer =
-      iree_hal_command_buffer_dyn_cast(base_command_buffer,
-                                       &iree_hal_task_command_buffer_vtable);
+      iree_hal_task_command_buffer_cast(base_command_buffer);
   IREE_ASSERT_TRUE(command_buffer);
 
   // If the command buffer is empty (valid!) then we are a no-op.
@@ -1053,7 +1043,6 @@ static iree_status_t iree_hal_task_command_buffer_execute_commands(
 static const iree_hal_command_buffer_vtable_t
     iree_hal_task_command_buffer_vtable = {
         .destroy = iree_hal_task_command_buffer_destroy,
-        .dyn_cast = iree_hal_task_command_buffer_dyn_cast,
         .begin = iree_hal_task_command_buffer_begin,
         .end = iree_hal_task_command_buffer_end,
         .begin_debug_group = iree_hal_task_command_buffer_begin_debug_group,

--- a/runtime/src/iree/hal/drivers/vulkan/direct_command_buffer.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/direct_command_buffer.cc
@@ -148,17 +148,8 @@ iree_status_t iree_hal_vulkan_direct_command_buffer_allocate(
 
 bool iree_hal_vulkan_direct_command_buffer_isa(
     iree_hal_command_buffer_t* command_buffer) {
-  return iree_hal_command_buffer_dyn_cast(
-      command_buffer, &iree_hal_vulkan_direct_command_buffer_vtable);
-}
-
-static void* iree_hal_vulkan_direct_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
-  if (vtable == &iree_hal_vulkan_direct_command_buffer_vtable) {
-    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
-    return command_buffer;
-  }
-  return NULL;
+  return iree_hal_resource_is(&command_buffer->resource,
+                              &iree_hal_vulkan_direct_command_buffer_vtable);
 }
 
 static void iree_hal_vulkan_direct_command_buffer_destroy(
@@ -183,11 +174,11 @@ static void iree_hal_vulkan_direct_command_buffer_destroy(
 
 VkCommandBuffer iree_hal_vulkan_direct_command_buffer_handle(
     iree_hal_command_buffer_t* base_command_buffer) {
+  if (!iree_hal_vulkan_direct_command_buffer_isa(base_command_buffer)) {
+    return VK_NULL_HANDLE;
+  }
   iree_hal_vulkan_direct_command_buffer_t* command_buffer =
-      (iree_hal_vulkan_direct_command_buffer_t*)
-          iree_hal_command_buffer_dyn_cast(
-              base_command_buffer,
-              &iree_hal_vulkan_direct_command_buffer_vtable);
+      iree_hal_vulkan_direct_command_buffer_cast(base_command_buffer);
   return command_buffer->handle;
 }
 
@@ -825,7 +816,6 @@ namespace {
 const iree_hal_command_buffer_vtable_t
     iree_hal_vulkan_direct_command_buffer_vtable = {
         /*.destroy=*/iree_hal_vulkan_direct_command_buffer_destroy,
-        /*.dyn_cast=*/iree_hal_vulkan_direct_command_buffer_dyn_cast,
         /*.begin=*/iree_hal_vulkan_direct_command_buffer_begin,
         /*.end=*/iree_hal_vulkan_direct_command_buffer_end,
         /*.begin_debug_group=*/

--- a/runtime/src/iree/hal/local/inline_command_buffer.c
+++ b/runtime/src/iree/hal/local/inline_command_buffer.c
@@ -192,17 +192,8 @@ static void iree_hal_inline_command_buffer_destroy(
 
 bool iree_hal_inline_command_buffer_isa(
     iree_hal_command_buffer_t* command_buffer) {
-  return iree_hal_command_buffer_dyn_cast(
-      command_buffer, &iree_hal_inline_command_buffer_vtable);
-}
-
-static void* iree_hal_inline_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
-  if (vtable == &iree_hal_inline_command_buffer_vtable) {
-    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
-    return command_buffer;
-  }
-  return NULL;
+  return iree_hal_resource_is(&command_buffer->resource,
+                              &iree_hal_inline_command_buffer_vtable);
 }
 
 //===----------------------------------------------------------------------===//
@@ -603,7 +594,6 @@ static iree_status_t iree_hal_inline_command_buffer_execute_commands(
 static const iree_hal_command_buffer_vtable_t
     iree_hal_inline_command_buffer_vtable = {
         .destroy = iree_hal_inline_command_buffer_destroy,
-        .dyn_cast = iree_hal_inline_command_buffer_dyn_cast,
         .begin = iree_hal_inline_command_buffer_begin,
         .end = iree_hal_inline_command_buffer_end,
         .begin_debug_group = iree_hal_inline_command_buffer_begin_debug_group,

--- a/runtime/src/iree/hal/utils/deferred_command_buffer.c
+++ b/runtime/src/iree/hal/utils/deferred_command_buffer.c
@@ -213,17 +213,8 @@ static void iree_hal_deferred_command_buffer_destroy(
 
 IREE_API_EXPORT bool iree_hal_deferred_command_buffer_isa(
     iree_hal_command_buffer_t* command_buffer) {
-  return iree_hal_command_buffer_dyn_cast(
-      command_buffer, &iree_hal_deferred_command_buffer_vtable);
-}
-
-static void* iree_hal_deferred_command_buffer_dyn_cast(
-    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
-  if (vtable == &iree_hal_deferred_command_buffer_vtable) {
-    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
-    return command_buffer;
-  }
-  return NULL;
+  return iree_hal_resource_is(&command_buffer->resource,
+                              &iree_hal_deferred_command_buffer_vtable);
 }
 
 static iree_status_t iree_hal_deferred_command_buffer_begin(
@@ -919,8 +910,7 @@ IREE_API_EXPORT iree_status_t iree_hal_deferred_command_buffer_apply(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_deferred_command_buffer_t* command_buffer =
-      (iree_hal_deferred_command_buffer_t*)iree_hal_command_buffer_dyn_cast(
-          base_command_buffer, &iree_hal_deferred_command_buffer_vtable);
+      iree_hal_deferred_command_buffer_cast(base_command_buffer);
   iree_hal_cmd_list_t* cmd_list = &command_buffer->cmd_list;
 
   iree_status_t status = iree_hal_command_buffer_begin(target_command_buffer);
@@ -953,7 +943,6 @@ IREE_API_EXPORT iree_status_t iree_hal_deferred_command_buffer_apply(
 static const iree_hal_command_buffer_vtable_t
     iree_hal_deferred_command_buffer_vtable = {
         .destroy = iree_hal_deferred_command_buffer_destroy,
-        .dyn_cast = iree_hal_deferred_command_buffer_dyn_cast,
         .begin = iree_hal_deferred_command_buffer_begin,
         .end = iree_hal_deferred_command_buffer_end,
         .execution_barrier = iree_hal_deferred_command_buffer_execution_barrier,


### PR DESCRIPTION
It wasn't used and the vtable usage was incompatible with dynamic linking. This removes the checks on the CUDA device accessor functions but those are unstable/experimental anyway so sharp edges are fine until there's a better solution.