### PR TITLE
[LLVMGPU][TD] Don't apply the unalgined strategy for unsupported cases

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -525,10 +525,11 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
   //   - n and k are not aligned to the tile sizes (conservatively, take 64, 16)
   // Other cases currently result in folding and fall back to the default
   // unaligned IREE strategy.
-  bool unsupportedAlignedCases =
-      (matmulSize[0] % 64 == 0 && matmulSize[2] % 16 == 0) ||
-      (matmulSize[1] % 64 == 0 && matmulSize[2] % 16 == 0);
-  if (unsupportedAlignedCases) {
+  bool supportedUnalignedCases =
+      (matmulSize[0] % 64 != 0 && matmulSize[2] % 16 != 0) ||
+      (matmulSize[1] % 64 != 0 && matmulSize[2] % 16 != 0);
+
+  if (!supportedUnalignedCases) {
     LDBG("--Matmul strategy alignment check failed\n");
     return failure();
   }


### PR DESCRIPTION
We currently have some limitations with respect to the optionality of pads in the current transform dialect strategy. As a result make sure we don't apply this strategy when some of the pads may be folded away.

The existing code was already checking for that, but the condition was slightly off.

Fix that, i.e., only apply the unaligned strategy when both M and K or N and K are unaligned.

This fixes https://github.com/openxla/iree/issues/13448