### PR TITLE
Fix documentation in ConvertToDestinationPassingStylePass.cpp

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -544,7 +544,7 @@ struct RemoveCstOutsDependency
 ///    flow.dispatch.tensor.store %true, %target
 ///  } else {
 ///    ...
-///    flow.dispatch.tensor.store %true, %target
+///    flow.dispatch.tensor.store %false, %target
 ///  }
 /// ```
 /// This is a workaround for #11273 while a proper fix lands.


### PR DESCRIPTION
The transformation in the documentation does not maintain the semantics of the original code. This is a small doc fix to fix this.