### PR TITLE
Re-enable bf16 native execution for the StableHLO Path

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
@@ -42,7 +42,7 @@ llvm::cl::opt<bool> clPromoteBF16ToF32(
     "iree-stablehlo-promote-bf16-to-f32",
     llvm::cl::desc(
         "Converts all StableHLO bf16 ops and values into f32 counterparts."),
-    llvm::cl::init(true));
+    llvm::cl::init(false));
 
 void registerStableHLOConversionPassPipeline() {
   PassPipelineRegistration<> stablehlo(

--- a/tests/e2e/stablehlo_ops/BUILD.bazel
+++ b/tests/e2e/stablehlo_ops/BUILD.bazel
@@ -114,7 +114,6 @@ iree_check_single_backend_test_suite(
             "cosine.mlir",
             "divide.mlir",
             "dot.mlir",
-            "dot_bf16.mlir",
             "dot_general.mlir",
             "dynamic_slice.mlir",
             "dynamic_update_slice.mlir",
@@ -159,6 +158,7 @@ iree_check_single_backend_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
+            "dot_bf16.mlir",
             "exponential_fp16.mlir",
         ],
     ),

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -103,7 +103,6 @@ iree_check_single_backend_test_suite(
     "cosine.mlir"
     "divide.mlir"
     "dot.mlir"
-    "dot_bf16.mlir"
     "dot_general.mlir"
     "dynamic_slice.mlir"
     "dynamic_update_slice.mlir"


### PR DESCRIPTION
This flag was erroneously set to true in the new StableHLO path. This should be fixed to match the previous `mhlo` path.