### PR TITLE
Avoid adding all results of an operation as result value for the Dispatch region.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -576,7 +576,7 @@ transform_dialect::MovePrecedingOpIntoDispatchRegionOp::apply(
   IRRewriter rewriter(regionOp->getContext());
   for (Operation *target : orderedTargets) {
     auto newRegionOp =
-        movePrecedingOpIntoDispatchRegion(rewriter, target, regionOp);
+        movePrecedingOpsIntoDispatchRegion(rewriter, target, regionOp);
     if (failed(newRegionOp)) return emitDefaultDefiniteFailure(target);
     regionOp = *newRegionOp;
   }
@@ -724,7 +724,7 @@ static FailureOr<Flow::DispatchRegionOp> moveSucceedingOpIntoDispatchRegion(
   // specific results in the future. Many ops have just one result, so this
   // should not be a large overhead.
   for (const auto &it : llvm::enumerate(target->getResults())) {
-    auto newRegionOp = appendDispatchRegionResult(
+    auto newRegionOp = appendDispatchRegionResults(
         rewriter, regionOp, it.value(), dynamicDims[it.index()]);
     if (failed(newRegionOp)) return failure();
     regionOp = *newRegionOp;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -788,7 +788,7 @@ static LogicalResult createFusionGroups(
       }
 
       auto newRegionOp =
-          movePrecedingOpIntoDispatchRegion(rewriter, producer, regionOp);
+          movePrecedingOpsIntoDispatchRegion(rewriter, producer, regionOp);
       if (failed(newRegionOp)) return failure();
       regionOp = *newRegionOp;
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -263,43 +263,56 @@ LogicalResult Flow::reifyDynamicResultDims(OpBuilder &b, Value value,
 
 // Append a result to the given DispatchRegionOp. The newly created
 // DispatchRegionOp is returned.
-FailureOr<Flow::DispatchRegionOp> Flow::appendDispatchRegionResult(
-    RewriterBase &rewriter, Flow::DispatchRegionOp regionOp, Value result,
-    const SmallVector<Value> &dynamicDims) {
-#ifndef NDEBUG
-  auto tensorType = result.getType().cast<RankedTensorType>();
-  assert(tensorType.getNumDynamicDims() == dynamicDims.size() &&
-         "incorrect number of dynamicDims provided");
-#endif  // NDEBUG
+FailureOr<Flow::DispatchRegionOp> Flow::appendDispatchRegionResults(
+    RewriterBase &rewriter, Flow::DispatchRegionOp regionOp,
+    ArrayRef<Value> results, ArrayRef<SmallVector<Value>> dynamicDims) {
+  if (results.empty()) {
+    return regionOp;
+  }
+  assert(results.size() == dynamicDims.size() &&
+         "expected as many dynamic dims list as the number of results");
 
-  OpBuilder::InsertionGuard guard(rewriter);
-
-  // Determine dynamic result dims.
-  rewriter.setInsertionPoint(regionOp);
+  // Collect the current region dynamic dims, and result types.
   SmallVector<Value> regionDynamicDims(regionOp.getResultDims().begin(),
                                        regionOp.getResultDims().end());
-  regionDynamicDims.append(dynamicDims);
-
-  // Determine result types of new RegionOp.
   SmallVector<Type> resultTypes(regionOp.getResultTypes().begin(),
                                 regionOp.getResultTypes().end());
-  resultTypes.push_back(result.getType());
+
+  // Collect the current dispatch yielded values.
+  auto returnOp =
+      cast<Flow::ReturnOp>(regionOp.getBody().front().getTerminator());
+  SmallVector<Value> returnedValues(returnOp.getOperands().begin(),
+                                    returnOp.getOperands().end());
+
+  for (auto [index, result] : llvm::enumerate(results)) {
+#ifndef NDEBUG
+    auto tensorType = result.getType().cast<RankedTensorType>();
+    assert(tensorType.getNumDynamicDims() == dynamicDims[index].size() &&
+           "incorrect number of dynamicDims provided");
+#endif  // NDEBUG
+    resultTypes.push_back(result.getType());
+    regionDynamicDims.append(dynamicDims[index]);
+    returnedValues.push_back(result);
+  }
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(regionOp);
 
   // Create new DispatchRegionOp and move over the body.
   auto newRegionOp = rewriter.create<Flow::DispatchRegionOp>(
       regionOp->getLoc(), resultTypes, regionDynamicDims,
       regionOp.getWorkload());
-  newRegionOp.getBody().takeBody(regionOp.getBody());
+  rewriter.inlineRegionBefore(regionOp.getBody(), newRegionOp.getBody(),
+                              newRegionOp.getBody().begin());
   rewriter.replaceOp(
       regionOp, newRegionOp.getResults().take_front(regionOp->getNumResults()));
 
   // Update terminator.
-  Flow::ReturnOp returnOp =
+  auto newRegionReturnOp =
       cast<Flow::ReturnOp>(newRegionOp.getBody().front().getTerminator());
-  SmallVector<Value> returnedValues(returnOp.getOperands().begin(),
-                                    returnOp.getOperands().end());
-  returnedValues.push_back(result);
-  returnOp.getOperandsMutable().assign(returnedValues);
+  rewriter.setInsertionPoint(newRegionReturnOp);
+  rewriter.replaceOpWithNewOp<Flow::ReturnOp>(newRegionReturnOp,
+                                              returnedValues);
 
   return newRegionOp;
 }
@@ -350,66 +363,73 @@ FailureOr<Operation *> Flow::clonePrecedingOpIntoDispatchRegion(
 
 // Move a `target` op that is preceding the given dispatch region op into the
 // dispatch region.
-FailureOr<Flow::DispatchRegionOp> Flow::movePrecedingOpIntoDispatchRegion(
-    RewriterBase &rewriter, Operation *target,
+FailureOr<Flow::DispatchRegionOp> Flow::movePrecedingOpsIntoDispatchRegion(
+    RewriterBase &rewriter, ArrayRef<Operation *> targets,
     Flow::DispatchRegionOp regionOp) {
-#ifndef NDEBUG
-  DominanceInfo domInfo;
-  for (OpOperand &use : target->getUses()) {
-    Operation *user = use.getOwner();
-    if (regionOp->isProperAncestor(user) || isa<tensor::DimOp>(user)) {
-      continue;
-    }
-    assert(domInfo.properlyDominates(regionOp, user) &&
-           "found use that does not post-dominate target");
-  }
-#endif  // NDEBUG
+  // Values replaced by moving the `targets` into the dispatch region.
+  SmallVector<Value> replacedValues;
+
+  // List of dynamic dimensions for each new results added to the dispatch
+  // region.
+  SmallVector<SmallVector<Value>> dispatchOpNewResultsDynamicDims;
+
+  // New values that are yielded from dispatch.
+  SmallVector<Value> yieldedResults;
+
+  llvm::SetVector<Operation *> targetSet;
+  targetSet.insert(targets.begin(), targets.end());
 
   Block &body = regionOp.getBody().front();
+  for (Operation *target : llvm::reverse(targets)) {
+    // Clone op into dispatch region.
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPointToStart(&body);
+    Operation *clonedTarget = rewriter.clone(*target);
 
-  // Gather all uses of `target`.
-  SmallVector<OpOperand *> usesOutsideOfRegion;
-  for (OpOperand &use : target->getUses())
-    if (!regionOp->isProperAncestor(use.getOwner()))
-      usesOutsideOfRegion.push_back(&use);
-
-  // Compute dynamic result dims.
-  SmallVector<SmallVector<Value>> dynamicDims;
-  for (Value v : target->getResults()) {
-    OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(target);
-    SmallVector<Value> &dims = dynamicDims.emplace_back();
-    if (failed(reifyDynamicResultDims(rewriter, v, dims))) return failure();
-  }
-
-  // Move op into dispatch region.
-  target->moveBefore(&body.front());
-
-  // Replace all uses outside of the dispatch region.
-  if (!usesOutsideOfRegion.empty()) {
-    unsigned previousNumResults = regionOp->getNumResults();
-
-    // Note: Appending results one-by-one here so that this can be extended to
-    // specific results in the future. Many ops have just one result, so this
-    // should not be a large overhead.
-    for (const auto &it : llvm::enumerate(target->getResults())) {
-      auto newRegionOp = appendDispatchRegionResult(
-          rewriter, regionOp, it.value(), dynamicDims[it.index()]);
-      if (failed(newRegionOp)) return failure();
-      regionOp = *newRegionOp;
+    // Gather all uses of `target`.
+    for (auto [index, result] : llvm::enumerate(target->getResults())) {
+      bool hasUsesOutsideOfRegion =
+          llvm::any_of(result.getUses(), [&](OpOperand &use) {
+            Operation *user = use.getOwner();
+            // The use is not in
+            // 1. the current dispatch
+            // 2. Not in one of the targets.
+            return !regionOp->isProperAncestor(user) && !targetSet.count(user);
+          });
+      if (hasUsesOutsideOfRegion) {
+        replacedValues.push_back(result);
+        yieldedResults.push_back(clonedTarget->getResult(index));
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(target);
+        SmallVector<Value> &dims =
+            dispatchOpNewResultsDynamicDims.emplace_back();
+        if (failed(reifyDynamicResultDims(rewriter, result, dims))) {
+          return target->emitOpError(
+              "failed to reify dynamic dims of result to be yielded from "
+              "dispatch region");
+        }
+      }
     }
 
-    // Replace uses of `target` after the dispatch region.
-    for (OpOperand *use : usesOutsideOfRegion) {
-      rewriter.updateRootInPlace(use->getOwner(), [&]() {
-        use->set(regionOp->getResult(
-            previousNumResults +
-            llvm::cast<OpResult>(use->get()).getResultNumber()));
-      });
-    }
+    rewriter.replaceOpWithinBlock(target, clonedTarget->getResults(), &body);
   }
 
-  return regionOp;
+  FailureOr<Flow::DispatchRegionOp> newRegionOp = appendDispatchRegionResults(
+      rewriter, regionOp, yieldedResults, dispatchOpNewResultsDynamicDims);
+
+  if (failed(newRegionOp)) {
+    return regionOp->emitOpError("failed to append results to op");
+  }
+
+  ValueRange replacements =
+      newRegionOp->getResults().take_back(replacedValues.size());
+  for (auto [index, replacedVal] : llvm::enumerate(replacedValues)) {
+    rewriter.replaceAllUsesWith(replacedVal, replacements[index]);
+  }
+  for (auto target : llvm::reverse(targets)) {
+    rewriter.eraseOp(target);
+  }
+  return newRegionOp.value();
 }
 
 FailureOr<Flow::DispatchRegionOp> Flow::wrapOpInDispatchRegion(
@@ -428,7 +448,7 @@ FailureOr<Flow::DispatchRegionOp> Flow::wrapOpInDispatchRegion(
       Flow::makeEmptyDispatchRegion(rewriter, op->getLoc(), workload);
 
   // Move the op into the dispatch region.
-  auto newRegionOp = movePrecedingOpIntoDispatchRegion(rewriter, op, regionOp);
+  auto newRegionOp = movePrecedingOpsIntoDispatchRegion(rewriter, op, regionOp);
 
   if (succeeded(newRegionOp) && useWorkloadCountFromDagRootMode) {
     auto newWorkload = newRegionOp->getWorkload();
@@ -442,6 +462,7 @@ FailureOr<Flow::DispatchRegionOp> Flow::wrapOpInDispatchRegion(
 
   return newRegionOp;
 }
+
 //===---------------------------------------------------------------------===//
 // Utilities to make a dispatch region isolated from above
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -172,7 +172,7 @@ static bool checkShapeIsDataDependant(Operation *op) {
 /// These is the legacy path for workgroup count calculation that
 /// arent handled by the current default.
 static void createWorkgroupCountFromDagRootRegion(
-    RewriterBase &rewriter, Location loc, Flow::DispatchRegionOp &regionOp,
+    RewriterBase &rewriter, Flow::DispatchRegionOp &regionOp,
     TypeRange workloadTypes, ArrayRef<Location> workloadLocs) {
   Region &countRegion = regionOp.getWorkgroupCount();
   if (!countRegion.empty()) return;
@@ -181,6 +181,7 @@ static void createWorkgroupCountFromDagRootRegion(
   auto args = body->getArguments();
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPointToStart(body);
+  Location loc = regionOp.getLoc();
   auto countOp =
       rewriter.create<Flow::DispatchWorkgroupCountFromDagRootOp>(loc, args);
   rewriter.create<Flow::ReturnOp>(loc, countOp->getResults());
@@ -456,8 +457,8 @@ FailureOr<Flow::DispatchRegionOp> Flow::wrapOpInDispatchRegion(
         llvm::map_range(newWorkload, [](Value v) { return v.getType(); }));
     auto workloadLocs = llvm::to_vector(
         llvm::map_range(newWorkload, [](Value v) { return v.getLoc(); }));
-    createWorkgroupCountFromDagRootRegion(rewriter, op->getLoc(), *newRegionOp,
-                                          workloadTypes, workloadLocs);
+    createWorkgroupCountFromDagRootRegion(rewriter, *newRegionOp, workloadTypes,
+                                          workloadLocs);
   }
 
   return newRegionOp;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
@@ -32,9 +32,9 @@ LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
 
 /// Append a result to the given DispatchRegionOp. The newly created
 /// DispatchRegionOp is returned.
-FailureOr<Flow::DispatchRegionOp> appendDispatchRegionResult(
-    RewriterBase &rewriter, Flow::DispatchRegionOp regionOp, Value result,
-    const SmallVector<Value> &dynamicDims);
+FailureOr<Flow::DispatchRegionOp> appendDispatchRegionResults(
+    RewriterBase &rewriter, Flow::DispatchRegionOp regionOp,
+    ArrayRef<Value> results, ArrayRef<SmallVector<Value>> dynamicDims);
 
 /// Create an empty DispatchRegionOp.
 Flow::DispatchRegionOp makeEmptyDispatchRegion(OpBuilder &builder, Location loc,
@@ -74,8 +74,9 @@ FailureOr<Operation *> clonePrecedingOpIntoDispatchRegion(
 ///   flow.return %1 : tensor<?xf32>
 /// }
 /// %2 = "yet_another_use"(%0) : (tensor<?xf32>) -> (tensor<?xf32>)
-FailureOr<Flow::DispatchRegionOp> movePrecedingOpIntoDispatchRegion(
-    RewriterBase &rewriter, Operation *target, Flow::DispatchRegionOp regionOp);
+FailureOr<Flow::DispatchRegionOp> movePrecedingOpsIntoDispatchRegion(
+    RewriterBase &rewriter, ArrayRef<Operation *> targets,
+    Flow::DispatchRegionOp regionOp);
 
 /// Wrap the given op in a new dispatch region op.
 FailureOr<Flow::DispatchRegionOp> wrapOpInDispatchRegion(RewriterBase &rewriter,


### PR DESCRIPTION
Adding all values of the operation moved into a dispatch as results can lead to wasted memory usage if the result is not used. This patch avoids doing that and refactors the methods as a precursor to #13711.