### PR TITLE
Cast Address Space in FuncOp and CallOpo for LLVMGPUs

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -20,6 +20,7 @@ iree_compiler_cc_library(
         "ConvertToROCDL.cpp",
         "ExtractAddressComputationGPUPass.cpp",
         "KernelConfig.cpp",
+        "LLVMGPUCastAddressSpaceFunction.cpp",
         "LLVMGPUCheckIRBeforeLLVMConversion.cpp",
         "LLVMGPUDistribute.cpp",
         "LLVMGPULowerExecutableTarget.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_library(
     "ConvertToROCDL.cpp"
     "ExtractAddressComputationGPUPass.cpp"
     "KernelConfig.cpp"
+    "LLVMGPUCastAddressSpaceFunction.cpp"
     "LLVMGPUCheckIRBeforeLLVMConversion.cpp"
     "LLVMGPUDistribute.cpp"
     "LLVMGPULowerExecutableTarget.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
@@ -1,16 +1,15 @@
-// Copyright 2022 The IREE Authors
+// Copyright 2023 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-#include <iree/compiler/Codegen/Utils/GPUUtils.h>
 
 #include "iree/compiler/Codegen/LLVMGPU/KernelConfig.h"
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/ADT/None.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
@@ -1,0 +1,95 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <iree/compiler/Codegen/Utils/GPUUtils.h>
+
+#include "iree/compiler/Codegen/LLVMGPU/KernelConfig.h"
+#include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "llvm/ADT/None.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/TransformOps/GPUTransformOps.h"
+#include "mlir/Dialect/GPU/Transforms/Passes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/MathExtras.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+#define DEBUG_TYPE "iree-llvmgpu-cast-address-space-function"
+
+namespace mlir {
+namespace iree_compiler {
+namespace {
+
+struct LLVMGPUCastAddressSpaceFunctionPass
+    : public LLVMGPUCastAddressSpaceFunctionBase<
+          LLVMGPUCastAddressSpaceFunctionPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<affine::AffineDialect, gpu::GPUDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    IRRewriter rewriter(context);
+
+    ModuleOp moduleOp = getOperation();
+
+    auto castOperands = [&](mlir::Operation::operand_range operands,
+                            SmallVector<Value> &new_operands) {
+      bool anyCasted = false;
+      for (auto operand : operands) {
+        if (auto memrefType = dyn_cast<mlir::MemRefType>(operand.getType())) {
+          if (hasSharedMemoryAddressSpace(memrefType)) {
+            mlir::MemRefType new_memrefType = mlir::MemRefType::get(
+                memrefType.getShape(), memrefType.getElementType(),
+                memrefType.getLayout());
+            operand = rewriter.create<memref::MemorySpaceCastOp>(
+                operand.getLoc(), new_memrefType, operand);
+            anyCasted = true;
+          }
+        }
+        new_operands.push_back(operand);
+      }
+      return anyCasted;
+    };
+
+    moduleOp->walk([&](func::CallOp callOp) {
+      SmallVector<Value> new_operands;
+      OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPoint(callOp);
+      if (castOperands(callOp->getOperands(), new_operands)) {
+        callOp.getOperandsMutable().assign(new_operands);
+        auto fnDecl = dyn_cast_or_null<func::FuncOp>(
+            SymbolTable::lookupSymbolIn(moduleOp, callOp.getCallee()));
+        if (fnDecl) {
+          SmallVector<Type> callArgumentTypes;
+          for (auto op : new_operands)
+            callArgumentTypes.push_back(op.getType());
+          FunctionType functionType = rewriter.getFunctionType(
+              callArgumentTypes, fnDecl->getResultTypes());
+          fnDecl.setFunctionType(functionType);
+        }
+      }
+    });
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createLLVMGPUCastAddressSpaceFunction() {
+  return std::make_unique<LLVMGPUCastAddressSpaceFunctionPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -522,6 +522,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   // Strip out the debug info for the kernel as CUDA driver doesn't diggest PTX
   // debug info well.
   pm.addPass(createStripDebugInfoPass());
+  // Cast address spaces of all function arguments to generic
+  if (!useROCM) pm.addPass(createLLVMGPUCastAddressSpaceFunction());
   if (useROCM) {
     // convert to ROCDL.
     pm.addPass(createConvertToROCDLPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "distribute_to_thread.mlir",
             "distribute_foreach.mlir",
             "elementwise_pipeline.mlir",
+            "cast_address_space_function.mlir",
             "extract_address_computation_gpu.mlir",
             "gpu_set_num_workgroups.mlir",
             "nvvm_extract_address_computation.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "attention.mlir"
+    "cast_address_space_function.mlir"
     "check_ir_before_llvm_conversion.mlir"
     "conv_pipeline_test.mlir"
     "convert_to_nvvm.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/cast_address_space_function.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/cast_address_space_function.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-llvmgpu-cast-address-space-function %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-lower-ukernel-ops-to-calls --iree-llvmgpu-cast-address-space-function %s --split-input-file | FileCheck %s
 
 module {
   func.func private @foo(memref<f32>, memref<f32, #gpu.address_space<workgroup>>, memref<f32, #gpu.address_space<workgroup>>) 
@@ -14,7 +14,6 @@ module {
   }
 }
 
-
 // CHECK:    func.func private @foo(memref<f32>, memref<f32>, memref<f32>) 
 
 // CHECK-LABEL: func.func @bar
@@ -25,3 +24,19 @@ module {
 // CHECK:     %[[C1:.+]] = memref.memory_space_cast %[[b1]] : memref<f32, #gpu.address_space<workgroup>> to memref<f32>
 // CHECK:     %[[C2:.+]] = memref.memory_space_cast %[[b2]] : memref<f32, #gpu.address_space<workgroup>> to memref<f32>
 // CHECK:     call @foo(%{{.*}}, %[[C1]], %[[C2]]) : (memref<f32>, memref<f32>, memref<f32>) -> ()
+
+// -----
+
+module {
+  func.func @bar() {
+    %alloc_1 = memref.alloc() : memref<110xf32, #gpu.address_space<workgroup>>    
+    %alloc_2 = memref.alloc() : memref<128xf32>
+    %alloc_3 = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
+    iree_codegen.ukernel.generic "fastfunction" ins(%alloc_1, %alloc_2 : memref<110xf32, #gpu.address_space<workgroup>>, memref<128xf32>) 
+    outs(%alloc_3 : memref<128xf32, #gpu.address_space<workgroup>>) 
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @bar
+// CHECK:     call @fastfunction(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (memref<f32>, index, index, memref<f32>, index, index, memref<f32>, index, index) -> ()

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/cast_address_space_function.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/cast_address_space_function.mlir
@@ -1,0 +1,27 @@
+// RUN: iree-opt --iree-llvmgpu-cast-address-space-function %s | FileCheck %s
+
+module {
+  func.func private @foo(memref<f32>, memref<f32, #gpu.address_space<workgroup>>, memref<f32, #gpu.address_space<workgroup>>) 
+  func.func @bar() {
+    %alloc_1 = memref.alloc() : memref<110xf32, #gpu.address_space<workgroup>>    
+    %alloc_2 = memref.alloc() : memref<128xf32>
+    %alloc_3 = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
+    %a1:4 = memref.extract_strided_metadata %alloc_1 : memref<110xf32, #gpu.address_space<workgroup>> -> memref<f32, #gpu.address_space<workgroup>>, index, index, index
+    %a2:4 = memref.extract_strided_metadata %alloc_2 : memref<128xf32> -> memref<f32>, index, index, index
+    %a3:4 = memref.extract_strided_metadata %alloc_3 : memref<128xf32, #gpu.address_space<workgroup>> -> memref<f32, #gpu.address_space<workgroup>>, index, index, index
+    call @foo(%a2, %a1, %a3) : (memref<f32>, memref<f32, #gpu.address_space<workgroup>>, memref<f32, #gpu.address_space<workgroup>>) -> ()
+    return
+  }
+}
+
+
+// CHECK:    func.func private @foo(memref<f32>, memref<f32>, memref<f32>) 
+
+// CHECK-LABEL: func.func @bar
+// CHECK:     %[[a1:.+]] = memref.alloc() : memref<110xf32, #gpu.address_space<workgroup>>    
+// CHECK:     %[[a2:.+]] = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>    
+// CHECK:     %[[b1:.+]], %{{.*}}, %{{.*}}, %{{.*}} = memref.extract_strided_metadata %[[a1]] : memref<110xf32, #gpu.address_space<workgroup>> -> memref<f32, #gpu.address_space<workgroup>>, index, index, index 
+// CHECK:     %[[b2:.+]], %{{.*}}, %{{.*}}, %{{.*}} = memref.extract_strided_metadata %[[a2]] : memref<128xf32, #gpu.address_space<workgroup>> -> memref<f32, #gpu.address_space<workgroup>>, index, index, index
+// CHECK:     %[[C1:.+]] = memref.memory_space_cast %[[b1]] : memref<f32, #gpu.address_space<workgroup>> to memref<f32>
+// CHECK:     %[[C2:.+]] = memref.memory_space_cast %[[b2]] : memref<f32, #gpu.address_space<workgroup>> to memref<f32>
+// CHECK:     call @foo(%{{.*}}, %[[C1]], %[[C2]]) : (memref<f32>, memref<f32>, memref<f32>) -> ()

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -559,6 +559,10 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTileAndDistribute(
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTileTensor(
     bool distributeToWarp = false);
 
+/// Cast address space to generic in CallOp and FuncOp
+std::unique_ptr<OperationPass<ModuleOp>>
+createLLVMGPUCastAddressSpaceFunction();
+
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUDistribute();
 
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTensorAlloc(

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -674,6 +674,12 @@ def LLVMGPULowerExecutableTarget :
   let constructor = "mlir::iree_compiler::createLLVMGPULowerExecutableTargetPass()";
 }
 
+def LLVMGPUCastAddressSpaceFunction :
+    Pass<"iree-llvmgpu-cast-address-space-function", "ModuleOp"> {
+  let summary = "Pass to cast";
+  let constructor = "mlir::iree_compiler::createLLVMGPUCastAddressSpaceFunction()";
+}
+
 def LLVMGPUTileAndDistribute :
     Pass<"iree-llvmgpu-tile-and-distribute", "func::FuncOp"> {
   let summary = "Pass to tile and distribute linalg ops within a workgroup.";


### PR DESCRIPTION
This PR addresses an issue with the address space in FuncOp and CallOp. By casting the Workgroup Address Space to generic address space, we can avoid an ABI mismatch that can prevent optimizations such as inlining. Functions are expected to be inlined, so this change should allow for inlining.

To demonstrate the problem, I've included an example on Godbolt. This example shows how inlining does not work when address space is present. https://godbolt.org/z/zGTqMobcj

I've also included an example of the issue with compiling CUDA and passing `__shared__` to a function. In this case, clang simply removes address space. https://godbolt.org/z/Edfhve7fb