### PR TITLE
Allowing complex types as dispatch operands.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Utils/StringUtils.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -256,6 +257,9 @@ static std::string summarizeDispatchWorkgroupsOp(
         // No summarization implemented, default to the op's name.
         bestSummary = op->getName().getStringRef().str();
       });
+
+  // Sanitize the string so that it contains only C literal-compatible chars.
+  bestSummary = sanitizeSymbolName(bestSummary);
 
   LLVM_DEBUG(llvm::dbgs() << "// best op summary: '" << bestSummary << "'\n");
   return bestSummary;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -62,8 +63,78 @@ namespace {
 // any i64 (or equivalent) operand and splits it in to two i32s that get
 // stitched back together.
 
-// TODO(benvanik): handle index types here based on target devices. For now
-// we assume 32-bit device sizes and cast all index operands to i32.
+// Converts |operand| to a sequence of one or more i32 values.
+static void convertAndDecomposeToI32s(
+    Location loc, Value operand, SmallVector<Value> &newOperands,
+    IREE::Stream::ResourceConfigAttr resourceConfig, OpBuilder &builder) {
+  // NOTE: we do these in sequence so that we can reuse type expansion; we
+  // want f64 to become i64 so that i64 can become i32+i32 etc.
+
+  // Complex types are decomposed into real/imaginary components and processed
+  // as if they were independent.
+  if (auto complexType = dyn_cast<ComplexType>(operand.getType())) {
+    auto real = builder.create<complex::ReOp>(loc, operand);
+    auto imag = builder.create<complex::ImOp>(loc, operand);
+    convertAndDecomposeToI32s(loc, real, newOperands, resourceConfig, builder);
+    convertAndDecomposeToI32s(loc, imag, newOperands, resourceConfig, builder);
+    return;
+  }
+
+  // index -> i32 or i64
+  if (operand.getType().isIndex()) {
+    // Convert index types to a concrete bit width. 'index' can mean different
+    // things on the host and device as well as varying across devices.
+    // Today we just hardcode to i32 as we are working with smallish data and
+    // i64 uses 2x as much of our limited push constant space and is much
+    // slower to work with on mobile GPUs. In the future we will want to flag
+    // this as a global setting as well as have some heuristics for deriving
+    // from target devices.
+    operand = builder.createOrFold<arith::IndexCastUIOp>(
+        loc, builder.getIntegerType(resourceConfig.getIndexBits()), operand);
+  }
+
+  // bf16 -> i16, f32 -> i32, f64 -> i64 ...
+  if (auto floatType = dyn_cast<FloatType>(operand.getType())) {
+    // Floats need to be bitcast into opaque integers so that our handling
+    // below can deal with simple fixed width ints (bf16->i16, etc).
+    operand = builder.createOrFold<arith::BitcastOp>(
+        loc, builder.getIntegerType(floatType.getIntOrFloatBitWidth()),
+        operand);
+  }
+
+  // i1-i31 -> i32 and i33-i63 -> i64
+  // TODO(benvanik): don't extend here but instead pack as we can fit 4 i8's
+  // into a single i32 and save 4x our push constant capacity
+  unsigned bitWidth = IREE::Util::getTypeBitWidth(operand.getType());
+  if (bitWidth < 31) {
+    operand = builder.createOrFold<arith::ExtUIOp>(loc, builder.getI32Type(),
+                                                   operand);
+  } else if (bitWidth > 32 && bitWidth < 64) {
+    operand = builder.createOrFold<arith::ExtUIOp>(loc, builder.getI64Type(),
+                                                   operand);
+  }
+
+  // i64 -> i32 + i32
+  if (operand.getType().isInteger(64)) {
+    // TODO(benvanik): reorder operands to preserve natural alignment; right
+    // now this can split i64 across 4 byte boundaries which sucks.
+    // TODO(benvanik): use something like IndexSet for the shift amount to
+    // reduce the amount of IR we emit when passing multiple operands.
+    // lo = i32(operand)
+    // hi = i32(operand >> 32)
+    auto lo = builder.createOrFold<arith::TruncIOp>(loc, builder.getI32Type(),
+                                                    operand);
+    auto hi = builder.createOrFold<arith::TruncIOp>(
+        loc, builder.getI32Type(),
+        builder.createOrFold<arith::ShRUIOp>(
+            loc, builder.getI64Type(), operand,
+            builder.create<arith::ConstantIntOp>(loc, 32, 64)));
+    newOperands.push_back(lo);
+    newOperands.push_back(hi);
+  } else {
+    newOperands.push_back(operand);
+  }
+}
 
 // Converts stream.cmd.dispatch operands into their packed representation. This
 // will add/remove/reorder operands and must mirrored in a consistent manner
@@ -80,65 +151,97 @@ static void updateDispatchOp(IREE::Stream::CmdDispatchOp dispatchOp,
   auto loc = dispatchOp.getLoc();
   SmallVector<Value> newOperands;
   for (auto operand : dispatchOp.getUniformOperands()) {
-    // NOTE: we do these in sequence so that we can reuse type expansion; we
-    // want f64 to become i64 so that i64 can become i32+i32 etc.
-
-    // index -> i32 or i64
-    if (operand.getType().isIndex()) {
-      // Convert index types to a concrete bit width. 'index' can mean different
-      // things on the host and device as well as varying across devices.
-      // Today we just hardcode to i32 as we are working with smallish data and
-      // i64 uses 2x as much of our limited push constant space and is much
-      // slower to work with on mobile GPUs. In the future we will want to flag
-      // this as a global setting as well as have some heuristics for deriving
-      // from target devices.
-      operand = builder.createOrFold<arith::IndexCastUIOp>(
-          loc, builder.getIntegerType(resourceConfig.getIndexBits()), operand);
-    }
-
-    // bf16 -> i16, f32 -> i32, f64 -> i64 ...
-    if (auto floatType = llvm::dyn_cast<FloatType>(operand.getType())) {
-      // Floats need to be bitcast into opaque integers so that our handling
-      // below can deal with simple fixed width ints (bf16->i16, etc).
-      operand = builder.createOrFold<arith::BitcastOp>(
-          loc, builder.getIntegerType(floatType.getIntOrFloatBitWidth()),
-          operand);
-    }
-
-    // i1-i31 -> i32 and i33-i63 -> i64
-    // TODO(benvanik): don't extend here but instead pack as we can fit 4 i8's
-    // into a single i32 and save 4x our push constant capacity
-    unsigned bitWidth = IREE::Util::getTypeBitWidth(operand.getType());
-    if (bitWidth < 31) {
-      operand = builder.createOrFold<arith::ExtUIOp>(loc, builder.getI32Type(),
-                                                     operand);
-    } else if (bitWidth > 32 && bitWidth < 64) {
-      operand = builder.createOrFold<arith::ExtUIOp>(loc, builder.getI64Type(),
-                                                     operand);
-    }
-
-    // i64 -> i32 + i32
-    if (operand.getType().isInteger(64)) {
-      // TODO(benvanik): reorder operands to preserve natural alignment; right
-      // now this can split i64 across 4 byte boundaries which sucks.
-      // TODO(benvanik): use something like IndexSet for the shift amount to
-      // reduce the amount of IR we emit when passing multiple operands.
-      // lo = i32(operand)
-      // hi = i32(operand >> 32)
-      auto lo = builder.createOrFold<arith::TruncIOp>(loc, builder.getI32Type(),
-                                                      operand);
-      auto hi = builder.createOrFold<arith::TruncIOp>(
-          loc, builder.getI32Type(),
-          builder.createOrFold<arith::ShRUIOp>(
-              loc, builder.getI64Type(), operand,
-              builder.create<arith::ConstantIntOp>(loc, 32, 64)));
-      newOperands.push_back(lo);
-      newOperands.push_back(hi);
-    } else {
-      newOperands.push_back(operand);
-    }
+    // Decompose the operand to a sequence of i32 values.
+    // This must be consistent with recomposeFromI32s.
+    convertAndDecomposeToI32s(loc, operand, newOperands, resourceConfig,
+                              builder);
   }
   dispatchOp.getUniformOperandsMutable().assign(newOperands);
+}
+
+// Recompose integer values from multiple i64 values. The values remain in their
+// integer types and need to be reconverted.
+static Value recomposeFromI32sAndConvert(
+    Block *entryBlock, Location loc, Type oldArgType, DictionaryAttr oldArgAttr,
+    SmallVector<Type> &newArgTypes, SmallVector<DictionaryAttr> &newArgAttrs,
+    IREE::Stream::ResourceConfigAttr resourceConfig, OpBuilder &builder) {
+  // NOTE: we do the packing in a reverse sequence so that we can reuse type
+  // expansion; if we did f64->i64->i32+i32 in convertAndDecomposeToI32s we need
+  // to do i32+i32->i64->f64 here.
+
+  // Complex types need to be reconstructed from their elemental parts.
+  if (auto complexType = dyn_cast<ComplexType>(oldArgType)) {
+    Value real = recomposeFromI32sAndConvert(
+        entryBlock, loc, complexType.getElementType(), oldArgAttr, newArgTypes,
+        newArgAttrs, resourceConfig, builder);
+    Value imag = recomposeFromI32sAndConvert(
+        entryBlock, loc, complexType.getElementType(), oldArgAttr, newArgTypes,
+        newArgAttrs, resourceConfig, builder);
+    return builder.create<complex::CreateOp>(loc, oldArgType, real, imag);
+  }
+
+  // Pass through/no change other types (!stream.binding, probably).
+  if (!oldArgType.isIntOrIndexOrFloat()) {
+    newArgTypes.push_back(oldArgType);
+    newArgAttrs.push_back(oldArgAttr);
+    return entryBlock->addArgument(oldArgType, loc);
+  }
+
+  // If the arg was decomposed into i32s then first recompose it into an i64.
+  Value value;
+  bool wasDecomposed =
+      (oldArgType.isIndex() && resourceConfig.getIndexBits() > 32) ||
+      (oldArgType.isIntOrFloat() && oldArgType.getIntOrFloatBitWidth() > 32);
+  if (wasDecomposed) {
+    // The existing arg becomes the lo word and we need to insert the hi word.
+    auto loArg = entryBlock->addArgument(builder.getI32Type(), loc);
+    newArgTypes.push_back(loArg.getType());
+    auto hiArg = entryBlock->addArgument(builder.getI32Type(), loc);
+    newArgTypes.push_back(hiArg.getType());
+    // i64(lo) | (i64(hi) << 32)
+    value = builder.create<arith::OrIOp>(
+        loc, builder.create<arith::ExtUIOp>(loc, builder.getI64Type(), loArg),
+        builder.create<arith::ShLIOp>(
+            loc,
+            builder.create<arith::ExtUIOp>(loc, builder.getI64Type(), hiArg),
+            builder.create<arith::ConstantIntOp>(loc, 32, 64)));
+  } else {
+    // Forced bitcast.
+    value = entryBlock->addArgument(builder.getI32Type(), loc);
+    newArgTypes.push_back(value.getType());
+  }
+
+  // i32 or i64 -> index
+  if (oldArgType.isIndex()) {
+    value = builder.create<arith::IndexCastUIOp>(loc, builder.getIndexType(),
+                                                 value);
+  }
+
+  // Truncate back to original bit width.
+  // i32 -> i16, i64 -> i48, ...
+  if (oldArgType.isIntOrFloat() && oldArgType.getIntOrFloatBitWidth() < 32) {
+    value = builder.create<arith::TruncIOp>(
+        loc, builder.getIntegerType(oldArgType.getIntOrFloatBitWidth()), value);
+  }
+
+  // i16 -> bf16, i32 -> f32, i64 -> f64 ...
+  if (auto floatType = llvm::dyn_cast<FloatType>(oldArgType)) {
+    value = builder.create<arith::BitcastOp>(loc, oldArgType, value);
+  }
+
+  // Preserve the arg attrs on either the final op or the function argument
+  // if none was required.
+  if (auto definingOp = value.getDefiningOp()) {
+    if (oldArgAttr) definingOp->setAttrs(oldArgAttr);
+    newArgAttrs.push_back(nullptr);
+  } else {
+    newArgAttrs.push_back(oldArgAttr);
+  }
+  // Note that if we had decomposed the arg we'll expect that there are two attr
+  // dicts for the two new args.
+  if (wasDecomposed) newArgAttrs.push_back(nullptr);
+
+  return value;
 }
 
 // Updates an exported function in a stream.executable to match the packing
@@ -149,164 +252,29 @@ static void updateExportFuncOp(mlir::func::FuncOp funcOp) {
   assert(!funcOp.empty() && "can't have empty exported functions");
   auto &entryBlock = funcOp.getFunctionBody().front();
   auto builder = OpBuilder::atBlockBegin(&entryBlock);
-  auto streamAlignmentAttr = builder.getStringAttr("stream.alignment");
-  auto streamValuesAttr = builder.getStringAttr("stream.values");
 
   auto resourceConfig = IREE::Stream::ResourceConfigAttr::lookup(funcOp);
 
-  // NOTE: we have !stream.binding mixed in here; we only want to look at
-  // primitives.
-
-  // NOTE: we do the packing in a reverse sequence so that we can reuse type
-  // expansion; if we did f64->i64->i32+i32 above we need to do
-  // i32+i32->i64->f64 here.
-
-  // i32+i32->i64 is the only case that adds arguments today so to keep things
-  // simple we do that first. This ensures we have single SSA values for arg
-  // to operand mapping.
+  // Recompose i32 args into i64s and (if needed) convert them.
+  // This appends new arguments and then we clean up the old ones below.
   SmallVector<Type> newArgTypes;
   SmallVector<DictionaryAttr> newArgAttrs;
-  auto oldArgAttrs = funcOp.getAllArgAttrs();
-  for (auto it :
-       llvm::enumerate(llvm::to_vector<4>(funcOp.getArgumentTypes()))) {
-    auto targetType = it.value();
-    if (!targetType.isIntOrIndexOrFloat() ||
-        (targetType.isIndex() && resourceConfig.getIndexBits() <= 32) ||
-        (targetType.isIntOrFloat() &&
-         targetType.getIntOrFloatBitWidth() <= 32)) {
-      // Pass through/no change.
-      if (oldArgAttrs) {
-        newArgAttrs.push_back(
-            llvm::dyn_cast_if_present<DictionaryAttr>(oldArgAttrs[it.index()]));
-      } else {
-        newArgAttrs.push_back(nullptr);
-      }
-      newArgTypes.push_back(targetType);
-      continue;
-    }
-
-    // The existing arg becomes the lo word and we need to insert the hi word.
-    auto loArg = entryBlock.getArgument(newArgTypes.size());
-    newArgTypes.push_back(builder.getI32Type());
-    loArg.setType(builder.getI32Type());
-    auto hiArg = entryBlock.insertArgument(
-        newArgTypes.size(), builder.getI32Type(), funcOp.getLoc());
-    newArgTypes.push_back(builder.getI32Type());
-
-    // i64(lo) | (i64(hi) << 32)
-    auto loc = loArg.getLoc();
-    auto loArgI64 =
-        builder.create<arith::ExtUIOp>(loc, builder.getI64Type(), loArg);
-    Operation *argOp = builder.create<arith::OrIOp>(
-        loc, loArgI64,
-        builder.create<arith::ShLIOp>(
-            loc,
-            builder.create<arith::ExtUIOp>(loc, builder.getI64Type(), hiArg),
-            builder.create<arith::ConstantIntOp>(loc, 32, 64)));
-
-    // If going to index we need to insert a cast as the type changes.
-    if (targetType.isIndex()) {
-      argOp = builder.create<arith::IndexCastUIOp>(loc, targetType,
-                                                   argOp->getResult(0));
-    }
-
-    // Replace all subsequent uses with the new reconstituted value.
-    loArg.replaceAllUsesExcept(argOp->getResult(0), loArgI64);
-
-    // Take the existing potential values, if present, and fix them up.
-    // If we had a `stream.values = [0xAA...BB... : i64]` then we can
-    // put a `stream.values = [0xBB... : i32]` on the lo and `[0xAA... : i32]`
-    // on the hi.
-    //
-    // TODO(benvanik): find a nicer way/write some utilities - manipulating
-    // these attributes is really annoying.
-    if (oldArgAttrs) {
-      auto oldArgAttr =
-          llvm::dyn_cast_if_present<DictionaryAttr>(oldArgAttrs[it.index()]);
-      if (auto alignmentAttr =
-              oldArgAttr.getAs<IntegerAttr>(streamAlignmentAttr)) {
-        argOp->setAttr(streamAlignmentAttr, alignmentAttr);
-      }
-      if (auto valuesAttr = oldArgAttr.getAs<ArrayAttr>(streamValuesAttr)) {
-        // Attach the original potential value set to the new arg value.
-        // This allows any further analysis walking the SSA values to find the
-        // easily understandable i64 types instead of having to reconstruct it
-        // from the i32 values and the combining operations (which MLIR doesn't
-        // do today).
-        argOp->setAttr(streamValuesAttr, valuesAttr);
-      }
-    }
-    newArgAttrs.push_back(nullptr);
-    newArgAttrs.push_back(nullptr);
-  }
-  if (newArgTypes.size() != funcOp.getNumArguments()) {
-    // Changed argument count; update signature.
-    funcOp.setType(builder.getFunctionType(
-        newArgTypes, funcOp.getFunctionType().getResults()));
-    funcOp.setAllArgAttrs(newArgAttrs);
+  auto oldArgs = llvm::to_vector(entryBlock.getArguments());
+  for (auto oldArg : oldArgs) {
+    auto oldArgAttr = funcOp.getArgAttrDict(oldArg.getArgNumber());
+    auto newArg = recomposeFromI32sAndConvert(
+        &entryBlock, oldArg.getLoc(), oldArg.getType(), oldArgAttr, newArgTypes,
+        newArgAttrs, resourceConfig, builder);
+    oldArg.replaceAllUsesWith(newArg);
   }
 
-  // -- now the function has all <= 32-bit operands --
+  // Remove all the original arguments from the entry block.
+  entryBlock.eraseArguments(0, oldArgs.size());
 
-  newArgTypes.clear();
-  for (auto arg : entryBlock.getArguments()) {
-    auto alignmentAttr = funcOp.getArgAttrOfType<IntegerAttr>(
-        arg.getArgNumber(), streamAlignmentAttr);
-    auto oldValuesAttr = funcOp.getArgAttrOfType<ArrayAttr>(arg.getArgNumber(),
-                                                            streamValuesAttr);
-    auto targetType = arg.getType();
-    if (!targetType.isIntOrIndexOrFloat()) {
-      // Pass-through !stream.bindings.
-      newArgTypes.push_back(targetType);
-      continue;
-    }
-
-    auto loc = arg.getLoc();
-    Value value = arg;
-    arg.setType(builder.getI32Type());
-
-    // i32 or i64 -> index
-    if (targetType.isIndex()) {
-      auto castOp = builder.create<arith::IndexCastUIOp>(
-          loc, builder.getIndexType(), value);
-      value.replaceAllUsesExcept(castOp.getResult(), castOp);
-      value = castOp.getResult();
-    }
-
-    // Truncate back to original bit width.
-    // i32 -> i16, i64 -> i48, ...
-    if (targetType.isIntOrFloat() && targetType.getIntOrFloatBitWidth() < 32) {
-      auto truncOp = builder.create<arith::TruncIOp>(
-          loc, builder.getIntegerType(targetType.getIntOrFloatBitWidth()),
-          value);
-      value.replaceAllUsesExcept(truncOp.getResult(), truncOp);
-      value = truncOp.getResult();
-    }
-
-    // i16 -> bf16, i32 -> f32, i64 -> f64 ...
-    if (auto floatType = llvm::dyn_cast<FloatType>(targetType)) {
-      auto bitcastOp = builder.create<arith::BitcastOp>(loc, targetType, value);
-      value.replaceAllUsesExcept(bitcastOp.getResult(), bitcastOp);
-      value = bitcastOp.getResult();
-    }
-
-    // Set the original streams.values attribute on the op with the type in the
-    // original form. This allows subsequent analysis to easily find the value.
-    if (auto definingOp = value.getDefiningOp()) {
-      if (alignmentAttr) {
-        definingOp->setAttr(streamAlignmentAttr, alignmentAttr);
-        funcOp.removeArgAttr(arg.getArgNumber(), streamAlignmentAttr);
-      }
-      if (oldValuesAttr) {
-        definingOp->setAttr(streamValuesAttr, oldValuesAttr);
-        funcOp.removeArgAttr(arg.getArgNumber(), streamValuesAttr);
-      }
-    }
-
-    newArgTypes.push_back(builder.getI32Type());
-  }
+  // Update the function signature and arg attrs that may have changed.
   funcOp.setType(builder.getFunctionType(
       newArgTypes, funcOp.getFunctionType().getResults()));
+  funcOp.setAllArgAttrs(newArgAttrs);
 }
 
 //===----------------------------------------------------------------------===//
@@ -318,6 +286,7 @@ class PackDispatchOperandsPass
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<mlir::arith::ArithDialect>();
+    registry.insert<mlir::complex::ComplexDialect>();
     registry.insert<IREE::Stream::StreamDialect>();
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -287,8 +287,9 @@ void buildStreamOptimizationPassPipeline(
   // add/remove operands.
   passManager.addPass(IREE::Stream::createPackDispatchOperandsPass());
 
-  // Folding operands requires that CSE folds the inputs that we check for.
-  passManager.addPass(mlir::createCSEPass());
+  // Folding operands requires that canonicalization/CSE folds the inputs that
+  // we check for.
+  addCleanupPatterns(passManager);
   passManager.addPass(IREE::Stream::createFoldUniformOperandsPass());
 
   // Only want to specialize after we've added all the operands we need above.


### PR DESCRIPTION
Supports both `complex<f32>` and (if we did elsewhere) `complex<f64>`. It's also much easier to follow the decompose/recompose logic now and in the future if we want to support new types (tuples/etc) we can easily do so.

Fixes #12747.