### PR TITLE
Disable *-demote-i64-to-i32 by default

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -29,7 +29,7 @@ static llvm::cl::opt<bool> clDemoteI64ToI32(
     "iree-mhlo-demote-i64-to-i32",
     llvm::cl::desc(
         "Converts all MHLO i64 ops and values into i32 counterparts."),
-    llvm::cl::init(true));
+    llvm::cl::init(false));
 static llvm::cl::opt<bool> clDemoteF64ToF32(
     "iree-mhlo-demote-f64-to-f32",
     llvm::cl::desc(

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
@@ -32,7 +32,7 @@ llvm::cl::opt<bool> clDemoteI64ToI32(
     "iree-stablehlo-demote-i64-to-i32",
     llvm::cl::desc(
         "Converts all StableHLO i64 ops and values into i32 counterparts."),
-    llvm::cl::init(true));
+    llvm::cl::init(false));
 llvm::cl::opt<bool> clDemoteF64ToF32(
     "iree-stablehlo-demote-f64-to-f32",
     llvm::cl::desc(
@@ -42,7 +42,7 @@ llvm::cl::opt<bool> clPromoteBF16ToF32(
     "iree-stablehlo-promote-bf16-to-f32",
     llvm::cl::desc(
         "Converts all StableHLO bf16 ops and values into f32 counterparts."),
-    llvm::cl::init(true));
+    llvm::cl::init(false));
 
 void registerStableHLOConversionPassPipeline() {
   PassPipelineRegistration<> stablehlo(


### PR DESCRIPTION
The lower pipeline better supports `i64` values now in comparison to when this was enabled by default. It is valuable to simplify to `i64` for embedded use cases but default should respect the input programs types.

Also disable bf16 promotion as StableHLO is using the outdated value