### PR TITLE
Fix stablehlo.reverse type conversion

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -410,7 +410,7 @@ struct ReverseOpConversion : public OpConversionPattern<mhlo::ReverseOp> {
     Value emptyTensor =
         rewriter.create<tensor::EmptyOp>(loc, mixedSizes, ty.getElementType());
     rewriter.replaceOpWithNewOp<IREE::LinalgExt::ReverseOp>(
-        op, op->getResultTypes(), adaptor.getOperands(), emptyTensor,
+        op, adaptor.getOperands().getType(), adaptor.getOperands(), emptyTensor,
         op.getDimensions());
     return success();
   }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -410,8 +410,8 @@ struct ReverseOpConversion : public OpConversionPattern<mhlo::ReverseOp> {
     Value emptyTensor =
         rewriter.create<tensor::EmptyOp>(loc, mixedSizes, ty.getElementType());
     rewriter.replaceOpWithNewOp<IREE::LinalgExt::ReverseOp>(
-        op, typeConverter->convertType(op.getType()), adaptor.getOperands(), emptyTensor,
-        op.getDimensions());
+        op, typeConverter->convertType(op.getType()), adaptor.getOperands(),
+        emptyTensor, op.getDimensions());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -410,7 +410,7 @@ struct ReverseOpConversion : public OpConversionPattern<mhlo::ReverseOp> {
     Value emptyTensor =
         rewriter.create<tensor::EmptyOp>(loc, mixedSizes, ty.getElementType());
     rewriter.replaceOpWithNewOp<IREE::LinalgExt::ReverseOp>(
-        op, adaptor.getOperands().getType(), adaptor.getOperands(), emptyTensor,
+        op, typeConverter->convertType(op.getType()), adaptor.getOperands(), emptyTensor,
         op.getDimensions());
     return success();
   }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
@@ -477,6 +477,25 @@ func.func @reverse_dim1(%arg0: tensor<3x5xi32>) -> tensor<3x5xi32> {
 
 // -----
 
+func.func @reverse_unsigned(%arg0: tensor<3x5xui32>) -> tensor<3x5xui32> {
+  %0 = "mhlo.reverse"(%arg0) {
+    dimensions = dense<1> : tensor<1xi64>
+  } : (tensor<3x5xui32>) -> tensor<3x5xui32>
+  return %0 : tensor<3x5xui32>
+}
+// CHECK-LABEL: func.func @reverse_unsigned
+// CHECK-SAME:   %[[IN:[a-zA-Z0-9]+]]
+// CHECK:        %[[BITCAST:.+]] = tensor.bitcast %[[IN]] : tensor<3x5xui32> to tensor<3x5xi32>
+// CHECK:        %[[INIT:.+]] = tensor.empty() : tensor<3x5xi32>
+// CHECK:        %[[REV:.+]] = iree_linalg_ext.reverse
+// CHECK-SAME:     dimensions(dense<1> : tensor<1xi64>)
+// CHECK-SAME:     ins(%[[BITCAST]] : tensor<3x5xi32>)
+// CHECK-SAME:     outs(%[[INIT]] : tensor<3x5xi32>) : tensor<3x5xi32>
+// CHECK:        %[[BITCAST:.+]] = tensor.bitcast %[[REV]] : tensor<3x5xi32> to tensor<3x5xui32>
+// CHECK:        return %[[BITCAST]]
+
+// -----
+
 func.func @reverse_multi_dim(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
   %0 = "mhlo.reverse"(%arg0) {
     dimensions = dense<[0, 1]> : tensor<2xi64>

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgExt.cpp
@@ -418,8 +418,8 @@ struct ReverseOpConversion final
     Value emptyTensor =
         rewriter.create<tensor::EmptyOp>(loc, mixedSizes, ty.getElementType());
     rewriter.replaceOpWithNewOp<IREE::LinalgExt::ReverseOp>(
-        op, typeConverter->convertType(op.getType()), adaptor.getOperands(), emptyTensor,
-        op.getDimensions());
+        op, typeConverter->convertType(op.getType()), adaptor.getOperands(),
+        emptyTensor, op.getDimensions());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgExt.cpp
@@ -418,7 +418,7 @@ struct ReverseOpConversion final
     Value emptyTensor =
         rewriter.create<tensor::EmptyOp>(loc, mixedSizes, ty.getElementType());
     rewriter.replaceOpWithNewOp<IREE::LinalgExt::ReverseOp>(
-        op, op->getResultTypes(), adaptor.getOperands(), emptyTensor,
+        op, adaptor.getOperands().getType(), adaptor.getOperands(), emptyTensor,
         op.getDimensions());
     return success();
   }

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgExt.cpp
@@ -418,7 +418,7 @@ struct ReverseOpConversion final
     Value emptyTensor =
         rewriter.create<tensor::EmptyOp>(loc, mixedSizes, ty.getElementType());
     rewriter.replaceOpWithNewOp<IREE::LinalgExt::ReverseOp>(
-        op, adaptor.getOperands().getType(), adaptor.getOperands(), emptyTensor,
+        op, typeConverter->convertType(op.getType()), adaptor.getOperands(), emptyTensor,
         op.getDimensions());
     return success();
   }

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg_ext.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg_ext.mlir
@@ -478,6 +478,25 @@ func.func @reverse_dim1(%arg0: tensor<3x5xi32>) -> tensor<3x5xi32> {
 
 // -----
 
+func.func @reverse_unsigned(%arg0: tensor<3x5xui32>) -> tensor<3x5xui32> {
+  %0 = "stablehlo.reverse"(%arg0) {
+    dimensions = dense<1> : tensor<1xi64>
+  } : (tensor<3x5xui32>) -> tensor<3x5xui32>
+  return %0 : tensor<3x5xui32>
+}
+// CHECK-LABEL: func.func @reverse_unsigned
+// CHECK-SAME:   %[[IN:[a-zA-Z0-9]+]]
+// CHECK:        %[[BITCAST:.+]] = builtin.unrealized_conversion_cast %[[IN]] : tensor<3x5xui32> to tensor<3x5xi32>
+// CHECK:        %[[INIT:.+]] = tensor.empty() : tensor<3x5xi32>
+// CHECK:        %[[REV:.+]] = iree_linalg_ext.reverse
+// CHECK-SAME:     dimensions(dense<1> : tensor<1xi64>)
+// CHECK-SAME:     ins(%[[BITCAST]] : tensor<3x5xi32>)
+// CHECK-SAME:     outs(%[[INIT]] : tensor<3x5xi32>) : tensor<3x5xi32>
+// CHECK:        %[[BITCAST:.+]] = builtin.unrealized_conversion_cast %[[REV]] : tensor<3x5xi32> to tensor<3x5xui32>
+// CHECK:        return %[[BITCAST]]
+
+// -----
+
 // CHECK-LABEL: func.func @reverse_multi_dim
 // CHECK-SAME:   %[[IN:[a-zA-Z0-9]+]]
 func.func @reverse_multi_dim(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {


### PR DESCRIPTION
The wrong return type was used when lowering to `iree_linalg_ext.reverse`. Correct to using the converted type