### PR TITLE
fix the `cpu_ukernel` standalone plugin: was missing `weak.c`

### DIFF
--- a/experimental/cpu_ukernel/CMakeLists.txt
+++ b/experimental/cpu_ukernel/CMakeLists.txt
@@ -57,13 +57,8 @@ iree_experimental_standalone_plugin(
     "arm_64"
   SRCS
     plugin.c
-    runtime/src/iree/builtins/ukernel/mmt4d.c
-    runtime/src/iree/builtins/ukernel/mmt4d_tile.c
-    runtime/src/iree/builtins/ukernel/unpack_tile.c
-    runtime/src/iree/builtins/ukernel/pack.c
-    runtime/src/iree/builtins/ukernel/query_tile_sizes.c
-    runtime/src/iree/builtins/ukernel/unpack.c
-    runtime/src/iree/builtins/ukernel/pack_tile.c
+    # ukernel/arch/ file come before ukernel/ (non-arch) files because they
+    # contains symbols that should override weak symbols in ukernel/weak.c.
     "x86_64:runtime/src/iree/builtins/ukernel/arch/x86_64/query_tile_sizes_x86_64.c"
     "x86_64:runtime/src/iree/builtins/ukernel/arch/x86_64/unpack_x86_64.c"
     "x86_64:runtime/src/iree/builtins/ukernel/arch/x86_64/pack_x86_64.c"
@@ -81,4 +76,12 @@ iree_experimental_standalone_plugin(
     "arm_64:runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.c"
     "arm_64:runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c:IREE_UK_ARM_64_DOTPROD_COPTS"
     "arm_64:runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c:IREE_UK_ARM_64_I8MM_COPTS"
+    runtime/src/iree/builtins/ukernel/mmt4d.c
+    runtime/src/iree/builtins/ukernel/mmt4d_tile.c
+    runtime/src/iree/builtins/ukernel/unpack_tile.c
+    runtime/src/iree/builtins/ukernel/pack.c
+    runtime/src/iree/builtins/ukernel/query_tile_sizes.c
+    runtime/src/iree/builtins/ukernel/unpack.c
+    runtime/src/iree/builtins/ukernel/pack_tile.c
+    runtime/src/iree/builtins/ukernel/weak.c
 )


### PR DESCRIPTION
I forgot to update this in #13715. This would result in linker errors when using this outside of x86_64 and arm64. Sorry! @lundong .

(The need for this standalone plugin is likely to diminish as #13804 is getting completed. Even if it stays around, it could be reimplemented as a thin shell around the bitcode.).