### PR TITLE
Adding IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION.

### DIFF
--- a/experimental/cuda2/cuda_allocator.c
+++ b/experimental/cuda2/cuda_allocator.c
@@ -306,6 +306,10 @@ static void iree_hal_cuda2_buffer_free(
       IREE_TRACE_ZONE_APPEND_TEXT(z0, "(ignored; async)");
       break;
     }
+    case IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL: {
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, "(ignored; external)");
+      break;
+    }
   }
   IREE_TRACE_ZONE_END(z0);
 }
@@ -564,6 +568,11 @@ static iree_status_t iree_hal_cuda2_allocator_import_buffer(
             cuMemHostGetDevicePointer(&device_ptr, host_ptr, 0),
             "cuMemHostGetDevicePointer");
       }
+      break;
+    }
+    case IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION: {
+      buffer_type = IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL;
+      device_ptr = (CUdeviceptr)external_buffer->handle.device_allocation.ptr;
       break;
     }
     case IREE_HAL_EXTERNAL_BUFFER_TYPE_OPAQUE_FD:

--- a/experimental/cuda2/cuda_buffer.h
+++ b/experimental/cuda2/cuda_buffer.h
@@ -27,6 +27,9 @@ typedef enum iree_hal_cuda2_buffer_type_e {
   // Device local buffer, allocated with cuMemAllocFromPoolAsync, freed with
   // cuMemFree/cuMemFreeAsync.
   IREE_HAL_CUDA_BUFFER_TYPE_ASYNC,
+  // Externally registered buffer whose providence is unknown.
+  // Must be freed by the user.
+  IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL,
 } iree_hal_cuda2_buffer_type_t;
 
 // Wraps a CUDA allocation in an iree_hal_buffer_t.

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -284,6 +284,10 @@ static void iree_hal_cuda_buffer_free(iree_hal_cuda_context_wrapper_t* context,
       IREE_TRACE_ZONE_APPEND_TEXT(z0, "(ignored; async)");
       break;
     }
+    case IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL: {
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, "(ignored; external)");
+      break;
+    }
   }
   IREE_TRACE_ZONE_END(z0);
 }
@@ -534,6 +538,11 @@ static iree_status_t iree_hal_cuda_allocator_import_buffer(
             cuMemHostGetDevicePointer(&device_ptr, host_ptr, 0),
             "cuMemHostGetDevicePointer");
       }
+      break;
+    }
+    case IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION: {
+      buffer_type = IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL;
+      device_ptr = (CUdeviceptr)external_buffer->handle.device_allocation.ptr;
       break;
     }
     case IREE_HAL_EXTERNAL_BUFFER_TYPE_OPAQUE_FD:

--- a/runtime/src/iree/hal/drivers/cuda/cuda_buffer.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_buffer.h
@@ -24,6 +24,9 @@ typedef enum iree_hal_cuda_buffer_type_e {
   IREE_HAL_CUDA_BUFFER_TYPE_HOST_REGISTERED,
   // cuMemAllocFromPoolAsync + cuMemFree/cuMemFreeAsync
   IREE_HAL_CUDA_BUFFER_TYPE_ASYNC,
+  // Externally registered buffer whose providence is unknown.
+  // Must be freed by the user.
+  IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL,
 } iree_hal_cuda_buffer_type_t;
 
 // Wraps a CUDA allocation in an iree_hal_buffer_t.


### PR DESCRIPTION
We can use this for other targets (Vulkan device pointers, etc) but for now we just support it on CPU with the default heap allocator (device pointers _are_ host pointers for most uses) and CUDA (where we allow a CUdeviceptr).