### PR TITLE
Add module dependencies via python bindings

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -54,6 +54,7 @@ iree_pyext_module(
     iree::hal::drivers
     iree::hal::utils::allocators
     iree::modules::hal
+    iree::tooling::modules
     iree::vm
     iree::vm::bytecode::module
 )

--- a/runtime/bindings/python/iree/runtime/system_api.py
+++ b/runtime/bindings/python/iree/runtime/system_api.py
@@ -242,7 +242,7 @@ class SystemContext:
 
   def add_module_dependency(self, name, minimum_version=0):
     resolved_module = _binding.VmModule.resolve_module_dependency(
-      self._config.vm_instance, name, minimum_version)
+        self._config.vm_instance, name, minimum_version)
     self._vm_context.register_modules([resolved_module])
 
   def add_vm_modules(self, vm_modules):

--- a/runtime/bindings/python/iree/runtime/system_api.py
+++ b/runtime/bindings/python/iree/runtime/system_api.py
@@ -240,6 +240,11 @@ class SystemContext:
   def modules(self) -> BoundModules:
     return self._bound_modules
 
+  def add_module_dependency(self, name, minimum_version=0):
+    resolved_module = _binding.VmModule.resolve_module_dependency(
+      self._config.vm_instance, name, minimum_version)
+    self._vm_context.register_modules([resolved_module])
+
   def add_vm_modules(self, vm_modules):
     assert self._is_dynamic, "Cannot 'add_module' on a static context"
     for m in vm_modules:

--- a/runtime/bindings/python/vm.h
+++ b/runtime/bindings/python/vm.h
@@ -129,6 +129,10 @@ class VmInstance : public ApiRefCounted<VmInstance, iree_vm_instance_t> {
 
 class VmModule : public ApiRefCounted<VmModule, iree_vm_module_t> {
  public:
+  static VmModule ResolveModuleDependency(VmInstance* instance,
+                                          const std::string& name,
+                                          uint32_t minimum_version);
+
   static VmModule FromFlatbufferBlob(VmInstance* instance,
                                      py::object flatbuffer_blob_object);
 


### PR DESCRIPTION
This change allows loading custom modules using python binding.

Example:

```python
ctx.add_module_dependency("cudnn")
ctx.add_vm_module(create_simple_mul_module(ctx.instance)) # depends on cuDNN module
```