### PR TITLE
Cast GPU Workgroup Address Space to generic for ukernel op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/LowerUKernelsToCalls.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerUKernelsToCalls.cpp
@@ -4,10 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Dialect/UKernelOps.h"
 #include "iree/compiler/Codegen/Interfaces/UKernelOpInterface.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -24,12 +26,53 @@ struct LowerUKernelOpsToCallsPass
 };
 }  // namespace
 
+/// Passing an argument with and address space cause ABI mismatch. Therefore,
+/// some optimizations such as inlining would not work. This function casts
+/// operands back to generic address space.
+static void castGpuAddressSpaceToGeneric(IRRewriter &rewriter, Operation *op) {
+  auto castOperands = [](IRRewriter &rewriter,
+                         mlir::Operation::operand_range operands,
+                         mlir::MutableOperandRange mutables) {
+    SmallVector<Value> new_operands;
+    for (auto operand : operands) {
+      if (auto memrefType = dyn_cast<mlir::MemRefType>(operand.getType())) {
+        auto addressSpace = memrefType.getMemorySpace()
+                                .dyn_cast_or_null<gpu::AddressSpaceAttr>();
+        if (addressSpace && addressSpace.getValue() ==
+                                gpu::GPUDialect::getWorkgroupAddressSpace()) {
+          mlir::MemRefType new_memrefType = mlir::MemRefType::get(
+              memrefType.getShape(), memrefType.getElementType(),
+              memrefType.getLayout());
+          operand = rewriter.create<memref::MemorySpaceCastOp>(
+              operand.getLoc(), new_memrefType, operand);
+        }
+      }
+      new_operands.push_back(operand);
+    }
+    mutables.assign(new_operands);
+  };
+
+  op->walk([&](IREE::Codegen::UKernelGenericOp microKernelOp) {
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(microKernelOp);
+    castOperands(rewriter, microKernelOp.getInputs(),
+                 microKernelOp.getInputsMutable());
+    castOperands(rewriter, microKernelOp.getOutputs(),
+                 microKernelOp.getOutputsMutable());
+    castOperands(rewriter, microKernelOp.getOtherOperands(),
+                 microKernelOp.getOtherOperandsMutable());
+  });
+}
+
 void LowerUKernelOpsToCallsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   SmallVector<Operation *> toDelete;
   Operation *errorOp = nullptr;
   IRRewriter rewriter(context);
+
+  castGpuAddressSpaceToGeneric(rewriter, getOperation());
+
   WalkResult result = getOperation().walk(
       [&](IREE::Codegen::UKernelOpInterface microKernelOp) -> WalkResult {
         OpBuilder::InsertionGuard g(rewriter);


### PR DESCRIPTION
This PR addresses an issue with the workgroup address space of inputs and outputs in the ukernel operation. By casting the Workgroup Address Space to generic address space, we can avoid an ABI mismatch that can prevent optimizations such as inlining. Microkernels are expected to be inlined, so this change should allow for inlining.

To demonstrate the problem with passing address space to ukernel function, I've included an example on Godbolt. This example shows how inlining does not work when address space is passed to ukernel. 
https://godbolt.org/z/zGTqMobcj

I've also included an example of the issue with compiling CUDA and passing `__shared__` to a function. In this case, clang simply removes `__shared__` (aka address space). 
https://godbolt.org/z/Edfhve7fb