### PR TITLE
Revert "[mhlo] Remove redundant preprocessing pattern. (#13153)"

### DIFF
--- a/build_tools/python/e2e_test_framework/models/model_groups.py
+++ b/build_tools/python/e2e_test_framework/models/model_groups.py
@@ -106,9 +106,8 @@ BERT_LARGE_TF_BATCHES = [
     tf_models.BERT_LARGE_48X384_FP32_TF,
     tf_models.BERT_LARGE_64X384_FP32_TF,
     tf_models.BERT_LARGE_512X384_FP32_TF,
-    # Disabled due to https://github.com/openxla/iree/issues/13211.
-    #tf_models.BERT_LARGE_1024X384_FP32_TF,
-    #tf_models.BERT_LARGE_1280X384_FP32_TF,
+    tf_models.BERT_LARGE_1024X384_FP32_TF,
+    tf_models.BERT_LARGE_1280X384_FP32_TF,
 ]
 
 RESNET50_TF_BATCHES = [
@@ -126,7 +125,7 @@ T5_LARGE_TF_BATCHES = [
     tf_models.T5_LARGE_24x512_FP32_TF,
     tf_models.T5_LARGE_32x512_FP32_TF,
     tf_models.T5_LARGE_48x512_FP32_TF,
-    # Disabled due to https://github.com/openxla/iree/issues/13189.
+    # Disabled due to # Disabled due to https://github.com/openxla/iree/issues/13189.
     #tf_models.T5_LARGE_64x512_FP32_TF,
     #tf_models.T5_LARGE_512x512_FP32_TF,
 ]

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -265,6 +265,181 @@ bool isConsecutive(ArrayRef<int64_t> array) {
   return true;
 }
 
+// Rewrites mhlo.dot_general so lhs contraction dimensions are innermost and rhs
+// contraction dimensions are dims right after batch dimension. The pattern
+// inserts transposes so the dot_general always has the form:
+// {batch_dims, parallel_dims, contraction_dims}.
+//   {batch_dims, contraction_dims, parallel_dims}
+// After that, batch_dims, contraction_dims, parallel_dims are
+// in consecutive order and not spliting the domain. This pattern inserts
+// reshapes to collapse consecutive reduction and parallel dims to always
+// generate a rank-3 dot_general op.
+class TransposeReshapeGenericDotGeneral
+    : public OpRewritePattern<mhlo::DotGeneralOp> {
+ public:
+  using OpRewritePattern<mhlo::DotGeneralOp>::OpRewritePattern;
+
+  Value TransposeIfNonConsecutive(OpBuilder &b, Location loc, Value src,
+                                  ArrayRef<int64_t> targetOrder) const {
+    if (isConsecutive(targetOrder)) return src;
+    auto type = src.getType().cast<RankedTensorType>();
+    SmallVector<int64_t, 4> transposeShape;
+    for (auto i : targetOrder) {
+      transposeShape.push_back(type.getDimSize(i));
+    }
+    return b.create<mhlo::TransposeOp>(
+        loc, RankedTensorType::get(transposeShape, type.getElementType()), src,
+        b.getI64TensorAttr(targetOrder));
+  }
+
+  Value ReshapeIfMorethan3D(OpBuilder &b, Location loc, Value src,
+                            size_t dimsBorder0, size_t dimsBorder1) const {
+    auto type = src.getType().cast<RankedTensorType>();
+    if (type.getRank() <= 3) return src;
+    auto shape = type.getShape();
+    SmallVector<int64_t, 4> result_shape = {
+        std::accumulate(shape.begin(), shape.begin() + dimsBorder0, 1,
+                        std::multiplies<int64_t>()),
+        std::accumulate(shape.begin() + dimsBorder0,
+                        shape.begin() + dimsBorder1, 1,
+                        std::multiplies<int64_t>()),
+        std::accumulate(shape.begin() + dimsBorder1, shape.end(), 1,
+                        std::multiplies<int64_t>())};
+    return b.create<mhlo::ReshapeOp>(
+        loc, RankedTensorType::get(result_shape, type.getElementType()), src);
+  }
+
+  LogicalResult matchAndRewrite(mhlo::DotGeneralOp op,
+                                PatternRewriter &rewriter) const override {
+    auto lhsShapeType = op.getLhs().getType().dyn_cast<RankedTensorType>();
+    auto rhsShapeType = op.getRhs().getType().dyn_cast<RankedTensorType>();
+    auto resultType = op.getResult().getType().dyn_cast<RankedTensorType>();
+    if (!lhsShapeType || !rhsShapeType || !resultType) return failure();
+
+    // TODO(jpienaar): This pattern is not safe for dynamic shapes and seems to
+    // be (now) redundant with later pass that does handle them. To decouple
+    // fixing and verifying redundant, this just limits to static shapes and
+    // then will remove this in follow up.
+    if (!lhsShapeType.hasStaticShape() || !rhsShapeType.hasStaticShape())
+      return failure();
+
+    SmallVector<int64_t> lhsTargetOrder, rhsTargetOrder;
+    mhlo::DotDimensionNumbersAttr dimNumbers = op.getDotDimensionNumbers();
+    auto lhsBatchingDims = dimNumbers.getLhsBatchingDimensions();
+    auto lhsContractingDims = dimNumbers.getLhsContractingDimensions();
+    auto rhsBatchingDims = dimNumbers.getRhsBatchingDimensions();
+    auto rhsContractingDims = dimNumbers.getRhsContractingDimensions();
+
+    // No contraction dims means this can be represented as a mul.
+    if (lhsContractingDims.size() == 0 || rhsContractingDims.size() == 0)
+      return rewriter.notifyMatchFailure(op, "can be represented as mhlo.mul");
+
+    // No batching dimensions means this can be represented a dot.
+    if (lhsBatchingDims.size() == 0 || rhsBatchingDims.size() == 0)
+      return rewriter.notifyMatchFailure(op, "can be represented as mhlo.dot");
+
+    SmallVector<bool> isLhsParallel(lhsShapeType.getRank(), true);
+    for (auto i : lhsBatchingDims) {
+      lhsTargetOrder.push_back(i);
+      isLhsParallel[i] = false;
+    }
+    for (auto i : lhsContractingDims) {
+      isLhsParallel[i] = false;
+    }
+    for (int64_t i = 0, e = lhsShapeType.getRank(); i < e; ++i) {
+      if (isLhsParallel[i]) {
+        lhsTargetOrder.push_back(i);
+      }
+    }
+    for (auto i : lhsContractingDims) {
+      lhsTargetOrder.push_back(i);
+    }
+
+    SmallVector<bool> isRhsParallel(rhsShapeType.getRank(), true);
+
+    for (auto i : rhsBatchingDims) {
+      rhsTargetOrder.push_back(i);
+      isRhsParallel[i] = false;
+    }
+    for (auto i : rhsContractingDims) {
+      rhsTargetOrder.push_back(i);
+      isRhsParallel[i] = false;
+    }
+    for (int64_t i = 0, e = rhsShapeType.getRank(); i < e; ++i) {
+      if (isRhsParallel[i]) {
+        rhsTargetOrder.push_back(i);
+      }
+    }
+
+    Value lhs = TransposeIfNonConsecutive(rewriter, op.getLoc(), op.getLhs(),
+                                          lhsTargetOrder);
+    Value rhs = TransposeIfNonConsecutive(rewriter, op.getLoc(), op.getRhs(),
+                                          rhsTargetOrder);
+
+    // The dimensions of this will always be transposed into {batch_dims,
+    // parallel_dims, contraction_dims}, and the
+    // following logic is based on this assumption.
+    // TODO(#7443): If we consider transpose performance, the above assumptions
+    // may not be true.
+    int64_t numLhsContractionDims = lhsContractingDims.size();
+    int64_t lhsContractionBase = lhsShapeType.getRank() - numLhsContractionDims;
+    int64_t rhsContractionBase = rhsBatchingDims.size();
+    int64_t numRhsContractionDims =
+        rhsContractionBase + rhsContractingDims.size();
+
+    lhs = ReshapeIfMorethan3D(rewriter, op.getLoc(), lhs,
+                              lhsBatchingDims.size(), lhsContractionBase);
+    rhs = ReshapeIfMorethan3D(rewriter, op.getLoc(), rhs,
+                              rhsBatchingDims.size(), numRhsContractionDims);
+
+    if (lhs == op.getLhs() && rhs == op.getRhs())
+      return rewriter.notifyMatchFailure(op, "already in canonical form");
+
+    auto dimensionNumbers = mhlo::DotDimensionNumbersAttr::get(
+        rewriter.getContext(), /*lhsBatchingDimensions=*/0,
+        /*rhsBatchingDimensions=*/0,
+        /*lhsContractingDimensions=*/
+        lhs.getType().cast<ShapedType>().getRank() - 1,
+        /*rhsContractingDimensions=*/1);
+    auto lhsNewType = lhs.getType().cast<RankedTensorType>();
+    auto rhsNewType = rhs.getType().cast<RankedTensorType>();
+
+    // if lhs's shape or rhs's shape has collapsed, we need reshape the result
+    bool needReshapeResult = lhsNewType.getRank() < lhsShapeType.getRank() ||
+                             rhsNewType.getRank() < rhsShapeType.getRank();
+    // batching、lhs parallel、rhs parallel this order is a convension
+    SmallVector<int64_t, 4> newShape = {lhsNewType.getShape()[0],
+                                        lhsNewType.getShape()[1]};
+    if (rhsNewType.getRank() > 2) newShape.push_back(rhsNewType.getDimSize(2));
+
+    auto newResultType =
+        needReshapeResult
+            ? RankedTensorType::get(newShape, resultType.getElementType())
+            : op.getType();
+
+    auto newOp = rewriter.create<mhlo::DotGeneralOp>(
+        op.getLoc(), newResultType, lhs, rhs, dimensionNumbers,
+        op.getPrecisionConfigAttr());
+
+    // Copy over unknown attributes as we currently rely on it to let user tune
+    // lowering parameters.
+    ArrayRef<StringRef> odsAttrs = op.getAttributeNames();
+    for (NamedAttribute kv : op->getAttrs()) {
+      if (!llvm::is_contained(odsAttrs, kv.getName().getValue())) {
+        newOp->setAttr(kv.getName(), kv.getValue());
+      }
+    }
+
+    Value result = newOp.getResult();
+    if (needReshapeResult) {
+      result =
+          rewriter.create<mhlo::ReshapeOp>(op.getLoc(), resultType, result);
+    }
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 struct ScatterInt64Indices : public OpRewritePattern<mhlo::ScatterOp> {
   using OpRewritePattern<mhlo::ScatterOp>::OpRewritePattern;
 
@@ -1277,6 +1452,10 @@ struct MHLOToMHLOPreprocessingPass
 
     // dot_general canoncalization patterns.
     mhlo::populateGeneralDotOpLoweringPatterns(&patterns, context);
+    // TODO(jpienaar): This may be redundant with lower_general_dot. Remove if
+    // so.
+    patterns.insert<TransposeReshapeGenericDotGeneral>(context,
+                                                       /*benefit=*/200);
     patterns.insert<DotGeneralIsMul>(context, /*benefit=*/300);
 
     // Fusion operations.

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/BUILD.bazel
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "flatten_tuples_in_cfg.mlir",
             "mhlo_to_linalg.mlir",
             "mhlo_to_mhlo_preprocessing.mlir",
+            "mhlo_to_mhlo_preprocessing_canonicalize_dot_general.mlir",
             "mhlo_to_mhlo_scatter.mlir",
             "missing_legalizations.mlir",
             "transformation_pipeline.mlir",

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_lit_test_suite(
     "flatten_tuples_in_cfg.mlir"
     "mhlo_to_linalg.mlir"
     "mhlo_to_mhlo_preprocessing.mlir"
+    "mhlo_to_mhlo_preprocessing_canonicalize_dot_general.mlir"
     "mhlo_to_mhlo_scatter.mlir"
     "missing_legalizations.mlir"
     "transformation_pipeline.mlir"

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing_canonicalize_dot_general.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing_canonicalize_dot_general.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-opt --split-input-file --verify-diagnostics --iree-mhlo-to-mhlo-preprocessing %s | FileCheck %s
+
+// CHECK-LABEL: @dot_general_2d
+func.func public @dot_general_2d(%arg0: tensor<4x3xf32> {mhlo.sharding = ""}, %arg1: tensor<4x3xf32> {mhlo.sharding = ""}) -> tensor<3xf32> {
+  %0 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [1], rhs_batching_dimensions = [1], lhs_contracting_dimensions = [0], rhs_contracting_dimensions = [0]>, precision_config = [#mhlo<precision HIGHEST>, #mhlo<precision HIGHEST>]} : (tensor<4x3xf32>, tensor<4x3xf32>) -> tensor<3xf32>
+
+  // CHECK: %[[LHS:.+]] = "mhlo.transpose"(%arg0) {permutation = dense<[1, 0]> : tensor<2xi64>} : (tensor<4x3xf32>) -> tensor<3x4xf32>
+  // CHECK: %[[RHS:.+]] = "mhlo.transpose"(%arg1) {permutation = dense<[1, 0]> : tensor<2xi64>} : (tensor<4x3xf32>) -> tensor<3x4xf32>
+  // CHECK: "mhlo.dot_general"(%[[LHS]], %[[RHS]])
+  // CHECK-SAME: dot_dimension_numbers = #mhlo.dot<
+  // CHECK-SAME: lhs_batching_dimensions = [0]
+  // CHECK-SAME: rhs_batching_dimensions = [0]
+  // CHECK-SAME: lhs_contracting_dimensions = [1]
+  // CHECK-SAME: rhs_contracting_dimensions = [1]>
+  // CHECK-SAME: precision_config = [#mhlo<precision HIGHEST>, #mhlo<precision HIGHEST>]
+  return %0 : tensor<3xf32>
+}

--- a/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
@@ -390,6 +390,26 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
+    "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024"
+  SOURCE_URL
+    "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_1024/hlo.mlirbc"
+  OUTPUT
+    "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024_BertLargeTFBatch1024.mlirbc"
+  UNPACK
+)
+
+iree_fetch_artifact(
+  NAME
+    "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280"
+  SOURCE_URL
+    "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_1280/hlo.mlirbc"
+  OUTPUT
+    "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280_BertLargeTFBatch1280.mlirbc"
+  UNPACK
+)
+
+iree_fetch_artifact(
+  NAME
     "model-587e595d-2adf-4e41-9617-43178a133725-batch-1"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/T5_LARGE/batch_1/hlo.mlirbc"

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -1104,6 +1104,38 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
+    "iree-module-88f03be31249d371d00c63d44d44732ad4c348bf2354bd2b3b042465d86f7183"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024_BertLargeTFBatch1024.mlirbc"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1024_module_88f03be31249d371d00c63d44d44732ad4c348bf2354bd2b3b042465d86f7183/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=cuda"
+    "--iree-input-type=mhlo"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+  FRIENDLY_NAME
+    "BertLargeTFBatch1024(mhlo) [cuda-sm_80-linux_gnu-cuda][default-flags]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-b3f2a0c268a0a8752ccbb56f013455197c466635637b535778a494dab316cf9e"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280_BertLargeTFBatch1280.mlirbc"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1280_module_b3f2a0c268a0a8752ccbb56f013455197c466635637b535778a494dab316cf9e/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=cuda"
+    "--iree-input-type=mhlo"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+  FRIENDLY_NAME
+    "BertLargeTFBatch1280(mhlo) [cuda-sm_80-linux_gnu-cuda][default-flags]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
     "iree-module-bf4bda91fb17ec7f3402e7b301cb3ab0b7a9b0b00d8cee29fd4cfa46262a5ea1"
   SRC
     "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-1_T5LargeTFBatch1.mlirbc"
@@ -3767,6 +3799,46 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
+    "iree-module-b180d82d1a87fe29e414ecd55bf8a82ff92b80d7c644d31769729160b27aa467"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024_BertLargeTFBatch1024.mlirbc"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1024_module_b180d82d1a87fe29e414ecd55bf8a82ff92b80d7c644d31769729160b27aa467/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=cuda"
+    "--iree-input-type=mhlo"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1024_module_b180d82d1a87fe29e414ecd55bf8a82ff92b80d7c644d31769729160b27aa467/scheduling_stats.json"
+  FRIENDLY_NAME
+    "BertLargeTFBatch1024(mhlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-6265e9506389bb29c551ad62f4ea05f54bd0e549c2d29bf425bac9d56aa55ef6"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280_BertLargeTFBatch1280.mlirbc"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1280_module_6265e9506389bb29c551ad62f4ea05f54bd0e549c2d29bf425bac9d56aa55ef6/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=cuda"
+    "--iree-input-type=mhlo"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1280_module_6265e9506389bb29c551ad62f4ea05f54bd0e549c2d29bf425bac9d56aa55ef6/scheduling_stats.json"
+  FRIENDLY_NAME
+    "BertLargeTFBatch1280(mhlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
     "iree-module-1ee530ad72c5711ee3abf11b27eed04e11d261fb6c0d23a6cb68c80c1a42580b"
   SRC
     "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-1_T5LargeTFBatch1.mlirbc"
@@ -5568,6 +5640,8 @@ add_dependencies(iree-benchmark-import-models
   ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-48
   ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-64
   ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-512
+  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024
+  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280
   ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-1
   ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-16
   ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-24
@@ -5634,6 +5708,8 @@ add_dependencies(iree-benchmark-suites
   ${PACKAGE_NAME}_iree-module-3385106a53075a52f4ae60523e09ad42cdad60475d97e84695a9c68584d9182a
   ${PACKAGE_NAME}_iree-module-2021b32a685c21ba21823416591c14fd79075595c101665abe565ff92335c3ef
   ${PACKAGE_NAME}_iree-module-57080e57e3ba061d70d35d8579824a8eab7ee05ef3e0eea02cc251bab87cfd10
+  ${PACKAGE_NAME}_iree-module-88f03be31249d371d00c63d44d44732ad4c348bf2354bd2b3b042465d86f7183
+  ${PACKAGE_NAME}_iree-module-b3f2a0c268a0a8752ccbb56f013455197c466635637b535778a494dab316cf9e
   ${PACKAGE_NAME}_iree-module-bf4bda91fb17ec7f3402e7b301cb3ab0b7a9b0b00d8cee29fd4cfa46262a5ea1
   ${PACKAGE_NAME}_iree-module-9900b1a0c52b31fc38f1d82ff088102f7131ecbb3fc1b8274929481337d031c5
   ${PACKAGE_NAME}_iree-module-25f1a116fad68b01401dfbd8462c7b2729ef2d504df0954509cd488cd5da17a1
@@ -5777,6 +5853,8 @@ add_dependencies(iree-e2e-compile-stats-suites
   ${PACKAGE_NAME}_iree-module-5b499a05fc60f78b5b11b1e9ba89ba797450e5b49b0613b3c23d996c6f767c64
   ${PACKAGE_NAME}_iree-module-40b0bd95d986d079ae0fc8cd57b473a150289a5f3ee6029b388ebc86edd4a60c
   ${PACKAGE_NAME}_iree-module-03736c12afe2b27f77101146eddaa80c8911cdbc2120ab574225c08b088e14f3
+  ${PACKAGE_NAME}_iree-module-b180d82d1a87fe29e414ecd55bf8a82ff92b80d7c644d31769729160b27aa467
+  ${PACKAGE_NAME}_iree-module-6265e9506389bb29c551ad62f4ea05f54bd0e549c2d29bf425bac9d56aa55ef6
   ${PACKAGE_NAME}_iree-module-1ee530ad72c5711ee3abf11b27eed04e11d261fb6c0d23a6cb68c80c1a42580b
   ${PACKAGE_NAME}_iree-module-38e99a06cd01399fe48cd9d860f65474e4fd7df1b3aca491766ff5f825315a79
   ${PACKAGE_NAME}_iree-module-db86dfb7ef5e59b31bf513df65fffd397f49e3fe3b5c03149140ccf3b6b2f821


### PR DESCRIPTION
This reverts commit 479900afe1467cd10f349894f758135e54d487e2 and 47da9cf8584dffe31a6834f12b62bfff347bdef3