### PR TITLE
[GPUCheckResourceUsage] Don't choke on alloc of memref of index

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:GPUTransformOps",
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:LinalgUtils",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_cc_library(
     MLIRGPUTransformOps
     MLIRGPUTransforms
     MLIRIR
+    MLIRLLVMCommonConversion
     MLIRLinalgDialect
     MLIRLinalgTransforms
     MLIRLinalgUtils

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CommonGPUPasses.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CommonGPUPasses.h
@@ -59,8 +59,13 @@ LogicalResult tileReductionToSerialLoops(func::FuncOp funcOp,
 // `getSharedMemoryLimit` is for querying the shared memory limit (in bytes);
 // it takes the current entry function as the argument. 64KB will be used if
 // nullptr.
+// `getIndexBitwidth` is for querying the bitwidth for the `index` type.
+// This size is used to check the allocation space required for memrefs of
+// indices. If this function is nullptr, this pass will query the datalayout to
+// get the index size.
 std::unique_ptr<OperationPass<ModuleOp>> createGPUCheckResourceUsagePass(
-    std::function<unsigned(func::FuncOp)> getSharedMemoryLimit = nullptr);
+    std::function<unsigned(func::FuncOp)> getSharedMemoryLimit = nullptr,
+    std::function<unsigned(func::FuncOp)> getIndexBitwidth = nullptr);
 
 /// Creates a pass to distribute scf.forall ops to GPU processors.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUDistribute();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
@@ -20,18 +20,28 @@ class GPUCheckResourceUsagePass final
     : public GPUCheckResourceUsageBase<GPUCheckResourceUsagePass> {
  public:
   explicit GPUCheckResourceUsagePass(
-      std::function<int(func::FuncOp)> getSharedMemoryLimit)
-      : getSharedMemoryLimit(getSharedMemoryLimit) {}
+      std::function<unsigned(func::FuncOp)> getSharedMemoryLimit,
+      std::function<unsigned(func::FuncOp)> getIndexBitwidth)
+      : getSharedMemoryLimit(getSharedMemoryLimit),
+        getIndexBitwidth(getIndexBitwidth) {}
 
   void runOnOperation() override;
 
  private:
   std::function<unsigned(func::FuncOp)> getSharedMemoryLimit;
+  std::function<unsigned(func::FuncOp)> getIndexBitwidth;
 };
 }  // namespace
 
-static int shapedTypeStaticSize(memref::AllocOp allocOp,
-                                ShapedType shapedType) {
+static unsigned getDatalayoutIndexBitwidth(func::FuncOp func) {
+  auto mod = func->getParentOfType<ModuleOp>();
+  LowerToLLVMOptions options(mod.getContext(), DataLayout(mod));
+  return options.getIndexBitwidth();
+}
+
+static int shapedTypeStaticSize(
+    memref::AllocOp allocOp, ShapedType shapedType,
+    std::function<unsigned(func::FuncOp)> getIndexBitwidth) {
   int allocSize = 1;
   for (auto dimSize : shapedType.getShape()) {
     if (ShapedType::isDynamic(dimSize)) continue;
@@ -39,13 +49,14 @@ static int shapedTypeStaticSize(memref::AllocOp allocOp,
   }
   if (auto elementType =
           llvm::dyn_cast<ShapedType>(shapedType.getElementType())) {
-    allocSize *= shapedTypeStaticSize(allocOp, elementType);
+    allocSize *= shapedTypeStaticSize(allocOp, elementType, getIndexBitwidth);
   } else {
     auto eltTy = shapedType.getElementType();
     if (eltTy.isIndex()) {
-      auto mod = allocOp->getParentOfType<ModuleOp>();
-      LowerToLLVMOptions options(mod.getContext(), DataLayout(mod));
-      allocSize *= options.getIndexBitwidth();
+      auto func = allocOp->getParentOfType<func::FuncOp>();
+      assert(getIndexBitwidth &&
+             "getIndexBitwidth should have been set earlier");
+      allocSize *= getIndexBitwidth(func);
     } else
       allocSize *= shapedType.getElementType().getIntOrFloatBitWidth();
   }
@@ -54,8 +65,9 @@ static int shapedTypeStaticSize(memref::AllocOp allocOp,
 
 /// Returns success if the total shared memory allocation size is less than the
 /// limit set by limit.
-static LogicalResult checkGPUAllocationSize(func::FuncOp funcOp,
-                                            unsigned limit) {
+static LogicalResult checkGPUAllocationSize(
+    func::FuncOp funcOp, unsigned limit,
+    std::function<unsigned(func::FuncOp)> getIndexBitwidth) {
   if (funcOp.getBody().empty()) return success();
 
   SmallVector<memref::AllocOp> allocOps;
@@ -72,7 +84,7 @@ static LogicalResult checkGPUAllocationSize(func::FuncOp funcOp,
           "has unsupported dynamic shared memory allocations");
     }
 
-    int allocSize = shapedTypeStaticSize(allocOp, allocType);
+    int allocSize = shapedTypeStaticSize(allocOp, allocType, getIndexBitwidth);
     if (allocOp.getAlignment()) {
       int64_t alignmentInBits = *allocOp.getAlignment() * 8;
       allocSize =
@@ -94,15 +106,20 @@ void GPUCheckResourceUsagePass::runOnOperation() {
     unsigned limit = this->getSharedMemoryLimit
                          ? this->getSharedMemoryLimit(funcOp)
                          : 64 * 1024;
-    if (failed(checkGPUAllocationSize(funcOp, limit))) {
+    if (failed(checkGPUAllocationSize(funcOp, limit,
+                                      this->getIndexBitwidth
+                                          ? this->getIndexBitwidth
+                                          : getDatalayoutIndexBitwidth))) {
       return signalPassFailure();
     }
   }
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createGPUCheckResourceUsagePass(
-    std::function<unsigned(func::FuncOp)> getSharedMemoryLimit) {
-  return std::make_unique<GPUCheckResourceUsagePass>(getSharedMemoryLimit);
+    std::function<unsigned(func::FuncOp)> getSharedMemoryLimit,
+    std::function<unsigned(func::FuncOp)> getIndexBitwidth) {
+  return std::make_unique<GPUCheckResourceUsagePass>(getSharedMemoryLimit,
+                                                     getIndexBitwidth);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_check_resource_usage.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_check_resource_usage.mlir
@@ -10,11 +10,22 @@ module {
 
 // -----
 
-// Check we don't choke on memrefs of index.
+// Check that we don't choke on memrefs of index.
 // CHECK-LABEL: @shared_mem_alloc_index(
 module {
   func.func @shared_mem_alloc_index(%arg0: index) {
     %alloc = memref.alloc() : memref<64xindex, #gpu.address_space<workgroup>>
+    return
+  }
+}
+
+// -----
+
+// Check that memrefs of index return a valid size.
+module {
+  // expected-error @+1 {{uses 144984 bytes of shared memory; exceeded the limit of 65536 bytes}}
+  func.func @shared_mem_alloc_index_too_big(%arg0: index) {
+    %alloc = memref.alloc() : memref<18123xindex, #gpu.address_space<workgroup>>
     return
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_check_resource_usage.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_check_resource_usage.mlir
@@ -1,9 +1,20 @@
-// RUN: iree-opt --iree-codegen-gpu-check-resource-usage %s --verify-diagnostics -split-input-file
+// RUN: iree-opt --iree-codegen-gpu-check-resource-usage %s --verify-diagnostics -split-input-file | FileCheck %s
 
 module {
   // expected-error @+1 {{uses 274432 bytes of shared memory; exceeded the limit of 65536 bytes}}
   func.func @shared_mem_alloc(%arg0: index) {
     %alloc = memref.alloc() : memref<274432xi8, #gpu.address_space<workgroup>>
+    return
+  }
+}
+
+// -----
+
+// Check we don't choke on memrefs of index.
+// CHECK-LABEL: @shared_mem_alloc_index(
+module {
+  func.func @shared_mem_alloc_index(%arg0: index) {
+    %alloc = memref.alloc() : memref<64xindex, #gpu.address_space<workgroup>>
     return
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -507,7 +507,9 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   // Run checks on shared memory usage.
   // TODO: query this from the target.
   auto getSharedMemoryLimit = [](func::FuncOp) { return 163 * 1024; };
-  pm.addPass(createGPUCheckResourceUsagePass(getSharedMemoryLimit));
+  auto getIndexBitwidth = [](func::FuncOp) { return 64; };
+  pm.addPass(
+      createGPUCheckResourceUsagePass(getSharedMemoryLimit, getIndexBitwidth));
 
   // SCF -> STD
   pm.addNestedPass<func::FuncOp>(createConvertSCFToCFPass());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -190,7 +190,10 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
     spirv::TargetEnvAttr target = getSPIRVTargetEnvAttr(moduleOp);
     return target.getResourceLimits().getMaxComputeSharedMemorySize();
   };
-  pm.addPass(createGPUCheckResourceUsagePass(getSharedMemoryLimit));
+  // TODO: query this from the target.
+  auto getIndexBitwidth = [](func::FuncOp) { return 32; };
+  pm.addPass(
+      createGPUCheckResourceUsagePass(getSharedMemoryLimit, getIndexBitwidth));
 
   // Fold load/store from/to subview ops into the original memref when possible.
   // In SPIR-V we don't use memref descriptor so it's not possible to handle


### PR DESCRIPTION
Prior to this patch the compiler would crash on memrefs of index because we would try to get the bitwidth of the index type as if it was an integer or a floating point type.

The bitwidth of the index type is actually carried by the datalayout of the module.

Update the code to query the datalayout to get the bitwidth.

Note: The GPUCheckResourceUsage pass runs relatively early in the pass pipeline (currently before we lower the `SCF` dialect). As a result, it wouldn't be reasonable, IMHO, to expect that index types have been lowered to their integer counterpart.