### PR TITLE
Assert when `createTargetMachine` fails

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -818,6 +818,8 @@ class LLVMCPUTargetBackend final : public TargetBackend {
 
   void initializeConfiguration(const LLVMTargetOptions &options) {
     auto targetMachine = createTargetMachine(options.target, options);
+    // TODO(#13988): proper error propagation. This is a common user scenario.
+    assert(targetMachine && "createTargetMachine failed");
 
     // Data layout
     llvm::DataLayout DL = targetMachine->createDataLayout();


### PR DESCRIPTION
See #13988. This is easy for users to run into, and currently segfaults. Adding an `assert` with a `TODO` linking to that issue is a first step. Hopefully someone else can implement proper error propagation.