### PR TITLE
[DRAFT] Adds support for mixed precision NVIDIA A100 Tensor Cores (F32 <= BF16 * BF16 + F32)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -30,6 +30,46 @@ using mlir::iree_compiler::IREE::LinalgExt::VectorizationPatterns;
 namespace mlir {
 namespace iree_compiler {
 
+/// Pattern to fold arithmetic extensions on floating point data types into
+/// vector contraction operations. linalg.matmul introduces arithmetic
+/// extensions on its operands. Please mlir snippets below for more details.
+/// ```mlir
+///   "linalg.matmul"(%lhs, %rhs, %acc) ({
+///      ^bb0(%arg1: f16, %arg2: f16, %arg3: f32):
+///        %lhs_f32 = "arith.extf"(%arg1) : (f16) -> f32
+///        %rhs_f32 = "arith.extf"(%arg2) : (f16) -> f32
+///        %mul = "arith.mulf"(%lhs_f32, %rhs_f32) : (f32, f32) -> f32
+///        %acc = "arith.addf"(%arg3, %mul) : (f32, f32) -> f32
+///        "linalg.yield"(%acc) : (f32) -> ()
+///     })
+/// ```
+/// This restricts the native usage of mixed precision NVIDIA Ampere Tensor
+/// Cores, i.e, `mma.sync.*.f32.f16.f16.f32` and `mma.sync.*.f32.bf16.bf16.f32`.
+/// This pattern folds the arithmetic extensions into the vector contraction and
+/// enables the usage of native mixed precision Tensor Core instructions.
+struct FoldArithExtIntoContractionOp
+    : public OpRewritePattern<vector::ContractionOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::ContractionOp contractOp,
+                                PatternRewriter &rewriter) const override {
+    auto lhsDefOp = contractOp.getLhs().getDefiningOp();
+    auto rhsDefOp = contractOp.getRhs().getDefiningOp();
+
+    if (!isa<arith::ExtFOp>(lhsDefOp) || !isa<arith::ExtFOp>(rhsDefOp)) {
+      return rewriter.notifyMatchFailure(
+          contractOp, "no arith::ExtFOp on contract operands");
+    }
+
+    rewriter.replaceOpWithNewOp<vector::ContractionOp>(
+        contractOp, lhsDefOp->getOperand(0), rhsDefOp->getOperand(0),
+        contractOp.getAcc(), contractOp.getIndexingMapsAttr(),
+        contractOp.getIteratorTypesAttr());
+
+    return success();
+  }
+};
+
 //====---------------------------------------------------------------------===//
 // Patterns for vectorization
 //====---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -30,46 +30,6 @@ using mlir::iree_compiler::IREE::LinalgExt::VectorizationPatterns;
 namespace mlir {
 namespace iree_compiler {
 
-/// Pattern to fold arithmetic extensions on floating point data types into
-/// vector contraction operations. linalg.matmul introduces arithmetic
-/// extensions on its operands. Please mlir snippets below for more details.
-/// ```mlir
-///   "linalg.matmul"(%lhs, %rhs, %acc) ({
-///      ^bb0(%arg1: f16, %arg2: f16, %arg3: f32):
-///        %lhs_f32 = "arith.extf"(%arg1) : (f16) -> f32
-///        %rhs_f32 = "arith.extf"(%arg2) : (f16) -> f32
-///        %mul = "arith.mulf"(%lhs_f32, %rhs_f32) : (f32, f32) -> f32
-///        %acc = "arith.addf"(%arg3, %mul) : (f32, f32) -> f32
-///        "linalg.yield"(%acc) : (f32) -> ()
-///     })
-/// ```
-/// This restricts the native usage of mixed precision NVIDIA Ampere Tensor
-/// Cores, i.e, `mma.sync.*.f32.f16.f16.f32` and `mma.sync.*.f32.bf16.bf16.f32`.
-/// This pattern folds the arithmetic extensions into the vector contraction and
-/// enables the usage of native mixed precision Tensor Core instructions.
-struct FoldArithExtIntoContractionOp
-    : public OpRewritePattern<vector::ContractionOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(vector::ContractionOp contractOp,
-                                PatternRewriter &rewriter) const override {
-    auto lhsDefOp = contractOp.getLhs().getDefiningOp();
-    auto rhsDefOp = contractOp.getRhs().getDefiningOp();
-
-    if (!isa<arith::ExtFOp>(lhsDefOp) || !isa<arith::ExtFOp>(rhsDefOp)) {
-      return rewriter.notifyMatchFailure(
-          contractOp, "no arith::ExtFOp on contract operands");
-    }
-
-    rewriter.replaceOpWithNewOp<vector::ContractionOp>(
-        contractOp, lhsDefOp->getOperand(0), rhsDefOp->getOperand(0),
-        contractOp.getAcc(), contractOp.getIndexingMapsAttr(),
-        contractOp.getIteratorTypesAttr());
-
-    return success();
-  }
-};
-
 //====---------------------------------------------------------------------===//
 // Patterns for vectorization
 //====---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -518,8 +518,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addPass(createConvertComplexToStandardPass());
 
   // Convert BF16 operations to occur as F32.
-  pm.addPass(createConvertBf16ArithToF32Pass());
-  pm.addPass(createConvertBf16ToUInt16BuffersPass());
+  // pm.addPass(createConvertBf16ArithToF32Pass());
+  // pm.addPass(createConvertBf16ToUInt16BuffersPass());
 
   pm.addNestedPass<func::FuncOp>(arith::createArithExpandOpsPass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -518,7 +518,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addPass(createConvertComplexToStandardPass());
 
   // Convert BF16 operations to occur as F32.
-  // pm.addPass(createConvertBf16ArithToF32Pass());
+  // pm.addPass(IREE::Util::createPromoteArithBF16ToF32Pass());
   // pm.addPass(createConvertBf16ToUInt16BuffersPass());
 
   pm.addNestedPass<func::FuncOp>(arith::createArithExpandOpsPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
@@ -191,7 +191,8 @@ void createAsyncGroups(RewriterBase& rewriter, func::FuncOp funcOp,
 
     VectorType vecType = llvm::cast<VectorType>(vectorVal.getType());
     if (!((vecType.getElementType().isF32() && vecType.getNumElements() <= 4) ||
-          (vecType.getElementType().isF16() &&
+          ((vecType.getElementType().isF16() ||
+            vecType.getElementType().isBF16()) &&
            vecType.getNumElements() <= 8))) {
       LDBG("----readOp is not (<=4)xf32 or (<=8)xf16 -> Skip");
       return WalkResult::advance();

--- a/experimental/dispatch_profiler/library.py
+++ b/experimental/dispatch_profiler/library.py
@@ -6,6 +6,7 @@
 
 import enum, re
 from enum import auto
+from ml_dtypes import bfloat16
 import numpy as np
 from abc import ABC, abstractmethod
 from collections import namedtuple
@@ -150,6 +151,7 @@ DataTypeName = {
 }
 
 DataTypeNumPyTag = {
+    DataType.bf16: bfloat16,
     DataType.f16: np.float16,
     DataType.f32: np.float32,
 }

--- a/experimental/dispatch_profiler/manifest.py
+++ b/experimental/dispatch_profiler/manifest.py
@@ -200,8 +200,8 @@ class Manifest:
   def initialize(self):
     """Initialize the mainfest object by generating dispatches for supported operations."""
     self.append(CudaMatmulGenerator(self.args).generate())
-    self.append(CudaSplitKMatmulGenerator(self.args).generate())
-    self.append(CudaBatchMatmulGenerator(self.args).generate())
+    #self.append(CudaSplitKMatmulGenerator(self.args).generate())
+    #self.append(CudaBatchMatmulGenerator(self.args).generate())
 
     # Serialize the initialized mainfest state.
     self.dump()

--- a/experimental/dispatch_profiler/manifest.py
+++ b/experimental/dispatch_profiler/manifest.py
@@ -200,8 +200,8 @@ class Manifest:
   def initialize(self):
     """Initialize the mainfest object by generating dispatches for supported operations."""
     self.append(CudaMatmulGenerator(self.args).generate())
-    #self.append(CudaSplitKMatmulGenerator(self.args).generate())
-    #self.append(CudaBatchMatmulGenerator(self.args).generate())
+    self.append(CudaSplitKMatmulGenerator(self.args).generate())
+    self.append(CudaBatchMatmulGenerator(self.args).generate())
 
     # Serialize the initialized mainfest state.
     self.dump()

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -461,7 +461,7 @@ class CudaMatmulGenerator:
     # List of pre-defined threadblock tile shapes for Tensor Core.
     self.tile_descriptions_tensor_cores_f16 = [
         #TileDescription([256, 128, 32], 3, [64, 4, 1]),
-        #TileDescription([128, 256, 32], 3, [128, 2, 1]),
+        TileDescription([128, 256, 32], 3, [128, 2, 1]),
         TileDescription([128, 128, 64], 4, [64, 2, 1]),
         #TileDescription([128, 128, 32], 5, [64, 2, 1]),
         #TileDescription([128, 64, 32], 5, [64, 2, 1]),

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -460,13 +460,13 @@ class CudaMatmulGenerator:
 
     # List of pre-defined threadblock tile shapes for Tensor Core.
     self.tile_descriptions_tensor_cores_f16 = [
-        TileDescription([256, 128, 32], 3, [64, 4, 1]),
-        TileDescription([128, 256, 32], 3, [128, 2, 1]),
+        #TileDescription([256, 128, 32], 3, [64, 4, 1]),
+        #TileDescription([128, 256, 32], 3, [128, 2, 1]),
         TileDescription([128, 128, 64], 4, [64, 2, 1]),
-        TileDescription([128, 128, 32], 5, [64, 2, 1]),
-        TileDescription([128, 64, 32], 5, [64, 2, 1]),
-        TileDescription([64, 64, 64], 5, [64, 2, 1]),
-        TileDescription([64, 64, 32], 10, [64, 2, 1]),
+        #TileDescription([128, 128, 32], 5, [64, 2, 1]),
+        #TileDescription([128, 64, 32], 5, [64, 2, 1]),
+        #TileDescription([64, 64, 64], 5, [64, 2, 1]),
+        #TileDescription([64, 64, 32], 10, [64, 2, 1]),
     ]
 
     self.tile_descriptions_tensor_cores_f32 = [
@@ -498,13 +498,13 @@ class CudaMatmulGenerator:
     n_list = get_cmd_line_argument_list(self.args.problem_n)
     k_list = get_cmd_line_argument_list(self.args.problem_k)
 
-    # If no command line matmul problem shapes are provided, only
-    # use the default shapes.
-    if len(m_list) == 0 and len(n_list) == 0 and len(k_list) == 0:
-      return
+
 
     # If any of the command line matmul problem shapes are provided,
     # set the default shapes to empty problem dimension.
+    if len(m_list) == 0 and len(n_list) == 0 and len(k_list) == 0:
+      return
+
     if len(m_list) == 0:
       m_list = [256]
     if len(n_list) == 0:
@@ -575,6 +575,15 @@ class CudaMatmulGenerator:
         self.tile_descriptions_tensor_cores_f16, self.translation_infos,
         OperationKind.Matmul)
     data_type = [DataType.f16, DataType.f16, DataType.f16]
+    self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
+                                            configuration_list)
+
+  def _cuda_matmul_tensor_cores_mixed_precision(self):
+    """Appends a list of matmul dispatches for GPU TensorCore F16 data type."""
+    configuration_list = self._get_matmul_custom_compilation_info_list(
+        self.tile_descriptions_tensor_cores_f16, self.translation_infos,
+        OperationKind.Matmul)
+    data_type = [DataType.f16, DataType.f16, DataType.f32]
     self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
                                             configuration_list)
 

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -460,13 +460,13 @@ class CudaMatmulGenerator:
 
     # List of pre-defined threadblock tile shapes for Tensor Core.
     self.tile_descriptions_tensor_cores_f16 = [
-        #TileDescription([256, 128, 32], 3, [64, 4, 1]),
-        #TileDescription([128, 256, 32], 3, [128, 2, 1]),
+        TileDescription([256, 128, 32], 3, [64, 4, 1]),
+        TileDescription([128, 256, 32], 3, [128, 2, 1]),
         TileDescription([128, 128, 64], 4, [64, 2, 1]),
-        #TileDescription([128, 128, 32], 5, [64, 2, 1]),
-        #TileDescription([128, 64, 32], 5, [64, 2, 1]),
-        #TileDescription([64, 64, 64], 5, [64, 2, 1]),
-        #TileDescription([64, 64, 32], 10, [64, 2, 1]),
+        TileDescription([128, 128, 32], 5, [64, 2, 1]),
+        TileDescription([128, 64, 32], 5, [64, 2, 1]),
+        TileDescription([64, 64, 64], 5, [64, 2, 1]),
+        TileDescription([64, 64, 32], 10, [64, 2, 1]),
     ]
 
     self.tile_descriptions_tensor_cores_f32 = [
@@ -575,15 +575,6 @@ class CudaMatmulGenerator:
         self.tile_descriptions_tensor_cores_f16, self.translation_infos,
         OperationKind.Matmul)
     data_type = [DataType.f16, DataType.f16, DataType.f16]
-    self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
-                                            configuration_list)
-
-  def _cuda_matmul_tensor_cores_mixed_precision(self):
-    """Appends a list of matmul dispatches for GPU TensorCore F16 data type."""
-    configuration_list = self._get_matmul_custom_compilation_info_list(
-        self.tile_descriptions_tensor_cores_f16, self.translation_infos,
-        OperationKind.Matmul)
-    data_type = [DataType.f16, DataType.f16, DataType.f32]
     self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
                                             configuration_list)
 

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -498,8 +498,6 @@ class CudaMatmulGenerator:
     n_list = get_cmd_line_argument_list(self.args.problem_n)
     k_list = get_cmd_line_argument_list(self.args.problem_k)
 
-
-
     # If any of the command line matmul problem shapes are provided,
     # set the default shapes to empty problem dimension.
     if len(m_list) == 0 and len(n_list) == 0 and len(k_list) == 0:
@@ -596,7 +594,7 @@ class CudaMatmulGenerator:
     self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
                                             configuration_list)
 
-  def _cuda_matmul_tensor_cores_mixed_precision(self):
+  def _cuda_matmul_tensor_cores_mixed_precision_f16(self):
     """Appends dispatches for TensorCore with F16 input, F32 accum, F32 output."""
     configuration_list = self._get_matmul_custom_compilation_info_list(
         self.tile_descriptions_tensor_cores_f16, self.translation_infos,
@@ -605,9 +603,19 @@ class CudaMatmulGenerator:
     self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
                                             configuration_list)
 
+  def _cuda_matmul_tensor_cores_mixed_precision_bf16(self):
+    """Appends dispatches for TensorCore with BF16 input, F32 accum, F32 output."""
+    configuration_list = self._get_matmul_custom_compilation_info_list(
+        self.tile_descriptions_tensor_cores_f16, self.translation_infos,
+        OperationKind.Matmul)
+    data_type = [DataType.bf16, DataType.bf16, DataType.f32]
+    self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
+                                            configuration_list)
+
   def generate(self):
     """Generates a list of matmul operations."""
     self._cuda_matmul_tensor_cores_f16()
-    self._cuda_matmul_tensor_cores_f32()
-    self._cuda_matmul_tensor_cores_mixed_precision()
+    #self._cuda_matmul_tensor_cores_f32()
+    self._cuda_matmul_tensor_cores_mixed_precision_f16()
+    self._cuda_matmul_tensor_cores_mixed_precision_bf16()
     return self.dispatches_collection_list

--- a/experimental/dispatch_profiler/matmul.py
+++ b/experimental/dispatch_profiler/matmul.py
@@ -460,13 +460,13 @@ class CudaMatmulGenerator:
 
     # List of pre-defined threadblock tile shapes for Tensor Core.
     self.tile_descriptions_tensor_cores_f16 = [
-        TileDescription([256, 128, 32], 3, [64, 4, 1]),
-        TileDescription([128, 256, 32], 3, [128, 2, 1]),
+        #TileDescription([256, 128, 32], 3, [64, 4, 1]),
+        #TileDescription([128, 256, 32], 3, [128, 2, 1]),
         TileDescription([128, 128, 64], 4, [64, 2, 1]),
-        TileDescription([128, 128, 32], 5, [64, 2, 1]),
-        TileDescription([128, 64, 32], 5, [64, 2, 1]),
-        TileDescription([64, 64, 64], 5, [64, 2, 1]),
-        TileDescription([64, 64, 32], 10, [64, 2, 1]),
+        #TileDescription([128, 128, 32], 5, [64, 2, 1]),
+        #TileDescription([128, 64, 32], 5, [64, 2, 1]),
+        #TileDescription([64, 64, 64], 5, [64, 2, 1]),
+        #TileDescription([64, 64, 32], 10, [64, 2, 1]),
     ]
 
     self.tile_descriptions_tensor_cores_f32 = [
@@ -575,6 +575,15 @@ class CudaMatmulGenerator:
         self.tile_descriptions_tensor_cores_f16, self.translation_infos,
         OperationKind.Matmul)
     data_type = [DataType.f16, DataType.f16, DataType.f16]
+    self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
+                                            configuration_list)
+
+  def _cuda_matmul_tensor_cores_mixed_precision(self):
+    """Appends a list of matmul dispatches for GPU TensorCore F16 data type."""
+    configuration_list = self._get_matmul_custom_compilation_info_list(
+        self.tile_descriptions_tensor_cores_f16, self.translation_infos,
+        OperationKind.Matmul)
+    data_type = [DataType.f16, DataType.f16, DataType.f32]
     self._append_matmul_dispatch_collection(self.matmul_shapes, data_type,
                                             configuration_list)
 


### PR DESCRIPTION
This PR adds support for mixed precision NVIDIA A100 Tensor Core support addressing the issue https://github.com/openxla/iree/issues/13414 from Epic #13812

BF16 input for lhs, and BF16 input for rhs, F32 for accumulation, and F32 output data types can be supported on CUDA backend by lowering to `mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32` ptx instruction. Inputs and outputs are different bit-width (16b inputs and 32b outputs)

Prerequisites for merging this PR:
1. Merge #13857
2. Rebase
3. Resolve the below error

Fails the at createIntrinsicCall on nvvm.mma.sync on `bf16`

```bash
#20 0x00007fa1561cbe62 mlir::LLVM::detail::createIntrinsicCall(llvm::IRBuilderBase&, unsigned int, llvm::ArrayRef<llvm::Value*>, llvm::ArrayRef<llvm::Type*>) /mnt/disks/gcloud_workspace/repos/iree/iree_tree_2/iree/third_party/llvm-project/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp:586:3

```

```mlir
%489 = nvvm.mma.sync A[%293, %295, %297, %299]  B[%392, %394]  C[%484, %485, %487, %488]  {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<bf16>, multiplicandBPtxType = #nvvm.mma_type<bf16>, shape = #nvvm.shape<m = 16, n = 8, k = 16>} : (vector<2xbf16>, vector<2xbf16>, f32) -> !llvm.struct<(f32, f32, f32, f32)>
```