### PR TITLE
Add missing `inline` keywords to public header functions

### DIFF
--- a/runtime/src/iree/base/loop_inline.h
+++ b/runtime/src/iree/base/loop_inline.h
@@ -82,7 +82,8 @@ static inline iree_loop_t iree_loop_inline_initialize(
   return loop;
 }
 
-static void iree_loop_inline_deinitialize(iree_loop_inline_storage_t* storage) {
+static inline void iree_loop_inline_deinitialize(
+    iree_loop_inline_storage_t* storage) {
   if (!storage) return;
   iree_status_ignore(storage->status);
   storage->status = iree_ok_status();

--- a/runtime/src/iree/hal/local/executable_loader.h
+++ b/runtime/src/iree/hal/local/executable_loader.h
@@ -81,7 +81,8 @@ iree_status_t iree_hal_executable_import_provider_try_resolve(
     iree_hal_executable_import_resolution_t* out_resolution);
 
 // Returns true if the import |symbol_name| is optional.
-static bool iree_hal_executable_import_is_optional(const char* symbol_name) {
+static inline bool iree_hal_executable_import_is_optional(
+    const char* symbol_name) {
   // A `?` prefix indicates the symbol is optional and can be NULL.
   // Since the strings are NUL terminated we know there's always 1 char and
   // we can just test that for the prefix.

--- a/runtime/src/iree/hal/local/executable_plugin.h
+++ b/runtime/src/iree/hal/local/executable_plugin.h
@@ -289,7 +289,7 @@ typedef struct iree_hal_executable_plugin_allocator_t {
   iree_hal_executable_plugin_allocator_ctl_fn_t ctl;
 } iree_hal_executable_plugin_allocator_t;
 
-static iree_hal_executable_plugin_status_t
+static inline iree_hal_executable_plugin_status_t
 iree_hal_executable_plugin_allocator_malloc(
     iree_hal_executable_plugin_allocator_t allocator, size_t byte_length,
     void** inout_ptr) {
@@ -299,7 +299,7 @@ iree_hal_executable_plugin_allocator_malloc(
                        &params, inout_ptr);
 }
 
-static iree_hal_executable_plugin_status_t
+static inline iree_hal_executable_plugin_status_t
 iree_hal_executable_plugin_allocator_free(
     iree_hal_executable_plugin_allocator_t allocator, void* ptr) {
   return allocator.ctl(allocator.self,

--- a/runtime/src/iree/vm/shims_emitc.h
+++ b/runtime/src/iree/vm/shims_emitc.h
@@ -16,7 +16,7 @@ typedef iree_status_t (*iree_vm_native_function_target_emitc_t)(
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
     void* IREE_RESTRICT module, void* IREE_RESTRICT module_state);
 
-static iree_status_t iree_emitc_shim(
+static inline iree_status_t iree_emitc_shim(
     iree_vm_stack_t* IREE_RESTRICT stack, iree_vm_native_function_flags_t flags,
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
     iree_vm_native_function_target_emitc_t target_fn,

--- a/runtime/src/iree/vm/type_def.h
+++ b/runtime/src/iree/vm/type_def.h
@@ -52,7 +52,8 @@ static_assert(
    iree_vm_type_def_as_ref(v) == IREE_VM_REF_TYPE_NULL)
 #define iree_vm_type_def_is_undefined(v) iree_vm_type_def_is_variant(v)
 
-static bool iree_vm_type_def_equal(iree_vm_type_def_t a, iree_vm_type_def_t b) {
+static inline bool iree_vm_type_def_equal(iree_vm_type_def_t a,
+                                          iree_vm_type_def_t b) {
   return a.value_type_bits == b.value_type_bits &&
          a.ref_type_bits == b.ref_type_bits;
 }


### PR DESCRIPTION
Suppresses warnings such as the following:

```
In file included from iree/base/api.h:88,
                 from iree/hal/drivers/vulkan/api.h:14:
iree/base/loop_inline.h:85:13: warning: ‘iree_loop_inline_deinitialize’ defined but not used [-Wunused-function]
   85 | static void iree_loop_inline_deinitialize(iree_loop_inline_storage_t* storage) {
```