### PR TITLE
Adding a VM implementation detail around expected import signatures.

### DIFF
--- a/runtime/bindings/python/py_module.cc
+++ b/runtime/bindings/python/py_module.cc
@@ -105,10 +105,10 @@ class PyModuleInterface {
     return iree_make_status(IREE_STATUS_NOT_FOUND);
   }
 
-  static iree_status_t ModuleLookupFunction(void* vself,
-                                            iree_vm_function_linkage_t linkage,
-                                            iree_string_view_t name,
-                                            iree_vm_function_t* out_function) {
+  static iree_status_t ModuleLookupFunction(
+      void* vself, iree_vm_function_linkage_t linkage, iree_string_view_t name,
+      const iree_vm_function_signature_t* expected_signature,
+      iree_vm_function_t* out_function) {
     auto self = AsSelf(vself);
     std::string_view name_cpp(name.data, name.size);
     if (linkage == IREE_VM_FUNCTION_LINKAGE_EXPORT) {

--- a/runtime/src/iree/vm/bytecode/module.c
+++ b/runtime/src/iree/vm/bytecode/module.c
@@ -248,6 +248,7 @@ iree_vm_bytecode_module_lookup_internal_function_name(
 
 static iree_status_t iree_vm_bytecode_module_lookup_function(
     void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
+    const iree_vm_function_signature_t* expected_signature,
     iree_vm_function_t* out_function) {
   IREE_ASSERT_ARGUMENT(out_function);
   memset(out_function, 0, sizeof(iree_vm_function_t));

--- a/runtime/src/iree/vm/context.c
+++ b/runtime/src/iree/vm/context.c
@@ -40,6 +40,11 @@ struct iree_vm_context_t {
   } list;
 };
 
+static iree_status_t iree_vm_context_resolve_function_impl(
+    const iree_vm_context_t* context, iree_string_view_t full_name,
+    const iree_vm_function_signature_t* expected_signature,
+    iree_vm_function_t* out_function);
+
 static void iree_vm_context_destroy(iree_vm_context_t* context);
 
 // Allocates a process-unique ID for a context to use.
@@ -182,8 +187,8 @@ static iree_status_t iree_vm_context_resolve_module_imports(
     // Resolve the function to the module that contains it and return the
     // information.
     iree_vm_function_t import_function;
-    iree_status_t resolve_status =
-        iree_vm_context_resolve_function(context, full_name, &import_function);
+    iree_status_t resolve_status = iree_vm_context_resolve_function_impl(
+        context, full_name, &expected_signature, &import_function);
     if (!iree_status_is_ok(resolve_status)) {
       if (iree_status_is_not_found(resolve_status) &&
           decl_function.linkage == IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL) {
@@ -560,8 +565,9 @@ IREE_API_EXPORT iree_status_t iree_vm_context_resolve_module_state(
                                             out_module_state);
 }
 
-IREE_API_EXPORT iree_status_t iree_vm_context_resolve_function(
+static iree_status_t iree_vm_context_resolve_function_impl(
     const iree_vm_context_t* context, iree_string_view_t full_name,
+    const iree_vm_function_signature_t* expected_signature,
     iree_vm_function_t* out_function) {
   IREE_ASSERT_ARGUMENT(context);
   IREE_ASSERT_ARGUMENT(out_function);
@@ -580,8 +586,9 @@ IREE_API_EXPORT iree_status_t iree_vm_context_resolve_function(
   for (int i = (int)context->list.count - 1; i >= 0; --i) {
     iree_vm_module_t* module = context->list.modules[i];
     if (iree_string_view_equal(module_name, iree_vm_module_name(module))) {
-      return iree_vm_module_lookup_function_by_name(
-          module, IREE_VM_FUNCTION_LINKAGE_EXPORT, function_name, out_function);
+      return module->lookup_function(
+          module->self, IREE_VM_FUNCTION_LINKAGE_EXPORT, function_name,
+          expected_signature, out_function);
     }
   }
 
@@ -590,6 +597,13 @@ IREE_API_EXPORT iree_status_t iree_vm_context_resolve_function(
                           "registered with the context",
                           (int)module_name.size, module_name.data,
                           (int)full_name.size, full_name.data);
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_context_resolve_function(
+    const iree_vm_context_t* context, iree_string_view_t full_name,
+    iree_vm_function_t* out_function) {
+  return iree_vm_context_resolve_function_impl(
+      context, full_name, /*expected_signature=*/NULL, out_function);
 }
 
 // Calls the '__notify(i32)' function in |module|, if present.

--- a/runtime/src/iree/vm/dynamic/module.c
+++ b/runtime/src/iree/vm/dynamic/module.c
@@ -126,10 +126,12 @@ static iree_status_t IREE_API_PTR iree_vm_dynamic_module_get_function_attr(
 
 static iree_status_t IREE_API_PTR iree_vm_dynamic_module_lookup_function(
     void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
+    const iree_vm_function_signature_t* expected_signature,
     iree_vm_function_t* out_function) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
   IREE_RETURN_IF_ERROR(module->user_module->lookup_function(
-      module->user_module->self, linkage, name, out_function));
+      module->user_module->self, linkage, name, expected_signature,
+      out_function));
   out_function->module = (iree_vm_module_t*)self;
   return iree_ok_status();
 }

--- a/runtime/src/iree/vm/module.c
+++ b/runtime/src/iree/vm/module.c
@@ -284,7 +284,8 @@ IREE_API_EXPORT iree_status_t iree_vm_module_lookup_function_by_name(
     const iree_vm_module_t* module, iree_vm_function_linkage_t linkage,
     iree_string_view_t name, iree_vm_function_t* out_function) {
   IREE_ASSERT_ARGUMENT(module);
-  return module->lookup_function(module->self, linkage, name, out_function);
+  return module->lookup_function(module->self, linkage, name,
+                                 /*expected_signature=*/NULL, out_function);
 }
 
 IREE_API_EXPORT iree_status_t iree_vm_module_lookup_function_by_ordinal(

--- a/runtime/src/iree/vm/module.h
+++ b/runtime/src/iree/vm/module.h
@@ -377,8 +377,12 @@ typedef struct iree_vm_module_t {
 
   // Looks up a function with the given name and linkage in the module.
   // This may perform a linear scan and results should be cached.
+  // An optional |expected_signature| can be specified in cases where the
+  // module may be able to provide additional validation or versioning based on
+  // it. Implementations should not assume all lookups will include a signature.
   iree_status_t(IREE_API_PTR* lookup_function)(
       void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
+      const iree_vm_function_signature_t* expected_signature,
       iree_vm_function_t* out_function);
 
   // Gets one or more pieces of function information:

--- a/runtime/src/iree/vm/native_module.c
+++ b/runtime/src/iree/vm/native_module.c
@@ -226,12 +226,13 @@ static iree_status_t IREE_API_PTR iree_vm_native_module_get_function_attr(
 
 static iree_status_t IREE_API_PTR iree_vm_native_module_lookup_function(
     void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
+    const iree_vm_function_signature_t* expected_signature,
     iree_vm_function_t* out_function) {
   iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
   memset(out_function, 0, sizeof(*out_function));
   if (module->user_interface.lookup_function) {
-    return module->user_interface.lookup_function(module->self, linkage, name,
-                                                  out_function);
+    return module->user_interface.lookup_function(
+        module->self, linkage, name, expected_signature, out_function);
   }
 
   if (IREE_UNLIKELY(linkage != IREE_VM_FUNCTION_LINKAGE_EXPORT)) {

--- a/runtime/src/iree/vm/native_module_cc.h
+++ b/runtime/src/iree/vm/native_module_cc.h
@@ -190,10 +190,10 @@ class NativeModule {
     return iree_ok_status();
   }
 
-  static iree_status_t ModuleLookupFunction(void* self,
-                                            iree_vm_function_linkage_t linkage,
-                                            iree_string_view_t name,
-                                            iree_vm_function_t* out_function) {
+  static iree_status_t ModuleLookupFunction(
+      void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
+      const iree_vm_function_signature_t* expected_signature,
+      iree_vm_function_t* out_function) {
     IREE_ASSERT_ARGUMENT(out_function);
     std::memset(out_function, 0, sizeof(*out_function));
     if (IREE_UNLIKELY(!name.data || !name.size)) {
@@ -210,6 +210,7 @@ class NativeModule {
         return iree_ok_status();
       }
     }
+
     return iree_make_status(IREE_STATUS_NOT_FOUND, "function %.*s not exported",
                             (int)name.size, name.data);
   }


### PR DESCRIPTION
This allows modules to snoop what importers are expecting the exporters to provide. This information is optional and not included in all cases as not all importers have the information available.