### PR TITLE
Resetting collective batch when the CUDA command buffer arena is set.

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.c
@@ -134,7 +134,7 @@ static void iree_hal_cuda_graph_command_buffer_destroy(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Drop any pending collective batches before we tear things down.
-  iree_hal_collective_batch_reset(&command_buffer->collective_batch);
+  iree_hal_collective_batch_clear(&command_buffer->collective_batch);
 
   if (command_buffer->graph != NULL) {
     CUDA_IGNORE_ERROR(command_buffer->context->syms,
@@ -206,7 +206,7 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_flush_collectives(
       IREE_STATUS_UNIMPLEMENTED,
       "CUDA graph capture of collective operations not yet implemented");
 
-  iree_hal_collective_batch_reset(&command_buffer->collective_batch);
+  iree_hal_collective_batch_clear(&command_buffer->collective_batch);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/utils/collective_batch.c
+++ b/runtime/src/iree/hal/utils/collective_batch.c
@@ -28,7 +28,9 @@ IREE_API_EXPORT void iree_hal_collective_batch_deinitialize(
     iree_hal_collective_batch_t* batch) {
   // Since we are just allocating from the arena we don't need to do anything
   // but clear our pointers for debugging clarity.
-  iree_hal_collective_batch_reset(batch);
+  batch->capacity = 0;
+  batch->count = 0;
+  batch->entries = NULL;
 }
 
 IREE_API_EXPORT bool iree_hal_collective_batch_is_empty(
@@ -36,7 +38,7 @@ IREE_API_EXPORT bool iree_hal_collective_batch_is_empty(
   return batch->count == 0;
 }
 
-IREE_API_EXPORT void iree_hal_collective_batch_reset(
+IREE_API_EXPORT void iree_hal_collective_batch_clear(
     iree_hal_collective_batch_t* batch) {
   // Reset the count to zero but keep the arena storage for reuse.
   // We could memset the contents if we wanted to make debugging easier as ASAN

--- a/runtime/src/iree/hal/utils/collective_batch.h
+++ b/runtime/src/iree/hal/utils/collective_batch.h
@@ -79,8 +79,9 @@ IREE_API_EXPORT void iree_hal_collective_batch_deinitialize(
 IREE_API_EXPORT bool iree_hal_collective_batch_is_empty(
     const iree_hal_collective_batch_t* batch);
 
-// Resets the collective batch and drops all storage.
-IREE_API_EXPORT void iree_hal_collective_batch_reset(
+// Clears the collective batch and discards batches while reusing the same
+// storage. Expects that the arena remains valid.
+IREE_API_EXPORT void iree_hal_collective_batch_clear(
     iree_hal_collective_batch_t* batch);
 
 // Appends a collective operation to the batch.


### PR DESCRIPTION
The stream command buffer in CUDA is special and reused for multiple submissions. The arena is reset each time a new submission comes in but the collective batch was potentially hanging on to a block of memory the arena had used. This always refreshes the collective batch each time the arena is reset.