### PR TITLE
Fix windows e2e tests

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -89,8 +89,8 @@ if [[ "$OSTYPE" =~ ^msys ]]; then
     # TODO(#11077): INVALID_ARGUMENT: argument/result signature mismatch
     "iree/tests/e2e/matmul/e2e_matmul_direct_i8_small_ukernel_vmvx_local-task"
     "iree/tests/e2e/matmul/e2e_matmul_direct_f32_small_ukernel_vmvx_local-task"
-    "iree/tests/e2e/matmul/e2e_matmul_mmt4d_i8_small_ukernel_vmvx_local-task"
-    "iree/tests/e2e/matmul/e2e_matmul_mmt4d_f32_small_ukernel_vmvx_local-task"
+    "iree/tests/e2e/matmul/e2e_matmul_mmt4d_i8_small_vmvx_ukernel_vmvx_local-task"
+    "iree/tests/e2e/matmul/e2e_matmul_mmt4d_f32_small_vmvx_ukernel_vmvx_local-task"
     # TODO: Regressed when `pack` ukernel gained a uint64_t parameter in #13264.
     "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_pack.mlir"
     "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_pack_dynamic_inner_tiles.mlir"


### PR DESCRIPTION
Known-failing tests had been renamed in #13846.

Fixes #13893.
