### PR TITLE
Update docs to indicate the migration is completed

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,8 +1,7 @@
 # IREE Benchmarks (Legacy)
 
-**We are migrating to the new benchmark suites. Currently IREE benchmark CI
-(https://perf.iree.dev) is using the new one for x86_64, CUDA, and all
-compilation statistics targets. To reproduce those results, please see the
+**IREE benchmark CI (https://perf.iree.dev) is using the new benchmark suites to
+run all benchmark targets. To reproduce those results, please see the
 [docs for IREE new benchmark suites](/docs/developers/developing_iree/benchmark_suites.md)**.
 
 This directory contains configuration definition for IREE's legacy benchmarks

--- a/docs/developers/developing_iree/benchmark_suites.md
+++ b/docs/developers/developing_iree/benchmark_suites.md
@@ -1,10 +1,5 @@
 # IREE Benchmark Suites
 
-**We are in the progress of replacing the legacy benchmark suites. Currently the
-new benchmark suites only support `x86_64`, `CUDA`, and `compilation statistics`
-benchmarks. For working with the legacy benchmark suites, see
-[IREE Benchmarks (Legacy)](/benchmarks/README.md)**.
-
 IREE Benchmarks Suites is a collection of benchmarks for IREE developers to
 track performance improvements/regressions during development.
 


### PR DESCRIPTION
Update benchmark docs to reflect that all benchmarks in CI are now running with the new benchmark suites.