### PR TITLE
e2e matmul test improvements

### DIFF
--- a/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
@@ -884,6 +884,12 @@ struct LinalgFillConversion : public OpRewritePattern<linalg::FillOp> {
   }
 
   LogicalResult handle2DTile(OpInfo &info, PatternRewriter &rewriter) const {
+    Type scalarType = info.scalar.getType();
+    if (!scalarType.isIntOrFloat() ||
+        scalarType.getIntOrFloatBitWidth() != 32) {
+      return rewriter.notifyMatchFailure(info.op,
+                                         "handling only 32-bit scalar types");
+    }
     auto loc = info.op.getLoc();
     StridedBufferDescriptor &outDesc = info.outAnal.getDesc(rewriter);
     Value m = outDesc.sizes[0];


### PR DESCRIPTION
* Test the non-accumulating matmul case (fill-zero accumulator). See discussion in #13582 with @ThomasRaoux .
* Drop the `MIXED` dynamicity: it was already unused, having been dropped out of actual test variants iterated over. Drop helpers that were only used for it, such as `pseudorandom_bool`.
* In case of numerical error, drop the logic re-running matmul tests on simpler matrices. Although potentially useful to help pinpoint the numerical issue, it was confusing when debugging (as discussed once with @manishucsd ), and it made test runner code substantially more complex.