### PR TITLE
[SPIRV] Unroll vector.gather to native vector sizes before lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -214,6 +214,13 @@ SmallVector<int64_t> getNativeVectorShapeImpl(vector::TransposeOp op) {
   return nativeSize;
 }
 
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::GatherOp op) {
+  VectorType vectorType = op.getVectorType();
+  SmallVector<int64_t> nativeSize(vectorType.getRank(), 1);
+  nativeSize.back() = getComputeVectorSize(vectorType.getShape().back());
+  return nativeSize;
+}
+
 std::optional<SmallVector<int64_t>> getNativeVectorShape(
     Operation *op, bool targetSupportsDotProd) {
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
@@ -226,7 +233,7 @@ std::optional<SmallVector<int64_t>> getNativeVectorShape(
 
   return TypeSwitch<Operation *, std::optional<SmallVector<int64_t>>>(op)
       .Case<VectorTransferOpInterface, vector::MultiDimReductionOp,
-            vector::ReductionOp, vector::TransposeOp>(
+            vector::ReductionOp, vector::TransposeOp, vector::GatherOp>(
           [](auto typedOp) { return getNativeVectorShapeImpl(typedOp); })
       .Case<vector::ContractionOp>([=](auto contract) {
         return getNativeVectorShapeImpl(contract, targetSupportsDotProd);
@@ -384,22 +391,6 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
 
     LLVM_DEBUG({
       llvm::dbgs() << "--- After lowering multi_reduction ops ---\n";
-      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-      llvm::dbgs() << "\n\n";
-    });
-
-    // Similarly for vector.gather ops, whose lowering patterns unroll
-    // internally.
-    {
-      RewritePatternSet patterns(context);
-      vector::populateVectorGatherLoweringPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-        return signalPassFailure();
-      }
-    }
-
-    LLVM_DEBUG({
-      llvm::dbgs() << "--- After lowering gather ops ---\n";
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });
@@ -580,6 +571,7 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       vector::populateVectorMultiReductionLoweringPatterns(
           patterns, vector::VectorMultiReductionLowering::InnerParallel);
       vector::populateVectorTransposeLoweringPatterns(patterns, options);
+      vector::populateVectorGatherLoweringPatterns(patterns);
       if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
@@ -600,6 +592,7 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       vector::TransferReadOp::getCanonicalizationPatterns(patterns, context);
       vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
       vector::ReductionOp::getCanonicalizationPatterns(patterns, context);
+      scf::IfOp::getCanonicalizationPatterns(patterns, context);
       if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_gather.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_gather.mlir
@@ -11,11 +11,27 @@ func.func @vector_gather(%arg0: memref<16x1082x1922xi8>, %index_vec: vector<16xi
 // CHECK-LABEL: func.func @vector_gather
 // CHECK-SAME:  %[[ARG0:.+]]: memref<16x1082x1922xi8>
 // CHECK-SAME:  %[[INDEX_VEC:.+]]: vector<16xindex>
-// CHECK:       %[[C0:.+]] = arith.constant 0 : index
-// CHECK:       %[[INIT:.+]] = arith.constant dense<0> : vector<16xi8>
-// CHECK:       %[[IND:.+]] = vector.extract %[[INDEX_VEC]][0] : vector<16xindex>
-// CHECK:       %[[LOAD:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND]]] : memref<16x1082x1922xi8>, vector<1xi8>
-// CHECK:       %[[EXTRACT:.+]] = vector.extract %[[LOAD]][0] : vector<1xi8>
-// CHECK:       %[[INSERT:.+]] = vector.insert %[[EXTRACT]], %[[INIT]] [0] : i8 into vector<16xi8>
-// CHECK-15:    vector.load %[[ARG0]][%[[C0]], %[[C0]], %{{.*}}] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK-DAG:   %[[SLICE_INIT:.+]] = arith.constant dense<0> : vector<4xi8>
+// CHECK-DAG:   %[[INIT:.+]] = arith.constant dense<0> : vector<16xi8>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+
+// CHECK:       %[[IND0:.+]] = vector.extract %[[INDEX_VEC]][0] : vector<16xindex>
+// CHECK:       %[[LOAD0:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND0]]] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK:       %[[EXTRACT0:.+]] = vector.extract %[[LOAD0]][0] : vector<1xi8>
+// CHECK:       %[[INSERT0:.+]] = vector.insert %[[EXTRACT0]], %[[SLICE_INIT]] [0] : i8 into vector<4xi8>
+// CHECK:       %[[IND1:.+]] = vector.extract %[[INDEX_VEC]][1] : vector<16xindex>
+// CHECK:       %[[LOAD1:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND1]]] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK:       %[[EXTRACT1:.+]] = vector.extract %[[LOAD1]][0] : vector<1xi8>
+// CHECK:       %[[INSERT1:.+]] = vector.insert %[[EXTRACT1]], %[[INSERT0]] [1] : i8 into vector<4xi8>
+// CHECK:       %[[IND2:.+]] = vector.extract %[[INDEX_VEC]][2] : vector<16xindex>
+// CHECK:       %[[LOAD2:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND2]]] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK:       %[[EXTRACT2:.+]] = vector.extract %[[LOAD2]][0] : vector<1xi8>
+// CHECK:       %[[INSERT2:.+]] = vector.insert %[[EXTRACT2]], %[[INSERT1]] [2] : i8 into vector<4xi8>
+// CHECK:       %[[IND3:.+]] = vector.extract %[[INDEX_VEC]][3] : vector<16xindex>
+// CHECK:       %[[LOAD3:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND3]]] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK:       %[[EXTRACT3:.+]] = vector.extract %[[LOAD3]][0] : vector<1xi8>
+// CHECK:       %[[INSERT3:.+]] = vector.insert %[[EXTRACT3]], %[[INSERT2]] [3] : i8 into vector<4xi8>
+
+// CHECK:       vector.insert_strided_slice %[[INSERT3]], %[[INIT]] {offsets = [0], strides = [1]} : vector<4xi8> into vector<16xi8>
+// CHECK-12:    vector.load %[[ARG0]][%[[C0]], %[[C0]], %{{.*}}] : memref<16x1082x1922xi8>, vector<1xi8>
 


### PR DESCRIPTION
Despite the vector.gather lowering to scalar loads, we still need to unroll to a native vector size to avoid materializing a large constant initial vector that we would be unable to later break down.