### PR TITLE
Let ukernel plugin entry points alias the underlying ukernel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -59,7 +59,7 @@ static FnNameAndDefAttrs getFnNameAndDefAttrs(
     result.defAttrs.emplace_back(rewriter.getStringAttr("vm.import.module"),
                                  rewriter.getStringAttr("vmvx"));
   } else {
-    result.name = std::string("ukernel.") + ukernelName;
+    result.name = std::string("iree_uk_") + ukernelName;
     result.defAttrs.emplace_back(
         rewriter.getStringAttr("hal.import.fields"),
         rewriter.getArrayAttr({rewriter.getStringAttr("processor_data")}));

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_ukernel_ops.mlir
@@ -24,7 +24,7 @@ func.func @mmt4d_f32f32f32(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "ukernel.mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
@@ -53,7 +53,7 @@ func.func @mmt4d_fill(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>, 
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "ukernel.mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
@@ -85,7 +85,7 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "ukernel.mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
@@ -107,7 +107,7 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 //  CHECK-DAG:   %[[OUT_SIZE1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE2:.+]] = arith.constant 7 : index
 //  CHECK-DAG:   %[[OUT_SIZE3:.+]] = arith.constant 8 : index
-//       CHECK: ukernel.generic "ukernel.pack"
+//       CHECK: ukernel.generic "iree_uk_pack"
 //  CHECK-SAME:   ins(%[[ARG0]] :
 //  CHECK-SAME:   outs(%[[ARG1]] :
 //  CHECK-SAME:   (%[[IN_SIZE0]], %[[IN_SIZE1]], %[[OUT_SIZE0]], %[[OUT_SIZE1]], %[[OUT_SIZE2]], %[[OUT_SIZE3]], %[[PAD]], %[[FLAGS]] :
@@ -133,7 +133,7 @@ func.func @pack_i8i8(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?x7x8xi8>, %arg2 :
 //  CHECK-DAG:   %[[OUT_SIZE1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE2:.+]] = arith.constant 7 : index
 //  CHECK-DAG:   %[[OUT_SIZE3:.+]] = arith.constant 8 : index
-//       CHECK: ukernel.generic "ukernel.pack"
+//       CHECK: ukernel.generic "iree_uk_pack"
 //  CHECK-SAME:   ins(%[[ARG0]] :
 //  CHECK-SAME:   outs(%[[ARG1]] :
 //  CHECK-SAME:   (%[[IN_SIZE0]], %[[IN_SIZE1]], %[[OUT_SIZE0]], %[[OUT_SIZE1]], %[[OUT_SIZE2]], %[[OUT_SIZE3]], %[[PAD]], %[[FLAGS]] :
@@ -160,7 +160,7 @@ func.func @pack_i32i32_transpose_inner(%arg0 : tensor<?x?xi32>, %arg1 : tensor<?
 //  CHECK-DAG:   %[[OUT_SIZE1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE2:.+]] = arith.constant 7 : index
 //  CHECK-DAG:   %[[OUT_SIZE3:.+]] = arith.constant 8 : index
-//       CHECK: ukernel.generic "ukernel.pack"
+//       CHECK: ukernel.generic "iree_uk_pack"
 //  CHECK-SAME:   ins(%[[ARG0]] :
 //  CHECK-SAME:   outs(%[[ARG1]] :
 //  CHECK-SAME:   (%[[IN_SIZE0]], %[[IN_SIZE1]], %[[OUT_SIZE0]], %[[OUT_SIZE1]], %[[OUT_SIZE2]], %[[OUT_SIZE3]], %[[PAD]], %[[FLAGS]] :
@@ -184,7 +184,7 @@ func.func @pack_f32f32_transpose_inner_and_outer(%arg0 : tensor<?x?xf32>, %arg1 
 //  CHECK-DAG:   %[[OUT_SIZE1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[IN_SIZE2:.+]] = arith.constant 7 : index
 //  CHECK-DAG:   %[[IN_SIZE3:.+]] = arith.constant 8 : index
-//       CHECK: ukernel.generic "ukernel.unpack"
+//       CHECK: ukernel.generic "iree_uk_unpack"
 //  CHECK-SAME:   ins(%[[ARG0]] :
 //  CHECK-SAME:   outs(%[[ARG1]] :
 //  CHECK-SAME:   (%[[IN_SIZE0]], %[[IN_SIZE1]], %[[IN_SIZE2]], %[[IN_SIZE3]], %[[OUT_SIZE0]], %[[OUT_SIZE1]], %[[FLAGS]] :
@@ -208,7 +208,7 @@ func.func @unpack_i32i32_transpose_inner(%arg0 : tensor<?x?x7x8xi32>, %arg1 : te
 //  CHECK-DAG:   %[[OUT_SIZE1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[IN_SIZE2:.+]] = arith.constant 7 : index
 //  CHECK-DAG:   %[[IN_SIZE3:.+]] = arith.constant 8 : index
-//       CHECK: ukernel.generic "ukernel.unpack"
+//       CHECK: ukernel.generic "iree_uk_unpack"
 //  CHECK-SAME:   ins(%[[ARG0]] :
 //  CHECK-SAME:   outs(%[[ARG1]] :
 //  CHECK-SAME:   (%[[IN_SIZE0]], %[[IN_SIZE1]], %[[IN_SIZE2]], %[[IN_SIZE3]], %[[OUT_SIZE0]], %[[OUT_SIZE1]], %[[FLAGS]] :

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -476,7 +476,7 @@ hal.executable private @mmt4d_ukernel {
 //       CHECK:   scf.for
 //       CHECK:     scf.for
 //   CHECK-NOT:       scf.for
-//       CHECK:   iree_codegen.ukernel.generic "ukernel.mmt4d"
+//       CHECK:   iree_codegen.ukernel.generic "iree_uk_mmt4d"
 
 // -----
 

--- a/experimental/cpu_ukernel/plugin.c
+++ b/experimental/cpu_ukernel/plugin.c
@@ -72,9 +72,9 @@ static iree_hal_executable_plugin_status_t iree_uk_plugin_resolve(
     const void* fn_ptr;
   } plugin_entry_point_t;
   static const plugin_entry_point_t entry_points[] = {
-      {"ukernel.mmt4d", iree_uk_plugin_mmt4d},
-      {"ukernel.pack", iree_uk_plugin_pack},
-      {"ukernel.unpack", iree_uk_plugin_unpack},
+      {"iree_uk_mmt4d", iree_uk_plugin_mmt4d},
+      {"iree_uk_pack", iree_uk_plugin_pack},
+      {"iree_uk_unpack", iree_uk_plugin_unpack},
   };
   *out_resolution = 0;
   bool any_required_not_found = false;


### PR DESCRIPTION
Plugin entry points have their own signature, taking 3 pointer args. They then call the actual ukernel entry point, passing it one of those pointers. https://github.com/openxla/iree/blob/2e939b0cb331ba07a62285c3268329394a665355/experimental/cpu_ukernel/plugin.c#L32-L37

Initially I chose to let the plugin advertise the plugin entry points using a custom namespace, `"ukernel."`, to disambiguate from the underlying entry point, namespaced `iree_uk_`.

But in #13460, @MaheshRavishankar is introducing bitcode ukernels, where the true `iree_uk_` ukernel function is called directly. In that case, the ukernel op needs to have that as its function-name attribute, and so Mahesh has to change that there, but then that means that the resulting compiled modules can't call plugins anymore. We would have to introduce a new iree-compile command-line switch to tell whether to use only bitcode ukernels or only plugin ukernels. There's no fundamental problem with that, but it's nice if we can avoid the additional switch and have everything just work.  

Apparently, this works. My only concern with this is that now `iree_uk_mmt4d` means 2 separate things, the actual ukernel and its exported name in the plugins. I think that's fine: once bitcode lands, plugins should be a minority case and for users who care about that minority case, this will be a lot more convenient.