### PR TITLE
Use remote ccache in mac x86_64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    # if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
     runs-on: macos-12-xl
     env:
       BUILD_DIR: build-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    # if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
     runs-on: macos-12-xl
     env:
       BUILD_DIR: build-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         # We need coreutils for `realpath` used in scripts.
         # We need bash because the default one on macOS is fairly old and lacks
         # features we use in scripts.
-        run: brew install ninja coreutils bash
+        run: brew install ninja ccache coreutils bash
       # Finally: build and run tests.
       - name: "Building IREE"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,14 +83,7 @@ jobs:
       BUILD_DIR: build-windows
       IREE_VULKAN_DISABLE: 1
     steps:
-      - id: "gcp-auth"
-        name: "Authenticating to Google Cloud"
-        uses: "google-github-actions/auth@v1"
-        with:
-          token_format: "access_token"
-          credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
-          create_credentials_file: false
-      # actions/cache is for some reason unusably slow on the large managed
+      # actions/checkout is for some reason unusably slow on the large managed
       # Windows GitHub runners so we roll our own. See
       # https://github.com/actions/checkout/issues/1186
       # TODO(gcmn): Factor this out into something reusable across jobs. Can't
@@ -105,6 +98,14 @@ jobs:
           git fetch --depth 1 "${REMOTE_URL}" "${GITHUB_SHA}"
           git checkout "${GITHUB_SHA}"
           git submodule update --init --jobs 8 --depth 1
+      - id: "gcp-auth"
+        name: "Authenticating to Google Cloud"
+        if: ${{ needs.setup.outputs.write-caches }} == 1
+        uses: "google-github-actions/auth@v1"
+        with:
+          token_format: "access_token"
+          credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
+          create_credentials_file: false
       - name: "Setting up Python"
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
@@ -174,6 +175,14 @@ jobs:
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - id: "gcp-auth"
+        name: "Authenticating to Google Cloud"
+        if: ${{ needs.setup.outputs.write-caches }} == 1
+        uses: "google-github-actions/auth@v1"
+        with:
+          token_format: "access_token"
+          credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
+          create_credentials_file: false
       - name: "Updating git submodules"
         run: git submodule update --init --jobs 8 --depth 1
       - name: "Setting up Python"
@@ -191,13 +200,9 @@ jobs:
       # Finally: build and run tests.
       - name: "Building IREE"
         env:
-          # Note: we would love to use caching here but the GitHub Actions cache
-          # is utterly broken. See https://github.com/actions/cache/issues/1115
-          # and https://github.com/openxla/iree/pull/12905
-          IREE_READ_REMOTE_CCACHE: 0
-          IREE_WRITE_REMOTE_CCACHE: 0
-          IREE_READ_LOCAL_CCACHE: 0
-          IREE_WRITE_LOCAL_CCACHE: 0
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+          IREE_CCACHE_GCP_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+          CCACHE_NAMESPACE: github-macos-12-xl
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -55,7 +55,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: ${{ steps.configure.outputs.should-run }}
+      should-run: "false"
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -55,7 +55,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: "false"
+      should-run: ${{ steps.configure.outputs.should-run }}
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -59,7 +59,7 @@ jobs:
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
-      write-caches: ${{ steps.configure.outputs.write-caches }}
+      write-caches: 1
       benchmark-presets: ${{ steps.configure.outputs.benchmark-presets }}
     steps:
       - name: "Checking out repository"

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -59,7 +59,7 @@ jobs:
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
-      write-caches: 1
+      write-caches: ${{ steps.configure.outputs.write-caches }}
       benchmark-presets: ${{ steps.configure.outputs.benchmark-presets }}
     steps:
       - name: "Checking out repository"


### PR DESCRIPTION
Fully cached rebuild appears to take 20m for the build step,
compared to 1h8m for the uncached build with remote cache writes
(attempts 2 and 1 of
[this workflow run](https://github.com/openxla/iree/actions/runs/4886873002/jobs/8724117607)).
That's unfortunately quite a bit slower than when we had caching that
restored a full ccache directory previously (e.g.
[this run](https://github.com/openxla/iree/actions/runs/4658305324/jobs/8243824546)).
The latter was disabled in https://github.com/openxla/iree/pull/12905
because the actions/cache restore was extremely unreliable, timing out
most of the time.

The latency difference appears to be due to the cache hit rate:

```
Cacheable calls:   4850 / 4865 (99.69%)
  Hits:            4734 / 4850 (97.61%)
    Direct:        4387 / 4734 (92.67%)
    Preprocessed:   347 / 4734 ( 7.33%)
  Misses:           116 / 4850 ( 2.39%)
Uncacheable calls:   15 / 4865 ( 0.31%)
Local storage:
  Cache size (GB): 2.94 / 4.00 (73.50%)
```

vs

```
Cacheable calls:    4922 / 4937 (99.70%)
  Hits:             4080 / 4922 (82.89%)
    Direct:         3729 / 4080 (91.40%)
    Preprocessed:    351 / 4080 ( 8.60%)
  Misses:            842 / 4922 (17.11%)
Uncacheable calls:    15 / 4937 ( 0.30%)
Local storage:
  Cache size (GiB):  0.0 /  5.0 ( 0.00%)
Remote storage:
  Hits:             4080 / 4922 (82.89%)
  Misses:            842 / 4922 (17.11%)
```

We'll need to debug why we're seeing the 17% cache miss rate (I could
wildly speculate), but this is still a sizable improvement.

Part of https://github.com/openxla/iree/issues/13028 

