### PR TITLE
Correcting link for iree/compiler/

### DIFF
--- a/docs/developers/developing_iree/developer_overview.md
+++ b/docs/developers/developing_iree/developer_overview.md
@@ -32,7 +32,7 @@ developers.
 
 ## IREE Compiler Code Layout
 
-[iree/compiler/](https://github.com/openxla/iree/blob/main/iree/compiler/)
+[iree/compiler/](https://github.com/openxla/iree/blob/main/compiler/)
 
 *   IREE's MLIR dialects, LLVM compiler passes, module translation code, etc.
 


### PR DESCRIPTION
Small correction on link for iree/compiler/ which would have resulted in 404 error.

It's overall a very tiny correction.