### PR TITLE
HLO input support for iree.abi.output and iree.abi.encoding attrs.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -18,6 +18,18 @@ namespace iree_compiler {
 
 namespace {
 
+// Returns the size in bytes of the buffer/buffer view |storage|.
+static Value getStorageSize(Value storage, OpBuilder &builder) {
+  if (storage.getType().isa<IREE::HAL::BufferViewType>()) {
+    storage = builder.create<IREE::HAL::BufferViewBufferOp>(
+        storage.getLoc(), builder.getType<IREE::HAL::BufferType>(), storage);
+  }
+  return builder
+      .create<IREE::HAL::BufferLengthOp>(storage.getLoc(),
+                                         builder.getIndexType(), storage)
+      .getResult();
+}
+
 // %1 = hal.tensor.import %0 : !hal.buffer_view -> tensor<4xf32>
 // ->
 // %1 = stream.tensor.import %0 : !hal.buffer_view ->
@@ -159,11 +171,7 @@ struct ConvertTensorExportOp
     if (adaptor.getTargetStorage()) {
       // Query the target storage buffer length; we will only populate up to
       // what is required for the output.
-      auto storageSize =
-          rewriter
-              .create<IREE::HAL::BufferLengthOp>(
-                  op.getLoc(), rewriter.getIndexType(), op.getTargetStorage())
-              .getResult();
+      auto storageSize = getStorageSize(op.getTargetStorage(), rewriter);
 
       // Import the target storage as a resource that we can use as an update
       // target. We overwrite the contents and just cast the storage to the

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
@@ -84,3 +84,18 @@ func.func @exportBufferViewInPlace(%tensor: tensor<?x?x4xf32>, %dim0: index, %di
   // CHECK: return %[[STORAGE_RESULT]]
   return %0 : !hal.buffer_view
 }
+
+// -----
+
+// As with @exportBufferViewInPlace above but using !hal.buffer_view storage.
+
+// CHECK-LABEL: @exportBufferViewInPlaceToView
+// CHECK-SAME: (%[[TENSOR:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index, %[[STORAGE:.+]]: !hal.buffer_view)
+func.func @exportBufferViewInPlaceToView(%tensor: tensor<?x?x4xf32>, %dim0: index, %dim1: index, %storage: !hal.buffer_view) -> !hal.buffer_view {
+  //      CHECK: %[[STORAGE_BUFFER:.+]] = hal.buffer_view.buffer<%[[STORAGE]]
+  //      CHECK: %[[STORAGE_LENGTH:.+]] = hal.buffer.length<%[[STORAGE_BUFFER]]
+  // CHECK-NEXT: %[[STORAGE_IMPORT:.+]] = stream.tensor.import %[[STORAGE]]
+  // CHECK-SAME:   : !hal.buffer_view -> tensor<?x?x4xf32>{%[[DIM0]], %[[DIM1]]} in !stream.resource<external>{%[[STORAGE_LENGTH]]}
+  %0 = hal.tensor.export %tensor into(%storage : !hal.buffer_view) : tensor<?x?x4xf32>{%dim0, %dim1} -> !hal.buffer_view
+  return %0 : !hal.buffer_view
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
@@ -374,7 +374,8 @@ static bool isSafeToElideCloneOp(IREE::Stream::AsyncCloneOp cloneOp,
   LLVM_DEBUG({
     llvm::dbgs() << "isSafeToElideCloneOp:\n";
     llvm::dbgs() << "  ";
-    cloneOp.print(llvm::dbgs(), OpPrintingFlags().elideLargeElementsAttrs());
+    cloneOp.print(llvm::dbgs(),
+                  OpPrintingFlags().elideLargeElementsAttrs().assumeVerified());
     llvm::dbgs() << "\n";
   });
 

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -240,6 +240,67 @@ struct OptimizationBarrierOpConversion
   }
 };
 
+// Returns true if all attributes in the given dictionary are valid for IREE
+// input dialects.
+static bool isValidFuncAttr(DictionaryAttr attrs) {
+  // TODO: switch to using a dialect-based exclusion list or some other way that
+  // is not a big string table.
+  for (auto attr : attrs) {
+    if (attr.getName() == "tf.aliasing_output") return false;
+  }
+  return true;
+}
+
+// Adds iree.abi.encoding attributes for arguments and results when they have
+// had their type changed during conversion.
+static void setFuncEncodings(func::FuncOp funcOp, FunctionType oldFuncType,
+                             FunctionType newFuncType) {
+  auto encodingName = StringAttr::get(funcOp.getContext(), "iree.abi.encoding");
+  for (auto [i, oldType, newType] :
+       llvm::enumerate(oldFuncType.getInputs(), newFuncType.getInputs())) {
+    if (oldType != newType)
+      funcOp.setArgAttr(i, encodingName, TypeAttr::get(oldType));
+  }
+  for (auto [i, oldType, newType] :
+       llvm::enumerate(oldFuncType.getResults(), newFuncType.getResults())) {
+    if (oldType != newType)
+      funcOp.setResultAttr(i, encodingName, TypeAttr::get(oldType));
+  }
+}
+
+// Rewrites attributes on the function from ones coming from HLO-based frontends
+// to the IREE supported versions.
+static void rewriteFuncAttrs(func::FuncOp funcOp) {
+  auto *context = funcOp.getContext();
+  auto indexType = IndexType::get(context);
+  auto abiOutputName = StringAttr::get(context, "iree.abi.output");
+  auto aliasingOutputName = StringAttr::get(context, "tf.aliasing_output");
+  auto rewriteAttrs = [&](DictionaryAttr &allAttrs) {
+    SmallVector<NamedAttribute> newAttrs;
+    newAttrs.reserve(allAttrs.size());
+    for (auto attr : allAttrs) {
+      if (attr.getName() == aliasingOutputName) {
+        newAttrs.push_back({
+            abiOutputName,
+            IntegerAttr::get(indexType,
+                             attr.getValue().cast<IntegerAttr>().getInt()),
+        });
+      } else {
+        newAttrs.push_back(attr);
+      }
+    }
+    allAttrs = DictionaryAttr::get(context, newAttrs);
+  };
+  SmallVector<DictionaryAttr> argAttrs;
+  funcOp.getAllArgAttrs(argAttrs);
+  llvm::for_each(argAttrs, rewriteAttrs);
+  funcOp.setAllArgAttrs(argAttrs);
+  SmallVector<DictionaryAttr> resultAttrs;
+  funcOp.getAllResultAttrs(resultAttrs);
+  llvm::for_each(resultAttrs, rewriteAttrs);
+  funcOp.setAllResultAttrs(resultAttrs);
+}
+
 // We need to convert func ops in order to convert types.
 class BuiltinFuncOpPattern : public OpConversionPattern<func::FuncOp> {
   using OpConversionPattern<func::FuncOp>::OpConversionPattern;
@@ -266,6 +327,7 @@ class BuiltinFuncOpPattern : public OpConversionPattern<func::FuncOp> {
     }
 
     // Create new function with converted argument and result types.
+    auto oldFuncType = srcOp.getFunctionType();
     auto newFuncType = mlir::FunctionType::get(
         srcOp.getContext(), signatureConversion.getConvertedTypes(),
         convertedResultTypes);
@@ -273,6 +335,8 @@ class BuiltinFuncOpPattern : public OpConversionPattern<func::FuncOp> {
     // Update the function in place.
     rewriter.startRootUpdate(srcOp);
     srcOp.setType(newFuncType);
+    rewriteFuncAttrs(srcOp);
+    setFuncEncodings(srcOp, oldFuncType, newFuncType);
 
     // Tell the rewriter to convert the region signature.
     TypeConverter &typeConverter = *getTypeConverter();
@@ -445,11 +509,6 @@ struct ConvertMHLOToLinalgOnTensorsPass
     ConversionTarget target(getContext());
 
     auto isIllegalType = [&](Type t) { return !typeConverter->isLegal(t); };
-    auto isIllegalFuncType = [&](Type t) {
-      // Allows unsigned integers for function inputs and outputs.
-      return !typeConverter->isLegal(t) &&
-             !getElementTypeOrSelf(t).isUnsignedInteger();
-    };
     auto isLegallyTypedOp = [&](Operation *op) -> bool {
       for (Type type : op->getResultTypes()) {
         if (isIllegalType(type)) return false;
@@ -465,34 +524,46 @@ struct ConvertMHLOToLinalgOnTensorsPass
 
     // Functions must have legal types.
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp funcOp) {
+      if (auto attrs = funcOp.getAllArgAttrs()) {
+        if (!llvm::all_of(attrs.getAsRange<DictionaryAttr>(),
+                          isValidFuncAttr)) {
+          return false;
+        }
+      }
+      if (auto attrs = funcOp.getAllResultAttrs()) {
+        if (!llvm::all_of(attrs.getAsRange<DictionaryAttr>(),
+                          isValidFuncAttr)) {
+          return false;
+        }
+      }
       for (Type type : funcOp.getFunctionType().getInputs()) {
-        if (isIllegalFuncType(type)) return false;
+        if (isIllegalType(type)) return false;
       }
       for (Type type : funcOp.getFunctionType().getResults()) {
-        if (isIllegalFuncType(type)) return false;
+        if (isIllegalType(type)) return false;
       }
       for (Block &block : funcOp.getFunctionBody()) {
         for (Type type : block.getArgumentTypes()) {
-          if (isIllegalFuncType(type)) return false;
+          if (isIllegalType(type)) return false;
         }
       }
       return true;
     });
     target.addDynamicallyLegalOp<func::ReturnOp>([&](func::ReturnOp op) {
       return llvm::all_of(op.getOperandTypes(),
-                          [&](Type type) { return !isIllegalFuncType(type); });
+                          [&](Type type) { return !isIllegalType(type); });
     });
     target.addDynamicallyLegalOp<func::CallOp>([&](func::CallOp op) {
       return llvm::all_of(op.getOperandTypes(),
-                          [&](Type type) { return !isIllegalFuncType(type); });
+                          [&](Type type) { return !isIllegalType(type); });
     });
     target.addDynamicallyLegalOp<cf::CondBranchOp>([&](cf::CondBranchOp op) {
       return llvm::all_of(op.getOperandTypes(),
-                          [&](Type type) { return !isIllegalFuncType(type); });
+                          [&](Type type) { return !isIllegalType(type); });
     });
     target.addDynamicallyLegalOp<cf::BranchOp>([&](cf::BranchOp op) {
       return llvm::all_of(op.getOperandTypes(),
-                          [&](Type type) { return !isIllegalFuncType(type); });
+                          [&](Type type) { return !isIllegalType(type); });
     });
     target.addDynamicallyLegalOp<ml_program::GlobalOp>(
         [&](ml_program::GlobalOp op) {

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/broadcasting.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/broadcasting.mlir
@@ -409,16 +409,14 @@ func.func @fallbackDynamicReshape(%arg0 : tensor<4x?x3x?xui32>, %arg1 : tensor<5
   // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
   // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
   // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-  // CHECK-DAG: %[[CAST_ARG:.*]] = tensor.bitcast %arg0 : tensor<4x?x3x?xui32> to tensor<4x?x3x?xi32>
   // CHECK-DAG: %[[RESULT_D1:.*]] = tensor.extract %arg1[%[[C1]]] : tensor<5xindex>
   // CHECK-DAG: %[[RESULT_D2:.*]] = tensor.extract %arg1[%[[C2]]] : tensor<5xindex>
   // CHECK-DAG: %[[RESULT_D4:.*]] = tensor.extract %arg1[%[[C4]]] : tensor<5xindex>
-  // CHECK-DAG: %[[ARG_D1:.*]] = tensor.dim %[[CAST_ARG]], %[[C1]] : tensor<4x?x3x?xi32>
-  // CHECK-DAG: %[[ARG_D3:.*]] = tensor.dim %[[CAST_ARG]], %[[C3]] : tensor<4x?x3x?xi32>
-  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %[[CAST_ARG]] : tensor<4x?x3x?xi32>{%[[ARG_D1]], %[[ARG_D3]]} -> tensor<12x?x?x1x?xi32>{%[[RESULT_D1]], %[[RESULT_D2]], %[[RESULT_D4]]}
+  // CHECK-DAG: %[[ARG_D1:.*]] = tensor.dim %arg0, %[[C1]] : tensor<4x?x3x?xi32>
+  // CHECK-DAG: %[[ARG_D3:.*]] = tensor.dim %arg0, %[[C3]] : tensor<4x?x3x?xi32>
+  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<4x?x3x?xi32>{%[[ARG_D1]], %[[ARG_D3]]} -> tensor<12x?x?x1x?xi32>{%[[RESULT_D1]], %[[RESULT_D2]], %[[RESULT_D4]]}
   %0 = "mhlo.dynamic_reshape"(%arg0, %arg1) : (tensor<4x?x3x?xui32>, tensor<5xindex>) -> tensor<12x?x?x1x?xui32>
-  // CHECK-DAG: %[[CAST_RESULT:.*]] = tensor.bitcast %[[RESULT]] : tensor<12x?x?x1x?xi32> to tensor<12x?x?x1x?xui32>
-  // CHECK: return %[[CAST_RESULT]]
+  // CHECK: return %[[RESULT]]
   return %0 : tensor<12x?x?x1x?xui32>
 }
 
@@ -429,18 +427,16 @@ func.func @fallbackDynamicReshapeInt(%arg0 : tensor<4x?x3x?xui32>, %arg1 : tenso
   // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
   // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
   // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
-  // CHECK-DAG: %[[CAST_ARG:.*]] = tensor.bitcast %arg0 : tensor<4x?x3x?xui32> to tensor<4x?x3x?xi32>
   // CHECK-DAG: %[[D1:.*]] = tensor.extract %arg1[%[[C1]]] : tensor<5xi32>
   // CHECK-DAG: %[[D2:.*]] = tensor.extract %arg1[%[[C2]]] : tensor<5xi32>
   // CHECK-DAG: %[[D4:.*]] = tensor.extract %arg1[%[[C4]]] : tensor<5xi32>
   // CHECK-DAG: %[[RESULT_D1:.*]] = arith.index_cast %[[D1]] : i32 to index
   // CHECK-DAG: %[[RESULT_D2:.*]] = arith.index_cast %[[D2]] : i32 to index
   // CHECK-DAG: %[[RESULT_D4:.*]] = arith.index_cast %[[D4]] : i32 to index
-  // CHECK-DAG: %[[ARG_D1:.*]] = tensor.dim %[[CAST_ARG]], %[[C1]] : tensor<4x?x3x?xi32>
-  // CHECK-DAG: %[[ARG_D3:.*]] = tensor.dim %[[CAST_ARG]], %[[C3]] : tensor<4x?x3x?xi32>
-  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %[[CAST_ARG]] : tensor<4x?x3x?xi32>{%[[ARG_D1]], %[[ARG_D3]]} -> tensor<12x?x?x1x?xi32>{%[[RESULT_D1]], %[[RESULT_D2]], %[[RESULT_D4]]}
+  // CHECK-DAG: %[[ARG_D1:.*]] = tensor.dim %arg0, %[[C1]] : tensor<4x?x3x?xi32>
+  // CHECK-DAG: %[[ARG_D3:.*]] = tensor.dim %arg0, %[[C3]] : tensor<4x?x3x?xi32>
+  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<4x?x3x?xi32>{%[[ARG_D1]], %[[ARG_D3]]} -> tensor<12x?x?x1x?xi32>{%[[RESULT_D1]], %[[RESULT_D2]], %[[RESULT_D4]]}
   %0 = "mhlo.dynamic_reshape"(%arg0, %arg1) : (tensor<4x?x3x?xui32>, tensor<5xi32>) -> tensor<12x?x?x1x?xui32>
-  // CHECK-DAG: %[[CAST_RESULT:.*]] = tensor.bitcast %[[RESULT]] : tensor<12x?x?x1x?xi32> to tensor<12x?x?x1x?xui32>
-  // CHECK: return %[[CAST_RESULT]]
+  // CHECK: return %[[RESULT]]
   return %0 : tensor<12x?x?x1x?xui32>
 }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_collective_ops.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_collective_ops.mlir
@@ -6,8 +6,7 @@ func.func @replica_id() -> tensor<ui32> {
   // CHECK-DAG: %[[RANK:.+]] = flow.channel.rank %[[CHANNEL]] : index
   // CHECK-DAG: %[[CAST:.+]] = arith.index_castui %[[RANK]] : index to i32
   // CHECK-DAG: %[[TENSOR:.+]] = tensor.from_elements %[[CAST]] : tensor<i32>
-  // CHECK-DAG: %[[BITCAST:.+]] = tensor.bitcast %[[TENSOR]] : tensor<i32> to tensor<ui32>
-  // CHECK-DAG: return %[[BITCAST]] : tensor<ui32>
+  // CHECK-DAG: return %[[TENSOR]] : tensor<i32>
   %id = mhlo.replica_id : tensor<ui32>
   return %id : tensor<ui32>
 }
@@ -22,8 +21,7 @@ module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 
     // CHECK-DAG: %[[DIV2:.+]] = arith.divui %[[RANK]], %c2 : index
     // CHECK-DAG: %[[CAST:.+]] = arith.index_castui %[[DIV2]] : index to i32
     // CHECK-DAG: %[[TENSOR:.+]] = tensor.from_elements %[[CAST]] : tensor<i32>
-    // CHECK-DAG: %[[BITCAST:.+]] = tensor.bitcast %[[TENSOR]] : tensor<i32> to tensor<ui32>
-    // CHECK-DAG: return %[[BITCAST]] : tensor<ui32>
+    // CHECK-DAG: return %[[TENSOR]] : tensor<i32>
     %id = mhlo.replica_id : tensor<ui32>
     return %id : tensor<ui32>
   }
@@ -36,8 +34,7 @@ module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 
 // CHECK-LABEL: @partition_id
 func.func @partition_id() -> tensor<ui32> {
   // CHECK-DAG: %[[CST0:.+]] = arith.constant dense<0> : tensor<i32>
-  // CHECK-DAG: %[[BITCAST:.+]] = tensor.bitcast %[[CST0]] : tensor<i32> to tensor<ui32>
-  // CHECK-DAG: return %[[BITCAST]] : tensor<ui32>
+  // CHECK-DAG: return %[[CST0]] : tensor<i32>
   %id = mhlo.partition_id : tensor<ui32>
   return %id : tensor<ui32>
 }
@@ -52,8 +49,7 @@ module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 
     // CHECK-DAG: %[[REM2:.+]] = arith.remui %[[RANK]], %c2 : index
     // CHECK-DAG: %[[CAST:.+]] = arith.index_castui %[[REM2]] : index to i32
     // CHECK-DAG: %[[TENSOR:.+]] = tensor.from_elements %[[CAST]] : tensor<i32>
-    // CHECK-DAG: %[[BITCAST:.+]] = tensor.bitcast %[[TENSOR]] : tensor<i32> to tensor<ui32>
-    // CHECK-DAG: return %[[BITCAST]] : tensor<ui32>
+    // CHECK-DAG: return %[[TENSOR]] : tensor<i32>
     %id = mhlo.partition_id : tensor<ui32>
     return %id : tensor<ui32>
   }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_structural_types.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_structural_types.mlir
@@ -2,33 +2,29 @@
 
 // CHECK-LABEL: @func_cfg_conversion
 module @func_cfg_conversion {
-  // CHECK: func.func @caller(%arg0: tensor<2xui32>, %arg1: i1) -> tensor<2xui32>
-  func.func @caller(%arg0: tensor<2xui32>, %arg1 : i1) -> tensor<2xui32> {
-    // CHECK: %[[RESULT:.*]] = call @callee(%arg0, %arg1) : (tensor<2xui32>, i1) -> tensor<2xui32>
-    %1 = call @callee(%arg0, %arg1) : (tensor<2xui32>, i1) -> tensor<2xui32>
-    // CHECK: return %[[RESULT]] : tensor<2xui32>
-    return %1 : tensor<2xui32>
+  // CHECK: func.func @caller(%arg0: tensor<2xi32>, %arg1: i1) -> tensor<2xi32>
+  func.func @caller(%arg0: tensor<2xi32>, %arg1 : i1) -> tensor<2xi32> {
+    // CHECK: %[[RESULT:.*]] = call @callee(%arg0, %arg1) : (tensor<2xi32>, i1) -> tensor<2xi32>
+    %1 = call @callee(%arg0, %arg1) : (tensor<2xi32>, i1) -> tensor<2xi32>
+    // CHECK: return %[[RESULT]] : tensor<2xi32>
+    return %1 : tensor<2xi32>
   }
 
-  // CHECK: func.func @callee(%arg0: tensor<2xui32>, %arg1: i1) -> tensor<2xui32>
-  func.func @callee(%arg0: tensor<2xui32>, %arg1: i1) -> tensor<2xui32> {
-    // CHECK: cf.cond_br %arg1, ^bb1(%arg0 : tensor<2xui32>), ^bb2(%arg0 : tensor<2xui32>)
-    cf.cond_br %arg1, ^bb1(%arg0 : tensor<2xui32>), ^bb2(%arg0 : tensor<2xui32>)
-  // CHECK: ^bb1(%[[BB1_PHI:.*]]: tensor<2xui32>)
-  ^bb1(%phi0 : tensor<2xui32>) :
-    // CHECK: tensor.bitcast %[[BB1_PHI]] : tensor<2xui32> to tensor<2xi32> 
+  // CHECK: func.func @callee(%arg0: tensor<2xi32>, %arg1: i1) -> tensor<2xi32>
+  func.func @callee(%arg0: tensor<2xi32>, %arg1: i1) -> tensor<2xi32> {
+    // CHECK: cf.cond_br %arg1, ^bb1(%arg0 : tensor<2xi32>), ^bb2(%arg0 : tensor<2xi32>)
+    cf.cond_br %arg1, ^bb1(%arg0 : tensor<2xi32>), ^bb2(%arg0 : tensor<2xi32>)
+  // CHECK: ^bb1(%[[BB1_PHI:.*]]: tensor<2xi32>)
+  ^bb1(%phi0 : tensor<2xi32>) :
     // CHECK: %[[BB1_PHI_ADD:.*]] = linalg.generic
-    // CHECK: %[[BB1_PHI_ADD_CAST:.*]] = tensor.bitcast %[[BB1_PHI_ADD]] : tensor<2xi32> to tensor<2xui32> 
-    // CHECK: cf.br ^bb2(%[[BB1_PHI_ADD_CAST]] : tensor<2xui32>)
-    %0 = "mhlo.add"(%phi0, %phi0) : (tensor<2xui32>, tensor<2xui32>) -> tensor<2xui32>
-    cf.br ^bb2(%0 : tensor<2xui32>)
-  // CHECK: ^bb2(%[[BB2_PHI:.*]]: tensor<2xui32>)
-  ^bb2(%phi1 : tensor<2xui32>):
-    // CHECK: tensor.bitcast %[[BB2_PHI]] : tensor<2xui32> to tensor<2xi32> 
+    // CHECK: cf.br ^bb2(%[[BB1_PHI_ADD]] : tensor<2xi32>)
+    %0 = "mhlo.add"(%phi0, %phi0) : (tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
+    cf.br ^bb2(%0 : tensor<2xi32>)
+  // CHECK: ^bb2(%[[BB2_PHI:.*]]: tensor<2xi32>)
+  ^bb2(%phi1 : tensor<2xi32>):
     // CHECK: %[[BB2_PHI_ADD:.*]] = linalg.generic
-    // CHECK: %[[BB2_PHI_ADD_CAST:.*]] = tensor.bitcast %[[BB2_PHI_ADD]] : tensor<2xi32> to tensor<2xui32> 
-    // CHECK: return %[[BB2_PHI_ADD_CAST]] : tensor<2xui32>
-    %1 = "mhlo.add"(%phi1, %phi1) : (tensor<2xui32>, tensor<2xui32>) -> tensor<2xui32>
-    return %1 : tensor<2xui32>
+    // CHECK: return %[[BB2_PHI_ADD]] : tensor<2xi32>
+    %1 = "mhlo.add"(%phi1, %phi1) : (tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
+    return %1 : tensor<2xi32>
   }
 }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_linalg.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_linalg.mlir
@@ -19,12 +19,11 @@ func.func @concatenate(%arg0: tensor<2x2xi32>, %arg1: tensor<2x4xi32>) -> tensor
 
 // CHECK: ml_program.global private mutable @variable(dense<0> : tensor<2xi32>) : tensor<2xi32>
 ml_program.global private mutable @variable(dense<0> : tensor<2xui32>) : tensor<2xui32>
-// CHECK: func.func @global_types() -> tensor<2xui32>
+// CHECK: func.func @global_types() -> (tensor<2xi32> {iree.abi.encoding = tensor<2xui32>})
 func.func @global_types() -> tensor<2xui32> {
   // CHECK-NEXT: %[[VALUE:.+]] = ml_program.global_load @variable : tensor<2xi32>
   %0 = ml_program.global_load @variable : tensor<2xui32>
-  // CHECK-NEXT: %[[CAST:.*]] = tensor.bitcast %[[VALUE]] : tensor<2xi32> to tensor<2xui32>
-  // CHECK: return %[[CAST]] : tensor<2xui32>
+  // CHECK: return %[[VALUE]] : tensor<2xi32>
   return %0 : tensor<2xui32>
 }
 
@@ -41,19 +40,25 @@ func.func @optimization_barrier(%arg0: tensor<3x4xf32>, %arg1: tensor<4xi32>) ->
 
 // -----
 
-// CHECK: @unsigned_integer_input_output(%[[ARG0:.*]]: tensor<2x2xui32>, %[[ARG1:.*]]: tensor<2x2xui32>) -> tensor<2x2xui32>
+// CHECK: @unsigned_integer_input_output(%[[ARG0:.*]]: tensor<2x2xi32> {iree.abi.encoding = tensor<2x2xui32>}, %[[ARG1:.*]]: tensor<2x2xi32> {iree.abi.encoding = tensor<2x2xui32>}) -> (tensor<2x2xi32> {iree.abi.encoding = tensor<2x2xui32>})
 func.func @unsigned_integer_input_output(%arg0: tensor<2x2xui32>, %arg1: tensor<2x2xui32>) -> tensor<2x2xui32> {
-  // CHECK: %[[CAST0:.*]] = tensor.bitcast %[[ARG0]] : tensor<2x2xui32> to tensor<2x2xi32>
-  // CHECK: %[[CAST1:.*]] = tensor.bitcast %[[ARG1]] : tensor<2x2xui32> to tensor<2x2xi32>
-  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<2x2xi32> 
-  // CHECK: %[[LINALG:.*]] = linalg.generic
-  //  CHECK-SAME:       ins(%[[CAST0]], %[[CAST1]] : tensor<2x2xi32>, tensor<2x2xi32>
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<2x2xi32>
+  // CHECK: %[[RESULT:.*]] = linalg.generic
+  //  CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] : tensor<2x2xi32>, tensor<2x2xi32>
   //  CHECK-SAME:       outs(%[[INIT]] : tensor<2x2xi32>)
-  // CHECK: ^bb0(%[[IN0:.*]]: i32, %[[IN1:.*]]: i32, %out: i32): 
+  // CHECK: ^bb0(%[[IN0:.*]]: i32, %[[IN1:.*]]: i32, %out: i32):
   // CHECK: %[[ADD:.*]] = arith.addi %[[IN0]], %[[IN1]] : i32
-  // CHECK: linalg.yield %[[ADD:.*]] : i32 
+  // CHECK: linalg.yield %[[ADD:.*]] : i32
   %0 = "mhlo.add"(%arg0, %arg1) : (tensor<2x2xui32>, tensor<2x2xui32>) -> tensor<2x2xui32>
-  // CHECK: %[[CAST_RESULT:.*]] = tensor.bitcast %[[LINALG]] : tensor<2x2xi32> to tensor<2x2xui32>
-  // CHECK: return %[[CAST_RESULT]]
+  // CHECK: return %[[RESULT]] : tensor<2x2xi32>
   return %0 : tensor<2x2xui32>
+}
+
+// -----
+
+// CHECK: func.func @aliasing_output
+// CHECK-SAME:    %[[ARG0:[^:]+]]: tensor<3x4xf32> {iree.abi.output = 1 : index}
+// CHECK-SAME:    %[[ARG1:[^:]+]]: tensor<4xi32> {iree.abi.encoding = tensor<4xui32>}
+func.func @aliasing_output(%arg0: tensor<3x4xf32> {tf.aliasing_output = 1 : i32}, %arg1: tensor<4xui32>) -> (tensor<4xui32>, tensor<3x4xf32>) {
+  return %arg1, %arg0 : tensor<4xui32>, tensor<3x4xf32>
 }

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_iree_input_dialects.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_iree_input_dialects.mlir
@@ -21,7 +21,7 @@ func.func @concatenate(%arg0: tensor<2x2xi32>, %arg1: tensor<2x4xi32>) -> tensor
 
 // CHECK: ml_program.global private mutable @variable(dense<0> : tensor<2xi32>) : tensor<2xi32>
 ml_program.global private mutable @variable(dense<0> : tensor<2xui32>) : tensor<2xui32>
-// CHECK: func.func @global_types() -> tensor<2xi32>
+// CHECK: func.func @global_types() -> (tensor<2xi32> {iree.abi.encoding = tensor<2xui32>}
 func.func @global_types() -> tensor<2xui32> {
   // CHECK-NEXT: %[[VALUE:.+]] = ml_program.global_load @variable : tensor<2xi32>
   %0 = ml_program.global_load @variable : tensor<2xui32>
@@ -41,3 +41,28 @@ func.func @optimization_barrier(%arg0: tensor<3x4xf32>, %arg1: tensor<4xi32>) ->
 // CHECK: %[[RESULT1:.+]] = util.optimization_barrier %[[ARG0]] : tensor<3x4xf32
 // CHECK: %[[RESULT2:.+]] = util.optimization_barrier %[[ARG1]] : tensor<4xi32>
 // CHECK: return %[[RESULT1]], %[[RESULT2]]
+
+// -----
+
+// CHECK: @unsigned_integer_input_output(%[[ARG0:.*]]: tensor<2x2xi32> {iree.abi.encoding = tensor<2x2xui32>}, %[[ARG1:.*]]: tensor<2x2xi32> {iree.abi.encoding = tensor<2x2xui32>}) -> (tensor<2x2xi32> {iree.abi.encoding = tensor<2x2xui32>})
+func.func @unsigned_integer_input_output(%arg0: tensor<2x2xui32>, %arg1: tensor<2x2xui32>) -> tensor<2x2xui32> {
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<2x2xi32>
+  // CHECK: %[[RESULT:.*]] = linalg.generic
+  //  CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] : tensor<2x2xi32>, tensor<2x2xi32>
+  //  CHECK-SAME:       outs(%[[INIT]] : tensor<2x2xi32>)
+  // CHECK: ^bb0(%[[IN0:.*]]: i32, %[[IN1:.*]]: i32, %out: i32):
+  // CHECK: %[[ADD:.*]] = arith.addi %[[IN0]], %[[IN1]] : i32
+  // CHECK: linalg.yield %[[ADD:.*]] : i32
+  %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<2x2xui32>, tensor<2x2xui32>) -> tensor<2x2xui32>
+  // CHECK: return %[[RESULT]] : tensor<2x2xi32>
+  return %0 : tensor<2x2xui32>
+}
+
+// -----
+
+// CHECK: func.func @aliasing_output
+// CHECK-SAME:    %[[ARG0:[^:]+]]: tensor<3x4xf32> {iree.abi.output = 1 : index}
+// CHECK-SAME:    %[[ARG1:[^:]+]]: tensor<4xi32> {iree.abi.encoding = tensor<4xui32>}
+func.func @aliasing_output(%arg0: tensor<3x4xf32> {tf.aliasing_output = 1 : i32}, %arg1: tensor<4xui32>) -> (tensor<4xui32>, tensor<3x4xf32>) {
+  return %arg1, %arg0 : tensor<4xui32>, tensor<3x4xf32>
+}


### PR DESCRIPTION
This allows the original HLO types to be passed down to the later ABI materialization passes even if the types are changed during conversion. JAX currently emits a tf.aliasing_output arg attr to indicate when outputs alias input memory and that's now passed down into the lower layers of IREE to ensure we (try to) do the same.

This approach is an alternative to #13090 that avoids issues around various sharp edges with signed types, func op legality, and the potential for the unsigned types to survive to layers of the stack where they are not expected.

Note that unfortunately this does not avoid the extra transient allocations for aliased outputs yet (in most cases) as there are improvements required in the `iree-stream-emplace-allocations` pass to handle some of the ops. For now this at least drops the number of external allocations to 0 but still needs the transients that get copied into them.