### PR TITLE
Fix bug in TopK pattern matching that sets K as 2nd dim rather than last.

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -1607,7 +1607,9 @@ struct IotaSortSliceIsTopK final : OpRewritePattern<mlir::stablehlo::SortOp> {
       // Treat the first slice as inputs, the second as indices.
       if (idx == 0) {
         topV = sliceOp.getResult();
-        k = sliceOp.getLimitIndices().getValues<int64_t>()[1];
+        SmallVector<int64_t> limitIndices =
+            llvm::to_vector(sliceOp.getLimitIndices().getValues<int64_t>());
+        k = limitIndices.back();
       } else {
         topI = sliceOp.getResult();
       }


### PR DESCRIPTION
Test cases coming in following PR, this is just a quick fix while it's out for review.