### PR TITLE
[StableHLO] Add pass to convert from MHLO to StableHLO

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -104,6 +104,7 @@ class TargetConverter:
             "MhloPasses",
             "MhloShapeOpsToStandard",
             "MhloToLinalg",
+            "MhloToStablehlo",
             "MhloToStandard",
             "StablehloToMhlo",
             # Note: We deliberately omit some passes that we do not use in IREE,

--- a/compiler/src/iree/compiler/InputConversion/MHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/BUILD.bazel
@@ -51,6 +51,7 @@ iree_compiler_cc_library(
         "ConvertMHLOToFlow.cpp",
         "ConvertMHLOToFlow.h",
         "ConvertMHLOToLinalgExt.cpp",
+        "ConvertMHLOToStableHLO.cpp",
         "FlattenTuplesInCFG.cpp",
         "MHLOToLinalgOnTensors.cpp",
         "MHLOToMHLOPreprocessing.cpp",

--- a/compiler/src/iree/compiler/InputConversion/MHLO/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/BUILD.bazel
@@ -106,5 +106,6 @@ iree_compiler_cc_library(
         "@mlir-hlo//:mlir_hlo",
         "@mlir-hlo//stablehlo:broadcast_utils",
         "@mlir-hlo//stablehlo:chlo_ops",
+        "@mlir-hlo//stablehlo:stablehlo_ops",
     ],
 )

--- a/compiler/src/iree/compiler/InputConversion/MHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/CMakeLists.txt
@@ -91,6 +91,7 @@ iree_cc_library(
     MhloToStablehlo
     MhloToStandard
     StablehloBroadcastUtils
+    StablehloOps
     StablehloToMhlo
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/InputConversion/MHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/CMakeLists.txt
@@ -46,6 +46,7 @@ iree_cc_library(
     "ConvertMHLOToFlow.cpp"
     "ConvertMHLOToFlow.h"
     "ConvertMHLOToLinalgExt.cpp"
+    "ConvertMHLOToStableHLO.cpp"
     "FlattenTuplesInCFG.cpp"
     "MHLOToLinalgOnTensors.cpp"
     "MHLOToMHLOPreprocessing.cpp"
@@ -87,6 +88,7 @@ iree_cc_library(
     MhloPasses
     MhloShapeOpsToStandard
     MhloToLinalg
+    MhloToStablehlo
     MhloToStandard
     StablehloBroadcastUtils
     StablehloToMhlo

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToStableHLO.cpp
@@ -1,0 +1,40 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/InputConversion/MHLO/PassDetail.h"
+#include "iree/compiler/InputConversion/MHLO/Passes.h"
+#include "mhlo/transforms/passes.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::MHLO {
+namespace {
+struct ConvertMHLOToStableHLOPass final
+    : ConvertMHLOToStableHLOPassBase<ConvertMHLOToStableHLOPass> {
+  void runOnOperation() override {
+    OpPassManager pm(ModuleOp::getOperationName(),
+                     OpPassManager::Nesting::Explicit);
+    pm.addPass(mlir::mhlo::createHloLegalizeToStablehloPass());
+
+    if (failed(runPipeline(pm, getOperation()))) {
+      signalPassFailure();
+    }
+  }
+
+  void getDependentDialects(DialectRegistry& registry) const override {
+    registry.insert<mlir::stablehlo::StablehloDialect>();
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertMHLOToStableHLOPass() {
+  return std::make_unique<ConvertMHLOToStableHLOPass>();
+}
+}  // namespace mlir::iree_compiler::MHLO

--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.h
@@ -58,6 +58,12 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createVerifyCompilerMHLOInputLegality();
 
 //------------------------------------------------------------------------------
+// Passes to aid in the MHLO to StableHLO transition
+//------------------------------------------------------------------------------
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertMHLOToStableHLOPass();
+
+//------------------------------------------------------------------------------
 // Test passes
 //------------------------------------------------------------------------------
 

--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.td
@@ -45,6 +45,11 @@ def VerifyCompilerMHLOInputLegality :
   let constructor = "mlir::iree_compiler::MHLO::createVerifyCompilerMHLOInputLegality()";
 }
 
+def ConvertMHLOToStableHLOPass : Pass<"iree-convert-mhlo-to-stablehlo", "ModuleOp"> {
+  let summary = "Convert MHLO to StableHLO, to aid in transiton to StableHLO.";
+  let constructor = "mlir::iree_compiler::MHLO::createConvertMHLOToStableHLOPass()";
+}
+
 //------------------------------------------------------------------------------
 // Test passes
 //------------------------------------------------------------------------------
@@ -54,6 +59,5 @@ def TestMHLOConvertComplexToReal :
   let summary = "Test pass that does an MHLO->MHLO conversion of just complex arithmetic ops.";
   let constructor = "mlir::iree_compiler::MHLO::createTestMHLOConvertComplexToRealPass()";
 }
-
 
 #endif // IREE_COMPILER_INPUTCONVERSION_MHLO_PASSES

--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.td
@@ -46,7 +46,7 @@ def VerifyCompilerMHLOInputLegality :
 }
 
 def ConvertMHLOToStableHLOPass : Pass<"iree-convert-mhlo-to-stablehlo", "ModuleOp"> {
-  let summary = "Convert MHLO to StableHLO, to aid in transiton to StableHLO.";
+  let summary = "Convert MHLO to StableHLO, to aid in transition to StableHLO.";
   let constructor = "mlir::iree_compiler::MHLO::createConvertMHLOToStableHLOPass()";
 }
 

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "broadcasting.mlir",
             "convert_mhlo_to_linalg_ext.mlir",
+            "convert_mhlo_to_stablehlo.mlir",
             "convert_collective_ops.mlir",
             "convert_complex_to_real.mlir",
             "convert_structural_types.mlir",

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "convert_collective_ops.mlir"
     "convert_complex_to_real.mlir"
     "convert_mhlo_to_linalg_ext.mlir"
+    "convert_mhlo_to_stablehlo.mlir"
     "convert_structural_types.mlir"
     "dynamic_shape.mlir"
     "fft.mlir"

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_stablehlo.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_stablehlo.mlir
@@ -1,0 +1,13 @@
+// RUN: iree-opt --iree-convert-mhlo-to-stablehlo %s | FileCheck %s
+
+// CHECK-LABEL: func.func @add
+// CHECK-NEXT:    stablehlo.add
+// CHECK-NEXT:    chlo.broadcast_add
+// CHECK-NEXT:    stablehlo.add
+// CHECK-NEXT:    return
+func.func @add(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = mhlo.add %arg0, %arg1 : tensor<4xf32>
+  %1 = chlo.broadcast_add %0, %arg1 : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  %2 = stablehlo.add %1, %arg1 : tensor<4xf32>
+  return %2 : tensor<4xf32>
+}


### PR DESCRIPTION
This is to aid in the migration of existing MHLO-based tests. The pass is expected to be short-lived and removed when we drop mhlo support.

The pass is available using a new flag `iree-opt --iree-convert-mhlo-to-stablehlo`.

Issue: https://github.com/openxla/iree/issues/13869