### PR TITLE
Revert "Dump benchmark flags in CI run"

### DIFF
--- a/.github/workflows/build_e2e_test_artifacts.yml
+++ b/.github/workflows/build_e2e_test_artifacts.yml
@@ -101,7 +101,6 @@ jobs:
         env:
           COMPILATION_BENCHMARK_CONFIG: ${{ steps.build.outputs.e2e-test-artifacts-dir }}/compilation-benchmark-config.json
           EXECUTION_BENCHMARK_CONFIG: ${{ steps.build.outputs.e2e-test-artifacts-dir }}/execution-benchmark-config.json
-          BENCHMARK_FLAG_DUMP: ${{ steps.build.outputs.e2e-test-artifacts-dir }}/benchmark-flag-dump.txt
           BENCHMARK_PRESETS: ${{ inputs.benchmark-presets }}
         run: |
           ./build_tools/benchmarks/export_benchmark_config.py \
@@ -111,11 +110,6 @@ jobs:
             execution \
             --benchmark_presets="${BENCHMARK_PRESETS}" \
             --output="${EXECUTION_BENCHMARK_CONFIG}"
-          ./build_tools/benchmarks/benchmark_helper.py dump-cmds \
-            --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
-            --compilation_benchmark_config="${COMPILATION_BENCHMARK_CONFIG}" \
-            > "${BENCHMARK_FLAG_DUMP}"
-          echo "benchmark-flag-dump=${BENCHMARK_FLAG_DUMP}" >> "${GITHUB_OUTPUT}"
       - name: "Uploading e2e test artifacts"
         id: upload
         env:
@@ -123,7 +117,6 @@ jobs:
           E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
           E2E_TEST_ARTIFACTS_BUILD_LOG: ${{ steps.build.outputs.e2e-test-artifacts-build-log }}
           E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT: ${{ env.GCS_DIR }}/e2e-test-artifacts/ninja_log
-          BENCHMARK_FLAG_DUMP: ${{ steps.export.outputs.benchmark-flag-dump }}
         run: |
           # Uploads all IREE artifacts and MLIR files (including the imported
           # MLIR files and MLIR source models).
@@ -132,8 +125,6 @@ jobs:
           find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 \
             -name "iree_*" -o -name "model_*.mlir" -o -name "model_*.mlirbc" -o -name "*.json" | \
             gcloud storage cp --read-paths-from-stdin -r \
-              "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
-          gcloud storage cp "${BENCHMARK_FLAG_DUMP}" \
               "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
           gcloud storage cp "${E2E_TEST_ARTIFACTS_BUILD_LOG}" \
               "${E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1092,11 +1092,6 @@ jobs:
           <summary>Click to show common usages</summary>
 
           \`\`\`sh
-          # Get compile and run flags of benchmarks
-          gcloud storage cp -r "\${E2E_TEST_ARTIFACTS_DIR_URL?}/benchmark-flag-dump.txt" /tmp/
-          \`\`\`
-
-          \`\`\`sh
           # Download all artifacts
           mkdir /tmp/iree_e2e_test_artifacts
           gcloud storage cp -r "\${E2E_TEST_ARTIFACTS_DIR_URL?}/*" /tmp/iree_e2e_test_artifacts


### PR DESCRIPTION
Reverts openxla/iree#13649 Didn't handle the case when the benchmark preset is empty