### PR TITLE
Adding task system utilization tracing.

### DIFF
--- a/runtime/src/iree/task/affinity_set.h
+++ b/runtime/src/iree/task/affinity_set.h
@@ -44,12 +44,14 @@ static inline iree_task_affinity_set_t iree_task_affinity_for_any_worker(void) {
   return UINT64_MAX;
 }
 
-#define iree_task_affinity_set_count_leading_zeros \
-  iree_math_count_leading_zeros_u64
-#define iree_task_affinity_set_count_trailing_zeros \
-  iree_math_count_trailing_zeros_u64
-#define iree_task_affinity_set_count_ones iree_math_count_ones_u64
-#define iree_task_affinity_set_rotr iree_math_rotr_u64
+#define iree_task_affinity_set_ones(count) \
+  (0xFFFFFFFFFFFFFFFFull >> (64 - (count)))
+#define iree_task_affinity_set_count_leading_zeros(set) \
+  iree_math_count_leading_zeros_u64(set)
+#define iree_task_affinity_set_count_trailing_zeros(set) \
+  iree_math_count_trailing_zeros_u64(set)
+#define iree_task_affinity_set_count_ones(set) iree_math_count_ones_u64(set)
+#define iree_task_affinity_set_rotr(set, count) iree_math_rotr_u64(set, count)
 
 //===----------------------------------------------------------------------===//
 // iree_atomic_task_affinity_set_t

--- a/runtime/src/iree/task/executor_impl.h
+++ b/runtime/src/iree/task/executor_impl.h
@@ -30,6 +30,11 @@ struct iree_task_executor_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 
+  // Leaked dynamically allocated name used for tracing calls.
+  // This pointer - once allocated - will be valid for the lifetime of the
+  // process and can be used for IREE_TRACE plotting/allocation calls.
+  IREE_TRACE(const char* trace_name;)
+
   // Defines how work is selected across queues.
   // TODO(benvanik): make mutable; currently always the same reserved value.
   iree_task_scheduling_mode_t scheduling_mode;

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -276,9 +276,16 @@ static void iree_task_worker_pump_until_exit(iree_task_worker_t* worker) {
     iree_wait_token_t wait_token =
         iree_notification_prepare_wait(&worker->wake_notification);
     // The masks are accessed with 'relaxed' order because they are just hints.
-    iree_atomic_task_affinity_set_fetch_and(&worker->executor->worker_idle_mask,
-                                            ~worker->worker_bit,
-                                            iree_memory_order_relaxed);
+    iree_task_affinity_set_t old_idle_mask =
+        iree_atomic_task_affinity_set_fetch_and(
+            &worker->executor->worker_idle_mask, ~worker->worker_bit,
+            iree_memory_order_relaxed);
+    (void)old_idle_mask;
+    IREE_TRACE_PLOT_VALUE_F32(
+        worker->executor->trace_name,
+        100.0f - 100.0f *
+                     (iree_task_affinity_set_count_ones(old_idle_mask) - 1) /
+                     (float)worker->executor->worker_count);
 
     // Check state to see if we've been asked to exit.
     if (iree_atomic_load_int32(&worker->state, iree_memory_order_acquire) ==
@@ -309,9 +316,15 @@ static void iree_task_worker_pump_until_exit(iree_task_worker_t* worker) {
     // We've finished all the work we have scheduled so set our idle flag.
     // This ensures that if any other thread comes in and wants to give us
     // work we will properly coordinate/wake below.
-    iree_atomic_task_affinity_set_fetch_or(&worker->executor->worker_idle_mask,
-                                           worker->worker_bit,
-                                           iree_memory_order_relaxed);
+    old_idle_mask = iree_atomic_task_affinity_set_fetch_or(
+        &worker->executor->worker_idle_mask, worker->worker_bit,
+        iree_memory_order_relaxed);
+    (void)old_idle_mask;
+    IREE_TRACE_PLOT_VALUE_F32(
+        worker->executor->trace_name,
+        100.0f - 100.0f *
+                     (iree_task_affinity_set_count_ones(old_idle_mask) + 1) /
+                     (float)worker->executor->worker_count);
 
     // When we encounter a complete lack of work we can self-nominate to check
     // the global work queue and distribute work to other threads. Only one


### PR DESCRIPTION
Adds one new plot per executor in a process showing a 0-100% utilization value as tracked by the workers (vs the CPU usage sampled a much lower rate).

![image](https://github.com/openxla/iree/assets/75337/7fc353d2-3fe8-4e33-8b60-056751231381)

Inspecting the area under/over the curve is an easy way to spot dispatches that could have improved distribution:
![image](https://github.com/openxla/iree/assets/75337/1383ad5d-c802-43ce-9352-e584eb040921)
(here 2x of the wall time is only 1x the utilization, meaning with perfect distribution we could go 2x faster by 2xing the utilization)