### PR TITLE
Support cross_replica and cross_partition for all_to_all and collective_permute

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/ConvertCollectives.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/ConvertCollectives.cpp
@@ -205,7 +205,7 @@ static std::pair<Value, Value> makeSplitColorAndKey(Location loc,
 static DenseIntElementsAttr convertToRankGroupsByCrossReplica(
     DenseIntElementsAttr replicaGroups, int32_t numPartitions,
     OpBuilder &builder) {
-  if (numPartitions < 1) {
+  if (numPartitions <= 1) {
     // Treat as a single partition.
     return replicaGroups;
   }
@@ -236,10 +236,48 @@ static DenseIntElementsAttr convertToRankGroupsByCrossReplica(
   return DenseIntElementsAttr::get(type, newValues);
 }
 
+static DenseIntElementsAttr convertToRankGroupsByCrossPartition(
+    DenseIntElementsAttr partitionGroups, int32_t numReplicas,
+    OpBuilder &builder) {
+  if (numReplicas <= 1) {
+    // Treat as a single replica.
+    return partitionGroups;
+  }
+
+  auto groupsType = partitionGroups.getType().cast<RankedTensorType>();
+  assert(groupsType.getRank() == 2);
+  int rows = groupsType.getShape()[0];
+  int cols = groupsType.getShape()[1];
+  auto values = partitionGroups.getValues<int64_t>();
+  SmallVector<Attribute> newValues;
+  // partitionGroups must have unique elements and cover all partition_ids, so
+  // numPartitions == values.size().
+  int64_t numPartitions = values.size();
+
+  // The number of groups is (rows * numReplicas).
+  for (int i = 0; i < rows; ++i) {
+    for (int r = 0; r < numReplicas; ++r) {
+      // Each group starts here. The group size is the same as the column size.
+      for (int j = 0; j < cols; ++j) {
+        const int index = i * cols + j;
+        const int64_t partitionId = values[index];
+        const int64_t value =
+            (partitionId == -1) ? -1 : r * numPartitions + partitionId;
+
+        newValues.push_back(builder.getI64IntegerAttr(value));
+      }
+    }
+  }
+
+  auto type =
+      RankedTensorType::get({rows * numReplicas, cols}, builder.getI64Type());
+  return DenseIntElementsAttr::get(type, newValues);
+}
+
 static DenseIntElementsAttr convertToRankGroupsByCrossReplicaAndPartition(
     DenseIntElementsAttr replicaGroups, int32_t numPartitions,
     OpBuilder &builder) {
-  if (numPartitions < 1) {
+  if (numPartitions <= 1) {
     // Treat as a single partition.
     return replicaGroups;
   }
@@ -269,12 +307,65 @@ static DenseIntElementsAttr convertToRankGroupsByCrossReplicaAndPartition(
   return DenseIntElementsAttr::get(type, newValues);
 }
 
+// The collective group mode determines how the StableHLO process grid is split
+// into independent process groups.
+enum class CollectiveOpGroupMode {
+  // Only cross-replica communications happen within each process group.
+  CrossReplica,
+  // Only cross-partition communications happen within each process group.
+  CrossPartition,
+  // Both cross-replica and cross-partition communications may happen within
+  // each process group.
+  CrossReplicaAndPartition,
+  // A list of flattened process ids is used to specify the process groups.
+  FlattenedIds,
+};
+
+// clang-format off
+// +--------------------+-----------+--------------------+--------------------------+
+// | Collective         | channelId | useGlobalDeviceIds | Collective Group Mode    |
+// +--------------------+-----------+--------------------+--------------------------+
+// | all_gather         |   <= 0    | false              | CrossReplica             |
+// |                    |    > 0    | false              | CrossReplicaAndPartition |
+// |                    |    > 0    | true               | FlattenedIds             |
+// +--------------------+-----------+--------------------+--------------------------+
+// | all_reduce         |   <= 0    | false              | CrossReplica             |
+// |                    |    > 0    | false              | CrossReplicaAndPartition |
+// |                    |    > 0    | true               | FlattenedIds             |
+// +--------------------+-----------+--------------------+--------------------------+
+// | all_to_all         |   <= 0    |                    | CrossReplica             |
+// |                    |    > 0    |                    | CrossPartition           |
+// +--------------------+-----------+--------------------+--------------------------+
+// | collective_permute |   <= 0    |                    | CrossReplica             |
+// |                    |    > 0    |                    | CrossPartition           |
+// +--------------------+-----------+--------------------+--------------------------+
+// | reduce_scatter     |   <= 0    | false              | CrossReplica             |
+// |                    |    > 0    | false              | CrossReplicaAndPartition |
+// |                    |    > 0    | true               | FlattenedIds             |
+// +--------------------+-----------+--------------------+--------------------------+
+// clang-format on
+static CollectiveOpGroupMode getCollectiveOpGroupMode(
+    int64_t channelId, std::optional<bool> useGlobalDeviceIds) {
+  if (channelId <= 0) {
+    assert(!useGlobalDeviceIds.has_value() || !*useGlobalDeviceIds);
+    return CollectiveOpGroupMode::CrossReplica;
+  } else {
+    if (!useGlobalDeviceIds.has_value()) {
+      return CollectiveOpGroupMode::CrossPartition;
+    } else if (!*useGlobalDeviceIds) {
+      return CollectiveOpGroupMode::CrossReplicaAndPartition;
+    } else {
+      return CollectiveOpGroupMode::FlattenedIds;
+    }
+  }
+}
+
 /// Creates a channel matching the given |channelHandleAttr| scoped to the
 /// requested group.
 static Value createChannelWithGroupInfo(
     Location loc, mlir::stablehlo::ChannelHandleAttr channelHandleAttr,
     int32_t numReplicas, int32_t numPartitions,
-    DenseIntElementsAttr replicaGroups, bool useGlobalDeviceIds,
+    DenseIntElementsAttr replicaGroups, std::optional<bool> useGlobalDeviceIds,
     OpBuilder &builder) {
   // Set numPartitions to 1 if not set by the user.
   if (numPartitions == -1) numPartitions = 1;
@@ -290,21 +381,23 @@ static Value createChannelWithGroupInfo(
     return baseChannel;
   }
 
-  // Convert replica_groups into flattened IDs.
+  // Convert replica_groups into flattened IDs depending on group mode.
   DenseIntElementsAttr rankGroups;
   int64_t channelId = channelHandleAttr ? channelHandleAttr.getHandle() : 0;
-  if (channelId <= 0) {
-    assert(!useGlobalDeviceIds);
+  CollectiveOpGroupMode mode =
+      getCollectiveOpGroupMode(channelId, useGlobalDeviceIds);
+  if (mode == CollectiveOpGroupMode::CrossReplica) {
     rankGroups = convertToRankGroupsByCrossReplica(replicaGroups, numPartitions,
                                                    builder);
-  } else {
-    if (useGlobalDeviceIds) {
-      // already flattened.
-      rankGroups = replicaGroups;
-    } else {
-      rankGroups = convertToRankGroupsByCrossReplicaAndPartition(
-          replicaGroups, numPartitions, builder);
-    }
+  } else if (mode == CollectiveOpGroupMode::CrossPartition) {
+    rankGroups = convertToRankGroupsByCrossPartition(replicaGroups, numReplicas,
+                                                     builder);
+  } else if (mode == CollectiveOpGroupMode::CrossReplicaAndPartition) {
+    rankGroups = convertToRankGroupsByCrossReplicaAndPartition(
+        replicaGroups, numPartitions, builder);
+  } else if (mode == CollectiveOpGroupMode::FlattenedIds) {
+    // already flattened.
+    rankGroups = replicaGroups;
   }
 
   // Construct lookups for color and key split parameters.
@@ -626,10 +719,14 @@ struct AllToAllOpConversion final
       ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
 
-    // Get the channel used for communication.
-    // TODO: update to use createChannelWithGroupInfo.
-    Value channel = rewriter.create<IREE::Flow::ChannelDefaultOp>(
-        loc, /*group=*/StringAttr{});
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    int32_t numReplicas = getNumReplicas(moduleOp);
+    int32_t numPartitions = getNumPartitions(moduleOp);
+
+    // Create a channel.
+    Value channel = createChannelWithGroupInfo(
+        loc, op.getChannelHandleAttr(), numReplicas, numPartitions,
+        op.getReplicaGroups(), /*useGlobalDeviceIds=*/std::nullopt, rewriter);
 
     // Get the collective element type attribute.
     auto resultType = cast<RankedTensorType>(op.getType());
@@ -785,15 +882,111 @@ struct ReduceScatterOpConversion final
   }
 };
 
+struct CollectivePermuteOpConversion
+    : public OpConversionPattern<mlir::stablehlo::CollectivePermuteOp> {
+  using OpConversionPattern<
+      mlir::stablehlo::CollectivePermuteOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::CollectivePermuteOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    int32_t numReplicas = getNumReplicas(moduleOp);
+    int32_t numPartitions = getNumPartitions(moduleOp);
+
+    // Replica group consists of all partitions or all replicas depending on the
+    // mode. If numPartitions is not set, a single group will result in the base
+    // channel being used.
+    int64_t channelId =
+        op.getChannelHandleAttr() ? op.getChannelHandleAttr().getHandle() : 0;
+    auto mode = getCollectiveOpGroupMode(channelId,
+                                         /*useGlobalDeviceIds=*/std::nullopt);
+    int64_t numParticipants = mode == CollectiveOpGroupMode::CrossReplica
+                                  ? numReplicas
+                                  : numPartitions;
+    if (numParticipants == -1) numParticipants = 1;
+    SmallVector<Attribute> replicaGroups;
+    for (int64_t i = 0; i < numParticipants; ++i) {
+      replicaGroups.push_back(rewriter.getI64IntegerAttr(i));
+    }
+    auto type =
+        RankedTensorType::get({1, numParticipants}, rewriter.getI64Type());
+    auto replicaGroupsAttr = DenseIntElementsAttr::get(type, replicaGroups);
+
+    // Create a channel.
+    Value channel = createChannelWithGroupInfo(
+        loc, op.getChannelHandleAttr(), numReplicas, numPartitions,
+        replicaGroupsAttr, /*useGlobalDeviceIds=*/std::nullopt, rewriter);
+
+    auto inputType = op.getOperand().getType().cast<RankedTensorType>();
+
+    // Get the collective element type attribute.
+    IREE::Flow::CollectiveElementTypeAttr elementTypeAttr =
+        getCollectiveElementTypeAttr(op.getContext(), inputType);
+    if (!elementTypeAttr) {
+      return rewriter.notifyMatchFailure(op, "unsupported input type");
+    }
+
+    // Convert source target pairs into a constant table that can be indexed by
+    // rank to find which ids that rank should send to and recv from, or -1 for
+    // no send/recv.
+    DenseIntElementsAttr sourceTargetPairs = op.getSourceTargetPairs();
+    llvm::DenseMap<int64_t, int64_t> sendMap, recvMap;
+    auto values = sourceTargetPairs.getValues<int64_t>();
+    // Find the max rank so we can size our tables.
+    int64_t maxRank = 0;
+    for (auto rank : values) {
+      if (rank > std::numeric_limits<int16_t>::max()) {
+        return rewriter.notifyMatchFailure(
+            op, "source or target id exceeds maximum value of 16-bit integer");
+      }
+      maxRank = std::max(maxRank, rank);
+    }
+    // Create tables. -1 is used to indicate no send or recv.
+    IndexSet indexSet(loc, rewriter);
+    Value noSendOrRecv = indexSet.get(-1);
+    SmallVector<Value> sendTable(maxRank + 1, noSendOrRecv);
+    SmallVector<Value> recvTable(maxRank + 1, noSendOrRecv);
+    for (auto i = values.begin(); i != values.end(); ++i) {
+      int64_t source = (*i);
+      int64_t target = (*++i);
+      sendTable[source] = indexSet.get(target);
+      recvTable[target] = indexSet.get(source);
+    }
+    // Look up the local send/recv values using rank.
+    Value rank =
+        rewriter.create<IREE::Flow::ChannelRankOp>(loc, channel).getResult();
+    Value send = rewriter.create<IREE::Util::SwitchOp>(loc, rank, noSendOrRecv,
+                                                       sendTable);
+    Value recv = rewriter.create<IREE::Util::SwitchOp>(loc, rank, noSendOrRecv,
+                                                       recvTable);
+
+    // Create an empty tensor for the result.
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    Value target = rewriter.create<tensor::EmptyOp>(loc, inputShape,
+                                                    inputType.getElementType());
+    auto collectiveSendRecvOp =
+        rewriter.create<IREE::Flow::CollectiveSendRecvOp>(
+            op.getLoc(), elementTypeAttr, target, op.getOperand(), channel,
+            send, recv);
+
+    rewriter.replaceOp(op, collectiveSendRecvOp.getResult());
+    return success();
+  }
+};
+
 }  // namespace
 
 void populateStableHloCollectivesConversionPatterns(
     MLIRContext *context, TypeConverter &typeConverter,
     RewritePatternSet *patterns) {
-  patterns->add<AllGatherOpConversion, AllReduceOpConversion,
-                AllToAllOpConversion, PartitionIdOpConversion,
-                ReduceScatterOpConversion, ReplicaIdOpConversion>(typeConverter,
-                                                                  context);
+  patterns
+      ->add<AllGatherOpConversion, AllReduceOpConversion, AllToAllOpConversion,
+            CollectivePermuteOpConversion, PartitionIdOpConversion,
+            ReduceScatterOpConversion, ReplicaIdOpConversion>(typeConverter,
+                                                              context);
 }
 
 }  // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/convert_collectives.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/convert_collectives.mlir
@@ -467,3 +467,84 @@ module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 
     return %out : tensor<2304xf32>
   }
 }
+
+// -----
+
+// cross_partition: channel_id > 0
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @cross_partition
+  func.func @cross_partition(%input : tensor<2304xf32>) -> tensor<2304xf32> {
+    // Cross partition should form groups (0,1),(2,3),(4,5),(6,7) where each number represents a cell below.
+    // +---+---+
+    // | 0   1 |
+    // +---+---+
+    // | 2   3 |
+    // |---+---|
+    // | 4   5 |
+    // +---+---+
+    // | 6   7 |
+    // +---+---+
+    //                          rank:   0    1    2    3    4    5    6    7
+    // CHECK: util.switch index from [%c0, %c0, %c1, %c1, %c2, %c2, %c3, %c3] at %channel_rank else %c-1 : index
+    // CHECK: util.switch index from [%c0, %c1, %c0, %c1, %c0, %c1, %c0, %c1] at %channel_rank else %c-1 : index
+    %out = "stablehlo.all_to_all"(%input) {
+      split_dimension = 0 : i64,
+      concat_dimension = 0 : i64,
+      split_count = 2 : i64,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>} : (tensor<2304xf32>) -> tensor<2304xf32>
+    return %out : tensor<2304xf32>
+  }
+}
+
+// -----
+
+// collective_permute cross_replica: channel_id <= 0
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @collective_permute_cross_replica
+  func.func @collective_permute_cross_replica(%input : tensor<8xf32>) -> tensor<8xf32> {
+    // Cross replica should form groups (0,2,4,6),(1,3,5,7) where each number represents a cell below.
+    // +---+---+
+    // | 0 | 1 |
+    // |   |   |
+    // | 2 | 3 |
+    // |   |   |
+    // | 4 | 5 |
+    // |   |   |
+    // | 6 | 7 |
+    // +---+---+
+    //                          rank:   0    1    2    3    4    5    6    7
+    // CHECK: util.switch index from [%c0, %c1, %c0, %c1, %c0, %c1, %c0, %c1] at %channel_rank else %c-1 : index
+    // CHECK: util.switch index from [%c0, %c0, %c1, %c1, %c2, %c2, %c3, %c3] at %channel_rank else %c-1 : index
+    %out = "stablehlo.collective_permute"(%input) {
+          source_target_pairs = dense<[[0, 1], [1, 2], [2, 3], [3, 0]]> : tensor<4x2xi64>,
+          channel_handle = #stablehlo.channel_handle<handle = 0, type = 1>} : (tensor<8xf32>) -> tensor<8xf32>
+    return %out : tensor<8xf32>
+  }
+}
+
+// -----
+
+// collective_permute cross_partition: channel_id > 0
+module @jit_fn attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 4 : i32 } {
+  // CHECK-LABEL: @collective_permute_cross_partition
+  func.func @collective_permute_cross_partition(%input : tensor<8xf32>) -> tensor<8xf32> {
+    // Cross partition should form groups (0,1),(2,3),(4,5),(6,7) where each number represents a cell below.
+    // +---+---+
+    // | 0   1 |
+    // +---+---+
+    // | 2   3 |
+    // |---+---|
+    // | 4   5 |
+    // +---+---+
+    // | 6   7 |
+    // +---+---+
+    //                          rank:   0    1    2    3    4    5    6    7
+    // CHECK: util.switch index from [%c0, %c0, %c1, %c1, %c2, %c2, %c3, %c3] at %channel_rank else %c-1 : index
+    // CHECK: util.switch index from [%c0, %c1, %c0, %c1, %c0, %c1, %c0, %c1] at %channel_rank else %c-1 : index
+    %out = "stablehlo.collective_permute"(%input) {
+          source_target_pairs = dense<[[0, 1]]> : tensor<1x2xi64>,
+          channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>} : (tensor<8xf32>) -> tensor<8xf32>
+    return %out : tensor<8xf32>
+  }
+}


### PR DESCRIPTION
Adds support for `cross_partition` which is used by all to all and collective permute.
I also added helper functions to make the collective group mode selection and usage more clear.

Fixes https://github.com/openxla/iree/issues/13628