### PR TITLE
[LLVMGPU][TD] Workaround a miscompile with gpu pipelining

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -72,8 +72,6 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.iree.forall_to_workgroup %{{.*}} : (!pdl.operation) -> ()
 // CHECK: transform.iree.map_nested_forall_to_gpu_threads %{{.*}} workgroup_dims = [64, 2, 1] warp_dims = [2, 2, 1] : (!pdl.operation) -> ()
 // CHECK: transform.iree.hoist_static_alloc %{{.*}} : (!pdl.operation) -> ()
-// CHECK: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases} : (!pdl.operation) -> ()
-// CHECK: transform.iree.apply_patterns %{{.*}} {extract_address_computations} : (!pdl.operation) -> ()
 // CHECK: transform.iree.apply_patterns %{{.*}} {unroll_vectors_gpu_wmma} : (!pdl.operation) -> ()
 // CHECK: transform.structured.hoist_redundant_vector_transfers %{{.*}} : (!pdl.operation) -> !pdl.operation
 // CHECK: transform.iree.apply_buffer_optimizations %{{.*}} : (!pdl.operation) -> ()
@@ -83,6 +81,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.vector.transfer_to_scf %{{.*}}   max_transfer_rank = 1 full_unroll = true : (!pdl.operation) -> !pdl.operation
 // CHECK: transform.iree.create_async_groups %{{.*}} {use_mma_sync = false} : (!pdl.operation) -> ()
 // CHECK: transform.iree.pipeline_shared_memory_copies %{{.*}} {depth = 3 : i64} : (!pdl.operation) -> !pdl.operation
+// CHECK: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases} : (!pdl.operation) -> ()
+// CHECK: transform.iree.apply_patterns %{{.*}} {extract_address_computations} : (!pdl.operation) -> ()
 // CHECK: transform.vector.lower_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
 // CHECK: transform.vector.materialize_masks %{{.*}} : (!pdl.operation) -> !pdl.operation
 // CHECK: transform.iree.apply_patterns %{{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization} : (!pdl.operation) -> ()

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -503,16 +503,6 @@ Value mlir::iree_compiler::gpu::buildConvertToTensorCoreOp(
   iree_compiler::buildCanonicalizationAndEnablingTransforms(
       b, ApplyPatternsOpPatterns(), funcH);
   b.create<iree_compiler::IREE::transform_dialect::HoistStaticAllocOp>(funcH);
-  {
-    ApplyPatternsOpPatterns config;
-    config.foldMemrefAliases = true;
-    b.create<ApplyPatternsOp>(funcH, config);
-  }
-  {
-    ApplyPatternsOpPatterns config;
-    config.extractAddressComputations = true;
-    b.create<ApplyPatternsOp>(funcH, config);
-  }
   iree_compiler::buildCanonicalizationAndEnablingTransforms(
       b, ApplyPatternsOpPatterns(), funcH);
   {

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -44,6 +44,7 @@ using iree_compiler::gpu::buildPipelineSharedMemoryCopies;
 using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::MatmulStrategy;
 using iree_compiler::gpu::scaleUpByBitWidth;
+using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
 using iree_compiler::IREE::transform_dialect::
     IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
@@ -285,6 +286,16 @@ void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
   }
 
   // Step 13. Late lowerings and cleanups.
+  {
+    ApplyPatternsOpPatterns config;
+    config.foldMemrefAliases = true;
+    b.create<ApplyPatternsOp>(funcH, config);
+  }
+  {
+    ApplyPatternsOpPatterns config;
+    config.extractAddressComputations = true;
+    b.create<ApplyPatternsOp>(funcH, config);
+  }
   // TODO: not a functional style op to avoid invalidating artificially.
   funcH = b.create<transform::LowerMasksOp>(
       pdl::OperationType::get(b.getContext()), funcH);


### PR DESCRIPTION
The pipelining of shared mem copies requires that the involved buffers have been multibuffered.
When this is not the case, this may lead to miscompiles like what we observed in https://github.com/openxla/iree/issues/13451.

In this specific case, multibuffering doesn't kick in for one of the buffer because one of its use is outside of the loop.
The use is hoisted out of the loop thanks to the
extract-address-computations optimization.

To workaround this miscompile, this patch runs extract-address-computations after the multi-buffering. This matches what we do for the aligned matmul strategy.

Ultimately we should fix the pipelining such that it doesn't kick in if the related buffers are not multi-buffered.

TODO: Add a proper test case.