### PR TITLE
Enable __builtin_trap for 'llvm_unrechable' in IREE codebase

### DIFF
--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -27,6 +27,9 @@ macro(iree_llvm_configure_bundled)
   # Disable LLVM's warnings.
   set(LLVM_ENABLE_WARNINGS OFF)
 
+  # Disable unsafe optimizations on 'llvm_unreachable'.
+  set(LLVM_UNREACHABLE_OPTIMIZE OFF)
+
   # Stash cmake build type in case LLVM messes with it.
   set(_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -262,8 +262,7 @@ static int64_t getNativeVectorSizeInBytes(func::FuncOp entryPointFn) {
     return defaultNativeVectorSizeforVMVX;
   }
 
-  assert(0 && "Missing 'native_vector_size' attribute");
-  return 0;
+  llvm_unreachable("Missing 'native_vector_size' attribute");
 }
 
 /// For a given `shapedType` or (`byteWidth` of element type) return the number

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -770,7 +770,7 @@ static LogicalResult matchAndSetReductionStrategy(func::FuncOp entryPoint,
       StagedReductionStrategy strategy(captures, reductionConfig);
       return buildStagedReductionStrategy(b, variant, strategy);
     } else {
-      return llvm_unreachable("Unknown strategy");
+      llvm_unreachable("Unknown strategy");
     }
   };
 


### PR DESCRIPTION
This PR re-enables the use of 'llvm_unreachable' after the community fix that lets us convert this construct into a `__builtin_trap()` even for builds without assertions. See https://github.com/openxla/iree/pull/8521#issuecomment-1565084742 for context.