### PR TITLE
Fixing vm.switch.* op encoding.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1926,7 +1926,7 @@ class VM_SwitchIntegerOp<I type, string mnemonic, VM_OPC opcode,
   let encoding = [
     VM_EncOpcode<opcode>,
     VM_EncOperand<"index", 0>,
-    VM_EncPrimitiveAttr<"default_value", type.bitwidth>,
+    VM_EncOperand<"default_value", 1>,
     VM_EncVariadicOperands<"values">,
     VM_EncResult<"result">,
   ];
@@ -1965,7 +1965,7 @@ class VM_SwitchFloatOp<F type, string mnemonic, VM_OPC opcode,
   let encoding = [
     VM_EncOpcode<opcode>,
     VM_EncOperand<"index", 0>,
-    VM_EncPrimitiveAttr<"default_value", type.bitwidth>,
+    VM_EncOperand<"default_value", 1>,
     VM_EncVariadicOperands<"values">,
     VM_EncResult<"result">,
   ];

--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -1260,7 +1260,7 @@ iree_status_t iree_vm_bytecode_disassemble_op(
 
     DISASM_OP(CORE, SwitchI32) {
       uint16_t index_reg = VM_ParseOperandRegI32("index");
-      int32_t default_value = VM_ParseIntAttr32("default_value");
+      int32_t default_value = VM_ParseOperandRegI32("default_value");
       const iree_vm_register_list_t* value_reg_list =
           VM_ParseVariadicOperands("values");
       uint16_t result_reg = VM_ParseResultRegI32("result");
@@ -1278,7 +1278,7 @@ iree_status_t iree_vm_bytecode_disassemble_op(
 
     DISASM_OP(CORE, SwitchI64) {
       uint16_t index_reg = VM_ParseOperandRegI32("index");
-      int64_t default_value = VM_ParseIntAttr64("default_value");
+      int64_t default_value = VM_ParseOperandRegI64("default_value");
       const iree_vm_register_list_t* value_reg_list =
           VM_ParseVariadicOperands("values");
       uint16_t result_reg = VM_ParseResultRegI64("result");
@@ -1926,7 +1926,7 @@ iree_status_t iree_vm_bytecode_disassemble_op(
 
     DISASM_OP(EXT_F32, SwitchF32) {
       uint16_t index_reg = VM_ParseOperandRegI32("index");
-      float default_value = VM_ParseFloatAttr32("default_value");
+      float default_value = VM_ParseOperandRegF32("default_value");
       const iree_vm_register_list_t* value_reg_list =
           VM_ParseVariadicOperands("values");
       uint16_t result_reg = VM_ParseResultRegF32("result");

--- a/runtime/src/iree/vm/bytecode/dispatch.c
+++ b/runtime/src/iree/vm/bytecode/dispatch.c
@@ -1374,7 +1374,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
 
     DISPATCH_OP(CORE, SwitchI32, {
       int32_t index = VM_DecOperandRegI32("index");
-      int32_t default_value = VM_DecIntAttr32("default_value");
+      int32_t default_value = VM_DecOperandRegI32("default_value");
       const iree_vm_register_list_t* value_reg_list =
           VM_DecVariadicOperands("values");
       int32_t* result = VM_DecResultRegI32("result");
@@ -1387,7 +1387,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
 
     DISPATCH_OP(CORE, SwitchI64, {
       int32_t index = VM_DecOperandRegI32("index");
-      int64_t default_value = VM_DecIntAttr64("default_value");
+      int64_t default_value = VM_DecOperandRegI64("default_value");
       const iree_vm_register_list_t* value_reg_list =
           VM_DecVariadicOperands("values");
       int64_t* result = VM_DecResultRegI64("result");
@@ -1926,7 +1926,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
 
       DISPATCH_OP(EXT_F32, SwitchF32, {
         int32_t index = VM_DecOperandRegI32("index");
-        float default_value = VM_DecFloatAttr32("default_value");
+        float default_value = VM_DecOperandRegF32("default_value");
         const iree_vm_register_list_t* value_reg_list =
             VM_DecVariadicOperands("values");
         float* result = VM_DecResultRegF32("result");

--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -1355,14 +1355,14 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
 
     VERIFY_OP(CORE, SwitchI32, {
       VM_VerifyOperandRegI32(index);
-      VM_VerifyIntAttr32(default_value);
+      VM_VerifyOperandRegI32(default_value);
       VM_VerifyVariadicOperandsI32(values);
       VM_VerifyResultRegI32(result);
     });
 
     VERIFY_OP(CORE, SwitchI64, {
       VM_VerifyOperandRegI32(index);
-      VM_VerifyIntAttr64(default_value);
+      VM_VerifyOperandRegI64(default_value);
       VM_VerifyVariadicOperandsI64(values);
       VM_VerifyResultRegI64(result);
     });
@@ -1732,7 +1732,7 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
 
     VERIFY_OP(EXT_F32, SwitchF32, {
       VM_VerifyOperandRegI32(index);
-      VM_VerifyFloatAttr32(default_value);
+      VM_VerifyOperandRegF32(default_value);
       VM_VerifyVariadicOperandsF32(values);
       VM_VerifyResultRegF32(result);
     });

--- a/runtime/src/iree/vm/test/assignment_ops.mlir
+++ b/runtime/src/iree/vm/test/assignment_ops.mlir
@@ -29,4 +29,32 @@ vm.module @assignment_ops {
     vm.check.eq %list, %list1, "0 ? list0 : list1 = list1" : !vm.list<i8>
     vm.return
   }
+
+  //===--------------------------------------------------------------------===//
+  // Lookup table
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_switch_i32 attributes {emitc.exclude}
+  vm.func private @test_switch_i32() {
+    %c100 = vm.const.i32 100
+    %c200 = vm.const.i32 200
+    %c300 = vm.const.i32 300
+
+    %i0 = vm.const.i32 0
+    %i0_dno = util.optimization_barrier %i0 : i32
+    %v0 = vm.switch.i32 %i0_dno[%c100, %c200] else %c300 : i32
+    vm.check.eq %v0, %c100, "index 0 is 100" : i32
+
+    %i1 = vm.const.i32 1
+    %i1_dno = util.optimization_barrier %i1 : i32
+    %v1 = vm.switch.i32 %i1_dno[%c100, %c200] else %c300 : i32
+    vm.check.eq %v1, %c200, "index 1 is 200" : i32
+
+    %i2 = vm.const.i32 2
+    %i2_dno = util.optimization_barrier %i2 : i32
+    %v2 = vm.switch.i32 %i2_dno[%c100, %c200] else %c300 : i32
+    vm.check.eq %v2, %c300, "index 2 (out of bounds) is default 300" : i32
+
+    vm.return
+  }
 }

--- a/runtime/src/iree/vm/test/assignment_ops_f32.mlir
+++ b/runtime/src/iree/vm/test/assignment_ops_f32.mlir
@@ -18,4 +18,32 @@ vm.module @assignment_ops_f32 {
     vm.check.eq %v2, %c2, "1 ? 0.0 : 1.0 = 0.0" : f32
     vm.return
   }
+
+  //===--------------------------------------------------------------------===//
+  // ExtF32: Lookup table
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_switch_f32 attributes {emitc.exclude}
+  vm.func private @test_switch_f32() {
+    %c100 = vm.const.f32 100.0
+    %c200 = vm.const.f32 200.0
+    %c300 = vm.const.f32 300.0
+
+    %i0 = vm.const.i32 0
+    %i0_dno = util.optimization_barrier %i0 : i32
+    %v0 = vm.switch.f32 %i0_dno[%c100, %c200] else %c300 : f32
+    vm.check.eq %v0, %c100, "index 0 is 100" : f32
+
+    %i1 = vm.const.i32 1
+    %i1_dno = util.optimization_barrier %i1 : i32
+    %v1 = vm.switch.f32 %i1_dno[%c100, %c200] else %c300 : f32
+    vm.check.eq %v1, %c200, "index 1 is 200" : f32
+
+    %i2 = vm.const.i32 2
+    %i2_dno = util.optimization_barrier %i2 : i32
+    %v2 = vm.switch.f32 %i2_dno[%c100, %c200] else %c300 : f32
+    vm.check.eq %v2, %c300, "index 2 (out of bounds) is default 300" : f32
+
+    vm.return
+  }
 }

--- a/runtime/src/iree/vm/test/assignment_ops_i64.mlir
+++ b/runtime/src/iree/vm/test/assignment_ops_i64.mlir
@@ -18,4 +18,32 @@ vm.module @assignment_ops_i64 {
     vm.check.eq %v2, %c2, "1 ? 0 : 1 = 0" : i64
     vm.return
   }
+
+  //===--------------------------------------------------------------------===//
+  // ExtI64: Lookup table
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_switch_i64 attributes {emitc.exclude}
+  vm.func private @test_switch_i64() {
+    %c100 = vm.const.i64 100
+    %c200 = vm.const.i64 200
+    %c300 = vm.const.i64 300
+
+    %i0 = vm.const.i32 0
+    %i0_dno = util.optimization_barrier %i0 : i32
+    %v0 = vm.switch.i64 %i0_dno[%c100, %c200] else %c300 : i64
+    vm.check.eq %v0, %c100, "index 0 is 100" : i64
+
+    %i1 = vm.const.i32 1
+    %i1_dno = util.optimization_barrier %i1 : i32
+    %v1 = vm.switch.i64 %i1_dno[%c100, %c200] else %c300 : i64
+    vm.check.eq %v1, %c200, "index 1 is 200" : i64
+
+    %i2 = vm.const.i32 2
+    %i2_dno = util.optimization_barrier %i2 : i32
+    %v2 = vm.switch.i64 %i2_dno[%c100, %c200] else %c300 : i64
+    vm.check.eq %v2, %c300, "index 2 (out of bounds) is default 300" : i64
+
+    vm.return
+  }
 }


### PR DESCRIPTION
Originally the op used a static default value but that got switched to be a dynamic one later on. Since prior to #13599 nothing was ever emitting these ops and the definition predated testing there was nothing covering this.