### PR TITLE
Introduce transform dialect Op for ukernel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -9,6 +9,7 @@
 #include "iree-dialects/Dialect/LinalgTransform/SimplePatternRewriter.h"
 #include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -48,7 +49,7 @@ iree_compiler::IREE::transform_dialect::LLVMGPUExtensions::LLVMGPUExtensions() {
   // CreateAsyncGroupsOp depends on the following two dialects.
   declareGeneratedDialect<gpu::GPUDialect>();
   declareGeneratedDialect<nvgpu::NVGPUDialect>();
-
+  declareGeneratedDialect<IREE::Codegen::IREECodegenDialect>();
   registerTransformOps<
 #define GET_OP_LIST
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.cpp.inc"
@@ -816,6 +817,51 @@ DiagnosedSilenceableFailure transform_dialect::ReorderTransposeOp::applyToOne(
   IRRewriter rewriter(getContext());
   iree_compiler::reorderTranspose(rewriter, cast<func::FuncOp>(target));
   results.push_back(target);
+  return DiagnosedSilenceableFailure::success();
+}
+
+//===---------------------------------------------------------------------===//
+// GPUMicrokernelOp
+//===---------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure transform_dialect::GPUMicrokernelOp::applyToOne(
+    ::mlir::Operation *target, transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  if (!isa<linalg::MatmulOp>(target)) {
+    return mlir::emitDefiniteFailure(
+        state.getTopLevel(), "expects a linalg:MatmulOp as the target op");
+  }
+  if (getTileK() <= 0) {
+    return mlir::emitDefiniteFailure(state.getTopLevel(),
+                                     "Tile K must be positive integer");
+  }
+  if (getStages() <= 0) {
+    return mlir::emitDefiniteFailure(
+        state.getTopLevel(), "Pipeline stages must be positive integer");
+  }
+
+  auto matmulOp = cast<linalg::MatmulOp>(target);
+
+  // Step 1. Fill the tile
+  Value out = matmulOp.getDpsInitOperand(0)->get();
+  TensorType outTensorType = out.getType().cast<TensorType>();
+  if (outTensorType.getNumDynamicDims() > 0) {
+    return mlir::emitDefiniteFailure(state.getTopLevel(),
+                                     "Dynamic sizes are not supported");
+  }
+  SmallVector<int64_t> tiles = {outTensorType.getDimSize(0),
+                                outTensorType.getDimSize(1),
+                                static_cast<int64_t>(getTileK())};
+
+  // Step 2. Lower matmul into microkernel op
+  IRRewriter rewriter(getContext());
+  rewriter.setInsertionPoint(matmulOp);
+  FailureOr<Operation *> ukernelOp =
+      mlir::iree_compiler::lowerMatmulToMicrokernel(rewriter, matmulOp, tiles,
+                                                    getStages(), getName());
+  if (failed(ukernelOp)) return emitDefaultSilenceableFailure(matmulOp);
+  results.push_back(ukernelOp.value());
+
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -558,4 +558,41 @@ def ReorderTransposeOp :
 
 }
 
+def GPUMicrokernelOp : Op<
+    Transform_Dialect, "iree.microkernel_gpu_matmul", [
+      FunctionalStyleTransformOpTrait,
+      MemoryEffectsOpInterface,
+      TransformEachOpTrait,
+      TransformOpInterface]> {
+
+  let description = [{
+    Transforms the tiled `linalg.matmul` Op to the `ukernel.generic` Op.
+  }];
+
+  let arguments = (
+      ins TransformHandleTypeInterface:$target,
+          I64Attr:$tile_k,
+          I64Attr:$stages,
+          OptionalAttr<StrAttr>:$name
+  );
+  let results = (outs TransformHandleTypeInterface:$result);
+
+  let assemblyFormat = "$target `,` (`name` `=` $name^ `,`)? `stages` `=` $stages `,` `tile_k` `=` $tile_k attr-dict `:` functional-type($target, results)";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+      OpBuilder<(ins "Value":$target,
+                   "int64_t":$tile_k,
+                   "int64_t":$stages,
+                   "StringAttr":$name)>
+  ];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMEXTENSIONS_LLVMGPUEXTENSIONS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_microkernel.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_microkernel.mlir
@@ -1,0 +1,79 @@
+// RUN: iree-opt %s --split-input-file -iree-transform-dialect-interpreter -transform-dialect-drop-schedule | FileCheck %s
+
+!tlhs = tensor<2048x2048xf32>
+!rlhs = tensor<2048x2048xf32>
+!tres = tensor<2048x2048xf32>
+
+func.func @fill_matmul(%lhs : !tlhs,   %rhs : !rlhs,   %accum : !tres) -> !tres {
+  %cst = arith.constant 40.0 : f32
+  %out = linalg.fill ins(%cst : f32) outs(%accum : !tres) -> !tres  
+  %matmul = linalg.matmul 
+                ins(%lhs, %rhs : !tlhs, !rlhs) 
+                outs(%out : !tres) -> !tres
+  return %matmul: !tres
+}
+
+transform.sequence failures(propagate) {
+  ^bb0(%variant_op: !pdl.operation):
+    // Fuse fill + matmul
+    // ==========================================
+    %fuseOp = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+
+    %matmulOp = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    %forall, %tiled_matmul = transform.structured.tile_to_forall_op %matmulOp tile_sizes [128, 128] 
+      ( mapping = [#gpu.block<x>, #gpu.block<y>] )
+
+    transform.structured.fuse_into_containing_op %fuseOp into %forall
+
+    // Transform tiled matmul to microkernel
+    // ==========================================
+    %tiledMatmulOp = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+
+    transform.iree.microkernel_gpu_matmul %tiledMatmulOp, stages = 3, tile_k = 32 : (!pdl.operation) -> !pdl.operation
+}
+
+// CHECK-LABEL: @fill_matmul
+//       CHECK:   bufferization.alloc_tensor() : tensor<128x128xf32>
+//       CHECK:   bufferization.alloc_tensor() : tensor<8192xf32>
+//       CHECK:   iree_codegen.ukernel.generic "__iree_matmul_tf32_tf32_f32_128_128_32_3_true_true" 
+
+
+// -----
+
+!tlhs = tensor<2048x2048xf32>
+!rlhs = tensor<2048x2048xf32>
+!tres = tensor<2048x2048xf32>
+
+func.func @fill_matmul(%lhs : !tlhs,   %rhs : !rlhs,   %accum : !tres) -> !tres {
+  %cst = arith.constant 40.0 : f32
+  %out = linalg.fill ins(%cst : f32) outs(%accum : !tres) -> !tres  
+  %matmul = linalg.matmul 
+                ins(%lhs, %rhs : !tlhs, !rlhs) 
+                outs(%out : !tres) -> !tres
+  return %matmul: !tres
+}
+
+transform.sequence failures(propagate) {
+  ^bb0(%variant_op: !pdl.operation):
+    // Fuse fill + matmul
+    // ==========================================
+    %fuseOp = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+
+    %matmulOp = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    %forall, %tiled_matmul = transform.structured.tile_to_forall_op %matmulOp tile_sizes [128, 128] 
+      ( mapping = [#gpu.block<x>, #gpu.block<y>] )
+
+    transform.structured.fuse_into_containing_op %fuseOp into %forall
+
+    // Transform tiled matmul to microkernel
+    // ==========================================
+    %tiledMatmulOp = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+
+    transform.iree.microkernel_gpu_matmul %tiledMatmulOp, name = "very_fast_code", stages = 3, tile_k = 32 : (!pdl.operation) -> !pdl.operation
+}
+
+// CHECK-LABEL: @fill_matmul
+//       CHECK:   bufferization.alloc_tensor() : tensor<128x128xf32>
+//       CHECK:   bufferization.alloc_tensor() : tensor<8192xf32>
+//       CHECK:   iree_codegen.ukernel.generic "very_fast_code" 
+


### PR DESCRIPTION
This PR adds a new `iree.microkernel_gpu_matmul` transform dialect op to IREE. The purpose of this op is to take the `linalg.matmul` op whose outermost two loops are already tiled and lower into ukernel op. In order to use the op, one will need to pass a tile size for the last loop, as well as specify software pipeline stages.

The main functionality of the op is to call an existing pattern to generate a `ukernel.generic ` op.

Overall, this PR provides microkernel support to the transform dialect, and I believe it will be a useful tool for developers working on GPU-based projects.