### PR TITLE
Fix tflite_text_classification.ipynb notebook.

### DIFF
--- a/samples/colab/tflite_text_classification.ipynb
+++ b/samples/colab/tflite_text_classification.ipynb
@@ -2,6 +2,15 @@
   "cells": [
     {
       "cell_type": "markdown",
+      "source": [
+        "##### Copyright 2021 The IREE Authors"
+      ],
+      "metadata": {
+        "id": "jFe0n0RUvf3t"
+      }
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "E8Ft5u8-s1tS"
       },
@@ -44,17 +53,44 @@
       "outputs": [],
       "source": [
         "%%capture\n",
+        "!python -m pip install --upgrade tf-nightly  # Needed for experimental_tflite_to_tosa_bytecode in TF>=2.13\n",
         "!python -m pip install iree-compiler iree-runtime iree-tools-tflite -f https://openxla.github.io/iree/pip-release-links.html\n",
-        "!pip3 install --extra-index-url https://google-coral.github.io/py-repo/ tflite_runtime"
+        "!python -m pip install tflite-runtime-nightly"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "source": [
+        "from tensorflow.python.pywrap_mlir import experimental_tflite_to_tosa_bytecode"
+      ],
       "metadata": {
-        "id": "hOUmhoAls1tb"
+        "id": "iGPG9DoEt2B5"
       },
-      "outputs": [],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "hOUmhoAls1tb",
+        "outputId": "ed50ae3d-f114-441a-8b8a-b57cf272a130",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "IREE (https://openxla.github.io/iree):\n",
+            "  IREE compiler version 20230512.517 @ 2778c08d7e49b3b26e107cb725d94bf1594ac0f3\n",
+            "  LLVM version 17.0.0git\n",
+            "  Optimized build\n"
+          ]
+        }
+      ],
       "source": [
         "import numpy as np\n",
         "import urllib.request\n",
@@ -68,7 +104,10 @@
         "from iree.tools import tflite as iree_tflite\n",
         "\n",
         "ARTIFACTS_DIR = pathlib.Path(tempfile.gettempdir(), \"iree\", \"colab_artifacts\")\n",
-        "ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)"
+        "ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "# Print version information for future notebook users to reference.\n",
+        "!iree-compile --version"
       ]
     },
     {
@@ -88,10 +127,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 4,
       "metadata": {
         "id": "2vlRjNSPs1tc",
-        "outputId": "d309076e-5098-4362-f28d-5e06631fc256",
+        "outputId": "a2c23d74-34b9-495b-d8ad-a8f14aabe2e2",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -102,11 +141,11 @@
           "data": {
             "text/plain": [
               "(PosixPath('/tmp/iree/colab_artifacts/text_classification.tflite'),\n",
-              " <http.client.HTTPMessage at 0x7f0c78baed10>)"
+              " <http.client.HTTPMessage at 0x7fc862349f30>)"
             ]
           },
           "metadata": {},
-          "execution_count": 3
+          "execution_count": 4
         }
       ],
       "source": [
@@ -117,10 +156,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 5,
       "metadata": {
         "id": "e9t6pCAVs1td",
-        "outputId": "76ebbe24-640f-49b2-e2fa-3e47d331eb4a",
+        "outputId": "ae106ff1-77de-4b27-9796-f85ddc251245",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -155,7 +194,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 6,
       "metadata": {
         "id": "g4QeoNHqs1te"
       },
@@ -206,10 +245,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 7,
       "metadata": {
         "id": "yXdBOIpBs1tf",
-        "outputId": "7c858a6d-c914-4165-a4e4-3e2dd125c1e8",
+        "outputId": "2b5a3a16-2132-4648-9aa8-c9cbc3b7b81b",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -268,7 +307,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 8,
       "metadata": {
         "id": "Y28pZUAZs1tg"
       },
@@ -289,10 +328,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 9,
       "metadata": {
         "id": "GFrbbHOgs1th",
-        "outputId": "5dd596b0-1549-45aa-a6f7-d4e7d277288d",
+        "outputId": "f7f73696-52ff-43f2-acc3-c923947faaaf",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -344,27 +383,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "id": "Y7gKbGVSs1ti"
-      },
-      "outputs": [],
-      "source": [
-        "# Convert TFLite model to TOSA MLIR (bytecode) with IREE's import tool.\n",
-        "IREE_TFLITE_TOOL = iree_tflite.get_tool('iree-import-tflite')\n",
-        "tosa_mlirbc_file = ARTIFACTS_DIR.joinpath(\"text_classification.mlirbc\")\n",
-        "!{IREE_TFLITE_TOOL} {ARTIFACTS_DIR}/text_classification.tflite --o={tosa_mlirbc_file}\n",
-        "\n",
-        "# The generated .mlirbc file could now be saved and used outside of Python, with\n",
-        "# IREE native tools or in apps, etc."
-      ]
-    },
-    {
-      "cell_type": "code",
       "execution_count": 10,
       "metadata": {
-        "id": "i2JGBMa-s1ti",
-        "outputId": "eae0100d-77ae-448b-ba20-82a22b4b8a39",
+        "id": "Y7gKbGVSs1ti",
+        "outputId": "8148f54a-d73b-49e4-d8de-e7e22f8b3c3e",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -374,39 +396,20 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "module {\n",
-            "  func.func @main(%arg0: tensor<1x256xi32> {iree.identifier = \"input_5\"}) -> (tensor<1x2xf32> {iree.identifier = \"Identity\"}) {\n",
-            "    %0 = \"tosa.const\"() {value = dense_resource<__elided__> : tensor<1x10003x16xf32>} : () -> tensor<1x10003x16xf32>\n",
-            "    %1 = \"tosa.const\"() {value = dense<3.906250e-03> : tensor<1x1xf32>} : () -> tensor<1x1xf32>\n",
-            "    %2 = \"tosa.const\"() {value = dense_resource<__elided__> : tensor<16x16xf32>} : () -> tensor<16x16xf32>\n",
-            "    %3 = \"tosa.const\"() {value = dense<[-0.00698487554, 0.0294856895, 0.0699710473, 0.130019352, -0.0490558445, 0.0987673401, 0.0744077861, 0.0948959812, -0.010937131, 0.0931261852, 0.0711835548, -0.0385615043, 9.962780e-03, 0.00283221388, 0.112116851, 0.0134318024]> : tensor<16xf32>} : () -> tensor<16xf32>\n",
-            "    %4 = \"tosa.const\"() {value = dense<[[0.091361463, -1.23269629, 1.33242488, 0.92142266, -0.445623249, 0.849273681, -1.27237022, 1.28574562, 0.436188251, -0.963210225, 0.745473146, -0.255745709, -1.4491415, -1.4687326, 0.900665163, -1.36293614], [-0.0968776941, 0.771379471, -1.36363328, -1.1110599, -0.304591209, -1.05579722, 0.795746565, -1.3122592, 0.352218777, 1.04682362, -1.18796027, -0.0409261398, 1.05883229, 1.48620188, -1.13325548, 1.03072512]]> : tensor<2x16xf32>} : () -> tensor<2x16xf32>\n",
-            "    %5 = \"tosa.const\"() {value = dense<[0.043447677, -0.0434476472]> : tensor<2xf32>} : () -> tensor<2xf32>\n",
-            "    %6 = \"tosa.gather\"(%0, %arg0) : (tensor<1x10003x16xf32>, tensor<1x256xi32>) -> tensor<1x256x16xf32>\n",
-            "    %7 = \"tosa.reduce_sum\"(%6) {axis = 1 : i64} : (tensor<1x256x16xf32>) -> tensor<1x1x16xf32>\n",
-            "    %8 = \"tosa.reshape\"(%7) {new_shape = [1, 16]} : (tensor<1x1x16xf32>) -> tensor<1x16xf32>\n",
-            "    %9 = \"tosa.mul\"(%8, %1) {shift = 0 : i32} : (tensor<1x16xf32>, tensor<1x1xf32>) -> tensor<1x16xf32>\n",
-            "    %10 = \"tosa.fully_connected\"(%9, %2, %3) : (tensor<1x16xf32>, tensor<16x16xf32>, tensor<16xf32>) -> tensor<1x16xf32>\n",
-            "    %11 = \"tosa.clamp\"(%10) {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<1x16xf32>) -> tensor<1x16xf32>\n",
-            "    %12 = \"tosa.fully_connected\"(%11, %4, %5) : (tensor<1x16xf32>, tensor<2x16xf32>, tensor<2xf32>) -> tensor<1x2xf32>\n",
-            "    %13 = \"tosa.exp\"(%12) : (tensor<1x2xf32>) -> tensor<1x2xf32>\n",
-            "    %14 = \"tosa.reduce_sum\"(%13) {axis = 1 : i64} : (tensor<1x2xf32>) -> tensor<1x1xf32>\n",
-            "    %15 = \"tosa.reciprocal\"(%14) : (tensor<1x1xf32>) -> tensor<1x1xf32>\n",
-            "    %16 = \"tosa.mul\"(%13, %15) {shift = 0 : i32} : (tensor<1x2xf32>, tensor<1x1xf32>) -> tensor<1x2xf32>\n",
-            "    return %16 : tensor<1x2xf32>\n",
-            "  }\n",
-            "}\n",
-            "\n"
+            "2023-05-12 16:24:00.764695: E tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc:7704] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+            "2023-05-12 16:24:00.764757: E tensorflow/compiler/xla/stream_executor/cuda/cuda_fft.cc:609] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+            "2023-05-12 16:24:00.764773: E tensorflow/compiler/xla/stream_executor/cuda/cuda_blas.cc:1520] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+            "2023-05-12 16:24:02.167994: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
           ]
         }
       ],
       "source": [
-        "# The model contains very large constants, so recompile a truncated version to print.\n",
-        "!{IREE_TFLITE_TOOL} {ARTIFACTS_DIR}/text_classification.tflite --o={ARTIFACTS_DIR}/text_classification_truncated.mlir --output-format=mlir-ir --mlir-elide-elementsattrs-if-larger=50\n",
+        "# Convert TFLite model to TOSA MLIR (bytecode) with IREE's import tool.\n",
+        "tosa_mlirbc_file = ARTIFACTS_DIR.joinpath(\"text_classification.mlirbc\")\n",
+        "!iree-import-tflite {ARTIFACTS_DIR}/text_classification.tflite -o={tosa_mlirbc_file}\n",
         "\n",
-        "with open(ARTIFACTS_DIR.joinpath(\"text_classification_truncated.mlir\")) as truncated_mlir_file:\n",
-        "  truncated_tosa_mlir = truncated_mlir_file.read()\n",
-        "  print(truncated_tosa_mlir, end='')"
+        "# The generated .mlirbc file could now be saved and used outside of Python, with\n",
+        "# IREE native tools or in apps, etc."
       ]
     },
     {
@@ -437,7 +440,7 @@
       "execution_count": 12,
       "metadata": {
         "id": "LQiDmXn_s1tj",
-        "outputId": "4353be9f-ae0d-44fa-b418-abcef2b02dc5",
+        "outputId": "d62e7a02-709c-4257-f2a5-ffc6c66d99cd",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -451,7 +454,7 @@
             "\n",
             "This is the best movie I've seen in recent years. Strongly recommend it!\n",
             "Label: Positive\n",
-            "Confidence: 0.8997293\n",
+            "Confidence: 0.8997294\n",
             "\n",
             "What a waste of my time.\n",
             "Label: Negative\n",


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/13583

* Install tf-nightly for tflite_to_tosa_bytecode
* Install tflite-runtime-nightly (has Python 3.10 wheels)
* Drop `iree_tflite.get_tool()` in favor of just using the installed `iree-import-tflite` tool (Python script)
* Drop .mlir text printing (unsupported output mode option, no `iree-opt` in the install to convert)