### PR TITLE
limit ukernel bitcode tests to x86-64

### DIFF
--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -305,6 +305,10 @@ function(iree_generated_trace_runner_test)
     return()
   endif()
 
+  if((NOT (IREE_ARCH STREQUAL "x86_64")) AND ("x86_64_only" IN_LIST _RULE_LABELS))
+    return()
+  endif()
+
   if(NOT DEFINED _RULE_TARGET_BACKENDS AND NOT DEFINED _RULE_DRIVERS)
     set(_RULE_TARGET_BACKENDS "vmvx" "vulkan-spirv" "llvm-cpu")
     set(_RULE_DRIVERS "local-task" "vulkan" "local-task")

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -175,6 +175,7 @@ py_binary(
     ],
     tags = [
         "hostonly",
+        "x86_64_only",
     ],
     target_backends_and_drivers = [
         ("llvm-cpu", "local-task"),

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -267,6 +267,7 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   LABELS
     "hostonly"
+    "x86_64_only"
 )
 
 iree_generated_trace_runner_test(
@@ -288,6 +289,7 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   LABELS
     "hostonly"
+    "x86_64_only"
 )
 
 iree_generated_trace_runner_test(


### PR DESCRIPTION
Following up on #13709 and hopefully finally fixing macOS arm64 CI... these tests had been labelled `hostonly` but that didn't prevent them being hit outside of x86-64 when the host itself is non-x86-64, as is the case on macOS arm64.

