### PR TITLE
Bring your own bitcode

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -410,7 +410,15 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     // This approximates LTO.
     llvm::Linker moduleLinker(*llvmModule);
 
-    // Link any user bitcode objects and specialize them for the current config.
+    // Link any bitcode files specified on the command line.
+    if (failed(linkCmdlineBitcodeFile(variantOp.getLoc(), moduleLinker,
+                                      llvm::Linker::OverrideFromSrc,
+                                      *targetMachine, context))) {
+      return failure();
+    }
+
+    // Link any bitcode objects specified in executable.object attributes and
+    // specialize them for the current config.
     if (failed(linkBitcodeObjects(variantOp.getLoc(), moduleLinker,
                                   llvm::Linker::LinkOnlyNeeded, *targetMachine,
                                   variantOp.getObjectsAttr(), context))) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.h
@@ -50,6 +50,11 @@ LogicalResult linkBitcodeObjects(
     llvm::LLVMContext &context,
     ModuleSpecializationCallback specializationCallback = {});
 
+LogicalResult linkCmdlineBitcodeFile(Location loc, llvm::Linker &linker,
+                                     unsigned linkerFlags,
+                                     llvm::TargetMachine &targetMachine,
+                                     llvm::LLVMContext &context);
+
 }  // namespace HAL
 }  // namespace IREE
 }  // namespace iree_compiler


### PR DESCRIPTION
This adds a `--iree-llvmcpu-link-bitcode=` flag allowing the user to pass a `.bc` file. 

To generate such a `.bc` file, users are encouraged to use/copy the `iree_bitcode_library` CMake function, or otherwise replicate a similar clang command line.

For users using binaries for iree-compile and/or clang (as opposed to building both from source from the IREE repo, which ensures they talk the exact same version of LLVM bitcode): Maybe use `llvm-dis` to disassemble the bitcode back to text IR as a more stable interchange format.