### PR TITLE
Extract a generic CopyMapping logic from the MatmulTensorCore strategy.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -73,13 +73,13 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.structured.pad %{{.*}} {pack_paddings = [1, 1, 1], pad_to_multiple_of = [1, 1, 1], padding_dimensions = [0, 1, 2], padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]}
 // CHECK: transform.structured.hoist_pad %{{.}} by 1 loops
 // CHECK: transform.structured.insert_slice_to_copy %{{.*}} : (!transform.any_op) -> !transform.any_op
-// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // CHECK:   transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!transform.any_op) -> ()
 // CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // CHECK: transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!transform.any_op) -> ()
 // CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
-// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
-// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
+// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [4, 4]
 // CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [4, 4]
 // CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [32, 4]
@@ -136,13 +136,13 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // WITH_OPTIONS: transform.structured.pad %{{.*}} {pack_paddings = [1, 1, 1], pad_to_multiple_of = [1, 1, 1], padding_dimensions = [0, 1, 2], padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]}
 // WITH_OPTIONS: transform.structured.hoist_pad %{{.}} by 1 loops
 // WITH_OPTIONS: transform.structured.insert_slice_to_copy %{{.*}} : (!transform.any_op) -> !transform.any_op
-// WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [64, 2] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [64, 2] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // WITH_OPTIONS:   transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!transform.any_op) -> ()
 // WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [8, 16] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // WITH_OPTIONS: transform.scf.take_assumed_branch %{{.*}} take_else_branch : (!transform.any_op) -> ()
 // WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [8, 16] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
-// WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [1, 4] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
-// WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [1, 4] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
+// WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [4, 1] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// WITH_OPTIONS: transform.structured.tile_to_forall_op %{{.*}}   num_threads [4, 1] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // WITH_OPTIONS: transform.structured.masked_vectorize %{{.*}} vector_sizes [4, 4]
 // WITH_OPTIONS: transform.structured.masked_vectorize %{{.*}} vector_sizes [1, 4]
 // WITH_OPTIONS: transform.structured.masked_vectorize %{{.*}} vector_sizes [32, 4]
@@ -238,19 +238,19 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK: transform.iree.populate_workgroup_count_region_using_num_threads_slice
 // CHECK: transform.structured.tile %{{.*}}[0, 0, 16]
 // align1
-// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [8, 16] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // align2
-// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 64] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
+// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // align2
-// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 64] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
-// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
-// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
+// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
+// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK: transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // align1
-// CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [16, 1]
+// CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [4, 4]
 // align2
-// CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [8, 2]
+// CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [4, 4]
 // align2
-// CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [64, 2]
+// CHECK: transform.structured.masked_vectorize %{{.*}} vector_sizes [32, 4]
 
 // WITH_OPTIONS_2-LABEL: func @matmul
 
@@ -336,14 +336,14 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK:      %[[RES_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[RES_PAD]]
 // CHECK:      %[[LHS_PAD:.+]] = get_producer_of_operand %{{.*}}[0]
 // CHECK:      %[[RHS_PAD:.+]] = get_producer_of_operand %{{.*}}[1]
-// CHECK:      %{{.*}}, %[[TILED_LHS:.+]] = transform.structured.tile_to_forall_op %[[LHS_PAD]]   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// CHECK:      %{{.*}}, %[[TILED_LHS:.+]] = transform.structured.tile_to_forall_op %[[LHS_PAD]]   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // CHECK:      transform.structured.match ops{["scf.if"]}
 // CHECK:      transform.scf.take_assumed_branch %{{.*}} take_else_branch
 // CHECK:      %{{.*}}, %[[TILED_RHS:.+]] = transform.structured.tile_to_forall_op %[[RHS_PAD]]   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // CHECK:      transform.structured.match ops{["scf.if"]}
 // CHECK:      transform.scf.take_assumed_branch %{{.*}} take_else_branch
-// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
-// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // CHECK:        transform.apply_patterns.canonicalization
 // CHECK       }
 // CHECK:      transform.iree.apply_licm
@@ -411,10 +411,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK:      %[[RHS_PAD:.+]] = get_producer_of_operand %{{.*}}[1]
 // CHECK:      %[[LHS_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[LHS_PAD]]
 // CHECK:      %[[RHS_COPY:.+]] = transform.structured.rewrite_in_destination_passing_style %[[RHS_PAD]]
-// CHECK:      transform.structured.tile_to_forall_op %[[LHS_COPY]]   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<x>, #gpu.linear<y>])
+// CHECK:      transform.structured.tile_to_forall_op %[[LHS_COPY]]   num_threads [32, 4] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
 // CHECK:      transform.structured.tile_to_forall_op %[[RHS_COPY]]   num_threads [4, 32] tile_sizes [](mapping = [#gpu.linear<y>, #gpu.linear<x>])
-// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
-// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<x>, #gpu.warp<y>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
+// CHECK:      transform.structured.tile_to_forall_op %{{.*}}   num_threads [2, 2] tile_sizes [](mapping = [#gpu.warp<y>, #gpu.warp<x>])
 // CHECK:        transform.apply_patterns.canonicalization
 // CHECK       }
 // CHECK:      transform.iree.apply_licm

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/BUILD.bazel
@@ -16,6 +16,8 @@ iree_compiler_cc_library(
     name = "GPU",
     srcs = [
         "Common.cpp",
+        "CopyMapping.cpp",
+        "MappingInfo.cpp",
         "MatmulTensorCoreStrategy.cpp",
         "PadStrategy.cpp",
         "SmallReductionStrategy.cpp",
@@ -25,6 +27,8 @@ iree_compiler_cc_library(
     hdrs = [
         "AbstractGemmLikeStrategy.h",
         "Common.h",
+        "CopyMapping.h",
+        "MappingInfo.h",
         "MatmulTensorCoreStrategy.h",
         "PadStrategy.h",
         "SmallReductionStrategy.h",

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CMakeLists.txt
@@ -16,6 +16,8 @@ iree_cc_library(
   HDRS
     "AbstractGemmLikeStrategy.h"
     "Common.h"
+    "CopyMapping.h"
+    "MappingInfo.h"
     "MatmulTensorCoreStrategy.h"
     "PadStrategy.h"
     "SmallReductionStrategy.h"
@@ -23,6 +25,8 @@ iree_cc_library(
     "Strategies.h"
   SRCS
     "Common.cpp"
+    "CopyMapping.cpp"
+    "MappingInfo.cpp"
     "MatmulTensorCoreStrategy.cpp"
     "PadStrategy.cpp"
     "SmallReductionStrategy.cpp"

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.cpp
@@ -45,7 +45,12 @@ iree_compiler::gpu::CopyMapping::numThreadsForCopy(int totalNumThreads,
   for (auto s : sizes) numElements *= s;
   LDBG("--numElements: " << numElements);
 
-  int64_t actualVectorSize = maxVectorSize;
+  // TODO: this implementation exhibits and issue with mapping to cp.async zfill
+  // in the presence of vectors of size > 1. This could also be related to the
+  // lack of substantial perf gains between masked vector<4> and masked
+  // vector<1>.
+  // int64_t actualVectorSize = maxVectorSize;
+  int64_t actualVectorSize = 1;
   if (!favorPredication) {
     // Bias towards reducing the vector size to avoid predication.
     // Predication occurs if we end up using fewer than totalNumThreads for a

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.cpp
@@ -1,0 +1,127 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Support/MathExtras.h"
+
+using namespace mlir;
+
+#define DEBUG_TYPE "iree-gpu-copy-mapping"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+int64_t iree_compiler::gpu::CopyMapping::maxContiguousElementsToTransfer(
+    int64_t numContiguousElements, int64_t elementalBitWidth) {
+  assert(kCudaMaxVectorLoadBitWidth % elementalBitWidth == 0 &&
+         "elemental bitwidth does not divide kCudaMaxVectorLoadBitWidth");
+  return std::gcd(numContiguousElements,
+                  kCudaMaxVectorLoadBitWidth / elementalBitWidth);
+}
+
+FailureOr<iree_compiler::gpu::CopyMapping>
+iree_compiler::gpu::CopyMapping::numThreadsForCopy(int totalNumThreads,
+                                                   ArrayRef<int64_t> sizes,
+                                                   bool favorPredication,
+                                                   int64_t elementalBitWidth) {
+  LDBG("\nSTART numThreadsForCopy, favorPredication: " << favorPredication);
+  LLVM_DEBUG(llvm::interleaveComma(sizes, DBGS() << "--sizes: ");
+             llvm::dbgs() << "\n";);
+
+  // Greedily find the largest vector size that can be used to copy the most
+  // minor dimension: we are in the business of filling 128B contiguous memory
+  // transactions with as few threads as possible.
+  int64_t maxVectorSize = CopyMapping::maxContiguousElementsToTransfer(
+      sizes.back(), elementalBitWidth);
+  LDBG("--maxVectorSize: " << maxVectorSize);
+  int64_t numElements = 1;
+  for (auto s : sizes) numElements *= s;
+  LDBG("--numElements: " << numElements);
+
+  int64_t actualVectorSize = maxVectorSize;
+  if (!favorPredication) {
+    // Bias towards reducing the vector size to avoid predication.
+    // Predication occurs if we end up using fewer than totalNumThreads for a
+    // particular copy.
+    // Predication chokes the current implementation of shared memory
+    // pipelining.
+    // TODO: Reevaluate this heuristic when we have a more robust pipelining
+    // implementation.
+    for (; actualVectorSize >= 1; actualVectorSize /= 2) {
+      LDBG("--step totalNumThreads * actualVectorSize: "
+           << totalNumThreads * actualVectorSize);
+      if (numElements % (totalNumThreads * actualVectorSize) != 0) continue;
+      break;
+    }
+    LDBG("--numElements: " << numElements);
+    LDBG("--totalNumThreads: " << totalNumThreads);
+    LDBG("--actualVectorSize: " << actualVectorSize);
+    if (actualVectorSize == 0) {
+      LDBG("--Could not map copy without predication -> FAIL");
+      return failure();
+    }
+  }
+
+  // Scale back the last size by actualVectorSize to account for the fact
+  // that we perform vector transfers.
+  assert(sizes.back() % actualVectorSize == 0 &&
+         "most-minor size not divisible by actualVectorSize");
+  SmallVector<int64_t> scaledSizes{sizes.begin(), sizes.end()};
+  scaledSizes.back() /= actualVectorSize;
+
+  int64_t numThreadsRemaining = totalNumThreads;
+  LDBG("--numThreadsRemaining: " << numThreadsRemaining);
+  SmallVector<int64_t> factors;
+  for (auto s : llvm::reverse(scaledSizes)) {
+    int64_t gcd = std::gcd(numThreadsRemaining, s);
+    factors.push_back(gcd);
+    numThreadsRemaining /= gcd;
+    LDBG("--new factors: " << gcd);
+    LDBG("--numThreadsRemaining: " << numThreadsRemaining);
+  }
+
+  std::reverse(factors.begin(), factors.end());
+
+  LLVM_DEBUG(llvm::interleaveComma(factors, DBGS() << "numThreads: ");
+             llvm::dbgs() << "\n";
+             LDBG("actualVectorSize: " << actualVectorSize););
+
+  return CopyMapping{actualVectorSize, factors};
+}
+
+iree_compiler::gpu::MappingInfo iree_compiler::gpu::CopyMapping::getMappingInfo(
+    MLIRContext* ctx, int totalNumThreads, ArrayRef<int64_t> sizes,
+    bool favorPredication, int64_t elementalBitWidth) {
+  assert(sizes.size() == 2 && "only 2-D copy supported for now");
+  FailureOr<CopyMapping> maybeCopyMapping = CopyMapping::numThreadsForCopy(
+      totalNumThreads, sizes, favorPredication, elementalBitWidth);
+  // If failed, try again with predication; this must succeed.
+  if (failed(maybeCopyMapping)) {
+    assert(!favorPredication &&
+           "maybe copy mapping may not fail with predication");
+    maybeCopyMapping = CopyMapping::numThreadsForCopy(
+        totalNumThreads, sizes, /*favorPredication=*/true, elementalBitWidth);
+  }
+  assert(succeeded(maybeCopyMapping) && "failed to compute copy mapping");
+  assert(maybeCopyMapping->numThreads.size() == 2 &&
+         "compute copy mapping expected size-2");
+  int64_t numThreadsY = maybeCopyMapping->numThreads[0];
+  int64_t numThreadsX = maybeCopyMapping->numThreads[1];
+  int64_t sizeY = sizes[0];
+  int64_t sizeX = sizes[1];
+  MappingInfo res{
+      /*numThreads=*/{numThreadsY, numThreadsX},
+      /*tileSizes=*/
+      {mlir::ceilDiv(sizeY, numThreadsY), mlir::ceilDiv(sizeX, numThreadsX)},
+      /*threadMapping=*/{linearIdY(ctx), linearIdX(ctx)},
+      /*vectorSize=*/maybeCopyMapping->vectorSize};
+  LLVM_DEBUG(res.print(DBGS()); llvm::dbgs() << "\n");
+  return res;
+}

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.cpp
@@ -45,12 +45,7 @@ iree_compiler::gpu::CopyMapping::numThreadsForCopy(int totalNumThreads,
   for (auto s : sizes) numElements *= s;
   LDBG("--numElements: " << numElements);
 
-  // TODO: this implementation exhibits and issue with mapping to cp.async zfill
-  // in the presence of vectors of size > 1. This could also be related to the
-  // lack of substantial perf gains between masked vector<4> and masked
-  // vector<1>.
-  // int64_t actualVectorSize = maxVectorSize;
-  int64_t actualVectorSize = 1;
+  int64_t actualVectorSize = maxVectorSize;
   if (!favorPredication) {
     // Bias towards reducing the vector size to avoid predication.
     // Predication occurs if we end up using fewer than totalNumThreads for a

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.h
@@ -28,29 +28,50 @@ struct CopyMapping {
 
   /// Determine the maximal vector size to use to copy a contiguous array of
   /// `numContiguousElements`, each of bitwidth `elementalBitWidth`.
+  /// The `alignment` is the number of elements by which the most minor
+  /// dimension of the copy is aligned. This is an approximation of actual
+  /// memory alignment after bufferization, for each row of the copy. This is
+  /// used to restrict the of the copied vector so that it is properly aligned
+  /// with the requirements of cp.async. If the copy alignemnt does not match
+  /// the required aligned for a cp.async, thae conversion to cp.async will be
+  /// skipped.
   /// Asserts that `elementalBitWidth` divides `numContiguousElements`.
   static int64_t maxContiguousElementsToTransfer(
-      int64_t numContiguousElements, int64_t elementalBitWidth = 32);
+      int64_t alignment, int64_t numContiguousElements,
+      int64_t elementalBitWidth = 32);
 
   /// Compute the number of threads to use to perform a copy of `sizes`
   /// elements of `elementalBitWidth`.
+  /// The `alignment` is the number of elements by which the most minor
+  /// dimension of the copy is aligned. This is an approximation of actual
+  /// memory alignment after bufferization, for each row of the copy. This is
+  /// used to restrict the of the copied vector so that it is properly aligned
+  /// with the requirements of cp.async. If the copy alignemnt does not match
+  /// the required aligned for a cp.async, thae conversion to cp.async will be
+  /// skipped.
   /// When `favorPredication` is false, the implementation avoids predication in
   /// the copy, even if it means reducing the granularity of the transfer.
   /// Otherwise, the implementation will come up with a best-effort predicated
   /// mapping that respects the maximal vector transfer size.
   static FailureOr<CopyMapping> numThreadsForCopy(
-      int totalNumThreads, ArrayRef<int64_t> sizes, bool favorPredication,
-      int64_t elementalBitWidth = 32);
+      int totalNumThreads, int64_t alignment, ArrayRef<int64_t> sizes,
+      bool favorPredication, int64_t elementalBitWidth = 32);
 
   /// Greedily compute the MappingInfo to use to perform a copy of `sizes`
   /// elements of bitwidth `elementalBitWidth`.
-  /// When `favorPredication` if false, the mapping is computed to fill all
-  /// threads with an equal amount of data to copy, so as to avoid predication.
-  /// Predication often ends up breaking current pipelining implementations down
-  /// the line and is generally discouraged.
-  /// At the moment, asserts that sizes has exactly 2 entries.
+  /// The `alignment` is the number of elements by which the most minor
+  /// dimension of the copy is aligned. This is an approximation of actual
+  /// memory alignment after bufferization, for each row of the copy. This is
+  /// used to restrict the of the copied vector so that it is properly aligned
+  /// with the requirements of cp.async. If the copy alignemnt does not match
+  /// the required aligned for a cp.async, thae conversion to cp.async will be
+  /// skipped. When `favorPredication` if false, the mapping is computed to fill
+  /// all threads with an equal amount of data to copy, so as to avoid
+  /// predication. Predication often ends up breaking current pipelining
+  /// implementations down the line and is generally discouraged. At the moment,
+  /// asserts that sizes has exactly 2 entries.
   static MappingInfo getMappingInfo(MLIRContext *ctx, int totalNumThreads,
-                                    ArrayRef<int64_t> sizes,
+                                    int64_t alignment, ArrayRef<int64_t> sizes,
                                     bool favorPredication = false,
                                     int64_t elementalBitWidth = 32);
 };

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.h
@@ -1,0 +1,62 @@
+
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_COPY_MAPPING_H_
+#define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_COPY_MAPPING_H_
+
+#include <numeric>
+
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/MappingInfo.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace gpu {
+
+struct CopyMapping {
+  /// Vector size to use for the copy.
+  int64_t vectorSize;
+
+  /// numThreads to use for the copy mapping, from most major to most minor dims
+  /// (i.e. numThreads.back() should be mapped to contiguous threads for best
+  /// coalescing).
+  SmallVector<int64_t> numThreads;
+
+  /// Determine the maximal vector size to use to copy a contiguous array of
+  /// `numContiguousElements`, each of bitwidth `elementalBitWidth`.
+  /// Asserts that `elementalBitWidth` divides `numContiguousElements`.
+  static int64_t maxContiguousElementsToTransfer(
+      int64_t numContiguousElements, int64_t elementalBitWidth = 32);
+
+  /// Compute the number of threads to use to perform a copy of `sizes`
+  /// elements of `elementalBitWidth`.
+  /// When `favorPredication` is false, the implementation avoids predication in
+  /// the copy, even if it means reducing the granularity of the transfer.
+  /// Otherwise, the implementation will come up with a best-effort predicated
+  /// mapping that respects the maximal vector transfer size.
+  static FailureOr<CopyMapping> numThreadsForCopy(
+      int totalNumThreads, ArrayRef<int64_t> sizes, bool favorPredication,
+      int64_t elementalBitWidth = 32);
+
+  /// Greedily compute the MappingInfo to use to perform a copy of `sizes`
+  /// elements of bitwidth `elementalBitWidth`.
+  /// When `favorPredication` if false, the mapping is computed to fill all
+  /// threads with an equal amount of data to copy, so as to avoid predication.
+  /// Predication often ends up breaking current pipelining implementations down
+  /// the line and is generally discouraged.
+  /// At the moment, asserts that sizes has exactly 2 entries.
+  static MappingInfo getMappingInfo(MLIRContext *ctx, int totalNumThreads,
+                                    ArrayRef<int64_t> sizes,
+                                    bool favorPredication = false,
+                                    int64_t elementalBitWidth = 32);
+};
+
+}  // namespace gpu
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_COPY_MAPPING_H_

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MappingInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MappingInfo.cpp
@@ -1,0 +1,23 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Support/MathExtras.h"
+
+using namespace mlir;
+
+void mlir::iree_compiler::gpu::MappingInfo::print(llvm::raw_ostream &os) const {
+  os << "MappingInfo{";
+  os << "vectorSize: " << ((vectorSize.has_value()) ? vectorSize.value() : 0);
+  llvm::interleaveComma(numThreads, os << ", numThreads: {");
+  llvm::interleaveComma(tileSizes, os << "}, tileSizes: {");
+  llvm::interleaveComma(threadMapping, os << "}, threadMapping: {");
+  os << "}}";
+}

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MappingInfo.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MappingInfo.h
@@ -1,0 +1,33 @@
+
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_MAPPING_INFO_H_
+#define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_MAPPING_INFO_H_
+
+#include "mlir/IR/Attributes.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace gpu {
+
+/// Helper struct to hold the mapping information for a given operation.
+struct MappingInfo {
+  SmallVector<int64_t> numThreads;
+  // Note: explicitly computing the tileSizes is only needed until masked
+  // vectorization properly computes the bounds automatically.
+  SmallVector<int64_t> tileSizes;
+  SmallVector<Attribute> threadMapping;
+  std::optional<int64_t> vectorSize;
+  void print(llvm::raw_ostream &os) const;
+  LLVM_DUMP_METHOD void dump() const;
+};
+
+}  // namespace gpu
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_MAPPING_INFO_H_

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -96,8 +96,10 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
 
   // LHS copy is of size mxk.
   MappingInfo lhsCopyMapping() const override {
-    return CopyMapping::getMappingInfo(ctx, totalNumThreads(),
-                                       {blockTileM(), reductionTileSize});
+    return CopyMapping::getMappingInfo(
+        ctx, totalNumThreads(),
+        /*alignment=*/k(),
+        /*copySizes=*/ArrayRef<int64_t>{blockTileM(), reductionTileSize});
   }
   LogicalResult validateLhsCopyMapping() const override {
     MappingInfo mapping = lhsCopyMapping();
@@ -113,8 +115,10 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
 
   // RHS copy is of size kxn.
   MappingInfo rhsCopyMapping() const override {
-    return CopyMapping::getMappingInfo(ctx, totalNumThreads(),
-                                       {reductionTileSize, blockTileN()});
+    return CopyMapping::getMappingInfo(
+        ctx, totalNumThreads(),
+        /*alignment=*/n(),
+        /*copySizes=*/ArrayRef<int64_t>{reductionTileSize, blockTileN()});
   }
   LogicalResult validateRhsCopyMapping() const override {
     MappingInfo mapping = rhsCopyMapping();
@@ -130,8 +134,10 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
 
   // RES copy is of size mxn.
   MappingInfo resCopyMapping() const override {
-    return CopyMapping::getMappingInfo(ctx, totalNumThreads(),
-                                       {blockTileM(), blockTileN()});
+    return CopyMapping::getMappingInfo(
+        ctx, totalNumThreads(),
+        /*alignment=*/n(),
+        /*copySizes=*/ArrayRef<int64_t>{blockTileM(), blockTileN()});
   }
 
   LogicalResult validateResCopyMapping() const override {

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -11,6 +11,8 @@
 #include "iree/compiler/Codegen/TransformStrategies/Common/Common.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/CopyMapping.h"
+#include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Support/MathExtras.h"
@@ -76,35 +78,27 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
     return blockTileSizes[1];
   }
 
-  int64_t numWarpsM() const override {
+  int64_t numWarpsX() const override {
     assert(numWarps.size() >= 2 && "need at least 2 warp sizes");
     return numWarps[0];
   }
-  int64_t numWarpsN() const override {
+  int64_t numWarpsY() const override {
     assert(numWarps.size() >= 2 && "need at least 2 warp sizes");
     return numWarps[1];
   }
 
-  using AbstractGemmLikeStrategy::MappingInfo;
-
   MappingInfo getBlockMapping() const override {
     return MappingInfo{/*numThreads=*/{},
                        /*tileSizes=*/{blockTileM(), blockTileN()},
-                       /*threadMapping=*/{blockY(ctx), blockX(ctx)}};
+                       /*threadMapping=*/{blockY(ctx), blockX(ctx)},
+                       /*vectorSize=*/std::nullopt};
   }
 
   // LHS copy is of size mxk.
   MappingInfo lhsCopyMapping() const override {
-    int64_t numThreadsK = mlir::ceilDiv(reductionTileSize, lhsCopyVectorSize());
-    int64_t numThreadsM =
-        std::min(blockTileM(), mlir::ceilDiv(totalNumThreads(), numThreadsK));
-    return MappingInfo{/*numThreads=*/{numThreadsM, numThreadsK},
-                       /*tileSizes=*/
-                       {mlir::ceilDiv(blockTileM(), numThreadsM),
-                        mlir::ceilDiv(reductionTileSize, numThreadsK)},
-                       /*threadMapping=*/{linearIdX(ctx), linearIdY(ctx)}};
+    return CopyMapping::getMappingInfo(ctx, totalNumThreads(),
+                                       {blockTileM(), reductionTileSize});
   }
-
   LogicalResult validateLhsCopyMapping() const override {
     MappingInfo mapping = lhsCopyMapping();
     // It is fine to use fewer threads to copy the LHS.
@@ -119,16 +113,9 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
 
   // RHS copy is of size kxn.
   MappingInfo rhsCopyMapping() const override {
-    int64_t numThreadsN = mlir::ceilDiv(blockTileN(), rhsCopyVectorSize());
-    int64_t numThreadsK = std::min(
-        reductionTileSize, mlir::ceilDiv(totalNumThreads(), numThreadsN));
-    return MappingInfo{/*numThreads=*/{numThreadsK, numThreadsN},
-                       /*tileSizes=*/
-                       {mlir::ceilDiv(reductionTileSize, numThreadsK),
-                        mlir::ceilDiv(blockTileN(), numThreadsN)},
-                       /*threadMapping=*/{linearIdY(ctx), linearIdX(ctx)}};
+    return CopyMapping::getMappingInfo(ctx, totalNumThreads(),
+                                       {reductionTileSize, blockTileN()});
   }
-
   LogicalResult validateRhsCopyMapping() const override {
     MappingInfo mapping = rhsCopyMapping();
     // It is fine to use fewer threads to copy the RHS.
@@ -143,16 +130,8 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
 
   // RES copy is of size mxn.
   MappingInfo resCopyMapping() const override {
-    int64_t numThreadsN = mlir::ceilDiv(blockTileN(), resCopyVectorSize());
-    int64_t numThreadsM =
-        std::min(blockTileM(), mlir::ceilDiv(totalNumThreads(), numThreadsN));
-    return MappingInfo{/*numThreads=*/{numThreadsM, numThreadsN},
-                       /*tileSizes=*/
-                       {std::max(static_cast<int64_t>(1),
-                                 mlir::ceilDiv(blockTileM(), numThreadsM)),
-                        std::max(static_cast<int64_t>(1),
-                                 mlir::ceilDiv(blockTileN(), numThreadsN))},
-                       /*threadMapping=*/{linearIdY(ctx), linearIdX(ctx)}};
+    return CopyMapping::getMappingInfo(ctx, totalNumThreads(),
+                                       {blockTileM(), blockTileN()});
   }
 
   LogicalResult validateResCopyMapping() const override {
@@ -169,12 +148,10 @@ class MatmulStrategy : public AbstractGemmLikeStrategy {
 
   // COMPUTE is of size mxn.
   MappingInfo computeMapping() const override {
-    // Warps along M and N need to properly be ordered along the X and Y
-    // dimensions respectively, otherwise we would improperly generate
-    // predicated code.
-    return MappingInfo{/*numThreads=*/{numWarpsM(), numWarpsN()},
+    return MappingInfo{/*numThreads=*/{numWarpsY(), numWarpsX()},
                        /*tileSizes=*/{},
-                       /*threadMapping=*/{warpX(ctx), warpY(ctx)}};
+                       /*threadMapping=*/{warpY(ctx), warpX(ctx)},
+                       /*vectorSize=*/std::nullopt};
   }
 
   LogicalResult validate() const override {


### PR DESCRIPTION
This is in prevision of future generalizations to various data types and other higher-dimensional operations.