### PR TITLE
Add `iree-stream-resource-alias-mutable-bindings` flag.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
@@ -319,7 +319,9 @@ def Stream_ResourceConfigAttr :
     // bindings.
     "int64_t":$minBufferRangeAlignment,
     // Number of bits in `index` values as passed across device boundaries.
-    "int64_t":$indexBits
+    "int64_t":$indexBits,
+    // Fuses bindings that are mutable instead of leaving them split.
+    "bool":$aliasMutableBindings
   );
 
   let valueType = NoneType;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -315,10 +315,13 @@ static void fuseDispatchBindings(
     IREE::Stream::ExecutableOp executableOp,
     IREE::Stream::ExecutableExportOp exportOp,
     ArrayRef<IREE::Stream::CmdDispatchOp> dispatchOps,
-    bool aliasMutableBindings, MemoizedCmdZeros &memoizedZeros) {
+    MemoizedCmdZeros &memoizedZeros) {
   if (dispatchOps.empty()) return;  // no-op if no dispatches
   auto anyDispatchOp = dispatchOps.front();
   unsigned bindingCount = anyDispatchOp.getResources().size();
+
+  auto configAttr = IREE::Stream::ResourceConfigAttr::lookup(exportOp);
+  bool aliasMutableBindings = configAttr.getAliasMutableBindings();
 
   LLVM_DEBUG({
     AsmState asmState(executableOp->getParentOp());
@@ -448,7 +451,7 @@ class FuseDispatchBindingsPass
       for (auto exportOp :
            executableOp.getOps<IREE::Stream::ExecutableExportOp>()) {
         fuseDispatchBindings(executableOp, exportOp, entryDispatchMap[exportOp],
-                             aliasMutableBindings, memoizedZeros);
+                             memoizedZeros);
       }
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -190,11 +190,6 @@ def FuseDispatchBindings :
   let constructor = [{
     mlir::iree_compiler::IREE::Stream::createFuseDispatchBindingsPass()
   }];
-  let options = [
-    Option<"aliasMutableBindings", "alias-mutable-bindings",
-           "bool", /*default=*/"false",
-           "Fuses bindings that are mutable instead of leaving them split.">
-  ];
 }
 
 def SpecializeDispatches :

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-stream-fuse-dispatch-bindings{alias-mutable-bindings=true})' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-stream-fuse-dispatch-bindings)' %s | FileCheck %s
 
 // Test that bindings that are unique are rebased to the widest possible access
 // and to have a 0 offset by passing in the actual offset as operands. The
@@ -8,9 +8,13 @@
 // TODO(benvanik): do this in a canonicalize bindings pass. This should not be
 // happening here!
 
+#aliasConfig = #stream.resource_config<{
+  alias_mutable_bindings = true
+}>
+
 // CHECK-LABEL: @rebaseBindingsEx
 stream.executable private @rebaseBindingsEx {
-  stream.executable.export public @dispatch
+  stream.executable.export public @dispatch attributes {stream.resources = #aliasConfig}
   builtin.module  {
     // CHECK: func.func @dispatch(%[[BINDING_A:.+]]: !stream.binding, %[[BINDING_B:.+]]: !stream.binding,
     // CHECK-SAME:           %[[OFFSET_A:.+]]: index, %[[OFFSET_B:.+]]: index, %[[OPERAND:.+]]: index)
@@ -85,9 +89,13 @@ func.func @rebaseBindings(%operand: index) {
 // in the order of the deduplicated bindings instead of the original order.
 // This is a bit weird and it would be nice to preserve the order in the future.
 
+#aliasConfig = #stream.resource_config<{
+  alias_mutable_bindings = true
+}>
+
 // CHECK-LABEL: @deduplicateBindingsEx
 stream.executable private @deduplicateBindingsEx {
-  stream.executable.export public @dispatch
+  stream.executable.export public @dispatch attributes {stream.resources = #aliasConfig}
   builtin.module  {
     // CHECK: func.func @dispatch(%[[BINDING_A:.+]]: !stream.binding, %[[BINDING_B:.+]]: !stream.binding,
     // CHECK-SAME:           %[[OFFSET_A:.+]]: index, %[[OFFSET_C:.+]]: index, %[[OFFSET_B:.+]]: index, %[[OPERAND:.+]]: index)

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings_noalias.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings_noalias.mlir
@@ -1,13 +1,17 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-stream-fuse-dispatch-bindings{alias-mutable-bindings=false})' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-stream-fuse-dispatch-bindings)' %s | FileCheck %s
 
 // TODO(benvanik): remove this file when aliasing mutable bindings is fixed.
 
 // Tests that bindings that are duplicated at all dispatch sites are folded
 // so long as they are not mutable.
 
+#noaliasConfig = #stream.resource_config<{
+  alias_mutable_bindings = false
+}>
+
 // CHECK-LABEL: @deduplicateBindingsEx
 stream.executable private @deduplicateBindingsEx {
-  stream.executable.export public @dispatch
+  stream.executable.export public @dispatch attributes {stream.resources = #noaliasConfig}
   builtin.module  {
     // CHECK: func.func @dispatch(%[[BINDING_A:.+]]: !stream.binding, %[[BINDING_C:.+]]: !stream.binding,
     // CHECK-SAME:           %[[OFFSET_A:.+]]: index, %[[OFFSET_B:.+]]: index, %[[OFFSET_C:.+]]: index, %[[OPERAND:.+]]: index)

--- a/experimental/web/sample_webgpu/build_sample.sh
+++ b/experimental/web/sample_webgpu/build_sample.sh
@@ -53,6 +53,7 @@ compile_sample() {
     --iree-input-type=$2 \
     --iree-hal-target-backends=webgpu \
     --iree-codegen-gpu-native-math-precision=true \
+    --iree-stream-resource-alias-mutable-bindings=true \
     --o ${BINARY_DIR}/$1_webgpu.vmfb
 }
 

--- a/experimental/web/sample_webgpu/index.html
+++ b/experimental/web/sample_webgpu/index.html
@@ -177,7 +177,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <textarea type="text" readonly spellcheck="false"
     class="form-control" style="width:610px; height:90px; resize:none; font-family: monospace;">
 --iree-hal-target-backends=webgpu \
---iree-codegen-gpu-native-math-precision=true \</textarea>
+--iree-codegen-gpu-native-math-precision=true \
+--iree-stream-resource-alias-mutable-bindings=true \</textarea>
 
   </div>
 


### PR DESCRIPTION
This pass option is currently necessary to run some WebGPU programs correctly, so this adds a compiler flag to set it. Without the option, I see errors like 
```
Writable storage buffer binding aliasing found between [BindGroup] set at bind group index 0, binding index 0, and [BindGroup] set at bind group index 0, binding index 2, with overlapping ranges (offset: 0, size: 256) and (offset: 0, size: 256) in [Buffer].
 - While encoding [ComputePassEncoder].DispatchWorkgroups(1, 5, 1).
 
[Invalid CommandBuffer] is invalid.
    at ValidateObject (../../third_party/dawn/src/dawn/native/Device.cpp:689)
    at ValidateSubmit (../../third_party/dawn/src/dawn/native/Queue.cpp:442)
```

We can't enable the option by default yet, since it causes some severe performance regressions on CUDA: https://github.com/openxla/iree/pull/13323. The tests also have a few suspicious TODOs, but I want to unblock correctness testing on WebGPU before digging in deeper.