### PR TITLE
Let `iree_add_all_subdirs` be a macro

### DIFF
--- a/build_tools/cmake/iree_add_all_subdirs.cmake
+++ b/build_tools/cmake/iree_add_all_subdirs.cmake
@@ -6,11 +6,11 @@
 
 # iree_add_all_subidrs
 #
-# CMake function to add all subdirectories of the current directory that contain
+# CMake macro to add all subdirectories of the current directory that contain
 # a CMakeLists.txt file
 #
 # Takes no arguments.
-function(iree_add_all_subdirs)
+macro(iree_add_all_subdirs)
   FILE(GLOB _CHILDREN RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
   SET(_DIRLIST "")
   foreach(_CHILD ${_CHILDREN})
@@ -22,4 +22,4 @@ function(iree_add_all_subdirs)
   foreach(subdir ${_DIRLIST})
     add_subdirectory(${subdir})
   endforeach()
-endfunction()
+endmacro()


### PR DESCRIPTION
Being a function meant it created its its own scope, so each subdir scope was *two* scopes nested below its parent. This means that setting a variable with `PARENT_SCOPE` in a subdir did not make it visible to its direct parent.

I had expected that to work in #13947; so that PR accidentally disabled architecture-specific code paths in the native build of microkernels. (@benvanik )