### PR TITLE
[Transform] Add op for unrolling to WMMA native vector sizes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -493,4 +493,60 @@ def IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp :
   }];
 }
 
+def UnrollVectorsGpuWmmaOp : Op<Transform_Dialect, "iree.unroll_vectors_gpu_wmma",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
+  let description = [{
+    Greedily unrolls vector operations to the specified native vector size.
+
+    Must be applied to an op with trait IsolatedFromAbove since the
+    GreedyPatternRewriter asserts those. Internally, uses the tracking rewriter
+    to preserve handles to payload operations nested within operations
+    associated with `target`. Fails if tracking cannot find replacement for a
+    payload operation.
+
+    Returns the IsolatedFromAbove op whose content it has modified for better
+    chaining APIs.
+
+    #### Return modes:
+
+    This operation must target an operation that is isolated from above,
+    otherwise the transform definitely fails.
+
+    If the pattern application fails, or if the underlying listener fails to
+    capture op handles, the transformation definitely fails.
+
+    Otherwise the transformation is successful.
+
+    This operation does not consume the target handle and does not produce any
+    handle.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target,
+                       I64Attr:$m,
+                       I64Attr:$n,
+                       I64Attr:$k);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $target ` ` `[` $m `,` $n `,` $k `]` attr-dict `:` functional-type($target, results)
+  }];
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target,
+                   "int64_t":$m,
+                   "int64_t":$n,
+                   "int64_t":$k)>
+  ];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" --iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy | FileCheck %s
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" --iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy --iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul | FileCheck %s
 // Check that setting the command line options affect the transform
 // strategy as expected.
 // RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" --iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy \
@@ -225,42 +225,6 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.sequence  failures(propagate) {
 
 // -----
-hal.executable @matmul {
-hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.export public @matmul ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
-    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @matmul() {
-      %c0 = arith.constant 0 : index
-      %cst = arith.constant 0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>>
-      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>>
-      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
-      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>> -> tensor<2048x2048xf32>
-      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>> -> tensor<2048x2048xf32>
-      %5 = tensor.empty() : tensor<2048x2048xf32>
-      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
-      %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xf32>, tensor<2048x2048xf32>) outs(%6 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
-      flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
-      return
-    }
-  }
-}
-}
-
-// CHECK-LABEL: func @matmul
-
-// "Enough" of this matmul's dimensions are divisible by 64/64/16.
-// We currently bail on such cases because at least one of the paddings involved
-// in the strategy fold away and result in the strategy failing to apply.
-// In the future we should also support this case but for now we are missing the 
-// generalization along this axis.
-// CHECK-NOT: transform.sequence
-
-// -----
 hal.executable @matmul_partially_unaligned {
 hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
   hal.executable.export public @matmul_partially_unaligned ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
@@ -287,15 +251,100 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 }
 }
 
-// CHECK:       iree_codegen.translation_info<LLVMGPUMatmulSimt>
 // CHECK-LABEL: func @matmul_partially_unaligned
 
-// "Enough" of this matmul's dimensions are divisible by 64/64/16.
-// We currently bail on such cases because at least one of the paddings involved
-// in the strategy fold away and result in the strategy failing to apply.
-// In the future we should also support this case but for now we are missing the
-// generalization along this axis.
-// CHECK-NOT: transform.sequence
+// CHECK: transform.structured.tile %tiled_op[0, 0, 16]
+
+// Make sure we do not canonicalize because the result is still aligned.
+// CHECK-NEXT: transform.structured.pad %tiled_linalg_op
+// CHECK-SAME:   pack_paddings = [1, 1, 1]
+// CHECK-SAME:   padding_dimensions = [0, 1, 2]
+// CHECK-SAME:   padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]
+// CHECK:      transform.structured.match ops{["linalg.fill"]}
+// CHECK:      transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
+// CHECK:      %[[RES_PAD:.+]] = get_producer_of_operand %{{.*}}[2]
+// CHECK:      %[[RES_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[RES_PAD]]
+// CHECK:      %[[LHS_PAD:.+]] = get_producer_of_operand %{{.*}}[0]
+// CHECK:      %[[RHS_PAD:.+]] = get_producer_of_operand %{{.*}}[1]
+// CHECK:      %{{.*}}, %[[TILED_LHS:.+]] = transform.structured.tile_to_forall_op %[[LHS_PAD]]   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// CHECK:      transform.structured.match ops{["scf.if"]}
+// CHECK:      transform.scf.take_assumed_branch %{{.*}} take_else_branch
+// CHECK:      %{{.*}}, %[[TILED_RHS:.+]] = transform.structured.tile_to_forall_op %[[RHS_PAD]]   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
+// CHECK:      transform.structured.match ops{["scf.if"]}
+// CHECK:      transform.scf.take_assumed_branch %{{.*}} take_else_branch
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
+
+// alignLhs
+// CHECK:      transform.structured.masked_vectorize %[[TILED_LHS]] vector_sizes [4, 4]
+// alignRhs
+// CHECK:      transform.structured.masked_vectorize %[[TILED_RHS]] vector_sizes [4, 4]
+
+// CHECK:      transform.vector.lower_masks
+// CHECK:      transform.vector.materialize_masks
+
+// -----
+hal.executable @aligned_matmul {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
+  hal.executable.export public @aligned_matmul ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @aligned_matmul() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>> -> tensor<2048x2048xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf32>> -> tensor<2048x2048xf32>
+      %5 = tensor.empty() : tensor<2048x2048xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
+      %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xf32>, tensor<2048x2048xf32>) outs(%6 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
+      flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
+      return
+    }
+  }
+}
+}
+
+// CHECK-LABEL: func @aligned_matmul
+
+// Block level is the same for aligned.
+// CHECK: transform.structured.tile %tiled_op[0, 0, 16] : (!pdl.operation) -> (!pdl.operation, !transform.any_op)
+
+// Make sure we do not canonicalize if the result is aligned to avoid folding the extract_slice on the iterator.
+// CHECK-NEXT: transform.structured.pad %tiled_linalg_op
+// CHECK-SAME:   pack_paddings = [1, 1, 1]
+// CHECK-SAME:   padding_dimensions = [0, 1, 2]
+// CHECK-SAME:   padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]
+// CHECK:      transform.structured.match ops{["linalg.fill"]}
+
+// Canonicalization is currently required here to enable pad to dps to produce linalg.copy ops.
+// CHECK:      transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
+// CHECK:      %[[RES_PAD:.+]] = get_producer_of_operand %{{.*}}[2]
+// CHECK:      %[[RES_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[RES_PAD]]
+// CHECK:      %[[LHS_PAD:.+]] = get_producer_of_operand %{{.*}}[0]
+// CHECK:      %[[RHS_PAD:.+]] = get_producer_of_operand %{{.*}}[1]
+// CHECK:      %[[LHS_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[LHS_PAD]] : (!pdl.operation) -> !pdl.operation
+// CHECK:      %[[RHS_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[RHS_PAD]] : (!pdl.operation) -> !pdl.operation
+// CHECK:      transform.structured.tile_to_forall_op %[[LHS_COPY]]   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// CHECK:      transform.structured.tile_to_forall_op %[[RHS_COPY]]   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.iree.apply_patterns %{{.*}} {canonicalization, cse, licm, tiling_canonicalization}
+
+// We shouldn't be generating masks so don't bother handling them.
+// CHECK-NOT:  transform.vector.lower_masks
+// CHECK-NOT:  transform.vector.materialize_masks
+
+// Verify we don't go down the path without the flag.
+// WITH_OPTIONS-LABEL: func @aligned_matmul
+
+// WITH_OPTIONS-NOT: transform.sequence  failures(propagate) {
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -74,7 +74,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.iree.hoist_static_alloc %{{.*}} : (!pdl.operation) -> ()
 // CHECK: transform.iree.apply_patterns %{{.*}} {fold_memref_aliases} : (!pdl.operation) -> ()
 // CHECK: transform.iree.apply_patterns %{{.*}} {extract_address_computations} : (!pdl.operation) -> ()
-// CHECK: transform.iree.apply_patterns %{{.*}} {unroll_vectors_gpu_wmma} : (!pdl.operation) -> ()
+// CHECK: transform.iree.unroll_vectors_gpu_wmma %{{.*}} [16, 16, 8] : (!pdl.operation) -> ()
 // CHECK: transform.structured.hoist_redundant_vector_transfers %{{.*}} : (!pdl.operation) -> !pdl.operation
 // CHECK: transform.iree.apply_buffer_optimizations %{{.*}} : (!pdl.operation) -> ()
 // CHECK: transform.iree.vector.vector_to_mma_conversion %{{.*}} {use_wmma} : (!pdl.operation) -> ()
@@ -314,9 +314,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK-LABEL: func @f16_matmul
 
 // Check 128 bit vector sizes.
-// CHECK:      transform.structured.masked_vectorize {{.*}} vector_sizes [2, 8]
-// CHECK:      transform.structured.masked_vectorize {{.*}} vector_sizes [2, 8]
-// CHECK:      transform.structured.masked_vectorize {{.*}} vector_sizes [16, 8]
+// CHECK: transform.structured.masked_vectorize {{.*}} vector_sizes [2, 8]
+// CHECK: transform.structured.masked_vectorize {{.*}} vector_sizes [2, 8]
+// CHECK: transform.structured.masked_vectorize {{.*}} vector_sizes [16, 8]
+// CHECK: transform.iree.unroll_vectors_gpu_wmma %{{.*}} [16, 16, 16]
 
 // Check for mma.sync we don't enable f16.
 // WITH_OPTIONS-LABEL: func @f16_matmul

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
@@ -50,7 +50,7 @@ func.func @matmul() {
 transform.sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!pdl.operation) -> ()
+  transform.iree.unroll_vectors_gpu_wmma %func [16, 16, 8] : (!pdl.operation) -> ()
   transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!pdl.operation) -> ()
 
   // Apply canonicalization post-hoc to trigger DCE and pass the test 
@@ -127,7 +127,7 @@ func.func @gathered_matmul() {
 transform.sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { unroll_vectors_gpu_wmma } : (!pdl.operation) -> ()
+  transform.iree.unroll_vectors_gpu_wmma %func [16, 16, 8] : (!pdl.operation) -> ()
   transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!pdl.operation) -> ()
   transform.iree.apply_patterns %func { canonicalization } : (!pdl.operation) -> ()
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
@@ -156,7 +156,8 @@ mlir::iree_compiler::TileToScfForAndFuseResult
 mlir::iree_compiler::buildTileFuseToScfFor(ImplicitLocOpBuilder &b,
                                            Value isolatedParentOpH, Value rootH,
                                            ValueRange opsHToFuse,
-                                           ArrayRef<OpFoldResult> tileSizes) {
+                                           ArrayRef<OpFoldResult> tileSizes,
+                                           bool canonicalize) {
   assert(opsHToFuse.empty() && "No fusion supported yet");
   iree_compiler::TileToScfForAndFuseResult result;
   // TODO: Replace by transform::TileToScfForOp and deprecate transform::TileOp.
@@ -164,11 +165,16 @@ mlir::iree_compiler::buildTileFuseToScfFor(ImplicitLocOpBuilder &b,
   result.forLoops = tiletoScfForOp.getLoops();
   result.tiledOpH = tiletoScfForOp.getTiledLinalgOp();
 
-  // Perform a pass of canonicalization + enabling after tiling.
-  ApplyPatternsOpPatterns configuration;
-  isolatedParentOpH =
-      mlir::iree_compiler::buildCanonicalizationAndEnablingTransforms(
-          b, configuration, isolatedParentOpH);
+  // Perform a pass of canonicalization + enabling after tiling. Currently this
+  // folds away the extract slice on the iterator, breaking padding on aligned
+  // matmuls.
+  // TODO: Make padding less brittle so that this toggle is unnecessary.
+  if (canonicalize) {
+    ApplyPatternsOpPatterns configuration;
+    isolatedParentOpH =
+        mlir::iree_compiler::buildCanonicalizationAndEnablingTransforms(
+            b, configuration, isolatedParentOpH);
+  }
   return result;
 }
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
@@ -119,7 +119,8 @@ struct TileToScfForAndFuseResult {
 /// Note: fusion is currently unsupported.
 TileToScfForAndFuseResult buildTileFuseToScfFor(
     ImplicitLocOpBuilder &b, Value isolatedParentOpH, Value rootH,
-    ValueRange opsHToFuse, ArrayRef<OpFoldResult> tileSizes);
+    ValueRange opsHToFuse, ArrayRef<OpFoldResult> tileSizes,
+    bool canonicalize = true);
 
 /// Result of the combined transform performing tiling, fusion and
 /// distribution to parallel constructs.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.cpp
@@ -1,0 +1,145 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+#define DEBUG_TYPE "iree-transform-builder"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+/// Options to set the default values of the matmul strategy.
+/// TODO: Replace flag soup in favor of a compilation config attribute similar
+/// to the current pipeline based approach.
+
+/// Block tile size X, Y, Z.
+static llvm::cl::opt<int64_t> clBlockTileSizeX(
+    "td-matmul-strategy-blk-size-x",
+    llvm::cl::desc("block tile size for dim X (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(128));
+static llvm::cl::opt<int64_t> clBlockTileSizeY(
+    "td-matmul-strategy-blk-size-y",
+    llvm::cl::desc("block tile size for dim Y (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(128));
+static llvm::cl::opt<int64_t> clBlockTileSizeZ(
+    "td-matmul-strategy-blk-size-z",
+    llvm::cl::desc("block tile size for dim z (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(1));
+
+static llvm::cl::opt<int64_t> clReductionTileSize(
+    "td-matmul-strategy-reduc-size",
+    llvm::cl::desc(
+        "reduction tile sized for the transform dialect matmul strategy"),
+    llvm::cl::init(16));
+
+/// Number of threads X, Y, Z.
+static llvm::cl::opt<int64_t> clNumThreadsX(
+    "td-matmul-strategy-num-threads-x",
+    llvm::cl::desc("number of threads for dim X (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(64));
+static llvm::cl::opt<int64_t> clNumThreadsY(
+    "td-matmul-strategy-num-threads-y",
+    llvm::cl::desc("number of threads for dim Y (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(2));
+static llvm::cl::opt<int64_t> clNumThreadsZ(
+    "td-matmul-strategy-num-threads-z",
+    llvm::cl::desc("number of threads for dim z (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(1));
+
+/// Number of warps X, Y, Z.
+static llvm::cl::opt<int64_t> clNumWarpsX(
+    "td-matmul-strategy-num-warps-x",
+    llvm::cl::desc("number of warps for dim X (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(2));
+static llvm::cl::opt<int64_t> clNumWarpsY(
+    "td-matmul-strategy-num-warps-y",
+    llvm::cl::desc("number of warps for dim Y (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(2));
+static llvm::cl::opt<int64_t> clNumWarpsZ(
+    "td-matmul-strategy-num-warps-z",
+    llvm::cl::desc("number of warps for dim z (x,y,z) for the transform "
+                   "dialect matmul strategy"),
+    llvm::cl::init(1));
+
+static llvm::cl::opt<bool> clUseAsyncCopies(
+    "td-matmul-strategy-use-async-copies",
+    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
+    llvm::cl::init(true));
+
+static llvm::cl::opt<bool> clUseMmaSync(
+    "td-matmul-strategy-use-mma-sync",
+    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<int64_t> clPipelineDepth(
+    "td-matmul-strategy-pipeline-depth",
+    llvm::cl::desc("pipeline depth for the transform dialect matmul strategy"),
+    llvm::cl::init(3));
+
+using iree_compiler::gpu::AbstractGemmLikeStrategy;
+
+/// Key function for vtable.
+AbstractGemmLikeStrategy::~AbstractGemmLikeStrategy() {}
+
+void AbstractGemmLikeStrategy::initDefaultValues() {
+  blockTileSizes = {clBlockTileSizeX, clBlockTileSizeY, clBlockTileSizeZ};
+  reductionTileSize = clReductionTileSize;
+  numThreads = {clNumThreadsX, clNumThreadsY, clNumThreadsZ};
+  numWarps = {clNumWarpsX, clNumThreadsY, clNumThreadsZ};
+  useAsyncCopies = clUseAsyncCopies;
+  useMmaSync = clUseMmaSync;
+  pipelineDepth = clPipelineDepth;
+}
+
+LLVM_DUMP_METHOD void AbstractGemmLikeStrategy::dump() const {
+  print(llvm::errs());
+}
+
+void AbstractGemmLikeStrategy::print(llvm::raw_ostream &os) const {
+  os << "- block tile sizes: {";
+  bool isFirst = true;
+  for (int64_t blockTileSize : blockTileSizes) {
+    if (!isFirst) os << ", ";
+    os << blockTileSize;
+    isFirst = false;
+  }
+  os << "}\n";
+  os << "- reduction tile size: " << reductionTileSize << '\n';
+
+  os << "- number of threads: {";
+  isFirst = true;
+  for (int64_t numThreadsForDim : numThreads) {
+    if (!isFirst) os << ", ";
+    os << numThreadsForDim;
+    isFirst = false;
+  }
+  os << "}\n";
+
+  os << "- number of warps: {";
+  isFirst = true;
+  for (int64_t numWarpsForDim : numWarps) {
+    if (!isFirst) os << ", ";
+    os << numWarpsForDim;
+    isFirst = false;
+  }
+  os << "}\n";
+
+  os << "- use async copies: " << useAsyncCopies << '\n';
+  os << "- use mma sync: " << useMmaSync << '\n';
+  os << "- pipeline depth: " << pipelineDepth << '\n';
+}

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -44,6 +44,10 @@ struct AbstractGemmLikeStrategy {
   virtual int64_t n() const = 0;
   virtual int64_t k() const = 0;
 
+  bool alignedLhs() const { return m() % 64 == 0 && k() % 16 == 0; }
+  bool alignedRhs() const { return n() % 64 == 0 && k() % 16 == 0; }
+  bool alignedRes() const { return m() % 64 == 0 && n() % 64 == 0; }
+
   /// Common values based on derived quantities.
   int64_t totalNumThreads() const {
     int64_t res = 1;

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -15,6 +15,9 @@ class raw_ostream;
 }
 
 namespace mlir {
+
+class OpBuilder;
+
 namespace iree_compiler {
 namespace gpu {
 
@@ -24,6 +27,8 @@ struct AbstractGemmLikeStrategy {
   AbstractGemmLikeStrategy() {}
 
   virtual ~AbstractGemmLikeStrategy();
+
+  virtual void initDefaultValues();
 
   /// Tile sizes for the workgroup / determines grid size for all known
   /// reduction strategies. The initial values are set by initDefaultValues();
@@ -87,8 +92,8 @@ struct AbstractGemmLikeStrategy {
   virtual MappingInfo resCopyMapping() const = 0;
   virtual MappingInfo computeMapping() const = 0;
 
-  virtual void print(llvm::raw_ostream &os) const = 0;
-  virtual LLVM_DUMP_METHOD void dump() const = 0;
+  virtual void print(llvm::raw_ostream &os) const;
+  virtual LLVM_DUMP_METHOD void dump() const;
 };
 
 }  // namespace gpu

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -28,7 +28,7 @@ struct AbstractGemmLikeStrategy {
 
   virtual ~AbstractGemmLikeStrategy();
 
-  virtual void initDefaultValues();
+  void initDefaultValues(bool optUseMmaSync = false);
 
   /// Tile sizes for the workgroup / determines grid size for all known
   /// reduction strategies. The initial values are set by initDefaultValues();
@@ -41,13 +41,23 @@ struct AbstractGemmLikeStrategy {
   bool useMmaSync;
   int64_t pipelineDepth;
 
-  SmallVector<float> paddingValues;
+  SmallVector<Type> paddingValueTypes;
   SmallVector<int64_t> paddingDimensions;
   SmallVector<int64_t> packingDimensions;
+
+  ArrayAttr getZeroPadAttrFromElementalTypes(OpBuilder &b) const;
+
+  int64_t lhsElementalBitWidth = 32;
+  int64_t rhsElementalBitWidth = 32;
+  int64_t resElementalBitWidth = 32;
 
   virtual int64_t m() const = 0;
   virtual int64_t n() const = 0;
   virtual int64_t k() const = 0;
+
+  virtual int64_t blockTileM() const = 0;
+  virtual int64_t blockTileN() const = 0;
+  virtual int64_t blockTileK() const = 0;
 
   bool alignedLhs() const { return m() % 64 == 0 && k() % 16 == 0; }
   bool alignedRhs() const { return n() % 64 == 0 && k() % 16 == 0; }
@@ -66,17 +76,9 @@ struct AbstractGemmLikeStrategy {
   }
 
   // Copy vector sizes based on inner most K/N dims.
-  int64_t lhsCopyVectorSize() const {
-    if (k() % 4 == 0) return 4;
-    if (k() % 2 == 0) return 2;
-    return 1;
-  }
-  int64_t rhsCopyVectorSize() const {
-    if (n() % 4 == 0) return 4;
-    if (n() % 2 == 0) return 2;
-    return 1;
-  }
-  int64_t resCopyVectorSize() const { return rhsCopyVectorSize(); }
+  int64_t lhsCopyVectorSize() const;
+  int64_t rhsCopyVectorSize() const;
+  int64_t resCopyVectorSize() const;
 
   struct MappingInfo {
     SmallVector<int64_t> numThreads;

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -22,9 +22,15 @@ namespace iree_compiler {
 namespace gpu {
 
 struct GPUModel;
+struct MMAShape {
+  int64_t m;
+  int64_t n;
+  int64_t k;
+};
 
 struct AbstractGemmLikeStrategy {
   AbstractGemmLikeStrategy() {}
+  AbstractGemmLikeStrategy(MMAShape mmaShape) : targetWmmaShape(mmaShape) {}
 
   virtual ~AbstractGemmLikeStrategy();
 
@@ -44,6 +50,8 @@ struct AbstractGemmLikeStrategy {
   SmallVector<Type> paddingValueTypes;
   SmallVector<int64_t> paddingDimensions;
   SmallVector<int64_t> packingDimensions;
+
+  MMAShape targetWmmaShape;
 
   ArrayAttr getZeroPadAttrFromElementalTypes(OpBuilder &b) const;
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/BUILD.bazel
@@ -15,6 +15,7 @@ package(
 iree_compiler_cc_library(
     name = "TransformDialectStrategies",
     srcs = [
+        "AbstractGemmLikeStrategy.cpp",
         "Common.cpp",
         "MatmulTensorCoreStrategy.cpp",
         "SmallReductionStrategy.cpp",

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
     "SmallReductionStrategy.h"
     "StagedReductionStrategy.h"
   SRCS
+    "AbstractGemmLikeStrategy.cpp"
     "Common.cpp"
     "MatmulTensorCoreStrategy.cpp"
     "SmallReductionStrategy.cpp"

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -333,9 +333,6 @@ std::pair<Value, Value> mlir::iree_compiler::gpu::buildCommonTrailingStrategy(
 // Subset of mid-level builders currently used for GEMM-like problems.
 //===----------------------------------------------------------------------===//
 
-/// Key function for vtable.
-AbstractGemmLikeStrategy::~AbstractGemmLikeStrategy() {}
-
 /// Build transform IR to hoist the padded output operand of a padded matmul.
 /// Additionally, this attempts to fold the padding into the producing fill, if
 /// available.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -44,6 +44,12 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectMatmulTensorCoreStrategy(
     llvm::cl::desc("activate the matmul tensorcore strategy"),
     llvm::cl::init(false));
 
+llvm::cl::opt<bool> clGPUEnableTransformDialectAlignedMatmul(
+    "iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul",
+    llvm::cl::desc(
+        "activate the matmul tensorcore strategy for tile aligned shapes"),
+    llvm::cl::init(false));
+
 // TODO: significantly better namespacing.
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
@@ -82,6 +88,7 @@ using iree_compiler::IREE::transform_dialect::
 using iree_compiler::IREE::transform_dialect::ShareForallOperandsOp;
 using transform::FuseIntoContainingOp;
 using transform::MatchOp;
+using transform::RewriteInDestinationPassingStyleOp;
 using transform::ScalarizeOp;
 using transform::SequenceOp;
 using transform_ext::MatchCallbackOp;
@@ -401,37 +408,58 @@ Value mlir::iree_compiler::gpu::buildDistributeOnePadOrCopy(
 std::tuple<Value, Value, Value> mlir::iree_compiler::gpu::buildDistributeCopies(
     ImplicitLocOpBuilder &b, Value variantH, Value paddedMatmulOpH,
     const AbstractGemmLikeStrategy &strategy) {
-  // Explicitly materialize the parent parallel_insert into a copy to avoid late
-  // bufferization interferences.
-  // TODO: Avoid brittle rematching.
-  Value insertSliceH = b.create<transform::MatchOp>(
-      variantH, tensor::ParallelInsertSliceOp::getOperationName());
-  Value copyBackOpH = b.create<transform::InsertSliceToCopyOp>(
-      insertSliceH.getType(), insertSliceH);
+  // Aligned vs unaligned handling deviates here by converting the pads to
+  // copies for the aligned case.
+  // TODO: Unify aligned and unaligned codegen.
+  Value copyBackOpH;
+  if (!strategy.alignedRes()) {
+    // Explicitly materialize the parent parallel_insert into a copy to avoid
+    // late bufferization interferences.
+    // TODO: Avoid brittle rematching.
+    Value insertSliceH = b.create<transform::MatchOp>(
+        variantH, tensor::ParallelInsertSliceOp::getOperationName());
+    copyBackOpH = b.create<transform::InsertSliceToCopyOp>(
+        insertSliceH.getType(), insertSliceH);
+  } else {
+    Value resH = b.create<transform::GetProducerOfOperand>(
+        paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(2));
+    copyBackOpH =
+        b.create<RewriteInDestinationPassingStyleOp>(resH.getType(), resH);
+  }
 
   Value lhsH = b.create<transform::GetProducerOfOperand>(
       paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(0));
   Value rhsH = b.create<transform::GetProducerOfOperand>(
       paddedMatmulOpH.getType(), paddedMatmulOpH, b.getI64IntegerAttr(1));
 
+  // Rewrite aligned pads as destination passing (linalg.copy)
+  if (strategy.alignedLhs())
+    lhsH = b.create<RewriteInDestinationPassingStyleOp>(lhsH.getType(), lhsH);
+  if (strategy.alignedRhs())
+    rhsH = b.create<RewriteInDestinationPassingStyleOp>(rhsH.getType(), rhsH);
+
   AbstractGemmLikeStrategy::MappingInfo lhsCopyMapping =
       strategy.lhsCopyMapping();
   Value lhsCopyOpH = buildDistributeOnePadOrCopy(
       b, variantH, lhsH, /*numThreads=*/lhsCopyMapping.numThreads,
-      /*threadDimMapping=*/lhsCopyMapping.threadMapping, /*foldIfBranch=*/true);
+      /*threadDimMapping=*/lhsCopyMapping.threadMapping,
+      /*foldIfBranch=*/!strategy.alignedLhs());
 
   AbstractGemmLikeStrategy::MappingInfo rhsCopyMapping =
       strategy.rhsCopyMapping();
   Value rhsCopyOpH = buildDistributeOnePadOrCopy(
       b, variantH, rhsH, /*numThreads=*/rhsCopyMapping.numThreads,
-      /*threadDimMapping=*/rhsCopyMapping.threadMapping, /*foldIfBranch=*/true);
+      /*threadDimMapping=*/rhsCopyMapping.threadMapping,
+      /*foldIfBranch=*/!strategy.alignedRhs());
 
-  AbstractGemmLikeStrategy::MappingInfo resCopyMapping =
-      strategy.resCopyMapping();
-  copyBackOpH = buildDistributeOnePadOrCopy(
-      b, variantH, copyBackOpH,
-      /*numThreads=*/resCopyMapping.numThreads,
-      /*threadDimMapping=*/rhsCopyMapping.threadMapping);
+  if (!strategy.alignedRes()) {
+    AbstractGemmLikeStrategy::MappingInfo resCopyMapping =
+        strategy.resCopyMapping();
+    copyBackOpH = buildDistributeOnePadOrCopy(
+        b, variantH, copyBackOpH,
+        /*numThreads=*/resCopyMapping.numThreads,
+        /*threadDimMapping=*/rhsCopyMapping.threadMapping);
+  }
 
   return std::make_tuple(lhsCopyOpH, rhsCopyOpH, copyBackOpH);
 }
@@ -453,24 +481,32 @@ void mlir::iree_compiler::gpu::buildMatmulVectorization(
         b, configuration, variantH);
   }
   // Apply vector masking.
-  AbstractGemmLikeStrategy::MappingInfo lhsCopyMapping =
-      strategy.lhsCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(lhsCopyOpH, ValueRange(), false,
-                                         lhsCopyMapping.tileSizes);
-  AbstractGemmLikeStrategy::MappingInfo rhsCopyMapping =
-      strategy.rhsCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(rhsCopyOpH, ValueRange(), false,
-                                         rhsCopyMapping.tileSizes);
-  AbstractGemmLikeStrategy::MappingInfo resCopyMapping =
-      strategy.resCopyMapping();
-  b.create<transform::MaskedVectorizeOp>(copyBackOpH, ValueRange(), false,
-                                         resCopyMapping.tileSizes);
+  if (!strategy.alignedLhs()) {
+    AbstractGemmLikeStrategy::MappingInfo lhsCopyMapping =
+        strategy.lhsCopyMapping();
+    b.create<transform::MaskedVectorizeOp>(lhsCopyOpH, ValueRange(), false,
+                                           lhsCopyMapping.tileSizes);
+  }
+  if (!strategy.alignedRhs()) {
+    AbstractGemmLikeStrategy::MappingInfo rhsCopyMapping =
+        strategy.rhsCopyMapping();
+    b.create<transform::MaskedVectorizeOp>(rhsCopyOpH, ValueRange(), false,
+                                           rhsCopyMapping.tileSizes);
+  }
+  if (!strategy.alignedRes()) {
+    AbstractGemmLikeStrategy::MappingInfo resCopyMapping =
+        strategy.resCopyMapping();
+    b.create<transform::MaskedVectorizeOp>(copyBackOpH, ValueRange(), false,
+                                           resCopyMapping.tileSizes);
+  }
 
   // TODO: don't rematch, apply on the variant op directly.
   Value funcH =
       b.create<transform::MatchOp>(variantH, func::FuncOp::getOperationName());
   // TODO: avoid functional style transform so we can apply to the variant.
-  funcH = b.create<transform::LowerMaskedTransfersOp>(funcH.getType(), funcH);
+  if (!strategy.alignedLhs() || !strategy.alignedRhs() ||
+      !strategy.alignedRes())
+    funcH = b.create<transform::LowerMaskedTransfersOp>(funcH.getType(), funcH);
   {
     ApplyPatternsOpPatterns configuration;
     configuration.rankReducingLinalg = true;
@@ -808,7 +844,7 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
   //   - f32 only atm.
   //   - Mandatory fill op.
   //   - No trailing op.
-  //   - If the matmul is "too aligned", then use the default IREE strategy.
+  //   - If the matmul is "too aligned", then guard on the alignment flag.
   //   - If the matmul is "too small", then use the default IREE strategy.
   //   - Otherwise, we take it.
   if (!fill->getCaptured() || trailing->getCaptured()) {
@@ -829,19 +865,15 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
     return failure();
   }
 
-  // Currently the unaligned transform strategy does not properly handle
-  // optionality when padding operations get folded away. So we only use it when
-  // all operands require a padding that does not fold. This is the case when
-  // either:
-  //   - m and k are not aligned to the tile sizes (conservatively, take 64, 16)
-  //   - n and k are not aligned to the tile sizes (conservatively, take 64, 16)
-  // Other cases currently result in folding and fall back to the default
-  // unaligned IREE strategy.
-  bool supportedUnalignedCases =
-      (matmulSize[0] % 64 != 0 && matmulSize[2] % 16 != 0) ||
-      (matmulSize[1] % 64 != 0 && matmulSize[2] % 16 != 0);
+  // Currently the fully aligned case still lags behind the current default
+  // pipeline and thus is guarded by a flag. This is the case when
+  //   - m is tile aligned (conservatively, take 64)
+  //   - n is tile aligned (conservatively, take 64)
+  //   - k is tile aligned (conservatively, take 16)
+  bool guardedAlignedCases = matmulSize[0] % 64 == 0 &&
+                             matmulSize[1] % 64 == 0 && matmulSize[2] % 16 == 0;
 
-  if (!supportedUnalignedCases) {
+  if (guardedAlignedCases && !clGPUEnableTransformDialectAlignedMatmul) {
     LDBG("--Matmul strategy alignment check failed\n");
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -50,6 +50,11 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectAlignedMatmul(
         "activate the matmul tensorcore strategy for tile aligned shapes"),
     llvm::cl::init(false));
 
+llvm::cl::opt<bool> clGPUTransformDialectUseMmaSync(
+    "td-matmul-strategy-use-mma-sync",
+    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
+    llvm::cl::init(false));
+
 // TODO: significantly better namespacing.
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
@@ -820,10 +825,6 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
     LDBG("--Matmul strategy flag turned off\n");
     return failure();
   }
-  if (!gpuModel.hasTF32TensorCore) {
-    LDBG("--Matmul strategy no TF32 tensor core\n");
-    return failure();
-  }
 
   // 1. Match a reduction and surrounding ops.
   StructuredOpMatcher *fill;
@@ -838,7 +839,7 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
   }
 
   // We are very peculiar about the dispatches we want to match for now:
-  //   - f32 only atm.
+  //   - f32 or f16 only atm.
   //   - Mandatory fill op.
   //   - No trailing op.
   //   - If the matmul is "too aligned", then guard on the alignment flag.
@@ -849,17 +850,58 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
     return failure();
   }
 
-  if (!captures.lhsElementType.isF32() || !captures.rhsElementType.isF32() ||
-      !captures.outputElementType.isF32()) {
-    LDBG("--Matmul strategy elemental type check failed\n");
-    return failure();
-  }
-
   // TODO: Generalize to a good mix of sizes, alignments and element types.
   const auto &matmulSize = captures.matmulOpSizes;
   if (matmulSize.size() != 3) {
     LDBG("--Matmul strategy size capture failed\n");
     return failure();
+  }
+
+  Type lhsElementType = captures.lhsElementType;
+  Type rhsElementType = captures.rhsElementType;
+  Type resElementType = captures.outputElementType;
+
+  if (lhsElementType != rhsElementType) {
+    LDBG("--Matmul strategy mixed input types\n");
+    return failure();
+  }
+
+  // Currently this is restricted by the supported vector unroll types/shapes
+  // for WMMA.
+  // TODO: Remove this once proper support for unrolling is in place.
+  if (!lhsElementType.isF32() && !lhsElementType.isF16()) {
+    LDBG("--Matmul strategy failed elemental type check\n");
+    return failure();
+  }
+
+  if (clGPUTransformDialectUseMmaSync) {
+    if (!gpuModel.hasMmaSync) {
+      LDBG("--Matmul strategy target does not support MMA.SYNC operations\n");
+      return failure();
+    }
+    // For unaligned f16 inputs conversion to subgroup_mma ops is failing and
+    // thus blowing up the generated code. Turn off f16 for mma sync for now.
+    if (!captures.lhsElementType.isF32() || !gpuModel.hasTF32TensorCore) {
+      LDBG("--Matmul strategy no TF32 tensor core\n");
+      return failure();
+    }
+  } else {
+    // Verify WMMA.
+    // Hard coded to reflect current WMMA unrolling support.
+    int reqM = 16;
+    int reqN = 16;
+    int reqK = lhsElementType.isF32() ? 8 : 16;
+    if (llvm::all_of(gpuModel.supportedWMMAConfigs,
+                     [&](iree_compiler::gpu::MMAConfig config) {
+                       return config.m != reqM || config.n != reqN ||
+                              config.k != reqK ||
+                              config.aType != lhsElementType ||
+                              config.bType != rhsElementType ||
+                              config.cType != resElementType;
+                     })) {
+      LDBG("--Matmul strategy failed wmma type check\n");
+      return failure();
+    }
   }
 
   // Currently the fully aligned case still lags behind the current default
@@ -892,7 +934,8 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
   // 2. Construct the configuration and the strategy builder.
   // TODO: Generalize along the HW axis.
   auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
-    iree_compiler::gpu::MatmulStrategy strategy(op->getContext(), captures);
+    iree_compiler::gpu::MatmulStrategy strategy(
+        op->getContext(), captures, clGPUTransformDialectUseMmaSync);
     return buildMatmulTensorCoreStrategy(b, variant, strategy);
   };
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h
@@ -191,6 +191,18 @@ struct ReductionConfig {
   ReductionStrategy strategy;
 };
 
+/// Placeholder for representing supported WMMA/Cooperative Matrix
+/// configurations. This is a reflection of
+/// SPIRV_CooperativeMatrixPropertiesNVArrayAttr.
+struct MMAConfig {
+  int64_t m;
+  int64_t n;
+  int64_t k;
+  Type aType;
+  Type bType;
+  Type cType;
+};
+
 /// Placeholder for some hardware model proxy that contains relevant information
 /// to configure the reduction strategy. In the future, this will need to be
 /// driven by some contract with the runtime.
@@ -199,6 +211,8 @@ struct GPUModel {
   StringRef model = kDefaultGPU;
   bool hasWarpShuffle = false;
   bool hasTF32TensorCore = false;
+  bool hasMmaSync = false;
+  SmallVector<MMAConfig> supportedWMMAConfigs = {};
 };
 
 /// Try to find an exisiting transform dialect strategy for a given entry point.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -221,9 +221,9 @@ void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
       buildMatmulStrategyBlockDistribution(b, variantH, strategy);
   // Tile reduction loop.
   SmallVector<int64_t> tileSizes{0, 0, strategy.reductionTileSize};
-  auto tileReductionResult =
-      buildTileFuseToScfFor(b, variantH, matmulH, {},
-                            getAsOpFoldResult(b.getI64ArrayAttr(tileSizes)));
+  auto tileReductionResult = buildTileFuseToScfFor(
+      b, variantH, matmulH, {}, getAsOpFoldResult(b.getI64ArrayAttr(tileSizes)),
+      /*canonicalize=*/!strategy.alignedRes());
 
   // Step 2. Pad the matmul op.
   // TODO: use captured type information to configure the padding values.
@@ -235,7 +235,16 @@ void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
   // Step 3. Hoist the padding of the output operand above the reduction loop.
   // The resulting fillOp will be mapped with the contraction using an SIMD
   // programming model.
-  Value fillOpH = buildHoistOutputPaddingOp(b, variantH, paddedMatmulOpH);
+  Value fillOpH;
+  if (!strategy.alignedRes()) {
+    fillOpH = buildHoistOutputPaddingOp(b, variantH, paddedMatmulOpH);
+  } else {
+    fillOpH = b.create<transform::MatchOp>(variantH,
+                                           linalg::FillOp::getOperationName());
+    ApplyPatternsOpPatterns config;
+    iree_compiler::buildCanonicalizationAndEnablingTransforms(b, config,
+                                                              variantH);
+  }
 
   // Step 4. Distribute pad and copies: SIMT programming model.
   auto [lhsCopyOpH, rhsCopyOpH, copyBackOpH] =
@@ -285,12 +294,15 @@ void iree_compiler::gpu::buildMatmulTensorCoreStrategy(
   }
 
   // Step 13. Late lowerings and cleanups.
-  // TODO: not a functional style op to avoid invalidating artificially.
-  funcH = b.create<transform::LowerMasksOp>(
-      pdl::OperationType::get(b.getContext()), funcH);
-  // TODO: not a functional style op to avoid invalidating artificially.
-  funcH = b.create<transform::MaterializeMasksOp>(
-      pdl::OperationType::get(b.getContext()), funcH);
+  if (!strategy.alignedLhs() || !strategy.alignedRhs() ||
+      !strategy.alignedRes()) {
+    // TODO: not a functional style op to avoid invalidating artificially.
+    funcH = b.create<transform::LowerMasksOp>(
+        pdl::OperationType::get(b.getContext()), funcH);
+    // TODO: not a functional style op to avoid invalidating artificially.
+    funcH = b.create<transform::MaterializeMasksOp>(
+        pdl::OperationType::get(b.getContext()), funcH);
+  }
   {
     ApplyPatternsOpPatterns config;
     config.foldMemrefAliases = true;

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -11,7 +11,6 @@
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -50,88 +49,9 @@ using iree_compiler::IREE::transform_dialect::
 using transform::MatchOp;
 using transform_ext::RegisterMatchCallbacksOp;
 
-/// Options to set the default values of the matmul strategy.
-
-/// Block tile size X, Y, Z.
-static llvm::cl::opt<int64_t> clBlockTileSizeX(
-    "td-matmul-strategy-blk-size-x",
-    llvm::cl::desc("block tile size for dim X (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(128));
-static llvm::cl::opt<int64_t> clBlockTileSizeY(
-    "td-matmul-strategy-blk-size-y",
-    llvm::cl::desc("block tile size for dim Y (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(128));
-static llvm::cl::opt<int64_t> clBlockTileSizeZ(
-    "td-matmul-strategy-blk-size-z",
-    llvm::cl::desc("block tile size for dim z (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(1));
-
-static llvm::cl::opt<int64_t> clReductionTileSize(
-    "td-matmul-strategy-reduc-size",
-    llvm::cl::desc(
-        "reduction tile sized for the transform dialect matmul strategy"),
-    llvm::cl::init(16));
-
-/// Number of threads X, Y, Z.
-static llvm::cl::opt<int64_t> clNumThreadsX(
-    "td-matmul-strategy-num-threads-x",
-    llvm::cl::desc("number of threads for dim X (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(64));
-static llvm::cl::opt<int64_t> clNumThreadsY(
-    "td-matmul-strategy-num-threads-y",
-    llvm::cl::desc("number of threads for dim Y (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(2));
-static llvm::cl::opt<int64_t> clNumThreadsZ(
-    "td-matmul-strategy-num-threads-z",
-    llvm::cl::desc("number of threads for dim z (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(1));
-
-/// Number of warps X, Y, Z.
-static llvm::cl::opt<int64_t> clNumWarpsX(
-    "td-matmul-strategy-num-warps-x",
-    llvm::cl::desc("number of warps for dim X (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(2));
-static llvm::cl::opt<int64_t> clNumWarpsY(
-    "td-matmul-strategy-num-warps-y",
-    llvm::cl::desc("number of warps for dim Y (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(2));
-static llvm::cl::opt<int64_t> clNumWarpsZ(
-    "td-matmul-strategy-num-warps-z",
-    llvm::cl::desc("number of warps for dim z (x,y,z) for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(1));
-
-static llvm::cl::opt<bool> clUseAsyncCopies(
-    "td-matmul-strategy-use-async-copies",
-    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
-    llvm::cl::init(true));
-
-static llvm::cl::opt<bool> clUseMmaSync(
-    "td-matmul-strategy-use-mma-sync",
-    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
-    llvm::cl::init(false));
-
-static llvm::cl::opt<int64_t> clPipelineDepth(
-    "td-matmul-strategy-pipeline-depth",
-    llvm::cl::desc("pipeline depth for the transform dialect matmul strategy"),
-    llvm::cl::init(3));
-
 void MatmulStrategy::initDefaultValues() {
-  blockTileSizes = {clBlockTileSizeX, clBlockTileSizeY, clBlockTileSizeZ};
-  reductionTileSize = clReductionTileSize;
-  numThreads = {clNumThreadsX, clNumThreadsY, clNumThreadsZ};
-  numWarps = {clNumWarpsX, clNumThreadsY, clNumThreadsZ};
-  useAsyncCopies = clUseAsyncCopies;
-  useMmaSync = clUseMmaSync;
-  pipelineDepth = clPipelineDepth;
+  // Pull in tile configs from flags.
+  AbstractGemmLikeStrategy::initDefaultValues();
 
   // TODO: Capture input/output element types properly for configuring the
   // padding values.
@@ -144,37 +64,7 @@ LLVM_DUMP_METHOD void MatmulStrategy::dump() const { print(llvm::errs()); }
 
 void MatmulStrategy::print(llvm::raw_ostream &os) const {
   os << "\n--- Matmul strategy ---\n";
-  os << "- block tile sizes: {";
-  bool isFirst = true;
-  for (int64_t blockTileSize : blockTileSizes) {
-    if (!isFirst) os << ", ";
-    os << blockTileSize;
-    isFirst = false;
-  }
-  os << "}\n";
-  os << "- reduction tile size: " << reductionTileSize << '\n';
-
-  os << "- number of threads: {";
-  isFirst = true;
-  for (int64_t numThreadsForDim : numThreads) {
-    if (!isFirst) os << ", ";
-    os << numThreadsForDim;
-    isFirst = false;
-  }
-  os << "}\n";
-
-  os << "- number of warps: {";
-  isFirst = true;
-  for (int64_t numWarpsForDim : numWarps) {
-    if (!isFirst) os << ", ";
-    os << numWarpsForDim;
-    isFirst = false;
-  }
-  os << "}\n";
-
-  os << "- use async copies: " << useAsyncCopies << '\n';
-  os << "- use mma sync: " << useMmaSync << '\n';
-  os << "- pipeline depth: " << pipelineDepth << '\n';
+  AbstractGemmLikeStrategy::print(os);
 }
 
 static std::tuple<Value, Value, Value, Value>

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -23,12 +23,16 @@ namespace gpu {
 
 struct GPUModel;
 
+using iree_compiler::gpu::MMAShape;
+
 class MatmulStrategy : public AbstractGemmLikeStrategy {
  public:
   MatmulStrategy(MLIRContext *context,
                  const transform_ext::MatchedMatmulCaptures &captures,
-                 bool optUseMmaSync)
-      : AbstractGemmLikeStrategy(), ctx(context), captures(captures) {
+                 bool optUseMmaSync, MMAShape targetWmmaShape)
+      : AbstractGemmLikeStrategy(targetWmmaShape),
+        ctx(context),
+        captures(captures) {
     initDefaultValues(optUseMmaSync);
   }
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -38,7 +38,7 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
   MLIRContext *ctx;
   transform_ext::MatchedMatmulCaptures captures;
 
-  void initDefaultValues();
+  void initDefaultValues() override;
 
   LogicalResult verify() const;
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -26,9 +26,10 @@ struct GPUModel;
 class MatmulStrategy : public AbstractGemmLikeStrategy {
  public:
   MatmulStrategy(MLIRContext *context,
-                 const transform_ext::MatchedMatmulCaptures &captures)
+                 const transform_ext::MatchedMatmulCaptures &captures,
+                 bool optUseMmaSync)
       : AbstractGemmLikeStrategy(), ctx(context), captures(captures) {
-    initDefaultValues();
+    initDefaultValues(optUseMmaSync);
   }
 
   MatmulStrategy(const MatmulStrategy &) = default;
@@ -38,7 +39,7 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
   MLIRContext *ctx;
   transform_ext::MatchedMatmulCaptures captures;
 
-  void initDefaultValues() override;
+  void initDefaultValues(bool optUseMmaSync = false);
 
   LogicalResult verify() const;
 
@@ -55,11 +56,21 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
     return captures.matmulOpSizes[2];
   }
 
+  int64_t blockTileM() const override {
+    assert(blockTileSizes.size() >= 2 && "need at least 2 block tile sizes");
+    return blockTileSizes[0];
+  }
+  int64_t blockTileN() const override {
+    assert(blockTileSizes.size() >= 2 && "need at least 2 block tile sizes");
+    return blockTileSizes[1];
+  }
+  int64_t blockTileK() const override { return reductionTileSize; }
+
   using AbstractGemmLikeStrategy::MappingInfo;
 
   MappingInfo getBlockMapping() const override {
     return MappingInfo{/*numThreads=*/{},
-                       /*tileSizes=*/{blockTileSizes[0], blockTileSizes[1]},
+                       /*tileSizes=*/{blockTileM(), blockTileN()},
                        /*threadMapping=*/{blockY(ctx), blockX(ctx)}};
   }
 
@@ -71,51 +82,50 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
     assert(totalNumThreads() % numThreadsK == 0 &&
            "num threads must be divisible by num threads along k");
     int64_t numThreadsM = totalNumThreads() / numThreadsK;
-    assert(blockTileSizes[0] % numThreadsM == 0 &&
-           "blockTileSizes[0] must be divisible by numThreadsM");
+    assert(blockTileM() % numThreadsM == 0 &&
+           "blockTileM must be divisible by numThreadsM");
     assert(reductionTileSize % numThreadsK == 0 &&
            "reductionTileSize must be divisible by numThreadsK");
     return MappingInfo{
         /*numThreads=*/{numThreadsM, numThreadsK},
         /*tileSizes=*/
-        {blockTileSizes[0] / numThreadsM, reductionTileSize / numThreadsK},
+        {blockTileM() / numThreadsM, reductionTileSize / numThreadsK},
         /*threadMapping=*/{linearIdX(ctx), linearIdY(ctx)}};
   }
   // RHS copy is of size kxn.
   MappingInfo rhsCopyMapping() const override {
     assert(blockTileSizes[1] % rhsCopyVectorSize() == 0 &&
            "vector size must divide blockTileSizes[1]");
-    int64_t numThreadsN = blockTileSizes[1] / rhsCopyVectorSize();
+    int64_t numThreadsN = blockTileN() / rhsCopyVectorSize();
     assert(totalNumThreads() % numThreadsN == 0 &&
            "num threads must be divisible by num threads along n");
     int64_t numThreadsK = totalNumThreads() / numThreadsN;
     assert(reductionTileSize % numThreadsK == 0 &&
-           "blockTileSizes[0] must be divisible by numThreadsK");
+           "reductionTileSize must be divisible by numThreadsK");
     assert(blockTileSizes[1] % numThreadsN == 0 &&
-           "reductionTileSize must be divisible by numThreadsN");
+           "blockTileSizes[1] must be divisible by numThreadsN");
     return MappingInfo{
         /*numThreads=*/{numThreadsK, numThreadsN},
         /*tileSizes=*/
-        {reductionTileSize / numThreadsK, blockTileSizes[1] / numThreadsN},
+        {reductionTileSize / numThreadsK, blockTileN() / numThreadsN},
         /*threadMapping=*/{linearIdY(ctx), linearIdX(ctx)}};
   }
   // RES copy is of size mxn.
   MappingInfo resCopyMapping() const override {
-    assert(blockTileSizes[1] % resCopyVectorSize() == 0 &&
+    assert(blockTileN() % resCopyVectorSize() == 0 &&
            "vector size must divide n");
-    int64_t numThreadsN = blockTileSizes[1] / resCopyVectorSize();
+    int64_t numThreadsN = blockTileN() / resCopyVectorSize();
     assert(totalNumThreads() % numThreadsN == 0 &&
            "num threads must be divisible by num threads along n");
     int64_t numThreadsM = totalNumThreads() / numThreadsN;
-    assert(blockTileSizes[0] % numThreadsM == 0 &&
-           "blockTileSizes[0] must be divisible by numThreadsM");
-    assert(blockTileSizes[1] % numThreadsN == 0 &&
-           "blockTileSizes[1] must be divisible by numThreadsN");
-    return MappingInfo{
-        /*numThreads=*/{numThreadsM, numThreadsN},
-        /*tileSizes=*/
-        {blockTileSizes[0] / numThreadsM, blockTileSizes[1] / numThreadsN},
-        /*threadMapping=*/{linearIdY(ctx), linearIdX(ctx)}};
+    assert(blockTileM() % numThreadsM == 0 &&
+           "blockTileM() must be divisible by numThreadsM");
+    assert(blockTileN() % numThreadsN == 0 &&
+           "blockTileN() must be divisible by numThreadsN");
+    return MappingInfo{/*numThreads=*/{numThreadsM, numThreadsN},
+                       /*tileSizes=*/
+                       {blockTileM() / numThreadsM, blockTileN() / numThreadsN},
+                       /*threadMapping=*/{linearIdY(ctx), linearIdX(ctx)}};
   }
   // COMPUTE is of size mxn.
   MappingInfo computeMapping() const override {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -82,9 +82,13 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
                             vector::CombiningKind kind, uint32_t size,
                             const int warpSize);
 
+/// Helper to infer the correct unroll shape from contract ops.
+LogicalResult getWmmaNativeVectorShapeFromContractOps(
+    Operation *containerOp, SmallVector<int64_t, 3> &nativeShape);
+
 /// Return the native size of an operation used in contraction calculation.
-// TODO: Make this take HW specific sizes.
-std::optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op);
+std::optional<SmallVector<int64_t>> getWmmaNativeVectorSize(
+    Operation *op, const SmallVector<int64_t, 3> &nativeShape);
 
 /// Helper function to return native size for MMA.SYNC-based operations.
 std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op);


### PR DESCRIPTION
To manage different hardware requirements for wmma vector sizes, in
particular for SPIR-V, the target unroll shape needs to be pluggable and
configured with the rest of the pipeline.

Depends on #13735