### PR TITLE
Retain the parent channel on a split in iree_hal_nccl_channel_t.

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
+++ b/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
@@ -53,6 +53,11 @@ typedef struct iree_hal_cuda_nccl_channel_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context_wrapper;
 
+  // Parent channel this was split from, if any.
+  // This is only used to keep the parent channel live for as long as there are
+  // any split channels live (including transitive splits).
+  iree_hal_channel_t* parent_channel;
+
   // Hash of the unique ID used to create the communicator.
   // This is consistent with the hashes NCCL itself uses for logging but is not
   // guaranteed to be unique - only use for informational purposes.
@@ -145,6 +150,8 @@ static void iree_hal_cuda_nccl_channel_destroy(
 
   NCCL_IGNORE_ERROR(channel->context_wrapper->syms,
                     ncclCommDestroy(channel->comm));
+
+  iree_hal_channel_release(channel->parent_channel);
   iree_allocator_free(host_allocator, channel);
 
   IREE_TRACE_ZONE_END(z0);
@@ -188,6 +195,8 @@ static iree_status_t iree_hal_cuda_nccl_channel_split(
     iree_hal_resource_initialize(&iree_hal_cuda_nccl_channel_vtable,
                                  &split_channel->resource);
     split_channel->context_wrapper = channel->context_wrapper;
+    split_channel->parent_channel = base_channel;
+    iree_hal_channel_retain(base_channel);
     split_channel->rank = split_rank;
     split_channel->count = split_count;
     split_channel->comm = split_comm;


### PR DESCRIPTION
This may not be required due to split channels being of the same communicator but it doesn't really hurt and other backends using the NCCL implementation as inspiration may require it.