### PR TITLE
Proper error-handling in ukernel bitcode loading.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/Builtins/UKernel.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/Builtins/UKernel.h
@@ -15,11 +15,11 @@ namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
-std::unique_ptr<llvm::Module>
+llvm::Expected<std::unique_ptr<llvm::Module>>
 loadUKernelBaseBitcode(llvm::TargetMachine *targetMachine,
                        llvm::LLVMContext &context);
 
-std::unique_ptr<llvm::Module>
+llvm::Expected<std::unique_ptr<llvm::Module>>
 loadUKernelArchBitcode(llvm::TargetMachine *targetMachine,
                        llvm::LLVMContext &context);
 


### PR DESCRIPTION
This is really just making my own recent code more in line with siblings. I had dropped some `llvm::Expected<>` around `std::unique_ptr`, thinking that was a case of double-nullable type, an anti-pattern, but the `Expected` potentially carries error messages and it's good to propagate that.