### PR TITLE
Support mhlo.collective_permute with NCCL

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1838,6 +1838,34 @@ void CollectiveReduceScatterOp::build(OpBuilder &builder, OperationState &state,
         channel, builder.getIndexArrayAttr({0}));
 }
 
+//===----------------------------------------------------------------------===//
+// flow.collective.send_recv
+//===----------------------------------------------------------------------===//
+
+Value CollectiveSendRecvOp::getTiedResult(unsigned resultIndex) {
+  return IREE::Util::TiedOpInterface::findTiedBaseValue(getTarget());
+}
+
+::llvm::Optional<unsigned> CollectiveSendRecvOp::getTiedResultOperandIndex(
+    unsigned resultIndex) {
+  return {0};  // target
+}
+
+SmallVector<int64_t, 4> CollectiveSendRecvOp::getTiedResultOperandIndices() {
+  return {0};  // target
+}
+
+void CollectiveSendRecvOp::build(OpBuilder &builder, OperationState &state,
+                                 CollectiveElementTypeAttr elementType,
+                                 Value target, Value source, Value channel,
+                                 Value send, Value recv) {
+  auto targetDims =
+      IREE::Util::buildDynamicDimsForValue(state.location, target, builder);
+
+  build(builder, state, elementType, target, targetDims, source, channel, send,
+        recv, builder.getIndexArrayAttr({0}));
+}
+
 }  // namespace Flow
 }  // namespace IREE
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1819,4 +1819,48 @@ def FLOW_CollectiveReduceScatterOp : FLOW_Op<"collective.reduce_scatter", [
   ];
 }
 
+def FLOW_CollectiveSendRecvOp : FLOW_Op<"collective.send_recv", [
+  AllTypesMatch<["source", "target", "result"]>,
+  DeclareOpInterfaceMethods<Util_TiedOpInterface, [
+    "getTiedResult",
+    "getTiedResultOperandIndex",
+    "getTiedResultOperandIndices",
+  ]>,
+]> {
+  let summary = [{performs a grouped send and receive operation}];
+  let description = [{The operation sends data to the rank specificied by send
+    and receives data from the rank specified by recv. If send is -1, this rank
+    will not send any data. If recv is -1, this rank will not receive any data
+    and the output will be all zeros.}];
+
+  let arguments = (ins
+    FLOW_CollectiveElementTypeAttr:$element_type,
+    FLOW_Tensor:$target,
+    FLOW_ShapeDynamicDims:$target_dims,
+    FLOW_Tensor:$source,
+    FLOW_Channel:$channel,
+    I32:$send,
+    I32:$recv,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands
+  );
+  let results = (outs
+    FLOW_Tensor:$result
+  );
+  let assemblyFormat = [{
+    $element_type `,` $target `,` $source `,` $channel `,` $send `,` $recv `:`
+    `(` type($target) `,` type($source) `,` type($channel) `,` type($send) `,` type($recv) `)` `->`
+    custom<ShapedTiedResult>(type($result), $target_dims, $tied_operands)
+    attr-dict-with-keyword
+  }];
+  let builders = [
+    OpBuilder<(ins
+      "CollectiveElementTypeAttr":$element_type,
+      "Value":$target,
+      "Value":$source,
+      "Value":$channel,
+      "Value":$send,
+      "Value":$recv)>,
+  ];
+}
+
 #endif  // IREE_DIALECT_FLOW_OPS

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1839,8 +1839,8 @@ def FLOW_CollectiveSendRecvOp : FLOW_Op<"collective.send_recv", [
     FLOW_ShapeDynamicDims:$target_dims,
     FLOW_Tensor:$source,
     FLOW_Channel:$channel,
-    I32:$send,
-    I32:$recv,
+    Index:$send,
+    Index:$recv,
     OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands
   );
   let results = (outs

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -242,6 +242,7 @@ def HAL_CollectiveKind_Reduce : I32EnumAttrCase<"Reduce", 4, "reduce">;
 def HAL_CollectiveKind_ReduceScatter : I32EnumAttrCase<"ReduceScatter", 5, "reduce_scatter">;
 def HAL_CollectiveKind_Send : I32EnumAttrCase<"Send", 6, "send">;
 def HAL_CollectiveKind_Recv : I32EnumAttrCase<"Recv", 7, "recv">;
+def HAL_CollectiveKind_SendRecv: I32EnumAttrCase<"SendRecv", 8, "send_recv">;
 def HAL_CollectiveKindAttr :
     I32EnumAttr<"CollectiveKind", "valid CollectiveKind", [
       HAL_CollectiveKind_AllGather,
@@ -252,6 +253,7 @@ def HAL_CollectiveKindAttr :
       HAL_CollectiveKind_ReduceScatter,
       HAL_CollectiveKind_Send,
       HAL_CollectiveKind_Recv,
+      HAL_CollectiveKind_SendRecv,
     ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -464,6 +464,51 @@ struct ConvertReduceScatterOp
   }
 };
 
+struct ConvertCollectiveSendRecvOp
+    : public OpConversionPattern<IREE::Flow::CollectiveSendRecvOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      IREE::Flow::CollectiveSendRecvOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto shape = op.getType().cast<ShapedType>();
+    auto collectiveAttr = IREE::Stream::CollectiveAttr::get(
+        op.getContext(), IREE::Stream::CollectiveKind::SendRecv,
+        /*reduction=*/std::nullopt,
+        static_cast<IREE::Stream::CollectiveElementType>(op.getElementType()));
+
+    auto zeroOffset = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+    auto elementCount = rewriter.create<arith::ConstantIndexOp>(
+        op.getLoc(), shape.getNumElements());
+    auto newTargetCast =
+        consumeTensorOperand(op.getLoc(), adaptor.getTarget(), rewriter);
+    auto newSourceCast =
+        consumeTensorOperand(op.getLoc(), adaptor.getSource(), rewriter);
+
+    // Pack send, recv into param. The values are checked to be within the
+    // 16-bit range during lowering to Flow dialect.
+    auto lo = rewriter.create<arith::AndIOp>(
+        op.getLoc(), adaptor.getSend(),
+        rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0xFFFF, 32));
+    auto hi = rewriter.create<arith::ShLIOp>(
+        op.getLoc(), adaptor.getRecv(),
+        rewriter.create<arith::ConstantIntOp>(op.getLoc(), 16, 32));
+    auto param = rewriter.create<arith::OrIOp>(op.getLoc(), hi, lo);
+
+    rewriter.replaceOpWithNewOp<IREE::Stream::AsyncCollectiveOp>(
+        op, collectiveAttr, adaptor.getTarget(),
+        /*target_size=*/newTargetCast.resourceSize,
+        /*target_offset=*/zeroOffset,
+        /*target_end=*/newTargetCast.resourceSize,
+        /*target_length=*/newTargetCast.resourceSize, adaptor.getSource(),
+        /*source_size=*/newSourceCast.resourceSize,
+        /*source_offset=*/zeroOffset, /*source_end=*/newSourceCast.resourceSize,
+        /*source_length=*/newSourceCast.resourceSize, elementCount,
+        adaptor.getChannel(),
+        /*param=*/param, getAffinityFor(op));
+    return success();
+  }
+};
+
 struct ConvertDispatchOp : public OpConversionPattern<IREE::Flow::DispatchOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult matchAndRewrite(
@@ -808,9 +853,10 @@ void populateFlowToStreamConversionPatterns(MLIRContext *context,
   patterns.insert<ConvertChannelDefaultOp, ConvertChannelSplitOp,
                   ConvertChannelRankOp, ConvertChannelCountOp>(typeConverter,
                                                                context);
-  patterns.insert<ConvertAllGatherOp, ConvertAllReduceOp,
-                  ConvertReduceScatterOp, ConvertAllToAllOp>(typeConverter,
-                                                             context);
+  patterns
+      .insert<ConvertAllGatherOp, ConvertAllReduceOp, ConvertReduceScatterOp,
+              ConvertAllToAllOp, ConvertCollectiveSendRecvOp>(typeConverter,
+                                                              context);
   patterns.insert<ConvertDispatchOp>(typeConverter, context);
   patterns.insert<ConvertFuncOp, ConvertCallOp>(typeConverter, context);
   patterns.insert<ConvertExecutableOp>(typeConverter, context);

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -486,11 +486,15 @@ struct ConvertCollectiveSendRecvOp
 
     // Pack send, recv into param. The values are checked to be within the
     // 16-bit range during lowering to Flow dialect.
+    auto send = rewriter.create<arith::IndexCastOp>(
+        op.getLoc(), rewriter.getI32Type(), adaptor.getSend());
     auto lo = rewriter.create<arith::AndIOp>(
-        op.getLoc(), adaptor.getSend(),
+        op.getLoc(), send,
         rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0xFFFF, 32));
+    auto recv = rewriter.create<arith::IndexCastOp>(
+        op.getLoc(), rewriter.getI32Type(), adaptor.getRecv());
     auto hi = rewriter.create<arith::ShLIOp>(
-        op.getLoc(), adaptor.getRecv(),
+        op.getLoc(), recv,
         rewriter.create<arith::ConstantIntOp>(op.getLoc(), 16, 32));
     auto param = rewriter.create<arith::OrIOp>(op.getLoc(), hi, lo);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/collective_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/collective_ops.mlir
@@ -86,3 +86,23 @@ func.func @reduce_scatter(%channel: !flow.channel, %arg0: !hal.buffer_view) -> !
   %3 = hal.tensor.export %2 : tensor<2x2xf32> -> !hal.buffer_view
   return %3 : !hal.buffer_view
 }
+
+//-----
+
+// CHECK-LABEL: @send_recv
+// CHECK-SAME: %arg1: !hal.buffer_view, [[SEND:%.+]]: i32, [[RECV:%.+]]: i32)
+func.func @send_recv(%channel: !flow.channel, %arg0: !hal.buffer_view, %send: i32, %recv: i32) -> !hal.buffer_view attributes {iree.abi.stub} {
+  // CHECK: stream.tensor.empty : tensor<1024xf32>
+  // CHECK-DAG: [[CST_LO_MASK:%.+]] = arith.constant 65535 : i32
+  // CHECK-DAG: [[CST_SHIFT16:%.+]] = arith.constant 16 : i32
+  // CHECK-DAG: [[LO:%.+]] = arith.andi [[SEND]], [[CST_LO_MASK]] : i32
+  // CHECK-DAG: [[HI:%.+]] = arith.shli [[RECV]], [[CST_SHIFT16]] : i32
+  // CHECK-DAG: [[PARAM:%.+]] = arith.ori [[HI]], [[LO]] : i32
+  // CHECK: stream.async.collective<send_recv : f32>
+  // CHECK-SAME: source_target_pair([[PARAM]])
+  %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<1024xf32>
+  %1 = flow.tensor.empty : tensor<1024xf32>
+  %2 = flow.collective.send_recv f32, %1, %0, %channel, %send, %recv : (tensor<1024xf32>, tensor<1024xf32>, !flow.channel, i32, i32) -> tensor<1024xf32>
+  %3 = hal.tensor.export %2 : tensor<1024xf32> -> !hal.buffer_view
+  return %3 : !hal.buffer_view
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/collective_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/collective_ops.mlir
@@ -90,19 +90,21 @@ func.func @reduce_scatter(%channel: !flow.channel, %arg0: !hal.buffer_view) -> !
 //-----
 
 // CHECK-LABEL: @send_recv
-// CHECK-SAME: %arg1: !hal.buffer_view, [[SEND:%.+]]: i32, [[RECV:%.+]]: i32)
-func.func @send_recv(%channel: !flow.channel, %arg0: !hal.buffer_view, %send: i32, %recv: i32) -> !hal.buffer_view attributes {iree.abi.stub} {
+// CHECK-SAME: %arg1: !hal.buffer_view, [[SEND:%.+]]: index, [[RECV:%.+]]: index)
+func.func @send_recv(%channel: !flow.channel, %arg0: !hal.buffer_view, %send: index, %recv: index) -> !hal.buffer_view attributes {iree.abi.stub} {
   // CHECK: stream.tensor.empty : tensor<1024xf32>
   // CHECK-DAG: [[CST_LO_MASK:%.+]] = arith.constant 65535 : i32
   // CHECK-DAG: [[CST_SHIFT16:%.+]] = arith.constant 16 : i32
-  // CHECK-DAG: [[LO:%.+]] = arith.andi [[SEND]], [[CST_LO_MASK]] : i32
-  // CHECK-DAG: [[HI:%.+]] = arith.shli [[RECV]], [[CST_SHIFT16]] : i32
+  // CHECK-DAG: [[SEND_I32:%.+]]  = arith.index_cast [[SEND]] : index to i32
+  // CHECK-DAG: [[RECV_I32:%.+]]  = arith.index_cast [[RECV]] : index to i32
+  // CHECK-DAG: [[LO:%.+]] = arith.andi [[SEND_I32]], [[CST_LO_MASK]] : i32
+  // CHECK-DAG: [[HI:%.+]] = arith.shli [[RECV_I32]], [[CST_SHIFT16]] : i32
   // CHECK-DAG: [[PARAM:%.+]] = arith.ori [[HI]], [[LO]] : i32
   // CHECK: stream.async.collective<send_recv : f32>
   // CHECK-SAME: source_target_pair([[PARAM]])
   %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<1024xf32>
   %1 = flow.tensor.empty : tensor<1024xf32>
-  %2 = flow.collective.send_recv f32, %1, %0, %channel, %send, %recv : (tensor<1024xf32>, tensor<1024xf32>, !flow.channel, i32, i32) -> tensor<1024xf32>
+  %2 = flow.collective.send_recv f32, %1, %0, %channel, %send, %recv : (tensor<1024xf32>, tensor<1024xf32>, !flow.channel, index, index) -> tensor<1024xf32>
   %3 = hal.tensor.export %2 : tensor<1024xf32> -> !hal.buffer_view
   return %3 : !hal.buffer_view
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
@@ -158,6 +158,7 @@ def Stream_CollectiveKind_Reduce : I32EnumAttrCase<"Reduce", 4, "reduce">;
 def Stream_CollectiveKind_ReduceScatter : I32EnumAttrCase<"ReduceScatter", 5, "reduce_scatter">;
 def Stream_CollectiveKind_Send : I32EnumAttrCase<"Send", 6, "send">;
 def Stream_CollectiveKind_Recv : I32EnumAttrCase<"Recv", 7, "recv">;
+def Stream_CollectiveKind_SendRecv : I32EnumAttrCase<"SendRecv", 8, "send_recv">;
 def Stream_CollectiveKindAttr :
     I32EnumAttr<"CollectiveKind", "valid CollectiveKind", [
       Stream_CollectiveKind_AllGather,
@@ -168,6 +169,7 @@ def Stream_CollectiveKindAttr :
       Stream_CollectiveKind_ReduceScatter,
       Stream_CollectiveKind_Send,
       Stream_CollectiveKind_Recv,
+      Stream_CollectiveKind_SendRecv,
     ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Stream";
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1424,6 +1424,8 @@ static const char *getCollectiveParamKeyword(Attribute opAttr) {
       return "target";
     case IREE::Stream::CollectiveKind::Recv:
       return "source";
+    case IREE::Stream::CollectiveKind::SendRecv:
+      return "source_target_pair";
     default:
       return nullptr;
   }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertCollectiveOps.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertCollectiveOps.cpp
@@ -825,65 +825,34 @@ struct CollectivePermuteOpConversion
     // no send/recv.
     DenseIntElementsAttr sourceTargetPairs = op.getSourceTargetPairs();
     llvm::DenseMap<int64_t, int64_t> sendMap, recvMap;
+    auto values = sourceTargetPairs.getValues<int64_t>();
+    // Find the max rank so we can size our tables.
     int64_t maxRank = 0;
-    for (auto i = sourceTargetPairs.begin(); i != sourceTargetPairs.end();
-         ++i) {
-      int64_t source = (*i).getSExtValue();
-      int64_t target = (*++i).getSExtValue();
-      if (source > std::numeric_limits<int16_t>::max() ||
-          target > std::numeric_limits<int16_t>::max()) {
+    for (auto rank : values) {
+      if (rank > std::numeric_limits<int16_t>::max()) {
         return rewriter.notifyMatchFailure(
             op, "source or target id exceeds maximum value of 16-bit integer");
       }
-      sendMap[source] = target;
-      recvMap[target] = source;
-      maxRank = std::max(std::max(maxRank, source), target);
+      maxRank = std::max(maxRank, rank);
     }
-    const int64_t numRanks = maxRank + 1;
-    SmallVector<int32_t, 8> sendTable, recvTable;
-    sendTable.reserve(numRanks + 1);
-    recvTable.reserve(numRanks + 1);
-    for (int64_t i = 0; i < numRanks; ++i) {
-      sendTable.push_back(sendMap.count(i) ? sendMap[i] : -1);
-      recvTable.push_back(recvMap.count(i) ? recvMap[i] : -1);
+    // Create tables. -1 is used to indicate no send or recv.
+    IndexSet indexSet(loc, rewriter);
+    Value noSendOrRecv = indexSet.get(-1);
+    SmallVector<Value> sendTable(maxRank + 1, noSendOrRecv);
+    SmallVector<Value> recvTable(maxRank + 1, noSendOrRecv);
+    for (auto i = values.begin(); i != values.end(); ++i) {
+      int64_t source = (*i);
+      int64_t target = (*++i);
+      sendTable[source] = indexSet.get(target);
+      recvTable[target] = indexSet.get(source);
     }
-    // For rank ids >= numRanks, we will clamp to this last entry which will
-    // return -1. This avoids control flow since the number of ranks in the
-    // channel is not statically known.
-    sendTable.push_back(-1);
-    recvTable.push_back(-1);
-
-    auto createAndIndexBuffer = [&](const SmallVector<int32_t, 8> &table,
-                                    Value index) {
-      // Create constant buffer to hold send/recv tables.
-      auto ty = RankedTensorType::get({static_cast<int64_t>(table.size())},
-                                      rewriter.getI32Type());
-      auto dataAttr = DenseIntElementsAttr::get(ty, table);
-      Value buffer = rewriter.create<IREE::Util::BufferConstantOp>(
-          loc, /*name=*/nullptr, dataAttr, /*alignment=*/IntegerAttr{},
-          /*mimeType=*/nullptr);
-
-      // Index into table.
-      Value elementTypeByteSize =
-          rewriter.create<arith::ConstantIndexOp>(loc, sizeof(int32_t));
-      Value bufferSize = rewriter.create<arith::ConstantIndexOp>(
-          loc, table.size() * sizeof(int32_t));
-      Value byteOffset =
-          rewriter.create<arith::MulIOp>(loc, elementTypeByteSize, index);
-      return rewriter.create<IREE::Util::BufferLoadOp>(
-          loc, rewriter.getI32Type(), buffer, bufferSize, byteOffset,
-          elementTypeByteSize);
-    };
-
-    // index = min(rank, numRanks)
+    // Look up the local send/recv values using rank.
     Value rank =
         rewriter.create<IREE::Flow::ChannelRankOp>(loc, channel).getResult();
-    Value cstLastEntryIndex =
-        rewriter.create<arith::ConstantIndexOp>(loc, numRanks);
-    Value index = rewriter.create<arith::MinSIOp>(loc, rank, cstLastEntryIndex);
-    // Look up send/recv using index
-    Value send = createAndIndexBuffer(sendTable, index);
-    Value recv = createAndIndexBuffer(recvTable, index);
+    Value send = rewriter.create<IREE::Util::SwitchOp>(loc, rank, noSendOrRecv,
+                                                       sendTable);
+    Value recv = rewriter.create<IREE::Util::SwitchOp>(loc, rank, noSendOrRecv,
+                                                       recvTable);
 
     // Create an empty tensor for the result.
     ArrayRef<int64_t> inputShape = inputType.getShape();

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_collective_ops.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_collective_ops.mlir
@@ -474,21 +474,15 @@ module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 
 // -----
 
 // CHECK-LABEL: @collective_permute
-// CHECK-SAME: ([[ARG0:%.+]]: tensor<8xf32>) -> tensor<8xf32>
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<8xf32>) -> tensor<8xf32>
 func.func @collective_permute(%input : tensor<8xf32>) -> tensor<8xf32> {
-  // CHECK: [[CST_BUFFER_SIZE:%.+]] = arith.constant 20 : index
-  // CHECK: [[CST_4:%.+]] = arith.constant 4 : index
-  // CHECK: [[CHANNEL:%.+]] = flow.channel.default : !flow.channel
-  // CHECK: [[RANK:%.+]] = flow.channel.rank [[CHANNEL]] : index
-  // CHECK: [[INDEX:%.+]] = arith.minsi [[RANK]], [[CST_4]] : index
-  // CHECK: [[CST_SEND_BUFFER:%.+]] = util.buffer.constant : !util.buffer = dense<[1, 2, 3, 0, -1]> : tensor<5xi32>
-  // CHECK: [[INDEX_MUL4:%.+]] = arith.muli [[INDEX]], [[CST_4]] : index
-  // CHECK: [[SEND:%.+]] = util.buffer.load [[CST_SEND_BUFFER]]{{\[}}[[INDEX_MUL4]] for [[CST_4]]] : !util.buffer{[[CST_BUFFER_SIZE]]} -> i32
-  // CHECK: [[CST_RECV_BUFFER:%.+]] = util.buffer.constant : !util.buffer = dense<[3, 0, 1, 2, -1]> : tensor<5xi32>
-  // CHECK: [[RECV:%.+]] = util.buffer.load [[CST_RECV_BUFFER]]{{\[}}[[INDEX_MUL4]] for [[CST_4]]] : !util.buffer{[[CST_BUFFER_SIZE]]} -> i32
-  // CHECK: [[EMPTY:%.+]] = tensor.empty() : tensor<8xf32>
-  // CHECK: [[OP:%.+]] = flow.collective.send_recv f32, [[EMPTY]], [[ARG0]], [[CHANNEL]], [[SEND]], [[RECV]] : (tensor<8xf32>, tensor<8xf32>, !flow.channel, i32, i32) -> [[EMPTY]] as tensor<8xf32>
-  // CHECK: return [[OP]] : tensor<8xf32>
+  // CHECK: %[[CHANNEL:.+]] = flow.channel.default : !flow.channel
+  // CHECK: %[[RANK:.+]] = flow.channel.rank %[[CHANNEL]] : index
+  // CHECK: %[[SEND:.+]] = util.switch index from [%c1, %c2, %c3, %c0] at %[[RANK]] else %c-1
+  // CHECK: %[[RECV:.+]] = util.switch index from [%c3, %c0, %c1, %c2] at %[[RANK]] else %c-1
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<8xf32>
+  // CHECK: %[[OP:.+]] = flow.collective.send_recv f32, %[[EMPTY]], %[[ARG0]], %[[CHANNEL]], %[[SEND]], %[[RECV]] : (tensor<8xf32>, tensor<8xf32>, !flow.channel, index, index) -> %[[EMPTY]] as tensor<8xf32>
+  // CHECK: return %[[OP]] : tensor<8xf32>
   %out = "mhlo.collective_permute"(%input) {
         source_target_pairs = dense<[[0, 1], [1, 2], [2, 3], [3, 0]]> : tensor<4x2xi64>,
         channel_handle = #mhlo.channel_handle<handle = 1, type = 1>} : (tensor<8xf32>) -> tensor<8xf32>

--- a/runtime/src/iree/hal/command_buffer.c
+++ b/runtime/src/iree/hal/command_buffer.c
@@ -50,6 +50,7 @@ IREE_API_EXPORT iree_string_view_t iree_hal_collective_op_format(
               IREE_SVL("reduce_scatter"),
           [IREE_HAL_COLLECTIVE_KIND_SEND] = IREE_SVL("send"),
           [IREE_HAL_COLLECTIVE_KIND_RECV] = IREE_SVL("recv"),
+          [IREE_HAL_COLLECTIVE_KIND_SEND_RECV] = IREE_SVL("send_recv"),
       };
   static const iree_string_view_t
       reduction_names[IREE_HAL_COLLECTIVE_REDUCTION_MAX_VALUE + 1] = {

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -298,8 +298,19 @@ enum iree_hal_collective_kind_e {
   //   ncclRecv
   IREE_HAL_COLLECTIVE_KIND_RECV,
 
+  // |param| is used to store the target rank in the low 16 bits, and the source
+  // rank in the high 16 bits. Sends |element_count| elements of the specified
+  // type in |send_binding| the target rank, unless it is -1. Receives
+  // |element_count| elements of the specified type in |recv_binding| from
+  // source rank, unless it is -1, then the result will be all zeros.
+  //
+  // |param|: first 16 bits are the target, last 16 bits are the source
+  // |send_binding|: used on source
+  // |recv_binding|: used on target
+  IREE_HAL_COLLECTIVE_KIND_SEND_RECV,
+
   // Maximum enumeration value for collective operations.
-  IREE_HAL_COLLECTIVE_KIND_MAX_VALUE = IREE_HAL_COLLECTIVE_KIND_RECV,
+  IREE_HAL_COLLECTIVE_KIND_MAX_VALUE = IREE_HAL_COLLECTIVE_KIND_SEND_RECV,
 };
 typedef uint8_t iree_hal_collective_kind_t;
 

--- a/runtime/src/iree/hal/command_buffer_validation.c
+++ b/runtime/src/iree/hal/command_buffer_validation.c
@@ -414,6 +414,9 @@ iree_status_t iree_hal_command_buffer_collective_validation(
               IREE_HAL_COLLECTIVE_REQUIRES_SEND_BINDING,
           [IREE_HAL_COLLECTIVE_KIND_RECV] =
               IREE_HAL_COLLECTIVE_REQUIRES_RECV_BINDING,
+          [IREE_HAL_COLLECTIVE_KIND_SEND_RECV] =
+              IREE_HAL_COLLECTIVE_REQUIRES_SEND_BINDING |
+              IREE_HAL_COLLECTIVE_REQUIRES_RECV_BINDING,
       };
   const uint32_t info_bits = info_bits_table[op.kind];
   if (!(info_bits & IREE_HAL_COLLECTIVE_IS_REDUCTION) && op.reduction != 0) {


### PR DESCRIPTION
Adds support for `mhlo.collective_permute`.

During lowering, the `source_target_pairs` are converted into a table of send/recv ids which can be indexed by the local rank. The send/recv id pair is stored in the `param` field of HAL `CollectiveKind::SendRecv`. The send and receive ids are packed as 16 bit integers into the 32 bit param.

Fixes https://github.com/openxla/iree/issues/13100