### PR TITLE
Add missing C++ stdint include

### DIFF
--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
Needed on my system to get uint8_t defined.

Encountered on:
gcc (SUSE Linux) 13.0.1 20230421 (prerelease) [revision f980561c60b0446cc427595198d7f3f4f90e0924]
clang version 16.0.3
libstdc++6 v13.0.1+git7231-1.1