### PR TITLE
Coalescing adjacent stream.async.fills and eliding useless ones.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -421,6 +421,16 @@ OpFoldResult AlignOp::fold(FoldAdaptor operands) {
   // If aligning an already-aligned value then fold if this is provably a
   // no-op. We can check this for equality even with dynamic alignments.
   if (isAlignedTo(getValue(), getAlignment())) return getValue();
+
+  // If values are static we can perform the alignment here.
+  APInt staticValue;
+  APInt staticAlignment;
+  if (matchPattern(getValue(), m_ConstantInt(&staticValue)) &&
+      matchPattern(getAlignment(), m_ConstantInt(&staticAlignment))) {
+    return IntegerAttr::get(getResult().getType(),
+                            align(staticValue.getZExtValue(), staticAlignment));
+  }
+
   return {};
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/alignment_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/alignment_folding.mlir
@@ -94,6 +94,22 @@ func.func @foldAddAlignmentConstant(%lhs: index) -> index {
 
 // -----
 
+// CHECK-LABEL: @foldConstantAlign
+func.func @foldConstantAlign() -> (index, index, index) {
+  %c0 = arith.constant 0 : index
+  %c7 = arith.constant 7 : index
+  %c8 = arith.constant 8 : index
+  %c9 = arith.constant 9 : index
+  %c64 = arith.constant 64 : index
+  %0 = util.align %c0, %c64 : index
+  %1 = util.align %c7, %c8 : index
+  %2 = util.align %c9, %c8 : index
+  // CHECK: return %c0, %c8, %c16
+  return %0, %1, %2 : index, index, index
+}
+
+// -----
+
 // CHECK-LABEL: @sizeofWholeInt
 func.func @sizeofWholeInt() -> index {
   // CHECK: = arith.constant 4 : index


### PR DESCRIPTION
These tend to arise from concats of padding or partially constant values (`concat(%value, %zero, %zero, %zero)`) and prior to this change would result in large sequences of fill->fill->fill at runtime. In some cases a tensor will be created from a splat of a constant (zero, etc) and then filled with that same constant and now those are handled (when found). Canonicalization after passes that do more involved analysis (iree-stream-emplace-allocations and iree-stream-elide-async-writes) do the heavy lifting and leave the rest of the cleanup to these canonicalizers.

![image](https://github.com/openxla/iree/assets/75337/995db391-ee3d-4dae-b5de-2ed2470c5ae7)

Fixes #13767.