### PR TITLE
[LLVMCPU] Add pass to enable Armv9 Streaming SVE mode

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -86,6 +86,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithTransforms",
         "@llvm-project//mlir:ArmNeon2dToIntr",
         "@llvm-project//mlir:ArmNeonDialect",
+        "@llvm-project//mlir:ArmSMETransforms",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:ComplexToLLVM",
         "@llvm-project//mlir:ComplexToStandard",
@@ -126,6 +127,5 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:VectorToLLVM",
         "@llvm-project//mlir:VectorToSCF",
         "@llvm-project//mlir:VectorTransforms",
-        "@llvm-project//mlir:ArmSMETransforms",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -126,5 +126,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:VectorToLLVM",
         "@llvm-project//mlir:VectorToSCF",
         "@llvm-project//mlir:VectorTransforms",
+        "@llvm-project//mlir:ArmSMETransforms",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -102,6 +102,7 @@ iree_cc_library(
     MLIRVectorToLLVM
     MLIRVectorToSCF
     MLIRVectorTransforms
+    MLIRArmSMETransforms
     iree::builtins::ukernel::exported_bits
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::CommonPasses

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -63,6 +63,7 @@ iree_cc_library(
     MLIRArithTransforms
     MLIRArmNeon2dToIntr
     MLIRArmNeonDialect
+    MLIRArmSMETransforms
     MLIRBufferizationDialect
     MLIRComplexToLLVM
     MLIRComplexToStandard
@@ -102,7 +103,6 @@ iree_cc_library(
     MLIRVectorToLLVM
     MLIRVectorToSCF
     MLIRVectorTransforms
-    MLIRArmSMETransforms
     iree::builtins::ukernel::exported_bits
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::CommonPasses

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -191,6 +191,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
           isX86(target) || isRISCV(target) ||
           (isAArch64(target) && hasAnySVEFeature(target));
       bool enableMicrokernels = hasMicrokernels(target);
+      bool enableAArch64SSVE = isAArch64(target) && hasAnySVEFeature(target) &&
+                               hasSMEFeature(target);
       if (!testLoweringConfiguration) {
         switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
@@ -200,7 +202,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUBufferOpsTileAndVectorize:
             addCPUBufferOpsTileAndVectorizePipeline(executableLoweringPipeline,
-                                                    enableVectorMasking);
+                                                    enableVectorMasking,
+                                                    enableAArch64SSVE);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUDoubleTilingExpert:
@@ -219,12 +222,14 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             addMultiTilingExpertPassPipeline(
                 executableLoweringPipeline,
                 static_cast<int>(TilingLevel::NumTileLevels),
-                /*enablePeeling=*/true, enableVectorMasking, lowerToAVX2);
+                /*enablePeeling=*/true, enableVectorMasking, lowerToAVX2,
+                enableAArch64SSVE);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUConvTileAndDecomposeExpert:
             addConvTileAndDecomposeExpertPassPipeline(
-                executableLoweringPipeline, enableVectorMasking);
+                executableLoweringPipeline, enableVectorMasking,
+                enableAArch64SSVE);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::Mmt4dTilingExpert:
             addMmt4dTilingExpertPassPipeline(executableLoweringPipeline,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPasses.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPasses.h
@@ -120,7 +120,8 @@ void populateVectorContractCustomKernelsPatterns(
 /// pipeline is only used for dispatches that just copy data from input
 /// interfaces to output interface.
 void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager,
-                                             bool enableVectorMasking);
+                                             bool enableVectorMasking,
+                                             bool enableAArch64SSVE = false);
 
 /// Populates the passes to lower ops through data tiling transformations.
 void addCPUDataTilingPipeline(OpPassManager &passManager);
@@ -131,7 +132,8 @@ void addCPUDataTilingPipeline(OpPassManager &passManager);
 void addCPUDefaultPassPipeline(OpPassManager &passManager);
 
 void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager,
-                                               bool enableVectorMasking);
+                                               bool enableVectorMasking,
+                                               bool enableAArch64SSVE = false);
 
 void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager,
                                           bool enableVectorMasking);
@@ -144,7 +146,8 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager,
 void addMultiTilingExpertPassPipeline(OpPassManager &passManager,
                                       int64_t numLevels, bool enablePeeling,
                                       bool enableVectorMasking,
-                                      bool lowerToAVX2);
+                                      bool lowerToAVX2,
+                                      bool enableAArch64SSVE = false);
 
 void addTensorToVectorsPassPipeline(OpPassManager &passManager,
                                     bool lowerToVectors = true);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
@@ -98,5 +98,9 @@ bool hasAnySVEFeature(IREE::HAL::ExecutableTargetAttr targetAttr) {
   return hasFeature(targetAttr, "+sve") || hasFeature(targetAttr, "+sve2");
 }
 
+bool hasSMEFeature(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  return hasFeature(targetAttr, "+sme");
+}
+
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
@@ -48,6 +48,9 @@ bool hasZve64xFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 /// features.
 bool hasAnySVEFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 
+/// Returns true if the 'targetAttr' contains '+sme' in its cpu features.
+bool hasSMEFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -602,3 +602,103 @@ hal.executable private @ukernel_pass_through {
 //  CHECK-SAME:         ins(%[[SUBVIEW_INPUT0]], %[[SUBVIEW_INPUT1]]
 //  CHECK-SAME:         outs(%[[SUBVIEW_OUTPUT]]
 
+// -----
+
+// Check Armv9 Streaming SVE mode is enabled for the following pipelines:
+//
+//   * CPUBufferOpsTileAndVectorize
+//   * CPUDoubleTilingPeelingExpert
+//   * CPUConvTileAndDecomposeExpert
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 2, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {
+  cpu_features = "+sve,+sme",
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 16 : index,
+  target_triple = "aarch64-unknown-unknown-eabi-elf"
+}>
+
+hal.executable private @aarch64_ssve__cpu_buffer_ops_tile_and_vectorize {
+  hal.executable.variant public @embedded_elf_arm_64, target = #executable_target_embedded_elf_arm_64_ {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
+      translation_info = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize>
+    } {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+      hal.return %arg1, %arg2, %arg2 : index, index, index
+    }
+    builtin.module {
+      func.func @dispatch() { return }
+    }
+  }
+}
+
+// CHECK-LABEL: @aarch64_ssve__cpu_buffer_ops_tile_and_vectorize
+// CHECK: func.func @dispatch() attributes {arm_locally_streaming}
+
+hal.executable private @aarch64_ssve__cpu_double_tiling_peeling_expert {
+  hal.executable.variant public @embedded_elf_arm_64, target = #executable_target_embedded_elf_arm_64_ {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
+      translation_info = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
+    } {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+      hal.return %arg1, %arg2, %arg2 : index, index, index
+    }
+    builtin.module {
+      func.func @dispatch() { return }
+    }
+  }
+}
+
+// CHECK-LABEL: @aarch64_ssve__cpu_double_tiling_peeling_expert
+// CHECK: func.func @dispatch() attributes {arm_locally_streaming}
+
+hal.executable private @aarch64_ssve__cpu_conv_tile_and_decompose_expert {
+  hal.executable.variant public @embedded_elf_arm_64, target = #executable_target_embedded_elf_arm_64_ {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
+      translation_info = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
+    } {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+      hal.return %arg1, %arg2, %arg2 : index, index, index
+    }
+    builtin.module {
+      func.func @dispatch() { return }
+    }
+  }
+}
+
+// CHECK-LABEL: @aarch64_ssve__cpu_conv_tile_and_decompose_expert
+// CHECK: func.func @dispatch() attributes {arm_locally_streaming}
+
+// Check Armv9 Streaming SVE mode is not enabled if +sve and +sme are not
+// specified.
+
+#executable_target_embedded_elf_arm_64_no_sve = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {
+  cpu_features = "+sme",
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 16 : index,
+  target_triple = "aarch64-unknown-unknown-eabi-elf"
+}>
+
+hal.executable private @aarch64_ssve_sve_disabled {
+  hal.executable.variant public @embedded_elf_arm_64, target = #executable_target_embedded_elf_arm_64_no_sve {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
+      translation_info = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize>
+    } {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+      hal.return %arg1, %arg2, %arg2 : index, index, index
+    }
+    builtin.module {
+      func.func @dispatch() { return }
+    }
+  }
+}
+
+// CHECK-LABEL: @aarch64_ssve_sve_disabled
+// CHECK-NOT: func.func @dispatch() attributes {arm_locally_streaming}


### PR DESCRIPTION
This patch adds a pass 'iree-llvmcpu-enable-aarch64-ssve' that enables the Armv9 Scalable Matrix Extension (SME) Streaming SVE (SSVE) mode [1].

SSVE is enabled in the LLVM backend at the function boundary by specifying one of the following attributes [2]:

  aarch64_pstate_sm_enabled - calls to functions with this attribute are
                              wrapped with 'smstart sm' / 'smstop sm' [3].
                              Changes the function ABI.

  aarch64_pstate_sm_body    - 'smstart sm' / 'smstop sm' are emitted in the
                              function prologue / epilogue for functions
                              marked with this attribute. This is internal
                              and doesn't change the function ABI.

This pass adds the 'aarch64_pstate_sm_body' attribute to functions via the passthrough mechanism [4].

This attribute is used because PSTATE.SM changes are kept internal to the function and the purpose of this pass is to enable SSVE for dispatch functions which are called by the IREE runtime. The AAPCS64 [5] states it is the caller's responsibility to ensure that PSTATE.SM has a valid value on entry to a callee, the 'aarch64_pstate_sm_enabled' attribute would change the function ABI forcing the caller (IREE runtime) to be responsible for managing PSTATE.SM before entry/exit. At present, the runtime doesn't know the details of dispatches such that it could emit these instructions.

The pass is enabled for AArch64 when SVE(2) and SME are enabled for the following lowering configurations:

  * CPUBufferOpsTileAndVectorize
  * CPUDoubleTilingPeelingExpert
  * CPUConvTileAndDecomposeExpert

These configurations were chosen simply because they're used in one of our pipelines.

[1] https://developer.arm.com/documentation/ddi0616/aa
[2] https://llvm.org/docs/AArch64SME.html
[3] https://developer.arm.com/documentation/ddi0602/2023-03/Base-Instructions/SMSTART--Enables-access-to-Streaming-SVE-mode-and-SME-architectural-state--an-alias-of-MSR--immediate--
[4] https://mlir.llvm.org/docs/Dialects/LLVM/#attribute-pass-through
[5] https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#671pstatesm-interfaces