### PR TITLE
Fix command arguments for multiple inputs in benchmark tools

### DIFF
--- a/build_tools/benchmarks/generate_benchmark_comment.py
+++ b/build_tools/benchmarks/generate_benchmark_comment.py
@@ -213,14 +213,14 @@ def parse_arguments():
       "--benchmark_files",
       metavar="<benchmark-json-files>",
       default=[],
-      nargs="+",
+      action="append",
       help=("Paths to the JSON files containing benchmark results, "
             "accepts wildcards"))
   parser.add_argument(
       "--compile_stats_files",
       metavar="<compile-stats-json-files>",
       default=[],
-      nargs="+",
+      action="append",
       help=("Paths to the JSON files containing compilation statistics, "
             "accepts wildcards"))
   parser.add_argument("--pr_number", required=True, type=int, help="PR number")

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -277,14 +277,14 @@ def parse_arguments():
       '--benchmark_files',
       metavar='<benchmark-json-files>',
       default=[],
-      nargs='+',
+      action="append",
       help=("Paths to the JSON files containing benchmark results, "
             "accepts wildcards"))
   parser.add_argument(
       "--compile_stats_files",
       metavar="<compile-stats-json-files>",
       default=[],
-      nargs="+",
+      action="append",
       help=("Paths to the JSON files containing compilation statistics, "
             "accepts wildcards"))
   parser.add_argument("--dry-run",


### PR DESCRIPTION
Change `nargs="+"` to `action="append"` in benchmark tools to correctly accept multiple inputs. 

Benchmark tools accept multiple results files in the command arguments. But it intends to accept:

```sh
tool.py --benchmark_files=a.json --bencmark_files=b.json
```

while currently with `nargs="+"`, it only accepts

```sh
tool.py --benchmark_files a.json b.json
```

Searched across the IREE codebase and looks like the first format is more commonly used.