### PR TITLE
Correctly tag Vulkan Ampere tests as requiring sm80

### DIFF
--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -116,9 +116,9 @@ jobs:
           - device-name: pixel-4
             label-exclude: "vulkan"
           - device-name: pixel-6-pro
-            label-exclude: "^requires-gpu-nvidia$"
+            label-exclude: "^requires-gpu"
           - device-name: moto-edge-x30
-            label-exclude: "^requires-gpu-nvidia$"
+            label-exclude: "^requires-gpu"
     name: test_on_${{ matrix.target.device-name }}
     runs-on:
       - self-hosted # must come first

--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -67,7 +67,7 @@ if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
   default_test_tag_filters+=("-driver=vulkan")
 fi
 if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE?}" == 1 ]]; then
-  default_test_tag_filters+=("-requires-gpu-nvidia")
+  default_test_tag_filters+=("-requires-gpu-nvidia" "-requires-gpu-sm80")
 fi
 
 # Use user-environment variables if set, otherwise use CI-friendly defaults.

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -117,7 +117,7 @@ for asan_in_bytecode_modules_ON_OFF in OFF ON; do
     label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
   fi
   if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE}" == 1 ]]; then
-    label_exclude_args+=("^requires-gpu-nvidia$")
+    label_exclude_args+=("^requires-gpu")
   fi
 
   label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -72,7 +72,7 @@ if [[ "${IREE_VULKAN_F16_DISABLE}" == 1 ]]; then
   label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
 fi
 if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE}" == 1 ]]; then
-  label_exclude_args+=("^requires-gpu-nvidia$")
+  label_exclude_args+=("^requires-gpu$")
 fi
 
 IFS=',' read -ra extra_label_exclude_args <<< "${IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}"

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -409,18 +409,15 @@ iree_generated_trace_runner_test(
 ]]
 
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_direct_{0}_gpu_large_{1}".format(
-        lhs_rhs_type,
-        vulkan_target_and_pipeline[0],
-    ),
+    name = "e2e_matmul_direct_{0}_gpu_large_valhall".format(lhs_rhs_type),
     compiler_flags = [
-        "--iree-vulkan-target-triple=%s" % vulkan_target_and_pipeline[0],
+        "--iree-vulkan-target-triple=valhall-unknown-android31",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=gpu_large_aligned",
-        "--compilation_info=%s" % vulkan_target_and_pipeline[1],
+        "--compilation_info=SPIRVVectorizeMali",
     ],
     tags = [
         "requires-gpu-nvidia",
@@ -430,10 +427,33 @@ iree_generated_trace_runner_test(
         ("vulkan-spirv", "vulkan"),
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
-) for vulkan_target_and_pipeline in [
-    ("valhall-unknown-android31", "SPIRVVectorizeMali"),
-    ("ampere-unknown-linux", "SPIRVVectorizeNVIDIA"),
-] for lhs_rhs_type in [
+) for lhs_rhs_type in [
+    "i8",
+    "f16",
+    "f32",
+]]
+
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_{0}_gpu_large_ampere".format(lhs_rhs_type),
+    compiler_flags = [
+        "--iree-vulkan-target-triple=ampere-unknown-linux",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=%s" % lhs_rhs_type,
+        "--shapes=gpu_large_aligned",
+        "--compilation_info=SPIRVVectorizeNVIDIA",
+    ],
+    tags = [
+        "requires-gpu-nvidia",
+        "requires-gpu-sm80",
+        "vulkan_uses_vk_khr_shader_float16_int8",
+    ],
+    target_backends_and_drivers = [
+        ("vulkan-spirv", "vulkan"),
+    ],
+    trace_runner = "//tools:iree-e2e-matmul-test",
+) for lhs_rhs_type in [
     "i8",
     "f16",
     "f32",

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -420,6 +420,7 @@ iree_generated_trace_runner_test(
         "--compilation_info=SPIRVVectorizeMali",
     ],
     tags = [
+        # Nvidia GPUs support a superset of Valhall features
         "requires-gpu-nvidia",
         "vulkan_uses_vk_khr_shader_float16_int8",
     ],

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -538,7 +538,7 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_i8_gpu_large_valhall-unknown-android31
+    e2e_matmul_direct_i8_gpu_large_valhall
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
@@ -560,7 +560,7 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f16_gpu_large_valhall-unknown-android31
+    e2e_matmul_direct_f16_gpu_large_valhall
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
@@ -582,7 +582,7 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f32_gpu_large_valhall-unknown-android31
+    e2e_matmul_direct_f32_gpu_large_valhall
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
@@ -604,7 +604,7 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_i8_gpu_large_ampere-unknown-linux
+    e2e_matmul_direct_i8_gpu_large_ampere
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
@@ -621,12 +621,13 @@ iree_generated_trace_runner_test(
     "--iree-vulkan-target-triple=ampere-unknown-linux"
   LABELS
     "requires-gpu-nvidia"
+    "requires-gpu-sm80"
     "vulkan_uses_vk_khr_shader_float16_int8"
 )
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f16_gpu_large_ampere-unknown-linux
+    e2e_matmul_direct_f16_gpu_large_ampere
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
@@ -643,12 +644,13 @@ iree_generated_trace_runner_test(
     "--iree-vulkan-target-triple=ampere-unknown-linux"
   LABELS
     "requires-gpu-nvidia"
+    "requires-gpu-sm80"
     "vulkan_uses_vk_khr_shader_float16_int8"
 )
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f32_gpu_large_ampere-unknown-linux
+    e2e_matmul_direct_f32_gpu_large_ampere
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
@@ -665,6 +667,7 @@ iree_generated_trace_runner_test(
     "--iree-vulkan-target-triple=ampere-unknown-linux"
   LABELS
     "requires-gpu-nvidia"
+    "requires-gpu-sm80"
     "vulkan_uses_vk_khr_shader_float16_int8"
 )
 

--- a/tests/transform_dialect/cuda/BUILD.bazel
+++ b/tests/transform_dialect/cuda/BUILD.bazel
@@ -104,6 +104,7 @@ iree_lit_test_suite(
         "nomsan",
         "notsan",
         "noubsan",
+        "requires-gpu-nvidia",
         "requires-gpu-sm80",
         "driver=cuda",
     ],

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -81,6 +81,7 @@ iree_lit_test_suite(
     "nomsan"
     "notsan"
     "noubsan"
+    "requires-gpu-nvidia"
     "requires-gpu-sm80"
     "driver=cuda"
 )


### PR DESCRIPTION
Also exclude requires-gpu-sm80 in the same places we exclude
requires-gpu-nvidia. I'm actually not sure how this wasn't causing
errors. I went with a relaxed regex of any label starting with
"requires-gpu" in our CMake build scripts, but Bazel requires listing
tags explicitly.

This actually also raised a question for me. Why are our tests for
Valhall tagges as "requires-gpu-nvidia"? I would expect these to not
even *run* on an Nvidia GPU... Do we just happen to not take advantage
of any Valhall-specific features?
