### PR TITLE
Loosen widen to work between differing types (int vs fp)

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -1184,12 +1184,8 @@ struct FuseWidenOperands : public OpRewritePattern<Op> {
       if (convertOp) {
         auto inputType = getElementTypeOrSelf(convertOp.getOperand().getType());
         auto castedType = getElementTypeOrSelf(convertOp.getResult().getType());
-        bool isSameCast = (llvm::isa<IntegerType>(inputType) &&
-                           llvm::isa<IntegerType>(castedType)) ||
-                          (llvm::isa<FloatType>(inputType) &&
-                           llvm::isa<FloatType>(castedType));
-        if (isSameCast && inputType.getIntOrFloatBitWidth() <
-                              castedType.getIntOrFloatBitWidth()) {
+        if (inputType.getIntOrFloatBitWidth() <
+            castedType.getIntOrFloatBitWidth()) {
           operands.push_back(convertOp.getOperand());
           continue;
         }

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -1198,11 +1198,8 @@ struct FuseWidenOperands final : OpRewritePattern<Op> {
       if (convertOp) {
         auto inputType = getElementTypeOrSelf(convertOp.getOperand().getType());
         auto castedType = getElementTypeOrSelf(convertOp.getResult().getType());
-        bool isSameCast =
-            (isa<IntegerType>(inputType) && isa<IntegerType>(castedType)) ||
-            (isa<FloatType>(inputType) && isa<FloatType>(castedType));
-        if (isSameCast && inputType.getIntOrFloatBitWidth() <
-                              castedType.getIntOrFloatBitWidth()) {
+        if (inputType.getIntOrFloatBitWidth() <
+            castedType.getIntOrFloatBitWidth()) {
           operands.push_back(convertOp.getOperand());
           continue;
         }


### PR DESCRIPTION
Dot and conv fusing with the conversion should support between integer and floating point operations. The linalg operations already understand how to perform the right type conversions, so respect those conversions.