### PR TITLE
Lowering flow.tensor.alloca (renamed) to stream.async.alloca.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -991,12 +991,12 @@ OpFoldResult TensorStoreOp::fold(FoldAdaptor operands) {
 }
 
 //===----------------------------------------------------------------------===//
-// flow.tensor.alloc
+// flow.tensor.alloca
 //===----------------------------------------------------------------------===//
 
-void TensorAllocOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                                MLIRContext *context) {
-  results.insert<ElideUnusedOp<TensorAllocOp>>(context);
+void TensorAllocaOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                                 MLIRContext *context) {
+  results.insert<ElideUnusedOp<TensorAllocaOp>>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1500,10 +1500,10 @@ LogicalResult TensorStoreOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// flow.tensor.alloc
+// flow.tensor.alloca
 //===----------------------------------------------------------------------===//
 
-LogicalResult TensorAllocOp::verify() {
+LogicalResult TensorAllocaOp::verify() {
   if (failed(verifyOpDynamicDims(getOperation(), {getResult()},
                                  getResultDims()))) {
     return failure();

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1205,7 +1205,7 @@ def FLOW_TensorStoreOp : FLOW_PureOp<"tensor.store", [
   let hasFolder = 1;
 }
 
-def FLOW_TensorAllocOp : FLOW_Op<"tensor.alloc", [
+def FLOW_TensorAllocaOp : FLOW_Op<"tensor.alloca", [
   Util_ShapeAwareOp,
   MemoryEffects<[MemAlloc]>,
 ]> {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -256,11 +256,11 @@ func.func @storeConstScalar() -> tensor<i32> {
 
 // -----
 
-// CHECK-LABEL: @allocDims
+// CHECK-LABEL: @allocaDims
 //  CHECK-SAME: (%[[DIM:.+]]: index)
-func.func @allocDims(%dim: index) -> (index, index, index) {
-  // CHECK-NOT: flow.tensor.alloc
-  %0 = flow.tensor.alloc : tensor<4x?x0xf32>{%dim}
+func.func @allocaDims(%dim: index) -> (index, index, index) {
+  // CHECK-NOT: flow.tensor.alloca
+  %0 = flow.tensor.alloca : tensor<4x?x0xf32>{%dim}
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -80,10 +80,10 @@ func.func @tensorStoreDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index, %arg2 : in
 
 // -----
 
-// CHECK-LABEL: @tensorAlloc
-func.func @tensorAlloc(%arg0: index) -> tensor<?x0x1xf32> {
-  // CHECK-NEXT: = flow.tensor.alloc : tensor<?x0x1xf32>{%arg0}
-  %0 = flow.tensor.alloc : tensor<?x0x1xf32>{%arg0}
+// CHECK-LABEL: @tensorAlloca
+func.func @tensorAlloca(%arg0: index) -> tensor<?x0x1xf32> {
+  // CHECK-NEXT: = flow.tensor.alloca : tensor<?x0x1xf32>{%arg0}
+  %0 = flow.tensor.alloca : tensor<?x0x1xf32>{%arg0}
   return %0 : tensor<?x0x1xf32>
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -67,18 +67,17 @@ struct ConvertTensorReshapeOp
   }
 };
 
-struct ConvertTensorAllocOp
-    : public OpConversionPattern<IREE::Flow::TensorAllocOp> {
+struct ConvertTensorAllocaOp
+    : public OpConversionPattern<IREE::Flow::TensorAllocaOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult matchAndRewrite(
-      IREE::Flow::TensorAllocOp op, OpAdaptor adaptor,
+      IREE::Flow::TensorAllocaOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     Type unknownType = IREE::Stream::ResourceType::get(getContext());
     auto resultSize = buildResultSizeOf(op.getLoc(), op.getResult(),
                                         op.getResultDims(), rewriter);
-    rewriter.replaceOpWithNewOp<IREE::Stream::ResourceAllocOp>(
-        op, unknownType, resultSize,
-        /*uninitialized*/ true, getAffinityFor(op));
+    rewriter.replaceOpWithNewOp<IREE::Stream::AsyncAllocaOp>(
+        op, unknownType, resultSize, getAffinityFor(op));
     return success();
   }
 };
@@ -847,7 +846,7 @@ void populateFlowToStreamConversionPatterns(MLIRContext *context,
                                             TypeConverter &typeConverter,
                                             RewritePatternSet &patterns) {
   patterns
-      .insert<ConvertTensorReshapeOp, ConvertTensorAllocOp,
+      .insert<ConvertTensorReshapeOp, ConvertTensorAllocaOp,
               ConvertTensorEmptyOp, ConvertTensorSplatOp, ConvertTensorCloneOp,
               ConvertTensorSliceOp, ConvertTensorUpdateOp, ConvertTensorLoadOp,
               ConvertTensorStoreOp, ConvertTensorTraceOp>(typeConverter,

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -46,13 +46,13 @@ func.func @tensorReshapeWithMultipleUses(%input: tensor<5x24x48xf32>)
 
 // -----
 
-// CHECK-LABEL: @tensorAlloc
+// CHECK-LABEL: @tensorAlloca
 //  CHECK-SAME: (%[[DIM0:.+]]: index)
-func.func @tensorAlloc(%dim0: index) -> tensor<?x0xf32> {
-  // CHECK: %[[ALLOC_SIZE:.+]] = stream.tensor.sizeof tensor<?x0xf32>{%[[DIM0]]}
-  // CHECK: %[[ALLOC:.+]] = stream.resource.alloc uninitialized : !stream.resource<*>{%[[ALLOC_SIZE]]}
-  %0 = flow.tensor.alloc : tensor<?x0xf32>{%dim0}
-  // CHECK: return %[[ALLOC]]
+func.func @tensorAlloca(%dim0: index) -> tensor<?x0xf32> {
+  // CHECK: %[[ALLOCA_SIZE:.+]] = stream.tensor.sizeof tensor<?x0xf32>{%[[DIM0]]}
+  // CHECK: %[[ALLOCA:.+]] = stream.async.alloca : !stream.resource<*>{%[[ALLOCA_SIZE]]}
+  %0 = flow.tensor.alloca : tensor<?x0xf32>{%dim0}
+  // CHECK: return %[[ALLOCA]]
   return %0 : tensor<?x0xf32>
 }
 


### PR DESCRIPTION
This ensures the allocations end up queue-ordered and their behavior matches that of flow.tensor.empty just uninitialized.