### PR TITLE
Swapping context/params order on CPU import functions.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -986,8 +986,8 @@ Value HALDispatchABI::callImport(Operation *forOp, StringRef importName,
                                    ValueRange{
                                        /*thunk_func_ptr=*/thunkPtrValue,
                                        /*import_func_ptr=*/importFunc.first,
-                                       /*context=*/importFunc.second,
                                        /*params=*/params,
+                                       /*context=*/importFunc.second,
                                        /*reserved=*/nullPtrValue,
                                    });
   return callOp.getResult();

--- a/experimental/cpu_ukernel/plugin.c
+++ b/experimental/cpu_ukernel/plugin.c
@@ -30,19 +30,19 @@ void iree_uk_assert_fail(const char* file, int line, const char* function,
 #endif  // defined(IREE_UK_STANDALONE)
 
 // Plugin entry points wrapping the actual ukernels.
-static int iree_uk_plugin_mmt4d(void* context, void* params_ptr,
+static int iree_uk_plugin_mmt4d(void* params_ptr, void* context,
                                 void* reserved) {
   iree_uk_mmt4d((const iree_uk_mmt4d_params_t*)params_ptr);
   return 0;
 }
 
-static int iree_uk_plugin_pack(void* context, void* params_ptr,
+static int iree_uk_plugin_pack(void* params_ptr, void* context,
                                void* reserved) {
   iree_uk_pack((const iree_uk_pack_params_t*)params_ptr);
   return 0;
 }
 
-static int iree_uk_plugin_unpack(void* context, void* params_ptr,
+static int iree_uk_plugin_unpack(void* params_ptr, void* context,
                                  void* reserved) {
   iree_uk_unpack((const iree_uk_unpack_params_t*)params_ptr);
   return 0;

--- a/runtime/src/iree/hal/local/executable_library.h
+++ b/runtime/src/iree/hal/local/executable_library.h
@@ -154,7 +154,7 @@ typedef const iree_hal_executable_library_header_t** (
 // a useful failure though the HAL does not mandate that all overflows are
 // caught and only that they are not harmful - clamping byte ranges and never
 // returning a failure is sufficient.
-typedef int (*iree_hal_executable_import_v0_t)(void* context, void* params,
+typedef int (*iree_hal_executable_import_v0_t)(void* params, void* context,
                                                void* reserved);
 
 // A thunk function used to call an import.
@@ -162,7 +162,7 @@ typedef int (*iree_hal_executable_import_v0_t)(void* context, void* params,
 // function pointer as the first argument followed by the arguments of the
 // import function itself.
 typedef int (*iree_hal_executable_import_thunk_v0_t)(
-    iree_hal_executable_import_v0_t fn_ptr, void* context, void* params,
+    iree_hal_executable_import_v0_t fn_ptr, void* params, void* context,
     void* reserved);
 
 // Declares imports available to the executable library at runtime.

--- a/runtime/src/iree/hal/local/loaders/static_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/static_library_loader.c
@@ -39,9 +39,9 @@ static const iree_hal_local_executable_vtable_t
     iree_hal_static_executable_vtable;
 
 static int iree_hal_static_executable_import_thunk_v0(
-    iree_hal_executable_import_v0_t fn_ptr, void* context, void* params,
+    iree_hal_executable_import_v0_t fn_ptr, void* params, void* context,
     void* reserved) {
-  return fn_ptr(context, params, reserved);
+  return fn_ptr(params, context, reserved);
 }
 
 static iree_status_t iree_hal_static_executable_create(

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -206,9 +206,9 @@ static iree_status_t iree_hal_system_executable_query_library(
 }
 
 static int iree_hal_system_executable_import_thunk_v0(
-    iree_hal_executable_import_v0_t fn_ptr, void* context, void* params,
+    iree_hal_executable_import_v0_t fn_ptr, void* params, void* context,
     void* reserved) {
-  return fn_ptr(context, params, reserved);
+  return fn_ptr(params, context, reserved);
 }
 
 static iree_status_t iree_hal_system_executable_create(

--- a/samples/custom_dispatch/cpu/plugin/standalone_plugin.c
+++ b/samples/custom_dispatch/cpu/plugin/standalone_plugin.c
@@ -43,7 +43,7 @@
 //
 // Expects a return of 0 on success and any other value indicates failure.
 // Try not to fail!
-static int simple_mul_workgroup(void* context, void* params_ptr,
+static int simple_mul_workgroup(void* params_ptr, void* context,
                                 void* reserved) {
   typedef struct {
     const float* restrict binding0;

--- a/samples/custom_dispatch/cpu/plugin/system_plugin.c
+++ b/samples/custom_dispatch/cpu/plugin/system_plugin.c
@@ -61,7 +61,7 @@ typedef struct {
 //
 // Expects a return of 0 on success and any other value indicates failure.
 // Try not to fail!
-static int simple_mul_workgroup(void* context, void* params_ptr,
+static int simple_mul_workgroup(void* params_ptr, void* context,
                                 void* reserved) {
   system_plugin_t* plugin = (system_plugin_t*)context;
   typedef struct {


### PR DESCRIPTION
This allows for functions intended for both static linking into generated binaries and dynamic linking into plugins to share the same interface when the context is not required.