### PR TITLE
DO NOT MERGE: Use transform dialect types everywhere

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -35,7 +35,6 @@
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/IndexingUtils.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
-#include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -877,7 +876,7 @@ void transform_dialect::IREEBufferizeOp::build(OpBuilder &builder,
                         builder.getUnitAttr());
   }
   MLIRContext *ctx = builder.getContext();
-  result.addTypes(pdl::OperationType::get(ctx));
+  result.addTypes(transform::AnyOpType::get(ctx));
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -7,7 +7,6 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS
 #define IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS
 
-include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformAttrs.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
@@ -479,7 +478,7 @@ def IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp :
     to different workgroups.
   }];
 
-  let arguments = (ins PDL_Operation:$for_all_op);
+  let arguments = (ins TransformHandleTypeInterface:$for_all_op);
   let results = (outs);
   let assemblyFormat = [{
     attr-dict $for_all_op `:` functional-type($for_all_op, results)

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
@@ -10,12 +10,14 @@ transform.sequence failures(propagate) {
   
   %_, %more_parallel_fill, %parallel_reduction, %combiner_op =
     transform.structured.split_reduction %reduction { split_factor = 2, insert_split_dimension = 1 }
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
 
   // Step 1. Map to a single block by tiling with size 1 and fusing.
   %fusion_root_1, %fusion_group_1 = transform.iree.take_first %maybe_trailing_0, %combiner_op
     : (!pdl.operation, !pdl.operation) -> (!pdl.operation, !pdl.operation)
   %grid_loop, %outer_tiled = transform.structured.tile_to_forall_op %fusion_root_1 tile_sizes [1]
     ( mapping = [#gpu.block<x>] )
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
   
   %func = transform.structured.match ops{["func.func"]} in %arg0 : (!pdl.operation) -> !pdl.operation
   transform.iree.apply_patterns %func { bubble_expand } : (!pdl.operation) -> ()
@@ -27,11 +29,11 @@ transform.sequence failures(propagate) {
     transform.sequence %arg0 : !pdl.operation -> !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation
     failures(propagate) {
   ^bb1(%arg1: !pdl.operation):
-    %fused_22 = transform.structured.fuse_into_containing_op %fusion_group_1 into %grid_loop
-    %parallel_reduction_22 = transform.structured.fuse_into_containing_op %parallel_reduction into %grid_loop
-    %more_parallel_fill_22 = transform.structured.fuse_into_containing_op %more_parallel_fill into %grid_loop
-    %original_fill_22 = transform.structured.fuse_into_containing_op %original_fill into %grid_loop
-    %maybe_leading_22 = transform.structured.fuse_into_containing_op %maybe_leading into %grid_loop
+    %fused_22 = transform.structured.fuse_into_containing_op %fusion_group_1 into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
+    %parallel_reduction_22 = transform.structured.fuse_into_containing_op %parallel_reduction into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
+    %more_parallel_fill_22 = transform.structured.fuse_into_containing_op %more_parallel_fill into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
+    %original_fill_22 = transform.structured.fuse_into_containing_op %original_fill into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
+    %maybe_leading_22 = transform.structured.fuse_into_containing_op %maybe_leading into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
 
     transform.yield %fused_22, %parallel_reduction_22, %more_parallel_fill_22, %original_fill_22, %maybe_leading_22
       : !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation
@@ -44,14 +46,17 @@ transform.sequence failures(propagate) {
   %block_loop_22, %fusion_root_22_tiled =
     transform.structured.tile_to_forall_op %outer_tiled
     tile_sizes [1] ( mapping = [#gpu.thread<z>] )
-  transform.structured.fuse_into_containing_op %fusion_group_22_full into %block_loop_22
+     : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  transform.structured.fuse_into_containing_op %fusion_group_22_full into %block_loop_22 : (!pdl.operation, !pdl.operation) -> !pdl.operation
+  
 
   %fusion_group_21 = transform.merge_handles %maybe_leading_2, %more_parallel_fill_2
     : !pdl.operation
   %block_loop_21, %fusion_root_21_tiled =
     transform.structured.tile_to_forall_op %parallel_reduction_2
     tile_sizes [1, 1] ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
-  transform.structured.fuse_into_containing_op %fusion_group_21 into %block_loop_21
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  transform.structured.fuse_into_containing_op %fusion_group_21 into %block_loop_21 : (!pdl.operation, !pdl.operation) -> !pdl.operation
   
   // Step 3. Rank-reduce.
   // ===========================================================================

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
@@ -1,66 +1,66 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
+^bb0(%arg0: !transform.any_op):
   transform.iree.register_match_callbacks
 
   %maybe_leading, %original_fill, %reduction, %maybe_trailing_0 =
     transform.iree.match_callback failures(propagate) "reduction"(%arg0)
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
   
   %_, %more_parallel_fill, %parallel_reduction, %combiner_op =
     transform.structured.split_reduction %reduction { split_factor = 2, insert_split_dimension = 1 }
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
 
   // Step 1. Map to a single block by tiling with size 1 and fusing.
   %fusion_root_1, %fusion_group_1 = transform.iree.take_first %maybe_trailing_0, %combiner_op
-    : (!pdl.operation, !pdl.operation) -> (!pdl.operation, !pdl.operation)
+    : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
   %grid_loop, %outer_tiled = transform.structured.tile_to_forall_op %fusion_root_1 tile_sizes [1]
     ( mapping = [#gpu.block<x>] )
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
   
-  %func = transform.structured.match ops{["func.func"]} in %arg0 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { bubble_expand } : (!pdl.operation) -> ()
+  %func = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func { bubble_expand } : (!transform.any_op) -> ()
 
   // Excessively eager canonicalization results in `fill`s being "fused" due to
   // swapping with `extract_slice`, which confuses the fusion operation below.
   // Wrap fusion into a non-canonicalized sequence.
   %fused_2, %parallel_reduction_2, %more_parallel_fill_2, %original_fill_2, %maybe_leading_2 =
-    transform.sequence %arg0 : !pdl.operation -> !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation
+    transform.sequence %arg0 : !transform.any_op -> !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op
     failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %fused_22 = transform.structured.fuse_into_containing_op %fusion_group_1 into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
-    %parallel_reduction_22 = transform.structured.fuse_into_containing_op %parallel_reduction into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
-    %more_parallel_fill_22 = transform.structured.fuse_into_containing_op %more_parallel_fill into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
-    %original_fill_22 = transform.structured.fuse_into_containing_op %original_fill into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
-    %maybe_leading_22 = transform.structured.fuse_into_containing_op %maybe_leading into %grid_loop : (!pdl.operation, !pdl.operation) -> !pdl.operation
+  ^bb1(%arg1: !transform.any_op):
+    %fused_22 = transform.structured.fuse_into_containing_op %fusion_group_1 into %grid_loop : (!transform.any_op, !transform.any_op) -> !transform.any_op
+    %parallel_reduction_22 = transform.structured.fuse_into_containing_op %parallel_reduction into %grid_loop : (!transform.any_op, !transform.any_op) -> !transform.any_op
+    %more_parallel_fill_22 = transform.structured.fuse_into_containing_op %more_parallel_fill into %grid_loop : (!transform.any_op, !transform.any_op) -> !transform.any_op
+    %original_fill_22 = transform.structured.fuse_into_containing_op %original_fill into %grid_loop : (!transform.any_op, !transform.any_op) -> !transform.any_op
+    %maybe_leading_22 = transform.structured.fuse_into_containing_op %maybe_leading into %grid_loop : (!transform.any_op, !transform.any_op) -> !transform.any_op
 
     transform.yield %fused_22, %parallel_reduction_22, %more_parallel_fill_22, %original_fill_22, %maybe_leading_22
-      : !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation
+      : !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op
   }
 
   // Step 2. Map reduction to thread X and parallel dimension to other threads.
   // ===========================================================================
   %fusion_group_22_full = transform.merge_handles %fused_2, %original_fill_2
-    : !pdl.operation
+    : !transform.any_op
   %block_loop_22, %fusion_root_22_tiled =
     transform.structured.tile_to_forall_op %outer_tiled
     tile_sizes [1] ( mapping = [#gpu.thread<z>] )
-     : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  transform.structured.fuse_into_containing_op %fusion_group_22_full into %block_loop_22 : (!pdl.operation, !pdl.operation) -> !pdl.operation
+     : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.structured.fuse_into_containing_op %fusion_group_22_full into %block_loop_22 : (!transform.any_op, !transform.any_op) -> !transform.any_op
   
 
   %fusion_group_21 = transform.merge_handles %maybe_leading_2, %more_parallel_fill_2
-    : !pdl.operation
+    : !transform.any_op
   %block_loop_21, %fusion_root_21_tiled =
     transform.structured.tile_to_forall_op %parallel_reduction_2
     tile_sizes [1, 1] ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  transform.structured.fuse_into_containing_op %fusion_group_21 into %block_loop_21 : (!pdl.operation, !pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.structured.fuse_into_containing_op %fusion_group_21 into %block_loop_21 : (!transform.any_op, !transform.any_op) -> !transform.any_op
   
   // Step 3. Rank-reduce.
   // ===========================================================================
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
 
   // We don't perform any following transformation (vectorization, bufferizaton,
   // mapping) because this schedule is applied to Linalg-only code without the

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions_match_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions_match_spec.mlir
@@ -1,15 +1,15 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
+^bb0(%arg0: !transform.any_op):
   transform.iree.register_match_callbacks
 
   %leading, %fill, %reduction, %trailing =
     transform.iree.match_callback failures(propagate) "reduction"(%arg0)
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
 
-  transform.iree.emit_remark "leading" at %leading : !pdl.operation
-  transform.iree.emit_remark "fill" at %fill : !pdl.operation
-  transform.iree.emit_remark "reduction" at %reduction : !pdl.operation
-  transform.iree.emit_remark "trailing" at %trailing : !pdl.operation
+  transform.iree.emit_remark "leading" at %leading : !transform.any_op
+  transform.iree.emit_remark "fill" at %fill : !transform.any_op
+  transform.iree.emit_remark "reduction" at %reduction : !transform.any_op
+  transform.iree.emit_remark "trailing" at %trailing : !transform.any_op
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/repeated_matcher_use.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/repeated_matcher_use.mlir
@@ -2,15 +2,15 @@
 
 module {
   transform.sequence failures(propagate) {
-  ^bb0(%arg0: !pdl.operation):
+  ^bb0(%arg0: !transform.any_op):
     transform.iree.register_match_callbacks
 
     %first, %second =
       transform.iree.match_callback failures(propagate) "_test_repeated_matcher_use_callback"(%arg0)
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    transform.iree.emit_remark "first" at %first : !pdl.operation
-    transform.iree.emit_remark "second" at %second : !pdl.operation
+    transform.iree.emit_remark "first" at %first : !transform.any_op
+    transform.iree.emit_remark "second" at %second : !transform.any_op
   }
 
   module {
@@ -55,16 +55,16 @@ module {
 // expected-error @below {{transform dialect interpreter failed}}
 module {
   transform.sequence failures(propagate) {
-  ^bb0(%arg0: !pdl.operation):
+  ^bb0(%arg0: !transform.any_op):
     transform.iree.register_match_callbacks
 
     // expected-error @+2 {{failed to match}}
     %first, %second =
       transform.iree.match_callback failures(propagate) "_test_repeated_matcher_use_callback"(%arg0)
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    transform.iree.emit_remark "first" at %first : !pdl.operation
-    transform.iree.emit_remark "second" at %second : !pdl.operation
+    transform.iree.emit_remark "first" at %first : !transform.any_op
+    transform.iree.emit_remark "second" at %second : !transform.any_op
   }
 
   module {
@@ -110,16 +110,16 @@ module {
 // expected-error @below {{transform dialect interpreter failed}}
 module {
   transform.sequence failures(propagate) {
-  ^bb0(%arg0: !pdl.operation):
+  ^bb0(%arg0: !transform.any_op):
     transform.iree.register_match_callbacks
 
     // expected-error @+2 {{failed to match}}
     %first, %second =
       transform.iree.match_callback failures(propagate) "_test_repeated_matcher_use_callback"(%arg0)
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    transform.iree.emit_remark "first" at %first : !pdl.operation
-    transform.iree.emit_remark "second" at %second : !pdl.operation
+    transform.iree.emit_remark "first" at %first : !transform.any_op
+    transform.iree.emit_remark "second" at %second : !transform.any_op
   }
 
   module {
@@ -162,15 +162,15 @@ module {
 
 module {
   transform.sequence failures(propagate) {
-  ^bb0(%arg0: !pdl.operation):
+  ^bb0(%arg0: !transform.any_op):
     transform.iree.register_match_callbacks
 
     %first, %second =
       transform.iree.match_callback failures(propagate) "_test_value_matcher_callback"(%arg0)
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    transform.iree.emit_remark "first" at %first : !pdl.operation
-    transform.iree.emit_remark "second" at %second : !pdl.operation
+    transform.iree.emit_remark "first" at %first : !transform.any_op
+    transform.iree.emit_remark "second" at %second : !transform.any_op
   }
 
   module {

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_buffer_opt.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_buffer_opt.mlir
@@ -16,10 +16,10 @@ func.func @store_to_load(%arg: vector<4xf32>) -> vector<4xf32> {
 }
 
 transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.apply_buffer_optimizations %0 : (!pdl.operation) -> ()
+^bb0(%arg0: !transform.any_op):
+  transform.sequence %arg0 : !transform.any_op failures(propagate) {
+  ^bb1(%arg1: !transform.any_op):
+    %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.iree.apply_buffer_optimizations %0 : (!transform.any_op) -> ()
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
@@ -9,11 +9,11 @@ func.func @select_cmp_eq_select(%arg0: i64, %arg1: i64) -> i64 {
 }
 
 transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.apply_patterns %0 { canonicalization } : (!pdl.operation) -> ()
+^bb0(%arg0: !transform.any_op):
+  transform.sequence %arg0 : !transform.any_op failures(propagate) {
+  ^bb1(%arg1: !transform.any_op):
+    %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.iree.apply_patterns %0 { canonicalization } : (!transform.any_op) -> ()
   }
 }
 
@@ -53,9 +53,9 @@ func.func @promote() -> (tensor<16x128xf32>) {
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["scf.forall"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %1 = transform.cast %0 : !pdl.operation to !transform.op<"scf.forall">
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["scf.forall"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %1 = transform.cast %0 : !transform.any_op to !transform.op<"scf.forall">
   transform.iree.share_forall_operands %1 share_operands = [0] : (!transform.op<"scf.forall">) -> !transform.op<"scf.forall">
 }
 
@@ -85,9 +85,9 @@ func.func @bubble_up(%arg0: tensor<32x64xf32>) -> tensor<32x2x32xf32> {
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %0 { bubble_expand } : (!pdl.operation) -> ()
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %0 { bubble_expand } : (!transform.any_op) -> ()
 }
 
 // -----
@@ -113,9 +113,9 @@ func.func @pad_fill_to_fill(%arg0: tensor<31x62xf32>) -> tensor<32x64xf32> {
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!pdl.operation) -> ()
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!transform.any_op) -> ()
 }
 
 // -----
@@ -142,9 +142,9 @@ func.func @pad_fill_different_ssa_value_but_same_cst(%arg0: tensor<31x62xf32>) -
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!pdl.operation) -> ()
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!transform.any_op) -> ()
 }
 
 // -----
@@ -172,9 +172,9 @@ func.func @pad_extract_fill_to_fill(%arg0: tensor<31x62xf32>,
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!pdl.operation) -> ()
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!transform.any_op) -> ()
 }
 
 // -----
@@ -204,9 +204,9 @@ func.func @pad_extract_extract_fill_to_fill(%arg0: tensor<31x62xf32>,
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!pdl.operation) -> ()
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!transform.any_op) -> ()
 }
 
 // -----
@@ -234,7 +234,7 @@ func.func @pad_extract_bigger_fill_to_fill(%arg0: tensor<253x123xf32>,
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!pdl.operation) -> ()
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %0 { tiling_canonicalization } : (!transform.any_op) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
@@ -34,9 +34,9 @@ hal.executable private @pad_matmul_static_dispatch_0 {
 }
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> (!pdl.operation)
-  %func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %func : (!pdl.operation) -> ()
+^bb1(%variant_op: !transform.any_op):
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> (!transform.any_op)
+  %func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %func : (!transform.any_op) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_iree_tile_to_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_iree_tile_to_forall.mlir
@@ -48,19 +48,19 @@ hal.executable private @matmul_static_dispatch_0 {
 }
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %original_matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
 
   %forall, %matmul =
     transform.structured.tile_to_forall_op %original_matmul num_threads [32]
       ( mapping = [#gpu.block<x>] )
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
   // Late canonicalizations to cleanup and pass the checks.
   // Needs to occur on the whole variant to perform cse on the workgroup_count region
   transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall
-    : (!pdl.operation) -> ()
+    : (!transform.any_op) -> ()
 }
 
 // -----
@@ -111,10 +111,10 @@ hal.executable private @matmul_static_dispatch_0 {
 }
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %1 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %forall_op, %tiled_op = transform.structured.tile_to_forall_op %1   num_threads [] tile_sizes [1, 1, 1](mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>]): (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_op : (!pdl.operation) -> ()
+^bb1(%variant_op: !transform.any_op):
+  %1 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %forall_op, %tiled_op = transform.structured.tile_to_forall_op %1   num_threads [] tile_sizes [1, 1, 1](mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>]): (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_op : (!transform.any_op) -> ()
 }
 
 // -----
@@ -161,8 +161,8 @@ hal.executable private @matmul_static_dispatch_0 {
 }
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %1 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %forall_op, %tiled_op = transform.structured.tile_to_forall_op %1   num_threads [] tile_sizes [5, 3](mapping = [#gpu.block<z>, #gpu.block<x>]) : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_op : (!pdl.operation) -> ()
+^bb1(%variant_op: !transform.any_op):
+  %1 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %forall_op, %tiled_op = transform.structured.tile_to_forall_op %1   num_threads [] tile_sizes [5, 3](mapping = [#gpu.block<z>, #gpu.block<x>]) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_op : (!transform.any_op) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_iree_tile_to_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_iree_tile_to_forall.mlir
@@ -55,6 +55,7 @@ transform.sequence failures(propagate) {
   %forall, %matmul =
     transform.structured.tile_to_forall_op %original_matmul num_threads [32]
       ( mapping = [#gpu.block<x>] )
+      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
 
   // Late canonicalizations to cleanup and pass the checks.
   // Needs to occur on the whole variant to perform cse on the workgroup_count region
@@ -112,7 +113,7 @@ hal.executable private @matmul_static_dispatch_0 {
 transform.sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %1 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %forall_op, %tiled_op = transform.structured.tile_to_forall_op %1   num_threads [] tile_sizes [1, 1, 1](mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>])
+  %forall_op, %tiled_op = transform.structured.tile_to_forall_op %1   num_threads [] tile_sizes [1, 1, 1](mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>]): (!pdl.operation) -> (!pdl.operation, !pdl.operation)
   transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_op : (!pdl.operation) -> ()
 }
 
@@ -162,6 +163,6 @@ hal.executable private @matmul_static_dispatch_0 {
 transform.sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %1 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %forall_op, %tiled_op = transform.structured.tile_to_forall_op %1   num_threads [] tile_sizes [5, 3](mapping = [#gpu.block<z>, #gpu.block<x>])
+  %forall_op, %tiled_op = transform.structured.tile_to_forall_op %1   num_threads [] tile_sizes [5, 3](mapping = [#gpu.block<z>, #gpu.block<x>]) : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
   transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_op : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -126,7 +126,7 @@ void transform_dialect::VectorToWarpExecuteOnLane0Op::build(
   result.addAttribute(
       VectorToWarpExecuteOnLane0Op::getWarpSizeAttrName(result.name),
       builder.getI64IntegerAttr(warpSize));
-  result.addTypes({pdl::OperationType::get(ctx)});
+  result.addTypes({transform::AnyOpType::get(ctx)});
 }
 
 /// Helper method to replace all uses of the laneId operand by the constant

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h
@@ -7,7 +7,6 @@
 #ifndef IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMEXTENSIONS_LLVMGPUEXTENSIONS_H_
 #define IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMEXTENSIONS_LLVMGPUEXTENSIONS_H_
 
-#include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -7,7 +7,6 @@
 #ifndef IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMEXTENSIONS_LLVMGPUEXTENSIONS
 #define IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMEXTENSIONS_LLVMGPUEXTENSIONS
 
-include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Dialect/Transform/IR/TransformTypes.td"
@@ -46,7 +45,7 @@ def MapNestedForallToGpuThreadsOp :
     fails.
 
     If all the scf.forall operations contained within the FuncOp
-    referred to by the `target` PDLOperation lower to GPU properly, the
+    referred to by the `target` handle lower to GPU properly, the
     transform succeeds. Otherwise the transform definitely fails.
 
     The returned handle points to the same FuncOp operand, consuming it and
@@ -135,7 +134,7 @@ def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_ex
     =============
     This operation ignores non-scf::IfOp ops and drops them in the return.
 
-    If all the operations referred to by the `target` PDLOperation are properly
+    If all the operations referred to by the `target` handle are properly
     properly, the transform succeeds. Otherwise the transform silently fails.
 
     If the transform is anchored at a top-level that is not isolated from above,
@@ -196,11 +195,12 @@ def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_ex
     ```
   }];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
                    DefaultValuedAttr<I64Attr, "{}">:$warp_size);
-  let results = (outs PDL_Operation:$result);
+  let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type($target, $result)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let builders = [
@@ -380,9 +380,9 @@ def PromoteOperandsOp :
     fails.
   }];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
                    DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$indices);
-  let results = (outs Variadic<PDL_Operation>:$result);
+  let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
   let assemblyFormat = [{ $target $indices attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -495,8 +495,8 @@ def LayoutAnalysisAndDistributionOp :
 
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs Variadic<PDL_Operation>:$result);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
   let assemblyFormat = [{ $target attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -539,8 +539,8 @@ def ReorderTransposeOp :
       %0 = arith.subf %transposed_a, %transposed_b : vector<8x16xf16>
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs Variadic<PDL_Operation>:$result);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
   let assemblyFormat = [{ $target attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention.mlir
@@ -30,53 +30,53 @@ hal.executable @_attention_dispatch_0 {
 }
 
 transform.sequence failures(propagate) {
-  ^bb0(%variant_op: !pdl.operation):
+  ^bb0(%variant_op: !transform.any_op):
 
     // Get attention op
     // ==========================================
-    %attention = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    %attention = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
     // Tile and distribute to workgroups
     // ==========================================
     %forall_grid, %tiled_attention =
     transform.structured.tile_to_forall_op %attention tile_sizes [1, 128]
       ( mapping = [#gpu.block<x>, #gpu.block<y>] )
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
     // Tile and decompose attention
     // ==========================================
-    %attention2 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    %attention2 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     %outer_loop, %max_fill, %sum_fill, %inner_loop, %fill_op, %first_matmul, %reduce_max, %partial_softmax, %reduce_sum, %update,
     %softmax, %scale_acc, %second_matmul = tile_and_decompose_attention %attention2 :
-       (!pdl.operation) -> (!pdl.operation, !pdl.operation,!pdl.operation,  !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+       (!transform.any_op) -> (!transform.any_op, !transform.any_op,!transform.any_op,  !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
 
     // Vectorize function
     // ==========================================
-    %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
-    %func_3 = transform.structured.vectorize %func : (!pdl.operation) -> !pdl.operation
+    %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
+    %func_3 = transform.structured.vectorize %func : (!transform.any_op) -> !transform.any_op
 
     // Bufferization
     // ==========================================
     transform.iree.apply_patterns %func_3
-      { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
-    transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-    transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
-    %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> (!pdl.operation)
-    %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-    transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+      { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!transform.any_op) -> ()
+    transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+    transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!transform.any_op) -> ()
+    %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> (!transform.any_op)
+    %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+    transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
     // Step 6. Post-bufferization vector distribution
     // ===========================================================================
-    %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-    transform.iree.forall_to_workgroup %func_7 : (!pdl.operation) -> ()
-    transform.iree.map_nested_forall_to_gpu_threads %func_7 workgroup_dims = [128, 1, 1] : (!pdl.operation) -> ()
+    %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+    transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
+    transform.iree.map_nested_forall_to_gpu_threads %func_7 workgroup_dims = [128, 1, 1] : (!transform.any_op) -> ()
 
     %func_8 = transform.structured.hoist_redundant_vector_transfers %memref_func
-    : (!pdl.operation) -> !pdl.operation
-    transform.iree.apply_patterns %func_8 { canonicalization } : (!pdl.operation) -> ()
-    transform.iree.apply_patterns %func_8 { cse } : (!pdl.operation) -> ()
-    transform.iree.apply_buffer_optimizations %func_8 : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+    transform.iree.apply_patterns %func_8 { canonicalization } : (!transform.any_op) -> ()
+    transform.iree.apply_patterns %func_8 { cse } : (!transform.any_op) -> ()
+    transform.iree.apply_buffer_optimizations %func_8 : (!transform.any_op) -> ()
 }
 
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<()[s0] -> (s0 * 128)>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention.mlir
@@ -41,6 +41,7 @@ transform.sequence failures(propagate) {
     %forall_grid, %tiled_attention =
     transform.structured.tile_to_forall_op %attention tile_sizes [1, 128]
       ( mapping = [#gpu.block<x>, #gpu.block<y>] )
+      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
 
     // Tile and decompose attention
     // ==========================================
@@ -53,7 +54,7 @@ transform.sequence failures(propagate) {
     // ==========================================
     %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
     transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
-    %func_3 = transform.structured.vectorize %func
+    %func_3 = transform.structured.vectorize %func : (!pdl.operation) -> !pdl.operation
 
     // Bufferization
     // ==========================================

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
@@ -23,9 +23,9 @@ builtin.module {
   }
 
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    transform.iree.create_async_groups %top_level_func {use_mma_sync = true} : (!pdl.operation) -> ()
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.create_async_groups %top_level_func {use_mma_sync = true} : (!transform.any_op) -> ()
   }
 }
 
@@ -55,9 +55,9 @@ builtin.module {
   }
 
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!pdl.operation) -> ()
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!transform.any_op) -> ()
   }
 }
 
@@ -83,11 +83,11 @@ builtin.module {
   }
 
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %vector_transfer = transform.structured.match ops{["memref.alloc"]} in %top_level_func : (!pdl.operation) -> !pdl.operation
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %vector_transfer = transform.structured.match ops{["memref.alloc"]} in %top_level_func : (!transform.any_op) -> !transform.any_op
     // expected-error@below {{transform applied to the wrong op kind}}
-    transform.iree.create_async_groups %vector_transfer {use_mma_sync = false} : (!pdl.operation) -> ()
+    transform.iree.create_async_groups %vector_transfer {use_mma_sync = false} : (!transform.any_op) -> ()
   }
 }
 
@@ -115,8 +115,8 @@ builtin.module {
   }
 
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!pdl.operation) -> ()
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!transform.any_op) -> ()
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/layout_analysis_and_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/layout_analysis_and_distribution.mlir
@@ -18,9 +18,9 @@ builtin.module {
     return
   }
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!pdl.operation) -> (!pdl.operation)
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!transform.any_op) -> (!transform.any_op)
   }
 }
 
@@ -150,9 +150,9 @@ builtin.module {
     return
   }
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!pdl.operation) -> (!pdl.operation)
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!transform.any_op) -> (!transform.any_op)
   }
 }
 
@@ -342,9 +342,9 @@ builtin.module {
     return
   }
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!pdl.operation) -> (!pdl.operation)
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!transform.any_op) -> (!transform.any_op)
   }
 }
 
@@ -529,9 +529,9 @@ builtin.module {
     return
   }
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!pdl.operation) -> (!pdl.operation)
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!transform.any_op) -> (!transform.any_op)
   }
 }
 
@@ -696,9 +696,9 @@ builtin.module {
     return
   }
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!pdl.operation) -> (!pdl.operation)
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!transform.any_op) -> (!transform.any_op)
   }
 }
 
@@ -845,9 +845,9 @@ builtin.module {
     return
   }
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!pdl.operation) -> (!pdl.operation)
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %transformed_func = transform.iree.layout_analysis_and_distribution %top_level_func : (!transform.any_op) -> (!transform.any_op)
   }
 }
 
@@ -967,10 +967,10 @@ builtin.module {
     return
   }
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    %reordered_func = transform.iree.reorder_transpose %top_level_func : (!pdl.operation) -> !pdl.operation
-    transform.iree.apply_patterns %reordered_func { cse } : (!pdl.operation) -> ()
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %reordered_func = transform.iree.reorder_transpose %top_level_func : (!transform.any_op) -> !transform.any_op
+    transform.iree.apply_patterns %reordered_func { cse } : (!transform.any_op) -> ()
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -53,39 +53,39 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.structured.tile %{{.*}}[0, 0, 16]
 // CHECK: transform.structured.pad %{{.*}} {pack_paddings = [1, 1, 1], padding_dimensions = [0, 1, 2], padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]}
 // CHECK: transform.structured.hoist_pad %{{.}} by 1 loops
-// CHECK: transform.structured.insert_slice_to_copy %{{.*}} : (!pdl.operation) -> !pdl.operation
+// CHECK: transform.structured.insert_slice_to_copy %{{.*}} : (!transform.any_op) -> !transform.any_op
 // CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
-// CHECK:   transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!pdl.operation) -> ()
+// CHECK:   transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!transform.any_op) -> ()
 // CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
-// CHECK: transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!pdl.operation) -> ()
+// CHECK: transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!transform.any_op) -> ()
 // CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [4, 4]
 // CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [4, 4]
 // CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [32, 4]
-// CHECK: transform.vector.lower_masked_transfers %{{.*}} : (!pdl.operation) -> !pdl.operation
+// CHECK: transform.vector.lower_masked_transfers %{{.*}}
 // CHECK: transform.structured.vectorize %{{.*}}
 // CHECK: transform.iree.eliminate_empty_tensors %{{.*}}
 // CHECK: transform.iree.bufferize {target_gpu} %{{.*}} : (!pdl.operation) -> !pdl.operation
-// CHECK: transform.iree.erase_hal_descriptor_type_from_memref %{{.*}} : (!pdl.operation) -> ()
-// CHECK: transform.iree.forall_to_workgroup %{{.*}} : (!pdl.operation) -> ()
-// CHECK: transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [64, 2, 1] warp_dims = [2, 2, 1] : (!pdl.operation) -> ()
-// CHECK: transform.iree.hoist_static_alloc %{{.*}} : (!pdl.operation) -> ()
-// CHECK: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases} : (!pdl.operation) -> ()
-// CHECK: transform.iree.apply_patterns %{{.*}} {extract_address_computations} : (!pdl.operation) -> ()
-// CHECK: transform.iree.apply_patterns %{{.*}} {unroll_vectors_gpu_wmma} : (!pdl.operation) -> ()
-// CHECK: transform.structured.hoist_redundant_vector_transfers %{{.*}} : (!pdl.operation) -> !pdl.operation
+// CHECK: transform.iree.erase_hal_descriptor_type_from_memref %{{.*}}
+// CHECK: transform.iree.forall_to_workgroup %{{.*}}
+// CHECK: transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [64, 2, 1] warp_dims = [2, 2, 1]
+// CHECK: transform.iree.hoist_static_alloc %{{.*}}
+// CHECK: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases}
+// CHECK: transform.iree.apply_patterns %{{.*}} {extract_address_computations}
+// CHECK: transform.iree.apply_patterns %{{.*}} {unroll_vectors_gpu_wmma}
+// CHECK: transform.structured.hoist_redundant_vector_transfers %{{.*}}
 // CHECK: transform.iree.apply_buffer_optimizations %{{.*}} : (!pdl.operation) -> ()
 // CHECK: transform.iree.vector.vector_to_mma_conversion %{{.*}} {use_wmma} : (!pdl.operation) -> ()
-// CHECK: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases} : (!pdl.operation) -> ()
+// CHECK: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases}
 // CHECK: transform.memref.multibuffer %{{.*}} {factor = 3 : i64, skip_analysis} : (!transform.op<"memref.alloc">) -> !pdl.operation
 // CHECK: transform.vector.transfer_to_scf %{{.*}}   max_transfer_rank = 1 full_unroll = true : (!pdl.operation) -> !pdl.operation
 // CHECK: transform.iree.create_async_groups %{{.*}} {use_mma_sync = false} : (!pdl.operation) -> ()
 // CHECK: transform.iree.pipeline_shared_memory_copies %{{.*}} {depth = 3 : i64} : (!pdl.operation) -> !pdl.operation
 // CHECK: transform.vector.lower_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
 // CHECK: transform.vector.materialize_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
-// CHECK: transform.iree.apply_patterns %{{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization} : (!pdl.operation) -> ()
+// CHECK: transform.iree.apply_patterns %{{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization}
 
 
 // WITH_OPTIONS-LABEL: func @matmul
@@ -100,37 +100,37 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // WITH_OPTIONS: transform.structured.tile %{{.*}}[0, 0, 8]
 // WITH_OPTIONS: transform.structured.pad %{{.*}} {pack_paddings = [1, 1, 1], padding_dimensions = [0, 1, 2], padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]}
 // WITH_OPTIONS: transform.structured.hoist_pad %{{.}} by 1 loops
-// WITH_OPTIONS: transform.structured.insert_slice_to_copy %{{.*}} : (!pdl.operation) -> !pdl.operation
+// WITH_OPTIONS: transform.structured.insert_slice_to_copy %{{.*}} : (!transform.any_op) -> !transform.any_op
 // WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [64, 2] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
-// WITH_OPTIONS:   transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!pdl.operation) -> ()
+// WITH_OPTIONS:   transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!transform.any_op) -> ()
 // WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [8, 16] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
-// WITH_OPTIONS: transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!pdl.operation) -> ()
+// WITH_OPTIONS: transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!transform.any_op) -> ()
 // WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [8, 16] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [1, 4] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [1, 4] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // WITH_OPTIONS: transform.structured.masked_vectorize %{{.*}} vector_sizes [4, 4]
 // WITH_OPTIONS: transform.structured.masked_vectorize %{{.*}} vector_sizes [1, 4]
 // WITH_OPTIONS: transform.structured.masked_vectorize %{{.*}} vector_sizes [32, 4]
-// WITH_OPTIONS: transform.vector.lower_masked_transfers %{{.*}} : (!pdl.operation) -> !pdl.operation
+// WITH_OPTIONS: transform.vector.lower_masked_transfers %{{.*}}
 // WITH_OPTIONS: transform.structured.vectorize %{{.*}}
 // WITH_OPTIONS: transform.iree.eliminate_empty_tensors %{{.*}}
 // WITH_OPTIONS: transform.iree.bufferize {target_gpu} %{{.*}} : (!pdl.operation) -> !pdl.operation
-// WITH_OPTIONS: transform.iree.erase_hal_descriptor_type_from_memref %{{.*}} : (!pdl.operation) -> ()
-// WITH_OPTIONS: transform.iree.forall_to_workgroup %{{.*}} : (!pdl.operation) -> ()
+// WITH_OPTIONS: transform.iree.erase_hal_descriptor_type_from_memref %{{.*}}
+// WITH_OPTIONS: transform.iree.forall_to_workgroup %{{.*}}
 // The workgroup dimensions are controled by td-matmul-strategy-num-threads-XX.
 // The warp dimensions are controled by td-matmul-strategy-num-warps-XX.
-// WITH_OPTIONS: transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [32, 4, 1] warp_dims = [1, 4, 1] : (!pdl.operation) -> ()
-// WITH_OPTIONS: transform.iree.hoist_static_alloc %{{.*}} : (!pdl.operation) -> ()
-// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases} : (!pdl.operation) -> ()
-// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {extract_address_computations} : (!pdl.operation) -> ()
+// WITH_OPTIONS: transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [32, 4, 1] warp_dims = [1, 4, 1]
+// WITH_OPTIONS: transform.iree.hoist_static_alloc %{{.*}}
+// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases}
+// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {extract_address_computations}
 // The unroll attribute should match td-matmul-use-mma-sync, for true: mma_sync,
 // for false:_wmma.
-// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {unroll_vectors_gpu_mma_sync} : (!pdl.operation) -> ()
-// WITH_OPTIONS: transform.structured.hoist_redundant_vector_transfers %{{.*}} : (!pdl.operation) -> !pdl.operation
+// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {unroll_vectors_gpu_mma_sync}
+// WITH_OPTIONS: transform.structured.hoist_redundant_vector_transfers %{{.*}}
 // WITH_OPTIONS: transform.iree.apply_buffer_optimizations %{{.*}} : (!pdl.operation) -> ()
 // The attribute should match td-matmul-use-mma-sync.
 // WITH_OPTIONS: transform.iree.vector.vector_to_mma_conversion %{{.*}} {use_mma_sync} : (!pdl.operation) -> ()
-// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases} : (!pdl.operation) -> ()
+// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases}
 // The multibuffer pass is only run when we set use-async-copies.
 // The factor should match td-matmul-strategy-pipeline-depth: 5.
 // WITH_OPTIONS: transform.memref.multibuffer %{{.*}} {factor = 5 : i64, skip_analysis} : (!transform.op<"memref.alloc">) -> !pdl.operation
@@ -141,7 +141,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // WITH_OPTIONS: transform.iree.pipeline_shared_memory_copies %{{.*}} {depth = 5 : i64} : (!pdl.operation) -> !pdl.operation
 // WITH_OPTIONS: transform.vector.lower_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
 // WITH_OPTIONS: transform.vector.materialize_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
-// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization} : (!pdl.operation) -> ()
+// WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -76,15 +76,15 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.iree.apply_patterns %{{.*}} {extract_address_computations}
 // CHECK: transform.iree.apply_patterns %{{.*}} {unroll_vectors_gpu_wmma}
 // CHECK: transform.structured.hoist_redundant_vector_transfers %{{.*}}
-// CHECK: transform.iree.apply_buffer_optimizations %{{.*}} : (!pdl.operation) -> ()
-// CHECK: transform.iree.vector.vector_to_mma_conversion %{{.*}} {use_wmma} : (!pdl.operation) -> ()
+// CHECK: transform.iree.apply_buffer_optimizations %{{.*}} : (!transform.any_op) -> ()
+// CHECK: transform.iree.vector.vector_to_mma_conversion %{{.*}} {use_wmma} : (!transform.any_op) -> ()
 // CHECK: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases}
-// CHECK: transform.memref.multibuffer %{{.*}} {factor = 3 : i64, skip_analysis} : (!transform.op<"memref.alloc">) -> !pdl.operation
-// CHECK: transform.vector.transfer_to_scf %{{.*}}   max_transfer_rank = 1 full_unroll = true : (!pdl.operation) -> !pdl.operation
-// CHECK: transform.iree.create_async_groups %{{.*}} {use_mma_sync = false} : (!pdl.operation) -> ()
-// CHECK: transform.iree.pipeline_shared_memory_copies %{{.*}} {depth = 3 : i64} : (!pdl.operation) -> !pdl.operation
-// CHECK: transform.vector.lower_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
-// CHECK: transform.vector.materialize_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
+// CHECK: transform.memref.multibuffer %{{.*}} {factor = 3 : i64, skip_analysis}
+// CHECK: transform.vector.transfer_to_scf %{{.*}}   max_transfer_rank = 1 full_unroll = true : (!transform.any_op) -> !transform.any_op
+// CHECK: transform.iree.create_async_groups %{{.*}} {use_mma_sync = false} : (!transform.any_op) -> ()
+// CHECK: transform.iree.pipeline_shared_memory_copies %{{.*}} {depth = 3 : i64} : (!transform.any_op) -> !transform.any_op
+// CHECK: transform.vector.lower_masks %{{.*}}
+// CHECK: transform.vector.materialize_masks %{{.*}}
 // CHECK: transform.iree.apply_patterns %{{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization}
 
 
@@ -127,20 +127,20 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // for false:_wmma.
 // WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {unroll_vectors_gpu_mma_sync}
 // WITH_OPTIONS: transform.structured.hoist_redundant_vector_transfers %{{.*}}
-// WITH_OPTIONS: transform.iree.apply_buffer_optimizations %{{.*}} : (!pdl.operation) -> ()
+// WITH_OPTIONS: transform.iree.apply_buffer_optimizations %{{.*}} : (!transform.any_op) -> ()
 // The attribute should match td-matmul-use-mma-sync.
-// WITH_OPTIONS: transform.iree.vector.vector_to_mma_conversion %{{.*}} {use_mma_sync} : (!pdl.operation) -> ()
+// WITH_OPTIONS: transform.iree.vector.vector_to_mma_conversion %{{.*}} {use_mma_sync} : (!transform.any_op) -> ()
 // WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases}
 // The multibuffer pass is only run when we set use-async-copies.
 // The factor should match td-matmul-strategy-pipeline-depth: 5.
-// WITH_OPTIONS: transform.memref.multibuffer %{{.*}} {factor = 5 : i64, skip_analysis} : (!transform.op<"memref.alloc">) -> !pdl.operation
-// WITH_OPTIONS: transform.vector.transfer_to_scf %{{.*}}   max_transfer_rank = 1 full_unroll = true : (!pdl.operation) -> !pdl.operation
+// WITH_OPTIONS: transform.memref.multibuffer %{{.*}} {factor = 5 : i64, skip_analysis}
+// WITH_OPTIONS: transform.vector.transfer_to_scf %{{.*}}   max_transfer_rank = 1 full_unroll = true : (!transform.any_op) -> !transform.any_op
 // The attribute should match td-matmul-use-mma-sync.
-// WITH_OPTIONS: transform.iree.create_async_groups %{{.*}} {use_mma_sync = true} : (!pdl.operation) -> ()
+// WITH_OPTIONS: transform.iree.create_async_groups %{{.*}} {use_mma_sync = true} : (!transform.any_op) -> ()
 // The depth should match td-matmul-strategy-pipeline-depth: 5.
-// WITH_OPTIONS: transform.iree.pipeline_shared_memory_copies %{{.*}} {depth = 5 : i64} : (!pdl.operation) -> !pdl.operation
-// WITH_OPTIONS: transform.vector.lower_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
-// WITH_OPTIONS: transform.vector.materialize_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
+// WITH_OPTIONS: transform.iree.pipeline_shared_memory_copies %{{.*}} {depth = 5 : i64} : (!transform.any_op) -> !transform.any_op
+// WITH_OPTIONS: transform.vector.lower_masks %{{.*}}
+// WITH_OPTIONS: transform.vector.materialize_masks %{{.*}}
 // WITH_OPTIONS: transform.iree.apply_patterns %{{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization}
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -67,7 +67,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.vector.lower_masked_transfers %{{.*}}
 // CHECK: transform.structured.vectorize %{{.*}}
 // CHECK: transform.iree.eliminate_empty_tensors %{{.*}}
-// CHECK: transform.iree.bufferize {target_gpu} %{{.*}} : (!pdl.operation) -> !pdl.operation
+// CHECK: transform.iree.bufferize {target_gpu} %{{.*}}
 // CHECK: transform.iree.erase_hal_descriptor_type_from_memref %{{.*}}
 // CHECK: transform.iree.forall_to_workgroup %{{.*}}
 // CHECK: transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [64, 2, 1] warp_dims = [2, 2, 1]
@@ -114,7 +114,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // WITH_OPTIONS: transform.vector.lower_masked_transfers %{{.*}}
 // WITH_OPTIONS: transform.structured.vectorize %{{.*}}
 // WITH_OPTIONS: transform.iree.eliminate_empty_tensors %{{.*}}
-// WITH_OPTIONS: transform.iree.bufferize {target_gpu} %{{.*}} : (!pdl.operation) -> !pdl.operation
+// WITH_OPTIONS: transform.iree.bufferize {target_gpu} %{{.*}}
 // WITH_OPTIONS: transform.iree.erase_hal_descriptor_type_from_memref %{{.*}}
 // WITH_OPTIONS: transform.iree.forall_to_workgroup %{{.*}}
 // The workgroup dimensions are controled by td-matmul-strategy-num-threads-XX.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
@@ -31,10 +31,10 @@ hal.executable private @pad_matmul_static_dispatch_0  {
   }
 
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
-    transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-    %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op: (!pdl.operation) -> !pdl.operation
-    %func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-    transform.iree.erase_hal_descriptor_type_from_memref %func : (!pdl.operation) -> ()
+  ^bb1(%variant_op: !transform.any_op):
+    transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+    %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op: (!transform.any_op) -> !transform.any_op
+    %func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+    transform.iree.erase_hal_descriptor_type_from_memref %func : (!transform.any_op) -> ()
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
@@ -1,7 +1,7 @@
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> !pdl.operation
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+^bb1(%variant_op: !transform.any_op):
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> !transform.any_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -1,29 +1,29 @@
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %0 = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+^bb1(%variant_op: !transform.any_op):
+  %0 = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %forall, %tiled_fill = transform.structured.tile_to_forall_op %0 num_threads [5, 1] 
   ( mapping = [#gpu.thread<y>, #gpu.thread<x>] )
-  : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-  %1 = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %1 = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %forall_2, %tiled_matmul = transform.structured.tile_to_forall_op %1 num_threads [7, 9]
   ( mapping = [#gpu.thread<x>, #gpu.thread<y>] )
-  : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
   // Canonicalization/CSE is needed before bufferization otherwise unnecessary
   // allocs will be created.
   %func = transform.structured.match ops{["func.func"]} in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   transform.iree.apply_patterns %func 
-    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> (!pdl.operation)
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> (!transform.any_op)
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
   transform.iree.map_nested_forall_to_gpu_threads %memref_func 
-    workgroup_dims = [10, 11, 1] : (!pdl.operation) -> ()
+    workgroup_dims = [10, 11, 1] : (!transform.any_op) -> ()
 
   // Late canonicalizations to cleanup and pass the checks
   transform.iree.apply_patterns %memref_func
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -3,10 +3,12 @@ transform.sequence failures(propagate) {
   %0 = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
   %forall, %tiled_fill = transform.structured.tile_to_forall_op %0 num_threads [5, 1] 
   ( mapping = [#gpu.thread<y>, #gpu.thread<x>] )
+  : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
 
   %1 = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
   %forall_2, %tiled_matmul = transform.structured.tile_to_forall_op %1 num_threads [7, 9]
   ( mapping = [#gpu.thread<x>, #gpu.thread<y>] )
+  : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
 
   // Canonicalization/CSE is needed before bufferization otherwise unnecessary
   // allocs will be created.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
@@ -3,6 +3,7 @@ transform.sequence failures(propagate) {
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op 
     : (!pdl.operation) -> !pdl.operation
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    : (!pdl.operation) -> !pdl.operation
   %isolated = transform.get_closest_isolated_parent %warp 
     : (!pdl.operation) -> !pdl.operation
   transform.iree.vector.warp_distribute %isolated

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
@@ -1,15 +1,15 @@
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op 
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %isolated = transform.get_closest_isolated_parent %warp 
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   transform.iree.vector.warp_distribute %isolated
-    : (!pdl.operation) -> ()
+    : (!transform.any_op) -> ()
 
   // Late canonicalizations to cleanup and pass the checks.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
@@ -1,11 +1,11 @@
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op 
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
 
   // Late canonicalizations to cleanup and pass the checks.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
@@ -3,6 +3,7 @@ transform.sequence failures(propagate) {
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op 
     : (!pdl.operation) -> !pdl.operation
   transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    : (!pdl.operation) -> !pdl.operation
 
   // Late canonicalizations to cleanup and pass the checks.
   transform.iree.apply_patterns %variant_op

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_hoist_allocs.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_hoist_allocs.mlir
@@ -15,9 +15,9 @@ func.func @non_entry_bb_allocs() {
 //  CHECK-NEXT:   return
 
 transform.sequence failures(propagate) {
-^bb1(%module: !pdl.operation):
+^bb1(%module: !transform.any_op):
     %func = transform.structured.match ops{["func.func"]} in %module
-      : (!pdl.operation) -> !transform.op<"func.func">
+      : (!transform.any_op) -> !transform.op<"func.func">
     transform.iree.hoist_static_alloc %func : (!transform.op<"func.func">) -> ()
 }
 
@@ -46,9 +46,9 @@ func.func @nested_op_alloc_subview_use_static(%arg0 : index, %o0 : index, %o1 : 
 //  CHECK-NEXT:   memref.dealloc %[[ALLOC]] : memref<16x16xi32>
 
 transform.sequence failures(propagate) {
-^bb1(%module: !pdl.operation):
+^bb1(%module: !transform.any_op):
     %func = transform.structured.match ops{["func.func"]} in %module
-      : (!pdl.operation) -> !transform.op<"func.func">
+      : (!transform.any_op) -> !transform.op<"func.func">
     transform.iree.hoist_static_alloc %func : (!transform.op<"func.func">) -> ()
 }
 
@@ -78,8 +78,8 @@ func.func @nested_op_alloc_subview_use_dynamic(%arg0 : index, %o0 : index, %o1 :
 //  CHECK-NEXT:   memref.dealloc %[[ALLOC]] : memref<16x16xi32>
 
 transform.sequence failures(propagate) {
-^bb1(%module: !pdl.operation):
+^bb1(%module: !transform.any_op):
     %func = transform.structured.match ops{["func.func"]} in %module
-      : (!pdl.operation) -> !transform.op<"func.func">
+      : (!transform.any_op) -> !transform.op<"func.func">
     transform.iree.hoist_static_alloc %func : (!transform.op<"func.func">) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_promote_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_promote_operands.mlir
@@ -29,16 +29,16 @@ hal.executable private @pad_matmul_static_dispatch_0  {
   }
 
   transform.sequence failures(propagate) {
-  ^bb1(%variant_op: !pdl.operation):
+  ^bb1(%variant_op: !transform.any_op):
     %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op
-      : (!pdl.operation) -> !pdl.operation
+      : (!transform.any_op) -> !transform.any_op
     %promoted_matmul, %alloc_0, %alloc_1 =
       transform.iree.promote_operands %matmul [0, 1] 
-        : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
+        : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
     // Late canonicalizations to cleanup and pass the checks.
     transform.iree.apply_patterns %variant_op
-      { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+      { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_distribute_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_distribute_forall.mlir
@@ -45,16 +45,16 @@ hal.executable private @distribute {
       }
       module {
         transform.sequence failures(propagate) {
-        ^bb0(%variant_op: !pdl.operation):
+        ^bb0(%variant_op: !transform.any_op):
         %17 = transform.structured.match ops{["func.func"]} in %variant_op 
-          : (!pdl.operation) -> !pdl.operation
+          : (!transform.any_op) -> !transform.any_op
         transform.iree.map_nested_forall_to_gpu_threads %17 
-          workgroup_dims = [256, 1, 1] warp_dims = [8, 1, 1] : (!pdl.operation) -> ()
+          workgroup_dims = [256, 1, 1] warp_dims = [8, 1, 1] : (!transform.any_op) -> ()
 
         // Late canonicalizations to cleanup and pass the checks.
         // Needs to occur on the whole variant to perform cse on the workgroup_count region
         transform.iree.apply_patterns %variant_op
-          { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+          { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
       }
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_gpu_pipelining.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_gpu_pipelining.mlir
@@ -53,9 +53,9 @@ func.func @matmul_pipelining() {
 }
 }
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %for = transform.structured.match ops{["scf.for"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %1 = transform.cast %for : !pdl.operation to !transform.op<"scf.for">
+^bb1(%variant_op: !transform.any_op):
+  %for = transform.structured.match ops{["scf.for"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %1 = transform.cast %for : !transform.any_op to !transform.op<"scf.for">
   %2 = transform.iree.pipeline_shared_memory_copies %1 { depth = 4 } : (!transform.op<"scf.for">) -> !transform.op<"scf.for">
 }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
@@ -48,14 +48,14 @@ func.func @matmul() {
 }
 }
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!pdl.operation) -> ()
-  transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!pdl.operation) -> ()
+^bb1(%variant_op: !transform.any_op):
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!transform.any_op) -> ()
+  transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!transform.any_op) -> ()
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
   // (i.e. all vector.contract are dead).
   // TODO: consider having the vector_to_mma_conversion do the DCE automatically.
-  transform.iree.apply_patterns %func { canonicalization } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func { canonicalization } : (!transform.any_op) -> ()
 }
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/transform_dialect_dummy_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/transform_dialect_dummy_spec.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
-  print %arg0 : !pdl.operation
+^bb0(%arg0: !transform.any_op):
+  print %arg0 : !transform.any_op
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
@@ -203,6 +203,13 @@ buildTileAndFuseAndDistributeImpl(ImplicitLocOpBuilder &b,
   iree_compiler::TileToForallAndFuseAndDistributeResult result;
   auto tileToForeachOp = b.create<TileToForallOp>(
       rootH, tileSizesOrNumThreads, TileOrNumThreadSpec(), threadDimMapping);
+
+  // TODO: remove this hack once all IREE transform ops no longer hardcode PDL.
+  static_cast<Value>(tileToForeachOp.getForallOp())
+      .setType(pdl::OperationType::get(b.getContext()));
+  static_cast<Value>(tileToForeachOp.getTiledOp())
+      .setType(pdl::OperationType::get(b.getContext()));
+
   result.forallH = tileToForeachOp.getForallOp();
   result.tiledOpH = tileToForeachOp.getTiledOp();
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -190,6 +190,8 @@ Value mlir::iree_compiler::gpu::buildDistributeVectors(ImplicitLocOpBuilder &b,
     OpBuilder::InsertionGuard guard(b);
     b.createBlock(&sequence.getBody(), sequence.getBody().begin(),
                   pdl::OperationType::get(b.getContext()), b.getLoc());
+    // TODO: remove this once all IREE transform ops no longer hardcode PDL.
+    ifH = b.create<transform::CastOp>(b.getType<pdl::OperationType>(), ifH);
     ifH = b.create<VectorToWarpExecuteOnLane0Op>(ifH, warpSize);
     b.create<transform::YieldOp>();
   }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -229,9 +229,9 @@ void mlir::iree_compiler::gpu::
 
   // Split, tile and map the most minor dimension to `mappingAttr`.
   if (splitPoint > 0) {
-    auto pdlOperation = pdl::OperationType::get(b.getContext());
+    auto anyOpType = transform::AnyOpType::get(b.getContext());
     auto split = b.create<transform::SplitOp>(
-        pdlOperation, pdlOperation, opH, b.getI64IntegerAttr(mostMinorDim),
+        anyOpType, anyOpType, opH, b.getI64IntegerAttr(mostMinorDim),
         Value(), b.getI64IntegerAttr(splitPoint));
     opH = split.getFirst();
     if (vectorSize > 1) {
@@ -525,7 +525,7 @@ Value mlir::iree_compiler::gpu::buildConvertToTensorCoreOp(
   }
   // TODO: not a functional style transform and avoid returning funcH.
   funcH = b.create<transform::HoistRedundantVectorTransfersOp>(
-      pdl::OperationType::get(b.getContext()), funcH);
+      transform::AnyOpType::get(b.getContext()), funcH);
   iree_compiler::buildCanonicalizationAndEnablingTransforms(
       b, ApplyPatternsOpPatterns(), funcH);
   b.create<ApplyBufferOptimizationsOp>(funcH);
@@ -569,7 +569,7 @@ Value mlir::iree_compiler::gpu::buildConvertToAsyncCopies(
   // Atm, vectors need to be lowered to 1-D for cp.async mapping to connect.
   // TODO: not a functional style op to avoid invalidating artificially.
   auto transferToScfOp = b.create<transform::TransferToScfOp>(
-      pdl::OperationType::get(b.getContext()), funcH);
+      transform::AnyOpType::get(b.getContext()), funcH);
   // TODO: proper builder instead of a setting post-hoc.
   transferToScfOp.setMaxTransferRank(1);
   transferToScfOp.setFullUnroll(true);
@@ -600,11 +600,11 @@ void mlir::iree_compiler::gpu::buildPipelineSharedMemoryCopies(
   }
   // TODO: Better builder.
   Value forOpH = b.create<transform::GetParentForOp>(
-      pdl::OperationType::get(b.getContext()), computeOpH);
+      transform::AnyOpType::get(b.getContext()), computeOpH);
   // TODO: Better builder instead of setting post-hoc.
   auto pipelineOp = b.create<
       iree_compiler::IREE::transform_dialect::PipelineSharedMemoryCopiesOp>(
-      pdl::OperationType::get(b.getContext()), forOpH);
+      transform::AnyOpType::get(b.getContext()), forOpH);
   // TODO: depth from strategy, or directly from individual buffers.
   pipelineOp.setDepth(strategy.pipelineDepth);
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -189,9 +189,7 @@ Value mlir::iree_compiler::gpu::buildDistributeVectors(ImplicitLocOpBuilder &b,
   {
     OpBuilder::InsertionGuard guard(b);
     b.createBlock(&sequence.getBody(), sequence.getBody().begin(),
-                  pdl::OperationType::get(b.getContext()), b.getLoc());
-    // TODO: remove this once all IREE transform ops no longer hardcode PDL.
-    ifH = b.create<transform::CastOp>(b.getType<pdl::OperationType>(), ifH);
+                  variantH.getType(), b.getLoc());
     ifH = b.create<VectorToWarpExecuteOnLane0Op>(ifH, warpSize);
     b.create<transform::YieldOp>();
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h
@@ -7,7 +7,6 @@
 #ifndef IREE_COMPILER_CODEGEN_FLOW_TRANSFORMEXTENSIONS_FLOWEXTENSIONS_H_
 #define IREE_COMPILER_CODEGEN_FLOW_TRANSFORMEXTENSIONS_FLOWEXTENSIONS_H_
 
-#include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -38,10 +38,11 @@ def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.forall
     handle.
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$transformed);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$transformed);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type($target, $transformed)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -69,10 +70,11 @@ def RegionToWorkgroupsOp : Op<Transform_Dialect, "iree.region_to_workgroups",
     handle.
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$transformed);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$transformed);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = 
+    "$target attr-dict `:` functional-type($target, $transformed)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -101,11 +103,12 @@ def WrapInDispatchRegionOp : Op<
     handle (i.e., the `dispatch.region` op).
   }];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
                        DefaultValuedAttr<BoolAttr, "true">:$generateWorkload);
-  let results = (outs PDL_Operation:$transformed);
+  let results = (outs TransformHandleTypeInterface:$transformed);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type($target, $transformed)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -133,10 +136,12 @@ def ClonePrecedingOpIntoDispatchRegionOp : Op<
     handle. It produces a new handle to the cloned ops.
   }];
 
-  let arguments = (ins PDL_Operation:$target,
-                       PDL_Operation:$dispatch_region);
-  let results = (outs PDL_Operation:$cloned);
-  let assemblyFormat = "$target `into` $dispatch_region attr-dict";
+  let arguments = (ins TransformHandleTypeInterface:$target,
+                       TransformHandleTypeInterface:$dispatch_region);
+  let results = (outs TransformHandleTypeInterface:$cloned);
+  let assemblyFormat = 
+      "$target `into` $dispatch_region attr-dict"
+      "`:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure apply(
@@ -166,10 +171,12 @@ def MovePrecedingOpIntoDispatchRegionOp : Op<
     handle. It produces a new handle to the extended dispatch region.
   }];
 
-  let arguments = (ins PDL_Operation:$target,
-                       PDL_Operation:$dispatch_region);
-  let results = (outs PDL_Operation:$transformed);
-  let assemblyFormat = "$target `into` $dispatch_region attr-dict";
+  let arguments = (ins TransformHandleTypeInterface:$target,
+                       TransformHandleTypeInterface:$dispatch_region);
+  let results = (outs TransformHandleTypeInterface:$transformed);
+  let assemblyFormat = 
+      "$target `into` $dispatch_region attr-dict"
+      "`:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure apply(
@@ -199,10 +206,12 @@ def CloneSucceedingOpIntoDispatchRegionOp : Op<
     handle. It produces a new handle to the cloned ops.
   }];
 
-  let arguments = (ins PDL_Operation:$target,
-                       PDL_Operation:$dispatch_region);
-  let results = (outs PDL_Operation:$cloned);
-  let assemblyFormat = "$target `into` $dispatch_region attr-dict";
+  let arguments = (ins TransformHandleTypeInterface:$target,
+                       TransformHandleTypeInterface:$dispatch_region);
+  let results = (outs TransformHandleTypeInterface:$cloned);
+  let assemblyFormat = 
+      "$target `into` $dispatch_region attr-dict"
+      "`:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure apply(
@@ -221,7 +230,7 @@ def MoveSucceedingOpIntoDispatchRegionOp : Op<
 
     All operands of the target are replaced with values that are defined inside
     of the dispatch region when possible. All uses of the target op are
-    replaced with a newly ammended results of the dispatch region op.
+    replaced with a newly amended results of the dispatch region op.
 
     #### Return modes
 
@@ -232,10 +241,12 @@ def MoveSucceedingOpIntoDispatchRegionOp : Op<
     handle. It produces a new handle to the new dispatch region.
   }];
 
-  let arguments = (ins PDL_Operation:$target,
-                       PDL_Operation:$dispatch_region);
-  let results = (outs PDL_Operation:$transformed);
-  let assemblyFormat = "$target `into` $dispatch_region attr-dict";
+  let arguments = (ins TransformHandleTypeInterface:$target,
+                       TransformHandleTypeInterface:$dispatch_region);
+  let results = (outs TransformHandleTypeInterface:$transformed);
+  let assemblyFormat = 
+      "$target `into` $dispatch_region attr-dict"
+      "`:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure apply(

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
@@ -2,5 +2,6 @@ transform.sequence failures(propagate) {
 ^bb1(%arg1: !pdl.operation):
   %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
   %foreach_op, %tiled_op = transform.structured.tile_to_forall_op %0 num_threads [42, 67]
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
   %dispatch_op = transform.iree.forall_to_flow %foreach_op
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
@@ -3,5 +3,5 @@ transform.sequence failures(propagate) {
   %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
   %foreach_op, %tiled_op = transform.structured.tile_to_forall_op %0 num_threads [42, 67]
     : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  %dispatch_op = transform.iree.forall_to_flow %foreach_op
+  %dispatch_op = transform.iree.forall_to_flow %foreach_op : (!pdl.operation) -> !pdl.operation
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
@@ -1,7 +1,7 @@
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
   %foreach_op, %tiled_op = transform.structured.tile_to_forall_op %0 num_threads [42, 67]
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  %dispatch_op = transform.iree.forall_to_flow %foreach_op : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %dispatch_op = transform.iree.forall_to_flow %foreach_op : (!transform.any_op) -> !transform.any_op
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dispatch_region_formation.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dispatch_region_formation.mlir
@@ -14,9 +14,9 @@ func.func @single_op(%arg0: tensor<?x?xf32>, %s1: index, %s2: index) -> tensor<?
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!transform.any_op) -> !transform.any_op
 }
 
 // -----
@@ -42,11 +42,11 @@ func.func @clone_preceding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1: 
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
-  %1 = transform.structured.match ops{["test.dummy"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!transform.any_op) -> !transform.any_op
+  %1 = transform.structured.match ops{["test.dummy"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op : (!transform.any_op, !transform.any_op) -> !transform.any_op
 }
 
 // -----
@@ -72,11 +72,11 @@ func.func @move_preceding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1: i
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
-  %1 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.move_preceding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!transform.any_op) -> !transform.any_op
+  %1 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.move_preceding_op_into_dispatch_region %1 into %dispatch_op : (!transform.any_op, !transform.any_op) -> !transform.any_op
 }
 
 // -----
@@ -96,10 +96,10 @@ func.func @create_region_and_convert_to_workgroups(
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %region_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
-  transform.iree.region_to_workgroups %region_op : (!pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %region_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!transform.any_op) -> !transform.any_op
+  transform.iree.region_to_workgroups %region_op : (!transform.any_op) -> !transform.any_op
 }
 
 // -----
@@ -128,11 +128,11 @@ func.func @clone_multiple_preceding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf3
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
-  %1 = transform.structured.match attributes{"__tagged__"} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!transform.any_op) -> !transform.any_op
+  %1 = transform.structured.match attributes{"__tagged__"} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op : (!transform.any_op, !transform.any_op) -> !transform.any_op
 }
 
 // -----
@@ -158,11 +158,11 @@ func.func @move_succeeding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1: 
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
-  %1 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.move_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!transform.any_op) -> !transform.any_op
+  %1 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.move_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!transform.any_op, !transform.any_op) -> !transform.any_op
 }
 
 // -----
@@ -191,11 +191,11 @@ func.func @move_multiple_succeeding(%arg0: tensor<50x90xf32>, %arg1: tensor<600x
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["test.dummy_op"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %dispatch_op = transform.iree.wrap_in_dispatch_region %0  {generateWorkload=false} : (!pdl.operation) -> !pdl.operation
-  %1 = transform.structured.match attributes{"__tagged__"} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.move_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["test.dummy_op"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0  {generateWorkload=false} : (!transform.any_op) -> !transform.any_op
+  %1 = transform.structured.match attributes{"__tagged__"} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.move_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!transform.any_op, !transform.any_op) -> !transform.any_op
 }
 
 // -----
@@ -218,11 +218,11 @@ func.func @clone_succeeding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1:
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %dispatch_op = transform.iree.wrap_in_dispatch_region %0  {generateWorkload=false} : (!pdl.operation) -> !pdl.operation
-  %1 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.clone_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0  {generateWorkload=false} : (!transform.any_op) -> !transform.any_op
+  %1 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.iree.clone_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!transform.any_op, !transform.any_op) -> !transform.any_op
 }
 
 // -----
@@ -251,7 +251,7 @@ func.func @reify_result_dims_regression(%s1: index, %s2: index) -> (tensor<4x?xf
 }
 
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!transform.any_op) -> !transform.any_op
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dispatch_region_formation.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dispatch_region_formation.mlir
@@ -13,13 +13,10 @@ func.func @single_op(%arg0: tensor<?x?xf32>, %s1: index, %s2: index) -> tensor<?
   return %0 : tensor<?x?xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false }
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
 }
 
 // -----
@@ -44,15 +41,12 @@ func.func @clone_preceding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1: 
   return %0, %1 : tensor<?x?xf32>, tensor<?x?xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false }
-    %1 = transform.structured.match ops{["test.dummy"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
+  %1 = transform.structured.match ops{["test.dummy"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
 }
 
 // -----
@@ -77,15 +71,12 @@ func.func @move_preceding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1: i
   return %1, %0 : tensor<?x?xf32>, tensor<?x?xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false }
-    %1 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.move_preceding_op_into_dispatch_region %1 into %dispatch_op
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
+  %1 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  transform.iree.move_preceding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
 }
 
 // -----
@@ -104,14 +95,11 @@ func.func @create_region_and_convert_to_workgroups(
   return %matmul : tensor<5x5xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %region_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false }
-    transform.iree.region_to_workgroups %region_op
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %region_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
+  transform.iree.region_to_workgroups %region_op : (!pdl.operation) -> !pdl.operation
 }
 
 // -----
@@ -139,15 +127,12 @@ func.func @clone_multiple_preceding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf3
   return %5 : tensor<?x?xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false }
-    %1 = transform.structured.match attributes{"__tagged__"} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
+  %1 = transform.structured.match attributes{"__tagged__"} in %arg1 : (!pdl.operation) -> !pdl.operation
+  transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
 }
 
 // -----
@@ -172,15 +157,12 @@ func.func @move_succeeding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1: 
   return %1, %0 : tensor<?x?xf32>, tensor<?x?xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false }
-    %1 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.move_succeeding_op_into_dispatch_region %1 into %dispatch_op
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
+  %1 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  transform.iree.move_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
 }
 
 // -----
@@ -208,15 +190,12 @@ func.func @move_multiple_succeeding(%arg0: tensor<50x90xf32>, %arg1: tensor<600x
   return %5, %u : tensor<600x700xf32>, tensor<50x90xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["test.dummy_op"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %dispatch_op = transform.iree.wrap_in_dispatch_region %0  {generateWorkload=false}
-    %1 = transform.structured.match attributes{"__tagged__"} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.move_succeeding_op_into_dispatch_region %1 into %dispatch_op
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["test.dummy_op"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0  {generateWorkload=false} : (!pdl.operation) -> !pdl.operation
+  %1 = transform.structured.match attributes{"__tagged__"} in %arg1 : (!pdl.operation) -> !pdl.operation
+  transform.iree.move_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
 }
 
 // -----
@@ -238,15 +217,12 @@ func.func @clone_succeeding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1:
   return %1, %0 : tensor<?x?xf32>, tensor<?x?xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %dispatch_op = transform.iree.wrap_in_dispatch_region %0  {generateWorkload=false}
-    %1 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.iree.clone_succeeding_op_into_dispatch_region %1 into %dispatch_op
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0  {generateWorkload=false} : (!pdl.operation) -> !pdl.operation
+  %1 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  transform.iree.clone_succeeding_op_into_dispatch_region %1 into %dispatch_op : (!pdl.operation, !pdl.operation) -> !pdl.operation
 }
 
 // -----
@@ -274,11 +250,8 @@ func.func @reify_result_dims_regression(%s1: index, %s2: index) -> (tensor<4x?xf
   return %1 : tensor<4x?xf32>
 }
 
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.sequence %arg0 : !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false }
-  }
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %dispatch_op = transform.iree.wrap_in_dispatch_region %0 { generateWorkload = false } : (!pdl.operation) -> !pdl.operation
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.h
@@ -10,7 +10,6 @@
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 #include "mlir/IR/OpDefinition.h"

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
@@ -7,7 +7,6 @@
 #ifndef IREE_DIALECT_LINALGEXT_TRANSFORMOPS
 #define IREE_DIALECT_LINALGEXT_TRANSFORMOPS
 
-include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -19,10 +18,10 @@ def FuseProducersOp : Op<Transform_Dialect, "fuse_producers",
      DeclareOpInterfaceMethods<TransformOpInterface>]> {
   let description = [{Fuses the producers for the operands to fuse.}];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$operands_to_fuse);
-  let results = (outs PDL_Operation:$transformed,
-                      Variadic<PDL_Operation>:$fused_ops);
+  let results = (outs TransformHandleTypeInterface:$transformed,
+                      Variadic<TransformHandleTypeInterface>:$fused_ops);
 
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
@@ -45,16 +44,17 @@ def RewriteForallToAsyncOp :
     This transform is currently only implemented for 1-D scf.forall that
     have been bufferized and definitely fail for the rest.
 
-    If all the operations referred to by the `target` PDLOperation lower
+    If all the operations referred to by the `target` handle lower
     properly, the transform succeeds. Otherwise the transform silently fails.
 
     The returned handle points to only the subset of successfully produced
     async operations, which can all be empty.
   }];
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$transformed);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$transformed);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = 
+      "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
 
   let extraClassDeclaration = [{
@@ -81,16 +81,17 @@ def RewriteForallToScfForOp :
     This transform is currently only implemented for 1-D scf.forall that
     have been bufferized and definitely fail for the rest.
 
-    If all the operations referred to by the `target` PDLOperation lower
+    If all the operations referred to by the `target` handle lower
     properly, the transform succeeds. Otherwise the transform silently fails.
 
     The returned handle points to only the subset of successfully produced
     scf.for operations, which can all be empty.
   }];
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$transformed);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$transformed);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = 
+      "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
 
   let extraClassDeclaration = [{
@@ -111,10 +112,8 @@ def TileAndDecomposeAttentionOp : Op<Transform_Dialect, "tile_and_decompose_atte
     This transform consumes the target handle and produces a result handle.
   }];
 
-  let arguments = (
-      ins PDL_Operation:$target
-  );
-  let results = (outs Variadic<PDL_Operation>:$result);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
   let assemblyFormat = "attr-dict $target";
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -9,7 +9,6 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
-include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 
@@ -64,11 +63,13 @@ def ExpertOp : Linalg_Transform_Operation<"expert"> {
   sequence of transformations. The details of the lowering depend on the name
   and are expressed declaratively.}];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
                    StrAttr:$expertName);
-  let results = (outs PDL_Operation:$transformed);
+  let results = (outs TransformHandleTypeInterface:$transformed);
 
-  let assemblyFormat = "`apply` $expertName `to` $target attr-dict";
+  let assemblyFormat = 
+      "`apply` $expertName `to` $target attr-dict `:` "
+      "functional-type(operands, results)";
 }
 
 #endif // LINALG_TRANSFORM_OPS

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -21,7 +21,7 @@ def Linalg_Transform_Dialect : Dialect {
 }
 
 // Operations with this trait must provide the following methods:
-//   - `Value target()` - returns the operation handle (value of !pdl.operation
+//   - `Value target()` - returns the operation handle (value of !transform.any_op
 //     type) targeted by this transformation, if available;
 //   - `Optional<SymbolRefAttr> matcher()` - returns the name of the PDL matcher
 //     that selects the ops targeted by this transformation, if provided.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
@@ -7,7 +7,6 @@
 #ifndef STRUCTURED_TRANSFORM_OPS_EXT
 #define STRUCTURED_TRANSFORM_OPS_EXT
 
-include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformAttrs.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/foreach-thread-to-async.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/foreach-thread-to-async.mlir
@@ -48,7 +48,7 @@ func.func @static_tile(%arg0: index, %arg1: memref<?xf32>, %arg2: memref<?xf32>)
 }
 
 transform.sequence failures(propagate) {
-^bb1(%module_op: !pdl.operation):
-  %0 = transform.structured.match ops{["scf.forall"]} in %module_op : (!pdl.operation) -> !pdl.operation
+^bb1(%module_op: !transform.any_op):
+  %0 = transform.structured.match ops{["scf.forall"]} in %module_op : (!transform.any_op) -> !transform.any_op
   %1 = forall_to_async %0
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/foreach-thread-to-scf-for.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/foreach-thread-to-scf-for.mlir
@@ -42,7 +42,7 @@ func.func @static_tile_buffers(%arg0: index, %arg1: memref<?xf32>, %arg2: memref
 }
 
 transform.sequence failures(propagate) {
-^bb1(%module_op: !pdl.operation):
-  %0 = transform.structured.match ops{["scf.forall"]} in %module_op : (!pdl.operation) -> !pdl.operation
+^bb1(%module_op: !transform.any_op):
+  %0 = transform.structured.match ops{["scf.forall"]} in %module_op : (!transform.any_op) -> !transform.any_op
   %1 = forall_to_scf_for %0
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fuse-operands.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fuse-operands.mlir
@@ -52,7 +52,7 @@ module {
   }
 
   transform.with_pdl_patterns {
-  ^bb0(%arg0: !pdl.operation):
+  ^bb0(%arg0: !transform.any_op):
     pdl.pattern @match_elemwise : benefit(1) {
       %0 = operands
       %1 = types
@@ -66,8 +66,8 @@ module {
       rewrite %2 with "transform.dialect"
     }
     transform.sequence %arg0 failures(propagate) {
-    ^bb1(%arg1: !pdl.operation):
-      %0 = pdl_match @match_elemwise in %arg1 : (!pdl.operation) -> !pdl.operation
+    ^bb1(%arg1: !transform.any_op):
+      %0 = pdl_match @match_elemwise in %arg1 : (!transform.any_op) -> !transform.any_op
       %1, %fusedOps:2 = fuse_producers %0 {operands_to_fuse=[0, 1]}
     }
   }
@@ -118,7 +118,7 @@ module {
   }
 
   transform.with_pdl_patterns {
-  ^bb0(%arg0: !pdl.operation):
+  ^bb0(%arg0: !transform.any_op):
     pdl.pattern @match_elemwise : benefit(1) {
       %0 = operands
       %1 = types
@@ -132,8 +132,8 @@ module {
       rewrite %2 with "transform.dialect"
     }
     transform.sequence %arg0 failures(propagate) {
-    ^bb1(%arg1: !pdl.operation):
-      %0 = pdl_match @match_elemwise in %arg1 : (!pdl.operation) -> !pdl.operation
+    ^bb1(%arg1: !transform.any_op):
+      %0 = pdl_match @match_elemwise in %arg1 : (!transform.any_op) -> !transform.any_op
       %1, %fusedOps = fuse_producers %0 {operands_to_fuse=[0]}
     }
   }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/drop-schedule.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/drop-schedule.mlir
@@ -11,22 +11,22 @@ func.func @matmul_tensors(
 
 // CHECK-NOT: pdl.pattern
 transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
+^bb0(%arg0: !transform.any_op):
   pdl.pattern @pdl_target : benefit(1) {
     %args = operands
     %results = types
     %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
     %1 = pdl.attribute = @matmul_tensors
-    apply_native_constraint "nestedInFunc"(%0, %1 : !pdl.operation, !pdl.attribute)
+    apply_native_constraint "nestedInFunc"(%0, %1 : !transform.any_op, !pdl.attribute)
     // TODO: we don't want this, but it is the required terminator for pdl.pattern
     rewrite %0 with "transform.apply"
   }
 
   // CHECK-NOT: sequence
-  transform.sequence %arg0: !pdl.operation failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_target in %arg1 : (!pdl.operation) -> !pdl.operation
+  transform.sequence %arg0: !transform.any_op failures(propagate) {
+  ^bb1(%arg1: !transform.any_op):
+    %0 = pdl_match @pdl_target in %arg1 : (!transform.any_op) -> !transform.any_op
     transform.structured.tile %0 [4, 4, 4]
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
   }
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/failure.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/failure.mlir
@@ -9,18 +9,18 @@ module {
   }
 
   transform.with_pdl_patterns {
-  ^bb0(%arg0: !pdl.operation):
+  ^bb0(%arg0: !transform.any_op):
     pdl.pattern @some_operation : benefit(1) {
       %0 = operation "some.operation"
       rewrite %0 with "transform.dialect"
     }
 
-    transform.sequence %arg0: !pdl.operation failures(propagate) {
-    ^bb1(%arg1: !pdl.operation):
-      %0 = pdl_match @some_operation in %arg1 : (!pdl.operation) -> !pdl.operation
+    transform.sequence %arg0: !transform.any_op failures(propagate) {
+    ^bb1(%arg1: !transform.any_op):
+      %0 = pdl_match @some_operation in %arg1 : (!transform.any_op) -> !transform.any_op
       // Make sure we don't crash on wrong operation type.
       // expected-error@below {{failed to outline}}
-      transform.loop.outline %0 {func_name = "outlined"} : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      transform.loop.outline %0 {func_name = "outlined"} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     }
   }
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/invalid.mlir
@@ -1,8 +1,8 @@
 // RUN: iree-dialects-opt %s --split-input-file -verify-diagnostics
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
-  %0 = pdl_match @match in %arg0 : (!pdl.operation) -> !pdl.operation
+^bb0(%arg0: !transform.any_op):
+  %0 = pdl_match @match in %arg0 : (!transform.any_op) -> !transform.any_op
   // expected-error@below {{expects iterator_interchange to be a permutation, found 1, 1}}
   transform.structured.interchange %0 iterator_interchange = [1, 1]
 }
@@ -10,8 +10,8 @@ transform.sequence failures(propagate) {
 // -----
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
-  %0 = pdl_match @match in %arg0 : (!pdl.operation) -> !pdl.operation
+^bb0(%arg0: !transform.any_op):
+  %0 = pdl_match @match in %arg0 : (!transform.any_op) -> !transform.any_op
   // expected-error@below {{expected 'tile_sizes' attribute}}
   transform.structured.fuse %0
 }
@@ -19,8 +19,8 @@ transform.sequence failures(propagate) {
 // -----
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
-  %0 = pdl_match @match in %arg0 : (!pdl.operation) -> !pdl.operation
+^bb0(%arg0: !transform.any_op):
+  %0 = pdl_match @match in %arg0 : (!transform.any_op) -> !transform.any_op
   // expected-error@below {{expects interchange to be a permutation, found [1, 1]}}
   transform.structured.fuse %0 {tile_sizes=[0, 1], tile_interchange = [1, 1]}
 }
@@ -28,8 +28,8 @@ transform.sequence failures(propagate) {
 // -----
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
-  %0 = pdl_match @match in %arg0 : (!pdl.operation) -> !pdl.operation
+^bb0(%arg0: !transform.any_op):
+  %0 = pdl_match @match in %arg0 : (!transform.any_op) -> !transform.any_op
   // expected-error@below {{expects pack_paddings to contain booleans (0/1), found [1, 7]}}
   transform.structured.pad %0 {pack_paddings=[1, 7]}
 }
@@ -37,8 +37,8 @@ transform.sequence failures(propagate) {
 // -----
 
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
-  %0 = pdl_match @match in %arg0 : (!pdl.operation) -> !pdl.operation
+^bb0(%arg0: !transform.any_op):
+  %0 = pdl_match @match in %arg0 : (!transform.any_op) -> !transform.any_op
   // expected-error@below {{expects transpose_paddings to be a permutation, found [1, 1]}}
   transform.structured.pad %0 {transpose_paddings=[[1, 1]]}
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
@@ -2,29 +2,29 @@
 
 // CHECK: transform.sequence
 transform.sequence failures(propagate) {
-^bb0(%arg0: !pdl.operation):
+^bb0(%arg0: !transform.any_op):
   // CHECK: %[[OPS:.*]] = pdl_match @match1 in %{{.*}}
-  %0 = pdl_match @match1 in %arg0 : (!pdl.operation) -> !pdl.operation
+  %0 = pdl_match @match1 in %arg0 : (!transform.any_op) -> !transform.any_op
   // CHECK: %[[TILED:.*]], %{{.*}}:3 = transform.structured.tile %[[OPS]][4, 4, 4]
   %1, %loops1:3 = transform.structured.tile %0 [4, 4, 4]
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
   // CHECK: %[[TILED2:.*]], %{{.*}}:3 = transform.structured.tile %[[TILED]]
   %2, %loops2:3  = transform.structured.tile %1 [2, 2, 2]
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
   // CHECK: %[[PADDED:.*]] = transform.structured.pad %[[TILED2]] {pack_paddings = [1, 1, 0]}
   %3 = transform.structured.pad %2 {pack_paddings = [1, 1, 0]}
   // CHECK: %{{.*}} = transform.structured.vectorize %[[PADDED]] {vectorize_padding}
   %4 = transform.structured.vectorize %3 { vectorize_padding }
   // CHECK: %[[OPS2:.*]] = pdl_match @{{.*}}
-  %5 = pdl_match @match2 in %arg0 : (!pdl.operation) -> !pdl.operation
+  %5 = pdl_match @match2 in %arg0 : (!transform.any_op) -> !transform.any_op
   // CHECK: transform.structured.vectorize %[[OPS2]]
   transform.structured.vectorize %5
   // CHECK: %[[FUNC:.*]] = transform.structured.match ops{["func.func"]} in %arg0
   // CHECK: vector.lower_contraction %[[FUNC]] {{.*}}
-  %6 = transform.structured.match ops{["func.func"]} in %arg0 : (!pdl.operation) -> !pdl.operation
+  %6 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
   transform.vector.lower_contraction %6
     lowering_strategy = "outerproduct"
-      : (!pdl.operation) -> !pdl.operation
+      : (!transform.any_op) -> !transform.any_op
   // CHECK: lower_to_llvm
-  lower_to_llvm %arg0 : (!pdl.operation) -> !pdl.operation
+  lower_to_llvm %arg0 : (!transform.any_op) -> !transform.any_op
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -15,26 +15,26 @@ func.func @matmul_tensors(
 
 
 transform.sequence failures(propagate) {
-^bb1(%module_op: !pdl.operation):
-  %0 = transform.structured.match ops{["linalg.matmul"]} in %module_op : (!pdl.operation) -> !pdl.operation
+^bb1(%module_op: !transform.any_op):
+  %0 = transform.structured.match ops{["linalg.matmul"]} in %module_op : (!transform.any_op) -> !transform.any_op
   %1, %loops:3 = transform.structured.tile %0 [4, 4, 4]
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
-  %2 = get_closest_isolated_parent %1 : (!pdl.operation) -> !pdl.operation
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+  %2 = get_closest_isolated_parent %1 : (!transform.any_op) -> !transform.any_op
   transform.structured.vectorize %2 { vectorize_padding }
   %module_op1 = transform.bufferization.one_shot_bufferize layout{IdentityLayoutMap} %module_op
-    {bufferize_function_boundaries = true} : (!pdl.operation) -> !pdl.operation
+    {bufferize_function_boundaries = true} : (!transform.any_op) -> !transform.any_op
   %3 = transform.structured.match ops{["func.func"]} in %module_op1
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
 
 
   %func = transform.structured.match ops{["func.func"]} in %module_op1
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %func_e_2 = transform.vector.lower_contraction %func
     lowering_strategy = "outerproduct"
-      : (!pdl.operation) -> !pdl.operation
+      : (!transform.any_op) -> !transform.any_op
   %func_e_3 = transform.vector.lower_transpose %func_e_2
     lowering_strategy = "shuffle_1d"
-      : (!pdl.operation) -> !pdl.operation
+      : (!transform.any_op) -> !transform.any_op
 
-  lower_to_llvm %module_op1 : (!pdl.operation) -> !pdl.operation
+  lower_to_llvm %module_op1 : (!transform.any_op) -> !transform.any_op
 }

--- a/tests/e2e/linalg_transform/transform_dialect_codegen_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_codegen_spec.mlir
@@ -1,6 +1,6 @@
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %variant_op_2 = transform.iree.bufferize %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> !pdl.operation
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> !transform.any_op
 }

--- a/tests/e2e/linalg_transform/transform_dialect_codegen_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_codegen_spec.mlir
@@ -2,5 +2,5 @@ transform.sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %variant_op_2 = transform.iree.bufferize %variant_op
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> !pdl.operation
 }

--- a/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
@@ -2,5 +2,6 @@ transform.sequence failures(propagate) {
 ^bb1(%arg1: !pdl.operation):
   %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
   %foreach_op, %tiled_op = transform.structured.tile_to_forall_op %0 num_threads [13, 33]
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
   %dispatch_op = transform.iree.forall_to_flow %foreach_op
 }

--- a/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
@@ -1,7 +1,7 @@
 transform.sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+^bb1(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
   %foreach_op, %tiled_op = transform.structured.tile_to_forall_op %0 num_threads [13, 33]
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  %dispatch_op = transform.iree.forall_to_flow %foreach_op : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %dispatch_op = transform.iree.forall_to_flow %foreach_op : (!transform.any_op) -> !transform.any_op
 }

--- a/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
@@ -3,5 +3,5 @@ transform.sequence failures(propagate) {
   %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
   %foreach_op, %tiled_op = transform.structured.tile_to_forall_op %0 num_threads [13, 33]
     : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  %dispatch_op = transform.iree.forall_to_flow %foreach_op
+  %dispatch_op = transform.iree.forall_to_flow %foreach_op : (!pdl.operation) -> !pdl.operation
 }

--- a/tests/transform_dialect/cpu/attention_codegen_spec.mlir
+++ b/tests/transform_dialect/cpu/attention_codegen_spec.mlir
@@ -10,6 +10,7 @@ transform.sequence failures(propagate) {
     %forall_grid, %tiled_attention =
     transform.structured.tile_to_forall_op %attention num_threads [2]
       ( mapping = [#gpu.block<x>] )
+      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
     transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid
     : (!pdl.operation) -> ()
 
@@ -24,7 +25,7 @@ transform.sequence failures(propagate) {
     // ==========================================
     %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
     transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
-    %func_3 = transform.structured.vectorize %func
+    %func_3 = transform.structured.vectorize %func : (!pdl.operation) -> !pdl.operation
     transform.iree.apply_patterns %variant_op
         { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
 

--- a/tests/transform_dialect/cpu/attention_codegen_spec.mlir
+++ b/tests/transform_dialect/cpu/attention_codegen_spec.mlir
@@ -1,49 +1,49 @@
 transform.sequence failures(propagate) {
-  ^bb0(%variant_op: !pdl.operation):
+  ^bb0(%variant_op: !transform.any_op):
 
     // Get attention op
     // ==========================================
-    %attention = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    %attention = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
     // Tile and distribute to workgroups
     // ==========================================
     %forall_grid, %tiled_attention =
     transform.structured.tile_to_forall_op %attention num_threads [2]
       ( mapping = [#gpu.block<x>] )
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid
-    : (!pdl.operation) -> ()
+    : (!transform.any_op) -> ()
 
     // Tile and decompose attention
     // ==========================================
-    %attention2 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    %attention2 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     %outer_loop, %max_fill, %sum_fill, %inner_loop, %fill_op, %first_matmul, %reduce_max, %partial_softmax, %reduce_sum, %update,
     %softmax, %scale_acc, %second_matmul = tile_and_decompose_attention %attention2 :
-       (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation,!pdl.operation,  !pdl.operation, !pdl.operation)
+       (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op,!transform.any_op,  !transform.any_op, !transform.any_op)
 
     // Vectorize function
     // ==========================================
-    %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-    transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
-    %func_3 = transform.structured.vectorize %func : (!pdl.operation) -> !pdl.operation
+    %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
+    %func_3 = transform.structured.vectorize %func : (!transform.any_op) -> !transform.any_op
     transform.iree.apply_patterns %variant_op
-        { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+        { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
     // Bufferization
     // ==========================================
-    transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-    transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
-    %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> (!pdl.operation)
-    %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-    transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+    transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+    transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!transform.any_op) -> ()
+    %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> (!transform.any_op)
+    %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+    transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
     // Step 6. Post-bufferization vector distribution
     // ===========================================================================
-    %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-    transform.iree.forall_to_workgroup %func_7 : (!pdl.operation) -> ()
+    %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+    transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
     %func_8 = transform.structured.hoist_redundant_vector_transfers %memref_func
-    : (!pdl.operation) -> !pdl.operation
-    transform.iree.apply_patterns %func_8 { canonicalization } : (!pdl.operation) -> ()
-    transform.iree.apply_patterns %func_8 { cse } : (!pdl.operation) -> ()
-    transform.iree.apply_buffer_optimizations %func_8 : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+    transform.iree.apply_patterns %func_8 { canonicalization } : (!transform.any_op) -> ()
+    transform.iree.apply_patterns %func_8 { cse } : (!transform.any_op) -> ()
+    transform.iree.apply_buffer_optimizations %func_8 : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cpu/contraction-packing-and-dispatch.mlir
+++ b/tests/transform_dialect/cpu/contraction-packing-and-dispatch.mlir
@@ -59,12 +59,12 @@ func.func @matmul(%arg0: !a_tensor_t, %arg2: !c_tensor_t) -> !c_tensor_t {
 //       CHECK:   tensor.unpack
 
 transform.sequence failures(propagate) {
-^bb1(%module_op: !pdl.operation):
+^bb1(%module_op: !transform.any_op):
   %matmul = transform.structured.match interface{LinalgOp} in %module_op
-    : (!pdl.operation) -> (!pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op)
 
   transform.structured.pack_greedily %matmul
       matmul_packed_sizes = [8, 16, 32] 
       matmul_inner_dims_order = [0, 1, 2]
-    : (!pdl.operation) -> !transform.op<"linalg.generic">
+    : (!transform.any_op) -> !transform.op<"linalg.generic">
 }

--- a/tests/transform_dialect/cpu/contraction-packing.mlir
+++ b/tests/transform_dialect/cpu/contraction-packing.mlir
@@ -137,9 +137,9 @@ func.func @matmul_nnt(%arg0: !a_tensor_t, %arg2: !ct_tensor_t) -> !ct_tensor_t {
 }
 
 transform.sequence failures(propagate) {
-^bb1(%module_op: !pdl.operation):
+^bb1(%module_op: !transform.any_op):
   %matmul = transform.structured.match interface{LinalgOp} in %module_op
-    : (!pdl.operation) -> (!pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op)
   
   // Generalized packing rewrite extracts a gemm from any linalg op that contains 
   // one. This acts as a powerful normalization step: after this point, we have a
@@ -147,5 +147,5 @@ transform.sequence failures(propagate) {
   // dimensions.
   transform.structured.pack_greedily %matmul
       matmul_packed_sizes = [8, 16, 32] matmul_inner_dims_order = [0, 1, 2]
-    : (!pdl.operation) -> !transform.op<"linalg.generic">
+    : (!transform.any_op) -> !transform.op<"linalg.generic">
 }

--- a/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
@@ -1,27 +1,27 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {  
-^bb1(%variant_op: !pdl.operation):
-  %0 = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+^bb1(%variant_op: !transform.any_op):
+  %0 = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
   %forall, %tiled_generic =
     transform.structured.tile_to_forall_op %0 num_threads [2] 
     // TODO: IREE needs own workgroup mapping attribute.
     ( mapping = [#gpu.block<x>] )
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall
-      : (!pdl.operation) -> ()
+      : (!transform.any_op) -> ()
 
   // Canonicalization/CSE is needed before bufferization otherwise unnecessary
   // allocs will be created.
   transform.iree.apply_patterns %variant_op 
-    { canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> (!pdl.operation)
+    { canonicalization, tiling_canonicalization, cse } : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> (!transform.any_op)
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
-  transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
+  transform.iree.forall_to_workgroup %memref_func : (!transform.any_op) -> ()
 
   // CSE is needed on the workgroup_count region to pass this particular test.
-  transform.iree.apply_patterns %variant_op_3 { cse } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %variant_op_3 { cse } : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
@@ -8,6 +8,7 @@ transform.sequence failures(propagate) {
     transform.structured.tile_to_forall_op %0 num_threads [2] 
     // TODO: IREE needs own workgroup mapping attribute.
     ( mapping = [#gpu.block<x>] )
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
     transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall
       : (!pdl.operation) -> ()
 

--- a/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
@@ -1,25 +1,25 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+^bb1(%variant_op: !transform.any_op):
+  %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
   // Step 1. Tile to forall with tile_sizes [2].
   // ===================================================
   %forall, %tiled_generic =
     transform.structured.tile_to_forall_op %matmul tile_sizes [2]
-      ( mapping = [#gpu.block<x>] ) : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+      ( mapping = [#gpu.block<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
   transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall
-    : (!pdl.operation) -> ()
+    : (!transform.any_op) -> ()
 
   // Step 2. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize %variant_op : (!pdl.operation) -> !pdl.operation
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> !transform.any_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 3. Post-bufferization mapping workgroup.
   // =========================================================
-  transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> ()
+  transform.iree.forall_to_workgroup %memref_func : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
@@ -8,7 +8,7 @@ transform.sequence failures(propagate) {
   // ===================================================
   %forall, %tiled_generic =
     transform.structured.tile_to_forall_op %matmul tile_sizes [2]
-      ( mapping = [#gpu.block<x>] )
+      ( mapping = [#gpu.block<x>] ) : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
   transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall
     : (!pdl.operation) -> ()
 

--- a/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
@@ -1,13 +1,13 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+^bb1(%variant_op: !transform.any_op):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
   // Step 1. Split the reduction to get meatier (size(red) / 2)-way parallelism.
   // ===========================================================================
-  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %eltwise, %reduction = transform.split_handle %0 : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %eltwise, %reduction = transform.split_handle %0 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
   %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
     transform.structured.split_reduction %reduction
       { split_factor = 2, insert_split_dimension = 1 }
@@ -24,32 +24,32 @@ transform.sequence failures(propagate) {
   // TODO: bubbling should be a proper transform op, at which point we will be
   // able to preserve the handles.
   // ===========================================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { bubble_expand } : (!pdl.operation) -> ()
-  %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func { bubble_expand } : (!transform.any_op) -> ()
+  %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %fill_2, %more_parallel_fill_2 = transform.split_handle %fills
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %expanded_eltwise, %more_parallel_2, %combiner_2 =
-    transform.split_handle %generics : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
-  %forall_grid_2 = transform.structured.match ops{["scf.forall"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %not_combiner = transform.merge_handles %fill_2, %more_parallel_fill_2, %more_parallel_2, %expanded_eltwise : !pdl.operation
+    transform.split_handle %generics : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+  %forall_grid_2 = transform.structured.match ops{["scf.forall"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %not_combiner = transform.merge_handles %fill_2, %more_parallel_fill_2, %more_parallel_2, %expanded_eltwise : !transform.any_op
   transform.structured.fuse_into_containing_op %not_combiner into %forall_grid_2
 
   // Step 3. Second level of tiling + fusion parallelizes to threads. Also
   // fuse in the leading elementwise.
   // ===========================================================================
-  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op : (!pdl.operation) -> !pdl.operation
+  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op : (!transform.any_op) -> !transform.any_op
   %forall_block_combiner_op, %block_combiner_op =
     transform.structured.tile_to_forall_op %combiner_2 tile_sizes [1]
     ( mapping = [#gpu.thread<z>] )
   transform.structured.fuse_into_containing_op %fill_1d into %forall_block_combiner_op
 
-  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op : (!pdl.operation) -> !pdl.operation
+  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op : (!transform.any_op) -> !transform.any_op
   %grid_more_parallel_op = transform.structured.match ops{["linalg.generic"]}
-    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %grid_eltwise_op = transform.structured.match ops{["linalg.generic"]}
-    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %forall_block_more_parallel_op, %block_more_parallel_op =
     transform.structured.tile_to_forall_op %grid_more_parallel_op tile_sizes [1, 1]
     ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
@@ -58,32 +58,32 @@ transform.sequence failures(propagate) {
 
   // Step 4. Rank-reduce and vectorize.
   // ===========================================================================
-  %func_1 = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func_1 = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_3 = transform.structured.vectorize %func_1
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> !pdl.operation
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> !transform.any_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
-  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_4 : (!pdl.operation) -> ()
-  transform.iree.map_nested_forall_to_gpu_threads %func_4 workgroup_dims = [32, 2, 1] : (!pdl.operation) -> ()
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_4 : (!transform.any_op) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_4 workgroup_dims = [32, 2, 1] : (!transform.any_op) -> ()
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_4 {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
+  transform.iree.apply_patterns %func_4 {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2 : (!transform.any_op) -> !transform.any_op
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
-  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
-  ^bb0(%arg0: !pdl.operation):
+  transform.sequence %variant_op_2 : !transform.any_op failures(suppress) {
+  ^bb0(%arg0: !transform.any_op):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_4 : (!pdl.operation) -> ()
+  transform.iree.vector.warp_distribute %func_4 : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
@@ -1,14 +1,14 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+^bb1(%variant_op: !transform.any_op):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
   // Step 1. Split the reduction to get meatier (size(red) / 2)-way parallelism.
   // ===========================================================================
-  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %leading_eltwise, %reduction, %trailing_eltwise = transform.split_handle %0
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
   %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
     transform.structured.split_reduction %reduction
       { split_factor = 2, insert_split_dimension = 1 }
@@ -26,37 +26,37 @@ transform.sequence failures(propagate) {
   // TODO: bubbling should be a proper transform op, at which point we will be
   // able to preserve the handles.
   // ===========================================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { bubble_expand } : (!pdl.operation) -> ()
-  %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func { bubble_expand } : (!transform.any_op) -> ()
+  %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %fill_2, %more_parallel_fill_2 = transform.split_handle %fill
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
-  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %expanded_eltwise, %more_parallel_2, %combiner_2, %trailing_eltwise_2 =
     transform.split_handle %generics
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
-  %forall_grid_2 = transform.structured.match ops{["scf.forall"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+  %forall_grid_2 = transform.structured.match ops{["scf.forall"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %not_trailing = transform.merge_handles %fill_2, %more_parallel_fill_2,
-    %more_parallel_2, %expanded_eltwise, %combiner_2 : !pdl.operation
+    %more_parallel_2, %expanded_eltwise, %combiner_2 : !transform.any_op
   transform.structured.fuse_into_containing_op %not_trailing into %forall_grid_2
 
   // Step 3. Second level of tiling + fusion parallelizes to threads. Also
   // fuse in the leading and trailing elementwise.
   // ===========================================================================
-  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op : (!pdl.operation) -> !pdl.operation
+  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op : (!transform.any_op) -> !transform.any_op
   %forall_trailing_eltwise_op, %block_trailing_eltwise_op =
     transform.structured.tile_to_forall_op %trailing_eltwise_2 tile_sizes [1]
     ( mapping = [#gpu.thread<z>] )
   %block_combiner_op = transform.structured.match ops{["linalg.generic"]}
-    attributes {iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %fill_and_reduction = transform.merge_handles %fill_1d, %block_combiner_op : !pdl.operation
+    attributes {iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %fill_and_reduction = transform.merge_handles %fill_1d, %block_combiner_op : !transform.any_op
   transform.structured.fuse_into_containing_op %fill_and_reduction into %forall_trailing_eltwise_op
 
-  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op : (!pdl.operation) -> !pdl.operation
+  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op : (!transform.any_op) -> !transform.any_op
   %grid_more_parallel_op = transform.structured.match ops{["linalg.generic"]}
-    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %grid_eltwise_op = transform.structured.match ops{["linalg.generic"]}
-    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %forall_block_more_parallel_op, %block_more_parallel_op =
     transform.structured.tile_to_forall_op %grid_more_parallel_op tile_sizes [1, 1]
     ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
@@ -65,32 +65,32 @@ transform.sequence failures(propagate) {
 
   // Step 4. Rank-reduce and vectorize.
   // ===========================================================================
-  %func_1 = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func_1 = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func_1 {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_2 = transform.structured.vectorize %func_1
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> !pdl.operation
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> !transform.any_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
-  %func_3 = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_3 : (!pdl.operation) -> ()
-  transform.iree.map_nested_forall_to_gpu_threads %func_3 workgroup_dims = [32, 2, 1] : (!pdl.operation) -> ()
+  %func_3 = transform.structured.match ops{["func.func"]} in %variant_op_2 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_3 : (!transform.any_op) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_3 workgroup_dims = [32, 2, 1] : (!transform.any_op) -> ()
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_3 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2 : (!pdl.operation) -> !pdl.operation
+  transform.iree.apply_patterns %func_3 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!transform.any_op) -> ()
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2 : (!transform.any_op) -> !transform.any_op
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
-  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
-  ^bb0(%arg0: !pdl.operation):
+  transform.sequence %variant_op_2 : !transform.any_op failures(suppress) {
+  ^bb0(%arg0: !transform.any_op):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_3 : (!pdl.operation) -> ()
+  transform.iree.vector.warp_distribute %func_3 : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/mma.mlir
+++ b/tests/transform_dialect/cuda/mma.mlir
@@ -28,16 +28,16 @@ func.func @wmma(%a: memref<16x16xf32>, %b: memref<16x16xf32>, %c: memref<16x16xf
 }
 
 transform.sequence failures(propagate) {
-^bb1(%module: !pdl.operation):
+^bb1(%module: !transform.any_op):
   %func = transform.structured.match ops{["func.func"]} in %module
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!pdl.operation) -> ()
-  transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!transform.any_op) -> ()
+  transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!transform.any_op) -> ()
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
   // (i.e. all vector.contract are dead).
   // TODO: consider having the vector_to_mma_conversion do the DCE automatically.
-  transform.iree.apply_patterns %func { canonicalization } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func { canonicalization } : (!transform.any_op) -> ()
 }
 
 // -----
@@ -68,14 +68,14 @@ func.func @mma_sync(%a: memref<16x16xf32>, %b: memref<16x16xf32>, %c: memref<16x
 }
 
 transform.sequence failures(propagate) {
-^bb1(%module: !pdl.operation):
+^bb1(%module: !transform.any_op):
   %func = transform.structured.match ops{["func.func"]} in %module
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { unroll_vectors_gpu_mma_sync } : (!pdl.operation) -> ()
-  transform.iree.vector.vector_to_mma_conversion %func { use_mma_sync } : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func { unroll_vectors_gpu_mma_sync } : (!transform.any_op) -> ()
+  transform.iree.vector.vector_to_mma_conversion %func { use_mma_sync } : (!transform.any_op) -> ()
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
   // (i.e. all vector.contract are dead).
   // TODO: consider having the vector_to_mma_conversion do the DCE automatically.
-  transform.iree.apply_patterns %func { canonicalization } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func { canonicalization } : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/mma_elemwise_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_elemwise_layout_analysis_codegen_spec.mlir
@@ -1,48 +1,48 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
 
   // Step 1. Find the fill, matmul and generic ops
   // ===========================================================================
-  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %matmul = transform.structured.match ops{["linalg.matmul_transpose_b"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %generic = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %matmul = transform.structured.match ops{["linalg.matmul_transpose_b"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %generic = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
   // Step 2. Tile the generic and fuse the fill and matmul
   // ===========================================================================
   %forall_grid, %grid_reduction =
   transform.structured.tile_to_forall_op %generic tile_sizes [16] ( mapping = [#gpu.block<x>] )
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
 
   transform.structured.fuse_into_containing_op %matmul into %forall_grid
   transform.structured.fuse_into_containing_op %fill into %forall_grid
 
   // Step 3. Vectorize
   // ===========================================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_3 = transform.structured.vectorize %func
 
   // Step 4. Bufferize
   // ===========================================================================
   transform.iree.apply_patterns %func_3
-    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> (!pdl.operation)
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> (!transform.any_op)
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization vector distribution
   // ===========================================================================
-  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_7 : (!pdl.operation) -> ()
+  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
   transform.iree.map_nested_forall_to_gpu_threads %func_7
-      workgroup_dims = [4, 8, 1] : (!pdl.operation) -> ()
+      workgroup_dims = [4, 8, 1] : (!transform.any_op) -> ()
 
   // Step 7. Do layout analysis and lower to mma
   // ===========================================================================
-  %func_10 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  %func_11 = transform.iree.layout_analysis_and_distribution %func_10 : (!pdl.operation) -> (!pdl.operation)
+  %func_10 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  %func_11 = transform.iree.layout_analysis_and_distribution %func_10 : (!transform.any_op) -> (!transform.any_op)
 }

--- a/tests/transform_dialect/cuda/mma_reduction_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_reduction_layout_analysis_codegen_spec.mlir
@@ -1,48 +1,48 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
 
   // Step 1. Find the fill, matmul and generic ops
   // ===========================================================================
-  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %matmul = transform.structured.match ops{["linalg.matmul_transpose_b"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %reduce, %broadcast = transform.split_handle %generics : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %matmul = transform.structured.match ops{["linalg.matmul_transpose_b"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %reduce, %broadcast = transform.split_handle %generics : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
   // Step 2. Tile the matmul and fuse the fill
   // ===========================================================================
   %forall_grid, %grid_reduction =
   transform.structured.tile_to_forall_op %broadcast tile_sizes [16] ( mapping = [#gpu.block<x>] )
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
   transform.structured.fuse_into_containing_op %reduce into %forall_grid
   transform.structured.fuse_into_containing_op %matmul into %forall_grid
   transform.structured.fuse_into_containing_op %fill into %forall_grid
 
   // Step 3. Vectorize
   // ===========================================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_3 = transform.structured.vectorize %func
 
   // Step 4. Bufferize
   // ===========================================================================
   transform.iree.apply_patterns %func_3
-    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> (!pdl.operation)
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> (!transform.any_op)
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization vector distribution
   // ===========================================================================
-  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_7 : (!pdl.operation) -> ()
-  transform.iree.map_nested_forall_to_gpu_threads %func_7 workgroup_dims = [4, 8, 1] : (!pdl.operation) -> ()
+  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_7 workgroup_dims = [4, 8, 1] : (!transform.any_op) -> ()
 
   // Step 7. Do layout analysis and lower to mma
   // ===========================================================================
-  %func_10 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  %func_11 = transform.iree.layout_analysis_and_distribution %func_10 : (!pdl.operation) -> (!pdl.operation)
+  %func_10 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  %func_11 = transform.iree.layout_analysis_and_distribution %func_10 : (!transform.any_op) -> (!transform.any_op)
 }

--- a/tests/transform_dialect/cuda/mma_reduction_layout_analysis_dispatch_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_reduction_layout_analysis_dispatch_spec.mlir
@@ -1,21 +1,21 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate){
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %ops = transform.structured.match ops{["linalg.fill", "linalg.matmul_transpose_b", "linalg.generic"]}
-    in %variant_op : (!pdl.operation) -> !pdl.operation
+    in %variant_op : (!transform.any_op) -> !transform.any_op
 
   %fill0, %fill1, %matmul, %reduce, %broadcast =
     transform.split_handle %ops
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation,
-                             !pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op,
+                             !transform.any_op, !transform.any_op)
 
   %region_op = transform.iree.wrap_in_dispatch_region %broadcast { generateWorkload = false }
 
-  %non_broadcast = transform.merge_handles %fill0, %fill1, %matmul, %reduce : !pdl.operation
+  %non_broadcast = transform.merge_handles %fill0, %fill1, %matmul, %reduce : !transform.any_op
   %region_op_2 = transform.iree.move_preceding_op_into_dispatch_region %non_broadcast into %region_op
 
-  %empty = transform.structured.match ops{["tensor.empty"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %empty = transform.structured.match ops{["tensor.empty"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %region_op_3 = transform.iree.move_preceding_op_into_dispatch_region %empty into %region_op_2
   transform.iree.region_to_workgroups %region_op_3
 }

--- a/tests/transform_dialect/cuda/mma_using_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_using_layout_analysis_codegen_spec.mlir
@@ -1,58 +1,58 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
 
   // Step 1. Find the fill and matmul ops
   // ===========================================================================
-  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
   // Step 2. Tile the matmul and fuse the fill
   // ===========================================================================
   %forall_grid, %grid_reduction =
   transform.structured.tile_to_forall_op %matmul tile_sizes [16] ( mapping = [#gpu.block<x>] )
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
 
   transform.structured.fuse_into_containing_op %fill into %forall_grid
 
   // Promote operands in order to test loading from shared memory.
-  %matmul_2 = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %matmul_2 = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %promoted_matmul, %alloc_0, %alloc_1 =
     transform.iree.promote_operands %matmul_2 [0, 1] 
-      : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
 
   // Step 3. Vectorize
   // ===========================================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_3 = transform.structured.vectorize %func
 
   // Step 4. Bufferize
   // ===========================================================================
   transform.iree.apply_patterns %func_3
-    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> (!pdl.operation)
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  transform.iree.apply_patterns %func_3 { erase_unnecessary_tensor_operands } : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> (!transform.any_op)
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 5. Pre-process the contract and transfer ops to put it in the right form.
   // ===========================================================================
-  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func_2 {  prepare_vector_to_mma } : (!pdl.operation) -> ()
+  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func_2 {  prepare_vector_to_mma } : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization vector distribution
   // ===========================================================================
-  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_7 : (!pdl.operation) -> ()
+  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
   transform.iree.map_nested_forall_to_gpu_threads %func_7
-      workgroup_dims = [4, 8, 1] : (!pdl.operation) -> ()
+      workgroup_dims = [4, 8, 1] : (!transform.any_op) -> ()
 
   // Step 7. Do layout analysis and lower to mma
   // ===========================================================================
-  %func_10 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  %func_11 = transform.iree.layout_analysis_and_distribution %func_10 : (!pdl.operation) -> (!pdl.operation)
+  %func_10 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  %func_11 = transform.iree.layout_analysis_and_distribution %func_10 : (!transform.any_op) -> (!transform.any_op)
 }

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -1,12 +1,12 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+^bb1(%variant_op: !transform.any_op):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
   // Step 1. Split the reduction to get meatier (size(red) / 2)-way parallelism.
   // ===========================================================================
-  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
     transform.structured.split_reduction %0
       { split_factor = 2, insert_split_dimension = 1 }
@@ -16,14 +16,14 @@ transform.sequence failures(propagate) {
   %forall_grid, %grid_combiner_op =
     transform.structured.tile_to_forall_op %combiner_op tile_sizes [1]
       ( mapping = [#gpu.block<x>] )
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!pdl.operation) -> ()
-  %not_combiner = transform.merge_handles %fill, %more_parallel_fill_op, %more_parallel_op : !pdl.operation
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
+  %not_combiner = transform.merge_handles %fill, %more_parallel_fill_op, %more_parallel_op : !transform.any_op
   transform.structured.fuse_into_containing_op %not_combiner into %forall_grid
 
   // Step 3. Second level of tiling + fusion parallelizes to threads.
   // ===========================================================================
   %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op 
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %forall_block_combiner_op, %block_combiner_op =
     transform.structured.tile_to_forall_op %grid_combiner_op tile_sizes [1] 
     ( mapping = [#gpu.thread<z>] )
@@ -31,13 +31,13 @@ transform.sequence failures(propagate) {
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
   %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op 
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %grid_more_parallel_op = transform.structured.match ops{["linalg.generic"]}
     attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op 
-      : (!pdl.operation) -> !pdl.operation
+      : (!transform.any_op) -> !transform.any_op
   %forall_block_more_parallel_op, %block_more_parallel_op =
     transform.structured.tile_to_forall_op %grid_more_parallel_op tile_sizes [1, 1] 
     ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
@@ -46,42 +46,42 @@ transform.sequence failures(propagate) {
   // Step 4. Rank-reduce and vectorize.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op 
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_3 = transform.structured.vectorize %func
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> !pdl.operation
+  transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> !transform.any_op
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
   %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_3 
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_5 : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_5 : (!transform.any_op) -> ()
   transform.iree.map_nested_forall_to_gpu_threads %func_5
-      workgroup_dims = [32, 2, 1] : (!pdl.operation) -> ()
+      workgroup_dims = [32, 2, 1] : (!transform.any_op) -> ()
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_5 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_5 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!transform.any_op) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
-  transform.sequence %variant_op_3 : !pdl.operation failures(suppress) {
-  ^bb0(%arg0: !pdl.operation):
+  transform.sequence %variant_op_3 : !transform.any_op failures(suppress) {
+  ^bb0(%arg0: !transform.any_op):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_5 : (!pdl.operation) -> ()
+  transform.iree.vector.warp_distribute %func_5 : (!transform.any_op) -> ()
 
 
   // Late Canonicalizations.
   transform.iree.apply_patterns %variant_op_3
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
@@ -1,60 +1,60 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
 
   // Step 1. Split the reduction to get meatier (size(red) / 2)-way parallelism.
   // ===========================================================================
   %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %reduction, %eltwise = transform.split_handle %0
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
   %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
     transform.structured.split_reduction %reduction
       { split_factor = 2, insert_split_dimension = 1 }
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
   // Step 2. First level of tiling + fusion parallelizes to blocks. Tile the
   // trailing elementwise the same way we want to tile the reduction.
   // ===========================================================================
   %grid_loop, %eltwise_grid_op = transform.structured.tile_to_forall_op %eltwise
     tile_sizes [1] (mapping = [#gpu.block<x>])
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %grid_loop : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %grid_loop : (!transform.any_op) -> ()
   %not_eltwise = transform.merge_handles %fill, %more_parallel_fill_op, %more_parallel_op, %combiner_op
-    : !pdl.operation
+    : !transform.any_op
   transform.structured.fuse_into_containing_op %not_eltwise into %grid_loop
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
   // Step 3. Second level of tiling + fusion parallelizes to threads.
   // ===========================================================================
   %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %eltwise_block_loop, %eltwise_block_op =
     transform.structured.tile_to_forall_op %eltwise_grid_op tile_sizes [1]
     ( mapping = [#gpu.thread<z>] )
   %block_combiner_op = transform.structured.match ops{["linalg.generic"]}
     attributes {iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op
-      : (!pdl.operation) -> !pdl.operation
-  %combined_and_fill = transform.merge_handles %fill_1d, %block_combiner_op : !pdl.operation
+      : (!transform.any_op) -> !transform.any_op
+  %combined_and_fill = transform.merge_handles %fill_1d, %block_combiner_op : !transform.any_op
   transform.structured.fuse_into_containing_op %combined_and_fill into %eltwise_block_loop
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
   %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %grid_more_parallel_op = transform.structured.match ops{["linalg.generic"]}
     attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op
-      : (!pdl.operation) -> !pdl.operation
+      : (!transform.any_op) -> !transform.any_op
   %forall_block_more_parallel_op, %block_more_parallel_op =
     transform.structured.tile_to_forall_op %grid_more_parallel_op tile_sizes [1, 1]
     ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
@@ -62,45 +62,45 @@ transform.sequence failures(propagate) {
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
   // Step 4. Rank-reduce and vectorize.
   // ===========================================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_3 = transform.structured.vectorize %func
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op: (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> (!pdl.operation)
+  transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op: (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> (!transform.any_op)
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func: (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func: (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
-  %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_5 : (!pdl.operation) -> ()
+  %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_5 : (!transform.any_op) -> ()
   transform.iree.map_nested_forall_to_gpu_threads %func_5
-      workgroup_dims = [32, 2, 1] : (!pdl.operation) -> ()
+      workgroup_dims = [32, 2, 1] : (!transform.any_op) -> ()
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_5 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_5 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!transform.any_op) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
-  transform.sequence %variant_op_3 : !pdl.operation failures(suppress) {
-  ^bb0(%arg0: !pdl.operation):
+  transform.sequence %variant_op_3 : !transform.any_op failures(suppress) {
+  ^bb0(%arg0: !transform.any_op):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_5 : (!pdl.operation) -> ()
+  transform.iree.vector.warp_distribute %func_5 : (!transform.any_op) -> ()
 
 
   // Late canonicalizations.
   transform.iree.apply_patterns %variant_op_3
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/reduction_v2_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v2_codegen_spec.mlir
@@ -1,16 +1,16 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
-  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  %reduction = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+^bb1(%variant_op: !transform.any_op):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %reduction = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
   // Step 1. First level of tiling + fusion parallelizes to blocks.
   // ===========================================================================
   %forall_grid, %grid_reduction =
     transform.structured.tile_to_forall_op %reduction tile_sizes [1]
       ( mapping = [#gpu.block<x>] )
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
   transform.structured.fuse_into_containing_op %fill into %forall_grid
 
   // Step 2. Split the reduction to get meatier parallelism.
@@ -35,8 +35,8 @@ transform.sequence failures(propagate) {
 
   // Step 4. Rank-reduce and vectorize.
   // ===========================================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_3 = transform.structured.vectorize %func
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
@@ -44,31 +44,31 @@ transform.sequence failures(propagate) {
   // Canonicalization/CSE is needed before bufferization otherwise unnecessary
   // allocs will be created.
   transform.iree.apply_patterns %func_3
-    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %func_5 = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func_5 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> (!pdl.operation)
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+    { fold_reassociative_reshapes, canonicalization, tiling_canonicalization, cse } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %func_5 = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func_5 { erase_unnecessary_tensor_operands } : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> (!transform.any_op)
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
-  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_7 : (!pdl.operation) -> ()
+  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
   transform.iree.map_nested_forall_to_gpu_threads %func_7
-      workgroup_dims = [32, 1, 1] : (!pdl.operation) -> ()
+      workgroup_dims = [32, 1, 1] : (!transform.any_op) -> ()
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_7 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_7 { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!transform.any_op) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   transform.iree.vector.warp_distribute %func_7
-    : (!pdl.operation) -> ()
+    : (!transform.any_op) -> ()
 
   // Late canonicalizations to cleanup and pass the checks
   transform.iree.apply_patterns %func_7
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
@@ -1,24 +1,24 @@
 // RUN: iree-opt %s
 
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %reduction = transform.structured.match ops{["linalg.generic"]} in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
 
   // Step 1. First level of tiling + fusion parallelizes to blocks.
   // ===========================================================================
   %forall_grid, %grid_reduction =
     transform.structured.tile_to_forall_op %reduction tile_sizes [1]
       ( mapping = [#gpu.block<x>] )
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
 
   transform.structured.fuse_into_containing_op %fill into %forall_grid
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
   // Step 2. Split the reduction to get meatier parallelism.
   // This also parallelizes to threads.
@@ -39,60 +39,60 @@ transform.sequence failures(propagate) {
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
   // Step 3. Rank-reduce and vectorize.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   // TODO: masked vectorization on block_more_parallel_op_2 if we want
   // vector<4> to work as intended.
   transform.iree.apply_patterns %func
-    { rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+    { rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   %func_3 = transform.structured.vectorize %func
 
   // Canonicalizations is necessary to get rid of some tensor.cast that block
   // hoisting.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
   transform.structured.hoist_redundant_tensor_subsets %func_3
-    : (!pdl.operation) -> ()
+    : (!transform.any_op) -> ()
 
 
   // Step 4. Bufferize and drop HAL descriptor from memref ops.
   // ===========================================================================
   // Canonicalizations required before bufferization to avoid unnecessary allocs.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
-  transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
+  transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
   %func_6 = transform.structured.match ops{["func.func"]} in %variant_op
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func_6 { erase_unnecessary_tensor_operands } : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func_6 { erase_unnecessary_tensor_operands } : (!transform.any_op) -> ()
   %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 5. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
   %func_m = transform.structured.match ops{["func.func"]} in %variant_op_3
-    : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_m : (!pdl.operation) -> ()
+    : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_m : (!transform.any_op) -> ()
   transform.iree.map_nested_forall_to_gpu_threads %func_m
-      workgroup_dims = [1024, 1, 1] : (!pdl.operation) -> ()
+      workgroup_dims = [1024, 1, 1] : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  transform.iree.apply_patterns %func_m { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %func_m { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!transform.any_op) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   transform.iree.vector.warp_distribute %func_m
-    : (!pdl.operation) -> ()
+    : (!transform.any_op) -> ()
 
   // Late canonicalizations.
   transform.iree.apply_patterns %variant_op_3
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
@@ -2,24 +2,24 @@
 
 // Codegen
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %ops = transform.structured.match ops{["linalg.fill", "linalg.generic"]}
-    in %variant_op : (!pdl.operation) -> !pdl.operation
+    in %variant_op : (!transform.any_op) -> !transform.any_op
   %input_max_fill,
   %input_max,
   %exps_sum_fill,
   %exps,
   %exps_sum,
   %div = transform.split_handle %ops
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation,
-                           !pdl.operation, !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op,
+                           !transform.any_op, !transform.any_op, !transform.any_op)
 
   // Step 1. First level of tiling + fusion parallelizes to blocks.
   // ==============================================================
   %forall, %_ =
     transform.structured.tile_to_forall_op %div tile_sizes [1, 4]
       ( mapping = [#gpu.block<x>, #gpu.block<y>] )
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall : (!transform.any_op) -> ()
 
   // TODO: Merging and fusing merged handles does not work properly atm.
   transform.structured.fuse_into_containing_op %exps_sum into %forall
@@ -31,22 +31,22 @@ transform.sequence failures(propagate) {
   // to shared as this involves a cross-thread dependence analysis.
   // Instead, we activate it explicitly post-hoc to promote all the extract_slice
   // ops that we find and match the prerequisites
-  %forall_with_type = transform.cast %forall : !pdl.operation to !transform.op<"scf.forall">
+  %forall_with_type = transform.cast %forall : !transform.any_op to !transform.op<"scf.forall">
   transform.iree.share_forall_operands %forall_with_type
     : (!transform.op<"scf.forall">) -> !transform.op<"scf.forall">
 
   // Step 2. Second level of tiling + fusion parallelizes to threads.
   // ================================================================
   %tiled_ops = transform.structured.match ops{["linalg.fill", "linalg.generic"]}
-    in %variant_op : (!pdl.operation) -> !pdl.operation
+    in %variant_op : (!transform.any_op) -> !transform.any_op
   %tiled_input_max_fill,
   %tiled_input_max,
   %tiled_exps_sum_fill,
   %tiled_exp_and_exps_sum,
   %tiled_exp_and_exps_sum_2,
   %tiled_div = transform.split_handle %tiled_ops
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation,
-                           !pdl.operation, !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op,
+                           !transform.any_op, !transform.any_op, !transform.any_op)
   // Leaving the reduction untiled on threadIdx.x makes it sequential on
   // threadIdx.x. After distribution, predication by `if (threadIdx.x == 0)` is
   // introduced and opportunities for distributing vector ops across warps
@@ -54,41 +54,41 @@ transform.sequence failures(propagate) {
   %reduction_linalg_ops = transform.merge_handles %tiled_input_max,
                                                   %tiled_exp_and_exps_sum,
                                                   %tiled_exp_and_exps_sum_2
-    : !pdl.operation
+    : !transform.any_op
   transform.structured.tile_to_forall_op %reduction_linalg_ops tile_sizes [1, 1]
     ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
   // Fully parallel ops are tiled and mapped.
   %parallel_linalg_ops = transform.merge_handles %tiled_input_max_fill,
                                                  %tiled_exps_sum_fill,
                                                  %tiled_div
-    : !pdl.operation
+    : !transform.any_op
   transform.structured.tile_to_forall_op %parallel_linalg_ops num_threads [1, 4, 32]
       ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
 
   // Step 3. Rank-reduce and vectorize.
   // ==================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   transform.structured.vectorize %func
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> !pdl.operation
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> !transform.any_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 5. Post-bufferization mapping to blocks and threads.
   // =========================================================
-  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.forall_to_workgroup %func_2 : (!pdl.operation) -> ()
-  transform.iree.map_nested_forall_to_gpu_threads %func_2 workgroup_dims = [32, 4, 1] : (!pdl.operation) -> ()
+  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_2 : (!transform.any_op) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_2 workgroup_dims = [32, 4, 1] : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===================================================================
-  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %end_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
+  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %end_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!transform.any_op) -> ()
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-  transform.iree.vector.warp_distribute %end_func : (!pdl.operation) -> ()
+  transform.iree.vector.warp_distribute %end_func : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/softmax_v2_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_v2_codegen_spec.mlir
@@ -2,23 +2,23 @@
 
 // Codegen
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %ops = transform.structured.match ops{["linalg.fill", "linalg.generic"]}
-    in %variant_op : (!pdl.operation) -> !pdl.operation
+    in %variant_op : (!transform.any_op) -> !transform.any_op
   %input_max_fill,
   %input_max,
   %exps_sum_fill,
   %exp_and_exps_sum,
   %div = transform.split_handle %ops
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation,
-                           !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op,
+                           !transform.any_op, !transform.any_op)
 
   // Step 1. First level of tiling + fusion parallelizes to blocks.
   // ==============================================================
   %forall, %_ =
   transform.structured.tile_to_forall_op %div tile_sizes [1, 4]
     ( mapping = [#gpu.block<x>, #gpu.block<y>] )
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall : (!transform.any_op) -> ()
 
   // TODO: Merging and fusing merged handles does not work properly atm.
   transform.structured.fuse_into_containing_op %exp_and_exps_sum into %forall
@@ -29,77 +29,77 @@ transform.sequence failures(propagate) {
   // to shared as this involves a cross-thread dependence analysis.
   // Instead, we activate it explicitly post-hoc to promote all the extract_slice
   // ops that we find and match the prerequisites
-  %forall_with_type = transform.cast %forall : !pdl.operation to !transform.op<"scf.forall">
+  %forall_with_type = transform.cast %forall : !transform.any_op to !transform.op<"scf.forall">
   transform.iree.share_forall_operands %forall_with_type
     : (!transform.op<"scf.forall">) -> !transform.op<"scf.forall">
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
 
   // Step 2. Second level of tiling + fusion parallelizes to threads.
   // ================================================================
   %tiled_ops = transform.structured.match ops{["linalg.fill", "linalg.generic"]}
-    in %variant_op : (!pdl.operation) -> !pdl.operation
+    in %variant_op : (!transform.any_op) -> !transform.any_op
   %tiled_input_max_fill,
   %tiled_input_max,
   %tiled_exps_sum_fill,
   %tiled_exp_and_exps_sum,
   %tiled_div = transform.split_handle %tiled_ops
-    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation,
-                           !pdl.operation, !pdl.operation)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op,
+                           !transform.any_op, !transform.any_op)
   // Leaving the reduction untiled on threadIdx.x makes it sequential on
   // threadIdx.x. After distribution, predication by `if (threadIdx.x == 0)` is
   // introduced and opportunities for distributing vector ops across warps
   // appear.
   %reduction_linalg_ops = transform.merge_handles %tiled_input_max,
                                                   %tiled_exp_and_exps_sum
-    : !pdl.operation
+    : !transform.any_op
   transform.structured.tile_to_forall_op %reduction_linalg_ops tile_sizes [1, 1]
     ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
   // Fully parallel ops are tiled and mapped.
   %parallel_linalg_ops = transform.merge_handles %tiled_input_max_fill,
                                                  %tiled_exps_sum_fill,
                                                  %tiled_div
-    : !pdl.operation
+    : !transform.any_op
   transform.structured.tile_to_forall_op %parallel_linalg_ops num_threads [1, 4, 32]
     ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
 
   // Canonicalizations.
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 
   // Step 3. Rank-reduce and vectorize.
   // ==================================
-  %funcx_2 = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %funcx_2 {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
+  %funcx_2 = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %funcx_2 {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
   transform.structured.vectorize %funcx_2
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> !pdl.operation
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> !transform.any_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 5. Post-bufferization mapping to blocks and threads.
   // =========================================================
-  transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> ()
+  transform.iree.forall_to_workgroup %memref_func : (!transform.any_op) -> ()
   transform.iree.map_nested_forall_to_gpu_threads %memref_func
-    workgroup_dims = [32, 4, 1] : (!pdl.operation) -> ()
+    workgroup_dims = [32, 4, 1] : (!transform.any_op) -> ()
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===================================================================
-  transform.iree.apply_patterns %memref_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!pdl.operation) -> ()
+  transform.iree.apply_patterns %memref_func { rank_reducing_linalg, rank_reducing_vector, fold_memref_aliases } : (!transform.any_op) -> ()
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   transform.iree.vector.warp_distribute %memref_func
-    : (!pdl.operation) -> ()
+    : (!transform.any_op) -> ()
 
 
   // Late canonicalizations.
   transform.iree.apply_patterns %variant_op_3
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
@@ -1,23 +1,23 @@
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   // Step 1. Find three linalg.generics and tile to GPU thread blocks.
   // ===========================================================================
-  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
   %forall_grid, %_ = transform.structured.tile_to_forall_op %generics 
                   tile_sizes [5, 3] ( mapping = [#gpu.block<z>, #gpu.block<x>])
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
 
 
   // Step 2. Rank reduce and bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!pdl.operation) -> ()
-  transform.iree.eliminate_empty_tensors %variant_op : (!pdl.operation) -> ()
-  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!pdl.operation) -> !pdl.operation
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!pdl.operation) -> !pdl.operation
-  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!pdl.operation) -> ()
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_patterns %func {  rank_reducing_linalg, rank_reducing_vector } : (!transform.any_op) -> ()
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> !transform.any_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
 
   // Step 3. Map to GPU thread blocks.
   // ===========================================================================
-  transform.iree.forall_to_workgroup %memref_func : (!pdl.operation) -> ()
+  transform.iree.forall_to_workgroup %memref_func : (!transform.any_op) -> ()
 }

--- a/tests/transform_dialect/cuda/vecadd2d_codegen_spec_partial_tile.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d_codegen_spec_partial_tile.mlir
@@ -1,15 +1,15 @@
 transform.sequence failures(propagate) {
-^bb1(%variant_op: !pdl.operation):
+^bb1(%variant_op: !transform.any_op):
   %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op 
-    : (!pdl.operation) -> !pdl.operation
+    : (!transform.any_op) -> !transform.any_op
   // Tile only one dimension, skip the other one.
   %forall_grid, %_ = transform.structured.tile_to_forall_op %generics 
                   tile_sizes [0, 3] ( mapping = [#gpu.block<z>])
-  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!pdl.operation) -> ()
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
 
 
   // Late canonicalizations to cleanup and pass the checks.
   // Needs to occur on the whole variant to perform cse on the workgroup_count region
   transform.iree.apply_patterns %variant_op
-    { canonicalization, tiling_canonicalization, licm, cse } : (!pdl.operation              ) -> ()
+    { canonicalization, tiling_canonicalization, licm, cse } : (!transform.any_op              ) -> ()
 }


### PR DESCRIPTION
** waiting for upstream integrate **

Types have been introduced a while ago and provide for better
readability and transform-time verification. Use them in all IREE
transform dialect extensions. All new ops use trailing functional type
specification similarly to the generic form so any downstream changes
should be straightforward.