### PR TITLE
Fix `bf16` cases involving `arith.bitcast` and `arith.constant`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_to_uInt16_buffers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_to_uInt16_buffers.mlir
@@ -28,3 +28,14 @@ func.func @bf16_conversion() {
   }
   return
 }
+
+// -----
+
+// CHECK-LABEL: @bf16_constant
+func.func @bf16_constant(%arg0 : bf16) -> bf16 {
+  // CHECK: %[[CNST:.+]] = arith.constant 16256 : i16
+  // CHECK: %[[CAST:.+]] = arith.bitcast %[[CNST]]
+  %c0 = arith.constant 1.0 : bf16
+  // CHECK: return %[[CAST]]
+  return %c0 : bf16
+}

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/ConvertPrimitiveType.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/ConvertPrimitiveType.cpp
@@ -327,6 +327,9 @@ struct ConvertArithTypesPass : public Base {
         .addDynamicallyLegalOp<vector::ReductionOp, vector::MultiDimReductionOp,
                                vector::MaskOp, vector::YieldOp>(checkOp);
 
+    // Some ops are always legal.
+    target.addLegalOp<arith::BitcastOp>();
+
     if (failed(applyFullConversion(this->getOperation(), target,
                                    std::move(patterns)))) {
       return this->signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/promote_arith_bf16_to_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/promote_arith_bf16_to_f32.mlir
@@ -47,3 +47,21 @@ func.func @addf_vector_bf16(%arg0 : vector<4xbf16>, %arg1 : vector<4xbf16>) -> v
 // CHECK: %[[EXT1:.+]] = arith.extf %[[ARG1]] : vector<4xbf16> to vector<4xf32>
 // CHECK: %[[ADD:.+]] = arith.addf %[[EXT0]], %[[EXT1]] : vector<4xf32>
 // CHECK: %[[TRUNC:.+]] = arith.truncf %[[ADD]] : vector<4xf32> to vector<4xbf16>
+
+// -----
+
+func.func @bitcast_bf16(%arg0 : vector<4xbf16>, %arg1 : vector<4xbf16>) -> vector<4xbf16> {
+    %0 = arith.bitcast %arg0 : vector<4xbf16> to vector<4xi16>
+    %1 = arith.bitcast %arg1 : vector<4xbf16> to vector<4xi16>
+    %2 = arith.xori %0, %1 : vector<4xi16>
+    %3 = arith.bitcast %2 : vector<4xi16> to vector<4xbf16>
+    return %3 : vector<4xbf16>
+}
+
+
+// CHECK-LABEL: @bitcast_bf16
+// CHECK-DAG: %[[BITCAST0:.+]] = arith.bitcast %arg0 : vector<4xbf16> to vector<4xi16>
+// CHECK-DAG: %[[BITCAST1:.+]] = arith.bitcast %arg1 : vector<4xbf16> to vector<4xi16>
+// CHECK-DAG: %[[XOR:.+]] = arith.xori %[[BITCAST0]], %[[BITCAST1]]
+// CHECK-DAG: %[[BITCAST2:.+]] = arith.bitcast %[[XOR]]
+// CHECK: return %[[BITCAST2]]


### PR DESCRIPTION
`arith.bitcast` is a cast where we do not wish to convert the `bf16` type to a `f32` as bit conversion should
generically work, fixes #13722.

Converting `arith.constant` in the `bf16` to `ui16` buffer promotion should raw convert the bits, not
perform an float-to-float cast. Fixes #13721.

This fixes also happen to fix #13720.