### PR TITLE
Add back `os.makedirs(BINDIST_DIR, ...)`.

### DIFF
--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -180,6 +180,8 @@ def build_py_tf_compiler_tools_pkg():
   shutil.rmtree(INSTALL_DIR, ignore_errors=True)
   remove_cmake_cache()
 
+  os.makedirs(BINDIST_DIR, exist_ok=True)
+
   for project in ["iree_tflite", "iree_tf"]:
     print(f"*** Building wheel for {project} ***")
     subprocess.run(


### PR DESCRIPTION
Missed that this was load bearing when working on https://github.com/openxla/iree/pull/13436.

Expected to fix https://github.com/openxla/iree/actions/runs/4913894090/jobs/8774588355#step:9:220
```
Wrote /work/main_checkout/configured.bazelrc
Traceback (most recent call last):
  File "/work/./main_checkout/build_tools/github_actions/build_dist.py", line 199, in <module>
    build_py_tf_compiler_tools_pkg()
Installing python requirements...
  File "/work/./main_checkout/build_tools/github_actions/build_dist.py", line 185, in build_py_tf_compiler_tools_pkg
Generating configured.bazelrc...
    subprocess.run(
  File "/opt/python/cp39-cp39/lib/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/opt/python/cp39-cp39/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/python/cp39-cp39/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/work/bindist'
```

Hopefully the rest of the release build works too.

skip-ci: not tested on presubmit