### PR TITLE
Remove unsupported test in module_utils_test.py 

### DIFF
--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils_test.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils_test.py
@@ -57,7 +57,6 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
               artifacts_dir=artifacts_dir))
 
       artifacts_to_check = [
-          'tf_input.mlir',
           'iree_input.mlir',
           compiled_path,
       ]


### PR DESCRIPTION
When iree-import-tf got migrated to purely python, the
save_temp_tf_input option wasn't migrated over and is now unsupported.