### PR TITLE
[ConvertToLLVM] Don't choke on alloc of memref of index

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -150,7 +150,11 @@ struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
       if (auto shapeType = llvm::dyn_cast<ShapedType>(elType))
         alignement =
             shapeType.getNumElements() * shapeType.getElementTypeBitWidth() / 8;
-      else
+      else if (elType.isIndex()) {
+        auto mod = allocOp->getParentOfType<ModuleOp>();
+        LowerToLLVMOptions options(mod.getContext(), DataLayout(mod));
+        alignement = options.getIndexBitwidth() / 8;
+      } else
         alignement = elType.getIntOrFloatBitWidth() / 8;
     }
     // In CUDA workgroup memory is represented by a global variable.


### PR DESCRIPTION
Prior to this patch the compiler would crash on alloc of memrefs of index on shared memory, because we would try to get the bitwidth of the index type as if it was an integer or a floating point type.

The bitwidth of the index type is actually carried by the datalayout of the module.

Update the code to query the datalayout to get the bitwidth.

Note: This particular pattern is called as part of convert-to-nvvm. In that pass we actually lower the index type to an integer type, but we do it after having lowered the `alloc`s from shared memory, i.e., where the code is choking.