### PR TITLE
Route demotion flag to Input options

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.h
@@ -7,12 +7,16 @@
 #ifndef IREE_COMPILER_INPUTCONVERSION_COMMON_PASSES_H_
 #define IREE_COMPILER_INPUTCONVERSION_COMMON_PASSES_H_
 
+#include "iree/compiler/InputConversion/Common/PassDetail.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
 namespace iree_compiler {
+
+#define GEN_PASS_DECL
+#include "iree/compiler/InputConversion/Common/Passes.h.inc"
 
 //===----------------------------------------------------------------------===//
 // Pipelines
@@ -28,6 +32,8 @@ void buildCommonInputConversionPassPipeline(OpPassManager &passManager);
 
 std::unique_ptr<OperationPass<ModuleOp>>
 createAutoInputConversionPipelinePass();
+std::unique_ptr<OperationPass<ModuleOp>> createAutoInputConversionPipelinePass(
+    const AutoInputConversionPipelineOptions& options);
 std::unique_ptr<OperationPass<ModuleOp>> createIREEImportPublicPass();
 std::unique_ptr<OperationPass<ModuleOp>> createImportMLProgramPass();
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.td
@@ -53,6 +53,14 @@ def AutoInputConversionPipeline :
     conversion to run, then run that conversion.
   }];
   let constructor = "mlir::iree_compiler::createAutoInputConversionPipelinePass()";
+  let options = [
+    Option<"demoteI64ToI32", "iree-autoinput-demote-i64-to-i32", "bool",
+           /*default=*/"true", "Convert I64 to I32 equivalents">,
+    Option<"demoteF64ToF32", "iree-autoinput-demote-f64-to-f32", "bool",
+           /*default=*/"false", "Convert F64 to F32 equivalents">,
+    Option<"promoteBF16ToF32", "iree-autoinput-demote-bf16-to-f32", "bool",
+           /*default=*/"false", "Convert BF16 to F32 equivalents">,
+  ];
 }
 
 #endif // IREE_COMPILER_INPUTCONVERSION_COMMON_PASSES

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.h
@@ -16,15 +16,23 @@ namespace iree_compiler::stablehlo {
 
 std::unique_ptr<TypeConverter> createStableHloToLinalgTypeConverter();
 
+struct StableHloOptions : public PassPipelineOptions<StableHloOptions> {
+  bool demoteI64ToI32 = true;
+  bool demoteF64ToF32 = false;
+  bool promoteBF16ToF32 = false;
+};
+
 //===----------------------------------------------------------------------===//
 // Pipelines
 //===----------------------------------------------------------------------===//
 
-void buildStableHLOInputConversionPassPipeline(OpPassManager &passManager);
+void buildStableHLOInputConversionPassPipeline(OpPassManager& passManager,
+                                               const StableHloOptions& options);
 
 // Performs input legalization on programs that may have originated from an XLA
 // import (or made to interop with it).
-void buildStableHLOXLAInputConversionPassPipeline(OpPassManager &passManager);
+void buildStableHLOXLAInputConversionPassPipeline(
+    OpPassManager& passManager, const StableHloOptions& options);
 
 //===----------------------------------------------------------------------===//
 // Register all Passes

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -68,6 +68,23 @@ void InputDialectOptions::bindOptions(OptionsBinder &binder) {
           ),
       // clang-format on
       llvm::cl::cat(category));
+
+#ifdef IREE_HAVE_MHLO_INPUT
+  binder.opt<bool>(
+      "iree-input-demote-i64-to-i32", demoteI64ToI32,
+      llvm::cl::desc("Converts all i64 ops and values into i32 counterparts."),
+      llvm::cl::cat(category));
+
+  binder.opt<bool>(
+      "iree-input-demote-f64-to-f32", demoteF64ToF32,
+      llvm::cl::desc("Converts all f64 ops and values into f32 counterparts."),
+      llvm::cl::cat(category));
+
+  binder.opt<bool>(
+      "iree-input-promote-bf16-to-f32", promoteBF16ToF32,
+      llvm::cl::desc("Converts all bf16 ops and values into f32 counterparts."),
+      llvm::cl::cat(category));
+#endif
 }
 
 void HighLevelOptimizationOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -59,6 +59,10 @@ struct InputDialectOptions {
   };
   Type type = Type::auto_detect;
 
+  bool demoteI64ToI32 = true;
+  bool demoteF64ToF32 = true;
+  bool promoteBF16ToF32 = true;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<InputDialectOptions>;
 };

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -51,18 +51,28 @@ void buildIREEVMTransformPassPipeline(
     hooks.pipelineExtensions->extendInputConversionPreprocessingPassPipeline(
         passManager, inputOptions.type);
   }
+  AutoInputConversionPipelineOptions autoOptions;
+
+#ifdef IREE_HAVE_MHLO_INPUT
+  stablehlo::StableHloOptions stablehloOptions;
+  stablehloOptions.demoteI64ToI32 = inputOptions.demoteI64ToI32;
+  stablehloOptions.demoteF64ToF32 = inputOptions.demoteF64ToF32;
+  stablehloOptions.promoteBF16ToF32 = inputOptions.promoteBF16ToF32;
+#endif
   switch (inputOptions.type) {
     case InputDialectOptions::Type::none:
       break;
     case InputDialectOptions::Type::auto_detect:
-      passManager.addPass(createAutoInputConversionPipelinePass());
+      passManager.addPass(createAutoInputConversionPipelinePass(autoOptions));
       break;
 #ifdef IREE_HAVE_MHLO_INPUT
     case InputDialectOptions::Type::stablehlo:
-      stablehlo::buildStableHLOInputConversionPassPipeline(passManager);
+      stablehlo::buildStableHLOInputConversionPassPipeline(passManager,
+                                                           stablehloOptions);
       break;
     case InputDialectOptions::Type::stablehlo_xla:
-      stablehlo::buildStableHLOXLAInputConversionPassPipeline(passManager);
+      stablehlo::buildStableHLOXLAInputConversionPassPipeline(passManager,
+                                                              stablehloOptions);
       break;
     case InputDialectOptions::Type::mhlo_legacy:
       MHLO::buildMHLOInputConversionPassPipeline(passManager);

--- a/tests/e2e/vulkan_specific/BUILD.bazel
+++ b/tests/e2e/vulkan_specific/BUILD.bazel
@@ -53,7 +53,7 @@ iree_check_single_backend_test_suite(
     ],
     compiler_flags = [
         "--iree-input-type=stablehlo",
-        "--iree-stablehlo-demote-i64-to-i32=false",
+        "--iree-input-demote-i64-to-i32=false",
         "--iree-vulkan-target-triple=valhall-unknown-android31",
     ],
     driver = "vulkan",

--- a/tests/e2e/vulkan_specific/CMakeLists.txt
+++ b/tests/e2e/vulkan_specific/CMakeLists.txt
@@ -55,7 +55,7 @@ iree_check_single_backend_test_suite(
     "vulkan"
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
-    "--iree-stablehlo-demote-i64-to-i32=false"
+    "--iree-input-demote-i64-to-i32=false"
     "--iree-vulkan-target-triple=valhall-unknown-android31"
   LABELS
     "manual"


### PR DESCRIPTION
Demotion should be configuration via the shared object file. The currentl flags are frontend specific. Rerouted the passes so it is configurable via `setFlags` for the libIREECompile.so file.