### PR TITLE
Change compilation time benchmark threshold to 100%

### DIFF
--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -104,9 +104,9 @@ BENCHMARK_THRESHOLDS = [
 ]
 
 COMPILATION_TIME_THRESHOLDS = [
-    # Compilation time measurement is very stable right now. Use a large
-    # threshold until we make it stable.
-    BenchmarkThreshold(re.compile(r".*"), 50, ThresholdUnit.PERCENTAGE),
+    # TODO(#11922): Compilation time measurement is very unstable right now.
+    # Use a large threshold until we make it stable.
+    BenchmarkThreshold(re.compile(r".*"), 100, ThresholdUnit.PERCENTAGE),
 ]
 
 TOTAL_DISPATCH_SIZE_THRESHOLDS = [


### PR DESCRIPTION
We are seeing more noises on compilation time metric exceeding 50% recently. It's probably due to more benchmarks are added (and we didn't implement isolation while compiling multiple benchmarks in parallel, with multi-threading).

Change the threshold to 100% for now, which should be still able to catch something very wrong.

Note that I'm planning to stablize the compilation time measurement in the following weeks (https://github.com/openxla/iree/issues/11922). An early prototype is in testing (https://github.com/openxla/iree/pull/13402)