### PR TITLE
Decompose complex.constant and linalg.fill before flow

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
@@ -44,6 +44,7 @@ iree_compiler_cc_library(
 iree_compiler_cc_library(
     name = "Common",
     srcs = [
+        "DecomposeComplex.cpp",
         "IREEImportPublic.cpp",
         "ImportMLProgram.cpp",
         "Passes.cpp",

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     "Passes.h"
     "Utils.h"
   SRCS
+    "DecomposeComplex.cpp"
     "IREEImportPublic.cpp"
     "ImportMLProgram.cpp"
     "Passes.cpp"

--- a/compiler/src/iree/compiler/InputConversion/Common/DecomposeComplex.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/DecomposeComplex.cpp
@@ -1,0 +1,101 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/InputConversion/Common/PassDetail.h"
+#include "iree/compiler/InputConversion/Common/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+struct LinalgFill : public OpRewritePattern<linalg::FillOp> {
+  using OpRewritePattern<linalg::FillOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::FillOp op,
+                                PatternRewriter &rewriter) const override {
+    auto value = op.value();
+    auto valueTy = value.getType();
+    auto complexTy = dyn_cast<ComplexType>(valueTy);
+    auto resultTy = op.getType(0).cast<ShapedType>();
+    if (!complexTy) return failure();
+
+    auto real = rewriter.create<complex::ReOp>(op.getLoc(), value);
+    auto imag = rewriter.create<complex::ImOp>(op.getLoc(), value);
+
+    SmallVector<utils::IteratorType> loops(resultTy.getRank(),
+                                           utils::IteratorType::parallel);
+    SmallVector<AffineMap> maps{
+        rewriter.getMultiDimIdentityMap(resultTy.getRank())};
+    auto generic = rewriter.create<linalg::GenericOp>(
+        op.getLoc(), resultTy, ValueRange{}, ValueRange{op.getOutputs()[0]},
+        maps, loops, [&](OpBuilder &b, Location loc, ValueRange args) {
+          auto cmplx =
+              b.create<complex::CreateOp>(loc, valueTy, real, imag).getResult();
+          b.create<linalg::YieldOp>(loc, cmplx);
+        });
+
+    rewriter.replaceOp(op, generic.getResult(0));
+    return success();
+  }
+};
+
+struct ComplexConstant : public OpRewritePattern<complex::ConstantOp> {
+  using OpRewritePattern<complex::ConstantOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(complex::ConstantOp op,
+                                PatternRewriter &rewriter) const override {
+    ArrayAttr attr = op.getValue().dyn_cast<ArrayAttr>();
+    auto realAttr = attr[0].cast<TypedAttr>();
+    auto imagAttr = attr[1].cast<TypedAttr>();
+
+    Value real = rewriter.create<arith::ConstantOp>(
+        op.getLoc(), realAttr.getType(), realAttr);
+    Value imag = rewriter.create<arith::ConstantOp>(
+        op.getLoc(), imagAttr.getType(), imagAttr);
+
+    auto result = op.getResult();
+    for (OpOperand &operand : llvm::make_early_inc_range(result.getUses())) {
+      Operation *targetOp = operand.getOwner();
+      rewriter.setInsertionPoint(targetOp);
+      auto newOp = rewriter.create<complex::CreateOp>(op.getLoc(), op.getType(),
+                                                      real, imag);
+      rewriter.updateRootInPlace(targetOp, [&]() { operand.set(newOp); });
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+/// Pass that lowers quantized_matmul to matmul.
+struct DecomposeComplexPass
+    : public DecomposeComplexPassBase<DecomposeComplexPass> {
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *context = op->getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<ComplexConstant, LinalgFill>(context);
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>> createDecomposeComplexPass() {
+  return std::make_unique<DecomposeComplexPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.cpp
@@ -23,6 +23,7 @@ void buildCommonInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createIREEImportPublicPass());
   passManager.addPass(createImportMLProgramPass());
   passManager.addPass(createSanitizeModuleNamesPass());
+  passManager.addNestedPass<func::FuncOp>(createDecomposeComplexPass());
 }
 
 void registerCommonInputConversionPasses() {

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.h
@@ -35,6 +35,7 @@ createAutoInputConversionPipelinePass();
 std::unique_ptr<OperationPass<ModuleOp>> createAutoInputConversionPipelinePass(
     const AutoInputConversionPipelineOptions& options);
 std::unique_ptr<OperationPass<ModuleOp>> createIREEImportPublicPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createDecomposeComplexPass();
 std::unique_ptr<OperationPass<ModuleOp>> createImportMLProgramPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createLinalgQuantizedConvToConvPass();

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.td
@@ -15,6 +15,12 @@ def IREEImportPublic :
   let constructor = "mlir::iree_compiler::createIREEImportPublicPass()";
 }
 
+def DecomposeComplexPass
+    : Pass<"iree-decompose-complex", "func::FuncOp"> {
+  let summary = "decompose complex dialect operations to IREE compatible cases.";
+  let constructor = "mlir::iree_compiler::createDecomposeComplexPass()";
+}
+
 def ImportMLProgram :
     Pass<"iree-import-ml-program", "ModuleOp"> {
   let summary = "Imports MLProgram dialect to IREE Equivalents.";

--- a/compiler/src/iree/compiler/InputConversion/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "auto_input_conversion_pipeline.mlir",
+            "decompose_complex.mlir",
             "import_ml_program.mlir",
             "iree_import_public.mlir",
             "linalg_quantized_conv_to_conv.mlir",

--- a/compiler/src/iree/compiler/InputConversion/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "auto_input_conversion_pipeline.mlir"
+    "decompose_complex.mlir"
     "import_ml_program.mlir"
     "iree_import_public.mlir"
     "linalg_quantized_conv_to_conv.mlir"

--- a/compiler/src/iree/compiler/InputConversion/Common/test/decompose_complex.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/decompose_complex.mlir
@@ -1,0 +1,96 @@
+// RUN: iree-opt --split-input-file --iree-decompose-complex %s | FileCheck %s
+
+func.func @fill_test() -> tensor<2x3xcomplex<f32>> {
+    %cst = complex.constant [0.000000e+00 : f32, 0.000000e+00 : f32] : complex<f32>
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<2x3xcomplex<f32>>
+    %1 = linalg.fill ins(%cst : complex<f32>) outs(%0 : tensor<2x3xcomplex<f32>>) -> tensor<2x3xcomplex<f32>>
+    func.return %1 : tensor<2x3xcomplex<f32>>
+}
+
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK: @fill_test
+// CHECK:   %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<2x3xcomplex<f32>>
+// CHECK:   %[[GENERIC:.+]] = linalg.generic {
+// CHECK-SAME: indexing_maps = [#[[MAP]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME: outs(%[[EMPTY]] : tensor<2x3xcomplex<f32>>)
+// CHECK:     %[[CREATE:.+]] = complex.create %[[CST]], %[[CST]]
+// CHECK:     linalg.yield %[[CREATE]]
+// CHECK:   return %[[GENERIC]]
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func public @linalg_generic_test(%arg0: tensor<2x3xcomplex<f32>>) -> (tensor<2x3xcomplex<f32>>) {
+  %cst = complex.constant [-1.000000e+00 : f32, 1.000000e+00 : f32] : complex<f32>
+  %0 = tensor.empty() : tensor<2x3xcomplex<f32>>
+  %2 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<2x3xcomplex<f32>>) outs(%0 : tensor<2x3xcomplex<f32>>) {
+  ^bb0(%in: complex<f32>, %out: complex<f32>):
+    %3 = linalg.index 0 : index
+    %4 = linalg.index 1 : index
+    %5 = arith.index_cast %3 : index to i32
+    %6 = arith.index_cast %4 : index to i32
+    %7 = arith.uitofp %5 : i32 to f32
+    %8 = arith.uitofp %6 : i32 to f32
+    %9 = complex.create %7, %8 : complex<f32>
+    %10 = complex.mul %cst, %9 : complex<f32>
+    %11 = complex.mul %in, %10 : complex<f32>
+    linalg.yield %11 : complex<f32>
+  } -> tensor<2x3xcomplex<f32>>
+  return %2 : tensor<2x3xcomplex<f32>>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK: @linalg_generic_test
+// CHECK: %[[C0:.+]] = arith.constant -1.000000e+00 : f32
+// CHECK: %[[C1:.+]] = arith.constant 1.000000e+00 : f32
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<2x3xcomplex<f32>>
+// CHECK: %[[GENERIC:.+]] = linalg.generic 
+// CHECK-SAME: indexing_maps = [#map, #map]
+// CHECK-SAME: iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME: ins(%arg0 : tensor<2x3xcomplex<f32>>)
+// CHECK-SAME:outs(%[[EMPTY]] : tensor<2x3xcomplex<f32>>)
+// CHECK: ^bb0(%[[IN:.+]]: complex<f32>, %[[OUT:.+]]: complex<f32>):
+// CHECK:   %[[IDX0:.+]] = linalg.index 0 : index
+// CHECK:   %[[IDX1:.+]] = linalg.index 1 : index
+// CHECK:   %[[CST0:.+]] = arith.index_cast %[[IDX0]] : index to i32
+// CHECK:   %[[CST1:.+]] = arith.index_cast %[[IDX1]] : index to i32
+// CHECK:   %[[FP0:.+]] = arith.uitofp %[[CST0]]
+// CHECK:   %[[FP1:.+]] = arith.uitofp %[[CST1]]
+// CHECK:   %[[CMPLX0:.+]] = complex.create %[[FP0]], %[[FP1]] : complex<f32>
+// CHECK:   %[[CMPLX1:.+]] = complex.create %[[C0]], %[[C1]] : complex<f32>
+// CHECK:   %[[MUL0:.+]] = complex.mul %[[CMPLX1]], %[[CMPLX0]] : complex<f32>
+// CHECK:   %[[MUL1:.+]] = complex.mul %[[IN]], %[[MUL0]]
+// CHECK:   linalg.yield %[[MUL1]]
+// CHECK: } -> tensor<2x3xcomplex<f32>>
+// CHECK: return %[[GENERIC]]
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func public @linalg_dual_generic_test(%arg0: tensor<2x3xcomplex<f32>>, %arg1: tensor<2x3xcomplex<f32>>) -> (tensor<2x3xcomplex<f32>>, tensor<2x3xcomplex<f32>>) {
+  %cst = complex.constant [-1.000000e+00 : f32, 1.000000e+00 : f32] : complex<f32>
+  %2 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%arg0 : tensor<2x3xcomplex<f32>>) {
+  ^bb0(%out: complex<f32>):
+    %mul = complex.mul %out, %cst : complex<f32>
+    linalg.yield %mul : complex<f32>
+  } -> tensor<2x3xcomplex<f32>>
+  %3 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%arg1 : tensor<2x3xcomplex<f32>>) {
+  ^bb0(%out: complex<f32>):
+    %mul = complex.div %out, %cst : complex<f32>
+    linalg.yield %mul : complex<f32>
+  } -> tensor<2x3xcomplex<f32>>
+  return %2, %3 : tensor<2x3xcomplex<f32>>, tensor<2x3xcomplex<f32>>
+
+}
+
+// CHECK-LABEL: @linalg_dual_generic
+// CHECK: linalg.generic
+// CHECK: complex.create
+// CHECK: complex.mul
+// CHECK: linalg.generic
+// CHECK: complex.create
+// CHECK: complex.div


### PR DESCRIPTION
Flow / HAL does not support `complex` types being passed via the outlined dispatch region. Decomposing `linalg.fill` and `complex.constant` into versions embedded within the dispatch regions should guarantee compilation.

Closes #12747 