### PR TITLE
Fix tests/transform_dialect/cuda/ dependencies

### DIFF
--- a/tests/transform_dialect/cuda/BUILD.bazel
+++ b/tests/transform_dialect/cuda/BUILD.bazel
@@ -27,7 +27,6 @@ iree_lit_test_suite(
     name = "lit",
     srcs = [
         "mma.mlir",
-        "mma_elemwise_layout_analysis.mlir",
         "reduction.mlir",
         "reduction_eltwise.mlir",
         "reduction_v2.mlir",
@@ -43,7 +42,6 @@ iree_lit_test_suite(
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.
     data = [
-        "mma_elemwise_layout_analysis_codegen_spec.mlir",
         "mma_reduction_layout_analysis_codegen_spec.mlir",
         "mma_reduction_layout_analysis_dispatch_spec.mlir",
         "mma_using_layout_analysis_codegen_spec.mlir",
@@ -62,6 +60,7 @@ iree_lit_test_suite(
         # First few ops of softmax only, acts as a proxy example.
         "softmax_partial_codegen_spec.mlir",
         "vecadd2d_codegen_spec.mlir",
+        "vecadd2d_codegen_spec_partial_tile.mlir",
     ],
     tags = [
         # CUDA cuInit fails with sanitizer on.
@@ -83,6 +82,7 @@ iree_lit_test_suite(
 iree_lit_test_suite(
     name = "sm80_lit",
     srcs = [
+        "mma_elemwise_layout_analysis.mlir",
         "mma_reduction_layout_analysis.mlir",
         "mma_using_layout_analysis.mlir",
     ],
@@ -90,6 +90,7 @@ iree_lit_test_suite(
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.
     data = [
+        "mma_elemwise_layout_analysis_codegen_spec.mlir",
         "mma_reduction_layout_analysis_codegen_spec.mlir",
         "mma_reduction_layout_analysis_dispatch_spec.mlir",
         "mma_using_layout_analysis_codegen_spec.mlir",

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -19,7 +19,6 @@ iree_lit_test_suite(
     lit
   SRCS
     "mma.mlir"
-    "mma_elemwise_layout_analysis.mlir"
     "reduction.mlir"
     "reduction_eltwise.mlir"
     "reduction_v2.mlir"
@@ -35,7 +34,6 @@ iree_lit_test_suite(
     iree-opt
     iree-run-module
   DATA
-    mma_elemwise_layout_analysis_codegen_spec.mlir
     mma_reduction_layout_analysis_codegen_spec.mlir
     mma_reduction_layout_analysis_dispatch_spec.mlir
     mma_using_layout_analysis_codegen_spec.mlir
@@ -48,6 +46,7 @@ iree_lit_test_suite(
     softmax_partial_codegen_spec.mlir
     softmax_v2_codegen_spec.mlir
     vecadd2d_codegen_spec.mlir
+    vecadd2d_codegen_spec_partial_tile.mlir
   LABELS
     "noasan"
     "nomsan"
@@ -61,6 +60,7 @@ iree_lit_test_suite(
   NAME
     sm80_lit
   SRCS
+    "mma_elemwise_layout_analysis.mlir"
     "mma_reduction_layout_analysis.mlir"
     "mma_using_layout_analysis.mlir"
   TOOLS
@@ -69,6 +69,7 @@ iree_lit_test_suite(
     iree-opt
     iree-run-module
   DATA
+    mma_elemwise_layout_analysis_codegen_spec.mlir
     mma_reduction_layout_analysis_codegen_spec.mlir
     mma_reduction_layout_analysis_dispatch_spec.mlir
     mma_using_layout_analysis_codegen_spec.mlir


### PR DESCRIPTION
mma_elemwise_layout_analysis.mlir has `--iree-hal-cuda-llvm-target-arch=sm_80` and should be in the sm80_lit test with the corresponding tags

Also, adds vecadd2d_codegen_spec_partial_tile.mlir to the data dependencies as it's being used in vecadd2d.mlir