### PR TITLE
Implement heuristic-based split reduction value selection for `topk` op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
@@ -96,9 +96,9 @@ static int64_t topkSplitReduceRatio(int64_t splitReductionDepth,
     return reductionRatios[splitReductionDepth];
   }
 
-  // Step 1. Hard to predict of advantage of splitting reduction more than 2
+  // Step 1. Hard to predict of advantage of splitting reduction more than 1
   // depth.
-  if (splitReductionDepth > 1) return kNOTopkSplitReductionRatioDefault;
+  if (splitReductionDepth > 0) return kNOTopkSplitReductionRatioDefault;
 
   LLVM_DEBUG({
     llvm::dbgs() << "\n--- topkSplitReduceRatio started :";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
@@ -96,9 +96,9 @@ static int64_t topkSplitReduceRatio(int64_t splitReductionDepth,
     return reductionRatios[splitReductionDepth];
   }
 
-  // Step 1. Hard to predict of advantage of splitting reduction more than 1
+  // Step 1. Hard to predict of advantage of splitting reduction more than 2
   // depth.
-  if (splitReductionDepth > 0) return kNOTopkSplitReductionRatioDefault;
+  if (splitReductionDepth > 1) return kNOTopkSplitReductionRatioDefault;
 
   LLVM_DEBUG({
     llvm::dbgs() << "\n--- topkSplitReduceRatio started :";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/IR/Visitors.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-flow-split-reduction"
@@ -150,9 +151,9 @@ static int64_t topkSplitReduceRatio(int64_t splitReductionDepth,
 
 /// Find there is a topk operation in the given operation.
 static bool hasTopk(Operation *op) {
-  bool hasTopk = false;
-  op->walk([&](LinalgExt::TopkOp topkOp) { hasTopk = true; });
-  return hasTopk;
+  auto result = op->walk(
+      [&](LinalgExt::TopkOp topkOp) { return WalkResult::interrupt(); });
+  return result.wasInterrupted();
 }
 
 struct SplitReductionPass : public SplitReductionBase<SplitReductionPass> {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "conv1x1_to_matmul.mlir",
             "convert_region_to_workgroups.mlir",
             "deduplicate_executables.mlir",
+            "split_reduction_topk.mlir",
             "detach_elementwise_from_named_ops.mlir",
             "dispatch_linalg_on_tensors.mlir",
             "collapse_linalg_generic_on_tensors.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -46,6 +46,7 @@ iree_lit_test_suite(
     "pipeline_tests.mlir"
     "raise_special_ops.mlir"
     "set_encoding.mlir"
+    "split_reduction_topk.mlir"
     "strip_and_splat_constant_variables.mlir"
     "strip_signedness.mlir"
     "tensor_pad_to_tensor_insert_slice.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/split_reduction_topk.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/split_reduction_topk.mlir
@@ -1,0 +1,26 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-flow-split-reduction-ops))" %s | FileCheck %s
+
+!typef32 = tensor<4x8000xf32>
+!otypef32 = tensor<4x40xf32>
+!otypei32 = tensor<4x40xi32>
+
+func.func @topk2d(
+  %input_values: !typef32,
+  %out_values: !otypef32, 
+  %out_indices: !otypei32) -> (!otypef32, !otypei32) {
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values: !typef32)
+        outs(%out_values, %out_indices : !otypef32, !otypei32) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> !otypef32, !otypei32
+  return %0#0, %0#1 : !otypef32, !otypei32
+}
+
+//      CHECK-LABEL: func.func @topk2d
+//      CHECK: iree_linalg_ext.topk dimension(2) ins(%{{.*}} : tensor<4x16x500xf32>) outs(%{{.*}}, %{{.*}} : tensor<4x16x40xf32>, tensor<4x16x40xi32>)
+//      CHECK: linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel", "parallel"]} outs(%{{.*}}#1 : tensor<4x16x40xi32>)
+//      CHECK: iree_linalg_ext.topk dimension(2) ins(%{{.*}}, %{{.*}} : tensor<4x5x128xf32>, tensor<4x5x128xi32>) outs(%{{.*}}, %{{.*}} : tensor<4x5x40xf32>, tensor<4x5x40xi32>)
+//      CHECK: iree_linalg_ext.topk dimension(1) ins(%{{.*}}, %{{.*}} : tensor<4x200xf32>, tensor<4x200xi32>) outs(%{{.*}}, %{{.*}} : tensor<4x40xf32>, tensor<4x40xi32>) {

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -448,9 +448,9 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
    A Top-K operation for N-D tensors. Reduces the target dimension from the input
    size N down to K elements based on the supplied binary region.
 
-   Accepts an N-D tensor input consisting of values and an optioanl N-D tensor
+   Accepts an N-D tensor input consisting of values and an optional N-D tensor
    for indices of those values (i32 type). If input indices aren't provided, the
-   index mapping is inferred based on the k dim.  Both input values/indices
+   index mapping is inferred based on the k dim. Both input values/indices
    tensors and output values/indicies tensors must have the same shape. Top-K is
    computed along the target dimension (from dimension()). Returns two output
    tensors of values and the indicies of Top-K results. The output dimensions

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -141,8 +141,8 @@ std::unique_ptr<OperationPass<>> createPadContractionToBlockSizePass();
 /// to the reduction dimension of TopK. If the ratio value is less or equal to 1
 /// then nothing will be done. Input is the current depth of recursive split
 /// reduction, starting from 0 (first level).
-using TopkSplitReductionControlFn =
-    std::function<int64_t(int64_t splitReductionDepth)>;
+using TopkSplitReductionControlFn = std::function<int64_t(
+    int64_t splitReductionDepth, TopkOp topkOp, int64_t kValue)>;
 
 /// Patterns to apply `topk split reduction` pass.
 void populateTopkSplitReductionPattern(

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
@@ -318,7 +318,8 @@ struct TopkOpSplitReduction : public OpRewritePattern<TopkOp> {
     int64_t kSize =
         topkOp.getResult(0).getType().cast<ShapedType>().getDimSize(kDimOrig);
     int64_t splitReductionDepth = getSplitReductionDepth(topkOp);
-    int64_t splitReductionRatio = splitReductionFn(splitReductionDepth);
+    int64_t splitReductionRatio =
+        splitReductionFn(splitReductionDepth, topkOp, kSize);
     SmallVector<ReassociationIndices> reassociationIndices =
         getReassociationIndices(topkOp.getInputRank(), splitDimParallel);
 
@@ -386,7 +387,8 @@ struct TopkSplitReductionPass
     }
     RewritePatternSet patterns(&getContext());
     TopkSplitReductionControlFn splitReductionFn =
-        [&](int64_t splitReductionDepth) -> int64_t {
+        [&](int64_t splitReductionDepth, TopkOp topkOp,
+            int64_t kValue) -> int64_t {
       SmallVector<int64_t, 4> reductionRatios(splitRatios.begin(),
                                               splitRatios.end());
       if (splitReductionDepth >= reductionRatios.size()) {


### PR DESCRIPTION
The current implementation of the `topk` operation lacks parallelism, causing performance issues on massively parallel architectures like GPUs.

The proposed change sets the split reduction values heuristically for the topk operation. The heuristic function analyzes the workload and balances the work between the initial topk kernel and the subsequent split topk kernel.

For example, when the input is a tensor of size 4x8000 and the value of K is 40, current implementation the last dimension (tensor<8000>) is run sequentially. The heuristic function selects 16 and 5, the amount of sequential work is significantly reduced, as demonstrated below:
```
topk2d_dispatch_0_topk_4x16x500xf32
topk2d_dispatch_1_generic --> this is entirely parallel, heuristic function doesn't check 
topk2d_dispatch_2_topk_4x5x128xf32
topk2d_dispatch_3_topk_4x200xf32
```

It is important to note that split reduction operates at the flow level, and the heuristic function is integrated there. While technically the heuristic function can split more depths, we limit it to two depths as the target architecture at the flow level is unknown.

By the way, the flag `iree-flow-topk-split-reduction` remains available. A user can opt-out the heuristic and set any value.

Note that, this is an interim solution and will not give peak performance. To achieve peak, it is crucial to have a GPU-optimized topk operation.