### PR TITLE
Remove redundant `requires-gpu-nvidia` added in #14039

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -446,7 +446,6 @@ iree_generated_trace_runner_test(
         "--compilation_info=SPIRVVectorizeNVIDIA",
     ],
     tags = [
-        "requires-gpu-nvidia",
         "requires-gpu-sm80",
         "vulkan_uses_vk_khr_shader_float16_int8",
     ],

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -620,7 +620,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-vulkan-target-triple=ampere-unknown-linux"
   LABELS
-    "requires-gpu-nvidia"
     "requires-gpu-sm80"
     "vulkan_uses_vk_khr_shader_float16_int8"
 )
@@ -643,7 +642,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-vulkan-target-triple=ampere-unknown-linux"
   LABELS
-    "requires-gpu-nvidia"
     "requires-gpu-sm80"
     "vulkan_uses_vk_khr_shader_float16_int8"
 )
@@ -666,7 +664,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-vulkan-target-triple=ampere-unknown-linux"
   LABELS
-    "requires-gpu-nvidia"
     "requires-gpu-sm80"
     "vulkan_uses_vk_khr_shader_float16_int8"
 )

--- a/tests/transform_dialect/cuda/BUILD.bazel
+++ b/tests/transform_dialect/cuda/BUILD.bazel
@@ -104,7 +104,6 @@ iree_lit_test_suite(
         "nomsan",
         "notsan",
         "noubsan",
-        "requires-gpu-nvidia",
         "requires-gpu-sm80",
         "driver=cuda",
     ],

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -81,7 +81,6 @@ iree_lit_test_suite(
     "nomsan"
     "notsan"
     "noubsan"
-    "requires-gpu-nvidia"
     "requires-gpu-sm80"
     "driver=cuda"
 )


### PR DESCRIPTION
I didn't mean to add this in https://github.com/openxla/iree/pull/14039
as it's already implied by `requires-gpu-sm80`. Google's internal
remote execution system, which I think is basically the de facto
standard for how this requirements stuff works, doesn't like you
listing both either.

I originally added it but then decided to instead update our scripts
that check for `requires-gpu-nvidia` to also check for the
arch-specific tags.