### PR TITLE
[StableHLO] Port IREE HLO preprocessing pass

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
@@ -65,6 +65,7 @@ iree_compiler_cc_library(
         "GatherToTorchIndexSelect.cpp",
         "LowerComplex.cpp",
         "Passes.cpp",
+        "StableHLOToStableHLO.cpp",
         "UnfuseBatchNorm.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
@@ -58,6 +58,7 @@ iree_cc_library(
     "GatherToTorchIndexSelect.cpp"
     "LowerComplex.cpp"
     "Passes.cpp"
+    "StableHLOToStableHLO.cpp"
     "UnfuseBatchNorm.cpp"
   DEPS
     ::ComplexLoweringPatterns

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
@@ -9,6 +9,15 @@
 
 include "mlir/Pass/PassBase.td"
 
+def StableHLOToStableHLOPreprocessing :
+    Pass<"iree-stablehlo-to-stablehlo-preprocessing", "func::FuncOp"> {
+  let summary = "Apply IREE-specific stablehlo to stablehlo preprocessing transformations";
+  let options = [
+    Option<"orderConvFeatures", "order-conv-features", "bool", /*default=*/"true",
+           "Guarantees input/output features ordered from conv kernel">
+  ];
+}
+
 def DotGeneralToDot :
     Pass<"iree-stablehlo-preprocessing-dot-general-to-dot", "func::FuncOp"> {
   let summary = "Lowers general dot to a non-batched dot when possible";

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -1,0 +1,1364 @@
+// Copyright 2020 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements StableHLO-to-StableHLO IREE-specific preprocessing.
+
+#include <numeric>
+#include <random>
+
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h"
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h"
+#include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/ChloOps.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_STABLEHLOTOSTABLEHLOPREPROCESSING
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h.inc"
+
+namespace {
+
+bool isIota(ArrayRef<int64_t> array) {
+  for (auto [idx, value] : llvm::enumerate(array)) {
+    if (static_cast<int64_t>(idx) != value) return false;
+  }
+  return true;
+}
+
+DenseIntElementsAttr make1DElementsAttr(OpBuilder &b,
+                                        ArrayRef<int64_t> integers) {
+  auto type = RankedTensorType::get({static_cast<int64_t>(integers.size())},
+                                    b.getIntegerType(64));
+  return DenseIntElementsAttr::get(type, integers);
+}
+
+DenseIntElementsAttr make1DElementsAttr(OpBuilder &b, int64_t start,
+                                        int64_t num) {
+  return make1DElementsAttr(
+      b, llvm::to_vector<4>(llvm::seq<int64_t>(start, start + num)));
+}
+
+Value getF32Const(ImplicitLocOpBuilder b, ArrayRef<int64_t> shapes,
+                  ArrayRef<float> values) {
+  RankedTensorType ty = RankedTensorType::get(shapes, b.getF32Type());
+  return b
+      .create<mlir::stablehlo::ConstantOp>(DenseFPElementsAttr::get(ty, values))
+      .getResult();
+}
+
+// Guarantee that the input dimensions are ordered batch, spatial_dims, feature
+// dim.
+struct ReorderConvOpInputDimensions final
+    : OpRewritePattern<mlir::stablehlo::ConvolutionOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ConvolutionOp op,
+                                PatternRewriter &rewriter) const override {
+    auto lhsType = cast<ShapedType>(op.getLhs().getType());
+    auto lhsShape = lhsType.getShape();
+    if (!lhsType.hasRank()) {
+      return failure();
+    }
+
+    auto dimensionNumbers = op.getDimensionNumbers();
+    auto spatialDims = dimensionNumbers.getInputSpatialDimensions();
+
+    // Compute the permutation required to create a standard order.
+    llvm::SmallVector<int64_t, 4> permutations;
+    permutations.push_back(dimensionNumbers.getInputBatchDimension());
+    llvm::append_range(permutations, spatialDims);
+    permutations.push_back(dimensionNumbers.getInputFeatureDimension());
+
+    // If the permutation is iota then no reordering is required.
+    if (isIota(permutations)) {
+      return failure();
+    }
+
+    llvm::SmallVector<int64_t, 4> transposeShape;
+    for (int64_t p : permutations) {
+      transposeShape.push_back(lhsShape[p]);
+    }
+
+    auto transposed = rewriter.create<mlir::stablehlo::TransposeOp>(
+        op.getLoc(),
+        RankedTensorType::get(transposeShape, lhsType.getElementType()),
+        op.getLhs(), rewriter.getI64TensorAttr(permutations));
+
+    llvm::SmallVector<int64_t, 4> newSpatialDimensions(spatialDims.size());
+    std::iota(newSpatialDimensions.begin(), newSpatialDimensions.end(), 1);
+
+    auto newDimensionNumbers = mlir::stablehlo::ConvDimensionNumbersAttr::get(
+        op.getContext(),
+        /*input_batch_dimension=*/0,
+        /*input_feature_dimension=*/newSpatialDimensions.size() + 1,
+        /*input_spatial_dimensions=*/newSpatialDimensions,
+        dimensionNumbers.getKernelInputFeatureDimension(),
+        dimensionNumbers.getKernelOutputFeatureDimension(),
+        dimensionNumbers.getKernelSpatialDimensions(),
+        dimensionNumbers.getOutputBatchDimension(),
+        dimensionNumbers.getOutputFeatureDimension(),
+        dimensionNumbers.getOutputSpatialDimensions());
+
+    SmallVector<Value, 2> operands = {transposed, op.getRhs()};
+    auto newConv = rewriter.create<mlir::stablehlo::ConvolutionOp>(
+        op.getLoc(), op.getType(), operands, op->getAttrs());
+    newConv.setDimensionNumbersAttr(newDimensionNumbers);
+    rewriter.replaceOp(op, newConv.getResult());
+
+    return success();
+  }
+};
+
+struct ReorderConvOpKernelDimensions final
+    : OpRewritePattern<mlir::stablehlo::ConvolutionOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(mlir::stablehlo::ConvolutionOp op,
+                                PatternRewriter &rewriter) const override {
+    auto kernel = op.getRhs();
+    auto kernelType = cast<ShapedType>(kernel.getType());
+    if (!kernelType.hasRank()) return failure();
+    auto kernelShape = kernelType.getShape();
+
+    auto dimensionNumbers = op.getDimensionNumbers();
+
+    auto spatialDims = dimensionNumbers.getKernelSpatialDimensions();
+
+    auto inputFeatureDimension =
+        dimensionNumbers.getKernelInputFeatureDimension();
+    auto outputFeatureDimension =
+        dimensionNumbers.getKernelOutputFeatureDimension();
+
+    // Compute the permutation for the transpose.
+    llvm::SmallVector<int64_t, 4> permutation(spatialDims.begin(),
+                                              spatialDims.end());
+    permutation.push_back(inputFeatureDimension);
+    permutation.push_back(outputFeatureDimension);
+
+    // If the permutation is iota, then no transpose is required.
+    if (isIota(permutation)) return failure();
+
+    llvm::SmallVector<int64_t, 4> transposeShape;
+    for (int64_t perm : permutation) {
+      transposeShape.push_back(kernelShape[perm]);
+    }
+
+    llvm::SmallVector<int64_t, 4> newSpatialDimensions(spatialDims.size());
+    std::iota(newSpatialDimensions.begin(), newSpatialDimensions.end(), 0);
+
+    auto transposeKernel = rewriter.create<mlir::stablehlo::TransposeOp>(
+        op.getLoc(),
+        RankedTensorType::get(transposeShape, kernelType.getElementType()),
+        kernel, rewriter.getI64TensorAttr(permutation));
+
+    auto newDimensionNumbers = mlir::stablehlo::ConvDimensionNumbersAttr::get(
+        op.getContext(), dimensionNumbers.getInputBatchDimension(),
+        dimensionNumbers.getInputFeatureDimension(),
+        dimensionNumbers.getInputSpatialDimensions(),
+        /*kernel_input_feature_dimension=*/
+        newSpatialDimensions.size(),
+        /*kernel_output_feature_dimension=*/
+        newSpatialDimensions.size() + 1, newSpatialDimensions,
+        dimensionNumbers.getOutputBatchDimension(),
+        dimensionNumbers.getOutputFeatureDimension(),
+        dimensionNumbers.getOutputSpatialDimensions());
+
+    SmallVector<Value, 2> operands = {op.getLhs(), transposeKernel};
+    mlir::stablehlo::ConvolutionOp newConv =
+        rewriter.create<mlir::stablehlo::ConvolutionOp>(
+            op.getLoc(), op.getType(), operands, op->getAttrs());
+    newConv.setDimensionNumbersAttr(newDimensionNumbers);
+
+    rewriter.replaceOp(op, {newConv.getResult()});
+    return success();
+  }
+};
+
+// Guarantee that the output dimensions are ordered batch, spatial_dims, feature
+// dim.
+struct ReorderConvOpOutputDimensions final
+    : OpRewritePattern<mlir::stablehlo::ConvolutionOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ConvolutionOp op,
+                                PatternRewriter &rewriter) const override {
+    auto resultType = op.getType().cast<ShapedType>();
+    auto resultShape = resultType.getShape();
+    if (!resultType.hasRank()) {
+      return failure();
+    }
+
+    auto dimensionNumbers = op.getDimensionNumbers();
+    auto spatialDims = dimensionNumbers.getOutputSpatialDimensions();
+
+    // Compute the permutation to transpose to an ordered output.
+    llvm::SmallVector<int64_t, 4> permutation;
+    permutation.push_back(dimensionNumbers.getOutputBatchDimension());
+    permutation.append(spatialDims.begin(), spatialDims.end());
+    permutation.push_back(dimensionNumbers.getOutputFeatureDimension());
+
+    // If the permutation is iota then no reordering is required.
+    if (isIota(permutation)) {
+      return failure();
+    }
+
+    // Compute what the new conv shape should be.
+    llvm::SmallVector<int64_t, 4> convShape;
+    for (auto p : permutation) {
+      convShape.push_back(resultShape[p]);
+    }
+
+    // Compute the inverse transpose to unordered and ordered output.
+    llvm::SmallVector<int64_t, 4> invertPermutation(permutation.size());
+    for (auto it : llvm::enumerate(permutation)) {
+      invertPermutation[it.value()] = it.index();
+    }
+
+    llvm::SmallVector<int64_t, 4> newSpatialDimensions(spatialDims.size());
+    std::iota(newSpatialDimensions.begin(), newSpatialDimensions.end(), 1);
+
+    auto newDimensionNumbers = mlir::stablehlo::ConvDimensionNumbersAttr::get(
+        op.getContext(), dimensionNumbers.getInputBatchDimension(),
+        dimensionNumbers.getInputFeatureDimension(),
+        dimensionNumbers.getInputSpatialDimensions(),
+        dimensionNumbers.getKernelInputFeatureDimension(),
+        dimensionNumbers.getKernelOutputFeatureDimension(),
+        dimensionNumbers.getKernelSpatialDimensions(),
+        /*output_batch_dimension=*/0,
+        /*output_feature_dimension=*/newSpatialDimensions.size() + 1,
+        /*output_spatial_dimensions=*/newSpatialDimensions);
+
+    SmallVector<Value, 2> operands = {op.getLhs(), op.getRhs()};
+    auto newConv = rewriter.create<mlir::stablehlo::ConvolutionOp>(
+        op.getLoc(),
+        RankedTensorType::get(convShape, resultType.getElementType()), operands,
+        op->getAttrs());
+    newConv.setDimensionNumbersAttr(newDimensionNumbers);
+
+    auto transposed = rewriter.create<mlir::stablehlo::TransposeOp>(
+        op.getLoc(), resultType, newConv,
+        rewriter.getI64TensorAttr(invertPermutation));
+
+    rewriter.replaceOp(op, transposed.getResult());
+    return success();
+  }
+};
+
+bool isConsecutive(ArrayRef<int64_t> array) {
+  for (size_t i = 1, e = array.size(); i < e; ++i) {
+    if (array[i] - array[i - 1] != 1) return false;
+  }
+  return true;
+}
+
+struct ScatterInt64Indices final
+    : OpRewritePattern<mlir::stablehlo::ScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    auto indices = op.getScatterIndices();
+    auto indicesTy = indices.getType();
+    auto indicesETy = indicesTy.getElementType();
+    if (indicesETy.isInteger(32)) {
+      return rewriter.notifyMatchFailure(op, "already has i32 index type");
+    }
+
+    if (!indicesTy.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(op, "cannot validate legal size");
+    }
+
+    uint64_t maxSize = std::numeric_limits<int32_t>::max();
+    if (indicesETy.getIntOrFloatBitWidth() > 32) {
+      for (int i = 0, s = indicesTy.getRank(); i < s; ++i) {
+        if (indicesTy.getDimSize(i) > maxSize) {
+          return rewriter.notifyMatchFailure(op, "index may exceed i32 max");
+        }
+      }
+    }
+
+    indices = rewriter.create<mlir::stablehlo::ConvertOp>(
+        op.getLoc(), indicesTy.clone(rewriter.getI32Type()), indices);
+
+    auto newScatter = rewriter.create<mlir::stablehlo::ScatterOp>(
+        op.getLoc(), op.getResultTypes(), op.getInputs(), indices,
+        op.getUpdates(), op.getScatterDimensionNumbers(),
+        op.getIndicesAreSorted(), op.getUniqueIndices());
+
+    Region &region = newScatter.getUpdateComputation();
+    rewriter.cloneRegionBefore(op.getUpdateComputation(), region, region.end());
+    rewriter.replaceOp(op, newScatter.getResults());
+
+    return success();
+  }
+};
+
+// If the indices tensor has an implicit index vector dim we expand and make it
+// an explicit dim.
+struct ScatterImplicitIndex final
+    : OpRewritePattern<mlir::stablehlo::ScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    auto dimNumbers = op.getScatterDimensionNumbers();
+    auto indexVectorDim = dimNumbers.getIndexVectorDim();
+    Value indices = op.getScatterIndices();
+    auto indicesTy = indices.getType().cast<ShapedType>();
+
+    // Check indices vector has an implicit dim.
+    if (indexVectorDim != indicesTy.getRank()) {
+      return rewriter.notifyMatchFailure(op, "no implicit index dim");
+    }
+
+    // Materialize the implicit indices dim.
+    SmallVector<ReassociationExprs, 4> reassociationMap;
+    reassociationMap.resize(indicesTy.getRank());
+    SmallVector<int64_t> newShape;
+    for (int i = 0, s = indicesTy.getRank(); i < s; ++i) {
+      reassociationMap[i].push_back(rewriter.getAffineDimExpr(i));
+      newShape.push_back(indicesTy.getDimSize(i));
+    }
+    if (!reassociationMap.empty()) {
+      reassociationMap.back().push_back(
+          rewriter.getAffineDimExpr(indicesTy.getRank()));
+    }
+    newShape.push_back(1);
+    indicesTy = RankedTensorType::get(newShape, indicesTy.getElementType());
+    indices = rewriter.create<tensor::ExpandShapeOp>(op.getLoc(), indicesTy,
+                                                     indices, reassociationMap);
+
+    auto newScatter = rewriter.create<mlir::stablehlo::ScatterOp>(
+        op.getLoc(), op.getResultTypes(), op.getInputs(), indices,
+        op.getUpdates(), dimNumbers, op.getIndicesAreSorted(),
+        op.getUniqueIndices());
+    Region &region = newScatter.getUpdateComputation();
+    rewriter.cloneRegionBefore(op.getUpdateComputation(), region, region.end());
+    rewriter.replaceOp(op, newScatter.getResults());
+    return success();
+  }
+};
+
+struct ScatterImplicitBatch final
+    : OpRewritePattern<mlir::stablehlo::ScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  static Value addUnitBatchDim(Location loc, Value value,
+                               PatternRewriter &rewriter) {
+    auto valueTy = cast<ShapedType>(value.getType());
+    if (!valueTy.hasRank()) return nullptr;
+
+    // Materialize the implicit indices dim.
+    SmallVector<ReassociationExprs, 4> reassociationMap(valueTy.getRank());
+    if (!reassociationMap.empty()) {
+      reassociationMap.front().push_back(rewriter.getAffineDimExpr(0));
+    }
+
+    SmallVector<int64_t> newShape = {1};
+    for (int i = 0, s = valueTy.getRank(); i < s; i++) {
+      reassociationMap[i].push_back(rewriter.getAffineDimExpr(i + 1));
+      newShape.push_back(valueTy.getDimSize(i));
+    }
+
+    valueTy = RankedTensorType::get(newShape, valueTy.getElementType());
+    return rewriter.create<tensor::ExpandShapeOp>(loc, valueTy, value,
+                                                  reassociationMap);
+  }
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    auto dimNumbers = op.getScatterDimensionNumbers();
+    auto indexVectorDim = dimNumbers.getIndexVectorDim();
+    auto indices = op.getScatterIndices().cast<Value>();
+    auto indicesTy = indices.getType().dyn_cast<RankedTensorType>();
+
+    // Check whether indices has no batch dimension.
+    if (!indicesTy) return failure();
+    if (indicesTy.getRank() != 1 || indexVectorDim != 0) {
+      return rewriter.notifyMatchFailure(op,
+                                         "no implicit batch dimension to add.");
+    }
+
+    indices = addUnitBatchDim(op.getLoc(), indices, rewriter);
+    if (!indices) {
+      return rewriter.notifyMatchFailure(
+          op, "Unable to add implicit batch dim to indices.");
+    }
+
+    llvm::SmallVector<int64_t> newUpdateWindowDims;
+    for (auto dim : dimNumbers.getUpdateWindowDims()) {
+      // Batch dimension is inserted at the start so window dimensions are shift
+      // forwards.
+      newUpdateWindowDims.push_back(dim + 1);
+    }
+
+    llvm::SmallVector<Value> updates;
+    for (Value update : op.getUpdates()) {
+      update = addUnitBatchDim(op.getLoc(), update, rewriter);
+      if (!update) {
+        return rewriter.notifyMatchFailure(
+            op, "Unable to add implicit batch dim to update.");
+      }
+      updates.push_back(update);
+    }
+
+    auto newDimNumbers = mlir::stablehlo::ScatterDimensionNumbersAttr::get(
+        op.getContext(), newUpdateWindowDims,
+        dimNumbers.getInsertedWindowDims(),
+        dimNumbers.getScatterDimsToOperandDims(),
+        dimNumbers.getIndexVectorDim() + 1);
+
+    auto newScatter = rewriter.create<mlir::stablehlo::ScatterOp>(
+        op.getLoc(), op.getResultTypes(), op.getInputs(), indices, updates,
+        newDimNumbers, op.getIndicesAreSorted(), op.getUniqueIndices());
+    Region &region = newScatter.getUpdateComputation();
+    rewriter.cloneRegionBefore(op.getUpdateComputation(), region, region.end());
+    rewriter.replaceOp(op, newScatter.getResults());
+    return success();
+  }
+};
+
+struct ScatterCollapseBatch final
+    : OpRewritePattern<mlir::stablehlo::ScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  static Value collapseBatchDims(Location loc, Value value, int64_t batchCount,
+                                 PatternRewriter &rewriter) {
+    auto valueTy = dyn_cast<ShapedType>(value.getType());
+    if (!valueTy) return nullptr;
+
+    SmallVector<ReassociationExprs, 4> reassociationMap(1);
+    reassociationMap.reserve(valueTy.getRank() - batchCount + 1);
+    int64_t batchSize = 1;
+    for (int i = 0, s = batchCount; i < s; i++) {
+      reassociationMap.front().push_back(rewriter.getAffineDimExpr(i));
+      bool isDynamic =
+          valueTy.isDynamicDim(i) || batchSize == ShapedType::kDynamic;
+      batchSize =
+          isDynamic ? ShapedType::kDynamic : valueTy.getDimSize(i) * batchSize;
+    }
+
+    SmallVector<int64_t> newShape = {batchSize};
+    for (int i = batchCount, s = valueTy.getRank(); i < s; i++) {
+      reassociationMap.push_back({rewriter.getAffineDimExpr(i)});
+      newShape.push_back(valueTy.getDimSize(i));
+    }
+
+    valueTy = RankedTensorType::get(newShape, valueTy.getElementType());
+    return rewriter.create<tensor::CollapseShapeOp>(loc, valueTy, value,
+                                                    reassociationMap);
+  }
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    auto dimNumbers = op.getScatterDimensionNumbers();
+    auto indexVectorDim = dimNumbers.getIndexVectorDim();
+    auto indices = op.getScatterIndices().cast<Value>();
+    auto indicesTy = indices.getType().cast<ShapedType>();
+    auto updatedWindowDims = dimNumbers.getUpdateWindowDims();
+
+    if (!indicesTy.hasRank()) {
+      return rewriter.notifyMatchFailure(op, "indices has unknown rank");
+    }
+
+    // Check for an explicit index dimension.
+    if (indexVectorDim != indicesTy.getRank() - 1) {
+      return rewriter.notifyMatchFailure(op, "no explicit indices dimension");
+    }
+
+    // Check that there are multiple batch dimensions.
+    if (indicesTy.getRank() < 3) {
+      return rewriter.notifyMatchFailure(op, "no multiple batch dimensions");
+    }
+
+    const int64_t batchCount = indicesTy.getRank() - 1;
+    for (auto it : llvm::enumerate(updatedWindowDims)) {
+      if (it.index() != it.value() - batchCount) {
+        return rewriter.notifyMatchFailure(
+            op, "update windows should be at the end.");
+      }
+    }
+
+    indices = collapseBatchDims(op.getLoc(), indices, batchCount, rewriter);
+    if (!indices) {
+      return rewriter.notifyMatchFailure(op,
+                                         "cannot collapse indices batch dims");
+    }
+
+    llvm::SmallVector<Value> updates;
+    for (Value update : op.getUpdates()) {
+      update = collapseBatchDims(op.getLoc(), update, batchCount, rewriter);
+      if (!update) {
+        return rewriter.notifyMatchFailure(op,
+                                           "cannot collapse update batch dims");
+      }
+      updates.push_back(update);
+    }
+
+    llvm::SmallVector<int64_t> newUpdatedWindowDims;
+    for (auto dim : updatedWindowDims) {
+      newUpdatedWindowDims.push_back(dim - batchCount + 1);
+    }
+
+    auto newDimNumbers = mlir::stablehlo::ScatterDimensionNumbersAttr::get(
+        op.getContext(), newUpdatedWindowDims,
+        dimNumbers.getInsertedWindowDims(),
+        dimNumbers.getScatterDimsToOperandDims(),
+        /*indexVectorDim=*/1);
+
+    auto newScatter = rewriter.create<mlir::stablehlo::ScatterOp>(
+        op.getLoc(), op.getResultTypes(), op.getInputs(), indices, updates,
+        newDimNumbers, op.getIndicesAreSorted(), op.getUniqueIndices());
+    Region &region = newScatter.getUpdateComputation();
+    rewriter.cloneRegionBefore(op.getUpdateComputation(), region, region.end());
+    rewriter.replaceOp(op, newScatter.getResults());
+    return success();
+  }
+};
+
+// Ensure the batch dimensions of both the indices and updates are the first
+// dimensions. If they are not, transpose them to the start.
+struct ScatterBatchFirst final : OpRewritePattern<mlir::stablehlo::ScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder builder(op.getLoc(), rewriter);
+    auto dimNumbers = op.getScatterDimensionNumbers();
+
+    // If the index vector dim is not implicitly or explicitly at the end
+    // we need to transpose the batch dimensions to the start.
+    Value indices = op.getScatterIndices();
+    auto indicesTy = indices.getType().cast<ShapedType>();
+    auto indexVectorDim = dimNumbers.getIndexVectorDim();
+    if (indexVectorDim < indicesTy.getRank() - 1) {
+      llvm::SmallVector<int64_t> perm;
+      perm.reserve(indicesTy.getRank());
+      for (int i = 0, s = indicesTy.getRank(); i < s; ++i)
+        if (i != indexVectorDim) perm.push_back(i);
+
+      if (perm.size() < indicesTy.getRank()) perm.push_back(indexVectorDim);
+
+      llvm::SmallVector<int64_t> newShape;
+      for (int i = 0, s = perm.size(); i < s; ++i)
+        newShape.push_back(indicesTy.getDimSize(perm[i]));
+
+      indices = builder.create<mlir::stablehlo::TransposeOp>(
+          indicesTy.clone(newShape), indices, builder.getI64TensorAttr(perm));
+      indicesTy = indices.getType().cast<RankedTensorType>();
+      indexVectorDim = indicesTy.getRank() - 1;
+    }
+
+    // Compute the permutation require to transpose the batch dimensions to
+    // the beginning.
+    auto updates = op.getUpdates();
+    auto updates0 = updates.front();
+    auto updates0Ty = updates0.getType().cast<ShapedType>();
+    auto updatedWindowDims = dimNumbers.getUpdateWindowDims();
+
+    // Determine which dimensions are batch dimensions.
+    llvm::SmallVector<bool> isBatch(updates0Ty.getRank(), true);
+    for (int i = 0, s = updatedWindowDims.size(); i < s; ++i)
+      isBatch[updatedWindowDims[i]] = false;
+
+    // Permute batch dimensions to the start of the update tensor.
+    llvm::SmallVector<int64_t> updatePerm;
+    updatePerm.reserve(updates0Ty.getRank());
+    for (int i = 0, s = isBatch.size(); i < s; ++i)
+      if (isBatch[i]) updatePerm.push_back(i);
+    updatePerm.append(updatedWindowDims.begin(), updatedWindowDims.end());
+
+    llvm::SmallVector<int64_t> newUpdatedWindowDims;
+    int64_t batchCount = updates0Ty.getRank() - updatedWindowDims.size();
+    for (int i = batchCount, s = updates0Ty.getRank(); i < s; i++)
+      newUpdatedWindowDims.push_back(i);
+
+    bool indicesChanged = indices != op.getScatterIndices();
+    bool updatesChanged =
+        llvm::any_of(llvm::enumerate(updatePerm),
+                     [](auto it) { return it.index() != it.value(); });
+    llvm::SmallVector<Value> newUpdates(updates.begin(), updates.end());
+    if (updatesChanged) {
+      for (Value &update : newUpdates) {
+        auto updateTy = update.getType().cast<ShapedType>();
+        llvm::SmallVector<int64_t> newShape;
+        newShape.reserve(updateTy.getRank());
+        for (int i = 0, s = updatePerm.size(); i < s; i++)
+          newShape.push_back(updateTy.getDimSize(updatePerm[i]));
+        update = builder.create<mlir::stablehlo::TransposeOp>(
+            updateTy.clone(newShape), update,
+            builder.getI64TensorAttr(updatePerm));
+      }
+    }
+
+    if (!indicesChanged && !updatesChanged)
+      return rewriter.notifyMatchFailure(
+          op, "batch dimensions are already leading");
+
+    auto newDimNumbers = mlir::stablehlo::ScatterDimensionNumbersAttr::get(
+        op.getContext(), newUpdatedWindowDims,
+        dimNumbers.getInsertedWindowDims(),
+        dimNumbers.getScatterDimsToOperandDims(),
+        /*indexVectorDim=*/indexVectorDim);
+
+    auto newScatter = rewriter.create<mlir::stablehlo::ScatterOp>(
+        op.getLoc(), op.getResultTypes(), op.getInputs(), indices, newUpdates,
+        newDimNumbers, op.getIndicesAreSorted(), op.getUniqueIndices());
+    Region &region = newScatter.getUpdateComputation();
+    rewriter.cloneRegionBefore(op.getUpdateComputation(), region, region.end());
+    rewriter.replaceOp(op, newScatter.getResults());
+    return success();
+  }
+};
+
+// stablehlo.scatter can materialize a unit dimension at both indexed dimensions
+// or at unary dimensions in the destination matrix. linalg_ext.scatter only
+// allows unit dimensions at indexed dimensions. This pattern inserts all
+// unary dimensions that are not index dimensions to be compatible with
+// linalg_ext.scatter.
+//
+// If converts an stablehlo.scatter as below:
+//  %result = "stablehlo.scatter"(...) ({
+//    indices_are_sorted = true,
+//    scatter_dimension_numbers = #stablehlo.scatter<
+//            update_window_dims = [1],
+//            inserted_window_dims = [0, 2],
+//            scatter_dims_to_operand_dims = [0],
+//            index_vector_dim = 1>,
+//    unique_indices = true} :
+//        (tensor<5x4x1xi32>, tensor<1x1xi32>, tensor<1x4xi32>)
+//
+// To:
+//  %result = "stablehlo.scatter"(...) ({
+//    indices_are_sorted = true,
+//    scatter_dimension_numbers = #stablehlo.scatter<
+//            update_window_dims = [1, 2],
+//            inserted_window_dims = [0],
+//            scatter_dims_to_operand_dims = [0],
+//            index_vector_dim = 1>,
+//     unique_indices = true} :
+//        (tensor<5x4x1xi32>, tensor<1x1xi32>, tensor<1x4x1xi32>)
+//  return %0 : tensor<5x4x1xi32>
+struct ScatterMaterializeInsertedDim final
+    : OpRewritePattern<mlir::stablehlo::ScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    auto indices = op.getScatterIndices();
+    auto operand = op.getInputs().front();
+    auto indicesTy = indices.getType().cast<ShapedType>();
+    auto operandTy = operand.getType().cast<ShapedType>();
+
+    if (!operandTy.hasRank() || !indicesTy.hasRank()) {
+      return rewriter.notifyMatchFailure(op, "operand/indices have no rank");
+    }
+
+    auto dimNumbers = op.getScatterDimensionNumbers();
+    auto updateDims = dimNumbers.getUpdateWindowDims();
+
+    if (indicesTy.getRank() != 2 || dimNumbers.getIndexVectorDim() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "indices is not of shape [batch, indices]");
+    }
+
+    if (!updateDims.empty() && updateDims.front() == 0) {
+      return rewriter.notifyMatchFailure(
+          op, "updates is not of shape [batch, ...]");
+    }
+
+    auto scatterDimsToOperandDims = dimNumbers.getScatterDimsToOperandDims();
+    llvm::SmallVector<bool> isIndexDim(operandTy.getRank(), false);
+    for (auto val : scatterDimsToOperandDims) {
+      isIndexDim[val] = true;
+    }
+
+    int64_t firstNonIndex = 0;
+    for (int64_t s = scatterDimsToOperandDims.size(); firstNonIndex < s;
+         ++firstNonIndex) {
+      if (!isIndexDim[firstNonIndex]) break;
+    }
+
+    llvm::SmallVector<bool> isInsertDims(operandTy.getRank(), false);
+    for (auto val : dimNumbers.getInsertedWindowDims()) {
+      isInsertDims[val] = true;
+    }
+
+    int64_t frontInsertedDims = 0;
+    for (; frontInsertedDims < firstNonIndex; ++frontInsertedDims) {
+      if (!isInsertDims[frontInsertedDims]) {
+        break;
+      }
+    }
+
+    llvm::ArrayRef<bool> toInsertDims =
+        llvm::ArrayRef<bool>(isInsertDims).drop_front(frontInsertedDims);
+    if (!llvm::any_of(toInsertDims, [](auto d) { return d; })) {
+      return rewriter.notifyMatchFailure(op, "no dimensions to insert");
+    }
+
+    // Create a reassociation map that starts with the batch dims.
+    SmallVector<ReassociationExprs, 4> reassociationMap;
+    reassociationMap.push_back({rewriter.getAffineDimExpr(0)});
+
+    for (auto it : llvm::enumerate(llvm::ArrayRef<bool>(toInsertDims))) {
+      if (!it.value()) reassociationMap.push_back({});
+      reassociationMap.back().push_back(
+          rewriter.getAffineDimExpr(it.index() + 1));
+    }
+
+    llvm::SmallVector<Value> expandedUpdates;
+    for (auto update : op.getUpdates()) {
+      auto updatesTy = update.getType().cast<ShapedType>();
+
+      llvm::SmallVector<int64_t> newShape;
+      for (int i = 0, s = reassociationMap.size(); i < s; ++i) {
+        newShape.push_back(updatesTy.getDimSize(i));
+        for (int j = 1, s = reassociationMap[i].size(); j < s; ++j) {
+          newShape.push_back(1);
+        }
+      }
+
+      Value expandUpdate = rewriter.create<tensor::ExpandShapeOp>(
+          op.getLoc(),
+          RankedTensorType::get(newShape, updatesTy.getElementType()), update,
+          reassociationMap);
+      expandedUpdates.push_back(expandUpdate);
+    }
+
+    llvm::SmallVector<int64_t> newUpdatedWindowDims(toInsertDims.size());
+    llvm::SmallVector<int64_t> newInsertedWindowDims(frontInsertedDims);
+    std::iota(newUpdatedWindowDims.begin(), newUpdatedWindowDims.end(), 1);
+    std::iota(newInsertedWindowDims.begin(), newInsertedWindowDims.end(), 0);
+
+    auto newDimNumbers = mlir::stablehlo::ScatterDimensionNumbersAttr::get(
+        op.getContext(), newUpdatedWindowDims, newInsertedWindowDims,
+        dimNumbers.getScatterDimsToOperandDims(),
+        /*indexVectorDim=*/1);
+
+    auto newScatter = rewriter.create<mlir::stablehlo::ScatterOp>(
+        op.getLoc(), op.getResultTypes(), op.getInputs(),
+        op.getScatterIndices(), expandedUpdates, newDimNumbers,
+        op.getIndicesAreSorted(), op.getUniqueIndices());
+    Region &region = newScatter.getUpdateComputation();
+    rewriter.cloneRegionBefore(op.getUpdateComputation(), region, region.end());
+    rewriter.replaceOp(op, newScatter.getResults());
+    return success();
+  }
+};
+
+// Traverse upward past common operations to see if the value came from a
+// boolean tensor.
+bool isFromBool(Value val) {
+  while (true) {
+    Operation *op = val.getDefiningOp();
+    if (!op) return false;
+
+    if (auto convertOp = dyn_cast<mlir::stablehlo::ConvertOp>(op)) {
+      auto inTy = convertOp.getOperand().getType().cast<ShapedType>();
+      if (inTy.getElementType().isInteger(1)) {
+        return true;
+      }
+      val = convertOp.getOperand();
+      continue;
+    }
+
+    if (isa<mlir::stablehlo::DynamicBroadcastInDimOp>(op) ||
+        isa<mlir::stablehlo::BroadcastInDimOp>(op) ||
+        isa<mlir::stablehlo::BroadcastOp>(op)) {
+      val = op->getOperand(0);
+      continue;
+    }
+
+    return false;
+  }
+}
+
+// StableHLO of non-finite values (e.g. NaN, inf) and 0.0 produce 0.0 for XLA.
+// For linalg we need to convert these to select operations.
+struct MulCastOfBool final : OpRewritePattern<mlir::stablehlo::MulOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::MulOp op,
+                                PatternRewriter &rewriter) const override {
+    auto resultTy = cast<ShapedType>(op.getType());
+    if (!isa<FloatType>(resultTy.getElementType())) return failure();
+    Value lhs = op.getLhs();
+    Value rhs = op.getRhs();
+    bool lhsIsBool = isFromBool(lhs);
+    bool rhsIsBool = isFromBool(rhs);
+
+    if (lhsIsBool == rhsIsBool) return failure();
+    if (rhsIsBool) std::swap(lhs, rhs);
+
+    Type eType = resultTy.getElementType();
+    auto lhsTy = cast<ShapedType>(lhs.getType());
+    Value lhsBool = rewriter.create<mlir::stablehlo::ConvertOp>(
+        op.getLoc(), lhsTy.clone(rewriter.getIntegerType(1)), lhs);
+    Value zero = rewriter.create<mlir::stablehlo::ConstantOp>(
+        op.getLoc(), DenseElementsAttr::get(RankedTensorType::get({}, eType),
+                                            rewriter.getZeroAttr(eType)));
+
+    auto lhsShape = rewriter.create<shape::ShapeOfOp>(
+        op.getLoc(),
+        RankedTensorType::get({lhsTy.getRank()}, rewriter.getIndexType()), lhs);
+
+    int64_t resultRank = resultTy.getRank();
+    auto broadcast = [&](Value value) -> Value {
+      auto valueTy = cast<ShapedType>(value.getType());
+      auto newTy =
+          RankedTensorType::get(resultTy.getShape(), valueTy.getElementType());
+      if (valueTy == newTy) return value;
+      auto dimensions = llvm::to_vector<4>(
+          llvm::seq<int64_t>(resultRank - valueTy.getRank(), resultRank));
+      return rewriter.create<mlir::stablehlo::DynamicBroadcastInDimOp>(
+          op.getLoc(), newTy, value, lhsShape,
+          rewriter.getI64TensorAttr(dimensions));
+    };
+
+    zero = broadcast(zero);
+
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::SelectOp>(op, resultTy,
+                                                           lhsBool, rhs, zero);
+    return success();
+  }
+};
+
+// Generates Gaussian noise with uniform random generator based on Box-Muller
+// transform.
+struct ExpandRngNormal final : OpRewritePattern<mlir::stablehlo::RngOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::RngOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getRngDistribution() != mlir::stablehlo::RngDistribution::NORMAL)
+      return failure();
+
+    auto resTy = dyn_cast<RankedTensorType>(op.getType());
+    // We can support static shapes, but it's easier to implement Box-Muller
+    // transform if we know the number of elements.
+    if (!resTy || !resTy.hasStaticShape()) return failure();
+
+    // The algorithm requires even numbers and will generate pairs.
+    auto numElems = resTy.getNumElements();
+    if (numElems & 1) numElems++;
+    auto halfNumElems = numElems / 2;
+
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+
+    // Explicitly set the seed to 0, so we have stateless generator. This is not
+    // a hard limit. Random generator is still a new topic, and we start with
+    // stateless random generator.
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> runif(0.0, 1.0);
+    SmallVector<float> sqrtValues(halfNumElems), cosValues(halfNumElems),
+        sinValues(halfNumElems);
+    for (auto i : llvm::seq<unsigned>(0, numElems / 2)) {
+      static constexpr float kEpsilon = std::numeric_limits<float>::epsilon();
+      static constexpr float kTwoPi = static_cast<float>(2.0 * M_PI);
+      float u1, u2;
+      do {
+        u1 = runif(rng);
+        u2 = runif(rng);
+      } while (u1 <= kEpsilon);
+      sqrtValues[i] = -2.0 * log(u1);
+      cosValues[i] = cos(kTwoPi * u2);
+      sinValues[i] = sin(kTwoPi * u2);
+    }
+
+    // mag = sigma * sqrt(-2.0 * log(u1));
+    Value mag = getF32Const(b, /*shapes=*/{halfNumElems}, sqrtValues);
+    Value sigma = b.create<mlir::stablehlo::BroadcastOp>(
+        mag.getType(), op.getB(), make1DElementsAttr(b, halfNumElems));
+    mag = b.create<mlir::stablehlo::MulOp>(
+        sigma, b.create<mlir::stablehlo::SqrtOp>(mag));
+
+    // z0 = mag * cos(two_pi * u2) + mu;
+    // z1 = mag * sin(two_pi * u2) + mu;
+    Value mu = b.create<mlir::stablehlo::BroadcastOp>(
+        mag.getType(), op.getA(), make1DElementsAttr(b, halfNumElems));
+    Value z0 = getF32Const(b, /*shapes=*/{halfNumElems}, cosValues);
+    z0 = b.create<mlir::stablehlo::MulOp>(mag, z0);
+    z0 = b.create<mlir::stablehlo::AddOp>(z0, mu);
+    Value z1 = getF32Const(b, /*shapes=*/{halfNumElems}, sinValues);
+    z1 = b.create<mlir::stablehlo::MulOp>(mag, z1);
+    z1 = b.create<mlir::stablehlo::AddOp>(z1, mu);
+
+    Value res = b.create<mlir::stablehlo::ConcatenateOp>(
+        ValueRange{z0, z1}, b.getI64IntegerAttr(0));
+    if (numElems != resTy.getNumElements()) {
+      OpFoldResult zero = b.getIndexAttr(0);
+      OpFoldResult one = b.getIndexAttr(1);
+      OpFoldResult size = b.getIndexAttr(resTy.getNumElements());
+      res = b.create<tensor::ExtractSliceOp>(res, zero, size, one);
+    }
+    if (resTy.getRank() != 1) {
+      res = b.create<mlir::stablehlo::ReshapeOp>(resTy, res);
+    }
+    rewriter.replaceOp(op, res);
+    return success();
+  }
+};
+
+// clang-format off
+//
+// Reorder BroadcastInDimOp and N-ary elementwise op.
+//
+// Rewrites the following pattern (take binary elementwise op as example)
+//
+// %bcastx = "mhlo.broadcast_in_dim"(%x) {broadcast_dimensions = %[[BCAST_DIMS]]} : (%[[SHAPE_BEFORE_BCAST]]) -> %[[SHAPE_AFTER_BCAST]]
+// %bcasty = "mhlo.broadcast_in_dim"(%y) {broadcast_dimensions = %[[BCAST_DIMS]]} : (%[[SHAPE_BEFORE_BCAST]]) -> %[[SHAPE_AFTER_BCAST]]
+// %result = "BinaryElementwiseOpT"(%bcastx, %bcasty) : (%[[SHAPE_AFTER_BCAST]], %[[SHAPE_AFTER_BCAST]]) -> %[[SHAPE_AFTER_BCAST]]
+//
+// into
+//
+// %z = "BinaryElementwiseOpT"(%x, %y) : (%[[SHAPE_BEFORE_BCAST]], %[[SHAPE_BEFORE_BCAST]]) -> %[[SHAPE_BEFORE_BCAST]]
+// %result = "mhlo.broadcast_in_dim"(%z) {broadcast_dimensions = %[[BCAST_DIMS]]} : (%[[SHAPE_BEFORE_BCAST]]) -> %[[SHAPE_AFTER_BCAST]]
+//
+// clang-format on
+template <typename ElementwiseOpT>
+struct ReorderBroadcastInDimOpAndElementwiseOp final
+    : OpRewritePattern<ElementwiseOpT> {
+  using OpRewritePattern<ElementwiseOpT>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ElementwiseOpT op,
+                                PatternRewriter &rewriter) const override {
+    Operation *operation = op.getOperation();
+    assert(operation->getNumOperands() >= 1 && operation->getNumResults() == 1);
+
+    // Verify if all operands are from BroadcastInDimOp and its
+    // broadcast_dimensions is the same.
+    llvm::SmallVector<mlir::stablehlo::BroadcastInDimOp, 2> bcastOps;
+    for (auto operand : operation->getOperands()) {
+      if (auto bcastOp =
+              operand.getDefiningOp<mlir::stablehlo::BroadcastInDimOp>()) {
+        bcastOps.push_back(bcastOp);
+      } else {
+        return failure();
+      }
+    }
+
+    if (llvm::any_of(bcastOps,
+                     [&bcastOps](mlir::stablehlo::BroadcastInDimOp bcastOp) {
+                       return bcastOp.getBroadcastDimensions() !=
+                              bcastOps[0].getBroadcastDimensions();
+                     })) {
+      return failure();
+    }
+
+    // Verify if all operands of BroadcastInDimOp are of same type and have
+    // static shape.
+    auto bcastOperandType =
+        dyn_cast<ShapedType>(bcastOps[0].getOperand().getType());
+    llvm::SmallVector<Value, 2> bcastOperands;
+    for (auto bcastOp : bcastOps) {
+      auto bcastOperand = bcastOp.getOperand();
+      auto type = dyn_cast<ShapedType>(bcastOperand.getType());
+      if (!type || !type.hasStaticShape() || type != bcastOperandType) {
+        return failure();
+      }
+      bcastOperands.push_back(bcastOperand);
+    }
+
+    // Some elementwise ops, mlir::stablehlo::RealOp for example, do not have
+    // SameOperandsAndResultType trait, so resultType might be different
+    // from bcastOperandType.
+    auto elementType = getElementTypeOrSelf(op.getResult());
+    auto resultShape = bcastOperandType.getShape();
+    auto resultType = RankedTensorType::get(resultShape, elementType);
+
+    Value result =
+        rewriter.create<ElementwiseOpT>(op.getLoc(), resultType, bcastOperands);
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::BroadcastInDimOp>(
+        op, op.getType(), result, bcastOps[0].getBroadcastDimensions());
+
+    for (auto bcastOp : bcastOps) {
+      if (bcastOp.getOperation()->use_empty()) {
+        rewriter.eraseOp(bcastOp);
+      }
+    }
+
+    return success();
+  }
+};
+
+// Identifies cases where a dense operation has inputs that come from widening
+// operations. For instance, a dot product widening from FP16 to FP32 is better
+// to have the casting operation fused into the dot operation. This decreases
+// the loading required during a dense computation.
+template <class Op>
+struct FuseWidenOperands final : OpRewritePattern<Op> {
+  using OpRewritePattern<Op>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(Op op,
+                                PatternRewriter &rewriter) const override {
+    llvm::SmallVector<Value> operands;
+    for (Value operand : op->getOperands()) {
+      auto convertOp =
+          dyn_cast_or_null<mlir::stablehlo::ConvertOp>(operand.getDefiningOp());
+      if (convertOp) {
+        auto inputType = getElementTypeOrSelf(convertOp.getOperand().getType());
+        auto castedType = getElementTypeOrSelf(convertOp.getResult().getType());
+        bool isSameCast =
+            (isa<IntegerType>(inputType) && isa<IntegerType>(castedType)) ||
+            (isa<FloatType>(inputType) && isa<FloatType>(castedType));
+        if (isSameCast && inputType.getIntOrFloatBitWidth() <
+                              castedType.getIntOrFloatBitWidth()) {
+          operands.push_back(convertOp.getOperand());
+          continue;
+        }
+      }
+      operands.push_back(operand);
+    }
+
+    if (llvm::all_of(
+            llvm::zip_equal(operands, op->getOperands()),
+            [](auto pair) { return std::get<0>(pair) == std::get<1>(pair); }))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<Op>(op, op->getResultTypes(), operands,
+                                    op->getAttrs());
+    return success();
+  }
+};
+
+struct DotToMul final : OpRewritePattern<mlir::stablehlo::DotOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::DotOp op,
+                                PatternRewriter &rewriter) const override {
+    auto lhs = op.getLhs();
+    auto rhs = op.getRhs();
+    auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+    auto resultTy = dyn_cast<RankedTensorType>(op.getType());
+
+    if (!lhsTy || !rhsTy) {
+      return rewriter.notifyMatchFailure(op, "lhs and rhs must be ranked");
+    }
+
+    if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2) {
+      return rewriter.notifyMatchFailure(op, "lhs and rhs must be rank-2");
+    }
+
+    if (lhsTy.getDimSize(1) != 1) return failure();
+
+    // Dynamically compute the shape of the result of the DotOp by querying
+    // the 0-th dimensions, of the left, and the 1st dimension of the right.
+    // Concatenating them togething to make the final shape.
+    Value batchSize = rewriter.create<mlir::stablehlo::GetDimensionSizeOp>(
+        op.getLoc(), lhs, rewriter.getI64IntegerAttr(0));
+    Value batchSize1 = rewriter.create<mlir::stablehlo::ReshapeOp>(
+        op.getLoc(), RankedTensorType::get({1}, rewriter.getI32Type()),
+        batchSize);
+
+    Value featureSize = rewriter.create<mlir::stablehlo::GetDimensionSizeOp>(
+        op.getLoc(), rhs, rewriter.getI64IntegerAttr(1));
+    Value featureSize1 = rewriter.create<mlir::stablehlo::ReshapeOp>(
+        op.getLoc(), RankedTensorType::get({1}, rewriter.getI32Type()),
+        featureSize);
+
+    Value outSize = rewriter.create<mlir::stablehlo::ConcatenateOp>(
+        op.getLoc(), RankedTensorType::get({2}, rewriter.getI32Type()),
+        ValueRange{batchSize1, featureSize1}, rewriter.getI64IntegerAttr(0));
+
+    lhs = rewriter.create<mlir::stablehlo::DynamicBroadcastInDimOp>(
+        op.getLoc(), resultTy.clone(lhsTy.getElementType()), lhs, outSize,
+        rewriter.getI64TensorAttr({0, 1}));
+
+    rhs = rewriter.create<mlir::stablehlo::DynamicBroadcastInDimOp>(
+        op.getLoc(), resultTy.clone(rhsTy.getElementType()), rhs, outSize,
+        rewriter.getI64TensorAttr({0, 1}));
+
+    auto computeETy = lhsTy.getElementType();
+    if (computeETy.getIntOrFloatBitWidth() < rhsTy.getElementTypeBitWidth())
+      computeETy = rhsTy.getElementType();
+    if (computeETy.getIntOrFloatBitWidth() < resultTy.getElementTypeBitWidth())
+      computeETy = resultTy.getElementType();
+
+    auto computeTy = resultTy.clone(computeETy);
+
+    rhs = rewriter.create<mlir::stablehlo::ConvertOp>(op.getLoc(), computeTy,
+                                                      rhs);
+    lhs = rewriter.create<mlir::stablehlo::ConvertOp>(op.getLoc(), computeTy,
+                                                      lhs);
+
+    auto result = rewriter.create<mlir::stablehlo::MulOp>(
+        op.getLoc(), resultTy.clone(computeETy), lhs, rhs);
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConvertOp>(op, resultTy,
+                                                            result);
+    return success();
+  }
+};
+
+// Similar to DotIsMul, this finds the case where a dot general
+// can be represented using a mul operation. This includes possibly making
+// an implicit cast explicit prior the mul.
+struct DotGeneralIsMul final : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::DotGeneralOp op,
+                                PatternRewriter &rewriter) const override {
+    auto lhs = cast<Value>(op.getLhs());
+    auto rhs = cast<Value>(op.getRhs());
+    auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+    auto resultTy = dyn_cast<RankedTensorType>(op.getType());
+    ImplicitLocOpBuilder builder(op.getLoc(), rewriter);
+
+    if (!lhsTy || !rhsTy || !resultTy) return failure();
+
+    auto dNums = op.getDotDimensionNumbers();
+    auto batchDimsL = dNums.getLhsBatchingDimensions();
+    auto batchDimsR = dNums.getRhsBatchingDimensions();
+    auto contractDimsL = dNums.getLhsContractingDimensions();
+    auto contractDimsR = dNums.getRhsContractingDimensions();
+
+    llvm::SmallVector<bool> isLhsParallelDim(lhsTy.getRank(), true);
+    llvm::SmallVector<bool> isRhsParallelDim(rhsTy.getRank(), true);
+
+    for (auto dim : batchDimsL) isLhsParallelDim[dim] = false;
+    for (auto dim : batchDimsR) isRhsParallelDim[dim] = false;
+    for (auto dim : contractDimsL) isLhsParallelDim[dim] = false;
+    for (auto dim : contractDimsR) isRhsParallelDim[dim] = false;
+
+    for (auto dim : contractDimsL) {
+      if (lhsTy.getDimSize(dim) != 1) {
+        return rewriter.notifyMatchFailure(op, "Non unit contract dimensions");
+      }
+    }
+
+    // Generate the permutation matrix to order BatchDims, ParallelDims,
+    // ContractDims.
+    llvm::SmallVector<int64_t> permLhs;
+    llvm::SmallVector<int64_t> permRhs;
+    permLhs.append(batchDimsL.begin(), batchDimsL.end());
+    permRhs.append(batchDimsR.begin(), batchDimsR.end());
+
+    for (auto [idx, value] : llvm::enumerate(isLhsParallelDim)) {
+      if (value) permLhs.push_back(idx);
+    }
+
+    for (auto [idx, value] : llvm::enumerate(isRhsParallelDim)) {
+      if (value) permRhs.push_back(idx);
+    }
+
+    llvm::append_range(permLhs, contractDimsL);
+    llvm::append_range(permRhs, contractDimsR);
+
+    // Determine the transpose shape based on the generate permutations.
+    llvm::SmallVector<int64_t> lhsTransposeShape;
+    llvm::SmallVector<int64_t> rhsTransposeShape;
+    for (auto dim : permLhs) lhsTransposeShape.push_back(lhsTy.getDimSize(dim));
+    for (auto dim : permRhs) rhsTransposeShape.push_back(rhsTy.getDimSize(dim));
+
+    // Transpose the left hand side and the right hand side.
+    lhs = builder.create<mlir::stablehlo::TransposeOp>(
+        RankedTensorType::get(lhsTransposeShape, lhsTy.getElementType()), lhs,
+        builder.getI64TensorAttr(permLhs));
+    lhsTy = lhs.getType().cast<RankedTensorType>();
+
+    rhs = builder.create<mlir::stablehlo::TransposeOp>(
+        RankedTensorType::get(rhsTransposeShape, rhsTy.getElementType()), rhs,
+        builder.getI64TensorAttr(permRhs));
+    rhsTy = rhs.getType().cast<RankedTensorType>();
+
+    auto dimI32Ty = RankedTensorType::get({1}, builder.getI32Type());
+
+    // Drop all of the non-concat dimensions from the lhs.
+    llvm::SmallVector<Value> lhsReshapeDims;
+    for (int i = 0, s = lhsTy.getRank() - contractDimsL.size(); i < s; i++) {
+      Value dim = builder.create<mlir::stablehlo::GetDimensionSizeOp>(lhs, i);
+      lhsReshapeDims.push_back(
+          builder.create<mlir::stablehlo::ReshapeOp>(dimI32Ty, dim));
+    }
+    Value lhsDynShape = builder.create<mlir::stablehlo::ConcatenateOp>(
+        RankedTensorType::get({static_cast<int64_t>(lhsReshapeDims.size())},
+                              builder.getI32Type()),
+        lhsReshapeDims, 0);
+    lhsTy =
+        RankedTensorType::get(lhsTy.getShape().drop_back(contractDimsL.size()),
+                              lhsTy.getElementType());
+    lhs = builder.create<mlir::stablehlo::DynamicReshapeOp>(lhsTy, lhs,
+                                                            lhsDynShape);
+
+    // Drop all of the non concat dimensions from the rhs.
+    llvm::SmallVector<Value> rhsReshapeDims;
+    for (int i = 0, s = rhsTy.getRank() - contractDimsR.size(); i < s; i++) {
+      Value dim = builder.create<mlir::stablehlo::GetDimensionSizeOp>(rhs, i);
+      rhsReshapeDims.push_back(
+          builder.create<mlir::stablehlo::ReshapeOp>(dimI32Ty, dim));
+    }
+    Value rhsDynShape = builder.create<mlir::stablehlo::ConcatenateOp>(
+        RankedTensorType::get({static_cast<int64_t>(rhsReshapeDims.size())},
+                              builder.getI32Type()),
+        rhsReshapeDims, 0);
+    rhsTy =
+        RankedTensorType::get(rhsTy.getShape().drop_back(contractDimsR.size()),
+                              rhsTy.getElementType());
+    rhs = builder.create<mlir::stablehlo::DynamicReshapeOp>(rhsTy, rhs,
+                                                            rhsDynShape);
+
+    // Compute the size of the output shape with dynamic shape support using the
+    // lhs and rhs dimensions.
+    llvm::SmallVector<Value> outputDims;
+    outputDims.append(lhsReshapeDims);
+    outputDims.append(rhsReshapeDims.begin() + batchDimsR.size(),
+                      rhsReshapeDims.end());
+    Value outputShape = builder.create<mlir::stablehlo::ConcatenateOp>(
+        RankedTensorType::get({resultTy.getRank()}, builder.getI32Type()),
+        outputDims, 0);
+
+    // Broadcast the left hand side to match the expect output shape.
+    llvm::SmallVector<int64_t> lhsDimMapping(lhsTy.getRank());
+    std::iota(lhsDimMapping.begin(), lhsDimMapping.end(), 0);
+    auto lhsBroadcastTy =
+        RankedTensorType::get(resultTy.getShape(), lhsTy.getElementType());
+    lhs = builder.createOrFold<mlir::stablehlo::DynamicBroadcastInDimOp>(
+        lhsBroadcastTy, lhs, outputShape,
+        rewriter.getI64TensorAttr(lhsDimMapping));
+
+    // Broadcast the right hand side to match the expected output shape.
+    llvm::SmallVector<int64_t> rhsDimMapping(rhsTy.getRank());
+    std::iota(rhsDimMapping.begin(), rhsDimMapping.begin() + batchDimsR.size(),
+              0);
+    std::iota(rhsDimMapping.begin() + batchDimsR.size(), rhsDimMapping.end(),
+              lhsTy.getRank());
+    auto rhsBroadcastTy =
+        RankedTensorType::get(resultTy.getShape(), rhsTy.getElementType());
+    rhs = builder.createOrFold<mlir::stablehlo::DynamicBroadcastInDimOp>(
+        rhsBroadcastTy, rhs, outputShape,
+        rewriter.getI64TensorAttr(rhsDimMapping));
+
+    lhs = builder.createOrFold<mlir::stablehlo::ConvertOp>(resultTy, lhs);
+    rhs = builder.createOrFold<mlir::stablehlo::ConvertOp>(resultTy, rhs);
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::MulOp>(op, resultTy, lhs, rhs);
+    return success();
+  }
+};
+
+struct StableHLOToStableHLOPreprocessing final
+    : impl::StableHLOToStableHLOPreprocessingBase<
+          StableHLOToStableHLOPreprocessing> {
+  using StableHLOToStableHLOPreprocessingBase::
+      StableHLOToStableHLOPreprocessingBase;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<shape::ShapeDialect, mlir::stablehlo::StablehloDialect,
+                    tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ConversionTarget conversionTarget(*context);
+    RewritePatternSet conversionPatterns(context);
+    conversionTarget
+        .addLegalDialect<shape::ShapeDialect, chlo::ChloDialect,
+                         mlir::stablehlo::StablehloDialect, math::MathDialect,
+                         mlir::func::FuncDialect, mlir::arith::ArithDialect,
+                         mlir::tensor::TensorDialect>();
+    if (failed(applyPartialConversion(getOperation(), conversionTarget,
+                                      std::move(conversionPatterns)))) {
+      return signalPassFailure();
+    }
+
+    RewritePatternSet patterns(context);
+    // TODO: Remove once we have a general contraction to matmul pass.
+    populatePreprocessingEinsumToDotGeneralPatterns(context, &patterns);
+    populatePreprocessingUnfuseBatchNormPatterns(context, &patterns);
+    populatePreprocessingComplexPatterns(context, &patterns);
+    populatePreprocessingGatherToTorchIndexSelectPatterns(context, &patterns);
+    patterns.insert<ExpandRngNormal, MulCastOfBool>(context);
+
+    // scatter canonicalization patterns
+    patterns.insert<ScatterInt64Indices, ScatterImplicitIndex,
+                    ScatterImplicitBatch, ScatterMaterializeInsertedDim,
+                    ScatterCollapseBatch, ScatterBatchFirst>(context);
+
+    // dot_general canoncalization patterns.
+    populatePreprocessingDotGeneralToDotPatterns(context, &patterns);
+    patterns.insert<DotGeneralIsMul>(context, /*benefit=*/300);
+
+    // Fusion operations.
+    patterns.insert<FuseWidenOperands<mlir::stablehlo::DotOp>,
+                    FuseWidenOperands<mlir::stablehlo::DotGeneralOp>,
+                    FuseWidenOperands<mlir::stablehlo::ConvolutionOp>>(
+        context,
+        /*benefit=*/400);
+
+    // Additional canonicalizers that simplify to computationally
+    // less-complex operations.
+    patterns.insert<DotToMul>(context);
+
+    // Unary elementwise op.
+    patterns.insert<
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::AbsOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::CeilOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::ConvertOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::ClzOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::CosineOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::ExpOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::Expm1Op>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::FloorOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::ImagOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::IsFiniteOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::LogOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::Log1pOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::LogisticOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::NotOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::NegOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<
+            mlir::stablehlo::PopulationCountOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::RealOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::RoundOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::RsqrtOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::SignOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::SineOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::SqrtOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::TanhOp>>(
+        context);
+    // Binary elementwise op.
+    patterns.insert<
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::AddOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::Atan2Op>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::ComplexOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::DivOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::MaxOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::MinOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::MulOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::PowOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::RemOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::ShiftLeftOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<
+            mlir::stablehlo::ShiftRightArithmeticOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<
+            mlir::stablehlo::ShiftRightLogicalOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::SubtractOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::AndOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::OrOp>,
+        ReorderBroadcastInDimOpAndElementwiseOp<mlir::stablehlo::XorOp>>(
+        context);
+    if (orderConvFeatures) {
+      patterns.insert<ReorderConvOpInputDimensions>(context);
+      patterns.insert<ReorderConvOpKernelDimensions>(context);
+      patterns.insert<ReorderConvOpOutputDimensions>(context);
+    }
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/BUILD.bazel
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "dot_general_to_dot.mlir",
             "einsum_to_dot_general.mlir",
             "gather_to_torch_index_select.mlir",
+            "stablehlo_to_stablehlo.mlir",
             "unfuse_batch_norm.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "dot_general_to_dot.mlir"
     "einsum_to_dot_general.mlir"
     "gather_to_torch_index_select.mlir"
+    "stablehlo_to_stablehlo.mlir"
     "unfuse_batch_norm.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/stablehlo_to_stablehlo.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/stablehlo_to_stablehlo.mlir
@@ -1,0 +1,359 @@
+// RUN: iree-opt --iree-stablehlo-to-stablehlo-preprocessing \
+// RUN:   --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: @batch_norm_inference
+// CHECK-SAME: %[[X:[^:[:space:]]+]]
+// CHECK-SAME: %[[SCALE:[^:[:space:]]+]]
+// CHECK-SAME: %[[OFFSET:[^:[:space:]]+]]
+// CHECK-SAME: %[[MEAN:[^:[:space:]]+]]
+// CHECK-SAME: %[[VARIANCE:[^:[:space:]]+]]
+func.func @batch_norm_inference(
+    %x: tensor<4x256xf32>, %scale: tensor<256xf32>, %offset: tensor<256xf32>,
+    %mean: tensor<256xf32>, %variance: tensor<256xf32>)
+    -> (tensor<4x256xf32>) {
+  // CHECK-DAG: %[[EPS:.+]] = stablehlo.constant dense<1.001000e-05> : tensor<f32>
+  // CHECK-DAG: %[[EPS_BCAST:.+]] = stablehlo.broadcast_in_dim %[[EPS]], dims = [] : (tensor<f32>) -> tensor<256xf32>
+  // CHECK-DAG: %[[VARIANCE_EPS:.+]] = stablehlo.add %[[VARIANCE]], %[[EPS_BCAST]] : tensor<256xf32>
+  // CHECK-DAG: %[[STDDEV:.+]] = stablehlo.sqrt %[[VARIANCE_EPS]] : tensor<256xf32>
+  // CHECK-DAG: %[[STDDEV_BCAST:.+]] = stablehlo.broadcast_in_dim %[[STDDEV]], dims = [1] : (tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-DAG: %[[SCALE_BCAST:.+]] = stablehlo.broadcast_in_dim %[[SCALE]], dims = [1] : (tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-DAG: %[[OFFSET_BCAST:.+]] = stablehlo.broadcast_in_dim %[[OFFSET]], dims = [1] : (tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-DAG: %[[MEAN_BCAST:.+]] = stablehlo.broadcast_in_dim %[[MEAN]], dims = [1] : (tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-DAG: %[[X_CENTER:.+]] = stablehlo.subtract %[[X]], %[[MEAN_BCAST]] : tensor<4x256xf32>
+  // CHECK:     %[[X_SCALED:.+]] = stablehlo.multiply %[[X_CENTER]], %[[SCALE_BCAST]] : tensor<4x256xf32>
+  // CHECK:     %[[X_NORMED:.+]] = stablehlo.divide %[[X_SCALED]], %[[STDDEV_BCAST]] : tensor<4x256xf32>
+  // CHECK:     %[[RESULT:.+]] = stablehlo.add %[[X_NORMED]], %[[OFFSET_BCAST]] : tensor<4x256xf32>
+  %0 = "stablehlo.batch_norm_inference"(%x, %scale, %offset, %mean, %variance)
+      {epsilon = 1.001000e-05 : f32, feature_index = 1 : i64} :
+      (tensor<4x256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>,
+        tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-NEXT: return %[[RESULT]]
+  return %0 : tensor<4x256xf32>
+}
+
+// -----
+
+// CHECK: @reorder_broadcast_in_dim_scalar_binary(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>, %[[ARG2:.*]]: tensor<i32>, %[[ARG3:.*]]: tensor<i32>)
+func.func @reorder_broadcast_in_dim_scalar_binary(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<i32>, %arg3: tensor<i32>) -> (tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xi32>) {
+  // CHECK: %[[ADD:.*]] = stablehlo.add %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[ADD]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[ATAN2:.*]] = stablehlo.atan2 %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[ATAN2]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[DIV:.*]] = stablehlo.divide %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[DIV]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[MAX:.*]] = stablehlo.maximum %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[MAX]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[MIN:.*]] = stablehlo.minimum %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[MIN]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[MUL:.*]] = stablehlo.multiply %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[MUL]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[POW:.*]] = stablehlo.power %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[POW]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[REM:.*]] = stablehlo.remainder %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[REM]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[SL:.*]] = stablehlo.shift_left %[[ARG2]], %[[ARG3]] : tensor<i32>
+  // CHECK: stablehlo.broadcast_in_dim %[[SL]], dims = [] : (tensor<i32>) -> tensor<1x8x8x64xi32>
+  // CHECK: %[[SRA:.*]] = stablehlo.shift_right_arithmetic %[[ARG2]], %[[ARG3]] : tensor<i32>
+  // CHECK: stablehlo.broadcast_in_dim %[[SRA]], dims = [] : (tensor<i32>) -> tensor<1x8x8x64xi32>
+  // CHECK: %[[SRL:.*]] = stablehlo.shift_right_logical %[[ARG2]], %[[ARG3]] : tensor<i32>
+  // CHECK: stablehlo.broadcast_in_dim %[[SRL]], dims = [] : (tensor<i32>) -> tensor<1x8x8x64xi32>
+  // CHECK: %[[SUB:.*]] = stablehlo.subtract %[[ARG0]], %[[ARG1]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[SUB]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[AND:.*]] = stablehlo.and %[[ARG2]], %[[ARG3]] : tensor<i32>
+  // CHECK: stablehlo.broadcast_in_dim %[[AND]], dims = [] : (tensor<i32>) -> tensor<1x8x8x64xi32>
+  // CHECK: %[[OR:.*]] = stablehlo.or %[[ARG2]], %[[ARG3]] : tensor<i32>
+  // CHECK: stablehlo.broadcast_in_dim %[[OR]], dims = [] : (tensor<i32>) -> tensor<1x8x8x64xi32>
+  // CHECK: %[[XOR:.*]] = stablehlo.xor %[[ARG2]], %[[ARG3]] : tensor<i32>
+  // CHECK: stablehlo.broadcast_in_dim %[[XOR]], dims = [] : (tensor<i32>) -> tensor<1x8x8x64xi32>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  %1 = "stablehlo.broadcast_in_dim"(%arg1) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  %2 = "stablehlo.broadcast_in_dim"(%arg2) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<i32>) -> tensor<1x8x8x64xi32>
+  %3 = "stablehlo.broadcast_in_dim"(%arg3) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<i32>) -> tensor<1x8x8x64xi32>
+  %4 = stablehlo.add %0, %1 : tensor<1x8x8x64xf32>
+  %5 = stablehlo.atan2 %0, %1 : tensor<1x8x8x64xf32>
+  %6 = stablehlo.divide %0, %1 : tensor<1x8x8x64xf32>
+  %7 = stablehlo.maximum %0, %1 : tensor<1x8x8x64xf32>
+  %8 = stablehlo.minimum %0, %1 : tensor<1x8x8x64xf32>
+  %9 = stablehlo.multiply %0, %1 : tensor<1x8x8x64xf32>
+  %10 = stablehlo.power %0, %1 : tensor<1x8x8x64xf32>
+  %11 = stablehlo.remainder %0, %1 : tensor<1x8x8x64xf32>
+  %12 = stablehlo.shift_left %2, %3 : tensor<1x8x8x64xi32>
+  %13 = stablehlo.shift_right_arithmetic %2, %3 : tensor<1x8x8x64xi32>
+  %14 = stablehlo.shift_right_logical %2, %3 : tensor<1x8x8x64xi32>
+  %15 = stablehlo.subtract %0, %1 : tensor<1x8x8x64xf32>
+  %16 = stablehlo.and %2, %3 : tensor<1x8x8x64xi32>
+  %17 = stablehlo.or %2, %3 : tensor<1x8x8x64xi32>
+  %18 = stablehlo.xor %2, %3 : tensor<1x8x8x64xi32>
+  return %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18 : tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xi32>, tensor<1x8x8x64xi32>
+}
+
+// -----
+
+// CHECK: @reorder_broadcast_in_dim_scalar_binary_diff_type(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>) -> tensor<1x8x8x64xcomplex<f32>>
+func.func @reorder_broadcast_in_dim_scalar_binary_diff_type(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<1x8x8x64xcomplex<f32>> {
+  // CHECK: %[[X:.+]] = stablehlo.complex %[[ARG0]], %[[ARG1]] : tensor<complex<f32>>
+  // CHECK: stablehlo.broadcast_in_dim %[[X]], dims = [] : (tensor<complex<f32>>) -> tensor<1x8x8x64xcomplex<f32>>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  %1 = "stablehlo.broadcast_in_dim"(%arg1) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  %2 = "stablehlo.complex"(%0, %1) : (tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>) -> tensor<1x8x8x64xcomplex<f32>>
+  return %2 : tensor<1x8x8x64xcomplex<f32>>
+}
+
+// -----
+
+// CHECK: @reorder_broadcast_in_dim_1d_binary(%[[ARG0:.*]]: tensor<3xf32>, %[[ARG1:.*]]: tensor<3xf32>) -> tensor<4x3xf32>
+func.func @reorder_broadcast_in_dim_1d_binary(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<4x3xf32> {
+  // CHECK: %[[ATAN2:.*]] = stablehlo.atan2 %[[ARG0]], %[[ARG1]] : tensor<3xf32>
+  // CHECK: %[[BCAST:.*]] = stablehlo.broadcast_in_dim %[[ATAN2]], dims = [1] : (tensor<3xf32>) -> tensor<4x3xf32>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1]> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<4x3xf32>
+  %1 = "stablehlo.broadcast_in_dim"(%arg1) {broadcast_dimensions = dense<[1]> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<4x3xf32>
+  %2 = stablehlo.atan2 %0, %1 : tensor<4x3xf32>
+  // CHECK: return %[[BCAST]]
+  return %2 : tensor<4x3xf32>
+}
+
+// -----
+
+// CHECK: @reorder_broadcast_in_dim_2d_binary(%[[ARG0:.*]]: tensor<2x4xi32>, %[[ARG1:.*]]: tensor<2x4xi32>) -> tensor<3x2x4xi32>
+func.func @reorder_broadcast_in_dim_2d_binary(%arg0: tensor<2x4xi32>, %arg1: tensor<2x4xi32>) -> tensor<3x2x4xi32> {
+  // CHECK: %[[POWER:.*]] = stablehlo.power %[[ARG0]], %[[ARG1]] : tensor<2x4xi32>
+  // CHECK: %[[BCAST:.*]] = stablehlo.broadcast_in_dim %[[POWER]], dims = [1, 2] : (tensor<2x4xi32>) -> tensor<3x2x4xi32>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<2x4xi32>) -> tensor<3x2x4xi32>
+  %1 = "stablehlo.broadcast_in_dim"(%arg1) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<2x4xi32>) -> tensor<3x2x4xi32>
+  %2 = stablehlo.power %0, %1 : tensor<3x2x4xi32>
+  // CHECK: return %[[BCAST]]
+  return %2 : tensor<3x2x4xi32>
+}
+
+// -----
+
+// CHECK: @reorder_broadcast_in_dim_scalar_unary(%[[ARG0:.*]]: tensor<f32>)
+func.func @reorder_broadcast_in_dim_scalar_unary(%arg0: tensor<f32>) -> (tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>) {
+  // CHECK: %[[ABS:.*]] = stablehlo.abs %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[ABS]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[CEIL:.*]] = stablehlo.ceil %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[CEIL]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[COSINE:.*]] = stablehlo.cosine %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[COSINE]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[EXP:.*]] = stablehlo.exponential %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[EXP]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[FLOOR:.*]] = stablehlo.floor %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[FLOOR]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[LOG:.*]] = stablehlo.log %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[LOG]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[NEG:.*]] = stablehlo.negate %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[NEG]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[ROUND:.*]] = stablehlo.round_nearest_afz %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[ROUND]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[RSQRT:.*]] = stablehlo.rsqrt %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[RSQRT]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[SIGN:.*]] = stablehlo.sign %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[SIGN]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[SINE:.*]] = stablehlo.sine %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[SINE]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[SQRT:.*]] = stablehlo.sqrt %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[SQRT]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[TANH:.*]] = stablehlo.tanh %[[ARG0]] : tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[TANH]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  %1 = stablehlo.abs %0 : tensor<1x8x8x64xf32>
+  %2 = stablehlo.ceil %0 : tensor<1x8x8x64xf32>
+  %3 = stablehlo.cosine %0 : tensor<1x8x8x64xf32>
+  %4 = stablehlo.exponential %0 : tensor<1x8x8x64xf32>
+  %5 = stablehlo.floor %0 : tensor<1x8x8x64xf32>
+  %6 = stablehlo.log %0 : tensor<1x8x8x64xf32>
+  %7 = stablehlo.negate %0 : tensor<1x8x8x64xf32>
+  %8 = stablehlo.round_nearest_afz %0 : tensor<1x8x8x64xf32>
+  %9 = stablehlo.rsqrt %0 : tensor<1x8x8x64xf32>
+  %10 = stablehlo.sign %0 : tensor<1x8x8x64xf32>
+  %11 = stablehlo.sine %0 : tensor<1x8x8x64xf32>
+  %12 = stablehlo.sqrt %0 : tensor<1x8x8x64xf32>
+  %13 = stablehlo.tanh %0 : tensor<1x8x8x64xf32>
+  return %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13: tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>
+}
+
+// -----
+
+// CHECK: @reorder_broadcast_in_dim_1d_unary(%[[ARG0:.*]]: tensor<3xf32>) -> tensor<4x3xf32>
+func.func @reorder_broadcast_in_dim_1d_unary(%arg0: tensor<3xf32>) -> tensor<4x3xf32> {
+  // CHECK: %[[COS:.*]] = stablehlo.cosine %[[ARG0]] : tensor<3xf32>
+  // CHECK: %[[BCAST:.*]] = stablehlo.broadcast_in_dim %[[COS]], dims = [1] : (tensor<3xf32>) -> tensor<4x3xf32>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1]> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<4x3xf32>
+  %1 = stablehlo.cosine %0 : tensor<4x3xf32>
+  // CHECK: return %[[BCAST]]
+  return %1 : tensor<4x3xf32>
+}
+
+// -----
+
+// CHECK: @reorder_in_dim_2d_unary(%[[ARG0:.*]]: tensor<2x4xf32>) -> tensor<3x2x4xf32>
+func.func @reorder_in_dim_2d_unary(%arg0: tensor<2x4xf32>) -> tensor<3x2x4xf32> {
+  // CHECK: %[[LOG:.*]] = stablehlo.log %[[ARG0]] : tensor<2x4xf32>
+  // CHECK: %[[BCAST:.*]] = stablehlo.broadcast_in_dim %[[LOG]], dims = [1, 2] : (tensor<2x4xf32>) -> tensor<3x2x4xf32>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<2x4xf32>) -> tensor<3x2x4xf32>
+  %1 = stablehlo.log %0 : tensor<3x2x4xf32>
+  // CHECK: return %[[BCAST]]
+  return %1 : tensor<3x2x4xf32>
+}
+
+// -----
+
+// CHECK: @reorder_broadcast_in_dim_scalar_unary_diff_type(%[[ARG0:.*]]: tensor<complex<f32>>) -> (tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>)
+func.func @reorder_broadcast_in_dim_scalar_unary_diff_type(%arg0: tensor<complex<f32>>) -> (tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>) {
+  // CHECK: %[[REAL:.*]] = stablehlo.real %[[ARG0]] : (tensor<complex<f32>>) -> tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[REAL]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  // CHECK: %[[IMAG:.*]] = stablehlo.imag %[[ARG0]] : (tensor<complex<f32>>) -> tensor<f32>
+  // CHECK: stablehlo.broadcast_in_dim %[[IMAG]], dims = [] : (tensor<f32>) -> tensor<1x8x8x64xf32>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<complex<f32>>) -> tensor<1x8x8x64xcomplex<f32>>
+  %1 = stablehlo.real %0 : (tensor<1x8x8x64xcomplex<f32>>) -> tensor<1x8x8x64xf32>
+  %2 = stablehlo.imag %0 : (tensor<1x8x8x64xcomplex<f32>>) -> tensor<1x8x8x64xf32>
+  return %1, %2: tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @rng_normal
+// CHECK-SAME:              (%[[ARG0:.+]]: tensor<f32>, %[[ARG1:.+]]: tensor<f32>)
+func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<3x5xf32> {
+  %shape = stablehlo.constant dense<[3, 5]> : tensor<2xi64>
+  %0 = "stablehlo.rng"(%arg0, %arg1, %shape) {rng_distribution = #stablehlo<rng_distribution NORMAL>} : (tensor<f32>, tensor<f32>, tensor<2xi64>) -> tensor<3x5xf32>
+  return %0 : tensor<3x5xf32>
+}
+// CHECK:         %{{.+}} = stablehlo.constant dense<{{.+}}> : tensor<8xf32>
+// CHECK:         %{{.+}} = stablehlo.constant dense<{{.+}}> : tensor<8xf32>
+// CHECK:         %{{.+}} = stablehlo.constant dense<{{.+}}> : tensor<8xf32>
+// CHECK:         %[[SIGMA:.+]] = stablehlo.broadcast %[[ARG1]], sizes = [8] : (tensor<f32>) -> tensor<8xf32>
+//
+//                mag = sigma * sqrt(-2.0 * log(u1)) where sqrt values are
+//                constants.
+//
+// CHECK:         %[[MAG:.+]] = stablehlo.multiply %[[SIGMA]], %{{.+}} : tensor<8xf32>
+//
+//                z0  = mag * cos(two_pi * u2) + mu;
+//                z1  = mag * sin(two_pi * u2) + mu;
+//
+// CHECK:         %[[MU:.+]] = stablehlo.broadcast %[[ARG0]], sizes = [8] : (tensor<f32>) -> tensor<8xf32>
+// CHECK:         %[[T1:.+]] = stablehlo.multiply %[[MAG]], %{{.+}} : tensor<8xf32>
+// CHECK:         %[[Z0:.+]] = stablehlo.add %[[T1:.+]], %[[MU]] : tensor<8xf32>
+// CHECK:         %[[T2:.+]] = stablehlo.multiply %[[MAG]], %{{.+}} : tensor<8xf32>
+// CHECK:         %[[Z1:.+]] = stablehlo.add %[[T2:.+]], %[[MU]] : tensor<8xf32>
+//
+//                Concate and reshape the output.
+// CHECK:         %[[CON:.+]] = stablehlo.concatenate %[[Z0]], %[[Z1]], dim = 0 : (tensor<8xf32>, tensor<8xf32>) -> tensor<16xf32>
+// CHECK:         %[[SLICE:.+]] = tensor.extract_slice %[[CON]][0] [15] [1] : tensor<16xf32> to tensor<15xf32>
+// CHECK:         %[[RES:.+]] = stablehlo.reshape %[[SLICE]] : (tensor<15xf32>) -> tensor<3x5xf32>
+// CHECK:         return %[[RES]]
+
+// -----
+
+// CHECK-LABEL: @mul_float_bool_cast
+func.func @mul_float_bool_cast(%arg0 : tensor<?xi1>, %arg1 : tensor<?xf32>) -> tensor<?xf32> {
+  %0 = stablehlo.convert %arg0 : (tensor<?xi1>) -> tensor<?xf32>
+  %1 = "stablehlo.multiply"(%0, %arg1) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  return %1 : tensor<?xf32>
+}
+
+// CHECK: %[[ZERO:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK: %[[BTOF:.+]] = stablehlo.convert %arg0 : (tensor<?xi1>) -> tensor<?xf32>
+// CHECK: %[[FTOB:.+]] = stablehlo.convert %[[BTOF]] : (tensor<?xf32>) -> tensor<?xi1>
+// CHECK: %[[SHP:.+]] = shape.shape_of %[[BTOF]] : tensor<?xf32> -> tensor<1xindex>
+// CHECK: %[[BROADCAST:.+]] = stablehlo.dynamic_broadcast_in_dim %[[ZERO]], %[[SHP]], dims = []
+// CHECK: %[[SELECT:.+]] = stablehlo.select %[[FTOB]], %arg1, %[[BROADCAST]]
+
+// -----
+
+// CHECK-LABEL: @mul_float_bool_cast_broadcast
+func.func @mul_float_bool_cast_broadcast(%arg0: tensor<5xi1>, %arg1: tensor<5x6xf32>) -> tensor<5x6xf32> {
+  %0 = stablehlo.convert %arg0 : (tensor<5xi1>) -> tensor<5xf32>
+  %1 = "stablehlo.broadcast_in_dim"(%0) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<5xf32>) -> tensor<5x6xf32>
+  %2 = stablehlo.multiply %1, %arg1 : tensor<5x6xf32>
+  return %2 : tensor<5x6xf32>
+}
+
+// CHECK: stablehlo.select
+
+// -----
+
+// CHECK-LABEL: @mul_float_bool_cast_dyn_broadcast
+func.func @mul_float_bool_cast_dyn_broadcast(%arg0: tensor<?xi1>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %0 = stablehlo.convert %arg0 : (tensor<?xi1>) -> tensor<?xf32>
+    %1 = shape.shape_of %arg1 : tensor<?x?xf32> -> tensor<2xindex>
+    %2 = "stablehlo.dynamic_broadcast_in_dim"(%0, %1) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<?xf32>, tensor<2xindex>) -> tensor<?x?xf32>
+    %3 = stablehlo.multiply %2, %arg1 : tensor<?x?xf32>
+    return %3 : tensor<?x?xf32>
+}
+
+// CHECK: stablehlo.select
+
+// -----
+
+// CHECK-LABEL: @dot_general_fuse_both_with_attrs
+// CHECK-SAME:     (%[[ARG0:.+]]: tensor<16x64x128xf16>, %[[ARG1:.+]]: tensor<16x128x3072xf16>)
+func.func @dot_general_fuse_both_with_attrs(%arg0: tensor<16x64x128xf16>, %arg1: tensor<16x128x3072xf16>) -> tensor<16x64x3072xf32> {
+  %0 = stablehlo.convert %arg0 : (tensor<16x64x128xf16>) -> tensor<16x64x128xf32>
+  %1 = stablehlo.convert %arg1 : (tensor<16x128x3072xf16>) -> tensor<16x128x3072xf32>
+  // CHECK: stablehlo.dot_general %[[ARG0]], %[[ARG1]]
+  // CHECK-SAME: batching_dims = [0] x [0]
+  // CHECK-SAME: contracting_dims = [2] x [1]
+  // CHECK-SAME: precision = [DEFAULT, DEFAULT]
+  // CHECK-SAME: -> tensor<16x64x3072xf32>
+  %2 = "stablehlo.dot_general"(%0, %1) {dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<16x64x128xf32>, tensor<16x128x3072xf32>) -> tensor<16x64x3072xf32>
+  return %2 : tensor<16x64x3072xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @dot_general_fuse_one
+// CHECK-SAME:     (%[[ARG0:.+]]: tensor<{{.+}}xf64>, %[[ARG1:.+]]: tensor<{{.+}}xf16>)
+func.func @dot_general_fuse_one(%arg0: tensor<16x64x128xf64>, %arg1: tensor<16x128x3072xf16>) -> tensor<16x64x3072xf32> {
+  %0 = stablehlo.convert %arg0 : (tensor<16x64x128xf64>) -> tensor<16x64x128xf32>
+  %1 = stablehlo.convert%arg1 : (tensor<16x128x3072xf16>) -> tensor<16x128x3072xf32>
+  // CHECK: %[[CONVERT:.+]] = stablehlo.convert %[[ARG0]]
+  // CHECK: stablehlo.dot_general %[[CONVERT]], %[[ARG1]]
+  %2 = "stablehlo.dot_general"(%0, %1) {dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<16x64x128xf32>, tensor<16x128x3072xf32>) -> tensor<16x64x3072xf32>
+  return %2 : tensor<16x64x3072xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @dot_basic
+// CHECK-SAME:     (%[[ARG0:.+]]: tensor<4x4xf16>, %[[ARG1:.+]]: tensor<4x4xf16>)
+func.func @dot_basic(%arg0: tensor<4x4xf16>, %arg1: tensor<4x4xf16>) -> tensor<4x4xf32> {
+  %0 = stablehlo.convert %arg0 : (tensor<4x4xf16>) -> tensor<4x4xf32>
+  %1 = stablehlo.convert %arg1 : (tensor<4x4xf16>) -> tensor<4x4xf32>
+  // CHECK: %[[DOT:.+]] = stablehlo.dot %[[ARG0]], %[[ARG1]]
+  %2 = "stablehlo.dot"(%0, %1) {precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+  // CHECK: return %[[DOT]]
+  return %2 : tensor<4x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @convolution
+// CHECK-SAME:     (%[[ARG0:.+]]: tensor<{{.+}}xbf16>, %[[ARG1:.+]]: tensor<{{.+}}xbf16>)
+func.func @convolution(%arg0: tensor<16x32x256xbf16>, %arg1: tensor<1x256x256xbf16>) -> tensor<16x32x256xf32> {
+  %cast = stablehlo.convert %arg0 : (tensor<16x32x256xbf16>) -> tensor<16x32x256xf32>
+  // CHECK: %[[CONV:.+]] = stablehlo.convolution(%[[ARG0]], %[[ARG1]])
+  // CHECK-SAME: -> tensor<16x32x256xf32>
+  %0 = "stablehlo.convolution"(%cast, %arg1) {
+     batch_group_count = 1 : i64,
+     dimension_numbers = #stablehlo.conv<[b, 0, f]x[0, i, o]->[b, 0, f]>,
+     feature_group_count = 1 : i64,
+     lhs_dilation = dense<1> : tensor<1xi64>,
+     padding = dense<0> : tensor<1x2xi64>,
+     precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>],
+     rhs_dilation = dense<1> : tensor<1xi64>,
+     window_strides = dense<1> : tensor<1xi64>
+   } : (tensor<16x32x256xf32>, tensor<1x256x256xbf16>) -> tensor<16x32x256xf32>
+  // CHECK: return %[[CONV]]
+  func.return %0 : tensor<16x32x256xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @dynamic_dot_general
+// This verifies non-crashing, the lowering to linalg happens elsewhere.
+func.func @dynamic_dot_general(%arg1: tensor<?x1024x16x64xf32>, %arg2: tensor<?x1024x16x64xf32>) -> tensor<?x16x1024x1024xf32> {
+  %2 = "stablehlo.dot_general"(%arg2, %arg1) {dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0, 2], rhs_batching_dimensions = [0, 2], lhs_contracting_dimensions = [3], rhs_contracting_dimensions = [3]>, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<?x1024x16x64xf32>, tensor<?x1024x16x64xf32>) -> tensor<?x16x1024x1024xf32>
+  return %2 : tensor<?x16x1024x1024xf32>
+}


### PR DESCRIPTION
This is based on an equivalent IREE pass for MHLO.

The changes compared to the mlir-hlo code are:
-  Code was ported to work on StableHLO ops.
-  Tests were ported to use stablehlo ops and match against how these are printed.
-  Test CHECKs were largely re-written to account for the lack of stablehlo folds and canonicalization patterns.

Issue: https://github.com/openxla/iree/issues/12678