### PR TITLE
[spirv] Fix out-of-bounds issue in kernel configuration deduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1444,7 +1444,8 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
     SmallVector<int64_t> loopTileSizes(linalgOp.getNumLoops(), 0);
     for (const auto &[i, iter] :
          llvm::enumerate(linalgOp.getIteratorTypesArray())) {
-      if (linalg::isReductionIterator(iter) || workgroupTileSizes[i] == 0) {
+      if (linalg::isReductionIterator(iter) || i >= workgroupTileSizes.size() ||
+          workgroupTileSizes[i] == 0) {
         loopTileSizes[i] = getReductionTilingFactor(loopBounds[i]);
       }
     }


### PR DESCRIPTION
When indexing into `workgroupTileSizes`, we need to make sure we are not out of bounds.

Progress towards https://github.com/openxla/iree/issues/13784