### PR TITLE
Adding `iree.abi.encoding` for specifying buffer view encoding.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -78,7 +78,8 @@ static IREE::Util::GlobalOp createBufferLikeGlobalOp(
       loc, tensorType, zeroOp, /*result_dims=*/ValueRange{});
   // hal.tensor.export
   auto bufferExportOp = initializerBuilder.create<IREE::HAL::TensorExportOp>(
-      loc, globalOp.getType(), splatOp.getResult(), /*name=*/nullptr);
+      loc, globalOp.getType(), splatOp.getResult(),
+      TypeAttr::get(splatOp.getType()), /*name=*/nullptr);
   // util.optimization_barrier (try to prevent optimizations across the export)
   auto barrierOp = initializerBuilder.create<IREE::Util::OptimizationBarrierOp>(
       loc, bufferExportOp.getTarget());
@@ -133,7 +134,7 @@ static IREE::Util::GlobalOp createImportBufferViewGlobalOp(
 // op.
 //
 // Example:
-//  %1 = hal.tensor.export %0 into %storage : tensor<4xi32> -> !hal.buffer_view
+//  %1 = hal.tensor.export %0 into(%storage) : tensor<4xi32> -> !hal.buffer_view
 // ->
 //  util.global @some_fn_arg0 : !hal.buffer
 //  util.initializer { ... }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
@@ -95,7 +95,7 @@ static LogicalResult replaceReturnWithOpResults(mlir::ModuleOp moduleOp,
     if (retVal.getType().isa<TensorType>()) {
       auto type = IREE::HAL::BufferViewType::get(context);
       auto exportOp = builder.create<IREE::HAL::TensorExportOp>(
-          loc, type, retVal, /*name=*/nullptr);
+          loc, type, retVal, TypeAttr::get(retVal.getType()), /*name=*/nullptr);
       exports.push_back(exportOp.getResult());
       newTypes.push_back(type);
     } else {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
@@ -95,7 +95,7 @@ func.func @importDynamicBufferView(%view: !hal.buffer_view) -> !hal.buffer_view 
 func.func @exportBufferViewInPlace(%view: !hal.buffer_view, %storage: !hal.buffer) -> !hal.buffer_view {
   %0 = hal.tensor.import %view : !hal.buffer_view -> tensor<4xi32>
   %1 = arith.muli %0, %0 : tensor<4xi32>
-  %2 = hal.tensor.export %1 into %storage : tensor<4xi32> -> !hal.buffer_view
+  %2 = hal.tensor.export %1 into(%storage : !hal.buffer) : tensor<4xi32> -> !hal.buffer_view
   return %2 : !hal.buffer_view
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -160,12 +160,15 @@ LogicalResult ReturnOp::verify() {
 //===----------------------------------------------------------------------===//
 
 void TensorImportOp::build(OpBuilder &builder, OperationState &result,
-                           Type resultType, Value source, StringAttr name) {
-  build(builder, result, resultType, source, /*waitFence=*/Value{}, name);
+                           Type resultType, Value source,
+                           TypeAttr targetEncoding, StringAttr name) {
+  build(builder, result, resultType, source, targetEncoding,
+        /*waitFence=*/Value{}, name);
 }
 
 void TensorImportOp::build(OpBuilder &builder, OperationState &result,
-                           Type resultType, Value source, Value waitFence,
+                           Type resultType, Value source,
+                           TypeAttr targetEncoding, Value waitFence,
                            StringAttr name) {
   auto shapedType = resultType.cast<ShapedType>();
   assert((source.getType().isa<IREE::HAL::BufferViewType>() ||
@@ -179,8 +182,8 @@ void TensorImportOp::build(OpBuilder &builder, OperationState &result,
         result.location, builder.getIndexType(), source,
         builder.getIndexAttr(i)));
   }
-  build(builder, result, resultType, source, TypeAttr::get(shapedType),
-        dynamicDims, waitFence, name);
+  build(builder, result, resultType, source, targetEncoding, dynamicDims,
+        waitFence, name);
 }
 
 Value TensorImportOp::getTiedResult(unsigned resultIndex) {
@@ -253,11 +256,12 @@ LogicalResult TensorImportOp::verify() {
 }
 
 void TensorExportOp::build(OpBuilder &builder, OperationState &result,
-                           Type resultType, Value source, StringAttr name) {
+                           Type resultType, Value source,
+                           TypeAttr sourceEncoding, StringAttr name) {
   auto dynamicDims =
       IREE::Util::buildDynamicDimsForValue(result.location, source, builder);
-  build(builder, result, resultType, source, TypeAttr::get(source.getType()),
-        dynamicDims, /*target_storage=*/nullptr, name);
+  build(builder, result, resultType, source, sourceEncoding, dynamicDims,
+        /*target_storage=*/nullptr, name);
 }
 
 Value TensorExportOp::getTiedResult(unsigned resultIndex) {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -100,11 +100,13 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
     OpBuilder<(ins
       "Type":$resultType,
       "Value":$source,
+      "TypeAttr":$targetEncoding,
       "StringAttr":$name
     )>,
     OpBuilder<(ins
       "Type":$resultType,
       "Value":$source,
+      "TypeAttr":$targetEncoding,
       "Value":$waitFence,
       "StringAttr":$name
     )>,
@@ -150,7 +152,7 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
     AnyTensor:$source,
     TypeAttr:$source_encoding,
     HAL_ShapeDynamicDims:$source_dims,
-    Optional<HAL_Buffer>:$target_storage,
+    Optional<AnyTypeOf<[HAL_Buffer, HAL_BufferView]>>:$target_storage,
     OptionalAttr<StrAttr>:$name
   );
   let results = (outs
@@ -160,7 +162,7 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
   let assemblyFormat = [{
     $source
     ($name^)?
-    (`into` $target_storage^)?
+    (`into` `(` $target_storage^ `:` type($target_storage) `)`)?
     `:`
     custom<TypeAlias>($source_encoding, type($source)) (`{` $source_dims^ `}`)?
     `->`
@@ -172,6 +174,7 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
     OpBuilder<(ins
       "Type":$resultType,
       "Value":$source,
+      "TypeAttr":$sourceEncoding,
       "StringAttr":$name
     )>,
   ];

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
@@ -38,8 +38,8 @@ func.func @tensorExportDynamic(%arg0: tensor<?x3xi32>, %arg1: index) -> !hal.buf
 
 // CHECK-LABEL: @tensorExportInPlace
 func.func @tensorExportInPlace(%arg0: tensor<?x3xi32>, %arg1: index, %arg2: !hal.buffer) -> !hal.buffer_view {
-  // CHECK: hal.tensor.export %arg0 into %arg2 : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
-  %0 = hal.tensor.export %arg0 into %arg2 : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
+  // CHECK: hal.tensor.export %arg0 into(%arg2 : !hal.buffer) : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
+  %0 = hal.tensor.export %arg0 into(%arg2 : !hal.buffer) : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/collective_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/collective_ops.mlir
@@ -24,7 +24,7 @@ func.func @channel_rank(%channel: !flow.channel) -> index {
   return %rank : index
 }
 
-//-----
+// -----
 
 // CHECK-LABEL: @channel_count
 //  CHECK-SAME: (%[[CHANNEL:.+]]: !stream.channel)
@@ -35,76 +35,66 @@ func.func @channel_count(%channel: !flow.channel) -> index {
   return %count : index
 }
 
-//-----
+// -----
 
 // CHECK-LABEL: @all_reduce_sum
-func.func @all_reduce_sum(%channel: !flow.channel, %arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub} {
+func.func @all_reduce_sum(%channel: !flow.channel, %arg0: tensor<2304xf32>) -> tensor<2304xf32> {
   // CHECK: stream.tensor.empty : tensor<2304xf32>
   // CHECK: stream.async.collective<all_reduce with sum : f32>
-  %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<2304xf32>
-  %1 = flow.tensor.empty : tensor<2304xf32>
-  %2 = flow.collective.all_reduce sum, f32, %1, %0, %channel : (tensor<2304xf32>, tensor<2304xf32>, !flow.channel) -> tensor<2304xf32>
-  %3 = hal.tensor.export %2 : tensor<2304xf32> -> !hal.buffer_view
-  return %3 : !hal.buffer_view
+  %0 = flow.tensor.empty : tensor<2304xf32>
+  %1 = flow.collective.all_reduce sum, f32, %0, %arg0, %channel : (tensor<2304xf32>, tensor<2304xf32>, !flow.channel) -> tensor<2304xf32>
+  return %1 : tensor<2304xf32>
 }
 
-//-----
+// -----
 
 // CHECK-LABEL: @all_gather
-func.func @all_gather(%channel: !flow.channel, %arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub} {
+func.func @all_gather(%channel: !flow.channel, %arg0: tensor<512xf32>) -> tensor<1024xf32> {
   // CHECK: stream.tensor.empty : tensor<1024xf32>
   // CHECK: stream.async.collective<all_gather : f32>
-  %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<512xf32>
-  %1 = flow.tensor.empty : tensor<1024xf32>
-  %2 = flow.collective.all_gather f32, %1, %0, %channel : (tensor<1024xf32>, tensor<512xf32>, !flow.channel) -> tensor<1024xf32>
-  %3 = hal.tensor.export %2 : tensor<1024xf32> -> !hal.buffer_view
-  return %3 : !hal.buffer_view
+  %0 = flow.tensor.empty : tensor<1024xf32>
+  %1 = flow.collective.all_gather f32, %0, %arg0, %channel : (tensor<1024xf32>, tensor<512xf32>, !flow.channel) -> tensor<1024xf32>
+  return %1 : tensor<1024xf32>
 }
 
-//-----
+// -----
 
 // CHECK-LABEL: @all_to_all
-func.func @all_to_all(%channel: !flow.channel, %arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub} {
+func.func @all_to_all(%channel: !flow.channel, %arg0: tensor<1024xf32>) -> tensor<1024xf32> {
   // CHECK: stream.tensor.empty : tensor<1024xf32>
   // CHECK: stream.async.collective<all_to_all : f32>
-  %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<1024xf32>
-  %1 = flow.tensor.empty : tensor<1024xf32>
-  %2 = flow.collective.all_to_all f32, %1, %0, %channel : (tensor<1024xf32>, tensor<1024xf32>, !flow.channel) -> tensor<1024xf32>
-  %3 = hal.tensor.export %2 : tensor<1024xf32> -> !hal.buffer_view
-  return %3 : !hal.buffer_view
+  %0 = flow.tensor.empty : tensor<1024xf32>
+  %1 = flow.collective.all_to_all f32, %0, %arg0, %channel : (tensor<1024xf32>, tensor<1024xf32>, !flow.channel) -> tensor<1024xf32>
+  return %1 : tensor<1024xf32>
 }
 
-//-----
+// -----
 
 // CHECK-LABEL: @reduce_scatter
-func.func @reduce_scatter(%channel: !flow.channel, %arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub} {
+func.func @reduce_scatter(%channel: !flow.channel, %arg0: tensor<4x2xf32>) -> tensor<2x2xf32> {
   // CHECK: stream.tensor.empty : tensor<2x2xf32>
   // CHECK: stream.async.collective<reduce_scatter with sum : f32>
-  %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<4x2xf32>
-  %1 = flow.tensor.empty : tensor<2x2xf32>
-  %2 = flow.collective.reduce_scatter sum, f32, %1, %0, %channel : (tensor<2x2xf32>, tensor<4x2xf32>, !flow.channel) -> tensor<2x2xf32>
-  %3 = hal.tensor.export %2 : tensor<2x2xf32> -> !hal.buffer_view
-  return %3 : !hal.buffer_view
+  %0 = flow.tensor.empty : tensor<2x2xf32>
+  %1 = flow.collective.reduce_scatter sum, f32, %0, %arg0, %channel : (tensor<2x2xf32>, tensor<4x2xf32>, !flow.channel) -> tensor<2x2xf32>
+  return %1 : tensor<2x2xf32>
 }
 
-//-----
+// -----
 
 // CHECK-LABEL: @send_recv
-// CHECK-SAME: %arg1: !hal.buffer_view, [[SEND:%.+]]: index, [[RECV:%.+]]: index)
-func.func @send_recv(%channel: !flow.channel, %arg0: !hal.buffer_view, %send: index, %recv: index) -> !hal.buffer_view attributes {iree.abi.stub} {
+// CHECK-SAME: index, %[[SEND:.+]]: index, %[[RECV:.+]]: index)
+func.func @send_recv(%channel: !flow.channel, %arg0: tensor<1024xf32>, %send: index, %recv: index) -> tensor<1024xf32> {
   // CHECK: stream.tensor.empty : tensor<1024xf32>
-  // CHECK-DAG: [[CST_LO_MASK:%.+]] = arith.constant 65535 : i32
-  // CHECK-DAG: [[CST_SHIFT16:%.+]] = arith.constant 16 : i32
-  // CHECK-DAG: [[SEND_I32:%.+]]  = arith.index_cast [[SEND]] : index to i32
-  // CHECK-DAG: [[RECV_I32:%.+]]  = arith.index_cast [[RECV]] : index to i32
-  // CHECK-DAG: [[LO:%.+]] = arith.andi [[SEND_I32]], [[CST_LO_MASK]] : i32
-  // CHECK-DAG: [[HI:%.+]] = arith.shli [[RECV_I32]], [[CST_SHIFT16]] : i32
-  // CHECK-DAG: [[PARAM:%.+]] = arith.ori [[HI]], [[LO]] : i32
+  // CHECK-DAG: %[[CST_LO_MASK:.+]] = arith.constant 65535 : i32
+  // CHECK-DAG: %[[CST_SHIFT16:.+]] = arith.constant 16 : i32
+  // CHECK-DAG: %[[SEND_I32:.+]]  = arith.index_cast %[[SEND]] : index to i32
+  // CHECK-DAG: %[[RECV_I32:.+]]  = arith.index_cast %[[RECV]] : index to i32
+  // CHECK-DAG: %[[LO:.+]] = arith.andi %[[SEND_I32]], %[[CST_LO_MASK]] : i32
+  // CHECK-DAG: %[[HI:.+]] = arith.shli %[[RECV_I32]], %[[CST_SHIFT16]] : i32
+  // CHECK-DAG: %[[PARAM:.+]] = arith.ori %[[HI]], %[[LO]] : i32
   // CHECK: stream.async.collective<send_recv : f32>
-  // CHECK-SAME: source_target_pair([[PARAM]])
-  %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<1024xf32>
-  %1 = flow.tensor.empty : tensor<1024xf32>
-  %2 = flow.collective.send_recv f32, %1, %0, %channel, %send, %recv : (tensor<1024xf32>, tensor<1024xf32>, !flow.channel, index, index) -> tensor<1024xf32>
-  %3 = hal.tensor.export %2 : tensor<1024xf32> -> !hal.buffer_view
-  return %3 : !hal.buffer_view
+  // CHECK-SAME: source_target_pair(%[[PARAM]])
+  %0 = flow.tensor.empty : tensor<1024xf32>
+  %1 = flow.collective.send_recv f32, %0, %arg0, %channel, %send, %recv : (tensor<1024xf32>, tensor<1024xf32>, !flow.channel, index, index) -> tensor<1024xf32>
+  return %1 : tensor<1024xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
@@ -80,7 +80,7 @@ func.func @exportBufferViewInPlace(%tensor: tensor<?x?x4xf32>, %dim0: index, %di
   // CHECK-NEXT: %[[STORAGE_RESULT:.+]] = stream.tensor.export %[[STORAGE_UPDATE]] :
   // CHECK-SAME:     tensor<?x?x4xf32>{%[[DIM0]], %[[DIM1]]} in !stream.resource<external>{%[[STORAGE_LENGTH]]}
   // CHECK-SAME:     -> !hal.buffer_view
-  %0 = hal.tensor.export %tensor into %storage : tensor<?x?x4xf32>{%dim0, %dim1} -> !hal.buffer_view
+  %0 = hal.tensor.export %tensor into(%storage : !hal.buffer) : tensor<?x?x4xf32>{%dim0, %dim1} -> !hal.buffer_view
   // CHECK: return %[[STORAGE_RESULT]]
   return %0 : !hal.buffer_view
 }

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -99,7 +99,8 @@ class BufferViewToTensorPattern
       // specified and we reify them here with the specific builder that does
       // the work.
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorImportOp>(
-          srcOp, resultType, adaptor.getSource(), /*name=*/nullptr);
+          srcOp, resultType, adaptor.getSource(), TypeAttr::get(resultType),
+          /*name=*/nullptr);
     } else {
       // Dynamic dims explicitly provided (or wrong, in which case the verifier
       // will get it).
@@ -126,7 +127,8 @@ class TensorToBufferViewPattern
       // specified and we reify them here with the specific builder that does
       // the work.
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorExportOp>(
-          srcOp, resultType, adaptor.getSource(), /*name=*/nullptr);
+          srcOp, resultType, adaptor.getSource(),
+          TypeAttr::get(adaptor.getSource().getType()), /*name=*/nullptr);
     } else {
       // Dynamic dims explicitly provided (or wrong, in which case the verifier
       // will get it).


### PR DESCRIPTION
The encoding attribute allows for the encoded tensor types asserted on import and stored in the buffer view on export lets higher layers of the stack specify what it wants without needing the MLIR types to match. HLO, for example, will change types to signless but still expects the original encodings on the ABI types.