### PR TITLE
[cuda][rocm] Move target pass management out of LLVMGPU

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -392,7 +392,10 @@ class CUDATargetBackend final : public TargetBackend {
     // ala libdevice.bc, etc).
     if (variantOp.isExternal()) return;
 
-    buildLLVMGPUTransformPassPipeline(passManager, false);
+    buildLLVMGPUTransformPassPipeline(passManager);
+    // Cast address spaces of all function arguments to generic
+    passManager.addPass(createLLVMGPUCastAddressSpaceFunction());
+    passManager.addPass(createConvertToNVVMPass());
   }
 
   LogicalResult serializeExecutable(const SerializationOptions &serOptions,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPasses.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPasses.h
@@ -52,7 +52,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm);
 /// Populates passes needed to lower a XLA HLO op to NVVM/ROCDL dialect via
 /// the structured ops path. The pass manager `pm` in here should operate on
 /// the module within the IREE::HAL::ExecutableOp.
-void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM);
+void buildLLVMGPUTransformPassPipeline(OpPassManager &pm);
 
 /// Performs the final conversion to NNVM+LLVM dialect.
 std::unique_ptr<OperationPass<ModuleOp>> createConvertToNVVMPass();

--- a/compiler/src/iree/compiler/Codegen/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Passes.cpp
@@ -39,19 +39,19 @@ void registerCodegenPasses() {
         buildLLVMCPUCodegenPassPipeline(passManager);
       });
 
-  static PassPipelineRegistration<> LinalgNVVMPipeline(
-      "iree-codegen-linalg-to-nvvm-pipeline",
-      "Runs the progressive lowering pipeline from Linalg to NVVM",
-      [](OpPassManager &passManager) {
-        buildLLVMGPUTransformPassPipeline(passManager, false);
-      });
+  // static PassPipelineRegistration<> LinalgNVVMPipeline(
+  //     "iree-codegen-linalg-to-nvvm-pipeline",
+  //     "Runs the progressive lowering pipeline from Linalg to NVVM",
+  //     [](OpPassManager &passManager) {
+  //       buildLLVMGPUTransformPassPipeline(passManager, false);
+  //     });
 
-  static PassPipelineRegistration<> LinalgROCDLPipeline(
-      "iree-codegen-linalg-to-rocdl-pipeline",
-      "Runs the progressive lowering pipeline from Linalg to ROCDL",
-      [](OpPassManager &passManager) {
-        buildLLVMGPUTransformPassPipeline(passManager, true);
-      });
+  // static PassPipelineRegistration<> LinalgROCDLPipeline(
+  //     "iree-codegen-linalg-to-rocdl-pipeline",
+  //     "Runs the progressive lowering pipeline from Linalg to ROCDL",
+  //     [](OpPassManager &passManager) {
+  //       buildLLVMGPUTransformPassPipeline(passManager, true);
+  //     });
 
   static PassPipelineRegistration<> LinalgSPIRVPipeline(
       "iree-codegen-linalg-to-spirv-pipeline",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -107,7 +107,8 @@ class ROCMTargetBackend final : public TargetBackend {
     // ala libdevice.bc, etc).
     if (variantOp.isExternal()) return;
 
-    buildLLVMGPUTransformPassPipeline(passManager, true);
+    buildLLVMGPUTransformPassPipeline(passManager);
+    passManager.addPass(createConvertToROCDLPass());
   }
 
   LogicalResult serializeExecutable(const SerializationOptions &options,


### PR DESCRIPTION
To generalize LLVMGPU to be applicable to more than just CUDA and ROCM, target codegen passes should be added by the target instead of LLVMGPU.