### PR TITLE
Fix many broken links across code and docs.

### DIFF
--- a/docs/developers/best_practices.md
+++ b/docs/developers/best_practices.md
@@ -66,7 +66,7 @@ TODO: sample code, profile numbers
 ### Tuning runtime settings
 
 When running on the CPU, the task system flags specified in
-[iree/task/api.c](https://github.com/openxla/iree/blob/main/iree/task/api.c)
+[iree/task/api.c](https://github.com/openxla/iree/blob/main/runtime/src/iree/task/api.c)
 give control over how worker threads will be created. For example, the
 `--task_topology_group_count=3` flag can be set to explicitly run on three
 workers rather than rely on heuristic selection that defaults to one worker

--- a/docs/developers/developing_iree/benchmarking.md
+++ b/docs/developers/developing_iree/benchmarking.md
@@ -156,7 +156,7 @@ model execution. So its performance is of crucial importance. We strive to
 introduce as little overhead as possible and have several benchmark binaries
 dedicated for evaluating the VM's performance. These benchmark binaries are
 named as `*_benchmark` in the
-[`iree/vm/`](https://github.com/openxla/iree/tree/main/iree/vm) directory. They
+[`iree/vm/`](https://github.com/openxla/iree/tree/main/runtime/src/iree/vm) directory. They
 also use the Google Benchmark library as the above.
 
 ## CPU Configuration

--- a/docs/developers/developing_iree/developer_overview.md
+++ b/docs/developers/developing_iree/developer_overview.md
@@ -8,74 +8,68 @@ developers.
 
 ## Project Code Layout
 
-[iree/](https://github.com/openxla/iree/blob/main/iree/)
-
-*   Core IREE project
-
-[integrations/](https://github.com/openxla/iree/blob/main/integrations/)
-
-*   Integrations between IREE and other frameworks, such as TensorFlow
-
-[runtime/](https://github.com/openxla/iree/tree/main/runtime/)
-
-*   IREE runtime code, with no dependencies on the compiler
-
-[bindings/](https://github.com/openxla/iree/blob/main/bindings/)
-
-*   Language and platform bindings, such as Python
-*   Also see [runtime/bindings/](https://github.com/openxla/iree/tree/main/runtime/bindings)
-
-[samples/](https://github.com/openxla/iree/blob/main/samples/)
-
-*   Samples built using IREE's runtime and compiler
-*   Also see the separate https://github.com/iree-org/iree-samples repository
+* [/compiler/](https://github.com/openxla/iree/blob/main/compiler/):
+  MLIR dialects, LLVM compiler passes, module translation code, etc.
+  * [bindings/](https://github.com/openxla/iree/blob/main/compiler/bindings/):
+    Python and other language bindings
+* [/runtime/](https://github.com/openxla/iree/tree/main/runtime/):
+  Standalone runtime code including the VM and HAL drivers
+  * [bindings/](https://github.com/openxla/iree/tree/main/runtime/bindings/):
+    Python and other language bindings
+* [/integrations/](https://github.com/openxla/iree/blob/main/integrations/):
+  Integrations between IREE and other frameworks, such as TensorFlow
+* [/tests/](https://github.com/openxla/iree/blob/main/tests/):
+  Tests for full compiler->runtime workflows
+* [/tools/](https://github.com/openxla/iree/blob/main/tools/):
+  Developer tools (`iree-compile`, `iree-run-module`, etc.)
+* [/samples/](https://github.com/openxla/iree/blob/main/samples/): Also see the
+  separate https://github.com/iree-org/iree-samples repository
 
 ## IREE Compiler Code Layout
 
-[iree/compiler/](https://github.com/openxla/iree/blob/main/iree/compiler/)
-
-*   IREE's MLIR dialects, LLVM compiler passes, module translation code, etc.
+* [API/](https://github.com/openxla/iree/tree/main/compiler/src/iree/compiler/API):
+  Public C API
+* [Codegen/](https://github.com/openxla/iree/tree/main/compiler/src/iree/compiler/Codegen):
+  Code generation for compute kernels
+* [Dialect/](https://github.com/openxla/iree/tree/main/compiler/src/iree/compiler/Dialect):
+  MLIR dialects (`Flow`, `HAL`, `Stream`, `VM`, etc.)
+* [InputConversion/](https://github.com/openxla/iree/tree/main/compiler/src/iree/compiler/InputConversion):
+  Conversions from input dialects and preprocessing
 
 ## IREE Runtime Code Layout
 
-[iree/base/](https://github.com/openxla/iree/blob/main/runtime/src/iree/base/)
-
-*   Common types and utilities used throughout the runtime
-
-[iree/hal/](https://github.com/openxla/iree/blob/main/runtime/src/iree/hal/)
-
-*   **H**ardware **A**bstraction **L**ayer for IREE's runtime, with
-    implementations for hardware and software backends
-
-[iree/schemas/](https://github.com/openxla/iree/blob/main/runtime/src/iree/schemas/)
-
-*   Shared data storage format definitions, primarily using
-    [FlatBuffers](https://google.github.io/flatbuffers/)
-
-[tools/](https://github.com/openxla/iree/blob/main/tools/)
-
-*   Assorted tools used to optimize, translate, and evaluate IREE
-
-[iree/vm/](https://github.com/openxla/iree/blob/main/runtime/src/iree/vm/)
-
-*   Bytecode **V**irtual **M**achine used to work with IREE modules and invoke
-    IREE functions
+* [base/](https://github.com/openxla/iree/blob/main/runtime/src/iree/base/):
+  Common types and utilities used throughout the runtime
+* [hal/](https://github.com/openxla/iree/blob/main/runtime/src/iree/hal/):
+  **H**ardware **A**bstraction **L**ayer for IREE's runtime, with
+  implementations for hardware and software backends
+* [schemas/](https://github.com/openxla/iree/blob/main/runtime/src/iree/schemas/):
+  Data storage format definitions, primarily using
+  [FlatBuffers](https://google.github.io/flatbuffers/)
+* [task/](https://github.com/openxla/iree/blob/main/runtime/src/iree/task/):
+  System for running tasks across multiple CPU threads
+* [tooling/](https://github.com/openxla/iree/blob/main/runtime/src/iree/tooling/):
+  Utilities for tests and developer tools, not suitable for use as-is in
+  downstream applications
+* [vm/](https://github.com/openxla/iree/blob/main/runtime/src/iree/vm/):
+  Bytecode **V**irtual **M**achine used to work with IREE modules and invoke
+  IREE functions
 
 ## Developer Tools
 
-IREE's compiler components accept programs and code fragments in several
-formats, including high level TensorFlow Python code, serialized TensorFlow
-[SavedModel](https://www.tensorflow.org/guide/saved_model) programs, and lower
-level textual MLIR files using combinations of supported dialects like `mhlo`
-and IREE's internal dialects. While input programs are ultimately compiled down
-to modules suitable for running on some combination of IREE's target deployment
-platforms, IREE's developer tools can run individual compiler passes,
-translations, and other transformations step by step.
+IREE's core compiler accepts programs in supported input MLIR dialects (e.g.
+`stablehlo`, `tosa`, `linalg`). Import tools and APIs may be used to convert
+from framework-specific formats like TensorFlow
+[SavedModel](https://www.tensorflow.org/guide/saved_model) to MLIR modules.
+While programs are ultimately compiled down to modules suitable for running on
+some combination of IREE's target deployment platforms, IREE's developer tools
+can run individual compiler passes, translations, and other transformations step
+by step.
 
 ### iree-opt
 
 `iree-opt` is a tool for testing IREE's compiler passes. It is similar to
-[mlir-opt](https://github.com/llvm/llvm-project/tree/master/mlir/tools/mlir-opt)
+[mlir-opt](https://github.com/llvm/llvm-project/tree/main/mlir/tools/mlir-opt)
 and runs sets of IREE's compiler passes on `.mlir` input files. See "conversion"
 in [MLIR's Glossary](https://mlir.llvm.org/getting_started/Glossary/#conversion)
 for more information. Transformations performed by `iree-opt` can range from
@@ -87,14 +81,14 @@ top of the file that specifies which passes should be performed and if
 `FileCheck` should be used to test the generated output.
 
 Here's an example of a small compiler pass running on a
-[test file](https://github.com/openxla/iree/blob/main/iree/compiler/Dialect/Util/Transforms/test/drop_compiler_hints.mlir):
+[test file](https://github.com/openxla/iree/blob/main/compiler/src/iree/compiler/Dialect/Util/Transforms/test/drop_compiler_hints.mlir):
 
 ```shell
 $ ../iree-build/tools/iree-opt \
   --split-input-file \
   --mlir-print-ir-before-all \
   --iree-drop-compiler-hints \
-  $PWD/iree/compiler/Dialect/Util/Transforms/test/drop_compiler_hints.mlir
+  $PWD/compiler/src/iree/compiler/Dialect/Util/Transforms/test/drop_compiler_hints.mlir
 ```
 
 For a more complex example, here's how to run IREE's complete transformation
@@ -108,10 +102,6 @@ $ ../iree-build/tools/iree-opt \
   --iree-hal-target-backends=vmvx \
   $PWD/tests/e2e/models/fullyconnected.mlir
 ```
-
-Custom passes may also be layered on top of `iree-opt`, see
-[samples/custom_modules/dialect](https://github.com/openxla/iree/blob/main/samples/custom_modules/dialect)
-for a sample.
 
 ### iree-compile
 
@@ -150,8 +140,7 @@ $ ../iree-build/tools/iree-run-module \
 The `iree-check-module` program takes an already translated IREE module as input
 and executes it as a series of
 [googletest](https://github.com/google/googletest) tests. This is the test
-runner for the IREE
-[check framework](https://github.com/openxla/iree/tree/main/docs/developing_iree/testing_guide.md#end-to-end-tests).
+runner for the IREE [check framework](./testing_guide.md#end-to-end-tests).
 
 ```shell
 $ ../iree-build/tools/iree-compile \
@@ -223,8 +212,3 @@ multiple dispatch function. When the flag is on, IREE will insert trace points
 before and after each dispatch function. The first trace op is for inputs, and
 the second trace op is for outputs. There will be two events for one dispatch
 function.
-
-### Useful Vulkan driver flags
-
-For IREE's Vulkan runtime driver, there are a few useful flags defined in
-[driver_module.cc](https://github.com/openxla/iree/blob/main/iree/hal/drivers/vulkan/registration/driver_module.cc):

--- a/docs/developers/developing_iree/profiling_with_tracy.md
+++ b/docs/developers/developing_iree/profiling_with_tracy.md
@@ -391,6 +391,6 @@ source view pointing to the `.mlir` file.
 ## Configuring Tracy instrumentation
 
 Set IREE's `IREE_TRACING_MODE` value (defined in
-[iree/base/tracing.h](https://github.com/openxla/iree/blob/main/iree/base/tracing.h))
+[iree/base/tracing.h](https://github.com/openxla/iree/blob/main/runtime/src/iree/base/tracing.h))
 to adjust which tracing features, such as allocation tracking and callstacks,
 are enabled.

--- a/docs/developers/developing_iree/testing_guide.md
+++ b/docs/developers/developing_iree/testing_guide.md
@@ -31,7 +31,7 @@ for compiler passes and pipelines in other `.../test/*.mlir` files.
 ### Running a Test
 
 For the test
-https://github.com/openxla/iree/blob/main/iree/compiler/Dialect/VM/Conversion/MathToVM/test/arithmetic_ops.mlir
+https://github.com/openxla/iree/blob/main/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/test/arithmetic_ops.mlir
 
 With CMake, run this from the build directory:
 
@@ -100,18 +100,19 @@ should generally follow the style and best practices of that framework.
 
 ### Running a Test
 
-For the test iree/base/arena_test.cc
+For the test
+[`/runtime/src/iree/base/bitfield_test.cc`](https://github.com/openxla/iree/blob/main/runtime/src/iree/base/bitfield_test.cc):
 
 With CMake, run this from the build directory:
 
 ```shell
-$ ctest -R iree/base/arena_test
+$ ctest -R iree/base/bitfield_test
 ```
 
 With Bazel, run this from the repo root:
 
 ```shell
-$ bazel test iree/base:arena_test
+$ bazel test //runtime/src/iree/base:arena_test
 ```
 
 ### Setting test environments
@@ -212,11 +213,6 @@ framework compiles test programs on the host machine into standalone test binary
 files that can be pushed to test devices (such as Android phones) where they
 run with gtest style assertions (e.g. `check.expect_almost_eq(lhs, rhs)`).
 
-> Note:<br>
-> &nbsp;&nbsp;&nbsp;&nbsp;IREE end-to-end tests historically used `iree-run-mlir`.
-> We are in the process of transitioning them to use the check framework, but
-> that migration is incomplete, so some tests still use `iree-run-mlir`.
-
 ### Building e2e tests
 
 The files needed by these tests are not built by default with CMake. You'll
@@ -294,7 +290,7 @@ an arbitrary SSA-value you can use `util.optimization_barrier`.
 Next we use this input constant to exercise the runtime feature under test (in
 this case, just a single floor operation). Finally, we use a check dialect
 operation to make an assertion about the output. There are a few different
-[assertion operations](https://github.com/openxla/iree/tree/main/iree/compiler/Modules/Check).
+[assertion operations](https://github.com/openxla/iree/tree/main/compiler/src/iree/compiler/Modules/Check).
 Here we use the `expect_almost_eq_const` op: *almost* because we are comparing
 floats and want to allow for floating-point imprecision, and *const* because we
 want to compare it to a constant value. This last part is just syntactic sugar

--- a/docs/website/docs/blog/2021-10-15-cuda-backend.md
+++ b/docs/website/docs/blog/2021-10-15-cuda-backend.md
@@ -31,7 +31,7 @@ using CUDA streams for comparison.
 
 HAL exposes an API that can be tested independently, even if we are not able to
 create CUDA kernels yet we can test a large portion of the CUDA driver using
-[CTS tests](https://github.com/openxla/iree/blob/main/iree/hal/cts/README.md).
+[CTS tests](https://github.com/openxla/iree/blob/main/runtime/src/iree/hal/cts/README.md).
 Those can be run to make sure a system has the required CUDA support.
 
  ![Compilation flow](./2021-10-15-cuda-compiler-flow.png){ align=left }

--- a/docs/website/docs/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/deployment-configurations/bare-metal.md
@@ -45,10 +45,10 @@ In which
 * `--iree-hal-target-backends=llvm-cpu`: Compile using the LLVM CPU target
 * `--iree-llvmcpu-target-triple`: Use the `<arch>-pc-linux-elf` LLVM target triple
     so the artifact has a fixed ABI to be rendered by the
-    [elf_module library](https://github.com/openxla/iree/tree/main/iree/hal/local/elf)
+    [elf_module library](https://github.com/openxla/iree/tree/main/runtime/src/iree/hal/local/elf)
 * `--iree-llvmcpu-debug-symbols=false`: To reduce the artifact size
 
-See [generate.sh](https://github.com/openxla/iree/blob/main/iree/hal/local/elf/testdata/generate.sh)
+See [generate.sh](https://github.com/openxla/iree/blob/main/runtime/src/iree/hal/local/elf/testdata/generate.sh)
 for example command-line instructions of some common architectures
 
 You can replace the MLIR file with the other MLIR model files, following the

--- a/docs/website/docs/extensions/index.md
+++ b/docs/website/docs/extensions/index.md
@@ -243,7 +243,7 @@ samples.
 
 The runtime portion requires that the code be exported to the VM system by way
 of an `iree_vm_module_t` interface. A low-level native interface exists with
-minimal overhead and is used for example [by the IREE HAL itself](https://github.com/openxla/iree/tree/main/iree/modules/hal).
+minimal overhead and is used for example [by the IREE HAL itself](https://github.com/openxla/iree/tree/main/runtime/src/iree/modules/hal).
 There is also a C++ wrapper that is significantly easier to work with however it
 needs some performance improvements.
 

--- a/experimental/web/sample_dynamic/index.html
+++ b/experimental/web/sample_dynamic/index.html
@@ -122,7 +122,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       <div class="row" style="padding:4px">
         <div class="col-sm">
           simple_abs
-          (<a href="https://github.com/openxla/iree/blob/main/iree/samples/models/simple_abs.mlir">source</a>)
+          (<a href="https://github.com/openxla/iree/blob/main/samples/models/simple_abs.mlir">source</a>)
         </div>
         <div class="col-sm-auto">
           <button class="btn btn-secondary" onclick="loadSample('simple_abs')">Load sample</button>

--- a/runtime/bindings/tflite/README.md
+++ b/runtime/bindings/tflite/README.md
@@ -174,7 +174,7 @@ avoiding it for now. ([1](https://www.google.com/search?q=%22TfLiteInterpreterOp
 
 Custom ops in tflite map to functions imported into compiled IREE modules.
 The IREE tflite API shim could provide a wrapper implemented as an
-[iree_vm_module_t](https://github.com/openxla/iree/blob/main/iree/vm/module.h)
+[iree_vm_module_t](https://github.com/openxla/iree/blob/main/runtime/src/iree/vm/module.h)
 that resolves and executes the functions as they are called by the VM. Having
 real IREE modules, though, provides significant benefits in representation
 such as the ability to have asynchronous custom behavior that interacts well

--- a/runtime/src/iree/tooling/vm_util.h
+++ b/runtime/src/iree/tooling/vm_util.h
@@ -62,7 +62,7 @@ iree_status_t iree_tooling_append_async_fence_inputs(
 // Prints buffers in the IREE standard shaped buffer format:
 //   [shape]xtype=[value]
 // described in
-// https://github.com/openxla/iree/tree/main/iree/hal/api.h
+// https://github.com/openxla/iree/tree/main/runtime/src/iree/hal/api.h
 iree_status_t iree_tooling_append_variant_list_lines(
     iree_string_view_t list_name, iree_vm_list_t* list,
     iree_host_size_t max_element_count, iree_string_builder_t* builder);

--- a/samples/dynamic_shapes/dynamic_shapes.ipynb
+++ b/samples/dynamic_shapes/dynamic_shapes.ipynb
@@ -243,7 +243,7 @@
         "\n",
         "_Note: you can stop after each step and use intermediate outputs with other tools outside of Colab._\n",
         "\n",
-        "_See the [README](https://github.com/openxla/iree/tree/main/iree/samples/dynamic_shapes#instructions) for more details and example command line instructions._\n",
+        "_See the [README](https://github.com/openxla/iree/tree/main/samples/dynamic_shapes#instructions) for more details and example command line instructions._\n",
         "\n",
         "* _The \"imported MLIR\" can be used by IREE's generic compiler tools_\n",
         "* _The \"flatbuffer blob\" can be saved and used by runtime applications_\n",

--- a/samples/variables_and_state/variables_and_state.ipynb
+++ b/samples/variables_and_state/variables_and_state.ipynb
@@ -244,7 +244,7 @@
         "\n",
         "_Note: you can stop after each step and use intermediate outputs with other tools outside of Colab._\n",
         "\n",
-        "_See the [README](https://github.com/openxla/iree/tree/main/iree/samples/variables_and_state#changing-compilation-options) for more details and example command line instructions._\n",
+        "_See the [README](https://github.com/openxla/iree/tree/main/samples/variables_and_state#changing-compilation-options) for more details and example command line instructions._\n",
         "\n",
         "* _The \"imported MLIR\" can be used by IREE's generic compiler tools_\n",
         "* _The \"flatbuffer blob\" can be saved and used by runtime applications_\n",


### PR DESCRIPTION
Fixing various broken links across code and docs, prompted by https://github.com/openxla/iree/pull/13587. Most of these come from the `iree/` -> `runtime/` and `compiler/` split (https://github.com/openxla/iree/issues/8955).

Also refreshed a few developer docs like `docs/developers/developing_iree/developer_overview.md`.