### PR TITLE
Avoid mapping the trailing element of the SmallReductionStrategy twice to threads

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
@@ -144,7 +144,9 @@ static void buildSmallReductionStrategyThreadDistribution(
       /*opSizes=*/strategy.captures.reductionOpSizes,
       /*numThreads=*/1);
 
-  // 3. apply the 1d splitting strategy to the trailing elementwise.
+  // 3. Apply the 1d splitting strategy to the trailing elementwise part while
+  // specifying a single thread. This triggers the splitting but not the thread
+  // mapping part.
   build1DSplittingStrategyWithOptionalThreadMapping(
       /*b=*/b,
       /*isolatedParentOpH=*/variantH,
@@ -153,8 +155,7 @@ static void buildSmallReductionStrategyThreadDistribution(
       // TODO: capture and generalize mostMinorDim.
       /*mostMinorDim=*/strategy.captures.maybeTrailingRank - 1,
       /*opSizes=*/strategy.captures.trailingOpSizes,
-      /*numThreads=*/strategy.workgroupTileSizes[0],
-      /*mappingAttr=*/threadX(ctx));
+      /*numThreads=*/1);
 }
 
 void mlir::iree_compiler::gpu::buildSmallReductionStrategy(

--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -31,18 +31,6 @@ if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
       "requires-gpu-nvidia"
       "driver=cuda"
   )
-
-  # The test fails on CUDA with `Mismatched elements: 1 / 100352 (0.000996%)`,
-  # so mark as WILL_FAIL if the test was defined.
-  # TODO(#13007): Plumb WILL_FAIL through the test rule instead of custom logic.
-  iree_package_path(PKG_PATH)
-  set(CUDA_TEST_NAME ${PKG_PATH}/mnist_train_test_cuda)
-  get_directory_property(TESTS_LIST TESTS)
-  if(${CUDA_TEST_NAME} IN_LIST TESTS_LIST)
-    set_tests_properties(
-      ${CUDA_TEST_NAME}
-      PROPERTIES WILL_FAIL TRUE)
-  endif()
 endif()
 
 if(IREE_TARGET_BACKEND_VULKAN_SPIRV AND IREE_HAL_DRIVER_VULKAN)


### PR DESCRIPTION
This PR fixes a bug where the trailing elementwise operation was mapped twice to threads: once during tiling to forall + fusion and a second time standalone.

Instead, the elementwise is mapped sequentially, just like the reduction.

Fixes #11991 