### PR TITLE
Enable all android tests on Github CI

### DIFF
--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -106,7 +106,7 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    # if: (! inputs.is-pr)
+    if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -106,7 +106,7 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    if: (! inputs.is-pr)
+    # if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -110,11 +110,11 @@ jobs:
     needs: cross_compile
     strategy:
       matrix:
-        # TODO(#9855): Add pixel-6-pro and moto-edge-x30.
         target:
           - device-name: pixel-4
             label-exclude: vulkan
-          - device-name: Pixel-6-Pro
+          - device-name: pixel-6-pro
+          - device-name: moto-edge-x30
     name: test_on_${{ matrix.target.device-name }}
     runs-on:
       - self-hosted # must come first

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -106,11 +106,13 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    # if: (! inputs.is-pr)
+    if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:
         target:
+          # Pixel 4 ships an old Adreno GPU driver. There are quite a few bugs
+          # triggered by our tests. Disable running tests entirely on Pixel 4.
           - device-name: pixel-4
             label-exclude: "vulkan"
           - device-name: pixel-6-pro

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -114,6 +114,7 @@ jobs:
         target:
           - device-name: pixel-4
             label-exclude: vulkan
+          - device-name: Pixel-6-Pro
     name: test_on_${{ matrix.target.device-name }}
     runs-on:
       - self-hosted # must come first

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -112,9 +112,11 @@ jobs:
       matrix:
         target:
           - device-name: pixel-4
-            label-exclude: vulkan
+            label-exclude: "vulkan"
           - device-name: pixel-6-pro
+            label-exclude: "^requires-gpu-nvidia$"
           - device-name: moto-edge-x30
+            label-exclude: "^requires-gpu-nvidia$"
     name: test_on_${{ matrix.target.device-name }}
     runs-on:
       - self-hosted # must come first


### PR DESCRIPTION
Enable all android tests on Github CI. The Buildkite pipeline will be stopped and removed in the follow-up.

Tested in presubmit: https://github.com/openxla/iree/actions/runs/4927131607