### PR TITLE
Add codegen strategy for GPU padding

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -11,7 +11,7 @@
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Codegen/Common/UserConfig.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
-#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -35,6 +35,7 @@ iree_lit_test_suite(
             "reduction_pipeline.mlir",
             "rocdl_pipeline_test.mlir",
             "set_transform_strategy.mlir",
+            "set_transform_strategy_pad.mlir",
             "illegal_configuration.mlir",
             "layout_analysis_and_distribution.mlir",
             "linalg_transform.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_lit_test_suite(
     "reduction_pipeline_transform.mlir"
     "rocdl_pipeline_test.mlir"
     "set_transform_strategy.mlir"
+    "set_transform_strategy_pad.mlir"
     "tensor_pad.mlir"
     "tensorcore_vectorization.mlir"
     "transform_dialect_bufferize.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy_pad.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy_pad.mlir
@@ -1,0 +1,106 @@
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" \
+// RUN: --iree-codegen-llvmgpu-enable-transform-dialect-pad-strategy | FileCheck %s
+
+// Check that setting the command line options affect the transform
+// strategy as expected.
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" \
+// RUN: --iree-codegen-llvmgpu-enable-transform-dialect-pad-strategy
+// RUN: -td-pad-strategy-blk-size-x=32 \
+// RUN: -td-pad-strategy-blk-size-y=32 \
+// RUN: -td-pad-strategy-blk-size-z=1 \
+// RUN: -td-pad-strategy-num-threads-x=8 \
+// RUN: -td-pad-strategy-num-threads-y=4 \
+// RUN: -td-pad-strategy-num-threads-z=1 \
+// RUN: -td-pad-strategy-vector-size={2, 2} \
+// RUN: -td-pad-strategy-use-async-copies=false \
+// RUN: | FileCheck --check-prefix=WITH_OPTIONS %s
+
+hal.executable @pad {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
+  hal.executable.export public @pad ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @pad() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<123x456xf32>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<128x512xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [123, 456], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<123x456xf32>> -> tensor<123x456xf32>
+
+      %pad = arith.constant 0.0 : f32
+      %padded = tensor.pad %3 low[0, 0] high[5, 56] {
+        ^bb0(%arg1: index, %arg2: index):
+          tensor.yield %pad : f32
+      } : tensor<123x456xf32> to tensor<128x512xf32>
+
+      flow.dispatch.tensor.store %padded, %2, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : tensor<128x512xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x512xf32>>
+      return
+    }
+  }
+}
+}
+
+// CHECK-LABEL: func @pad
+//       CHECK:   transform.sequence  failures(propagate) {
+//       CHECK:   transform.iree.register_match_callbacks
+//       CHECK:   {{.*}} = transform.iree.match_callback failures(propagate) "pad"({{.*}}) : (!transform.any_op) -> !transform.any_op
+//       CHECK:   transform.structured.tile_to_forall_op {{.*}}   num_threads [] tile_sizes [64, 64](mapping = [#gpu.block<y>, #gpu.block<x>]) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+//       CHECK:   transform.iree.apply_patterns {{.*}} {canonicalization, cse, licm, tiling_canonicalization} : (!transform.any_op) -> ()
+//       CHECK:   {{.*}} = transform.structured.match ops{["scf.if"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       CHECK:   transform.scf.take_assumed_branch {{.*}} take_else_branch : (!transform.any_op) -> ()
+//       CHECK:   transform.iree.populate_workgroup_count_region_using_num_threads_slice {{.*}} : (!transform.any_op) -> ()
+//       CHECK:   {{.*}} = transform.structured.tile_to_forall_op {{.*}}   num_threads [16, 16] tile_sizes [](mapping = [#gpu.thread<y>, #gpu.thread<x>]) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+//       CHECK:   transform.iree.apply_patterns {{.*}} {canonicalization, cse, licm, tiling_canonicalization} : (!transform.any_op) -> ()
+//       CHECK:   {{.*}} = transform.structured.match ops{["scf.if"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       CHECK:   transform.scf.take_assumed_branch {{.*}} take_else_branch : (!transform.any_op) -> ()
+//       CHECK:   transform.structured.masked_vectorize {{.*}} vector_sizes [4, 4] : !transform.any_op
+//       CHECK:   {{.*}} = transform.structured.match ops{["func.func"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       CHECK:     transform.apply_patterns.vector.lower_masked_transfers
+//       CHECK:   transform.iree.apply_patterns {{.*}} {rank_reducing_linalg, rank_reducing_vector} : (!transform.any_op) -> ()
+//       CHECK:   {{.*}} = transform.structured.vectorize {{.*}} : (!transform.any_op) -> !transform.any_op
+//       CHECK:   transform.iree.apply_patterns {{.*}} {canonicalization, cse, licm, tiling_canonicalization} : (!transform.any_op) -> ()
+//       CHECK:   transform.iree.eliminate_empty_tensors {{.*}} : (!transform.any_op) -> ()
+//       CHECK:   {{.*}} = transform.iree.bufferize {target_gpu} {{.*}} : (!transform.any_op) -> !transform.any_op
+//       CHECK:   {{.*}} = transform.structured.match ops{["func.func"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       CHECK:   transform.iree.erase_hal_descriptor_type_from_memref {{.*}} : (!transform.any_op) -> ()
+//       CHECK:   transform.iree.apply_buffer_optimizations {{.*}} : (!transform.any_op) -> ()
+//       CHECK:   {{.*}} = transform.structured.match ops{["func.func"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       CHECK:   transform.iree.forall_to_workgroup {{.*}} : (!transform.any_op) -> ()
+//       CHECK:   transform.iree.map_nested_forall_to_gpu_threads {{.*}} workgroup_dims = [64, 64, 1] warp_dims = [] : (!transform.any_op) -> ()
+//       CHECK:     transform.apply_patterns.vector.lower_masks
+//       CHECK:     transform.apply_patterns.vector.materialize_masks
+//       CHECK:   transform.iree.apply_patterns {{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization} : (!transform.any_op) -> ()
+
+// WITH_OPTIONS-LABEL: func @pad
+//       WITH_OPTIONS:   transform.sequence  failures(propagate) {
+//       WITH_OPTIONS:   transform.iree.register_match_callbacks
+//       WITH_OPTIONS:   {{.*}} = transform.iree.match_callback failures(propagate) "pad"({{.*}}) : (!transform.any_op) -> !transform.any_op
+//       WITH_OPTIONS:   transform.structured.tile_to_forall_op {{.*}}   num_threads [] tile_sizes [64, 64](mapping = [#gpu.block<y>, #gpu.block<x>]) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+//       WITH_OPTIONS:   transform.iree.apply_patterns {{.*}} {canonicalization, cse, licm, tiling_canonicalization} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   {{.*}} = transform.structured.match ops{["scf.if"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       WITH_OPTIONS:   transform.scf.take_assumed_branch {{.*}} take_else_branch : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   transform.iree.populate_workgroup_count_region_using_num_threads_slice {{.*}} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   {{.*}} = transform.structured.tile_to_forall_op {{.*}}   num_threads [16, 16] tile_sizes [](mapping = [#gpu.thread<y>, #gpu.thread<x>]) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+//       WITH_OPTIONS:   transform.iree.apply_patterns {{.*}} {canonicalization, cse, licm, tiling_canonicalization} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   {{.*}} = transform.structured.match ops{["scf.if"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       WITH_OPTIONS:   transform.scf.take_assumed_branch {{.*}} take_else_branch : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   transform.structured.masked_vectorize {{.*}} vector_sizes [4, 4] : !transform.any_op
+//       WITH_OPTIONS:   {{.*}} = transform.structured.match ops{["func.func"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       WITH_OPTIONS:     transform.apply_patterns.vector.lower_masked_transfers
+//       WITH_OPTIONS:   transform.iree.apply_patterns {{.*}} {rank_reducing_linalg, rank_reducing_vector} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   {{.*}} = transform.structured.vectorize {{.*}} : (!transform.any_op) -> !transform.any_op
+//       WITH_OPTIONS:   transform.iree.apply_patterns {{.*}} {canonicalization, cse, licm, tiling_canonicalization} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   transform.iree.eliminate_empty_tensors {{.*}} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   {{.*}} = transform.iree.bufferize {target_gpu} {{.*}} : (!transform.any_op) -> !transform.any_op
+//       WITH_OPTIONS:   {{.*}} = transform.structured.match ops{["func.func"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       WITH_OPTIONS:   transform.iree.erase_hal_descriptor_type_from_memref {{.*}} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   transform.iree.apply_buffer_optimizations {{.*}} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   {{.*}} = transform.structured.match ops{["func.func"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
+//       WITH_OPTIONS:   transform.iree.forall_to_workgroup {{.*}} : (!transform.any_op) -> ()
+//       WITH_OPTIONS:   transform.iree.map_nested_forall_to_gpu_threads {{.*}} workgroup_dims = [64, 64, 1] warp_dims = [] : (!transform.any_op) -> ()
+//       WITH_OPTIONS:     transform.apply_patterns.vector.lower_masks
+//       WITH_OPTIONS:     transform.apply_patterns.vector.materialize_masks
+//       WITH_OPTIONS:   transform.iree.apply_patterns {{.*}} {canonicalization, cse, fold_memref_aliases, licm, tiling_canonicalization} : (!transform.any_op) -> ()

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/BUILD.bazel
@@ -17,8 +17,10 @@ iree_compiler_cc_library(
     srcs = [
         "Common.cpp",
         "MatmulTensorCoreStrategy.cpp",
+        "PadStrategy.cpp",
         "SmallReductionStrategy.cpp",
         "StagedReductionStrategy.cpp",
+        "Strategies.cpp",
     ],
     hdrs = [
         "AbstractGemmLikeStrategy.h",
@@ -26,6 +28,7 @@ iree_compiler_cc_library(
         "MatmulTensorCoreStrategy.h",
         "SmallReductionStrategy.h",
         "StagedReductionStrategy.h",
+        "Strategies.h",
     ],
     deps = [
         # Dialects

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/BUILD.bazel
@@ -26,6 +26,7 @@ iree_compiler_cc_library(
         "AbstractGemmLikeStrategy.h",
         "Common.h",
         "MatmulTensorCoreStrategy.h",
+        "PadStrategy.h",
         "SmallReductionStrategy.h",
         "StagedReductionStrategy.h",
         "Strategies.h",

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/CMakeLists.txt
@@ -19,11 +19,14 @@ iree_cc_library(
     "MatmulTensorCoreStrategy.h"
     "SmallReductionStrategy.h"
     "StagedReductionStrategy.h"
+    "Strategies.h"
   SRCS
     "Common.cpp"
     "MatmulTensorCoreStrategy.cpp"
+    "PadStrategy.cpp"
     "SmallReductionStrategy.cpp"
     "StagedReductionStrategy.cpp"
+    "Strategies.cpp"
   DEPS
     IREEDialectsTransforms
     IREELinalgExtDialect

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_cc_library(
     "AbstractGemmLikeStrategy.h"
     "Common.h"
     "MatmulTensorCoreStrategy.h"
+    "PadStrategy.h"
     "SmallReductionStrategy.h"
     "StagedReductionStrategy.h"
     "Strategies.h"

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -9,15 +9,11 @@
 #include <tuple>
 
 #include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
+#include "iree-dialects/Transforms/TransformMatchers.h"
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h"
-#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.h"
-#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -37,21 +33,6 @@
 
 using namespace mlir;
 
-#define DEBUG_TYPE "iree-transform-builder"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << '[' << DEBUG_TYPE << "] " << X)
-
-llvm::cl::opt<bool> clGPUEnableTransformDialectMatmulTensorCoreStrategy(
-    "iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy",
-    llvm::cl::desc("activate the matmul tensorcore strategy"),
-    llvm::cl::init(true));
-
-llvm::cl::opt<bool> clGPUEnableTransformDialectAlignedMatmul(
-    "iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul",
-    llvm::cl::desc(
-        "activate the matmul tensorcore strategy for tile aligned shapes"),
-    llvm::cl::init(false));
-
 // TODO: significantly better namespacing.
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
@@ -69,17 +50,7 @@ using iree_compiler::gpu::AbstractGemmLikeStrategy;
 using iree_compiler::gpu::build1DSplittingStrategyWithOptionalThreadMapping;
 using iree_compiler::gpu::buildCommonTrailingStrategy;
 using iree_compiler::gpu::buildMapToBlockAndThreads;
-using iree_compiler::gpu::buildSmallReductionStrategy;
-using iree_compiler::gpu::buildStagedReductionStrategy;
 using iree_compiler::gpu::GPUModel;
-using iree_compiler::gpu::kCudaMaxNumThreads;
-using iree_compiler::gpu::kCudaMaxVectorLoadBitWidth;
-using iree_compiler::gpu::kCudaWarpSize;
-using iree_compiler::gpu::ReductionConfig;
-using iree_compiler::gpu::ReductionStrategy;
-using iree_compiler::gpu::scaleUpByBitWidth;
-using iree_compiler::gpu::SmallReductionStrategy;
-using iree_compiler::gpu::StagedReductionStrategy;
 using iree_compiler::IREE::transform_dialect::ApplyBufferOptimizationsOp;
 using iree_compiler::IREE::transform_dialect::IREEBufferizeOp;
 using iree_compiler::IREE::transform_dialect::IREEEliminateEmptyTensorsOp;
@@ -93,9 +64,6 @@ using transform::MatchOp;
 using transform::RewriteInDestinationPassingStyleOp;
 using transform::ScalarizeOp;
 using transform::SequenceOp;
-using transform_ext::MatchCallbackOp;
-using transform_ext::RegisterMatchCallbacksOp;
-using transform_ext::StructuredOpMatcher;
 
 //===----------------------------------------------------------------------===//
 // General helpers.
@@ -683,271 +651,4 @@ Value mlir::iree_compiler::gpu::buildBufferize(ImplicitLocOpBuilder &b,
   b.create<IREEEraseHALDescriptorTypeFromMemRefOp>(memrefFunc);
   b.create<ApplyBufferOptimizationsOp>(memrefFunc);
   return variantH;
-}
-
-//===----------------------------------------------------------------------===//
-// Higher-level problem-specific strategy creation APIs, these should favor
-// user-friendliness.
-//===----------------------------------------------------------------------===//
-
-/// Placeholder to encode fixed reductions that should take finer-grained
-/// precedence over other heuristics. In the future, this could be lifted to
-/// e.g. `gpuModel` or higher up in some transform dialect database summary of
-/// "known good things".
-static FailureOr<ReductionConfig> applyKnownGoodReductionConfigurations(
-    const transform_ext::MatchedReductionCaptures &captures,
-    const GPUModel &gpuModel) {
-  auto staged = ReductionStrategy::Staged;
-  int64_t reductionSize = captures.reductionOpSizes.back();
-  if (gpuModel.model == GPUModel::kDefaultGPU) {
-    if (captures.reductionOutputElementalTypeBitWidth == 32) {
-      if (reductionSize == 64)
-        return ReductionConfig{/*maxNumThreads=*/64, /*vectorSize=*/1, staged};
-      if (reductionSize == 128)
-        return ReductionConfig{/*maxNumThreads=*/32, /*vectorSize=*/4, staged};
-      if (reductionSize == 512)
-        return ReductionConfig{/*maxNumThreads=*/256, /*vectorSize=*/2, staged};
-    }
-  }
-  return failure();
-}
-
-/// The configurations below have been determined empirically by performing a
-/// manual tradeoff between problem size, amount of parallelism and vector
-/// size on a particular NVIDIA RTX2080Ti 12GB card. This is a coarse tradeoff
-/// that should generally give reasonably good results but that begs to be
-/// complemented by hardcoded known good configurations and ultimately a
-/// database and/or a random forest compression of configurations with
-/// guaranteed performance.
-// TODO: Lift some of the strategy sizing logic as hints and/or heuristics to
-// also work properly in the dynamic case.
-// TODO: Support more HW configs and make it more pluggable.
-static ReductionConfig getReductionConfig(
-    const transform_ext::MatchedReductionCaptures &captures,
-    const GPUModel &gpuModel) {
-  auto maybeHardcodedConfiguration =
-      applyKnownGoodReductionConfigurations(captures, gpuModel);
-  if (succeeded(maybeHardcodedConfiguration))
-    return *maybeHardcodedConfiguration;
-
-  //===--------------------------------------------------------------------===//
-  // Small reduction strategy.
-  //===--------------------------------------------------------------------===//
-  // Dynamic reductions are never supported by default because we can
-  // never know offhand whether we are in a small-reduction regime mode.
-  // Since this mode does not coalesce reads, perf will suffer
-  // catastrophically on larger runtime reduction.
-  // TODO: explicit hint from above that we really want to do that.
-  int64_t redSize = captures.reductionOpSizes.back();
-  bool isDynamicReduction = ShapedType::isDynamic(redSize);
-  // Otherwise, still only support the small cases for now and fall back to
-  // other strategies otherwise.
-  bool isSmallReduction = (redSize < 2 * kCudaWarpSize);
-  if (!isDynamicReduction && isSmallReduction) {
-    int64_t maxNumThreads = 4 * kCudaWarpSize;
-    return ReductionConfig{maxNumThreads, 0, ReductionStrategy::Small};
-  }
-
-  //===--------------------------------------------------------------------===//
-  // Staged reduction strategy.
-  //===--------------------------------------------------------------------===//
-  int64_t bitWidth = captures.reductionOutputElementalTypeBitWidth;
-  int64_t vectorSize = scaleUpByBitWidth(4, bitWidth);
-  int64_t maxNumThreads = 8 * kCudaWarpSize;
-  // No adjustments in the dynamic case, we need extra information to make a
-  // good decision.
-  if (ShapedType::isDynamic(redSize))
-    return ReductionConfig{maxNumThreads, vectorSize,
-                           ReductionStrategy::Staged};
-  // Scale down to smaller sizes (4, 8, 16)-warps.
-  if (scaleUpByBitWidth(redSize, bitWidth) <= 4 * kCudaWarpSize) {
-    vectorSize = scaleUpByBitWidth(1, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
-  } else if (scaleUpByBitWidth(redSize, bitWidth) <= 8 * kCudaWarpSize) {
-    vectorSize = scaleUpByBitWidth(2, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
-  } else if (scaleUpByBitWidth(redSize, bitWidth) <= 8 * 2 * kCudaWarpSize) {
-    vectorSize = scaleUpByBitWidth(4, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
-  }
-  // Scale up to larger sizes (32, 64, 128+)-warps, using vector-4.
-  if (!captures.trailingOpSizes.empty()) {
-    if (scaleUpByBitWidth(redSize, bitWidth) >= 128 * 4 * kCudaWarpSize) {
-      vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 32 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 64 * 4 * kCudaWarpSize) {
-      vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 16 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 32 * 4 * kCudaWarpSize) {
-      vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 8 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 16 * 4 * kCudaWarpSize) {
-      vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 4 * kCudaWarpSize;
-    }
-  }
-  return ReductionConfig{maxNumThreads, vectorSize, ReductionStrategy::Staged};
-}
-
-/// Map an N-D parallel, 1-D reduction operation with optional leading and
-/// optional trailing elementwise operations.
-/// The 1-D reduction dimension must be in the most minor dimension.
-/// The innermost dimensions of the leading and trailing operations must be
-/// most minor along all accesses. Return failure if matching fails. On a
-/// successful match, configure a reduction strategy based on a proxy model of
-/// the hardware and construct transform dialect IR that implements the
-/// reduction strategy. The transform dialect IR is added in a top-level
-/// ModuleOp after the `entryPoint` func::FuncOp.
-static LogicalResult matchAndSetReductionStrategy(func::FuncOp entryPoint,
-                                                  linalg::LinalgOp op,
-                                                  const GPUModel &gpuModel) {
-  if (!gpuModel.hasWarpShuffle) {
-    LDBG("--Reduction strategy no warp shuffle\n");
-    return failure();
-  }
-
-  // 1. Match a reduction and surrounding ops.
-  StructuredOpMatcher *reduction;
-  transform_ext::MatchedReductionCaptures captures;
-  transform_ext::MatcherContext matcherContext;
-  makeReductionMatcher(matcherContext, reduction, captures,
-                       /*mustMatchEntireFunc=*/true);
-  if (!matchPattern(op, *reduction)) {
-    LDBG("--Reduction strategy failed to match\n");
-    return failure();
-  }
-
-  // 2. Construct the configuration and the strategy builder.
-  // TODO: Generalize along the HW axis.
-  auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
-    ReductionConfig reductionConfig = getReductionConfig(captures, gpuModel);
-    if (reductionConfig.strategy == ReductionStrategy::Small) {
-      SmallReductionStrategy strategy(captures, reductionConfig);
-      return buildSmallReductionStrategy(b, variant, strategy);
-    } else if (reductionConfig.strategy == ReductionStrategy::Staged) {
-      // Otherwise, always fallback to the staged strategy.
-      StagedReductionStrategy strategy(captures, reductionConfig);
-      return buildStagedReductionStrategy(b, variant, strategy);
-    } else {
-      return llvm_unreachable("Unknown strategy");
-    }
-  };
-
-  // 3. Build strategy embedded into the IR.
-  mlir::iree_compiler::createTransformRegion(entryPoint, strategyBuilder);
-
-  return success();
-}
-
-static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
-                                               linalg::LinalgOp op,
-                                               const GPUModel &gpuModel) {
-  if (!clGPUEnableTransformDialectMatmulTensorCoreStrategy) {
-    LDBG("--Matmul strategy flag turned off\n");
-    return failure();
-  }
-  if (!gpuModel.hasTF32TensorCore) {
-    LDBG("--Matmul strategy no TF32 tensor core\n");
-    return failure();
-  }
-
-  // 1. Match a reduction and surrounding ops.
-  StructuredOpMatcher *fill;
-  StructuredOpMatcher *matmul;
-  StructuredOpMatcher *trailing;
-  transform_ext::MatchedMatmulCaptures captures;
-  transform_ext::MatcherContext matcherContext;
-  makeMatmulMatcher(matcherContext, matmul, fill, trailing, captures,
-                    /*mustMatchEntireFunc=*/true);
-  if (!matchPattern(op, *matmul)) {
-    LDBG("--Matmul strategy fail to match\n");
-    return failure();
-  }
-
-  // We are very peculiar about the dispatches we want to match for now:
-  //   - f32 only atm.
-  //   - Mandatory fill op.
-  //   - No trailing op.
-  //   - If the matmul is "too aligned", then guard on the alignment flag.
-  //   - If the matmul is "too small", then use the default IREE strategy.
-  //   - Otherwise, we take it.
-  if (!fill->getCaptured() || trailing->getCaptured()) {
-    LDBG("--Matmul strategy fill / trailing preconditions failed\n");
-    return failure();
-  }
-
-  if (!captures.lhsElementType.isF32() || !captures.rhsElementType.isF32() ||
-      !captures.outputElementType.isF32()) {
-    LDBG("--Matmul strategy elemental type check failed\n");
-    return failure();
-  }
-
-  // TODO: Generalize to a good mix of sizes, alignments and element types.
-  const auto &matmulSize = captures.matmulOpSizes;
-  if (matmulSize.size() != 3) {
-    LDBG("--Matmul strategy size capture failed\n");
-    return failure();
-  }
-
-  // Currently the fully aligned case still lags behind the current default
-  // pipeline and thus is guarded by a flag. This is the case when at least one
-  // of the following holds
-  //   - m is tile aligned (conservatively, take 64)
-  //   - n is tile aligned (conservatively, take 64)
-  //   - k is tile aligned (conservatively, take 16)
-  bool guardedAlignedCases = matmulSize[0] % 64 == 0 ||
-                             matmulSize[1] % 64 == 0 || matmulSize[2] % 16 == 0;
-
-  if (guardedAlignedCases && !clGPUEnableTransformDialectAlignedMatmul) {
-    LDBG("--Matmul strategy alignment check failed\n");
-    return failure();
-  }
-
-  // Currently the unaligned transform strategy does not properly handle
-  // degenerate dimensions that should have been rank-reduced (e.g. `1`).
-  // Also, it is unprofitable to force small matmuls through a high latency
-  // tensorcore path, we are better off with a simple simt strategy.
-  // TODO: profitability details can be ironed out in the future when we have a
-  // heuristic to better select strategy parameters.
-  bool unsupportedSmallCases = (matmulSize[0] > 0 && matmulSize[0] < 8) ||
-                               (matmulSize[1] > 0 && matmulSize[1] < 8) ||
-                               (matmulSize[2] > 0 && matmulSize[2] < 8);
-  if (unsupportedSmallCases) {
-    LDBG("--Matmul strategy small size check failed\n");
-    return failure();
-  }
-
-  // 2. Construct the configuration and the strategy builder.
-  // TODO: Generalize along the HW axis.
-  auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
-    iree_compiler::gpu::MatmulStrategy strategy(op->getContext(), captures);
-    return buildMatmulTensorCoreStrategy(b, variant, strategy);
-  };
-
-  // 3. Build strategy embedded into the IR.
-  mlir::iree_compiler::createTransformRegion(entryPoint, strategyBuilder);
-
-  return success();
-}
-
-LogicalResult mlir::iree_compiler::gpu::matchAndSetTransformStrategy(
-    func::FuncOp entryPoint, Operation *op, const GPUModel &gpuModel) {
-  LDBG("Look up a TD strategy for entryPoint:\n" << entryPoint << "\n");
-  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-  if (!linalgOp) {
-    LDBG("Not a Linalg op: " << *op << " -> Fail\n");
-    return failure();
-  }
-  if (succeeded(matchAndSetReductionStrategy(entryPoint, linalgOp, gpuModel))) {
-    LDBG("Activate reduction strategy\n");
-    return success();
-  }
-  if (succeeded(matchAndSetMatmulStrategy(entryPoint, linalgOp, gpuModel))) {
-    LDBG("Activate matmul\n");
-    return success();
-  }
-  // TODO: Add more transform dialect strategy for other kind of dispatch
-  // regions.
-  LDBG("No suitable strategy found\n");
-  return failure();
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h
@@ -189,29 +189,6 @@ Value buildBufferize(ImplicitLocOpBuilder &b, Value variantH);
 // Higher-level problem-specific strategy creation APIs, these should favor
 // user-friendliness.
 //===----------------------------------------------------------------------===//
-/// Structure to hold a summary of HW-derived properties to configure the
-/// reduction strategy.
-/// The objective of this struct is to act as a minimal summary of key
-/// properties derived from the hardware (e.g. by an oracle) and that are
-/// sufficient to steer the strategy to produce a good version.
-/// These can be thought of as latent variables or embeddings that directly
-/// control the strategy and can be derived from the hardware by some procedure.
-enum class ReductionStrategy { Small, Staged };
-struct ReductionConfig {
-  int64_t maxNumThreads;
-  int64_t vectorSize;
-  ReductionStrategy strategy;
-};
-
-/// Placeholder for some hardware model proxy that contains relevant information
-/// to configure the reduction strategy. In the future, this will need to be
-/// driven by some contract with the runtime.
-struct GPUModel {
-  static constexpr StringLiteral kDefaultGPU = "DefaultGPU";
-  StringRef model = kDefaultGPU;
-  bool hasWarpShuffle = false;
-  bool hasTF32TensorCore = false;
-};
 
 /// Try to find an exisiting transform dialect strategy for a given entry point.
 LogicalResult matchAndSetTransformStrategy(func::FuncOp entryPoint,

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -136,9 +136,6 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
   LLVM_DUMP_METHOD void dump() const;
 };
 
-void buildMatmulTensorCoreStrategy(ImplicitLocOpBuilder &b, Value variantH,
-                                   const MatmulStrategy &strategy);
-
 }  // namespace gpu
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/PadStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/PadStrategy.cpp
@@ -50,44 +50,22 @@ using iree_compiler::IREE::transform_dialect::
 using transform::MatchOp;
 using transform_ext::RegisterMatchCallbacksOp;
 
-/// Block tile size X, Y, Z.
-static llvm::cl::opt<int64_t> clBlockTileSizeX(
-    "td-pad-strategy-blk-size-x",
-    llvm::cl::desc("block tile size for dim X (x,y,z) for the transform "
+static llvm::cl::list<int64_t> clBlockTileSizes(
+    "td-pad-strategy-blk-sizes",
+    llvm::cl::desc("block tile sizes for dims (x,y,z) for the transform "
                    "dialect pad strategy"),
-    llvm::cl::init(64));
-static llvm::cl::opt<int64_t> clBlockTileSizeY(
-    "td-pad-strategy-blk-size-y",
-    llvm::cl::desc("block tile size for dim Y (x,y,z) for the transform "
+    llvm::cl::list_init(ArrayRef<int64_t>{64, 64, 1}),
+    llvm::cl::CommaSeparated);
+static llvm::cl::list<int64_t> clNumThreads(
+    "td-pad-strategy-num-threads",
+    llvm::cl::desc("number of threads for dims (x,y,z) for the transform "
                    "dialect pad strategy"),
-    llvm::cl::init(64));
-static llvm::cl::opt<int64_t> clBlockTileSizeZ(
-    "td-pad-strategy-blk-size-z",
-    llvm::cl::desc("block tile size for dim z (x,y,z) for the transform "
-                   "dialect pad strategy"),
-    llvm::cl::init(1));
-
-/// Number of threads X, Y, Z.
-static llvm::cl::opt<int64_t> clNumThreadsX(
-    "td-pad-strategy-num-threads-x",
-    llvm::cl::desc("number of threads for dim X (x,y,z) for the transform "
-                   "dialect pad strategy"),
-    llvm::cl::init(16));
-static llvm::cl::opt<int64_t> clNumThreadsY(
-    "td-pad-strategy-num-threads-y",
-    llvm::cl::desc("number of threads for dim Y (x,y,z) for the transform "
-                   "dialect pad strategy"),
-    llvm::cl::init(16));
-static llvm::cl::opt<int64_t> clNumThreadsZ(
-    "td-pad-strategy-num-threads-z",
-    llvm::cl::desc("number of threads for dim z (x,y,z) for the transform "
-                   "dialect pad strategy"),
-    llvm::cl::init(1));
-
+    llvm::cl::list_init(ArrayRef<int64_t>{16, 16, 1}),
+    llvm::cl::CommaSeparated);
 static llvm::cl::list<int64_t> clVectorSize(
     "td-pad-strategy-vector-size",
-    llvm::cl::desc("vector size  for the transform dialect pad strategy"),
-    llvm::cl::list_init(ArrayRef<int64_t>{4, 4}));
+    llvm::cl::desc("vector size for the transform dialect pad strategy"),
+    llvm::cl::list_init(ArrayRef<int64_t>{4, 4}), llvm::cl::CommaSeparated);
 static llvm::cl::opt<bool> clUseAsyncCopies(
     "td-pad-strategy-use-async-copies",
     llvm::cl::desc(
@@ -95,8 +73,9 @@ static llvm::cl::opt<bool> clUseAsyncCopies(
     llvm::cl::init(false));
 
 void iree_compiler::gpu::PadStrategy::initDefaultValues() {
-  blockTileSizes = {clBlockTileSizeX, clBlockTileSizeY, clBlockTileSizeZ};
-  numThreads = {clNumThreadsX, clNumThreadsY, clNumThreadsZ};
+  blockTileSizes =
+      SmallVector<int64_t>{clBlockTileSizes.begin(), clBlockTileSizes.end()};
+  numThreads = SmallVector<int64_t>{clNumThreads.begin(), clNumThreads.end()};
   vectorSize = SmallVector<int64_t>{clVectorSize.begin(), clVectorSize.end()};
   useAsyncCopies = clUseAsyncCopies;
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/PadStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/PadStrategy.h
@@ -37,6 +37,13 @@ class PadStrategy {
   void initDefaultValues();
   void configure(GPUModel gpuModel);
 
+  int64_t blockTileSizeX() const { return blockTileSizes[0]; }
+  int64_t blockTileSizeY() const { return blockTileSizes[1]; }
+  int64_t blockTileSizeZ() const { return blockTileSizes[2]; }
+  int64_t numThreadsX() const { return numThreads[0]; }
+  int64_t numThreadsY() const { return numThreads[1]; }
+  int64_t numThreadsZ() const { return numThreads[2]; }
+
   /// Constructor quantities.
   MLIRContext *ctx;
   transform_ext::MatchedPadCaptures captures;

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/PadStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/PadStrategy.h
@@ -1,0 +1,57 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_PAD_STRATEGY_H_
+#define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_PAD_STRATEGY_H_
+
+#include <array>
+
+#include "iree-dialects/Transforms/TransformMatchers.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace gpu {
+
+struct GPUModel;
+
+struct PadConfig {};
+
+/// Simple padding strategy.
+class PadStrategy {
+ public:
+  PadStrategy(MLIRContext *context,
+              const transform_ext::MatchedPadCaptures &captures,
+              const PadConfig &config)
+      : ctx(context), captures(captures) {
+    initDefaultValues();
+    (void)config;
+  }
+
+  PadStrategy(const PadStrategy &) = default;
+  PadStrategy &operator=(const PadStrategy &) = default;
+
+  void initDefaultValues();
+  void configure(GPUModel gpuModel);
+
+  /// Constructor quantities.
+  MLIRContext *ctx;
+  transform_ext::MatchedPadCaptures captures;
+
+  /// Tile sizes for the workgroup / determines grid size for all known
+  /// reduction strategies.
+  SmallVector<int64_t> blockTileSizes;
+  SmallVector<int64_t> numThreads;
+  SmallVector<int64_t> vectorSize;
+  // TODO: implement this case.
+  bool useAsyncCopies = false;
+};
+
+}  // namespace gpu
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_PAD_STRATEGY_H_

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.h
@@ -17,6 +17,7 @@ namespace iree_compiler {
 namespace gpu {
 
 struct GPUModel;
+struct ReductionConfig;
 
 /// Encode a strategy targeted at (very) small reductions, for which other
 /// strategies perform poorly.
@@ -61,12 +62,6 @@ class SmallReductionStrategy : public AbstractReductionStrategy {
   /// `maxNumThreadsToUse`.
   void configure(const ReductionConfig &reductionConfig);
 };
-
-/// Build the transform IR tiling reductions for the whole GPU.
-/// Supports reductions in the last dimension, with optional leading and
-/// trailing elementwise operations.
-void buildSmallReductionStrategy(ImplicitLocOpBuilder &b, Value variantH,
-                                 const SmallReductionStrategy &strategy);
 
 }  // namespace gpu
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h"
 #include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.h
@@ -15,6 +15,7 @@ namespace iree_compiler {
 namespace gpu {
 
 struct GPUModel;
+struct ReductionConfig;
 
 /// Encode a 3-staged strategy for a 1-d reduction mapped to a block.
 ///
@@ -81,14 +82,6 @@ class StagedReductionStrategy : public AbstractReductionStrategy {
   /// This is also the blockDim.x of the kernel.
   int64_t numThreadsXInBlock;
 };
-
-/// Entry point to build the transform IR corresponding to a staged reduction
-/// strategy.
-/// This is used for mapping a N-D parallel, 1-D reduction operation.
-/// The 1-D reduction dimensions must be in the most minor dimension.
-/// Supports an optional leading and an optional trailing elementwise operation.
-void buildStagedReductionStrategy(ImplicitLocOpBuilder &b, Value variantH,
-                                  const StagedReductionStrategy &strategy);
 
 }  // namespace gpu
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.cpp
@@ -1,0 +1,436 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.h"
+
+#include <tuple>
+
+#include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
+#include "iree-dialects/Transforms/TransformMatchers.h"
+#include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
+#include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.h"
+#include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/TransformOps/SCFTransformOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/IR/TransformOps.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/TypeUtilities.h"
+
+using namespace mlir;
+
+#define DEBUG_TYPE "iree-transform-builder"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << '[' << DEBUG_TYPE << "] " << X)
+
+llvm::cl::opt<bool> clGPUEnableTransformDialectMatmulTensorCoreStrategy(
+    "iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy",
+    llvm::cl::desc("activate the matmul tensorcore strategy"),
+    llvm::cl::init(true));
+
+llvm::cl::opt<bool> clGPUEnableTransformDialectAlignedMatmul(
+    "iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul",
+    llvm::cl::desc(
+        "activate the matmul tensorcore strategy for tile aligned shapes"),
+    llvm::cl::init(false));
+
+llvm::cl::opt<bool> clGPUEnableTransformDialectPadStrategy(
+    "iree-codegen-llvmgpu-enable-transform-dialect-pad-strategy",
+    llvm::cl::desc("activate the pad strategy"), llvm::cl::init(true));
+
+// TODO: significantly better namespacing.
+using iree_compiler::gpu::AbstractGemmLikeStrategy;
+using iree_compiler::gpu::GPUModel;
+using iree_compiler::gpu::kCudaMaxNumThreads;
+using iree_compiler::gpu::kCudaMaxVectorLoadBitWidth;
+using iree_compiler::gpu::kCudaWarpSize;
+using iree_compiler::gpu::PadConfig;
+using iree_compiler::gpu::PadStrategy;
+using iree_compiler::gpu::ReductionConfig;
+using iree_compiler::gpu::ReductionStrategy;
+using iree_compiler::gpu::scaleUpByBitWidth;
+using iree_compiler::gpu::SmallReductionStrategy;
+using iree_compiler::gpu::StagedReductionStrategy;
+using transform_ext::CapturingOpMatcher;
+using transform_ext::MatchCallbackOp;
+using transform_ext::MatchedMatmulCaptures;
+using transform_ext::MatchedPadCaptures;
+using transform_ext::MatchedReductionCaptures;
+using transform_ext::MatcherContext;
+using transform_ext::RegisterMatchCallbacksOp;
+using transform_ext::StructuredOpMatcher;
+
+//===----------------------------------------------------------------------===//
+// Higher-level problem-specific strategy creation APIs, these should favor
+// user-friendliness.
+//===----------------------------------------------------------------------===//
+
+//===--------------------------------------------------------------------===//
+// Reduction strategies.
+//===--------------------------------------------------------------------===//
+/// Placeholder to encode fixed reductions that should take finer-grained
+/// precedence over other heuristics. In the future, this could be lifted to
+/// e.g. `gpuModel` or higher up in some transform dialect database summary of
+/// "known good things".
+static FailureOr<ReductionConfig> applyKnownGoodReductionConfigurations(
+    const transform_ext::MatchedReductionCaptures &captures,
+    const GPUModel &gpuModel) {
+  auto staged = ReductionStrategy::Staged;
+  int64_t reductionSize = captures.reductionOpSizes.back();
+  if (gpuModel.model == GPUModel::kDefaultGPU) {
+    if (captures.reductionOutputElementalTypeBitWidth == 32) {
+      if (reductionSize == 64)
+        return ReductionConfig{/*maxNumThreads=*/64, /*vectorSize=*/1, staged};
+      if (reductionSize == 128)
+        return ReductionConfig{/*maxNumThreads=*/32, /*vectorSize=*/4, staged};
+      if (reductionSize == 512)
+        return ReductionConfig{/*maxNumThreads=*/256, /*vectorSize=*/2, staged};
+    }
+  }
+  return failure();
+}
+
+/// The configurations below have been determined empirically by performing a
+/// manual tradeoff between problem size, amount of parallelism and vector
+/// size on a particular NVIDIA RTX2080Ti 12GB card. This is a coarse tradeoff
+/// that should generally give reasonably good results but that begs to be
+/// complemented by hardcoded known good configurations and ultimately a
+/// database and/or a random forest compression of configurations with
+/// guaranteed performance.
+// TODO: Lift some of the strategy sizing logic as hints and/or heuristics to
+// also work properly in the dynamic case.
+// TODO: Support more HW configs and make it more pluggable.
+static ReductionConfig getReductionConfig(
+    const transform_ext::MatchedReductionCaptures &captures,
+    const GPUModel &gpuModel) {
+  auto maybeHardcodedConfiguration =
+      applyKnownGoodReductionConfigurations(captures, gpuModel);
+  if (succeeded(maybeHardcodedConfiguration))
+    return *maybeHardcodedConfiguration;
+
+  //===--------------------------------------------------------------------===//
+  // Small reduction strategy.
+  //===--------------------------------------------------------------------===//
+  // Dynamic reductions are never supported by default because we can
+  // never know offhand whether we are in a small-reduction regime mode.
+  // Since this mode does not coalesce reads, perf will suffer
+  // catastrophically on larger runtime reduction.
+  // TODO: explicit hint from above that we really want to do that.
+  int64_t redSize = captures.reductionOpSizes.back();
+  bool isDynamicReduction = ShapedType::isDynamic(redSize);
+  // Otherwise, still only support the small cases for now and fall back to
+  // other strategies otherwise.
+  bool isSmallReduction = (redSize < 2 * kCudaWarpSize);
+  if (!isDynamicReduction && isSmallReduction) {
+    int64_t maxNumThreads = 4 * kCudaWarpSize;
+    return ReductionConfig{maxNumThreads, 0, ReductionStrategy::Small};
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Staged reduction strategy.
+  //===--------------------------------------------------------------------===//
+  int64_t bitWidth = captures.reductionOutputElementalTypeBitWidth;
+  int64_t vectorSize = scaleUpByBitWidth(4, bitWidth);
+  int64_t maxNumThreads = 8 * kCudaWarpSize;
+  // No adjustments in the dynamic case, we need extra information to make a
+  // good decision.
+  if (ShapedType::isDynamic(redSize))
+    return ReductionConfig{maxNumThreads, vectorSize,
+                           ReductionStrategy::Staged};
+  // Scale down to smaller sizes (4, 8, 16)-warps.
+  if (scaleUpByBitWidth(redSize, bitWidth) <= 4 * kCudaWarpSize) {
+    vectorSize = scaleUpByBitWidth(1, bitWidth);
+    maxNumThreads = 4 * kCudaWarpSize;
+  } else if (scaleUpByBitWidth(redSize, bitWidth) <= 8 * kCudaWarpSize) {
+    vectorSize = scaleUpByBitWidth(2, bitWidth);
+    maxNumThreads = 4 * kCudaWarpSize;
+  } else if (scaleUpByBitWidth(redSize, bitWidth) <= 8 * 2 * kCudaWarpSize) {
+    vectorSize = scaleUpByBitWidth(4, bitWidth);
+    maxNumThreads = 4 * kCudaWarpSize;
+  }
+  // Scale up to larger sizes (32, 64, 128+)-warps, using vector-4.
+  if (!captures.trailingOpSizes.empty()) {
+    if (scaleUpByBitWidth(redSize, bitWidth) >= 128 * 4 * kCudaWarpSize) {
+      vectorSize = scaleUpByBitWidth(4, bitWidth);
+      maxNumThreads = 32 * kCudaWarpSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 64 * 4 * kCudaWarpSize) {
+      vectorSize = scaleUpByBitWidth(4, bitWidth);
+      maxNumThreads = 16 * kCudaWarpSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 32 * 4 * kCudaWarpSize) {
+      vectorSize = scaleUpByBitWidth(4, bitWidth);
+      maxNumThreads = 8 * kCudaWarpSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 16 * 4 * kCudaWarpSize) {
+      vectorSize = scaleUpByBitWidth(4, bitWidth);
+      maxNumThreads = 4 * kCudaWarpSize;
+    }
+  }
+  return ReductionConfig{maxNumThreads, vectorSize, ReductionStrategy::Staged};
+}
+
+/// Map an N-D parallel, 1-D reduction operation with optional leading and
+/// optional trailing elementwise operations.
+/// The 1-D reduction dimension must be in the most minor dimension.
+/// The innermost dimensions of the leading and trailing operations must be
+/// most minor along all accesses. Return failure if matching fails. On a
+/// successful match, configure a reduction strategy based on a proxy model of
+/// the hardware and construct transform dialect IR that implements the
+/// reduction strategy. The transform dialect IR is added in a top-level
+/// ModuleOp after the `entryPoint` func::FuncOp.
+static LogicalResult matchAndSetReductionStrategy(func::FuncOp entryPoint,
+                                                  linalg::LinalgOp op,
+                                                  const GPUModel &gpuModel) {
+  if (!gpuModel.hasWarpShuffle) {
+    LDBG("--Reduction strategy no warp shuffle\n");
+    return failure();
+  }
+
+  // 1. Match a reduction and surrounding ops.
+  StructuredOpMatcher *reduction;
+  transform_ext::MatchedReductionCaptures captures;
+  transform_ext::MatcherContext matcherContext;
+  makeReductionMatcher(matcherContext, reduction, captures,
+                       /*mustMatchEntireFunc=*/true);
+  if (!matchPattern(op, *reduction)) {
+    LDBG("--Reduction strategy failed to match\n");
+    return failure();
+  }
+
+  // 2. Construct the configuration and the strategy builder.
+  // TODO: Generalize along the HW axis.
+  auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
+    ReductionConfig reductionConfig = getReductionConfig(captures, gpuModel);
+    if (reductionConfig.strategy == ReductionStrategy::Small) {
+      SmallReductionStrategy strategy(captures, reductionConfig);
+      return buildSmallReductionStrategy(b, variant, strategy);
+    } else if (reductionConfig.strategy == ReductionStrategy::Staged) {
+      // Otherwise, always fallback to the staged strategy.
+      StagedReductionStrategy strategy(captures, reductionConfig);
+      return buildStagedReductionStrategy(b, variant, strategy);
+    } else {
+      return llvm_unreachable("Unknown strategy");
+    }
+  };
+
+  // 3. Build strategy embedded into the IR.
+  mlir::iree_compiler::createTransformRegion(entryPoint, strategyBuilder);
+
+  return success();
+}
+
+//===--------------------------------------------------------------------===//
+// Matmul strategies.
+//===--------------------------------------------------------------------===//
+
+static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
+                                               linalg::LinalgOp op,
+                                               const GPUModel &gpuModel) {
+  if (!clGPUEnableTransformDialectMatmulTensorCoreStrategy) {
+    LDBG("--Matmul strategy flag turned off\n");
+    return failure();
+  }
+  if (!gpuModel.hasTF32TensorCore) {
+    LDBG("--Matmul strategy no TF32 tensor core\n");
+    return failure();
+  }
+
+  // 1. Match a reduction and surrounding ops.
+  StructuredOpMatcher *fill;
+  StructuredOpMatcher *matmul;
+  StructuredOpMatcher *trailing;
+  transform_ext::MatchedMatmulCaptures captures;
+  transform_ext::MatcherContext matcherContext;
+  makeMatmulMatcher(matcherContext, matmul, fill, trailing, captures,
+                    /*mustMatchEntireFunc=*/true);
+  if (!matchPattern(op, *matmul)) {
+    LDBG("--Matmul strategy fail to match\n");
+    return failure();
+  }
+
+  // We are very peculiar about the dispatches we want to match for now:
+  //   - f32 only atm.
+  //   - Mandatory fill op.
+  //   - No trailing op.
+  //   - If the matmul is "too aligned", then guard on the alignment flag.
+  //   - If the matmul is "too small", then use the default IREE strategy.
+  //   - Otherwise, we take it.
+  if (!fill->getCaptured() || trailing->getCaptured()) {
+    LDBG("--Matmul strategy fill / trailing preconditions failed\n");
+    return failure();
+  }
+
+  if (!captures.lhsElementType.isF32() || !captures.rhsElementType.isF32() ||
+      !captures.outputElementType.isF32()) {
+    LDBG("--Matmul strategy elemental type check failed\n");
+    return failure();
+  }
+
+  // TODO: Generalize to a good mix of sizes, alignments and element types.
+  const auto &matmulSize = captures.matmulOpSizes;
+  if (matmulSize.size() != 3) {
+    LDBG("--Matmul strategy size capture failed\n");
+    return failure();
+  }
+
+  // Currently the fully aligned case still lags behind the current default
+  // pipeline and thus is guarded by a flag. This is the case when at least one
+  // of the following holds
+  //   - m is tile aligned (conservatively, take 64)
+  //   - n is tile aligned (conservatively, take 64)
+  //   - k is tile aligned (conservatively, take 16)
+  bool guardedAlignedCases = matmulSize[0] % 64 == 0 ||
+                             matmulSize[1] % 64 == 0 || matmulSize[2] % 16 == 0;
+
+  if (guardedAlignedCases && !clGPUEnableTransformDialectAlignedMatmul) {
+    LDBG("--Matmul strategy alignment check failed\n");
+    return failure();
+  }
+
+  // Currently the unaligned transform strategy does not properly handle
+  // degenerate dimensions that should have been rank-reduced (e.g. `1`).
+  // Also, it is unprofitable to force small matmuls through a high latency
+  // tensorcore path, we are better off with a simple simt strategy.
+  // TODO: profitability details can be ironed out in the future when we have a
+  // heuristic to better select strategy parameters.
+  bool unsupportedSmallCases = (matmulSize[0] > 0 && matmulSize[0] < 8) ||
+                               (matmulSize[1] > 0 && matmulSize[1] < 8) ||
+                               (matmulSize[2] > 0 && matmulSize[2] < 8);
+  if (unsupportedSmallCases) {
+    LDBG("--Matmul strategy small size check failed\n");
+    return failure();
+  }
+
+  // 2. Construct the configuration and the strategy builder.
+  // TODO: Generalize along the HW axis.
+  auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
+    iree_compiler::gpu::MatmulStrategy strategy(op->getContext(), captures);
+    return buildMatmulTensorCoreStrategy(b, variant, strategy);
+  };
+
+  // 3. Build strategy embedded into the IR.
+  mlir::iree_compiler::createTransformRegion(entryPoint, strategyBuilder);
+
+  return success();
+}
+
+//===--------------------------------------------------------------------===//
+// Pad strategies.
+//===--------------------------------------------------------------------===//
+
+/// Placeholder to encode fixed pads that should take finer-grained precedence
+/// over other heuristics. In the future, this could be lifted to
+/// e.g. `gpuModel` or higher up in some transform dialect database summary of
+/// "known good things".
+static FailureOr<PadConfig> applyKnownGoodPadConfigurations(
+    const transform_ext::MatchedPadCaptures &captures,
+    const GPUModel &gpuModel) {
+  if (ArrayRef<int64_t>{captures.dims} == ArrayRef<int64_t>{1024, 1024}) {
+    return PadConfig{};
+  }
+  return failure();
+}
+
+/// Placeholder to encode simple heuristics.
+static PadConfig getPadConfig(const transform_ext::MatchedPadCaptures &captures,
+                              const GPUModel &gpuModel) {
+  auto maybeHardcodedConfiguration =
+      applyKnownGoodPadConfigurations(captures, gpuModel);
+  if (succeeded(maybeHardcodedConfiguration))
+    return *maybeHardcodedConfiguration;
+  return PadConfig{};
+}
+
+static LogicalResult matchAndSetPadStrategy(func::FuncOp entryPoint,
+                                            tensor::PadOp op,
+                                            const GPUModel &gpuModel) {
+  if (!clGPUEnableTransformDialectPadStrategy) {
+    LDBG("--Pad strategy flag turned off\n");
+    return failure();
+  }
+
+  // 1. Match a padOp.
+  CapturingOpMatcher *pad;
+  MatchedPadCaptures captures;
+  MatcherContext matcherContext;
+  makePadMatcher(matcherContext, pad, captures, /*mustMatchEntireFunc=*/true);
+
+  if (!matchPattern(op.getOperation(), *pad)) {
+    LDBG("--Pad strategy failed to match\n");
+    return failure();
+  }
+  if (captures.rank != 2) {
+    LDBG("--Pad strategy supported ranks check failed\n");
+    return failure();
+  }
+  if (!captures.elementType.isF32()) {
+    LDBG("--Pad strategy elemental type check failed\n");
+    return failure();
+  }
+
+  // 2. Construct the strategy builder.
+  PadConfig padConfig = getPadConfig(captures, gpuModel);
+  auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
+    iree_compiler::gpu::PadStrategy strategy(op->getContext(), captures,
+                                             padConfig);
+    return buildPadStrategy(b, variant, strategy);
+  };
+
+  // 3. Build strategy embedded into the IR.
+  mlir::iree_compiler::createTransformRegion(entryPoint, strategyBuilder);
+
+  return success();
+}
+
+//===--------------------------------------------------------------------===//
+// Switch between strategies depending on matched IR.
+//===--------------------------------------------------------------------===//
+LogicalResult mlir::iree_compiler::gpu::matchAndSetTransformStrategy(
+    func::FuncOp entryPoint, Operation *op, const GPUModel &gpuModel) {
+  LDBG("Look up a TD strategy for entryPoint:\n" << entryPoint << "\n");
+  auto padOp = dyn_cast<tensor::PadOp>(op);
+  if (padOp) {
+    if (succeeded(matchAndSetPadStrategy(entryPoint, padOp, gpuModel))) {
+      LDBG("Activate pad strategy\n");
+      return success();
+    }
+    LDBG("Unmatched pad strategy\n");
+    return failure();
+  }
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+  if (!linalgOp) {
+    LDBG("Not a Linalg op: " << *op << " -> Fail\n");
+    return failure();
+  }
+  if (succeeded(matchAndSetReductionStrategy(entryPoint, linalgOp, gpuModel))) {
+    LDBG("Activate reduction strategy\n");
+    return success();
+  }
+  if (succeeded(matchAndSetMatmulStrategy(entryPoint, linalgOp, gpuModel))) {
+    LDBG("Activate matmul\n");
+    return success();
+  }
+  // TODO: Add more transform dialect strategy for other kind of dispatch
+  // regions.
+  LDBG("No suitable strategy found\n");
+  return failure();
+}

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.cpp
@@ -48,16 +48,14 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectMatmulTensorCoreStrategy(
     "iree-codegen-llvmgpu-enable-transform-dialect-matmul-tensorcore-strategy",
     llvm::cl::desc("activate the matmul tensorcore strategy"),
     llvm::cl::init(true));
-
 llvm::cl::opt<bool> clGPUEnableTransformDialectAlignedMatmul(
     "iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul",
     llvm::cl::desc(
         "activate the matmul tensorcore strategy for tile aligned shapes"),
     llvm::cl::init(false));
-
 llvm::cl::opt<bool> clGPUEnableTransformDialectPadStrategy(
     "iree-codegen-llvmgpu-enable-transform-dialect-pad-strategy",
-    llvm::cl::desc("activate the pad strategy"), llvm::cl::init(true));
+    llvm::cl::desc("activate the pad strategy"), llvm::cl::init(false));
 
 // TODO: significantly better namespacing.
 using iree_compiler::gpu::AbstractGemmLikeStrategy;

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.h
@@ -1,0 +1,88 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_STRATEGIES_H_
+#define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_STRATEGIES_H_
+
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/MatmulTensorCoreStrategy.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/PadStrategy.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.h"
+#include "iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.h"
+
+namespace mlir {
+class ImplicitLocOpBuilder;
+class Value;
+namespace iree_compiler {
+namespace gpu {
+
+/// Placeholder for some hardware model proxy that contains relevant information
+/// to configure the reduction strategy. In the future, this will need to be
+/// driven by some contract with the runtime.
+struct GPUModel {
+  static constexpr StringLiteral kDefaultGPU = "DefaultGPU";
+  StringRef model = kDefaultGPU;
+  bool hasWarpShuffle = false;
+  bool hasTF32TensorCore = false;
+};
+
+//===--------------------------------------------------------------------===//
+// Matmul strategies.
+//===--------------------------------------------------------------------===//
+/// Entry point to build the transform IR corresponding to a tensorcore-based
+/// strategy for linalg.fill + linalg.matmul on f32.
+/// Does not support leading or trailing operations atm.
+void buildMatmulTensorCoreStrategy(ImplicitLocOpBuilder &b, Value variantH,
+                                   const MatmulStrategy &strategy);
+
+//===--------------------------------------------------------------------===//
+// Pad strategies.
+//===--------------------------------------------------------------------===//
+/// Entry point to build the transform IR corresponding to a simple pad
+/// strategy.
+/// Does not support leading or trailing operations atm.
+void buildPadStrategy(ImplicitLocOpBuilder &b, Value variantH,
+                      const PadStrategy &strategy);
+
+//===--------------------------------------------------------------------===//
+// Reduction strategies.
+//===--------------------------------------------------------------------===//
+/// Structure to hold a summary of HW-derived properties to configure the
+/// reduction strategy.
+/// The objective of this struct is to act as a minimal summary of key
+/// properties derived from the hardware (e.g. by an oracle) and that are
+/// sufficient to steer the strategy to produce a good version.
+/// These can be thought of as latent variables or embeddings that directly
+/// control the strategy and can be derived from the hardware by some procedure.
+enum class ReductionStrategy { Small, Staged };
+struct ReductionConfig {
+  int64_t maxNumThreads;
+  int64_t vectorSize;
+  ReductionStrategy strategy;
+};
+
+/// Entry point to build the transform IR corresponding to a staged reduction
+/// strategy.
+/// This is used for mapping a N-D parallel, 1-D reduction operation with a
+/// small reduction on which the default staged reduction strategy is otherwise
+/// inefficient.
+/// The 1-D reduction dimensions must be in the most minor dimension.
+/// Supports an optional leading and an optional trailing elementwise operation.
+void buildSmallReductionStrategy(ImplicitLocOpBuilder &b, Value variantH,
+                                 const SmallReductionStrategy &strategy);
+
+/// Entry point to build the transform IR corresponding to a staged reduction
+/// strategy.
+/// This is used for mapping a N-D parallel, 1-D reduction operation.
+/// The 1-D reduction dimensions must be in the most minor dimension.
+/// Supports an optional leading and an optional trailing elementwise operation.
+void buildStagedReductionStrategy(ImplicitLocOpBuilder &b, Value variantH,
+                                  const StagedReductionStrategy &strategy);
+
+}  // namespace gpu
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_STRATEGIES_H_

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -534,7 +534,7 @@ void transform_ext::MatchCallbackOp::getEffects(
 }
 
 //===---------------------------------------------------------------------===//
-// RegisterMatchCallbacksOp
+// Callbacks for tests driven by RegisterMatchCallbacksOp
 //===---------------------------------------------------------------------===//
 
 /// Match callback for "_test_match_callback" hook. Matches any payload
@@ -667,6 +667,70 @@ static DiagnosedSilenceableFailure testShapedValueMatcherCallback(
   return emitSilenceableFailure(loc) << "failed to match";
 }
 
+//===---------------------------------------------------------------------===//
+// Callbacks for codegen driven by RegisterMatchCallbacksOp.
+//===---------------------------------------------------------------------===//
+
+/// Match callback for a convolution with optional fill and trailing
+/// elementwise operations. Matches *the first* occurrence of such a convolution
+/// within an op associated with the given handle.
+///
+/// Input handles:
+///
+///   - container op, must be associated with one operation.
+///
+/// Output handles:
+///
+///   - the "fill" op preceding the convolution, if present;
+///   - convolution op;
+///   - trailing elementwise op, if any.
+static DiagnosedSilenceableFailure
+convolutionCallback(transform_ext::MatchCallbackResult &res, Location loc,
+                    const mlir::transform::TransformState &state,
+                    ValueRange handles) {
+  if (handles.size() != 1 ||
+      !llvm::hasSingleElement(state.getPayloadOps(handles[0]))) {
+    return emitSilenceableFailure(loc)
+           << "expected one handle to one operation";
+  }
+
+  transform_ext::StructuredOpMatcher *pattern, *fill, *trailing;
+  transform_ext::MatchedConvolutionCaptures ignore;
+  transform_ext::MatcherContext matcherContext;
+  makeConvolutionMatcher(matcherContext, pattern, fill, trailing, ignore,
+                         /*mustMatchEntireFunc=*/true);
+
+  // TODO: need a mechanism for this to go around the entire IR,
+  // potentially with list matches for each group.
+  Operation *root = *state.getPayloadOps(handles[0]).begin();
+
+  WalkResult walkResult = root->walk([&](Operation *op) {
+    pattern->resetCapture();
+    if (!matchPattern(op, *pattern))
+      return WalkResult::advance();
+
+    // TODO: notify properly.
+    LLVM_DEBUG({
+      DBGS() << "fill:\n";
+      if (fill->getCaptured())
+        DBGS() << fill->getCaptured() << "\n";
+      DBGS() << "pattern: " << pattern->getCaptured() << "\n";
+      DBGS() << "trailing:\n";
+      if (trailing->getCaptured())
+        DBGS() << trailing->getCaptured() << "\n";
+    });
+
+    res.addPotentiallyEmptyPayloadGroup(fill->getCaptured());
+    res.addPayloadGroup({pattern->getCaptured()});
+    res.addPotentiallyEmptyPayloadGroup(trailing->getCaptured());
+    return WalkResult::interrupt();
+  });
+
+  if (walkResult.wasInterrupted())
+    return DiagnosedSilenceableFailure::success();
+  return emitSilenceableFailure(loc) << "failed to match";
+}
+
 /// Match callback for a reduction with optional leading and trailing
 /// elementwise operations. Matches *the first* occurrence of such a reduction
 /// within an op associated with the given handle.
@@ -720,66 +784,6 @@ reductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
 
     res.addPotentiallyEmptyPayloadGroup(leading->getCaptured());
     res.addPayloadGroup({fill->getCaptured()});
-    res.addPayloadGroup({pattern->getCaptured()});
-    res.addPotentiallyEmptyPayloadGroup(trailing->getCaptured());
-    return WalkResult::interrupt();
-  });
-
-  if (walkResult.wasInterrupted())
-    return DiagnosedSilenceableFailure::success();
-  return emitSilenceableFailure(loc) << "failed to match";
-}
-
-/// Match callback for a convolution with optional fill and trailing
-/// elementwise operations. Matches *the first* occurrence of such a convolution
-/// within an op associated with the given handle.
-///
-/// Input handles:
-///
-///   - container op, must be associated with one operation.
-///
-/// Output handles:
-///
-///   - the "fill" op preceding the convolution, if present;
-///   - convolution op;
-///   - trailing elementwise op, if any.
-static DiagnosedSilenceableFailure
-convolutionCallback(transform_ext::MatchCallbackResult &res, Location loc,
-                    const mlir::transform::TransformState &state,
-                    ValueRange handles) {
-  if (handles.size() != 1 ||
-      !llvm::hasSingleElement(state.getPayloadOps(handles[0]))) {
-    return emitSilenceableFailure(loc)
-           << "expected one handle to one operation";
-  }
-
-  transform_ext::StructuredOpMatcher *pattern, *fill, *trailing;
-  transform_ext::MatchedConvolutionCaptures ignore;
-  transform_ext::MatcherContext matcherContext;
-  makeConvolutionMatcher(matcherContext, pattern, fill, trailing, ignore,
-                         /*mustMatchEntireFunc=*/true);
-
-  // TODO: need a mechanism for this to go around the entire IR,
-  // potentially with list matches for each group.
-  Operation *root = *state.getPayloadOps(handles[0]).begin();
-
-  WalkResult walkResult = root->walk([&](Operation *op) {
-    pattern->resetCapture();
-    if (!matchPattern(op, *pattern))
-      return WalkResult::advance();
-
-    // TODO: notify properly.
-    LLVM_DEBUG({
-      DBGS() << "fill:\n";
-      if (fill->getCaptured())
-        DBGS() << fill->getCaptured() << "\n";
-      DBGS() << "pattern: " << pattern->getCaptured() << "\n";
-      DBGS() << "trailing:\n";
-      if (trailing->getCaptured())
-        DBGS() << trailing->getCaptured() << "\n";
-    });
-
-    res.addPotentiallyEmptyPayloadGroup(fill->getCaptured());
     res.addPayloadGroup({pattern->getCaptured()});
     res.addPotentiallyEmptyPayloadGroup(trailing->getCaptured());
     return WalkResult::interrupt();
@@ -850,6 +854,58 @@ matmulCallback(transform_ext::MatchCallbackResult &res, Location loc,
   return emitSilenceableFailure(loc) << "failed to match";
 }
 
+/// Match callback for a tensor.pad. Matches *the first* occurrence of such pad
+/// within an op associated with the given handle.
+///
+/// Input handles:
+///
+///   - the container op, must be associated with one operation.
+///
+/// Output handles:
+///
+///   - the pad op.
+static DiagnosedSilenceableFailure
+padCallback(transform_ext::MatchCallbackResult &res, Location loc,
+            const mlir::transform::TransformState &state, ValueRange handles,
+            bool mustMatchEntireFunc) {
+  if (handles.size() != 1 ||
+      !llvm::hasSingleElement(state.getPayloadOps(handles[0]))) {
+    return emitSilenceableFailure(loc)
+           << "expected one handle to one operation";
+  }
+
+  transform_ext::CapturingOpMatcher *pattern;
+  transform_ext::MatchedPadCaptures ignore;
+  transform_ext::MatcherContext matcherContext;
+  makePadMatcher(matcherContext, pattern, ignore, mustMatchEntireFunc);
+
+  Operation *root = *state.getPayloadOps(handles[0]).begin();
+
+  WalkResult walkResult = root->walk([&](Operation *op) {
+    pattern->resetCapture();
+    if (!matchPattern(op, *pattern))
+      return WalkResult::advance();
+
+    // TODO: notify properly.
+    LLVM_DEBUG({
+      DBGS() << "pad:\n";
+      if (pattern->getCaptured())
+        DBGS() << pattern->getCaptured() << "\n";
+    });
+
+    res.addPayloadGroup({pattern->getCaptured()});
+    return WalkResult::interrupt();
+  });
+
+  if (walkResult.wasInterrupted())
+    return DiagnosedSilenceableFailure::success();
+  return emitSilenceableFailure(loc) << "failed to match";
+}
+
+//===---------------------------------------------------------------------===//
+// RegisterMatchCallbacksOp
+//===---------------------------------------------------------------------===//
+
 DiagnosedSilenceableFailure transform_ext::RegisterMatchCallbacksOp::apply(
     mlir::transform::TransformResults &results,
     mlir::transform::TransformState &state) {
@@ -861,12 +917,13 @@ DiagnosedSilenceableFailure transform_ext::RegisterMatchCallbacksOp::apply(
                             testValueMatcherCallback);
   registry.registerCallback("_test_shaped_value_matcher_callback",
                             testShapedValueMatcherCallback);
+  registry.registerCallback("convolution", convolutionCallback);
+  registry.registerCallback("matmul", matmulCallback);
+  registry.registerCallback("pad", wrapAsEntireFuncMatch(padCallback));
   registry.registerCallback("reduction",
                             wrapAsEntireFuncMatch(reductionCallback));
   registry.registerCallback("reduction_partial",
                             wrapAsPartialMatch(reductionCallback));
-  registry.registerCallback("convolution", convolutionCallback);
-  registry.registerCallback("matmul", matmulCallback);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -93,6 +93,27 @@ void transform_ext::CapturingMatcherBase::resetCapture() {
 // CapturingOpMatcher
 //===---------------------------------------------------------------------===//
 
+bool transform_ext::CapturingOpMatcher::checkAllTilableMatched(
+    Operation *parent, Operation *op,
+    ArrayRef<transform_ext::CapturingOpMatcher *> matchers) {
+  LLVM_DEBUG(DBGS() << "all tilable ops captured");
+  int64_t numTilableOps = 0;
+  if (!parent)
+    return false;
+  parent->walk([&](TilingInterface Op) { ++numTilableOps; });
+
+  llvm::SmallPtrSet<Operation *, 6> matched;
+  for (CapturingOpMatcher *nested : matchers) {
+    if (Operation *captured = nested->getCaptured()) {
+      matched.insert(captured);
+    }
+  }
+
+  // Don't forget to include the root matcher.
+  matched.insert(op);
+  return numTilableOps == matched.size();
+}
+
 bool transform_ext::CapturingOpMatcher::match(Operation *op) {
   auto debugRAII =
       llvm::make_scope_exit([] { LLVM_DEBUG(DBGS() << "-------\n"); });
@@ -369,6 +390,16 @@ transform_ext::ShapedValueMatcher::dim(AllDims tag, CaptureDims captures) {
     LLVM_DEBUG(DBGS() << "capturing all shaped value dimensions");
     ArrayRef<int64_t> shape = value.getType().cast<ShapedType>().getShape();
     captures.value.assign(shape.begin(), shape.end());
+    return true;
+  });
+  return *this;
+}
+
+transform_ext::ShapedValueMatcher &
+transform_ext::ShapedValueMatcher::elementType(CaptureElementType captures) {
+  addPredicate([=](Value value) {
+    LLVM_DEBUG(DBGS() << "capturing elementType");
+    captures.value = value.getType().cast<ShapedType>().getElementType();
     return true;
   });
   return *this;
@@ -1077,27 +1108,6 @@ void transform_ext::StructuredOpMatcher::addResultMatcher(
   });
 }
 
-bool transform_ext::StructuredOpMatcher::checkAllTilableMatched(
-    Operation *parent, linalg::LinalgOp linalgOp,
-    ArrayRef<transform_ext::CapturingOpMatcher *> matchers) {
-  LLVM_DEBUG(DBGS() << "all tilable ops captured");
-  int64_t numTilableOps = 0;
-  if (!parent)
-    return false;
-  parent->walk([&](TilingInterface Op) { ++numTilableOps; });
-
-  llvm::SmallPtrSet<Operation *, 6> matched;
-  for (CapturingOpMatcher *nested : matchers) {
-    if (Operation *captured = nested->getCaptured()) {
-      matched.insert(captured);
-    }
-  }
-
-  // Don't forget to include the root matcher.
-  matched.insert(linalgOp);
-  return numTilableOps == matched.size();
-}
-
 //===-------------------------------------------------------------------===//
 // Constraints on op region.
 //===-------------------------------------------------------------------===//
@@ -1588,4 +1598,19 @@ void transform_ext::makeConvolutionMatcher(
   StructuredOpMatcher *trailing;
   makeConvolutionMatcher(context, convolutionCapture, fill, trailing, captures,
                          mustMatchEntireFunc);
+}
+
+void transform_ext::makePadMatcher(MatcherContext &context,
+                                   CapturingOpMatcher *&padCapture,
+                                   MatchedPadCaptures &captures,
+                                   bool mustMatchEntireFunc) {
+  auto &value = transform_ext::m_ShapedValue(context);
+  value.rank(transform_ext::CaptureRank(captures.rank))
+      .dim(transform_ext::AllDims(), transform_ext::CaptureDims(captures.dims))
+      .elementType(CaptureElementType(captures.elementType));
+  auto &opMatcher =
+      transform_ext::m_Operation<tensor::PadOp>(context).result(0, value);
+  if (mustMatchEntireFunc)
+    opMatcher = opMatcher.allTilableOpsCaptured<func::FuncOp>();
+  padCapture = &opMatcher;
 }


### PR DESCRIPTION
This revision introduces a matcher for a single tensor.pad operation and a simple codegen strategy that reuses a subset of the transformations of the matmul strategy.

With now 3 strategies available, some code reorganization occured: the top-level switch and strategy decisions have been moved into Strategies.cpp and out of Common.cpp which remains a place for building common C++ transformation APIs to construct TD.

For now, this is only targeting 2-D pad operations on f32 and should be further tightened to capture only the high paddings for which vector masking is known to apply. 

This is the common case that can also lower to the `zfill` form of `cp.async`.

This will later be generalized along the common axes following the MO from the reductions work.
For now this is sufficient to enable the higher order `unaligned -> aligned matmul` and the `split-K` work to run end-to-end.

Basic early profiling shows a performance around 30% of peak memory BW and simple means to increase the utilization, in particular in conjunction with multiple `cp.async` operations (future work).

For now this is only activated behind a flag `--iree-codegen-llvmgpu-enable-transform-dialect-pad-strategy` that will be retired in due time, following the steps taken in the past for reductions. 