### PR TITLE
Rename mobile device names in benchmarks to more friendly ones

### DIFF
--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -106,7 +106,8 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    if: (! inputs.is-pr)
+    # TODO: Remove before submit
+    # if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -110,9 +110,9 @@ jobs:
     needs: cross_compile
     strategy:
       matrix:
-        # TODO(#9855): Add Pixel-6-Pro and XT2201-2
+        # TODO(#9855): Add pixel-6-pro and moto-edge-x30.
         target:
-          - device-name: Pixel-4
+          - device-name: pixel-4
             label-exclude: vulkan
     name: test_on_${{ matrix.target.device-name }}
     runs-on:

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -56,13 +56,13 @@ BENCHMARK_PRESET_MATCHERS: Dict[str, PresetMatcher] = {
         lambda config: "cuda" in config.tags and "long-running" in config.tags,
     "vulkan-nvidia":
         lambda config: "vulkan-nvidia" in config.tags,
-    # TODO(#9855): Enable benchmarks on Pixel-6-Pro and XT2201-2.
+    # TODO(#9855): Enable benchmarks on pixel-6-pro and moto-edge-x30.
     "experimental-android-cpu":
         lambda config:
         (config.target_device_spec.architecture.type == common_definitions.
          ArchitectureType.CPU and config.target_device_spec.host_environment.
          platform == "android" and config.target_device_spec.device_name in
-         ["Pixel-4"]),
+         ["pixel-4"]),
     "experimental-android-gpu":
         lambda config:
         (config.target_device_spec.architecture.type == common_definitions.

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -59,7 +59,7 @@ elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
         --device_model=GCP-c2-standard-16 \
         --cpu_uarch=CascadeLake \
         --verbose
-elif [[ "${TARGET_DEVICE_NAME}" == "Pixel-4" ]]; then
+elif [[ "${TARGET_DEVICE_NAME}" == "pixel-4" ]]; then
   ./build_tools/benchmarks/run_benchmarks_on_android.py \
     --normal_benchmark_tool_dir="${NORMAL_BENCHMARK_TOOLS_DIR}" \
     --traced_benchmark_tool_dir="${TRACED_BENCHMARK_TOOLS_DIR}" \

--- a/build_tools/python/e2e_test_framework/device_specs/moto_edge_x30_specs.py
+++ b/build_tools/python/e2e_test_framework/device_specs/moto_edge_x30_specs.py
@@ -8,7 +8,7 @@
 from e2e_test_framework import unique_ids
 from e2e_test_framework.definitions import common_definitions
 
-DEVICE_NAME = "XT2201-2"
+DEVICE_NAME = "moto-edge-x30"
 
 GPU = common_definitions.DeviceSpec.build(
     id=unique_ids.DEVICE_SPEC_MOBILE_MOTO_EDGE_X30 + "-gpu",

--- a/build_tools/python/e2e_test_framework/device_specs/pixel_4_specs.py
+++ b/build_tools/python/e2e_test_framework/device_specs/pixel_4_specs.py
@@ -9,7 +9,7 @@ from e2e_test_framework import unique_ids
 from e2e_test_framework.definitions import common_definitions
 from e2e_test_framework.device_specs import device_parameters
 
-DEVICE_NAME = "Pixel-4"
+DEVICE_NAME = "pixel-4"
 
 BIG_CORES = common_definitions.DeviceSpec.build(
     id=unique_ids.DEVICE_SPEC_MOBILE_PIXEL_4 + "-big-core",

--- a/build_tools/python/e2e_test_framework/device_specs/pixel_6_pro_specs.py
+++ b/build_tools/python/e2e_test_framework/device_specs/pixel_6_pro_specs.py
@@ -9,7 +9,7 @@ from e2e_test_framework import unique_ids
 from e2e_test_framework.definitions import common_definitions
 from e2e_test_framework.device_specs import device_parameters
 
-DEVICE_NAME = "Pixel-6-Pro"
+DEVICE_NAME = "pixel-6-pro"
 
 BIG_CORES = common_definitions.DeviceSpec.build(
     id=unique_ids.DEVICE_SPEC_MOBILE_PIXEL_6_PRO + "-big-core",


### PR DESCRIPTION
Originally I want to stick on using device model (reported by adb) as the device name for mobile devices instead of naming by ourselves. But the `XT2201-2` for Moto Edge X30 isn't really friendly to read and remember.

This change renames all mobile phones to a more commonly recognized ones and follows the naming convention of GCP devices to use all lowercase letters.