### PR TITLE
Switching to --iree-stream-partitioning-favor=min-peak-memory.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -28,7 +28,7 @@ namespace Stream {
 static llvm::cl::opt<Favor> clPartitioningFavor(
     "iree-stream-partitioning-favor",
     llvm::cl::desc("Default stream partitioning favor configuration."),
-    llvm::cl::init(Favor::MaxConcurrency),
+    llvm::cl::init(Favor::MinPeakMemory),
     llvm::cl::values(
         clEnumValN(Favor::Debug, "debug",
                    "Force debug partitioning (no concurrency or pipelining)."),


### PR DESCRIPTION
The current value of max-concurrency can be dangerous on models that are near the max of device memory and min-peak-memory allows us to still get some concurrency while being more conservative about extending lifetimes. Users not concerned with peak memory usage but wanting the most concurrency can still use the flag to get the old behavior.

Progress on #13545.