### PR TITLE
Improving iree_arena_t/iree_resource_set_t ASAN debugging.

### DIFF
--- a/build_tools/cmake/iree_setup_toolchain.cmake
+++ b/build_tools/cmake/iree_setup_toolchain.cmake
@@ -109,8 +109,10 @@ macro(iree_setup_toolchain)
     # uninitialized memory. See the extensive description in that patch that
     # originally introduced it:
     # https://reviews.llvm.org/rG14daa20be1ad89639ec209d969232d19cf698845
-    string(APPEND CMAKE_CXX_FLAGS " -ftrivial-auto-var-init=pattern")
-    string(APPEND CMAKE_C_FLAGS " -ftrivial-auto-var-init=pattern")
+    if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+      string(APPEND CMAKE_CXX_FLAGS " -ftrivial-auto-var-init=pattern")
+      string(APPEND CMAKE_C_FLAGS " -ftrivial-auto-var-init=pattern")
+    endif()
 
     # If doing any kind of shared library builds, then we have to link against
     # the shared libasan, and the user will be responsible for adding the

--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -74,6 +74,7 @@ iree_runtime_cc_library(
     hdrs = ["arena.h"],
     deps = [
         ":atomic_slist",
+        ":internal",
         ":synchronization",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:core_headers",

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -60,6 +60,7 @@ iree_cc_library(
     "arena.c"
   DEPS
     ::atomic_slist
+    ::internal
     ::synchronization
     iree::base
     iree::base::core_headers

--- a/runtime/src/iree/base/internal/debugging.h
+++ b/runtime/src/iree/base/internal/debugging.h
@@ -102,6 +102,34 @@ IREE_ATTRIBUTE_ALWAYS_INLINE static inline void iree_debug_break(void) {
 #define IREE_LEAK_CHECK_DISABLE_POP()
 #endif  // IREE_SANITIZER_ADDRESS
 
+// Manual address poisoning; see
+// https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning.
+#if defined(IREE_SANITIZER_ADDRESS)
+// Marks memory region [addr, addr+size) as unaddressable.
+// This memory must be previously allocated by the user program. Accessing
+// addresses in this region from instrumented code is forbidden until
+// this region is unpoisoned. This function is not guaranteed to poison
+// the whole region - it may poison only subregion of [addr, addr+size) due
+// to ASan alignment restrictions.
+// Method is NOT thread-safe in the sense that no two threads can
+// (un)poison memory in the same memory region simultaneously.
+#define IREE_ASAN_POISON_MEMORY_REGION(addr, size) \
+  __asan_poison_memory_region((addr), (size))
+// Marks memory region [addr, addr+size) as addressable.
+// This memory must be previously allocated by the user program. Accessing
+// addresses in this region is allowed until this region is poisoned again.
+// This function may unpoison a superregion of [addr, addr+size) due to
+// ASan alignment restrictions.
+// Method is NOT thread-safe in the sense that no two threads can
+// (un)poison memory in the same memory region simultaneously.
+#define IREE_ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+  __asan_unpoison_memory_region((addr), (size))
+#else
+#define IREE_ASAN_POISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
+#define IREE_ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+  ((void)(addr), (void)(size))
+#endif  // IREE_SANITIZER_ADDRESS
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.c
@@ -257,6 +257,8 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_end(
     command_buffer->graph = NULL;
   }
 
+  iree_hal_resource_set_freeze(command_buffer->resource_set);
+
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
@@ -221,6 +221,8 @@ static iree_status_t iree_hal_task_command_buffer_end(
                         &command_buffer->root_tasks);
   }
 
+  iree_hal_resource_set_freeze(command_buffer->resource_set);
+
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/drivers/vulkan/direct_command_buffer.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/direct_command_buffer.cc
@@ -225,6 +225,8 @@ static iree_status_t iree_hal_vulkan_direct_command_buffer_end(
   command_buffer->descriptor_set_group =
       command_buffer->descriptor_set_arena.Flush();
 
+  iree_hal_resource_set_freeze(command_buffer->resource_set);
+
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/utils/BUILD.bazel
+++ b/runtime/src/iree/hal/utils/BUILD.bazel
@@ -140,6 +140,7 @@ iree_runtime_cc_library(
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/base/internal",
         "//runtime/src/iree/base/internal:arena",
         "//runtime/src/iree/hal",
     ],

--- a/runtime/src/iree/hal/utils/CMakeLists.txt
+++ b/runtime/src/iree/hal/utils/CMakeLists.txt
@@ -153,6 +153,7 @@ iree_cc_library(
     "resource_set.c"
   DEPS
     iree::base
+    iree::base::internal
     iree::base::internal::arena
     iree::base::tracing
     iree::hal

--- a/runtime/src/iree/hal/utils/deferred_command_buffer.c
+++ b/runtime/src/iree/hal/utils/deferred_command_buffer.c
@@ -230,6 +230,9 @@ static iree_status_t iree_hal_deferred_command_buffer_begin(
 
 static iree_status_t iree_hal_deferred_command_buffer_end(
     iree_hal_command_buffer_t* base_command_buffer) {
+  iree_hal_deferred_command_buffer_t* command_buffer =
+      iree_hal_deferred_command_buffer_cast(base_command_buffer);
+  iree_hal_resource_set_freeze(command_buffer->resource_set);
   return iree_ok_status();
 }
 


### PR DESCRIPTION
When ASAN is enabled uninitialized arena memory is poisoned to help identify buffer overruns and resource sets will poison their data until they are freed to ensure they are treated as immutable.

Also fixed file_io to not use errno as, uh, that's not what that is for.