### PR TITLE
Remove expression syntax from workflow if conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           git submodule update --init --jobs 8 --depth 1
       - id: "gcp-auth"
         name: "Authenticating to Google Cloud"
-        if: ${{ needs.setup.outputs.write-caches }} == 1
+        if: needs.setup.outputs.write-caches == 1
         uses: "google-github-actions/auth@v1"
         with:
           token_format: "access_token"
@@ -177,7 +177,7 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - id: "gcp-auth"
         name: "Authenticating to Google Cloud"
-        if: ${{ needs.setup.outputs.write-caches }} == 1
+        if: needs.setup.outputs.write-caches == 1
         uses: "google-github-actions/auth@v1"
         with:
           token_format: "access_token"
@@ -894,7 +894,7 @@ jobs:
             "${DOCKER_IMAGE}" \
             "${BUILD_SCRIPT}"
       - name: "Test cross-compiling target"
-        if: ${{ matrix.target.test_script }}
+        if: matrix.target.test_script
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "IREE_TARGET_PLATFORM=${PLATFORM}" \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,7 +67,7 @@ jobs:
           git diff -U0 "${GITHUB_BASE_REF?}" | python3 third_party/format_diff/format_diff.py yapf -i
           git diff --exit-code
       - name: Instructions for fixing the above linting errors
-        if: ${{ failure() }}
+        if: failure()
         run: |
           printf "You can fix the lint errors above by running\n"
           printf "  git diff -U0 "${GITHUB_BASE_REF?}" | python3 third_party/format_diff/format_diff.py yapf -i\n"
@@ -167,7 +167,7 @@ jobs:
       - name: Check BUILD files are not named BUILD (prefer BUILD.bazel)
         run: exit $(git ls-files '**/BUILD' | wc -l)
       - name: Instructions for fixing the above linting error
-        if: ${{ failure() }}
+        if: failure()
         run: |
           echo "failure: found files named BUILD. Please rename the following files to BUILD.bazel:"
           git ls-files '**/BUILD'

--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -153,6 +153,6 @@ jobs:
         run: |
           gcloud storage cp "${BENCHMARK_RESULTS_DIR}/summary.html" "${GCS_UPLOAD_DIR}/"
       - name: "Updating latest"
-        if: ${{ github.event_name != 'pull_request' }}
+        if: github.event_name != 'pull_request'
         run: |
           gcloud storage cp "${BENCHMARK_RESULTS_DIR}/summary.html" "${GCS_LATEST_DIR}/"


### PR DESCRIPTION
This is optional, but also including it can result in some really weird
behavior. These conditions both run the step in question, for instance,
even if `write-caches` is 0:

```
if: ${{ needs.setup.outputs.write-caches }} == 1
if: ${{ needs.does-not-exist }} == 1
```

My guess is that the issue is with including the expression syntax
around only the variable and not the literal, though it seems like that
should really just be a hard error if it's invalid syntax...

This fixes the conditional for only attempting GCP auth if running in a
context that has secrets (not a fork).
