### PR TITLE
Reword comments for `IREE_BUILD_DOCS`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ option(IREE_ENABLE_CPUINFO "Enables runtime use of cpuinfo for processor topolog
 
 option(IREE_BUILD_COMPILER "Builds the IREE compiler." ON)
 option(IREE_BUILD_TESTS "Builds IREE unit tests." ON)
-option(IREE_BUILD_DOCS "Builds IREE docs." OFF)
+option(IREE_BUILD_DOCS "Builds IREE documentation files." OFF)
 option(IREE_BUILD_SAMPLES "Builds IREE sample projects." ON)
 option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" OFF)
 option(IREE_BUILD_TRACY "Builds tracy server tools." OFF)
@@ -700,9 +700,8 @@ if(IREE_BUILD_MICROBENCHMARKS)
 endif()
 
 if(IREE_BUILD_DOCS)
-  # Add a top-level custom target to drive generating all documentation.
-  # Register it to the default target given that IREE_BUILD_DOCS is explicitly
-  # requested.
+  # Define a top-level custom target to drive generating documentation files.
+  # Add to the default target given that docs were explicitly requested.
   add_custom_target(iree-doc ALL)
 endif()
 

--- a/docs/developers/get_started/cmake_options_and_variables.md
+++ b/docs/developers/get_started/cmake_options_and_variables.md
@@ -36,7 +36,7 @@ Builds IREE unit tests. Defaults to `ON`.
 
 #### `IREE_BUILD_DOCS`:BOOL
 
-Builds IREE documentation. Defaults to `OFF`.
+Builds IREE documentation files. Defaults to `OFF`.
 
 #### `IREE_BUILD_SAMPLES`:BOOL
 


### PR DESCRIPTION
This CMake option just generates _some_ files (tablegen .md files), not "all documentation".

skip-ci: comment-only change