### PR TITLE
Hotfixes following #13460

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on: windows-2022-64core
     defaults:
       run:
@@ -132,7 +132,7 @@ jobs:
 
   build_test_all_macos_arm64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - ${{ github.repository == 'openxla/iree' && 'self-hosted' || 'macos-11' }} # must come first
       - runner-group=postsubmit
@@ -165,7 +165,7 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on: macos-12-xl
     env:
       BUILD_DIR: build-macos

--- a/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+iree_add_all_subdirs()
+
 # Our inline assembly is of the GCC/Clang flavor. Enable it by default when it
 # is expected to compile.
 iree_select_compiler_opts(IREE_UK_ENABLE_INLINE_ASM_DEFAULT
@@ -23,13 +25,11 @@ option(IREE_UK_ENABLE_INTRINSICS_EVEN_WHEN_INLINE_ASM_AVAILABLE
 
 if (IREE_ARCH STREQUAL "arm_64")
   set(IREE_UK_ARCH_ARM_64 TRUE)
-  add_subdirectory(arm_64)
   list(APPEND IREE_UK_ARCH_DEPS
     "iree::builtins::ukernel::arch::arm_64"
   )
 elseif (IREE_ARCH STREQUAL "x86_64")
   set(IREE_UK_ARCH_X86_64 TRUE)
-  add_subdirectory(x86_64)
   list(APPEND IREE_UK_ARCH_DEPS
     "iree::builtins::ukernel::arch::x86_64"
   )

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
@@ -4,6 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+if (NOT (IREE_ARCH STREQUAL "arm_64"))
+  return()
+endif()
+
 iree_select_compiler_opts(IREE_UK_COPTS_ARM_64_DOTPROD
   CLANG_OR_GCC
     "-march=armv8.2-a+dotprod"

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
@@ -216,6 +216,10 @@ endif()  # IREE_BUILD_COMPILER AND IREE_TARGET_BACKEND_LLVM_CPU
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
+if (NOT (IREE_ARCH STREQUAL "x86_64"))
+  return()
+endif()
+
 # Target CPUs supporting AVX2+FMA3. That includes Intel Haswell (2013) and newer
 # and AMD Excavator (2015) and newer. There is no current plan to look after
 # SIMD performance on x86 microarchitectures not supporting this.

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/common_x86_64.h
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/common_x86_64.h
@@ -35,26 +35,13 @@ static inline bool iree_uk_cpu_supports_avx512_vnni(
          iree_uk_all_bits_set(cpu_data[0], IREE_CPU_DATA0_X86_64_AVX512VNNI);
 }
 
+#if defined(__AVX2__)
+
 static inline __m256i iree_uk_avx_loadu_2x128(const void* src0,
                                               const void* src1) {
   __m128i v128_0 = _mm_loadu_si128((const __m128i*)src0);
   __m128i v128_1 = _mm_loadu_si128((const __m128i*)src1);
   return _mm256_inserti128_si256(_mm256_castsi128_si256(v128_0), v128_1, 1);
-}
-
-static inline __m512i iree_uk_avx512_loadu_4x128(const void* src0,
-                                                 const void* src1,
-                                                 const void* src2,
-                                                 const void* src3) {
-  __m128i v128_0 = _mm_loadu_si128((const __m128i*)src0);
-  __m128i v128_1 = _mm_loadu_si128((const __m128i*)src1);
-  __m128i v128_2 = _mm_loadu_si128((const __m128i*)src2);
-  __m128i v128_3 = _mm_loadu_si128((const __m128i*)src3);
-  __m512i result = _mm512_castsi128_si512(v128_0);
-  result = _mm512_inserti32x4(result, v128_1, 1);
-  result = _mm512_inserti32x4(result, v128_2, 2);
-  result = _mm512_inserti32x4(result, v128_3, 3);
-  return result;
 }
 
 static inline void iree_uk_avx_storeu_2x128(void* dst0, void* dst1,
@@ -65,33 +52,6 @@ static inline void iree_uk_avx_storeu_2x128(void* dst0, void* dst1,
   _mm_storeu_si128((__m128i*)dst1, v128_1);
 }
 
-static inline void iree_uk_avx512_storeu_4x128(void* dst0, void* dst1,
-                                               void* dst2, void* dst3,
-                                               __m512i vec512) {
-  __m128i v128_0 = _mm512_extracti32x4_epi32(vec512, 0);
-  __m128i v128_1 = _mm512_extracti32x4_epi32(vec512, 1);
-  __m128i v128_2 = _mm512_extracti32x4_epi32(vec512, 2);
-  __m128i v128_3 = _mm512_extracti32x4_epi32(vec512, 3);
-  _mm_storeu_si128((__m128i*)dst0, v128_0);
-  _mm_storeu_si128((__m128i*)dst1, v128_1);
-  _mm_storeu_si128((__m128i*)dst2, v128_2);
-  _mm_storeu_si128((__m128i*)dst3, v128_3);
-}
-
-static inline __m512i iree_uk_avx512_loadu_4x128_from_16x16xi32(
-    const iree_uk_int32_t* src, int i0, int j0, int i1, int j1, int i2, int j2,
-    int i3, int j3) {
-  return iree_uk_avx512_loadu_4x128(src + i0 * 16 + j0, src + i1 * 16 + j1,
-                                    src + i2 * 16 + j2, src + i3 * 16 + j3);
-}
-
-static inline void iree_uk_avx512_storeu_4x128_to_16x16xi32(
-    iree_uk_int32_t* dst, int i0, int j0, int i1, int j1, int i2, int j2,
-    int i3, int j3, __m512i vec512) {
-  return iree_uk_avx512_storeu_4x128(dst + i0 * 16 + j0, dst + i1 * 16 + j1,
-                                     dst + i2 * 16 + j2, dst + i3 * 16 + j3,
-                                     vec512);
-}
 
 static inline void iree_uk_copy_8x32xi8_strided_to_strided(
     iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
@@ -116,14 +76,6 @@ static inline __m256i iree_uk_avx2_load_8x4xi8_strided(
   __m256i indices = _mm256_mullo_epi32(
       _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7), _mm256_set1_epi32(stride));
   return _mm256_i32gather_epi32(src, indices, 1);
-}
-
-static inline __m512i iree_uk_avx512_load_16x4xi8_strided(
-    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
-  __m512i indices = _mm512_mullo_epi32(
-      _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
-      _mm512_set1_epi32(stride));
-  return _mm512_i32gather_epi32(indices, src, 1);
 }
 
 static inline __m128i iree_uk_avx2_load_8x2xi8_strided(
@@ -195,13 +147,6 @@ static inline void iree_uk_avx2_copy_8x4xi8_strided_to_unstrided(
   _mm256_storeu_si256((__m256i*)out_ptr, in);
 }
 
-static inline void iree_uk_avx512_copy_16x4xi8_strided_to_unstrided(
-    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
-    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
-  __m512i in = iree_uk_avx512_load_16x4xi8_strided(in_ptr, in_stride);
-  _mm512_storeu_si512((__m512i*)out_ptr, in);
-}
-
 static inline void iree_uk_avx2_copy_8x2xi8_strided_to_unstrided(
     iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
     const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
@@ -245,57 +190,6 @@ iree_uk_avx2_copy_8x16xi8_tiled_1x4_transpose_strided_to_strided(
   _mm256_storeu_si256((__m256i*)(out_ptr + 1 * out_stride), r01234567_1);
   _mm256_storeu_si256((__m256i*)(out_ptr + 2 * out_stride), r01234567_2);
   _mm256_storeu_si256((__m256i*)(out_ptr + 3 * out_stride), r01234567_3);
-}
-
-static inline void
-iree_uk_avx512_copy_16x16xi8_tiled_1x4_transpose_strided_to_strided(
-    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
-    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
-    iree_uk_ssize_t in_stride) {
-  __m512i r000044448888CCCC = iree_uk_avx512_loadu_4x128(
-      in_ptr + 0 * in_stride, in_ptr + 4 * in_stride, in_ptr + 8 * in_stride,
-      in_ptr + 12 * in_stride);
-  __m512i r111155559999DDDD = iree_uk_avx512_loadu_4x128(
-      in_ptr + 1 * in_stride, in_ptr + 5 * in_stride, in_ptr + 9 * in_stride,
-      in_ptr + 13 * in_stride);
-  __m512i r22226666AAAAEEEE = iree_uk_avx512_loadu_4x128(
-      in_ptr + 2 * in_stride, in_ptr + 6 * in_stride, in_ptr + 10 * in_stride,
-      in_ptr + 14 * in_stride);
-  __m512i r33337777BBBBFFFF = iree_uk_avx512_loadu_4x128(
-      in_ptr + 3 * in_stride, in_ptr + 7 * in_stride, in_ptr + 11 * in_stride,
-      in_ptr + 15 * in_stride);
-  __m512i r0022446688AACCEE_0 =
-      _mm512_unpacklo_epi64(r000044448888CCCC, r22226666AAAAEEEE);
-  __m512i r0022446688AACCEE_1 =
-      _mm512_unpackhi_epi64(r000044448888CCCC, r22226666AAAAEEEE);
-  __m512i r1133557799BBDDFF_0 =
-      _mm512_unpacklo_epi64(r111155559999DDDD, r33337777BBBBFFFF);
-  __m512i r1133557799BBDDFF_1 =
-      _mm512_unpackhi_epi64(r111155559999DDDD, r33337777BBBBFFFF);
-  __m512i r010145458989CDCD_0 =
-      _mm512_unpacklo_epi32(r0022446688AACCEE_0, r1133557799BBDDFF_0);
-  __m512i r010145458989CDCD_1 =
-      _mm512_unpacklo_epi32(r0022446688AACCEE_1, r1133557799BBDDFF_1);
-  __m512i r23236767ABABEFEF_0 =
-      _mm512_unpackhi_epi32(r0022446688AACCEE_0, r1133557799BBDDFF_0);
-  __m512i r23236767ABABEFEF_1 =
-      _mm512_unpackhi_epi32(r0022446688AACCEE_1, r1133557799BBDDFF_1);
-  __m512i r0123456789ABCDEF_0 =
-      _mm512_unpacklo_epi64(r010145458989CDCD_0, r23236767ABABEFEF_0);
-  __m512i r0123456789ABCDEF_1 =
-      _mm512_unpackhi_epi64(r010145458989CDCD_0, r23236767ABABEFEF_0);
-  __m512i r0123456789ABCDEF_2 =
-      _mm512_unpacklo_epi64(r010145458989CDCD_1, r23236767ABABEFEF_1);
-  __m512i r0123456789ABCDEF_3 =
-      _mm512_unpackhi_epi64(r010145458989CDCD_1, r23236767ABABEFEF_1);
-  _mm512_storeu_si512((__m512i*)(out_ptr + 0 * out_stride),
-                      r0123456789ABCDEF_0);
-  _mm512_storeu_si512((__m512i*)(out_ptr + 1 * out_stride),
-                      r0123456789ABCDEF_1);
-  _mm512_storeu_si512((__m512i*)(out_ptr + 2 * out_stride),
-                      r0123456789ABCDEF_2);
-  _mm512_storeu_si512((__m512i*)(out_ptr + 3 * out_stride),
-                      r0123456789ABCDEF_3);
 }
 
 static inline void
@@ -355,6 +249,117 @@ iree_uk_avx2_copy_8x16xi8_tiled_1x2_transpose_strided_to_strided(
                            r0123456701234567_2);
   iree_uk_avx_storeu_2x128(out_ptr + 6 * out_stride, out_ptr + 7 * out_stride,
                            r0123456701234567_3);
+}
+
+#if defined (__AVX512F__)
+
+static inline __m512i iree_uk_avx512_loadu_4x128(const void* src0,
+                                                 const void* src1,
+                                                 const void* src2,
+                                                 const void* src3) {
+  __m128i v128_0 = _mm_loadu_si128((const __m128i*)src0);
+  __m128i v128_1 = _mm_loadu_si128((const __m128i*)src1);
+  __m128i v128_2 = _mm_loadu_si128((const __m128i*)src2);
+  __m128i v128_3 = _mm_loadu_si128((const __m128i*)src3);
+  __m512i result = _mm512_castsi128_si512(v128_0);
+  result = _mm512_inserti32x4(result, v128_1, 1);
+  result = _mm512_inserti32x4(result, v128_2, 2);
+  result = _mm512_inserti32x4(result, v128_3, 3);
+  return result;
+}
+
+static inline void iree_uk_avx512_storeu_4x128(void* dst0, void* dst1,
+                                               void* dst2, void* dst3,
+                                               __m512i vec512) {
+  __m128i v128_0 = _mm512_extracti32x4_epi32(vec512, 0);
+  __m128i v128_1 = _mm512_extracti32x4_epi32(vec512, 1);
+  __m128i v128_2 = _mm512_extracti32x4_epi32(vec512, 2);
+  __m128i v128_3 = _mm512_extracti32x4_epi32(vec512, 3);
+  _mm_storeu_si128((__m128i*)dst0, v128_0);
+  _mm_storeu_si128((__m128i*)dst1, v128_1);
+  _mm_storeu_si128((__m128i*)dst2, v128_2);
+  _mm_storeu_si128((__m128i*)dst3, v128_3);
+}
+
+static inline __m512i iree_uk_avx512_loadu_4x128_from_16x16xi32(
+    const iree_uk_int32_t* src, int i0, int j0, int i1, int j1, int i2, int j2,
+    int i3, int j3) {
+  return iree_uk_avx512_loadu_4x128(src + i0 * 16 + j0, src + i1 * 16 + j1,
+                                    src + i2 * 16 + j2, src + i3 * 16 + j3);
+}
+
+static inline void iree_uk_avx512_storeu_4x128_to_16x16xi32(
+    iree_uk_int32_t* dst, int i0, int j0, int i1, int j1, int i2, int j2,
+    int i3, int j3, __m512i vec512) {
+  return iree_uk_avx512_storeu_4x128(dst + i0 * 16 + j0, dst + i1 * 16 + j1,
+                                     dst + i2 * 16 + j2, dst + i3 * 16 + j3,
+                                     vec512);
+}
+
+static inline __m512i iree_uk_avx512_load_16x4xi8_strided(
+    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
+  __m512i indices = _mm512_mullo_epi32(
+      _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+      _mm512_set1_epi32(stride));
+  return _mm512_i32gather_epi32(indices, src, 1);
+}
+
+static inline void iree_uk_avx512_copy_16x4xi8_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  __m512i in = iree_uk_avx512_load_16x4xi8_strided(in_ptr, in_stride);
+  _mm512_storeu_si512((__m512i*)out_ptr, in);
+}
+
+static inline void
+iree_uk_avx512_copy_16x16xi8_tiled_1x4_transpose_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  __m512i r000044448888CCCC = iree_uk_avx512_loadu_4x128(
+      in_ptr + 0 * in_stride, in_ptr + 4 * in_stride, in_ptr + 8 * in_stride,
+      in_ptr + 12 * in_stride);
+  __m512i r111155559999DDDD = iree_uk_avx512_loadu_4x128(
+      in_ptr + 1 * in_stride, in_ptr + 5 * in_stride, in_ptr + 9 * in_stride,
+      in_ptr + 13 * in_stride);
+  __m512i r22226666AAAAEEEE = iree_uk_avx512_loadu_4x128(
+      in_ptr + 2 * in_stride, in_ptr + 6 * in_stride, in_ptr + 10 * in_stride,
+      in_ptr + 14 * in_stride);
+  __m512i r33337777BBBBFFFF = iree_uk_avx512_loadu_4x128(
+      in_ptr + 3 * in_stride, in_ptr + 7 * in_stride, in_ptr + 11 * in_stride,
+      in_ptr + 15 * in_stride);
+  __m512i r0022446688AACCEE_0 =
+      _mm512_unpacklo_epi64(r000044448888CCCC, r22226666AAAAEEEE);
+  __m512i r0022446688AACCEE_1 =
+      _mm512_unpackhi_epi64(r000044448888CCCC, r22226666AAAAEEEE);
+  __m512i r1133557799BBDDFF_0 =
+      _mm512_unpacklo_epi64(r111155559999DDDD, r33337777BBBBFFFF);
+  __m512i r1133557799BBDDFF_1 =
+      _mm512_unpackhi_epi64(r111155559999DDDD, r33337777BBBBFFFF);
+  __m512i r010145458989CDCD_0 =
+      _mm512_unpacklo_epi32(r0022446688AACCEE_0, r1133557799BBDDFF_0);
+  __m512i r010145458989CDCD_1 =
+      _mm512_unpacklo_epi32(r0022446688AACCEE_1, r1133557799BBDDFF_1);
+  __m512i r23236767ABABEFEF_0 =
+      _mm512_unpackhi_epi32(r0022446688AACCEE_0, r1133557799BBDDFF_0);
+  __m512i r23236767ABABEFEF_1 =
+      _mm512_unpackhi_epi32(r0022446688AACCEE_1, r1133557799BBDDFF_1);
+  __m512i r0123456789ABCDEF_0 =
+      _mm512_unpacklo_epi64(r010145458989CDCD_0, r23236767ABABEFEF_0);
+  __m512i r0123456789ABCDEF_1 =
+      _mm512_unpackhi_epi64(r010145458989CDCD_0, r23236767ABABEFEF_0);
+  __m512i r0123456789ABCDEF_2 =
+      _mm512_unpacklo_epi64(r010145458989CDCD_1, r23236767ABABEFEF_1);
+  __m512i r0123456789ABCDEF_3 =
+      _mm512_unpackhi_epi64(r010145458989CDCD_1, r23236767ABABEFEF_1);
+  _mm512_storeu_si512((__m512i*)(out_ptr + 0 * out_stride),
+                      r0123456789ABCDEF_0);
+  _mm512_storeu_si512((__m512i*)(out_ptr + 1 * out_stride),
+                      r0123456789ABCDEF_1);
+  _mm512_storeu_si512((__m512i*)(out_ptr + 2 * out_stride),
+                      r0123456789ABCDEF_2);
+  _mm512_storeu_si512((__m512i*)(out_ptr + 3 * out_stride),
+                      r0123456789ABCDEF_3);
 }
 
 static inline void
@@ -427,3 +432,7 @@ iree_uk_avx512_copy_16x16xi8_tiled_1x2_transpose_strided_to_strided(
       out_ptr + 6 * out_stride + 16, out_ptr + 7 * out_stride + 16,
       r0123456701234567_3);
 }
+
+#endif  // defined (__AVX512F__)
+
+#endif // defined(__AVX2__)


### PR DESCRIPTION
* On Windows, compile errors in x86 intrinsics code apparently caused by using AVX512 types in translation units where AVX512 was not enabled, in the bitcode builds i.e. using Clang-on-Windows. Maybe it's stricter than other compilers that have been quietly compiling this code so far (Clang on other OSes, MSVC on Windows).
* On Mac/arm64, CMake build errors caused by not `add_subdirectory` the x86-64 directory, which is now necessary to build bitcode.