### PR TITLE
Harden the PadOp matcher

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy_pad.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy_pad.mlir
@@ -24,13 +24,14 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
   builtin.module {
     func.func @pad() {
       %c0 = arith.constant 0 : index
+      %c56 = arith.constant 56 : index
       %cst = arith.constant 0.000000e+00 : f32
       %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<123x456xf32>>
       %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<128x512xf32>>
       %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [123, 456], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<123x456xf32>> -> tensor<123x456xf32>
 
       %pad = arith.constant 0.0 : f32
-      %padded = tensor.pad %3 low[0, 0] high[5, 56] {
+      %padded = tensor.pad %3 low[%c0, 0] high[5, %c56] {
         ^bb0(%arg1: index, %arg2: index):
           tensor.yield %pad : f32
       } : tensor<123x456xf32> to tensor<128x512xf32>

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Strategies.cpp
@@ -40,7 +40,7 @@
 
 using namespace mlir;
 
-#define DEBUG_TYPE "iree-transform-builder"
+#define DEBUG_TYPE "iree-transform-strategy-builder"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(llvm::dbgs() << '[' << DEBUG_TYPE << "] " << X)
 

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -15,7 +15,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/Debug.h"
-#include <mlir/Dialect/Tensor/IR/Tensor.h>
 
 using namespace mlir;
 
@@ -1210,7 +1209,11 @@ transform_ext::TensorPadOpMatcher::low(ArrayRef<int64_t> sizes) {
       DBGS() << "low pad sizes are ";
       llvm::interleaveComma(sizes, llvm::dbgs());
     });
-    return tensorPad.getStaticLow() == sizes;
+    for (auto [ofr, sz] : llvm::zip(tensorPad.getMixedLowPad(), sizes)) {
+      if (isConstantIntValue(ofr, sz))
+        return false;
+    }
+    return true;
   });
   return *this;
 }
@@ -1219,8 +1222,9 @@ transform_ext::TensorPadOpMatcher &
 transform_ext::TensorPadOpMatcher::low(AllDims tag, int64_t size) {
   addPredicate([=](tensor::PadOp tensorPad) {
     LLVM_DEBUG(DBGS() << "all low pad sizes are " << size);
-    return llvm::all_of(tensorPad.getStaticLow(),
-                        [&](int64_t v) { return v == size; });
+    return llvm::all_of(tensorPad.getMixedLowPad(), [&](OpFoldResult ofr) {
+      return isConstantIntValue(ofr, size);
+    });
   });
   return *this;
 }
@@ -1232,7 +1236,11 @@ transform_ext::TensorPadOpMatcher::high(ArrayRef<int64_t> sizes) {
       DBGS() << "high pad sizes are ";
       llvm::interleaveComma(sizes, llvm::dbgs());
     });
-    return tensorPad.getStaticHigh() == sizes;
+    for (auto [ofr, sz] : llvm::zip(tensorPad.getMixedHighPad(), sizes)) {
+      if (isConstantIntValue(ofr, sz))
+        return false;
+    }
+    return true;
   });
   return *this;
 }
@@ -1241,8 +1249,9 @@ transform_ext::TensorPadOpMatcher &
 transform_ext::TensorPadOpMatcher::high(AllDims tag, int64_t size) {
   addPredicate([=](tensor::PadOp tensorPad) {
     LLVM_DEBUG(DBGS() << "all high pad sizes are " << size);
-    return llvm::all_of(tensorPad.getStaticHigh(),
-                        [&](int64_t v) { return v == size; });
+    return llvm::all_of(tensorPad.getMixedHighPad(), [&](OpFoldResult ofr) {
+      return isConstantIntValue(ofr, size);
+    });
   });
   return *this;
 }


### PR DESCRIPTION
`tensor.pad` operations are not always guaranteed to arrive in constant folded form.

Be more robust when matching the form that TD supports.