### PR TITLE
[spirv] Vectorize before bufferization in SIMT pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMultiBuffering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMultiBuffering.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/GPU/CommonGPUPasses.h"
 #include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
@@ -25,7 +26,27 @@ struct GPUMultiBufferingPass
 
   void runOnOperation() override {
     auto funcOp = getOperation();
+
+    // First hoist all shared memory allocations to the entry block of the
+    // function. We can see memref.alloc in loops after bufferizing scf.forall
+    // with promoted shared memory usage inside.
+
     SmallVector<memref::AllocOp> allocs;
+    // Collect all the alloc operations.
+    funcOp.walk([&](memref::AllocOp allocOp) {
+      if (hasSharedMemoryAddressSpace(allocOp.getType()))
+        allocs.push_back(allocOp);
+    });
+
+    assert(funcOp.getBlocks().size() == 1);
+    for (memref::AllocOp allocOp : allocs) {
+      if (allocOp->getParentOp() != funcOp)
+        allocOp->moveBefore(&*funcOp.begin()->begin());
+    }
+
+    // Then perform multibuffering transformations.
+
+    allocs.clear();
     // Collect all the alloc operations.
     funcOp.walk([&](memref::AllocOp allocOp) {
       // Skip allocations not used in a loop.
@@ -38,10 +59,12 @@ struct GPUMultiBufferingPass
     });
     // Apply multi-buffering to all of them.
     for (memref::AllocOp alloc : allocs) {
-      if (failed(memref::multiBuffer(alloc, numBuffers)))
-        // Stop if any buffer cannot be multi buffered as pipelining will assume
-        // this happened.
+      if (failed(memref::multiBuffer(alloc, numBuffers))) {
+        // Error out and stop if any buffer cannot be multi buffered, as future
+        // software pipelining transformations will assume this happened.
+        alloc.emitOpError("cannot be multi-buffered");
         return signalPassFailure();
+      }
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
@@ -19,6 +19,8 @@
 namespace mlir {
 namespace iree_compiler {
 
+using CodeGenPipeline = IREE::Codegen::DispatchLoweringPassPipeline;
+
 constexpr unsigned kWorkgroupTileLevel = 0;
 constexpr unsigned kThreadTileLevel = 1;
 constexpr unsigned kReductionTileLevel = 2;
@@ -29,16 +31,13 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
     ArrayRef<int64_t> workgroupSize) {
   // Verify that the translation info is using the right pipeline.
   if (translationInfo.getDispatchLoweringPassPipeline() !=
-      IREE::Codegen::DispatchLoweringPassPipeline::
-          SPIRVMatmulPromoteVectorize) {
+      CodeGenPipeline::SPIRVMatmulPromoteVectorize) {
     return op->emitOpError("expected pipeline in translation_info to be ")
-           << stringifyEnum(IREE::Codegen::DispatchLoweringPassPipeline::
-                                SPIRVMatmulPromoteVectorize);
+           << stringifyEnum(CodeGenPipeline::SPIRVMatmulPromoteVectorize);
   }
 
-  if (!isa<linalg::MatmulOp, linalg::BatchMatmulOp>(op)) {
-    return success();
-  }
+  if (!isa<linalg::MatmulOp, linalg::BatchMatmulOp>(op)) return success();
+
   LLVM_DEBUG({
     llvm::dbgs() << "verifying op: " << *op << "\n";
     llvm::dbgs() << "chosen workgroup size: [";
@@ -98,43 +97,29 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
   ArrayRef<int64_t> rhsShape =
       llvm::cast<ShapedType>(op->getOperand(1).getType()).getShape();
 
-  SmallVector<int64_t> workgroupTileSizes =
-      loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
-  SmallVector<int64_t> threadTileSizes =
-      loweringConfig.getTileSizeVals(kThreadTileLevel);
-  SmallVector<int64_t> reductionTileSizes =
-      loweringConfig.getTileSizeVals(kReductionTileLevel);
-
-  if (loweringConfig.getTileSizes().size() != 3) {
-    return op->emitOpError("expected 3 levels of tiling sizes, got ")
+  if (loweringConfig.getTileSizes().size() != 1) {
+    return op->emitOpError("expected 1 levels of tiling sizes, got ")
            << loweringConfig.getTileSizes().size();
   }
+
+  SmallVector<int64_t> tileSizes =
+      loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
 
   // For BatchMatmul, the first dimension is the batch dimension.
   // We don't check the batch.
   if (isa<linalg::BatchMatmulOp>(op)) {
     lhsShape = lhsShape.drop_front(1);
     rhsShape = rhsShape.drop_front(1);
-    workgroupTileSizes.erase(workgroupTileSizes.begin());
-    threadTileSizes.erase(threadTileSizes.begin());
-    reductionTileSizes.erase(reductionTileSizes.begin());
+    tileSizes.erase(tileSizes.begin());
   }
 
   // Verify the tile size divides the matmul inputs A [M x K] & B [K x N].
   const int64_t dimM = lhsShape[0], dimN = rhsShape[1], dimK = lhsShape[1];
-  if (dimM % workgroupTileSizes[0] != 0 || dimK % reductionTileSizes[2] != 0) {
+  if (dimM % tileSizes[0] != 0 || dimK % tileSizes[2] != 0) {
     return op->emitOpError("LHS shape is indivisible by first level tile size");
   }
-  if (dimK % reductionTileSizes[2] != 0 || dimN % workgroupTileSizes[1] != 0) {
+  if (dimK % tileSizes[2] != 0 || dimN % tileSizes[1] != 0) {
     return op->emitOpError("RHS shape is indivisible by first level tile size");
-  }
-
-  // Verify that workgroup_tile_size = thread_tile_size * workgroup_size.
-  if (threadTileSizes[0] * workgroupSize[1] != workgroupTileSizes[0] ||
-      threadTileSizes[1] * workgroupSize[0] != workgroupTileSizes[1]) {
-    return op->emitOpError(
-        "expected workgroup tile sizes to be the product of thread tile "
-        "sizes and workgroup sizes");
   }
 
   auto pipelineDepth = translationInfo.getSoftwarePipelineDepth();
@@ -149,11 +134,9 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
     ArrayRef<int64_t> workgroupSize) {
   // Verify that the translation info is using the right pipeline.
   if (translationInfo.getDispatchLoweringPassPipeline() !=
-      IREE::Codegen::DispatchLoweringPassPipeline::
-          SPIRVCooperativeMatrixVectorize) {
+      CodeGenPipeline::SPIRVCooperativeMatrixVectorize) {
     return op->emitOpError("expected pipeline in translation_info to be ")
-           << stringifyEnum(IREE::Codegen::DispatchLoweringPassPipeline::
-                                SPIRVCooperativeMatrixVectorize);
+           << stringifyEnum(CodeGenPipeline::SPIRVCooperativeMatrixVectorize);
   }
 
   if (!isa<linalg::MatmulOp, linalg::BatchMatmulOp>(op)) {
@@ -316,10 +299,9 @@ LogicalResult verifySPIRVBaseVectorizePassPipeline(
     ArrayRef<int64_t> workgroupSize) {
   // Verify that the translation info is using the right pipeline.
   if (translationInfo.getDispatchLoweringPassPipeline() !=
-      IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseVectorize) {
+      CodeGenPipeline::SPIRVBaseVectorize) {
     return op->emitOpError("expected pipeline in translation_info to be ")
-           << stringifyEnum(IREE::Codegen::DispatchLoweringPassPipeline::
-                                SPIRVBaseVectorize);
+           << stringifyEnum(CodeGenPipeline::SPIRVBaseVectorize);
   }
 
   if (!isa<linalg::Conv2DNhwcHwcfOp, linalg::DepthwiseConv2DNhwcHwcOp>(op)) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
@@ -33,7 +33,7 @@ hal.executable @batch_matmul_f32_16x4096x40x4096 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 512, 8], [1, 8, 4], [0, 0, 0, 16]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 512, 8, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 //      CHECK: hal.executable.export public @batch_matmul_f32_16x4096x40x4096
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -79,7 +79,7 @@ hal.executable @matmul_f16_64x640x320 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128], [4, 8], [0, 0, 32]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2 store_stage = 0>
 //      CHECK: hal.executable.export public @matmul_f16_64x640x320
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -125,7 +125,7 @@ hal.executable @batch_matmul_f32_16x4096x40x4096 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256, 16], [1, 8, 4], [0, 0, 0, 32]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256, 16, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 //      CHECK: hal.executable.export public @batch_matmul_f32_16x4096x40x4096
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -177,7 +177,7 @@ hal.executable @batch_matmul_f16_1x4096x4096x512 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 256], [1, 8, 8], [0, 0, 0, 32]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 256, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 //      CHECK: hal.executable.export public @batch_matmul_f16_1x4096x4096x512
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul.mlir
@@ -38,7 +38,7 @@ hal.executable @matmul_1x4096x9216 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256], [1, 4], [0, 0, 32]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 //      CHECK: hal.executable.export public @matmul_1x4096x9216
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -94,7 +94,7 @@ hal.executable private @multi_reduction_transposed_b_matmul {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128], [4, 4], [0, 0, 1, 32]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128, 1, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 //      CHECK: hal.executable.export public @multi_reduction_transposed_b_matmul
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/illegal_configuration.mlir
@@ -26,7 +26,7 @@ hal.executable private @matmul_tensors {
         %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4x8xf32>
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
-        // expected-error @+1 {{expected 3 levels of tiling sizes, got 0}}
+        // expected-error @+1 {{expected 1 levels of tiling sizes, got 0}}
         linalg.matmul {compilation_info = #compilation} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
         return
@@ -186,43 +186,6 @@ hal.executable private @matmul_tensors {
 // -----
 
 #compilation = #iree_codegen.compilation_info<
-    lowering_config  = <tile_sizes = [[32, 64], [4, 4], [0, 0, 4]]>,
-    translation_info = <SPIRVMatmulPromoteVectorize>,
-    workgroup_size = [32, 8, 1]>
-#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>,
-    #hal.descriptor_set.binding<2, storage_buffer>
-  ]>
-]>
-hal.executable private @matmul_tensors {
-  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb", {
-      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader], []>, Unknown:IntegratedGPU, #spirv.resource_limits<
-        max_compute_shared_memory_size = 32768,
-        max_compute_workgroup_invocations = 512,
-        max_compute_workgroup_size = [512, 512, 512],
-        subgroup_size = 16>>
-    }> {
-    hal.executable.export @illegal layout(#pipeline_layout)
-    builtin.module {
-      func.func @illegal() {
-        %c0 = arith.constant 0 : index
-        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<64x16xf32>
-        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x128xf32>
-        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<64x128xf32>
-        // expected-error @+1 {{expected workgroup tile sizes to be the product of thread tile sizes and workgroup sizes}}
-        linalg.matmul {compilation_info = #compilation} ins(%lhs, %rhs : memref<64x16xf32>, memref<16x128xf32>)
-          outs(%result: memref<64x128xf32>)
-        return
-      }
-    }
-  }
-}
-
-// -----
-
-#compilation = #iree_codegen.compilation_info<
     lowering_config  = <tile_sizes = [[32, 60], [4, 4], [0, 0, 4]]>,
     translation_info = <SPIRVMatmulPromoteVectorize>,
     workgroup_size = [15, 8, 1]>
@@ -260,7 +223,7 @@ hal.executable private @matmul_tensors {
 // -----
 
 #compilation = #iree_codegen.compilation_info<
-    lowering_config  = <tile_sizes = [[32, 64], [4, 4], [0, 0, 4]]>,
+    lowering_config  = <tile_sizes = [[32, 64, 4]]>,
     translation_info = <SPIRVMatmulPromoteVectorize>,
     workgroup_size = [16, 8, 1]>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
@@ -297,7 +260,7 @@ hal.executable private @matmul_tensors {
 // -----
 
 #compilation = #iree_codegen.compilation_info<
-    lowering_config  = <tile_sizes = [[32, 64], [4, 4], [0, 0, 4]]>,
+    lowering_config  = <tile_sizes = [[32, 64, 4]]>,
     translation_info = <SPIRVMatmulPromoteVectorize>,
     workgroup_size = [16, 8, 1]>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
@@ -3,7 +3,7 @@
 // Verify pipelining + multi-buffering.
 
 #compilation = #iree_codegen.compilation_info<
-    lowering_config  = <tile_sizes = [[64, 64], [8, 4], [0, 0, 16]]>,
+    lowering_config  = <tile_sizes = [[64, 64, 16]]>,
     translation_info = <SPIRVMatmulPromoteVectorize pipeline_depth = 2>,
     workgroup_size = [16, 8, 1]>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -173,7 +173,7 @@ hal.executable @matmul_f16_128x256x64 {
 ]>
 
 #user_config = #iree_codegen.compilation_info<
-  lowering_config = <tile_sizes = [[16, 128], [2, 8], [0, 0, 16]]>,
+  lowering_config = <tile_sizes = [[16, 128, 16]]>,
   translation_info = <SPIRVMatmulPromoteVectorize>,
   workgroup_size = [16, 8, 1]>
 


### PR DESCRIPTION
This commit switches the matmul SIMT pipeline to performx vectorization before bufferization like LLVMGPU by reusing passes there.