### PR TITLE
Lower stablehlo.custom_call @TopK to chlo.top_k

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
@@ -68,8 +68,7 @@ void buildStableHLOInputConversionPassPipelineImpl(OpPassManager &passManager,
   passManager.addNestedPass<func::FuncOp>(createTopLevelSCFToCFGPass());
   if (detuple) passManager.addPass(createFlattenTuplesInCFG());
 
-  passManager.addNestedPass<func::FuncOp>(
-      createStableHLOToStableHLOPreprocessing());
+  passManager.addPass(createStableHLOToStableHLOPreprocessing());
   passManager.addNestedPass<func::FuncOp>(createStableHLOCanonicalize());
 
   // Various shape functions may have been materialized in the `shape.shape_of`

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
@@ -10,7 +10,7 @@
 include "mlir/Pass/PassBase.td"
 
 def StableHLOToStableHLOPreprocessing :
-    Pass<"iree-stablehlo-to-stablehlo-preprocessing", "func::FuncOp"> {
+    Pass<"iree-stablehlo-to-stablehlo-preprocessing", "ModuleOp"> {
   let summary = "Applies IREE-specific stablehlo to stablehlo preprocessing transformations";
   let options = [
     Option<"orderConvFeatures", "order-conv-features", "bool", /*default=*/"true",


### PR DESCRIPTION
TopK can sometimes appear as a custom call after running through the spmd splitter. Best to pattern match after the conversion to raise to chlo.top_k where we have a fast path.