### PR TITLE
Increase the PotentialValuesState analysis max value count.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/State.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/State.h
@@ -429,7 +429,7 @@ struct PotentialValuesState : AbstractState {
   }
 
   // Maximum number of potential values to be tracked.
-  static constexpr unsigned maxPotentialValues = 32;
+  static constexpr unsigned maxPotentialValues = 256;
 
   // Returns empty set as the best state of potential values.
   static PotentialValuesState getBestState() {


### PR DESCRIPTION
32 was too conservative and very easily hit in even moderately sized programs. This would result in passes that use this state like iree-stream-elide-timepoints stopping after the first few timepoints. This eats a bit more memory but is a drop in the bucket (4k instead of 512b per state entry, of which there are only dozens).

Progress on #13637 (LLM's with control flow and lots of values were hitting this).