### PR TITLE
Adding `--iree-util-annotate-op-ordinals` pass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/AnnotateOpOrdinals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/AnnotateOpOrdinals.cpp
@@ -1,0 +1,43 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Util {
+
+namespace {
+
+class AnnotateOpOrdinalsPass
+    : public AnnotateOpOrdinalsBase<AnnotateOpOrdinalsPass> {
+ public:
+  void runOnOperation() override {
+    auto *context = &getContext();
+    auto attrName = StringAttr::get(context, "util.ordinal");
+    auto indexType = IndexType::get(context);
+    int64_t globalOrdinal = 0;
+    getOperation().walk<WalkOrder::PreOrder>([&](Operation *op) {
+      op->setAttr(attrName, IntegerAttr::get(indexType, globalOrdinal++));
+    });
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createAnnotateOpOrdinalsPass() {
+  return std::make_unique<AnnotateOpOrdinalsPass>();
+}
+
+}  // namespace Util
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
@@ -15,6 +15,7 @@ package(
 iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
+        "AnnotateOpOrdinals.cpp",
         "ApplyPatterns.cpp",
         "CombineInitializers.cpp",
         "ConvertPrimitiveType.cpp",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
     "Passes.h.inc"
     "Patterns.h"
   SRCS
+    "AnnotateOpOrdinals.cpp"
     "ApplyPatterns.cpp"
     "CombineInitializers.cpp"
     "ConvertPrimitiveType.cpp"

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -38,7 +38,8 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createPromoteBF16ToF32Pass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createPromoteArithBF16ToF32Pass();
 
-// Test passes.
+// Debug/test passes.
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createAnnotateOpOrdinalsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createTestConversionPass();
 std::unique_ptr<OperationPass<void>> createTestFloatRangeAnalysisPass();
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -148,8 +148,15 @@ def PromoteArithBF16ToF32 : Pass<"iree-util-promote-arith-bf16-to-f32", "mlir::M
 }
 
 //===----------------------------------------------------------------------===//
-// Test passes
+// Debug/test passes
 //===----------------------------------------------------------------------===//
+
+def AnnotateOpOrdinals : Pass<"iree-util-annotate-op-ordinals", "mlir::ModuleOp"> {
+  let summary = "Annotates ops with globally unique IDs for debugging.";
+  let constructor = [{
+    mlir::iree_compiler::IREE::Util::createAnnotateOpOrdinalsPass()
+  }];
+}
 
 def TestConversion : Pass<"iree-util-test-conversion", "mlir::ModuleOp"> {
   let summary = "Tests util dialect conversion patterns.";

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "annotate_op_ordinals.mlir",
             "block_patterns.mlir",
             "combine_initializers.mlir",
             "demote_f32_to_f16.mlir",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "annotate_op_ordinals.mlir"
     "block_patterns.mlir"
     "combine_initializers.mlir"
     "demote_f32_to_f16.mlir"

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/annotate_op_ordinals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/annotate_op_ordinals.mlir
@@ -1,0 +1,34 @@
+// RUN: iree-opt --split-input-file --iree-util-annotate-op-ordinals %s | FileCheck %s
+
+// CHECK: module attributes {util.ordinal = 0 : index}
+module {
+
+// CHECK-NEXT: util.initializer attributes {util.ordinal = 1 : index}
+util.initializer {
+  // CHECK-NEXT: arith.constant {util.ordinal = 2 : index} true
+  %cond = arith.constant true
+  // CHECK-NEXT: cf.cond_br {{.+}} {util.ordinal = 3 : index}
+  cf.cond_br %cond, ^bb1, ^bb2
+^bb1:
+  // CHECK: arith.constant {util.ordinal = 4 : index} 100
+  %c100 = arith.constant 100 : index
+  // CHECK-NEXT: cf.br {{.+}} {util.ordinal = 5 : index}
+  cf.br ^bb2
+^bb2:
+  // CHECK: util.initializer.return {util.ordinal = 6 : index}
+  util.initializer.return
+}
+
+// CHECK: util.global private mutable @globalB {util.ordinal = 7 : index}
+util.global private mutable @globalB : index
+// CHECK-NEXT: func.func @setterFunc() attributes {util.ordinal = 8 : index}
+func.func @setterFunc() {
+  // CHECK-NEXT: arith.constant {util.ordinal = 9 : index} 300
+  %c300 = arith.constant 300 : index
+  // CHECK-NEXT: util.global.store {{.+}} {util.ordinal = 10 : index}
+  util.global.store %c300, @globalB : index
+  // CHECK-NEXT: return {util.ordinal = 11 : index}
+  return
+}
+
+}


### PR DESCRIPTION
This is a debugging pass that adds a unique ordinal dialect attr to all ops in a module. This makes it easy to track ops through `-debug` output that may be reordering/adding/removing/converting ops and invalidating the SSA values.