### PR TITLE
Adding a fallback for when CUDA memory pools are unsupported.

### DIFF
--- a/experimental/cuda2/cuda_allocator.c
+++ b/experimental/cuda2/cuda_allocator.c
@@ -30,6 +30,7 @@ typedef struct iree_hal_cuda2_allocator_t {
   // The CUDA stream that allocations should be used in.
   CUstream stream;
 
+  // NOTE: optional depending on device support.
   iree_hal_cuda2_memory_pools_t* pools;
 
   const iree_hal_cuda2_dynamic_symbols_t* symbols;
@@ -136,8 +137,10 @@ static void iree_hal_cuda2_allocator_query_statistics(
     iree_hal_cuda2_allocator_t* allocator =
         iree_hal_cuda2_allocator_cast(base_allocator);
     memcpy(out_statistics, &allocator->statistics, sizeof(*out_statistics));
-    iree_hal_cuda2_memory_pools_merge_statistics(allocator->pools,
-                                                 out_statistics);
+    if (allocator->pools) {
+      iree_hal_cuda2_memory_pools_merge_statistics(allocator->pools,
+                                                   out_statistics);
+    }
   });
 }
 

--- a/experimental/cuda2/cuda_allocator.h
+++ b/experimental/cuda2/cuda_allocator.h
@@ -19,7 +19,8 @@ extern "C" {
 // Creates a CUDA memory allocator.
 // |device| and |stream| will be used for management operations.
 // |pools| provides memory pools that may be shared across multiple allocators
-// and the pointer must remain valid for the lifetime of the allocator.
+// and the pointer must remain valid for the lifetime of the allocator. Pools
+// may not be supported on all devices and can be NULL.
 iree_status_t iree_hal_cuda2_allocator_create(
     iree_hal_device_t* base_device,
     const iree_hal_cuda2_dynamic_symbols_t* cuda_symbols, CUdevice device,

--- a/experimental/cuda2/memory_pools.c
+++ b/experimental/cuda2/memory_pools.c
@@ -178,6 +178,21 @@ void iree_hal_cuda2_memory_pools_merge_statistics(
   });
 }
 
+iree_status_t iree_hal_cuda2_memory_pools_trim(
+    iree_hal_cuda2_memory_pools_t* pools,
+    const iree_hal_cuda2_memory_pooling_params_t* pooling_params) {
+  IREE_CUDA_RETURN_IF_ERROR(
+      pools->cuda_symbols,
+      cuMemPoolTrimTo(pools->device_local,
+                      pooling_params->device_local.minimum_capacity),
+      "cuMemPoolTrimTo");
+  IREE_CUDA_RETURN_IF_ERROR(
+      pools->cuda_symbols,
+      cuMemPoolTrimTo(pools->other, pooling_params->other.minimum_capacity),
+      "cuMemPoolTrimTo");
+  return iree_ok_status();
+}
+
 // NOTE: this is only issued if the buffer is destroyed without having had been
 // scheduled for deallocation asynchronously. When a buffer is scheduled we drop
 // the release callback so that this isn't called and we don't double-free.

--- a/experimental/cuda2/memory_pools.h
+++ b/experimental/cuda2/memory_pools.h
@@ -52,6 +52,11 @@ void iree_hal_cuda2_memory_pools_merge_statistics(
     iree_hal_cuda2_memory_pools_t* pools,
     iree_hal_allocator_statistics_t* statistics);
 
+// Trims all memory pools by releasing resources back to the system.
+iree_status_t iree_hal_cuda2_memory_pools_trim(
+    iree_hal_cuda2_memory_pools_t* pools,
+    const iree_hal_cuda2_memory_pooling_params_t* pooling_params);
+
 // Asynchronously allocates a buffer from an appropriate pool.
 // The allocation will be stream-ordered on |stream|.
 iree_status_t iree_hal_cuda2_memory_pools_alloca(

--- a/runtime/src/iree/hal/drivers/cuda/api.h
+++ b/runtime/src/iree/hal/drivers/cuda/api.h
@@ -84,6 +84,10 @@ typedef struct iree_hal_cuda_device_params_t {
   // tracing with this enabled.
   bool stream_tracing;
 
+  // Whether to use async allocations even if reported as available by the
+  // device. Defaults to true when the device supports it.
+  bool async_allocations;
+
   // Parameters for each CUmemoryPool used for queue-ordered allocations.
   iree_hal_cuda_memory_pooling_params_t memory_pools;
 } iree_hal_cuda_device_params_t;

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -119,8 +119,10 @@ static void iree_hal_cuda_allocator_query_statistics(
     iree_hal_cuda_allocator_t* allocator =
         iree_hal_cuda_allocator_cast(base_allocator);
     memcpy(out_statistics, &allocator->statistics, sizeof(*out_statistics));
-    iree_hal_cuda_memory_pools_merge_statistics(allocator->pools,
-                                                out_statistics);
+    if (allocator->pools) {
+      iree_hal_cuda_memory_pools_merge_statistics(allocator->pools,
+                                                  out_statistics);
+    }
   });
 }
 

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.h
@@ -20,7 +20,8 @@ extern "C" {
 // Creates a CUDA memory allocator.
 // |device| and |stream| will be used for management operations.
 // |pools| provides memory pools that may be shared across multiple allocators
-// and the pointer must remain valid for the lifetime of the allocator.
+// and the pointer must remain valid for the lifetime of the allocator. Pools
+// may not be supported on all devices and can be NULL.
 iree_status_t iree_hal_cuda_allocator_create(
     iree_hal_device_t* base_device, iree_hal_cuda_context_wrapper_t* context,
     CUdevice device, CUstream stream, iree_hal_cuda_memory_pools_t* pools,

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -56,6 +56,7 @@ typedef struct iree_hal_cuda_device_t {
   iree_hal_cuda_context_wrapper_t context_wrapper;
   iree_hal_cuda_tracing_context_t* tracing_context;
 
+  bool supports_memory_pools;
   iree_hal_cuda_memory_pools_t memory_pools;
   iree_hal_allocator_t* device_allocator;
 
@@ -88,6 +89,7 @@ IREE_API_EXPORT void iree_hal_cuda_device_params_initialize(
   out_params->command_buffer_mode = IREE_HAL_CUDA_COMMAND_BUFFER_MODE_GRAPH;
   out_params->allow_inline_execution = false;
   out_params->stream_tracing = false;
+  out_params->async_allocations = true;
 }
 
 static iree_status_t iree_hal_cuda_device_check_params(
@@ -137,8 +139,20 @@ static iree_status_t iree_hal_cuda_device_create_internal(
         &device->block_pool, host_allocator, &device->tracing_context);
   }
 
+  // Memory pool support is conditional.
+  if (iree_status_is_ok(status) && params->async_allocations) {
+    int supports_memory_pools = 0;
+    status = CU_RESULT_TO_STATUS(
+        syms,
+        cuDeviceGetAttribute(&supports_memory_pools,
+                             CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
+                             cu_device),
+        "cuDeviceGetAttribute");
+    device->supports_memory_pools = supports_memory_pools ? true : false;
+  }
+
   // Create memory pools first so that we can share them with the allocator.
-  if (iree_status_is_ok(status)) {
+  if (iree_status_is_ok(status) && device->supports_memory_pools) {
     status = iree_hal_cuda_memory_pools_initialize(
         &device->context_wrapper, &params->memory_pools, &device->memory_pools);
   }
@@ -146,7 +160,8 @@ static iree_status_t iree_hal_cuda_device_create_internal(
   if (iree_status_is_ok(status)) {
     status = iree_hal_cuda_allocator_create(
         (iree_hal_device_t*)device, &device->context_wrapper, cu_device, stream,
-        &device->memory_pools, &device->device_allocator);
+        device->supports_memory_pools ? &device->memory_pools : NULL,
+        &device->device_allocator);
   }
 
   if (iree_status_is_ok(status) &&
@@ -287,18 +302,10 @@ static iree_status_t iree_hal_cuda_device_trim(iree_hal_device_t* base_device) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   iree_arena_block_pool_trim(&device->block_pool);
   IREE_RETURN_IF_ERROR(iree_hal_allocator_trim(device->device_allocator));
-  // TODO: move to memory pool manager.
-  CUDA_RETURN_IF_ERROR(
-      device->context_wrapper.syms,
-      cuMemPoolTrimTo(
-          device->memory_pools.device_local,
-          device->params.memory_pools.device_local.minimum_capacity),
-      "cuMemPoolTrimTo");
-  CUDA_RETURN_IF_ERROR(
-      device->context_wrapper.syms,
-      cuMemPoolTrimTo(device->memory_pools.other,
-                      device->params.memory_pools.other.minimum_capacity),
-      "cuMemPoolTrimTo");
+  if (device->supports_memory_pools) {
+    IREE_RETURN_IF_ERROR(iree_hal_cuda_memory_pools_trim(
+        &device->memory_pools, &device->params.memory_pools));
+  }
   return iree_ok_status();
 }
 
@@ -516,9 +523,18 @@ static iree_status_t iree_hal_cuda_device_queue_alloca(
 
   // Allocate from the pool; likely to fail in cases of virtual memory
   // exhaustion but the error may be deferred until a later synchronization.
-  iree_status_t status = iree_hal_cuda_memory_pools_alloca(
-      &device->memory_pools, device->stream, pool, params, allocation_size,
-      out_buffer);
+  // If pools are not supported we allocate a buffer as normal from whatever
+  // allocator is set on the device.
+  iree_status_t status = iree_ok_status();
+  if (device->supports_memory_pools) {
+    status = iree_hal_cuda_memory_pools_alloca(&device->memory_pools,
+                                               device->stream, pool, params,
+                                               allocation_size, out_buffer);
+  } else {
+    status = iree_hal_allocator_allocate_buffer(
+        iree_hal_device_allocator(base_device), params, allocation_size,
+        iree_const_byte_span_empty(), out_buffer);
+  }
 
   // Only signal if not returning a synchronous error - synchronous failure
   // indicates that the stream is unchanged (it's not really since we waited
@@ -546,9 +562,13 @@ static iree_status_t iree_hal_cuda_device_queue_dealloca(
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
                                                     iree_infinite_timeout()));
 
-  // Schedule the buffer deallocation.
-  iree_status_t status = iree_hal_cuda_memory_pools_dealloca(
-      &device->memory_pools, device->stream, buffer);
+  // Schedule the buffer deallocation if we got it from a pool and otherwise
+  // drop it on the floor and let it be freed when the buffer is released.
+  iree_status_t status = iree_ok_status();
+  if (device->supports_memory_pools) {
+    status = iree_hal_cuda_memory_pools_dealloca(&device->memory_pools,
+                                                 device->stream, buffer);
+  }
 
   // Only signal if not returning a synchronous error - synchronous failure
   // indicates that the stream is unchanged (it's not really since we waited

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -148,7 +148,7 @@ static iree_status_t iree_hal_cuda_device_create_internal(
                              CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
                              cu_device),
         "cuDeviceGetAttribute");
-    device->supports_memory_pools = supports_memory_pools ? true : false;
+    device->supports_memory_pools = supports_memory_pools != 0;
   }
 
   // Create memory pools first so that we can share them with the allocator.

--- a/runtime/src/iree/hal/drivers/cuda/memory_pools.c
+++ b/runtime/src/iree/hal/drivers/cuda/memory_pools.c
@@ -174,6 +174,21 @@ void iree_hal_cuda_memory_pools_merge_statistics(
   });
 }
 
+iree_status_t iree_hal_cuda_memory_pools_trim(
+    iree_hal_cuda_memory_pools_t* pools,
+    const iree_hal_cuda_memory_pooling_params_t* pooling_params) {
+  CUDA_RETURN_IF_ERROR(
+      pools->context->syms,
+      cuMemPoolTrimTo(pools->device_local,
+                      pooling_params->device_local.minimum_capacity),
+      "cuMemPoolTrimTo");
+  CUDA_RETURN_IF_ERROR(
+      pools->context->syms,
+      cuMemPoolTrimTo(pools->other, pooling_params->other.minimum_capacity),
+      "cuMemPoolTrimTo");
+  return iree_ok_status();
+}
+
 // NOTE: this is only issued if the buffer is destroyed without having had been
 // scheduled for deallocation asynchronously. When a buffer is scheduled we drop
 // the release callback so that this isn't called and we don't double-free.

--- a/runtime/src/iree/hal/drivers/cuda/memory_pools.h
+++ b/runtime/src/iree/hal/drivers/cuda/memory_pools.h
@@ -50,6 +50,11 @@ void iree_hal_cuda_memory_pools_merge_statistics(
     iree_hal_cuda_memory_pools_t* pools,
     iree_hal_allocator_statistics_t* statistics);
 
+// Trims all memory pools by releasing resources back to the system.
+iree_status_t iree_hal_cuda_memory_pools_trim(
+    iree_hal_cuda_memory_pools_t* pools,
+    const iree_hal_cuda_memory_pooling_params_t* pooling_params);
+
 // Asynchronously allocates a buffer from an appropriate pool.
 // The allocation will be stream-ordered on |stream|.
 iree_status_t iree_hal_cuda_memory_pools_alloca(

--- a/runtime/src/iree/hal/drivers/cuda/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/cuda/registration/driver_module.c
@@ -31,6 +31,10 @@ IREE_FLAG(
     "Severely impacts benchmark timings and should only be used when\n"
     "analyzing dispatch timings.");
 
+IREE_FLAG(
+    bool, cuda_async_allocations, true,
+    "Enables CUDA asynchronous stream-ordered allocations when supported.");
+
 IREE_FLAG(int32_t, cuda_default_index, 0, "Index of the default CUDA device.");
 
 IREE_FLAG(bool, cuda_default_index_from_mpi, true,
@@ -92,6 +96,7 @@ static iree_status_t iree_hal_cuda_driver_factory_try_create(
   }
   default_params.allow_inline_execution = FLAG_cuda_allow_inline_execution;
   default_params.stream_tracing = FLAG_cuda_tracing;
+  default_params.async_allocations = FLAG_cuda_async_allocations;
 
   iree_hal_cuda_driver_options_t driver_options;
   iree_hal_cuda_driver_options_initialize(&driver_options);


### PR DESCRIPTION
This uses the existing behavior of allocating discrete buffers and dropping them on the floor when done with them.

The fallback can be forced even when devices support async allocations with the `--cuda_async_allocations=false` flag.