### PR TITLE
Make Discord notification link directly to workflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1067,9 +1067,6 @@ jobs:
             echo "The following jobs failed: ${FAILED_JOBS}"
             exit 1
           fi
-      - name: Echo link
-        if: failure()
-        run: echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
       - name: Show useful artifact links
         if: always()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1059,13 +1059,6 @@ jobs:
             echo "The following jobs failed: ${FAILED_JOBS}"
             exit 1
           fi
-      - name: Posting to Discord
-        uses: sarisia/actions-status-discord@61114b793b460ee85fe38ad3fccc78c7ead38d55 # v1.11.1
-        if: failure() && github.ref_name == 'main'
-        with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"
-          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
       - name: Show useful artifact links
         if: always()
         env:
@@ -1114,3 +1107,10 @@ jobs:
           To run benchmarks locally with the CI-built e2e test artifacts, see [IREE Benchmark Suites](
           https://github.com/${GITHUB_REPOSITORY}/blob/main/docs/developers/developing_iree/benchmark_suites.md#3-fetch-the-benchmark-artifacts).
           EOF
+      - name: Posting to Discord
+        uses: sarisia/actions-status-discord@61114b793b460ee85fe38ad3fccc78c7ead38d55 # v1.11.1
+        if: failure() && github.ref_name == 'main'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1067,6 +1067,9 @@ jobs:
             echo "The following jobs failed: ${FAILED_JOBS}"
             exit 1
           fi
+      - name: Echo link
+        if: failure()
+        run: echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
       - name: Show useful artifact links
         if: always()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1065,6 +1065,7 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
       - name: Show useful artifact links
         if: always()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1117,7 +1117,7 @@ jobs:
           EOF
       - name: Posting to Discord
         uses: sarisia/actions-status-discord@61114b793b460ee85fe38ad3fccc78c7ead38d55 # v1.11.1
-        if: failure() && github.ref_name == 'main'
+        if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,13 @@ jobs:
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
+  test_job_please_ignore:
+    needs: setup
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail
+        run: exit 1
+
   build_test_all_macos_x86_64:
     needs: setup
     if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
@@ -1000,6 +1007,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - setup
+      - test_job_please_ignore
 
       # Basic
       - build_all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,13 +163,6 @@ jobs:
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
-  test_job_please_ignore:
-    needs: setup
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Fail
-        run: exit 1
-
   build_test_all_macos_x86_64:
     needs: setup
     if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
@@ -1007,7 +1000,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - setup
-      - test_job_please_ignore
 
       # Basic
       - build_all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1120,5 +1120,6 @@ jobs:
         if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          nocontext: true
           description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"
           url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1117,7 +1117,7 @@ jobs:
           EOF
       - name: Posting to Discord
         uses: sarisia/actions-status-discord@61114b793b460ee85fe38ad3fccc78c7ead38d55 # v1.11.1
-        if: failure()
+        if: failure() && github.ref_name == 'main'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1120,6 +1120,5 @@ jobs:
         if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          nocontext: true
           description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"
           url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -55,7 +55,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: "false" # ${{ steps.configure.outputs.should-run }}
+      should-run: ${{ steps.configure.outputs.should-run }}
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -55,7 +55,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: ${{ steps.configure.outputs.should-run }}
+      should-run: "false" # ${{ steps.configure.outputs.should-run }}
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}


### PR DESCRIPTION
This makes the title a URL that takes you to the thing you actually
want to see: the failing run. Currently the closest thing is the checks
page, which is super noisy for commits on main because all the stuff
running on `schedule` or `pull_request_target` run in the context of
the HEAD commit on main and apparently post all their checks there...

I tried also making the message less noisy in general, but it removed
too much context. If we want something different, we'll have to switch
to a different action: this one deliberately already has everything
formatted for you. Although really I'd love to figure out a way we can
use issues for CI failures. Discord kind of sucks for tracking.