### PR TITLE
Add python registration support for IREE dialects.

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -31,6 +31,7 @@ set(_PYTHON_INSTALL_PREFIX "python_packages/iree_compiler")
 # to be fixed to capture the correct include directories in that macro.
 include_directories(
   "${IREE_SOURCE_DIR}/compiler/src"
+  "${IREE_SOURCE_DIR}/compiler/bindings/c"
   "${IREE_SOURCE_DIR}/llvm-external-projects/iree-dialects/include"
   "${IREE_SOURCE_DIR}/third_party/llvm-project/mlir/include"
   "${IREE_SOURCE_DIR}/third_party/mlir-hlo/include"
@@ -61,12 +62,30 @@ declare_mlir_python_sources(IREECompilerAPIPythonTools
 )
 
 ################################################################################
+# Extensions
+################################################################################
+
+declare_mlir_python_sources(IREECompilerPythonExtensions)
+
+declare_mlir_python_extension(IREECompilerPythonExtensions.Registration
+  MODULE_NAME _site_initialize_0
+  ADD_TO_PARENT IREECompilerPythonExtensions
+  SOURCES
+    IREECompilerRegistration.cpp
+  EMBED_CAPI_LINK_LIBS
+    iree_compiler_API_SharedImpl
+  PRIVATE_LINK_LIBS
+    LLVMSupport
+)
+
+################################################################################
 # Generate packages and shared library
 ################################################################################
 
 set(_SOURCE_COMPONENTS
   # Local sources.
   IREECompilerAPIPythonTools
+  IREECompilerPythonExtensions
 
   MLIRPythonSources.Core
 

--- a/compiler/bindings/python/IREECompilerRegistration.cpp
+++ b/compiler/bindings/python/IREECompilerRegistration.cpp
@@ -1,0 +1,20 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/API/MLIRInterop.h"
+#include "mlir-c/IR.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+
+namespace py = pybind11;
+using namespace mlir::python::adaptors;
+
+PYBIND11_MODULE(_site_initialize_0, m) {
+  m.doc() = "iree-compile registration";
+
+  m.def("register_dialects", [](MlirDialectRegistry registry) {
+    ireeCompilerRegisterDialects(registry);
+  });
+}

--- a/compiler/bindings/python/test/ir/CMakeLists.txt
+++ b/compiler/bindings/python/test/ir/CMakeLists.txt
@@ -1,8 +1,13 @@
-# Copyright 2022 The IREE Authors
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_subdirectory(ir)
-add_subdirectory(tools)
+iree_py_test(
+  NAME
+    registration_test
+  SRCS
+    "registration_test.py"
+)
+

--- a/compiler/bindings/python/test/ir/registration_test.py
+++ b/compiler/bindings/python/test/ir/registration_test.py
@@ -1,0 +1,20 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from iree.compiler import ir
+
+# Just a simple test that dialects have been registered properly on the
+# context.
+with ir.Context() as ctx:
+  input_module = ir.Module.parse(r"""
+    builtin.module  {
+      func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+        %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
+        return %0 : tensor<4xf32>
+      }
+    }
+  """)
+  print(input_module)

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -408,6 +408,7 @@ setup(
         # it also needs to be enabled on the build side.
         # CMakeExtension("iree.compiler._mlir_libs._mlirHlo"),
         CMakeExtension("iree.compiler._mlir_libs._mlirLinalgPasses"),
+        CMakeExtension("iree.compiler._mlir_libs._site_initialize_0"),
     ],
     cmdclass={
         "build": CustomBuild,

--- a/compiler/src/iree/compiler/API/Internal/Embed.cpp
+++ b/compiler/src/iree/compiler/API/Internal/Embed.cpp
@@ -1155,6 +1155,12 @@ iree_compiler_error_t *ireeCompilerInvocationOutputHALExecutable(
 // Unstable MLIRInterop.h helpers
 //===----------------------------------------------------------------------===//
 
+void ireeCompilerRegisterDialects(MlirDialectRegistry registry) {
+  mlir::DialectRegistry *cppRegistry = unwrap(registry);
+  mlir::iree_compiler::registerAllDialects(*cppRegistry);
+  mlir::iree_compiler::registerLLVMIRTranslations(*cppRegistry);
+}
+
 MlirContext ireeCompilerSessionGetContext(iree_compiler_session_t *session) {
   return wrap(&unwrap(session)->context);
 }

--- a/compiler/src/iree/compiler/API/MLIRInterop.h
+++ b/compiler/src/iree/compiler/API/MLIRInterop.h
@@ -14,12 +14,17 @@
 #define IREE_COMPILER_API_MLIR_INTEROP_H
 
 #include "iree/compiler/embedding_api.h"
+#include "mlir-c/IR.h"
 #include "mlir-c/Pass.h"
 #include "mlir-c/Support.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Registers all dialects and extensions known to the IREE compiler.
+MLIR_CAPI_EXPORTED void ireeCompilerRegisterDialects(
+    MlirDialectRegistry registry);
 
 // Gets the MlirContext that the session manages. The context is owned by the
 // session and valid until it is destroyed.

--- a/compiler/src/iree/compiler/API/api_exports.c
+++ b/compiler/src/iree/compiler/API/api_exports.c
@@ -37,6 +37,7 @@ extern void ireeCompilerOutputOpenFD();
 extern void ireeCompilerOutputOpenFile();
 extern void ireeCompilerOutputOpenMembuffer();
 extern void ireeCompilerOutputWrite();
+extern void ireeCompilerRegisterDialects();
 extern void ireeCompilerRunLldMain();
 extern void ireeCompilerRunMain();
 extern void ireeCompilerSessionCreate();
@@ -627,6 +628,7 @@ uintptr_t __iree_compiler_hidden_force_extern() {
   x += (uintptr_t)&ireeCompilerOutputOpenFile;
   x += (uintptr_t)&ireeCompilerOutputOpenMembuffer;
   x += (uintptr_t)&ireeCompilerOutputWrite;
+  x += (uintptr_t)&ireeCompilerRegisterDialects;
   x += (uintptr_t)&ireeCompilerRunLldMain;
   x += (uintptr_t)&ireeCompilerRunMain;
   x += (uintptr_t)&ireeCompilerSessionCreate;

--- a/compiler/src/iree/compiler/API/api_exports.def
+++ b/compiler/src/iree/compiler/API/api_exports.def
@@ -29,6 +29,7 @@ EXPORTS
   ireeCompilerOutputOpenFile
   ireeCompilerOutputOpenMembuffer
   ireeCompilerOutputWrite
+  ireeCompilerRegisterDialects
   ireeCompilerRunLldMain
   ireeCompilerRunMain
   ireeCompilerSessionCreate

--- a/compiler/src/iree/compiler/API/api_exports.ld
+++ b/compiler/src/iree/compiler/API/api_exports.ld
@@ -30,6 +30,7 @@ VER_0 {
     ireeCompilerOutputOpenFile;
     ireeCompilerOutputOpenMembuffer;
     ireeCompilerOutputWrite;
+    ireeCompilerRegisterDialects;
     ireeCompilerRunLldMain;
     ireeCompilerRunMain;
     ireeCompilerSessionCreate;

--- a/compiler/src/iree/compiler/API/api_exports.macos.lst
+++ b/compiler/src/iree/compiler/API/api_exports.macos.lst
@@ -28,6 +28,7 @@ _ireeCompilerOutputOpenFD
 _ireeCompilerOutputOpenFile
 _ireeCompilerOutputOpenMembuffer
 _ireeCompilerOutputWrite
+_ireeCompilerRegisterDialects
 _ireeCompilerRunLldMain
 _ireeCompilerRunMain
 _ireeCompilerSessionCreate


### PR DESCRIPTION
Unlike the previous mechanism, this will automatically register all known dialects with any context created from python.

Fixes #13477 after #13395 removed an API that was load bearing to a customer use case.