### PR TITLE
Move collapse of reduction dimension earlier in the Flow pipeline.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -241,6 +241,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(mlir::createLinalgFoldUnitExtentDimsPass)
       .addPass(createRaiseSpecialOps)
       .addPass(createInterchangeGenericOpsPass)
+      .addPass(createCollapseDimsPass)
       .addPass(memref::createResolveShapedTypeResultDimsPass)
       .addPass(mlir::createCanonicalizerPass)
       .addPass(mlir::createCSEPass)
@@ -250,7 +251,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPredicatedPass(clDetensoring, mlir::createLinalgDetensorizePass)
       .addPass(mlir::createCanonicalizerPass)
       .addPass(mlir::createCSEPass)
-      .addPass(createCollapseDimsPass)
       // Split reduction operations into parallel and reduction.
       .addPass(createSplitReductionPass)
       // SplitReductionPass may create reduction dimension that are not the last

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -44,6 +44,7 @@ iree_lit_test_suite(
             "outline_dispatch_regions.mlir",
             "pad_fusion_with_consumer.mlir",
             "pad_fusion_with_producer.mlir",
+            "pipeline_tests.mlir",
             "raise_special_ops.mlir",
             "set_encoding.mlir",
             "strip_and_splat_constant_variables.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_lit_test_suite(
     "outline_dispatch_regions.mlir"
     "pad_fusion_with_consumer.mlir"
     "pad_fusion_with_producer.mlir"
+    "pipeline_tests.mlir"
     "raise_special_ops.mlir"
     "set_encoding.mlir"
     "strip_and_splat_constant_variables.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pipeline_tests.mlir
@@ -1,0 +1,55 @@
+// RUN: iree-opt --iree-flow-transformation-pipeline --split-input-file %s | FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0)>
+#map1 = affine_map<(d0, d1) -> (d1)>
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+#map3 = affine_map<(d0, d1) -> ()>
+module {
+  func.func @main(%arg0: tensor<833xi32>, %arg1: tensor<833x833xf32>, %arg2: tensor<f32>) -> tensor<f32> {
+    %cst = arith.constant 5.66893432E-4 : f32
+    %0 = tensor.empty() : tensor<833x833xf32>
+    %1 = linalg.generic {
+        indexing_maps = [#map2, #map3, #map2], iterator_types = ["parallel", "parallel"]}
+        ins(%arg1, %arg2 : tensor<833x833xf32>, tensor<f32>)
+        outs(%0 : tensor<833x833xf32>) {
+      ^bb0(%b0 : f32, %b1 : f32, %b2 : f32):
+        %2 = arith.divf %b0, %b1 : f32
+        linalg.yield %2 : f32
+      } -> tensor<833x833xf32>
+    %4 = linalg.generic {
+        indexing_maps = [#map, #map1, #map2, #map2], iterator_types = ["parallel", "parallel"]}
+        ins(%arg0, %arg0, %1 : tensor<833xi32>, tensor<833xi32>, tensor<833x833xf32>)
+        outs(%0 : tensor<833x833xf32>) {
+      ^bb0(%b0 : i32, %b1 : i32, %b2 : f32, %b3 : f32):
+        %5 = arith.cmpi eq, %b0, %b1 : i32
+        %6 = arith.select %5, %b2, %cst : f32
+        linalg.yield %6 : f32
+      } -> tensor<833x833xf32>
+    %7 = tensor.empty() : tensor<f32>
+    %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<f32>) -> tensor<f32>
+    %9 = linalg.generic {
+        indexing_maps = [#map2, #map3], iterator_types = ["reduction", "reduction"]}
+        ins(%4 : tensor<833x833xf32>) outs(%7 : tensor<f32>) {
+      ^bb0(%b0 : f32, %b1 : f32):
+        %10 = arith.addf %b1, %b0 : f32
+        linalg.yield %10 : f32
+      } -> tensor<f32>
+    return %9 : tensor<f32>
+  }
+}
+// Check that the linalg op with two reduction loops get folded into a single reduction
+// which then prevents the parallel ops to be folded into it.
+// See https://github.com/openxla/iree/issues/13285
+//       CHECK:   flow.executable private @[[EXECUTABLE0:[a-zA-Z0-9_]+]]
+//       CHECK:     func.func @[[FUNC0:[a-zA-Z0-9_x]+]]
+//       CHECK:       linalg.generic
+//  CHECK-SAME:         ["parallel", "parallel"]
+//       CHECK:   flow.executable private @[[EXECUTABLE1:[a-zA-Z0-9_]+]]
+//       CHECK:     func.func @[[FUNC1:[a-zA-Z0-9_x]+]]
+//       CHECK:       linalg.generic
+//  CHECK-SAME:         ["reduction"]
+//       CHECK:   func.func @main(
+//       CHECK:     %[[T0:.+]] = flow.dispatch @[[EXECUTABLE0]]::@[[FUNC0]]
+//       CHECK:     %[[T1:.+]] = flow.tensor.reshape %[[T0]] : tensor<833x833xf32> -> tensor<693889xf32>
+//       CHECK:     %[[T2:.+]] = flow.dispatch @[[EXECUTABLE1]]::@[[FUNC1]](%[[T1]])
+//       CHECK:     return %[[T2]]


### PR DESCRIPTION
Collapsing multiple reduction dimensions into a single reduction dimension early in the pipeline will make sure we dont fold into this elementwise operations that will subsequently prevent collapsing multiple reduction dimensions into one.

Issue #13285