### PR TITLE
[CPU] Move 'vector.shape_cast' lowering to the end of LLVMCPUVectorLowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorLowering.cpp
@@ -65,7 +65,6 @@ void LLVMCPUVectorLoweringPass::runOnOperation() {
         patterns, vectorTransformOptions,
         /*benefit=*/1,
         /*disableOuterProductLowering=*/true);
-    vector::populateVectorShapeCastLoweringPatterns(patterns);
     vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);
     vector::populateVectorMultiReductionLoweringPatterns(
         patterns, vectorMultiReductionLowering);
@@ -132,6 +131,16 @@ void LLVMCPUVectorLoweringPass::runOnOperation() {
     funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
     llvm::dbgs() << "\n\n";
   });
+
+  // 'vector.shape_cast' are very expensive operations that are even generated
+  // by some of the lowerings above (e.g., transpose lowering). There are
+  // chances to cancel them out if they are not lowered too early so we lower
+  // them at the very end of the pass.
+  {
+    RewritePatternSet patterns(ctx);
+    vector::populateVectorShapeCastLoweringPatterns(patterns);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
`vector.shape_cast` are very expensive operations. There are chances to cancel them out if they are not lowered too early so this patch is moving `vector.shape_cast` to the end of of the vector lowering pass. I think it was also like this in codegen driver.