### PR TITLE
[TransformStrategies] Add support for aligned and partially aligned matmul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" --iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy | FileCheck %s
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" --iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy --iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul | FileCheck %s
 // Check that setting the command line options affect the transform
 // strategy as expected.
 // RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" --iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy \
@@ -225,42 +225,6 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.sequence  failures(propagate) {
 
 // -----
-hal.executable @matmul {
-hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.export public @matmul ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
-    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @matmul() {
-      %c0 = arith.constant 0 : index
-      %cst = arith.constant 0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>>
-      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>>
-      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
-      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>> -> tensor<2048x2048xf32>
-      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>> -> tensor<2048x2048xf32>
-      %5 = tensor.empty() : tensor<2048x2048xf32>
-      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
-      %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xf32>, tensor<2048x2048xf32>) outs(%6 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
-      flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
-      return
-    }
-  }
-}
-}
-
-// CHECK-LABEL: func @matmul
-
-// "Enough" of this matmul's dimensions are divisible by 64/64/16.
-// We currently bail on such cases because at least one of the paddings involved
-// in the strategy fold away and result in the strategy failing to apply.
-// In the future we should also support this case but for now we are missing the 
-// generalization along this axis.
-// CHECK-NOT: transform.sequence
-
-// -----
 hal.executable @matmul_partially_unaligned {
 hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
   hal.executable.export public @matmul_partially_unaligned ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
@@ -287,15 +251,100 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 }
 }
 
-// CHECK:       iree_codegen.translation_info<LLVMGPUMatmulSimt>
 // CHECK-LABEL: func @matmul_partially_unaligned
 
-// "Enough" of this matmul's dimensions are divisible by 64/64/16.
-// We currently bail on such cases because at least one of the paddings involved
-// in the strategy fold away and result in the strategy failing to apply.
-// In the future we should also support this case but for now we are missing the
-// generalization along this axis.
-// CHECK-NOT: transform.sequence
+// CHECK: transform.structured.tile %tiled_op[0, 0, 16]
+
+// Make sure we do not canonicalize because the result is still aligned.
+// CHECK-NEXT: transform.structured.pad %tiled_linalg_op
+// CHECK-SAME:   pack_paddings = [1, 1, 1]
+// CHECK-SAME:   padding_dimensions = [0, 1, 2]
+// CHECK-SAME:   padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]
+// CHECK:      transform.structured.match ops{["linalg.fill"]}
+// CHECK:      transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
+// CHECK:      %[[RES_PAD:.+]] = get_producer_of_operand %{{.*}}[2]
+// CHECK:      %[[RES_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[RES_PAD]]
+// CHECK:      %[[LHS_PAD:.+]] = get_producer_of_operand %{{.*}}[0]
+// CHECK:      %[[RHS_PAD:.+]] = get_producer_of_operand %{{.*}}[1]
+// CHECK:      %{{.*}}, %[[TILED_LHS:.+]] = transform.structured.tile_to_forall_op %[[LHS_PAD]]   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// CHECK:      transform.structured.match ops{["scf.if"]}
+// CHECK:      transform.scf.take_assumed_branch %{{.*}} take_else_branch
+// CHECK:      %{{.*}}, %[[TILED_RHS:.+]] = transform.structured.tile_to_forall_op %[[RHS_PAD]]   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
+// CHECK:      transform.structured.match ops{["scf.if"]}
+// CHECK:      transform.scf.take_assumed_branch %{{.*}} take_else_branch
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
+
+// alignLhs
+// CHECK:      transform.structured.masked_vectorize %[[TILED_LHS]] vector_sizes [4, 4]
+// alignRhs
+// CHECK:      transform.structured.masked_vectorize %[[TILED_RHS]] vector_sizes [4, 4]
+
+// CHECK:      transform.vector.lower_masks
+// CHECK:      transform.vector.materialize_masks
+
+// -----
+hal.executable @aligned_matmul {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
+  hal.executable.export public @aligned_matmul ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @aligned_matmul() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>> -> tensor<2048x2048xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>> -> tensor<2048x2048xf32>
+      %5 = tensor.empty() : tensor<2048x2048xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
+      %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xf32>, tensor<2048x2048xf32>) outs(%6 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
+      flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
+      return
+    }
+  }
+}
+}
+
+// CHECK-LABEL: func @aligned_matmul
+
+// Block level is the same for aligned.
+// CHECK: transform.structured.tile %tiled_op[0, 0, 16] : (!pdl.operation) -> (!pdl.operation, !transform.any_op)
+
+// Make sure we do not canonicalize if the result is aligned to avoid folding the extract_slice on the iterator.
+// CHECK-NEXT: transform.structured.pad %tiled_linalg_op
+// CHECK-SAME:   pack_paddings = [1, 1, 1]
+// CHECK-SAME:   padding_dimensions = [0, 1, 2]
+// CHECK-SAME:   padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]
+// CHECK:      transform.structured.match ops{["linalg.fill"]}
+
+// Canonicalization is currently required here to enable pad to dps to produce linalg.copy ops.
+// CHECK:      transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
+// CHECK:      %[[RES_PAD:.+]] = get_producer_of_operand %{{.*}}[2]
+// CHECK:      %[[RES_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[RES_PAD]]
+// CHECK:      %[[LHS_PAD:.+]] = get_producer_of_operand %{{.*}}[0]
+// CHECK:      %[[RHS_PAD:.+]] = get_producer_of_operand %{{.*}}[1]
+// CHECK:      %[[LHS_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[LHS_PAD]] : (!pdl.operation) -> !pdl.operation
+// CHECK:      %[[RHS_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[RHS_PAD]] : (!pdl.operation) -> !pdl.operation
+// CHECK:      transform.structured.tile_to_forall_op %[[LHS_COPY]]   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// CHECK:      transform.structured.tile_to_forall_op %[[RHS_COPY]]   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
+
+// We shouldn't be generating masks so don't bother handling them.
+// CHECK-NOT:  transform.vector.lower_masks
+// CHECK-NOT:  transform.vector.materialize_masks
+
+// Verify we don't go down the path without the flag.
+// WITH_OPTIONS-LABEL: func @aligned_matmul
+
+// WITH_OPTIONS-NOT: transform.sequence  failures(propagate) {
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
@@ -119,7 +119,8 @@ struct TileToScfForAndFuseResult {
 /// Note: fusion is currently unsupported.
 TileToScfForAndFuseResult buildTileFuseToScfFor(
     ImplicitLocOpBuilder &b, Value isolatedParentOpH, Value rootH,
-    ValueRange opsHToFuse, ArrayRef<OpFoldResult> tileSizes);
+    ValueRange opsHToFuse, ArrayRef<OpFoldResult> tileSizes,
+    bool canonicalize = true);
 
 /// Result of the combined transform performing tiling, fusion and
 /// distribution to parallel constructs.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -44,6 +44,10 @@ struct AbstractGemmLikeStrategy {
   virtual int64_t n() const = 0;
   virtual int64_t k() const = 0;
 
+  bool alignedLhs() const { return m() % 64 == 0 && k() % 16 == 0; }
+  bool alignedRhs() const { return n() % 64 == 0 && k() % 16 == 0; }
+  bool alignedRes() const { return m() % 64 == 0 && n() % 64 == 0; }
+
   /// Common values based on derived quantities.
   int64_t totalNumThreads() const {
     int64_t res = 1;

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -44,9 +44,18 @@ struct AbstractGemmLikeStrategy {
   virtual int64_t n() const = 0;
   virtual int64_t k() const = 0;
 
-  bool alignedLhs() const { return m() % 64 == 0 && k() % 16 == 0; }
-  bool alignedRhs() const { return n() % 64 == 0 && k() % 16 == 0; }
-  bool alignedRes() const { return m() % 64 == 0 && n() % 64 == 0; }
+  virtual int64_t blockTileM() const = 0;
+  virtual int64_t blockTileN() const = 0;
+
+  bool alignedLhs() const {
+    return m() % blockTileM() == 0 && k() % reductionTileSize == 0;
+  }
+  bool alignedRhs() const {
+    return n() % blockTileN() == 0 && k() % reductionTileSize == 0;
+  }
+  bool alignedRes() const {
+    return m() % blockTileM() == 0 && n() % blockTileN() == 0;
+  }
 
   /// Common values based on derived quantities.
   int64_t totalNumThreads() const {

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -46,6 +46,12 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectMatmulTensorCoreStrategy(
     llvm::cl::desc("activate the matmul tensorcore strategy"),
     llvm::cl::init(true));
 
+llvm::cl::opt<bool> clGPUEnableTransformDialectAlignedMatmul(
+    "iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul",
+    llvm::cl::desc(
+        "activate the matmul tensorcore strategy for tile aligned shapes"),
+    llvm::cl::init(false));
+
 // TODO: significantly better namespacing.
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
@@ -84,6 +90,7 @@ using iree_compiler::IREE::transform_dialect::
 using iree_compiler::IREE::transform_dialect::ShareForallOperandsOp;
 using transform::FuseIntoContainingOp;
 using transform::MatchOp;
+using transform::RewriteInDestinationPassingStyleOp;
 using transform::ScalarizeOp;
 using transform::SequenceOp;
 using transform_ext::MatchCallbackOp;
@@ -433,37 +440,58 @@ std::tuple<Value, Value, Value>
 mlir::iree_compiler::gpu::buildDistributeMatmulCopies(
     ImplicitLocOpBuilder &b, Value variantH, Value paddedMatmulOpH,
     const AbstractGemmLikeStrategy &strategy) {
-  // Explicitly materialize the parent parallel_insert into a copy to avoid late
-  // bufferization interferences.
-  // TODO: Avoid brittle rematching.
-  Value insertSliceH = b.create<transform::MatchOp>(
-      variantH, tensor::ParallelInsertSliceOp::getOperationName());
-  Value copyBackOpH = b.create<transform::InsertSliceToCopyOp>(
-      insertSliceH.getType(), insertSliceH);
+  // Aligned vs unaligned handling deviates here by converting the pads to
+  // copies for the aligned case.
+  // TODO: Unify aligned and unaligned codegen.
+  Value copyBackOpH;
+  if (!strategy.alignedRes()) {
+    // Explicitly materialize the parent parallel_insert into a copy to avoid
+    // late bufferization interferences.
+    // TODO: Avoid brittle rematching.
+    Value insertSliceH = b.create<transform::MatchOp>(
+        variantH, tensor::ParallelInsertSliceOp::getOperationName());
+    copyBackOpH = b.create<transform::InsertSliceToCopyOp>(
+        insertSliceH.getType(), insertSliceH);
+  } else {
+    Value resH = b.create<transform::GetProducerOfOperand>(
+        paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(2));
+    copyBackOpH =
+        b.create<RewriteInDestinationPassingStyleOp>(resH.getType(), resH);
+  }
 
   Value lhsH = b.create<transform::GetProducerOfOperand>(
       paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(0));
   Value rhsH = b.create<transform::GetProducerOfOperand>(
       paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(1));
 
+  // Rewrite aligned pads as destination passing (linalg.copy)
+  if (strategy.alignedLhs())
+    lhsH = b.create<RewriteInDestinationPassingStyleOp>(lhsH.getType(), lhsH);
+  if (strategy.alignedRhs())
+    rhsH = b.create<RewriteInDestinationPassingStyleOp>(rhsH.getType(), rhsH);
+
   AbstractGemmLikeStrategy::MappingInfo lhsCopyMapping =
       strategy.lhsCopyMapping();
   Value lhsCopyOpH = buildDistributeOnePadOrCopyWithNumThreads(
       b, variantH, lhsH, /*numThreads=*/lhsCopyMapping.numThreads,
-      /*threadDimMapping=*/lhsCopyMapping.threadMapping, /*foldIfBranch=*/true);
+      /*threadDimMapping=*/lhsCopyMapping.threadMapping,
+      /*foldIfBranch=*/!strategy.alignedLhs());
 
   AbstractGemmLikeStrategy::MappingInfo rhsCopyMapping =
       strategy.rhsCopyMapping();
   Value rhsCopyOpH = buildDistributeOnePadOrCopyWithNumThreads(
       b, variantH, rhsH, /*numThreads=*/rhsCopyMapping.numThreads,
-      /*threadDimMapping=*/rhsCopyMapping.threadMapping, /*foldIfBranch=*/true);
+      /*threadDimMapping=*/rhsCopyMapping.threadMapping,
+      /*foldIfBranch=*/!strategy.alignedRhs());
 
-  AbstractGemmLikeStrategy::MappingInfo resCopyMapping =
-      strategy.resCopyMapping();
-  copyBackOpH = buildDistributeOnePadOrCopyWithNumThreads(
-      b, variantH, copyBackOpH,
-      /*numThreads=*/resCopyMapping.numThreads,
-      /*threadDimMapping=*/rhsCopyMapping.threadMapping);
+  if (!strategy.alignedRes()) {
+    AbstractGemmLikeStrategy::MappingInfo resCopyMapping =
+        strategy.resCopyMapping();
+    copyBackOpH = buildDistributeOnePadOrCopyWithNumThreads(
+        b, variantH, copyBackOpH,
+        /*numThreads=*/resCopyMapping.numThreads,
+        /*threadDimMapping=*/rhsCopyMapping.threadMapping);
+  }
 
   return std::make_tuple(lhsCopyOpH, rhsCopyOpH, copyBackOpH);
 }
@@ -484,18 +512,24 @@ void mlir::iree_compiler::gpu::buildMatmulVectorization(
       b, configuration, variantH);
 
   // Apply vector masking.
-  AbstractGemmLikeStrategy::MappingInfo lhsCopyMapping =
-      strategy.lhsCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(lhsCopyOpH, ValueRange(), false,
-                                         lhsCopyMapping.tileSizes);
-  AbstractGemmLikeStrategy::MappingInfo rhsCopyMapping =
-      strategy.rhsCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(rhsCopyOpH, ValueRange(), false,
-                                         rhsCopyMapping.tileSizes);
-  AbstractGemmLikeStrategy::MappingInfo resCopyMapping =
-      strategy.resCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(copyBackOpH, ValueRange(), false,
-                                         resCopyMapping.tileSizes);
+  if (!strategy.alignedLhs()) {
+    AbstractGemmLikeStrategy::MappingInfo lhsCopyMapping =
+        strategy.lhsCopyMapping();
+    b.create<transform::MaskedVectorizeOp>(lhsCopyOpH, ValueRange(), false,
+                                           lhsCopyMapping.tileSizes);
+  }
+  if (!strategy.alignedRhs()) {
+    AbstractGemmLikeStrategy::MappingInfo rhsCopyMapping =
+        strategy.rhsCopyMapping();
+    b.create<transform::MaskedVectorizeOp>(rhsCopyOpH, ValueRange(), false,
+                                           rhsCopyMapping.tileSizes);
+  }
+  if (!strategy.alignedRes()) {
+    AbstractGemmLikeStrategy::MappingInfo resCopyMapping =
+        strategy.resCopyMapping();
+    b.create<transform::MaskedVectorizeOp>(copyBackOpH, ValueRange(), false,
+                                           resCopyMapping.tileSizes);
+  }
 
   // Lower all masked vector transfers at this point, as they make
   // canonicalization generate incorrect IR.
@@ -831,7 +865,7 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
   //   - f32 only atm.
   //   - Mandatory fill op.
   //   - No trailing op.
-  //   - If the matmul is "too aligned", then use the default IREE strategy.
+  //   - If the matmul is "too aligned", then guard on the alignment flag.
   //   - If the matmul is "too small", then use the default IREE strategy.
   //   - Otherwise, we take it.
   if (!fill->getCaptured() || trailing->getCaptured()) {
@@ -852,19 +886,15 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
     return failure();
   }
 
-  // Currently the unaligned transform strategy does not properly handle
-  // optionality when padding operations get folded away. So we only use it when
-  // all operands require a padding that does not fold. This is the case when
-  // either:
-  //   - m and k are not aligned to the tile sizes (conservatively, take 64, 16)
-  //   - n and k are not aligned to the tile sizes (conservatively, take 64, 16)
-  // Other cases currently result in folding and fall back to the default
-  // unaligned IREE strategy.
-  bool supportedUnalignedCases =
-      (matmulSize[0] % 64 != 0 && matmulSize[2] % 16 != 0) ||
-      (matmulSize[1] % 64 != 0 && matmulSize[2] % 16 != 0);
+  // Currently the fully aligned case still lags behind the current default
+  // pipeline and thus is guarded by a flag. This is the case when
+  //   - m is tile aligned (conservatively, take 64)
+  //   - n is tile aligned (conservatively, take 64)
+  //   - k is tile aligned (conservatively, take 16)
+  bool guardedAlignedCases = matmulSize[0] % 64 == 0 &&
+                             matmulSize[1] % 64 == 0 && matmulSize[2] % 16 == 0;
 
-  if (!supportedUnalignedCases) {
+  if (guardedAlignedCases && !clGPUEnableTransformDialectAlignedMatmul) {
     LDBG("--Matmul strategy alignment check failed\n");
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -887,12 +887,13 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
   }
 
   // Currently the fully aligned case still lags behind the current default
-  // pipeline and thus is guarded by a flag. This is the case when
+  // pipeline and thus is guarded by a flag. This is the case when at least one
+  // of the following holds
   //   - m is tile aligned (conservatively, take 64)
   //   - n is tile aligned (conservatively, take 64)
   //   - k is tile aligned (conservatively, take 16)
-  bool guardedAlignedCases = matmulSize[0] % 64 == 0 &&
-                             matmulSize[1] % 64 == 0 && matmulSize[2] % 16 == 0;
+  bool guardedAlignedCases = matmulSize[0] % 64 == 0 ||
+                             matmulSize[1] % 64 == 0 || matmulSize[2] % 16 == 0;
 
   if (guardedAlignedCases && !clGPUEnableTransformDialectAlignedMatmul) {
     LDBG("--Matmul strategy alignment check failed\n");

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -221,9 +221,11 @@ void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
       buildMatmulStrategyBlockDistribution(b, variantH, strategy);
   // Tile reduction loop.
   SmallVector<int64_t> tileSizes{0, 0, strategy.reductionTileSize};
+  // Avoid canonicalizing before the pad to avoid folding away the extract_slice
+  // on the output needed to hoist the output pad.
   auto tileReductionResult = buildTileFuseToScfFor(
       b, variantH, matmulH, {}, getAsOpFoldResult(b.getI64ArrayAttr(tileSizes)),
-      /*canonicalize=*/!strategy.alignedRes());
+      /*canonicalize=*/false);
 
   // Step 2. Pad the matmul op.
   // TODO: use captured type information to configure the padding values.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -235,16 +235,16 @@ void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
   // Step 3. Hoist the padding of the output operand above the reduction loop.
   // The resulting fillOp will be mapped with the contraction using an SIMD
   // programming model.
-  Value fillOpH;
+  Value fillOpH = fillH;
   if (!strategy.alignedRes()) {
     fillOpH = buildHoistOutputPaddingOp(b, variantH, paddedMatmulOpH);
-  } else {
-    fillOpH = b.create<transform::MatchOp>(variantH,
-                                           linalg::FillOp::getOperationName());
-    ApplyPatternsOpPatterns config;
-    iree_compiler::buildCanonicalizationAndEnablingTransforms(b, config,
-                                                              variantH);
   }
+
+  // Running canonicalization is required here to enable aligned pads to become
+  // linalg.copy ops when rewriting in DPS.
+  ApplyPatternsOpPatterns config;
+  iree_compiler::buildCanonicalizationAndEnablingTransforms(b, config,
+                                                            variantH);
 
   // Step 4. Distribute pad and copies: SIMT programming model.
   auto [lhsCopyOpH, rhsCopyOpH, copyBackOpH] =

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -161,6 +161,9 @@ def get_test_shapes(shapes_id: ShapesId):
         TestShape(m=1000, k=4, n=512, accumulate=False),
         TestShape(m=4, k=1000, n=512, accumulate=False),
         TestShape(m=512, k=1000, n=4, accumulate=False),
+        TestShape(m=512, k=128, n=500, accumulate=False),
+        TestShape(m=457, k=160, n=512, accumulate=False),
+        TestShape(m=512, k=330, n=512, accumulate=False),
     ]
 
   raise ValueError(shapes_id)


### PR DESCRIPTION
Current handling of tile aligned matmuls differs from unaligned in the way the tensor.pad ops are lowered. When the pad is aligned and would otherwise fold, we convert to a linalg.copy and don't need to do masked vectorization. In the future the plan is to unify aligned and unaligned cases.

Currently due to some observed performance regressions, any alignment is guarded behind `--iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul`.