### PR TITLE
Add AArch64 builds and move to manylinux_2_28

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -41,8 +41,8 @@ set -xeu -o errtrace
 
 this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
-repo_root="$(cd "${this_dir}" && git rev-parse --show-toplevel)"
-manylinux_docker_image="${manylinux_docker_image:-gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:794513562cca263480c0c169c708eec9ff70abfe279d6dc44e115b04488b9ab5}"
+repo_root="$(cd "${this_dir}" && while [[ "$(pwd)" != "/" && ! -d .git ]]; do cd ..; done; [[ -d .git ]] && pwd || echo "No git repo found")"
+manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:794513562cca263480c0c169c708eec9ff70abfe279d6dc44e115b04488b9ab5" }')}"
 python_versions="${override_python_versions:-cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-runtime iree-runtime-instrumented iree-compiler}"
@@ -75,6 +75,9 @@ function run_on_host() {
 
 function run_in_docker() {
   echo "Running in docker"
+  echo "Marking git safe.directory"
+  git config --global --add safe.directory '*'
+
   echo "Using python versions: ${python_versions}"
 
   local orig_path="${PATH}"
@@ -95,16 +98,19 @@ function run_in_docker() {
       case "${package}" in
         iree-runtime)
           clean_wheels "iree_runtime${package_suffix}" "${python_version}"
+          install_deps "iree_runtime${package_suffix}" "${python_version}"
           build_iree_runtime
           run_audit_wheel "iree_runtime${package_suffix}" "${python_version}"
           ;;
         iree-runtime-instrumented)
           clean_wheels "iree_runtime_instrumented${package_suffix}" "${python_version}"
+          install_deps "iree_runtime${package_suffix}" "${python_version}"
           build_iree_runtime_instrumented
           run_audit_wheel "iree_runtime_instrumented${package_suffix}" "${python_version}"
           ;;
         iree-compiler)
           clean_wheels "iree_compiler${package_suffix}" "${python_version}"
+          install_deps "iree_runtime${package_suffix}" "${python_version}"
           build_iree_compiler
           run_audit_wheel "iree_compiler${package_suffix}" "${python_version}"
           ;;
@@ -122,18 +128,19 @@ function build_wheel() {
 }
 
 function build_iree_runtime() {
-  IREE_HAL_DRIVER_CUDA=ON \
+  IREE_HAL_DRIVER_CUDA=$(uname -m | awk '{print ($1 == "x86_64") ? "ON" : "OFF"}') \
   build_wheel runtime/
 }
 
 function build_iree_runtime_instrumented() {
-  IREE_HAL_DRIVER_CUDA=ON IREE_BUILD_TRACY=ON IREE_ENABLE_RUNTIME_TRACING=ON \
+  IREE_HAL_DRIVER_CUDA=$(uname -m | awk '{print ($1 == "x86_64") ? "ON" : "OFF"}') \
+  IREE_BUILD_TRACY=ON IREE_ENABLE_RUNTIME_TRACING=ON \
   IREE_RUNTIME_CUSTOM_PACKAGE_SUFFIX="-instrumented" \
   build_wheel runtime/
 }
 
 function build_iree_compiler() {
-  IREE_TARGET_BACKEND_CUDA=ON \
+  IREE_TARGET_BACKEND_CUDA=$(uname -m | awk '{print ($1 == "x86_64") ? "ON" : "OFF"}') \
   build_wheel compiler/
 }
 
@@ -141,7 +148,7 @@ function run_audit_wheel() {
   local wheel_basename="$1"
   local python_version="$2"
   # Force wildcard expansion here
-  generic_wheel="$(echo "${output_dir}/${wheel_basename}-"*"-${python_version}-linux_x86_64.whl")"
+  generic_wheel="$(echo "${output_dir}/${wheel_basename}-"*"-${python_version}-linux_$(uname -m).whl")"
   ls "${generic_wheel}"
   echo ":::: Auditwheel ${generic_wheel}"
   auditwheel repair -w "${output_dir}" "${generic_wheel}"
@@ -154,6 +161,33 @@ function clean_wheels() {
   echo ":::: Clean wheels ${wheel_basename} ${python_version}"
   rm -f -v "${output_dir}/${wheel_basename}-"*"-${python_version}-"*".whl"
 }
+
+function install_deps() {
+  local wheel_basename="$1"
+  local python_version="$2"
+  echo ":::: Install Deps for ${wheel_basename} ${python_version}"
+
+  # Get the output of uname -m
+  uname_m=$(uname -m)
+
+  # Check if the output is aarch64
+  if [[ "$uname_m" == "aarch64" ]]; then
+    echo "The architecture is aarch64 and we use manylinux 2_28 so install deps"
+    yum install -y epel-release
+    yum update -y
+    # Required for Tracy
+    yum install -y capstone-devel tbb-devel libzstd-devel
+  else
+    # Check if the output is x86_64
+    if [[ "$uname_m" == "x86_64" ]]; then
+      echo "The architecture is x86_64 so assume we are on older manylinux2014 with TBB deps installed in the image"
+    else
+      echo "The architecture is unknown. Exiting"
+      exit 1
+   fi
+  fi
+}
+
 
 # Trampoline to the docker container if running on the host.
 if [ -z "${__MANYLINUX_BUILD_WHEELS_IN_DOCKER-}" ]; then


### PR DESCRIPTION
Use uname -m to key off architecture
Disable CUDA on ARM64 until we move to 12.1
Use canconical docker image to key off Architectures.
Remove use of git to find root directory so we don't get errors about safe directories
Add an install_deps() to install tracy deps
Migrate to using manylinux_2_28