### PR TITLE
Fix the ignored list of markdownlint

### DIFF
--- a/build_tools/scripts/run_markdownlint.sh
+++ b/build_tools/scripts/run_markdownlint.sh
@@ -24,6 +24,9 @@ declare -a excluded_files_patterns=(
   "**/node_modules/**"
 )
 
+# ${excluded_files_patterns} is expanded into
+# "--ignore pattern1 --ignore pattern2 ...", since markdownlint doesn't accept
+# "--ignore pattern1 pattern2 ...".
 markdownlint "${included_files_patterns[*]}" \
     --config ./docs/.markdownlint.yml \
-    --ignore "${excluded_files_patterns[*]}"
+    ${excluded_files_patterns[*]/#/--ignore }

--- a/build_tools/scripts/run_markdownlint.sh
+++ b/build_tools/scripts/run_markdownlint.sh
@@ -25,10 +25,10 @@ declare -a excluded_files_patterns=(
 )
 
 # ${excluded_files_patterns} is expanded into
-# "--ignore pattern1 --ignore pattern2 ...", since markdownlint doesn't accept
+# "--ignore=pattern1 --ignore=pattern2 ...", since markdownlint doesn't accept
 # "--ignore pattern1 pattern2 ...".
 # The expansion trick is explained in
 # https://stackoverflow.com/questions/20366609/prefix-and-postfix-elements-of-a-bash-array
-markdownlint "${included_files_patterns[*]}" \
-    --config ./docs/.markdownlint.yml \
-    ${excluded_files_patterns[*]/#/"--ignore "}
+markdownlint "${included_files_patterns[@]}" \
+    --config=./docs/.markdownlint.yml \
+    "${excluded_files_patterns[@]/#/--ignore=}"

--- a/build_tools/scripts/run_markdownlint.sh
+++ b/build_tools/scripts/run_markdownlint.sh
@@ -27,6 +27,8 @@ declare -a excluded_files_patterns=(
 # ${excluded_files_patterns} is expanded into
 # "--ignore pattern1 --ignore pattern2 ...", since markdownlint doesn't accept
 # "--ignore pattern1 pattern2 ...".
+# The expansion trick is explained in
+# https://stackoverflow.com/questions/20366609/prefix-and-postfix-elements-of-a-bash-array
 markdownlint "${included_files_patterns[*]}" \
     --config ./docs/.markdownlint.yml \
-    ${excluded_files_patterns[*]/#/--ignore }
+    ${excluded_files_patterns[*]/#/"--ignore "}

--- a/build_tools/scripts/run_markdownlint.sh
+++ b/build_tools/scripts/run_markdownlint.sh
@@ -20,7 +20,7 @@ declare -a included_files_patterns=(
 )
 
 declare -a excluded_files_patterns=(
-  "/third_party/"
+  "**/third_party/**"
   "**/node_modules/**"
 )
 


### PR DESCRIPTION
Pass the arguments `--ignore=pattern1 --ignore=pattern2` instead of `--ignore pattern1 pattern2`, which the later one isn't accepted by `markdownlint`. 

Also fix the wildcard to match `third_party` directories at any level in the repo.

This was found when reusing the same script in https://github.com/openxla/openxla-benchmark/pull/5