### PR TITLE
Integrate llvm-project at dc63b35b0223

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/BUILD.bazel
@@ -96,6 +96,7 @@ iree_compiler_cc_library(
         ":UtilTypesGen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:CastInterface",
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/Dialect/Util/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/BUILD.bazel
@@ -96,7 +96,7 @@ iree_compiler_cc_library(
         ":UtilTypesGen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
-        "@llvm-project//mlir:CastInterface",
+        "@llvm-project//mlir:CastInterfaces",
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
@@ -64,6 +64,7 @@ iree_cc_library(
     ::UtilTypesGen
     LLVMSupport
     MLIRArithDialect
+    MLIRCastInterface
     MLIRControlFlowDialect
     MLIRControlFlowInterfaces
     MLIRFuncDialect

--- a/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
@@ -64,7 +64,7 @@ iree_cc_library(
     ::UtilTypesGen
     LLVMSupport
     MLIRArithDialect
-    MLIRCastInterface
+    MLIRCastInterfaces
     MLIRControlFlowDialect
     MLIRControlFlowInterfaces
     MLIRFuncDialect

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
@@ -17,6 +17,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"


### PR DESCRIPTION
* Reset third_party/llvm-project: dc63b35b02231a75d131fb6376d2e58a7ad9b7e4 (2023-06-02 11:06:57 +0000): [SVE ACLE] Extend IR combines for fmul, fsub, fadd to cover _u variants