### PR TITLE
Disabling detensoring by default until #6948 can be completed.

### DIFF
--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -266,7 +266,7 @@ iree_check_single_backend_test_suite(
     # "table.mlir"  # TODO(#10906): fix (i8/i16?)
     "tanh.mlir"
     "transpose.mlir"
-    "while.mlir"
+    # "while.mlir"  # TODO(#12509): WebGPU SPIR-V broken
   TARGET_BACKEND
     "webgpu"
   # Only test compilation for now, the WebGPU driver is not stable/tested yet.

--- a/tests/e2e/xla_ops/CMakeLists.txt
+++ b/tests/e2e/xla_ops/CMakeLists.txt
@@ -505,7 +505,7 @@ iree_check_single_backend_test_suite(
     "tanh.mlir"
     "torch_index_select.mlir"
     "transpose.mlir"
-    "while.mlir"
+    # "while.mlir"  # TODO(#12509): WebGPU SPIR-V broken
   TARGET_BACKEND
     "webgpu"
   # Only test compilation for now, the WebGPU driver is not stable/tested yet.


### PR DESCRIPTION
Detensoring is useful in small scale (a single while-loop with a tensor<i64> iterator like from JAX) but results in pathologically bad device<->host behavior in all other cases. Without improvements to dispatch region formation for small scalar workloads or a retensoring pass that eliminates the device<->host transfers we can't have it on by default.

This makes HLO while loops less efficient as they represent the loop iterator and condition as tensor operations that get performed on device even though the loop happens on the host. It makes everything else significantly better, though, and in the LLM modules under inspection in #13637 reduces the number of host<->device round trips from ~500-1000 (depending on model) to ~3 (all while loop math). We could investigate an HLO-level specialized detensoring of while loops until we can fix #6948.

WebGPU's SPIR-V -> WGSL lowering currently has issues with non-detensored comparisons (#12509) and those `while.mlir` tests have been disabled.