### PR TITLE
[Transform] Capture the element types of the matmul in the matcher

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -830,15 +830,8 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
     return failure();
   }
 
-  // TODO: Capture in the matcher.
-  captures.lhsType =
-      getElementTypeOrSelf(op.getDpsInputOperand(0)->get().getType());
-  captures.rhsType =
-      getElementTypeOrSelf(op.getDpsInputOperand(1)->get().getType());
-  captures.outputType =
-      getElementTypeOrSelf(op.getDpsInitOperand(0)->get().getType());
-  if (!captures.lhsType.isF32() || !captures.rhsType.isF32() ||
-      !captures.outputType.isF32()) {
+  if (!captures.lhsElementType.isF32() || !captures.rhsElementType.isF32() ||
+      !captures.outputElementType.isF32()) {
     LDBG("--Matmul strategy elemental type check failed\n");
     return failure();
   }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -87,6 +87,11 @@ struct CaptureElementTypeBitWidth : public CaptureStaticValue<int64_t> {
   using Base::Base;
 };
 
+/// Captures element element type.
+struct CaptureElementType : public CaptureStaticValue<Type> {
+  using Base::Base;
+};
+
 /// A tag indicating to look for any user of the operation's result that would
 /// satisfy the predicate.
 struct HasAnyUse {};
@@ -447,6 +452,9 @@ public:
   StructuredOpMatcher &input(int64_t position,
                              CaptureElementTypeBitWidth width);
 
+  /// Capture the elemental type of input operand `position`.
+  StructuredOpMatcher &input(int64_t position, CaptureElementType elem);
+
   /// Check if input is equal to a known constant.
   // TODO: Support matching for constant ops.
   StructuredOpMatcher &input(int64_t position, ConstantFloatMinOrMinusInf);
@@ -504,6 +512,9 @@ public:
   /// Capture the elemental type bitwidth of output operand `position`.
   StructuredOpMatcher &output(int64_t position,
                               CaptureElementTypeBitWidth width);
+
+  /// Capture the elemental type of output operand `position`.
+  StructuredOpMatcher &output(int64_t position, CaptureElementType elem);
 
   /// Adds a predicate checking that the output of the structured op is produced
   /// by a reduction with a single-operation combinator (such as addf or mulf,
@@ -741,7 +752,7 @@ struct MatchedReductionCaptures {
 };
 
 struct MatchedMatmulCaptures {
-  Type lhsType, rhsType, outputType;
+  Type lhsElementType, rhsElementType, outputElementType;
   SmallVector<int64_t> matmulOpSizes = {};
 };
 


### PR DESCRIPTION
In the future when more than just F32 is supported, the element type will need to be captured to properly select padding values. This captures the element types in the matcher in preparation for that.

This patch is nearly NFC; some of the matcher cleanup also fixes boundary conditions for cases like `input(position, ...)` which previously checked `index <= 0`.

Also cleans up a test case in set_transform_strategy that wasn't properly testing the alignment condition for using the strategy.