### PR TITLE
Update tile and decompose attention pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention.mlir
@@ -13,16 +13,16 @@ hal.executable @_attention_dispatch_0 {
     builtin.module {
       func.func @_attention_dispatch_0() {
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf32>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf32>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf32>>
-        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<192x1024x64xf32>>
-        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [192, 1024, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf32>> -> tensor<192x1024x64xf32>
-        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [192, 1024, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf32>> -> tensor<192x1024x64xf32>
-        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [192, 1024, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf32>> -> tensor<192x1024x64xf32>
-        %7 = tensor.empty() : tensor<192x1024x64xf32>
-        %8 = iree_linalg_ext.attention ins(%4, %5, %6 : tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>) outs(%7 : tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
-        flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [192, 1024, 64], strides = [1, 1, 1] : tensor<192x1024x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<192x1024x64xf32>>
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf16>>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<192x1024x64xf16>>
+        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [192, 1024, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf16>> -> tensor<192x1024x64xf16>
+        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [192, 1024, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf16>> -> tensor<192x1024x64xf16>
+        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [192, 1024, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<192x1024x64xf16>> -> tensor<192x1024x64xf16>
+        %7 = tensor.empty() : tensor<192x1024x64xf16>
+        %8 = iree_linalg_ext.attention ins(%4, %5, %6 : tensor<192x1024x64xf16>, tensor<192x1024x64xf16>, tensor<192x1024x64xf16>) outs(%7 : tensor<192x1024x64xf16>) -> tensor<192x1024x64xf16>
+        flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [192, 1024, 64], strides = [1, 1, 1] : tensor<192x1024x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<192x1024x64xf16>>
         return
       }
     }
@@ -32,137 +32,277 @@ hal.executable @_attention_dispatch_0 {
 transform.sequence failures(propagate) {
   ^bb0(%variant_op: !transform.any_op):
 
-    // Get attention op
-    // ==========================================
-    %attention = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  // Get attention op
+  // ==========================================
+  %attention = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
-    // Tile and distribute to workgroups
-    // ==========================================
-    %forall_grid, %tiled_attention =
-    transform.structured.tile_to_forall_op %attention tile_sizes [1, 128]
-      ( mapping = [#gpu.block<x>, #gpu.block<y>] )
-      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  // Tile and distribute to workgroups
+  // ==========================================
+  %forall_grid, %tiled_attention =
+  transform.structured.tile_to_forall_op %attention tile_sizes [1, 128]
+    ( mapping = [#gpu.block<x>, #gpu.block<y>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid : (!transform.any_op) -> ()
 
-    // Tile and decompose attention
-    // ==========================================
-    %attention2 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    %outer_loop, %max_fill, %sum_fill, %inner_loop, %fill_op, %first_matmul, %reduce_max, %partial_softmax, %reduce_sum, %update,
-    %softmax, %scale_acc, %second_matmul = tile_and_decompose_attention %attention2 :
-       (!transform.any_op) -> (!transform.any_op, !transform.any_op,!transform.any_op,  !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+  // Tile batch dimensions of attention
+  // ==========================================
+  %attention2 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %batch_tiled_attn, %loop = transform.structured.tile %attention2 [1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.apply_patterns to %top_level_func {
+    transform.apply_patterns.canonicalization
+  } : !transform.any_op
+  transform.iree.apply_cse %top_level_func : !transform.any_op
 
-    // Vectorize function
-    // ==========================================
-    %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.apply_patterns to %func {
-      transform.apply_patterns.iree.fold_reshape_into_tensor_hal_interface
-      transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices
-      transform.apply_patterns.vector.cast_away_vector_leading_one_dim
-    } : !transform.any_op
-    %func_3 = transform.structured.vectorize %func : (!transform.any_op) -> !transform.any_op
+  // Promote query and output operands
+  // ==========================================
+  %attention3 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %promoted_attention, %alloc_a0, %alloc_a1 = transform.iree.promote_operands %attention3 [0, 3]
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
-    // Bufferization
-    // ==========================================
-    transform.apply_patterns to %func_3 {
-      transform.apply_patterns.iree.fold_fill_into_pad
-      transform.apply_patterns.linalg.tiling_canonicalization
-      transform.apply_patterns.scf.for_loop_canonicalization
-    } : !transform.any_op
-    transform.apply_patterns to %func_3 {
-      transform.apply_patterns.tensor.reassociative_reshape_folding
-      transform.apply_patterns.canonicalization
-    } : !transform.any_op
-    transform.iree.apply_cse %func_3 : !transform.any_op
-    transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
-    transform.apply_patterns to %func_3 {
-      transform.apply_patterns.linalg.erase_unnecessary_inputs
-    } : !transform.any_op
-    %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> (!transform.any_op)
-    %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
-    transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
+  // Tile and decompose attention
+  // ==========================================
+  %attention4 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  %acc_fill, %max_fill, %sum_fill, %inner_loop,
+  %fill_op, %first_matmul, %reduce_max, %partial_softmax, %update, %reduce_sum, %reciprocal_sum, %softmax, %truncate, %scale_acc, %second_matmul, %last_truncate
+      = tile_and_decompose_attention %attention4 :
+     (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
 
-    // Step 6. Post-bufferization vector distribution
-    // ===========================================================================
-    %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
-    transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
-    transform.iree.map_nested_forall_to_gpu_threads %func_7 workgroup_dims = [128, 1, 1] : (!transform.any_op) -> ()
+  // Promote key and value operands
+  // ==========================================
+  %promoted_first_matmul, %alloc0 = transform.iree.promote_operands %first_matmul [1]
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %promoted_second_matmul, %alloc1 = transform.iree.promote_operands %second_matmul [1]
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    %func_8 = transform.structured.hoist_redundant_vector_transfers %memref_func
-    : (!transform.any_op) -> !transform.any_op
-    transform.apply_patterns to %func_8 {
-      transform.apply_patterns.canonicalization
-    } : !transform.any_op
-    transform.iree.apply_cse %func_8 : !transform.any_op
-    transform.iree.apply_buffer_optimizations %func_8 : (!transform.any_op) -> ()
+  // Tile and fuse attention ops
+  // ==========================================
+  %forall, %tiled_matmul = transform.structured.tile_to_forall_op %promoted_second_matmul tile_sizes [32] (mapping = [#gpu.warp<x>]) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+  %f0, %loop0 = transform.structured.fuse_into_containing_op %scale_acc into %forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %f1, %loop1 = transform.structured.fuse_into_containing_op %truncate into %loop0 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %f2, %loop2 = transform.structured.fuse_into_containing_op %softmax into %loop1 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+  %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+  transform.iree.apply_cse %func : !transform.any_op
+
+  %f3, %loop3 = transform.structured.fuse_into_containing_op %reciprocal_sum into %loop2 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %f4, %loop4 = transform.structured.fuse_into_containing_op %reduce_sum into %loop3 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.iree.apply_cse %func : !transform.any_op
+
+  %f5, %loop5 = transform.structured.fuse_into_containing_op %update into %loop4 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %f6, %loop6 = transform.structured.fuse_into_containing_op %partial_softmax into %loop5 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.iree.apply_cse %func : !transform.any_op
+
+  %f7, %loop7 = transform.structured.fuse_into_containing_op %reduce_max into %loop6 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %f8, %loop8 = transform.structured.fuse_into_containing_op %promoted_first_matmul into %loop7 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %f9, %loop9 = transform.structured.fuse_into_containing_op %fill_op into %loop8 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.iree.apply_cse %func : !transform.any_op
+
+  // Distribute fills and last truncate
+  // ==========================================
+  %fills = transform.merge_handles %acc_fill, %max_fill, %sum_fill, %last_truncate : !transform.any_op
+  %fill_grid, %tiled_fill = transform.structured.tile_to_forall_op %fills tile_sizes[32] (mapping = [#gpu.warp<x>]) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+  // Vectorize function
+  // ==========================================
+  transform.apply_patterns to %func {
+    transform.apply_patterns.iree.fold_reshape_into_tensor_hal_interface
+    transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices
+    transform.apply_patterns.vector.cast_away_vector_leading_one_dim
+  } : !transform.any_op
+  %func_3 = transform.structured.vectorize %func : (!transform.any_op) -> (!transform.any_op)
+
+  // Bufferization
+  // ==========================================
+  transform.apply_patterns to %func_3 {
+     transform.apply_patterns.tensor.reassociative_reshape_folding
+     transform.apply_patterns.canonicalization
+     transform.apply_patterns.iree.fold_fill_into_pad
+     transform.apply_patterns.linalg.tiling_canonicalization
+     transform.apply_patterns.scf.for_loop_canonicalization
+  } : !transform.any_op
+  transform.iree.apply_cse %func_3 : !transform.any_op
+  transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+  transform.apply_patterns to %func_3 { transform.apply_patterns.linalg.erase_unnecessary_inputs } : !transform.any_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op : (!transform.any_op) -> (!transform.any_op)
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func : (!transform.any_op) -> ()
+
+  // Step 5. Pre-process the contract and transfer ops to put it in the right form.
+  // ===========================================================================
+  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.apply_patterns to %func_2 {
+    transform.apply_patterns.iree.prepare_vector_to_mma
+  } : !transform.any_op
+
+  // Step 6. Post-bufferization vector distribution
+  // ===========================================================================
+  %func_7 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
+  transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
+  transform.iree.map_nested_forall_to_gpu_threads %func_7 workgroup_dims = [4, 8, 4] warp_dims = [4, 1, 1] : (!transform.any_op) -> ()
+
+  transform.apply_patterns to %func_7 {
+     transform.apply_patterns.memref.fold_memref_alias_ops
+  } : !transform.any_op
+  transform.iree.apply_licm %func_7 : !transform.any_op
+  transform.apply_patterns to %func_7 {
+     transform.apply_patterns.canonicalization
+  } : !transform.any_op
+  transform.iree.apply_cse %func_7 : !transform.any_op
+  %func_8 = transform.structured.hoist_redundant_vector_transfers %memref_func
+  : (!transform.any_op) -> !transform.any_op
+  transform.apply_patterns to %func_8 {
+    transform.apply_patterns.canonicalization
+  } : !transform.any_op
+  transform.iree.apply_cse %func_8 : !transform.any_op
+  transform.iree.apply_buffer_optimizations %func_8 : (!transform.any_op) -> ()
+
 }
 
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<()[s0] -> (s0 * 128)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
-// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK-DAG:  #[[MAP4:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-// CHECK-DAG:  func.func @_attention_dispatch_0() {
-// CHECK-DAG:    %[[CST:.+]] = arith.constant dense<-1.000000e+30> : vector<128xf32>
-// CHECK-DAG:    %[[CST_0:.+]] = arith.constant dense<0.000000e+00> : vector<128xf32>
-// CHECK-DAG:    %[[CST_1:.+]] = arith.constant dense<0.000000e+00> : vector<128x128xf32>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<()[s0, s1, s2] -> (s2 * 32 + ((s0 + s1 * 4) floordiv 32) * 32 - ((s2 + (s0 + s1 * 4) floordiv 32) floordiv 4) * 128)>
+// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG:  #[[MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG:  #[[MAP5:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK-DAG:  #[[MAP6:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK:      func.func @_attention_dispatch_0() {
+// CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<32x64xf32>
+// CHECK-DAG:    %[[CST_0:.+]] = arith.constant dense<-1.000000e+30> : vector<32xf32>
+// CHECK-DAG:    %[[CST_1:.+]] = arith.constant dense<0.000000e+00> : vector<32xf32>
+// CHECK-DAG:    %[[CST_2:.+]] = arith.constant dense<0.000000e+00> : vector<32x128xf32>
+// CHECK-DAG:    %[[CST_3:.+]] = arith.constant dense<1.000000e+00> : vector<32xf32>
+// CHECK-DAG:    %[[CST_4:.+]] = arith.constant 0.000000e+00 : f16
 // CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:    %[[C128:.+]] = arith.constant 128 : index
 // CHECK-DAG:    %[[C1024:.+]] = arith.constant 1024 : index
-// CHECK-DAG:    %[[CST_2:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:    %[[CST_5:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK:        %[[D0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64)
-// CHECK-SAME:     offset(%[[C0]]) flags(ReadOnly) : memref<192x1024x64xf32>
-// CHECK:        memref.assume_alignment %[[D0]], 64 : memref<192x1024x64xf32>
+// CHECK-SAME:     offset(%[[C0]]) flags(ReadOnly) : memref<192x1024x64xf16>
+// CHECK:        memref.assume_alignment %[[D0]], 64 : memref<192x1024x64xf16>
 // CHECK:        %[[D1:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64)
-// CHECK-SAME:     offset(%[[C0]]) flags(ReadOnly) : memref<192x1024x64xf32>
-// CHECK:        memref.assume_alignment %[[D1]], 64 : memref<192x1024x64xf32>
+// CHECK-SAME:     offset(%[[C0]]) flags(ReadOnly) : memref<192x1024x64xf16>
+// CHECK:        memref.assume_alignment %[[D1]], 64 : memref<192x1024x64xf16>
 // CHECK:        %[[D2:.+]] = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64)
-// CHECK-SAME:     offset(%[[C0]]) flags(ReadOnly) : memref<192x1024x64xf32>
-// CHECK:        memref.assume_alignment %[[D2]], 64 : memref<192x1024x64xf32>
+// CHECK-SAME:     offset(%[[C0]]) flags(ReadOnly) : memref<192x1024x64xf16>
+// CHECK:        memref.assume_alignment %[[D2]], 64 : memref<192x1024x64xf16>
 // CHECK:        %[[D3:.+]] = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64)
-// CHECK-SAME:     offset(%[[C0]]) : memref<192x1024x64xf32>
-// CHECK:        memref.assume_alignment %[[D3]], 64 : memref<192x1024x64xf32>
+// CHECK-SAME:     offset(%[[C0]]) : memref<192x1024x64xf16>
+// CHECK:        memref.assume_alignment %[[D3]], 64 : memref<192x1024x64xf16>
 // CHECK:        %[[WORKGROUP_ID_X:.+]] = hal.interface.workgroup.id[0] : index
 // CHECK:        %[[WORKGROUP_ID_Y:.+]] = hal.interface.workgroup.id[1] : index
-// CHECK-DAG:      %[[D4:.+]] = affine.apply #[[MAP]]()[%[[WORKGROUP_ID_Y]]]
-// CHECK:        %[[SUBVIEW:.+]] = memref.subview %[[D3]][%[[WORKGROUP_ID_X]], %[[D4]], 0] [1, 128, 64] [1, 1, 1]
-// CHECK-SAME:     : memref<192x1024x64xf32> to memref<1x128x64xf32, strided<[65536, 64, 1], offset: ?>>
-// CHECK:        %[[D7:.+]] = vector.transfer_read %[[D0]][%[[WORKGROUP_ID_X]], %[[D4]], %[[C0]]], %[[CST_2]]
-// CHECK-SAME:     {in_bounds = [true, true]} : memref<192x1024x64xf32>, vector<128x64xf32>
-// CHECK:        %[[D5:.+]] = vector.transfer_read %[[SUBVIEW]][%[[C0]], %[[C0]], %[[C0]]], %[[CST_2]] {in_bounds
-// CHECK-SAME:     = [true, true]} : memref<1x128x64xf32, strided<[65536, 64, 1], offset: ?>>, vector<128x64xf32>
-// CHECK:        %[[D6:.+]]:3 = scf.for %[[ARG0:.+]] = %[[C0]] to %[[C1024]] step %[[C128]]
-// CHECK-SAME:     iter_args(%[[ARG1:.+]] = %[[CST]], %[[ARG2:.+]] = %[[CST_0]], %[[ARG3:.+]] = %[[D5]]) -> (vector<128xf32>,
-// CHECK-SAME:     vector<128xf32>, vector<128x64xf32>) {
-// CHECK:          %[[D8:.+]] = vector.transfer_read %[[D1]][%[[WORKGROUP_ID_X]], %[[ARG0]], %[[C0]]], %[[CST_2]]
-// CHECK-SAME:       {in_bounds = [true, true]} : memref<192x1024x64xf32>, vector<128x64xf32>
-// CHECK:          %[[D9:.+]] = vector.contract {indexing_maps = [#[[MAP1]], #[[MAP2]], #[[MAP3]]], iterator_types
-// CHECK-SAME:       = ["parallel", "parallel", "reduction"], kind = #[[VECTOR:.+]].kind<add>} %[[D7]], %[[D8]],
-// CHECK-SAME:       %[[CST_1]] : vector<128x64xf32>, vector<128x64xf32> into vector<128x128xf32>
-// CHECK:          %[[D10:.+]] = vector.multi_reduction <maxf>, %[[D9]], %[[ARG1]] [1] : vector<128x128xf32> to
-// CHECK-SAME:       vector<128xf32>
-// CHECK:          %[[D11:.+]] = vector.broadcast %[[D10]] : vector<128xf32> to vector<128x128xf32>
-// CHECK:          %[[D12:.+]] = vector.transpose %[[D11]], [1, 0] : vector<128x128xf32> to vector<128x128xf32>
-// CHECK:          %[[D13:.+]] = arith.subf %[[D9]], %[[D12]] : vector<128x128xf32>
-// CHECK:          %[[D14:.+]] = math.exp %[[D13]] : vector<128x128xf32>
-// CHECK:          %[[D15:.+]] = arith.subf %[[ARG1]], %[[D10]] : vector<128xf32>
-// CHECK:          %[[D16:.+]] = math.exp %[[D15]] : vector<128xf32>
-// CHECK:          %[[D17:.+]] = arith.mulf %[[D16]], %[[ARG2]] : vector<128xf32>
-// CHECK:          %[[D18:.+]] = vector.multi_reduction <add>, %[[D14]], %[[D17]] [1] : vector<128x128xf32> to
-// CHECK-SAME:       vector<128xf32>
-// CHECK:          %[[D19:.+]] = vector.broadcast %[[D18]] : vector<128xf32> to vector<128x128xf32>
-// CHECK:          %[[D20:.+]] = vector.transpose %[[D19]], [1, 0] : vector<128x128xf32> to vector<128x128xf32>
-// CHECK:          %[[D21:.+]] = arith.divf %[[D14]], %[[D20]] : vector<128x128xf32>
-// CHECK:          %[[D22:.+]] = arith.divf %[[D17]], %[[D18]] : vector<128xf32>
-// CHECK:          %[[D23:.+]] = vector.broadcast %[[D22]] : vector<128xf32> to vector<64x128xf32>
-// CHECK:          %[[D24:.+]] = vector.transpose %[[D23]], [1, 0] : vector<64x128xf32> to vector<128x64xf32>
-// CHECK:          %[[D25:.+]] = arith.mulf %[[D24]], %[[ARG3]] : vector<128x64xf32>
-// CHECK:          %[[D26:.+]] = vector.transfer_read %[[D2]][%[[WORKGROUP_ID_X]], %[[ARG0]], %[[C0]]], %[[CST_2]]
-// CHECK-SAME:       {in_bounds = [true, true]} : memref<192x1024x64xf32>, vector<128x64xf32>
-// CHECK:          %[[D27:.+]] = vector.contract {indexing_maps = [#[[MAP1]], #[[MAP4]], #[[MAP3]]],
-// CHECK-SAME:       iterator_types = ["parallel", "parallel", "reduction"], kind = #[[VECTOR]].kind<add>}
-// CHECK-SAME:       %[[D21]], %[[D26]], %[[D25]] : vector<128x128xf32>, vector<128x64xf32> into
-// CHECK-SAME:       vector<128x64xf32>
-// CHECK:          scf.yield %[[D10]], %[[D18]], %[[D27]] : vector<128xf32>, vector<128xf32>, vector<128x64xf32>
+// CHECK-DAG:    %[[D4:.+]] = affine.apply #[[MAP]]()[%[[WORKGROUP_ID_Y]]]
+// CHECK:        %[[SUBVIEW:.+]] = memref.subview %[[D0]][%[[WORKGROUP_ID_X]], %[[D4]], 0] [1, 128, 64] [1, 1, 1] :
+// CHECK-SAME:     memref<192x1024x64xf16> to memref<1x128x64xf16, strided<[65536, 64, 1], offset: ?>>
+// CHECK:        %[[SUBVIEW_6:.+]] = memref.subview %[[D3]][%[[WORKGROUP_ID_X]], %[[D4]], 0] [1, 128, 64] [1, 1, 1] :
+// CHECK-SAME:     memref<192x1024x64xf16> to memref<1x128x64xf16, strided<[65536, 64, 1], offset: ?>>
+// CHECK:        %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<1x128x64xf16,
+// CHECK-SAME:     #[[GPU:.+]].address_space<workgroup>>
+// CHECK:        gpu.barrier
+// CHECK:        linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP1]]], iterator_types = ["parallel", "parallel",
+// CHECK-SAME:     "parallel"]} ins(%[[SUBVIEW]] : memref<1x128x64xf16, strided<[65536, 64, 1], offset: ?>>)
+// CHECK-SAME:     outs(%[[ALLOC]] : memref<1x128x64xf16, #[[GPU]].address_space<workgroup>>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f16, %[[OUT:.+]]: f16):
+// CHECK:          linalg.yield %[[IN]] : f16
 // CHECK:        }
-// CHECK:        vector.transfer_write %[[D6]]#[[D2:.+]], %[[SUBVIEW]][%[[C0]], %[[C0]], %[[C0]]] {in_bounds =
-// CHECK-SAME:     [true, true]} : vector<128x64xf32>, memref<1x128x64xf32, strided<[65536, 64, 1], offset: ?>>
-// CHECK:        return
+// CHECK:        gpu.barrier
+// CHECK:        %[[ALLOC_7:.+]] = memref.alloc() {alignment = 64 : i64} : memref<1x128x64xf16,
+// CHECK-SAME:     #[[GPU]].address_space<workgroup>>
+// CHECK:        gpu.barrier
+// CHECK:        linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP1]]], iterator_types = ["parallel", "parallel",
+// CHECK-SAME:     "parallel"]} ins(%[[SUBVIEW_6]] : memref<1x128x64xf16, strided<[65536, 64, 1], offset: ?>>)
+// CHECK-SAME:     outs(%[[ALLOC_7]] : memref<1x128x64xf16, #[[GPU]].address_space<workgroup>>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f16, %[[OUT:.+]]: f16):
+// CHECK:          linalg.yield %[[IN]] : f16
+// CHECK:        }
+// CHECK:        gpu.barrier
+// CHECK-DAG:    %[[D5:.+]] = gpu.thread_id  x
+// CHECK-DAG:    %[[D6:.+]] = gpu.thread_id  y
+// CHECK-DAG:    %[[D7:.+]] = gpu.thread_id  z
+// CHECK-DAG:    %[[D8:.+]] = affine.apply #[[MAP2]]()[%[[D5]], %[[D6]], %[[D7]]]
+// CHECK:        gpu.barrier
+// CHECK:        gpu.barrier
+// CHECK:        gpu.barrier
+// CHECK:        %[[D9:.+]] = vector.transfer_read %[[ALLOC]][%[[C0]], %[[D8]], %[[C0]]], %[[CST_4]] {in_bounds = [true,
+// CHECK-SAME:     true]} : memref<1x128x64xf16, #[[GPU]].address_space<workgroup>>, vector<32x64xf16>
+// CHECK:        %[[D10:.+]] = arith.extf %[[D9]] : vector<32x64xf16> to vector<32x64xf32>
+// CHECK:        %[[D11:.+]]:3 = scf.for %[[ARG0:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C128]]
+// CHECK-SAME:     iter_args(%[[ARG1:[a-zA-Z0-9_]+]] = %[[CST_0]], %[[ARG2:[a-zA-Z0-9_]+]] = %[[CST_1]],
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] = %[[CST]]) -> (vector<32xf32>, vector<32xf32>, vector<32x64xf32>) {
+// CHECK:          %[[SUBVIEW_8:.+]] = memref.subview %[[D1]][%[[WORKGROUP_ID_X]], %[[ARG0]], 0] [1, 128, 64] [1, 1, 1]
+// CHECK-SAME:       : memref<192x1024x64xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+// CHECK:          %[[SUBVIEW_9:.+]] = memref.subview %[[D2]][%[[WORKGROUP_ID_X]], %[[ARG0]], 0] [1, 128, 64] [1, 1, 1]
+// CHECK-SAME:       : memref<192x1024x64xf16> to memref<128x64xf16, strided<[64, 1], offset: ?>>
+// CHECK:          %[[ALLOC_10:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128x64xf16,
+// CHECK-SAME:       #[[GPU]].address_space<workgroup>>
+// CHECK:          gpu.barrier
+// CHECK:          linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP3]]], iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME:       ins(%[[SUBVIEW_8]] : memref<128x64xf16, strided<[64, 1], offset: ?>>) outs(%[[ALLOC_10]] :
+// CHECK-SAME:       memref<128x64xf16, #[[GPU]].address_space<workgroup>>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f16, %[[OUT:.+]]: f16):
+// CHECK:            linalg.yield %[[IN]] : f16
+// CHECK:          }
+// CHECK:          gpu.barrier
+// CHECK:          %[[ALLOC_11:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128x64xf16,
+// CHECK-SAME:       #[[GPU]].address_space<workgroup>>
+// CHECK:          gpu.barrier
+// CHECK:          linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP3]]], iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME:       ins(%[[SUBVIEW_9]] : memref<128x64xf16, strided<[64, 1], offset: ?>>) outs(%[[ALLOC_11]] :
+// CHECK-SAME:       memref<128x64xf16, #[[GPU]].address_space<workgroup>>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f16, %[[OUT:.+]]: f16):
+// CHECK:            linalg.yield %[[IN]] : f16
+// CHECK:          }
+// CHECK:          gpu.barrier
+// CHECK:          %[[D13:.+]] = vector.transfer_read %[[ALLOC_10]][%[[C0]], %[[C0]]], %[[CST_4]] {in_bounds = [true,
+// CHECK-SAME:       true]} : memref<128x64xf16, #[[GPU]].address_space<workgroup>>, vector<128x64xf16>
+// CHECK:          %[[D14:.+]] = arith.extf %[[D13]] : vector<128x64xf16> to vector<128x64xf32>
+// CHECK:          %[[D15:.+]] = vector.contract {indexing_maps = [#[[MAP4]], #[[MAP5]], #[[MAP6]]], iterator_types =
+// CHECK-SAME:       ["parallel", "parallel", "reduction"], kind = #[[VECTOR:.+]].kind<add>} %[[D10]], %[[D14]],
+// CHECK-SAME:       %[[CST_2]] : vector<32x64xf32>, vector<128x64xf32> into vector<32x128xf32>
+// CHECK:          %[[D16:.+]] = vector.multi_reduction <maxf>, %[[D15]], %[[ARG1]] [1] : vector<32x128xf32> to
+// CHECK-SAME:       vector<32xf32>
+// CHECK:          %[[D17:.+]] = vector.broadcast %[[D16]] : vector<32xf32> to vector<128x32xf32>
+// CHECK:          %[[D18:.+]] = vector.transpose %[[D17]], [1, 0] : vector<128x32xf32> to vector<32x128xf32>
+// CHECK:          %[[D19:.+]] = arith.subf %[[D15]], %[[D18]] : vector<32x128xf32>
+// CHECK:          %[[D20:.+]] = math.exp2 %[[D19]] : vector<32x128xf32>
+// CHECK:          %[[D21:.+]] = arith.subf %[[ARG1]], %[[D16]] : vector<32xf32>
+// CHECK:          %[[D22:.+]] = math.exp2 %[[D21]] : vector<32xf32>
+// CHECK:          %[[D23:.+]] = arith.mulf %[[D22]], %[[ARG2]] : vector<32xf32>
+// CHECK:          %[[D24:.+]] = vector.multi_reduction <add>, %[[D20]], %[[D23]] [1] : vector<32x128xf32> to
+// CHECK-SAME:       vector<32xf32>
+// CHECK:          %[[D25:.+]] = arith.divf %[[CST_3]], %[[D24]] : vector<32xf32>
+// CHECK:          %[[D26:.+]] = vector.broadcast %[[D25]] : vector<32xf32> to vector<128x32xf32>
+// CHECK:          %[[D27:.+]] = vector.transpose %[[D26]], [1, 0] : vector<128x32xf32> to vector<32x128xf32>
+// CHECK:          %[[D28:.+]] = arith.mulf %[[D20]], %[[D27]] : vector<32x128xf32>
+// CHECK:          %[[D29:.+]] = arith.truncf %[[D28]] : vector<32x128xf32> to vector<32x128xf16>
+// CHECK:          %[[D30:.+]] = arith.mulf %[[D23]], %[[D25]] : vector<32xf32>
+// CHECK:          %[[D31:.+]] = vector.broadcast %[[D30]] : vector<32xf32> to vector<64x32xf32>
+// CHECK:          %[[D33:.+]] = vector.transpose %[[D31]], [1, 0] : vector<64x32xf32> to vector<32x64xf32>
+// CHECK:          %[[D34:.+]] = arith.mulf %[[D33]], %[[ARG3]] : vector<32x64xf32>
+// CHECK:          %[[D35:.+]] = vector.transfer_read %[[ALLOC_11]][%[[C0]], %[[C0]]], %[[CST_4]] {in_bounds = [true,
+// CHECK-SAME:       true]} : memref<128x64xf16, #[[GPU]].address_space<workgroup>>, vector<128x64xf16>
+// CHECK:          %[[D36:.+]] = arith.extf %[[D29]] : vector<32x128xf16> to vector<32x128xf32>
+// CHECK:          %[[D37:.+]] = arith.extf %[[D35]] : vector<128x64xf16> to vector<128x64xf32>
+// CHECK:          %[[D38:.+]] = vector.transpose %[[D37]], [1, 0] : vector<128x64xf32> to vector<64x128xf32>
+// CHECK:          %[[D39:.+]] = vector.contract {indexing_maps = [#[[MAP4]], #[[MAP5]], #[[MAP6]]], iterator_types =
+// CHECK-SAME:       ["parallel", "parallel", "reduction"], kind = #[[VECTOR]].kind<add>} %[[D36]], %[[D38]], %[[D34]] :
+// CHECK-SAME:       vector<32x128xf32>, vector<64x128xf32> into vector<32x64xf32>
+// CHECK:          gpu.barrier
+// CHECK:          memref.dealloc %[[ALLOC_10]] : memref<128x64xf16, #[[GPU]].address_space<workgroup>>
+// CHECK:          memref.dealloc %[[ALLOC_11]] : memref<128x64xf16, #[[GPU]].address_space<workgroup>>
+// CHECK:          scf.yield %[[D16]], %[[D24]], %[[D39]] : vector<32xf32>, vector<32xf32>, vector<32x64xf32>
+// CHECK:        }
+// CHECK:        %[[D12:.+]] = arith.truncf %[[D11]]#[[D2:.+]] : vector<32x64xf32> to vector<32x64xf16>
+// CHECK:        vector.transfer_write %[[D12]], %[[ALLOC_7]][%[[C0]], %[[D8]], %[[C0]]] {in_bounds = [true, true]} :
+// CHECK-SAME:     vector<32x64xf16>, memref<1x128x64xf16, #[[GPU]].address_space<workgroup>>
+// CHECK:        gpu.barrier
+// CHECK:        memref.dealloc %[[ALLOC]] : memref<1x128x64xf16, #[[GPU]].address_space<workgroup>>
+// CHECK:        gpu.barrier
+// CHECK:        linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP1]]], iterator_types = ["parallel", "parallel",
+// CHECK-SAME:     "parallel"]} ins(%[[ALLOC_7]] : memref<1x128x64xf16, #[[GPU]].address_space<workgroup>>)
+// CHECK-SAME:     outs(%[[SUBVIEW_6]] : memref<1x128x64xf16, strided<[65536, 64, 1], offset: ?>>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f16, %[[OUT:.+]]: f16):
+// CHECK:          linalg.yield %[[IN]] : f16
+// CHECK:        }
+// CHECK:        gpu.barrier
+// CHECK:        memref.dealloc %[[ALLOC_7]] : memref<1x128x64xf16, #[[GPU]].address_space<workgroup>>

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeAttention.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeAttention.cpp
@@ -67,7 +67,7 @@ static Value computePartialSoftmax(Value qkTranspose, Value currentMax,
       indexingMaps, iteratorTypes,
       [&](OpBuilder &b, Location loc, ValueRange args) {
         Value diff = b.create<arith::SubFOp>(loc, args[1], args[0]);
-        Value result = b.create<math::ExpOp>(loc, diff);
+        Value result = b.create<math::Exp2Op>(loc, diff);
         b.create<linalg::YieldOp>(loc, result);
       });
   ops.push_back(genericOp);
@@ -87,7 +87,7 @@ static Value updateAndScale(Value oldMax, Value newMax, Value oldSum,
       indexingMaps, iteratorTypes,
       [&](OpBuilder &b, Location loc, ValueRange args) {
         Value diff = b.create<arith::SubFOp>(loc, args[0], args[1]);
-        Value weight = b.create<math::ExpOp>(loc, diff);
+        Value weight = b.create<math::Exp2Op>(loc, diff);
         Value scaledOldSum = b.create<arith::MulFOp>(loc, weight, args[2]);
         b.create<linalg::YieldOp>(loc, ValueRange{scaledOldSum});
       });
@@ -95,8 +95,8 @@ static Value updateAndScale(Value oldMax, Value newMax, Value oldSum,
   return genericOp.getResult(0);
 }
 
-static Value scalePartialSoftmax(Value softmax, Value newSum, Location loc,
-                                 OpBuilder &builder,
+static Value scalePartialSoftmax(Value softmax, Value inverseNewSum,
+                                 Location loc, OpBuilder &builder,
                                  SmallVectorImpl<Operation *> &ops) {
   AffineMap identityMap =
       AffineMap::getMultiDimIdentityMap(2, builder.getContext());
@@ -108,9 +108,28 @@ static Value scalePartialSoftmax(Value softmax, Value newSum, Location loc,
   SmallVector<utils::IteratorType> iteratorTypes(2,
                                                  utils::IteratorType::parallel);
   auto genericOp = builder.create<linalg::GenericOp>(
-      loc, softmax.getType(), ValueRange{newSum}, softmax, indexingMaps,
+      loc, softmax.getType(), ValueRange{inverseNewSum}, softmax, indexingMaps,
       iteratorTypes, [&](OpBuilder &b, Location loc, ValueRange args) {
-        Value result = b.create<arith::DivFOp>(loc, args[1], args[0]);
+        Value result = b.create<arith::MulFOp>(loc, args[1], args[0]);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  ops.push_back(genericOp);
+  return genericOp.getResult(0);
+}
+
+static Value computeReciprocal(Value x, Location loc, OpBuilder &builder,
+                               SmallVectorImpl<Operation *> &ops) {
+  AffineMap identityMap =
+      AffineMap::getMultiDimIdentityMap(1, builder.getContext());
+  SmallVector<AffineMap> indexingMaps{identityMap};
+  SmallVector<utils::IteratorType> iteratorTypes(1,
+                                                 utils::IteratorType::parallel);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, x.getType(), ValueRange{}, x, indexingMaps, iteratorTypes,
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value one = b.create<arith::ConstantOp>(
+            loc, b.getFloatAttr(args[0].getType(), 1.0));
+        Value result = b.create<arith::DivFOp>(loc, one, args[0]);
         b.create<linalg::YieldOp>(loc, result);
       });
   ops.push_back(genericOp);
@@ -118,7 +137,7 @@ static Value scalePartialSoftmax(Value softmax, Value newSum, Location loc,
 }
 
 static Value scaleAccumulator(Value accumulator, Value scaledOldSum,
-                              Value newSum, Value output, Location loc,
+                              Value inverseNewSum, Location loc,
                               OpBuilder &builder,
                               SmallVectorImpl<Operation *> &ops) {
   AffineMap identityMap =
@@ -127,15 +146,15 @@ static Value scaleAccumulator(Value accumulator, Value scaledOldSum,
   bindDims(builder.getContext(), d0, d1);
   // (d0, d1) -> (d0)
   auto rowMap = AffineMap::get(2, 0, {d0}, builder.getContext());
-  SmallVector<AffineMap> indexingMaps{identityMap, rowMap, rowMap, identityMap};
+  SmallVector<AffineMap> indexingMaps{rowMap, rowMap, identityMap};
   SmallVector<utils::IteratorType> iteratorTypes(2,
                                                  utils::IteratorType::parallel);
   auto genericOp = builder.create<linalg::GenericOp>(
-      loc, accumulator.getType(), ValueRange{accumulator, scaledOldSum, newSum},
-      output, indexingMaps, iteratorTypes,
+      loc, accumulator.getType(), ValueRange{scaledOldSum, inverseNewSum},
+      accumulator, indexingMaps, iteratorTypes,
       [&](OpBuilder &b, Location loc, ValueRange args) {
-        Value ratio = b.create<arith::DivFOp>(loc, args[1], args[2]);
-        Value result = b.create<arith::MulFOp>(loc, ratio, args[0]);
+        Value ratio = b.create<arith::MulFOp>(loc, args[0], args[1]);
+        Value result = b.create<arith::MulFOp>(loc, ratio, args[2]);
         b.create<linalg::YieldOp>(loc, result);
       });
   ops.push_back(genericOp);
@@ -154,11 +173,11 @@ static Value computeQKTranspose(Value query, Value key, Value output,
   return matmulOp.getResult(0);
 }
 
-static std::tuple<Value, Value, Value, Value>
-extractSlices(Value key, Value value, Value query, Value output,
-              ArrayRef<int64_t> queryShape, ArrayRef<Value> ivs,
-              OpFoldResult sequenceTileLength, OpFoldResult headDimension,
-              Type elementType, Location loc, OpBuilder &builder) {
+static std::tuple<Value, Value, Value>
+extractSlices(Value key, Value value, Value query, ArrayRef<int64_t> queryShape,
+              ArrayRef<Value> ivs, OpFoldResult sequenceTileLength,
+              OpFoldResult headDimension, Type elementType, Location loc,
+              OpBuilder &builder) {
   auto one = builder.getIndexAttr(1);
   auto zero = builder.getIndexAttr(0);
   SmallVector<OpFoldResult> strides(queryShape.size(), one);
@@ -166,8 +185,7 @@ extractSlices(Value key, Value value, Value query, Value output,
   SmallVector<OpFoldResult> offsets(queryShape.size(), zero);
   sizes[1] = sequenceTileLength;
   sizes[2] = headDimension;
-  offsets[0] = ivs[0];
-  offsets[1] = ivs[1];
+  offsets[1] = ivs[0];
   SmallVector<int64_t> tensorShape{queryShape[1], queryShape[2]};
   auto tensorType = RankedTensorType::get(tensorShape, elementType);
   Value keySlice = builder.create<tensor::ExtractSliceOp>(
@@ -176,12 +194,9 @@ extractSlices(Value key, Value value, Value query, Value output,
       loc, tensorType, value, offsets, sizes, strides);
 
   offsets = SmallVector<OpFoldResult>(queryShape.size(), zero);
-  offsets[0] = ivs[0];
   Value querySlice = builder.create<tensor::ExtractSliceOp>(
       loc, tensorType, query, offsets, sizes, strides);
-  Value outputSlice = builder.create<tensor::ExtractSliceOp>(
-      loc, tensorType, output, offsets, sizes, strides);
-  return std::make_tuple(keySlice, valueSlice, querySlice, outputSlice);
+  return std::make_tuple(keySlice, valueSlice, querySlice);
 }
 
 static std::tuple<Value, Value, Value>
@@ -189,20 +204,7 @@ insertSlices(Value newResult, Value result, Value newMax, Value max,
              Value newSum, Value sum, ArrayRef<int64_t> queryShape,
              ArrayRef<Value> ivs, OpFoldResult sequenceTileLength,
              OpFoldResult headDimension, Location loc, OpBuilder &builder) {
-  auto one = builder.getIndexAttr(1);
-  auto zero = builder.getIndexAttr(0);
-  SmallVector<OpFoldResult> strides(queryShape.size(), one);
-  SmallVector<OpFoldResult> sizes(queryShape.size(), one);
-  SmallVector<OpFoldResult> offsets(queryShape.size(), zero);
-  sizes[1] = sequenceTileLength;
-  sizes[2] = headDimension;
-  offsets[0] = ivs[0];
-  Value updatedAcc = builder.create<tensor::InsertSliceOp>(
-      loc, newResult, result, offsets, sizes, strides);
-  offsets = SmallVector<OpFoldResult>(queryShape.size() - 1, zero);
-  sizes = SmallVector<OpFoldResult>{one, sequenceTileLength};
-  strides = SmallVector<OpFoldResult>(queryShape.size() - 1, one);
-  return std::make_tuple(updatedAcc, newMax, newSum);
+  return std::make_tuple(newResult, newMax, newSum);
 }
 
 static scf::LoopNest createLoopNest(SmallVectorImpl<Value> &ivs, Value lb,
@@ -220,6 +222,24 @@ static scf::LoopNest createLoopNest(SmallVectorImpl<Value> &ivs, Value lb,
   return loopNest;
 }
 
+static Value truncateToF16(Value input, Value output,
+                           SmallVectorImpl<Operation *> &ops,
+                           OpBuilder &builder, Location loc) {
+  AffineMap identityMap =
+      AffineMap::getMultiDimIdentityMap(2, builder.getContext());
+  SmallVector<AffineMap> indexingMaps{identityMap, identityMap};
+  SmallVector<utils::IteratorType> iteratorTypes(2,
+                                                 utils::IteratorType::parallel);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, output.getType(), ValueRange{input}, output, indexingMaps,
+      iteratorTypes, [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value result = b.create<arith::TruncFOp>(loc, b.getF16Type(), args[0]);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  ops.push_back(genericOp);
+  return genericOp.getResult(0);
+}
+
 static std::tuple<Value, Value, Value>
 createAttentionBody(Value keySlice, Value valueSlice, Value querySlice,
                     Value outputSlice, Value maxSlice, Value sumSlice,
@@ -227,12 +247,13 @@ createAttentionBody(Value keySlice, Value valueSlice, Value querySlice,
                     Type elementType, SmallVectorImpl<Operation *> &ops,
                     Location loc, OpBuilder &builder) {
 
+  Type f32Type = builder.getF32Type();
   // Compute matmul(q, transpose(k))
   Value zero =
-      builder.create<arith::ConstantOp>(loc, builder.getZeroAttr(elementType));
+      builder.create<arith::ConstantOp>(loc, builder.getZeroAttr(f32Type));
   SmallVector<OpFoldResult> resultShape{sequenceTileLength, sequenceTileLength};
   Value emptySquare =
-      builder.create<tensor::EmptyOp>(loc, resultShape, elementType);
+      builder.create<tensor::EmptyOp>(loc, resultShape, f32Type);
   Value qkTranspose = computeQKTranspose(querySlice, keySlice, emptySquare,
                                          zero, loc, builder, ops);
 
@@ -245,22 +266,65 @@ createAttentionBody(Value keySlice, Value valueSlice, Value querySlice,
       updateAndScale(maxSlice, newMax, sumSlice, loc, builder, ops);
   Value newSum = computeRowwiseReduction<arith::AddFOp>(
       partialSoftmax, scaledOldSum, loc, builder, ops);
+  Value inverseNewSum = computeReciprocal(newSum, loc, builder, ops);
   Value softmax =
-      scalePartialSoftmax(partialSoftmax, newSum, loc, builder, ops);
+      scalePartialSoftmax(partialSoftmax, inverseNewSum, loc, builder, ops);
+  if (elementType.isF16()) {
+    Value empty =
+        builder.create<tensor::EmptyOp>(loc, resultShape, builder.getF16Type());
+    softmax = truncateToF16(softmax, empty, ops, builder, loc);
+  }
 
   // Update accumulator
-  Value empty = builder.create<tensor::EmptyOp>(
-      loc, SmallVector<OpFoldResult>{sequenceTileLength, headDimension},
-      elementType);
-  Value scaledAcc = scaleAccumulator(outputSlice, scaledOldSum, newSum, empty,
+  Value scaledAcc = scaleAccumulator(outputSlice, scaledOldSum, inverseNewSum,
                                      loc, builder, ops);
 
   // Compute matmul(softmax, v)
   auto matmulOp = builder.create<linalg::MatmulOp>(
-      loc, outputSlice.getType(), ValueRange{softmax, valueSlice}, scaledAcc);
+      loc, scaledAcc.getType(), ValueRange{softmax, valueSlice}, scaledAcc);
   ops.push_back(matmulOp);
   Value result = matmulOp.getResult(0);
   return std::make_tuple(result, newMax, newSum);
+}
+
+static Value extractOrInsertOutputSlice(Value src, Value dst,
+                                        ArrayRef<int64_t> queryShape,
+                                        OpFoldResult sequenceTileLength,
+                                        OpFoldResult headDimension,
+                                        Location loc, OpBuilder &builder) {
+  auto one = builder.getIndexAttr(1);
+  auto zero = builder.getIndexAttr(0);
+  SmallVector<OpFoldResult> strides(3, one);
+  SmallVector<OpFoldResult> sizes{one, sequenceTileLength, headDimension};
+  SmallVector<OpFoldResult> offsets(3, zero);
+  Value slice;
+  if (!dst) {
+    SmallVector<int64_t> accShape{queryShape[1], queryShape[2]};
+    Type elementType = src.getType().cast<ShapedType>().getElementType();
+    auto tensorType = RankedTensorType::get(accShape, elementType);
+    slice = builder.create<tensor::ExtractSliceOp>(loc, tensorType, src,
+                                                   offsets, sizes, strides);
+  } else {
+    slice = builder.create<tensor::InsertSliceOp>(loc, src, dst, offsets, sizes,
+                                                  strides);
+  }
+  return slice;
+}
+
+static Value extractOutputSlice(Value src, ArrayRef<int64_t> queryShape,
+                                OpFoldResult sequenceTileLength,
+                                OpFoldResult headDimension, Location loc,
+                                OpBuilder &builder) {
+  return extractOrInsertOutputSlice(src, {}, queryShape, sequenceTileLength,
+                                    headDimension, loc, builder);
+}
+
+static Value insertOutputSlice(Value src, Value dst,
+                               OpFoldResult sequenceTileLength,
+                               OpFoldResult headDimension, Location loc,
+                               OpBuilder &builder) {
+  return extractOrInsertOutputSlice(src, dst, {}, sequenceTileLength,
+                                    headDimension, loc, builder);
 }
 
 } // namespace
@@ -281,7 +345,6 @@ tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
       tensor::getMixedSizes(rewriter, loc, query);
   OpFoldResult headDimension = queryDimValues[2];
   OpFoldResult sequenceTileLength = queryDimValues[1];
-  OpFoldResult batchTileLength = queryDimValues[0];
 
   Value key = attnOp.getKey();
   Value value = attnOp.getValue();
@@ -289,82 +352,82 @@ tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
       tensor::getMixedSizes(rewriter, loc, key);
   OpFoldResult sequenceLength = keyDimValues[1];
 
-  // Construct first loop
-  Value zeroValue = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value oneValue = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-  SmallVector<Value> ivs;
+  // Create output accumulator
   Value output = attnOp.getOutput();
-  scf::LoopNest firstLoopNest = createLoopNest(
-      ivs, zeroValue, oneValue,
-      getValueOrCreateConstantIndexOp(rewriter, loc, batchTileLength),
-      ValueRange({output}), loc, rewriter);
-  Value iterArg = firstLoopNest.loops.back().getRegionIterArg(0);
-  ops.push_back(firstLoopNest.loops.back());
+  Type f32Type = rewriter.getF32Type();
+  SmallVector<OpFoldResult> accShape{queryDimValues[1], queryDimValues[2]};
+  Value accumulatorF32 =
+      rewriter.create<tensor::EmptyOp>(loc, accShape, f32Type);
 
-  OpBuilder::InsertionGuard guardFirstLoop(rewriter);
-  rewriter.setInsertionPointToStart(firstLoopNest.loops.back().getBody());
+  // Create accumulator, max and sum statistics
+  Value outputSlice = extractOutputSlice(output, queryShape, sequenceTileLength,
+                                         headDimension, loc, rewriter);
+  Value zeroF32 =
+      rewriter.create<arith::ConstantOp>(loc, rewriter.getZeroAttr(f32Type));
+  auto accumulatorFill =
+      rewriter.create<linalg::FillOp>(loc, ValueRange{zeroF32}, accumulatorF32);
+  accumulatorF32 = accumulatorFill.result();
+  ops.push_back(accumulatorFill);
 
-  // Create max and sum statistics
-  Value zeroF32 = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getZeroAttr(elementType));
   Value largeNegativeF32 = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getFloatAttr(elementType, -1.0e+30));
+      loc, rewriter.getFloatAttr(f32Type, -1.0e+30));
   SmallVector<OpFoldResult> dims{sequenceTileLength};
-  Value max = rewriter.create<tensor::EmptyOp>(loc, dims, elementType);
+  Value max = rewriter.create<tensor::EmptyOp>(loc, dims, f32Type);
   auto maxFill =
       rewriter.create<linalg::FillOp>(loc, ValueRange{largeNegativeF32}, max);
   Value negativeMax = maxFill.result();
   ops.push_back(maxFill);
-  Value sum = rewriter.create<tensor::EmptyOp>(loc, dims, elementType);
+  Value sum = rewriter.create<tensor::EmptyOp>(loc, dims, f32Type);
   auto sumFill = rewriter.create<linalg::FillOp>(loc, ValueRange{zeroF32}, sum);
   Value zeroSum = sumFill.result();
   ops.push_back(sumFill);
 
-  // Construct second loop
-  scf::LoopNest secondLoopNest = createLoopNest(
+  // Construct sequential loop
+  SmallVector<Value> ivs;
+  Value zeroValue = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  scf::LoopNest loopNest = createLoopNest(
       ivs, zeroValue,
       getValueOrCreateConstantIndexOp(rewriter, loc, sequenceTileLength),
       getValueOrCreateConstantIndexOp(rewriter, loc, sequenceLength),
-      ValueRange({iterArg, negativeMax, zeroSum}), loc, rewriter);
-  ops.push_back(secondLoopNest.loops.back());
+      ValueRange({accumulatorF32, negativeMax, zeroSum}), loc, rewriter);
+  ops.push_back(loopNest.loops.back());
 
-  Value iterArgResult = secondLoopNest.loops.back().getRegionIterArg(0);
-  Value iterArgMax = secondLoopNest.loops.back().getRegionIterArg(1);
-  Value iterArgSum = secondLoopNest.loops.back().getRegionIterArg(2);
+  Value iterArgResult = loopNest.loops.back().getRegionIterArg(0);
+  Value iterArgMax = loopNest.loops.back().getRegionIterArg(1);
+  Value iterArgSum = loopNest.loops.back().getRegionIterArg(2);
 
   OpBuilder::InsertionGuard guardSecondLoop(rewriter);
-  rewriter.setInsertionPointToStart(secondLoopNest.loops.back().getBody());
+  rewriter.setInsertionPointToStart(loopNest.loops.back().getBody());
 
   // Extract slices
-  auto [keySlice, valueSlice, querySlice, outputSlice] = extractSlices(
-      key, value, query, iterArgResult, queryShape, ivs, sequenceTileLength,
-      headDimension, elementType, loc, rewriter);
+  auto [keySlice, valueSlice, querySlice] =
+      extractSlices(key, value, query, queryShape, ivs, sequenceTileLength,
+                    headDimension, elementType, loc, rewriter);
 
   // Create body of innermost loop
   auto [result, newMax, newSum] = createAttentionBody(
-      keySlice, valueSlice, querySlice, outputSlice, iterArgMax, iterArgSum,
+      keySlice, valueSlice, querySlice, iterArgResult, iterArgMax, iterArgSum,
       sequenceTileLength, headDimension, elementType, ops, loc, rewriter);
 
-  // Insert slices
-  auto [updatedAcc, updatedMax, updatedSum] = insertSlices(
-      result, iterArgResult, newMax, iterArgMax, newSum, iterArgSum, queryShape,
-      ivs, sequenceTileLength, headDimension, loc, rewriter);
-
   if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
-          secondLoopNest.loops.back().getBody()->getTerminator())) {
-    rewriter.replaceOpWithNewOp<scf::YieldOp>(
-        yieldOp, ValueRange{updatedAcc, updatedMax, updatedSum});
-  }
-
-  if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
-          firstLoopNest.loops.back().getBody()->getTerminator())) {
+          loopNest.loops.back().getBody()->getTerminator())) {
     OpBuilder::InsertionGuard yieldGuard(rewriter);
     rewriter.setInsertionPoint(yieldOp);
     rewriter.replaceOpWithNewOp<scf::YieldOp>(
-        yieldOp, ValueRange{secondLoopNest.results[0]});
+        yieldOp, ValueRange{result, newMax, newSum});
   }
 
-  attnOp.getResults()[0].replaceAllUsesWith(firstLoopNest.results[0]);
+  OpBuilder::InsertionGuard yieldGuard(rewriter);
+  rewriter.setInsertionPointAfter(loopNest.loops.back());
+  if (elementType.isF16()) {
+    loopNest.results[0] =
+        truncateToF16(loopNest.results[0], outputSlice, ops, rewriter, loc);
+  }
+  loopNest.results[0] =
+      insertOutputSlice(loopNest.results[0], output, sequenceTileLength,
+                        headDimension, loc, rewriter);
+
+  attnOp.getResults()[0].replaceAllUsesWith(loopNest.results[0]);
   return ops;
 }
 
@@ -375,26 +438,26 @@ namespace {
 /// The attention operator computes:
 /// matmul(softmax(matmul(Q, transpose(K))), V)
 /// where: Q is the query matrix [B x N x d]
-///        K is the key matrix   [B x N x d]
-///        V is the value matrix [B x N x d]
+///        K is the key matrix   [B x S x d]
+///        V is the value matrix [B x S x d]
 ///
 /// The core algorithm is as follows:
 /// For each element in B,
 /// 1. Load a tile from the Q matrix of size T x d -> q
 /// 2. Initialize statistics: running_sum, running_max
-/// 3. for i = 0 to N with step T
+/// 3. for i = 0 to S with step T
 ///    a. Load a tile from the K matrix of size T x d -> k
-///    a. Load a tile from the V matrix of size T x d -> v
-///    b. Transpose(k) -> kT
-///    c. Compute matmul(q, kT) -> qkT
-///    d. Compute sum(qkT) along rows -> current_sum
-///    e. Compute max(qkT) along rows -> current_max
-///    f. Compute new max: max(current_max, running_max)
-///    g. Compute new sum: alpha * running_sum + beta * current_sum
-///    h. Compute curent estimate of softmax: exp(qKT - current_max) -> s
-///    i. Scale softmax estimate and current value of result by
-///       appropriate factors
-///    j. Compute matmul(s, v) and add to accumulator
+///    b. Load a tile from the V matrix of size T x d -> v
+///    c. Compute matmul_transpose_b(q, k) -> qkT
+///    d. Compute max(max(qkT) along rows, old_max) -> new_max
+///    e. Compute curent estimate of softmax: exp(qKT - current_max) -> s
+///    f. Compute product of fixup and old_sum -> fsum
+///    g. Compute sum(sum(qkT) along rows, fsum) -> new_sum
+///    h. Compute 1.0 / new_sum -> inv_new_sum
+///    i. Compute softmax = softmax * inv_new_sum
+///    j. Truncate softmax to fp16
+///    k. Compute fsum  * inv_new_sum * accumulator -> new_accumulator
+///    j. Compute matmul(s, v) and add new_accumulator
 ///
 ///
 LogicalResult reifyAttentionTransform(func::FuncOp funcOp) {

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeAttention.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeAttention.cpp
@@ -199,14 +199,6 @@ extractSlices(Value key, Value value, Value query, ArrayRef<int64_t> queryShape,
   return std::make_tuple(keySlice, valueSlice, querySlice);
 }
 
-static std::tuple<Value, Value, Value>
-insertSlices(Value newResult, Value result, Value newMax, Value max,
-             Value newSum, Value sum, ArrayRef<int64_t> queryShape,
-             ArrayRef<Value> ivs, OpFoldResult sequenceTileLength,
-             OpFoldResult headDimension, Location loc, OpBuilder &builder) {
-  return std::make_tuple(newResult, newMax, newSum);
-}
-
 static scf::LoopNest createLoopNest(SmallVectorImpl<Value> &ivs, Value lb,
                                     Value step, Value ub, ValueRange args,
                                     Location loc, OpBuilder &builder) {
@@ -295,7 +287,7 @@ static Value extractOrInsertOutputSlice(Value src, Value dst,
   auto one = builder.getIndexAttr(1);
   auto zero = builder.getIndexAttr(0);
   SmallVector<OpFoldResult> strides(3, one);
-  SmallVector<OpFoldResult> sizes{one, sequenceTileLength, headDimension};
+  SmallVector<OpFoldResult> sizes = {one, sequenceTileLength, headDimension};
   SmallVector<OpFoldResult> offsets(3, zero);
   Value slice;
   if (!dst) {

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_attention.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_attention.mlir
@@ -1,100 +1,98 @@
 // RUN: iree-dialects-opt --split-input-file -iree-linalg-ext-tile-and-decompose-attention -cse %s | FileCheck %s
 
-func.func @attention(%query: tensor<192x1024x64xf32>, %key: tensor<192x1024x64xf32>, %value: tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32> {
-  %0 = tensor.empty() : tensor<192x1024x64xf32>
-  %1 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>) outs(%0 : tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
-  return %1 : tensor<192x1024x64xf32>
+func.func @attention(%query: tensor<1x1024x64xf32>, %key: tensor<1x1024x64xf32>, %value: tensor<1x1024x64xf32>) -> tensor<1x1024x64xf32> {
+  %0 = tensor.empty() : tensor<1x1024x64xf32>
+  %1 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<1x1024x64xf32>, tensor<1x1024x64xf32>, tensor<1x1024x64xf32>) outs(%0 : tensor<1x1024x64xf32>) -> tensor<1x1024x64xf32>
+  return %1 : tensor<1x1024x64xf32>
 }
 
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0)>
 // CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0)>
-// CHECK:      func.func @attention(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>, %[[ARG1:[a-zA-Z0-9_]+]]:
-// CHECK-SAME:   tensor<192x1024x64xf32>, %[[ARG2:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
-// CHECK-SAME:   {
-// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<192x1024x64xf32>
-// CHECK-DAG:      %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:      %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:      %[[C192:.+]] = arith.constant 192 : index
-// CHECK:        %[[D1:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C192]] step %[[C1]]
-// CHECK-SAME:     iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[D0]]) -> (tensor<192x1024x64xf32>) {
-// CHECK-DAG:        %[[CST:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:        %[[CST_0:.+]] = arith.constant -1.000000e+30 : f32
-// CHECK:          %[[D2:.+]] = tensor.empty() : tensor<1024xf32>
-// CHECK:          %[[D3:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D2]] : tensor<1024xf32>) -> tensor<1024xf32>
-// CHECK:          %[[D4:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D2]] : tensor<1024xf32>) -> tensor<1024xf32>
-// CHECK-DAG:        %[[C1024:.+]] = arith.constant 1024 : index
-// CHECK:          %[[D5:.+]]:3 = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C1024]]
-// CHECK-SAME:       iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[ARG4]], %[[ARG7:[a-zA-Z0-9_]+]] = %[[D3]],
-// CHECK-SAME:       %[[ARG8:[a-zA-Z0-9_]+]] = %[[D4]]) -> (tensor<192x1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>)
-// CHECK-SAME:       {
-// CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG3]], %[[ARG5]], 0] [1, 1024, 64] [1,
-// CHECK-SAME:         1, 1] : tensor<192x1024x64xf32> to tensor<1024x64xf32>
-// CHECK:            %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[ARG2]][%[[ARG3]], %[[ARG5]], 0] [1, 1024, 64]
-// CHECK-SAME:         [1, 1, 1] : tensor<192x1024x64xf32> to tensor<1024x64xf32>
-// CHECK:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG3]], 0, 0] [1, 1024, 64] [1, 1, 1]
-// CHECK-SAME:         : tensor<192x1024x64xf32> to tensor<1024x64xf32>
-// CHECK:            %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[ARG6]][%[[ARG3]], 0, 0] [1, 1024, 64] [1, 1, 1]
-// CHECK-SAME:         : tensor<192x1024x64xf32> to tensor<1024x64xf32>
-// CHECK:            %[[D6:.+]] = tensor.empty() : tensor<1024x1024xf32>
-// CHECK:            %[[D7:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D6]] : tensor<1024x1024xf32>) ->
-// CHECK-SAME:         tensor<1024x1024xf32>
-// CHECK:            %[[D8:.+]] = linalg.matmul_transpose_b ins(%[[EXTRACTED_SLICE_2]], %[[EXTRACTED_SLICE]] :
-// CHECK-SAME:         tensor<1024x64xf32>, tensor<1024x64xf32>) outs(%[[D7]] : tensor<1024x1024xf32>) ->
-// CHECK-SAME:         tensor<1024x1024xf32>
-// CHECK:            %[[D9:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
-// CHECK-SAME:         "reduction"]} ins(%[[D8]] : tensor<1024x1024xf32>) outs(%[[ARG7]] : tensor<1024xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
-// CHECK:              linalg.yield %[[D17]] : f32
-// CHECK:            } -> tensor<1024xf32>
-// CHECK:            %[[D10:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
-// CHECK-SAME:         "parallel"]} ins(%[[D9]] : tensor<1024xf32>) outs(%[[D8]] : tensor<1024x1024xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.subf %[[OUT]], %[[IN]] : f32
-// CHECK:              %[[D18:.+]] = math.exp %[[D17]] : f32
-// CHECK:              linalg.yield %[[D18]] : f32
-// CHECK:            } -> tensor<1024x1024xf32>
-// CHECK:            %[[D11:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]], #[[MAP2]]], iterator_types =
-// CHECK-SAME:         ["parallel"]} ins(%[[ARG7]], %[[D9]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[ARG8]] :
-// CHECK-SAME:         tensor<1024xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[IN_4:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.subf %[[IN]], %[[IN_4]] : f32
-// CHECK:              %[[D18]] = math.exp %[[D17]] : f32
-// CHECK:              %[[D19:.+]] = arith.mulf %[[D18]], %[[OUT]] : f32
-// CHECK:              linalg.yield %[[D19]] : f32
-// CHECK:            } -> tensor<1024xf32>
-// CHECK:            %[[D12:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
-// CHECK-SAME:         "reduction"]} ins(%[[D10]] : tensor<1024x1024xf32>) outs(%[[D11]] : tensor<1024xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.addf %[[IN]], %[[OUT]] : f32
-// CHECK:              linalg.yield %[[D17]] : f32
-// CHECK:            } -> tensor<1024xf32>
-// CHECK:            %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
-// CHECK-SAME:         "parallel"]} ins(%[[D12]] : tensor<1024xf32>) outs(%[[D10]] : tensor<1024x1024xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.divf %[[OUT]], %[[IN]] : f32
-// CHECK:              linalg.yield %[[D17]] : f32
-// CHECK:            } -> tensor<1024x1024xf32>
-// CHECK:            %[[D14:.+]] = tensor.empty() : tensor<1024x64xf32>
-// CHECK:            %[[D15:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP1]], #[[MAP]]],
-// CHECK-SAME:         iterator_types = ["parallel", "parallel"]} ins(%[[EXTRACTED_SLICE_3]], %[[D11]], %[[D12]] :
-// CHECK-SAME:         tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>) outs(%[[D14]] : tensor<1024x64xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[IN_4:.+]]: f32, %[[IN_5:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.divf %[[IN_4]], %[[IN_5]] : f32
-// CHECK:              %[[D18]] = arith.mulf %[[D17]], %[[IN]] : f32
-// CHECK:              linalg.yield %[[D18]] : f32
-// CHECK:            } -> tensor<1024x64xf32>
-// CHECK:            %[[D16:.+]] = linalg.matmul ins(%[[D13]], %[[EXTRACTED_SLICE_1]] : tensor<1024x1024xf32>,
-// CHECK-SAME:         tensor<1024x64xf32>) outs(%[[D15]] : tensor<1024x64xf32>) -> tensor<1024x64xf32>
-// CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D16]] into %[[ARG6]][%[[ARG3]], 0, 0] [1, 1024, 64]
-// CHECK-SAME:         [1, 1, 1] : tensor<1024x64xf32> into tensor<192x1024x64xf32>
-// CHECK:            scf.yield %[[INSERTED_SLICE]], %[[D9]], %[[D12]] : tensor<192x1024x64xf32>, tensor<1024xf32>,
-// CHECK-SAME:         tensor<1024xf32>
-// CHECK:          }
-// CHECK:          scf.yield %[[D5]]#[[D0:.+]] : tensor<192x1024x64xf32>
+// CHECK:      func.func @attention(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x1024x64xf32>, %[[ARG1:[a-zA-Z0-9_]+]]:
+// CHECK-SAME:   tensor<1x1024x64xf32>, %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x1024x64xf32>) -> tensor<1x1024x64xf32> {
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<1x1024x64xf32>
+// CHECK:        %[[D1:.+]] = tensor.empty() : tensor<1024x64xf32>
+// CHECK-DAG:    %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<1024x64xf32>) ->
+// CHECK-SAME:     tensor<1024x64xf32>
+// CHECK-DAG:    %[[CST_0:.+]] = arith.constant -1.000000e+30 : f32
+// CHECK:        %[[D3:.+]] = tensor.empty() : tensor<1024xf32>
+// CHECK:        %[[D4:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D3]] : tensor<1024xf32>) -> tensor<1024xf32>
+// CHECK:        %[[D5:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D3]] : tensor<1024xf32>) -> tensor<1024xf32>
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK:        %[[D6:.+]]:3 = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C1024]]
+// CHECK-SAME:     iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[D2]], %[[ARG5:[a-zA-Z0-9_]+]] = %[[D4]],
+// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] = %[[D5]]) -> (tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>) {
+// CHECK:          %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG3]], 0] [1, 1024, 64] [1, 1, 1] :
+// CHECK-SAME:       tensor<1x1024x64xf32> to tensor<1024x64xf32>
+// CHECK:          %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[ARG2]][0, %[[ARG3]], 0] [1, 1024, 64] [1, 1, 1] :
+// CHECK-SAME:       tensor<1x1024x64xf32> to tensor<1024x64xf32>
+// CHECK:          %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[ARG0]][0, 0, 0] [1, 1024, 64] [1, 1, 1] :
+// CHECK-SAME:       tensor<1x1024x64xf32> to tensor<1024x64xf32>
+// CHECK:          %[[D7:.+]] = tensor.empty() : tensor<1024x1024xf32>
+// CHECK:          %[[D8:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D7]] : tensor<1024x1024xf32>) ->
+// CHECK-SAME:       tensor<1024x1024xf32>
+// CHECK:          %[[D9:.+]] = linalg.matmul_transpose_b ins(%[[EXTRACTED_SLICE_2]], %[[EXTRACTED_SLICE]] :
+// CHECK-SAME:       tensor<1024x64xf32>, tensor<1024x64xf32>) outs(%[[D8]] : tensor<1024x1024xf32>) ->
+// CHECK-SAME:       tensor<1024x1024xf32>
+// CHECK:          %[[D10:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:       "reduction"]} ins(%[[D9]] : tensor<1024x1024xf32>) outs(%[[ARG5]] : tensor<1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D18]] : f32
+// CHECK:          } -> tensor<1024xf32>
+// CHECK:          %[[D11:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
+// CHECK-SAME:       "parallel"]} ins(%[[D10]] : tensor<1024xf32>) outs(%[[D9]] : tensor<1024x1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.subf %[[OUT]], %[[IN]] : f32
+// CHECK:            %[[D19:.+]] = math.exp2 %[[D18]] : f32
+// CHECK:            linalg.yield %[[D19]] : f32
+// CHECK:          } -> tensor<1024x1024xf32>
+// CHECK:          %[[D12:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]], #[[MAP2]]], iterator_types =
+// CHECK-SAME:       ["parallel"]} ins(%[[ARG5]], %[[D10]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[ARG6]] :
+// CHECK-SAME:       tensor<1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[IN_3:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.subf %[[IN]], %[[IN_3]] : f32
+// CHECK:            %[[D19]] = math.exp2 %[[D18]] : f32
+// CHECK:            %[[D20:.+]] = arith.mulf %[[D19]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D20]] : f32
+// CHECK:          } -> tensor<1024xf32>
+// CHECK:          %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:       "reduction"]} ins(%[[D11]] : tensor<1024x1024xf32>) outs(%[[D12]] : tensor<1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.addf %[[IN]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D18]] : f32
+// CHECK:          } -> tensor<1024xf32>
+// CHECK:          %[[D14:.+]] = linalg.generic {indexing_maps = [#[[MAP2]]], iterator_types = ["parallel"]}
+// CHECK-SAME:       outs(%[[D13]] : tensor<1024xf32>) {
+// CHECK:          ^bb0(%[[OUT:.+]]: f32):
+// CHECK-DAG:        %[[CST_3:.+]] = arith.constant 1.000000e+00 : f32
+// CHECK:            %[[D18]] = arith.divf %[[CST_3]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D18]] : f32
+// CHECK:          } -> tensor<1024xf32>
+// CHECK:          %[[D15:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
+// CHECK-SAME:       "parallel"]} ins(%[[D14]] : tensor<1024xf32>) outs(%[[D11]] : tensor<1024x1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.mulf %[[OUT]], %[[IN]] : f32
+// CHECK:            linalg.yield %[[D18]] : f32
+// CHECK:          } -> tensor<1024x1024xf32>
+// CHECK:          %[[D16:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP1]], #[[MAP]]], iterator_types =
+// CHECK-SAME:       ["parallel", "parallel"]} ins(%[[D12]], %[[D14]] : tensor<1024xf32>, tensor<1024xf32>)
+// CHECK-SAME:       outs(%[[ARG4]] : tensor<1024x64xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[IN_3:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.mulf %[[IN]], %[[IN_3]] : f32
+// CHECK:            %[[D19]] = arith.mulf %[[D18]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D19]] : f32
+// CHECK:          } -> tensor<1024x64xf32>
+// CHECK:          %[[D17:.+]] = linalg.matmul ins(%[[D15]], %[[EXTRACTED_SLICE_1]] : tensor<1024x1024xf32>,
+// CHECK-SAME:       tensor<1024x64xf32>) outs(%[[D16]] : tensor<1024x64xf32>) -> tensor<1024x64xf32>
+// CHECK:          scf.yield %[[D17]], %[[D10]], %[[D13]] : tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>
 // CHECK:        }
-// CHECK:        return %[[D1]] : tensor<192x1024x64xf32>
+// CHECK:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]]#[[D0:.+]] into %[[D0]][0, 0, 0] [1, 1024, 64] [1,
+// CHECK-SAME:     1, 1] : tensor<1024x64xf32> into tensor<1x1024x64xf32>
+// CHECK:        return %[[INSERTED_SLICE]] : tensor<1x1024x64xf32>
 // CHECK:      }
 
 // -----
@@ -113,84 +111,198 @@ func.func @attention(%query: tensor<?x?x?xf32>, %key: tensor<?x?x?xf32>, %value:
 // CHECK-SAME:   %[[ARG4:[a-zA-Z0-9_]+]]: index, %[[ARG5:[a-zA-Z0-9_]+]]: index) -> tensor<?x?x?xf32> {
 // CHECK:        %[[D0:.+]] = tensor.empty(%[[ARG3]], %[[ARG4]], %[[ARG5]]) : tensor<?x?x?xf32>
 // CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
-// CHECK:        %[[DIM:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?x?xf32>
 // CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
-// CHECK:        %[[DIM_0:.+]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?x?xf32>
+// CHECK:        %[[DIM:.+]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?x?xf32>
 // CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : index
-// CHECK:        %[[DIM_1:.+]] = tensor.dim %[[ARG0]], %[[C2]] : tensor<?x?x?xf32>
-// CHECK:        %[[DIM_2:.+]] = tensor.dim %[[ARG1]], %[[C1]] : tensor<?x?x?xf32>
-// CHECK:        %[[D1:.+]] = scf.for %[[ARG6:[a-zA-Z0-9_]+]] = %[[C0]] to %[[DIM]] step %[[C1]]
-// CHECK-SAME:     iter_args(%[[ARG7:[a-zA-Z0-9_]+]] = %[[D0]]) -> (tensor<?x?x?xf32>) {
-// CHECK-DAG:      %[[CST:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:      %[[CST_3:.+]] = arith.constant -1.000000e+30 : f32
-// CHECK:          %[[D2:.+]] = tensor.empty(%[[DIM_0]]) : tensor<?xf32>
-// CHECK:          %[[D3:.+]] = linalg.fill ins(%[[CST_3]] : f32) outs(%[[D2]] : tensor<?xf32>) -> tensor<?xf32>
-// CHECK:          %[[D4:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D2]] : tensor<?xf32>) -> tensor<?xf32>
-// CHECK:          %[[D5:.+]]:3 = scf.for %[[ARG8:[a-zA-Z0-9_]+]] = %[[C0]] to %[[DIM_2]] step %[[DIM_0]]
-// CHECK-SAME:       iter_args(%[[ARG9:[a-zA-Z0-9_]+]] = %[[ARG7]], %[[ARG10:[a-zA-Z0-9_]+]] = %[[D3]],
-// CHECK-SAME:       %[[ARG11:[a-zA-Z0-9_]+]] = %[[D4]]) -> (tensor<?x?x?xf32>, tensor<?xf32>, tensor<?xf32>) {
-// CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG6]], %[[ARG8]], 0] [1, %[[DIM_0]],
-// CHECK-SAME:         %[[DIM_1]]] [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
-// CHECK:            %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[ARG2]][%[[ARG6]], %[[ARG8]], 0] [1, %[[DIM_0]],
-// CHECK-SAME:         %[[DIM_1]]] [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
-// CHECK:            %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG6]], 0, 0] [1, %[[DIM_0]],
-// CHECK-SAME:         %[[DIM_1]]] [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
-// CHECK:            %[[EXTRACTED_SLICE_6:.+]] = tensor.extract_slice %[[ARG9]][%[[ARG6]], 0, 0] [1, %[[DIM_0]],
-// CHECK-SAME:         %[[DIM_1]]] [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
-// CHECK:            %[[D6:.+]] = tensor.empty(%[[DIM_0]], %[[DIM_0]]) : tensor<?x?xf32>
-// CHECK:            %[[D7:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D6]] : tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:            %[[D8:.+]] = linalg.matmul_transpose_b ins(%[[EXTRACTED_SLICE_5]], %[[EXTRACTED_SLICE]] :
-// CHECK-SAME:         tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[D7]] : tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:            %[[D9:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
-// CHECK-SAME:         "reduction"]} ins(%[[D8]] : tensor<?x?xf32>) outs(%[[ARG10]] : tensor<?xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
-// CHECK:              linalg.yield %[[D17]] : f32
-// CHECK:            } -> tensor<?xf32>
-// CHECK:            %[[D10:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
-// CHECK-SAME:         "parallel"]} ins(%[[D9]] : tensor<?xf32>) outs(%[[D8]] : tensor<?x?xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.subf %[[OUT]], %[[IN]] : f32
-// CHECK:              %[[D18:.+]] = math.exp %[[D17]] : f32
-// CHECK:              linalg.yield %[[D18]] : f32
-// CHECK:            } -> tensor<?x?xf32>
-// CHECK:            %[[D11:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]], #[[MAP2]]], iterator_types =
-// CHECK-SAME:         ["parallel"]} ins(%[[ARG10]], %[[D9]] : tensor<?xf32>, tensor<?xf32>) outs(%[[ARG11]] :
-// CHECK-SAME:         tensor<?xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[IN_7:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.subf %[[IN]], %[[IN_7]] : f32
-// CHECK:              %[[D18]] = math.exp %[[D17]] : f32
-// CHECK:              %[[D19:.+]] = arith.mulf %[[D18]], %[[OUT]] : f32
-// CHECK:              linalg.yield %[[D19]] : f32
-// CHECK:            } -> tensor<?xf32>
-// CHECK:            %[[D12:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
-// CHECK-SAME:         "reduction"]} ins(%[[D10]] : tensor<?x?xf32>) outs(%[[D11]] : tensor<?xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.addf %[[IN]], %[[OUT]] : f32
-// CHECK:              linalg.yield %[[D17]] : f32
-// CHECK:            } -> tensor<?xf32>
-// CHECK:            %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
-// CHECK-SAME:         "parallel"]} ins(%[[D12]] : tensor<?xf32>) outs(%[[D10]] : tensor<?x?xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.divf %[[OUT]], %[[IN]] : f32
-// CHECK:              linalg.yield %[[D17]] : f32
-// CHECK:            } -> tensor<?x?xf32>
-// CHECK:            %[[D14:.+]] = tensor.empty(%[[DIM_0]], %[[DIM_1]]) : tensor<?x?xf32>
-// CHECK:            %[[D15:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP1]], #[[MAP]]],
-// CHECK-SAME:         iterator_types = ["parallel", "parallel"]} ins(%[[EXTRACTED_SLICE_6]], %[[D11]], %[[D12]] :
-// CHECK-SAME:         tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>) outs(%[[D14]] : tensor<?x?xf32>) {
-// CHECK:            ^bb0(%[[IN:.+]]: f32, %[[IN_7:.+]]: f32, %[[IN_8:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:              %[[D17]] = arith.divf %[[IN_7]], %[[IN_8]] : f32
-// CHECK:              %[[D18]] = arith.mulf %[[D17]], %[[IN]] : f32
-// CHECK:              linalg.yield %[[D18]] : f32
-// CHECK:            } -> tensor<?x?xf32>
-// CHECK:            %[[D16:.+]] = linalg.matmul ins(%[[D13]], %[[EXTRACTED_SLICE_4]] : tensor<?x?xf32>,
-// CHECK-SAME:         tensor<?x?xf32>) outs(%[[D15]] : tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D16]] into %[[ARG9]][%[[ARG6]], 0, 0] [1,
-// CHECK-SAME:         %[[DIM_0]], %[[DIM_1]]] [1, 1, 1] : tensor<?x?xf32> into tensor<?x?x?xf32>
-// CHECK:            scf.yield %[[INSERTED_SLICE]], %[[D9]], %[[D12]] : tensor<?x?x?xf32>, tensor<?xf32>, tensor<?xf32>
-// CHECK:          }
-// CHECK:          scf.yield %[[D5]]#[[D0:.+]] : tensor<?x?x?xf32>
+// CHECK:        %[[DIM_0:.+]] = tensor.dim %[[ARG0]], %[[C2]] : tensor<?x?x?xf32>
+// CHECK:        %[[DIM_1:.+]] = tensor.dim %[[ARG1]], %[[C1]] : tensor<?x?x?xf32>
+// CHECK:        %[[D1:.+]] = tensor.empty(%[[DIM]], %[[DIM_0]]) : tensor<?x?xf32>
+// CHECK-DAG:    %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK-DAG:    %[[CST_2:.+]] = arith.constant -1.000000e+30 : f32
+// CHECK:        %[[D3:.+]] = tensor.empty(%[[DIM]]) : tensor<?xf32>
+// CHECK:        %[[D4:.+]] = linalg.fill ins(%[[CST_2]] : f32) outs(%[[D3]] : tensor<?xf32>) -> tensor<?xf32>
+// CHECK:        %[[D5:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D3]] : tensor<?xf32>) -> tensor<?xf32>
+// CHECK:        %[[D6:.+]]:3 = scf.for %[[ARG6:[a-zA-Z0-9_]+]] = %[[C0]] to %[[DIM_1]] step %[[DIM]]
+// CHECK-SAME:     iter_args(%[[ARG7:[a-zA-Z0-9_]+]] = %[[D2]], %[[ARG8:[a-zA-Z0-9_]+]] = %[[D4]],
+// CHECK-SAME:     %[[ARG9:[a-zA-Z0-9_]+]] = %[[D5]]) -> (tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>) {
+// CHECK:          %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG6]], 0] [1, %[[DIM]], %[[DIM_0]]]
+// CHECK-SAME:       [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
+// CHECK:          %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[ARG2]][0, %[[ARG6]], 0] [1, %[[DIM]], %[[DIM_0]]]
+// CHECK-SAME:       [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
+// CHECK:          %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[ARG0]][0, 0, 0] [1, %[[DIM]], %[[DIM_0]]] [1, 1,
+// CHECK-SAME:       1] : tensor<?x?x?xf32> to tensor<?x?xf32>
+// CHECK:          %[[D7:.+]] = tensor.empty(%[[DIM]], %[[DIM]]) : tensor<?x?xf32>
+// CHECK:          %[[D8:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D7]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:          %[[D9:.+]] = linalg.matmul_transpose_b ins(%[[EXTRACTED_SLICE_4]], %[[EXTRACTED_SLICE]] :
+// CHECK-SAME:       tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[D8]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:          %[[D10:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:       "reduction"]} ins(%[[D9]] : tensor<?x?xf32>) outs(%[[ARG8]] : tensor<?xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D18]] : f32
+// CHECK:          } -> tensor<?xf32>
+// CHECK:          %[[D11:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
+// CHECK-SAME:       "parallel"]} ins(%[[D10]] : tensor<?xf32>) outs(%[[D9]] : tensor<?x?xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.subf %[[OUT]], %[[IN]] : f32
+// CHECK:            %[[D19:.+]] = math.exp2 %[[D18]] : f32
+// CHECK:            linalg.yield %[[D19]] : f32
+// CHECK:          } -> tensor<?x?xf32>
+// CHECK:          %[[D12:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]], #[[MAP2]]], iterator_types =
+// CHECK-SAME:       ["parallel"]} ins(%[[ARG8]], %[[D10]] : tensor<?xf32>, tensor<?xf32>) outs(%[[ARG9]] :
+// CHECK-SAME:       tensor<?xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[IN_5:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.subf %[[IN]], %[[IN_5]] : f32
+// CHECK:            %[[D19]] = math.exp2 %[[D18]] : f32
+// CHECK:            %[[D20:.+]] = arith.mulf %[[D19]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D20]] : f32
+// CHECK:          } -> tensor<?xf32>
+// CHECK:          %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:       "reduction"]} ins(%[[D11]] : tensor<?x?xf32>) outs(%[[D12]] : tensor<?xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.addf %[[IN]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D18]] : f32
+// CHECK:          } -> tensor<?xf32>
+// CHECK:          %[[D14:.+]] = linalg.generic {indexing_maps = [#[[MAP2]]], iterator_types = ["parallel"]}
+// CHECK-SAME:       outs(%[[D13]] : tensor<?xf32>) {
+// CHECK:          ^bb0(%[[OUT:.+]]: f32):
+// CHECK-DAG:        %[[CST_5:.+]] = arith.constant 1.000000e+00 : f32
+// CHECK:            %[[D18]] = arith.divf %[[CST_5]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D18]] : f32
+// CHECK:          } -> tensor<?xf32>
+// CHECK:          %[[D15:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
+// CHECK-SAME:       "parallel"]} ins(%[[D14]] : tensor<?xf32>) outs(%[[D11]] : tensor<?x?xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.mulf %[[OUT]], %[[IN]] : f32
+// CHECK:            linalg.yield %[[D18]] : f32
+// CHECK:          } -> tensor<?x?xf32>
+// CHECK:          %[[D16:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP1]], #[[MAP]]], iterator_types =
+// CHECK-SAME:       ["parallel", "parallel"]} ins(%[[D12]], %[[D14]] : tensor<?xf32>, tensor<?xf32>) outs(%[[ARG7]] :
+// CHECK-SAME:       tensor<?x?xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[IN_5:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D18]] = arith.mulf %[[IN]], %[[IN_5]] : f32
+// CHECK:            %[[D19]] = arith.mulf %[[D18]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D19]] : f32
+// CHECK:          } -> tensor<?x?xf32>
+// CHECK:          %[[D17:.+]] = linalg.matmul ins(%[[D15]], %[[EXTRACTED_SLICE_3]] : tensor<?x?xf32>, tensor<?x?xf32>)
+// CHECK-SAME:       outs(%[[D16]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:          scf.yield %[[D17]], %[[D10]], %[[D13]] : tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>
 // CHECK:        }
-// CHECK:        return %[[D1]] : tensor<?x?x?xf32>
+// CHECK:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]]#[[D0:.+]] into %[[D0]][0, 0, 0] [1, %[[DIM]],
+// CHECK-SAME:     %[[DIM_0]]] [1, 1, 1] : tensor<?x?xf32> into tensor<?x?x?xf32>
+// CHECK:        return %[[INSERTED_SLICE]] : tensor<?x?x?xf32>
+// CHECK:      }
+
+// -----
+
+func.func @attention(%query: tensor<1x1024x64xf16>, %key: tensor<1x1024x64xf16>, %value: tensor<1x1024x64xf16>) -> tensor<1x1024x64xf16> {
+  %0 = tensor.empty() : tensor<1x1024x64xf16>
+  %1 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<1x1024x64xf16>, tensor<1x1024x64xf16>, tensor<1x1024x64xf16>) outs(%0 : tensor<1x1024x64xf16>) -> tensor<1x1024x64xf16>
+  return %1 : tensor<1x1024x64xf16>
+}
+
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0)>
+// CHECK:      func.func @attention(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x1024x64xf16>, %[[ARG1:[a-zA-Z0-9_]+]]:
+// CHECK-SAME:   tensor<1x1024x64xf16>, %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x1024x64xf16>) -> tensor<1x1024x64xf16> {
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<1x1024x64xf16>
+// CHECK:        %[[D1:.+]] = tensor.empty() : tensor<1024x64xf32>
+// CHECK:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[D0]][0, 0, 0] [1, 1024, 64] [1, 1, 1] :
+// CHECK-SAME:     tensor<1x1024x64xf16> to tensor<1024x64xf16>
+// CHECK-DAG:    %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<1024x64xf32>) ->
+// CHECK-SAME:     tensor<1024x64xf32>
+// CHECK-DAG:    %[[CST_0:.+]] = arith.constant -1.000000e+30 : f32
+// CHECK:        %[[D3:.+]] = tensor.empty() : tensor<1024xf32>
+// CHECK:        %[[D4:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D3]] : tensor<1024xf32>) -> tensor<1024xf32>
+// CHECK:        %[[D5:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D3]] : tensor<1024xf32>) -> tensor<1024xf32>
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK:        %[[D6:.+]]:3 = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C1024]]
+// CHECK-SAME:     iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[D2]], %[[ARG5:[a-zA-Z0-9_]+]] = %[[D4]],
+// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] = %[[D5]]) -> (tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>) {
+// CHECK:          %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG3]], 0] [1, 1024, 64] [1, 1, 1] :
+// CHECK-SAME:       tensor<1x1024x64xf16> to tensor<1024x64xf16>
+// CHECK:          %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[ARG2]][0, %[[ARG3]], 0] [1, 1024, 64] [1, 1, 1] :
+// CHECK-SAME:       tensor<1x1024x64xf16> to tensor<1024x64xf16>
+// CHECK:          %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[ARG0]][0, 0, 0] [1, 1024, 64] [1, 1, 1] :
+// CHECK-SAME:       tensor<1x1024x64xf16> to tensor<1024x64xf16>
+// CHECK:          %[[D8:.+]] = tensor.empty() : tensor<1024x1024xf32>
+// CHECK:          %[[D9:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D8]] : tensor<1024x1024xf32>) ->
+// CHECK-SAME:       tensor<1024x1024xf32>
+// CHECK:          %[[D10:.+]] = linalg.matmul_transpose_b ins(%[[EXTRACTED_SLICE_3]], %[[EXTRACTED_SLICE_1]] :
+// CHECK-SAME:       tensor<1024x64xf16>, tensor<1024x64xf16>) outs(%[[D9]] : tensor<1024x1024xf32>) ->
+// CHECK-SAME:       tensor<1024x1024xf32>
+// CHECK:          %[[D11:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:       "reduction"]} ins(%[[D10]] : tensor<1024x1024xf32>) outs(%[[ARG5]] : tensor<1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D21:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D21]] : f32
+// CHECK:          } -> tensor<1024xf32>
+// CHECK:          %[[D12:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
+// CHECK-SAME:       "parallel"]} ins(%[[D11]] : tensor<1024xf32>) outs(%[[D10]] : tensor<1024x1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D21]] = arith.subf %[[OUT]], %[[IN]] : f32
+// CHECK:            %[[D22:.+]] = math.exp2 %[[D21]] : f32
+// CHECK:            linalg.yield %[[D22]] : f32
+// CHECK:          } -> tensor<1024x1024xf32>
+// CHECK:          %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]], #[[MAP2]]], iterator_types =
+// CHECK-SAME:       ["parallel"]} ins(%[[ARG5]], %[[D11]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[ARG6]] :
+// CHECK-SAME:       tensor<1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[IN_4:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D21]] = arith.subf %[[IN]], %[[IN_4]] : f32
+// CHECK:            %[[D22]] = math.exp2 %[[D21]] : f32
+// CHECK:            %[[D23:.+]] = arith.mulf %[[D22]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D23]] : f32
+// CHECK:          } -> tensor<1024xf32>
+// CHECK:          %[[D14:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:       "reduction"]} ins(%[[D12]] : tensor<1024x1024xf32>) outs(%[[D13]] : tensor<1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D21]] = arith.addf %[[IN]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D21]] : f32
+// CHECK:          } -> tensor<1024xf32>
+// CHECK:          %[[D15:.+]] = linalg.generic {indexing_maps = [#[[MAP2]]], iterator_types = ["parallel"]}
+// CHECK-SAME:       outs(%[[D14]] : tensor<1024xf32>) {
+// CHECK:          ^bb0(%[[OUT:.+]]: f32):
+// CHECK-DAG:        %[[CST_4:.+]] = arith.constant 1.000000e+00 : f32
+// CHECK:            %[[D21]] = arith.divf %[[CST_4]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D21]] : f32
+// CHECK:          } -> tensor<1024xf32>
+// CHECK:          %[[D16:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP]]], iterator_types = ["parallel",
+// CHECK-SAME:       "parallel"]} ins(%[[D15]] : tensor<1024xf32>) outs(%[[D12]] : tensor<1024x1024xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D21]] = arith.mulf %[[OUT]], %[[IN]] : f32
+// CHECK:            linalg.yield %[[D21]] : f32
+// CHECK:          } -> tensor<1024x1024xf32>
+// CHECK:          %[[D17:.+]] = tensor.empty() : tensor<1024x1024xf16>
+// CHECK:          %[[D18:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel",
+// CHECK-SAME:       "parallel"]} ins(%[[D16]] : tensor<1024x1024xf32>) outs(%[[D17]] : tensor<1024x1024xf16>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f16):
+// CHECK:            %[[D21]] = arith.truncf %[[IN]] : f32 to f16
+// CHECK:            linalg.yield %[[D21]] : f16
+// CHECK:          } -> tensor<1024x1024xf16>
+// CHECK:          %[[D19:.+]] = linalg.generic {indexing_maps = [#[[MAP1]], #[[MAP1]], #[[MAP]]], iterator_types =
+// CHECK-SAME:       ["parallel", "parallel"]} ins(%[[D13]], %[[D15]] : tensor<1024xf32>, tensor<1024xf32>)
+// CHECK-SAME:       outs(%[[ARG4]] : tensor<1024x64xf32>) {
+// CHECK:          ^bb0(%[[IN:.+]]: f32, %[[IN_4:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:            %[[D21]] = arith.mulf %[[IN]], %[[IN_4]] : f32
+// CHECK:            %[[D22]] = arith.mulf %[[D21]], %[[OUT]] : f32
+// CHECK:            linalg.yield %[[D22]] : f32
+// CHECK:          } -> tensor<1024x64xf32>
+// CHECK:          %[[D20:.+]] = linalg.matmul ins(%[[D18]], %[[EXTRACTED_SLICE_2]] : tensor<1024x1024xf16>,
+// CHECK-SAME:       tensor<1024x64xf16>) outs(%[[D19]] : tensor<1024x64xf32>) -> tensor<1024x64xf32>
+// CHECK:          scf.yield %[[D20]], %[[D11]], %[[D14]] : tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>
+// CHECK:        }
+// CHECK:        %[[D7:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel",
+// CHECK-SAME:     "parallel"]} ins(%[[D6]]#[[D0:.+]] : tensor<1024x64xf32>) outs(%[[EXTRACTED_SLICE]] :
+// CHECK-SAME:     tensor<1024x64xf16>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f16):
+// CHECK:          %[[D8]] = arith.truncf %[[IN]] : f32 to f16
+// CHECK:          linalg.yield %[[D8]] : f16
+// CHECK:        } -> tensor<1024x64xf16>
+// CHECK:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D7]] into %[[D0]][0, 0, 0] [1, 1024, 64] [1, 1, 1] :
+// CHECK-SAME:     tensor<1024x64xf16> into tensor<1x1024x64xf16>
+// CHECK:        return %[[INSERTED_SLICE]] : tensor<1x1024x64xf16>
 // CHECK:      }

--- a/tests/transform_dialect/cpu/attention.mlir
+++ b/tests/transform_dialect/cpu/attention.mlir
@@ -8,6 +8,20 @@ func.func @attention() -> tensor<1x4x4xf32> {
   return %1 : tensor<1x4x4xf32>
 }
 
+// RUN: iree-opt %s --iree-hal-target-backends=llvm-cpu \
+// RUN:   --iree-abi-transformation-pipeline \
+// RUN:   --iree-flow-transformation-pipeline \
+// RUN:   --iree-stream-transformation-pipeline \
+// RUN:   --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' \
+// RUN:   --iree-codegen-llvmcpu-use-transform-dialect=%p/attention_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefixes=CODEGEN-DEFAULT
+
+// CODEGEN-DEFAULT:     hal.executable.export public @attention_dispatch_0_attention_1x4x4xf32
+// CODEGEN-DEFAULT:         %[[C2:.+]] = arith.constant 2 : index
+// CODEGEN-DEFAULT:         %[[C1:.+]] = arith.constant 1 : index
+// CODEGEN-DEFAULT:         hal.return %[[C2]], %[[C1]], %[[C1]]
+
 // RUN: iree-compile %s --iree-hal-target-backends=llvm-cpu \
 // RUN: --iree-codegen-llvmcpu-use-transform-dialect=%p/attention_codegen_spec.mlir | \
 // RUN: iree-run-module --module=- --function=attention | \

--- a/tests/transform_dialect/cpu/attention.mlir
+++ b/tests/transform_dialect/cpu/attention.mlir
@@ -8,20 +8,6 @@ func.func @attention() -> tensor<1x4x4xf32> {
   return %1 : tensor<1x4x4xf32>
 }
 
-// RUN: iree-opt %s --iree-hal-target-backends=llvm-cpu \
-// RUN:   --iree-abi-transformation-pipeline \
-// RUN:   --iree-flow-transformation-pipeline \
-// RUN:   --iree-stream-transformation-pipeline \
-// RUN:   --iree-hal-configuration-pipeline | \
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' \
-// RUN:   --iree-codegen-llvmcpu-use-transform-dialect=%p/attention_codegen_spec.mlir | \
-// RUN: FileCheck %s --check-prefixes=CODEGEN-DEFAULT
-
-// CODEGEN-DEFAULT:     hal.executable.export public @attention_dispatch_0_attention_1x4x4xf32
-// CODEGEN-DEFAULT:         %[[C2:.+]] = arith.constant 2 : index
-// CODEGEN-DEFAULT:         %[[C1:.+]] = arith.constant 1 : index
-// CODEGEN-DEFAULT:         hal.return %[[C2]], %[[C1]], %[[C1]]
-
 // RUN: iree-compile %s --iree-hal-target-backends=llvm-cpu \
 // RUN: --iree-codegen-llvmcpu-use-transform-dialect=%p/attention_codegen_spec.mlir | \
 // RUN: iree-run-module --module=- --function=attention | \

--- a/tests/transform_dialect/cpu/attention_codegen_spec.mlir
+++ b/tests/transform_dialect/cpu/attention_codegen_spec.mlir
@@ -17,9 +17,9 @@ transform.sequence failures(propagate) {
     // Tile and decompose attention
     // ==========================================
     %attention2 = transform.structured.match ops{["iree_linalg_ext.attention"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    %outer_loop, %max_fill, %sum_fill, %inner_loop, %fill_op, %first_matmul, %reduce_max, %partial_softmax, %reduce_sum, %update,
-    %softmax, %scale_acc, %second_matmul = tile_and_decompose_attention %attention2 :
-       (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op,!transform.any_op,  !transform.any_op, !transform.any_op)
+    %acc_fill, %max_fill, %sum_fill, %inner_loop, %fill_op, %first_matmul, %reduce_max, %partial_softmax, %update, %reduce_sum,
+    %reciprocal_sum, %softmax, %scale_acc, %second_matmul = tile_and_decompose_attention %attention2 :
+       (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op,!transform.any_op,  !transform.any_op, !transform.any_op)
 
     // Vectorize function
     // ==========================================

--- a/tests/transform_dialect/cpu/attention_codegen_spec.mlir
+++ b/tests/transform_dialect/cpu/attention_codegen_spec.mlir
@@ -8,7 +8,7 @@ transform.sequence failures(propagate) {
     // Tile and distribute to workgroups
     // ==========================================
     %forall_grid, %tiled_attention =
-    transform.structured.tile_to_forall_op %attention num_threads [2]
+    transform.structured.tile_to_forall_op %attention num_threads [1]
       ( mapping = [#gpu.block<x>] )
       : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall_grid


### PR DESCRIPTION
This patch adds the following updates to the tile and decompose pass:
1. Does matmuls in fp16 with fp32 accumulators
2. Does softmax in fp32
3. Reduces number of divisions to 1 (from 2) for faster performance
4. Change exp to exp2 for faster performance