### PR TITLE
[cuda] Dump useful GPU characteristics

### DIFF
--- a/experimental/cuda2/cuda_dynamic_symbol_table.h
+++ b/experimental/cuda2/cuda_dynamic_symbol_table.h
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+IREE_CU_PFN_DECL(cuDriverGetVersion, int*)
 IREE_CU_PFN_DECL(cuCtxCreate, CUcontext*, unsigned int, CUdevice)
 IREE_CU_PFN_DECL(cuCtxDestroy, CUcontext)
 IREE_CU_PFN_DECL(cuDevicePrimaryCtxRetain, CUcontext*, CUdevice)


### PR DESCRIPTION
This commit implements `iree_hal_cuda_driver_dump_device_info` to print out GPU characteristics including launch configuration size limits, per block/multiprocessor resource limits, memory system characteristics, and others.

On NVIDIA GeForce RTX 2070 SUPER, `iree-run-module --dump_devices` shows:

```
- gpu-compute-capability: 7.5
- driver-max-cuda-version: 12.1

- launch-max-block-dims: (1024, 1024, 64)
- launch-max-grid-dims: (2147483647, 65535, 65535)

- block-max-thread-count: 1024
- block-max-32-bit-register-count: 65536
- block-max-shared-memory: 49152 bytes

- multiprocessor-max-thread-count: 1024
- multiprocessor-max-block-count: 16
- multiprocessor-max-32-bit-register-count: 65536
- multiprocessor-max-shared-memory: 65536 bytes

- memory-has-unified-address-space: 1
- memory-supports-managed-memory: 1
- memory-can-map-host-memory-to-device: 1
- memory-supports-pageable-memory-access-from-device: 0
- memory-supports-concurrent-managed-access: 1
- memory-supports-memory-pools: 1
- memory-l2-cache-size: 4194304 bytes

- gpu-multiprocessor-count: 40
- gpu-clock-rate: 1815000 kHz
- gpu-warp-size: 32
- kernel-has-execution-timeout: 1
```

Progress towards https://github.com/openxla/iree/issues/13245