### PR TITLE
Convert all website reference links to inline links.

### DIFF
--- a/docs/.markdownlint.yml
+++ b/docs/.markdownlint.yml
@@ -56,9 +56,6 @@ no-duplicate-heading:
 # Allow images w/o alt-text
 no-alt-text: false
 
-# Allow bare URLs
-no-bare-urls: false
-
 # Allow first line to be something other than a heading
 # (we use this for date/author in blog posts)
 first-line-heading: false

--- a/docs/.markdownlint.yml
+++ b/docs/.markdownlint.yml
@@ -60,6 +60,24 @@ no-alt-text: false
 # (we use this for date/author in blog posts)
 first-line-heading: false
 
-# markdownlint does not recognize link references in content tabs, so it
-# reports false positive errors for "unused" link references
-link-image-reference-definitions: false
+# Link style:
+#   Markdown links can normally provide link destinations elsewhere and
+#   simply reference those destinations by a label, e.g.
+#
+#     <!-- Middle of file -->
+#     [text][label]
+#
+#     <!-- Bottom of file -->
+#     [label]: https://example.com/label
+#
+#   The 'reference-links-images' and 'link-image-reference-definitions' rules
+#   can (respectively) help ensure that all referenced labels exist and that no
+#   labels are orphaned. However, markdownlint does not recognize link
+#   references in content tabs so it reports false positive errors for "unused"
+#   link references. Because we can't reliably lint such references, we
+#   recommend _not using that style of linking at all_.
+#
+#   There is no rule (yet?) to enforce inline links over reference links, but
+#   https://github.com/DavidAnson/markdownlint/issues/40 may add one.
+#
+# TLDR: Add your links inline, as in [text](www.example.com).

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -8,8 +8,8 @@ The website is generated using [MkDocs](https://www.mkdocs.org/), with the
 
 ## How to edit this documentation
 
-Follow https://squidfunk.github.io/mkdocs-material/getting-started/ and read
-https://www.mkdocs.org/.
+Follow <https://squidfunk.github.io/mkdocs-material/getting-started/> and read
+<https://www.mkdocs.org/>.
 
 Develop (from this folder):
 

--- a/docs/website/docs/deployment-configurations/cpu.md
+++ b/docs/website/docs/deployment-configurations/cpu.md
@@ -1,9 +1,9 @@
 # CPU Deployment
 
-IREE supports efficient program execution on CPU devices by using [LLVM][llvm]
-to compile all dense computations in each program into highly optimized CPU
-native instruction streams, which are embedded in one of IREE's deployable
-formats.
+IREE supports efficient program execution on CPU devices by using
+[LLVM](https://llvm.org/) to compile all dense computations in each program into
+highly optimized CPU native instruction streams, which are embedded in one of
+IREE's deployable formats.
 
 To compile a program for CPU execution, pick one of IREE's supported executable
 formats:
@@ -34,8 +34,9 @@ At runtime, CPU executables can be loaded using one of IREE's CPU HAL drivers:
 #### Download as Python package
 
 Python packages for various IREE functionalities are regularly published
-to [PyPI][pypi]. See the [Python Bindings][python-bindings] page for more
-details. The core `iree-compiler` package includes the LLVM-based CPU compiler:
+to [PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+[Python Bindings](../bindings/python.md) page for more details. The core
+`iree-compiler` package includes the LLVM-based CPU compiler:
 
 ``` shell
 python -m pip install iree-compiler
@@ -53,11 +54,13 @@ python -m pip install iree-compiler
 
 #### Build compiler from source
 
-Please make sure you have followed the [Getting started][get-started] page
-to build IREE for your host platform and the
-[Android cross-compilation][android-cc] or [iOS cross-compilation][ios-cc] page
-if you are cross compiling for a mobile device. The LLVM (CPU) compiler backend
-is compiled in by default on all platforms.
+Please make sure you have followed the
+[Getting started](../building-from-source/getting-started.md) page to build IREE
+for your host platform and the
+[Android cross-compilation](../building-from-source/android.md) or
+[iOS cross-compilation](../building-from-source/ios.md) page if you are cross
+compiling for a mobile device. The LLVM (CPU) compiler backend is compiled in by
+default on all platforms.
 
 Ensure that the `IREE_TARGET_BACKEND_LLVM_CPU` CMake option is `ON` when
 configuring for the host.
@@ -76,11 +79,13 @@ model and run it.
 The IREE compiler transforms a model into its final deployable format in many
 sequential steps. A model authored with Python in an ML framework should use the
 corresponding framework's import tool to convert into a format (i.e.,
-[MLIR][mlir]) expected by the IREE compiler first.
+[MLIR](https://mlir.llvm.org/)) expected by the IREE compiler first.
 
 Using MobileNet v2 as an example, you can download the SavedModel with trained
-weights from [TensorFlow Hub][tf-hub-mobilenetv2] and convert it using IREE's
-[TensorFlow importer][tf-import]. Then,
+weights from
+[TensorFlow Hub](https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification)
+and convert it using IREE's
+[TensorFlow importer](../getting-started/tensorflow.md). Then,
 
 #### Compile using the command-line
 
@@ -100,8 +105,8 @@ where `iree_input.mlir` is the imported program.
 
     The `--iree-llvmcpu-target-triple=` flag tells the compiler to generate code
     for a specific type of CPU. You can see the list of supported targets with
-    `iree-compile --iree-llvmcpu-list-targets`, or omit the flag to let LLVM infer
-    the triple from your host machine (e.g. `x86_64-linux-gnu`).
+    `iree-compile --iree-llvmcpu-list-targets`, or omit the flag to let LLVM
+    infer the triple from your host machine (e.g. `x86_64-linux-gnu`).
 
 ### Get IREE runtime with local CPU HAL driver
 
@@ -110,10 +115,12 @@ along with the appropriate executable loaders for your application.
 
 #### Build runtime from source
 
-Please make sure you have followed the [Getting started][get-started] page
-to build IREE for your host platform and the
-[Android cross-compilation][android-cc] page if you are cross compiling for
-Android. The local CPU HAL drivers are compiled in by default on all platforms.
+Please make sure you have followed the
+[Getting started](../building-from-source/getting-started.md) page to build IREE
+for your host platform and the
+[Android cross-compilation](../building-from-source/android.md) page if you are
+cross compiling for Android. The local CPU HAL drivers are compiled in by
+default on all platforms.
 
 <!-- TODO(??): a way to verify the driver is compiled in and supported -->
 
@@ -145,13 +152,3 @@ concrete values.
 <!-- TODO(??): measuring performance -->
 
 <!-- TODO(??): troubleshooting -->
-
-[android-cc]: ../building-from-source/android.md
-[ios-cc]: ../building-from-source/ios.md
-[get-started]: ../building-from-source/getting-started.md
-[llvm]: https://llvm.org/
-[mlir]: https://mlir.llvm.org/
-[pypi]: https://pypi.org/user/google-iree-pypi-deploy/
-[python-bindings]: ../bindings/python.md
-[tf-hub-mobilenetv2]: https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification
-[tf-import]: ../getting-started/tensorflow.md

--- a/docs/website/docs/deployment-configurations/gpu-cuda-rocm.md
+++ b/docs/website/docs/deployment-configurations/gpu-cuda-rocm.md
@@ -24,7 +24,7 @@ CUDA or ROCm environment. It can be verified by the following steps:
     ```
 
     If `nvidia-smi` does not exist, you will need to
-    [install the latest CUDA Toolkit SDK][cuda-toolkit].
+    [install the latest CUDA Toolkit SDK](https://developer.nvidia.com/cuda-downloads).
 
 === "AMD/ROCm"
 
@@ -35,7 +35,7 @@ CUDA or ROCm environment. It can be verified by the following steps:
     ```
 
     If `rocm-smi` does not exist, you will need to
-    [install the latest ROCm Toolkit SDK][rocm-toolkit].
+    [install the latest ROCm Toolkit SDK](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation_new.html)).
 
 ## Get runtime and compiler
 
@@ -46,8 +46,9 @@ hardware) or ROCm (for AMD hardware) HAL driver.
 
 #### Build runtime from source
 
-Please make sure you have followed the [Getting started][get-started] page
-to build IREE from source, then enable the CUDA HAL driver with the
+Please make sure you have followed the
+[Getting started](../building-from-source/getting-started.md) page to build
+IREE from source, then enable the CUDA HAL driver with the
 `IREE_HAL_DRIVER_CUDA` option or the experimental ROCm HAL driver with the
 `IREE_EXTERNAL_HAL_DRIVERS=rocm` option.
 
@@ -56,7 +57,7 @@ to build IREE from source, then enable the CUDA HAL driver with the
 === "Nvidia/CUDA"
 
     Python packages for various IREE functionalities are regularly published
-    to [PyPI][pypi]. See the [Python Bindings][python-bindings] page for more
+    to [PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the [Python Bindings][../bindings/python.md] page for more
     details. The core `iree-compiler` package includes the CUDA compiler:
 
     ``` shell
@@ -78,8 +79,9 @@ to build IREE from source, then enable the CUDA HAL driver with the
 
 #### Build compiler from source
 
-Please make sure you have followed the [Getting started][get-started] page
-to build the IREE compiler, then enable the CUDA compiler target with the
+Please make sure you have followed the
+[Getting started](../building-from-source/getting-started.md) page to build the
+IREE compiler, then enable the CUDA compiler target with the
 `IREE_TARGET_BACKEND_CUDA` option or the ROCm compiler target with the
 `IREE_TARGET_BACKEND_ROCM` option.
 
@@ -93,11 +95,13 @@ the GPU.
 IREE compilers transform a model into its final deployable format in many
 sequential steps. A model authored with Python in an ML framework should use the
 corresponding framework's import tool to convert into a format (i.e.,
-[MLIR][mlir]) expected by main IREE compilers first.
+[MLIR](https://mlir.llvm.org/)) expected by main IREE compilers first.
 
 Using MobileNet v2 as an example, you can download the SavedModel with trained
-weights from [TensorFlow Hub][tf-hub-mobilenetv2] and convert it using IREE's
-[TensorFlow importer][tf-import]. Then,
+weights from
+[TensorFlow Hub](https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification)
+and convert it using IREE's
+[TensorFlow importer](../getting-started/tensorflow.md). Then,
 
 #### Compile using the command-line
 
@@ -190,12 +194,3 @@ The above assumes the exported function in the model is named as `predict` and
 it expects one 224x224 RGB image. We are feeding in an image with all 0 values
 here for brevity, see `iree-run-module --help` for the format to specify
 concrete values.
-
-[get-started]: ../building-from-source/getting-started.md
-[mlir]: https://mlir.llvm.org/
-[python-bindings]: ../bindings/python.md
-[tf-hub-mobilenetv2]: https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification
-[tf-import]: ../getting-started/tensorflow.md
-[tflite-import]: ../getting-started/tensorflow-lite.md
-[cuda-toolkit]: https://developer.nvidia.com/cuda-downloads
-[rocm-toolkit]: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation_new.html

--- a/docs/website/docs/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/deployment-configurations/gpu-vulkan.md
@@ -1,10 +1,10 @@
 # Vulkan GPU HAL Driver
 
-IREE can accelerate model execution on GPUs via [Vulkan][vulkan], a low-overhead
-graphics and compute API. Vulkan is cross-platform: it is available on many
-operating systems, including Android, Linux, and Windows. Vulkan is also
-cross-vendor: it is supported by most GPU vendors, including AMD, ARM, Intel,
-NVIDIA, and Qualcomm.
+IREE can accelerate model execution on GPUs via
+[Vulkan](https://www.khronos.org/vulkan/), a low-overhead graphics and compute
+API. Vulkan is cross-platform: it is available on many operating systems,
+including Android, Linux, and Windows. Vulkan is also cross-vendor: it is
+supported by most GPU vendors, including AMD, ARM, Intel, NVIDIA, and Qualcomm.
 
 <!-- TODO(??): when to use CPU vs GPU -->
 
@@ -42,9 +42,9 @@ verified by the following steps:
     ```
 
     If `vulkaninfo` does not exist, you will need to [install the latest Vulkan
-    SDK][vulkan-sdk]. For Ubuntu 18.04/20.04, installing via LunarG's package
-    repository is recommended, as it places Vulkan libraries and tools under
-    system paths so it's easy to discover.
+    SDK](https://vulkan.lunarg.com/sdk/home/). For Ubuntu 18.04/20.04,
+    installing via LunarG's package repository is recommended, as it places
+    Vulkan libraries and tools under system paths so it's easy to discover.
 
     If the showed version is lower than Vulkan 1.2, you will need to update the
     driver for your GPU.
@@ -58,7 +58,7 @@ verified by the following steps:
     ```
 
     If `vulkaninfo` does not exist, you will need to [install the latest Vulkan
-    SDK][vulkan-sdk].
+    SDK](https://vulkan.lunarg.com/sdk/home/).
 
     If the showed version is lower than Vulkan 1.2, you will need to update the
     driver for your GPU.
@@ -74,10 +74,11 @@ so it can execute the model on GPU via Vulkan.
 
 #### Build runtime from source
 
-Please make sure you have followed the [Getting started][get-started] page
-to build IREE for Linux/Windows and the [Android cross-compilation][android-cc]
-page for Android. The Vulkan HAL driver is compiled in by default on non-Apple
-platforms.
+Please make sure you have followed the
+[Getting started](../building-from-source/getting-started.md) page to build IREE
+for Linux/Windows and the
+[Android cross-compilation](../building-from-source/android.md) page for
+Android. The Vulkan HAL driver is compiled in by default on non-Apple platforms.
 
 <!-- TODO(??): a way to verify Vulkan is compiled in and supported -->
 
@@ -86,15 +87,17 @@ for the target.
 
 ### Get compiler for SPIR-V exchange format
 
-Vulkan expects the program running on GPU to be expressed by the [SPIR-V][spirv]
-binary exchange format, which the model must be compiled into.
+Vulkan expects the program running on GPU to be expressed by the
+[SPIR-V](https://www.khronos.org/registry/spir-v/) binary exchange format, which
+the model must be compiled into.
 
 <!-- TODO(??): vcpkg -->
 
 #### Download as Python package
 
 Python packages for various IREE functionalities are regularly published
-to [PyPI][pypi]. See the [Python Bindings][python-bindings] page for more
+to [PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+[Python Bindings](../bindings/python.md) page for more
 details. The core `iree-compiler` package includes the SPIR-V compiler:
 
 ``` shell
@@ -113,10 +116,11 @@ python -m pip install iree-compiler
 
 #### Build compiler from source
 
-Please make sure you have followed the [Getting started][get-started] page
-to build IREE for Linux/Windows and the [Android cross-compilation][android-cc]
-page for Android. The SPIR-V compiler backend is compiled in by default on all
-platforms.
+Please make sure you have followed the
+[Getting started](../building-from-source/getting-started.md) page to build IREE
+for Linux/Windows and the
+[Android cross-compilation](../building-from-source/android.md) page for
+Android. The SPIR-V compiler backend is compiled in by default on all platforms.
 
 Ensure that the `IREE_TARGET_BACKEND_VULKAN_SPIRV` CMake option is `ON` when
 configuring for the host.
@@ -131,11 +135,13 @@ and run it on the GPU.
 IREE compilers transform a model into its final deployable format in many
 sequential steps. A model authored with Python in an ML framework should use the
 corresponding framework's import tool to convert into a format (i.e.,
-[MLIR][mlir]) expected by main IREE compilers first.
+[MLIR](https://mlir.llvm.org/)) expected by main IREE compilers first.
 
 Using MobileNet v2 as an example, you can download the SavedModel with trained
-weights from [TensorFlow Hub][tf-hub-mobilenetv2] and convert it using IREE's
-[TensorFlow importer][tf-import]. Then,
+weights from
+[TensorFlow Hub](https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification)
+and convert it using IREE's
+[TensorFlow importer](../getting-started/tensorflow.md). Then,
 
 #### Compile using the command-line
 
@@ -153,9 +159,9 @@ iree-compile \
 where `iree_input.mlir` is the imported program.
 
 Note that a target triple of the form `<vendor/arch>-<product>-<os>` is needed
-to compile towards each GPU architecture. If no triple is specified then a safe but
-more limited default will be used.
-We don't support the full spectrum here[^1]; the following table summarizes the
+to compile towards each GPU architecture. If no triple is specified then a safe
+but more limited default will be used. We don't support the full spectrum
+here[^1]; the following table summarizes the
 currently recognized ones:
 
 GPU Vendor | Target Triple
@@ -196,14 +202,3 @@ concrete values.
 [^1]: It's also impossible to capture all details of a Vulkan implementation
 with a target triple, given the allowed variances on extensions, properties,
 limits, etc. So the target triple is just an approximation for usage.
-
-[android-cc]: ../building-from-source/android.md
-[get-started]: ../building-from-source/getting-started.md
-[mlir]: https://mlir.llvm.org/
-[pypi]: https://pypi.org/user/google-iree-pypi-deploy/
-[python-bindings]: ../bindings/python.md
-[spirv]: https://www.khronos.org/registry/spir-v/
-[tf-hub-mobilenetv2]: https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification
-[tf-import]: ../getting-started/tensorflow.md
-[vulkan]: https://www.khronos.org/vulkan/
-[vulkan-sdk]: https://vulkan.lunarg.com/sdk/home/


### PR DESCRIPTION
I noticed a broken link here: https://openxla.github.io/iree/deployment-configurations/gpu-cuda-rocm/#download-compiler-as-python-package (oops - https://github.com/openxla/iree/pull/12106)
![image](https://github.com/openxla/iree/assets/4010439/eae4b479-4ce2-4492-aabf-3f2a73c682a8)

These reference links are difficult to maintain if we're inconsistent in their use. The linter we're using now technically supports analyzing them, but it does not see through content blocks (a markdown extension used by mkdocs). From what I can tell, reference links are pitched as a way to save character counts when repeating links and to make paragraphs smaller in the source. Neither of those are good reasons to compromise on tooling support for identifying dead links, and broken inline links are much easier to spot manually.