### PR TITLE
Avoid redundant transfers during usage refinement.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -296,6 +296,14 @@ class ValueResourceUsage : public AbstractResourceUsage<DFX::ValueElement> {
               DFX::Resolution::REQUIRED);
           getState() ^= resultUsage.getState();
         })
+        .Case([&](IREE::Stream::AsyncAllocaOp op) {
+          // NOTE: allocas imply non-constant/immutable.
+          removeAssumedBits(NOT_MUTATED);
+          auto resultUsage = solver.getElementFor<ValueResourceUsage>(
+              *this, Position::forValue(op.getResult()),
+              DFX::Resolution::REQUIRED);
+          getState() ^= resultUsage.getState();
+        })
         .Case([&](IREE::Stream::AsyncConstantOp op) {
           removeAssumedBits(NOT_CONSTANT | NOT_TRANSFER_WRITE);
           auto resultUsage = solver.getElementFor<ValueResourceUsage>(

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -171,7 +171,8 @@ namespace {
 // the MLIR CSE pass would deduplicate them.
 template <typename Op>
 struct ElideUnusedOp : public OpRewritePattern<Op> {
-  using OpRewritePattern<Op>::OpRewritePattern;
+  explicit ElideUnusedOp(MLIRContext *context)
+      : OpRewritePattern<Op>(context, /*benefit=*/1000) {}
   LogicalResult matchAndRewrite(Op op,
                                 PatternRewriter &rewriter) const override {
     if (!op.use_empty()) return failure();
@@ -1648,12 +1649,37 @@ struct RedundantTransferElision : public OpRewritePattern<AsyncTransferOp> {
   }
 };
 
+// Collapses chains of transfers that have no use.
+struct IntermediateTransferElision : public OpRewritePattern<AsyncTransferOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AsyncTransferOp transferOp,
+                                PatternRewriter &rewriter) const override {
+    // Walk up the transfer chain to the first non-transfer op.
+    AsyncTransferOp originTransferOp = transferOp;
+    while (true) {
+      auto source = originTransferOp.getSource();
+      auto previousTransferOp =
+          dyn_cast_or_null<AsyncTransferOp>(source.getDefiningOp());
+      if (!previousTransferOp) break;
+      originTransferOp = previousTransferOp;
+    }
+    if (originTransferOp == transferOp) return failure();
+    rewriter.replaceOpWithNewOp<AsyncTransferOp>(
+        transferOp, transferOp.getResult().getType(),
+        originTransferOp.getSource(), originTransferOp.getSourceSize(),
+        transferOp.getResultSize(), originTransferOp.getSourceAffinityAttr(),
+        transferOp.getResultAffinityAttr());
+    return success();
+  }
+};
+
 }  // namespace
 
 void AsyncTransferOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                   MLIRContext *context) {
   // TODO(benvanik): staging propagation (fill of staging -> fill on device).
   results.insert<RedundantTransferElision>(context);
+  results.insert<IntermediateTransferElision>(context);
   results.insert<ElideUnusedOp<AsyncTransferOp>>(context);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
@@ -224,6 +224,19 @@ func.func @RedundantTransferElision(%arg0: !stream.resource<transient>, %arg1: i
 
 // -----
 
+// CHECK-LABEL: @IntermediateTransferElision
+// CHECK-SAME: (%[[SOURCE:.+]]: !stream.resource<constant>, %[[SIZE:.+]]: index)
+func.func @IntermediateTransferElision(%source: !stream.resource<constant>, %size: index) -> !stream.resource<external> {
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[SOURCE]] : !stream.resource<constant>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
+  %transfer0 = stream.async.transfer %source : !stream.resource<constant>{%size} -> !stream.resource<staging>{%size}
+  // CHECK-NOT: stream.async.transfer
+  %transfer1 = stream.async.transfer %transfer0 : !stream.resource<staging>{%size} -> !stream.resource<external>{%size}
+  // CHECK-NEXT: return %[[TRANSFER]]
+  return %transfer1 : !stream.resource<external>
+}
+
+// -----
+
 // CHECK-LABEL: @FoldAsyncLoadBitcast
 func.func @FoldAsyncLoadBitcast(%arg0: !stream.resource<staging>, %arg1: index) -> f32 {
   %c0 = arith.constant 0 : index


### PR DESCRIPTION
These transfers shouldn't exist in most cases but when they appear with fixed lifetimes on both source and sink the previous behavior would lead to infinite expansion.

Fixes #13347.
Fixes #13559.