### PR TITLE
[StableHLO] Add custom canonicalization pass

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
@@ -65,7 +65,8 @@ void buildStableHLOInputConversionPassPipelineImpl(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(createTopLevelSCFToCFGPass());
   // TODO(#12678): Port StableHLO detuple pass.
 
-  // TODO(#12678): Port StableHLO-StableHLO preprocessing.
+  passManager.addNestedPass<func::FuncOp>(
+      createStableHLOToStableHLOPreprocessing());
   passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
   // Various shape functions may have been materialized in the `shape.shape_of`

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
@@ -60,6 +60,7 @@ iree_gentbl_cc_library(
 iree_compiler_cc_library(
     name = "Preprocessing",
     srcs = [
+        "Canonicalization.cpp",
         "DotGeneralToDot.cpp",
         "EinsumToDotGeneral.cpp",
         "GatherToTorchIndexSelect.cpp",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_cc_library(
     "Passes.h"
     "Rewriters.h"
   SRCS
+    "Canonicalization.cpp"
     "DotGeneralToDot.cpp"
     "EinsumToDotGeneral.cpp"
     "GatherToTorchIndexSelect.cpp"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -12,17 +12,12 @@
 
 #include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h"
 #include "iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h"
-#include "llvm/ADT/APInt.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Attributes.h"
-#include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/IR/TypeUtilities.h"
-#include "mlir/IR/ValueRange.h"
-#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "stablehlo/dialect/StablehloOps.h"
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1,0 +1,235 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements optional canonicalization patterns for StableHLO ops.
+
+#include <cassert>
+#include <functional>
+#include <numeric>
+
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h"
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h"
+#include "llvm/ADT/APInt.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_STABLEHLOCANONICALIZE
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h.inc"
+
+namespace {
+
+// This is an upper limit on how many elements canonicalization patterns are
+// allowed to materialize as new constants.
+constexpr int64_t kFoldOpEltLimit = 65536;
+
+struct ConcatenateOpCanon final
+    : OpRewritePattern<mlir::stablehlo::ConcatenateOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ConcatenateOp op,
+                                PatternRewriter &rewriter) const override {
+    auto type = dyn_cast<RankedTensorType>(op.getType());
+    if (!type || !type.hasStaticShape()) return failure();
+
+    size_t numElems = type.getNumElements();
+    if (numElems > kFoldOpEltLimit) return failure();
+
+    // Fold concatenate when all inputs are constants.
+    OperandRange inputs = op.getInputs();
+    SmallVector<DenseElementsAttr> constants(inputs.size());
+    for (auto [input, constant] : llvm::zip_equal(inputs, constants)) {
+      if (!matchPattern(input, m_Constant(&constant))) {
+        return failure();
+      }
+    }
+
+    uint64_t axis = op.getDimension();
+    ArrayRef<int64_t> shape = type.getShape();
+    int64_t topSize = std::accumulate(shape.begin(), shape.begin() + axis,
+                                      int64_t{1}, std::multiplies<>{});
+
+    SmallVector<Attribute> newElems;
+    newElems.reserve(numElems);
+
+    for (int64_t i = 0; i != topSize; ++i) {
+      for (ElementsAttr attr : constants) {
+        size_t bottomSize = attr.getNumElements() / topSize;
+        auto begin = attr.value_begin<Attribute>() + (i * bottomSize);
+        newElems.append(begin, begin + bottomSize);
+      }
+    }
+
+    assert(newElems.size() == numElems);
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+        op, DenseElementsAttr::get(op.getType(), newElems));
+    return success();
+  }
+};
+
+struct ConvertOpCanon final : OpRewritePattern<mlir::stablehlo::ConvertOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ConvertOp op,
+                                PatternRewriter &rewriter) const override {
+    // Check if this convert is a noop.
+    if (op.getOperand().getType() != op.getType()) return failure();
+
+    rewriter.replaceOp(op, op.getOperand());
+    return success();
+  }
+};
+
+struct DynamicReshapeOpCanon final
+    : OpRewritePattern<mlir::stablehlo::DynamicReshapeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::DynamicReshapeOp op,
+                                PatternRewriter &rewriter) const override {
+    // This is a noop when the output type is already a static shape.
+    auto type = dyn_cast<RankedTensorType>(op.getType());
+    if (!type || !type.hasStaticShape())
+      return failure();
+
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(
+        op, type, op.getOperand());
+    return success();
+  }
+};
+
+struct RealOpCanon final : OpRewritePattern<mlir::stablehlo::RealOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::RealOp op,
+                                PatternRewriter &rewriter) const override {
+    auto complex = op.getOperand().getDefiningOp<mlir::stablehlo::ComplexOp>();
+    if (!complex) return failure();
+
+    rewriter.replaceOp(op, complex.getLhs());
+    return success();
+  }
+};
+
+struct ImagOpCanon final : OpRewritePattern<mlir::stablehlo::ImagOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ImagOp op,
+                                PatternRewriter &rewriter) const override {
+    auto complex = op.getOperand().getDefiningOp<mlir::stablehlo::ComplexOp>();
+    if (!complex) return failure();
+
+    rewriter.replaceOp(op, complex.getRhs());
+    return success();
+  }
+};
+
+struct GetDimensionSizeOpCanon final
+    : OpRewritePattern<mlir::stablehlo::GetDimensionSizeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::GetDimensionSizeOp op,
+                                PatternRewriter &rewriter) const override {
+    // Fold get_dimension_size when the queried dim is statically known.
+    auto tensorTy = dyn_cast<RankedTensorType>(op.getOperand().getType());
+    if (!tensorTy) return failure();
+
+    int64_t dimSize = tensorTy.getDimSize(op.getDimension());
+    if (dimSize < 0) return failure();
+
+    auto elemTy = cast<IntegerType>(op.getType().getElementType());
+    IntegerAttr elemVal = rewriter.getIntegerAttr(elemTy, dimSize);
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+        op, DenseElementsAttr::get(op.getType(), elemVal));
+    return success();
+  }
+};
+
+struct ReshapeOpCanon final : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ReshapeOp op,
+                                PatternRewriter &rewriter) const override {
+    // Fold noop reshape.
+    if (op.getType() == op.getOperand().getType()) {
+      rewriter.replaceOp(op, op.getOperand());
+      return success();
+    }
+
+    // Fold reshape of a constant.
+    ElementsAttr cstAttr;
+    if (!matchPattern(op.getOperand(), m_Constant(&cstAttr))) {
+      return failure();
+    }
+
+    if (auto splat = dyn_cast<SplatElementsAttr>(cstAttr)) {
+      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+          op, SplatElementsAttr::get(op.getType(),
+                                     splat.getSplatValue<Attribute>()));
+      return success();
+    }
+
+    auto elements =
+        llvm::to_vector_of<Attribute>(cstAttr.getValues<Attribute>());
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+        op, DenseElementsAttr::get(op.getType(), elements));
+    return success();
+  }
+};
+
+struct TransposeOpCanon final : OpRewritePattern<mlir::stablehlo::TransposeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::TransposeOp op,
+                                PatternRewriter &rewriter) const override {
+    // Check if this transpose is a noop and use the operand instead.
+    auto dims = op.getPermutation().tryGetValues<APInt>();
+    if (failed(dims)) return failure();
+
+    // Check if dims is an iota range.
+    for (auto [idx, dim] : llvm::enumerate(*dims)) {
+      if (idx != dim.getLimitedValue()) {
+        return failure();
+      }
+    }
+
+    rewriter.replaceOp(op, op.getOperand());
+    return success();
+  }
+};
+
+struct StableHLOCanonicalize final
+    : impl::StableHLOCanonicalizeBase<StableHLOCanonicalize> {
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    populateCanonicalizationPatterns(ctx, &patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+void populateCanonicalizationPatterns(MLIRContext *context,
+                                      RewritePatternSet *patterns,
+                                      PatternBenefit benefit) {
+  patterns->add<ConcatenateOpCanon, ConvertOpCanon, DynamicReshapeOpCanon,
+                RealOpCanon, ImagOpCanon, GetDimensionSizeOpCanon,
+                ReshapeOpCanon, TransposeOpCanon>(context, benefit);
+}
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -102,11 +102,10 @@ struct DynamicReshapeOpCanon final
                                 PatternRewriter &rewriter) const override {
     // This is a noop when the output type is already a static shape.
     auto type = dyn_cast<RankedTensorType>(op.getType());
-    if (!type || !type.hasStaticShape())
-      return failure();
+    if (!type || !type.hasStaticShape()) return failure();
 
-    rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(
-        op, type, op.getOperand());
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(op, type,
+                                                            op.getOperand());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/ComplexLoweringPatterns.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/ComplexLoweringPatterns.td
@@ -15,18 +15,6 @@ class ConstantSplat<string value> : NativeCodeCall<
     "::mlir::iree_compiler::stablehlo::getSplat(&$_builder, $0, " # value # ")">;
 
 //===----------------------------------------------------------------------===//
-// Folds
-//===----------------------------------------------------------------------===//
-
-// real(complex x, y) -> x
-def : Pat<(StableHLO_RealOp (StableHLO_ComplexOp $lhs, $rhs)),
-          (replaceWithValue $lhs)>;
-
-// imag(complex x, y) -> y
-def : Pat<(StableHLO_ImagOp (StableHLO_ComplexOp $lhs, $rhs)),
-          (replaceWithValue $rhs)>;
-
-//===----------------------------------------------------------------------===//
 // Binary op patterns.
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/LowerComplex.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/LowerComplex.cpp
@@ -25,6 +25,7 @@ struct LowerComplex final : impl::LowerComplexBase<LowerComplex> {
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     populatePreprocessingComplexPatterns(ctx, &patterns);
+    populateCanonicalizationPatterns(ctx, &patterns);
     if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {
       signalPassFailure();

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
@@ -11,11 +11,16 @@ include "mlir/Pass/PassBase.td"
 
 def StableHLOToStableHLOPreprocessing :
     Pass<"iree-stablehlo-to-stablehlo-preprocessing", "func::FuncOp"> {
-  let summary = "Apply IREE-specific stablehlo to stablehlo preprocessing transformations";
+  let summary = "Applies IREE-specific stablehlo to stablehlo preprocessing transformations";
   let options = [
     Option<"orderConvFeatures", "order-conv-features", "bool", /*default=*/"true",
            "Guarantees input/output features ordered from conv kernel">
   ];
+}
+
+def StableHLOCanonicalize :
+    Pass<"iree-stablehlo-canonicalize", "func::FuncOp"> {
+  let summary = "Canonicalizes StableHLO operations";
 }
 
 def DotGeneralToDot :
@@ -35,7 +40,7 @@ def GatherToTorchIndexSelect :
 
 def LowerComplex :
     Pass<"iree-stablehlo-preprocessing-lower-complex", "func::FuncOp"> {
-  let summary = "Lower complex operations into non-complex operations";
+  let summary = "Lowers complex operations into non-complex operations";
 }
 
 def UnfuseBatchNorm :

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_INPUTCONVERSION_STABLEHLO_PREPROCESSING_REWRITERS_H_
 #define IREE_COMPILER_INPUTCONVERSION_STABLEHLO_PREPROCESSING_REWRITERS_H_
 
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir::iree_compiler::stablehlo {
@@ -14,6 +15,11 @@ namespace mlir::iree_compiler::stablehlo {
 //===----------------------------------------------------------------------===//
 // General StableHLO/CHLO preprocessing patterns.
 //===----------------------------------------------------------------------===//
+
+/// Collection of canonicalization patterns for StableHLO.
+void populateCanonicalizationPatterns(MLIRContext *context,
+                                      RewritePatternSet *patterns,
+                                      PatternBenefit benefit = 1);
 
 /// Collection of rewrite patterns for lowering of StableHLO dot general
 /// operations.

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "stablehlo/dialect/ChloOps.h"
@@ -1275,6 +1276,9 @@ struct StableHLOToStableHLOPreprocessing final
     }
 
     RewritePatternSet patterns(context);
+    // General canonicalization patterns.
+    populateCanonicalizationPatterns(context, &patterns, PatternBenefit{1024});
+
     // TODO: Remove once we have a general contraction to matmul pass.
     populatePreprocessingEinsumToDotGeneralPatterns(context, &patterns);
     populatePreprocessingUnfuseBatchNormPatterns(context, &patterns);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -1276,7 +1276,11 @@ struct StableHLOToStableHLOPreprocessing final
     }
 
     RewritePatternSet patterns(context);
-    // General canonicalization patterns.
+    // General StableHLO canonicalization patterns. Run these with a high
+    // benefit to enable more rewrites and avoid needless expansions that could
+    // be more difficult to fold away. Note that we need to manually add these
+    // because StableHLO does not provide constant folders or canonicalization
+    // patterns for its ops.
     populateCanonicalizationPatterns(context, &patterns, PatternBenefit{1024});
 
     // TODO: Remove once we have a general contraction to matmul pass.

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "canonicalization.mlir",
             "complex_lowering.mlir",
             "dot_general_to_dot.mlir",
             "einsum_to_dot_general.mlir",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "canonicalization.mlir"
     "complex_lowering.mlir"
     "dot_general_to_dot.mlir"
     "einsum_to_dot_general.mlir"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
@@ -1,0 +1,127 @@
+// RUN: iree-opt --iree-stablehlo-canonicalize --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @concatenate
+func.func @concatenate() -> (tensor<6xi32>, tensor<3xi32>, tensor<3x3xi32>, tensor<2x5xi32>) {
+  %c0 = stablehlo.constant dense<[0, 1]> : tensor<2xi32>
+  %c1 = stablehlo.constant dense<[2, 3, 4]> : tensor<3xi32>
+  %c2 = stablehlo.constant dense<[5]> : tensor<1xi32>
+
+  %c3 = stablehlo.constant dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi32>
+  %c4 = stablehlo.constant dense<[[6, 7, 8]]> : tensor<1x3xi32>
+  %c5 = stablehlo.constant dense<[[11, 12], [13, 14]]> : tensor<2x2xi32>
+
+  %0 = stablehlo.concatenate %c0, %c1, %c2, dim = 0 : (tensor<2xi32>, tensor<3xi32>, tensor<1xi32>) -> tensor<6xi32>
+  %1 = stablehlo.concatenate %c0, %c2, dim = 0 : (tensor<2xi32>, tensor<1xi32>) -> tensor<3xi32>
+
+  %2 = stablehlo.concatenate %c3, %c4, dim = 0 : (tensor<2x3xi32>, tensor<1x3xi32>) -> tensor<3x3xi32>
+  %3 = stablehlo.concatenate %c3, %c5, dim = 1 : (tensor<2x3xi32>, tensor<2x2xi32>) -> tensor<2x5xi32>
+
+  // CHECK-DAG:  [[R0:%.+]] = stablehlo.constant dense<[0, 1, 2, 3, 4, 5]> : tensor<6xi32>
+  // CHECK-DAG:  [[R1:%.+]] = stablehlo.constant dense<[0, 1, 5]> : tensor<3xi32
+  // CHECK-DAG:  [[R2:%.+]] = stablehlo.constant dense<{{\[\[0, 1, 2\], \[3, 4, 5\], \[6, 7, 8\]\]}}> : tensor<3x3xi32>
+  // CHECK-DAG:  [[R3:%.+]] = stablehlo.constant dense<{{\[\[0, 1, 2, 11, 12\], \[3, 4, 5, 13, 14\]\]}}> : tensor<2x5xi32>
+  // CHECK-NEXT: return [[R0]], [[R1]], [[R2]], [[R3]]
+  return %0, %1, %2, %3 : tensor<6xi32>, tensor<3xi32>, tensor<3x3xi32>, tensor<2x5xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @convert
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<2xf32>)
+func.func @convert(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+  %r = stablehlo.convert %arg0 : tensor<2xf32>
+
+  // CHECK: return [[ARG0]]
+  return %r : tensor<2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @complex
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<2xf32>, [[ARG1:%.+]]: tensor<2xf32>)
+func.func @complex(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+  %c = stablehlo.complex %arg0, %arg1 : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+
+  %r = stablehlo.real %c : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+  %i = stablehlo.imag %c : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+
+  // CHECK: return [[ARG0]], [[ARG1]]
+  return %r, %i : tensor<2xf32>, tensor<2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dynamic_reshape
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<1xf32>, [[ARG1:%.+]]: tensor<?x?xf32>, [[ARG2:%.+]]: tensor<2xi32>)
+func.func @dynamic_reshape(%arg0: tensor<1xf32>, %arg1: tensor<?x?xf32>, %arg2: tensor<2xi32>)
+          -> (tensor<1x1xf32>, tensor<2x1xf32>, tensor<1x2xi32>) {
+  %c0 = stablehlo.constant dense<[2, 1]> : tensor<2xi32>
+
+  %0 = stablehlo.dynamic_reshape %arg0, %arg2 : (tensor<1xf32>, tensor<2xi32>) -> tensor<1x1xf32>
+  %1 = stablehlo.dynamic_reshape %arg1, %c0 : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<2x1xf32>
+  %2 = stablehlo.dynamic_reshape %arg2, %arg2 : (tensor<2xi32>, tensor<2xi32>) -> tensor<1x2xi32>
+
+  // CHECK-DAG:  [[R0:%.+]] = stablehlo.reshape [[ARG0]] : (tensor<1xf32>) -> tensor<1x1xf32>
+  // CHECK-DAG:  [[R1:%.+]] = stablehlo.reshape [[ARG1]] : (tensor<?x?xf32>) -> tensor<2x1xf32>
+  // CHECK-DAG:  [[R2:%.+]] = stablehlo.reshape [[ARG2]] : (tensor<2xi32>) -> tensor<1x2xi32>
+  // CHECK-NEXT: return [[R0]], [[R1]], [[R2]]
+  return %0, %1, %2 : tensor<1x1xf32>, tensor<2x1xf32>, tensor<1x2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @get_dimension_size
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<1x2x3xf32>, [[ARG1:%.+]]: tensor<?x2xf32>)
+func.func @get_dimension_size(%arg0: tensor<1x2x3xf32>, %arg1: tensor<?x2xf32>)
+          -> (tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>) {
+  %a = stablehlo.get_dimension_size %arg0, dim = 0 : (tensor<1x2x3xf32>) -> tensor<i32>
+  %b = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<1x2x3xf32>) -> tensor<i32>
+  %c = stablehlo.get_dimension_size %arg0, dim = 2 : (tensor<1x2x3xf32>) -> tensor<i32>
+
+  %d = stablehlo.get_dimension_size %arg1, dim = 0 : (tensor<?x2xf32>) -> tensor<i32>
+  %e = stablehlo.get_dimension_size %arg1, dim = 1 : (tensor<?x2xf32>) -> tensor<i32>
+
+  // CHECK-DAG:  [[CST1:%.+]] = stablehlo.constant dense<1> : tensor<i32>
+  // CHECK-DAG:  [[CST2:%.+]] = stablehlo.constant dense<2> : tensor<i32>
+  // CHECK-DAG:  [[CST3:%.+]] = stablehlo.constant dense<3> : tensor<i32>
+  // CHECK-DAG:  [[DYN:%.+]]  = stablehlo.get_dimension_size [[ARG1]], dim = 0 : (tensor<?x2xf32>) -> tensor<i32>
+  // CHECK-NEXT: return [[CST1]], [[CST2]], [[CST3]], [[DYN]], [[CST2]]
+  return %a, %b, %c, %d, %e : tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @reshape
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<1xf32>)
+func.func @reshape(%arg0: tensor<1xf32>)
+          -> (tensor<1xf32>, tensor<1xi32>, tensor<i32>, tensor<2x2xi32>) {
+  %c0 = stablehlo.constant dense<2> : tensor<i32>
+  %c1 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+
+  %0 = stablehlo.reshape %arg0 : (tensor<1xf32>) -> tensor<1xf32>
+  %1 = stablehlo.reshape %c0 : (tensor<i32>) -> tensor<1xi32>
+  %2 = stablehlo.reshape %1 : (tensor<1xi32>) -> tensor<i32>
+  %3 = stablehlo.reshape %c1 : (tensor<4xi32>) -> tensor<2x2xi32>
+
+  // CHECK-DAG:  [[CST1:%.+]] = stablehlo.constant dense<2> : tensor<i32>
+  // CHECK-DAG:  [[CST2:%.+]] = stablehlo.constant dense<2> : tensor<1xi32>
+  // CHECK-DAG:  [[CST3:%.+]] = stablehlo.constant dense<{{\[\[1, 2\], \[3, 4\]\]}}> : tensor<2x2xi32>
+  // CHECK-NEXT: return [[ARG0]], [[CST2]], [[CST1]], [[CST3]]
+  return %0, %1, %2, %3 : tensor<1xf32>, tensor<1xi32>, tensor<i32>, tensor<2x2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @transpose
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<2xf32>, [[ARG1:%.+]]: tensor<1x2xf32>, [[ARG2:%.+]]: tensor<f32>)
+func.func @transpose(%arg0: tensor<2xf32>, %arg1: tensor<1x2xf32>, %arg2: tensor<f32>)
+          -> (tensor<2xf32>, tensor<1x2xf32>, tensor<2x1xf32>, tensor<f32>) {
+  %a = stablehlo.transpose %arg0, dims = [0] : (tensor<2xf32>) -> tensor<2xf32>
+  %b = stablehlo.transpose %arg1, dims = [0, 1] : (tensor<1x2xf32>) -> tensor<1x2xf32>
+  %c = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<1x2xf32>) -> tensor<2x1xf32>
+  %d = stablehlo.transpose %arg2, dims = [] : (tensor<f32>) -> tensor<f32>
+
+  // CHECK-NEXT: [[X:%.+]] = stablehlo.transpose [[ARG1]], dims = [1, 0]
+  // CHECK-NEXT: return [[ARG0]], [[ARG1]], [[X]], [[ARG2]]
+  return %a, %b, %c, %d : tensor<2xf32>, tensor<1x2xf32>, tensor<2x1xf32>, tensor<f32>
+}


### PR DESCRIPTION
We need these because StableHLO does not provide folds or canicalization patterns, unlike MHLO. Because the rest of the input conversion is based on the MHLO code, some patterns require/assume such canicalizations to happen. Note that these canonicalizations are, by design, very unopinionated and not IREE-specific.

This enables us to enable hlo-to-hlo preprocessing and not crash in e2e tests.

Only the concatenation indexing logic was ported from mlir-hlo; other canonicalization patterns are implemented from scratch.

Issue: https://github.com/openxla/iree/issues/12678