### PR TITLE
[NCCL] check version first before loading symbols

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -298,8 +298,10 @@ static iree_status_t iree_hal_cuda_device_create_channel(
   if (!device->context_wrapper.syms->nccl_library) {
     return iree_make_status(
         IREE_STATUS_UNAVAILABLE,
-        "NCCL runtime library not available; ensure installed and the "
-        "shared library is on your PATH/LD_LIBRARY_PATH (nccl.dll/libnccl.so)");
+        "NCCL runtime library (%d.%d.%d) not available; ensure installed and "
+        "the shared library is on your PATH/LD_LIBRARY_PATH "
+        "(nccl.dll/libnccl.so)",
+        NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
   }
 
   // Today we only allow a single logical device per channel.

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
@@ -101,6 +101,46 @@ iree_status_t iree_hal_cuda_dynamic_symbols_initialize(
   return status;
 }
 
+static iree_status_t iree_hal_cuda_nccl_check_version(
+    iree_dynamic_library_t* nccl_library) {
+  IREE_ASSERT_ARGUMENT(nccl_library);
+
+  ncclResult_t (*ncclGetVersion)(int*) = NULL;
+
+  IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(
+      nccl_library, "ncclGetVersion", (void**)&ncclGetVersion));
+
+  // Check the NCCL version compatibility
+  int nccl_version = 0;
+  ncclResult_t result = ncclGetVersion(&nccl_version);
+  if (result != ncclSuccess) {
+    return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                            "ncclGetVersion() failed (%d)", result);
+  }
+
+  int major = 0;
+  int minor = 0;
+  int patch = 0;
+  if (nccl_version < 20000) {
+    major = nccl_version / 1000;
+    minor = (nccl_version % 1000) / 100;
+  } else {
+    major = nccl_version / 10000;
+    minor = (nccl_version % 10000) / 100;
+  }
+  patch = nccl_version % 100;
+  if (major != NCCL_MAJOR || minor != NCCL_MINOR || patch != NCCL_PATCH) {
+    printf("NCCL version is %d.%d.%d, but %d.%d.%d is required", major, minor,
+           patch, NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
+
+    return iree_make_status(
+        IREE_STATUS_UNAVAILABLE,
+        "NCCL version is %d.%d.%d, but %d.%d.%d is required", major, minor,
+        patch, NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
+  }
+  return iree_ok_status();
+}
+
 iree_status_t iree_hal_cuda_nccl_dynamic_symbols_initialize(
     iree_allocator_t host_allocator,
     iree_hal_cuda_dynamic_symbols_t* out_syms) {
@@ -130,33 +170,16 @@ iree_status_t iree_hal_cuda_nccl_dynamic_symbols_initialize(
         "shared library is on your PATH/LD_LIBRARY_PATH (nccl.dll/libnccl.so)");
   }
 
+  if (iree_status_is_ok(status)) {
+    // Check the version first before resolving all symbols. This makes sure
+    // that we have the right version and all symbols are available at the
+    // time of resolving.
+    status = iree_hal_cuda_nccl_check_version(out_syms->nccl_library);
+  }
+
   // Resolve all symbols; this will fail if any required symbols are missing.
   if (iree_status_is_ok(status)) {
     status = iree_hal_cuda_nccl_dynamic_symbols_resolve_all(out_syms);
-  }
-
-  // Check the NCCL version compatibility
-  int nccl_version = 0;
-  if (iree_status_is_ok(status)) {
-    status = NCCL_RESULT_TO_STATUS(out_syms, ncclGetVersion(&nccl_version));
-  }
-  if (iree_status_is_ok(status)) {
-    int major = 0;
-    int minor = 0;
-    if (nccl_version < 20000) {
-      major = nccl_version / 1000;
-      minor = (nccl_version % 1000) / 100;
-    } else {
-      major = nccl_version / 10000;
-      minor = (nccl_version % 10000) / 100;
-    }
-    if (nccl_version < NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, 0) ||
-        major != NCCL_MAJOR) {
-      status = iree_make_status(
-          IREE_STATUS_INTERNAL,
-          "NCCL version %d.%d found but at least version %d.%d is required",
-          major, minor, NCCL_MAJOR, NCCL_MINOR);
-    }
   }
 
   if (!iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
@@ -170,8 +170,10 @@ iree_status_t iree_hal_cuda_nccl_dynamic_symbols_initialize(
     iree_status_ignore(status);
     status = iree_make_status(
         IREE_STATUS_UNAVAILABLE,
-        "NCCL runtime library not available; ensure installed and the "
-        "shared library is on your PATH/LD_LIBRARY_PATH (nccl.dll/libnccl.so)");
+        "NCCL runtime library (%d.%d.%d) not available; ensure installed and "
+        "the shared library is on your PATH/LD_LIBRARY_PATH "
+        "(nccl.dll/libnccl.so)",
+        NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
   }
 
   if (iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
@@ -107,10 +107,14 @@ static iree_status_t iree_hal_cuda_nccl_check_version(
 
   ncclResult_t (*ncclGetVersion)(int*) = NULL;
 
-  IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(
-      nccl_library, "ncclGetVersion", (void**)&ncclGetVersion));
+  iree_status_t status = iree_dynamic_library_lookup_symbol(
+      nccl_library, "ncclGetVersion", (void**)&ncclGetVersion);
+  if (!iree_status_is_ok(status)) {
+    return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                            "ncclGetVersion() not found");
+  }
 
-  // Check the NCCL version compatibility
+  // Check the NCCL version compatibility.
   int nccl_version = 0;
   ncclResult_t result = ncclGetVersion(&nccl_version);
   if (result != ncclSuccess) {


### PR DESCRIPTION
Now the version check is more specific, since NCCL breaks compatibility even with the minor version bump.

The current supported version is 2.15.5.