### PR TITLE
[LLVMCPU] Simplify vector lowering for Mmt4dTilingExpert.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
@@ -152,6 +152,16 @@ void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
       llvm::dbgs() << "\n\n";
     });
   }
+
+  // Flatten transfer ops.
+  {
+    RewritePatternSet patterns(&getContext());
+    mlir::vector::populateVectorTransferDropUnitDimsPatterns(patterns);
+    mlir::vector::populateFlattenVectorTransferPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -571,8 +571,6 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager,
   if (!enableMicrokernels) {
     nestedModulePM.addNestedPass<func::FuncOp>(
         createLLVMCPUMmt4dVectorLoweringPass());
-    nestedModulePM.addNestedPass<func::FuncOp>(
-        createOptimizeVectorTransferPass(/*flatten=*/true));
   }
 }
 


### PR DESCRIPTION
It removes OptimizeVectorTransferPass from the pipeline, and adds the flatten patterns to Mmt4dTilingExpert. This removes unneeded patterns from the pipeline.

Fixes https://github.com/openxla/iree/issues/13753