### PR TITLE
Revert "[CPU] Enable 'iree-llvmcpu-reassociate-fp-reductions' by default"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -63,7 +63,7 @@ static llvm::cl::opt<bool> clEnableMicrokernelsDecomposeLinalgGeneric(
 static llvm::cl::opt<bool> clEnableReassociateFpReductions(
     "iree-llvmcpu-reassociate-fp-reductions",
     llvm::cl::desc("Enables reassociation for FP reductions"),
-    llvm::cl::init(true));
+    llvm::cl::init(false));
 
 static llvm::cl::opt<bool> clInstrumentMemoryAccesses{
     "iree-llvmcpu-instrument-memory-accesses",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -57,11 +57,10 @@ hal.executable private @check_no_cse {
 }
 // CHECK-LABEL: func.func @check_no_cse()
 //   CHECK-NOT:    memref.alloc
-//       CHECK:    scf.for
-//       CHECK:      arith.addf
-//       CHECK:    vector.reduction <add>
-//       CHECK:    arith.divf
-//       CHECK:    memref.store
+//       CHECK:    %[[FOR:.+]] = scf.for
+//       CHECK:    %[[DIVF:.+]] = arith.divf %[[FOR]]
+//       CHECK:    %[[RES:.+]] = vector.extract %[[DIVF]]
+//       CHECK:    memref.store %[[RES]]
 
 // -----
 
@@ -546,8 +545,8 @@ hal.executable private @mmt4d_ukernel {
 hal.executable private @ukernel_pass_through {
   hal.executable.variant public @embedded_elf_x86_64, target = <
     "llvm-cpu", "embedded-elf-x86_64", {
-      cpu = "generic", cpu_features = "",
-      data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+      cpu = "generic", cpu_features = "", 
+      data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", 
       native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf",
       ukernels = false}> {
     hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/split_reduction_pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/split_reduction_pipeline_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' --iree-llvmcpu-reassociate-fp-reductions=false --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' --split-input-file %s | FileCheck %s
 // RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' --iree-llvmcpu-reassociate-fp-reductions=true --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
 
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_masking.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_masking.mlir
@@ -124,8 +124,9 @@ hal.executable private @preset_config_reduction  {
 }
 
 //   CHECK-LABEL: func.func @mask_dynamic_reduction
-//         CHECK:   vector.maskedload
-//         CHECK:   vector.mask %{{.*}} { vector.reduction <add>
+// CHECK-COUNT-5:   vector.maskedload
+// CHECK-COUNT-4:   vector.mask %{{.*}} { vector.reduction <add>
+//         CHECK:   vector.maskedstore
 
 // -----
 

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -58,21 +58,9 @@ iree_lit_test_suite(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_fp_reassoc_regression_llvm-cpu",
-    srcs = [
-        "associative_reordering.mlir",
-    ],
-    compiler_flags = [
-        "--iree-input-type=mhlo",
-        "--iree-llvmcpu-reassociate-fp-reductions=false",
-    ],
-    driver = "local-task",
-    target_backend = "llvm-cpu",
-)
-
-iree_check_single_backend_test_suite(
     name = "check_regression_llvm-cpu",
     srcs = [
+        "associative_reordering.mlir",
         "layernorm.mlir",
         "lowering_config.mlir",
         "pack_pad_transpose_1x9_into_2x4x8x4_issue_12546.mlir",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -33,22 +33,9 @@ iree_lit_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_fp_reassoc_regression_llvm-cpu
-  SRCS
-    "associative_reordering.mlir"
-  TARGET_BACKEND
-    "llvm-cpu"
-  DRIVER
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-input-type=mhlo"
-    "--iree-llvmcpu-reassociate-fp-reductions=false"
-)
-
-iree_check_single_backend_test_suite(
-  NAME
     check_regression_llvm-cpu
   SRCS
+    "associative_reordering.mlir"
     "dynamic_abs.mlir"
     "dynamic_add.mlir"
     "dynamic_dot.mlir"


### PR DESCRIPTION
Reverts openxla/iree#13685 due to https://github.com/openxla/iree/issues/13706