### PR TITLE
Skip testing tflite_text_classification Colab notebook.

### DIFF
--- a/samples/colab/test_notebooks.py
+++ b/samples/colab/test_notebooks.py
@@ -11,7 +11,12 @@ import os
 import subprocess
 import unittest
 
-NOTEBOOKS_TO_SKIP = []
+NOTEBOOKS_TO_SKIP = [
+    # Generally unstable since this installs tf-nightly. tflite_runtime also
+    # requires some deps ("version `GLIBC_2.29' not found") that
+    # samples.Dockerfile does not currently include.
+    "tflite_text_classification.ipynb",
+]
 
 NOTEBOOKS_EXPECTED_TO_FAIL = [
     # None!


### PR DESCRIPTION
This fixes the 'samples' CI job that runs nightly, tested (via workflow_dispatch) here: https://github.com/openxla/iree/actions/runs/5006009311

Previous failure: https://github.com/openxla/iree/actions/runs/4999234145
```
File /work/.notebook.venv/lib/python3.8/site-packages/tflite_runtime/interpreter.py:33
     30   from tensorflow.python.util.tf_export import tf_export as _tf_export
     31 else:
     32   # This file is part of tflite_runtime package.
---> 33   from tflite_runtime import _pywrap_tensorflow_interpreter_wrapper as _interpreter_wrapper
     34   from tflite_runtime import metrics_portable as metrics
     36   def _tf_export(*x, **kwargs):

ImportError: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /work/.notebook.venv/lib/python3.8/site-packages/tflite_runtime/_pywrap_tensorflow_interpreter_wrapper.so)
```

skip-ci: doesn't affect presubmit CI
