### PR TITLE
Update cast form to preferred form

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
@@ -92,7 +92,7 @@ static Optional<StreamableFunc> convertStreamableFunc(
   // Because streamable ops are asynchronous they must be able to declare their
   // result shapes before they execute so memory can be allocated.
   for (auto resultType : functionType.getResults()) {
-    if (auto shapedType = resultType.dyn_cast<ShapedType>()) {
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(resultType)) {
       streamableFunc.requiredResultDims += shapedType.getNumDynamicDims();
     }
   }
@@ -149,7 +149,7 @@ static Optional<StreamableFunc> convertStreamableFunc(
     // arbitrarily complex (up to and including calling a function to compute
     // dims).
     SmallVector<int64_t> dynamicDimArgs;
-    auto shapedType = resultType.dyn_cast<ShapedType>();
+    auto shapedType = llvm::dyn_cast<ShapedType>(resultType);
     if (shapedType) {
       // Initialize dynamic dim args - we'll verify that they all get covered.
       dynamicDimArgs.resize(shapedType.getNumDynamicDims(), kUnspecifiedDim);
@@ -242,7 +242,7 @@ static LogicalResult convertStreamableCall(StreamableFunc &streamableFunc,
   // Capture all argument dynamic dimensions.
   SmallVector<Value> argDims;
   for (auto arg : callOp.getOperands()) {
-    if (arg.getType().isa<ShapedType>()) {
+    if (llvm::isa<ShapedType>(arg.getType())) {
       llvm::append_range(argDims, IREE::Util::buildDynamicDimsForValue(
                                       callOp.getLoc(), arg, builder));
     }
@@ -262,7 +262,7 @@ static LogicalResult convertStreamableCall(StreamableFunc &streamableFunc,
   } else {
     // Get the shape dimensions from existing call arguments or tied operands.
     for (auto [i, resultType] : llvm::enumerate(callOp.getResultTypes())) {
-      if (auto shapedType = resultType.dyn_cast<ShapedType>()) {
+      if (auto shapedType = llvm::dyn_cast<ShapedType>(resultType)) {
         const auto &resultDimArgs = streamableFunc.resultDimArgs[i];
         if (resultDimArgs.empty()) continue;
         if (resultDimArgs.front() == kTiedDim) {

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -173,7 +173,7 @@ class WrapEntryPointsPass
     for (auto [arg, inputName, inputType] : llvm::zip_equal(
              funcOp.getArguments(), inputNames, funcType.getInputs())) {
       auto fullName = (namePrefix + "_" + inputName + "_shape").str();
-      auto tensorType = inputType.dyn_cast<TensorType>();
+      auto tensorType = llvm::dyn_cast<TensorType>(inputType);
       assert(tensorType && "expecting only tensors in tflite function I/O");
       inputDynamicDims.push_back(createDynamicDimGlobals(
           arg.getLoc(), fullName, tensorType, moduleBuilder));
@@ -182,7 +182,7 @@ class WrapEntryPointsPass
     for (auto [outputName, outputType] :
          llvm::zip_equal(outputNames, funcType.getResults())) {
       auto fullName = (namePrefix + "_" + outputName + "_shape").str();
-      auto tensorType = outputType.dyn_cast<TensorType>();
+      auto tensorType = llvm::dyn_cast<TensorType>(outputType);
       assert(tensorType && "expecting only tensors in tflite function I/O");
       outputDynamicDims.push_back(
           createDynamicDimGlobals(loc, fullName, tensorType, moduleBuilder));

--- a/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
@@ -33,7 +33,7 @@ static Value getAsIndexValue(OpFoldResult attrOrValue, OpBuilder &builder,
     if (val.getType().isIndex()) return val;
     matchPattern(val, m_Constant(&attr));
   } else {
-    attr = attrOrValue.get<Attribute>().cast<IntegerAttr>();
+    attr = llvm::cast<IntegerAttr>(attrOrValue.get<Attribute>());
   }
   return builder.createOrFold<arith::ConstantIndexOp>(
       loc, attr.getValue().getSExtValue());

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -74,7 +74,7 @@ struct FoldTrailingUnitTranspose
 
   LogicalResult matchAndRewrite(linalg::TransposeOp op,
                                 PatternRewriter &rewriter) const override {
-    auto inputTy = op.getInput().getType().cast<ShapedType>();
+    auto inputTy = llvm::cast<ShapedType>(op.getInput().getType());
     int numDropDims = 0;
     ArrayRef<int64_t> perm = op.getPermutation();
     for (int idx = inputTy.getRank() - 1; idx >= 0; idx--) {
@@ -98,7 +98,7 @@ struct FoldTrailingUnitTranspose
 
     SmallVector<OpFoldResult> destMixedSizes =
         tensor::createDimValues(rewriter, loc, op.getInit());
-    auto initTy = op.getInit().getType().cast<ShapedType>();
+    auto initTy = llvm::cast<ShapedType>(op.getInit().getType());
     destMixedSizes.resize(initTy.getRank() - numDropDims);
     auto dest = rewriter.create<tensor::EmptyOp>(loc, destMixedSizes,
                                                  initTy.getElementType());

--- a/compiler/src/iree/compiler/Codegen/Common/EraseHALDescriptorTypeFromMemRef.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EraseHALDescriptorTypeFromMemRef.cpp
@@ -39,11 +39,11 @@ struct MemRefTypeConverter final : public TypeConverter {
       // Expect #hal.descriptor_type memory spaces.
       Attribute spaceAttr = memRefType.getMemorySpace();
       if (!spaceAttr) return std::nullopt;
-      auto dtAttr = spaceAttr.dyn_cast<IREE::HAL::DescriptorTypeAttr>();
+      auto dtAttr = llvm::dyn_cast<IREE::HAL::DescriptorTypeAttr>(spaceAttr);
       if (!dtAttr) return std::nullopt;
 
       // Erase the #hal.descriptor_type memory space.
-      if (auto rankedType = memRefType.dyn_cast<MemRefType>()) {
+      if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
         return MemRefType::get(memRefType.getShape(),
                                memRefType.getElementType(),
                                rankedType.getLayout());
@@ -60,9 +60,9 @@ struct MemRefTypeConverter final : public TypeConverter {
 
 /// Returns true if the given `type` is considered as legal.
 static bool isLegalType(Type type) {
-  if (auto memRefType = type.dyn_cast<BaseMemRefType>()) {
+  if (auto memRefType = llvm::dyn_cast<BaseMemRefType>(type)) {
     Attribute spaceAttr = memRefType.getMemorySpace();
-    return !spaceAttr || !spaceAttr.isa<IREE::HAL::DescriptorTypeAttr>();
+    return !spaceAttr || !llvm::isa<IREE::HAL::DescriptorTypeAttr>(spaceAttr);
   }
   return true;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
@@ -41,7 +41,7 @@ namespace iree_compiler {
 static Value getAsValue(OpFoldResult attrOrValue, OpBuilder &builder,
                         Location loc) {
   if (Value val = attrOrValue.dyn_cast<Value>()) return val;
-  auto attr = attrOrValue.get<Attribute>().cast<IntegerAttr>();
+  auto attr = llvm::cast<IntegerAttr>(attrOrValue.get<Attribute>());
   return builder.create<arith::ConstantIndexOp>(loc, attr.getInt());
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
@@ -35,7 +35,8 @@ static int shapedTypeStaticSize(ShapedType shapedType) {
     if (ShapedType::isDynamic(dimSize)) continue;
     allocSize *= dimSize;
   }
-  if (auto elementType = shapedType.getElementType().dyn_cast<ShapedType>()) {
+  if (auto elementType =
+          llvm::dyn_cast<ShapedType>(shapedType.getElementType())) {
     allocSize *= shapedTypeStaticSize(elementType);
   } else {
     allocSize *= shapedType.getElementType().getIntOrFloatBitWidth();
@@ -55,7 +56,7 @@ static LogicalResult checkGPUAllocationSize(func::FuncOp funcOp,
 
   int cumSize = 0;
   for (auto allocOp : allocOps) {
-    auto allocType = allocOp.getType().cast<MemRefType>();
+    auto allocType = llvm::cast<MemRefType>(allocOp.getType());
     if (!hasSharedMemoryAddressSpace(allocType)) continue;
 
     if (!allocOp.getDynamicSizes().empty()) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistribute.cpp
@@ -28,8 +28,9 @@ struct GPUDistributePass : public GPUDistributeBase<GPUDistributePass> {
     if (!isEntryPoint(funcOp)) return;
 
     auto workgroupSize = llvm::to_vector(llvm::map_range(
-        getEntryPoint(funcOp)->getWorkgroupSize().value(),
-        [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
+        getEntryPoint(funcOp)->getWorkgroupSize().value(), [&](Attribute attr) {
+          return llvm::cast<IntegerAttr>(attr).getInt();
+        }));
 
     IRRewriter rewriter(funcOp->getContext());
     rewriter.setInsertionPointToStart(&funcOp.getBody().front());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
@@ -51,9 +51,9 @@ struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
                                 PatternRewriter &rewriter) const override {
     auto loc = transferReadOp.getLoc();
     Value vector = transferReadOp.getVector();
-    VectorType vectorType = vector.getType().cast<VectorType>();
+    VectorType vectorType = llvm::cast<VectorType>(vector.getType());
     Value source = transferReadOp.getSource();
-    MemRefType sourceType = source.getType().dyn_cast<MemRefType>();
+    MemRefType sourceType = llvm::dyn_cast<MemRefType>(source.getType());
     // Contiguity check is valid on tensors only.
     if (!sourceType) return failure();
     // Already 2D or lower nothing to do.
@@ -115,10 +115,10 @@ struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
       subViewOffsets.push_back(transferReadOp.getIndices()[i]);
       subViewStrides.push_back(rewriter.getIndexAttr(1));
     }
-    MemRefType resultType = memref::SubViewOp::inferRankReducedResultType(
-                                vectorShapeCollapse, sourceType, subViewOffsets,
-                                subViewSizes, subViewStrides)
-                                .cast<MemRefType>();
+    MemRefType resultType =
+        llvm::cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
+            vectorShapeCollapse, sourceType, subViewOffsets, subViewSizes,
+            subViewStrides));
     Value subView = rewriter.create<memref::SubViewOp>(
         loc, resultType, source, subViewOffsets, subViewSizes, subViewStrides);
     Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
@@ -38,7 +38,7 @@ static bool contractOpFilter(Operation *op) {
   // Check if the shape is tile-distributable. The leading dimension must be a
   // multiple of the target vector size, which is 128b / the element bit width.
   auto isTileDistributable = [&](OpOperand *v) {
-    ShapedType ty = v->get().getType().cast<ShapedType>();
+    ShapedType ty = llvm::cast<ShapedType>(v->get().getType());
     unsigned bitWidth = ty.getElementTypeBitWidth();
     int targetVectorSize = copyVectorNumBits / bitWidth;
     return ty.getShape().back() % targetVectorSize == 0;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTile.cpp
@@ -219,8 +219,9 @@ struct GPUTensorTilePass : public GPUTensorTileBase<GPUTensorTilePass> {
     });
 
     auto workgroupSize = llvm::to_vector<4>(llvm::map_range(
-        getEntryPoint(funcOp)->getWorkgroupSize().value(),
-        [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
+        getEntryPoint(funcOp)->getWorkgroupSize().value(), [&](Attribute attr) {
+          return llvm::cast<IntegerAttr>(attr).getInt();
+        }));
     if (failed(tileParallelDims(funcOp, workgroupSize, distributeToWarp))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorization.cpp
@@ -48,7 +48,7 @@ static void populateVectorizationPatterns(RewritePatternSet &patterns,
     if (!linalgOp) return success();
     int64_t maxFlatVecSize = 1;
     for (OpOperand &operand : linalgOp->getOpOperands()) {
-      auto type = operand.get().getType().dyn_cast<ShapedType>();
+      auto type = llvm::dyn_cast<ShapedType>(operand.get().getType());
       if (!type) continue;
       if (!type.hasStaticShape()) return failure();
       maxFlatVecSize = std::max(maxFlatVecSize, type.getNumElements());

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -97,7 +97,7 @@ class IREEComprehensiveBufferizePass
 };
 }  // namespace
 
-static bool isaTensor(Type t) { return t.isa<TensorType>(); };
+static bool isaTensor(Type t) { return llvm::isa<TensorType>(t); };
 
 // Default allocation functions.
 static FailureOr<Value> defaultAllocationFn(OpBuilder &builder, Location loc,
@@ -110,7 +110,7 @@ static FailureOr<Value> defaultAllocationFn(OpBuilder &builder, Location loc,
     // type memory space; that's runtime allocations. So erase and fallback to
     // the default 0 memory space. It is fine given this is just the default
     // allocator; backends are expected to control by themselves.
-    if (storage.isa<IREE::HAL::DescriptorTypeAttr>())
+    if (llvm::isa<IREE::HAL::DescriptorTypeAttr>(storage))
       type = MemRefType::get(type.getShape(), type.getElementType(),
                              type.getLayout());
   }
@@ -140,7 +140,7 @@ static IREEOneShotBufferizationOptions getBufferizationOptions() {
   // memref type can be inferred from the context.
   options.unknownTypeConverterFn = [](Value value, Attribute memorySpace,
                                       const BufferizationOptions &options) {
-    auto tensorType = value.getType().cast<TensorType>();
+    auto tensorType = llvm::cast<TensorType>(value.getType());
 
     // Special rule for ConstantOps: These always lower to some memref with a
     // static identity layout.

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -63,7 +63,7 @@ static SmallVector<OpFoldResult> getStridesFromSizes(
 static FailureOr<DescriptorInfo> resolveBufferDescriptorForInterfaceBinding(
     IREE::HAL::InterfaceBindingSubspanOp binding, RewriterBase &rewriter,
     Location loc) {
-  auto memRefType = binding.getResult().getType().template cast<MemRefType>();
+  auto memRefType = llvm::cast<MemRefType>(binding.getResult().getType());
   int rank = memRefType.getRank();
   DescriptorInfo resultDescriptor;
 
@@ -130,7 +130,7 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
         op.getSource()
             .template getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>();
     if (!binding) return failure();
-    auto memRefType = binding.getResult().getType().template cast<MemRefType>();
+    auto memRefType = llvm::cast<MemRefType>(binding.getResult().getType());
     if (memRefType.getRank() < 1) return failure();
 
     auto loc = op.getLoc();
@@ -193,7 +193,7 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
 
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() + 2);
-    auto baseBufferType = op.getBaseBuffer().getType().cast<MemRefType>();
+    auto baseBufferType = llvm::cast<MemRefType>(op.getBaseBuffer().getType());
     if (newBufferType == baseBufferType) {
       results.push_back(linearInterfaceBinding);
     } else {

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -129,7 +129,7 @@ getMaterializationInfo(tensor::PackOp packOp) {
       encodingInfo.innerTileSizes.push_back(ShapedType::kDynamic);
     } else {
       encodingInfo.innerTileSizes.push_back(
-          tileSize.get<Attribute>().cast<IntegerAttr>().getInt());
+          llvm::cast<IntegerAttr>(tileSize.get<Attribute>()).getInt());
     }
   }
   encodingInfo.innerDimsPos = llvm::to_vector(packOp.getInnerDimsPos());

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -248,9 +248,9 @@ static LogicalResult replaceAllStoresWithTiledVersion(
       return rewriter.notifyMatchFailure(
           untiledOp, "failed to rewrite destructive update");
     }
-    if (failed(replaceStoresWithTiledVersion(rewriter, result.cast<OpResult>(),
-                                             tiledValues[index], resultOffsets,
-                                             resultSizes, innerLoopBody))) {
+    if (failed(replaceStoresWithTiledVersion(
+            rewriter, llvm::cast<OpResult>(result), tiledValues[index],
+            resultOffsets, resultSizes, innerLoopBody))) {
       return failure();
     }
   }
@@ -519,7 +519,7 @@ FailureOr<IREETileAndFuseResult> tileAndFuseDispatchUsingSCFForOp(
       rewriter.setInsertionPoint(sliceOp);
 
       // Generate the tiled implementation of the producer.
-      OpResult untiledValue = sliceOp.getSource().cast<OpResult>();
+      OpResult untiledValue = llvm::cast<OpResult>(sliceOp.getSource());
       FailureOr<TilingResult> swapSliceResult =
           tensor::replaceExtractSliceWithTiledProducer(rewriter, sliceOp,
                                                        untiledValue);

--- a/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
@@ -43,7 +43,8 @@ static Value convertElementType(OpBuilder &b, Location loc, Type targetType,
                                 Value source) {
   Type sourceType = source.getType();
   if (sourceType == targetType) return source;
-  if (sourceType.isa<IntegerType>() && targetType.isa<IntegerType>()) {
+  if (llvm::isa<IntegerType>(sourceType) &&
+      llvm::isa<IntegerType>(targetType)) {
     unsigned sourceBitWidth = sourceType.getIntOrFloatBitWidth();
     unsigned destBitWidth = targetType.getIntOrFloatBitWidth();
     if (sourceBitWidth > destBitWidth) {
@@ -58,7 +59,7 @@ static Value convertElementType(OpBuilder &b, Location loc, Type targetType,
 /// Legalizes the given type. If the type is already legal, returns
 /// std::nullopt.
 static std::optional<Type> getLegalizedType(Type t) {
-  if (auto shapedType = t.dyn_cast<RankedTensorType>()) {
+  if (auto shapedType = llvm::dyn_cast<RankedTensorType>(t)) {
     Type elementType = shapedType.getElementType();
     std::optional<Type> legalizedElementType =
         legalizeStorageElementType(elementType);
@@ -99,8 +100,8 @@ struct ConstantOpTypeConversion
   LogicalResult matchAndRewrite(
       arith::ConstantOp constantOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    auto attr = constantOp.getValue().cast<DenseElementsAttr>();
-    auto attrType = attr.getType().dyn_cast<ShapedType>();
+    auto attr = llvm::cast<DenseElementsAttr>(constantOp.getValue());
+    auto attrType = llvm::dyn_cast<ShapedType>(attr.getType());
     if (!attrType) {
       return rewriter.notifyMatchFailure(
           constantOp, "expected attribute type to be shaped type");

--- a/compiler/src/iree/compiler/Codegen/Common/VectorizePad.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorizePad.cpp
@@ -36,7 +36,7 @@ static Value getAsIndexValue(OpFoldResult attrOrValue, OpBuilder &builder,
     if (val.getType().isIndex()) return val;
     matchPattern(val, m_Constant(&attr));
   } else {
-    attr = attrOrValue.get<Attribute>().cast<IntegerAttr>();
+    attr = llvm::cast<IntegerAttr>(attrOrValue.get<Attribute>());
   }
   return builder.createOrFold<arith::ConstantIndexOp>(loc, attr.getInt());
 }
@@ -98,7 +98,7 @@ struct VectorizePadWithConditions final
     /// Return true if the given `attrOrValue` is a constant zero.
     auto isConstantZero = [](OpFoldResult attrOrValue) {
       if (attrOrValue.is<Attribute>()) {
-        auto attr = attrOrValue.get<Attribute>().dyn_cast<IntegerAttr>();
+        auto attr = llvm::dyn_cast<IntegerAttr>(attrOrValue.get<Attribute>());
         return attr && attr.getValue().getZExtValue() == 0;
       }
       IntegerAttr attr;

--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.cpp
@@ -19,13 +19,13 @@ namespace Codegen {
 struct IREECodegenDialectOpAsmInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (attr.isa<TranslationInfoAttr>()) {
+    if (llvm::isa<TranslationInfoAttr>(attr)) {
       os << "translation";
       return AliasResult::OverridableAlias;
-    } else if (attr.isa<CompilationInfoAttr>()) {
+    } else if (llvm::isa<CompilationInfoAttr>(attr)) {
       os << "compilation";
       return AliasResult::OverridableAlias;
-    } else if (attr.isa<LoweringConfigAttr>()) {
+    } else if (llvm::isa<LoweringConfigAttr>(attr)) {
       os << "config";
       return AliasResult::OverridableAlias;
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
@@ -28,8 +28,8 @@ namespace iree_compiler {
 //===----------------------------------------------------------------------===//
 
 static bool checkIntegerArrayAttr(ArrayAttr arrayAttr) {
-  return !llvm::any_of(arrayAttr,
-                       [](Attribute attr) { return !attr.isa<IntegerAttr>(); });
+  return !llvm::any_of(
+      arrayAttr, [](Attribute attr) { return !llvm::isa<IntegerAttr>(attr); });
 }
 
 /// Returns an `ArrayAttr` where each element is an `IntegerAttr` of `IndexType`
@@ -61,7 +61,7 @@ static SmallVector<int64_t> getIntegerVals(ArrayAttr arrayAttr) {
   if (!arrayAttr) return {};
   SmallVector<int64_t> values(arrayAttr.size());
   for (auto [index, attr] : llvm::enumerate(arrayAttr)) {
-    values[index] = attr.cast<IntegerAttr>().getInt();
+    values[index] = llvm::cast<IntegerAttr>(attr).getInt();
   }
   return values;
 }
@@ -129,7 +129,7 @@ TileSizesListType LoweringConfigAttr::getTileSizeVals() {
   if (!tileSizesAttr) return {};
   TileSizesListType tileSizes;
   for (auto attr : tileSizesAttr) {
-    auto vals = getIntegerVals(attr.cast<ArrayAttr>());
+    auto vals = getIntegerVals(llvm::cast<ArrayAttr>(attr));
     tileSizes.emplace_back(std::move(vals));
   }
   return tileSizes;
@@ -138,14 +138,14 @@ TileSizesListType LoweringConfigAttr::getTileSizeVals() {
 SmallVector<int64_t> LoweringConfigAttr::getTileSizeVals(unsigned level) {
   ArrayAttr tileSizesAttr = getTileSizes();
   if (!tileSizesAttr || tileSizesAttr.size() <= level) return {};
-  return getIntegerVals(tileSizesAttr[level].cast<ArrayAttr>());
+  return getIntegerVals(llvm::cast<ArrayAttr>(tileSizesAttr[level]));
 }
 
 SmallVector<int64_t> LoweringConfigAttr::getTileInterchangeVals(
     unsigned level) {
   ArrayAttr tileInterchangeAttr = getTileInterchange();
   if (!tileInterchangeAttr || tileInterchangeAttr.size() <= level) return {};
-  return getIntegerVals(tileInterchangeAttr[level].cast<ArrayAttr>());
+  return getIntegerVals(llvm::cast<ArrayAttr>(tileInterchangeAttr[level]));
 }
 
 SmallVector<int64_t> LoweringConfigAttr::getNativeVectorSizeVals() {
@@ -163,7 +163,7 @@ LogicalResult LoweringConfigAttr::verify(
   }
   auto hasNonIntElems = [](ArrayAttr sizes) -> bool {
     return llvm::any_of(sizes, [](Attribute attr) {
-      auto arrayAttr = attr.dyn_cast<ArrayAttr>();
+      auto arrayAttr = llvm::dyn_cast<ArrayAttr>(attr);
       return !arrayAttr || !checkIntegerArrayAttr(arrayAttr);
     });
   };

--- a/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.cpp
@@ -148,7 +148,7 @@ static FailureOr<func::CallOp> lowerUKernelGenericToFunctionCall(
   }
   SmallVector<Type> callResultTypes;
   for (auto resultType : op->getResultTypes()) {
-    if (resultType.isa<ShapedType>()) {
+    if (llvm::isa<ShapedType>(resultType)) {
       return rewriter.notifyMatchFailure(
           op, "cannot lower a `ShapedType` return value to function call");
     }
@@ -212,7 +212,7 @@ struct UKernelOpsBufferizationInterface
     // Replace all `tensor` operands with corresponding `memref` operands.
     for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
       // For `tensor` type operands, replace with `memref` type operand.
-      if (operand.getType().template isa<RankedTensorType>()) {
+      if (llvm::isa<RankedTensorType>(operand.getType())) {
         FailureOr<Value> memrefOperand = getBuffer(rewriter, operand, options);
         if (failed(memrefOperand)) {
           return op->emitOpError(
@@ -229,7 +229,7 @@ struct UKernelOpsBufferizationInterface
     // Ignore all result types that are tensor types.
     SmallVector<Type> resultTypes;
     for (auto resultType : op->getResultTypes()) {
-      if (resultType.isa<RankedTensorType>()) continue;
+      if (llvm::isa<RankedTensorType>(resultType)) continue;
       resultTypes.push_back(resultType);
     }
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -53,7 +53,7 @@ llvm::SmallVector<unsigned> getPartitionableLoopsImpl(
 static llvm::SmallVector<utils::IteratorType> getIteratorTypesFromAttr(
     ArrayAttr iteratorTypesAttr) {
   return llvm::to_vector(llvm::map_range(iteratorTypesAttr, [](Attribute attr) {
-    return utils::symbolizeIteratorType(attr.cast<StringAttr>().getValue())
+    return utils::symbolizeIteratorType(llvm::cast<StringAttr>(attr).getValue())
         .value();
   }));
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -302,7 +302,7 @@ static SmallVector<int64_t> getMinTilingSizesForEachDim(
 
     // If the indexing map has result it has to be a shaped type.
     auto operandType =
-        inputOutputOpOperands[index].get().getType().cast<ShapedType>();
+        llvm::cast<ShapedType>(inputOutputOpOperands[index].get().getType());
     int64_t tileSize = getVectorSize(entryPointFn, operandType);
 
     minTileSizes[fastestVaryingDim] =
@@ -796,7 +796,7 @@ static LogicalResult setMatmulPadRootConfig(
   // TODO(hanchung): Make logic more heuristic. Padding hurts performance a lot
   // if the dim size is small (e.g., K=24).
   SmallVector<int64_t> reductionTileSizes(workgroupTileSizes.size() - 1, 0);
-  auto lhsShapedType = op.lhs().getType().cast<ShapedType>();
+  auto lhsShapedType = llvm::cast<ShapedType>(op.lhs().getType());
   int64_t K = lhsShapedType.getShape().back();
   reductionTileSizes.push_back(
       getMaxVectorTileSize(0, K, workgroupTileSizes.back(), vectorSize));
@@ -892,7 +892,7 @@ static LogicalResult setAArch64RootConfig(func::FuncOp entryPointFn,
                              workgroupTileSizes[index], vectorSize));
   }
 
-  auto lhsShapedType = op.lhs().getType().cast<ShapedType>();
+  auto lhsShapedType = llvm::cast<ShapedType>(op.lhs().getType());
   int64_t K = lhsShapedType.getShape().back();
   parallelTileSizes.push_back(
       getMaxVectorTileSize(0, K, workgroupTileSizes.back(), vectorSize));
@@ -995,10 +995,10 @@ static LogicalResult setRootConfig(
 
   // Consider all element types and use the smallest vector size. The tiling
   // sizes are chosen based on the vector size.
-  auto lhsShapedType = contractionOp.lhs().getType().cast<ShapedType>();
-  auto rhsShapedType = contractionOp.rhs().getType().cast<ShapedType>();
+  auto lhsShapedType = llvm::cast<ShapedType>(contractionOp.lhs().getType());
+  auto rhsShapedType = llvm::cast<ShapedType>(contractionOp.rhs().getType());
   auto resShapedType =
-      linalgOp.getDpsInitOperand(0)->get().getType().cast<ShapedType>();
+      llvm::cast<ShapedType>(linalgOp.getDpsInitOperand(0)->get().getType());
   int64_t vectorSize = getVectorSize(entryPointFn, lhsShapedType);
   vectorSize = std::min(vectorSize, getVectorSize(entryPointFn, rhsShapedType));
   vectorSize = std::min(vectorSize, getVectorSize(entryPointFn, resShapedType));
@@ -1095,9 +1095,9 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
 
   auto getL1TileSizes = [&]() -> SmallVector<int64_t> {
     auto lhsShape =
-        mmt4dOp.getInputs()[0].getType().cast<ShapedType>().getShape();
+        llvm::cast<ShapedType>(mmt4dOp.getInputs()[0].getType()).getShape();
     auto rhsShape =
-        mmt4dOp.getInputs()[1].getType().cast<ShapedType>().getShape();
+        llvm::cast<ShapedType>(mmt4dOp.getInputs()[1].getType()).getShape();
     int M0 = lhsShape[2];
     int N0 = rhsShape[2];
     int K0 = lhsShape[3];

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
@@ -51,7 +51,7 @@ static LogicalResult checkStackAllocationSize(func::FuncOp funcOp) {
           "function");
     }
     int allocaSize = 1;
-    auto allocaType = allocaOp.getType().cast<ShapedType>();
+    auto allocaType = llvm::cast<ShapedType>(allocaOp.getType());
     for (auto dimSize : allocaType.getShape()) {
       if (ShapedType::isDynamic(dimSize)) continue;
       allocaSize *= dimSize;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -82,9 +82,9 @@ static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
   Value lhs = op.getDpsInputOperand(0)->get();
   Value rhs = op.getDpsInputOperand(1)->get();
   Value out = op.getDpsInitOperand(0)->get();
-  auto lhsType = lhs.getType().cast<ShapedType>();
-  auto rhsType = rhs.getType().cast<ShapedType>();
-  auto outType = out.getType().cast<ShapedType>();
+  auto lhsType = llvm::cast<ShapedType>(lhs.getType());
+  auto rhsType = llvm::cast<ShapedType>(rhs.getType());
+  auto outType = llvm::cast<ShapedType>(out.getType());
   Type lhsElemType = lhsType.getElementType();
   Type rhsElemType = rhsType.getElementType();
   Type outElemType = outType.getElementType();
@@ -142,8 +142,8 @@ static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
     RewriterBase &rewriter, tensor::PackOp op) {
   Value in = op.getSource();
   Value out = op.getDest();
-  auto inType = in.getType().cast<ShapedType>();
-  auto outType = out.getType().cast<ShapedType>();
+  auto inType = llvm::cast<ShapedType>(in.getType());
+  auto outType = llvm::cast<ShapedType>(out.getType());
   Type inElemType = inType.getElementType();
   Type outElemType = outType.getElementType();
   uint32_t flags = 0;
@@ -254,8 +254,8 @@ static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
     RewriterBase &rewriter, tensor::UnPackOp op) {
   Value in = op.getSource();
   Value out = op.getDest();
-  auto inType = in.getType().cast<ShapedType>();
-  auto outType = out.getType().cast<ShapedType>();
+  auto inType = llvm::cast<ShapedType>(in.getType());
+  auto outType = llvm::cast<ShapedType>(out.getType());
   Type inElemType = inType.getElementType();
   Type outElemType = outType.getElementType();
   uint32_t flags = 0;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorization.cpp
@@ -132,8 +132,8 @@ static FailureOr<SmallVector<int64_t>> inferVectorSizesFromIR(
     unsigned firstOperandDim = operandDimPairs[0].second;
 
     // Trivial case: `dim` size is available in the operand type.
-    int64_t dimSize =
-        firstOperand.getType().cast<ShapedType>().getShape()[firstOperandDim];
+    int64_t dimSize = llvm::cast<ShapedType>(firstOperand.getType())
+                          .getShape()[firstOperandDim];
     if (!ShapedType::isDynamic(dimSize)) {
       vectorSizes.push_back(dimSize);
       LLVM_DEBUG(VEC_DBGS() << "Inferred vector size '" << dimSize

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -115,8 +115,8 @@ static bool matchMMT(vector::ContractionOp contractionOp, int64_t mSize,
   if (!isMatrixTimesMatrixTransposed(contractionOp)) {
     return false;
   }
-  VectorType lhsType = contractionOp.getLhs().getType().cast<VectorType>();
-  VectorType rhsType = contractionOp.getRhs().getType().cast<VectorType>();
+  VectorType lhsType = llvm::cast<VectorType>(contractionOp.getLhs().getType());
+  VectorType rhsType = llvm::cast<VectorType>(contractionOp.getRhs().getType());
   auto lhsShape = lhsType.getShape();
   auto rhsShape = rhsType.getShape();
   if (lhsShape[1] != kSize || rhsShape[1] != kSize) {
@@ -146,7 +146,7 @@ static bool matchMMT(vector::ContractionOp contractionOp, int64_t mSize,
 static Value getUnpromotedInput(Type unpromotedType, Type promotedType,
                                 Value promotedResult) {
   VectorType promotedResultVectorType =
-      promotedResult.getType().cast<VectorType>();
+      llvm::cast<VectorType>(promotedResult.getType());
   if (promotedResultVectorType.getElementType() != promotedType) {
     return nullptr;
   }
@@ -160,7 +160,7 @@ static Value getUnpromotedInput(Type unpromotedType, Type promotedType,
     return nullptr;
   }
   Value extInput = extSIOp.getIn();
-  if (extInput.getType().cast<VectorType>().getElementType() !=
+  if (llvm::cast<VectorType>(extInput.getType()).getElementType() !=
       unpromotedType) {
     return nullptr;
   }
@@ -181,7 +181,7 @@ static Value extract1DSlice(PatternRewriter &rewriter, Location loc,
 // Helper to extract an element of a 1D vector.
 static Value extract(PatternRewriter &rewriter, Location loc, Value input,
                      int position) {
-  VectorType vectorType = input.getType().cast<VectorType>();
+  VectorType vectorType = llvm::cast<VectorType>(input.getType());
   assert(vectorType.getRank() == 1);
   (void)vectorType;
   std::array<int64_t, 1> offsets{position};
@@ -190,7 +190,7 @@ static Value extract(PatternRewriter &rewriter, Location loc, Value input,
 
 // Helper to flatten a N-dimensional vector to a 1D vector.
 static Value flatten(PatternRewriter &rewriter, Location loc, Value vector) {
-  VectorType inputVecType = vector.getType().cast<VectorType>();
+  VectorType inputVecType = llvm::cast<VectorType>(vector.getType());
   VectorType dstType = VectorType::get(inputVecType.getNumElements(),
                                        inputVecType.getElementType());
   return rewriter.create<vector::ShapeCastOp>(loc, dstType, vector);
@@ -854,7 +854,7 @@ class MMTKernelGenerator {
     // the constraints string. Not confusing at all!
     inputs.append(lhs.begin(), lhs.end());
     for (const auto &v : rhs) {
-      if (v.getType().cast<VectorType>().getNumElements() == 1)
+      if (llvm::cast<VectorType>(v.getType()).getNumElements() == 1)
         inputs.push_back(extract(rewriter, loc, v, 0));
       else
         inputs.push_back(v);
@@ -923,7 +923,8 @@ class MMTCustomKernelPattern : public OpRewritePattern<vector::ContractionOp> {
     Type lhsElemType = generator.getLhsType();
     Type rhsElemType = generator.getRhsType();
     Type accElemType = generator.getAccType();
-    VectorType accType = contractionOp.getAcc().getType().cast<VectorType>();
+    VectorType accType =
+        llvm::cast<VectorType>(contractionOp.getAcc().getType());
     if (accType.getElementType() != accElemType) {
       return failure();
     }
@@ -1032,7 +1033,7 @@ struct MMT_8x4x8_i8i8i32_Aarch64Dotprod_Intrinsics
     auto acc = contractionOp.getAcc();
     auto lhs = contractionOp.getLhs();
     auto rhs = contractionOp.getRhs();
-    if (acc.getType().cast<VectorType>().getElementType() != I32Type) {
+    if (llvm::cast<VectorType>(acc.getType()).getElementType() != I32Type) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -101,7 +101,7 @@ struct ScalarizeMathOp : public OpRewritePattern<MathOpTy> {
 
   LogicalResult matchAndRewrite(MathOpTy mathOp,
                                 PatternRewriter &rewriter) const override {
-    auto vecType = mathOp.getType().template dyn_cast<VectorType>();
+    auto vecType = llvm::dyn_cast<VectorType>(mathOp.getType());
     if (!vecType) return failure();
     Location loc = mathOp.getLoc();
     Value newVector = rewriter.create<arith::ConstantOp>(
@@ -147,7 +147,7 @@ struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
     } else {
       // If no alignment specified align at least to the size of an element.
       Type elType = allocOp.getType().getElementType();
-      if (auto shapeType = elType.dyn_cast<ShapedType>())
+      if (auto shapeType = llvm::dyn_cast<ShapedType>(elType))
         alignement =
             shapeType.getNumElements() * shapeType.getElementTypeBitWidth() / 8;
       else
@@ -333,7 +333,7 @@ class ConvertIREEBindingSubspanOp : public ConvertToLLVMPattern {
     IREE::HAL::InterfaceBindingSubspanOpAdaptor adaptor(
         operands, op->getAttrDictionary());
     MemRefType memrefType =
-        subspanOp.getResult().getType().dyn_cast<MemRefType>();
+        llvm::dyn_cast<MemRefType>(subspanOp.getResult().getType());
     mlir::BlockArgument llvmBufferArg = llvmFuncOp.getArgument(
         argMapping[SetBinding(subspanOp.getSet(), subspanOp.getBinding())]);
     // As a convention with HAL all the kernel argument pointers are 16Bytes

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -46,7 +46,7 @@ struct DropSharedMemoryDeallocOp : public OpRewritePattern<memref::DeallocOp> {
   LogicalResult matchAndRewrite(memref::DeallocOp op,
                                 PatternRewriter &rewriter) const override {
     if (!hasSharedMemoryAddressSpace(
-            op.getMemref().getType().cast<MemRefType>()))
+            llvm::cast<MemRefType>(op.getMemref().getType())))
       return failure();
     rewriter.eraseOp(op);
     return success();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -100,7 +100,7 @@ static LogicalResult verifyEntryPoint(
   if (workgroupSizeAttr.has_value()) {
     std::array<int64_t, 3> workgroupSizes;
     for (auto [index, attr] : llvm::enumerate(workgroupSizeAttr.value())) {
-      workgroupSizes[index] = attr.cast<IntegerAttr>().getInt();
+      workgroupSizes[index] = llvm::cast<IntegerAttr>(attr).getInt();
     }
     return verifyLoweringConfiguration(moduleOp, translationInfo,
                                        workgroupSizes, verifyGPUMatmulPipeline);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorPad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorPad.cpp
@@ -99,7 +99,8 @@ static FailureOr<SmallVector<Value>> rewriteAsPaddedOp(
   paddedSubviewResults.reserve(paddedOp->getNumResults());
   for (const auto &[resultNumber, paddedResult] :
        llvm::enumerate(paddedOp->getResults())) {
-    int64_t rank = paddedResult.getType().cast<RankedTensorType>().getRank();
+    int64_t rank =
+        llvm::cast<RankedTensorType>(paddedResult.getType()).getRank();
     SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
     SmallVector<OpFoldResult> sizes;
     for (OpFoldResult v : reifiedResultShapes[resultNumber]) sizes.push_back(v);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -216,8 +216,9 @@ struct LLVMGPUTileAndDistributePass
     });
 
     auto workgroupSize = llvm::to_vector<4>(llvm::map_range(
-        getEntryPoint(funcOp)->getWorkgroupSize().value(),
-        [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
+        getEntryPoint(funcOp)->getWorkgroupSize().value(), [&](Attribute attr) {
+          return llvm::cast<IntegerAttr>(attr).getInt();
+        }));
 
     int64_t flatWorkgroupSize =
         workgroupSize[0] * workgroupSize[1] * workgroupSize[2];

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -62,10 +62,10 @@ static LogicalResult gpuDeallocationFn(OpBuilder &builder, Location loc,
 static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
                                Value to) {
   bool needsBarrier = false;
-  if (hasSharedMemoryAddressSpace(from.getType().cast<MemRefType>())) {
+  if (hasSharedMemoryAddressSpace(llvm::cast<MemRefType>(from.getType()))) {
     needsBarrier = true;
   }
-  if (hasSharedMemoryAddressSpace(to.getType().cast<MemRefType>())) {
+  if (hasSharedMemoryAddressSpace(llvm::cast<MemRefType>(to.getType()))) {
     needsBarrier = true;
   }
   if (needsBarrier) builder.create<gpu::BarrierOp>(loc);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -321,7 +321,7 @@ transform_dialect::VectorToWarpExecuteOnLane0Op::applyToOne(
               "--- the transform is not applied";
   }
 
-  int64_t workgroupSizeX = (*maybeAttr)[0].cast<IntegerAttr>().getInt();
+  int64_t workgroupSizeX = llvm::cast<IntegerAttr>((*maybeAttr)[0]).getInt();
   int64_t warpSize = getWarpSize();
   if (workgroupSizeX % warpSize != 0) {
     // Return a silenceable failure and set the expected 1 result to
@@ -380,7 +380,7 @@ static Value allocateGlobalSharedMemory(Location loc, OpBuilder &builder,
   MemRefType memrefType;
   auto addressSpaceAttr = gpu::AddressSpaceAttr::get(
       builder.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
-  if (auto vectorType = type.dyn_cast<VectorType>()) {
+  if (auto vectorType = llvm::dyn_cast<VectorType>(type)) {
     memrefType =
         MemRefType::get(vectorType.getShape(), vectorType.getElementType(),
                         MemRefLayoutAttrInterface{}, addressSpaceAttr);
@@ -518,7 +518,7 @@ static void populateMultiReductionLoweringPatterns(Operation *target,
 
 static AffineMap simpleDistributionFunction(Value val) {
   AffineMap map = AffineMap::get(val.getContext());
-  auto vecType = val.getType().dyn_cast<VectorType>();
+  auto vecType = llvm::dyn_cast<VectorType>(val.getType());
   if (!vecType) return map;
   // Create a map (d0, d1) -> (d1) to distribute along the inner
   // dimension. Once we support n-d distribution we can add more

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -107,8 +107,8 @@ LogicalResult verifyGPUMatmulPipeline(
          "supported yet in IREE Codegen.");
 
   // Get lhs and rhs shapes.
-  ArrayRef<int64_t> lhsShape = lhsType.cast<ShapedType>().getShape();
-  ArrayRef<int64_t> rhsShape = rhsType.cast<ShapedType>().getShape();
+  ArrayRef<int64_t> lhsShape = llvm::cast<ShapedType>(lhsType).getShape();
+  ArrayRef<int64_t> rhsShape = llvm::cast<ShapedType>(rhsType).getShape();
 
   // Tile shapes in number of elements.
   SmallVector<int64_t> tileShape =
@@ -199,9 +199,9 @@ LogicalResult verifyGPUMatmulPipeline(
 
   // Instruction shape in number of elements in M, N, and K dim.
   SmallVector<int64_t> instructionShape;
-  if (failed(getInstructionShape(op, pipeline,
-                                 lhsType.cast<ShapedType>().getElementType(),
-                                 instructionShape))) {
+  if (failed(getInstructionShape(
+          op, pipeline, llvm::cast<ShapedType>(lhsType).getElementType(),
+          instructionShape))) {
     return failure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -47,7 +47,8 @@ static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
   const int subgroupSize = limits.getSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 8};
   std::array<int64_t, 3> threadMNK;
-  auto inputType = op.getDpsInputOperand(0)->get().getType().cast<ShapedType>();
+  auto inputType =
+      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
   if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
     threadMNK = {8, 8, 32};
   } else {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
@@ -26,7 +26,8 @@ static LogicalResult setAdrenoMatmulConfig(linalg::LinalgOp op,
   const int subgroupSize = limits.getSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 2};
   std::array<int64_t, 3> threadMNK;
-  auto inputType = op.getDpsInputOperand(0)->get().getType().cast<ShapedType>();
+  auto inputType =
+      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
   if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
     threadMNK = {16, 8, 8};
   } else {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
@@ -26,7 +26,8 @@ static LogicalResult setAppleMatmulConfig(linalg::LinalgOp op,
                                           spirv::ResourceLimitsAttr limits) {
   const std::array<int64_t, 2> workgroupXY = {256, 1};
   std::array<int64_t, 3> threadMNK;
-  auto inputType = op.getDpsInputOperand(0)->get().getType().cast<ShapedType>();
+  auto inputType =
+      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
   if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
     threadMNK = {4, 8, 8};
   } else {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -292,8 +292,8 @@ struct RemoveStaticDynamicCast final : public OpRewritePattern<memref::CastOp> {
 
   LogicalResult matchAndRewrite(memref::CastOp castOp,
                                 PatternRewriter &rewriter) const override {
-    auto srcType = castOp.getSource().getType().cast<MemRefType>();
-    auto dstType = castOp.getType().cast<MemRefType>();
+    auto srcType = llvm::cast<MemRefType>(castOp.getSource().getType());
+    auto dstType = llvm::cast<MemRefType>(castOp.getType());
     if (srcType.getRank() == 1 && dstType.getRank() == 1 &&
         srcType.hasStaticShape() != dstType.hasStaticShape()) {
       rewriter.replaceOp(castOp, castOp.getSource());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -27,7 +27,7 @@ static LogicalResult setMaliMatmulConfig(linalg::LinalgOp op,
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 2};
   std::array<int64_t, 3> threadMNK;
   Type inputType = op.getDpsInputOperand(0)->get().getType();
-  Type elementType = inputType.cast<ShapedType>().getElementType();
+  Type elementType = llvm::cast<ShapedType>(inputType).getElementType();
   if (elementType.getIntOrFloatBitWidth() == 16) {
     threadMNK = {2, 8, 8};
   } else if (elementType.isInteger(8)) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -44,7 +44,8 @@ static LogicalResult setNVIDIAMatmulConfig(linalg::LinalgOp op,
   const int subgroupSize = limits.getSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize, 8};
   std::array<int64_t, 3> threadMNK;
-  auto inputType = op.getDpsInputOperand(0)->get().getType().cast<ShapedType>();
+  auto inputType =
+      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
   if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
     threadMNK = {8, 8, 32};
   } else {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -93,8 +93,8 @@ static LogicalResult gpuDeallocationFn(OpBuilder &builder, Location loc,
 
 static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
                                Value to) {
-  auto fromType = from.getType().cast<MemRefType>();
-  auto toType = to.getType().cast<MemRefType>();
+  auto fromType = llvm::cast<MemRefType>(from.getType());
+  auto toType = llvm::cast<MemRefType>(to.getType());
 
   bool needsBarrier = hasSharedMemoryAddressSpace(fromType) ||
                       hasSharedMemoryAddressSpace(toType);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -74,7 +74,7 @@ struct ConvertHalInterfaceBindingSubspan final
 
 // Tries to flatten `type` to a 1-D vector type. Returns `nullptr` on failure.
 static VectorType flattenVectorType(Type type) {
-  auto vecTy = type.dyn_cast<VectorType>();
+  auto vecTy = llvm::dyn_cast<VectorType>(type);
   if (!vecTy) return nullptr;
 
   if (vecTy.isScalable() || vecTy.getRank() <= 1) return nullptr;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
@@ -35,10 +35,10 @@ class EraseStorageBufferStaticShapePass final
 /// buffer.
 bool is1DStaticShapedStorageBuffer(
     IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
-  auto type = subspanOp.getType().dyn_cast<MemRefType>();
+  auto type = llvm::dyn_cast<MemRefType>(subspanOp.getType());
   if (!type) return false;
-  auto attr =
-      type.getMemorySpace().dyn_cast_or_null<IREE::HAL::DescriptorTypeAttr>();
+  auto attr = llvm::dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(
+      type.getMemorySpace());
   if (!attr) return false;
   return type.hasStaticShape() && type.getRank() == 1 &&
          attr.getValue() == IREE::HAL::DescriptorType::StorageBuffer;
@@ -70,7 +70,7 @@ IREE::HAL::InterfaceBindingSubspanOp rewriteStorageBufferSubspanOp(
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(subspanOp);
 
-  auto oldType = subspanOp.getType().cast<MemRefType>();
+  auto oldType = llvm::cast<MemRefType>(subspanOp.getType());
   auto newType =
       MemRefType::get({ShapedType::kDynamic}, oldType.getElementType(),
                       oldType.getLayout(), oldType.getMemorySpace());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -98,7 +98,7 @@ static LogicalResult verifyEntryPoint(
 
   std::array<int64_t, 3> workgroupSizes;
   for (auto [index, attr] : llvm::enumerate(workgroupSizeAttr.value())) {
-    workgroupSizes[index] = attr.cast<IntegerAttr>().getInt();
+    workgroupSizes[index] = llvm::cast<IntegerAttr>(attr).getInt();
   }
 
   switch (translationInfo.getDispatchLoweringPassPipeline()) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMapMemRefStorageClass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMapMemRefStorageClass.cpp
@@ -24,7 +24,8 @@ namespace {
 
 std::optional<spirv::StorageClass> mapHALDescriptorTypeForVulkan(
     Attribute attr) {
-  if (auto dtAttr = attr.dyn_cast_or_null<IREE::HAL::DescriptorTypeAttr>()) {
+  if (auto dtAttr =
+          llvm::dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(attr)) {
     switch (dtAttr.getValue()) {
       case IREE::HAL::DescriptorType::UniformBuffer:
         return spirv::StorageClass::Uniform;
@@ -34,7 +35,7 @@ std::optional<spirv::StorageClass> mapHALDescriptorTypeForVulkan(
         return std::nullopt;
     }
   }
-  if (auto gpuAttr = attr.dyn_cast_or_null<gpu::AddressSpaceAttr>()) {
+  if (auto gpuAttr = llvm::dyn_cast_if_present<gpu::AddressSpaceAttr>(attr)) {
     switch (gpuAttr.getValue()) {
       case gpu::AddressSpace::Workgroup:
         return spirv::StorageClass::Workgroup;
@@ -47,7 +48,8 @@ std::optional<spirv::StorageClass> mapHALDescriptorTypeForVulkan(
 
 std::optional<spirv::StorageClass> mapHALDescriptorTypeForOpenCL(
     Attribute attr) {
-  if (auto dtAttr = attr.dyn_cast_or_null<IREE::HAL::DescriptorTypeAttr>()) {
+  if (auto dtAttr =
+          llvm::dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(attr)) {
     switch (dtAttr.getValue()) {
       case IREE::HAL::DescriptorType::UniformBuffer:
         return spirv::StorageClass::Uniform;
@@ -55,7 +57,7 @@ std::optional<spirv::StorageClass> mapHALDescriptorTypeForOpenCL(
         return spirv::StorageClass::CrossWorkgroup;
     }
   }
-  if (auto gpuAttr = attr.dyn_cast_or_null<gpu::AddressSpaceAttr>()) {
+  if (auto gpuAttr = llvm::dyn_cast_if_present<gpu::AddressSpaceAttr>(attr)) {
     switch (gpuAttr.getValue()) {
       case gpu::AddressSpace::Workgroup:
         return spirv::StorageClass::Workgroup;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -199,7 +199,7 @@ void SPIRVTileAndPromotePass::runOnOperation() {
 
   auto workgroupSize = llvm::to_vector<4>(llvm::map_range(
       exportOp->getWorkgroupSize().value(),
-      [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
+      [&](Attribute attr) { return llvm::cast<IntegerAttr>(attr).getInt(); }));
   int64_t totalThreads = workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
   std::optional<int> subgroupSize = getSPIRVSubgroupSize(funcOp);
   if (!subgroupSize) {
@@ -317,7 +317,7 @@ LogicalResult SPIRVTileAndPromotePass::doPromoteCMatrix(
   auto genericOp = cast<linalg::GenericOp>(*linalgOps.back());
 
   auto matmulType =
-      matmulOp.getDpsInitOperand(0)->get().getType().cast<MemRefType>();
+      llvm::cast<MemRefType>(matmulOp.getDpsInitOperand(0)->get().getType());
   if (hasSharedMemoryAddressSpace(matmulType)) {
     // The matmul output is already in shared memory. This can happen when
     // bufferization decides an allocation is needed, e.g., matmul + arith.extf,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -161,7 +161,7 @@ std::optional<SmallVector<int64_t>> getExtOpVectorShape(
   for (Operation *users : op->getUsers()) {
     auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
     if (!extract) return std::nullopt;
-    auto vecType = extract.getResult().getType().cast<VectorType>();
+    auto vecType = llvm::cast<VectorType>(extract.getResult().getType());
     if (!llvm::equal(sliceType.getShape(), vecType.getShape()))
       return std::nullopt;
   }
@@ -180,7 +180,7 @@ std::optional<SmallVector<int64_t>> getCooperativeOpVectorShape(
 
   // Unroll elementwise ops according to native cooperative matrix size.
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
-    if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>())
+    if (auto vecType = llvm::dyn_cast<VectorType>(op->getResultTypes()[0]))
       return llvm::to_vector(nativeShape.drop_back());  // Drop K dim size
   }
 
@@ -218,7 +218,7 @@ std::optional<SmallVector<int64_t>> getCooperativeOpVectorShape(
     for (Operation *users : sourceOp->getUsers()) {
       auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
       if (!extract) return std::nullopt;
-      auto vecType = extract.getResult().getType().cast<VectorType>();
+      auto vecType = llvm::cast<VectorType>(extract.getResult().getType());
       if (sliceType && sliceType != vecType) return std::nullopt;
       sliceType = vecType;
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -227,7 +227,7 @@ SmallVector<int64_t> getNativeVectorShapeImpl(vector::GatherOp op) {
 std::optional<SmallVector<int64_t>> getNativeVectorShape(
     Operation *op, bool targetSupportsDotProd) {
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
-    if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>()) {
+    if (auto vecType = llvm::dyn_cast<VectorType>(op->getResultTypes()[0])) {
       SmallVector<int64_t> nativeSize(vecType.getRank(), 1);
       nativeSize.back() = getComputeVectorSize(vecType.getShape().back());
       return nativeSize;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
@@ -94,9 +94,9 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
   }
 
   ArrayRef<int64_t> lhsShape =
-      op->getOperand(0).getType().cast<ShapedType>().getShape();
+      llvm::cast<ShapedType>(op->getOperand(0).getType()).getShape();
   ArrayRef<int64_t> rhsShape =
-      op->getOperand(1).getType().cast<ShapedType>().getShape();
+      llvm::cast<ShapedType>(op->getOperand(1).getType()).getShape();
 
   SmallVector<int64_t> workgroupTileSizes =
       loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
@@ -220,9 +220,9 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
   }
 
   ArrayRef<int64_t> lhsShape =
-      op->getOperand(0).getType().cast<ShapedType>().getShape();
+      llvm::cast<ShapedType>(op->getOperand(0).getType()).getShape();
   ArrayRef<int64_t> rhsShape =
-      op->getOperand(1).getType().cast<ShapedType>().getShape();
+      llvm::cast<ShapedType>(op->getOperand(1).getType()).getShape();
 
   SmallVector<int64_t> workgroupTileSizes =
       loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
@@ -244,7 +244,7 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
   }
 
   auto getElementType = [](Value v) {
-    return v.getType().cast<ShapedType>().getElementType();
+    return llvm::cast<ShapedType>(v.getType()).getElementType();
   };
 
   Type lhsType = getElementType(op->getOperand(0));
@@ -340,7 +340,7 @@ LogicalResult verifySPIRVBaseVectorizePassPipeline(
   }
 
   ArrayRef<int64_t> outputShape =
-      op->getOperand(2).getType().cast<ShapedType>().getShape();
+      llvm::cast<ShapedType>(op->getOperand(2).getType()).getShape();
   const int64_t oh = outputShape[1], ow = outputShape[2], oc = outputShape[3];
 
   // Verify the first level tile size divides the Convolution

--- a/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
@@ -42,7 +42,7 @@ static bool affineMinOpDivisible(affine::AffineMinOp minOp, int64_t dividend) {
   Value step;
   // Check if any of the dimensions is a ForOp or ParallelOp induction variable.
   for (auto dim : minOp.getDimOperands()) {
-    auto ivArg = dim.dyn_cast<BlockArgument>();
+    auto ivArg = llvm::dyn_cast<BlockArgument>(dim);
     if (!ivArg) continue;
     Operation *containingOp = ivArg.getOwner()->getParentOp();
     auto forOp = dyn_cast_or_null<scf::ForOp>(containingOp);

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -403,9 +403,8 @@ namespace {
 // TODO(antigainst): enable dynamic shape support once they are needed.
 template <typename TensorReshapeOp>
 static std::optional<Value> getStaticReshapeOpSrc(TensorReshapeOp reshapeOp) {
-  auto reshapeSrcType =
-      reshapeOp.getSrc().getType().template cast<ShapedType>();
-  auto reshapeDstType = reshapeOp.getType().template cast<ShapedType>();
+  auto reshapeSrcType = llvm::cast<ShapedType>(reshapeOp.getSrc().getType());
+  auto reshapeDstType = llvm::cast<ShapedType>(reshapeOp.getType());
   if (!reshapeSrcType.hasStaticShape() || !reshapeDstType.hasStaticShape())
     return std::nullopt;
   return reshapeOp.getSrc();
@@ -457,9 +456,9 @@ struct FoldReshapeIntoInterfaceTensorLoad : OpRewritePattern<TensorReshapeOp> {
     if (!subspanOp) return failure();
     assert(subspanOp.getDynamicDims().empty());
 
-    auto tensorAccess = subspanOp.getType()
-                            .template cast<IREE::Flow::DispatchTensorType>()
-                            .getAccess();
+    auto tensorAccess =
+        llvm::cast<IREE::Flow::DispatchTensorType>(subspanOp.getType())
+            .getAccess();
     auto newSubspanType = IREE::Flow::DispatchTensorType::get(
         tensorAccess, reshapeOp.getResultType());
 
@@ -528,9 +527,9 @@ struct FoldReshapeIntoInterfaceTensorStore
     if (!subspanOp) return failure();
     assert(subspanOp.getDynamicDims().empty());
 
-    auto tensorAccess = subspanOp.getType()
-                            .template cast<IREE::Flow::DispatchTensorType>()
-                            .getAccess();
+    auto tensorAccess =
+        llvm::cast<IREE::Flow::DispatchTensorType>(subspanOp.getType())
+            .getAccess();
     auto newSubspanType = IREE::Flow::DispatchTensorType::get(
         tensorAccess, reshapeSrc->getType());
 
@@ -711,10 +710,9 @@ void packAllocs(OpBuilder &builder, func::FuncOp funcOp,
     }
     maxAlloc = std::max(maxAlloc, allocSize);
   }
-  Attribute memorySpace = aliasGroups[0][0]
-                              ->getResultTypes()[0]
-                              .cast<MemRefType>()
-                              .getMemorySpace();
+  Attribute memorySpace =
+      llvm::cast<MemRefType>(aliasGroups[0][0]->getResultTypes()[0])
+          .getMemorySpace();
   MemRefType allocType = MemRefType::get({maxAlloc}, builder.getI8Type(),
                                          AffineMap(), memorySpace);
   Value packedAlloc =

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
@@ -161,14 +161,14 @@ static void replaceEntryPointUses(
             if (attr == oldAttr) {
               // Found old->new replacement.
               return {newAttr, WalkResult::skip()};
-            } else if (attr.isa<SymbolRefAttr>()) {
+            } else if (llvm::isa<SymbolRefAttr>(attr)) {
               // Don't recurse into symbol refs - we only want to match roots.
               return {attr, WalkResult::skip()};
             }
             // Non-symbol ref attr.
             return {attr, WalkResult::advance()};
           });
-      use.getUser()->setAttrs(newDict.cast<DictionaryAttr>());
+      use.getUser()->setAttrs(llvm::cast<DictionaryAttr>(newDict));
     }
   };
   replaceSymbolRefs(moduleOp, symbolReplacements.exportRefs);

--- a/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
@@ -167,7 +167,7 @@ class StridedBufferAnalysis {
   bool isValid() { return true; }
 
   // Gets the type of the buffer being analyzed.
-  MemRefType getType() { return buffer.getType().cast<MemRefType>(); }
+  MemRefType getType() { return llvm::cast<MemRefType>(buffer.getType()); }
 
   // Gets the rank of the buffer being analyzed.
   unsigned getRank() { return getType().getRank(); }
@@ -187,7 +187,7 @@ class StridedBufferAnalysis {
 
     Location loc = buffer.getLoc();
     desc = StridedBufferDescriptor();
-    desc->memRefType = buffer.getType().cast<MemRefType>();
+    desc->memRefType = llvm::cast<MemRefType>(buffer.getType());
 
     int rank = getType().getRank();
     SmallVector<Type> sizeStrideTypes;
@@ -543,9 +543,9 @@ struct LinalgBinaryGenericConversion
       return failure();
     }
     BlockArgument operandScalar0 =
-        binaryOp->getOperands()[0].dyn_cast<BlockArgument>();
+        llvm::dyn_cast<BlockArgument>(binaryOp->getOperands()[0]);
     BlockArgument operandScalar1 =
-        binaryOp->getOperands()[1].dyn_cast<BlockArgument>();
+        llvm::dyn_cast<BlockArgument>(binaryOp->getOperands()[1]);
     if (!operandScalar0 || !operandScalar1) return failure();
 
     // Construct the emitter and start lowering.
@@ -718,7 +718,7 @@ struct LinalgUnaryGenericConversion
       return failure();
     }
     BlockArgument operandScalar0 =
-        unaryOp->getOperands()[0].dyn_cast<BlockArgument>();
+        llvm::dyn_cast<BlockArgument>(unaryOp->getOperands()[0]);
     if (!operandScalar0) return failure();
 
     // Construct the emitter and start lowering.
@@ -831,7 +831,7 @@ struct LinalgTrivialGenericConversion
     Operation &yieldOp = children.front();
     for (auto [outputIndex, yieldOperand] :
          llvm::enumerate(yieldOp.getOperands())) {
-      if (auto blockArg = yieldOperand.dyn_cast<BlockArgument>()) {
+      if (auto blockArg = llvm::dyn_cast<BlockArgument>(yieldOperand)) {
         unsigned inputIndex = blockArg.getArgNumber();
         OpOperand *input = op.getDpsInputOperand(inputIndex);
         OpOperand *output = op.getDpsInitOperand(outputIndex);

--- a/compiler/src/iree/compiler/Codegen/WGSL/WGSLReplacePushConstants.cpp
+++ b/compiler/src/iree/compiler/Codegen/WGSL/WGSLReplacePushConstants.cpp
@@ -40,7 +40,7 @@ static Value convertOpTypeFromI32(IREE::HAL::InterfaceConstantLoadOp loadOp,
   unsigned destBitWidth = opType.getIntOrFloatBitWidth();
 
   // AnySignlessInteger
-  if (opType.isa<IntegerType>()) {
+  if (llvm::isa<IntegerType>(opType)) {
     if (sourceBitWidth > destBitWidth) {
       return builder.create<arith::TruncIOp>(loc, opType, extractElementOp);
     } else if (sourceBitWidth < destBitWidth) {

--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -160,8 +160,8 @@ bool CompiledBinary::isSupportedResultType(Type type) {
   // TODO(laurenzo): Not currently supported. VMVX would need to support these
   // and today it doesn't. We could use alternative backends (LLVM CPU/etc) if
   // we wanted to handle f64, but f16 and bf16 often need special hardware.
-  if (type.isa<Float16Type>() || type.isa<BFloat16Type>() ||
-      type.isa<Float64Type>()) {
+  if (llvm::isa<Float16Type>(type) || llvm::isa<BFloat16Type>(type) ||
+      llvm::isa<Float64Type>(type)) {
     return false;
   }
 
@@ -171,12 +171,12 @@ bool CompiledBinary::isSupportedResultType(Type type) {
   }
 
   // Special support for i1.
-  if (type.isa<IntegerType>() && type.getIntOrFloatBitWidth() == 1) {
+  if (llvm::isa<IntegerType>(type) && type.getIntOrFloatBitWidth() == 1) {
     return true;
   }
 
   // Support tensors.
-  if (auto tt = type.dyn_cast<RankedTensorType>()) {
+  if (auto tt = llvm::dyn_cast<RankedTensorType>(type)) {
     return isSupportedResultType(tt.getElementType());
   }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -101,9 +101,9 @@ struct ConvertTensorCastPattern : public OpRewritePattern<tensor::CastOp> {
 
     auto loc = op.getLoc();
     Value input = op.getOperand();
-    ShapedType inputType = input.getType().dyn_cast<ShapedType>();
+    ShapedType inputType = llvm::dyn_cast<ShapedType>(input.getType());
     ShapedType resultType =
-        op.getResult().getType().dyn_cast_or_null<ShapedType>();
+        llvm::dyn_cast_if_present<ShapedType>(op.getResult().getType());
     if (!inputType || !resultType || !inputType.hasRank() ||
         !resultType.hasRank()) {
       return rewriter.notifyMatchFailure(op, "not ranked shaped types");

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
@@ -35,7 +35,7 @@ static SmallVector<int64_t, 4> getShapeFromSizes(
   return llvm::to_vector<4>(llvm::map_range(
       valueOrAttrList, [&](OpFoldResult valueOrAttr) -> int64_t {
         if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
-          return attr.cast<IntegerAttr>().getInt();
+          return llvm::cast<IntegerAttr>(attr).getInt();
         }
         return ShapedType::kDynamic;
       }));
@@ -55,7 +55,7 @@ static bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
   }
   auto getVal = [](OpFoldResult valueOrAttr, int64_t dynamicVal) -> int64_t {
     auto attr = valueOrAttr.dyn_cast<Attribute>();
-    return attr ? attr.cast<IntegerAttr>().getInt() : dynamicVal;
+    return attr ? llvm::cast<IntegerAttr>(attr).getInt() : dynamicVal;
   };
   /// To ensure contiguity, start from the least significant dimension. As long
   /// as the inner slices are "full slices", the current slice can be any offset

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -87,10 +87,10 @@ static LogicalResult verifyOpDynamicDims(Operation *op, ValueRange values,
                                          ValueRange dynamicDims) {
   unsigned requiredCount = 0;
   for (auto value : values) {
-    if (auto shapedType = value.getType().dyn_cast<ShapedType>()) {
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(value.getType())) {
       requiredCount += shapedType.getNumDynamicDims();
     } else if (auto tensorType =
-                   value.getType().dyn_cast<DispatchTensorType>()) {
+                   llvm::dyn_cast<DispatchTensorType>(value.getType())) {
       requiredCount += tensorType.getNumDynamicDims();
     }
   }
@@ -129,7 +129,7 @@ static llvm::SmallBitVector getDroppedDimsImpl(
 
 /// Returns the `hal.interface.binding` a value comes from.
 static std::optional<BlockArgument> getBindingArgument(Value v) {
-  if (BlockArgument blockArg = v.dyn_cast<BlockArgument>()) {
+  if (BlockArgument blockArg = llvm::dyn_cast<BlockArgument>(v)) {
     if (isa<IREE::Flow::DispatchWorkgroupsOp>(
             blockArg.getOwner()->getParentOp())) {
       return blockArg;
@@ -295,7 +295,7 @@ LogicalResult DispatchRegionOp::verify() {
 
   // Make sure that all returned values are ranked tensors.
   for (Type t : getResultTypes())
-    if (!t.isa<RankedTensorType>())
+    if (!llvm::isa<RankedTensorType>(t))
       return emitOpError() << "only ranked tensor results are allowed";
 
   return success();
@@ -320,7 +320,7 @@ ParseResult DispatchRegionOp::parse(OpAsmParser &parser,
     ParseResult typeListResult =
         parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, [&]() {
           if (parser.parseType(resultTypes.emplace_back())) return failure();
-          auto shapedType = resultTypes.back().dyn_cast<ShapedType>();
+          auto shapedType = llvm::dyn_cast<ShapedType>(resultTypes.back());
           if (!shapedType) return success();
           if (shapedType.hasStaticShape()) return success();
           SmallVector<OpAsmParser::UnresolvedOperand> dynamicDims;
@@ -372,7 +372,7 @@ void DispatchRegionOp::print(OpAsmPrinter &p) {
   for (const auto &it : llvm::enumerate(getResult().getTypes())) {
     Type type = it.value();
     p << type;
-    if (auto shapedType = type.dyn_cast<ShapedType>()) {
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
       if (!shapedType.hasStaticShape()) {
         p << "{";
         p << getResultDims().slice(resultDimCounter,
@@ -400,9 +400,9 @@ void DispatchRegionOp::print(OpAsmPrinter &p) {
 ValueRange DispatchRegionOp::getResultDynamicDims(unsigned idx) {
   unsigned counter = 0;
   for (unsigned i = 0; i < idx; ++i)
-    if (auto shapedType = getResultTypes()[i].dyn_cast<ShapedType>())
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(getResultTypes()[i]))
       counter += shapedType.getNumDynamicDims();
-  auto shapedType = getResultTypes()[idx].dyn_cast<ShapedType>();
+  auto shapedType = llvm::dyn_cast<ShapedType>(getResultTypes()[idx]);
   return getResultDims().slice(counter,
                                shapedType ? shapedType.getNumDynamicDims() : 0);
 }
@@ -422,7 +422,7 @@ bool dropUnusedDispatchRegionResults(RewriterBase &rewriter,
   unsigned dimOffset = 0;
   for (const auto &it : llvm::enumerate(regionOp.getResults())) {
     Type type = it.value().getType();
-    auto shapedType = type.dyn_cast<ShapedType>();
+    auto shapedType = llvm::dyn_cast<ShapedType>(type);
     if (it.value().use_empty()) {
       unusedResults.insert(it.index());
     } else {
@@ -497,7 +497,7 @@ LogicalResult DispatchTieShapeOp::reifyResultShapes(
   SmallVector<OpFoldResult> shape;
   unsigned dynamicIdx = 0;
   auto tensorType =
-      getResult().getType().cast<IREE::Flow::DispatchTensorType>();
+      llvm::cast<IREE::Flow::DispatchTensorType>(getResult().getType());
   for (int64_t dim : tensorType.getShape()) {
     if (dim == ShapedType::kDynamic) {
       shape.push_back(getDynamicDims()[dynamicIdx++]);
@@ -532,7 +532,7 @@ static void processMixedOperands(ArrayRef<OpFoldResult> valueOrAttrs,
       staticValues.push_back(dynamicIndexValue);
     } else {
       auto operandValue =
-          valueOrAttr.dyn_cast<Attribute>().cast<IntegerAttr>().getInt();
+          llvm::cast<IntegerAttr>(valueOrAttr.dyn_cast<Attribute>()).getInt();
       staticValues.push_back(operandValue);
     }
   }
@@ -571,7 +571,7 @@ RankedTensorType DispatchTensorLoadOp::inferResultType(
   auto shape = llvm::to_vector<4>(
       llvm::map_range(mixedSizes, [&](OpFoldResult valueOrAttr) -> int64_t {
         if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
-          return attr.cast<IntegerAttr>().getInt();
+          return llvm::cast<IntegerAttr>(attr).getInt();
         }
         return ShapedType::kDynamic;
       }));
@@ -588,7 +588,7 @@ void DispatchTensorLoadOp::build(OpBuilder &builder, OperationState &state,
                                  ArrayRef<NamedAttribute> attributes) {
   SmallVector<OpFoldResult> offsets, strides, sizes;
   getDefaultOffsetSizeAndStrides(
-      builder, source.getType().cast<IREE::Flow::DispatchTensorType>(),
+      builder, llvm::cast<IREE::Flow::DispatchTensorType>(source.getType()),
       sourceDynamicDims, offsets, sizes, strides);
   build(builder, state, returnType, source, sourceDynamicDims, offsets, sizes,
         strides, attributes);
@@ -625,8 +625,8 @@ void DispatchTensorLoadOp::build(OpBuilder &builder, OperationState &state,
                                  ArrayRef<OpFoldResult> mixedSizes,
                                  ArrayRef<OpFoldResult> mixedStrides,
                                  ArrayRef<NamedAttribute> attributes) {
-  auto returnType =
-      inferResultType(source.getType().cast<DispatchTensorType>(), mixedSizes);
+  auto returnType = inferResultType(
+      llvm::cast<DispatchTensorType>(source.getType()), mixedSizes);
   build(builder, state, returnType, source, sourceDynamicDims, mixedOffsets,
         mixedSizes, mixedStrides);
 }
@@ -697,7 +697,7 @@ void DispatchTensorStoreOp::build(OpBuilder &builder, OperationState &state,
                                   ArrayRef<NamedAttribute> attributes) {
   SmallVector<OpFoldResult> offsets, sizes, strides;
   getDefaultOffsetSizeAndStrides(
-      builder, target.getType().cast<IREE::Flow::DispatchTensorType>(),
+      builder, llvm::cast<IREE::Flow::DispatchTensorType>(target.getType()),
       targetDynamicDims, offsets, sizes, strides);
   build(builder, state, value, target, targetDynamicDims, offsets, sizes,
         strides, attributes);
@@ -724,7 +724,7 @@ void DispatchTensorStoreOp::build(OpBuilder &builder, OperationState &state,
 }
 
 llvm::SmallBitVector DispatchTensorStoreOp::getDroppedDims() {
-  return getDroppedDimsImpl(getValue().getType().cast<RankedTensorType>(),
+  return getDroppedDimsImpl(llvm::cast<RankedTensorType>(getValue().getType()),
                             getMixedSizes());
 }
 
@@ -782,7 +782,7 @@ void DispatchWorkgroupsOp::build(OpBuilder &builder, OperationState &state,
   }
   for (auto operand : llvm::enumerate(arguments)) {
     Type type = operand.value().getType();
-    if (auto tensorType = type.dyn_cast<RankedTensorType>()) {
+    if (auto tensorType = llvm::dyn_cast<RankedTensorType>(type)) {
       type = DispatchTensorType::get(operandAliases[operand.index()]
                                          ? TensorAccess::ReadWrite
                                          : TensorAccess::ReadOnly,
@@ -796,7 +796,7 @@ void DispatchWorkgroupsOp::build(OpBuilder &builder, OperationState &state,
       continue;
     }
     Type type = resultType.value();
-    if (auto tensorType = type.dyn_cast<RankedTensorType>()) {
+    if (auto tensorType = llvm::dyn_cast<RankedTensorType>(type)) {
       type = DispatchTensorType::get(TensorAccess::WriteOnly, tensorType);
     }
     workgroupBody->addArgument(type, state.location);
@@ -894,7 +894,7 @@ LogicalResult DispatchWorkgroupsOp::verify() {
   }
 
   auto verifyIOType = [&](Type type) -> LogicalResult {
-    if (auto shapedType = type.dyn_cast<ShapedType>()) {
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
       if (shapedType.getElementType().isIndex()) {
         return op->emitOpError() << "I/O type " << type
                                  << " is invalid: index types must not cross "
@@ -930,14 +930,14 @@ BlockArgument DispatchWorkgroupsOp::getOutputBlockArgument(unsigned idx) {
 
   // Some outputs are tied to inputs and share their block arguments.
   int64_t tiedOperand =
-      (*tiedOperands)[idx].cast<IntegerAttr>().getValue().getSExtValue();
+      llvm::cast<IntegerAttr>((*tiedOperands)[idx]).getValue().getSExtValue();
   if (tiedOperand != IREE::Util::TiedOpInterface::kUntiedIndex)
     // This output is tied to an input.
     return getInputBlockArgument(tiedOperand);
 
   unsigned nextOutArgIdx = getArguments().size();
   for (unsigned i = 0; i < idx; ++i)
-    if ((*tiedOperands)[i].cast<IntegerAttr>().getValue().getSExtValue() ==
+    if (llvm::cast<IntegerAttr>((*tiedOperands)[i]).getValue().getSExtValue() ==
         IREE::Util::TiedOpInterface::kUntiedIndex)
       nextOutArgIdx++;
   return getWorkgroupBody().getArguments()[nextOutArgIdx];
@@ -1005,7 +1005,7 @@ static TensorAccess refineTensorAccess(Value value, DispatchTensorType type) {
 IREE::Util::ValueAccess DispatchWorkgroupsOp::getOperandAccess(
     unsigned operandIndex) {
   BlockArgument arg = getWorkgroupBody().front().getArgument(operandIndex);
-  if (auto tensorType = arg.getType().dyn_cast<DispatchTensorType>()) {
+  if (auto tensorType = llvm::dyn_cast<DispatchTensorType>(arg.getType())) {
     auto tensorAccess = refineTensorAccess(arg, tensorType);
     return IREE::Util::ValueAccess(
         /*isRead=*/(tensorAccess == TensorAccess::ReadOnly) ||
@@ -1025,7 +1025,7 @@ IREE::Util::ValueAccess DispatchWorkgroupsOp::getResultAccess(
   unsigned startIndex = getBody()->getNumArguments() - getNumResults();
   BlockArgument arg =
       getWorkgroupBody().front().getArgument(startIndex + resultIndex);
-  if (auto tensorType = arg.getType().dyn_cast<DispatchTensorType>()) {
+  if (auto tensorType = llvm::dyn_cast<DispatchTensorType>(arg.getType())) {
     auto tensorAccess = refineTensorAccess(arg, tensorType);
     return IREE::Util::ValueAccess(
         /*isRead=*/(tensorAccess == TensorAccess::ReadOnly) ||
@@ -1126,7 +1126,7 @@ SmallVector<int64_t> DispatchWorkgroupsOp::getTiedOperandsAsIntegerList() {
   ArrayAttr attr = getTiedOperandsAttr();
   if (!attr) return {};
   return llvm::to_vector(llvm::map_range(attr, [](Attribute intAttr) {
-    return intAttr.cast<IntegerAttr>().getInt();
+    return llvm::cast<IntegerAttr>(intAttr).getInt();
   }));
 }
 
@@ -1427,7 +1427,7 @@ LogicalResult TensorTieShapeOp::reifyResultShapes(
     OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
   SmallVector<OpFoldResult> shape;
   unsigned dynamicIdx = 0;
-  auto tensorType = getResult().getType().cast<RankedTensorType>();
+  auto tensorType = llvm::cast<RankedTensorType>(getResult().getType());
   for (int64_t dim : tensorType.getShape()) {
     if (dim == ShapedType::kDynamic) {
       shape.push_back(getDynamicDims()[dynamicIdx++]);
@@ -1445,8 +1445,8 @@ LogicalResult TensorTieShapeOp::reifyResultShapes(
 
 LogicalResult TensorReshapeOp::verify() {
   // The element types don't need to match but the bit widths need to.
-  auto sourceType = getSource().getType().cast<ShapedType>();
-  auto resultType = getResult().getType().cast<ShapedType>();
+  auto sourceType = llvm::cast<ShapedType>(getSource().getType());
+  auto resultType = llvm::cast<ShapedType>(getResult().getType());
   if (sourceType.getElementTypeBitWidth() !=
       resultType.getElementTypeBitWidth()) {
     return emitOpError() << "element bit widths must match";

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
@@ -56,7 +56,7 @@ Type DispatchTensorType::getBoundElementType() const {
   if (boundType.isIntOrFloat()) {
     return boundType;
   }
-  return boundType.cast<RankedTensorType>().getElementType();
+  return llvm::cast<RankedTensorType>(boundType).getElementType();
 }
 
 unsigned DispatchTensorType::getBoundElementTypeBitWidth() const {
@@ -76,7 +76,7 @@ int64_t DispatchTensorType::getRank() const {
   if (boundType.isIntOrIndexOrFloat()) {
     return 0;
   }
-  return boundType.cast<RankedTensorType>().getRank();
+  return llvm::cast<RankedTensorType>(boundType).getRank();
 }
 
 bool DispatchTensorType::hasRank() const { return true; }
@@ -102,7 +102,7 @@ ArrayRef<int64_t> DispatchTensorType::getShape() const {
   if (boundType.isIntOrIndexOrFloat()) {
     return {};
   }
-  return boundType.cast<RankedTensorType>().getShape();
+  return llvm::cast<RankedTensorType>(boundType).getShape();
 }
 
 int64_t DispatchTensorType::getNumDynamicDims() const {
@@ -120,7 +120,7 @@ bool DispatchTensorType::hasStaticShape(ArrayRef<int64_t> shape) const {
 LogicalResult DispatchTensorType::verify(
     function_ref<InFlightDiagnostic()> emitError, uint32_t access,
     Type boundType) {
-  if (!boundType.isIntOrFloat() && !boundType.isa<RankedTensorType>()) {
+  if (!boundType.isIntOrFloat() && !llvm::isa<RankedTensorType>(boundType)) {
     return emitError() << "unhandled bounded type in dispatch. Must by int, "
                           "float or ranked tensor type";
   }
@@ -213,7 +213,7 @@ Type FlowDialect::parseType(DialectAsmParser &parser) const {
 }
 
 void FlowDialect::printType(Type type, DialectAsmPrinter &p) const {
-  if (auto inputType = type.dyn_cast<DispatchTensorType>()) {
+  if (auto inputType = llvm::dyn_cast<DispatchTensorType>(type)) {
     IREE::Flow::printType(inputType, p);
   } else if (failed(generatedTypePrinter(type, p))) {
     assert(false && "unknown Flow type");

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CaptureDispatchDynamicDims.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CaptureDispatchDynamicDims.cpp
@@ -52,7 +52,7 @@ static void captureDims(IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
   auto entryBuilder = OpBuilder::atBlockBegin(entryBlock);
   auto captureTensorDims = [&](Value externalValue, Value internalValue) {
     auto tensorType =
-        internalValue.getType().dyn_cast<IREE::Flow::DispatchTensorType>();
+        llvm::dyn_cast<IREE::Flow::DispatchTensorType>(internalValue.getType());
     if (!tensorType) return;
     if (tensorType.hasStaticShape()) return;
 
@@ -69,7 +69,8 @@ static void captureDims(IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
     // "writeonly" tensors corresponding to the result.
     unsigned insertionPosition = entryBlock->getNumArguments();
     for (auto argType : llvm::reverse(entryBlock->getArgumentTypes())) {
-      auto flowTensorType = argType.dyn_cast<IREE::Flow::DispatchTensorType>();
+      auto flowTensorType =
+          llvm::dyn_cast<IREE::Flow::DispatchTensorType>(argType);
       if (!flowTensorType ||
           flowTensorType.getAccess() != IREE::Flow::TensorAccess::WriteOnly) {
         break;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Convert1X1FilterConv2DToMatmul.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Convert1X1FilterConv2DToMatmul.cpp
@@ -27,18 +27,12 @@ class Convert1x1FilterConvToMatmul : public OpRewritePattern<Conv2DOpType> {
 
   LogicalResult matchAndRewrite(Conv2DOpType convOp,
                                 PatternRewriter &rewriter) const override {
-    auto inputShapeType = convOp.getDpsInputOperand(0)
-                              ->get()
-                              .getType()
-                              .template dyn_cast<RankedTensorType>();
-    auto filterShapeType = convOp.getDpsInputOperand(1)
-                               ->get()
-                               .getType()
-                               .template dyn_cast<RankedTensorType>();
-    auto outputShapeType = convOp.getDpsInitOperand(0)
-                               ->get()
-                               .getType()
-                               .template dyn_cast<RankedTensorType>();
+    auto inputShapeType = llvm::dyn_cast<RankedTensorType>(
+        convOp.getDpsInputOperand(0)->get().getType());
+    auto filterShapeType = llvm::dyn_cast<RankedTensorType>(
+        convOp.getDpsInputOperand(1)->get().getType());
+    auto outputShapeType = llvm::dyn_cast<RankedTensorType>(
+        convOp.getDpsInitOperand(0)->get().getType());
 
     const bool isNCHW = isa<linalg::Conv2DNchwFchwOp>(convOp);
     const bool isNHWC = isa<linalg::Conv2DNhwcHwcfOp>(convOp);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -27,7 +27,7 @@ namespace {
 /// Compute the dynamic dims of the given value and add them to the vector.
 static void appendDynamicDims(OpBuilder &b, Location loc,
                               SmallVector<Value> &argumentDims, Value tensor) {
-  auto tensorType = tensor.getType().cast<RankedTensorType>();
+  auto tensorType = llvm::cast<RankedTensorType>(tensor.getType());
 
   // Fast-path for if the value comes from ops that support our dynamic
   // shape interfaces. Otherwise we have to insert tensor.dim ops.
@@ -52,7 +52,7 @@ static std::optional<Value> findFirstTiedValueOutsideOfRegionOp(
     Flow::DispatchRegionOp regionOp, Value value) {
   // Check if `v` is defined outside of `regionOp`.
   auto isOutside = [&](Value v) {
-    if (v.isa<OpResult>()) return !regionOp->isAncestor(v.getDefiningOp());
+    if (llvm::isa<OpResult>(v)) return !regionOp->isAncestor(v.getDefiningOp());
     assert(v.isa<BlockArgument>() && "expected bbArg");
     // DispatchRegionOp does not have block arguments.
     return true;
@@ -104,7 +104,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   // Compute dimensions of tensor args.
   SmallVector<Value> argumentDims;
   for (Value tensor : argumentsSet) {
-    auto tensorType = tensor.getType().dyn_cast<RankedTensorType>();
+    auto tensorType = llvm::dyn_cast<RankedTensorType>(tensor.getType());
     if (!tensorType) continue;
     appendDynamicDims(rewriter, loc, argumentDims, tensor);
   }
@@ -165,7 +165,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   assert(newBody.empty() && "expected empty block after constructor");
   rewriter.setInsertionPointToStart(&newBody);
   for (const auto &it : llvm::enumerate(arguments)) {
-    auto tensorType = it.value().getType().dyn_cast<RankedTensorType>();
+    auto tensorType = llvm::dyn_cast<RankedTensorType>(it.value().getType());
     if (!tensorType) continue;
     auto inputBbArg = workgroupsOp.getInputBlockArgument(it.index());
     auto dims =

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
@@ -191,7 +191,7 @@ void replaceEntryPointUses(
     funcLikeOp->walk([&](DispatchOp dispatchOp) {
       auto it = replacements.find(dispatchOp.getEntryPoint());
       if (it != replacements.end()) {
-        dispatchOp.setEntryPointAttr(it->second.cast<SymbolRefAttr>());
+        dispatchOp.setEntryPointAttr(llvm::cast<SymbolRefAttr>(it->second));
       }
     });
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DetachElementwiseFromNamedOps.cpp
@@ -59,7 +59,7 @@ struct DetachElementwisePattern
       // If not linalg op, or is a fill op, do nothing.
       return failure();
     }
-    auto outputType = outputOperand.getType().cast<RankedTensorType>();
+    auto outputType = llvm::cast<RankedTensorType>(outputOperand.getType());
     if (!outputType.getElementType().isIntOrFloat()) return failure();
     auto elementType = outputType.getElementType();
 
@@ -103,7 +103,7 @@ struct DetachElementwisePattern
         fill, maps, iterators,
         [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
           Value result;
-          if (elementType.isa<FloatType>()) {
+          if (llvm::isa<FloatType>(elementType)) {
             result = b.create<arith::AddFOp>(nestedLoc, args[0], args[1]);
           } else {
             result = b.create<arith::AddIOp>(nestedLoc, args[0], args[1]);
@@ -144,10 +144,10 @@ struct DetachSplatConstantOutsOperands
       if (!constOp) continue;
 
       auto resultType =
-          constOp.getResult().getType().template dyn_cast<RankedTensorType>();
+          llvm::dyn_cast<RankedTensorType>(constOp.getResult().getType());
       if (!resultType || !resultType.getElementType().isIntOrFloat()) continue;
 
-      auto attr = constOp.getValue().template dyn_cast<DenseElementsAttr>();
+      auto attr = llvm::dyn_cast<DenseElementsAttr>(constOp.getValue());
       if (!attr || !attr.isSplat()) continue;
 
       Location loc = constOp.getLoc();
@@ -155,7 +155,7 @@ struct DetachSplatConstantOutsOperands
       Value emptyTensorOp = rewriter.create<tensor::EmptyOp>(
           loc, resultType.getShape(), elementType);
       TypedAttr constValue;
-      if (elementType.isa<IntegerType>()) {
+      if (llvm::isa<IntegerType>(elementType)) {
         constValue = rewriter.getIntegerAttr(
             elementType, attr.template getSplatValue<APInt>());
       } else {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
@@ -201,13 +201,13 @@ class DumpDispatchGraphPass
     int64_t largeAttrLimit = getLargeAttributeSizeLimit();
 
     // Always emit splat attributes.
-    if (attr.isa<SplatElementsAttr>()) {
+    if (llvm::isa<SplatElementsAttr>(attr)) {
       attr.print(os);
       return;
     }
 
     // Elide "big" elements attributes.
-    auto elements = attr.dyn_cast<ElementsAttr>();
+    auto elements = llvm::dyn_cast<ElementsAttr>(attr);
     if (elements && elements.getNumElements() > largeAttrLimit) {
       auto type = cast<ShapedType>(elements.getType());
       os << std::string(type.getRank(), '[') << "..."
@@ -215,7 +215,7 @@ class DumpDispatchGraphPass
       return;
     }
 
-    auto array = attr.dyn_cast<ArrayAttr>();
+    auto array = llvm::dyn_cast<ArrayAttr>(attr);
     if (array && static_cast<int64_t>(array.size()) > largeAttrLimit) {
       os << "[...]";
       return;
@@ -406,9 +406,9 @@ class DumpDispatchGraphPass
 
       if (op && isScalarConstantOp(op)) {
         auto ty = operand.getType();
-        if (ty.isa<IntegerType>()) {
+        if (llvm::isa<IntegerType>(ty)) {
           os << cast<arith::ConstantIntOp>(op).value();
-        } else if (ty.isa<FloatType>()) {
+        } else if (llvm::isa<FloatType>(ty)) {
           cast<arith::ConstantFloatOp>(op).value().print(os);
         } else {
           os << cast<arith::ConstantIndexOp>(op).value();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -117,7 +117,7 @@ static IREE::Util::GlobalOp createImportBufferViewGlobalOp(
 
   // Extract the type, which must be a static tensor.
   auto targetType = importOp.getTarget().getType();
-  auto tensorType = targetType.dyn_cast<RankedTensorType>();
+  auto tensorType = llvm::dyn_cast<RankedTensorType>(targetType);
   if (!tensorType || !tensorType.hasStaticShape()) {
     mlir::emitError(loc) << "unsupported buffer view import tensor type on "
                          << arg << " used as " << targetType;
@@ -158,7 +158,7 @@ static IREE::Util::GlobalOp createExportBufferGlobalOp(std::string name,
 
   // Extract the type, which must be a static tensor.
   auto sourceType = exportOp.getSourceEncoding();
-  auto tensorType = sourceType.dyn_cast<RankedTensorType>();
+  auto tensorType = llvm::dyn_cast<RankedTensorType>(sourceType);
   if (!tensorType || !tensorType.hasStaticShape()) {
     mlir::emitError(loc) << "unsupported buffer view export tensor type on "
                          << arg << " used as " << sourceType;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchWorkgroups.cpp
@@ -197,7 +197,7 @@ static void createDefaultWorkgroupCountRegion(
   SmallVector<Location> workloadLocs;
   for (auto argument : workgroupsOp.getArguments()) {
     Type argumentType = argument.getType();
-    if (!argumentType.isa<IndexType>()) continue;
+    if (!llvm::isa<IndexType>(argumentType)) continue;
     workload.push_back(argument);
     workloadTypes.push_back(argumentType);
     workloadLocs.push_back(argument.getLoc());
@@ -225,7 +225,7 @@ static void createDefaultWorkgroupCountRegion(
     rewriter.setInsertionPointToStart(workgroupsOp.getBody());
     int ordinalNumber = 0;
     for (auto [index, operand] : llvm::enumerate(workgroupsOp.getArguments())) {
-      if (!operand.getType().isa<IndexType>()) continue;
+      if (!llvm::isa<IndexType>(operand.getType())) continue;
       BlockArgument arg = workgroupsOp.getInputBlockArgument(index);
       auto ordinalOp = rewriter.create<Flow::DispatchWorkloadOrdinalOp>(
           loc, arg, rewriter.getIndexAttr(ordinalNumber++));

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -68,7 +68,7 @@ static bool areFusableOps(MLIRContext *context, OpOperand *fusedOperand) {
   // Check for i1 return types, if so aggressively fuse to avoid `i1` buffers.
   if (llvm::all_of(producerOp->getResultTypes(), [](Type t) {
         if (t.isInteger(1)) return true;
-        if (auto shapedType = t.dyn_cast<ShapedType>()) {
+        if (auto shapedType = llvm::dyn_cast<ShapedType>(t)) {
           if (shapedType.getElementType().isInteger(1)) return true;
         }
         return false;
@@ -192,7 +192,7 @@ static FailureOr<unsigned> fuseMultiUseProducers(Operation *funcOp,
     auto consumer = dyn_cast<linalg::GenericOp>(fusableUse.value()->getOwner());
     auto isParallelIteratorType = [](Attribute attr) {
       return linalg::isParallelIterator(
-          attr.cast<linalg::IteratorTypeAttr>().getValue());
+          llvm::cast<linalg::IteratorTypeAttr>(attr).getValue());
     };
     if (!consumer ||
         !(llvm::all_of(genericOp.getIteratorTypes(), isParallelIteratorType) &&

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
@@ -22,10 +22,10 @@ namespace Flow {
 /// Returns failure, when the type is not handled.
 static FailureOr<TypedAttr> getZero(OpBuilder &builder, Location loc,
                                     Type elementType) {
-  if (auto intType = elementType.dyn_cast<IntegerType>()) {
+  if (auto intType = llvm::dyn_cast<IntegerType>(elementType)) {
     return cast<TypedAttr>(builder.getIntegerAttr(intType, 0));
   }
-  if (auto floatType = elementType.dyn_cast<FloatType>()) {
+  if (auto floatType = llvm::dyn_cast<FloatType>(elementType)) {
     return cast<TypedAttr>(builder.getFloatAttr(floatType, 0.0));
   }
   return failure();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
@@ -23,7 +23,7 @@ namespace Flow {
 static SmallVector<Value, 4> filterTensorValues(ValueRange&& range) {
   SmallVector<Value, 4> result;
   for (auto value : range) {
-    if (value.getType().isa<TensorType>()) result.push_back(value);
+    if (llvm::isa<TensorType>(value.getType())) result.push_back(value);
   }
   return result;
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
@@ -28,7 +28,7 @@ namespace Flow {
 static SmallVector<Value, 4> filterNonTensorValues(ValueRange &&range) {
   SmallVector<Value, 4> result;
   for (auto value : range) {
-    if (value.getType().isa<TensorType>()) result.push_back(value);
+    if (llvm::isa<TensorType>(value.getType())) result.push_back(value);
   }
   return result;
 }
@@ -92,7 +92,7 @@ static LogicalResult replaceReturnWithOpResults(mlir::ModuleOp moduleOp,
   SmallVector<Value> exports;
   SmallVector<Type> newTypes;
   for (auto retVal : op->getResults()) {
-    if (retVal.getType().isa<TensorType>()) {
+    if (llvm::isa<TensorType>(retVal.getType())) {
       auto type = IREE::HAL::BufferViewType::get(context);
       auto exportOp = builder.create<IREE::HAL::TensorExportOp>(
           loc, type, retVal, TypeAttr::get(retVal.getType()), /*name=*/nullptr);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OptimizeNumerics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OptimizeNumerics.cpp
@@ -28,7 +28,7 @@ int getNextPotBitWidth(int bitWidth, int minBitWidth = 8) {
 }
 
 Type withNewElementType(Type origType, Type elementType) {
-  if (auto st = origType.dyn_cast<ShapedType>()) {
+  if (auto st = llvm::dyn_cast<ShapedType>(origType)) {
     return st.clone(elementType);
   } else {
     return elementType;
@@ -47,14 +47,15 @@ Value castNumeric(Value origValue, Type toType, bool isSigned,
   Type origElementType = getElementTypeOrSelf(origValue.getType());
   Type toElementType = getElementTypeOrSelf(toType);
 
-  if (origElementType.isa<FloatType>() && toElementType.isa<IntegerType>()) {
+  if (llvm::isa<FloatType>(origElementType) &&
+      llvm::isa<IntegerType>(toElementType)) {
     if (isSigned) {
       return builder.create<arith::FPToSIOp>(loc, toType, origValue);
     } else {
       return builder.create<arith::FPToUIOp>(loc, toType, origValue);
     }
-  } else if (origElementType.isa<IntegerType>() &&
-             toElementType.isa<FloatType>()) {
+  } else if (llvm::isa<IntegerType>(origElementType) &&
+             llvm::isa<FloatType>(toElementType)) {
     if (isSigned) {
       return builder.create<arith::SIToFPOp>(loc, toType, origValue);
     } else {
@@ -85,13 +86,19 @@ struct NarrowParams {
     return {};
   }
 
-  bool isFromFloat() { return getElementTypeOrSelf(fromType).isa<FloatType>(); }
+  bool isFromFloat() {
+    return llvm::isa<FloatType>(getElementTypeOrSelf(fromType));
+  }
 
-  bool isToInteger() { return toElementType.isa<IntegerType>(); }
+  bool isToInteger() { return llvm::isa<IntegerType>(toElementType); }
 
-  bool isToSigned() { return toElementType.cast<IntegerType>().isSigned(); }
+  bool isToSigned() {
+    return llvm::cast<IntegerType>(toElementType).isSigned();
+  }
 
-  int getToBitWidth() { return toElementType.cast<IntegerType>().getWidth(); }
+  int getToBitWidth() {
+    return llvm::cast<IntegerType>(toElementType).getWidth();
+  }
 
   Value producer;
   Type fromType;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -55,7 +55,7 @@ static TensorType getMainTensorForLinalgExtOp(Operation *op) {
   auto operandTypes = llvm::to_vector(op->getOperandTypes());
   auto resultTypes = llvm::to_vector(op->getResultTypes());
   for (Type t : llvm::concat<Type>(operandTypes, resultTypes)) {
-    auto tensorType = t.dyn_cast<TensorType>();
+    auto tensorType = llvm::dyn_cast<TensorType>(t);
     if (!tensorType) continue;
     if (!main) {
       main = tensorType;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SetEncoding.cpp
@@ -38,7 +38,7 @@ using IREE::LinalgExt::TensorEncoding;
 // Returns the element type of `t` if it is a `ShapedType`, else return
 // `t` itself.
 static Type getElementTypeOrType(Type t) {
-  if (auto shapedType = t.dyn_cast<ShapedType>()) {
+  if (auto shapedType = llvm::dyn_cast<ShapedType>(t)) {
     return shapedType.getElementType();
   }
   return t;
@@ -123,7 +123,7 @@ struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
     auto inputs = matmulOp.getDpsInputOperands();
     auto outputs = matmulOp.getDpsInitOperands();
     auto hasEncoding = [](OpOperand *operand) -> bool {
-      auto type = operand->get().getType().dyn_cast<RankedTensorType>();
+      auto type = llvm::dyn_cast<RankedTensorType>(operand->get().getType());
       return type && type.getEncoding();
     };
     if (llvm::any_of(inputs, hasEncoding) ||
@@ -136,7 +136,7 @@ struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
     Value origOut = outputs[0]->get();
 
     auto getElemType = [](Value v) -> Type {
-      if (auto tensorType = v.getType().dyn_cast<RankedTensorType>()) {
+      if (auto tensorType = llvm::dyn_cast<RankedTensorType>(v.getType())) {
         return tensorType.getElementType();
       }
       return {};
@@ -206,7 +206,7 @@ struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
     // If the output was padded, extract the actual output.
     if (paddedOut.value() != origOut) {
       auto replacementRank =
-          replacement.getType().cast<RankedTensorType>().getRank();
+          llvm::cast<RankedTensorType>(replacement.getType()).getRank();
       // Offsets are all 0.
       OpFoldResult zero = rewriter.getIndexAttr(0);
       SmallVector<OpFoldResult> offsets(replacementRank, zero);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
@@ -47,7 +47,7 @@ class StripAndSplatConstantVariablesPass
     auto getSplatAttr = [&](TensorType tensorType) {
       auto elementType = tensorType.getElementType();
       TypedAttr newAttr;
-      if (elementType.isa<FloatType>()) {
+      if (llvm::isa<FloatType>(elementType)) {
         newAttr = DenseElementsAttr::get(
             tensorType, FloatAttr::get(elementType, 1.0 / replaceIndex));
       } else {
@@ -66,9 +66,9 @@ class StripAndSplatConstantVariablesPass
         if (globalOp.getIsMutable()) return;
 
         // Only strip tensor type constants (to replace with dense<>).
-        if (!globalOp.getType().isa<TensorType>()) return;
+        if (!llvm::isa<TensorType>(globalOp.getType())) return;
 
-        auto tensorType = globalOp.getType().cast<TensorType>();
+        auto tensorType = llvm::cast<TensorType>(globalOp.getType());
         TypedAttr newValue = getSplatAttr(tensorType);
 
         builder.setInsertionPoint(globalOp);
@@ -79,9 +79,9 @@ class StripAndSplatConstantVariablesPass
         newOp->setAttr("noinline", UnitAttr::get(builder.getContext()));
         globalOp.erase();
       } else if (auto cstOp = dyn_cast<arith::ConstantOp>(op)) {
-        if (!cstOp.getType().isa<TensorType>()) return;
+        if (!llvm::isa<TensorType>(cstOp.getType())) return;
 
-        auto tensorType = cstOp.getType().cast<TensorType>();
+        auto tensorType = llvm::cast<TensorType>(cstOp.getType());
         TypedAttr newValue = getSplatAttr(tensorType);
         builder.setInsertionPoint(cstOp);
         auto newOp =

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/StripSignedness.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/StripSignedness.cpp
@@ -28,7 +28,7 @@ class StripSignednessPass : public StripSignednessBase<StripSignednessPass> {
 class IntegerTypeConverter : public TypeConverter {
  public:
   static Type convertType(Type type) {
-    if (auto iType = type.dyn_cast<IntegerType>()) {
+    if (auto iType = llvm::dyn_cast<IntegerType>(type)) {
       if (!iType.isSignless()) {
         return IntegerType::get(type.getContext(),
                                 iType.getIntOrFloatBitWidth());
@@ -80,8 +80,9 @@ class GenericTypeConvert : public ConversionPattern {
 };
 
 static bool isIllegalType(Type type) {
-  if (IntegerType ity = type.dyn_cast<IntegerType>()) return !ity.isSignless();
-  if (auto shapedType = type.dyn_cast<ShapedType>()) {
+  if (IntegerType ity = llvm::dyn_cast<IntegerType>(type))
+    return !ity.isSignless();
+  if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
     return isIllegalType(shapedType.getElementType());
   }
   return false;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/TensorPadToTensorInsertSlice.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/TensorPadToTensorInsertSlice.cpp
@@ -87,7 +87,7 @@ struct TensorPadOpConversion : public OpRewritePattern<tensor::PadOp> {
       unsigned numSymbols = 0;
       auto addValueOrAttr = [&](AffineExpr e, OpFoldResult valueOrAttr) {
         if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
-          e = e + attr.cast<IntegerAttr>().getInt();
+          e = e + llvm::cast<IntegerAttr>(attr).getInt();
           return e;
         }
         e = e + rewriter.getAffineSymbolExpr(numSymbols++);

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
@@ -81,7 +81,7 @@ static PipelineLayout deriveExportLayout(
   unsigned operandCount = 0;
   unsigned bindingCount = 0;
   for (auto arg : funcOp.getArgumentTypes()) {
-    if (arg.isa<IREE::Stream::BindingType>()) {
+    if (llvm::isa<IREE::Stream::BindingType>(arg)) {
       ++bindingCount;
     } else {
       ++operandCount;
@@ -94,8 +94,8 @@ static PipelineLayout deriveExportLayout(
     auto resourceAccessesAttrs = dispatchOp.getResourceAccesses().getValue();
     for (unsigned i = 0; i < bindingCount; ++i) {
       auto resourceAccessAttr =
-          resourceAccessesAttrs[i]
-              .cast<IREE::Stream::ResourceAccessBitfieldAttr>();
+          llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
+              resourceAccessesAttrs[i]);
       auto resourceAccess = static_cast<IREE::Stream::ResourceAccessBitfield>(
           resourceAccessAttr.getInt());
       if (!bitEnumContainsAll(resourceAccess,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
@@ -83,7 +83,7 @@ class BufferLoadOpConversion
     }
 
     // i32 -> f32, etc
-    if (targetType.isa<FloatType>()) {
+    if (llvm::isa<FloatType>(targetType)) {
       value = rewriter.create<arith::BitcastOp>(op.getLoc(), targetType, value);
     }
 
@@ -124,7 +124,7 @@ class BufferStoreOpConversion
 
     // f32 -> i32, etc
     auto value = adaptor.getValue();
-    if (elementType.isa<FloatType>()) {
+    if (llvm::isa<FloatType>(elementType)) {
       value = rewriter.createOrFold<arith::BitcastOp>(
           op.getLoc(),
           rewriter.getIntegerType(value.getType().getIntOrFloatBitWidth()),

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
@@ -275,7 +275,7 @@ class CommandBufferPushDescriptorSetOpConversion
       callOperands.push_back(
           castToImportType(adaptor.getBindingOrdinals()[i], i32Type, rewriter));
       auto bindingBuffer = adaptor.getBindingBuffers()[i];
-      if (bindingBuffer.getType().isa<IREE::VM::RefType>()) {
+      if (llvm::isa<IREE::VM::RefType>(bindingBuffer.getType())) {
         // Buffer binding; pass 0 for table slot.
         callOperands.push_back(getI32Zero());
         callOperands.push_back(bindingBuffer);

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertDeviceOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertDeviceOps.cpp
@@ -38,7 +38,7 @@ class DeviceQueryIntCastOpConversion
         op.getLoc(), rewriter.getI1Type(), rewriter.getI64Type(),
         adaptor.getDevice(), op.getCategoryAttr(), op.getKeyAttr(),
         TypedAttr{});
-    auto ok = queryOp.getOk().cast<Value>();
+    auto ok = llvm::cast<Value>(queryOp.getOk());
     auto value = queryOp.getValue();
 
     // Truncate or extend based on the target type.
@@ -46,7 +46,7 @@ class DeviceQueryIntCastOpConversion
       // i64 -> index cast.
       value = rewriter.createOrFold<arith::IndexCastOp>(op.getLoc(), targetType,
                                                         value);
-    } else if (targetType.isa<IntegerType>()) {
+    } else if (llvm::isa<IntegerType>(targetType)) {
       // i64 -> {integer} cast.
       if (targetType.getIntOrFloatBitWidth() <
           value.getType().getIntOrFloatBitWidth()) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertShapeOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertShapeOps.cpp
@@ -22,7 +22,7 @@ struct BufferViewDimPattern : public OpConversionPattern<tensor::DimOp> {
   LogicalResult matchAndRewrite(
       tensor::DimOp dimOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    if (!adaptor.getSource().getType().isa<IREE::HAL::BufferViewType>()) {
+    if (!llvm::isa<IREE::HAL::BufferViewType>(adaptor.getSource().getType())) {
       return failure();
     }
     std::optional<int64_t> index = dimOp.getConstantIndex();
@@ -39,7 +39,7 @@ struct BufferViewRankPattern : public OpConversionPattern<tensor::RankOp> {
   LogicalResult matchAndRewrite(
       tensor::RankOp rankOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    if (!adaptor.getTensor().getType().isa<IREE::HAL::BufferViewType>()) {
+    if (!llvm::isa<IREE::HAL::BufferViewType>(adaptor.getTensor().getType())) {
       return failure();
     }
     rewriter.replaceOpWithNewOp<IREE::HAL::BufferViewRankOp>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
@@ -41,9 +41,9 @@ HALTypeConverter::HALTypeConverter(
   addTargetMaterialization([](OpBuilder &builder, IREE::HAL::BufferType type,
                               ValueRange inputs, Location loc) -> Value {
     assert(inputs.size() == 1);
-    if (inputs[0].getType().isa<TensorType>()) {
+    if (llvm::isa<TensorType>(inputs[0].getType())) {
       return builder.create<IREE::HAL::TensorExportOp>(loc, type, inputs[0]);
-    } else if (inputs[0].getType().isa<IREE::HAL::BufferViewType>()) {
+    } else if (llvm::isa<IREE::HAL::BufferViewType>(inputs[0].getType())) {
       return builder.create<IREE::HAL::BufferViewBufferOp>(loc, type,
                                                            inputs[0]);
     } else {
@@ -58,9 +58,9 @@ HALTypeConverter::HALTypeConverter(
     assert(inputs.size() == 1);
     auto inputValue = inputs[0];
     auto inputType = inputValue.getType();
-    if (inputType.isa<TensorType>()) {
+    if (llvm::isa<TensorType>(inputType)) {
       return builder.create<IREE::HAL::TensorExportOp>(loc, type, inputValue);
-    } else if (inputType.isa<IREE::HAL::BufferType>()) {
+    } else if (llvm::isa<IREE::HAL::BufferType>(inputType)) {
       // Look for the buffer view this buffer came from, if any.
       // If we don't have the origin buffer view then we can't know the shape
       // and can't materialize one here - it's too late.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -40,13 +40,13 @@ struct HALOpAsmInterface : public OpAsmDialectInterface {
   /// end with a numeric digit([0-9]+). Returns success if an alias was
   /// provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (auto targetAttr = attr.dyn_cast<DeviceTargetAttr>()) {
+    if (auto targetAttr = llvm::dyn_cast<DeviceTargetAttr>(attr)) {
       os << "device_target_" << targetAttr.getSymbolNameFragment();
       return AliasResult::OverridableAlias;
-    } else if (auto targetAttr = attr.dyn_cast<ExecutableTargetAttr>()) {
+    } else if (auto targetAttr = llvm::dyn_cast<ExecutableTargetAttr>(attr)) {
       os << "executable_target_" << targetAttr.getSymbolNameFragment();
       return AliasResult::OverridableAlias;
-    } else if (auto layoutAttr = attr.dyn_cast<PipelineLayoutAttr>()) {
+    } else if (auto layoutAttr = llvm::dyn_cast<PipelineLayoutAttr>(attr)) {
       os << "pipeline_layout";
       return AliasResult::OverridableAlias;
     }
@@ -102,7 +102,7 @@ class HALToVMConversionInterface : public VMConversionDialectInterface {
     MLIRContext *context = attr.getContext();
     // TODO(benvanik): remove this interface or make it an attr interface.
     if (auto bindingAttr =
-            attr.dyn_cast<IREE::HAL::DescriptorSetBindingAttr>()) {
+            llvm::dyn_cast<IREE::HAL::DescriptorSetBindingAttr>(attr)) {
       fn(IntegerAttr::get(IndexType::get(context),
                           APInt(64, bindingAttr.getOrdinal())));
       fn(IREE::HAL::DescriptorTypeAttr::get(context, bindingAttr.getType()));
@@ -111,7 +111,7 @@ class HALToVMConversionInterface : public VMConversionDialectInterface {
           bindingAttr.getFlags().value_or(IREE::HAL::DescriptorFlags::None)));
       return success();
     }
-    if (auto dtAttr = attr.dyn_cast<IREE::HAL::DescriptorTypeAttr>()) {
+    if (auto dtAttr = llvm::dyn_cast<IREE::HAL::DescriptorTypeAttr>(attr)) {
       // Repack as a normal integer attribute.
       fn(IntegerAttr::get(IntegerType::get(context, 32),
                           APInt(32, static_cast<uint32_t>(dtAttr.getValue()))));
@@ -145,11 +145,11 @@ HALDialect::HALDialect(MLIRContext *context)
 
 Operation *HALDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                            Type type, Location loc) {
-  if (type.isa<IndexType>()) {
+  if (llvm::isa<IndexType>(type)) {
     // Some folders materialize raw index types, which just become std
     // constants.
     return builder.create<mlir::arith::ConstantIndexOp>(
-        loc, value.cast<IntegerAttr>().getValue().getSExtValue());
+        loc, llvm::cast<IntegerAttr>(value).getValue().getSExtValue());
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -132,7 +132,7 @@ struct FoldBufferViewCreateSubspan
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
-    auto newSourceOffset = op.getSourceOffset().cast<Value>();
+    auto newSourceOffset = llvm::cast<Value>(op.getSourceOffset());
     if (auto subspanOp = dyn_cast_or_null<BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
@@ -244,7 +244,7 @@ struct FoldCommandBufferFillBufferSubspans
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newTargetBuffer = op.getTargetBuffer();
-    auto newTargetOffset = op.getTargetOffset().cast<Value>();
+    auto newTargetOffset = llvm::cast<Value>(op.getTargetOffset());
     if (auto subspanOp = dyn_cast_or_null<BufferSubspanOp>(
             op.getTargetBuffer().getDefiningOp())) {
       newTargetBuffer = subspanOp.getSourceBuffer();
@@ -283,7 +283,7 @@ struct FoldCommandBufferCopyBufferSubspans
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
-    auto newSourceOffset = op.getSourceOffset().cast<Value>();
+    auto newSourceOffset = llvm::cast<Value>(op.getSourceOffset());
     if (auto subspanOp = dyn_cast_or_null<BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
@@ -293,7 +293,7 @@ struct FoldCommandBufferCopyBufferSubspans
       needsUpdate = true;
     }
     auto newTargetBuffer = op.getTargetBuffer();
-    auto newTargetOffset = op.getTargetOffset().cast<Value>();
+    auto newTargetOffset = llvm::cast<Value>(op.getTargetOffset());
     if (auto subspanOp = dyn_cast_or_null<BufferSubspanOp>(
             op.getTargetBuffer().getDefiningOp())) {
       newTargetBuffer = subspanOp.getSourceBuffer();

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -401,7 +401,8 @@ class CUDATargetBackend final : public TargetBackend {
       if (std::optional<ArrayAttr> workgroupSizeAttr =
               exportOp.getWorkgroupSize()) {
         for (auto it : llvm::enumerate(workgroupSizeAttr.value())) {
-          workgroupSize[it.index()] = it.value().cast<IntegerAttr>().getInt();
+          workgroupSize[it.index()] =
+              llvm::cast<IntegerAttr>(it.value()).getInt();
         }
       } else {
         workgroupSize = {1, 1, 1};
@@ -440,10 +441,8 @@ class CUDATargetBackend final : public TargetBackend {
         entryPointNames.emplace_back(exportOp.getSymName());
       }
 
-      auto objectAttr = variantOp.getObjects()
-                            ->getValue()
-                            .front()
-                            .cast<IREE::HAL::ExecutableObjectAttr>();
+      auto objectAttr = llvm::cast<IREE::HAL::ExecutableObjectAttr>(
+          variantOp.getObjects()->getValue().front());
       if (auto data = objectAttr.loadData()) {
         ptxImage = data.value();
       } else {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -195,7 +195,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     auto configAttr = variantOp.getTarget().getConfiguration();
     auto tryAttrLookup = [&](StringRef name, StringRef fallback) {
       if (!configAttr) return fallback.str();
-      auto value = configAttr.get(name).dyn_cast_or_null<StringAttr>();
+      auto value = llvm::dyn_cast_if_present<StringAttr>(configAttr.get(name));
       if (!value) return fallback.str();
       return value.str();
     };
@@ -304,8 +304,8 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     if (auto importsAttr =
             variantOp->getAttrOfType<ArrayAttr>(importsAttrName)) {
       for (auto importAttr : importsAttr.getAsValueRange<ArrayAttr>()) {
-        auto nameAttr = importAttr[0].cast<StringAttr>();
-        auto weakAttr = importAttr[1].cast<BoolAttr>();
+        auto nameAttr = llvm::cast<StringAttr>(importAttr[0]);
+        auto weakAttr = llvm::cast<BoolAttr>(importAttr[1]);
         libraryBuilder.addImport(nameAttr.getValue(), weakAttr.getValue());
       }
       variantOp->removeAttr(importsAttrName);
@@ -532,7 +532,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
                                                    {".o", ".obj", ".a", ".lib"},
                                                    linkerObjectAttrs);
     for (auto [index, attr] : llvm::enumerate(linkerObjectAttrs)) {
-      auto objectAttr = attr.cast<IREE::HAL::ExecutableObjectAttr>();
+      auto objectAttr = llvm::cast<IREE::HAL::ExecutableObjectAttr>(attr);
       if (auto dataAttr = objectAttr.getData()) {
         objectFiles.push_back(Artifact::createTemporary(
             objectFiles.front().path + "_object_" + std::to_string(index),

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -68,7 +68,7 @@ static spirv::TargetEnvAttr getSPIRVTargetEnv(
     MLIRContext *context) {
   if (!vulkanTargetEnv.empty()) {
     if (auto attr = parseAttribute(vulkanTargetEnv, context)) {
-      if (auto vkTargetEnv = attr.dyn_cast<Vulkan::TargetEnvAttr>()) {
+      if (auto vkTargetEnv = llvm::dyn_cast<Vulkan::TargetEnvAttr>(attr)) {
         return convertTargetEnv(vkTargetEnv);
       }
     }
@@ -237,10 +237,8 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     }
 
     // Load .spv object file.
-    auto objectAttr = variantOp.getObjects()
-                          ->getValue()
-                          .front()
-                          .cast<IREE::HAL::ExecutableObjectAttr>();
+    auto objectAttr = llvm::cast<IREE::HAL::ExecutableObjectAttr>(
+        variantOp.getObjects()->getValue().front());
     std::string spvBinary;
     if (auto data = objectAttr.loadData()) {
       spvBinary = data.value();

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -66,8 +66,8 @@ static DispatchParamsMap gatherDispatchParams(mlir::ModuleOp moduleOp) {
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
     funcOp.walk([&](IREE::Stream::CmdDispatchOp dispatchOp) {
       // TODO(benvanik): typed accessors for bindings.
-      auto bindingAttrs = dispatchOp->getAttr("hal.interface.bindings")
-                              .dyn_cast_or_null<ArrayAttr>();
+      auto bindingAttrs = llvm::dyn_cast_if_present<ArrayAttr>(
+          dispatchOp->getAttr("hal.interface.bindings"));
       assert(bindingAttrs &&
              "interface materialization must annotate dispatch sites");
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
@@ -98,8 +98,8 @@ static void buildConditionDispatchTable(IREE::HAL::DeviceSwitchOp switchOp,
   for (auto condition :
        llvm::enumerate(llvm::zip_equal(switchOp.getConditions().getValue(),
                                        switchOp.getConditionRegions()))) {
-    auto conditionAttr =
-        std::get<0>(condition.value()).cast<IREE::HAL::MatchAttrInterface>();
+    auto conditionAttr = llvm::cast<IREE::HAL::MatchAttrInterface>(
+        std::get<0>(condition.value()));
     auto &conditionRegion = std::get<1>(condition.value());
 
     // Insert the branch based on the match. We either match and jump to a

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -150,7 +150,7 @@ static LogicalResult materializeExecutablesFromSourceOps(
 static LogicalResult verifyEntryPointTypes(mlir::func::FuncOp entryFuncOp) {
   for (auto inputType :
        llvm::enumerate(entryFuncOp.getFunctionType().getInputs())) {
-    if (inputType.value().isa<IREE::Stream::BindingType>() ||
+    if (llvm::isa<IREE::Stream::BindingType>(inputType.value()) ||
         inputType.value().isInteger(32)) {
       // OK - directly translates to a HAL interface binding.
     } else {
@@ -238,13 +238,13 @@ static mlir::func::FuncOp cloneFuncWithInterface(
   // for use by the binding accessors.
   unsigned operandIdx = 0;
   for (auto arg : entryBlock->getArguments()) {
-    if (!arg.getType().isa<IREE::Stream::BindingType>()) {
+    if (!llvm::isa<IREE::Stream::BindingType>(arg.getType())) {
       convertOperandUsage(sourceFuncOp, arg, operandIdx++, entryBuilder);
     }
   }
   unsigned resourceIdx = 0;
   for (auto arg : entryBlock->getArguments()) {
-    if (!arg.getType().isa<IREE::Stream::BindingType>()) continue;
+    if (!llvm::isa<IREE::Stream::BindingType>(arg.getType())) continue;
     auto setBinding = pipelineLayout.resourceMap[resourceIdx++];
     auto setLayoutAttr = layoutAttr.getSetLayouts()[setBinding.first];
     auto bindingAttr = setLayoutAttr.getBindings()[setBinding.second];

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyTargetEnvironment.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyTargetEnvironment.cpp
@@ -74,7 +74,7 @@ class VerifyTargetEnvironmentPass
 
     // Verify each target is registered.
     for (auto attr : targetsAttr) {
-      auto targetAttr = attr.dyn_cast<IREE::HAL::DeviceTargetAttr>();
+      auto targetAttr = llvm::dyn_cast<IREE::HAL::DeviceTargetAttr>(attr);
       if (!targetAttr) {
         moduleOp.emitError() << "invalid target attr type: " << attr;
         signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -30,19 +30,19 @@ struct ConvertTensorImportOp
       ConversionPatternRewriter &rewriter) const override {
     auto sourceType = op.getSource().getType();
     auto targetType = op.getTargetEncoding();
-    if (!sourceType.isa<IREE::HAL::BufferType>() &&
-        !sourceType.isa<IREE::HAL::BufferViewType>()) {
+    if (!llvm::isa<IREE::HAL::BufferType>(sourceType) &&
+        !llvm::isa<IREE::HAL::BufferViewType>(sourceType)) {
       return rewriter.notifyMatchFailure(op, "unsupported HAL cast conversion");
     }
 
     // Assert the shape of the buffer view matches the expected encoding
     // shape. We can only do this when we are importing a buffer view as that's
     // what carries the information we need to validate.
-    if (sourceType.isa<IREE::HAL::BufferViewType>()) {
+    if (llvm::isa<IREE::HAL::BufferViewType>(sourceType)) {
       // NOTE: we do this before the other checks as it's the most likely
       // mistake and it's better to know of a shape mismatch than just buffer
       // byte length difference.
-      if (auto tensorType = targetType.dyn_cast<RankedTensorType>()) {
+      if (auto tensorType = llvm::dyn_cast<RankedTensorType>(targetType)) {
         if (failed(buildEncodingAssertions(op.getLoc(), adaptor.getSource(),
                                            op.getNameAttr(), tensorType,
                                            op.getTargetDims(), rewriter))) {
@@ -145,8 +145,8 @@ struct ConvertTensorExportOp
       ConversionPatternRewriter &rewriter) const override {
     auto sourceType = op.getSourceEncoding();
     auto targetType = op.getTarget().getType();
-    if (!targetType.isa<IREE::HAL::BufferType>() &&
-        !targetType.isa<IREE::HAL::BufferViewType>()) {
+    if (!llvm::isa<IREE::HAL::BufferType>(targetType) &&
+        !llvm::isa<IREE::HAL::BufferViewType>(targetType)) {
       return rewriter.notifyMatchFailure(op, "unsupported HAL cast conversion");
     }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -16,7 +16,7 @@ namespace iree_compiler {
 ConvertedTensor consumeTensorOperand(Location loc, Value operand,
                                      OpBuilder &builder) {
   auto operandType = operand.getType();
-  if (operandType.isa<IREE::Stream::ResourceType>()) {
+  if (llvm::isa<IREE::Stream::ResourceType>(operandType)) {
     // Prior to https://reviews.llvm.org/D111620 this is the path we'd take;
     // the tensor operands would be remapped into their new resource types.
     // This is still possible during rewriting if we ourselves produce a new

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
@@ -70,11 +70,11 @@ static SmallVector<Value> expandResourceOperands(
   SmallVector<Value> expandedOperands;
   expandedOperands.reserve(operands.size());
   for (auto operand : operands) {
-    if (operand.getType().isa<TensorType>()) {
+    if (llvm::isa<TensorType>(operand.getType())) {
       auto value = consumeTensorOperand(loc, operand, rewriter);
       expandedOperands.push_back(value.resource);
       expandedOperands.push_back(value.resourceSize);
-    } else if (operand.getType().isa<IREE::Stream::ResourceType>()) {
+    } else if (llvm::isa<IREE::Stream::ResourceType>(operand.getType())) {
       expandedOperands.push_back(operand);
       expandedOperands.push_back(
           rewriter.createOrFold<IREE::Stream::ResourceSizeOp>(loc, operand));
@@ -124,7 +124,7 @@ struct CallOpConversion : public OpConversionPattern<mlir::func::CallOp> {
     // original op.
     SmallVector<Value> results;
     for (auto result : resultMap) {
-      if (result.newType.isa<IREE::Stream::ResourceType>()) {
+      if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
         auto oldType = op.getResult(result.originalIndex).getType();
         auto resource = callOp.getResult(result.newIndex + 0);
         auto resourceSize = callOp.getResult(result.newIndex + 1);
@@ -194,7 +194,7 @@ struct SelectOpConversion : public OpConversionPattern<mlir::arith::SelectOp> {
       mlir::arith::SelectOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     // Only handle selects where the operands are tensors (resources).
-    if (!op.getTrueValue().getType().isa<TensorType>()) return failure();
+    if (!llvm::isa<TensorType>(op.getTrueValue().getType())) return failure();
     auto trueOperand =
         consumeTensorOperand(op.getLoc(), adaptor.getTrueValue(), rewriter);
     auto falseOperand =

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
@@ -71,7 +71,8 @@ struct StripResourceConversionCastPattern
   LogicalResult matchAndRewrite(UnrealizedConversionCastOp castOp,
                                 PatternRewriter &rewriter) const override {
     auto result = castOp.getResult(0);
-    if (!result.getType().isa<IREE::Stream::ResourceType>()) return failure();
+    if (!llvm::isa<IREE::Stream::ResourceType>(result.getType()))
+      return failure();
     assert(castOp.getNumOperands() == 2 &&
            "expect resource, index -> resource");
     auto resourceValue = castOp.getOperand(0);
@@ -116,10 +117,10 @@ Operation *StreamDialect::materializeConstant(OpBuilder &builder,
                                               Location loc) {
   if (mlir::func::ConstantOp::isBuildableWith(value, type)) {
     return builder.create<mlir::func::ConstantOp>(
-        loc, type, value.cast<FlatSymbolRefAttr>());
+        loc, type, llvm::cast<FlatSymbolRefAttr>(value));
   } else if (arith::ConstantOp::isBuildableWith(value, type)) {
     return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
-  } else if (value.isa<IREE::Stream::TimepointAttr>()) {
+  } else if (llvm::isa<IREE::Stream::TimepointAttr>(value)) {
     return builder.create<IREE::Stream::TimepointImmediateOp>(loc);
   }
   return nullptr;

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -323,12 +323,12 @@ void ResourceType::print(AsmPrinter &p) const {
 }
 
 bool ResourceType::isAccessStorageCompatible(Type accessType) const {
-  if (auto resourceType = accessType.dyn_cast<ResourceType>()) {
+  if (auto resourceType = llvm::dyn_cast<ResourceType>(accessType)) {
     // We could allow widening loads or stores here but today we require
     // transfers to accomplish that.
     return accessType == resourceType;
   }
-  return accessType.isa<ShapedType>();
+  return llvm::isa<ShapedType>(accessType);
 }
 
 Value ResourceType::inferSizeFromValue(Location loc, Value value,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchArguments.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchArguments.cpp
@@ -201,8 +201,8 @@ void GlobalPVS::initializeOperation(IREE::Util::GlobalOp globalOp,
     // Cannot perform analysis.
     indicatePessimisticFixpoint();
   } else if (globalInfo) {
-    if (auto initialValue =
-            globalOp.getInitialValueAttr().dyn_cast_or_null<IntegerAttr>()) {
+    if (auto initialValue = llvm::dyn_cast_if_present<IntegerAttr>(
+            globalOp.getInitialValueAttr())) {
       // Initial value is available for use; stored values from the rest of the
       // program will come during iteration.
       unionAssumed(initialValue.getValue());
@@ -493,8 +493,8 @@ static void annotateExport(IREE::Stream::ExecutableOp executableOp,
         potentialValues.push_back(IntegerAttr::get(argType, value));
       }
       llvm::sort(potentialValues, [](Attribute lhs, Attribute rhs) {
-        auto lhsInt = lhs.dyn_cast<IntegerAttr>();
-        auto rhsInt = rhs.dyn_cast<IntegerAttr>();
+        auto lhsInt = llvm::dyn_cast<IntegerAttr>(lhs);
+        auto rhsInt = llvm::dyn_cast<IntegerAttr>(rhs);
         if (!lhsInt || !rhsInt) return false;
         return lhsInt.getValue().ult(rhsInt.getValue());
       });

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -58,7 +58,7 @@ struct UsageInfo {
   void analyze(mlir::ModuleOp moduleOp) {
     SymbolTable symbolTable(moduleOp);
     for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOp>()) {
-      if (globalOp.getType().isa<IREE::Stream::ResourceType>()) {
+      if (llvm::isa<IREE::Stream::ResourceType>(globalOp.getType())) {
         resourceGlobalOps[globalOp.getName()] = globalOp;
       }
     }
@@ -122,7 +122,7 @@ struct Statistics {
     // Globals:
     for (auto it : usageInfo.resourceGlobalOps) {
       auto globalType =
-          it.second.getType().dyn_cast<IREE::Stream::ResourceType>();
+          llvm::dyn_cast<IREE::Stream::ResourceType>(it.second.getType());
       if (!globalType) continue;
       // TODO(benvanik): analyze size in UsageInfo.
       switch (globalType.getLifetime()) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
@@ -46,7 +46,7 @@ static LogicalResult checkEncoding(Operation *op, RankedTensorType encodingType,
                                    ValueRange encodingDims,
                                    PatternRewriter &rewriter) {
   auto encoding = encodingType.getEncoding();
-  if (encoding && !encoding.isa<IREE::LinalgExt::EncodingAttr>()) {
+  if (encoding && !llvm::isa<IREE::LinalgExt::EncodingAttr>(encoding)) {
     return rewriter.notifyMatchFailure(op, [=](Diagnostic &d) {
       d << "unsupported tensor encoding: " << encodingType;
     });
@@ -121,7 +121,7 @@ struct EncodeTensorImportOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorImportOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = op.getResultEncoding().cast<RankedTensorType>();
+    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -144,7 +144,7 @@ struct EncodeTensorExportOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorExportOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = op.getSourceEncoding().cast<RankedTensorType>();
+    auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
     auto sourceDims = op.getSourceEncodingDims();
     if (failed(checkEncoding(op, sourceType, sourceDims, rewriter))) {
       return failure();
@@ -167,7 +167,7 @@ struct EncodeTensorSizeOfOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSizeOfOp op,
                                 PatternRewriter &rewriter) const override {
-    auto encodingType = op.getEncoding().cast<RankedTensorType>();
+    auto encodingType = llvm::cast<RankedTensorType>(op.getEncoding());
     auto encodingDims = op.getEncodingDims();
     if (failed(checkEncoding(op, encodingType, encodingDims, rewriter))) {
       return failure();
@@ -195,7 +195,7 @@ struct EncodeTensorEmptyOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorEmptyOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = op.getResultEncoding().cast<RankedTensorType>();
+    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -218,7 +218,7 @@ struct EncodeTensorConstantOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorConstantOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = op.getResultEncoding().cast<RankedTensorType>();
+    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -243,7 +243,7 @@ struct EncodeTensorConstantOp
     RankedTensorType alignedType = alignTensorType(resultType);
     ElementsAttr encodedAttr = op.getValue();
     if (alignedType != resultType) {
-      if (auto sourceAttr = encodedAttr.dyn_cast<DenseIntElementsAttr>()) {
+      if (auto sourceAttr = llvm::dyn_cast<DenseIntElementsAttr>(encodedAttr)) {
         auto alignedBitWidth = alignedType.getElementTypeBitWidth();
         encodedAttr = sourceAttr.mapValues(
             alignedType.getElementType(), [=](APInt sourceValue) {
@@ -299,7 +299,7 @@ static Value canonicalizeFillPattern(Value pattern, PatternRewriter &rewriter) {
   unsigned elementBitWidth = IREE::Util::getTypeBitWidth(patternType);
   elementBitWidth =
       (isa<ComplexType>(patternType) ? elementBitWidth / 2 : elementBitWidth);
-  if (patternType.isa<FloatType>()) {
+  if (llvm::isa<FloatType>(patternType)) {
     pattern = rewriter.createOrFold<arith::BitcastOp>(
         loc, rewriter.getIntegerType(elementBitWidth), pattern);
   }
@@ -365,7 +365,7 @@ struct EncodeTensorSplatOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSplatOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = op.getResultEncoding().cast<RankedTensorType>();
+    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -410,12 +410,12 @@ struct EncodeTensorCloneOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorCloneOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = op.getSourceEncoding().cast<RankedTensorType>();
+    auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
     auto sourceDims = op.getSourceEncodingDims();
     if (failed(checkEncoding(op, sourceType, sourceDims, rewriter))) {
       return failure();
     }
-    auto resultType = op.getResultEncoding().cast<RankedTensorType>();
+    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -439,12 +439,12 @@ struct EncodeTensorSliceOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSliceOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = op.getSourceEncoding().cast<RankedTensorType>();
+    auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
     auto sourceDims = op.getSourceEncodingDims();
     if (failed(checkEncoding(op, sourceType, sourceDims, rewriter))) {
       return failure();
     }
-    auto resultType = op.getResultEncoding().cast<RankedTensorType>();
+    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -472,7 +472,7 @@ struct EncodeTensorFillOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorFillOp op,
                                 PatternRewriter &rewriter) const override {
-    auto targetType = op.getTargetEncoding().cast<RankedTensorType>();
+    auto targetType = llvm::cast<RankedTensorType>(op.getTargetEncoding());
     auto targetDims = op.getTargetEncodingDims();
     if (failed(checkEncoding(op, targetType, targetDims, rewriter))) {
       return failure();
@@ -531,12 +531,12 @@ struct EncodeTensorUpdateOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorUpdateOp op,
                                 PatternRewriter &rewriter) const override {
-    auto updateType = op.getUpdateEncoding().cast<RankedTensorType>();
+    auto updateType = llvm::cast<RankedTensorType>(op.getUpdateEncoding());
     auto updateDims = op.getUpdateEncodingDims();
     if (failed(checkEncoding(op, updateType, updateDims, rewriter))) {
       return failure();
     }
-    auto targetType = op.getTargetEncoding().cast<RankedTensorType>();
+    auto targetType = llvm::cast<RankedTensorType>(op.getTargetEncoding());
     auto targetDims = op.getTargetEncodingDims();
     if (failed(checkEncoding(op, targetType, targetDims, rewriter))) {
       return failure();
@@ -565,7 +565,7 @@ struct EncodeTensorLoadOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorLoadOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = op.getSourceEncoding().cast<RankedTensorType>();
+    auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
     auto sourceDims = op.getSourceEncodingDims();
     if (failed(checkEncoding(op, sourceType, sourceDims, rewriter))) {
       return failure();
@@ -596,7 +596,7 @@ struct EncodeTensorStoreOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::TensorStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    auto targetType = op.getTargetEncoding().cast<RankedTensorType>();
+    auto targetType = llvm::cast<RankedTensorType>(op.getTargetEncoding());
     auto targetDims = op.getTargetEncodingDims();
     if (failed(checkEncoding(op, targetType, targetDims, rewriter))) {
       return failure();
@@ -673,8 +673,8 @@ struct EncodeBindingSubspanOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::BindingSubspanOp op,
                                 PatternRewriter &rewriter) const override {
-    auto originalType =
-        op.getResult().getType().dyn_cast<IREE::Flow::DispatchTensorType>();
+    auto originalType = llvm::dyn_cast<IREE::Flow::DispatchTensorType>(
+        op.getResult().getType());
     if (!originalType) {
       return rewriter.notifyMatchFailure(op, "binding type not supported");
     }
@@ -702,7 +702,7 @@ struct EncodeDispatchTensorLoadOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Flow::DispatchTensorLoadOp op,
                                 PatternRewriter &rewriter) const override {
-    auto targetType = op.getResult().getType().cast<RankedTensorType>();
+    auto targetType = llvm::cast<RankedTensorType>(op.getResult().getType());
 
     // Align the element type, if needed.
     RankedTensorType alignedType = alignTensorType(targetType);
@@ -735,7 +735,7 @@ struct EncodeDispatchTensorStoreOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Flow::DispatchTensorStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = op.getValue().getType().cast<RankedTensorType>();
+    auto sourceType = llvm::cast<RankedTensorType>(op.getValue().getType());
 
     // Align the element type, if needed.
     RankedTensorType alignedType = alignTensorType(sourceType);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -40,8 +40,8 @@ struct BindingRange {
   BindingRange() = default;
   BindingRange(IREE::Stream::CmdDispatchOp dispatchOp, unsigned idx)
       : idx(idx),
-        access(dispatchOp.getResourceAccesses()[idx]
-                   .cast<IREE::Stream::ResourceAccessBitfieldAttr>()
+        access(llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
+                   dispatchOp.getResourceAccesses()[idx])
                    .getValue()),
         resource(dispatchOp.getResources()[idx]),
         resourceSize(dispatchOp.getResourceSizes()[idx]),
@@ -92,7 +92,8 @@ static SmallVector<Binding> findCorrelatedBindings(
       // If the resource is mutable and we were told not to alias mutable
       // bindings we always put the resource into its own class.
       auto resourceAccess =
-          resourceAccessAttr.cast<IREE::Stream::ResourceAccessBitfieldAttr>();
+          llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
+              resourceAccessAttr);
       if (!aliasMutableBindings &&
           bitEnumContainsAll(resourceAccess.getValue(),
                              IREE::Stream::ResourceAccessBitfield::Write)) {
@@ -178,7 +179,7 @@ static void updateExecutableSignature(IREE::Stream::ExecutableOp executableOp,
   // Gather old bindings (in order).
   SmallVector<BlockArgument> oldBindingArgs;
   for (auto arg : entryBlock.getArguments()) {
-    if (arg.getType().isa<IREE::Stream::BindingType>()) {
+    if (llvm::isa<IREE::Stream::BindingType>(arg.getType())) {
       oldBindingArgs.push_back(arg);
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/OutlineConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/OutlineConstants.cpp
@@ -27,7 +27,7 @@ namespace Stream {
 
 // Returns true if |value| is worth outlining (large, etc).
 static bool isOutlinableValue(Attribute value) {
-  if (auto elementsAttr = value.dyn_cast<DenseElementsAttr>()) {
+  if (auto elementsAttr = llvm::dyn_cast<DenseElementsAttr>(value)) {
     // Don't outline splats - we want those fused.
     return !elementsAttr.isSplat();
   }
@@ -53,7 +53,7 @@ static SmallVector<ConstantDef> findConstantsInModule(mlir::ModuleOp moduleOp) {
             results.push_back(ConstantDef{
                 constantOp,
                 constantOp.getType(),
-                constantOp.getValue().cast<ElementsAttr>(),
+                llvm::cast<ElementsAttr>(constantOp.getValue()),
             });
           }
         }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
@@ -49,9 +49,9 @@ struct ConstantSlice {
   // padding.
   uint64_t getStorageSize() const {
     if (auto serializableAttr =
-            value.dyn_cast<IREE::Util::SerializableAttrInterface>()) {
+            llvm::dyn_cast<IREE::Util::SerializableAttrInterface>(value)) {
       return serializableAttr.getStorageSize();
-    } else if (auto denseAttr = value.dyn_cast<DenseElementsAttr>()) {
+    } else if (auto denseAttr = llvm::dyn_cast<DenseElementsAttr>(value)) {
       return denseAttr.getRawData().size();
     } else {
       assert(false && "invalid constant attr type");
@@ -432,7 +432,8 @@ static Value generateUpload(IREE::Stream::ResourceConstantsOp constantsOp,
   for (auto [result, resultSize, value] :
        llvm::zip_equal(constantsOp.getResults(), constantsOp.getResultSizes(),
                        constantsOp.getValues())) {
-    auto resourceType = result.getType().cast<IREE::Stream::ResourceType>();
+    auto resourceType =
+        llvm::cast<IREE::Stream::ResourceType>(result.getType());
     if (resourceType.getLifetime() != lifetime) continue;
     slices.push_back(ConstantSlice{
         result,
@@ -463,7 +464,8 @@ static Value generateUpload(IREE::Stream::ResourceConstantsOp constantsOp,
   // fast-path where we directly map the constant memory. If producing
   // variables then we always need to stage and clone.
   auto anyResult = slices.front().result;
-  auto resourceType = anyResult.getType().cast<IREE::Stream::ResourceType>();
+  auto resourceType =
+      llvm::cast<IREE::Stream::ResourceType>(anyResult.getType());
   UploadResult uploadResult;
   if (resourceType.getLifetime() == IREE::Stream::Lifetime::Constant) {
     uploadResult = buildTryMapConstantResources(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -97,7 +97,7 @@ static void updateDispatchOp(IREE::Stream::CmdDispatchOp dispatchOp,
     }
 
     // bf16 -> i16, f32 -> i32, f64 -> i64 ...
-    if (auto floatType = operand.getType().dyn_cast<FloatType>()) {
+    if (auto floatType = llvm::dyn_cast<FloatType>(operand.getType())) {
       // Floats need to be bitcast into opaque integers so that our handling
       // below can deal with simple fixed width ints (bf16->i16, etc).
       operand = builder.createOrFold<arith::BitcastOp>(
@@ -177,7 +177,7 @@ static void updateExportFuncOp(mlir::func::FuncOp funcOp) {
       // Pass through/no change.
       if (oldArgAttrs) {
         newArgAttrs.push_back(
-            oldArgAttrs[it.index()].dyn_cast_or_null<DictionaryAttr>());
+            llvm::dyn_cast_if_present<DictionaryAttr>(oldArgAttrs[it.index()]));
       } else {
         newArgAttrs.push_back(nullptr);
       }
@@ -222,7 +222,7 @@ static void updateExportFuncOp(mlir::func::FuncOp funcOp) {
     // these attributes is really annoying.
     if (oldArgAttrs) {
       auto oldArgAttr =
-          oldArgAttrs[it.index()].dyn_cast_or_null<DictionaryAttr>();
+          llvm::dyn_cast_if_present<DictionaryAttr>(oldArgAttrs[it.index()]);
       if (auto alignmentAttr =
               oldArgAttr.getAs<IntegerAttr>(streamAlignmentAttr)) {
         argOp->setAttr(streamAlignmentAttr, alignmentAttr);
@@ -284,7 +284,7 @@ static void updateExportFuncOp(mlir::func::FuncOp funcOp) {
     }
 
     // i16 -> bf16, i32 -> f32, i64 -> f64 ...
-    if (auto floatType = targetType.dyn_cast<FloatType>()) {
+    if (auto floatType = llvm::dyn_cast<FloatType>(targetType)) {
       auto bitcastOp = builder.create<arith::BitcastOp>(loc, targetType, value);
       value.replaceAllUsesExcept(bitcastOp.getResult(), bitcastOp);
       value = bitcastOp.getResult();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -60,7 +60,7 @@ static ExpandedGlobalMap expandResourceGlobals(Operation *rootOp) {
   // Gather all of the resource globals in the root.
   for (auto &region : rootOp->getRegions()) {
     for (auto globalOp : region.getOps<IREE::Util::GlobalOp>()) {
-      if (!globalOp.getType().isa<IREE::Stream::ResourceType>()) continue;
+      if (!llvm::isa<IREE::Stream::ResourceType>(globalOp.getType())) continue;
       expandedGlobals[globalOp.getName()].resourceOp = globalOp;
     }
   }
@@ -90,7 +90,7 @@ static ExpandedGlobalMap expandResourceGlobals(Operation *rootOp) {
 //===----------------------------------------------------------------------===//
 
 static bool isResourceType(Type type) {
-  return type.isa<IREE::Stream::ResourceType>();
+  return llvm::isa<IREE::Stream::ResourceType>(type);
 }
 
 // Returns true if an operands or results of |op| use !stream.resources.
@@ -192,7 +192,7 @@ static Value makeBlockArgResourceSize(Location loc, Value resourceValue,
       // Size value found and implicitly captured; we can reuse (could be
       // a parent block argument, a constant, computed, etc).
       return sizeValue;
-    } else if (auto blockArg = sizeValue.dyn_cast<BlockArgument>()) {
+    } else if (auto blockArg = llvm::dyn_cast<BlockArgument>(sizeValue)) {
       if (blockArg.getParentBlock()->isEntryBlock()) {
         // Dynamic dimension passed in to the entry block; safe to use.
         return sizeValue;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
@@ -91,7 +91,7 @@ struct WavePartitionBuilder {
     operandTypes.reserve(partition->ins.size());
     operandSizes.reserve(partition->ins.size());
     for (auto in : partition->ins) {
-      if (!in.getType().isa<IREE::Stream::ResourceType>()) continue;
+      if (!llvm::isa<IREE::Stream::ResourceType>(in.getType())) continue;
       operands.push_back(in);
       operandTypes.push_back(in.getType());
       auto operandSize = IREE::Util::SizeAwareTypeInterface::queryValueSize(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -91,7 +91,7 @@ struct ExecutePartitionBuilder {
     operandTypes.reserve(partition->ins.size());
     operandSizes.reserve(partition->ins.size());
     for (auto in : partition->ins) {
-      if (!in.getType().isa<IREE::Stream::ResourceType>()) continue;
+      if (!llvm::isa<IREE::Stream::ResourceType>(in.getType())) continue;
       operands.push_back(in);
       operandTypes.push_back(in.getType());
       auto operandSize = IREE::Util::SizeAwareTypeInterface::queryValueSize(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
@@ -133,8 +133,8 @@ static TypedAttr buildConstantSetAttr(ConstantSet &set, OpBuilder &builder) {
     for (int64_t value = 0; value < valueCount; ++value) {
       auto valueAttr = set.values[value].second[site];
       if (storageType != valueAttr.getType()) {
-        valueAttr = IntegerAttr::get(storageType,
-                                     valueAttr.cast<IntegerAttr>().getInt());
+        valueAttr = IntegerAttr::get(
+            storageType, llvm::cast<IntegerAttr>(valueAttr).getInt());
       }
       flattenedAttrs.push_back(valueAttr);
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
@@ -86,7 +86,9 @@ class Verifier {
 
   template <typename TypeT>
   void addTypeVerifier(std::function<Legality(TypeT)> fn) {
-    auto wrapperFn = [=](Type baseType) { return fn(baseType.cast<TypeT>()); };
+    auto wrapperFn = [=](Type baseType) {
+      return fn(llvm::cast<TypeT>(baseType));
+    };
     if (typeVerifiers.insert({TypeID::get<TypeT>(), wrapperFn}).second ==
         false) {
       assert(false && "already registered for this type");

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/Range.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/Range.cpp
@@ -108,7 +108,7 @@ const char FloatRangeValueElement::ID = 0;
 // of fp types.
 // TODO: getElementTypeOrSelf?
 static bool isFpType(Type type) {
-  return getElementTypeOrSelf(type).isa<FloatType>();
+  return llvm::isa<FloatType>(getElementTypeOrSelf(type));
 }
 
 void FloatRangeValueElement::initializeValue(Value value, DFX::Solver &solver) {
@@ -132,7 +132,7 @@ ChangeStatus FloatRangeValueElement::updateValue(Value value,
   // TODO: We shouldn't need to hard switch on LinalgOp here and should
   // be relying on some kind of concept/interface. It just isn't
   // clear what that would be.
-  if (auto valueBlockArg = value.dyn_cast<BlockArgument>()) {
+  if (auto valueBlockArg = llvm::dyn_cast<BlockArgument>(value)) {
     Block *ownerBlock = valueBlockArg.getOwner();
     if (auto linalgParent = llvm::dyn_cast_or_null<linalg::LinalgOp>(
             ownerBlock->getParentOp())) {
@@ -146,12 +146,12 @@ ChangeStatus FloatRangeValueElement::updateValue(Value value,
       *this, Position::forValue(value), DFX::Resolution::OPTIONAL);
   if (pvs.isValidState() && !pvs.isUndefContained()) {
     for (Attribute constValue : pvs.getAssumedSet()) {
-      if (auto scalarValue = constValue.dyn_cast<FloatAttr>()) {
+      if (auto scalarValue = llvm::dyn_cast<FloatAttr>(constValue)) {
         FloatRangeStats stats;
         stats.addDomainValue(scalarValue.getValueAsDouble());
         newState.setAssumed(stats);
         newState.indicateOptimisticFixpoint();
-      } else if (auto elements = constValue.dyn_cast<ElementsAttr>()) {
+      } else if (auto elements = llvm::dyn_cast<ElementsAttr>(constValue)) {
         FloatRangeStats stats;
         for (APFloat elementValue : elements.getValues<APFloat>()) {
           stats.addDomainValue(elementValue.convertToDouble());

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
@@ -115,8 +115,8 @@ bool isHoistableConstExprLeaf(const ConstExprAnalysis::ConstValueInfo *info) {
 
   // Never hoist sub-byte aligned values: in legal programs, these will be
   // cast or packed in some successor.
-  if (auto integerType = getElementTypeOrSelf(info->constValue.getType())
-                             .dyn_cast<IntegerType>()) {
+  if (auto integerType = llvm::dyn_cast<IntegerType>(
+          getElementTypeOrSelf(info->constValue.getType()))) {
     if (integerType.getWidth() % 8 != 0) {
       return false;
     }

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
@@ -578,7 +578,7 @@ TraversalResult Explorer::walkDefiningOps(Value value, ResultWalkFn fn) {
   // Fast-path short-circuit for constants, which are like 25% of all IR.
   if (value.getDefiningOp() &&
       value.getDefiningOp()->hasTrait<OpTrait::ConstantLike>()) {
-    fn(value.cast<OpResult>());
+    fn(llvm::cast<OpResult>(value));
     return TraversalResult::COMPLETE;
   }
 
@@ -723,7 +723,7 @@ TraversalResult Explorer::walkDefiningOps(Value value, ResultWalkFn fn) {
     if (!definingOp) {
       // Op comes from a block argument; we need to continue walking through all
       // predecessors.
-      result |= traverseBlockArg(work.cast<BlockArgument>());
+      result |= traverseBlockArg(llvm::cast<BlockArgument>(work));
       continue;
     }
 
@@ -737,7 +737,7 @@ TraversalResult Explorer::walkDefiningOps(Value value, ResultWalkFn fn) {
     }
 
     // Op is visible in the CFG as a leaf.
-    auto resultValue = work.cast<OpResult>();
+    auto resultValue = llvm::cast<OpResult>(work);
     LLVM_DEBUG(llvm::dbgs() << "  == emitting op "
                             << definingOp->getName().getStringRef() << "\n");
     auto fnResult = fn(resultValue);

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
@@ -27,7 +27,7 @@ namespace {
 
 /// Returns true if the given `type` is a MemRef of rank 0 or 1.
 static bool isRankZeroOrOneMemRef(Type type) {
-  if (auto memrefType = type.dyn_cast<MemRefType>()) {
+  if (auto memrefType = llvm::dyn_cast<MemRefType>(type)) {
     return memrefType.hasRank() && memrefType.getRank() <= 1 &&
            memrefType.getLayout().isIdentity();
   }
@@ -36,7 +36,8 @@ static bool isRankZeroOrOneMemRef(Type type) {
 
 static Value getElementTypeByteSize(OpBuilder &builder, Location loc,
                                     Value memrefValue) {
-  auto elementType = memrefValue.getType().cast<ShapedType>().getElementType();
+  auto elementType =
+      llvm::cast<ShapedType>(memrefValue.getType()).getElementType();
   return builder.createOrFold<IREE::Util::SizeOfOp>(loc, elementType);
 }
 
@@ -48,7 +49,7 @@ static Value getElementTypeByteSize(OpBuilder &builder, Location loc,
 static Value getByteOffsetForIndices(OpBuilder &builder, Location loc,
                                      Value memrefValue, ValueRange indices,
                                      Value elementTypeByteSize) {
-  auto memrefType = memrefValue.getType().cast<MemRefType>();
+  auto memrefType = llvm::cast<MemRefType>(memrefValue.getType());
   if (memrefType.getRank() == 0) {
     // Rank 0 buffers (like memref<i32>) have only a single valid offset at 0.
     return builder.createOrFold<arith::ConstantIndexOp>(loc, 0);
@@ -72,7 +73,7 @@ static Value getByteOffsetForIndices(OpBuilder &builder, Location loc,
 
 static Value getByteLength(OpBuilder &builder, Location loc,
                            Value memrefValue) {
-  auto memrefType = memrefValue.getType().cast<MemRefType>();
+  auto memrefType = llvm::cast<MemRefType>(memrefValue.getType());
   if (memrefType.getRank() == 0) {
     return getElementTypeByteSize(builder, loc, memrefValue);
   }
@@ -196,7 +197,7 @@ struct ConvertMemRefDimOp : public OpConversionPattern<memref::DimOp> {
           dimOp, "only rank-0 and rank-1 memrefs are supported; flatten first");
     }
     auto elementType =
-        dimOp.getSource().getType().cast<MemRefType>().getElementType();
+        llvm::cast<MemRefType>(dimOp.getSource().getType()).getElementType();
     Value elementSize = rewriter.createOrFold<IREE::Util::SizeOfOp>(
         dimOp.getLoc(), elementType);
     Value bufferSize = rewriter.create<IREE::Util::BufferSizeOp>(

--- a/compiler/src/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
@@ -53,9 +53,9 @@ void excludeClosureOperandsAndResults(
   for (auto it : llvm::enumerate(oldOperandValues)) {
     unsigned numDynamicDims = 0;
     auto type = it.value().getType();
-    if (auto shapedType = type.dyn_cast<ShapedType>()) {
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
       numDynamicDims = shapedType.getNumDynamicDims();
-    } else if (type.isa<IREE::Util::SizeAwareTypeInterface>()) {
+    } else if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(type)) {
       numDynamicDims = 1;
     }
     if (!llvm::count(excludedOperandIndices, it.index())) {
@@ -75,9 +75,9 @@ void excludeClosureOperandsAndResults(
   for (auto it : llvm::enumerate(oldResultTypes)) {
     unsigned numDynamicDims = 0;
     auto type = it.value();
-    if (auto shapedType = type.dyn_cast<ShapedType>()) {
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
       numDynamicDims = shapedType.getNumDynamicDims();
-    } else if (type.isa<IREE::Util::SizeAwareTypeInterface>()) {
+    } else if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(type)) {
       numDynamicDims = 1;
     }
     if (!llvm::count(excludedResultIndices, it.index())) {
@@ -131,14 +131,15 @@ static bool isConstantInlinable(const ClosureOptimizationOptions &options,
 
   auto constantValueAttr = constantOp.getValue();
   auto constantType = constantOp.getType();
-  if (constantValueAttr.isa<SplatElementsAttr>()) {
+  if (llvm::isa<SplatElementsAttr>(constantValueAttr)) {
     // Splats are always small and can often have special handling when we
     // know they are a splat - which is why it's so important we inline them
     // here so we know when they are used that's the case.
     return true;
-  } else if (auto denseAttr = constantValueAttr.dyn_cast<DenseElementsAttr>()) {
+  } else if (auto denseAttr =
+                 llvm::dyn_cast<DenseElementsAttr>(constantValueAttr)) {
     // Smallish constants are worth moving inside.
-    auto shapedType = constantType.cast<ShapedType>();
+    auto shapedType = llvm::cast<ShapedType>(constantType);
     uint64_t estimatedByteLength =
         shapedType.getNumElements() *
         getRoundedElementByteWidth(shapedType.getElementType());

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
@@ -37,7 +37,7 @@ struct UtilOpAsmInterface : public OpAsmDialectInterface {
   /// end with a numeric digit([0-9]+). Returns success if an alias was
   /// provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (auto compositeAttr = attr.dyn_cast<CompositeAttr>()) {
+    if (auto compositeAttr = llvm::dyn_cast<CompositeAttr>(attr)) {
       os << "composite_of_" << compositeAttr.getTotalLength() << "b";
       return AliasResult::OverridableAlias;
     }
@@ -121,7 +121,7 @@ struct FoldDimOp : public OpRewritePattern<DimOp> {
     }
 
     // If it's a static dim then just fold to that.
-    auto type = op.getSource().getType().template cast<ShapedType>();
+    auto type = llvm::cast<ShapedType>(op.getSource().getType());
     int64_t staticDim = type.getDimSize(index.getZExtValue());
     if (staticDim != ShapedType::kDynamic) {
       rewriter.replaceOpWithNewOp<arith::ConstantIndexOp>(op, staticDim);

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/ConvertPrimitiveType.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/ConvertPrimitiveType.cpp
@@ -41,7 +41,7 @@ Value convertRankedFloat(OpBuilder &builder, Type type, ValueRange inputs,
                          Location loc) {
   Type eTy = getElementTypeOrSelf(type);
   Type inputETy = getElementTypeOrSelf(inputs[0].getType());
-  if (!getElementTypeOrSelf(type).isa<FloatType>()) return nullptr;
+  if (!llvm::isa<FloatType>(getElementTypeOrSelf(type))) return nullptr;
 
   if (inputETy.getIntOrFloatBitWidth() > eTy.getIntOrFloatBitWidth()) {
     return builder.create<arith::TruncFOp>(loc, type, inputs[0]);
@@ -58,7 +58,7 @@ Value convertRankedInteger(OpBuilder &builder, Type type, ValueRange inputs,
                            Location loc) {
   Type eTy = getElementTypeOrSelf(type);
   Type inputETy = getElementTypeOrSelf(inputs[0].getType());
-  if (!getElementTypeOrSelf(type).isa<FloatType>()) return nullptr;
+  if (!llvm::isa<FloatType>(getElementTypeOrSelf(type))) return nullptr;
   bool isUnsigned = eTy.isUnsignedInteger();
 
   int64_t inBitwidth = inputETy.getIntOrFloatBitWidth();

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -262,7 +262,7 @@ static Value tryMaterializeConstant(Location loc, Type type, Attribute attr,
     return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(attr));
   } else if (mlir::func::ConstantOp::isBuildableWith(attr, type)) {
     return builder.create<mlir::func::ConstantOp>(
-        loc, type, attr.cast<FlatSymbolRefAttr>());
+        loc, type, llvm::cast<FlatSymbolRefAttr>(attr));
   }
   // Fallback that asks a dialect to materialize things. This may fail!
   auto *op = attr.getDialect().materializeConstant(builder, attr, type, loc);
@@ -279,7 +279,8 @@ static bool inlineConstantGlobalLoads(GlobalTable &globalTable) {
     if (global.op->hasAttr("noinline")) return GlobalAction::PRESERVE;
     if (!global.op.getGlobalInitialValue()) return GlobalAction::PRESERVE;
 
-    if (global.op.getGlobalType().isa<IREE::Util::ReferenceTypeInterface>()) {
+    if (llvm::isa<IREE::Util::ReferenceTypeInterface>(
+            global.op.getGlobalType())) {
       // We only inline value types; reference types have meaning as globals.
       return GlobalAction::PRESERVE;
     }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -209,7 +209,7 @@ static FuncAnalysis analyzeFuncOp(func::FuncOp funcOp, Explorer &explorer) {
 
       // If the result value is an argument track that here.
       // We'll only use this value if all return sites are uniform.
-      if (auto arg = value.dyn_cast<BlockArgument>()) {
+      if (auto arg = llvm::dyn_cast<BlockArgument>(value)) {
         if (arg.getParentBlock()->isEntryBlock()) {
           analysis.passthroughResultArgs[i] =
               static_cast<int>(arg.getArgNumber());

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
@@ -248,7 +248,7 @@ struct ElideBranchOperandsPattern
 
           // Operand for this source differs from previous. This is either
           // because it's non-uniform _or_ that it's a cycle.
-          if (auto sourceArg = operand.dyn_cast<BlockArgument>()) {
+          if (auto sourceArg = llvm::dyn_cast<BlockArgument>(operand)) {
             // Operand comes from a block argument. If that is the block
             // argument we are analyzing it means there's a cycle (%0 -> %0) and
             // we can ignore it for the purposes of this analysis.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
@@ -37,7 +37,7 @@ namespace {
 // This pass is paired with the subrange type. Any type implementing the
 // interface can be used.
 static bool isResourceType(Type type) {
-  return type.isa<IREE::Util::SubrangeTypeInterface>();
+  return llvm::isa<IREE::Util::SubrangeTypeInterface>(type);
 }
 
 //===----------------------------------------------------------------------===//
@@ -138,7 +138,7 @@ struct Subrange {
   Value subrangeOffset;
   Value subrangeLength;
   IREE::Util::SubrangeTypeInterface getResourceType() {
-    return resource.getType().cast<IREE::Util::SubrangeTypeInterface>();
+    return llvm::cast<IREE::Util::SubrangeTypeInterface>(resource.getType());
   }
 };
 using SubrangeMap = llvm::DenseMap<Value, Subrange>;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyGlobalAccesses.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyGlobalAccesses.cpp
@@ -52,7 +52,7 @@ static void hoistImmutableLoads(Region &region,
         llvm::to_vector<8>(block.getOps<IREE::Util::GlobalLoadOpInterface>());
     for (auto &op : ops) {
       if (!immutableGlobals.contains(op.getGlobalName())) continue;
-      auto globalRef = op.getGlobalAttr().cast<Attribute>();
+      auto globalRef = llvm::cast<Attribute>(op.getGlobalAttr());
       auto it = loadOps.find(globalRef);
       if (it == loadOps.end()) {
         // Move to entry block; even if it's already there (so loads are

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -275,8 +275,9 @@ LogicalResult RegisterAllocation::recalculate(IREE::VM::FuncOp funcOp) {
       for (auto result : op.getResults()) {
         auto reg = registerUsage.allocateRegister(result.getType());
         if (!reg.has_value()) {
-          return op.emitError() << "register allocation failed for result "
-                                << result.cast<OpResult>().getResultNumber();
+          return op.emitError()
+                 << "register allocation failed for result "
+                 << llvm::cast<OpResult>(result).getResultNumber();
         }
         map_[result] = reg.value();
         if (result.use_empty()) {

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
@@ -66,7 +66,7 @@ LogicalResult ValueLiveness::annotateIR(IREE::VM::FuncOp funcOp) {
     SmallVector<StringAttr, 8> valueNames;
     for (auto value : values) {
       std::string str;
-      if (auto blockArg = value.dyn_cast<BlockArgument>()) {
+      if (auto blockArg = llvm::dyn_cast<BlockArgument>(value)) {
         if (blockArg.getOwner()->isEntryBlock()) {
           str = llvm::formatv("%arg{0}", blockArg.getArgNumber());
         } else {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/ConvertMathToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/ConvertMathToVM.cpp
@@ -32,8 +32,7 @@ class UnaryArithmeticOpConversion : public OpConversionPattern<SrcOpTy> {
       SrcOpTy srcOp, typename SrcOpTy::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     // TODO(benvanik): support vectors.
-    if (srcOp.getResult().getType().template isa<VectorType>())
-      return failure();
+    if (llvm::isa<VectorType>(srcOp.getResult().getType())) return failure();
 
     switch (adaptor.getOperand().getType().getIntOrFloatBitWidth()) {
       case 32:
@@ -59,8 +58,7 @@ class BinaryArithmeticOpConversion : public OpConversionPattern<SrcOpTy> {
       SrcOpTy srcOp, typename SrcOpTy::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     // TODO(benvanik): support vectors.
-    if (srcOp.getResult().getType().template isa<VectorType>())
-      return failure();
+    if (llvm::isa<VectorType>(srcOp.getResult().getType())) return failure();
 
     switch (adaptor.getLhs().getType().getIntOrFloatBitWidth()) {
       case 32:

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -195,7 +195,7 @@ class ExternalFuncOpConversion : public OpConversionPattern<func::FuncOp> {
     auto signatureAttr = srcOp->getAttrOfType<TypeAttr>("vm.signature");
     if (signatureAttr) {
       // Directly use the signature from the user.
-      newSignature = signatureAttr.getValue().dyn_cast<FunctionType>();
+      newSignature = llvm::dyn_cast<FunctionType>(signatureAttr.getValue());
       if (!newSignature) {
         return rewriter.notifyMatchFailure(srcOp, "invalid vm.signature");
       }
@@ -282,7 +282,7 @@ class CallOpConversion : public OpConversionPattern<func::CallOp> {
         if (auto signatureAttr =
                 funcOp->getAttrOfType<TypeAttr>("vm.signature")) {
           if (auto importSignature =
-                  signatureAttr.getValue().dyn_cast<FunctionType>()) {
+                  llvm::dyn_cast<FunctionType>(signatureAttr.getValue())) {
             convertedSignature = importSignature;
           }
         }
@@ -426,8 +426,8 @@ struct ConstantOpConversion : public OpConversionPattern<arith::ConstantOp> {
       return srcOp.emitError() << "could not convert type: " << srcOp.getType()
                                << " (check -iree-vm-target-* options)";
     }
-    if (targetType.isa<IntegerType>()) {
-      auto integerAttr = srcOp.getValue().dyn_cast<IntegerAttr>();
+    if (llvm::isa<IntegerType>(targetType)) {
+      auto integerAttr = llvm::dyn_cast<IntegerAttr>(srcOp.getValue());
       if (!integerAttr) {
         return srcOp.emitRemark() << "unsupported const type for dialect";
       }
@@ -454,8 +454,8 @@ struct ConstantOpConversion : public OpConversionPattern<arith::ConstantOp> {
           return srcOp.emitRemark()
                  << "unsupported const integer bit width for dialect";
       }
-    } else if (targetType.isa<FloatType>()) {
-      auto floatAttr = srcOp.getValue().dyn_cast<FloatAttr>();
+    } else if (llvm::isa<FloatType>(targetType)) {
+      auto floatAttr = llvm::dyn_cast<FloatAttr>(srcOp.getValue());
       if (!floatAttr) {
         return srcOp.emitRemark() << "unsupported const type for dialect";
       }
@@ -1014,7 +1014,7 @@ class SelectOpConversion : public OpConversionPattern<arith::SelectOp> {
           srcOp, valueType, adaptor.getCondition(), adaptor.getTrueValue(),
           adaptor.getFalseValue());
       return success();
-    } else if (valueType.isa<IREE::VM::RefType>()) {
+    } else if (llvm::isa<IREE::VM::RefType>(valueType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::SelectRefOp>(
           srcOp, valueType, adaptor.getCondition(), adaptor.getTrueValue(),
           adaptor.getFalseValue());

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
@@ -109,7 +109,8 @@ TypeConverter::TypeConverter(TargetOptions targetOptions)
 
   addSourceMaterialization([](OpBuilder &builder, IndexType type,
                               ValueRange inputs, Location loc) -> Value {
-    if (inputs.size() != 1 || !inputs.front().getType().isa<IntegerType>()) {
+    if (inputs.size() != 1 ||
+        !llvm::isa<IntegerType>(inputs.front().getType())) {
       return nullptr;
     }
     return builder.create<arith::IndexCastOp>(loc, type, inputs.front());

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAlignmentOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAlignmentOps.cpp
@@ -87,7 +87,7 @@ struct FixateIndexSizeofConversion
       IREE::Util::SizeOfOp sizeofOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     Type sizedType = sizeofOp.getSizedType();
-    if (sizedType.isa<IndexType>()) {
+    if (llvm::isa<IndexType>(sizedType)) {
       Type converted = getTypeConverter()->convertType(sizedType);
       if (converted) {
         Value newSizeof = rewriter.createOrFold<IREE::Util::SizeOfOp>(

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertBufferOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertBufferOps.cpp
@@ -175,7 +175,7 @@ struct BufferFillOpConversion
       ConversionPatternRewriter &rewriter) const override {
     auto oldType = fillOp.getPattern().getType();
     auto newType = adaptor.getPattern().getType();
-    if (oldType.isa<IndexType>()) {
+    if (llvm::isa<IndexType>(oldType)) {
       // Use the actual converted type for IndexType.
       oldType = newType;
     }
@@ -187,7 +187,7 @@ struct BufferFillOpConversion
     auto elementLength =
         unscaleOffset(fillOp.getLoc(), byteLength, elementSize, rewriter);
     auto pattern = adaptor.getPattern();
-    if (auto integerType = oldType.dyn_cast<IntegerType>()) {
+    if (auto integerType = llvm::dyn_cast<IntegerType>(oldType)) {
       if (integerType.isInteger(1) || integerType.isInteger(8)) {
         rewriter.replaceOpWithNewOp<IREE::VM::BufferFillI8Op>(
             fillOp, adaptor.getTarget(), byteOffset, byteLength, pattern);
@@ -226,14 +226,14 @@ struct BufferLoadOpConversion
       ConversionPatternRewriter &rewriter) const override {
     auto oldType = loadOp.getResult().getType();
     auto newType = getTypeConverter()->convertType(oldType);
-    if (oldType.isa<IndexType>()) {
+    if (llvm::isa<IndexType>(oldType)) {
       oldType = newType;
     }
     auto byteOffset = castToI64(adaptor.getSourceOffset(), rewriter);
     int64_t elementSize = IREE::Util::getRoundedElementByteWidth(oldType);
     auto elementOffset =
         unscaleOffset(loadOp.getLoc(), byteOffset, elementSize, rewriter);
-    if (auto integerType = oldType.dyn_cast<IntegerType>()) {
+    if (auto integerType = llvm::dyn_cast<IntegerType>(oldType)) {
       if (integerType.isInteger(1) || integerType.isInteger(8)) {
         if (integerType.isSigned() || integerType.isSignless()) {
           rewriter.replaceOpWithNewOp<IREE::VM::BufferLoadI8SOp>(
@@ -282,7 +282,7 @@ struct BufferStoreOpConversion
       ConversionPatternRewriter &rewriter) const override {
     auto oldType = storeOp.getSource().getType();
     auto newType = adaptor.getSource().getType();
-    if (oldType.isa<IndexType>()) {
+    if (llvm::isa<IndexType>(oldType)) {
       oldType = newType;
     }
     auto byteOffset = castToI64(adaptor.getTargetOffset(), rewriter);

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
@@ -60,7 +60,7 @@ class GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       ConversionPatternRewriter &rewriter) const override {
     Operation *newOp = nullptr;
     auto convertedType = typeConverter.convertType(op.getType());
-    if (convertedType.isa<IREE::VM::RefType>() ||
+    if (llvm::isa<IREE::VM::RefType>(convertedType) ||
         IREE::VM::RefType::isCompatible(convertedType)) {
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalRefOp>(
           op, op.getSymName(), op.getIsMutable(), convertedType,
@@ -69,7 +69,7 @@ class GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       std::optional<TypedAttr> convertedValue = std::nullopt;
       if (op.getInitialValue().has_value()) {
         convertedValue = rewriter.getI32IntegerAttr(static_cast<int32_t>(
-            op.getInitialValue().value().cast<IntegerAttr>().getInt()));
+            llvm::cast<IntegerAttr>(op.getInitialValue().value()).getInt()));
       }
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalI32Op>(
           op, op.getSymName(), op.getIsMutable(), convertedType, convertedValue,
@@ -78,7 +78,7 @@ class GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       std::optional<TypedAttr> convertedValue = std::nullopt;
       if (op.getInitialValue().has_value()) {
         convertedValue = rewriter.getI64IntegerAttr(
-            op.getInitialValue().value().cast<IntegerAttr>().getInt());
+            llvm::cast<IntegerAttr>(op.getInitialValue().value()).getInt());
       }
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalI64Op>(
           op, op.getSymName(), op.getIsMutable(), convertedType, convertedValue,
@@ -87,7 +87,8 @@ class GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       std::optional<TypedAttr> convertedValue = std::nullopt;
       if (op.getInitialValue().has_value()) {
         convertedValue = rewriter.getF32FloatAttr(static_cast<float>(
-            op.getInitialValue().value().cast<FloatAttr>().getValueAsDouble()));
+            llvm::cast<FloatAttr>(op.getInitialValue().value())
+                .getValueAsDouble()));
       }
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalF32Op>(
           op, op.getSymName(), op.getIsMutable(), convertedType, convertedValue,
@@ -96,7 +97,8 @@ class GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       std::optional<TypedAttr> convertedValue = std::nullopt;
       if (op.getInitialValue().has_value()) {
         convertedValue = rewriter.getF64FloatAttr(
-            op.getInitialValue().value().cast<FloatAttr>().getValueAsDouble());
+            llvm::cast<FloatAttr>(op.getInitialValue().value())
+                .getValueAsDouble());
       }
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalF64Op>(
           op, op.getSymName(), op.getIsMutable(), convertedType, convertedValue,
@@ -216,7 +218,7 @@ class GlobalStoreOpConversion
       IREE::Util::GlobalStoreOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     auto operandType = adaptor.getValue().getType();
-    if (operandType.isa<IREE::VM::RefType>()) {
+    if (llvm::isa<IREE::VM::RefType>(operandType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::GlobalStoreRefOp>(
           op, adaptor.getValue(), op.getGlobal());
     } else if (operandType.isInteger(32)) {
@@ -249,7 +251,7 @@ class GlobalStoreIndirectOpConversion
       IREE::Util::GlobalStoreIndirectOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     auto operandType = adaptor.getValue().getType();
-    if (operandType.isa<IREE::VM::RefType>()) {
+    if (llvm::isa<IREE::VM::RefType>(operandType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::GlobalStoreIndirectRefOp>(
           op, adaptor.getValue(), adaptor.getGlobal());
     } else if (operandType.isInteger(32)) {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
@@ -145,8 +145,8 @@ void populateUtilListToVMPatterns(MLIRContext *context,
   typeConverter.addConversion(
       [&typeConverter](IREE::Util::ListType type) -> std::optional<Type> {
         Type elementType;
-        if (type.getElementType().isa<IREE::Util::ObjectType>() ||
-            type.getElementType().isa<IREE::Util::VariantType>()) {
+        if (llvm::isa<IREE::Util::ObjectType>(type.getElementType()) ||
+            llvm::isa<IREE::Util::VariantType>(type.getElementType())) {
           elementType = IREE::VM::OpaqueType::get(type.getContext());
         } else {
           elementType = typeConverter.convertType(type.getElementType());

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertUtilToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertUtilToVM.cpp
@@ -72,7 +72,7 @@ struct CmpEQOpConversion : public OpConversionPattern<IREE::Util::CmpEQOp> {
       IREE::Util::CmpEQOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     auto operandType = adaptor.getLhs().getType();
-    if (operandType.isa<IREE::VM::RefType>()) {
+    if (llvm::isa<IREE::VM::RefType>(operandType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::CmpEQRefOp>(
           op, rewriter.getI32Type(), adaptor.getLhs(), adaptor.getRhs());
       return success();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -143,7 +143,7 @@ Value contentsOf(OpBuilder builder, Location location, Value operand) {
   return builder
       .create<emitc::ApplyOp>(
           /*location=*/location,
-          /*result=*/type.cast<emitc::PointerType>().getPointee(),
+          /*result=*/llvm::cast<emitc::PointerType>(type).getPointee(),
           /*applicableOperator=*/StringAttr::get(ctx, "*"),
           /*operand=*/operand)
       .getResult();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -61,7 +61,7 @@ EmitCTypeConverter::EmitCTypeConverter() {
 Type EmitCTypeConverter::convertTypeAsNonPointer(Type type) {
   Type convertedType = convertType(type);
 
-  if (auto ptrType = convertedType.dyn_cast<emitc::PointerType>()) {
+  if (auto ptrType = llvm::dyn_cast<emitc::PointerType>(convertedType)) {
     return ptrType.getPointee();
   }
 
@@ -75,11 +75,11 @@ Type EmitCTypeConverter::convertTypeAsPointer(Type type) {
 emitc::OpaqueType EmitCTypeConverter::convertTypeAsCType(Type type) {
   Type convertedType = convertTypeAsNonPointer(type);
 
-  if (auto oType = convertedType.dyn_cast<emitc::OpaqueType>()) {
+  if (auto oType = llvm::dyn_cast<emitc::OpaqueType>(convertedType)) {
     return oType;
   }
 
-  if (auto iType = type.dyn_cast<IntegerType>()) {
+  if (auto iType = llvm::dyn_cast<IntegerType>(type)) {
     std::string typeLiteral;
     switch (iType.getWidth()) {
       case 32: {
@@ -96,7 +96,7 @@ emitc::OpaqueType EmitCTypeConverter::convertTypeAsCType(Type type) {
     return emitc::OpaqueType::get(type.getContext(), typeLiteral);
   }
 
-  if (auto fType = type.dyn_cast<FloatType>()) {
+  if (auto fType = llvm::dyn_cast<FloatType>(type)) {
     std::string typeLiteral;
     switch (fType.getWidth()) {
       case 32: {
@@ -135,7 +135,7 @@ std::optional<Value> EmitCTypeConverter::materializeRef(Value ref) {
   if (auto definingOp = ref.getDefiningOp()) {
     funcOp = definingOp->getParentOfType<mlir::func::FuncOp>();
   } else {
-    Operation *op = ref.cast<BlockArgument>().getOwner()->getParentOp();
+    Operation *op = llvm::cast<BlockArgument>(ref).getOwner()->getParentOp();
     funcOp = cast<mlir::func::FuncOp>(op);
   }
 

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -40,12 +40,12 @@ Attribute zeroOfType(Type type) {
 /// Creates a constant one attribute matching the given type.
 Attribute oneOfType(Type type) {
   Builder builder(type.getContext());
-  if (type.isa<FloatType>()) {
+  if (llvm::isa<FloatType>(type)) {
     return builder.getFloatAttr(type, 1.0);
-  } else if (auto integerTy = type.dyn_cast<IntegerType>()) {
+  } else if (auto integerTy = llvm::dyn_cast<IntegerType>(type)) {
     return builder.getIntegerAttr(integerTy, APInt(integerTy.getWidth(), 1));
-  } else if (type.isa<RankedTensorType, VectorType>()) {
-    auto vtType = type.cast<ShapedType>();
+  } else if (llvm::isa<RankedTensorType, VectorType>(type)) {
+    auto vtType = llvm::cast<ShapedType>(type);
     auto element = oneOfType(vtType.getElementType());
     if (!element) return {};
     return DenseElementsAttr::get(vtType, element);
@@ -135,11 +135,10 @@ struct DropDefaultConstGlobalOpInitializer : public OpRewritePattern<T> {
   LogicalResult matchAndRewrite(T op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getInitialValue().has_value()) return failure();
-    if (auto value =
-            op.getInitialValueAttr().template dyn_cast<IntegerAttr>()) {
+    if (auto value = llvm::dyn_cast<IntegerAttr>(op.getInitialValueAttr())) {
       if (value.getValue() != 0) return failure();
     } else if (auto value =
-                   op.getInitialValueAttr().template dyn_cast<FloatAttr>()) {
+                   llvm::dyn_cast<FloatAttr>(op.getInitialValueAttr())) {
       if (value.getValue().isNonZero()) return failure();
     }
     auto visibility = op.getVisibility();
@@ -477,15 +476,17 @@ template <class AttrElementT,
           class CalculationT = std::function<APInt(ElementValueT)>>
 static Attribute constFoldUnaryOp(Attribute rawOperand,
                                   const CalculationT &calculate) {
-  if (auto operand = rawOperand.dyn_cast_or_null<AttrElementT>()) {
+  if (auto operand = llvm::dyn_cast_if_present<AttrElementT>(rawOperand)) {
     return AttrElementT::get(operand.getType(), calculate(operand.getValue()));
-  } else if (auto operand = rawOperand.dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto operand =
+                 llvm::dyn_cast_if_present<SplatElementsAttr>(rawOperand)) {
     auto elementResult = constFoldUnaryOp<AttrElementT>(
         {operand.getSplatValue<Attribute>()}, calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(operand.getType(), elementResult);
-  } else if (auto operand = rawOperand.dyn_cast_or_null<ElementsAttr>()) {
-    return operand.cast<DenseIntOrFPElementsAttr>().mapValues(
+  } else if (auto operand =
+                 llvm::dyn_cast_if_present<ElementsAttr>(rawOperand)) {
+    return llvm::cast<DenseIntOrFPElementsAttr>(operand).mapValues(
         cast<ShapedType>(operand.getType()).getElementType(),
         llvm::function_ref<ElementValueT(const ElementValueT &)>(
             [&](const ElementValueT &value) { return calculate(value); }));
@@ -497,15 +498,17 @@ static Attribute constFoldUnaryOp(Attribute rawOperand,
 /// attribute in `operands` and returns the result if possible.
 static Attribute constFoldFloatUnaryOp(
     Attribute rawOperand, const std::function<APFloat(APFloat)> &calculate) {
-  if (auto operand = rawOperand.dyn_cast_or_null<FloatAttr>()) {
+  if (auto operand = llvm::dyn_cast_if_present<FloatAttr>(rawOperand)) {
     return FloatAttr::get(operand.getType(), calculate(operand.getValue()));
-  } else if (auto operand = rawOperand.dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto operand =
+                 llvm::dyn_cast_if_present<SplatElementsAttr>(rawOperand)) {
     auto elementResult =
         constFoldFloatUnaryOp({operand.getSplatValue<Attribute>()}, calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(operand.getType(), elementResult);
-  } else if (auto operand = rawOperand.dyn_cast_or_null<ElementsAttr>()) {
-    return operand.cast<DenseIntOrFPElementsAttr>().mapValues(
+  } else if (auto operand =
+                 llvm::dyn_cast_if_present<ElementsAttr>(rawOperand)) {
+    return llvm::cast<DenseIntOrFPElementsAttr>(operand).mapValues(
         cast<ShapedType>(operand.getType()).getElementType(),
         llvm::function_ref<APInt(const APFloat &)>([&](const APFloat &value) {
           return calculate(value).bitcastToAPInt();
@@ -523,22 +526,22 @@ template <class AttrElementT,
               std::function<ElementValueT(ElementValueT, ElementValueT)>>
 static TypedAttr constFoldBinaryOp(Attribute rawLhs, Attribute rawRhs,
                                    const CalculationT &calculate) {
-  if (auto lhs = rawLhs.dyn_cast_or_null<AttrElementT>()) {
-    auto rhs = rawRhs.dyn_cast_or_null<AttrElementT>();
+  if (auto lhs = llvm::dyn_cast_if_present<AttrElementT>(rawLhs)) {
+    auto rhs = llvm::dyn_cast_if_present<AttrElementT>(rawRhs);
     if (!rhs) return {};
     return AttrElementT::get(lhs.getType(),
                              calculate(lhs.getValue(), rhs.getValue()));
-  } else if (auto lhs = rawLhs.dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto lhs = llvm::dyn_cast_if_present<SplatElementsAttr>(rawLhs)) {
     // TODO(benvanik): handle splat/otherwise.
-    auto rhs = rawRhs.dyn_cast_or_null<SplatElementsAttr>();
+    auto rhs = llvm::dyn_cast_if_present<SplatElementsAttr>(rawRhs);
     if (!rhs || lhs.getType() != rhs.getType()) return {};
     auto elementResult = constFoldBinaryOp<AttrElementT>(
         lhs.getSplatValue<Attribute>(), rhs.getSplatValue<Attribute>(),
         calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(lhs.getType(), elementResult);
-  } else if (auto lhs = rawLhs.dyn_cast_or_null<ElementsAttr>()) {
-    auto rhs = rawRhs.dyn_cast_or_null<ElementsAttr>();
+  } else if (auto lhs = llvm::dyn_cast_if_present<ElementsAttr>(rawLhs)) {
+    auto rhs = llvm::dyn_cast_if_present<ElementsAttr>(rawRhs);
     if (!rhs || lhs.getType() != rhs.getType()) return {};
     auto lhsIt = lhs.getValues<AttrElementT>().begin();
     auto rhsIt = rhs.getValues<AttrElementT>().begin();
@@ -564,18 +567,18 @@ template <class AttrElementT,
 static Attribute constFoldTernaryOp(Attribute rawA, Attribute rawB,
                                     Attribute rawC,
                                     const CalculationT &calculate) {
-  if (auto a = rawA.dyn_cast_or_null<AttrElementT>()) {
-    auto b = rawB.dyn_cast_or_null<AttrElementT>();
-    auto c = rawC.dyn_cast_or_null<AttrElementT>();
+  if (auto a = llvm::dyn_cast_if_present<AttrElementT>(rawA)) {
+    auto b = llvm::dyn_cast_if_present<AttrElementT>(rawB);
+    auto c = llvm::dyn_cast_if_present<AttrElementT>(rawC);
     if (!b || !c || a.getType() != b.getType() || a.getType() != c.getType()) {
       return {};
     }
     return AttrElementT::get(
         a.getType(), calculate(a.getValue(), b.getValue(), c.getValue()));
-  } else if (auto a = rawA.dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto a = llvm::dyn_cast_if_present<SplatElementsAttr>(rawA)) {
     // TODO(benvanik): handle splat/otherwise.
-    auto b = rawB.dyn_cast_or_null<SplatElementsAttr>();
-    auto c = rawC.dyn_cast_or_null<SplatElementsAttr>();
+    auto b = llvm::dyn_cast_if_present<SplatElementsAttr>(rawB);
+    auto c = llvm::dyn_cast_if_present<SplatElementsAttr>(rawC);
     if (!b || !c || a.getType() != b.getType() || a.getType() != c.getType()) {
       return {};
     }
@@ -584,9 +587,9 @@ static Attribute constFoldTernaryOp(Attribute rawA, Attribute rawB,
         c.getSplatValue<Attribute>(), calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(a.getType(), elementResult);
-  } else if (auto a = rawA.dyn_cast_or_null<ElementsAttr>()) {
-    auto b = rawB.dyn_cast_or_null<ElementsAttr>();
-    auto c = rawC.dyn_cast_or_null<ElementsAttr>();
+  } else if (auto a = llvm::dyn_cast_if_present<ElementsAttr>(rawA)) {
+    auto b = llvm::dyn_cast_if_present<ElementsAttr>(rawB);
+    auto c = llvm::dyn_cast_if_present<ElementsAttr>(rawC);
     if (!b || !c || a.getType() != b.getType() || a.getType() != c.getType()) {
       return {};
     }
@@ -1450,7 +1453,7 @@ template <class AttrElementT,
           class CalculationT = std::function<ElementValueT(ElementValueT)>>
 static Attribute constFoldConversionOp(Type resultType, Attribute rawOperand,
                                        const CalculationT &calculate) {
-  if (auto operand = rawOperand.dyn_cast_or_null<AttrElementT>()) {
+  if (auto operand = llvm::dyn_cast_if_present<AttrElementT>(rawOperand)) {
     return AttrElementT::get(resultType, calculate(operand.getValue()));
   }
   return {};
@@ -1618,7 +1621,7 @@ template <
     class CalculationT = std::function<DstElementValueT(SrcElementValueT)>>
 static Attribute constFoldCastOp(Type resultType, Attribute rawOperand,
                                  const CalculationT &calculate) {
-  if (auto operand = rawOperand.dyn_cast_or_null<SrcAttrElementT>()) {
+  if (auto operand = llvm::dyn_cast_if_present<SrcAttrElementT>(rawOperand)) {
     return DstAttrElementT::get(resultType, calculate(operand.getValue()));
   }
   return {};
@@ -1736,12 +1739,13 @@ template <class AttrElementT,
           class CalculationT = std::function<APInt(ElementValueT)>>
 static Attribute constFoldUnaryCmpOp(Attribute rawOperand,
                                      const CalculationT &calculate) {
-  if (auto operand = rawOperand.dyn_cast_or_null<AttrElementT>()) {
+  if (auto operand = llvm::dyn_cast_if_present<AttrElementT>(rawOperand)) {
     auto boolType = IntegerType::get(operand.getContext(), 32);
     return IntegerAttr::get(boolType, calculate(operand.getValue()));
-  } else if (auto operand = rawOperand.dyn_cast_or_null<ElementsAttr>()) {
+  } else if (auto operand =
+                 llvm::dyn_cast_if_present<ElementsAttr>(rawOperand)) {
     auto boolType = IntegerType::get(operand.getContext(), 32);
-    return operand.cast<DenseIntOrFPElementsAttr>().mapValues(
+    return llvm::cast<DenseIntOrFPElementsAttr>(operand).mapValues(
         boolType,
         llvm::function_ref<APInt(const ElementValueT &)>(
             [&](const ElementValueT &value) { return calculate(value); }));
@@ -1757,8 +1761,8 @@ template <class AttrElementT,
               std::function<ElementValueT(ElementValueT, ElementValueT)>>
 static Attribute constFoldBinaryCmpOp(Attribute rawLhs, Attribute rawRhs,
                                       const CalculationT &calculate) {
-  if (auto lhs = rawLhs.dyn_cast_or_null<AttrElementT>()) {
-    auto rhs = rawRhs.dyn_cast_or_null<AttrElementT>();
+  if (auto lhs = llvm::dyn_cast_if_present<AttrElementT>(rawLhs)) {
+    auto rhs = llvm::dyn_cast_if_present<AttrElementT>(rawRhs);
     if (!rhs) return {};
     auto boolType = IntegerType::get(lhs.getContext(), 32);
     return AttrElementT::get(boolType,
@@ -1783,7 +1787,7 @@ struct SwapInvertedCmpOps : public OpRewritePattern<OP> {
       Attribute rhs;
       if (xorOp.getLhs() == op.getResult() &&
           matchPattern(xorOp.getRhs(), m_Constant(&rhs)) &&
-          rhs.cast<IntegerAttr>().getInt() == 1) {
+          llvm::cast<IntegerAttr>(rhs).getInt() == 1) {
         auto invValue = rewriter.createOrFold<INV>(
             op.getLoc(), op.getResult().getType(), op.getLhs(), op.getRhs());
         rewriter.replaceOp(op, {invValue});
@@ -2182,14 +2186,14 @@ template <class AttrElementT,
               std::function<ElementValueT(ElementValueT, ElementValueT)>>
 static TypedAttr constFoldBinaryCmpFOp(Attribute rawLhs, Attribute rawRhs,
                                        const CalculationT &calculate) {
-  if (auto lhs = rawLhs.dyn_cast_or_null<AttrElementT>()) {
-    auto rhs = rawRhs.dyn_cast_or_null<AttrElementT>();
+  if (auto lhs = llvm::dyn_cast_if_present<AttrElementT>(rawLhs)) {
+    auto rhs = llvm::dyn_cast_if_present<AttrElementT>(rawRhs);
     if (!rhs) return {};
     return IntegerAttr::get(IntegerType::get(lhs.getContext(), 32),
                             calculate(lhs.getValue(), rhs.getValue()));
-  } else if (auto lhs = rawLhs.dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto lhs = llvm::dyn_cast_if_present<SplatElementsAttr>(rawLhs)) {
     // TODO(benvanik): handle splat/otherwise.
-    auto rhs = rawRhs.dyn_cast_or_null<SplatElementsAttr>();
+    auto rhs = llvm::dyn_cast_if_present<SplatElementsAttr>(rawRhs);
     if (!rhs || lhs.getType() != rhs.getType()) return {};
     auto elementResult = constFoldBinaryCmpFOp<AttrElementT>(
         lhs.getSplatValue<Attribute>(), rhs.getSplatValue<Attribute>(),
@@ -2198,8 +2202,8 @@ static TypedAttr constFoldBinaryCmpFOp(Attribute rawLhs, Attribute rawRhs,
     auto resultType = lhs.getType().clone(
         std::nullopt, IntegerType::get(lhs.getContext(), 32));
     return DenseElementsAttr::get(resultType, elementResult);
-  } else if (auto lhs = rawLhs.dyn_cast_or_null<ElementsAttr>()) {
-    auto rhs = rawRhs.dyn_cast_or_null<ElementsAttr>();
+  } else if (auto lhs = llvm::dyn_cast_if_present<ElementsAttr>(rawLhs)) {
+    auto rhs = llvm::dyn_cast_if_present<ElementsAttr>(rawRhs);
     if (!rhs || lhs.getType() != rhs.getType()) return {};
     auto lhsIt = lhs.getValues<AttrElementT>().begin();
     auto rhsIt = rhs.getValues<AttrElementT>().begin();
@@ -2711,7 +2715,8 @@ void CmpNZF64UOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult CmpNaNF32Op::fold(FoldAdaptor operands) {
-  if (auto operand = operands.getOperand().dyn_cast_or_null<FloatAttr>()) {
+  if (auto operand =
+          llvm::dyn_cast_if_present<FloatAttr>(operands.getOperand())) {
     return operand.getValue().isNaN() ? oneOfType(getType())
                                       : zeroOfType(getType());
   }
@@ -2719,7 +2724,8 @@ OpFoldResult CmpNaNF32Op::fold(FoldAdaptor operands) {
 }
 
 OpFoldResult CmpNaNF64Op::fold(FoldAdaptor operands) {
-  if (auto operand = operands.getOperand().dyn_cast_or_null<FloatAttr>()) {
+  if (auto operand =
+          llvm::dyn_cast_if_present<FloatAttr>(operands.getOperand())) {
     return operand.getValue().isNaN() ? oneOfType(getType())
                                       : zeroOfType(getType());
   }
@@ -2854,7 +2860,7 @@ static LogicalResult collapseBranch(Block *&successor,
 
   // Otherwise, we need to remap any argument operands.
   for (Value operand : operands) {
-    BlockArgument argOperand = operand.dyn_cast<BlockArgument>();
+    BlockArgument argOperand = llvm::dyn_cast<BlockArgument>(operand);
     if (argOperand && argOperand.getOwner() == successor)
       argStorage.push_back(successorOperands[argOperand.getArgNumber()]);
     else
@@ -3126,7 +3132,7 @@ struct RewriteCheckToCondFail : public OpRewritePattern<CheckOp> {
     Type condType = rewriter.getI32Type();
     Value condValue;
     Type operandType = op.getOperation()->getOperand(0).getType();
-    if (operandType.template isa<RefType>()) {
+    if (llvm::isa<RefType>(operandType)) {
       condValue = rewriter.template createOrFold<CmpRefOp>(
           op.getLoc(), ArrayRef<Type>{condType},
           op.getOperation()->getOperands());

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMTypes.cpp
@@ -50,10 +50,10 @@ struct ListTypeStorage : public TypeStorage {
 
 // static
 bool ListType::isCompatible(Type type) {
-  if (type.isa<OpaqueType>()) {
+  if (llvm::isa<OpaqueType>(type)) {
     // Allow all types (variant).
     return true;
-  } else if (type.isa<RefType>()) {
+  } else if (llvm::isa<RefType>(type)) {
     // Allow all ref types.
     return true;
   } else if (type.isIntOrFloat()) {
@@ -86,7 +86,7 @@ Type ListType::getElementType() { return getImpl()->elementType; }
 namespace detail {
 
 struct RefTypeStorage : public TypeStorage {
-  RefTypeStorage(Type objectType) : objectType(objectType.cast<Type>()) {}
+  RefTypeStorage(Type objectType) : objectType(llvm::cast<Type>(objectType)) {}
 
   /// The hash key used for uniquing.
   using KeyTy = Type;
@@ -105,10 +105,11 @@ struct RefTypeStorage : public TypeStorage {
 
 // static
 bool RefType::isCompatible(Type type) {
-  if (type.isa<RefType>()) {
+  if (llvm::isa<RefType>(type)) {
     // Already a ref - don't double-wrap.
     return false;
-  } else if (type.isSignlessIntOrIndexOrFloat() || type.isa<ComplexType>()) {
+  } else if (type.isSignlessIntOrIndexOrFloat() ||
+             llvm::isa<ComplexType>(type)) {
     // Ignore known primitive types.
     return false;
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -75,7 +75,7 @@ class V0BytecodeEncoder : public BytecodeEncoder {
   }
 
   LogicalResult encodeType(Value value) override {
-    auto refPtrType = value.getType().dyn_cast<IREE::VM::RefType>();
+    auto refPtrType = llvm::dyn_cast<IREE::VM::RefType>(value.getType());
     if (!refPtrType) {
       return currentOp_->emitOpError()
              << "type " << value.getType()
@@ -86,8 +86,8 @@ class V0BytecodeEncoder : public BytecodeEncoder {
 
   LogicalResult encodeType(Type type) override {
     // HACK: it'd be nice to remove the implicit ref wrapper hiding.
-    if (auto refType = type.dyn_cast<IREE::VM::RefType>()) {
-      if (refType.getObjectType().isa<IREE::VM::ListType>()) {
+    if (auto refType = llvm::dyn_cast<IREE::VM::RefType>(type)) {
+      if (llvm::isa<IREE::VM::ListType>(refType.getObjectType())) {
         type = refType.getObjectType();
       }
     }
@@ -103,7 +103,7 @@ class V0BytecodeEncoder : public BytecodeEncoder {
 
   LogicalResult encodePrimitiveAttr(TypedAttr attr) override {
     unsigned int bitWidth = attr.getType().getIntOrFloatBitWidth();
-    if (auto integerAttr = attr.dyn_cast<IntegerAttr>()) {
+    if (auto integerAttr = llvm::dyn_cast<IntegerAttr>(attr)) {
       uint64_t limitedValue =
           integerAttr.getValue().extractBitsAsZExtValue(bitWidth, 0);
       switch (bitWidth) {
@@ -119,7 +119,7 @@ class V0BytecodeEncoder : public BytecodeEncoder {
           return currentOp_->emitOpError()
                  << "attribute of bitwidth " << bitWidth << " not supported";
       }
-    } else if (auto floatAttr = attr.dyn_cast<FloatAttr>()) {
+    } else if (auto floatAttr = llvm::dyn_cast<FloatAttr>(attr)) {
       switch (bitWidth) {
         case 32: {
           union {

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -107,7 +107,7 @@ static flatbuffers_uint8_vec_ref_t serializeEmbeddedData(
     return {};
   }
 
-  auto value = valueAttr.dyn_cast<IREE::Util::SerializableAttrInterface>();
+  auto value = llvm::dyn_cast<IREE::Util::SerializableAttrInterface>(valueAttr);
   assert(value && "expected a serializable rodata value");
 
   // Reserve memory in the FlatBuffer for the data.
@@ -241,7 +241,7 @@ static iree_vm_FunctionSignatureDef_ref_t makeFunctionSignatureDef(
     SmallVector<iree_vm_AttrDef_ref_t, 4> attrRefs;
     for (auto attr : attrs) {
       auto key = attr.getName().strref();
-      auto value = attr.getValue().dyn_cast<StringAttr>();
+      auto value = llvm::dyn_cast<StringAttr>(attr.getValue());
       if (!value || key.empty()) continue;
       // NOTE: if we actually want to keep these we should dedupe them (as the
       // keys and likely several of the values are shared across all functions).
@@ -628,8 +628,8 @@ LogicalResult translateModuleToBytecode(
   SmallVector<RodataRef> rodataRefs;
   rodataRefs.resize(rodataOps.size());
   for (auto &rodataOp : rodataOps) {
-    auto rodataValue =
-        rodataOp.getValue().dyn_cast<IREE::Util::SerializableAttrInterface>();
+    auto rodataValue = llvm::dyn_cast<IREE::Util::SerializableAttrInterface>(
+        rodataOp.getValue());
     assert(rodataValue && "expected a serializable rodata value");
 
     // Split large rodata out of the FlatBuffer to avoid going over 2GB.

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -182,7 +182,7 @@ class GlobalInitializationPass
     for (auto &op : moduleOp.getBlock().getOperations()) {
       if (auto globalOp = dyn_cast<IREE::VM::GlobalRefOp>(op)) {
       } else if (auto globalOp = dyn_cast<IREE::Util::GlobalOpInterface>(op)) {
-        if (globalOp.getGlobalType().isa<IREE::VM::RefType>()) {
+        if (llvm::isa<IREE::VM::RefType>(globalOp.getGlobalType())) {
           if (failed(appendRefInitialization(globalOp, initBuilder))) {
             globalOp.emitOpError()
                 << "ref-type global unable to be initialized";
@@ -250,7 +250,7 @@ class GlobalInitializationPass
   // Returns {} if the constant is zero.
   std::pair<LogicalResult, Value> createConst(Location loc, Attribute value,
                                               OpBuilder &builder) {
-    if (auto integerAttr = value.dyn_cast<IntegerAttr>()) {
+    if (auto integerAttr = llvm::dyn_cast<IntegerAttr>(value)) {
       if (integerAttr.getValue().isZero()) {
         // Globals are zero-initialized by default.
         return {success(), {}};
@@ -265,7 +265,7 @@ class GlobalInitializationPass
         default:
           return {failure(), {}};
       }
-    } else if (auto floatAttr = value.dyn_cast<FloatAttr>()) {
+    } else if (auto floatAttr = llvm::dyn_cast<FloatAttr>(value)) {
       if (floatAttr.getValue().isZero()) {
         // Globals are zero-initialized by default.
         return {success(), {}};
@@ -287,7 +287,7 @@ class GlobalInitializationPass
   // Stores a value to a global; the global must be mutable.
   LogicalResult storePrimitiveGlobal(Location loc, StringRef symName,
                                      Value value, OpBuilder &builder) {
-    if (auto integerType = value.getType().dyn_cast<IntegerType>()) {
+    if (auto integerType = llvm::dyn_cast<IntegerType>(value.getType())) {
       switch (integerType.getIntOrFloatBitWidth()) {
         case 32:
           builder.create<IREE::VM::GlobalStoreI32Op>(loc, value, symName);
@@ -298,7 +298,7 @@ class GlobalInitializationPass
         default:
           return failure();
       }
-    } else if (auto floatType = value.getType().dyn_cast<FloatType>()) {
+    } else if (auto floatType = llvm::dyn_cast<FloatType>(value.getType())) {
       switch (floatType.getIntOrFloatBitWidth()) {
         case 32:
           builder.create<IREE::VM::GlobalStoreF32Op>(loc, value, symName);

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
@@ -73,7 +73,7 @@ class OrdinalAllocationPass
       } else if (isa<RodataOp>(op)) {
         ordinal = nextRodataOrdinal++;
       } else if (auto globalOp = dyn_cast<IREE::Util::GlobalOpInterface>(op)) {
-        if (globalOp.getGlobalType().isa<IREE::VM::RefType>()) {
+        if (llvm::isa<IREE::VM::RefType>(globalOp.getGlobalType())) {
           ordinal = nextGlobalRefOrdinal++;
         } else {
           // Bucket the primitive global ops (like vm.global.i32) by byte size

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ResolveRodataLoads.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ResolveRodataLoads.cpp
@@ -135,9 +135,9 @@ class ResolveRodataLoadsPass
     // loads/stores to the globals and leaves the globals for SymbolDCE.
     DenseSet<Operation *> deadOps;
     explorer.forEachGlobal([&](const Explorer::GlobalInfo *globalInfo) {
-      if (auto refType =
-              globalInfo->op.getGlobalType().dyn_cast<IREE::VM::RefType>()) {
-        if (refType.getObjectType().isa<IREE::VM::BufferType>()) {
+      if (auto refType = llvm::dyn_cast<IREE::VM::RefType>(
+              globalInfo->op.getGlobalType())) {
+        if (llvm::isa<IREE::VM::BufferType>(refType.getObjectType())) {
           processBufferGlobal(explorer, globalInfo, deadOps);
         }
       }

--- a/compiler/src/iree/compiler/Dialect/VM/Utils/CallingConvention.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Utils/CallingConvention.cpp
@@ -26,10 +26,10 @@ namespace VM {
 //  tuple<i32, i64>  -> iI
 LogicalResult encodeCallingConventionType(Operation *op, Type type,
                                           SmallVectorImpl<char> &s) {
-  if (auto refPtrType = type.dyn_cast<IREE::VM::RefType>()) {
+  if (auto refPtrType = llvm::dyn_cast<IREE::VM::RefType>(type)) {
     s.push_back('r');
     return success();
-  } else if (auto integerType = type.dyn_cast<IntegerType>()) {
+  } else if (auto integerType = llvm::dyn_cast<IntegerType>(type)) {
     switch (integerType.getIntOrFloatBitWidth()) {
       default:
       case 32:
@@ -39,7 +39,7 @@ LogicalResult encodeCallingConventionType(Operation *op, Type type,
         s.push_back('I');
         return success();
     }
-  } else if (auto floatType = type.dyn_cast<FloatType>()) {
+  } else if (auto floatType = llvm::dyn_cast<FloatType>(type)) {
     switch (floatType.getIntOrFloatBitWidth()) {
       default:
       case 32:
@@ -49,7 +49,7 @@ LogicalResult encodeCallingConventionType(Operation *op, Type type,
         s.push_back('F');
         return success();
     }
-  } else if (auto tupleType = type.dyn_cast<TupleType>()) {
+  } else if (auto tupleType = llvm::dyn_cast<TupleType>(type)) {
     // Flatten tuple (so tuple<i32, i64> -> `...iI...`).
     SmallVector<Type, 4> flattenedTypes;
     tupleType.getFlattenedTypes(flattenedTypes);

--- a/compiler/src/iree/compiler/Dialect/VM/Utils/TypeTable.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Utils/TypeTable.cpp
@@ -17,7 +17,7 @@ std::vector<TypeDef> buildTypeTable(IREE::VM::ModuleOp moduleOp) {
   llvm::DenseMap<Type, std::string> typeMap;
   std::function<void(Type)> tryInsertType;
   tryInsertType = [&](Type type) {
-    if (auto refPtrType = type.dyn_cast<IREE::VM::RefType>()) {
+    if (auto refPtrType = llvm::dyn_cast<IREE::VM::RefType>(type)) {
       type = refPtrType.getObjectType();
     }
     if (typeMap.count(type)) return;
@@ -26,7 +26,7 @@ std::vector<TypeDef> buildTypeTable(IREE::VM::ModuleOp moduleOp) {
     type.print(sstream);
     sstream.flush();
     typeMap.try_emplace(type, str);
-    if (auto listType = type.dyn_cast<IREE::VM::ListType>()) {
+    if (auto listType = llvm::dyn_cast<IREE::VM::ListType>(type)) {
       assert(listType.getElementType());
       tryInsertType(listType.getElementType());
     }

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
@@ -223,8 +223,8 @@ struct ConvertGetRawInterfaceBindingBufferOp
     }
 
     IndexSet indexSet(op.getLoc(), rewriter);
-    auto bindingType =
-        bindingsArg.getType().cast<IREE::Util::ListType>().getElementType();
+    auto bindingType = llvm::cast<IREE::Util::ListType>(bindingsArg.getType())
+                           .getElementType();
     rewriter
         .replaceOpWithNewOp<IREE::Util::ListGetOp>(
             op, bindingType, bindingsArg,
@@ -255,8 +255,8 @@ struct ConvertHALInterfaceBindingSubspanOp
     }
 
     IndexSet indexSet(op.getLoc(), rewriter);
-    auto bindingType =
-        bindingsArg.getType().cast<IREE::Util::ListType>().getElementType();
+    auto bindingType = llvm::cast<IREE::Util::ListType>(bindingsArg.getType())
+                           .getElementType();
     auto sourceBuffer =
         rewriter
             .create<IREE::Util::ListGetOp>(
@@ -272,7 +272,7 @@ struct ConvertHALInterfaceBindingSubspanOp
 
       // Compute the dest size by multiplying the element size by all extents
       // (static and dynamic).
-      auto memRefType = op.getResult().getType().cast<MemRefType>();
+      auto memRefType = llvm::cast<MemRefType>(op.getResult().getType());
       Value destSize = rewriter.createOrFold<IREE::Util::SizeOfOp>(
           op.getLoc(), memRefType.getElementType());
       auto dynamicExtentIt = adaptor.getDynamicDims().begin();

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
@@ -92,13 +92,13 @@ class VMVXImportOpConversion : public OpConversionPattern<T> {
 
   std::string getTypedTypeStr(Type type, bool forceUnsigned = false) const {
     Type elementType = type;
-    auto shapedType = type.dyn_cast<ShapedType>();
+    auto shapedType = llvm::dyn_cast<ShapedType>(type);
     if (shapedType) {
       elementType = shapedType.getElementType();
     }
 
     std::string typePrefix = "x";
-    if (elementType.isa<FloatType>()) {
+    if (llvm::isa<FloatType>(elementType)) {
       typePrefix = "f";
     } else if (elementType.isSignlessInteger()) {
       typePrefix = forceUnsigned ? "u" : "i";

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/MaterializeConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/MaterializeConstants.cpp
@@ -71,9 +71,9 @@ class MaterializeConstantsPass
                 return loadOp.getLoc();
               })));
       auto globalType = loadOps.front().getType();
-      auto globalName =
-          (kConstantBlockGlobalPrefix + keyAttr.cast<StringAttr>().getValue())
-              .str();
+      auto globalName = (kConstantBlockGlobalPrefix +
+                         llvm::cast<StringAttr>(keyAttr).getValue())
+                            .str();
 
       // Placeholder ordinal that'll be updated during linking.
       auto ordinalGlobalOp = moduleBuilder.create<IREE::Util::GlobalOp>(

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
@@ -96,7 +96,7 @@ static SmallVector<OpFoldResult> getStridesFromSizes(
 static FailureOr<DescriptorInfo> resolveBufferDescriptorForInterfaceBinding(
     IREE::HAL::InterfaceBindingSubspanOp binding, RewriterBase &rewriter,
     Location loc) {
-  auto memRefType = binding.getResult().getType().template cast<MemRefType>();
+  auto memRefType = llvm::cast<MemRefType>(binding.getResult().getType());
   int rank = memRefType.getRank();
   DescriptorInfo resultDescriptor;
 
@@ -130,7 +130,7 @@ static FailureOr<DescriptorInfo> resolveBufferDescriptorForAllocation(
   //   offset: byte offset from subspan divided by element type size
   //   sizes: static and dynamic sizes from the subspan
   //   strides: identity strides
-  auto memRefType = alloca.getResult().getType().cast<MemRefType>();
+  auto memRefType = llvm::cast<MemRefType>(alloca.getResult().getType());
   int rank = memRefType.getRank();
 
   // Compute sizes.
@@ -163,7 +163,7 @@ static FailureOr<DescriptorInfo> resolveBufferDescriptorForGetGlobalOp(
   //   offset: byte offset from subspan divided by element type size
   //   sizes: static and dynamic sizes from the subspan
   //   strides: identity strides
-  auto memRefType = global.getResult().getType().cast<MemRefType>();
+  auto memRefType = llvm::cast<MemRefType>(global.getResult().getType());
   int rank = memRefType.getRank();
 
   // Compute sizes.
@@ -228,9 +228,9 @@ struct FromMemRefSubView : public OpRewritePattern<GetBufferDescriptorOp> {
     IndexSet indexSet(loc, rewriter);
 
     // Get types.
-    auto subType = subview.getResult().getType().template cast<MemRefType>();
+    auto subType = llvm::cast<MemRefType>(subview.getResult().getType());
     Value source = subview.getSource();
-    auto sourceType = source.getType().template cast<MemRefType>();
+    auto sourceType = llvm::cast<MemRefType>(source.getType());
     int sourceRank = sourceType.getRank();
     int subRank = subType.getRank();
     (void)subRank;
@@ -333,7 +333,7 @@ struct FromAllocation : public OpRewritePattern<GetBufferDescriptorOp> {
                                 PatternRewriter &rewriter) const override {
     auto alloca = op.getSource().template getDefiningOp<memref::AllocaOp>();
     if (!alloca) return failure();
-    auto memRefType = alloca.getResult().getType().template cast<MemRefType>();
+    auto memRefType = llvm::cast<MemRefType>(alloca.getResult().getType());
     if (!memRefType.getLayout().isIdentity()) {
       return rewriter.notifyMatchFailure(op, "not identity allocation");
     }
@@ -366,7 +366,7 @@ struct FromGlobal : public OpRewritePattern<GetBufferDescriptorOp> {
                                 PatternRewriter &rewriter) const override {
     auto global = op.getSource().template getDefiningOp<memref::GetGlobalOp>();
     if (!global) return failure();
-    auto memRefType = global.getResult().getType().template cast<MemRefType>();
+    auto memRefType = llvm::cast<MemRefType>(global.getResult().getType());
     if (!memRefType.getLayout().isIdentity()) {
       return rewriter.notifyMatchFailure(op, "not identity allocation");
     }

--- a/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.cpp
@@ -105,17 +105,17 @@ StringRef TargetEnvAttr::getKindName() { return "target_env"; }
 
 Version TargetEnvAttr::getVersion() {
   return static_cast<Version>(
-      getImpl()->version.cast<IntegerAttr>().getValue().getZExtValue());
+      llvm::cast<IntegerAttr>(getImpl()->version).getValue().getZExtValue());
 }
 
 unsigned TargetEnvAttr::getRevision() {
-  return getImpl()->revision.cast<IntegerAttr>().getValue().getZExtValue();
+  return llvm::cast<IntegerAttr>(getImpl()->revision).getValue().getZExtValue();
 }
 
 TargetEnvAttr::ext_iterator::ext_iterator(ArrayAttr::iterator it)
     : llvm::mapped_iterator<ArrayAttr::iterator, Extension (*)(Attribute)>(
           it, [](Attribute attr) {
-            return attr.cast<ExtensionAttr>().getValue();
+            return llvm::cast<ExtensionAttr>(attr).getValue();
           }) {}
 
 TargetEnvAttr::ext_range TargetEnvAttr::getExtensions() {
@@ -124,7 +124,7 @@ TargetEnvAttr::ext_range TargetEnvAttr::getExtensions() {
 }
 
 ArrayAttr TargetEnvAttr::getExtensionsAttr() {
-  return getImpl()->extensions.cast<ArrayAttr>();
+  return llvm::cast<ArrayAttr>(getImpl()->extensions);
 }
 
 spirv::Vendor TargetEnvAttr::getVendorID() { return getImpl()->vendorID; }
@@ -136,7 +136,7 @@ spirv::DeviceType TargetEnvAttr::getDeviceType() {
 uint32_t TargetEnvAttr::getDeviceID() { return getImpl()->deviceID; }
 
 CapabilitiesAttr TargetEnvAttr::getCapabilitiesAttr() {
-  return getImpl()->capabilities.cast<CapabilitiesAttr>();
+  return llvm::cast<CapabilitiesAttr>(getImpl()->capabilities);
 }
 
 LogicalResult TargetEnvAttr::verify(
@@ -331,7 +331,7 @@ void VulkanDialect::printAttribute(Attribute attr,
                                    DialectAsmPrinter &printer) const {
   if (succeeded(generatedAttributePrinter(attr, printer))) return;
 
-  if (auto targetEnv = attr.dyn_cast<TargetEnvAttr>())
+  if (auto targetEnv = llvm::dyn_cast<TargetEnvAttr>(attr))
     return print(targetEnv, printer);
 
   assert(false && "unhandled Vulkan attribute kind");

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -90,9 +90,8 @@ class BufferViewToTensorPattern
   LogicalResult matchAndRewrite(
       IREE::Input::BufferViewToTensorOp srcOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    TensorType resultType =
-        typeConverter->convertType(srcOp.getTarget().getType())
-            .dyn_cast_or_null<TensorType>();
+    TensorType resultType = llvm::dyn_cast_if_present<TensorType>(
+        typeConverter->convertType(srcOp.getTarget().getType()));
     if (!resultType) return failure();
     if (adaptor.getTargetDims().empty() && !resultType.hasStaticShape()) {
       // For the input dialect, we allow ops that don't have their dims
@@ -120,7 +119,7 @@ class TensorToBufferViewPattern
       IREE::Input::TensorToBufferViewOp srcOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     Type resultType = typeConverter->convertType(srcOp.getTarget().getType());
-    auto sourceType = adaptor.getSource().getType().dyn_cast<TensorType>();
+    auto sourceType = llvm::dyn_cast<TensorType>(adaptor.getSource().getType());
     if (!resultType || !sourceType) return failure();
     if (adaptor.getSourceDims().empty() && !sourceType.hasStaticShape()) {
       // For the input dialect, we allow ops that don't have their dims

--- a/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
@@ -100,7 +100,7 @@ class MLProgramGlobalOpPattern
     bool isExtern = srcOpAttr && isa<ml_program::ExternAttr>(*srcOpAttr);
     auto srcOpTypedAttr =
         (srcOpAttr && !isExtern)
-            ? std::optional<TypedAttr>(srcOpAttr.value().cast<TypedAttr>())
+            ? std::optional<TypedAttr>(llvm::cast<TypedAttr>(srcOpAttr.value()))
             : std::nullopt;
     const SymbolTable::Visibility visibility = srcOp.getVisibility();
     // Create util Global which is mutable if the ML program global was or if

--- a/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
@@ -52,7 +52,7 @@ Value emptyZero(ImplicitLocOpBuilder &builder, RankedTensorType ty,
 Value applyZeroPoint(ImplicitLocOpBuilder &builder, Value conv, Value sum,
                      Value zp, ArrayRef<int> affine_map) {
   auto context = builder.getContext();
-  auto convTy = conv.getType().cast<RankedTensorType>();
+  auto convTy = llvm::cast<RankedTensorType>(conv.getType());
 
   llvm::SmallVector<AffineExpr> sumExprs;
   for (auto i : affine_map) {
@@ -82,7 +82,7 @@ Value applyZeroPoint(ImplicitLocOpBuilder &builder, Value conv, Value sum,
 
 // Add the scalar value to the tensor.
 Value addScalar(ImplicitLocOpBuilder &builder, Value value, Value scalar) {
-  auto ty = value.getType().cast<RankedTensorType>();
+  auto ty = llvm::cast<RankedTensorType>(value.getType());
   SmallVector<utils::IteratorType> iterators(ty.getRank(),
                                              utils::IteratorType::parallel);
   auto map = builder.getMultiDimIdentityMap(ty.getRank());
@@ -102,7 +102,7 @@ void GetDynamicDym(ImplicitLocOpBuilder &builder,
                    llvm::SmallVector<int64_t> &dims,
                    llvm::SmallVector<Value> &dynDims, Value value,
                    int64_t dim) {
-  ShapedType ty = value.getType().cast<ShapedType>();
+  ShapedType ty = llvm::cast<ShapedType>(value.getType());
   dims.push_back(ty.getDimSize(dim));
   if (ty && ty.isDynamicDim(dim))
     dynDims.push_back(builder.create<tensor::DimOp>(value, dim));
@@ -135,8 +135,8 @@ struct QuantizedConvToConv
     auto filter = op.getInputs()[1];
     auto iZp = op.getInputs()[2];
     auto fZp = op.getInputs()[3];
-    auto inputTy = input.getType().cast<RankedTensorType>();
-    auto resultTy = op.getType(0).cast<ShapedType>();
+    auto inputTy = llvm::cast<RankedTensorType>(input.getType());
+    auto resultTy = llvm::cast<ShapedType>(op.getType(0));
     auto accETy = resultTy.getElementType();
 
     auto strides = op.getStrides();
@@ -255,7 +255,7 @@ struct QuantizedDepthwiseConvToDepthwiseConv
     auto filter = op.getInputs()[1];
     auto iZp = op.getInputs()[2];
     auto fZp = op.getInputs()[3];
-    auto resultTy = op.getType(0).cast<ShapedType>();
+    auto resultTy = llvm::cast<ShapedType>(op.getType(0));
     auto accETy = resultTy.getElementType();
 
     auto strides = op.getStrides();

--- a/compiler/src/iree/compiler/InputConversion/Common/QuantizedMatmulToMatmul.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/QuantizedMatmulToMatmul.cpp
@@ -64,7 +64,7 @@ struct QuantizedMatmulToMatmul
       return success();
     }
     // Create the result. No need to zero-fill it as we will overwrite it.
-    ShapedType accType = acc.getType().cast<ShapedType>();
+    ShapedType accType = llvm::cast<ShapedType>(acc.getType());
     auto accDynShape = linalg::createDynamicDimensions(rewriter, loc, acc);
     Value initResult = builder.create<tensor::EmptyOp>(
         accType.getShape(), accType.getElementType(), accDynShape);

--- a/compiler/src/iree/compiler/InputConversion/Common/Utils.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/Utils.cpp
@@ -25,7 +25,7 @@ namespace iree_compiler {
 Value sumReduceDimensionSubset(ImplicitLocOpBuilder &rewriter, Value val,
                                Type accETy, ArrayRef<bool> is_reduction) {
   auto context = val.getContext();
-  RankedTensorType ty = val.getType().cast<RankedTensorType>();
+  RankedTensorType ty = llvm::cast<RankedTensorType>(val.getType());
 
   llvm::SmallVector<int64_t> staticSizes;
   SmallVector<Value> dynSizes;

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertComplexToReal.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertComplexToReal.cpp
@@ -58,21 +58,21 @@ inline std::optional<chlo::ComparisonType> chloComparisonType(
 }
 
 bool isComplexTensor(Value v) {
-  if (auto tt = v.getType().dyn_cast<TensorType>()) {
-    return tt.getElementType().isa<ComplexType>();
+  if (auto tt = llvm::dyn_cast<TensorType>(v.getType())) {
+    return llvm::isa<ComplexType>(tt.getElementType());
   }
   return false;
 }
 
 Type convertComplexTensorTypeToReal(Type complexTensorType) {
-  auto newElementType = complexTensorType.cast<TensorType>()
-                            .getElementType()
-                            .cast<ComplexType>()
-                            .getElementType();
-  if (auto tt = complexTensorType.dyn_cast<RankedTensorType>()) {
+  auto newElementType =
+      llvm::cast<ComplexType>(
+          complexTensorType.cast<TensorType>().getElementType())
+          .getElementType();
+  if (auto tt = llvm::dyn_cast<RankedTensorType>(complexTensorType)) {
     return RankedTensorType::get(tt.getShape(), newElementType,
                                  tt.getEncoding());
-  } else if (auto tt = complexTensorType.dyn_cast<UnrankedTensorType>()) {
+  } else if (auto tt = llvm::dyn_cast<UnrankedTensorType>(complexTensorType)) {
     return UnrankedTensorType::get(newElementType);
   }
   assert(false && "unknown TensorType subclass");
@@ -473,15 +473,15 @@ struct TestMHLOConvertComplexToRealPass
     ConversionTarget target(*context);
     auto hasNoComplexTypes = [](Operation *op) {
       for (Value operand : op->getOperands()) {
-        if (auto st = operand.getType().dyn_cast<ShapedType>()) {
-          if (st.getElementType().isa<ComplexType>()) {
+        if (auto st = llvm::dyn_cast<ShapedType>(operand.getType())) {
+          if (llvm::isa<ComplexType>(st.getElementType())) {
             return false;
           }
         }
       }
       for (Value result : op->getResults()) {
-        if (auto st = result.getType().dyn_cast<ShapedType>()) {
-          if (st.getElementType().isa<ComplexType>()) {
+        if (auto st = llvm::dyn_cast<ShapedType>(result.getType())) {
+          if (llvm::isa<ComplexType>(st.getElementType())) {
             return false;
           }
         }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -45,14 +45,14 @@ static std::optional<Type> convertRank0TensorToScalar(
     RankedTensorType tensorType) {
   if (tensorType.getRank() != 0) return std::nullopt;
   Type elementType = tensorType.getElementType();
-  if (auto intType = elementType.dyn_cast<IntegerType>()) {
+  if (auto intType = llvm::dyn_cast<IntegerType>(elementType)) {
     elementType = convertIntegerToSignless(intType);
   }
   return elementType;
 }
 
 static Type convertShapedToSignless(ShapedType shapedType) {
-  if (auto intType = shapedType.getElementType().dyn_cast<IntegerType>())
+  if (auto intType = llvm::dyn_cast<IntegerType>(shapedType.getElementType()))
     return shapedType.clone(convertIntegerToSignless(intType));
   return shapedType;
 }
@@ -61,12 +61,13 @@ static std::optional<Value> materializeCast(OpBuilder &builder, Type toType,
                                             ValueRange inputs, Location loc) {
   assert(inputs.size() == 1 && "too many inputs to type conversion");
   Value fromValue = inputs[0];
-  auto fromType = fromValue.getType().dyn_cast<RankedTensorType>();
+  auto fromType = llvm::dyn_cast<RankedTensorType>(fromValue.getType());
   if (!fromType) return std::nullopt;
 
-  if (auto intFromType = fromType.getElementType().dyn_cast<IntegerType>()) {
+  if (auto intFromType =
+          llvm::dyn_cast<IntegerType>(fromType.getElementType())) {
     Type castType = getElementTypeOrSelf(toType);
-    if (auto shapedType = fromType.dyn_cast<ShapedType>())
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(fromType))
       castType = shapedType.clone(castType);
 
     if (castType != fromType)
@@ -119,7 +120,7 @@ struct LinalgExtRegionHLOOpConversion : public OpConversionPattern<OpTy> {
       OpTy op, typename OpTy::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     if (!isInBodyOfLinalgExtOps(op)) return failure();
-    TensorType origRetType = op.getType().template dyn_cast<TensorType>();
+    TensorType origRetType = llvm::dyn_cast<TensorType>(op.getType());
     if (!origRetType) return failure();
     SmallVector<Value> scalarArgs;
     Type newRetType = getElementTypeOrSelf(
@@ -201,7 +202,7 @@ struct ScatterOpConversion : public OpConversionPattern<mhlo::ScatterOp> {
   /// * Update window dims order: (d + 1, ... , m)
   static bool hasCanonicalDimensionNumbers(mhlo::ScatterOp op) {
     auto dimNumbers = op.getScatterDimensionNumbers();
-    auto indicesType = op.getScatterIndices().getType().cast<ShapedType>();
+    auto indicesType = llvm::cast<ShapedType>(op.getScatterIndices().getType());
     auto indicesRank = indicesType.getRank();
     auto indexVectorDim = dimNumbers.getIndexVectorDim();
     auto indexDepth = indicesType.getShape().back();
@@ -291,7 +292,7 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
 
   static SmallVector<Value> getBitReversalOrder(ImplicitLocOpBuilder &b,
                                                 Value real, int fftLength) {
-    auto realType = real.getType().cast<ShapedType>();
+    auto realType = llvm::cast<ShapedType>(real.getType());
     auto rank = realType.getRank();
 
     SmallVector<OpFoldResult> mixedSizes =
@@ -319,11 +320,11 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
           b.create<linalg::YieldOp>(
               loc, b.create<tensor::ExtractOp>(loc, real, ivs).getResult());
         });
-    return {
-        genericOp.getResult(0),
-        b.create<arith::ConstantOp>(
-            realType, DenseFPElementsAttr::get(
-                          realType, b.getF32FloatAttr(0.0).cast<Attribute>()))};
+    return {genericOp.getResult(0),
+            b.create<arith::ConstantOp>(
+                realType,
+                DenseFPElementsAttr::get(
+                    realType, llvm::cast<Attribute>(b.getF32FloatAttr(0.0))))};
   }
 
   static SmallVector<Value> getCoeffConstants(ImplicitLocOpBuilder &b,
@@ -349,7 +350,7 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
       ConversionPatternRewriter &rewriter) const final {
     // Only handle 2^n fft length.
     auto operandType =
-        adaptor.getOperand().getType().dyn_cast<RankedTensorType>();
+        llvm::dyn_cast<RankedTensorType>(adaptor.getOperand().getType());
     if (!operandType || !operandType.hasStaticShape()) {
       return failure();
     }
@@ -401,7 +402,8 @@ struct ReverseOpConversion : public OpConversionPattern<mhlo::ReverseOp> {
   LogicalResult matchAndRewrite(
       mhlo::ReverseOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    auto ty = adaptor.getOperands()[0].getType().dyn_cast<RankedTensorType>();
+    auto ty =
+        llvm::dyn_cast<RankedTensorType>(adaptor.getOperands()[0].getType());
     if (!ty) return failure();
 
     Location loc = op.getLoc();
@@ -428,9 +430,11 @@ struct TopkOpConversion : public OpConversionPattern<chlo::TopKOp> {
     Location loc = op.getLoc();
     Value operand = adaptor.getOperand();
 
-    auto inputValuesType = operand.getType().dyn_cast<ShapedType>();
-    auto outputValuesType = op.getValues().getType().dyn_cast<ShapedType>();
-    auto outputIndicesType = op.getIndices().getType().dyn_cast<ShapedType>();
+    auto inputValuesType = llvm::dyn_cast<ShapedType>(operand.getType());
+    auto outputValuesType =
+        llvm::dyn_cast<ShapedType>(op.getValues().getType());
+    auto outputIndicesType =
+        llvm::dyn_cast<ShapedType>(op.getIndices().getType());
     if (!inputValuesType || !outputValuesType || !outputIndicesType) {
       return rewriter.notifyMatchFailure(
           op, "Input and output must be of ShapedType");
@@ -439,7 +443,7 @@ struct TopkOpConversion : public OpConversionPattern<chlo::TopKOp> {
     Type valueElementType = outputValuesType.getElementType();
     Type indicesElementType = outputIndicesType.getElementType();
     // Only handle integer types for indicies. Index type is not supported.
-    if (!indicesElementType.isa<IntegerType>()) {
+    if (!llvm::isa<IntegerType>(indicesElementType)) {
       return rewriter.notifyMatchFailure(
           op, "Output indices must be of integer type.");
     }
@@ -455,12 +459,12 @@ struct TopkOpConversion : public OpConversionPattern<chlo::TopKOp> {
         loc, mixedSizes, indicesElementType);
     // Initialize indices to 0 and values to negative infinity
     TypedAttr negInfAttr;
-    if (auto intType = valueElementType.dyn_cast<IntegerType>()) {
+    if (auto intType = llvm::dyn_cast<IntegerType>(valueElementType)) {
       negInfAttr = rewriter.getIntegerAttr(
           intType, APInt::getSignedMinValue(intType.getWidth()));
     } else {
       auto negApFloat = APFloat::getInf(
-          valueElementType.cast<FloatType>().getFloatSemantics(),
+          llvm::cast<FloatType>(valueElementType).getFloatSemantics(),
           /*Negative=*/true);
       negInfAttr = rewriter.getFloatAttr(valueElementType, negApFloat);
     }
@@ -492,7 +496,7 @@ struct TopkOpConversion : public OpConversionPattern<chlo::TopKOp> {
       Value lhs = block->getArgument(0);
       Value rhs = block->getArgument(1);
       Value condition;
-      if (valueElementType.isa<IntegerType>()) {
+      if (llvm::isa<IntegerType>(valueElementType)) {
         condition = rewriter.create<arith::CmpIOp>(
             loc, arith::CmpIPredicate::sge, lhs, rhs);
       } else {

--- a/compiler/src/iree/compiler/InputConversion/MHLO/FlattenTuplesInCFG.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/FlattenTuplesInCFG.cpp
@@ -28,8 +28,8 @@ namespace {
 // Given a set of types, unpack to a list of a types, removing all tuples.
 void untupleTypes(TypeRange types, llvm::SmallVectorImpl<Type> &newTypes) {
   for (Type type : types) {
-    if (type.isa<TupleType>()) {
-      untupleTypes(type.dyn_cast<TupleType>().getTypes(), newTypes);
+    if (llvm::isa<TupleType>(type)) {
+      untupleTypes(llvm::dyn_cast<TupleType>(type).getTypes(), newTypes);
     } else {
       newTypes.push_back(type);
     }
@@ -37,11 +37,11 @@ void untupleTypes(TypeRange types, llvm::SmallVectorImpl<Type> &newTypes) {
 }
 
 Value processTuple(Type type, Location loc, Block *block, OpBuilder &builder) {
-  if (!type.isa<TupleType>()) {
+  if (!llvm::isa<TupleType>(type)) {
     return block->addArgument(type, loc);
   }
 
-  auto tupleType = type.dyn_cast<TupleType>();
+  auto tupleType = llvm::dyn_cast<TupleType>(type);
   llvm::SmallVector<Value, 4> values;
   values.reserve(tupleType.size());
   for (auto subtype : tupleType.getTypes()) {
@@ -68,12 +68,12 @@ bool recursiveUntuple(Value value, Location loc, OpBuilder &builder,
                       llvm::SmallVectorImpl<Value> *newValues) {
   Type type = value.getType();
   // We can return the value as is.
-  if (!type.isa<TupleType>()) {
+  if (!llvm::isa<TupleType>(type)) {
     newValues->push_back(value);
     return false;
   }
 
-  TupleType tupleType = type.dyn_cast<TupleType>();
+  TupleType tupleType = llvm::dyn_cast<TupleType>(type);
   for (int i = 0; i < tupleType.size(); i++) {
     auto subType = tupleType.getType(i);
 
@@ -87,13 +87,13 @@ bool recursiveUntuple(Value value, Location loc, OpBuilder &builder,
 
 Value recursiveRetuple(Type oldType, Operation::result_range *values,
                        OpBuilder &builder, Location loc) {
-  if (!oldType.isa<TupleType>()) {
+  if (!llvm::isa<TupleType>(oldType)) {
     Value returnValue = *values->begin();
     *values = {values->begin() + 1, values->end()};
     return returnValue;
   }
 
-  TupleType tupleType = oldType.dyn_cast<TupleType>();
+  TupleType tupleType = llvm::dyn_cast<TupleType>(oldType);
   llvm::SmallVector<Value, 10> subValues;
   for (auto subtype : tupleType.getTypes()) {
     subValues.push_back(recursiveRetuple(subtype, values, builder, loc));

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/ConvertCollectives.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/ConvertCollectives.cpp
@@ -158,7 +158,7 @@ static std::pair<Value, Value> makeSplitColorAndKey(Location loc,
   Value noColor = indexSet.get(-1);
   if (!groups) return std::make_pair(noColor, noColor);
 
-  auto groupsType = groups.getType().cast<RankedTensorType>();
+  auto groupsType = llvm::cast<RankedTensorType>(groups.getType());
   assert(groupsType.getRank() == 2);
   int64_t rows = groupsType.getShape()[0];
   int64_t cols = groupsType.getShape()[1];
@@ -210,7 +210,7 @@ static DenseIntElementsAttr convertToRankGroupsByCrossReplica(
     return replicaGroups;
   }
 
-  auto groupsType = replicaGroups.getType().cast<RankedTensorType>();
+  auto groupsType = llvm::cast<RankedTensorType>(replicaGroups.getType());
   assert(groupsType.getRank() == 2);
   int rows = groupsType.getShape()[0];
   int cols = groupsType.getShape()[1];
@@ -244,7 +244,7 @@ static DenseIntElementsAttr convertToRankGroupsByCrossPartition(
     return partitionGroups;
   }
 
-  auto groupsType = partitionGroups.getType().cast<RankedTensorType>();
+  auto groupsType = llvm::cast<RankedTensorType>(partitionGroups.getType());
   assert(groupsType.getRank() == 2);
   int rows = groupsType.getShape()[0];
   int cols = groupsType.getShape()[1];
@@ -282,7 +282,7 @@ static DenseIntElementsAttr convertToRankGroupsByCrossReplicaAndPartition(
     return replicaGroups;
   }
 
-  auto groupsType = replicaGroups.getType().cast<RankedTensorType>();
+  auto groupsType = llvm::cast<RankedTensorType>(replicaGroups.getType());
   assert(groupsType.getRank() == 2);
   int rows = groupsType.getShape()[0];
   int cols = groupsType.getShape()[1];
@@ -476,7 +476,8 @@ struct PartitionIdOpConversion
                                                   /*value=*/numPartitions);
       value = rewriter.create<arith::RemUIOp>(loc, rank, cst);
     }
-    auto resultType = op.getType().cast<RankedTensorType>();  // tensor<ui32>
+    auto resultType =
+        llvm::cast<RankedTensorType>(op.getType());  // tensor<ui32>
     auto elemType = resultType.getElementType();
     // index -> ui32
     auto rankElem = rewriter.create<arith::IndexCastUIOp>(loc, elemType, value);
@@ -510,7 +511,8 @@ struct ReplicaIdOpConversion
       rank = rewriter.create<arith::DivUIOp>(loc, rank, cst);
     }
 
-    auto resultType = op.getType().cast<RankedTensorType>();  // tensor<ui32>
+    auto resultType =
+        llvm::cast<RankedTensorType>(op.getType());  // tensor<ui32>
     auto elemType = resultType.getElementType();
     // index -> ui32
     auto rankElem = rewriter.create<arith::IndexCastUIOp>(loc, elemType, rank);
@@ -920,7 +922,7 @@ struct CollectivePermuteOpConversion
         loc, op.getChannelHandleAttr(), numReplicas, numPartitions,
         replicaGroupsAttr, /*useGlobalDeviceIds=*/std::nullopt, rewriter);
 
-    auto inputType = op.getOperand().getType().cast<RankedTensorType>();
+    auto inputType = llvm::cast<RankedTensorType>(op.getOperand().getType());
 
     // Get the collective element type attribute.
     IREE::Flow::CollectiveElementTypeAttr elementTypeAttr =

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/LegalizeShapeComputations.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/LegalizeShapeComputations.cpp
@@ -92,7 +92,7 @@ struct ConcatenateConverter final
     elements.reserve(resultTy.getNumElements());
 
     for (Value operand : op->getOperands()) {
-      ShapedType operandTy = operand.getType().cast<ShapedType>();
+      ShapedType operandTy = llvm::cast<ShapedType>(operand.getType());
       if (operandTy.getRank() == 0) {
         Value extract =
             rewriter.create<tensor::ExtractOp>(loc, operand, ValueRange({}));

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
@@ -51,9 +51,8 @@ Value transposeReshape(Value arg, Location loc,
                             rewriter.getIntegerType(64));
 
   auto transposePermutationAttr =
-      DenseIntElementsAttr::get(transposePermutationType,
-                                llvm::ArrayRef(transposePermutation))
-          .cast<DenseIntElementsAttr>();
+      llvm::cast<DenseIntElementsAttr>(DenseIntElementsAttr::get(
+          transposePermutationType, llvm::ArrayRef(transposePermutation)));
 
   // Compute the resulting shape.
   llvm::SmallVector<int64_t, 5> transposedShape;
@@ -120,7 +119,7 @@ Value transposeReshape(Value arg, Location loc,
 
 Value processDotArg(Value arg, Location loc, ArrayRef<int64_t> contractDimsAttr,
                     bool outerDimsFirst, PatternRewriter &rewriter) {
-  auto shape = arg.getType().cast<ShapedType>().getShape();
+  auto shape = llvm::cast<ShapedType>(arg.getType()).getShape();
 
   llvm::SmallVector<bool, 5> isOuterDim;
   isOuterDim.resize(shape.size(), true);
@@ -270,7 +269,7 @@ struct GeneralDotConvert final
 
     auto getDynamicDims = [&](Value arg,
                               llvm::ArrayRef<int64_t> contractingDims) {
-      RankedTensorType ty = arg.getType().cast<RankedTensorType>();
+      RankedTensorType ty = llvm::cast<RankedTensorType>(arg.getType());
       int index = 0;
       for (int64_t contractingDim : contractingDims) {
         for (; index < contractingDim; ++index) {

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/GatherToTorchIndexSelect.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/GatherToTorchIndexSelect.cpp
@@ -60,7 +60,8 @@ struct GatherIsTorchIndexSelectPattern final
       return rewriter.notifyMatchFailure(gather, "start_index_map != [0]");
     }
 
-    auto resultTy = gather.getResult().getType().dyn_cast<RankedTensorType>();
+    auto resultTy =
+        llvm::dyn_cast<RankedTensorType>(gather.getResult().getType());
     if (!resultTy) {
       return rewriter.notifyMatchFailure(gather, "unranked result");
     }

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/UnfuseBatchNorm.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/UnfuseBatchNorm.cpp
@@ -96,7 +96,7 @@ struct UnfuseBatchNormInferencePattern final
     // which should not be subject to quantization at a higher level.
     auto inputType = dyn_cast<RankedTensorType>(bnOp.getOperand().getType());
     auto varianceType =
-        bnOp.getVariance().getType().dyn_cast<RankedTensorType>();
+        llvm::dyn_cast<RankedTensorType>(bnOp.getVariance().getType());
     if (!inputType || !varianceType) {
       return failure();
     }

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToIREEInputDialects.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToIREEInputDialects.cpp
@@ -141,7 +141,7 @@ Value createLinalgMatmulOnTensors(OpBuilder b, Location loc,
   Value zeroTensor =
       b.create<linalg::FillOp>(loc, zero, emptyTensor).getResult(0);
 
-  switch (lhs.getType().cast<RankedTensorType>().getRank()) {
+  switch (llvm::cast<RankedTensorType>(lhs.getType()).getRank()) {
     case 1:
       return b
           .create<linalg::VecmatOp>(loc, TypeRange{resultType},
@@ -185,9 +185,9 @@ struct FftOpConversion final : OpConversionPattern<mlir::stablehlo::FftOp> {
     Location loc = op.getLoc();
     auto matrixType =
         RankedTensorType::get({n, fftLength}, inputType.getElementType());
-    auto resultType =
-        RankedTensorType::get(op.getType().cast<RankedTensorType>().getShape(),
-                              inputType.getElementType());
+    auto resultType = RankedTensorType::get(
+        llvm::cast<RankedTensorType>(op.getType()).getShape(),
+        inputType.getElementType());
 
     Value realMatrix =
         getDFTMatmulCoeff(rewriter, loc, matrixType, /*isRealPart=*/true);
@@ -268,7 +268,7 @@ static void rewriteFuncAttrs(func::FuncOp funcOp) {
         newAttrs.push_back({
             abiOutputName,
             IntegerAttr::get(indexType,
-                             attr.getValue().cast<IntegerAttr>().getInt()),
+                             llvm::cast<IntegerAttr>(attr.getValue()).getInt()),
         });
       } else {
         newAttrs.push_back(attr);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalg.cpp
@@ -53,7 +53,7 @@ namespace {
 Value getResultValue(Operation* op) { return op->getResult(0); }
 
 ShapedType getHloOpResultType(Operation* op) {
-  return getResultValue(op).getType().cast<ShapedType>();
+  return llvm::cast<ShapedType>(getResultValue(op).getType());
 }
 
 /// Extracts an element from a tensor and optionally converts it to an index
@@ -89,15 +89,15 @@ struct RngUniformConversion
       return failure();
     }
     // TODO(raikonenfnu): Handle other element types as well.
-    auto minTy = adaptor.getOperands()[0].getType().dyn_cast<ShapedType>();
-    auto maxTy = adaptor.getOperands()[0].getType().dyn_cast<ShapedType>();
-    if (!minTy.getElementType().dyn_cast<FloatType>() ||
-        !maxTy.getElementType().dyn_cast<FloatType>()) {
+    auto minTy = llvm::dyn_cast<ShapedType>(adaptor.getOperands()[0].getType());
+    auto maxTy = llvm::dyn_cast<ShapedType>(adaptor.getOperands()[0].getType());
+    if (!llvm::dyn_cast<FloatType>(minTy.getElementType()) ||
+        !llvm::dyn_cast<FloatType>(maxTy.getElementType())) {
       return rewriter.notifyMatchFailure(
           op, "expected min/max for rng op to be FloatType");
     }
-    auto targetTy = this->typeConverter->convertType(op.getResult().getType())
-                        .cast<ShapedType>();
+    auto targetTy = llvm::cast<ShapedType>(
+        this->typeConverter->convertType(op.getResult().getType()));
     if (!targetTy) {
       return rewriter.notifyMatchFailure(
           op, "expected target shape of rng op to be ShapedType");
@@ -195,14 +195,16 @@ SmallVector<Value, 2> extractDynamicEinsumSizes(
     if (dimIndIt != lhsLoopVec.end()) {
       // Query from lhs vars.
       auto dimIndPos = dimIndIt - lhsLoopVec.begin();
-      auto lhsShape = lhs.getType().dyn_cast<RankedTensorType>().getShape();
+      auto lhsShape =
+          llvm::dyn_cast<RankedTensorType>(lhs.getType()).getShape();
       if (lhsShape[dimIndPos] != ShapedType::kDynamic) continue;
       dimSize = b.create<tensor::DimOp>(loc, lhs, dimIndPos);
     } else {
       // query from rhs vars.
       dimIndIt = std::find(rhsLoopVec.begin(), rhsLoopVec.end(), dimInd);
       auto dimIndPos = dimIndIt - rhsLoopVec.begin();
-      auto rhsShape = rhs.getType().dyn_cast<RankedTensorType>().getShape();
+      auto rhsShape =
+          llvm::dyn_cast<RankedTensorType>(rhs.getType()).getShape();
       if (rhsShape[dimIndPos] != ShapedType::kDynamic) continue;
       dimSize = b.create<tensor::DimOp>(loc, rhs, dimIndPos);
     }
@@ -264,7 +266,7 @@ class EinsumToLinalgConverter
       mlir::stablehlo::EinsumOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const final {
     auto getRank = [](Value v) {
-      return v.getType().cast<ShapedType>().getRank();
+      return llvm::cast<ShapedType>(v.getType()).getRank();
     };
     auto einsumConfig = op.getEinsumConfig();
 
@@ -290,8 +292,8 @@ class EinsumToLinalgConverter
     }
 
     // Find result type, if on tensors.
-    auto resultTy = this->typeConverter->convertType(getHloOpResultType(op))
-                        .dyn_cast<RankedTensorType>();
+    auto resultTy = llvm::dyn_cast<RankedTensorType>(
+        this->typeConverter->convertType(getHloOpResultType(op)));
 
     // Check result type compatibility.
     if (!resultTy || !(resultTy.getElementType().isSignlessIntOrFloat())) {
@@ -462,8 +464,8 @@ class DataMovementOpConverter : public OpConversionPattern<OpTy> {
       ConversionPatternRewriter& rewriter) const final {
     if (failed(verifyHloOpBufferOrTensorSemantics(op))) return failure();
     auto resultType = getHloOpResultType(op);
-    resultType = this->typeConverter->convertType(resultType)
-                     .template cast<ShapedType>();
+    resultType =
+        llvm::cast<ShapedType>(this->typeConverter->convertType(resultType));
 
     SmallVector<AffineMap, 2> indexingMaps =
         Derived::getIndexingMaps(op, &rewriter);
@@ -501,7 +503,7 @@ class BroadcastConverter
   static SmallVector<AffineMap, 2> getIndexingMaps(OpTy broadcastOp,
                                                    Builder* b) {
     ShapedType inputType =
-        broadcastOp.getOperand().getType().template cast<ShapedType>();
+        llvm::cast<ShapedType>(broadcastOp.getOperand().getType());
     unsigned inputRank = inputType.getRank();
     unsigned nloops = getHloOpResultType(broadcastOp).getRank();
 
@@ -534,7 +536,8 @@ class BroadcastOpToBroadcastConverter
   LogicalResult matchAndRewrite(
       mlir::stablehlo::BroadcastOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
-    auto resultTy = typeConverter->convertType(op.getType()).cast<ShapedType>();
+    auto resultTy =
+        llvm::cast<ShapedType>(typeConverter->convertType(op.getType()));
 
     int64_t numPrependedDims = op.getBroadcastSizes().size();
     SmallVector<int64_t> dimensions =
@@ -563,7 +566,7 @@ class HloBroadcastInDimConverter
       mlir::stablehlo::BroadcastInDimOp broadcastOp, Builder* b) {
     auto resultType = getHloOpResultType(broadcastOp);
     auto operandType =
-        broadcastOp.getOperand().getType().template cast<ShapedType>();
+        llvm::cast<ShapedType>(broadcastOp.getOperand().getType());
     unsigned nloops = resultType.getRank();
 
     // The input is a scalar, i.e. this is a scalar broadcast op.
@@ -595,7 +598,7 @@ class HloBroadcastInDimConverter
 Value collapseExpandingDims(PatternRewriter& rewriter, Location loc,
                             Value operand, SmallVector<int64_t>& dimensions,
                             llvm::function_ref<bool(int64_t)> isExpandingDim) {
-  auto operandTy = operand.getType().cast<RankedTensorType>();
+  auto operandTy = llvm::cast<RankedTensorType>(operand.getType());
 
   SmallVector<ReassociationIndices> reassociationMap;
   ReassociationIndices currentIndices;
@@ -646,7 +649,7 @@ Value transposeBroadcastOperand(PatternRewriter& rewriter, Location loc,
     return dimensions[lhs] < dimensions[rhs];
   });
 
-  auto operandTy = operand.getType().cast<ShapedType>();
+  auto operandTy = llvm::cast<ShapedType>(operand.getType());
   ArrayRef<int64_t> operandShape = operandTy.getShape();
   SmallVector<int64_t> transposedOperandShape, transposedDimensions;
 
@@ -677,8 +680,9 @@ class BroadcastInDimOpToBroadcastConverter
         llvm::to_vector(op.getBroadcastDimensions().getValues<int64_t>());
 
     Value operand = adaptor.getOperand();
-    auto operandTy = operand.getType().cast<ShapedType>();
-    auto resultTy = typeConverter->convertType(op.getType()).cast<ShapedType>();
+    auto operandTy = llvm::cast<ShapedType>(operand.getType());
+    auto resultTy =
+        llvm::cast<ShapedType>(typeConverter->convertType(op.getType()));
 
     ArrayRef<int64_t> operandShape = operandTy.getShape();
     ArrayRef<int64_t> resultShape = resultTy.getShape();
@@ -727,10 +731,10 @@ class HloDynamicBroadcastInDimConverter
       mlir::stablehlo::DynamicBroadcastInDimOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const final {
     Value operand = adaptor.getOperand();
-    auto operandType = operand.getType().dyn_cast<RankedTensorType>();
+    auto operandType = llvm::dyn_cast<RankedTensorType>(operand.getType());
     if (!operandType) return failure();
-    auto resultType =
-        typeConverter->convertType(op.getType()).dyn_cast<RankedTensorType>();
+    auto resultType = llvm::dyn_cast<RankedTensorType>(
+        typeConverter->convertType(op.getType()));
     if (!resultType) return failure();
 
     // Determine dimension expressions based on whether the dimension is
@@ -804,10 +808,10 @@ class DynamicBroadcastInDimOpToBroadcastConverter
     Location loc = op.getLoc();
 
     Value operand = adaptor.getOperand();
-    auto operandTy = operand.getType().dyn_cast<RankedTensorType>();
+    auto operandTy = llvm::dyn_cast<RankedTensorType>(operand.getType());
     if (!operandTy) return failure();
-    auto resultTy =
-        typeConverter->convertType(op.getType()).dyn_cast<RankedTensorType>();
+    auto resultTy = llvm::dyn_cast<RankedTensorType>(
+        typeConverter->convertType(op.getType()));
     if (!resultTy) return failure();
 
     SmallVector<int64_t> broadcastDimensions =
@@ -882,7 +886,7 @@ class DynamicBroadcastInDimOpToBroadcastConverter
   static Value getBroadcastOperand(
       PatternRewriter& rewriter, Location loc, Value operand,
       llvm::function_ref<bool(int64_t)> isExpandingDim) {
-    auto operandTy = operand.getType().dyn_cast<RankedTensorType>();
+    auto operandTy = llvm::dyn_cast<RankedTensorType>(operand.getType());
 
     SmallVector<int64_t> updatedOperandShape =
         llvm::to_vector(operandTy.getShape());
@@ -903,7 +907,8 @@ class DynamicBroadcastInDimOpToBroadcastConverter
   static ShapedType getBroadcastResultType(
       Value operand, RankedTensorType resultTy, ArrayRef<int64_t> dimensions,
       llvm::function_ref<bool(int64_t)> isExpandingDim) {
-    auto operandShape = operand.getType().cast<RankedTensorType>().getShape();
+    auto operandShape =
+        llvm::cast<RankedTensorType>(operand.getType()).getShape();
     auto broadcastResultShape = llvm::to_vector(resultTy.getShape());
 
     for (auto [operandIndex, resultIndex] : llvm::enumerate(dimensions)) {
@@ -923,7 +928,7 @@ class TransposeConverter
   using DataMovementOpConverter<TransposeConverter<OpTy>,
                                 OpTy>::DataMovementOpConverter;
   static SmallVector<AffineMap, 2> getIndexingMaps(OpTy op, Builder* b) {
-    auto resultType = getHloOpResultType(op).template cast<ShapedType>();
+    auto resultType = llvm::cast<ShapedType>(getHloOpResultType(op));
     auto nloops = resultType.getRank();
     SmallVector<AffineExpr, 2> inputExprs;
     inputExprs.resize(resultType.getRank());
@@ -944,7 +949,8 @@ class TransposeOpToTransposeConverter
   LogicalResult matchAndRewrite(
       mlir::stablehlo::TransposeOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
-    auto resultTy = typeConverter->convertType(op.getType()).cast<ShapedType>();
+    auto resultTy =
+        llvm::cast<ShapedType>(typeConverter->convertType(op.getType()));
 
     auto loc = op.getLoc();
     Value emptyTensor =
@@ -969,9 +975,10 @@ class BitcastConvertConverter
       ConversionPatternRewriter& rewriter) const final {
     if (failed(verifyHloOpBufferOrTensorSemantics(op))) return failure();
 
-    auto inputType = adaptor.getOperand().getType().cast<RankedTensorType>();
+    auto inputType =
+        llvm::cast<RankedTensorType>(adaptor.getOperand().getType());
     auto outputType =
-        typeConverter->convertType(op.getType()).cast<RankedTensorType>();
+        llvm::cast<RankedTensorType>(typeConverter->convertType(op.getType()));
     auto loc = op.getLoc();
 
     // Fallback to pointwise conversion if the tensor dimensions are not
@@ -1084,7 +1091,7 @@ class RealDynamicSliceConverter
       mlir::stablehlo::RealDynamicSliceOp realDynamicSliceOp, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const final {
     Location loc = realDynamicSliceOp.getLoc();
-    auto argType = adaptor.getOperand().getType().dyn_cast<ShapedType>();
+    auto argType = llvm::dyn_cast<ShapedType>(adaptor.getOperand().getType());
     if (!argType || !argType.hasRank()) {
       return rewriter.notifyMatchFailure(realDynamicSliceOp,
                                          "require known-rank args");
@@ -1101,9 +1108,8 @@ class RealDynamicSliceConverter
         dimElementType.isIndex() ? rewriter.getI64Type() : dimElementType;
     Type indexType = rewriter.getIndexType();
 
-    auto resultType =
-        this->typeConverter->convertType(realDynamicSliceOp.getType())
-            .cast<RankedTensorType>();
+    auto resultType = llvm::cast<RankedTensorType>(
+        this->typeConverter->convertType(realDynamicSliceOp.getType()));
     Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     SmallVector<OpFoldResult, 4> offsets, sizes, strides;
     SmallVector<Type, 3> clampType(3, arithType);
@@ -1175,9 +1181,9 @@ class ReshapeOpConverter
       ConversionPatternRewriter& rewriter) const final {
     if (failed(verifyHloOpBufferOrTensorSemantics(reshapeOp))) return failure();
     auto operand = adaptor.getOperand();
-    auto operandType = operand.getType().cast<ShapedType>();
+    auto operandType = llvm::cast<ShapedType>(operand.getType());
     auto elemType = operandType.getElementType();
-    auto resultType = reshapeOp.getType().cast<ShapedType>();
+    auto resultType = llvm::cast<ShapedType>(reshapeOp.getType());
 
     if (!resultType.hasStaticShape()) return failure();
 
@@ -1189,7 +1195,7 @@ class ReshapeOpConverter
       return success();
     }
 
-    resultType = typeConverter->convertType(resultType).cast<ShapedType>();
+    resultType = llvm::cast<ShapedType>(typeConverter->convertType(resultType));
 
     // Special case where the result is a scalar.
     if (resultType.getRank() == 0 && !operandType.hasStaticShape()) {
@@ -1290,8 +1296,8 @@ class IotaConverter : public OpConversionPattern<OpTy> {
       ConversionPatternRewriter& rewriter) const final {
     ShapedType resultShapedType = getHloOpResultType(iotaOp);
     if (!resultShapedType) return failure();
-    resultShapedType = this->typeConverter->convertType(resultShapedType)
-                           .template dyn_cast<ShapedType>();
+    resultShapedType = llvm::dyn_cast<ShapedType>(
+        this->typeConverter->convertType(resultShapedType));
 
     Type resultElementType = resultShapedType.getElementType();
 
@@ -1315,7 +1321,7 @@ class IotaConverter : public OpConversionPattern<OpTy> {
               nestedLoc, iotaOp.getIotaDimension());
           Type unwrappedResultElementType = resultElementType;
           if (auto complexType =
-                  unwrappedResultElementType.dyn_cast<ComplexType>())
+                  llvm::dyn_cast<ComplexType>(unwrappedResultElementType))
             unwrappedResultElementType = complexType.getElementType();
           Value castOp = nestedBuilder.create<arith::IndexCastOp>(
               nestedLoc,
@@ -1344,8 +1350,8 @@ class IotaToMapConverter : public OpConversionPattern<OpTy> {
       ConversionPatternRewriter& rewriter) const final {
     ShapedType resultTy = getHloOpResultType(iotaOp);
     if (!resultTy) return failure();
-    resultTy = this->typeConverter->convertType(resultTy)
-                   .template dyn_cast<ShapedType>();
+    resultTy =
+        llvm::dyn_cast<ShapedType>(this->typeConverter->convertType(resultTy));
 
     Location loc = iotaOp.getLoc();
     Value empty = getEmptyTensorFor(rewriter, loc, resultTy, iotaOp,
@@ -1384,8 +1390,8 @@ struct ConcatenateConverter
       return success();
     }
 
-    auto resultType = this->typeConverter->convertType(op.getResult().getType())
-                          .dyn_cast<RankedTensorType>();
+    auto resultType = llvm::dyn_cast<RankedTensorType>(
+        this->typeConverter->convertType(op.getResult().getType()));
     if (!resultType) return failure();
 
     uint64_t dim = op.getDimension();
@@ -1468,9 +1474,9 @@ class ConstConverterTensor
   LogicalResult matchAndRewrite(
       mlir::stablehlo::ConstantOp constOp, OpAdaptor /*adaptor*/,
       ConversionPatternRewriter& rewriter) const final {
-    auto valueAttr = constOp.getValue().cast<DenseElementsAttr>();
+    auto valueAttr = llvm::cast<DenseElementsAttr>(constOp.getValue());
     auto type =
-        typeConverter->convertType(constOp.getType()).cast<ShapedType>();
+        llvm::cast<ShapedType>(typeConverter->convertType(constOp.getType()));
     if (type != constOp.getType()) {
       // Signedness conversion.
       valueAttr = valueAttr.mapValues(type.getElementType(),
@@ -1490,7 +1496,7 @@ class ReverseConverter
       ReverseConverter, mlir::stablehlo::ReverseOp>::DataMovementOpConverter;
   static SmallVector<AffineMap, 2> getIndexingMaps(
       mlir::stablehlo::ReverseOp op, Builder* b) {
-    auto resultType = getHloOpResultType(op).cast<ShapedType>();
+    auto resultType = llvm::cast<ShapedType>(getHloOpResultType(op));
     auto nloops = resultType.getRank();
     SmallVector<AffineExpr, 2> inputExprs;
     inputExprs.reserve(nloops);
@@ -1516,7 +1522,8 @@ class SliceConverter : public OpConversionPattern<mlir::stablehlo::SliceOp> {
       mlir::stablehlo::SliceOp sliceOp,
       typename mlir::stablehlo::SliceOp::Adaptor adaptor,
       ConversionPatternRewriter& rewriter) const final {
-    auto argType = adaptor.getOperands()[0].getType().dyn_cast<ShapedType>();
+    auto argType =
+        llvm::dyn_cast<ShapedType>(adaptor.getOperands()[0].getType());
     if (!argType || !argType.hasRank()) {
       return rewriter.notifyMatchFailure(sliceOp, "expects known-rank args");
     }
@@ -1551,15 +1558,15 @@ class DynamicSliceConverter
       mlir::stablehlo::DynamicSliceOp dynamicSliceOp, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const final {
     auto loc = dynamicSliceOp.getLoc();
-    auto argType = adaptor.getOperand().getType().dyn_cast<ShapedType>();
+    auto argType = llvm::dyn_cast<ShapedType>(adaptor.getOperand().getType());
     if (!argType || !argType.hasRank()) {
       return rewriter.notifyMatchFailure(dynamicSliceOp,
                                          "require known-rank args");
     }
 
     SmallVector<OpFoldResult, 3> startIndices, sizes;
-    auto originalStartIndexType =
-        dynamicSliceOp.getStartIndices().front().getType().cast<ShapedType>();
+    auto originalStartIndexType = llvm::cast<ShapedType>(
+        dynamicSliceOp.getStartIndices().front().getType());
     for (const auto& en : llvm::enumerate(
              llvm::zip(adaptor.getStartIndices(),
                        dynamicSliceOp.getSliceSizes().getValues<int64_t>()))) {
@@ -1588,8 +1595,8 @@ class DynamicSliceConverter
     int64_t rank = argType.getRank();
     SmallVector<OpFoldResult, 3> strides(rank, rewriter.getI64IntegerAttr(1));
 
-    auto resultType = this->typeConverter->convertType(dynamicSliceOp.getType())
-                          .cast<RankedTensorType>();
+    auto resultType = llvm::cast<RankedTensorType>(
+        this->typeConverter->convertType(dynamicSliceOp.getType()));
 
     rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
         dynamicSliceOp, resultType, adaptor.getOperand(), startIndices, sizes,
@@ -1609,14 +1616,14 @@ class DynamicUpdateSliceConverter
       ConversionPatternRewriter& rewriter) const final {
     auto loc = op.getLoc();
     auto operandType =
-        adaptor.getOperand().getType().dyn_cast<RankedTensorType>();
+        llvm::dyn_cast<RankedTensorType>(adaptor.getOperand().getType());
     if (!operandType || !operandType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(
           op, "require static ranked type for operand");
     }
 
     auto updateType =
-        adaptor.getUpdate().getType().dyn_cast<RankedTensorType>();
+        llvm::dyn_cast<RankedTensorType>(adaptor.getUpdate().getType());
     if (!updateType || !updateType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(
           op, "require static ranked type for operand");
@@ -1667,7 +1674,7 @@ class MapOpToGenericConverter
     if (failed(verifyHloOpBufferOrTensorSemantics(op))) return failure();
 
     auto resultType =
-        typeConverter->convertType(op.getType()).cast<ShapedType>();
+        llvm::cast<ShapedType>(typeConverter->convertType(op.getType()));
     assert(op.getDimensions().size() == resultType.getRank() &&
            "Expected a pointwise map");
 
@@ -1694,7 +1701,7 @@ class MapOpToGenericConverter
       signatureConverter.addInputs(
           it.index(),
           typeConverter->convertType(
-              it.value().getType().cast<ShapedType>().getElementType()));
+              llvm::cast<ShapedType>(it.value().getType()).getElementType()));
     }
     signatureConverter.addInputs(resultType.getElementType());
 
@@ -1714,7 +1721,7 @@ class MapOpToMapConverter : public OpConversionPattern<mlir::stablehlo::MapOp> {
     if (failed(verifyHloOpBufferOrTensorSemantics(op))) return failure();
 
     auto resultType =
-        typeConverter->convertType(op.getType()).cast<ShapedType>();
+        llvm::cast<ShapedType>(typeConverter->convertType(op.getType()));
     assert(op.getDimensions().size() == resultType.getRank() &&
            "Expected a pointwise map");
 
@@ -1744,7 +1751,7 @@ class MapOpToMapConverter : public OpConversionPattern<mlir::stablehlo::MapOp> {
       signatureConverter.addInputs(
           it.index(),
           typeConverter->convertType(
-              it.value().getType().cast<ShapedType>().getElementType()));
+              llvm::cast<ShapedType>(it.value().getType()).getElementType()));
     }
 
     rewriter.applySignatureConversion(&region, signatureConverter,
@@ -1773,10 +1780,10 @@ struct SelectAndScatterNoOverlapConverter
     Value operand = op.getOperand();
     Value init = op.getInitValue();
 
-    auto sourceTy = source.getType().dyn_cast<RankedTensorType>();
-    auto operandTy = operand.getType().dyn_cast<RankedTensorType>();
-    auto initTy = init.getType().dyn_cast<RankedTensorType>();
-    auto resultTy = op.getResult().getType().dyn_cast<RankedTensorType>();
+    auto sourceTy = llvm::dyn_cast<RankedTensorType>(source.getType());
+    auto operandTy = llvm::dyn_cast<RankedTensorType>(operand.getType());
+    auto initTy = llvm::dyn_cast<RankedTensorType>(init.getType());
+    auto resultTy = llvm::dyn_cast<RankedTensorType>(op.getResult().getType());
     if (!sourceTy || !operandTy || !initTy || !resultTy)
       return rewriter.notifyMatchFailure(op, "inputs/outputs must be ranked");
 
@@ -1960,7 +1967,7 @@ struct SelectAndScatterNoOverlapConverter
     b.setInsertionPoint(op);
 
     Value reduceIndex = reduceGeneric.getResult(1);
-    ShapedType reduceIndexTy = reduceIndex.getType().cast<ShapedType>();
+    ShapedType reduceIndexTy = llvm::cast<ShapedType>(reduceIndex.getType());
 
     // For the second generic we restricted to only cases where there are
     // no window overlaps. This guarantees that each source value is scattered
@@ -2071,7 +2078,7 @@ struct SelectAndScatterNoOverlapConverter
 
     Value collapse = b.create<tensor::CollapseShapeOp>(
         scatterGeneric.getResult(0), reassociationMap);
-    auto collapseTy = collapse.getType().cast<ShapedType>();
+    auto collapseTy = llvm::cast<ShapedType>(collapse.getType());
 
     // After collapsing it it possible that the target may need to be padded.
     auto zero = b.createOrFold<arith::ConstantIndexOp>(0);
@@ -2214,7 +2221,7 @@ struct PadOpConversion : public OpConversionPattern<mlir::stablehlo::PadOp> {
         rewriter.create<linalg::FillOp>(loc, paddingVal, emptyTensor).result();
 
     // Get sizes of the original operand.
-    auto operandType = adaptor.getOperand().getType().cast<ShapedType>();
+    auto operandType = llvm::cast<ShapedType>(adaptor.getOperand().getType());
     auto sizes = llvm::to_vector<4>(llvm::map_range(
         llvm::seq<int64_t>(0, operandType.getRank()),
         [&](int64_t dim) -> OpFoldResult {
@@ -2247,15 +2254,16 @@ struct TorchIndexSelectOpConversion
       ConversionPatternRewriter& rewriter) const final {
     int axis = static_cast<int>(op.getDim());
     int batch = static_cast<int>(op.getBatchDims());
-    auto indexShapedType = adaptor.getIndex().getType().cast<ShapedType>();
+    auto indexShapedType = llvm::cast<ShapedType>(adaptor.getIndex().getType());
     int numIndices = static_cast<int>(indexShapedType.getRank());
-    auto operandShapedType = adaptor.getOperand().getType().cast<ShapedType>();
+    auto operandShapedType =
+        llvm::cast<ShapedType>(adaptor.getOperand().getType());
     if (axis < 0) axis += static_cast<int>(operandShapedType.getRank());
     if (batch < 0) batch += numIndices;
 
     Location loc = op.getLoc();
-    auto resultType = this->typeConverter->convertType(op.getResult().getType())
-                          .cast<ShapedType>();
+    auto resultType = llvm::cast<ShapedType>(
+        this->typeConverter->convertType(op.getResult().getType()));
     int rank = static_cast<int>(resultType.getRank());
 
     // The output shape is
@@ -2332,7 +2340,7 @@ struct TorchIndexSelectOpConversion
     auto* block = rewriter.createBlock(region, region->end());
     for (auto blockArgs : linalgOpArgs) {
       bodyArgTypes.push_back(
-          blockArgs.getType().cast<ShapedType>().getElementType());
+          llvm::cast<ShapedType>(blockArgs.getType()).getElementType());
     }
     block->addArguments(bodyArgTypes,
                         SmallVector<Location>(bodyArgTypes.size(), loc));
@@ -2372,7 +2380,8 @@ class SetDimensionSizeConverter
     // regular dynamic shape. Note that the bounds annotation is still around
     // but may be no longer valid depending on choices made by bufferization.
     Location loc = setDimensionSizeOp.getLoc();
-    auto resultType = setDimensionSizeOp.getType().cast<RankedTensorType>();
+    auto resultType =
+        llvm::cast<RankedTensorType>(setDimensionSizeOp.getType());
 
     SmallVector<OpFoldResult> offsets(resultType.getRank(),
                                       rewriter.getIndexAttr(0));

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgDotProd.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgDotProd.cpp
@@ -59,19 +59,19 @@ SmallVector<Value, 2> getDotOpEmptyTensorDynSizes(OpBuilder& b, Location loc,
   SmallVector<Value, 2> dynShape;
   switch (type) {
     case DotOperationType::kMatrixMatrix: {
-      if (lhs.getType().cast<ShapedType>().isDynamicDim(0))
+      if (llvm::cast<ShapedType>(lhs.getType()).isDynamicDim(0))
         dynShape.push_back(b.create<tensor::DimOp>(loc, lhs, 0));
-      if (rhs.getType().cast<ShapedType>().isDynamicDim(1))
+      if (llvm::cast<ShapedType>(rhs.getType()).isDynamicDim(1))
         dynShape.push_back(b.create<tensor::DimOp>(loc, rhs, 1));
       break;
     }
     case DotOperationType::kMatrixVector: {
-      if (lhs.getType().cast<ShapedType>().isDynamicDim(0))
+      if (llvm::cast<ShapedType>(lhs.getType()).isDynamicDim(0))
         dynShape.push_back(b.create<tensor::DimOp>(loc, lhs, 0));
       break;
     }
     case DotOperationType::kVectorMatrix: {
-      if (rhs.getType().cast<ShapedType>().isDynamicDim(1))
+      if (llvm::cast<ShapedType>(rhs.getType()).isDynamicDim(1))
         dynShape.push_back(b.create<tensor::DimOp>(loc, rhs, 1));
       break;
     }
@@ -125,7 +125,7 @@ struct DotGeneralBatchMatMulOpConversion final
     if (failed(verifyHloOpBufferOrTensorSemantics(op))) {
       return failure();
     }
-    if (op.getType().cast<RankedTensorType>().getRank() != 3) {
+    if (llvm::cast<RankedTensorType>(op.getType()).getRank() != 3) {
       return rewriter.notifyMatchFailure(op, "expected a batch matmul");
     }
 
@@ -204,10 +204,12 @@ struct DotGeneralOpConversion final
     size_t targetRank = outputType.getRank();
     size_t totalLoopCount = numContracting + targetRank;
 
-    int64_t lhsRank = adaptor.getLhs().getType().cast<ShapedType>().getRank();
+    int64_t lhsRank =
+        llvm::cast<ShapedType>(adaptor.getLhs().getType()).getRank();
     size_t lhsExtraDims =
         lhsRank - lhsBatchingDims.size() - lhsContractingDims.size();
-    int64_t rhsRank = adaptor.getRhs().getType().cast<ShapedType>().getRank();
+    int64_t rhsRank =
+        llvm::cast<ShapedType>(adaptor.getRhs().getType()).getRank();
 
     Location loc = op.getLoc();
     Value emptyTensor =

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgRandom.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgRandom.cpp
@@ -342,7 +342,7 @@ LogicalResult generateLinalgThreeFry32(OpBuilder &builder, Location loc,
   Value destRight = builder.create<tensor::EmptyOp>(
       loc, ArrayRef<int64_t>({count}), resultETy);
 
-  ShapedType destTy = destLeft.getType().cast<ShapedType>();
+  ShapedType destTy = llvm::cast<ShapedType>(destLeft.getType());
 
   SmallVector<AffineMap> indexingMaps(2, builder.getMultiDimIdentityMap(1));
   SmallVector<utils::IteratorType> iterators(1, utils::IteratorType::parallel);
@@ -423,7 +423,7 @@ LogicalResult generateLinalgThreeFry64(OpBuilder &builder, Location loc,
   // Generate a 1D tensor with for the random values.
   Value dest = builder.create<tensor::EmptyOp>(loc, ArrayRef<int64_t>({count}),
                                                resultETy);
-  ShapedType destTy = dest.getType().cast<ShapedType>();
+  ShapedType destTy = llvm::cast<ShapedType>(dest.getType());
 
   SmallVector<AffineMap> indexingMaps(1, builder.getMultiDimIdentityMap(1));
   SmallVector<utils::IteratorType> iterators(1, utils::IteratorType::parallel);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/TypeConversion.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/TypeConversion.cpp
@@ -26,7 +26,7 @@ Type convertInteger(IntegerType intType) {
 }
 
 Type convertShapedType(ShapedType shapedType) {
-  if (auto intType = shapedType.getElementType().dyn_cast<IntegerType>())
+  if (auto intType = llvm::dyn_cast<IntegerType>(shapedType.getElementType()))
     return shapedType.clone(convertInteger(intType));
   return shapedType;
 }
@@ -59,7 +59,7 @@ std::optional<Value> materializeCastToIllegal(OpBuilder& builder, Type type,
 std::optional<Value> scalarToTensor(OpBuilder& builder, Type /*type*/,
                                     ValueRange inputs, Location loc) {
   assert(inputs.size() == 1);
-  if (inputs.front().getType().isa<ShapedType>()) {
+  if (llvm::isa<ShapedType>(inputs.front().getType())) {
     return std::nullopt;
   }
   return builder

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
@@ -204,7 +204,7 @@ void populateHALToHALInlinePatterns(MLIRContext *context,
       [](OpBuilder &builder, IREE::Util::BufferType type, ValueRange inputs,
          Location loc) -> Value {
         assert(inputs.size() == 1);
-        if (inputs[0].getType().isa<IREE::HAL::BufferType>()) {
+        if (llvm::isa<IREE::HAL::BufferType>(inputs[0].getType())) {
           return builder.createOrFold<IREE::HAL::Inline::BufferStorageOp>(
               loc, inputs[0]);
         } else {

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
@@ -161,7 +161,7 @@ struct FoldBufferViewCreateSubspan
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
-    auto newSourceOffset = op.getSourceOffset().cast<Value>();
+    auto newSourceOffset = llvm::cast<Value>(op.getSourceOffset());
     if (auto subspanOp = dyn_cast_or_null<BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
@@ -227,7 +227,8 @@ void BufferViewBufferOp::getCanonicalizationPatterns(RewritePatternSet &results,
 LogicalResult DeviceQueryOp::verify() {
   DeviceQueryOp op = *this;
   if (op.getDefaultValue().has_value()) {
-    if (auto typedDefaultValue = op.getDefaultValue()->dyn_cast<TypedAttr>()) {
+    if (auto typedDefaultValue =
+            llvm::dyn_cast<TypedAttr>(*op.getDefaultValue())) {
       if (typedDefaultValue.getType() != op.getValue().getType()) {
         return op.emitOpError()
                << "type mismatch between result and default value";

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
@@ -71,7 +71,7 @@ class InlineExecutablesPass
           return WalkResult::interrupt();
         }
         auto targetFuncName =
-            exportToFuncMap[entryPointAttrs.front()].cast<StringAttr>();
+            llvm::cast<StringAttr>(exportToFuncMap[entryPointAttrs.front()]);
         assert(targetFuncName && "missing mapping");
         dispatchOp->setAttr("hal_inline.target",
                             FlatSymbolRefAttr::get(targetFuncName));

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
@@ -28,7 +28,7 @@ namespace {
 // either a !util.buffer or an external !hal.buffer.
 static Value getResourceBuffer(Location loc, Value resource,
                                OpBuilder &builder) {
-  if (resource.getType().isa<IREE::HAL::BufferType>()) {
+  if (llvm::isa<IREE::HAL::BufferType>(resource.getType())) {
     // Get the storage of the buffer; the returned buffer is already a subspan.
     return builder.createOrFold<IREE::HAL::Inline::BufferStorageOp>(loc,
                                                                     resource);
@@ -56,7 +56,7 @@ struct CmdDispatchOpPattern
                                          "multiple variant targets not yet "
                                          "supported in the inline HAL loader");
     }
-    auto entryPointAttr = entryPointAttrs.front().cast<SymbolRefAttr>();
+    auto entryPointAttr = llvm::cast<SymbolRefAttr>(entryPointAttrs.front());
 
     // Get the handle to the executable that is compatible with our device.
     auto executableOp =

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -82,9 +82,9 @@ class ConvertConv2DNhwcHwcf final
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
                                 PatternRewriter &rewriter) const override {
-    auto inputType = convOp.getInputs()[0].getType().cast<ShapedType>();
-    auto filterType = convOp.getInputs()[1].getType().cast<ShapedType>();
-    auto outputType = convOp.getOutputs()[0].getType().cast<ShapedType>();
+    auto inputType = llvm::cast<ShapedType>(convOp.getInputs()[0].getType());
+    auto filterType = llvm::cast<ShapedType>(convOp.getInputs()[1].getType());
+    auto outputType = llvm::cast<ShapedType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return failure();
@@ -199,7 +199,7 @@ class ConvertConv2DNhwcHwcf final
       auto resultMap = AffineMap::get(4, 0, {bDim, mDim, nDim}, getContext());
       SmallVector<utils::IteratorType> genericIterators = {parallel, parallel,
                                                            parallel, reduction};
-      bool isInt = outputType.getElementType().isa<IntegerType>();
+      bool isInt = llvm::isa<IntegerType>(outputType.getElementType());
       auto genericOp = rewriter.create<linalg::GenericOp>(
           loc, reshapedOutputType,
           /*inputs=*/ValueRange{reshapedImg2ColTensor, reshapedFilter},
@@ -233,9 +233,12 @@ class ConvertDepthwiseConv2DNhwcHwc final
 
   LogicalResult matchAndRewrite(linalg::DepthwiseConv2DNhwcHwcOp convOp,
                                 PatternRewriter &rewriter) const override {
-    auto inputType = convOp.getInputs()[0].getType().cast<RankedTensorType>();
-    auto filterType = convOp.getInputs()[1].getType().cast<RankedTensorType>();
-    auto outputType = convOp.getOutputs()[0].getType().cast<RankedTensorType>();
+    auto inputType =
+        llvm::cast<RankedTensorType>(convOp.getInputs()[0].getType());
+    auto filterType =
+        llvm::cast<RankedTensorType>(convOp.getInputs()[1].getType());
+    auto outputType =
+        llvm::cast<RankedTensorType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return failure();
@@ -247,7 +250,7 @@ class ConvertDepthwiseConv2DNhwcHwc final
     auto loc = convOp.getLoc();
 
     auto transposeOperand = [&](Value operand, ArrayRef<int64_t> indices) {
-      auto operandTensorType = operand.getType().cast<RankedTensorType>();
+      auto operandTensorType = llvm::cast<RankedTensorType>(operand.getType());
       auto nloops = indices.size();
       auto inputShape = operandTensorType.getShape();
 
@@ -289,7 +292,8 @@ class ConvertDepthwiseConv2DNhwcHwc final
     // Transpose input, filter so channels are outermost
     auto inputT = transposeOperand(input, {0, 3, 1, 2});
     auto filterT = transposeOperand(filter, {2, 0, 1});
-    auto filterTShape = filterT.getType().cast<RankedTensorType>().getShape();
+    auto filterTShape =
+        llvm::cast<RankedTensorType>(filterT.getType()).getShape();
     auto outputShape = outputType.getShape();
 
     const int n = outputShape[0];
@@ -386,9 +390,9 @@ class ConvertConv2DNchwFchw final
 
   LogicalResult matchAndRewrite(linalg::Conv2DNchwFchwOp convOp,
                                 PatternRewriter &rewriter) const override {
-    auto inputType = convOp.getInputs()[0].getType().cast<ShapedType>();
-    auto filterType = convOp.getInputs()[1].getType().cast<ShapedType>();
-    auto outputType = convOp.getOutputs()[0].getType().cast<ShapedType>();
+    auto inputType = llvm::cast<ShapedType>(convOp.getInputs()[0].getType());
+    auto filterType = llvm::cast<ShapedType>(convOp.getInputs()[1].getType());
+    auto outputType = llvm::cast<ShapedType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return failure();
@@ -502,7 +506,7 @@ class ConvertConv2DNchwFchw final
       auto resultMap = AffineMap::get(4, 0, {bDim, mDim, nDim}, getContext());
       SmallVector<utils::IteratorType> genericIterators = {parallel, parallel,
                                                            parallel, reduction};
-      bool isInt = outputType.getElementType().isa<IntegerType>();
+      bool isInt = llvm::isa<IntegerType>(outputType.getElementType());
       auto genericOp = rewriter.create<linalg::GenericOp>(
           loc, reshapedOutputType,
           /*inputs=*/ValueRange{reshapedFilter, reshapedImg2ColTensor},

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadLinalgOps.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadLinalgOps.cpp
@@ -38,9 +38,9 @@ class PadMatmulOp : public OpInterfaceRewritePattern<linalg::LinalgOp> {
     Value rhs = linalgOp.getDpsInputOperand(1)->get();
     Value result = linalgOp.getDpsInitOperand(0)->get();
 
-    auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
-    auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
-    auto resultType = result.getType().dyn_cast<RankedTensorType>();
+    auto lhsType = llvm::dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsType = llvm::dyn_cast<RankedTensorType>(rhs.getType());
+    auto resultType = llvm::dyn_cast<RankedTensorType>(result.getType());
 
     if (!lhsType || !rhsType) return failure();
 

--- a/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
@@ -18,29 +18,29 @@ namespace mlir {
 namespace iree_compiler {
 
 std::optional<FileLineColLoc> findFirstFileLoc(Location baseLoc) {
-  if (auto loc = baseLoc.dyn_cast<FileLineColLoc>()) {
+  if (auto loc = llvm::dyn_cast<FileLineColLoc>(baseLoc)) {
     return loc;
   }
 
-  if (auto loc = baseLoc.dyn_cast<FusedLoc>()) {
+  if (auto loc = llvm::dyn_cast<FusedLoc>(baseLoc)) {
     // Recurse through fused locations.
     for (auto &childLoc : loc.getLocations()) {
       auto childResult = findFirstFileLoc(childLoc);
       if (childResult) return childResult;
     }
-  } else if (auto loc = baseLoc.dyn_cast<CallSiteLoc>()) {
+  } else if (auto loc = llvm::dyn_cast<CallSiteLoc>(baseLoc)) {
     // First check caller...
     auto callerResult = findFirstFileLoc(loc.getCaller());
     if (callerResult) return callerResult;
     // Then check callee...
     auto calleeResult = findFirstFileLoc(loc.getCallee());
     if (calleeResult) return calleeResult;
-  } else if (auto loc = baseLoc.dyn_cast<NameLoc>()) {
+  } else if (auto loc = llvm::dyn_cast<NameLoc>(baseLoc)) {
     auto childResult = findFirstFileLoc(loc.getChildLoc());
     if (childResult) return childResult;
-  } else if (auto loc = baseLoc.dyn_cast<OpaqueLoc>()) {
+  } else if (auto loc = llvm::dyn_cast<OpaqueLoc>(baseLoc)) {
     // TODO(scotttodd): Use loc.fallbackLocation()?
-  } else if (auto loc = baseLoc.dyn_cast<UnknownLoc>()) {
+  } else if (auto loc = llvm::dyn_cast<UnknownLoc>(baseLoc)) {
     // ¯\_(ツ)_/¯
   }
 


### PR DESCRIPTION
Following https://reviews.llvm.org/D150348 and
https://mlir.llvm.org/deprecation/'s "Use the free function variants for dyn_cast/cast/isa/…".

Kept it mechanical rather and used namespaced version of tool. The only place where the tool struggled was OpFoldResult instances which didn't work as advertised and so I manually reverted those (so all changes here are due to tool, but it subset of what tool produced).