### PR TITLE
Bumping NCCL to 2.18.1 in order to get ncclCommSplit.

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
@@ -76,6 +76,7 @@ NCCL_PFN_DECL(ncclCommInitRankConfig, ncclComm_t*, int, ncclUniqueId, int,
               ncclConfig_t*)
 NCCL_PFN_DECL(ncclCommInitRank, ncclComm_t*, int, ncclUniqueId, int)
 NCCL_PFN_DECL(ncclCommInitAll, ncclComm_t*, int, const int*)
+NCCL_PFN_DECL(ncclCommSplit, ncclComm_t, int, int, ncclComm_t*, ncclConfig_t*)
 NCCL_PFN_DECL(ncclCommFinalize, ncclComm_t)
 NCCL_PFN_DECL(ncclCommDestroy, ncclComm_t)
 NCCL_PFN_DECL(ncclCommAbort, ncclComm_t)
@@ -106,5 +107,3 @@ NCCL_PFN_DECL(ncclRecv, void*, size_t, ncclDataType_t, int, ncclComm_t,
               cudaStream_t)
 NCCL_PFN_DECL(ncclGroupStart)
 NCCL_PFN_DECL(ncclGroupEnd)
-
-

--- a/third_party/nccl/README.md
+++ b/third_party/nccl/README.md
@@ -1,6 +1,6 @@
 # The declaration-only header for NCCL
 
-The header is copied from a build of NCCL (2.15.5 as of writing).
+The header is copied from a build of NCCL (2.18.1 as of writing).
 
 This declaration-only header is required to query the dynamically injected
 NCCL API at runtime. See the following for more information:


### PR DESCRIPTION
This primitive is identical to MPI_Comm_split and will let us split groups in the same way across NCCL and MPI implementations.

Taken from https://github.com/NVIDIA/nccl/commit/d97a32fac84f69cbd022ffdc57d5687c760742c7.