### PR TITLE
Make reduction/matmul/conv matchers optionally partial

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -53,6 +53,7 @@ iree_lit_test_suite(
             "tile_and_distribute_to_workgroups.mlir",
             "transform_buffer_opt.mlir",
             "transform_dialect_apply_pattern_op.mlir",
+            "transform_match_partial_reduction.mlir",
             "transform_ops_invalid.mlir",
             "transpose_canonicalization.mlir",
             "type_propagation.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_lit_test_suite(
     "tile_and_distribute_to_workgroups.mlir"
     "transform_buffer_opt.mlir"
     "transform_dialect_apply_pattern_op.mlir"
+    "transform_match_partial_reduction.mlir"
     "transform_ops_invalid.mlir"
     "transpose_canonicalization.mlir"
     "type_propagation.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_match_partial_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_match_partial_reduction.mlir
@@ -1,0 +1,43 @@
+// RUN: iree-opt %s --iree-transform-dialect-interpreter --verify-diagnostics --split-input-file
+
+// This can be matched by "reduction_partial" but not by "reduction".
+
+func.func @reduction_with_extra_op_in_func(%arg0: tensor<8x479xf32>, %arg1: tensor<32x32xf32>) -> (tensor<8xf32>, tensor<32xf32>) {
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<8xf32>
+  // expected-remark @below {{fill}}
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
+  // expected-remark @below {{reduction}}
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%arg0 : tensor<8x479xf32>)
+    outs(%fill : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<8xf32>
+
+  %empty2 = tensor.empty() : tensor<32xf32>
+  %fill2 = linalg.fill ins(%cst : f32) outs(%empty2 : tensor<32xf32>) -> tensor<32xf32>
+  return %result, %fill2 : tensor<8xf32>, tensor<32xf32>
+}
+
+transform.sequence failures(propagate) {
+^bb0(%arg0: !transform.any_op):
+  transform.iree.register_match_callbacks
+
+  %leading, %fill, %reduction, %trailing =
+    transform.iree.match_callback failures(propagate) "reduction_partial"(%arg0)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+
+  transform.iree.emit_remark "leading" at %leading : !transform.any_op
+  transform.iree.emit_remark "fill" at %fill : !transform.any_op
+  transform.iree.emit_remark "reduction" at %reduction : !transform.any_op
+  transform.iree.emit_remark "trailing" at %trailing : !transform.any_op
+
+  // expected-error @below {{failed to match}}
+  transform.iree.match_callback failures(propagate) "reduction"(%arg0)
+    : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+}

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
@@ -155,7 +155,8 @@ LogicalResult iree_compiler::cpu::matchAndSetReductionStrategy(
   StructuredOpMatcher *reduction;
   transform_ext::MatchedReductionCaptures captures;
   transform_ext::MatcherContext matcherContext;
-  makeReductionMatcher(matcherContext, reduction, captures);
+  makeReductionMatcher(matcherContext, reduction, captures,
+                       /*mustMatchEntireFunc=*/true);
   if (!matchPattern(op, *reduction)) return failure();
 
   // 2. Construct the configuration and the strategy builder.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -809,7 +809,8 @@ static LogicalResult matchAndSetReductionStrategy(func::FuncOp entryPoint,
   StructuredOpMatcher *reduction;
   transform_ext::MatchedReductionCaptures captures;
   transform_ext::MatcherContext matcherContext;
-  makeReductionMatcher(matcherContext, reduction, captures);
+  makeReductionMatcher(matcherContext, reduction, captures,
+                       /*mustMatchEntireFunc=*/true);
   if (!matchPattern(op, *reduction)) {
     LDBG("--Reduction strategy failed to match\n");
     return failure();
@@ -855,7 +856,8 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
   StructuredOpMatcher *trailing;
   transform_ext::MatchedMatmulCaptures captures;
   transform_ext::MatcherContext matcherContext;
-  makeMatmulMatcher(matcherContext, matmul, fill, trailing, captures);
+  makeMatmulMatcher(matcherContext, matmul, fill, trailing, captures,
+                    /*mustMatchEntireFunc=*/true);
   if (!matchPattern(op, *matmul)) {
     LDBG("--Matmul strategy fail to match\n");
     return failure();


### PR DESCRIPTION
When matching reductions, matmuls or convolutions, make the optional constraint that all tileable operations are matched. This is useful to enable matching prior to dispatch region formation and will remove code duplication in the nvgpu plugin.

This should be a noop for the existing flows.