### PR TITLE
Improvements to target CPU features variants in e2e tests

### DIFF
--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -97,7 +97,6 @@ function(iree_trace_runner_test)
       ${_RULE_RUNNER_ARGS}
     LABELS
       ${_RULE_LABELS}
-      ${_RULE_TARGET_CPU_FEATURES}
   )
 endfunction()
 
@@ -320,11 +319,18 @@ function(iree_generated_trace_runner_test)
     else()
       set(_TARGET_CPU_FEATURES_VARIANTS "default")
     endif()
-    foreach(_TARGET_CPU_FEATURES_LIST_ELEM IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
-      process_target_cpu_features("${_TARGET_CPU_FEATURES_LIST_ELEM}" _ENABLED _TARGET_CPU_FEATURES _TARGET_CPU_FEATURES_SUFFIX)
+    foreach(_VARIANT_STRING IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
+      parse_target_cpu_features_variant("${_VARIANT_STRING}"
+        _ENABLED _TARGET_CPU_FEATURES_NAME _TARGET_CPU_FEATURES)
       if(NOT _ENABLED)
         # The current entry is disabled on the target CPU architecture.
         continue()
+      endif()
+      set(_TARGET_CPU_FEATURES_SUFFIX "")
+      set(_LABELS "${_RULE_LABELS}")
+      if (_TARGET_CPU_FEATURES_NAME)
+        set(_TARGET_CPU_FEATURES_SUFFIX "_${_TARGET_CPU_FEATURES_NAME}")
+        list(APPEND _LABELS "cpu_features=${_TARGET_CPU_FEATURES_NAME}")
       endif()
       iree_single_backend_generated_trace_runner_test(
         NAME
@@ -344,7 +350,7 @@ function(iree_generated_trace_runner_test)
         RUNNER_ARGS
           ${_RULE_RUNNER_ARGS}
         LABELS
-          ${_RULE_LABELS}
+          ${_LABELS}
         TARGET_CPU_FEATURES
           ${_TARGET_CPU_FEATURES}
       )

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -50,8 +50,8 @@ py_binary(
     ],
     target_cpu_features_variants = ["default"] +
                                    ([
-                                       "arm_64:+dotprod",
-                                       "arm_64:+i8mm",
+                                       "arm_64:dotprod:+dotprod",
+                                       "arm_64:i8mm:+i8mm",
                                    ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [
@@ -70,16 +70,17 @@ py_binary(
         "--shapes=large",
     ],
     tags = [
-        # "--shapes=large" can cause timeouts on riscv emulator.
+        # "--shapes=large" can cause timeouts on riscv emulator and TSan.
         "noriscv",
+        "notsan",
     ],
     target_backends_and_drivers = [
         ("llvm-cpu", "local-task"),
     ],
     target_cpu_features_variants = ["default"] +
                                    ([
-                                       "arm_64:+dotprod",
-                                       "arm_64:+i8mm",
+                                       "arm_64:dotprod:+dotprod",
+                                       "arm_64:i8mm:+i8mm",
                                    ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [
@@ -106,8 +107,8 @@ py_binary(
     ],
     target_cpu_features_variants = ["default"] +
                                    ([
-                                       "arm_64:+dotprod",
-                                       "arm_64:+i8mm",
+                                       "arm_64:dotprod:+dotprod",
+                                       "arm_64:i8mm:+i8mm",
                                    ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [
@@ -189,17 +190,22 @@ X86_64_AVX512_VNNI = X86_64_AVX512_BASE + [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=%s" % size,
     ],
+    tags = [
+        # "--shapes=large" can cause timeouts on riscv emulator and TSan.
+        "noriscv",
+        "notsan",
+    ] if size == "large" else [],
     target_backends_and_drivers = [
         ("llvm-cpu", "local-task"),
     ],
     target_cpu_features_variants = [
         "default",
-        "x86_64:" + ",".join(X86_64_AVX2_FMA),
-        "x86_64:" + ",".join(X86_64_AVX512_BASE),
+        "x86_64:avx2_fma:" + ",".join(X86_64_AVX2_FMA),
+        "x86_64:avx512_base:" + ",".join(X86_64_AVX512_BASE),
     ] + ([
-        "x86_64:" + ",".join(X86_64_AVX512_VNNI),
-        "arm_64:+dotprod",
-        "arm_64:+i8mm",
+        "x86_64:avx512_vnni:" + ",".join(X86_64_AVX512_VNNI),
+        "arm_64:dotprod:+dotprod",
+        "arm_64:i8mm:+i8mm",
     ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -60,8 +60,8 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "arm_64:+dotprod"
-    "arm_64:+i8mm"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
 )
 
 iree_generated_trace_runner_test(
@@ -102,10 +102,11 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   LABELS
     "noriscv"
+    "notsan"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "arm_64:+dotprod"
-    "arm_64:+i8mm"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
 )
 
 iree_generated_trace_runner_test(
@@ -126,6 +127,7 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   LABELS
     "noriscv"
+    "notsan"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
 )
@@ -149,8 +151,8 @@ iree_generated_trace_runner_test(
     "--iree-flow-enable-data-tiling"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "arm_64:+dotprod"
-    "arm_64:+i8mm"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
 )
 
 iree_generated_trace_runner_test(
@@ -265,13 +267,15 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-llvmcpu-enable-microkernels"
     "--iree-flow-enable-data-tiling"
+  LABELS
+
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "x86_64:+avx,+avx2,+fma"
-    "x86_64:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
-    "arm_64:+dotprod"
-    "arm_64:+i8mm"
+    "x86_64:avx2_fma:+avx,+avx2,+fma"
+    "x86_64:avx512_base:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512_vnni:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
 )
 
 iree_generated_trace_runner_test(
@@ -291,13 +295,16 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-llvmcpu-enable-microkernels"
     "--iree-flow-enable-data-tiling"
+  LABELS
+    "noriscv"
+    "notsan"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "x86_64:+avx,+avx2,+fma"
-    "x86_64:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
-    "arm_64:+dotprod"
-    "arm_64:+i8mm"
+    "x86_64:avx2_fma:+avx,+avx2,+fma"
+    "x86_64:avx512_base:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512_vnni:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
 )
 
 iree_generated_trace_runner_test(
@@ -317,10 +324,12 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-llvmcpu-enable-microkernels"
     "--iree-flow-enable-data-tiling"
+  LABELS
+
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "x86_64:+avx,+avx2,+fma"
-    "x86_64:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx2_fma:+avx,+avx2,+fma"
+    "x86_64:avx512_base:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
 )
 
 iree_generated_trace_runner_test(
@@ -340,10 +349,13 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-llvmcpu-enable-microkernels"
     "--iree-flow-enable-data-tiling"
+  LABELS
+    "noriscv"
+    "notsan"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-    "x86_64:+avx,+avx2,+fma"
-    "x86_64:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx2_fma:+avx,+avx2,+fma"
+    "x86_64:avx512_base:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
 )
 
 iree_generated_trace_runner_test(


### PR DESCRIPTION
* CPU feature variants now have a short mnemonic. Test names use it, so they stay short regardless of the number of CPU features enabled. (Test names were generated by joining all CPU feature strings, which was too much with AVX-512 consisting of several sub-features such as `+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni`).
* The CMake helper functions `process_target_cpu_features` is much simplified, and renamed `parse_target_cpu_features_variant`. It's also made more correct: it was suggesting that it was taking names of output-variables as arguments, but was actually ignoring them and writing to fixed variables. Now it's honoring its output-var arguments.
* Some recently added tests used the `"large"` matmul shapes set, but weren't tagged `noriscv` and `notsan`, and as a result, were hitting > 10s latencies, a potential timeout risk. Fixed.