### PR TITLE
Better TrackingListener error messages

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -357,10 +357,11 @@ void ErrorCheckingTrackingListener::notifyPayloadReplacementNotFound(
     return;
   }
 
-  hadErrors = true;
-#ifdef LLVM_ENABLE_ABI_BREAKING_CHECKS
-  errorStateChecked = false;
-#endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
+  status = emitSilenceableFailure(
+      getTransformOp(), "tracking listener failed to find replacement op");
+  status.attachNote(op->getLoc()) << "replaced op";
+  for (Value v : values)
+    status.attachNote(v.getLoc()) << "replacement value";
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
* Include the transform op and replacement details when the ErrorCheckingTrackingListener failed to find a replacement op.
* Simplify ErrorCheckingTrackingListener: store the last error in the listener object and assert that error was reset in the destructor.
* To simply the API, check listener failures and other errors separately (do not chain errors).

