### PR TITLE
Remove platform specific logic from iree_tools_tf

### DIFF
--- a/build_tools/python_deploy/pypi_deploy.sh
+++ b/build_tools/python_deploy/pypi_deploy.sh
@@ -52,18 +52,6 @@ function download_wheels() {
   gh release download "${RELEASE}" --repo openxla/iree --pattern "*.whl"
 }
 
-# For some reason auditwheel detects these as not manylinux compliant even
-# though they are (we think). Use repair to fix the platform
-function repair_wheels() {
-  echo ""
-  echo "Repairing tool wheels"
-  for f in iree_tools_*linux_x86_64*; do
-    auditwheel repair --plat manylinux_2_17_x86_64 --wheel-dir . "$f"
-    echo "Deleting non-compliant wheel '$f'"
-    rm "$f"
-  done
-}
-
 function upload_wheels() {
   twine upload --verbose -u google-iree-pypi-deploy *
 }
@@ -81,7 +69,6 @@ function main() {
   fi
 
   download_wheels
-  repair_wheels
   upload_wheels
 }
 

--- a/build_tools/python_deploy/pypi_deploy_requirements.txt
+++ b/build_tools/python_deploy/pypi_deploy_requirements.txt
@@ -1,3 +1,1 @@
 twine
-auditwheel
-patchelf

--- a/integrations/tensorflow/python_projects/iree_tf/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tf/setup.py
@@ -41,39 +41,6 @@ except FileNotFoundError:
 PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
 PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
 
-# Force platform specific wheel.
-# https://stackoverflow.com/questions/45150304
-try:
-  from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-
-  class bdist_wheel(_bdist_wheel):
-
-    def finalize_options(self):
-      _bdist_wheel.finalize_options(self)
-      self.root_is_pure = False
-
-    def get_tag(self):
-      python, abi, plat = _bdist_wheel.get_tag(self)
-      # We don't contain any python extensions so are version agnostic
-      # but still want to be platform specific.
-      python, abi = 'py3', 'none'
-      return python, abi, plat
-
-except ImportError:
-  bdist_wheel = None
-
-
-# Force installation into platlib.
-# Since this is a pure-python library with platform binaries, it is
-# mis-detected as "pure", which fails audit. Usually, the presence of an
-# extension triggers non-pure install. We force it here.
-class platlib_install(install):
-
-  def finalize_options(self):
-    install.finalize_options(self)
-    self.install_lib = self.install_platlib
-
-
 setup(
     name=f"iree-tools-tf{PACKAGE_SUFFIX}",
     version=f"{PACKAGE_VERSION}",
@@ -100,10 +67,6 @@ setup(
     ]),
     package_data={
         "iree.tools.tf": [f"iree-import-tf{exe_suffix}",],
-    },
-    cmdclass={
-        'bdist_wheel': bdist_wheel,
-        'install': platlib_install,
     },
     entry_points={
         "console_scripts": [

--- a/integrations/tensorflow/python_projects/iree_tflite/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tflite/setup.py
@@ -41,39 +41,6 @@ except FileNotFoundError:
 PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
 PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
 
-# Force platform specific wheel.
-# https://stackoverflow.com/questions/45150304
-try:
-  from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-
-  class bdist_wheel(_bdist_wheel):
-
-    def finalize_options(self):
-      _bdist_wheel.finalize_options(self)
-      self.root_is_pure = False
-
-    def get_tag(self):
-      python, abi, plat = _bdist_wheel.get_tag(self)
-      # We don't contain any python extensions so are version agnostic
-      # but still want to be platform specific.
-      python, abi = 'py3', 'none'
-      return python, abi, plat
-
-except ImportError:
-  bdist_wheel = None
-
-
-# Force installation into platlib.
-# Since this is a pure-python library with platform binaries, it is
-# mis-detected as "pure", which fails audit. Usually, the presence of an
-# extension triggers non-pure install. We force it here.
-class platlib_install(install):
-
-  def finalize_options(self):
-    install.finalize_options(self)
-    self.install_lib = self.install_platlib
-
-
 setup(
     name=f"iree-tools-tflite{PACKAGE_SUFFIX}",
     version=f"{PACKAGE_VERSION}",
@@ -99,10 +66,6 @@ setup(
     ]),
     package_data={
         "iree.tools.tflite": [f"iree-import-tflite{exe_suffix}",],
-    },
-    cmdclass={
-        'bdist_wheel': bdist_wheel,
-        'install': platlib_install,
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Testing: succesfully build wheel with `python -m pip wheel integrations/tensorflow/python_projects/iree_tf`