### PR TITLE
Move Android benchmarks out of experimental presets

### DIFF
--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -56,12 +56,12 @@ BENCHMARK_PRESET_MATCHERS: Dict[str, PresetMatcher] = {
         lambda config: "cuda" in config.tags and "long-running" in config.tags,
     "vulkan-nvidia":
         lambda config: "vulkan-nvidia" in config.tags,
-    "experimental-android-cpu":
+    "android-cpu":
         lambda config:
         (config.target_device_spec.architecture.type == common_definitions.
          ArchitectureType.CPU and config.target_device_spec.host_environment.
          platform == "android"),
-    "experimental-android-gpu":
+    "android-gpu":
         lambda config:
         (config.target_device_spec.architecture.type == common_definitions.
          ArchitectureType.GPU and config.target_device_spec.host_environment.

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -77,11 +77,12 @@ SKIP_PATH_PATTERNS = [
 RUNNER_ENV_DEFAULT = "prod"
 RUNNER_ENV_OPTIONS = [RUNNER_ENV_DEFAULT, "testing"]
 
-DEFAULT_BENCHMARK_PRESETS = ["cuda", "x86_64", "vulkan-nvidia", "comp-stats"]
-BENCHMARK_PRESET_OPTIONS = DEFAULT_BENCHMARK_PRESETS + [
-    "experimental-android-cpu",
-    "experimental-android-gpu",
+DEFAULT_BENCHMARK_PRESETS = [
+    "cuda", "x86_64", "android-cpu", "android-gpu", "vulkan-nvidia",
+    "comp-stats"
 ]
+# All available benchmark preset options including experimental presets.
+BENCHMARK_PRESET_OPTIONS = DEFAULT_BENCHMARK_PRESETS
 
 PR_DESCRIPTION_TEMPLATE = "{title}" "\n\n" "{body}"
 
@@ -278,9 +279,7 @@ def get_benchmark_presets(trailers: Mapping[str, str], labels: Sequence[str],
           f"description has '{SKIP_LLVM_INTEGRATE_BENCHMARK_KEY}' trailer.")
 
   if not is_pr:
-    # TODO(#9855): Only enable android benchmarks in postsubmit before the
-    # migration is finished.
-    preset_options = {"all", "experimental-android-cpu"}
+    preset_options = {"all"}
     print(f"Using benchmark presets '{preset_options}' for non-PR run")
   elif is_llvm_integrate_pr and not skip_llvm_integrate_benchmark:
     # Run all benchmark presets for LLVM integration PRs.


### PR DESCRIPTION
Android benchmarks on Github CI are ready to use. Drop "experimental_" prefix and move them out of experimental presets.

The results are still not uploaded to the dashboard until we migrate the database.