### PR TITLE
Cleaning up target CPU feature handling in build rules.

### DIFF
--- a/build_tools/bazel/iree_bytecode_module.bzl
+++ b/build_tools/bazel/iree_bytecode_module.bzl
@@ -45,7 +45,10 @@ def iree_bytecode_module(
         module_name = "%s.vmfb" % (name)
 
     out_files = [module_name]
-    flags.append("--output-format=vm-bytecode")
+    flags += [
+        "--output-format=vm-bytecode",
+        "--mlir-print-op-on-diagnostic=false",
+    ]
     if static_lib_path:
         static_header_path = static_lib_path.replace(".o", ".h")
         out_files.extend([static_lib_path, static_header_path])

--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -55,7 +55,6 @@ def iree_check_test(
         name = bytecode_module_name,
         src = src,
         flags = [
-            "--mlir-print-op-on-diagnostic=false",
             "--iree-hal-target-backends=%s" % target_backend,
         ] + compiler_flags,
         visibility = ["//visibility:private"],
@@ -181,16 +180,19 @@ def iree_check_test_suite(
           suites, manual is treated specially and will also apply to the test
           suite itself.
       target_cpu_features_variants: list of target cpu features variants.
-          Currently unimplemented, so each entry must be either "default" or
-          start with "aarch64:" so as Bazel builds are currently x86-only, we
-          know that it is correct to ignore this.
+          Currently unimplemented in Bazel due to difficulty of specializing
+          to target architecture in Bazel. The following describes the
+          semantics that this should have if implemented. Each
+          entry is either "default" for the architecture defaults, or a colon-
+          separated triple "arch:name:cpu_features" where "arch" filters
+          for a target CPU architecture (in IREE_ARCH format), "name" is a
+          short name for the CPU features set (used to generate target names)
+          and cpu_features is a comma-separated list of LLVM target attributes
+          to enable. Example:
+            x86_64:avx2_fma:+avx,+avx2,+fma
       **kwargs: any additional attributes to pass to the underlying tests and
           test suite.
     """
-
-    for target_cpu_features in target_cpu_features_variants:
-        if not (target_cpu_features == "default" or target_cpu_features.startswith("aarch64:")):
-            fail("Entry %s in target_cpu_features_variants: unimplemented" % target_cpu_features)
 
     # We could have complicated argument override logic for runner_args and such, or... the client
     # could just create a test suite. The latter seems simpler and more readable.

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -68,7 +68,10 @@ function(iree_bytecode_module)
     set(_MODULE_FILE_NAME "${_RULE_NAME}.vmfb")
   endif()
 
-  set(_ARGS "--output-format=vm-bytecode")
+  set(_ARGS
+    "--output-format=vm-bytecode"
+    "--mlir-print-op-on-diagnostic=false"
+  )
   list(APPEND _ARGS "${_RULE_FLAGS}")
 
   get_filename_component(_SRC_PATH "${_RULE_SRC}" REALPATH)

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -303,12 +303,14 @@ endfunction()
 #       test, create a separate suite or iree_check_test.
 #   LABELS: Additional labels to apply to the generated tests. The package path is
 #       added automatically.
-#   TARGET_CPU_FEATURES_VARIANTS: list of target cpu features variants. Only used
-#       for drivers that vary based on the target CPU features. For each list
-#       element, a separate test is created, with the list element passed as
-#       argument to --iree-llvmcpu-target-cpu-features. The special value "default"
-#       is interpreted as no --iree-llvmcpu-target-cpu-features flag to work around
-#       corner cases with empty entries in CMake lists.
+#   TARGET_CPU_FEATURES_VARIANTS:list of target cpu features variants. Each
+#       entry is either "default" for the architecture defaults, or a colon-
+#       separated triple "arch:name:cpu_features" where "arch" filters
+#       for a target CPU architecture (in IREE_ARCH format), "name" is a
+#       short name for the CPU features set (used to generate target names)
+#       and cpu_features is a comma-separated list of LLVM target attributes
+#       to enable. Example:
+#         x86_64:avx2_fma:+avx,+avx2,+fma
 function(iree_check_test_suite)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -321,6 +323,12 @@ function(iree_check_test_suite)
     "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS;TIMEOUT"
     ${ARGN}
   )
+
+  if(_RULE_TARGET_CPU_FEATURES_VARIANTS)
+    set(_TARGET_CPU_FEATURES_VARIANTS "${_RULE_TARGET_CPU_FEATURES_VARIANTS}")
+  else()
+    set(_TARGET_CPU_FEATURES_VARIANTS "default")
+  endif()
 
   if(NOT DEFINED _RULE_TARGET_BACKENDS AND NOT DEFINED _RULE_DRIVERS)
     set(_RULE_TARGET_BACKENDS "vmvx" "vulkan-spirv" "llvm-cpu")
@@ -339,11 +347,6 @@ function(iree_check_test_suite)
   foreach(_INDEX RANGE "${_MAX_INDEX}")
     list(GET _RULE_TARGET_BACKENDS ${_INDEX} _TARGET_BACKEND)
     list(GET _RULE_DRIVERS ${_INDEX} _DRIVER)
-    if(_TARGET_BACKEND STREQUAL "llvm-cpu" AND _RULE_TARGET_CPU_FEATURES_VARIANTS)
-      set(_TARGET_CPU_FEATURES_VARIANTS "${_RULE_TARGET_CPU_FEATURES_VARIANTS}")
-    else()
-      set(_TARGET_CPU_FEATURES_VARIANTS "default")
-    endif()
     foreach(_VARIANT_STRING IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
       parse_target_cpu_features_variant("${_VARIANT_STRING}"
         _ENABLED _TARGET_CPU_FEATURES_NAME _TARGET_CPU_FEATURES)

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -303,7 +303,7 @@ endfunction()
 #       test, create a separate suite or iree_check_test.
 #   LABELS: Additional labels to apply to the generated tests. The package path is
 #       added automatically.
-#   TARGET_CPU_FEATURES_VARIANTS:list of target cpu features variants. Each
+#   TARGET_CPU_FEATURES_VARIANTS: list of target cpu features variants. Each
 #       entry is either "default" for the architecture defaults, or a colon-
 #       separated triple "arch:name:cpu_features" where "arch" filters
 #       for a target CPU architecture (in IREE_ARCH format), "name" is a

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -278,12 +278,14 @@ endfunction()
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
 #   TRACE_RUNNER: trace-runner program to run.
-#   TARGET_CPU_FEATURES_VARIANTS: list of target cpu features variants. Only used
-#       for drivers that vary based on the target CPU features. For each list
-#       element, a separate test is created, with the list element passed as
-#       argument to --iree-llvmcpu-target-cpu-features. The special value "default"
-#       is interpreted as no --iree-llvmcpu-target-cpu-features flag to work around
-#       corner cases with empty entries in CMake lists.
+#   TARGET_CPU_FEATURES_VARIANTS:list of target cpu features variants. Each
+#       entry is either "default" for the architecture defaults, or a colon-
+#       separated triple "arch:name:cpu_features" where "arch" filters
+#       for a target CPU architecture (in IREE_ARCH format), "name" is a
+#       short name for the CPU features set (used to generate target names)
+#       and cpu_features is a comma-separated list of LLVM target attributes
+#       to enable. Example:
+#         x86_64:avx2_fma:+avx,+avx2,+fma
 function(iree_generated_trace_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -296,6 +298,12 @@ function(iree_generated_trace_runner_test)
     "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
+
+  if(_RULE_TARGET_CPU_FEATURES_VARIANTS)
+    set(_TARGET_CPU_FEATURES_VARIANTS "${_RULE_TARGET_CPU_FEATURES_VARIANTS}")
+  else()
+    set(_TARGET_CPU_FEATURES_VARIANTS "default")
+  endif()
 
   if(NOT DEFINED _RULE_TARGET_BACKENDS AND NOT DEFINED _RULE_DRIVERS)
     set(_RULE_TARGET_BACKENDS "vmvx" "vulkan-spirv" "llvm-cpu")
@@ -314,11 +322,6 @@ function(iree_generated_trace_runner_test)
   foreach(_INDEX RANGE "${_MAX_INDEX}")
     list(GET _RULE_TARGET_BACKENDS ${_INDEX} _TARGET_BACKEND)
     list(GET _RULE_DRIVERS ${_INDEX} _DRIVER)
-    if(_RULE_TARGET_CPU_FEATURES_VARIANTS)
-      set(_TARGET_CPU_FEATURES_VARIANTS "${_RULE_TARGET_CPU_FEATURES_VARIANTS}")
-    else()
-      set(_TARGET_CPU_FEATURES_VARIANTS "default")
-    endif()
     foreach(_VARIANT_STRING IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
       parse_target_cpu_features_variant("${_VARIANT_STRING}"
         _ENABLED _TARGET_CPU_FEATURES_NAME _TARGET_CPU_FEATURES)

--- a/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
@@ -6,18 +6,6 @@
 
 iree_add_all_subdirs()
 
-if (IREE_ARCH STREQUAL "arm_64")
-  set(IREE_UK_ARCH_ARM_64 TRUE)
-  list(APPEND IREE_UK_ARCH_DEPS
-    "iree::builtins::ukernel::arch::arm_64"
-  )
-elseif (IREE_ARCH STREQUAL "x86_64")
-  set(IREE_UK_ARCH_X86_64 TRUE)
-  list(APPEND IREE_UK_ARCH_DEPS
-    "iree::builtins::ukernel::arch::x86_64"
-  )
-endif()
-
 iree_cc_library(
   NAME
     ukernel_arch

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
@@ -124,3 +124,5 @@ iree_cc_library(
     ${IREE_UK_ARM_64_DEPS}
   PUBLIC
 )
+
+set(IREE_UK_ARCH_DEPS "iree::builtins::ukernel::arch::arm_64" PARENT_SCOPE)

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
@@ -213,3 +213,5 @@ iree_cc_library(
     ${IREE_UK_X86_64_DEPS}
   PUBLIC
 )
+
+set(IREE_UK_ARCH_DEPS "iree::builtins::ukernel::arch::x86_64" PARENT_SCOPE)


### PR DESCRIPTION
* The `mlir-print-op-on-diagnostic=false` flags used to be passed separately in N places, some were dropped semi-consciously in   #13889, now I think this is really a useful flag to have, but let's pass it consistently in one place, in iree_bytecode_module.
* Some comments were out of date.
* In ukernel/arch/CMakeLists.txt, some if-else chain could be dropped.