### PR TITLE
Check `nvidia-bleeding-edge` during image setup

### DIFF
--- a/build_tools/github_actions/runner/gcp/create_image.sh
+++ b/build_tools/github_actions/runner/gcp/create_image.sh
@@ -32,7 +32,7 @@ CPU_IMAGE_SIZE_GB=10
 # We need enough space to fetch Docker images that we test with
 # TODO(gcmn): See if we can make the image smaller, e.g. by resizing after setup
 # or using a local ssd for scratch space during setup.
-GPU_IMAGE_SIZE_GB=50
+GPU_IMAGE_SIZE_GB=100
 
 # It takes a little bit to bring up ssh on the instance. I haven't found a
 # better way to wait for this than just polling.

--- a/build_tools/github_actions/runner/gcp/image_setup.sh
+++ b/build_tools/github_actions/runner/gcp/image_setup.sh
@@ -316,6 +316,7 @@ EOF
 
     check_docker gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02
     check_docker gcr.io/iree-oss/frontends-nvidia@sha256:bc217d1a226f778e44874b989d6ead3a3085f04643a40aa301f5d30661356d07
+    check_docker gcr.io/iree-oss/nvidia-bleeding-edge@sha256:a14a1c9442a40f02023c8a30a025902f4c8cd06bf37dac605e48521296fb23be
 
     # Remove the docker images we've fetched. We might want to pre-fetch Docker
     # images into the VM image, but that should be a separate decision.


### PR DESCRIPTION
Also check `nvidia-bleeding-edge` docker image when creating the GPU VM image, as it uses a newer version of ubuntu.

skip-ci: Manually tested with `env RUNNER_TYPE=gpu ZONE=us-central1-c ./build_tools/github_actions/runner/gcp/create_image.sh`