### PR TITLE
return 0 in ukernels

### DIFF
--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -120,16 +120,17 @@ static bool iree_uk_mmt4d_early(const iree_uk_mmt4d_params_t* params) {
   return false;
 }
 
-IREE_UK_EXPORT void iree_uk_mmt4d(const iree_uk_mmt4d_params_t* params) {
+IREE_UK_EXPORT int iree_uk_mmt4d(const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_validate(params);
 
   // Maybe handle this mmt4d "early", without needing to select a tile_func.
   // Typical cases include trivial cases (e.g. when params->K == 0) and hardware
   // targets that want to handle the entire loop nest in target-specific code.
-  if (iree_uk_mmt4d_early(params)) return;
+  if (iree_uk_mmt4d_early(params)) return 0;
 
   // Select a target-specific tile_func (inner loop on K, computing one M0xN0
   // tile) and use that with generic outer loops.
   iree_uk_mmt4d_tile_func_t tile_func = iree_uk_mmt4d_select_tile_func(params);
   iree_uk_mmt4d_using_tile_func(params, tile_func);
+  return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/mmt4d.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.h
@@ -33,7 +33,7 @@ typedef struct iree_uk_mmt4d_params_t {
   const iree_uk_uint64_t* cpu_data;
 } iree_uk_mmt4d_params_t;
 
-IREE_UK_EXPORT void iree_uk_mmt4d(const iree_uk_mmt4d_params_t* params);
+IREE_UK_EXPORT int iree_uk_mmt4d(const iree_uk_mmt4d_params_t* params);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/builtins/ukernel/pack.c
+++ b/runtime/src/iree/builtins/ukernel/pack.c
@@ -247,12 +247,13 @@ static void iree_uk_pack_using_tile_func(const iree_uk_pack_params_t* params,
   }
 }
 
-IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params) {
+IREE_UK_EXPORT int iree_uk_pack(const iree_uk_pack_params_t* params) {
   iree_uk_pack_validate(params);
 
-  if (iree_uk_pack_early(params)) return;
+  if (iree_uk_pack_early(params)) return 0;
 
   // Select a target-specific tile_func and use that with generic outer loops.
   iree_uk_pack_tile_func_t tile_func = iree_uk_pack_select_tile_func(params);
   iree_uk_pack_using_tile_func(params, tile_func);
+  return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -41,7 +41,7 @@ typedef struct iree_uk_pack_params_t {
   const iree_uk_uint64_t* cpu_data;
 } iree_uk_pack_params_t;
 
-IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params);
+IREE_UK_EXPORT int iree_uk_pack(const iree_uk_pack_params_t* params);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/builtins/ukernel/query_tile_sizes.c
+++ b/runtime/src/iree/builtins/ukernel/query_tile_sizes.c
@@ -76,7 +76,7 @@ static void iree_uk_query_tile_sizes_2d_matmul(
   }
 }
 
-IREE_UK_EXPORT void iree_uk_query_tile_sizes_2d(
+IREE_UK_EXPORT int iree_uk_query_tile_sizes_2d(
     const iree_uk_query_tile_sizes_2d_params_t* params,
     iree_uk_query_tile_sizes_2d_out_params_t* out_params) {
   iree_uk_query_tile_sizes_2d_validate(params);
@@ -87,4 +87,5 @@ IREE_UK_EXPORT void iree_uk_query_tile_sizes_2d(
     // Can't happen, validated earlier.
     IREE_UK_ASSUME_UNREACHABLE;
   }
+  return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/query_tile_sizes.h
+++ b/runtime/src/iree/builtins/ukernel/query_tile_sizes.h
@@ -26,7 +26,7 @@ typedef struct iree_uk_query_tile_sizes_2d_out_params_t {
   iree_uk_ssize_t tile_size1;
 } iree_uk_query_tile_sizes_2d_out_params_t;
 
-IREE_UK_EXPORT void iree_uk_query_tile_sizes_2d(
+IREE_UK_EXPORT int iree_uk_query_tile_sizes_2d(
     const iree_uk_query_tile_sizes_2d_params_t* params,
     iree_uk_query_tile_sizes_2d_out_params_t* out_params);
 

--- a/runtime/src/iree/builtins/ukernel/unpack.c
+++ b/runtime/src/iree/builtins/ukernel/unpack.c
@@ -188,12 +188,13 @@ static void iree_uk_unpack_using_tile_func(
   }
 }
 
-IREE_UK_EXPORT void iree_uk_unpack(const iree_uk_unpack_params_t* params) {
+IREE_UK_EXPORT int iree_uk_unpack(const iree_uk_unpack_params_t* params) {
   iree_uk_unpack_validate(params);
 
-  if (iree_uk_unpack_early(params)) return;
+  if (iree_uk_unpack_early(params)) return 0;
 
   // Select a target-specific tile_func and use that with generic outer loops.
   iree_uk_unpack_tile_func_t func = iree_uk_unpack_select_tile_func(params);
   iree_uk_unpack_using_tile_func(params, func);
+  return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/unpack.h
+++ b/runtime/src/iree/builtins/ukernel/unpack.h
@@ -30,7 +30,7 @@ typedef struct iree_uk_unpack_params_t {
   const iree_uk_uint64_t* cpu_data;
 } iree_uk_unpack_params_t;
 
-IREE_UK_EXPORT void iree_uk_unpack(const iree_uk_unpack_params_t* params);
+IREE_UK_EXPORT int iree_uk_unpack(const iree_uk_unpack_params_t* params);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Context: https://github.com/openxla/iree/pull/13600#issuecomment-1546129017

We always return 0 in these ukernels because validation is assertions - the idea was that these ukernels are called internally by compiler-generated code, and if the compiler generates an invalid call, that's a bug, so it's fair to assert. We can revisit if we believe the sociology of who's calling ukernels is changing, but keep in mind that validation-as-asserts was a nice code-size win in release builds, and conveniently freed us from having to think about validation overhead.