### PR TITLE
[StableHLO][NFC] Enable pow e2e test on llvm-cpu

### DIFF
--- a/build_tools/cmake/test_riscv.sh
+++ b/build_tools/cmake/test_riscv.sh
@@ -83,6 +83,7 @@ if [[ "${RISCV_PLATFORM}-${RISCV_ARCH}" == "linux-riscv_32" ]]; then
   # mhlo.power is also disabled because musl math library is not compiled for
   # 32-bit.
   test_exclude_args+=(
+    "stablehlo.*llvm-cpu.*pow"
     "xla.*llvm-cpu.*pow"
   )
 fi

--- a/tests/e2e/stablehlo_ops/BUILD.bazel
+++ b/tests/e2e/stablehlo_ops/BUILD.bazel
@@ -57,6 +57,7 @@ iree_check_single_backend_test_suite(
             "multiply.mlir",
             "negate.mlir",
             "pad.mlir",
+            "pow.mlir",
             "reduce.mlir",
             "reduce_window.mlir",
             "remainder.mlir",
@@ -80,9 +81,7 @@ iree_check_single_backend_test_suite(
             "while.mlir",
         ],
         include = ["*.mlir"],
-        exclude = [
-            "pow.mlir",  # TODO(#12678): Investigate this failing on riscv-32.
-        ],
+        exclude = [],
     ),
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "local-task",

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_check_single_backend_test_suite(
     "multiply.mlir"
     "negate.mlir"
     "pad.mlir"
+    "pow.mlir"
     "reduce.mlir"
     "reduce_window.mlir"
     "remainder.mlir"


### PR DESCRIPTION
This test is disabled on rv32 due to known issues with the musl lib. I checked the generated code and it looks identical to the mhlo output now.

Issue: https://github.com/openxla/iree/issues/12678