### PR TITLE
Remove compiler/Codegen/Sandbox from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,7 +62,6 @@
 /compiler/src/iree/compiler/Codegen/ @MaheshRavishankar
 /compiler/src/iree/compiler/Codegen/LLVMCPU/ @dcaballe @hanhanW @MaheshRavishankar
 /compiler/src/iree/compiler/Codegen/LLVMGPU/ @MaheshRavishankar
-/compiler/src/iree/compiler/Codegen/Sandbox/ @dcaballe @hanhanW @MaheshRavishankar
 /compiler/src/iree/compiler/Codegen/SPIRV/ @antiagainst @MaheshRavishankar
 /compiler/src/iree/compiler/ConstEval/ @stellaraccident
 /compiler/src/iree/compiler/Dialect/Flow/ @hanhanW @MaheshRavishankar


### PR DESCRIPTION
The directory no longer exists.