### PR TITLE
Fix workflow condition in build_and_test_android

### DIFF
--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -106,8 +106,7 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    # TODO: Remove before submit
-    # if: (! inputs.is-pr)
+    if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:


### PR DESCRIPTION
Fix the workflow condition in `build_and_test_android` accidentally removed by #13454