### PR TITLE
Enable all Android benchmarks in Github CI

### DIFF
--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -56,13 +56,11 @@ BENCHMARK_PRESET_MATCHERS: Dict[str, PresetMatcher] = {
         lambda config: "cuda" in config.tags and "long-running" in config.tags,
     "vulkan-nvidia":
         lambda config: "vulkan-nvidia" in config.tags,
-    # TODO(#9855): Enable benchmarks on pixel-6-pro and moto-edge-x30.
     "experimental-android-cpu":
         lambda config:
         (config.target_device_spec.architecture.type == common_definitions.
          ArchitectureType.CPU and config.target_device_spec.host_environment.
-         platform == "android" and config.target_device_spec.device_name in
-         ["pixel-4"]),
+         platform == "android"),
     "experimental-android-gpu":
         lambda config:
         (config.target_device_spec.architecture.type == common_definitions.

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -59,7 +59,7 @@ elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
         --device_model=GCP-c2-standard-16 \
         --cpu_uarch=CascadeLake \
         --verbose
-elif [[ "${TARGET_DEVICE_NAME}" == "pixel-4" ]]; then
+elif [[ "${TARGET_DEVICE_NAME}" =~ ^(pixel-4|pixel-6-pro|moto-edge-x30)$ ]]; then
   ./build_tools/benchmarks/run_benchmarks_on_android.py \
     --normal_benchmark_tool_dir="${NORMAL_BENCHMARK_TOOLS_DIR}" \
     --traced_benchmark_tool_dir="${TRACED_BENCHMARK_TOOLS_DIR}" \

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -79,7 +79,8 @@ RUNNER_ENV_OPTIONS = [RUNNER_ENV_DEFAULT, "testing"]
 
 DEFAULT_BENCHMARK_PRESETS = ["cuda", "x86_64", "vulkan-nvidia", "comp-stats"]
 BENCHMARK_PRESET_OPTIONS = DEFAULT_BENCHMARK_PRESETS + [
-    "experimental-android-cpu"
+    "experimental-android-cpu",
+    "experimental-android-gpu",
 ]
 
 PR_DESCRIPTION_TEMPLATE = "{title}" "\n\n" "{body}"


### PR DESCRIPTION
Enable Android benchmarks to run on all mobile devices in Github CI.

The benchmarks will run in postsubmit but not uploading results until we backfill the dashboard.