### PR TITLE
Populate dependent dialects in auto input conversion pipeline

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/AutoInputConversionPipeline.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/AutoInputConversionPipeline.cpp
@@ -172,6 +172,9 @@ void AutoInputConversionPipelinePass::getDependentDialects(
   // Register dialects from all possible pipelines, as we do not statically know
   // which pipeline will be selected, while dialect registration happens before
   // we run any detection on the input.
+  //
+  // TODO(kuhar): Find a better registration mechanism so that we do not have to
+  // build pipelines just to query dialects and discard them immediately after.
   auto appendPipelineDialects =
       [&registry](function_ref<void(OpPassManager&)> buildFn) {
         OpPassManager pm;

--- a/compiler/src/iree/compiler/InputConversion/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "auto_input_conversion_pipeline.mlir",
             "import_ml_program.mlir",
             "iree_import_public.mlir",
             "linalg_quantized_conv_to_conv.mlir",

--- a/compiler/src/iree/compiler/InputConversion/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "auto_input_conversion_pipeline.mlir"
     "import_ml_program.mlir"
     "iree_import_public.mlir"
     "linalg_quantized_conv_to_conv.mlir"

--- a/compiler/src/iree/compiler/InputConversion/Common/test/auto_input_conversion_pipeline.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/auto_input_conversion_pipeline.mlir
@@ -1,0 +1,10 @@
+// RUN: iree-opt --iree-auto-input-conversion %s | FileCheck %s
+
+// Check that the input conversion pipeline handles a simple input and does not crash.
+
+// CHECK-LABEL: func.func @simple_add
+// CHECK:  arith.addi
+func.func @simple_add(%arg0: tensor<2x2xi32>, %arg1: tensor<2x2xi32>) -> tensor<2x2xi32> {
+  %0 = "mhlo.add"(%arg0, %arg1) : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
+  return %0 : tensor<2x2xi32>
+}

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -448,10 +448,10 @@ struct ConvertMHLOToLinalgOnTensorsPass
     : public ConvertMHLOToLinalgOnTensorsBase<
           ConvertMHLOToLinalgOnTensorsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<IREE::Flow::FlowDialect, IREE::Util::UtilDialect,
-                    linalg::LinalgDialect, mhlo::MhloDialect,
-                    shape::ShapeDialect, math::MathDialect,
-                    memref::MemRefDialect, complex::ComplexDialect>();
+    registry.insert<
+        IREE::Flow::FlowDialect, IREE::Util::UtilDialect, linalg::LinalgDialect,
+        mhlo::MhloDialect, shape::ShapeDialect, tensor::TensorDialect,
+        math::MathDialect, memref::MemRefDialect, complex::ComplexDialect>();
   }
 
   void runOnOperation() override {


### PR DESCRIPTION
Because we don't statically know the exact pipeline, add dialects from all pipelines.

Add a missing dialect to the MHLO pipeline.

Fixes: https://github.com/openxla/iree/issues/13860