### PR TITLE
Moving cached rodata buffers to bytecode modules.

### DIFF
--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -636,8 +636,7 @@ iree_status_t iree_vm_bytecode_disassemble_op(
       uint32_t rodata_ordinal = VM_ParseRodataAttr("rodata");
       bool result_is_move;
       uint16_t result_reg = VM_ParseResultRegRef("value", &result_is_move);
-      iree_vm_buffer_t* buffer =
-          &module_state->rodata_ref_table[rodata_ordinal];
+      iree_vm_buffer_t* buffer = &module->rodata_ref_table[rodata_ordinal];
       EMIT_REF_REG_NAME(result_reg);
       IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
           b, " = vm.const.ref.rodata %u  // 0x%p %" PRIhsz "b", rodata_ordinal,

--- a/runtime/src/iree/vm/bytecode/dispatch.c
+++ b/runtime/src/iree/vm/bytecode/dispatch.c
@@ -869,12 +869,12 @@ static iree_status_t iree_vm_bytecode_dispatch(
 
     DISPATCH_OP(CORE, ConstRefRodata, {
       uint32_t rodata_ordinal = VM_DecRodataAttr("rodata");
-      IREE_ASSERT(rodata_ordinal < module_state->rodata_ref_count);
+      IREE_ASSERT(rodata_ordinal < module->rodata_ref_count);
       bool result_is_move;
       iree_vm_ref_t* result = VM_DecResultRegRef("value", &result_is_move);
-      IREE_RETURN_IF_ERROR(iree_vm_ref_wrap_retain(
-          &module_state->rodata_ref_table[rodata_ordinal],
-          iree_vm_buffer_type(), result));
+      IREE_RETURN_IF_ERROR(
+          iree_vm_ref_wrap_retain(&module->rodata_ref_table[rodata_ordinal],
+                                  iree_vm_buffer_type(), result));
     });
 
     //===------------------------------------------------------------------===//

--- a/runtime/src/iree/vm/bytecode/module_impl.h
+++ b/runtime/src/iree/vm/bytecode/module_impl.h
@@ -41,13 +41,12 @@ typedef struct iree_vm_bytecode_module_t {
   iree_const_byte_span_t archive_contents;
   iree_allocator_t archive_allocator;
 
-  // Offset into the archive data where external read-only data begins.
-  // This is added to any relative rodata reference in the FlatBuffer to get the
-  // aligned physical offset where content is located.
-  iree_host_size_t archive_rodata_offset;
-
   // Loaded FlatBuffer module pointing into the archive contents.
   iree_vm_BytecodeModuleDef_table_t def;
+
+  // Initialized references to rodata segments.
+  iree_host_size_t rodata_ref_count;
+  iree_vm_buffer_t* rodata_ref_table;
 
   // Type table mapping module type IDs to registered VM types.
   iree_host_size_t type_count;
@@ -88,13 +87,6 @@ typedef struct iree_vm_bytecode_module_state_t {
   // Global ref values, indexed by global ordinal.
   iree_host_size_t global_ref_count;
   iree_vm_ref_t* global_ref_table;
-
-  // TODO(benvanik): move to iree_vm_bytecode_module_t if always static.
-  // Initialized references to rodata segments.
-  // Right now these don't do much, however we can perform lazy caching and
-  // on-the-fly decompression using this information.
-  iree_host_size_t rodata_ref_count;
-  iree_vm_buffer_t* rodata_ref_table;
 
   // Resolved function imports.
   iree_host_size_t import_count;


### PR DESCRIPTION
Read-only data is read-only data and can be cached on the module such that it can be shared across all contexts that may instantiate the module.