### PR TITLE
Fuse iota ops with consumers always.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -95,6 +95,11 @@ static bool areFusableOps(MLIRContext *context, OpOperand *fusedOperand) {
   // If the generic op is "just" copy, then fuse always.
   Block &body = producerOp->getRegion(0).front();
   if (std::begin(body)->hasTrait<OpTrait::IsTerminator>()) return true;
+  if (llvm::all_of(body.getArguments(),
+                   [](BlockArgument arg) { return arg.use_empty(); })) {
+    // THe operands arent used, its just an `linalg.index` op.
+    return true;
+  }
 
   // If producer does not have a single user, dont fuse.
   if (!producerOp->hasOneUse()) return false;


### PR DESCRIPTION
Current fusion heuristics always fuse copy-like ops with its consumers. Iota ops are also copy-like ops (indeed if the deprecated `linalg.indexed_generic` were around it would still be a copy-like op).

Fixes #13745