### PR TITLE
Handle Windows `C:/`-style absolute paths in `iree_c_embed_data`

### DIFF
--- a/build_tools/cmake/iree_c_embed_data.cmake
+++ b/build_tools/cmake/iree_c_embed_data.cmake
@@ -62,7 +62,10 @@ function(iree_c_embed_data)
 
   foreach(_SRC ${_RULE_SRCS})
     if(_SRC MATCHES "^/")
-      # _SRC is an absolute path (starts with `/`).
+      # _SRC is a Unix-style absolute path (starts with `/`).
+      list(APPEND _RESOLVED_SRCS "${_SRC}")
+    elseif(_SRC MATCHES "^[a-zA-Z]:/")
+      # _SRC is a Windows-style absolute path (starts with `X:/`).
       list(APPEND _RESOLVED_SRCS "${_SRC}")
     elseif(_SRC MATCHES "^[$]<")
       # _SRC is a CMake generator expression (starts with `$<`).


### PR DESCRIPTION
Fixed breakage https://github.com/openxla/iree/actions/runs/5125490369/jobs/9218738653 caused by https://github.com/openxla/iree/pull/13814:

```
FindFirstFileExA(build_tools/third_party/cuda/c:/a/iree/iree/build-windows/build_tools/third_party/cuda/11.6.2/windows-x86_64/nvvm/libdevice)
```

If my MS-DOS memory serves, the c:/ indicates the start of an absolute path.  my PR had logic to recognize absolute paths.... by looking for '/' prefix.  this adds logic to handle the Windows flavor of absolute paths.

See https://github.com/openxla/iree/pull/13814 for why we need a heuristic to tell whether a path is absolute.