### PR TITLE
[TransformStrategies] Add support for f16 to matmul strategy

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -76,6 +76,7 @@ struct TargetInfo {
   // TODO: add finer grain control for other tensorcore types.
   bool hasTF32TensorCore = false;
   bool hasWarpShuffle = false;
+  bool hasMmaSync = false;
 };
 
 struct TileWorkgroupSizePair {
@@ -179,7 +180,10 @@ static TargetInfo getTargetInfo(func::FuncOp entryPoint) {
     return info;
   }
   int64_t smVersion = version.getZExtValue();
-  if (smVersion >= 80) info.hasTF32TensorCore = true;
+  if (smVersion >= 80) {
+    info.hasTF32TensorCore = true;
+    info.hasMmaSync = true;
+  }
   return info;
 }
 
@@ -670,6 +674,8 @@ static LogicalResult setTransformDialectConfig(func::FuncOp entryPoint,
   iree_compiler::gpu::GPUModel gpuModel;
   gpuModel.hasWarpShuffle = targetInfo.hasWarpShuffle;
   gpuModel.hasTF32TensorCore = targetInfo.hasTF32TensorCore;
+  gpuModel.hasMmaSync = targetInfo.hasMmaSync;
+
   if (failed(iree_compiler::gpu::matchAndSetTransformStrategy(entryPoint, op,
                                                               gpuModel)))
     return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -676,6 +676,31 @@ static LogicalResult setTransformDialectConfig(func::FuncOp entryPoint,
   gpuModel.hasTF32TensorCore = targetInfo.hasTF32TensorCore;
   gpuModel.hasMmaSync = targetInfo.hasMmaSync;
 
+  // Populates a subset of the fragment combinations supported in MLIR lowerings
+  // to NVVM (which is itself a subset of what LLVM supports) based on what the
+  // pipeline currently supports.
+  // TODO: avoid hard coding this and populate based on hardware capabilities.
+  // TODO: add missing supported configs once the pipeline supports it.
+  // TODO: add similar configurations for mma_sync as the need arises.
+  MLIRContext *context = entryPoint.getContext();
+  Type f32Type = Float32Type::get(context);
+  Type f16Type = Float16Type::get(context);
+
+  iree_compiler::gpu::MMAConfig f16f32AccConfig = {
+      /*m=*/16,          /*n=*/16,          /*k=*/16,
+      /*aType=*/f16Type, /*bType=*/f16Type, /*cType=*/f32Type};
+  iree_compiler::gpu::MMAConfig f16f16AccConfig = {
+      /*m=*/16,          /*n=*/16,          /*k=*/16,
+      /*aType=*/f16Type, /*bType=*/f16Type, /*cType=*/f16Type};
+  gpuModel.supportedWMMAConfigs = {f16f32AccConfig, f16f16AccConfig};
+
+  if (targetInfo.hasTF32TensorCore) {
+    iree_compiler::gpu::MMAConfig tf32WmmaConfig = {
+        /*m=*/16,          /*n=*/16,          /*k=*/8,
+        /*aType=*/f32Type, /*bType=*/f32Type, /*cType=*/f32Type};
+    gpuModel.supportedWMMAConfigs.push_back(tf32WmmaConfig);
+  }
+
   if (failed(iree_compiler::gpu::matchAndSetTransformStrategy(entryPoint, op,
                                                               gpuModel)))
     return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -366,6 +366,61 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // WITH_OPTIONS_3-LABEL: func @matmul_4_partially_unaligned
 
 // -----
+hal.executable @f16_matmul {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
+  hal.executable.export public @f16_matmul ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @f16_matmul() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f16
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2056x2568xf16>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2568x2056xf16>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2056x2056xf16>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2056, 2568], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2056x2568xf16>> -> tensor<2056x2568xf16>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2568, 2056], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2568x2056xf16>> -> tensor<2568x2056xf16>
+      %5 = tensor.empty() : tensor<2056x2056xf16>
+      %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2056x2056xf16>) -> tensor<2056x2056xf16>
+      %7 = linalg.matmul ins(%3, %4 : tensor<2056x2568xf16>, tensor<2568x2056xf16>) outs(%6 : tensor<2056x2056xf16>) -> tensor<2056x2056xf16>
+      flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2056, 2056], strides = [1, 1] : tensor<2056x2056xf16> -> !flow.dispatch.tensor<writeonly:tensor<2056x2056xf16>>
+      return
+    }
+  }
+}
+}
+
+// CHECK-LABEL: func @f16_matmul
+
+// Check reduction tile size of 32 to get 2 kgroups.
+// CHECK:      transform.structured.tile %{{.*}}[0, 0, 32]
+
+// CHECK:      transform.structured.pad
+// CHECK-SAME:   padding_values = [0.000000e+00 : f16, 0.000000e+00 : f16, 0.000000e+00 : f16]
+
+// Verify 128-bit vector sizes.
+// CHECK:      transform.structured.masked_vectorize {{.*}} vector_sizes [4, 8]
+// CHECK:      transform.structured.masked_vectorize {{.*}} vector_sizes [4, 8]
+// CHECK:      transform.structured.masked_vectorize {{.*}} vector_sizes [16, 8]
+
+// WITH_OPTIONS-LABEL: func @f16_matmul
+// WITH_OPTIONS:      transform.structured.masked_vectorize {{.*}} vector_sizes [2, 8]
+// WITH_OPTIONS:      transform.structured.masked_vectorize {{.*}} vector_sizes [1, 4]
+// WITH_OPTIONS:      transform.structured.masked_vectorize {{.*}} vector_sizes [16, 8]
+
+// WITH_OPTIONS_2-LABEL: func @f16_matmul
+// WITH_OPTIONS_2:      transform.structured.masked_vectorize {{.*}} vector_sizes [2, 8]
+// WITH_OPTIONS_2:      transform.structured.masked_vectorize {{.*}} vector_sizes [2, 8]
+// WITH_OPTIONS_2:      transform.structured.masked_vectorize {{.*}} vector_sizes [1, 8]
+
+// WITH_OPTIONS_3-LABEL: func @f16_matmul
+// WITH_OPTIONS_3:      transform.structured.masked_vectorize {{.*}} vector_sizes [2, 8]
+// WITH_OPTIONS_3:      transform.structured.masked_vectorize {{.*}} vector_sizes [1, 8]
+// WITH_OPTIONS_3:      transform.structured.masked_vectorize {{.*}} vector_sizes [4, 8]
+
+// -----
 hal.executable @aligned_matmul {
 hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
   hal.executable.export public @aligned_matmul ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
@@ -478,26 +533,26 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 // -----
 
-hal.executable @f16_matmul {
+hal.executable @int8_matmul {
 hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.export public @f16_matmul ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
+  hal.executable.export public @int8_matmul ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
   ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
     %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
     hal.return %x, %y, %z : index, index, index
   }
   builtin.module {
-    func.func @f16_matmul() {
+    func.func @int8_matmul() {
       %c0 = arith.constant 0 : index
-      %cst = arith.constant 0.000000e+00 : f16
-      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2052x2556xf16>>
-      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2556x2052xf16>>
-      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2052x2052xf16>>
-      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2052, 2556], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2052x2556xf16>> -> tensor<2052x2556xf16>
-      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2556, 2052], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2556x2052xf16>> -> tensor<2556x2052xf16>
-      %5 = tensor.empty() : tensor<2052x2052xf16>
-      %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2052x2052xf16>) -> tensor<2052x2052xf16>
-      %7 = linalg.matmul ins(%3, %4 : tensor<2052x2556xf16>, tensor<2556x2052xf16>) outs(%6 : tensor<2052x2052xf16>) -> tensor<2052x2052xf16>
-      flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2052, 2052], strides = [1, 1] : tensor<2052x2052xf16> -> !flow.dispatch.tensor<writeonly:tensor<2052x2052xf16>>
+      %cst = arith.constant 0 : i8
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2052x2556xi8>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2556x2052xi8>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2052x2052xi8>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2052, 2556], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2052x2556xi8>> -> tensor<2052x2556xi8>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2556, 2052], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2556x2052xi8>> -> tensor<2556x2052xi8>
+      %5 = tensor.empty() : tensor<2052x2052xi8>
+      %6 = linalg.fill ins(%cst : i8) outs(%5 : tensor<2052x2052xi8>) -> tensor<2052x2052xi8>
+      %7 = linalg.matmul ins(%3, %4 : tensor<2052x2556xi8>, tensor<2556x2052xi8>) outs(%6 : tensor<2052x2052xi8>) -> tensor<2052x2052xi8>
+      flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2052, 2052], strides = [1, 1] : tensor<2052x2052xi8> -> !flow.dispatch.tensor<writeonly:tensor<2052x2052xi8>>
       return
     }
   }
@@ -505,7 +560,9 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 }
 
 // CHECK:       iree_codegen.translation_info<LLVMGPUMatmulSimt>
-// CHECK-LABEL: func @f16_matmul
+// CHECK-LABEL: func @int8_matmul
+
+// Currently WMMA unrolling does not properly unroll for non-f16 and f32 types (such as int8) so disable for now.
 // CHECK-NOT: transform.sequence
 
 // WITH_OPTIONS_2-LABEL: func @f16_matmul

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
@@ -1,0 +1,252 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h"
+
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+#define DEBUG_TYPE "iree-transform-builder"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+/// Options to set the default values of the matmul strategy.
+
+static llvm::cl::list<int64_t> clBlockTileSizes(
+    "td-matmul-strategy-blk-sizes",
+    llvm::cl::desc("block tile size for dims (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::list_init(ArrayRef<int64_t>{128, 128, 1}),
+    llvm::cl::CommaSeparated);
+static llvm::cl::opt<int64_t> clReductionTileSize(
+    "td-matmul-strategy-reduc-size",
+    llvm::cl::desc(
+        "reduction tile sized for the transform dialect matmul strategy"),
+    llvm::cl::init(16));
+static llvm::cl::list<int64_t> clNumThreads(
+    "td-matmul-strategy-num-threads",
+    llvm::cl::desc("number of threads for dims (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::list_init(ArrayRef<int64_t>{64, 2, 1}), llvm::cl::CommaSeparated);
+static llvm::cl::list<int64_t> clNumWarps(
+    "td-matmul-strategy-num-warps",
+    llvm::cl::desc("number of warps for dims (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::list_init(ArrayRef<int64_t>{2, 2, 1}), llvm::cl::CommaSeparated);
+static llvm::cl::opt<bool> clUseAsyncCopies(
+    "td-matmul-strategy-use-async-copies",
+    llvm::cl::desc(
+        "use asynchronous copies for the transform dialect matmul strategy"),
+    llvm::cl::init(true));
+static llvm::cl::opt<bool> clUseMmaSync(
+    "td-matmul-strategy-use-mma-sync",
+    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
+    llvm::cl::init(true));
+static llvm::cl::opt<bool> clUseWmma(
+    "td-matmul-strategy-use-wmma",
+    llvm::cl::desc("use wmma for the transform dialect matmul strategy"),
+    llvm::cl::init(false));
+static llvm::cl::opt<bool> clUseFma(
+    "td-matmul-strategy-use-fma",
+    llvm::cl::desc("use fma for the transform dialect matmul strategy"),
+    llvm::cl::init(false));
+static llvm::cl::opt<int64_t> clPipelineDepth(
+    "td-matmul-strategy-pipeline-depth",
+    llvm::cl::desc("pipeline depth for the transform dialect matmul strategy"),
+    llvm::cl::init(3));
+
+using iree_compiler::gpu::AbstractGemmLikeStrategy;
+using iree_compiler::gpu::kCudaWarpSize;
+
+/// Key function for vtable.
+AbstractGemmLikeStrategy::~AbstractGemmLikeStrategy() {}
+
+void AbstractGemmLikeStrategy::initDefaultValues() {
+  blockTileSizes =
+      SmallVector<int64_t>{clBlockTileSizes.begin(), clBlockTileSizes.end()};
+  numThreads = SmallVector<int64_t>{clNumThreads.begin(), clNumThreads.end()};
+  numWarps = SmallVector<int64_t>{clNumWarps.begin(), clNumWarps.end()};
+  reductionTileSize = clReductionTileSize;
+  useAsyncCopies = clUseAsyncCopies;
+  useMmaSync = clUseMmaSync;
+  useWmma = clUseWmma;
+  useFma = clUseFma;
+  pipelineDepth = clPipelineDepth;
+
+  if (!clBlockTileSizes.isDefaultAssigned() ||
+      !clNumThreads.isDefaultAssigned() || !clNumWarps.isDefaultAssigned() ||
+      reductionTileSize != clReductionTileSize.getDefault().getValue() ||
+      useAsyncCopies != clUseAsyncCopies.getDefault().getValue() ||
+      useMmaSync != clUseMmaSync.getDefault().getValue() ||
+      useWmma != clUseWmma.getDefault().getValue() ||
+      useFma != clUseFma.getDefault().getValue() ||
+      pipelineDepth != clPipelineDepth.getDefault().getValue()) {
+    cliOptionsSpecified = true;
+  }
+}
+
+ArrayAttr AbstractGemmLikeStrategy::getZeroPadAttrFromElementalTypes(
+    OpBuilder &b) const {
+  SmallVector<Attribute> paddingValues;
+  for (Type t : paddingValueTypes) paddingValues.push_back(b.getZeroAttr(t));
+  return b.getArrayAttr(paddingValues);
+}
+
+//===--------------------------------------------------------------------===//
+// Validation of support for the configured strategy.
+//===--------------------------------------------------------------------===//
+
+LogicalResult AbstractGemmLikeStrategy::validate(
+    const GPUModel &gpuModel) const {
+  if (totalNumThreads() != totalNumWarps() * kCudaWarpSize) {
+    llvm::errs() << "Number of threads specified by warps must match total "
+                    "number of threads\n";
+    return failure();
+  }
+  if (m() < blockTileM()) {
+    llvm::errs() << "m(" << m() << ") < blockTileM(" << blockTileM() << ") ";
+    llvm::errs() << "this is at risk of not vectorizing and is NYI";
+    return failure();
+  }
+  if (n() < blockTileN()) {
+    llvm::errs() << "n(" << n() << ") < blockTileN(" << blockTileN() << ") ";
+    llvm::errs() << "this is at risk of not vectorizing and is NYI";
+    return failure();
+  }
+  if (k() < reductionTileSize) {
+    llvm::errs() << "k(" << k() << ") < reductionTileSize(" << reductionTileSize
+                 << ") ";
+    llvm::errs() << "this is at risk of not vectorizing and is NYI";
+    return failure();
+  }
+
+  if (failed(validateLhsCopyMapping())) {
+    llvm::errs() << "invalid lhs copy mapping";
+    return failure();
+  }
+  if (failed(validateRhsCopyMapping())) {
+    llvm::errs() << "invalid rhs copy mapping";
+    return failure();
+  }
+  if (failed(validateResCopyMapping())) {
+    llvm::errs() << "invalid res copy mapping";
+    return failure();
+  }
+
+  if (pipelineDepth > 1 && reductionTileSize * pipelineDepth > k()) {
+    llvm::errs() << "pipeline depth too large for reduction tile size";
+    return failure();
+  }
+
+  bool oneOption =
+      (useMmaSync ^ useWmma ^ useFma) && !(useMmaSync && useWmma && useFma);
+  if (!oneOption) {
+    llvm::errs() << "at most one of useMmaSync, useWmma, useFma can be true";
+    return failure();
+  }
+
+  if (useMmaSync) {
+    if (blockTileM() < kMinMmaSyncMinM) {
+      llvm::errs() << "mma.sync requires at least " << kMinMmaSyncMinM
+                   << " block tile size in M";
+      return failure();
+    }
+    if (blockTileN() < kMinMmaSyncMinN) {
+      llvm::errs() << "mma.sync requires at least " << kMinMmaSyncMinN
+                   << " block tile size in N";
+      return failure();
+    }
+    if (reductionTileSize < kMinMmaSyncMinK) {
+      llvm::errs() << "mma.sync requires at least " << kMinMmaSyncMinK
+                   << " block tile size in K";
+      return failure();
+    }
+    if (pipelineDepth > 1 && pipelineDepth < kMinMmaSyncPipelineDepth) {
+      llvm::errs() << "mma.sync pipelining requires at least "
+                   << kMinMmaSyncPipelineDepth << " stages";
+      return failure();
+    }
+    if (pipelineDepth > 1 && reductionTileSize * kMinMmaSyncGroups > k()) {
+      llvm::errs() << "mma.sync pipelining requires at least "
+                   << kMinMmaSyncGroups << " k groups";
+      return failure();
+    }
+  } else if (useWmma) {
+    if (blockTileM() < kMinWmmaMinM) {
+      llvm::errs() << "wmma requires at least " << kMinWmmaMinM
+                   << " block tile size in M";
+      return failure();
+    }
+    if (blockTileN() < kMinWmmaMinN) {
+      llvm::errs() << "wmma requires at least " << kMinWmmaMinN
+                   << " block tile size in N";
+      return failure();
+    }
+    if (reductionTileSize < kMinWmmaMinK) {
+      llvm::errs() << "wmma requires at least " << kMinWmmaMinK
+                   << " block tile size in K";
+      return failure();
+    }
+  }
+  return success();
+}
+
+//===--------------------------------------------------------------------===//
+// Strategy printing for debugging.
+//===--------------------------------------------------------------------===//
+
+LLVM_DUMP_METHOD void AbstractGemmLikeStrategy::dump() const {
+  print(llvm::errs());
+}
+
+void AbstractGemmLikeStrategy::print(llvm::raw_ostream &os) const {
+  os << "- forced by CLI specification: "
+     << (cliOptionsSpecified ? "true" : "false") << "\n";
+  os << "- block tile sizes: {";
+  bool isFirst = true;
+  for (int64_t blockTileSize : blockTileSizes) {
+    if (!isFirst) os << ", ";
+    os << blockTileSize;
+    isFirst = false;
+  }
+  os << "}\n";
+  os << "- reduction tile size: " << reductionTileSize << '\n';
+
+  os << "- number of threads: {";
+  isFirst = true;
+  for (int64_t numThreadsForDim : numThreads) {
+    if (!isFirst) os << ", ";
+    os << numThreadsForDim;
+    isFirst = false;
+  }
+  os << "}\n";
+
+  os << "- number of warps: {";
+  isFirst = true;
+  for (int64_t numWarpsForDim : numWarps) {
+    if (!isFirst) os << ", ";
+    os << numWarpsForDim;
+    isFirst = false;
+  }
+  os << "}\n";
+  os << "- use async copies: " << useAsyncCopies << '\n';
+  os << "- use fma: " << useFma << '\n';
+  os << "- use wmma: " << useWmma << '\n';
+  os << "- use mma sync: " << useMmaSync << '\n';
+  os << "- pipeline depth: " << pipelineDepth << '\n';
+
+  os << "\n-- Derived quantities --\n";
+  os << "- lhs copy:\n";
+  lhsCopyMapping().print(os << "    -> ");
+  os << "\n- rhs copy:\n";
+  rhsCopyMapping().print(os << "    -> ");
+  os << "\n- res copy:\n";
+  resCopyMapping().print(os << "    -> ");
+  os << "\n";
+}

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
@@ -89,6 +89,10 @@ void AbstractGemmLikeStrategy::initDefaultValues() {
       pipelineDepth != clPipelineDepth.getDefault().getValue()) {
     cliOptionsSpecified = true;
   }
+
+  // Adjust default reduction tile size for f16.
+  if (reductionTileSize == clReductionTileSize.getDefault().getValue())
+    reductionTileSize = lhsElementalBitWidth == 32 ? 16 : 32;
 }
 
 ArrayAttr AbstractGemmLikeStrategy::getZeroPadAttrFromElementalTypes(
@@ -162,8 +166,8 @@ LogicalResult AbstractGemmLikeStrategy::validate(
                    << " block tile size in N";
       return failure();
     }
-    if (reductionTileSize < kMinMmaSyncMinK) {
-      llvm::errs() << "mma.sync requires at least " << kMinMmaSyncMinK
+    if (reductionTileSize < kMinMmaSyncMinK()) {
+      llvm::errs() << "mma.sync requires at least " << kMinMmaSyncMinK()
                    << " block tile size in K";
       return failure();
     }
@@ -188,8 +192,8 @@ LogicalResult AbstractGemmLikeStrategy::validate(
                    << " block tile size in N";
       return failure();
     }
-    if (reductionTileSize < kMinWmmaMinK) {
-      llvm::errs() << "wmma requires at least " << kMinWmmaMinK
+    if (reductionTileSize < kMinWmmaMinK()) {
+      llvm::errs() << "wmma requires at least " << kMinWmmaMinK()
                    << " block tile size in K";
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -134,26 +134,27 @@ struct AbstractGemmLikeStrategy {
 
   // wmma preconditions that we want to lift out in an actionnable top-level
   // error message instead of failing late in the transformation schedule.
-  // TODO: These are now hardcoded for f32 but are element-type dependent.
-  // Precondition: the pipeline transformation for wmma requires at least 2
-  // k-groups.
+  // TODO: These are now hardcoded for f16 and f32 but are element-type
+  // dependent. Precondition: the pipeline transformation for wmma requires at
+  // least 2 k-groups.
   constexpr static int64_t kMinWmmaMinM = 16;
   constexpr static int64_t kMinWmmaMinN = 16;
-  constexpr static int64_t kMinWmmaMinK = 8;
+  int64_t kMinWmmaMinK() const { return lhsElementalBitWidth == 32 ? 8 : 16; }
 
   // mma.sync preconditions that we want to lift out in an actionnable top-level
   // error message instead of failing late in the transformation schedule.
-  // TODO: These are now hardcoded for f32 but are element-type dependent.
-  // Precondition: the pipeline transformation for mma.sync requires at least 2
-  // k-groups.
+  // TODO: These are now hardcoded for f16 and f32 but are element-type
+  // dependent. Precondition: the pipeline transformation for mma.sync requires
+  // at least 2 k-groups.
   constexpr static int64_t kMinMmaSyncGroups = 2;
   // Precondition: the pipeline transformation for mma.sync requires at least a
   // pipeline depth of 3.
   constexpr static int64_t kMinMmaSyncPipelineDepth = 3;
-  // Precondition: if mma.sync is used, the tile sizes must be at least 8x8x4.
+  // Precondition: if mma.sync is used, the tile sizes must be at least 8x8x4
+  // for f32 and 8x8x8 for f16.
   constexpr static int64_t kMinMmaSyncMinM = 8;
   constexpr static int64_t kMinMmaSyncMinN = 8;
-  constexpr static int64_t kMinMmaSyncMinK = 4;
+  int64_t kMinMmaSyncMinK() const { return lhsElementalBitWidth == 32 ? 4 : 8; }
 };
 
 }  // namespace gpu

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/BUILD.bazel
@@ -15,6 +15,7 @@ package(
 iree_compiler_cc_library(
     name = "GPU",
     srcs = [
+        "AbstractGemmLikeStrategy.cpp",
         "Common.cpp",
         "CopyMapping.cpp",
         "MappingInfo.cpp",

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_library(
     "StagedReductionStrategy.h"
     "Strategies.h"
   SRCS
+    "AbstractGemmLikeStrategy.cpp"
     "Common.cpp"
     "CopyMapping.cpp"
     "MappingInfo.cpp"

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.cpp
@@ -74,7 +74,7 @@ using transform::SequenceOp;
 /// Return max(1, (value * 32) / bitwidth).
 int64_t mlir::iree_compiler::gpu::scaleUpByBitWidth(int64_t value,
                                                     int64_t bitWidth) {
-  assert((bitWidth & bitWidth - 1) == 0 && "bitWidth must be a power of 2");
+  assert((bitWidth & (bitWidth - 1)) == 0 && "bitWidth must be a power of 2");
   return std::max((value * 32) / bitWidth, int64_t(1));
 }
 
@@ -307,9 +307,6 @@ std::pair<Value, Value> mlir::iree_compiler::gpu::buildCommonTrailingStrategy(
 //===----------------------------------------------------------------------===//
 // Subset of mid-level builders currently used for GEMM-like problems.
 //===----------------------------------------------------------------------===//
-
-/// Key function for vtable.
-AbstractGemmLikeStrategy::~AbstractGemmLikeStrategy() {}
 
 /// Build transform IR to hoist the padded output operand of a padded matmul.
 /// Additionally, this attempts to fold the padding into the producing fill, if

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -14,7 +14,6 @@
 #include "iree/compiler/Codegen/TransformStrategies/GPU/MappingInfo.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -55,127 +54,33 @@ using iree_compiler::IREE::transform_dialect::
 using transform::MatchOp;
 using transform_ext::RegisterMatchCallbacksOp;
 
-/// Options to set the default values of the matmul strategy.
-
-static llvm::cl::list<int64_t> clBlockTileSizes(
-    "td-matmul-strategy-blk-sizes",
-    llvm::cl::desc("block tile size for dims (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::list_init(ArrayRef<int64_t>{128, 128, 1}),
-    llvm::cl::CommaSeparated);
-static llvm::cl::opt<int64_t> clReductionTileSize(
-    "td-matmul-strategy-reduc-size",
-    llvm::cl::desc(
-        "reduction tile sized for the transform dialect matmul strategy"),
-    llvm::cl::init(16));
-static llvm::cl::list<int64_t> clNumThreads(
-    "td-matmul-strategy-num-threads",
-    llvm::cl::desc("number of threads for dims (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::list_init(ArrayRef<int64_t>{64, 2, 1}), llvm::cl::CommaSeparated);
-static llvm::cl::list<int64_t> clNumWarps(
-    "td-matmul-strategy-num-warps",
-    llvm::cl::desc("number of warps for dims (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::list_init(ArrayRef<int64_t>{2, 2, 1}), llvm::cl::CommaSeparated);
-static llvm::cl::opt<bool> clUseAsyncCopies(
-    "td-matmul-strategy-use-async-copies",
-    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
-    llvm::cl::init(true));
-static llvm::cl::opt<bool> clUseMmaSync(
-    "td-matmul-strategy-use-mma-sync",
-    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
-    llvm::cl::init(true));
-static llvm::cl::opt<bool> clUseWmma(
-    "td-matmul-strategy-use-wmma",
-    llvm::cl::desc("use wmma for the transform dialect matmul strategy"),
-    llvm::cl::init(false));
-static llvm::cl::opt<bool> clUseFma(
-    "td-matmul-strategy-use-fma",
-    llvm::cl::desc("use fma for the transform dialect matmul strategy"),
-    llvm::cl::init(false));
-static llvm::cl::opt<int64_t> clPipelineDepth(
-    "td-matmul-strategy-pipeline-depth",
-    llvm::cl::desc("pipeline depth for the transform dialect matmul strategy"),
-    llvm::cl::init(3));
-
 void MatmulStrategy::initDefaultValues() {
-  blockTileSizes =
-      SmallVector<int64_t>{clBlockTileSizes.begin(), clBlockTileSizes.end()};
-  numThreads = SmallVector<int64_t>{clNumThreads.begin(), clNumThreads.end()};
-  numWarps = SmallVector<int64_t>{clNumWarps.begin(), clNumWarps.end()};
-  reductionTileSize = clReductionTileSize;
-  useAsyncCopies = clUseAsyncCopies;
-  useMmaSync = clUseMmaSync;
-  useWmma = clUseWmma;
-  useFma = clUseFma;
-  pipelineDepth = clPipelineDepth;
-
-  // TODO: Capture input/output element types properly for configuring the
-  // padding values.
-  paddingValues = {0.0f, 0.0f, 0.0f};
+  // Set the configuration for padding the matmul.
+  paddingValueTypes = {captures.lhsElementType, captures.rhsElementType,
+                       captures.outputElementType};
   paddingDimensions = {0, 1, 2};
   packingDimensions = {1, 1, 1};
 
-  if (!clBlockTileSizes.isDefaultAssigned() ||
-      !clNumThreads.isDefaultAssigned() || !clNumWarps.isDefaultAssigned() ||
-      reductionTileSize != clReductionTileSize.getDefault().getValue() ||
-      useAsyncCopies != clUseAsyncCopies.getDefault().getValue() ||
-      useMmaSync != clUseMmaSync.getDefault().getValue() ||
-      useWmma != clUseWmma.getDefault().getValue() ||
-      useFma != clUseFma.getDefault().getValue() ||
-      pipelineDepth != clPipelineDepth.getDefault().getValue()) {
-    cliOptionsSpecified = true;
-  }
+  lhsElementalBitWidth = captures.lhsElementType.getIntOrFloatBitWidth();
+  rhsElementalBitWidth = captures.rhsElementType.getIntOrFloatBitWidth();
+  resElementalBitWidth = captures.outputElementType.getIntOrFloatBitWidth();
+
+  // Pull in tile configs from flags.
+  AbstractGemmLikeStrategy::initDefaultValues();
 }
 
 LLVM_DUMP_METHOD void MatmulStrategy::dump() const { print(llvm::errs()); }
 
 void MatmulStrategy::print(llvm::raw_ostream &os) const {
   os << "\n--- Matmul strategy ---\n";
-  os << "- forced by CLI specification: "
-     << (cliOptionsSpecified ? "true" : "false") << "\n";
-  os << "- block tile sizes: {";
-  bool isFirst = true;
-  for (int64_t blockTileSize : blockTileSizes) {
-    if (!isFirst) os << ", ";
-    os << blockTileSize;
-    isFirst = false;
-  }
-  os << "}\n";
-  os << "- reduction tile size: " << reductionTileSize << '\n';
+  AbstractGemmLikeStrategy::print(os);
+}
 
-  os << "- number of threads: {";
-  isFirst = true;
-  for (int64_t numThreadsForDim : numThreads) {
-    if (!isFirst) os << ", ";
-    os << numThreadsForDim;
-    isFirst = false;
-  }
-  os << "}\n";
+LogicalResult MatmulStrategy::validate(const GPUModel &gpuModel) const {
+  // Validate the parent strategy.
+  if (failed(AbstractGemmLikeStrategy::validate(gpuModel))) return failure();
 
-  os << "- number of warps: {";
-  isFirst = true;
-  for (int64_t numWarpsForDim : numWarps) {
-    if (!isFirst) os << ", ";
-    os << numWarpsForDim;
-    isFirst = false;
-  }
-  os << "}\n";
-  os << "- use async copies: " << useAsyncCopies << '\n';
-  os << "- use fma: " << useFma << '\n';
-  os << "- use wmma: " << useWmma << '\n';
-  os << "- use mma sync: " << useMmaSync << '\n';
-  os << "- pipeline depth: " << pipelineDepth << '\n';
-
-  os << "\n-- Derived quantities --\n";
-  os << "- lhs copy:\n";
-  lhsCopyMapping().print(os << "    -> ");
-  os << "\n- rhs copy:\n";
-  rhsCopyMapping().print(os << "    -> ");
-  os << "\n- res copy:\n";
-  resCopyMapping().print(os << "    -> ");
-  os << "\n";
+  return success();
 }
 
 static std::tuple<Value, Value, Value, Value>
@@ -213,10 +118,6 @@ buildMatmulStrategyBlockDistribution(ImplicitLocOpBuilder &b, Value variantH,
 
 void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
     ImplicitLocOpBuilder &b, Value variantH, const MatmulStrategy &strategy) {
-  if (failed(strategy.validate())) {
-    strategy.print(llvm::errs());
-    assert(false && "invalid strategy");
-  }
   LLVM_DEBUG(strategy.print(DBGS()));
 
   // Step 1. Apply block-level part of the strategy, keeps everything fused.
@@ -231,10 +132,9 @@ void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
       /*canonicalize=*/false);
 
   // Step 2. Pad the matmul op.
-  // TODO: use captured type information to configure the padding values.
   auto paddedMatmulOpH =
       buildPad(b, tileReductionResult.tiledOpH,
-               b.getF32ArrayAttr(strategy.paddingValues).getValue(),
+               strategy.getZeroPadAttrFromElementalTypes(b).getValue(),
                strategy.paddingDimensions, strategy.packingDimensions);
 
   // Step 3. Hoist the padding of the output operand above the reduction loop.

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -31,10 +31,7 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
  public:
   MatmulStrategy(MLIRContext *context,
                  const transform_ext::MatchedMatmulCaptures &captures)
-      : AbstractGemmLikeStrategy(),
-        ctx(context),
-        captures(captures),
-        cliOptionsSpecified(false) {
+      : AbstractGemmLikeStrategy(), ctx(context), captures(captures) {
     initDefaultValues();
   }
 
@@ -45,16 +42,11 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
   MLIRContext *ctx;
   transform_ext::MatchedMatmulCaptures captures;
 
-  /// Encodes whether the user has specified any CLI options. When true, the
-  /// strategy should just run what was specified and is not allowed to
-  /// override the user's choices.
-  bool cliOptionsSpecified;
-
   /// Initialize values from the CLI. Set cliOptionsSpecified to true if the
   /// default CLI values have been overriden.
-  void initDefaultValues();
+  void initDefaultValues() override;
 
-  LogicalResult verify() const;
+  LogicalResult validate(const GPUModel &gpuModel) const override;
 
   int64_t m() const override {
     assert(captures.matmulOpSizes.size() == 3 && "need 3 sizes");
@@ -99,7 +91,9 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
     return CopyMapping::getMappingInfo(
         ctx, totalNumThreads(),
         /*alignment=*/k(),
-        /*copySizes=*/ArrayRef<int64_t>{blockTileM(), reductionTileSize});
+        /*copySizes=*/ArrayRef<int64_t>{blockTileM(), reductionTileSize},
+        /*favorPredication=*/false,
+        /*elementalBitWidth=*/lhsElementalBitWidth);
   }
   LogicalResult validateLhsCopyMapping() const override {
     MappingInfo mapping = lhsCopyMapping();
@@ -118,7 +112,9 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
     return CopyMapping::getMappingInfo(
         ctx, totalNumThreads(),
         /*alignment=*/n(),
-        /*copySizes=*/ArrayRef<int64_t>{reductionTileSize, blockTileN()});
+        /*copySizes=*/ArrayRef<int64_t>{reductionTileSize, blockTileN()},
+        /*favorPredication=*/false,
+        /*elementalBitWidth=*/rhsElementalBitWidth);
   }
   LogicalResult validateRhsCopyMapping() const override {
     MappingInfo mapping = rhsCopyMapping();
@@ -134,9 +130,12 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
 
   // RES copy is of size mxn.
   MappingInfo resCopyMapping() const override {
-    return CopyMapping::getMappingInfo(ctx, totalNumThreads(),
-                                       /*alignment=*/n(),
-                                       {blockTileM(), blockTileN()});
+    return CopyMapping::getMappingInfo(
+        ctx, totalNumThreads(),
+        /*alignment=*/n(),
+        /*copySizes=*/ArrayRef<int64_t>{blockTileM(), blockTileN()},
+        /*favorPredication=*/false,
+        /*elementalBitWidth=*/resElementalBitWidth);
   }
 
   LogicalResult validateResCopyMapping() const override {
@@ -164,100 +163,6 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
                        /*tileSizes=*/{},
                        /*threadMapping=*/{warpY(ctx), warpX(ctx)},
                        /*vectorSize=*/std::nullopt};
-  }
-
-  LogicalResult validate() const override {
-    if (totalNumThreads() != totalNumWarps() * kCudaWarpSize) {
-      llvm::errs() << "Number of threads specified by warps must match total "
-                      "number of threads\n";
-      return failure();
-    }
-    if (m() < blockTileM()) {
-      llvm::errs() << "m(" << m() << ") < blockTileM(" << blockTileM() << ") ";
-      llvm::errs() << "this is at risk of not vectorizing and is NYI";
-      return failure();
-    }
-    if (n() < blockTileN()) {
-      llvm::errs() << "n(" << n() << ") < blockTileN(" << blockTileN() << ") ";
-      llvm::errs() << "this is at risk of not vectorizing and is NYI";
-      return failure();
-    }
-    if (k() < reductionTileSize) {
-      llvm::errs() << "k(" << k() << ") < reductionTileSize("
-                   << reductionTileSize << ") ";
-      llvm::errs() << "this is at risk of not vectorizing and is NYI";
-      return failure();
-    }
-
-    if (failed(validateLhsCopyMapping())) {
-      llvm::errs() << "invalid lhs copy mapping";
-      return failure();
-    }
-    if (failed(validateRhsCopyMapping())) {
-      llvm::errs() << "invalid rhs copy mapping";
-      return failure();
-    }
-    if (failed(validateResCopyMapping())) {
-      llvm::errs() << "invalid res copy mapping";
-      return failure();
-    }
-
-    if (pipelineDepth > 1 && reductionTileSize * pipelineDepth > k()) {
-      llvm::errs() << "pipeline depth too large for reduction tile size";
-      return failure();
-    }
-
-    bool oneOption =
-        (useMmaSync ^ useWmma ^ useFma) && !(useMmaSync && useWmma && useFma);
-    if (!oneOption) {
-      llvm::errs() << "at most one of useMmaSync, useWmma, useFma can be true";
-      return failure();
-    }
-
-    if (useMmaSync) {
-      if (blockTileM() < kMinMmaSyncMinM) {
-        llvm::errs() << "mma.sync requires at least " << kMinMmaSyncMinM
-                     << " block tile size in M";
-        return failure();
-      }
-      if (blockTileN() < kMinMmaSyncMinN) {
-        llvm::errs() << "mma.sync requires at least " << kMinMmaSyncMinN
-                     << " block tile size in N";
-        return failure();
-      }
-      if (reductionTileSize < kMinMmaSyncMinK) {
-        llvm::errs() << "mma.sync requires at least " << kMinMmaSyncMinK
-                     << " block tile size in K";
-        return failure();
-      }
-      if (pipelineDepth > 1 && pipelineDepth < kMinMmaSyncPipelineDepth) {
-        llvm::errs() << "mma.sync pipelining requires at least "
-                     << kMinMmaSyncPipelineDepth << " stages";
-        return failure();
-      }
-      if (pipelineDepth > 1 && reductionTileSize * kMinMmaSyncGroups > k()) {
-        llvm::errs() << "mma.sync pipelining requires at least "
-                     << kMinMmaSyncGroups << " k groups";
-        return failure();
-      }
-    } else if (useWmma) {
-      if (blockTileM() < kMinWmmaMinM) {
-        llvm::errs() << "wmma requires at least " << kMinWmmaMinM
-                     << " block tile size in M";
-        return failure();
-      }
-      if (blockTileN() < kMinWmmaMinN) {
-        llvm::errs() << "wmma requires at least " << kMinWmmaMinN
-                     << " block tile size in N";
-        return failure();
-      }
-      if (reductionTileSize < kMinWmmaMinK) {
-        llvm::errs() << "wmma requires at least " << kMinWmmaMinK
-                     << " block tile size in K";
-        return failure();
-      }
-    }
-    return success();
   }
 
   void print(llvm::raw_ostream &os) const;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/StagedReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/StagedReductionStrategy.cpp
@@ -94,7 +94,7 @@ void mlir::iree_compiler::gpu::StagedReductionStrategy::configure(
   } else {
     // Adjust the vector size to the max power of 2 that divides the reduction,
     // this dimensions the vector properly, whatever the elemental type.
-    assert((maxVectorSize & maxVectorSize - 1) == 0 &&
+    assert((maxVectorSize & (maxVectorSize - 1)) == 0 &&
            "maxVectorSize must be a power of 2");
     // TODO: we could also split out the first multiple of vectorSize instead
     // of reducing the vectorSize. This is better done with future stride /

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
@@ -366,12 +366,6 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
     return failure();
   }
 
-  if (!captures.lhsElementType.isF32() || !captures.rhsElementType.isF32() ||
-      !captures.outputElementType.isF32()) {
-    LDBG("--Matmul strategy elemental type check failed\n");
-    return failure();
-  }
-
   // TODO: Generalize to a good mix of sizes, alignments and element types.
   const auto &matmulSize = captures.matmulOpSizes;
   if (matmulSize.size() != 3) {

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h
@@ -26,6 +26,7 @@ struct GPUModel {
   StringRef model = kDefaultGPU;
   bool hasWarpShuffle = false;
   bool hasTF32TensorCore = false;
+  bool hasMmaSync = false;
 };
 
 //===--------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h
@@ -18,6 +18,18 @@ class Value;
 namespace iree_compiler {
 namespace gpu {
 
+/// Placeholder for representing supported WMMA/Cooperative Matrix
+/// configurations. This is a reflection of
+/// SPIRV_CooperativeMatrixPropertiesNVArrayAttr.
+struct MMAConfig {
+  int64_t m;
+  int64_t n;
+  int64_t k;
+  Type aType;
+  Type bType;
+  Type cType;
+};
+
 /// Placeholder for some hardware model proxy that contains relevant information
 /// to configure the reduction strategy. In the future, this will need to be
 /// driven by some contract with the runtime.
@@ -27,6 +39,7 @@ struct GPUModel {
   bool hasWarpShuffle = false;
   bool hasTF32TensorCore = false;
   bool hasMmaSync = false;
+  SmallVector<MMAConfig> supportedWMMAConfigs = {};
 };
 
 //===--------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -747,7 +747,6 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
         // OptimizeVectorTransfer, matrixC reads are moved above the mainloop
         // and writes are moved below the mainloop. Thus, mma.sync read/write
         // accumulator inplace.
-
         SmallVector<int64_t> readShape;
         readShape.append({16, 16});
         LLVM_DEBUG({

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -291,6 +291,30 @@ iree_generated_trace_runner_test(
     trace_runner = "//tools:iree-e2e-matmul-test",
 )
 
+iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f16_gpu_large_unaligned",
+    compiler_flags = [
+        "--iree-hal-cuda-llvm-target-arch=sm_80",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f16",
+        "--shapes=gpu_large",
+    ],
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    trace_runner = "//tools:iree-e2e-matmul-test",
+)
+
 # MMA.SYNC TensorCore(F32): mma.sync.1688.f32.t32
 iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_f32_gpu_large_mma_sync_LLVMGPUMatmulTensorCoreMmaSync",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -436,6 +436,30 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
+    e2e_matmul_direct_f16_gpu_large_unaligned
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--shapes=gpu_large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+)
+
+iree_generated_trace_runner_test(
+  NAME
     e2e_matmul_direct_f32_gpu_large_mma_sync_LLVMGPUMatmulTensorCoreMmaSync
   GENERATOR
     "generate_e2e_matmul_tests.py"


### PR DESCRIPTION
Support for further element types is currently blocked by hard-coded
unrolling support (for WMMA). Handling smaller bit width types requires
slightly more careful selection of copy vector sizes due to a larger
number of elements required to copy the same number of bits. This will
attempt to pick the largest vector size it can up to 128 bits and then
scale down to a single element per thread, with the requirement that
there are at least as many elements as threads.

The existing pipeline for mma.sync produces transposed reads when
vectorizing and as a result is able to unroll to a native vector size of
`16x16xf16` for the mma inputs, at which point `8x16xf16` size vectors
are extracted out for the compute. This currently is problematic for the
transform dialect based approach because we rely on the transpose to be
later folded into the read during conversion to nvgpu. This will then
fail due to the intermediate `vector.extract_strided_slice`, e.g.

```mlir
%38 = vector.transfer_read %subview_6[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x?xf16, strided<[128, 1], offset: ?>, #gpu.address_space<workgroup>>, vector<16x16xf16>
%42 = vector.extract_strided_slice %38 {offsets = [0, 0], sizes = [16, 8], strides = [1, 1]} : vector<16x16xf16> to vector<16x8xf16>
%43 = vector.transpose %42, [1, 0] : vector<16x8xf16> to vector<8x16xf16>
%44 = vector.contract {indexing_maps = [#map18, #map19, #map20], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %34, %43, %arg1 : vector<16x16xf16>, vector<8x16xf16> into vector<16x8xf16>
```

Rebased on top of #14083