### PR TITLE
Removing frame requirement from iree_vm_module_resolve_source_location.

### DIFF
--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -2172,7 +2172,7 @@ iree_status_t iree_vm_bytecode_trace_disassembly(
 #if IREE_VM_EXECUTION_TRACING_SRC_LOC_ENABLE
   iree_vm_source_location_t source_location;
   iree_status_t status = iree_vm_module_resolve_source_location(
-      frame->function.module, frame, &source_location);
+      frame->function.module, frame->function, pc, &source_location);
   if (iree_status_is_ok(status)) {
     status = iree_vm_source_location_format(
         &source_location, IREE_VM_SOURCE_LOCATION_FORMAT_FLAG_SINGLE_LINE, &b);

--- a/runtime/src/iree/vm/bytecode/module.c
+++ b/runtime/src/iree/vm/bytecode/module.c
@@ -546,7 +546,7 @@ static iree_status_t iree_vm_bytecode_module_source_location_format(
 }
 
 static iree_status_t iree_vm_bytecode_module_resolve_source_location(
-    void* self, iree_vm_stack_frame_t* frame,
+    void* self, iree_vm_function_t function, iree_vm_source_offset_t pc,
     iree_vm_source_location_t* out_source_location) {
   // Get module debug database, if available.
   iree_vm_bytecode_module_t* module = (iree_vm_bytecode_module_t*)self;
@@ -560,11 +560,11 @@ static iree_status_t iree_vm_bytecode_module_resolve_source_location(
   // Map the (potentially) export ordinal into the internal function ordinal in
   // the function descriptor table.
   uint16_t ordinal;
-  if (frame->function.linkage == IREE_VM_FUNCTION_LINKAGE_INTERNAL) {
-    ordinal = frame->function.ordinal;
+  if (function.linkage == IREE_VM_FUNCTION_LINKAGE_INTERNAL) {
+    ordinal = function.ordinal;
   } else {
-    IREE_RETURN_IF_ERROR(iree_vm_bytecode_map_internal_ordinal(
-        module, frame->function, &ordinal, NULL));
+    IREE_RETURN_IF_ERROR(iree_vm_bytecode_map_internal_ordinal(module, function,
+                                                               &ordinal, NULL));
   }
 
   // Lookup the source map for the function, if available.
@@ -582,7 +582,7 @@ static iree_status_t iree_vm_bytecode_module_resolve_source_location(
   // actual lookup within the source map on demand.
   out_source_location->self = (void*)debug_database_def;
   out_source_location->data[0] = (uint64_t)source_map_def;
-  out_source_location->data[1] = (uint64_t)frame->pc;
+  out_source_location->data[1] = (uint64_t)pc;
   out_source_location->format = iree_vm_bytecode_module_source_location_format;
   return iree_ok_status();
 }

--- a/runtime/src/iree/vm/dynamic/module.c
+++ b/runtime/src/iree/vm/dynamic/module.c
@@ -138,11 +138,11 @@ static iree_status_t IREE_API_PTR iree_vm_dynamic_module_lookup_function(
 
 static iree_status_t IREE_API_PTR
 iree_vm_dynamic_module_resolve_source_location(
-    void* self, iree_vm_stack_frame_t* frame,
+    void* self, iree_vm_function_t function, iree_vm_source_offset_t pc,
     iree_vm_source_location_t* out_source_location) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
   return module->user_module->resolve_source_location(
-      module->user_module->self, frame, out_source_location);
+      module->user_module->self, function, pc, out_source_location);
 }
 
 static iree_status_t IREE_API_PTR

--- a/runtime/src/iree/vm/module.c
+++ b/runtime/src/iree/vm/module.c
@@ -298,14 +298,14 @@ IREE_API_EXPORT iree_status_t iree_vm_module_lookup_function_by_ordinal(
 }
 
 IREE_API_EXPORT iree_status_t iree_vm_module_resolve_source_location(
-    const iree_vm_module_t* module, iree_vm_stack_frame_t* frame,
+    const iree_vm_module_t* module, iree_vm_function_t function,
+    iree_vm_source_offset_t pc,
     iree_vm_source_location_t* out_source_location) {
   IREE_ASSERT_ARGUMENT(module);
-  IREE_ASSERT_ARGUMENT(frame);
   IREE_ASSERT_ARGUMENT(out_source_location);
   memset(out_source_location, 0, sizeof(*out_source_location));
   if (module->resolve_source_location) {
-    return module->resolve_source_location(module->self, frame,
+    return module->resolve_source_location(module->self, function, pc,
                                            out_source_location);
   }
   return iree_status_from_code(IREE_STATUS_UNAVAILABLE);

--- a/runtime/src/iree/vm/module.h
+++ b/runtime/src/iree/vm/module.h
@@ -404,10 +404,10 @@ typedef struct iree_vm_module_t {
       void* self, iree_vm_function_linkage_t linkage, iree_host_size_t ordinal,
       iree_host_size_t index, iree_string_pair_t* out_attr);
 
-  // Resolves a stack |frame| from the module to a |out_source_location|, if
-  // debug information is available.
+  // Resolves a |function| at |pc| from the module to a |out_source_location|,
+  // if debug information is available.
   iree_status_t(IREE_API_PTR* resolve_source_location)(
-      void* self, iree_vm_stack_frame_t* frame,
+      void* self, iree_vm_function_t function, iree_vm_source_offset_t pc,
       iree_vm_source_location_t* out_source_location);
 
   // Allocates module state data.
@@ -512,11 +512,11 @@ IREE_API_EXPORT iree_status_t iree_vm_module_lookup_function_by_ordinal(
     const iree_vm_module_t* module, iree_vm_function_linkage_t linkage,
     iree_host_size_t ordinal, iree_vm_function_t* out_function);
 
-// Resolves a stack |frame| from the module to a |out_source_location|, if
+// Resolves a |function| at |pc| from the module to a |out_source_location|, if
 // debug information is available.
 IREE_API_EXPORT iree_status_t iree_vm_module_resolve_source_location(
-    const iree_vm_module_t* module, iree_vm_stack_frame_t* frame,
-    iree_vm_source_location_t* out_source_location);
+    const iree_vm_module_t* module, iree_vm_function_t function,
+    iree_vm_source_offset_t pc, iree_vm_source_location_t* out_source_location);
 
 //===----------------------------------------------------------------------===//
 // iree_vm_function_t

--- a/runtime/src/iree/vm/stack.c
+++ b/runtime/src/iree/vm/stack.c
@@ -671,7 +671,7 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_format_backtrace(
 
     iree_vm_source_location_t source_location;
     iree_status_t status = iree_vm_module_resolve_source_location(
-        module, &frame->frame, &source_location);
+        module, frame->frame.function, frame->frame.pc, &source_location);
     if (iree_status_is_ok(status)) {
       status = iree_vm_source_location_format(
           &source_location, IREE_VM_SOURCE_LOCATION_FORMAT_FLAG_NONE, builder);


### PR DESCRIPTION
This allows source locations to be looked up without needing an active stack frame.