### PR TITLE
Fix GitHub runner update documentation

### DIFF
--- a/build_tools/github_actions/runner/README.md
+++ b/build_tools/github_actions/runner/README.md
@@ -217,8 +217,8 @@ To deploy to prod, create new prod templates. Then use the update script to
 canary to a single instance:
 
 ```shell
-build_tools/github_actions/runner/update_instance_groups.py canary-update \
-  --prod --region=all --group=all --type=all --version="${VERSION}"
+build_tools/github_actions/runner/gcp/update_instance_groups.py canary \
+  --env=prod --region=all --group=all --type=all --version="${VERSION}"
 ```
 
 Watch to make sure that your new runners are starting up and registering as
@@ -227,8 +227,8 @@ on the order of days before proceeding. When you are satisfied that your new
 configuration is good, complete the update with your new template:
 
 ```shell
-build_tools/github_actions/runner/update_instance_groups.py promote-canary \
-  --prod --region=all --group=all --type=all
+build_tools/github_actions/runner/gcp/update_instance_groups.py promote-canary \
+  --env=prod --region=all --group=all --type=all
 ```
 
 ## Known Issues / Future Work

--- a/build_tools/github_actions/runner/gcp/update_runner_version.py
+++ b/build_tools/github_actions/runner/gcp/update_runner_version.py
@@ -29,7 +29,7 @@ import requests
 VERSION_LINE_FORMAT_STRING = 'GITHUB_RUNNER_VERSION="${GITHUB_RUNNER_VERSION:-%s}"'
 DIGEST_LINE_FORMAT_STRING = 'GITHUB_RUNNER_ARCHIVE_DIGEST="${GITHUB_RUNNER_ARCHIVE_DIGEST:-%s}"'
 
-DIGEST_SEARCH_PATTERN = r".*\bBEGIN.SHA linux-x64\b.*\b([a-fA-F0-9]{64})\b.*END.SHA linux-x64\b.*"
+DIGEST_SEARCH_PATTERN = r"^.*\bBEGIN.SHA linux-x64\b.*\b([a-fA-F0-9]{64})\b.*END.SHA linux-x64\b.*$"
 
 RUNNER_ARCHIVE_TEMPLATE = string.Template(
     "actions-runner-linux-x64-${version}.tar.gz")
@@ -62,7 +62,7 @@ if __name__ == "__main__":
   version = release["tag_name"][1:]
   digest = None
 
-  sha_pattern = re.compile(f"^{DIGEST_SEARCH_PATTERN}$", flags=re.MULTILINE)
+  sha_pattern = re.compile(DIGEST_SEARCH_PATTERN, flags=re.MULTILINE)
   matches = sha_pattern.findall(release["body"])
 
   if not matches:

--- a/build_tools/github_actions/runner/gcp/update_runner_version.py
+++ b/build_tools/github_actions/runner/gcp/update_runner_version.py
@@ -62,12 +62,8 @@ if __name__ == "__main__":
   version = release["tag_name"][1:]
   digest = None
 
-  sha_pattern = re.compile(DIGEST_SEARCH_PATTERN)
-
-  matches = [
-      m for m in (sha_pattern.fullmatch(l)
-                  for l in release["body"].splitlines()) if m
-  ]
+  sha_pattern = re.compile(f"^{DIGEST_SEARCH_PATTERN}$", flags=re.MULTILINE)
+  matches = sha_pattern.findall(release["body"])
 
   if not matches:
     error(
@@ -76,7 +72,7 @@ if __name__ == "__main__":
   if len(matches) > 1:
     error(f"ERROR: Multiple lines match digest search regex:", matches)
 
-  digest = matches[0].group(1)
+  digest = matches[0]
 
   archive = RUNNER_ARCHIVE_TEMPLATE.substitute(version=version)
   asset_url = ASSET_URL_TEMPLATE.substitute(version=version, archive=archive)


### PR DESCRIPTION
I tried actually copy-pasting the commands from my documentation when
doing this rollout and they were quite out of date :facepalm:

I was *just* having a conversation about testing documentation code
snippets too...

Also script improvement recommended from post-submit review of
https://github.com/openxla/iree/pull/13644
