### PR TITLE
`iree_c_embed_data` improvements

### DIFF
--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -158,7 +158,7 @@ function(iree_bytecode_module)
         "${_RULE_NAME}_c"
       IDENTIFIER
         "${_RULE_C_IDENTIFIER}"
-      GENERATED_SRCS
+      SRCS
         "${_RULE_NAME}.vmfb"
       C_FILE_OUTPUT
         "${_RULE_NAME}_c.c"

--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -111,7 +111,7 @@ function(iree_hal_cts_test_suite)
       iree_c_embed_data(
         NAME
           ${_EXECUTABLES_TESTDATA_NAME}_c
-        GENERATED_SRCS
+        SRCS
           ${_EMBED_DATA_SOURCES}
         C_FILE_OUTPUT
           "${_EXECUTABLES_TESTDATA_NAME}_c.c"
@@ -180,6 +180,7 @@ function(iree_hal_cts_test_suite)
     set(IREE_CTS_DRIVER_REGISTRATION_FN "${_RULE_DRIVER_REGISTRATION_FN}")
     set(IREE_CTS_TEST_CLASS_NAME "${_TEST_NAME}_test")
     set(IREE_CTS_DRIVER_NAME "${_RULE_DRIVER_NAME}")
+    set(IREE_CTS_TARGET_BACKEND "${_RULE_COMPILER_TARGET_BACKEND}")
 
     configure_file(
       "${IREE_ROOT_DIR}/runtime/src/iree/hal/cts/cts_test_template.cc.in"

--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -90,6 +90,11 @@ static bool GenerateHeader(const std::string& identifier,
                            const std::string& header_file,
                            const std::vector<std::string>& toc_files) {
   std::ofstream f(header_file, std::ios::out | std::ios::trunc);
+  if (!f) {
+    fprintf(stderr, "Failed to open '%s' for write.\n", header_file.c_str());
+    exit(EXIT_FAILURE);
+  }
+
   f << "#pragma once\n";  // Pragma once isn't great but is the best we can do.
   f << "#include <stddef.h>\n";
   GenerateTocStruct(f);
@@ -106,6 +111,10 @@ static bool GenerateHeader(const std::string& identifier,
 static bool SlurpFile(const std::string& file_name, std::string* contents) {
   constexpr std::streamoff kMaxSize = 100000000;
   std::ifstream f(file_name, std::ios::in | std::ios::binary);
+  if (!f) {
+    fprintf(stderr, "Failed to open '%s' for read.\n", file_name.c_str());
+    exit(EXIT_FAILURE);
+  }
   // get length of file:
   f.seekg(0, f.end);
   std::streamoff length = f.tellg();
@@ -133,6 +142,11 @@ static bool GenerateImpl(const std::string& identifier,
                          const std::vector<std::string>& input_files,
                          const std::vector<std::string>& toc_files) {
   std::ofstream f(impl_file, std::ios::out | std::ios::trunc);
+  if (!f) {
+    fprintf(stderr, "Failed to open '%s' for write.\n", impl_file.c_str());
+    exit(EXIT_FAILURE);
+  }
+
   f << "#include <stddef.h>\n";
   f << "#include <stdint.h>\n";
   f << R"(

--- a/runtime/src/iree/base/testing/CMakeLists.txt
+++ b/runtime/src/iree/base/testing/CMakeLists.txt
@@ -19,7 +19,7 @@ iree_cc_library(
 iree_c_embed_data(
   NAME
     dynamic_library_test_library
-  GENERATED_SRCS
+  SRCS
     "$<TARGET_FILE:iree::base::testing::dynamic_library_test_library.so>"
   C_FILE_OUTPUT
     "dynamic_library_test_library_embed.c"

--- a/runtime/src/iree/builtins/device/CMakeLists.txt
+++ b/runtime/src/iree/builtins/device/CMakeLists.txt
@@ -71,7 +71,7 @@ iree_bitcode_library(
 iree_c_embed_data(
   NAME
     libdevice_bitcode
-  GENERATED_SRCS
+  SRCS
     "libdevice_wasm32_generic.bc"
     "libdevice_wasm64_generic.bc"
   DEPS

--- a/runtime/src/iree/builtins/ukernel/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/CMakeLists.txt
@@ -172,7 +172,7 @@ iree_link_bitcode(
 iree_c_embed_data(
   NAME
     libukernel_bitcode
-  GENERATED_SRCS
+  SRCS
     "ukernel_bitcode.bc"
   DEPS
 

--- a/runtime/src/iree/hal/cts/cts_test_template.cc.in
+++ b/runtime/src/iree/hal/cts/cts_test_template.cc.in
@@ -12,6 +12,8 @@
 #cmakedefine IREE_CTS_DRIVER_NAME "@IREE_CTS_DRIVER_NAME@"
 #cmakedefine IREE_CTS_EXECUTABLE_FORMAT @IREE_CTS_EXECUTABLE_FORMAT@
 #cmakedefine IREE_CTS_EXECUTABLES_TESTDATA_HDR "@IREE_CTS_EXECUTABLES_TESTDATA_HDR@"
+#cmakedefine IREE_CTS_TARGET_BACKEND "@IREE_CTS_TARGET_BACKEND@"
+
 // clang-format on
 
 #include IREE_CTS_TEST_FILE_PATH
@@ -43,9 +45,15 @@ const char* get_test_executable_format() {
 iree_const_byte_span_t get_test_executable_data(iree_string_view_t file_name) {
 #ifdef IREE_CTS_EXECUTABLES_TESTDATA_HDR
   const struct iree_file_toc_t* toc = iree_cts_testdata_executables_create();
+  char file_name_with_target_backend[256];
+  snprintf(file_name_with_target_backend, sizeof file_name_with_target_backend,
+    "%s_%.*s", IREE_CTS_TARGET_BACKEND, static_cast<int>(file_name.size), file_name.data);
   for (size_t i = 0; i < iree_cts_testdata_executables_size(); ++i) {
     const auto& file = toc[i];
-    if (iree_string_view_equal(file_name, iree_make_cstring_view(file.name))) {
+    if (iree_string_view_equal(
+      iree_make_cstring_view(file_name_with_target_backend),
+      iree_make_cstring_view(file.name)))
+    {
       return iree_make_const_byte_span(file.data, file.size);
     }
   }

--- a/runtime/src/iree/vm/test/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 iree_c_embed_data(
   NAME
     all_bytecode_modules_c
-  GENERATED_SRCS
+  SRCS
     "arithmetic_ops.vmfb"
     "arithmetic_ops_f32.vmfb"
     "arithmetic_ops_i64.vmfb"
@@ -293,7 +293,7 @@ iree_bytecode_module(
 iree_c_embed_data(
   NAME
     async_bytecode_modules_c
-  GENERATED_SRCS
+  SRCS
     "async_ops.vmfb"
   C_FILE_OUTPUT
     "async_bytecode_modules.c"

--- a/samples/static_library/CMakeLists.txt
+++ b/samples/static_library/CMakeLists.txt
@@ -55,7 +55,7 @@ iree_c_embed_data(
     simple_mul_c
   IDENTIFIER
     iree_samples_static_library_simple_mul
-  GENERATED_SRCS
+  SRCS
     simple_mul.vmfb
   C_FILE_OUTPUT
     simple_mul_c.c


### PR DESCRIPTION
* Reconcile CMake with Bazel by dropping the CMake-specific `GENERATED_SRCS` argument and instead just putting everything in `SRCS`, like in Bazel.
    * To bridge that difference, `bazel_to_cmake_converter.py` was facing the impossible task of choosing, for each `srcs` entry, whether to put it in `SRCS` or `GENERATED_SRCS`. It was simply deciding that based on whether the leading character was a `:`, offering a way to distinguish generated files in the case where they were generated within the current package. But that didn't generalize to generated files from other packages.
* In `SRCS` support various syntaxes for files in the source or in the build directory (generated files) and automatically do the right thing to match Bazel. In particular, make it simple to reference generated files in a subdirectory.
   * Concretely, to address #13804, ukernel bitcode will need to reference generated bitcode in architecture-specific subdirectories.
* In `generate_embed_data_main.cc`, generate clear errors on failure to open an input/output file (would've saved some head scratching).

For some reason, this exposed an issue in `hal/cts`. The filenames were missing a `"${TARGET_BACKEND}_"` prefix and somehow that was still working; now with my changes that wasn't working anymore. Fixed by adding the missing prefixes.

(This commit is one of a chain in completing https://github.com/openxla/iree/issues/13804).