### PR TITLE
[StableHLO] Add stablehlo_xla input conversion pipeline

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.h
@@ -22,6 +22,10 @@ std::unique_ptr<TypeConverter> createStableHloToLinalgTypeConverter();
 
 void buildStableHLOInputConversionPassPipeline(OpPassManager &passManager);
 
+// Performs input legalization on programs that may have originated from an XLA
+// import (or made to interop with it).
+void buildStableHLOXLAInputConversionPassPipeline(OpPassManager &passManager);
+
 //===----------------------------------------------------------------------===//
 // Register all Passes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
@@ -63,6 +63,7 @@ iree_compiler_cc_library(
         "Canonicalization.cpp",
         "DotGeneralToDot.cpp",
         "EinsumToDotGeneral.cpp",
+        "FlattenTuplesInCFG.cpp",
         "GatherToTorchIndexSelect.cpp",
         "LowerComplex.cpp",
         "Passes.cpp",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
@@ -79,6 +79,7 @@ iree_compiler_cc_library(
         ":PassHeaders",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MathDialect",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
@@ -56,6 +56,7 @@ iree_cc_library(
     "Canonicalization.cpp"
     "DotGeneralToDot.cpp"
     "EinsumToDotGeneral.cpp"
+    "FlattenTuplesInCFG.cpp"
     "GatherToTorchIndexSelect.cpp"
     "LowerComplex.cpp"
     "Passes.cpp"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
@@ -68,6 +68,7 @@ iree_cc_library(
     ChloOps
     LLVMSupport
     MLIRArithDialect
+    MLIRControlFlowDialect
     MLIRFuncDialect
     MLIRIR
     MLIRMathDialect

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/FlattenTuplesInCFG.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/FlattenTuplesInCFG.cpp
@@ -1,0 +1,343 @@
+// Copyright 2019 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements IREE-specific preprocessing for XLA inputs.
+
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h"
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_FLATTENTUPLESINCFG
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h.inc"
+
+namespace {
+// Given a set of types, unpack to a list of a types, removing all tuples.
+void untupleTypes(TypeRange types, llvm::SmallVectorImpl<Type> &newTypes) {
+  for (Type type : types) {
+    if (auto tupleTy = dyn_cast<TupleType>(type)) {
+      untupleTypes(tupleTy.getTypes(), newTypes);
+    } else {
+      newTypes.push_back(type);
+    }
+  }
+}
+
+Value processTuple(Type type, Location loc, Block &block, OpBuilder &builder) {
+  auto tupleType = dyn_cast<TupleType>(type);
+  if (!tupleType) {
+    return block.addArgument(type, loc);
+  }
+
+  llvm::SmallVector<Value, 4> values;
+  values.reserve(tupleType.size());
+  for (Type subtype : tupleType.getTypes()) {
+    values.push_back(processTuple(subtype, loc, block, builder));
+  }
+
+  return builder.create<mlir::stablehlo::TupleOp>(loc, tupleType, values);
+}
+
+void copyOperationAttrs(Operation *oldOp, Operation *newOp) {
+  for (NamedAttribute oldAttr : oldOp->getAttrs()) {
+    // Don't copy segment attributes as these correspond to the number operands,
+    // which may be different.
+    if (oldAttr.getName() == "operand_segment_sizes" ||
+        oldAttr.getName() == "result_segment_sizes")
+      continue;
+
+    newOp->setAttr(oldAttr.getName(), oldAttr.getValue());
+  }
+}
+
+void recursiveUntuple(Value value, Location loc, OpBuilder &builder,
+                      IRMapping &mapping,
+                      llvm::SmallVectorImpl<Value> &newValues) {
+  auto tupleType = dyn_cast<TupleType>(value.getType());
+  if (!tupleType) {
+    // We can return the value as is.
+    newValues.push_back(value);
+    return;
+  }
+
+  for (auto [idx, subType] : llvm::enumerate(tupleType.getTypes())) {
+    auto elementOp = builder.create<mlir::stablehlo::GetTupleElementOp>(
+        loc, subType, value, builder.getI32IntegerAttr(idx));
+    recursiveUntuple(elementOp.getResult(), loc, builder, mapping, newValues);
+  }
+}
+
+Value recursiveRetuple(Type oldType, Operation::result_range *values,
+                       OpBuilder &builder, Location loc) {
+  auto tupleType = dyn_cast<TupleType>(oldType);
+  if (!tupleType) {
+    Value returnValue = *values->begin();
+    *values = {values->begin() + 1, values->end()};
+    return returnValue;
+  }
+
+  llvm::SmallVector<Value> subValues;
+  for (Type subType : tupleType.getTypes()) {
+    subValues.push_back(recursiveRetuple(subType, values, builder, loc));
+  }
+
+  return builder.create<mlir::stablehlo::TupleOp>(loc, tupleType, subValues)
+      .getResult();
+}
+
+template <typename T>
+LogicalResult untupleAndLookupValues(T values,
+                                     llvm::SmallVectorImpl<Value> &newValues,
+                                     OpBuilder &builder, Location loc,
+                                     IRMapping &mapping) {
+  for (auto operand : values) {
+    auto newValue = mapping.lookupOrNull(operand);
+    if (!newValue) {
+      return failure();
+    }
+
+    recursiveUntuple(newValue, loc, builder, mapping, newValues);
+  }
+
+  return success();
+}
+
+LogicalResult convertOp(mlir::func::ReturnOp op, OpBuilder &builder,
+                        IRMapping &mapping) {
+  llvm::SmallVector<Value> newOperands;
+  if (failed(untupleAndLookupValues(op.getOperands(), newOperands, builder,
+                                    op.getLoc(), mapping))) {
+    return failure();
+  }
+
+  builder.create<mlir::func::ReturnOp>(op->getLoc(), newOperands);
+  return success();
+}
+
+LogicalResult convertOp(func::CallOp oldOp, OpBuilder &builder,
+                        IRMapping &mapping) {
+  llvm::SmallVector<Value, 4> newArgs;
+  if (failed(untupleAndLookupValues(oldOp.getOperands(), newArgs, builder,
+                                    oldOp.getLoc(), mapping))) {
+    return failure();
+  }
+
+  SmallVector<Type, 4> resultTypes;
+  untupleTypes(oldOp.getResultTypes(), resultTypes);
+  auto newOp = builder.create<func::CallOp>(oldOp->getLoc(), oldOp.getCallee(),
+                                            resultTypes, newArgs);
+  copyOperationAttrs(oldOp, newOp);
+
+  auto newResults = newOp.getResults();
+  for (auto oldResult : oldOp.getResults()) {
+    llvm::SmallVector<Value, 10> subValues;
+    auto newResult = recursiveRetuple(oldResult.getType(), &newResults, builder,
+                                      oldOp->getLoc());
+    mapping.map(oldResult, newResult);
+  }
+
+  return success();
+}
+
+LogicalResult convertOp(func::CallIndirectOp oldOp, OpBuilder &builder,
+                        IRMapping &mapping) {
+  llvm::SmallVector<Value, 4> newArgs;
+  if (failed(untupleAndLookupValues(oldOp.getOperands(), newArgs, builder,
+                                    oldOp.getLoc(), mapping))) {
+    return failure();
+  }
+
+  auto newOp = builder.create<func::CallIndirectOp>(oldOp.getLoc(),
+                                                    oldOp.getCallee(), newArgs);
+  copyOperationAttrs(oldOp, newOp);
+
+  for (auto [oldResult, newResult] :
+       llvm::zip_equal(oldOp.getResults(), newOp.getResults())) {
+    mapping.map(oldResult, newResult);
+  }
+
+  return success();
+}
+
+LogicalResult convertOp(cf::BranchOp oldOp, OpBuilder &builder,
+                        IRMapping &mapping) {
+  llvm::SmallVector<Value, 4> newArgs;
+  if (failed(untupleAndLookupValues(oldOp.getOperands(), newArgs, builder,
+                                    oldOp.getLoc(), mapping))) {
+    return failure();
+  }
+
+  auto newOp = builder.create<cf::BranchOp>(
+      oldOp.getLoc(), mapping.lookupOrNull(oldOp.getDest()), newArgs);
+
+  copyOperationAttrs(oldOp, newOp);
+  return success();
+}
+
+LogicalResult convertOp(cf::CondBranchOp oldOp, OpBuilder &builder,
+                        IRMapping &mapping) {
+  llvm::SmallVector<Value, 4> trueArgs;
+  if (failed(untupleAndLookupValues(oldOp.getTrueOperands(), trueArgs, builder,
+                                    oldOp.getLoc(), mapping))) {
+    return failure();
+  }
+
+  llvm::SmallVector<Value, 4> falseArgs;
+  if (failed(untupleAndLookupValues(oldOp.getFalseOperands(), falseArgs,
+                                    builder, oldOp.getLoc(), mapping))) {
+    return failure();
+  }
+
+  auto newOp = builder.create<cf::CondBranchOp>(
+      oldOp.getLoc(), mapping.lookupOrNull(oldOp.getCondition()),
+      mapping.lookupOrNull(oldOp.getTrueDest()), trueArgs,
+      mapping.lookupOrNull(oldOp.getFalseDest()), falseArgs);
+
+  copyOperationAttrs(oldOp, newOp);
+  return success();
+}
+
+LogicalResult convertOperation(Operation *operation, OpBuilder &builder,
+                               IRMapping &mapping) {
+  return llvm::TypeSwitch<Operation *, LogicalResult>(operation)
+      .Case<func::ReturnOp, func::CallOp, func::CallIndirectOp, cf::BranchOp,
+            cf::CondBranchOp>(
+          [&](auto op) { return convertOp(op, builder, mapping); })
+      .Default([&](Operation *op) {
+        builder.clone(*operation, mapping);
+        return success();
+      });
+}
+
+LogicalResult convertFunction(func::FuncOp oldFunction,
+                              func::FuncOp newFunction) {
+  OpBuilder builder(newFunction.getBody());
+  IRMapping mapping;
+
+  // Check whether has tuple in signature.
+  bool hasTupleSig = (oldFunction.getArgumentTypes().size() !=
+                      newFunction.getArgumentTypes().size()) ||
+                     (oldFunction.getResultTypes().size() !=
+                      newFunction.getResultTypes().size());
+
+  auto xlaAbiParam = StringAttr::get(newFunction.getContext(),
+                                     "xla_entry_computation_parameter_layouts");
+  auto xlaAbiLayout = StringAttr::get(newFunction.getContext(),
+                                      "xla_entry_computation_result_layout");
+
+  for (NamedAttribute attr : oldFunction->getAttrs()) {
+    // Currently skipping all arg, result and XLA specific ABI attributes.
+    if (llvm::is_contained(
+            {oldFunction.getFunctionTypeAttrName(), xlaAbiParam, xlaAbiLayout},
+            attr.getName())) {
+      continue;
+    }
+
+    // If it has tuples in sig, then skip arg and res attrs. None of the
+    // existing ones along path that produces tuples are used further, so just
+    // remove instead of flattening.
+    if (hasTupleSig && (attr.getName() == oldFunction.getArgAttrsAttrName() ||
+                        attr.getName() == oldFunction.getResAttrsAttrName()))
+      continue;
+    newFunction->setAttr(attr.getName(), attr.getValue());
+  }
+
+  newFunction.getBlocks().clear();
+  for (Block &oldBlock : oldFunction.getBlocks()) {
+    Block *newBlock = builder.createBlock(&newFunction.getBody());
+    for (BlockArgument oldArg : oldBlock.getArguments()) {
+      llvm::SmallVector<Type> newTypes;
+      untupleTypes(oldArg.getType(), newTypes);
+
+      Value newTuple = processTuple(oldArg.getType(), oldFunction.getLoc(),
+                                    *newBlock, builder);
+      if (!newTuple) {
+        return failure();
+      }
+
+      mapping.map(oldArg, newTuple);
+    }
+    mapping.map(&oldBlock, newBlock);
+  }
+
+  // Convert all ops in the blocks.
+  for (Block &oldBlock : oldFunction.getBlocks()) {
+    builder.setInsertionPointToEnd(mapping.lookupOrNull(&oldBlock));
+    for (Operation &oldOp : oldBlock.getOperations()) {
+      if (failed(convertOperation(&oldOp, builder, mapping))) {
+        return failure();
+      }
+    }
+  }
+
+  return success();
+}
+
+struct FlattenTuplesInCFG final
+    : impl::FlattenTuplesInCFGBase<FlattenTuplesInCFG> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *ctx = module.getContext();
+    Builder builder(ctx);
+
+    // Build a list of (oldFunction, newFunction) for all functions we need to
+    // replace. This will ensure that when we go to convert function bodies we
+    // have only new functions defined.
+    SmallVector<std::pair<func::FuncOp, func::FuncOp>> convertedFunctions;
+    for (auto oldFunction : module.getOps<func::FuncOp>()) {
+      FunctionType oldFunctionType = oldFunction.getFunctionType();
+
+      llvm::SmallVector<Type> newInputTypes;
+      untupleTypes(oldFunctionType.getInputs(), newInputTypes);
+
+      llvm::SmallVector<Type> newResultTypes;
+      untupleTypes(oldFunctionType.getResults(), newResultTypes);
+
+      FunctionType newFunctionType =
+          builder.getFunctionType(newInputTypes, newResultTypes);
+      func::FuncOp newFunction =
+          func::FuncOp::create(oldFunction.getLoc(), oldFunction.getName(),
+                               newFunctionType, oldFunction->getDialectAttrs());
+      convertedFunctions.push_back({oldFunction, newFunction});
+
+      // Perform the actual body conversion now that we have proper signatures.
+      if (failed(convertFunction(oldFunction, newFunction))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Replace functions in the module.
+    for (auto [oldFunction, newFunction] : convertedFunctions) {
+      oldFunction.erase();
+      module.push_back(newFunction);
+    }
+
+    // Run canonicalization patterns to cancel out remaining tuple ops. We need
+    // to run these manually here because StableHLO does not define
+    // folds/canonicalization patterns for its ops.
+    RewritePatternSet patterns(ctx);
+    populateCanonicalizationPatterns(ctx, &patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+}  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
@@ -33,6 +33,11 @@ def EinsumToDotGeneral :
   let summary = "Legalizes einsum ops to general dot ops";
 }
 
+def FlattenTuplesInCFG :
+    Pass<"iree-stablehlo-preprocessing-flatten-tuples", "ModuleOp"> {
+  let summary = "Flattens tuples in the CFG form of StableHLO";
+}
+
 def GatherToTorchIndexSelect :
     Pass<"iree-stablehlo-preprocessing-gather-to-torch-index-select", "func::FuncOp"> {
   let summary = "Legalizes gathers to a torch index select";

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "complex_lowering.mlir",
             "dot_general_to_dot.mlir",
             "einsum_to_dot_general.mlir",
+            "flatten_tuples_in_cfg.mlir",
             "gather_to_torch_index_select.mlir",
             "stablehlo_to_stablehlo.mlir",
             "unfuse_batch_norm.mlir",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "complex_lowering.mlir"
     "dot_general_to_dot.mlir"
     "einsum_to_dot_general.mlir"
+    "flatten_tuples_in_cfg.mlir"
     "gather_to_torch_index_select.mlir"
     "stablehlo_to_stablehlo.mlir"
     "unfuse_batch_norm.mlir"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
@@ -91,6 +91,24 @@ func.func @get_dimension_size(%arg0: tensor<1x2x3xf32>, %arg1: tensor<?x2xf32>)
 
 // -----
 
+// CHECK-LABEL: func.func @get_tuple_element
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<f32>, [[ARG1:%.+]]: tensor<i32>, [[ARG2:%.+]]: tuple<tensor<f32>, tensor<f16>>)
+func.func @get_tuple_element(%arg0: tensor<f32>, %arg1: tensor<i32>, %arg2: tuple<tensor<f32>, tensor<f16>>)
+          -> (tensor<f32>, tensor<i32>, tensor<f16>) {
+  %t = stablehlo.tuple %arg0, %arg1 : tuple<tensor<f32>, tensor<i32>>
+
+  %a = stablehlo.get_tuple_element %t[0] : (tuple<tensor<f32>, tensor<i32>>) -> tensor<f32>
+  %b = stablehlo.get_tuple_element %t[1] : (tuple<tensor<f32>, tensor<i32>>) -> tensor<i32>
+
+  %c = stablehlo.get_tuple_element %arg2[1] : (tuple<tensor<f32>, tensor<f16>>) -> tensor<f16>
+
+  // CHECK:      [[GTE:%.+]] = stablehlo.get_tuple_element [[ARG2]][1] : (tuple<tensor<f32>, tensor<f16>>) -> tensor<f16>
+  // CHECK-NEXT: return [[ARG0]], [[ARG1]], [[GTE]]
+  return %a, %b, %c : tensor<f32>, tensor<i32>, tensor<f16>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @reshape
 // CHECK-SAME:   ([[ARG0:%.+]]: tensor<1xf32>)
 func.func @reshape(%arg0: tensor<1xf32>)

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/flatten_tuples_in_cfg.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/flatten_tuples_in_cfg.mlir
@@ -1,0 +1,30 @@
+// RUN: iree-opt --iree-stablehlo-preprocessing-flatten-tuples %s | FileCheck %s
+
+// CHECK-LABEL: @flatten_func
+module @flatten_func {
+  // CHECK: func.func @caller(%arg0: i1, %arg1: tensor<f32>) -> tensor<f32>
+  func.func @caller(%arg0 : i1, %arg1: tensor<f32>) -> tensor<f32> {
+    // CHECK: %[[RESULT:.*]]:2 = call @callee(%arg0, %arg1, %arg1, %arg1) : (i1, tensor<f32>, tensor<f32>, tensor<f32>) -> (tensor<f32>, tensor<f32>)
+    %0 = stablehlo.tuple %arg1, %arg1 : tuple<tensor<f32>, tensor<f32>>
+    %1 = stablehlo.tuple %arg1, %0 : tuple<tensor<f32>, tuple<tensor<f32>, tensor<f32>>>
+    %2 = call @callee(%arg0, %1) : (i1, tuple<tensor<f32>, tuple<tensor<f32>, tensor<f32>>>) -> tuple<tensor<f32>, tensor<f32>>
+    %3 = stablehlo.get_tuple_element %2[0] : (tuple<tensor<f32>, tensor<f32>>) -> tensor<f32>
+    // CHECK: return %[[RESULT]]#0 : tensor<f32>
+    return %3 : tensor<f32>
+  }
+
+  // CHECK: func.func private @callee(%arg0: i1, %arg1: tensor<f32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> (tensor<f32>, tensor<f32>)
+  func.func private @callee(%arg0: i1, %arg1: tuple<tensor<f32>, tuple<tensor<f32>, tensor<f32>>>) -> tuple<tensor<f32>, tensor<f32>> {
+    // CHECK-NEXT: cf.cond_br %arg0, ^[[BB:.+]](%arg2, %arg3 : tensor<f32>, tensor<f32>), ^bb2(%arg1 : tensor<f32>)
+    // CHECK:      ^[[BB]](%[[V0:[^:]+]]: tensor<f32>, %[[V1:[^:]+]]: tensor<f32>)
+    // CHECK-NEXT:   return %[[V0]], %[[V1]] : tensor<f32>, tensor<f32>
+    %0 = stablehlo.get_tuple_element %arg1[0] : (tuple<tensor<f32>, tuple<tensor<f32>, tensor<f32>>>) -> tensor<f32>
+    %1 = stablehlo.get_tuple_element %arg1[1] : (tuple<tensor<f32>, tuple<tensor<f32>, tensor<f32>>>) -> tuple<tensor<f32>, tensor<f32>>
+    cf.cond_br %arg0, ^bb1(%1 : tuple<tensor<f32>, tensor<f32>>), ^bb2(%0 : tensor<f32>)
+  ^bb1(%phi0 : tuple<tensor<f32>, tensor<f32>>):
+    return %phi0 : tuple<tensor<f32>, tensor<f32>>
+  ^bb2(%phi1 : tensor<f32>):
+    %2 = stablehlo.tuple %phi1, %phi1 : tuple<tensor<f32>, tensor<f32>>
+    cf.br ^bb1(%2 : tuple<tensor<f32>, tensor<f32>>)
+  }
+}

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -52,6 +52,10 @@ void InputDialectOptions::bindOptions(OptionsBinder &binder) {
         , clEnumValN(InputDialectOptions::Type::stablehlo,
             "stablehlo",
             "Legalize from StableHLO ops. WARNING: This is work in progress.")
+        , clEnumValN(InputDialectOptions::Type::stablehlo_xla,
+            "stablehlo_xla",
+            "Legalize from StableHLO ops (with XLA cleanup preprocessing). "
+            "WARNING: This is work in progress.")
 #endif  // IREE_HAVE_MHLO_INPUT
 #ifdef IREE_HAVE_TORCH_INPUT
         , clEnumValN(InputDialectOptions::Type::tm_tensor, "tm_tensor",

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -44,6 +44,9 @@ struct InputDialectOptions {
     xla,
     // Legalizes input defined over StableHLO ops.
     stablehlo,
+    // Special case of 'stablehlo' legalization which also performs some XLA
+    // preprocessing, e.g., flattening of tuples.
+    stablehlo_xla,
 #endif  // IREE_HAVE_MHLO_INPUT
 #ifdef IREE_HAVE_TORCH_INPUT
     // Legalizes input defined over TMTensor ops.

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -62,6 +62,9 @@ void buildIREEVMTransformPassPipeline(
     case InputDialectOptions::Type::stablehlo:
       stablehlo::buildStableHLOInputConversionPassPipeline(passManager);
       break;
+    case InputDialectOptions::Type::stablehlo_xla:
+      stablehlo::buildStableHLOXLAInputConversionPassPipeline(passManager);
+      break;
 #endif  // IREE_HAVE_MHLO_INPUT
 #ifdef IREE_HAVE_TORCH_INPUT
     case InputDialectOptions::Type::tm_tensor:


### PR DESCRIPTION
The only difference between `--iree-input-type=stablehlo` and the new pipeline, `stablehlo_xla` is extra preprocessing to flatten tuples in the CFG.

The tuple flattening pass is ported from the MHLO equivalent in IREE. The main changes are:
*  Use of `LogicalResult` instead of `bool` for helper functions. I found `true`/`false` return values too confusing.
*  This pass does not rely on the full canonicalization pass and instead schedules the IREE canonicalization patterns inside the tuple flattening pass. This is because, unlike MHLO, StableHLO does not come with folds/canon patterns.
*  Added a new canon pattern for `stablehlo.get_tuple_element`.

Issue: https://github.com/openxla/iree/issues/12678