### PR TITLE
[spirv] Use GPUCheckResourceUsage to check shared memory usage 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CommonGPUPasses.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CommonGPUPasses.h
@@ -53,7 +53,11 @@ LogicalResult tileToSerialLoops(func::FuncOp funcOp, bool onlyReduction = true);
 //===----------------------------------------------------------------------===//
 
 /// Checks GPU specific resource usage constraints like shared memory limits.
-std::unique_ptr<OperationPass<ModuleOp>> createGPUCheckResourceUsagePass();
+// `getSharedMemoryLimit` is for querying the shared memory limit (in bytes);
+// it takes the current entry function as the argument. 64KB will be used if
+// nullptr.
+std::unique_ptr<OperationPass<ModuleOp>> createGPUCheckResourceUsagePass(
+    std::function<unsigned(func::FuncOp)> getSharedMemoryLimit = nullptr);
 
 /// Creates a pass to distribute scf.forall ops to GPU processors.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUDistribute();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_check_resource_usage.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_check_resource_usage.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --iree-codegen-gpu-check-resource-usage %s --verify-diagnostics -split-input-file
 
 module {
-  // expected-error @+1 {{'func.func' op exceeded GPU memory limit of 166912 bytes for function. Got 274432 bytes}}
+  // expected-error @+1 {{uses 274432 bytes of shared memory; exceeded the limit of 65536 bytes}}
   func.func @shared_mem_alloc(%arg0: index) {
     %alloc = memref.alloc() : memref<274432xi8, #gpu.address_space<workgroup>>
     return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -505,7 +505,9 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   // THIS NEEDS TO RUN BEFORE SCF ->CF OFF
 
   // Run checks on shared memory usage.
-  pm.addPass(createGPUCheckResourceUsagePass());
+  // TODO: query this from the target.
+  auto getSharedMemoryLimit = [](func::FuncOp) { return 163 * 1024; };
+  pm.addPass(createGPUCheckResourceUsagePass(getSharedMemoryLimit));
 
   // SCF -> STD
   pm.addNestedPass<func::FuncOp>(createConvertSCFToCFPass());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
@@ -55,7 +55,6 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
   auto funcOp = op->getParentOfType<func::FuncOp>();
   const std::optional<int> subgroupSize = getSPIRVSubgroupSize(funcOp);
   if (!subgroupSize) return funcOp->emitError("failed to query subgroup size");
-  const int maxSharedMemory = limits.getMaxComputeSharedMemorySize();
   const int maxThreads = limits.getMaxComputeWorkgroupInvocations();
   const auto maxWorkGroupSize = llvm::to_vector<3>(llvm::map_range(
       limits.getMaxComputeWorkgroupSize().getAsValueRange<IntegerAttr>(),
@@ -98,7 +97,6 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
       op->getOperand(0).getType().cast<ShapedType>().getShape();
   ArrayRef<int64_t> rhsShape =
       op->getOperand(1).getType().cast<ShapedType>().getShape();
-  Type inputType = op->getOperand(0).getType();
 
   SmallVector<int64_t> workgroupTileSizes =
       loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
@@ -142,19 +140,6 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
   auto pipelineDepth = translationInfo.getSoftwarePipelineDepth();
   pipelineDepth = pipelineDepth ? pipelineDepth : 1;
 
-  // Verify shared memory usage of operands after tiling <= maxSharedMemory.
-  unsigned tilingSharedMemSizeBytes = getTileBytes(
-      workgroupTileSizes[0], workgroupTileSizes[1], reductionTileSizes[2],
-      inputType.cast<ShapedType>().getElementType().getIntOrFloatBitWidth(),
-      false);
-  unsigned totalSharedMemSizeBytes = getMultiBufferMemoryUsage(
-      tilingSharedMemSizeBytes, pipelineDepth,
-      translationInfo.getSoftwarePipelineStoreStage());
-
-  if (totalSharedMemSizeBytes > maxSharedMemory) {
-    return op->emitOpError("expected shared memory usage <= ")
-           << maxSharedMemory << ", got " << totalSharedMemSizeBytes;
-  }
   return success();
 }
 
@@ -190,7 +175,6 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
   auto funcOp = op->getParentOfType<func::FuncOp>();
   const std::optional<int> subgroupSize = getSPIRVSubgroupSize(funcOp);
   if (!subgroupSize) return funcOp->emitError("failed to query subgroup size");
-  const int maxSharedMemory = limits.getMaxComputeSharedMemorySize();
   const int maxThreads = limits.getMaxComputeWorkgroupInvocations();
   const auto maxWorkGroupSize = llvm::to_vector<3>(llvm::map_range(
       limits.getMaxComputeWorkgroupSize().getAsValueRange<IntegerAttr>(),
@@ -323,21 +307,6 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
         "subgroup_tile_m)");
   }
 
-  // Check if the C matrix will be promoted for computing shared memory usage.
-  bool promoteC = needToPrmoteCForCooperativeMatrix(cast<linalg::LinalgOp>(op));
-
-  // Verify shared memory usage of operands after tiling <= maxSharedMemory.
-  unsigned tilingSharedMemSizeBytes = getTileBytes(
-      workgroupTileSizes[0], workgroupTileSizes[1], reductionTileSizes[2],
-      lhsType.getIntOrFloatBitWidth(), promoteC);
-  unsigned totalSharedMemSizeBytes = getMultiBufferMemoryUsage(
-      tilingSharedMemSizeBytes, translationInfo.getSoftwarePipelineDepth(),
-      translationInfo.getSoftwarePipelineStoreStage());
-
-  if (totalSharedMemSizeBytes > maxSharedMemory) {
-    return op->emitOpError("expected shared memory usage <= ")
-           << maxSharedMemory << ", got " << totalSharedMemSizeBytes;
-  }
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/illegal_configuration.mlir
@@ -112,48 +112,6 @@ hal.executable private @matmul_tensors {
 // -----
 
 #compilation = #iree_codegen.compilation_info<
-    lowering_config  = <tile_sizes = [[64, 256], [8, 8], [0, 0, 32]]>,
-    translation_info = <SPIRVMatmulPromoteVectorize pipeline_depth = 2>,
-    workgroup_size = [32, 8, 1]>
-#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>,
-    #hal.descriptor_set.binding<2, storage_buffer>
-  ]>
-]>
-hal.executable private @matmul_tensors {
-  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb", {
-      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader, Float16], []>, Unknown:IntegratedGPU, #spirv.resource_limits<
-        max_compute_shared_memory_size = 32768,
-        max_compute_workgroup_invocations = 1024,
-        max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>>
-    }> {
-    hal.executable.export @illegal layout(#pipeline_layout)
-    builtin.module {
-      func.func @illegal() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<64x320xf16>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<320x1280xf16>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<64x1280xf16>>
-        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [64, 320], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x320xf16>> -> tensor<64x320xf16>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [320, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<320x1280xf16>> -> tensor<320x1280xf16>
-        %5 = tensor.empty() : tensor<64x1280xf16>
-        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<64x1280xf16>) -> tensor<64x1280xf16>
-        // expected-error @+1 {{expected shared memory usage <= 32768, got 51200}}
-        %7 = linalg.matmul {compilation_info = #compilation} ins(%3, %4 : tensor<64x320xf16>, tensor<320x1280xf16>) outs(%6 : tensor<64x1280xf16>) -> tensor<64x1280xf16>
-        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 1280], strides = [1, 1] : tensor<64x1280xf16> -> !flow.dispatch.tensor<writeonly:tensor<64x1280xf16>>
-        return
-      }
-    }
-  }
-}
-
-// -----
-
-#compilation = #iree_codegen.compilation_info<
     lowering_config  = <tile_sizes = [[32, 64], [4, 2], [0, 0, 4]]>,
     translation_info = <SPIRVMatmulPromoteVectorize>,
     workgroup_size = [32, 8, 1]>
@@ -632,68 +590,6 @@ hal.executable public @matmul_tensor {
             ins(%8, %10 : tensor<64x32xf16>, tensor<32x128xf16>) outs(%16 : tensor<64x128xf16>) -> tensor<64x128xf16>
         flow.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [64, 128], strides = [1, 1]
             : tensor<64x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<64x128xf16>>
-        return
-      }
-    }
-  }
-}
-
-// -----
-
-#compilation = #iree_codegen.compilation_info<
-    lowering_config  = <tile_sizes = [[64, 128], [32, 64], [0, 0, 32], [16, 16, 16]]>,
-    translation_info = <SPIRVCooperativeMatrixVectorize>,
-    workgroup_size = [128, 2, 1], subgroup_size = 64>
-#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>,
-    #hal.descriptor_set.binding<2, storage_buffer>,
-    #hal.descriptor_set.binding<3, storage_buffer>
-  ]>
-]>
-hal.executable public @matmul_tensor {
-  hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
-    spirv.target_env = #spirv.target_env<
-      #spirv.vce<v1.6,
-      [Shader, Float16, StorageBuffer16BitAccess, StorageUniform16, CooperativeMatrixNV],
-      [SPV_KHR_variable_pointers, SPV_NV_cooperative_matrix]>, AMD:DiscreteGPU,
-      #spirv.resource_limits<
-        cooperative_matrix_properties_nv = [
-          #spirv.coop_matrix_props<
-            a_type = f16, b_type = f16, c_type = f16, k_size = 16,
-            m_size = 16, n_size = 16, result_type = f16, scope = <Subgroup>>
-        ],
-        max_compute_shared_memory_size = 12800,
-        max_compute_workgroup_invocations = 1024,
-        max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
-       >}> {
-    hal.executable.export public @matmul_tensor layout(#pipeline_layout)
-    builtin.module {
-      func.func @matmul_tensor() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<512x64xf16>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<64x4096xf16>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<512xf16>>
-        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<512x4096xf16>>
-        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x64xf16>> -> tensor<512x64xf16>
-        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [64, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x4096xf16>> -> tensor<64x4096xf16>
-        %6 = flow.dispatch.tensor.load %2, offsets = [0], sizes = [512], strides = [1] : !flow.dispatch.tensor<readonly:tensor<512xf16>> -> tensor<512xf16>
-        %7 = tensor.empty() : tensor<512x4096xf16>
-        %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<512x4096xf16>) -> tensor<512x4096xf16>
-        // This does not need to promote C matrix, so we only need 15360 bytes.
-        // expected-error @+1 {{op expected shared memory usage <= 12800, got 15360}}
-        %9 = linalg.matmul {compilation_info = #compilation}
-            ins(%4, %5 : tensor<512x64xf16>, tensor<64x4096xf16>) outs(%8 : tensor<512x4096xf16>) -> tensor<512x4096xf16>
-        %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
-            ins(%9, %6 : tensor<512x4096xf16>, tensor<512xf16>) outs(%7 : tensor<512x4096xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %11 = arith.addf %in, %in_0 : f16
-          linalg.yield %11 : f16
-        } -> tensor<512x4096xf16>
-        flow.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [512, 4096], strides = [1, 1] : tensor<512x4096xf16> -> !flow.dispatch.tensor<writeonly:tensor<512x4096xf16>>
         return
       }
     }


### PR DESCRIPTION
Shared memory usage could be affected by multibuffering and
bank conflict avoiding. It's hard to calculate the total size
used before running the full compilation pipeline. So this
commit switches to follow LLVMGPU to perform the check after
running the compilation pipeline to be exact.