### PR TITLE
Upload Android benchmark results in Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -804,17 +804,13 @@ jobs:
         env:
           EXECUTION_BENCHMARK_RESULTS_PATTERN: ${{ steps.download-execution-results.outputs.execution-benchmark-results-pattern }}
           IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}
-        # TODO(#9855): Specify CPU and GPU benchmark results to exclude mobile
-        # results until we migrate the dashboard. The tool ignores the file path
-        # if it doesn't exist.
         run: |
           build_tools/github_actions/docker_run.sh \
             --env "IREE_DASHBOARD_API_TOKEN=${IREE_DASHBOARD_API_TOKEN}" \
             gcr.io/iree-oss/benchmark-report@sha256:7498c6f32f63f13faf085463cc38656d4297519c824e63e1c99c8c258147f6ff \
             ./build_tools/benchmarks/upload_benchmarks_to_dashboard.py \
               --verbose \
-              --benchmark_files="${EXECUTION_BENCHMARK_RESULTS_DIR}/benchmark-results-c2-standard-16.json" \
-              --benchmark_files="${EXECUTION_BENCHMARK_RESULTS_DIR}/benchmark-results-a2-highgpu-1g.json" \
+              --benchmark_files="${EXECUTION_BENCHMARK_RESULTS_PATTERN}" \
               --compile_stats_files="${COMPILE_STATS_RESULTS}"
 
   ############################## Crosscompilation ##############################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,11 +800,10 @@ jobs:
             "${BENCHMARK_COMMENT_ARTIFACT}" \
             "${BENCHMARK_COMMENT_GCS_ARTIFACT}"
       - name: Uploading results to dashboard
-        # if: github.ref_name == 'main'
+        if: github.ref_name == 'main'
         env:
           EXECUTION_BENCHMARK_RESULTS_PATTERN: ${{ steps.download-execution-results.outputs.execution-benchmark-results-pattern }}
-          # IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}
-          IREE_DASHBOARD_API_TOKEN: "dummy-token"
+          IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}
         run: |
           build_tools/github_actions/docker_run.sh \
             --env "IREE_DASHBOARD_API_TOKEN=${IREE_DASHBOARD_API_TOKEN}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,10 +800,11 @@ jobs:
             "${BENCHMARK_COMMENT_ARTIFACT}" \
             "${BENCHMARK_COMMENT_GCS_ARTIFACT}"
       - name: Uploading results to dashboard
-        if: github.ref_name == 'main'
+        # if: github.ref_name == 'main'
         env:
           EXECUTION_BENCHMARK_RESULTS_PATTERN: ${{ steps.download-execution-results.outputs.execution-benchmark-results-pattern }}
-          IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}
+          # IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}
+          IREE_DASHBOARD_API_TOKEN: "dummy-token"
         run: |
           build_tools/github_actions/docker_run.sh \
             --env "IREE_DASHBOARD_API_TOKEN=${IREE_DASHBOARD_API_TOKEN}" \


### PR DESCRIPTION
Upload Android benchmark results in Github CI to the https://perf.iree.dev

This will be merged once the database migration is done.

skip-ci: Not run in presubmit