### PR TITLE
[NFC][TransformStrategies] Abstract out a GEMM like strategy from MatmulTensorCoreStrategy

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -1,0 +1,97 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_ABSTRACT_GEMM_LIKE_STRATEGY_H_
+#define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_ABSTRACT_GEMM_LIKE_STRATEGY_H_
+
+#include "iree-dialects/Transforms/TransformMatchers.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGpuStrategy.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+
+namespace llvm {
+class raw_ostream;
+}
+
+namespace mlir {
+namespace iree_compiler {
+namespace gpu {
+
+struct GPUModel;
+
+using iree_compiler::gpu::StrategyBase;
+
+struct AbstractGemmLikeStrategy : StrategyBase {
+  AbstractGemmLikeStrategy(MLIRContext *context) : StrategyBase(context) {}
+
+  virtual ~AbstractGemmLikeStrategy();
+
+  /// Tile sizes for the workgroup / determines grid size for all known
+  /// reduction strategies. The initial values are set by initDefaultValues();
+  SmallVector<int64_t> blockTileSizes;
+  int64_t reductionTileSize;
+  SmallVector<int64_t> numThreads;
+  SmallVector<int64_t> numWarps;
+
+  bool useAsyncCopies;
+  bool useMmaSync;
+  int64_t pipelineDepth;
+
+  SmallVector<float> paddingValues;
+  SmallVector<int64_t> paddingDimensions;
+  SmallVector<int64_t> packingDimensions;
+
+  virtual int64_t m() const = 0;
+  virtual int64_t n() const = 0;
+  virtual int64_t k() const = 0;
+
+  /// Common values based on derived quantities.
+  int64_t totalNumThreads() const {
+    int64_t res = 1;
+    for (auto v : numThreads) res *= v;
+    return res;
+  }
+  int64_t totalNumWarps() const {
+    int64_t res = 1;
+    for (auto v : numWarps) res *= v;
+    return res;
+  }
+
+  // Copy vector sizes based on inner most K/N dims.
+  int64_t lhsCopyVectorSize() const {
+    if (k() % 4 == 0) return 4;
+    if (k() % 2 == 0) return 2;
+    return 1;
+  }
+  int64_t rhsCopyVectorSize() const {
+    if (n() % 4 == 0) return 4;
+    if (n() % 2 == 0) return 2;
+    return 1;
+  }
+  int64_t resCopyVectorSize() const { return rhsCopyVectorSize(); }
+
+  struct MappingInfo {
+    SmallVector<int64_t> numThreads;
+    // Explicitly computing the tileSizes is only needed until masked
+    // vectorization properly computes the bounds automatically.
+    SmallVector<int64_t> tileSizes;
+    SmallVector<Attribute> threadMapping;
+  };
+
+  virtual MappingInfo getBlockMapping() const = 0;
+  virtual MappingInfo lhsCopyMapping() const = 0;
+  virtual MappingInfo rhsCopyMapping() const = 0;
+  virtual MappingInfo resCopyMapping() const = 0;
+  virtual MappingInfo computeMapping() const = 0;
+
+  virtual void print(llvm::raw_ostream &os) const = 0;
+  virtual LLVM_DUMP_METHOD void dump() const = 0;
+};
+
+}  // namespace gpu
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_ABSTRACT_GEMM_LIKE_STRATEGY_H_

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGpuStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGpuStrategy.h
@@ -1,0 +1,70 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_ABSTRACT_GPU_STRATEGY_H_
+#define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_ABSTRACT_GPU_STRATEGY_H_
+
+#include "iree-dialects/Transforms/TransformMatchers.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/Common/AbstractReductionStrategy.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace gpu {
+
+/// Base quantities generally useful for all GPU strategies.
+struct StrategyBase {
+  StrategyBase(MLIRContext *ctx) : ctx(ctx) {}
+
+  /// Constructor quantities.
+  MLIRContext *ctx;
+
+  Attribute blockX() const {
+    return mlir::gpu::GPUBlockMappingAttr::get(ctx, mlir::gpu::Blocks::DimX);
+  }
+  Attribute blockY() const {
+    return mlir::gpu::GPUBlockMappingAttr::get(ctx, mlir::gpu::Blocks::DimY);
+  }
+  Attribute blockZ() const {
+    return mlir::gpu::GPUBlockMappingAttr::get(ctx, mlir::gpu::Blocks::DimZ);
+  }
+  Attribute threadX() const {
+    return mlir::gpu::GPUThreadMappingAttr::get(ctx, mlir::gpu::Threads::DimX);
+  }
+  Attribute threadY() const {
+    return mlir::gpu::GPUThreadMappingAttr::get(ctx, mlir::gpu::Threads::DimY);
+  }
+  Attribute threadZ() const {
+    return mlir::gpu::GPUThreadMappingAttr::get(ctx, mlir::gpu::Threads::DimZ);
+  }
+  Attribute warpX() const {
+    return mlir::gpu::GPUWarpMappingAttr::get(ctx, mlir::gpu::Warps::DimX);
+  }
+  Attribute warpY() const {
+    return mlir::gpu::GPUWarpMappingAttr::get(ctx, mlir::gpu::Warps::DimY);
+  }
+  Attribute warpZ() const {
+    return mlir::gpu::GPUWarpMappingAttr::get(ctx, mlir::gpu::Warps::DimZ);
+  }
+  Attribute linearIdX() const {
+    return mlir::gpu::GPULinearIdMappingAttr::get(ctx,
+                                                  mlir::gpu::LinearId::DimX);
+  }
+  Attribute linearIdY() const {
+    return mlir::gpu::GPULinearIdMappingAttr::get(ctx,
+                                                  mlir::gpu::LinearId::DimY);
+  }
+  Attribute linearIdZ() const {
+    return mlir::gpu::GPULinearIdMappingAttr::get(ctx,
+                                                  mlir::gpu::LinearId::DimZ);
+  }
+};
+
+}  // namespace gpu
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_ABSTRACT_GPU_STRATEGY_H_

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/BUILD.bazel
@@ -21,6 +21,8 @@ iree_compiler_cc_library(
         "StagedReductionStrategy.cpp",
     ],
     hdrs = [
+        "AbstractGemmLikeStrategy.h",
+        "AbstractGpuStrategy.h",
         "AbstractReductionStrategy.h",
         "Common.h",
         "MatmulTensorCoreStrategy.h",

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/CMakeLists.txt
@@ -14,6 +14,8 @@ iree_cc_library(
   NAME
     TransformDialectStrategies
   HDRS
+    "AbstractGemmLikeStrategy.h"
+    "AbstractGpuStrategy.h"
     "AbstractReductionStrategy.h"
     "Common.h"
     "MatmulTensorCoreStrategy.h"

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -16,12 +16,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.h"
-#include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/SCF/TransformOps/SCFTransformOps.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Transform/IR/TransformTypes.h"
@@ -34,39 +29,26 @@ using namespace mlir;
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 // TODO: significantly better namespacing.
-using iree_compiler::IREE::transform_dialect::ApplyBufferOptimizationsOp;
-using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
-using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
-using iree_compiler::IREE::transform_dialect::ForallToWorkgroupOp;
-using iree_compiler::IREE::transform_dialect::IREEBufferizeOp;
-using iree_compiler::IREE::transform_dialect::IREEEliminateEmptyTensorsOp;
-using iree_compiler::IREE::transform_dialect::
-    IREEEraseHALDescriptorTypeFromMemRefOp;
-using iree_compiler::IREE::transform_dialect::
-    IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
-using iree_compiler::IREE::transform_dialect::ShareForallOperandsOp;
-using iree_compiler::IREE::transform_dialect::VectorToWarpExecuteOnLane0Op;
-using iree_compiler::IREE::transform_dialect::VectorWarpDistributionOp;
-using transform::FuseIntoContainingOp;
-using transform::MatchOp;
-using transform::ScalarizeOp;
-using transform::SequenceOp;
-using transform_ext::RegisterMatchCallbacksOp;
-using transform_ext::StructuredOpMatcher;
-
-using iree_compiler::buildSelectFirstNonEmpty;
 using iree_compiler::buildTileFuseDistToForallWithNumThreads;
 using iree_compiler::buildTileFuseDistToForallWithTileSizes;
 using iree_compiler::TileToForallAndFuseAndDistributeResult;
-using iree_compiler::gpu::adjustNumberOfWarpsForBlockShuffle;
-using iree_compiler::gpu::build1DSplittingStrategyWithOptionalThreadMapping;
-using iree_compiler::gpu::buildCommonTrailingStrategy;
-using iree_compiler::gpu::buildDistributeVectors;
-using iree_compiler::gpu::kCudaMaxNumThreads;
-using iree_compiler::gpu::kCudaMaxVectorLoadBitWidth;
+using iree_compiler::gpu::buildBufferize;
+using iree_compiler::gpu::buildConvertToAsyncCopies;
+using iree_compiler::gpu::buildConvertToTensorCoreOp;
+using iree_compiler::gpu::buildDistributeCopies;
+using iree_compiler::gpu::buildHoistOutputPaddingOp;
+using iree_compiler::gpu::buildMatmulVectorization;
+using iree_compiler::gpu::buildMultiBuffering;
+using iree_compiler::gpu::buildPadMatmul;
+using iree_compiler::gpu::buildPipelineSharedMemoryCopies;
 using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::MatmulStrategy;
 using iree_compiler::gpu::scaleUpByBitWidth;
+using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
+using iree_compiler::IREE::transform_dialect::
+    IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
+using transform::MatchOp;
+using transform_ext::RegisterMatchCallbacksOp;
 
 /// Options to set the default values of the matmul strategy.
 
@@ -150,6 +132,12 @@ void MatmulStrategy::initDefaultValues() {
   useAsyncCopies = clUseAsyncCopies;
   useMmaSync = clUseMmaSync;
   pipelineDepth = clPipelineDepth;
+
+  // TODO: Capture input/output element types properly for configuring the
+  // padding values.
+  paddingValues = {0.0f, 0.0f, 0.0f};
+  paddingDimensions = {0, 1, 2};
+  packingDimensions = {1, 1, 1};
 }
 
 LLVM_DUMP_METHOD void MatmulStrategy::dump() const { print(llvm::errs()); }
@@ -189,295 +177,6 @@ void MatmulStrategy::print(llvm::raw_ostream &os) const {
   os << "- pipeline depth: " << pipelineDepth << '\n';
 }
 
-/// Build the transform IR to pad a matmul op `matmulOpH`.
-// TODO: Less hardcoded, more generalization, extract information from strategy.
-static Value buildPadMatmul(ImplicitLocOpBuilder &b, Value matmulOpH,
-                            const MatmulStrategy &strategy) {
-  SmallVector<float> paddingValues = {0.f, 0.f, 0.f};
-  SmallVector<int64_t> paddingDimensions = {0, 1, 2};
-  SmallVector<int64_t> packingDimensions = {1, 1, 1};
-  // TODO: Better upstream builder.
-  return b.create<transform::PadOp>(
-      matmulOpH.getType(), matmulOpH, b.getF32ArrayAttr(paddingValues),
-      b.getI64ArrayAttr(paddingDimensions),
-      b.getI64ArrayAttr(packingDimensions), ArrayAttr());
-}
-
-/// Build transform IR to hoist the padded output operand of a padded matmul.
-/// Additionally, this attempts to fold the padding into the producing fill, if
-/// available.
-// TODO: Generalize, this is not specific to a matmul.
-// TODO: Better API
-static Value buildHoistOutputPaddingOp(ImplicitLocOpBuilder &b, Value variantH,
-                                       Value paddedMatmulOpH,
-                                       int64_t numLoopsToHoist = 1) {
-  // Find the output pad and hoist it.
-  // TODO: don't hardcode output operand number.
-  // TODO: Better builders.
-  Value outputH = b.create<transform::GetProducerOfOperand>(
-      paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(2));
-
-  // Hoist the padding above the 1 innermost reduction loop.
-  auto padOpType = transform::OperationType::get(
-      b.getContext(), tensor::PadOp::getOperationName());
-  outputH = b.create<transform::CastOp>(padOpType, outputH);
-  b.create<transform::HoistPadOp>(paddedMatmulOpH.getType(), outputH,
-                                  numLoopsToHoist);
-
-  // Perform a pass of canonicalization cleanups + folding fill + pad into pad
-  // by applying `foldTensorSubsets` and `tilingCanonicalization`.
-  {
-    ApplyPatternsOpPatterns config;
-    config.foldTensorSubsets = true;
-    config.tilingCanonicalization = true;
-    iree_compiler::buildCanonicalizationAndEnablingTransforms(b, config,
-                                                              variantH);
-  }
-
-  // The canonicalization above should have rewritten hoistPad into a FillOp.
-  // Unfortunately, the listener drops handles if the op types don't match. We
-  // need better behavior here, for now we rematch.
-  // TODO: use value handles.
-  Value fillOpH = b.create<transform::MatchOp>(
-      variantH, linalg::FillOp::getOperationName());
-
-  return fillOpH;
-}
-
-/// Helper function to distribute one pad or copy operation.
-/// Note: When `foldIfBranch` is true, one must later perform masked
-/// vectorization of the result.
-/// This amounts to injecting knowledge about future transformations without
-/// adding leaky semantics.
-static Value buildDistributeOnePadOrCopy(ImplicitLocOpBuilder &b,
-                                         Value variantH, Value copyOpH,
-                                         ArrayRef<int64_t> numThreads,
-                                         ArrayRef<Attribute> threadDimMapping,
-                                         bool foldIfBranch = false) {
-  TileToForallAndFuseAndDistributeResult res =
-      buildTileFuseDistToForallWithNumThreads(
-          /*builder=*/b,
-          /*isolatedParentOpH=*/variantH,
-          /*rootH=*/copyOpH,
-          /*opsToFuseH=*/{},
-          /*numThreads=*/
-          getAsOpFoldResult(b.getI64ArrayAttr(numThreads)),
-          /*threadDimMapping=*/
-          b.getArrayAttr(threadDimMapping));
-  if (foldIfBranch) {
-    Value ifOpH = b.create<transform::MatchOp>(res.forallH,
-                                               scf::IfOp::getOperationName());
-    b.create<transform::TakeAssumedBranchOp>(
-        ifOpH, /*takeElseBranch=*/b.getUnitAttr());
-  }
-  return res.tiledOpH;
-}
-
-/// Distribute the explicit copies involved in a matmul operation
-/// `paddedMatmulOpH`.
-static std::tuple<Value, Value, Value> buildDistributeCopies(
-    ImplicitLocOpBuilder &b, Value variantH, Value paddedMatmulOpH,
-    const MatmulStrategy &strategy) {
-  // Explicitly materialize the parent parallel_insert into a copy to avoid late
-  // bufferization interferences.
-  // TODO: Avoid brittle rematching.
-  Value insertSliceH = b.create<transform::MatchOp>(
-      variantH, tensor::ParallelInsertSliceOp::getOperationName());
-  Value copyBackOpH = b.create<transform::InsertSliceToCopyOp>(
-      insertSliceH.getType(), insertSliceH);
-
-  Value lhsH = b.create<transform::GetProducerOfOperand>(
-      paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(0));
-  Value rhsH = b.create<transform::GetProducerOfOperand>(
-      paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(1));
-
-  MatmulStrategy::MappingInfo lhsCopyMapping = strategy.lhsCopyMapping();
-  Value lhsCopyOpH = buildDistributeOnePadOrCopy(
-      b, variantH, lhsH, /*numThreads=*/lhsCopyMapping.numThreads,
-      /*threadDimMapping=*/lhsCopyMapping.threadMapping, /*foldIfBranch=*/true);
-
-  MatmulStrategy::MappingInfo rhsCopyMapping = strategy.rhsCopyMapping();
-  Value rhsCopyOpH = buildDistributeOnePadOrCopy(
-      b, variantH, rhsH, /*numThreads=*/rhsCopyMapping.numThreads,
-      /*threadDimMapping=*/rhsCopyMapping.threadMapping, /*foldIfBranch=*/true);
-
-  MatmulStrategy::MappingInfo resCopyMapping = strategy.resCopyMapping();
-  copyBackOpH = buildDistributeOnePadOrCopy(
-      b, variantH, copyBackOpH,
-      /*numThreads=*/resCopyMapping.numThreads,
-      /*threadDimMapping=*/rhsCopyMapping.threadMapping);
-
-  return std::make_tuple(lhsCopyOpH, rhsCopyOpH, copyBackOpH);
-}
-
-/// Specific pattern to perform masked vectorization of copies give as
-/// parameters, cleanup and vectorize the rest.
-// TODO: generalize and don't hardcode.
-static void buildMatmulVectorization(ImplicitLocOpBuilder &b, Value variantH,
-                                     Value lhsCopyOpH, Value rhsCopyOpH,
-                                     Value copyBackOpH,
-                                     const MatmulStrategy &strategy) {
-  // Canonicalize to make padOp outputs static shaped: this is currently a
-  // prerequisite for vector masking.
-  // Also, no canonicalization is allowed after vector masking and before we
-  // lower the masks: masks are currently quite brittle and do not like
-  // canonicalization or anything else that may insert an op in their region.
-  {
-    ApplyPatternsOpPatterns configuration;
-    variantH = iree_compiler::buildCanonicalizationAndEnablingTransforms(
-        b, configuration, variantH);
-  }
-  // Apply vector masking.
-  MatmulStrategy::MappingInfo lhsCopyMapping = strategy.lhsCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(lhsCopyOpH, ValueRange(), false,
-                                         lhsCopyMapping.tileSizes);
-  MatmulStrategy::MappingInfo rhsCopyMapping = strategy.rhsCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(rhsCopyOpH, ValueRange(), false,
-                                         rhsCopyMapping.tileSizes);
-  MatmulStrategy::MappingInfo resCopyMapping = strategy.resCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(copyBackOpH, ValueRange(), false,
-                                         resCopyMapping.tileSizes);
-
-  // TODO: don't rematch, apply on the variant op directly.
-  Value funcH =
-      b.create<transform::MatchOp>(variantH, func::FuncOp::getOperationName());
-  // TODO: avoid functional style transform so we can apply to the variant.
-  funcH = b.create<transform::LowerMaskedTransfersOp>(funcH.getType(), funcH);
-  {
-    ApplyPatternsOpPatterns configuration;
-    configuration.rankReducingLinalg = true;
-    configuration.rankReducingVector = true;
-    b.create<ApplyPatternsOp>(funcH, configuration);
-  }
-  b.create<transform::VectorizeOp>(funcH);
-  {
-    ApplyPatternsOpPatterns configuration;
-    variantH = iree_compiler::buildCanonicalizationAndEnablingTransforms(
-        b, configuration, variantH);
-  }
-}
-
-/// Build the transform IR to perform conversion to tensor core operations.
-/// This is currently subject to phase orderings as follows:
-///   - Vector transfer_read and transfer_write patterns have different subview
-///     folding behavior, force a fold_memref_aliases on them to enable
-///     redundant vector transfer hoisting.
-///   - Unfortunately, fold_memref_aliases breaks vector_to_mma conversion
-///     across scf.for after unrolling due to insert_strided_slice /
-///     extract_strided_slice across iter_args boundaries.
-///   - Hoist redundant vector transfers to allow conversion to tensor core to
-///     proceed. We really don't want to do this after bufferization but we need
-///     to atm.
-static Value buildConvertToTensorCoreOp(ImplicitLocOpBuilder &b, Value funcH,
-                                        const MatmulStrategy &strategy) {
-  // TODO: Fewer canonicalization.
-  iree_compiler::buildCanonicalizationAndEnablingTransforms(
-      b, ApplyPatternsOpPatterns(), funcH);
-  b.create<iree_compiler::IREE::transform_dialect::HoistStaticAllocOp>(funcH);
-  {
-    ApplyPatternsOpPatterns config;
-    config.foldMemrefAliases = true;
-    b.create<ApplyPatternsOp>(funcH, config);
-  }
-  {
-    ApplyPatternsOpPatterns config;
-    config.extractAddressComputations = true;
-    b.create<ApplyPatternsOp>(funcH, config);
-  }
-  iree_compiler::buildCanonicalizationAndEnablingTransforms(
-      b, ApplyPatternsOpPatterns(), funcH);
-  {
-    ApplyPatternsOpPatterns config;
-    if (strategy.useMmaSync)
-      config.unrollVectorsGpuMmaSync = true;
-    else
-      config.unrollVectorsGpuWmma = true;
-    b.create<ApplyPatternsOp>(funcH, config);
-  }
-  // TODO: not a functional style transform and avoid returning funcH.
-  funcH = b.create<transform::HoistRedundantVectorTransfersOp>(
-      pdl::OperationType::get(b.getContext()), funcH);
-  iree_compiler::buildCanonicalizationAndEnablingTransforms(
-      b, ApplyPatternsOpPatterns(), funcH);
-  b.create<ApplyBufferOptimizationsOp>(funcH);
-  auto vectorToMMaConversionOp =
-      b.create<iree_compiler::IREE::transform_dialect::VectorToMMAConversionOp>(
-          funcH);
-  // TODO: proper builder instead of a setting post-hoc.
-  if (strategy.useMmaSync)
-    vectorToMMaConversionOp.setUseMmaSync(true);
-  else
-    vectorToMMaConversionOp.setUseWmma(true);
-  return funcH;
-}
-
-static void buildMultiBuffering(ImplicitLocOpBuilder &b, Value funcH,
-                                const MatmulStrategy &strategy) {
-  iree_compiler::buildCanonicalizationAndEnablingTransforms(
-      b, ApplyPatternsOpPatterns(), funcH);
-  ApplyPatternsOpPatterns config;
-  config.foldMemrefAliases = true;
-  b.create<ApplyPatternsOp>(funcH, config);
-  // TODO: Avoid brittle matching here.
-  // TODO: Better builder after integrate.
-  Value allocH = b.create<transform::MatchOp>(
-      transform::OperationType::get(b.getContext(), "memref.alloc"), funcH,
-      b.getStrArrayAttr({memref::AllocOp::getOperationName()}),
-      /*matchInterfaceEnum=*/transform::MatchInterfaceEnumAttr(),
-      /*opAttrs=*/DictionaryAttr(),
-      /*filterResultType=*/TypeAttr());
-  // TODO: Better builder instead of setting post-hoc.
-  auto multiBufferOp = b.create<transform::MemRefMultiBufferOp>(
-      pdl::OperationType::get(b.getContext()), allocH);
-  multiBufferOp.setFactor(strategy.pipelineDepth);
-  multiBufferOp.setSkipAnalysis(true);
-}
-
-static Value buildConvertToAsyncCopies(ImplicitLocOpBuilder &b, Value funcH,
-                                       const MatmulStrategy &strategy) {
-  // Atm, vectors need to be lowered to 1-D for cp.async mapping to connect.
-  // TODO: not a functional style op to avoid invalidating artificially.
-  auto transferToScfOp = b.create<transform::TransferToScfOp>(
-      pdl::OperationType::get(b.getContext()), funcH);
-  // TODO: proper builder instead of a setting post-hoc.
-  transferToScfOp.setMaxTransferRank(1);
-  transferToScfOp.setFullUnroll(true);
-  funcH = transferToScfOp->getResult(0);
-  iree_compiler::buildCanonicalizationAndEnablingTransforms(
-      b, ApplyPatternsOpPatterns(), funcH);
-  auto createAsyncGroupOp =
-      b.create<iree_compiler::IREE::transform_dialect::CreateAsyncGroupsOp>(
-          TypeRange{}, funcH);
-  // TODO: proper builder instead of a setting post-hoc.
-  createAsyncGroupOp.setUseMmaSync(strategy.useMmaSync);
-  ApplyPatternsOpPatterns config;
-  config.foldMemrefAliases = true;
-  iree_compiler::buildCanonicalizationAndEnablingTransforms(b, config, funcH);
-  return funcH;
-}
-
-static void buildPipelineSharedMemoryCopies(ImplicitLocOpBuilder &b,
-                                            Value funcH,
-                                            const MatmulStrategy &strategy) {
-  Value computeOpH;
-  if (strategy.useMmaSync) {
-    computeOpH = b.create<transform::MatchOp>(
-        funcH, mlir::nvgpu::MmaSyncOp::getOperationName());
-  } else {
-    computeOpH = b.create<transform::MatchOp>(
-        funcH, mlir::gpu::SubgroupMmaComputeOp::getOperationName());
-  }
-  // TODO: Better builder.
-  Value forOpH = b.create<transform::GetParentForOp>(
-      pdl::OperationType::get(b.getContext()), computeOpH);
-  // TODO: Better builder instead of setting post-hoc.
-  auto pipelineOp = b.create<
-      iree_compiler::IREE::transform_dialect::PipelineSharedMemoryCopiesOp>(
-      pdl::OperationType::get(b.getContext()), forOpH);
-  // TODO: depth from strategy, or directly from individual buffers.
-  pipelineOp.setDepth(strategy.pipelineDepth);
-}
-
 static std::tuple<Value, Value, Value, Value>
 buildMatmulStrategyBlockDistribution(ImplicitLocOpBuilder &b, Value variantH,
                                      const MatmulStrategy &strategy) {
@@ -509,23 +208,6 @@ buildMatmulStrategyBlockDistribution(ImplicitLocOpBuilder &b, Value variantH,
   // TODO: handle trailing op.
   return std::make_tuple(tileResult.resultingFusedOpsHandles.front(),
                          tileResult.tiledOpH, Value(), tileResult.forallH);
-}
-
-static Value buildBufferize(ImplicitLocOpBuilder &b, Value variantH) {
-  ApplyPatternsOpPatterns patterns;
-  patterns.canonicalization = true;
-  patterns.cse = true;
-  patterns.licm = true;
-  b.create<ApplyPatternsOp>(variantH, patterns);
-  b.create<IREEEliminateEmptyTensorsOp>(variantH);
-  auto bufferizeOp = b.create<IREEBufferizeOp>(variantH, /*targetGpu=*/true);
-  bufferizeOp.setTargetGpu(true);
-  variantH = bufferizeOp.getResult();
-  Value memrefFunc =
-      b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
-  b.create<IREEEraseHALDescriptorTypeFromMemRefOp>(memrefFunc);
-  b.create<ApplyBufferOptimizationsOp>(memrefFunc);
-  return variantH;
 }
 
 void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
@@ -573,7 +255,7 @@ void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
                            strategy);
 
   // Step 7. Bufferize and drop HAL descriptor from memref ops.
-  variantH = ::buildBufferize(b, variantH);
+  variantH = buildBufferize(b, variantH);
 
   // Step 8. Post-bufferization mapping to blocks and threads.
   // Need to match again since bufferize invalidated all handles.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_TENSOR_CORE_MATMUL_STRATEGY_H_
 
 #include "iree-dialects/Transforms/TransformMatchers.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 
 namespace llvm {
@@ -20,126 +21,49 @@ namespace gpu {
 
 struct GPUModel;
 
-/// Base quantities generally useful for all GPU strategies.
-// TODO: refactor into a common place.
-struct StrategyBase {
-  StrategyBase(MLIRContext *ctx) : ctx(ctx) {}
+using iree_compiler::gpu::AbstractGemmLikeStrategy;
 
-  /// Constructor quantities.
-  MLIRContext *ctx;
-
-  Attribute blockX() const {
-    return mlir::gpu::GPUBlockMappingAttr::get(ctx, mlir::gpu::Blocks::DimX);
-  }
-  Attribute blockY() const {
-    return mlir::gpu::GPUBlockMappingAttr::get(ctx, mlir::gpu::Blocks::DimY);
-  }
-  Attribute blockZ() const {
-    return mlir::gpu::GPUBlockMappingAttr::get(ctx, mlir::gpu::Blocks::DimZ);
-  }
-  Attribute threadX() const {
-    return mlir::gpu::GPUThreadMappingAttr::get(ctx, mlir::gpu::Threads::DimX);
-  }
-  Attribute threadY() const {
-    return mlir::gpu::GPUThreadMappingAttr::get(ctx, mlir::gpu::Threads::DimY);
-  }
-  Attribute threadZ() const {
-    return mlir::gpu::GPUThreadMappingAttr::get(ctx, mlir::gpu::Threads::DimZ);
-  }
-  Attribute warpX() const {
-    return mlir::gpu::GPUWarpMappingAttr::get(ctx, mlir::gpu::Warps::DimX);
-  }
-  Attribute warpY() const {
-    return mlir::gpu::GPUWarpMappingAttr::get(ctx, mlir::gpu::Warps::DimY);
-  }
-  Attribute warpZ() const {
-    return mlir::gpu::GPUWarpMappingAttr::get(ctx, mlir::gpu::Warps::DimZ);
-  }
-  Attribute linearIdX() const {
-    return mlir::gpu::GPULinearIdMappingAttr::get(ctx,
-                                                  mlir::gpu::LinearId::DimX);
-  }
-  Attribute linearIdY() const {
-    return mlir::gpu::GPULinearIdMappingAttr::get(ctx,
-                                                  mlir::gpu::LinearId::DimY);
-  }
-  Attribute linearIdZ() const {
-    return mlir::gpu::GPULinearIdMappingAttr::get(ctx,
-                                                  mlir::gpu::LinearId::DimZ);
-  }
-};
-
-struct MatmulStrategy : StrategyBase {
+class MatmulStrategy : public AbstractGemmLikeStrategy {
+ public:
   MatmulStrategy(MLIRContext *context,
                  const transform_ext::MatchedMatmulCaptures &captures)
-      : StrategyBase(context), captures(captures) {
+      : AbstractGemmLikeStrategy(context), captures(captures) {
     initDefaultValues();
   }
+
+  MatmulStrategy(const MatmulStrategy &) = default;
+  MatmulStrategy &operator=(const MatmulStrategy &) = default;
 
   /// Constructor quantities.
   transform_ext::MatchedMatmulCaptures captures;
 
-  /// Tile sizes for the workgroup / determines grid size for all known
-  /// reduction strategies. The initial values are set by initDefaultValues();
-  SmallVector<int64_t> blockTileSizes;
-  int64_t reductionTileSize;
-  SmallVector<int64_t> numThreads;
-  SmallVector<int64_t> numWarps;
-  bool useAsyncCopies;
-  bool useMmaSync;
-  int64_t pipelineDepth;
-
   void initDefaultValues();
 
-  int64_t m() const {
+  LogicalResult verify() const;
+
+  int64_t m() const override {
     assert(captures.matmulOpSizes.size() == 3 && "need 3 sizes");
     return captures.matmulOpSizes[0];
   }
-  int64_t n() const {
+  int64_t n() const override {
     assert(captures.matmulOpSizes.size() == 3 && "need 3 sizes");
     return captures.matmulOpSizes[1];
   }
-  int64_t k() const {
+  int64_t k() const override {
     assert(captures.matmulOpSizes.size() == 3 && "need 3 sizes");
     return captures.matmulOpSizes[2];
   }
-  int64_t totalNumThreads() const {
-    int64_t res = 1;
-    for (auto v : numThreads) res *= v;
-    return res;
-  }
-  int64_t totalNumWarps() const {
-    int64_t res = 1;
-    for (auto v : numWarps) res *= v;
-    return res;
-  }
 
-  int64_t lhsCopyVectorSize() const {
-    if (k() % 4 == 0) return 4;
-    if (k() % 2 == 0) return 2;
-    return 1;
-  }
-  int64_t rhsCopyVectorSize() const {
-    if (n() % 4 == 0) return 4;
-    if (n() % 2 == 0) return 2;
-    return 1;
-  }
-  int64_t resCopyVectorSize() const { return rhsCopyVectorSize(); }
+  using AbstractGemmLikeStrategy::MappingInfo;
 
-  struct MappingInfo {
-    SmallVector<int64_t> numThreads;
-    // Explicitly computing the tileSizes is only needed until masked
-    // vectorization properly computes the bounds automatically.
-    SmallVector<int64_t> tileSizes;
-    SmallVector<Attribute> threadMapping;
-  };
-  MappingInfo getBlockMapping() const {
+  MappingInfo getBlockMapping() const override {
     return MappingInfo{/*numThreads=*/{},
                        /*tileSizes=*/{blockTileSizes[0], blockTileSizes[1]},
                        /*threadMapping=*/{blockY(), blockX()}};
   }
+
   // LHS copy is of size mxk.
-  MappingInfo lhsCopyMapping() const {
+  MappingInfo lhsCopyMapping() const override {
     assert(reductionTileSize % lhsCopyVectorSize() == 0 &&
            "vector size must divide reductionTileSize");
     int64_t numThreadsK = reductionTileSize / lhsCopyVectorSize();
@@ -157,7 +81,7 @@ struct MatmulStrategy : StrategyBase {
         /*threadMapping=*/{linearIdX(), linearIdY()}};
   }
   // RHS copy is of size kxn.
-  MappingInfo rhsCopyMapping() const {
+  MappingInfo rhsCopyMapping() const override {
     assert(blockTileSizes[1] % rhsCopyVectorSize() == 0 &&
            "vector size must divide blockTileSizes[1]");
     int64_t numThreadsN = blockTileSizes[1] / rhsCopyVectorSize();
@@ -175,7 +99,7 @@ struct MatmulStrategy : StrategyBase {
         /*threadMapping=*/{linearIdY(), linearIdX()}};
   }
   // RES copy is of size mxn.
-  MappingInfo resCopyMapping() const {
+  MappingInfo resCopyMapping() const override {
     assert(blockTileSizes[1] % resCopyVectorSize() == 0 &&
            "vector size must divide n");
     int64_t numThreadsN = blockTileSizes[1] / resCopyVectorSize();
@@ -193,7 +117,7 @@ struct MatmulStrategy : StrategyBase {
         /*threadMapping=*/{linearIdY(), linearIdX()}};
   }
   // COMPUTE is of size mxn.
-  MappingInfo computeMapping() const {
+  MappingInfo computeMapping() const override {
     return MappingInfo{/*numThreads=*/{numWarps[0], numWarps[1]},
                        /*tileSizes=*/{},
                        /*threadMapping=*/{warpY(), warpX()}};


### PR DESCRIPTION
In preparation for other GEMM-like transform dialect strategies, this makes the strategy building helpers for the existing matmul strategy available for use elsewhere.

Separated from the implicit gemm work in #13449.