### PR TITLE
Fix --benchmark_files argument in Android pipeline

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -144,7 +144,7 @@ steps:
       buildkite-agent artifact download benchmark-results-*.json ./
       python3 build_tools/benchmarks/upload_benchmarks_to_dashboard.py \
         --verbose \
-        --benchmark_files benchmark-results-*.json
+        --benchmark_files="benchmark-results-*.json"
     key: "upload-to-dashboard"
     branches: "main"
     agents:


### PR DESCRIPTION
Fix the `--benchmark_files` in Android benchmark pipeline, which didn't use quotes to pass the non-expanded wildcard pattern to the tool.

skip-ci: Not running in Github CI