### PR TITLE
[StableHLO] Rename the `stablehlo_experimental` to `stablehlo`

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -49,8 +49,8 @@ void InputDialectOptions::bindOptions(OptionsBinder &binder) {
                      "Legalize from MHLO ops.")
         , clEnumValN(InputDialectOptions::Type::xla, "xla",
             "Legalize from MHLO ops (with XLA cleanup preprocessing).")
-        , clEnumValN(InputDialectOptions::Type::stablehlo_experimental,
-            "stablehlo_experimental",
+        , clEnumValN(InputDialectOptions::Type::stablehlo,
+            "stablehlo",
             "Legalize from StableHLO ops. WARNING: This is work in progress.")
 #endif  // IREE_HAVE_MHLO_INPUT
 #ifdef IREE_HAVE_TORCH_INPUT

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -43,7 +43,7 @@ struct InputDialectOptions {
     // cleanup activities.
     xla,
     // Legalizes input defined over StableHLO ops.
-    stablehlo_experimental,
+    stablehlo,
 #endif  // IREE_HAVE_MHLO_INPUT
 #ifdef IREE_HAVE_TORCH_INPUT
     // Legalizes input defined over TMTensor ops.

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -59,7 +59,7 @@ void buildIREEVMTransformPassPipeline(
     case InputDialectOptions::Type::xla:
       MHLO::buildXLAInputConversionPassPipeline(passManager);
       break;
-    case InputDialectOptions::Type::stablehlo_experimental:
+    case InputDialectOptions::Type::stablehlo:
       stablehlo::buildStableHLOInputConversionPassPipeline(passManager);
       break;
 #endif  // IREE_HAVE_MHLO_INPUT

--- a/tests/e2e/stablehlo_ops/BUILD.bazel
+++ b/tests/e2e/stablehlo_ops/BUILD.bazel
@@ -82,7 +82,7 @@ iree_check_single_backend_test_suite(
             "pow.mlir",  # TODO(#12678): Investigate this failing on riscv-32.
         ],
     ),
-    compiler_flags = ["--iree-input-type=stablehlo_experimental"],
+    compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "local-task",
     target_backend = "llvm-cpu",
 )
@@ -148,7 +148,7 @@ iree_check_single_backend_test_suite(
         include = ["*.mlir"],
         exclude = [],
     ),
-    compiler_flags = ["--iree-input-type=stablehlo_experimental"],
+    compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "local-task",
     target_backend = "vmvx",
 )
@@ -215,7 +215,7 @@ iree_check_single_backend_test_suite(
             "reverse.mlir",  # TODO(#12415): disabled due to miscompilation on Pixel 6.
         ],
     ),
-    compiler_flags = ["--iree-input-type=stablehlo_experimental"],
+    compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "vulkan",
     target_backend = "vulkan-spirv",
 )
@@ -283,7 +283,7 @@ iree_check_single_backend_test_suite(
         exclude = [],
     ),
     compiler_flags = [
-        "--iree-input-type=stablehlo_experimental",
+        "--iree-input-type=stablehlo",
         "--iree-llvmcpu-target-cpu-features=host",
     ],
     driver = "local-task",

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -70,7 +70,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "local-task"
   COMPILER_FLAGS
-    "--iree-input-type=stablehlo_experimental"
+    "--iree-input-type=stablehlo"
 )
 
 iree_check_single_backend_test_suite(
@@ -134,7 +134,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "local-task"
   COMPILER_FLAGS
-    "--iree-input-type=stablehlo_experimental"
+    "--iree-input-type=stablehlo"
 )
 
 iree_check_single_backend_test_suite(
@@ -196,7 +196,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "vulkan"
   COMPILER_FLAGS
-    "--iree-input-type=stablehlo_experimental"
+    "--iree-input-type=stablehlo"
 )
 
 iree_check_single_backend_test_suite(
@@ -260,7 +260,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "local-task"
   COMPILER_FLAGS
-    "--iree-input-type=stablehlo_experimental"
+    "--iree-input-type=stablehlo"
     "--iree-llvmcpu-target-cpu-features=host"
   LABELS
     "hostonly"


### PR DESCRIPTION
Now that the stablehlo input conversion pipeline nearly reached the parity with the mhlo/xla pipelines, drop the experimental suffix and rename `--iree-input-type=stablehlo_experimental` to `stablehlo`.

Issue: https://github.com/openxla/iree/issues/12678