### PR TITLE
[spirv] Enable vectorizing tensor.extract into vector.gather

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -246,14 +246,16 @@ std::optional<SmallVector<int64_t>> getNativeVectorShape(
 
 /// Add patterns to vectorize any supported Linalg ops.
 void populateVectorizationPatterns(RewritePatternSet &patterns) {
-  IREE::LinalgExt::LinalgTransformationFilter f;
-  IREE::LinalgExt::LinalgVectorizationOptions vectorizationOptions;
+  IREE::LinalgExt::LinalgTransformationFilter filter;
+  IREE::LinalgExt::LinalgVectorizationOptions options;
+  // Enable vectorizing tensor.extract in Linalg ops.
+  options.vectorizeGatherAccesses = true;
   VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(
-      patterns, vectorizationOptions, f);
+      patterns, options, filter);
   linalg::populateConvolutionVectorizationPatterns(patterns);
   patterns.add<LinalgVectorizationPattern>(
-      patterns.getContext(), vectorizationOptions,
-      f.addOpFilter<linalg::ContractionOpInterface>());
+      patterns.getContext(), options,
+      filter.addOpFilter<linalg::ContractionOpInterface>());
 }
 
 /// Adds patterns to unroll vector ops to SPIR-V native vector size.
@@ -323,6 +325,14 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });
+
+    {
+      auto result = funcOp.walk([&](linalg::LinalgOp op) {
+        op.emitOpError("should not remain after vectorization");
+        return WalkResult::interrupt();
+      });
+      if (result.wasInterrupted()) return signalPassFailure();
+    }
 
     // Special peephole optimizations to clean up IR before further processing.
     {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -328,6 +328,12 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
 
     {
       auto result = funcOp.walk([&](linalg::LinalgOp op) {
+        // linalg.generic ops for copy are fine to not vectorize; they will be
+        // handled in later steps.
+        if (isa<linalg::YieldOp>(op.getBlock()->begin())) {
+          return WalkResult::advance();
+        }
+        // Other ones should error out.
         op.emitOpError("should not remain after vectorization");
         return WalkResult::interrupt();
       });


### PR DESCRIPTION
This also adds a check in `SPIRVVectorizePass` to make sure that we don't have remaining linalg ops after vectorization to avoid suprises.