### PR TITLE
[IREE dispatch profiler] Separate iree build folder and generated folder

### DIFF
--- a/experimental/dispatch_profiler/README.md
+++ b/experimental/dispatch_profiler/README.md
@@ -18,7 +18,7 @@ The IREE Dispatch Profiler is a Python-based tool designed to achieve two primar
 IREE dispatch profiler provides [`generator.py`](generator.py) that can be used to generate dispatches. Please find a sample run below:
 
 ```bash
-build-debug $ python3 ../iree/experimental/dispatch_profiler/generator.py 
+$ python3 dispatch_profiler/generator.py --generated-dir </path/to/create/`generated`/dir>
 [Generating]: ./generated/linalg/matmul/matmul_128x128x256_f16t_f16t_f16t/matmul_128x128x256_f16t_f16t_f16t.mlir
     Emitting tuning configuration : tile_config_128x128_64x4_tensorcore_mmasync
     Emitting tuning configuration : tile_config_128x128_32x5_tensorcore_mmasync
@@ -35,7 +35,7 @@ The `generator.py` script serves as a generator for implemented operation data t
 #### Generating user-specified matmul shape `768x512x1024`
 
 ```bash
-python3 ../iree/experimental/dispatch_profiler/generator.py --problem-m=768 --problem-n=512 --problem-k=1024
+python3 ../iree/experimental/dispatch_profiler/generator.py --generated-dir </path/to/create/`generated`/dir> --problem-m=768 --problem-n=512 --problem-k=1024
 ...
 [Generating]: ./generated/linalg/matmul/matmul_768x512x1024_f16t_f16t_f16t/matmul_768x512x1024_f16t_f16t_f16t.mlir
 [Generating]: ./generated/linalg/matmul/matmul_768x512x1024_f32t_f32t_f32t/matmul_768x512x1024_f32t_f32t_f32t.mlir
@@ -47,7 +47,7 @@ python3 ../iree/experimental/dispatch_profiler/generator.py --problem-m=768 --pr
 Generate matmuls where M ranges from 64 to 1024 in increments of 128, N varies from 64 to 1024 in steps of 128, and K is fixed at 4096.
 
 ```bash
-$ python3 ../iree/experimental/dispatch_profiler/generator.py --problem-m=64:1024:128 --problem-n=64:1024:128 --problem-k=4096
+$ python3 ../iree/experimental/dispatch_profiler/generator.py --generated-dir </path/to/create/`generated`/dir> --problem-m=64:1024:128 --problem-n=64:1024:128 --problem-k=4096
 ...
 ```
 
@@ -56,7 +56,7 @@ $ python3 ../iree/experimental/dispatch_profiler/generator.py --problem-m=64:102
 IREE dispatch profiler provies `compile.py` that trigges `iree-compile` with appropiate compilation flags. The output of `iree-compile` vmfb files are placed in `mlir_dialect/operation_path/operation_name.mlir`. The `compiler.py` uses all the possible cpus on your machine to compile all different generated mlir source files.
 
 ```bash
-python3 ../iree/experimental/dispatch_profiler/compile.py
+python3 ../iree/experimental/dispatch_profiler/compile.py --build-dir </path/to/iree/build/dir> --generated-dir </path/to/create/`generated`/dir>
 ```
 
 Compiles all the generated source mlir dispatches. One can check the generated dispatched folder to find the vmfb files.
@@ -73,7 +73,7 @@ The tool provides [`profiler.py`](profiler.py) script which can be used to trigg
 ### Functional verification and performance profiling of a _single_ dispatch
 
 ```
-$ python3 ../iree/experimental/dispatch_profiler/profiler.py --dispatches=matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync --verification-enabled=true --profiling-enabled=true
+$ python3 profiler.py --build-dir </path/to/iree/build/dir> --generated-dir </path/to/create/`generated`/dir> --dispatches=matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync --verification-enabled=true --profiling-enabled=true
 ---------------------------------------------------------------- 
 Dispatch      : matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync
 Provider      : IREE Codegen
@@ -92,7 +92,7 @@ GFLOPs        : 233798.62
 Verification, particularly for large matrix multiplications, can be time-consuming when using a CPU-based numpy reference. To prioritize profiling speed and when functional correctness is assured, disable verification using `--verification-enabled=false`.
 
 ```bash
- python3 ../iree/experimental/dispatch_profiler/profiler.py --dispatches=matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync --verification-enabled=false --profiling-enabled=true
+python3 profiler.py --build-dir </path/to/iree/build/dir> --generated-dir </path/to/create/`generated`/dir> --dispatches=matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync --verification-enabled=false --profiling-enabled=true
 ```
 
 ### Performance profile _single_ operation and _sweep_ tunning configurations
@@ -100,7 +100,7 @@ Verification, particularly for large matrix multiplications, can be time-consumi
 The `--dispatch` option accepts a comma-separated list of regex patterns to profile all tuning configurations generated for a operation. The command-line argument is formatted as `--dispatch=<regex>,<regex>`. Additionally, you can export the profiled output to a CSV file for further analysis using `--output=<filepath>`.
 
 ```bash
-$ python3 ../iree/experimental/dispatch_profiler/profiler.py --dispatches=matmul_3456x1024x2048_f16t_f16t_f16t_*_tensorcore_mmasync --verification-enabled=false --profiling-enabled=true --output=data.csv
+$ python3 profiler.py --build-dir </path/to/iree/build/dir> --generated-dir </path/to/create/`generated`/dir> --dispatches=matmul_3456x1024x2048_f16t_f16t_f16t_*_tensorcore_mmasync --verification-enabled=false --profiling-enabled=true --output=data.csv
 ---------------------------------------------------------------- 
 Dispatch      : matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x256_32x3_tensorcore_mmasync
 Provider      : IREE Codegen
@@ -146,7 +146,7 @@ Writing performance report to data.csv
 Another example showcasing the use of `--dispatch` to profile a matmul_3456x1024x2048 targetting F16 and F32 NVIDIA A100 Tensor Cores.
 
 ```bash
-$ python3 ../iree/experimental/dispatch_profiler/profiler.py --dispatches=matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync,matmul_3456x1024x2048_f32t_f32t_f32t_tile_config_128x128_16x5_tensorcore_mmasync 
+$ python3 profiler.py --build-dir </path/to/iree/build/dir> --generated-dir </path/to/create/`generated`/dir>  --dispatches=matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync,matmul_3456x1024x2048_f32t_f32t_f32t_tile_config_128x128_16x5_tensorcore_mmasync 
 ---------------------------------------------------------------- 
 Dispatch      : matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_128x128_32x5_tensorcore_mmasync
 Provider      : IREE Codegen

--- a/experimental/dispatch_profiler/launchers.py
+++ b/experimental/dispatch_profiler/launchers.py
@@ -17,7 +17,8 @@ class IreeToolsLauncher:
   def __init__(self, args, operation):
     self.operation = operation
 
-    self.generated_path = Path(args.build_dir, 'generated', args.mlir_dialect)
+    self.generated_path = Path(args.generated_dir, 'generated',
+                               args.mlir_dialect)
 
     self.args = args
     self.benchmark_dispatch_repeat_count = args.batch_size
@@ -31,7 +32,7 @@ class IreeToolsLauncher:
         operation.name()).with_suffix(".mlir")
 
     # path to cached numpy refernece input and expected output files.
-    self.op_reference_cache_path = Path(args.build_dir, 'generated',
+    self.op_reference_cache_path = Path(args.generated_dir, 'generated',
                                         'reference_cache', operation.name())
 
     if not self.op_reference_cache_path.exists():

--- a/experimental/dispatch_profiler/manifest.py
+++ b/experimental/dispatch_profiler/manifest.py
@@ -118,7 +118,7 @@ class Manifest:
       self.dispatch_names = [x for x in args.dispatches.split(',') if x != '']
 
     # Paths to the generated directory (e.g. `./generated/linalg`).
-    self.generated_path = Path(self.args.build_dir, 'generated',
+    self.generated_path = Path(self.args.generated_dir, 'generated',
                                self.args.mlir_dialect)
 
     # Create the directories in self.generated_path, if it does not exist.

--- a/experimental/dispatch_profiler/options.py
+++ b/experimental/dispatch_profiler/options.py
@@ -22,9 +22,14 @@ import argparse
 def add_typical_arguments(parser):
   """Adds typical command line arguments to the parser."""
   parser.add_argument("--build-dir", default=".", \
-                      help="IREE top-level build directory is used to generate "\
-                      "operations and npy files.This should be same that used "\
-                      "to call generated.py")
+                      help="IREE top-level build directory. Looks for "\
+                      "`iree/build/tools` dir in the build directory. "\
+                      "The dispatch profiler scripts uses iree-compile, "\
+                      "iree-benchmark-module from `build_dir` directory.")
+  parser.add_argument("--generated-dir", default=".", \
+                      help="The dispatch profiler scripts generate "\
+                      "mlir dispatches, compiled vmfbs, and reference_chache "\
+                      "containing golden npy files in the generated-dir")
   parser.add_argument("--operation-kind","--op-kind", \
                       dest="operation_kind", default="all", \
                       help="Specifies the operation kinds to generate.", \


### PR DESCRIPTION
Separate arguments for iree `build_dir` and the `generated` folder. Also, updated README.md accordingly. 