### PR TITLE
[StableHLO] Port reduce canon patterns

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -737,9 +737,7 @@ struct EmptyReduceOpCanon final : OpRewritePattern<mlir::stablehlo::ReduceOp> {
                                          "unranked input unsupported");
     }
 
-    if (llvm::all_of(elemTy.getShape(), [](int64_t d) { return d != 0; })) {
-      return failure();
-    }
+    if (!llvm::is_contained(elemTy.getShape(), 0)) return failure();
 
     Location loc = op.getLoc();
     DenseIntElementsAttr empty = rewriter.getI64TensorAttr({});

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -694,6 +694,82 @@ struct DynamicBroadcastInDimAllDimsNonExpanding final
   }
 };
 
+struct NoopReduceOpCanon final : OpRewritePattern<mlir::stablehlo::ReduceOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ReduceOp op,
+                                PatternRewriter &rewriter) const override {
+    // No dimensions to reduce.
+    if (op.getDimensions().empty()) {
+      rewriter.replaceOp(op, op.getInputs());
+      return success();
+    }
+
+    // If all returned values in the ReduceOp region exists outside the
+    // region, replace the ReduceOp with those values.
+    if (auto retOp = dyn_cast<mlir::stablehlo::ReturnOp>(
+            op.getBody().front().getTerminator())) {
+      Region *retRegion = retOp->getParentRegion();
+      if (llvm::any_of(retOp.getResults(), [retRegion](Value result) {
+            return result.getParentRegion() == retRegion;
+          })) {
+        return failure();
+      }
+
+      rewriter.replaceOp(op, retOp.getResults());
+      return success();
+    }
+
+    return failure();
+  }
+};
+
+struct EmptyReduceOpCanon final : OpRewritePattern<mlir::stablehlo::ReduceOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::ReduceOp op,
+                                PatternRewriter &rewriter) const override {
+    // We require all reduce shapes to be the same, up to the element types, so
+    // we can just the first operand and the first result as a representative.
+    auto elemTy = dyn_cast<RankedTensorType>(op.getInputs().getType().front());
+    if (!elemTy) {
+      return rewriter.notifyMatchFailure(op.getLoc(),
+                                         "unranked input unsupported");
+    }
+
+    if (llvm::all_of(elemTy.getShape(), [](int64_t d) { return d != 0; })) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+    DenseIntElementsAttr empty = rewriter.getI64TensorAttr({});
+    if (elemTy.hasStaticShape()) {
+      SmallVector<Value> broadcasts(op.getNumResults());
+      for (auto [bcast, init, outTy] : llvm::zip_equal(
+               broadcasts, op.getInitValues(), op.getResultTypes())) {
+        bcast = rewriter.create<mlir::stablehlo::BroadcastInDimOp>(loc, outTy,
+                                                                   init, empty);
+      }
+      rewriter.replaceOp(op, broadcasts);
+      return success();
+    }
+
+    SmallVector<Value> shapes;
+    if (failed(op.reifyReturnTypeShapes(rewriter, op.getOperands(), shapes))) {
+      return failure();
+    }
+
+    SmallVector<Value> broadcasts(op.getNumResults());
+    for (auto [bcast, init, shape, outTy] : llvm::zip_equal(
+             broadcasts, op.getInitValues(), shapes, op.getResultTypes())) {
+      bcast = rewriter.create<mlir::stablehlo::DynamicBroadcastInDimOp>(
+          loc, outTy, init, shape, empty);
+    }
+    rewriter.replaceOp(op, broadcasts);
+    return success();
+  }
+};
+
 struct DynamicReshapeOpCanon final
     : OpRewritePattern<mlir::stablehlo::DynamicReshapeOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -922,6 +998,8 @@ void populateCanonicalizationPatterns(MLIRContext *context,
       BroadcastInDimOpCanon, DynamicBroadcastInDimOpNotActuallyDynamic,
       ChainedDynamicBroadcastInDimCanonicalization,
       DynamicBroadcastInDimAllDimsNonExpanding,
+      // Reduce op.
+      NoopReduceOpCanon, EmptyReduceOpCanon,
       // Shape manipulation(-ish) ops.
       ConcatenateOpCanon, ConvertOpCanon, DynamicReshapeOpCanon, GatherOpCanon,
       ReshapeOpCanon, TransposeOpCanon>(context, benefit);


### PR DESCRIPTION
Turns out that linalg lowering depends on these.

The code is ported from equivalent folds and rewrite patterns in the mlir-hlo repo. The only notable difference is that this implementation fixes bugs with rewrite patterns performing op updates without going through the pattern rewriter. Also added a new test for the second noop case.

Fixes: https://github.com/openxla/iree/issues/14042
Issue: https://github.com/openxla/iree/issues/12678