### PR TITLE
Stop trying to build TF with Bazel for releases.

### DIFF
--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -180,22 +180,6 @@ def build_py_tf_compiler_tools_pkg():
   shutil.rmtree(INSTALL_DIR, ignore_errors=True)
   remove_cmake_cache()
 
-  print("*** Building TF import tool with Bazel ***")
-  cmd = [
-      "bazel",
-      "build",
-      "--config=release",
-      "--keep_going",
-      "//iree_tf_compiler:importer-binaries",
-  ]
-  process = subprocess.run(cmd, cwd=TF_INTEGRATIONS_DIR, check=True)
-
-  print("*** Symlinking built binaries ***")
-  subprocess.run(["bash", "symlink_binaries.sh"],
-                 cwd=TF_INTEGRATIONS_DIR,
-                 check=True)
-  os.makedirs(BINDIST_DIR, exist_ok=True)
-
   for project in ["iree_tflite", "iree_tf"]:
     print(f"*** Building wheel for {project} ***")
     subprocess.run(


### PR DESCRIPTION
Follow-up to https://github.com/openxla/iree/pull/13361

Untested, but I think this will help with https://github.com/openxla/iree/actions/runs/4881477162/jobs/8710428798#step:9:220
```
*** Building TF import tool with Bazel ***
  File "/work/./main_checkout/build_tools/github_actions/build_dist.py", line 215, in <module>
    build_py_tf_compiler_tools_pkg()
  File "/work/./main_checkout/build_tools/github_actions/build_dist.py", line 191, in build_py_tf_compiler_tools_pkg
    process = subprocess.run(cmd, cwd=TF_INTEGRATIONS_DIR, check=True)
  File "/opt/python/cp39-cp39/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['bazel', 'build', '--config=release', '--keep_going', '//iree_tf_compiler:importer-binaries']' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```

skip-ci: release builds are not tested on presubmit?