### PR TITLE
Add auto input pipeline conversion detection to python bindings

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/core.py
+++ b/compiler/bindings/python/iree/compiler/tools/core.py
@@ -41,7 +41,7 @@ class InputType(Enum):
   `CompilerOptions.input_type`.
   """
   NONE = "none"
-  AUTO= "auto"
+  AUTO = "auto"
   STABLEHLO = "stablehlo"
   STABLEHLO_XLA = "stablehlo_xla"
   TOSA = "tosa"

--- a/compiler/bindings/python/iree/compiler/tools/core.py
+++ b/compiler/bindings/python/iree/compiler/tools/core.py
@@ -41,6 +41,7 @@ class InputType(Enum):
   `CompilerOptions.input_type`.
   """
   NONE = "none"
+  AUTO= "auto"
   STABLEHLO = "stablehlo"
   STABLEHLO_XLA = "stablehlo_xla"
   TOSA = "tosa"
@@ -110,7 +111,7 @@ class CompilerOptions:
       or more of the compiled backends.
     input_type: The type of input legalization to perform prior to full
       compilation. Values can either be an `InputType` enum value or a
-      case-insensitive name. Defaults to `InputType.NONE`.
+      case-insensitive name. Defaults to `InputType.AUTO`.
     output_format: Override the output format. See the `OutputFormat` enum.
       Values can either be an enum value or a case-insensitive name of
       the option. Typically used for debugging Defaults to
@@ -139,7 +140,7 @@ class CompilerOptions:
 
   output_file: Optional[str] = None
   target_backends: Sequence[str] = ()
-  input_type: Union[InputType, str] = InputType.NONE
+  input_type: Union[InputType, str] = InputType.AUTO
   output_format: Union[OutputFormat, str] = OutputFormat.FLATBUFFER_BINARY
   extra_args: Sequence[str] = ()
   optimize: bool = True

--- a/compiler/bindings/python/test/tools/compiler_core_test.py
+++ b/compiler/bindings/python/test/tools/compiler_core_test.py
@@ -105,7 +105,7 @@ class CompilerTest(unittest.TestCase):
   def testBadInputType(self):
     with self.assertRaisesRegex(
         ValueError, "For input_type= argument, expected one of: "
-        "NONE, STABLEHLO, STABLEHLO_XLA, TOSA"):
+        "NONE, AUTO, STABLEHLO, STABLEHLO_XLA, TOSA"):
       _ = iree.compiler.tools.compile_str(
           SIMPLE_MUL_ASM,
           input_type="not-existing",


### PR DESCRIPTION
This is to match the new option added in
https://github.com/openxla/iree/pull/13443.