### PR TITLE
Fix tests/transform_dialect/cuda/ dependencies

### DIFF
--- a/tests/transform_dialect/cuda/BUILD.bazel
+++ b/tests/transform_dialect/cuda/BUILD.bazel
@@ -26,7 +26,6 @@ endif()
 iree_lit_test_suite(
     name = "lit",
     srcs = [
-        "double_mma_layout_analysis.mlir",
         "mma.mlir",
         "reduction.mlir",
         "reduction_eltwise.mlir",
@@ -43,8 +42,6 @@ iree_lit_test_suite(
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.
     data = [
-        "double_mma_layout_analysis_codegen_spec.mlir",
-        "double_mma_layout_analysis_dispatch_spec.mlir",
         "mma_reduction_layout_analysis_codegen_spec.mlir",
         "mma_reduction_layout_analysis_dispatch_spec.mlir",
         "mma_using_layout_analysis_codegen_spec.mlir",
@@ -85,6 +82,7 @@ iree_lit_test_suite(
 iree_lit_test_suite(
     name = "sm80_lit",
     srcs = [
+        "double_mma_layout_analysis.mlir",
         "mma_elemwise_layout_analysis.mlir",
         "mma_reduction_layout_analysis.mlir",
         "mma_using_layout_analysis.mlir",
@@ -93,6 +91,8 @@ iree_lit_test_suite(
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.
     data = [
+        "double_mma_layout_analysis_codegen_spec.mlir",
+        "double_mma_layout_analysis_dispatch_spec.mlir",
         "mma_elemwise_layout_analysis_codegen_spec.mlir",
         "mma_reduction_layout_analysis_codegen_spec.mlir",
         "mma_reduction_layout_analysis_dispatch_spec.mlir",

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -18,7 +18,6 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "double_mma_layout_analysis.mlir"
     "mma.mlir"
     "reduction.mlir"
     "reduction_eltwise.mlir"
@@ -35,8 +34,6 @@ iree_lit_test_suite(
     iree-opt
     iree-run-module
   DATA
-    double_mma_layout_analysis_codegen_spec.mlir
-    double_mma_layout_analysis_dispatch_spec.mlir
     mma_reduction_layout_analysis_codegen_spec.mlir
     mma_reduction_layout_analysis_dispatch_spec.mlir
     mma_using_layout_analysis_codegen_spec.mlir
@@ -63,6 +60,7 @@ iree_lit_test_suite(
   NAME
     sm80_lit
   SRCS
+    "double_mma_layout_analysis.mlir"
     "mma_elemwise_layout_analysis.mlir"
     "mma_reduction_layout_analysis.mlir"
     "mma_using_layout_analysis.mlir"
@@ -72,6 +70,8 @@ iree_lit_test_suite(
     iree-opt
     iree-run-module
   DATA
+    double_mma_layout_analysis_codegen_spec.mlir
+    double_mma_layout_analysis_dispatch_spec.mlir
     mma_elemwise_layout_analysis_codegen_spec.mlir
     mma_reduction_layout_analysis_codegen_spec.mlir
     mma_reduction_layout_analysis_dispatch_spec.mlir


### PR DESCRIPTION
double_mma_layout_analysis.mlir has `--iree-hal-cuda-llvm-target-arch=sm_80` and should be in the sm80_lit test with the corresponding tags