### PR TITLE
Add tags to website pages.

### DIFF
--- a/docs/website/docs/building-from-source/android.md
+++ b/docs/website/docs/building-from-source/android.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - tags
+tags:
+  - Android
+---
+
 # Android cross-compilation
 
 Running on a platform like Android involves cross-compiling from a _host_

--- a/docs/website/docs/building-from-source/ios.md
+++ b/docs/website/docs/building-from-source/ios.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - tags
+tags:
+  - iOS
+---
+
 # iOS cross-compilation
 
 Cross-compilation for iOS consists of the two steps below.

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - tags
+tags:
+  - CPU
+---
+
 # RISC-V cross-compilation
 
 Running on a platform like RISC-V involves cross-compiling from a _host_

--- a/docs/website/docs/community/blog/2021-07-19-tflite-tosa.md
+++ b/docs/website/docs/community/blog/2021-07-19-tflite-tosa.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - TensorFlow
+---
+
 Monday, July 19, 2021<br>
 By Rob Suderman and Jenni Kilduff
 

--- a/docs/website/docs/community/blog/2021-10-13-mmt4d.md
+++ b/docs/website/docs/community/blog/2021-10-13-mmt4d.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - CPU
+---
+
 Wednesday, October 13, 2021<br>
 By Ahmed Taei, Benoit Jacob
 

--- a/docs/website/docs/community/blog/2021-10-15-cuda-backend.md
+++ b/docs/website/docs/community/blog/2021-10-15-cuda-backend.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - GPU
+  - CUDA
+---
+
 Friday, October 15, 2021<br>
 By Thomas Raoux
 

--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - tags
+tags:
+  - CPU
+---
+
 # Run on a Bare-Metal Platform
 
 IREE supports CPU model execution on bare-metal platforms. That is, platforms

--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - tags
+tags:
+  - CPU
+---
+
 # CPU Deployment
 
 IREE supports efficient program execution on CPU devices by using

--- a/docs/website/docs/guides/deployment-configurations/gpu-cuda-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-cuda-rocm.md
@@ -1,3 +1,11 @@
+---
+hide:
+  - tags
+tags:
+  - GPU
+  - CUDA
+---
+
 # CUDA and ROCm GPU HAL Driver
 
 IREE can accelerate model execution on NVIDIA GPUs using CUDA and on AMD GPUs

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -1,3 +1,11 @@
+---
+hide:
+  - tags
+tags:
+  - GPU
+  - Vulkan
+---
+
 # Vulkan GPU HAL Driver
 
 IREE can accelerate model execution on GPUs via

--- a/docs/website/docs/guides/ml-frameworks/jax.md
+++ b/docs/website/docs/guides/ml-frameworks/jax.md
@@ -1,3 +1,11 @@
+---
+hide:
+  - tags
+tags:
+  - Python
+  - JAX
+---
+
 # JAX Integration
 
 !!! note

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -1,3 +1,11 @@
+---
+hide:
+  - tags
+tags:
+  - Python
+  - PyTorch
+---
+
 # PyTorch Integration
 
 IREE supports compiling and running PyTorch programs represented as

--- a/docs/website/docs/guides/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/guides/ml-frameworks/tensorflow.md
@@ -1,3 +1,11 @@
+---
+hide:
+  - tags
+tags:
+  - Python
+  - TensorFlow
+---
+
 # TensorFlow Integration
 
 IREE supports compiling and running TensorFlow programs represented as

--- a/docs/website/docs/guides/ml-frameworks/tflite.md
+++ b/docs/website/docs/guides/ml-frameworks/tflite.md
@@ -1,3 +1,11 @@
+---
+hide:
+  - tags
+tags:
+  - Python
+  - TensorFlow
+---
+
 # TFLite Integration
 
 IREE supports compiling and running TensorFlow Lite programs stored as [TFLite

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - tags
+tags:
+  - Python
+---
+
 # Python bindings
 
 !!! info

--- a/docs/website/docs/reference/bindings/tensorflow-lite.md
+++ b/docs/website/docs/reference/bindings/tensorflow-lite.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - tags
+tags:
+  - TensorFlow
+---
+
 # TensorFlow Lite bindings
 
 !!! todo

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -145,6 +145,9 @@ plugins:
   # https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/
   - search
 
+  # https://squidfunk.github.io/mkdocs-material/setup/setting-up-tags/
+  - tags
+
   # https://github.com/mkdocs/mkdocs-redirects
   - redirects:
       redirect_maps:  # old -> new


### PR DESCRIPTION
https://squidfunk.github.io/mkdocs-material/setup/setting-up-tags/

This helps with searching.

Search before: 
![image](https://github.com/openxla/iree/assets/4010439/5daac7c0-e3a7-4d58-b9d9-3dcf5b7ad599)

Search after (note the results and how all tags are shown for each page): 
![image](https://github.com/openxla/iree/assets/4010439/d0660430-7bf5-4781-a986-d728f3ab2720)

I opted to hide the tags on all pages _except_ the blog posts, since they appear at the top of the page and are usually redundant: 
![image](https://github.com/openxla/iree/assets/4010439/59fb29e9-b9dc-49da-8753-31a39aa2fe8a)
