### PR TITLE
Exposing device configuration higher in the stack.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -689,6 +689,35 @@ def HAL_DeviceTargetAttr :
     // the `hal.device.targets` attribute is found.
     static SmallVector<DeviceTargetAttr, 4> lookup(Operation *op);
 
+    // Returns true if there is any UnitAttr with |name| in any device
+    // configuration for the given |op|.
+    static bool lookupConfigAttrAny(Operation *op, StringRef name);
+
+    // Returns true if all device configurations found for the given |op| have
+    // a UnitAttr with |name|.
+    static bool lookupConfigAttrAll(Operation *op, StringRef name);
+
+    // Returns the AND of boolean attributes of |name| in all device
+    // configurations found for the given |op|.
+    // Returns nullopt if any config does not have the key defined indicating
+    // that it's not statically known/runtime dynamic.
+    static std::optional<bool>
+    lookupConfigAttrAnd(Operation *op, StringRef name);
+
+    // Returns the OR of boolean attributes of |name| in all device
+    // configurations found for the given |op|.
+    // Returns nullopt if any config does not have the key defined indicating
+    // that it's not statically known/runtime dynamic.
+    static std::optional<bool>
+    lookupConfigAttrOr(Operation *op, StringRef name);
+
+    // Returns the range of integer attributes of |name| in all device
+    // configurations found for the given |op|.
+    // Returns nullopt if any config does not have the key defined indicating
+    // that it's not statically known/runtime dynamic.
+    static std::optional<StaticRange<APInt>>
+    lookupConfigAttrRange(Operation *op, StringRef name);
+
     // Returns a list of all target executable configurations that may be
     // required for the given operation.
     static SmallVector<ExecutableTargetAttr, 4>

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -308,6 +308,125 @@ SmallVector<IREE::HAL::DeviceTargetAttr, 4> DeviceTargetAttr::lookup(
   return {};  // No devices found; let caller decide what to do.
 }
 
+// Returns a set of all configuration attributes from all device targets with
+// a configuration set. Targets with no configuration set are ignored.
+static SmallVector<DictionaryAttr> lookupOptionalConfigAttrs(Operation *op) {
+  auto targetAttrs = IREE::HAL::DeviceTargetAttr::lookup(op);
+  if (targetAttrs.empty()) return {};
+  SmallVector<DictionaryAttr> configAttrs;
+  for (auto targetAttr : targetAttrs) {
+    auto configAttr = targetAttr.getConfiguration();
+    if (configAttr) configAttrs.push_back(configAttr);
+  }
+  return configAttrs;
+}
+
+// Returns a set of all configuration attributes from all device targets.
+// Returns nullopt if any target is missing a configuration attribute.
+static std::optional<SmallVector<DictionaryAttr>> lookupRequiredConfigAttrs(
+    Operation *op) {
+  auto targetAttrs = IREE::HAL::DeviceTargetAttr::lookup(op);
+  if (targetAttrs.empty()) return std::nullopt;
+  SmallVector<DictionaryAttr> configAttrs;
+  for (auto targetAttr : targetAttrs) {
+    auto configAttr = targetAttr.getConfiguration();
+    if (!configAttr) return std::nullopt;
+    configAttrs.push_back(configAttr);
+  }
+  return configAttrs;
+}
+
+template <typename AttrT>
+static std::optional<typename AttrT::ValueType> joinConfigAttrs(
+    ArrayRef<DictionaryAttr> configAttrs, StringRef name,
+    std::function<typename AttrT::ValueType(typename AttrT::ValueType,
+                                            typename AttrT::ValueType)>
+        join) {
+  if (configAttrs.empty()) return std::nullopt;
+  auto firstValue = configAttrs.front().getAs<AttrT>(name);
+  if (!firstValue) return std::nullopt;
+  auto result = firstValue.getValue();
+  for (auto configAttr : configAttrs.drop_front(1)) {
+    auto value = configAttr.getAs<AttrT>(name);
+    if (!value) return std::nullopt;
+    result = join(result, value.getValue());
+  }
+  return result;
+}
+
+template <typename AttrT>
+static std::optional<StaticRange<typename AttrT::ValueType>>
+joinConfigStaticRanges(ArrayRef<DictionaryAttr> configAttrs, StringRef name,
+                       std::function<StaticRange<typename AttrT::ValueType>(
+                           StaticRange<typename AttrT::ValueType>,
+                           StaticRange<typename AttrT::ValueType>)>
+                           join) {
+  if (configAttrs.empty()) return std::nullopt;
+  auto firstValue = configAttrs.front().getAs<AttrT>(name);
+  if (!firstValue) return std::nullopt;
+  StaticRange<typename AttrT::ValueType> result{firstValue.getValue()};
+  for (auto configAttr : configAttrs.drop_front(1)) {
+    auto value = configAttr.getAs<AttrT>(name);
+    if (!value) return std::nullopt;
+    result =
+        join(result, StaticRange<typename AttrT::ValueType>{value.getValue()});
+  }
+  return result;
+}
+
+// static
+bool DeviceTargetAttr::lookupConfigAttrAny(Operation *op, StringRef name) {
+  auto configAttrs = lookupOptionalConfigAttrs(op);
+  if (configAttrs.empty()) return false;
+  for (auto configAttr : configAttrs) {
+    if (configAttr.get(name)) return true;
+  }
+  return false;
+}
+
+// static
+bool DeviceTargetAttr::lookupConfigAttrAll(Operation *op, StringRef name) {
+  auto configAttrs = lookupRequiredConfigAttrs(op);
+  if (!configAttrs) return false;
+  for (auto configAttr : *configAttrs) {
+    if (!configAttr.get(name)) return false;
+  }
+  return true;
+}
+
+// static
+std::optional<bool> DeviceTargetAttr::lookupConfigAttrAnd(Operation *op,
+                                                          StringRef name) {
+  auto configAttrs = lookupRequiredConfigAttrs(op);
+  if (!configAttrs) return std::nullopt;
+  return joinConfigAttrs<BoolAttr>(
+      configAttrs.value(), name, [](bool lhs, bool rhs) { return lhs && rhs; });
+}
+
+// static
+std::optional<bool> DeviceTargetAttr::lookupConfigAttrOr(Operation *op,
+                                                         StringRef name) {
+  auto configAttrs = lookupRequiredConfigAttrs(op);
+  if (!configAttrs) return std::nullopt;
+  return joinConfigAttrs<BoolAttr>(
+      configAttrs.value(), name, [](bool lhs, bool rhs) { return lhs || rhs; });
+}
+
+// static
+std::optional<StaticRange<APInt>> DeviceTargetAttr::lookupConfigAttrRange(
+    Operation *op, StringRef name) {
+  auto configAttrs = lookupRequiredConfigAttrs(op);
+  if (!configAttrs) return std::nullopt;
+  return joinConfigStaticRanges<IntegerAttr>(
+      configAttrs.value(), name,
+      [](StaticRange<APInt> lhs, StaticRange<APInt> rhs) {
+        return StaticRange<APInt>{
+            llvm::APIntOps::smin(lhs.min, rhs.min),
+            llvm::APIntOps::smax(lhs.max, rhs.max),
+        };
+      });
+}
+
 // static
 SmallVector<ExecutableTargetAttr, 4> DeviceTargetAttr::lookupExecutableTargets(
     Operation *op) {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
@@ -154,6 +154,14 @@ struct DescriptorSetBindingValue {
   Value byteLength;
 };
 
+template <typename T>
+struct StaticRange {
+  T min;
+  T max;
+  StaticRange(T value) : min(value), max(value) {}
+  StaticRange(T min, T max) : min(min), max(max) {}
+};
+
 }  // namespace HAL
 }  // namespace IREE
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/FixupLegacySync.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/FixupLegacySync.cpp
@@ -153,15 +153,10 @@ struct FixupLegacySyncPass
 
     // See if any devices are marked as requiring the legacy_sync behavior.
     // If any single device does we must uniformly apply the fixups.
-    bool anyRequireFixup = false;
-    auto deviceTargetAttrs = IREE::HAL::DeviceTargetAttr::lookup(moduleOp);
-    for (auto deviceTargetAttr : deviceTargetAttrs) {
-      if (deviceTargetAttr.hasConfigurationAttr("legacy_sync")) {
-        anyRequireFixup = true;
-        break;
-      }
+    if (!IREE::HAL::DeviceTargetAttr::lookupConfigAttrAny(moduleOp,
+                                                          "legacy_sync")) {
+      return;
     }
-    if (!anyRequireFixup) return;
 
     // This could use an interface but it'd be better to remove the need for
     // this pass instead.

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -42,6 +42,15 @@ void buildIREEVMTransformPassPipeline(
     IREE::HAL::TargetOptions executableOptions,
     IREE::VM::TargetOptions targetOptions, IREEVMPipelineHooks &hooks,
     OpPassManager &passManager, IREEVMPipelinePhase compileTo) {
+  // If the user specified a set of target devices we attach them to the module
+  // IR so that they are available for all passes that may want to use this
+  // information. If trying to compile in a generic mode the user should omit
+  // specifying targets.
+  if (!executableOptions.targets.empty()) {
+    passManager.addPass(IREE::HAL::createAssignTargetDevicesPass(
+        targetRegistry, executableOptions.targets));
+  }
+
   // Input pipelines can result in changes to the exported functions and types
   // and must run before generating bindings.
   // After input processing, there should only be IREE legal types in


### PR DESCRIPTION
AssignTargetDevices now runs at the head of the translation pipeline so that the hal.device.target attrs are available. Users can also provide their own attrs on the module before invoking IREE.

As a first step toward target information the DeviceTargetAttr has gained a few query calls that allow for semantically meaningful queries of device attributes. For example, asking if any device being targeted has trait 'foo' a pass can get a bool from `IREE::HAL::DeviceTargetAttr::lookupConfigAttrAny(op, "foo")`. Additional queries exist for BoolAttr and IntegerAttr. Targets can populate the configuration attributes in their `TargetBackend::getDefaultDeviceTarget` implementation and since they are just dictionary entries out-of-tree backends can inject their own arbitrary attributes. The namespace is wide open so it's up to people adding them to keep things clean/conflict-free (hopefully with some namespacing).

This is just the first step; we can do things like add an attr interface to allow for arbitrary attribute types in the target configuration that still support the multi-target-aware query operations. A larger bit of design work around doing these queries dynamically can probably be built with a similar structure but returning OpFoldResult instead of the attributes.

Note that this does make IR dumped at intermediate stages device-dependent and changing the targets midway through won't really be possible once more passes changing behavior are added. It's still possible to get generic IR when lowering with --compile-to= by just omitting the --iree-hal-target-backends= flag.

**NOTE**: this is not a way to suddenly put a lot of target-specific passes in flow - flow is meant to be multi-target, and the configuration attributes exposed should be generic things usable by multiple targets with similar properties ("all GPUs like X so vulkan, metal, webgpu, and cuda targets all set X" etc). Adding "cuda.sm = 80" or something and then making decisions in flow on that is not ok.
![image](https://github.com/openxla/iree/assets/75337/596aa5ef-c74c-4d7e-88ff-738b84e8c0f5)

Fixes #14003 (it's a start, anyway).