### PR TITLE
Add sharding to benchmark execution

### DIFF
--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -69,14 +69,15 @@ jobs:
         id: generate
         run: >
           gcloud storage cp "${BENCHMARK_CONFIG_GCS_ARTIFACT}" "${BENCHMARK_CONFIG}";
-          echo benchmark-matrix=$(jq 'to_entries[]
-          | .key as $device_name
-          | .value.host_environment as $host_environment
-          | (.value.shards | length) as $shard_count
-          | .value.shards[]
-          | { device_name: $device_name, host_environment: $host_environment,
-          shard: { index: .shard_index, count: $shard_count }
-          }' "${BENCHMARK_CONFIG}" | jq -s '.') >> "${GITHUB_OUTPUT}"
+          echo benchmark-matrix=$(jq '[ . | to_entries[]
+            | .key as $device_name
+            | .value.host_environment as $host_environment
+            | (.value.shards | length) as $shard_count
+            | .value.shards[]
+            | { device_name: $device_name, host_environment: $host_environment,
+                shard: { index: .shard_index, count: $shard_count }
+              }
+            ]' "${BENCHMARK_CONFIG}") >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:
     needs: [generate_matrix]
@@ -134,13 +135,7 @@ jobs:
             --arg DEVICE_NAME "${DEVICE_NAME}" \
             --arg SHARD_INDEX "${SHARD_INDEX}" \
             --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
-            '.[$DEVICE_NAME].shards[] | select((.shard_index | tostring) == $SHARD_INDEX) | .module_dir_paths[] | "\($GCS_ARTIFACT_DIR)/\(.)"' \
-            "${BENCHMARK_CONFIG}"
-          jq -r \
-            --arg DEVICE_NAME "${DEVICE_NAME}" \
-            --arg SHARD_INDEX "${SHARD_INDEX}" \
-            --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
-            '.[$DEVICE_NAME].shards[] | select((.shard_index | tostring) == $SHARD_INDEX) | .module_dir_paths[] | "\($GCS_ARTIFACT_DIR)/\(.)"' \
+            '.[$DEVICE_NAME].shards[($SHARD_INDEX | tonumber)] | .module_dir_paths[] | "\($GCS_ARTIFACT_DIR)/\(.)"' \
             "${BENCHMARK_CONFIG}" | \
             gcloud storage cp -r --read-paths-from-stdin "${E2E_TEST_ARTIFACTS_DIR}"
           echo "benchmark-config=${BENCHMARK_CONFIG}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -69,12 +69,14 @@ jobs:
         id: generate
         run: >
           gcloud storage cp "${BENCHMARK_CONFIG_GCS_ARTIFACT}" "${BENCHMARK_CONFIG}";
-          echo benchmark-matrix=$(jq 'to_entries[] | .key as $device_name | .value[] |
-               {
-                 "device_name": $device_name,
-                 "host_environment": .host_environment,
-                 "shard": .shard
-               }' "${BENCHMARK_CONFIG}" | jq -s '.') >> "${GITHUB_OUTPUT}"
+          echo benchmark-matrix=$(jq 'to_entries[]
+          | .key as $device_name
+          | .value.host_environment as $host_environment
+          | (.value.shards | length) as $shard_count
+          | .value.shards[]
+          | { device_name: $device_name, host_environment: $host_environment,
+          shard: { index: .shard_index, count: $shard_count }
+          }' "${BENCHMARK_CONFIG}" | jq -s '.') >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:
     needs: [generate_matrix]
@@ -99,7 +101,10 @@ jobs:
       E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ inputs.e2e-test-artifacts-gcs-artifact-dir }}
       E2E_TEST_ARTIFACTS_DIR: ${{ inputs.e2e-test-artifacts-dir }}
       BENCHMARK_RESULTS_DIR: benchmark-results
-      SHARDING_SUFFIX: ${{ matrix.benchmark.shard.count > 1 && format('-shard{0}of{1}', matrix.benchmark.shard.index, matrix.benchmark.shard.count) || '' }}
+      SHARDING_SUFFIX: |-
+        ${{ matrix.benchmark.shard.count > 1
+        && format('-shard{0}of{1}', matrix.benchmark.shard.index,
+        matrix.benchmark.shard.count) || '' }}
     outputs:
       benchmark-results-dir: ${{ env.BENCHMARK_RESULTS_DIR }}
       # Ideally this should be defined in env, so it can be used in the upload
@@ -129,7 +134,13 @@ jobs:
             --arg DEVICE_NAME "${DEVICE_NAME}" \
             --arg SHARD_INDEX "${SHARD_INDEX}" \
             --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
-            '.[$DEVICE_NAME][] | select((.shard.index | tostring) == $SHARD_INDEX) | .module_dir_paths[] | "\($GCS_ARTIFACT_DIR)/\(.)"' \
+            '.[$DEVICE_NAME].shards[] | select((.shard_index | tostring) == $SHARD_INDEX) | .module_dir_paths[] | "\($GCS_ARTIFACT_DIR)/\(.)"' \
+            "${BENCHMARK_CONFIG}"
+          jq -r \
+            --arg DEVICE_NAME "${DEVICE_NAME}" \
+            --arg SHARD_INDEX "${SHARD_INDEX}" \
+            --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
+            '.[$DEVICE_NAME].shards[] | select((.shard_index | tostring) == $SHARD_INDEX) | .module_dir_paths[] | "\($GCS_ARTIFACT_DIR)/\(.)"' \
             "${BENCHMARK_CONFIG}" | \
             gcloud storage cp -r --read-paths-from-stdin "${E2E_TEST_ARTIFACTS_DIR}"
           echo "benchmark-config=${BENCHMARK_CONFIG}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -173,7 +173,7 @@ jobs:
       - name: "Determine Shard Suffix"
         id: sharding
         run: |
-          if [[ ${SHARD_COUNT} -gt 1 ]]; then
+          if (( SHARD_COUNT > 1 )); then
             echo "suffix=$(printf -- "-%02d-of-%02d" "${SHARD_INDEX}" "${SHARD_COUNT}")" >> "${GITHUB_OUTPUT}"
           else
             echo "suffix=" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -67,17 +67,40 @@ jobs:
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: "Generating benchmark matrix"
         id: generate
-        run: >
-          gcloud storage cp "${BENCHMARK_CONFIG_GCS_ARTIFACT}" "${BENCHMARK_CONFIG}";
-          echo benchmark-matrix=$(jq '[ . | to_entries[]
+        run: |
+          gcloud storage cp "${BENCHMARK_CONFIG_GCS_ARTIFACT}" "${BENCHMARK_CONFIG}"
+          # This jq command takes a benchmark config with the following structure:
+          #
+          #   { "target_device_name" : {
+          #      "host_environment" : { ... },
+          #      "shards" : [ { ... }, { ... } ]
+          #     },
+          #     "other_target_device_name" : { ... }
+          #
+          # and turns it into a flat list of benchmark jobs:
+          #
+          #   [
+          #     { "device_name" : "target_device_name",
+          #       "host_environment" : { ... },
+          #       "shard" : { index: 0, count: 2 }
+          #     },
+          #     { "device_name" : "target_device_name",
+          #       "host_environment" : { ... },
+          #       "shard" : { index: 1, count: 2 }
+          #     },
+          #     { "device_name" : "other_target_device_name",
+          #       "host_environment" : { ... },
+          #       "shard" : { index: 0, count: N }
+          #     },
+          #     ...
+          #   ]
+          echo benchmark-matrix="$(jq -c '[ . | to_entries[]
             | .key as $device_name
             | .value.host_environment as $host_environment
-            | (.value.shards | length) as $shard_count
+            | (.value.shards | length) as $count
             | .value.shards[]
-            | { device_name: $device_name, host_environment: $host_environment,
-                shard: { index: .shard_index, count: $shard_count }
-              }
-            ]' "${BENCHMARK_CONFIG}") >> "${GITHUB_OUTPUT}"
+            | {$device_name, $host_environment, shard: {index, $count}}
+            ]' "${BENCHMARK_CONFIG}")" >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:
     needs: [generate_matrix]
@@ -102,10 +125,6 @@ jobs:
       E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ inputs.e2e-test-artifacts-gcs-artifact-dir }}
       E2E_TEST_ARTIFACTS_DIR: ${{ inputs.e2e-test-artifacts-dir }}
       BENCHMARK_RESULTS_DIR: benchmark-results
-      SHARDING_SUFFIX: |-
-        ${{ matrix.benchmark.shard.count > 1
-        && format('-shard{0}of{1}', matrix.benchmark.shard.index,
-        matrix.benchmark.shard.count) || '' }}
     outputs:
       benchmark-results-dir: ${{ env.BENCHMARK_RESULTS_DIR }}
       # Ideally this should be defined in env, so it can be used in the upload
@@ -151,6 +170,14 @@ jobs:
           echo "normal-benchmark-tools-dir=${BENCHMARK_TOOLS_DIR}/build/tools" >> "${GITHUB_OUTPUT}"
           echo "traced-benchmark-tools-dir=${BENCHMARK_TOOLS_DIR}/build-traced/tools" >> "${GITHUB_OUTPUT}"
           echo "tracy-capture-tool=${BENCHMARK_TOOLS_DIR}/build-traced/tracy-capture" >> "${GITHUB_OUTPUT}"
+      - name: "Determine Shard Suffix"
+        id: sharding
+        run: |
+          if [[ ${SHARD_COUNT} -gt 1 ]]; then
+            echo "suffix=$(printf -- "-%02d-of-%02d" "${SHARD_INDEX}" "${SHARD_COUNT}")" >> "${GITHUB_OUTPUT}"
+          else
+            echo "suffix=" >> "${GITHUB_OUTPUT}"
+          fi
       - name: "Running benchmarks"
         env:
           IREE_EXECUTION_BENCHMARK_CONFIG: ${{ steps.download-assets.outputs.benchmark-config }}
@@ -159,10 +186,10 @@ jobs:
           IREE_TRACED_BENCHMARK_TOOLS_DIR: ${{ steps.unpack-tools.outputs.traced-benchmark-tools-dir }}
           IREE_TRACY_CAPTURE_TOOL: ${{ steps.unpack-tools.outputs.tracy-capture-tool }}
           IREE_TARGET_DEVICE_NAME: ${{ env.DEVICE_NAME }}
-          IREE_SHARD_INDEX: ${{ env.SHARD_INDEX }}
+          IREE_SHARD_INDEX: ${{ matrix.benchmark.shard.index }}
           IREE_E2E_TEST_ARTIFACTS_DIR: ${{ env.E2E_TEST_ARTIFACTS_DIR }}
-          IREE_BENCHMARK_RESULTS: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-results-${{ matrix.benchmark.device_name }}${{ env.SHARDING_SUFFIX }}.json
-          IREE_BENCHMARK_TRACES: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-traces-${{ matrix.benchmark.device_name }}${{ env.SHARDING_SUFFIX }}.tar.gz
+          IREE_BENCHMARK_RESULTS: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-results-${{ matrix.benchmark.device_name }}${{ steps.sharding.outputs.suffix }}.json
+          IREE_BENCHMARK_TRACES: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-traces-${{ matrix.benchmark.device_name }}${{ steps.sharding.outputs.suffix }}.tar.gz
         run: |
           mkdir -p ${BENCHMARK_RESULTS_DIR}
           ./build_tools/benchmarks/run_benchmarks.sh

--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -67,12 +67,14 @@ jobs:
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: "Generating benchmark matrix"
         id: generate
-        run: |
-          gcloud storage cp "${BENCHMARK_CONFIG_GCS_ARTIFACT}" "${BENCHMARK_CONFIG}"
-          echo benchmark-matrix=$(jq \
-              'to_entries | map({"device_name": .key, "host_environment": .value.host_environment})' \
-              "${BENCHMARK_CONFIG}") \
-            >> "${GITHUB_OUTPUT}"
+        run: >
+          gcloud storage cp "${BENCHMARK_CONFIG_GCS_ARTIFACT}" "${BENCHMARK_CONFIG}";
+          echo benchmark-matrix=$(jq 'to_entries[] | .key as $device_name | .value[] |
+               {
+                 "device_name": $device_name,
+                 "host_environment": .host_environment,
+                 "shard": .shard
+               }' "${BENCHMARK_CONFIG}" | jq -s '.') >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:
     needs: [generate_matrix]
@@ -91,10 +93,13 @@ jobs:
       - machine-type=${{ matrix.benchmark.device_name }}
     env:
       DEVICE_NAME: ${{ matrix.benchmark.device_name }}
+      SHARD_INDEX: ${{ matrix.benchmark.shard.index }}
+      SHARD_COUNT: ${{ matrix.benchmark.shard.count }}
       PLATFORM_ARCH: ${{ matrix.benchmark.host_environment.platform }}-${{ matrix.benchmark.host_environment.architecture }}
       E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ inputs.e2e-test-artifacts-gcs-artifact-dir }}
       E2E_TEST_ARTIFACTS_DIR: ${{ inputs.e2e-test-artifacts-dir }}
       BENCHMARK_RESULTS_DIR: benchmark-results
+      SHARDING_SUFFIX: ${{ matrix.benchmark.shard.count > 1 && format('-shard{0}of{1}', matrix.benchmark.shard.index, matrix.benchmark.shard.count) || '' }}
     outputs:
       benchmark-results-dir: ${{ env.BENCHMARK_RESULTS_DIR }}
       # Ideally this should be defined in env, so it can be used in the upload
@@ -122,8 +127,9 @@ jobs:
           mkdir -p "${E2E_TEST_ARTIFACTS_DIR}"
           jq -r \
             --arg DEVICE_NAME "${DEVICE_NAME}" \
+            --arg SHARD_INDEX "${SHARD_INDEX}" \
             --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
-            '.[$DEVICE_NAME] | .module_dir_paths | map("\($GCS_ARTIFACT_DIR)/\(.)") | join("\n")' \
+            '.[$DEVICE_NAME][] | select((.shard.index | tostring) == $SHARD_INDEX) | .module_dir_paths[] | "\($GCS_ARTIFACT_DIR)/\(.)"' \
             "${BENCHMARK_CONFIG}" | \
             gcloud storage cp -r --read-paths-from-stdin "${E2E_TEST_ARTIFACTS_DIR}"
           echo "benchmark-config=${BENCHMARK_CONFIG}" >> "${GITHUB_OUTPUT}"
@@ -147,9 +153,10 @@ jobs:
           IREE_TRACED_BENCHMARK_TOOLS_DIR: ${{ steps.unpack-tools.outputs.traced-benchmark-tools-dir }}
           IREE_TRACY_CAPTURE_TOOL: ${{ steps.unpack-tools.outputs.tracy-capture-tool }}
           IREE_TARGET_DEVICE_NAME: ${{ env.DEVICE_NAME }}
+          IREE_SHARD_INDEX: ${{ env.SHARD_INDEX }}
           IREE_E2E_TEST_ARTIFACTS_DIR: ${{ env.E2E_TEST_ARTIFACTS_DIR }}
-          IREE_BENCHMARK_RESULTS: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-results-${{ matrix.benchmark.device_name }}.json
-          IREE_BENCHMARK_TRACES: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-traces-${{ matrix.benchmark.device_name }}.tar.gz
+          IREE_BENCHMARK_RESULTS: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-results-${{ matrix.benchmark.device_name }}${{ env.SHARDING_SUFFIX }}.json
+          IREE_BENCHMARK_TRACES: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-traces-${{ matrix.benchmark.device_name }}${{ env.SHARDING_SUFFIX }}.tar.gz
         run: |
           mkdir -p ${BENCHMARK_RESULTS_DIR}
           ./build_tools/benchmarks/run_benchmarks.sh

--- a/.github/workflows/benchmark_large.yml
+++ b/.github/workflows/benchmark_large.yml
@@ -20,7 +20,7 @@ on:
           Allows to assign a distinct shard count for each target device.
           The reserved keyword `default` assigns a shard count to all target devices
           that are not explicitly listed.
-        # Please keep the shard count default value in sync with jobs.build_e2e_test_artifacts.with.shard-count
+        # Please keep this default value in sync with the jobs.build_e2e_test_artifacts.with.shard-count field below
         default: a2-highgpu-1g=2,c2-standard-16=2,default=1
         type: string
 

--- a/.github/workflows/benchmark_large.yml
+++ b/.github/workflows/benchmark_large.yml
@@ -13,15 +13,16 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
-    shard-count:
-      description: |
-        A device-name to integer mapping as a comma separated list.
-        Allows to assign a distinct shard count for each target device.
-        The reserved keyword `default` assigns a shard count to all target devices
-        that are not explicitly listed.
-      # Please keep the shard count default value in sync with jobs.build_e2e_test_artifacts.with.shard-count
-      default: a2-highgpu-1g=2,c2-standard-16=2,default=1
-      type: string
+    inputs:
+      shard-count:
+        description: |
+          A device-name to integer mapping as a comma separated list.
+          Allows to assign a distinct shard count for each target device.
+          The reserved keyword `default` assigns a shard count to all target devices
+          that are not explicitly listed.
+        # Please keep the shard count default value in sync with jobs.build_e2e_test_artifacts.with.shard-count
+        default: a2-highgpu-1g=2,c2-standard-16=2,default=1
+        type: string
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/benchmark_large.yml
+++ b/.github/workflows/benchmark_large.yml
@@ -9,10 +9,20 @@
 name: Benchmark Large
 
 on:
+  pull_request: # DO NOT SUBMIT
   schedule:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
+    shard-count:
+      description: |
+        A device-name to integer mapping as a comma separated list.
+        Allows to assign a distinct shard count for each target device.
+        The reserved keyword `default` assigns a shard count to all target devices
+        that are not explicitly listed.
+      # Please keep the shard count default value in sync with jobs.build_e2e_test_artifacts.with.shard-count
+      default: a2-highgpu-1g=2,c2-standard-16=2,default=1
+      type: string
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -65,6 +75,8 @@ jobs:
       build-dir-gcs-artifact: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
       benchmark-presets: cuda-large,comp-stats-large,x86_64-large
       build-default-benchmark-suites: 0
+      # Please keep the shard count default value in sync with on.workflow_dispatch.shard-count.default
+      shard-count: ${{ inputs && inputs.shard_count || 'a2-highgpu-1g=2,c2-standard-16=2,default=1' }}
 
   compilation_benchmarks:
     needs: [setup, build_e2e_test_artifacts]

--- a/.github/workflows/benchmark_large.yml
+++ b/.github/workflows/benchmark_large.yml
@@ -9,7 +9,6 @@
 name: Benchmark Large
 
 on:
-  pull_request: # DO NOT SUBMIT
   schedule:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'

--- a/.github/workflows/benchmark_large.yml
+++ b/.github/workflows/benchmark_large.yml
@@ -21,7 +21,7 @@ on:
           The reserved keyword `default` assigns a shard count to all target devices
           that are not explicitly listed.
         # Please keep this default value in sync with the jobs.build_e2e_test_artifacts.with.shard-count field below
-        default: a2-highgpu-1g=2,c2-standard-16=2,default=1
+        default: a2-highgpu-1g=1,c2-standard-16=2,default=1
         type: string
 
 concurrency:
@@ -76,7 +76,7 @@ jobs:
       benchmark-presets: cuda-large,comp-stats-large,x86_64-large
       build-default-benchmark-suites: 0
       # Please keep the shard count default value in sync with on.workflow_dispatch.shard-count.default
-      shard-count: ${{ inputs && inputs.shard_count || 'a2-highgpu-1g=2,c2-standard-16=2,default=1' }}
+      shard-count: ${{ inputs && inputs.shard_count || 'a2-highgpu-1g=1,c2-standard-16=2,default=1' }}
 
   compilation_benchmarks:
     needs: [setup, build_e2e_test_artifacts]

--- a/.github/workflows/build_e2e_test_artifacts.yml
+++ b/.github/workflows/build_e2e_test_artifacts.yml
@@ -39,6 +39,14 @@ on:
           if set to 1.
         default: 1
         type: number
+      shard-count:
+        description: |
+          A device-name to integer mapping as a comma separated list.
+          Allows to assign a distinct shard count for each target device.
+          The reserved keyword `default` assigns a shard count to all target devices
+          that are not explicitly listed.
+        default: default=1
+        type: string
     outputs:
       e2e-test-artifacts-dir:
         description: |
@@ -97,6 +105,7 @@ jobs:
           IREE_BENCHMARK_PRESETS: ${{ inputs.benchmark-presets }}
           IREE_BUILD_DEFAULT_BENCHMARK_SUITES: ${{ inputs.build-default-benchmark-suites }}
           BUILD_E2E_TEST_ARTIFACTS_DIR: build-e2e-test-artifacts
+          IREE_SHARD_COUNT: ${{ inputs.shard-count }}
         run: |
           build_tools/github_actions/docker_run.sh \
             --env "IREE_HOST_BIN_DIR=${HOST_BUILD_DIR}/install/bin" \

--- a/build_tools/benchmarks/benchmark_helper.py
+++ b/build_tools/benchmarks/benchmark_helper.py
@@ -133,7 +133,7 @@ def _dump_cmds_handler(
                     lines.append(f"Execution Benchmark ID: {run_config.composite_id}")
                     lines.append(f"Name: {run_config}")
                     lines.append(f"Target Device: {target_device}")
-                    lines.append(f"Shard: {shard['shard_index']} / {shard_count}")
+                    lines.append(f"Shard: {shard['index']} / {shard_count}")
                     lines.append("")
                     lines += _dump_cmds_from_run_config(
                         run_config=run_config, root_path=e2e_test_artifacts_dir
@@ -166,21 +166,15 @@ class JSONBackedBenchmarkData:
     def __init__(self, source_filepath: pathlib.PurePath, data: Dict):
         if not isinstance(data, dict):
             raise ValueError(
-                '"{}" seems not to be a valid benchmark-results-file (No JSON struct as root element).'.format(
-                    source_filepath
-                )
+                f"'{source_filepath}' seems not to be a valid benchmark-results-file (No JSON struct as root element)."
             )
         if "commit" not in data:
             raise ValueError(
-                '"{}" seems not to be a valid benchmark-results-file ("commit" field not found).'.format(
-                    source_filepath
-                )
+                f"'{source_filepath}' seems not to be a valid benchmark-results-file ('commit' field not found)."
             )
         if "benchmarks" not in data:
             raise ValueError(
-                '"{}" seems not to be a valid benchmark-results-file ("benchmarks" field not found).'.format(
-                    source_filepath
-                )
+                f"'{source_filepath}' seems not to be a valid benchmark-results-file ('benchmarks' field not found)."
             )
 
         self.source_filepath: pathlib.PurePath = source_filepath
@@ -192,9 +186,7 @@ class JSONBackedBenchmarkData:
         try:
             data = json.loads(filepath.read_bytes())
         except json.JSONDecodeError as e:
-            raise ValueError(
-                '"{}" seems not to be a valid JSON file: {}'.format(filepath, e.msg)
-            )
+            raise ValueError(f"'{filepath}' seems not to be a valid JSON file: {e.msg}")
         return JSONBackedBenchmarkData(filepath, data)
 
     # A convenience wrapper around `loadFromFile` that accepts a sequence of paths and returns a sequence of JSONBackedBenchmarkData objects as a generator.
@@ -209,13 +201,9 @@ class JSONBackedBenchmarkData:
 def _merge_two_resultsets(
     left: JSONBackedBenchmarkData, right: JSONBackedBenchmarkData
 ) -> JSONBackedBenchmarkData:
-    # left_content = left if isinstance(left, dict) else _load(left)
-    # right_content = right if isinstance(right, dict) else _load(right)
     if left.data["commit"] != right.data["commit"]:
         raise ValueError(
-            '"{}" and the previous files are based on different commits ({} != {}). Merging not supported.'.format(
-                right.source_filepath, left.data["commit"], right.data["commit"]
-            )
+            f"'{right.source_filepath}' and the previous files are based on different commits ({left.data['commit']} != {right.data['commit']}). Merging not supported."
         )
     left.data["benchmarks"].extend(right.data["benchmarks"])
     return left

--- a/build_tools/benchmarks/benchmark_helper.py
+++ b/build_tools/benchmarks/benchmark_helper.py
@@ -113,10 +113,11 @@ def _dump_cmds_handler(
 
     if execution_benchmark_config is not None:
         benchmark_groups = json.loads(execution_benchmark_config.read_text())
-        for target_device, benchmark_shards in benchmark_groups.items():
-            for benchmark_shard in benchmark_shards:
+        for target_device, benchmark_group in benchmark_groups.items():
+            shard_count = len(benchmark_group["shards"])
+            for shard in benchmark_group["shards"]:
                 run_configs = serialization.unpack_and_deserialize(
-                    data=benchmark_shard["run_configs"],
+                    data=shard["run_configs"],
                     root_type=List[iree_definitions.E2EModelRunConfig],
                 )
                 for run_config in run_configs:
@@ -131,9 +132,7 @@ def _dump_cmds_handler(
                     lines.append(f"Execution Benchmark ID: {run_config.composite_id}")
                     lines.append(f"Name: {run_config}")
                     lines.append(f"Target Device: {target_device}")
-                    lines.append(
-                        f"Shard: {benchmark_shard['shard']['index']} / {benchmark_shard['shard']['count']}"
-                    )
+                    lines.append(f"Shard: {shard['shard_index']} / {shard_count}")
                     lines.append("")
                     lines += _dump_cmds_from_run_config(
                         run_config=run_config, root_path=e2e_test_artifacts_dir

--- a/build_tools/benchmarks/benchmark_helper.py
+++ b/build_tools/benchmarks/benchmark_helper.py
@@ -113,24 +113,31 @@ def _dump_cmds_handler(
 
     if execution_benchmark_config is not None:
         benchmark_groups = json.loads(execution_benchmark_config.read_text())
-        for target_device, benchmark_group in benchmark_groups.items():
-            run_configs = serialization.unpack_and_deserialize(
-                data=benchmark_group["run_configs"],
-                root_type=List[iree_definitions.E2EModelRunConfig],
-            )
-            for run_config in run_configs:
-                if benchmark_id is not None and benchmark_id != run_config.composite_id:
-                    continue
-
-                lines.append("################")
-                lines.append("")
-                lines.append(f"Execution Benchmark ID: {run_config.composite_id}")
-                lines.append(f"Name: {run_config}")
-                lines.append(f"Target Device: {target_device}")
-                lines.append("")
-                lines += _dump_cmds_from_run_config(
-                    run_config=run_config, root_path=e2e_test_artifacts_dir
+        for target_device, benchmark_shards in benchmark_groups.items():
+            for benchmark_shard in benchmark_shards:
+                run_configs = serialization.unpack_and_deserialize(
+                    data=benchmark_shard["run_configs"],
+                    root_type=List[iree_definitions.E2EModelRunConfig],
                 )
+                for run_config in run_configs:
+                    if (
+                        benchmark_id is not None
+                        and benchmark_id != run_config.composite_id
+                    ):
+                        continue
+
+                    lines.append("################")
+                    lines.append("")
+                    lines.append(f"Execution Benchmark ID: {run_config.composite_id}")
+                    lines.append(f"Name: {run_config}")
+                    lines.append(f"Target Device: {target_device}")
+                    lines.append(
+                        f"Shard: {benchmark_shard['shard']['index']} / {benchmark_shard['shard']['count']}"
+                    )
+                    lines.append("")
+                    lines += _dump_cmds_from_run_config(
+                        run_config=run_config, root_path=e2e_test_artifacts_dir
+                    )
 
     if compilation_benchmark_config is not None:
         benchmark_config = json.loads(compilation_benchmark_config.read_text())

--- a/build_tools/benchmarks/benchmark_helper.py
+++ b/build_tools/benchmarks/benchmark_helper.py
@@ -182,7 +182,7 @@ class JSONBackedBenchmarkData:
 
     # Parses a JSON benchmark results file and makes some sanity checks
     @staticmethod
-    def loadFromFile(filepath: pathlib.Path):
+    def load_from_file(filepath: pathlib.Path):
         try:
             data = json.loads(filepath.read_bytes())
         except json.JSONDecodeError as e:
@@ -191,9 +191,9 @@ class JSONBackedBenchmarkData:
 
     # A convenience wrapper around `loadFromFile` that accepts a sequence of paths and returns a sequence of JSONBackedBenchmarkData objects as a generator.
     @staticmethod
-    def loadManyFromFiles(filepaths: Sequence[pathlib.Path]):
+    def load_many_from_files(filepaths: Sequence[pathlib.Path]):
         return (
-            JSONBackedBenchmarkData.loadFromFile(filepath) for filepath in filepaths
+            JSONBackedBenchmarkData.load_from_file(filepath) for filepath in filepaths
         )
 
 
@@ -219,7 +219,7 @@ def _merge_results_handler(
     print(
         json.dumps(
             merge_results(
-                JSONBackedBenchmarkData.loadManyFromFiles(benchmark_results_files)
+                JSONBackedBenchmarkData.load_many_from_files(benchmark_results_files)
             )
         )
     )

--- a/build_tools/benchmarks/benchmark_helper_test.py
+++ b/build_tools/benchmarks/benchmark_helper_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import io
+import json
+import unittest
+import benchmark_helper
+
+
+class BenchmarkHelperTest(unittest.TestCase):
+    def test_merge_results_simple(self):
+        first = io.StringIO(
+            json.dumps(
+                {
+                    "commit": "123",
+                    "benchmarks": [
+                        {"benchmark_id": "first1"},
+                        {"benchmark_id": "first2"},
+                    ],
+                }
+            )
+        )
+        setattr(first, "name", "first.json")
+
+        second = io.StringIO(
+            json.dumps(
+                {
+                    "commit": "123",
+                    "benchmarks": [
+                        {"benchmark_id": "second1"},
+                        {"benchmark_id": "second2"},
+                    ],
+                }
+            )
+        )
+        setattr(second, "name", "second.json")
+
+        result = benchmark_helper.merge_results([first, second])
+
+        self.assertEqual(
+            result,
+            {
+                "commit": "123",
+                "benchmarks": [
+                    {"benchmark_id": "first1"},
+                    {"benchmark_id": "first2"},
+                    {"benchmark_id": "second1"},
+                    {"benchmark_id": "second2"},
+                ],
+            },
+        )
+
+    def test_merge_results_mismatching_commits(self):
+        first = io.StringIO(json.dumps({"commit": "123", "benchmarks": []}))
+        setattr(first, "name", "first.json")
+
+        second = io.StringIO(json.dumps({"commit": "456", "benchmarks": []}))
+        setattr(second, "name", "second.json")
+
+        with self.assertRaisesRegex(RuntimeError, "based on different commits"):
+            benchmark_helper.merge_results([first, second])
+
+    def test_merge_results_missing_benchmark_list(self):
+        first = io.StringIO(json.dumps({"commit": "123", "benchmarks": []}))
+        setattr(first, "name", "first.json")
+
+        second = io.StringIO(json.dumps({"commit": "123"}))
+        setattr(second, "name", "second.json")
+
+        with self.assertRaisesRegex(RuntimeError, '"benchmarks" field not found'):
+            benchmark_helper.merge_results([first, second])
+
+    def test_merge_results_invalid_json(self):
+        first = io.StringIO(json.dumps({"commit": "123", "benchmarks": []}))
+        setattr(first, "name", "first.json")
+
+        second = io.StringIO("bliblablub")
+        setattr(second, "name", "second.notjson")
+
+        with self.assertRaisesRegex(RuntimeError, "seems not to be a valid JSON file"):
+            benchmark_helper.merge_results([first, second])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/benchmarks/benchmark_helper_test.py
+++ b/build_tools/benchmarks/benchmark_helper_test.py
@@ -65,7 +65,7 @@ class BenchmarkHelperTest(unittest.TestCase):
         )
 
     def test_create_json_backed_benchmark_data_with_missing_benchmark_list(self):
-        with self.assertRaisesRegex(ValueError, '"benchmarks" field not found'):
+        with self.assertRaisesRegex(ValueError, "'benchmarks' field not found"):
             benchmark_helper.JSONBackedBenchmarkData(
                 pathlib.Path("second.json"), {"commit": "123"}
             )
@@ -76,7 +76,7 @@ class BenchmarkHelperTest(unittest.TestCase):
             contents = {"commit": "123", "benchmarks": []}
             filepath.write_text(json.dumps(contents))
 
-            result = benchmark_helper.JSONBackedBenchmarkData.loadFromFile(filepath)
+            result = benchmark_helper.JSONBackedBenchmarkData.load_from_file(filepath)
             self.assertEqual(result.data, contents)
             self.assertEqual(result.source_filepath, filepath)
 
@@ -88,7 +88,7 @@ class BenchmarkHelperTest(unittest.TestCase):
             with self.assertRaisesRegex(
                 ValueError, "seems not to be a valid JSON file"
             ):
-                benchmark_helper.JSONBackedBenchmarkData.loadFromFile(filepath)
+                benchmark_helper.JSONBackedBenchmarkData.load_from_file(filepath)
 
 
 if __name__ == "__main__":

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -182,6 +182,12 @@ class Parser(argparse.ArgumentParser):
             required=True,
             help="Target device in benchmark config to run",
         )
+        self.add_argument(
+            "--shard_index",
+            type=int,
+            default=1,
+            help="Shard in benchmark config to run",
+        )
 
 
 def expand_and_check_file_paths(paths: Sequence[str]) -> List[pathlib.Path]:

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -185,7 +185,7 @@ class Parser(argparse.ArgumentParser):
         self.add_argument(
             "--shard_index",
             type=int,
-            default=1,
+            default=None,
             help="Shard in benchmark config to run",
         )
 

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -122,7 +122,7 @@ def _export_execution_handler(
             for shard_idx in range(current_shard_count)
         ]
 
-        for shard_index, shard in enumerate(sharded_run_configs):
+        for index, shard in enumerate(sharded_run_configs):
             distinct_module_dir_paths = _get_distinct_module_dir_paths(
                 config.module_generation_config for config in shard
             )
@@ -137,7 +137,7 @@ def _export_execution_handler(
             )
             output_map[device_name]["shards"].append(
                 {
-                    "shard_index": shard_index,
+                    "index": index,
                     "module_dir_paths": distinct_module_dir_paths,
                     "run_configs": serialized_run_configs,
                 }

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -87,7 +87,7 @@ def _get_distinct_module_dir_paths(
 def _export_execution_handler(
     presets: Optional[Sequence[str]] = None,
     target_device_names: Optional[Sequence[str]] = None,
-    shard_count: Dict[str, int] = {},
+    shard_count: Optional[Dict[str, int]] = None,
     **_unused_args,
 ):
     _, all_run_configs = benchmark_collections.generate_benchmarks()
@@ -100,6 +100,7 @@ def _export_execution_handler(
         presets=None if presets is None else set(presets),
     )
 
+    shard_count = {} if shard_count is None else shard_count
     default_shard_count = shard_count.get("default", 1)
 
     output_map = {}

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -12,10 +12,15 @@
 # the script to learn about the required setup.
 #
 # IREE_NORMAL_BENCHMARK_TOOLS_DIR needs to point to a directory contains IREE
-# benchmark tools. See benchmarks/README.md for more information. The first
-# argument is the path of e2e test artifacts directory. The second argument is
-# the path of IREE benchmark run config. The third argument is the path to write
-# benchmark results.
+# benchmark tools. See benchmarks/README.md for more information.
+#
+# Command line arguments:
+# 1. The path of e2e test artifacts directory
+# 2. The path of IREE benchmark run config
+# 3. The target device name
+# 4. The shard index
+# 5. The path to write benchmark results
+# 6. The path to write benchmark traces
 
 set -euo pipefail
 
@@ -26,8 +31,9 @@ TRACY_CAPTURE_TOOL="${IREE_TRACY_CAPTURE_TOOL}"
 E2E_TEST_ARTIFACTS_DIR="${1:-${IREE_E2E_TEST_ARTIFACTS_DIR}}"
 EXECUTION_BENCHMARK_CONFIG="${2:-${IREE_EXECUTION_BENCHMARK_CONFIG}}"
 TARGET_DEVICE_NAME="${3:-${IREE_TARGET_DEVICE_NAME}}"
-BENCHMARK_RESULTS="${4:-${IREE_BENCHMARK_RESULTS}}"
-BENCHMARK_TRACES="${5:-${IREE_BENCHMARK_TRACES}}"
+SHARD_INDEX="${4:-${IREE_SHARD_INDEX}}"
+BENCHMARK_RESULTS="${5:-${IREE_BENCHMARK_RESULTS}}"
+BENCHMARK_TRACES="${6:-${IREE_BENCHMARK_TRACES}}"
 
 if [[ "${TARGET_DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
   ${DOCKER_WRAPPER} \
@@ -42,6 +48,7 @@ if [[ "${TARGET_DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
         --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
         --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
         --target_device_name="${TARGET_DEVICE_NAME}" \
+        --shard_index="${SHARD_INDEX}" \
         --output="${BENCHMARK_RESULTS}" \
         --verbose
 elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
@@ -55,6 +62,7 @@ elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
         --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
         --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
         --target_device_name="${TARGET_DEVICE_NAME}" \
+        --shard_index="${SHARD_INDEX}" \
         --output="${BENCHMARK_RESULTS}" \
         --device_model=GCP-c2-standard-16 \
         --cpu_uarch=CascadeLake \
@@ -68,6 +76,7 @@ elif [[ "${TARGET_DEVICE_NAME}" =~ ^(pixel-4|pixel-6-pro|moto-edge-x30)$ ]]; the
     --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
     --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
     --target_device_name="${TARGET_DEVICE_NAME}" \
+    --shard_index="${SHARD_INDEX}" \
     --output="${BENCHMARK_RESULTS}" \
     --pin-cpu-freq \
     --pin-gpu-freq \

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -162,7 +162,7 @@ def main(args):
             (
                 shard
                 for shard in benchmark_group["shards"]
-                if shard["shard_index"] == args.shard_index
+                if shard["index"] == args.shard_index
             ),
             None,
         )
@@ -171,7 +171,7 @@ def main(args):
                 "Given shard (index={}) not found in the benchmark config group. Available indexes: [{}].".format(
                     args.shard_index,
                     ", ".join(
-                        str(shard["shard_index"]) for shard in benchmark_group["shards"]
+                        str(shard["index"]) for shard in benchmark_group["shards"]
                     ),
                 )
             )

--- a/build_tools/cmake/build_e2e_test_artifacts.sh
+++ b/build_tools/cmake/build_e2e_test_artifacts.sh
@@ -101,7 +101,8 @@ FLAG_DUMP="${E2E_TEST_ARTIFACTS_DIR}/benchmark-flag-dump.txt"
 ./build_tools/benchmarks/export_benchmark_config.py \
   execution \
   --benchmark_presets="${EXECUTION_PRESETS}" \
-  --output="${EXECUTION_CONFIG}"
+  --output="${EXECUTION_CONFIG}" \
+  --shard_count="a2-highgpu-1g=2" # Just an experiment for now
 ./build_tools/benchmarks/benchmark_helper.py dump-cmds \
   --execution_benchmark_config="${EXECUTION_CONFIG}" \
   --compilation_benchmark_config="${COMPILATION_CONFIG}" \

--- a/build_tools/cmake/build_e2e_test_artifacts.sh
+++ b/build_tools/cmake/build_e2e_test_artifacts.sh
@@ -28,6 +28,8 @@ BUILD_DIR="${1:-${IREE_BUILD_E2E_TEST_ARTIFACTS_DIR:-build-e2e-test-artifacts}}"
 IREE_HOST_BIN_DIR="$(realpath ${IREE_HOST_BIN_DIR})"
 BENCHMARK_PRESETS="${IREE_BENCHMARK_PRESETS:-}"
 BUILD_DEFAULT_BENCHMARK_SUITES="${IREE_BUILD_DEFAULT_BENCHMARK_SUITES:-1}"
+SHARD_COUNT="${IREE_SHARD_COUNT:-default=1}"
+SHARD_COUNT="c2-standard-16=2,default=1" # DO NOT SUBMIT: Hard coded for testing
 
 source build_tools/cmake/setup_build.sh
 source build_tools/cmake/setup_tf_python.sh
@@ -102,7 +104,7 @@ FLAG_DUMP="${E2E_TEST_ARTIFACTS_DIR}/benchmark-flag-dump.txt"
   execution \
   --benchmark_presets="${EXECUTION_PRESETS}" \
   --output="${EXECUTION_CONFIG}" \
-  --shard_count="a2-highgpu-1g=2" # Just an experiment for now
+  --shard_count="${SHARD_COUNT}"
 ./build_tools/benchmarks/benchmark_helper.py dump-cmds \
   --execution_benchmark_config="${EXECUTION_CONFIG}" \
   --compilation_benchmark_config="${COMPILATION_CONFIG}" \

--- a/build_tools/cmake/build_e2e_test_artifacts.sh
+++ b/build_tools/cmake/build_e2e_test_artifacts.sh
@@ -29,7 +29,6 @@ IREE_HOST_BIN_DIR="$(realpath ${IREE_HOST_BIN_DIR})"
 BENCHMARK_PRESETS="${IREE_BENCHMARK_PRESETS:-}"
 BUILD_DEFAULT_BENCHMARK_SUITES="${IREE_BUILD_DEFAULT_BENCHMARK_SUITES:-1}"
 SHARD_COUNT="${IREE_SHARD_COUNT:-default=1}"
-SHARD_COUNT="c2-standard-16=2,default=1" # DO NOT SUBMIT: Hard coded for testing
 
 source build_tools/cmake/setup_build.sh
 source build_tools/cmake/setup_tf_python.sh

--- a/docs/developers/developing_iree/benchmark_suites.md
+++ b/docs/developers/developing_iree/benchmark_suites.md
@@ -306,9 +306,7 @@ Benchmark raw results and traces can be downloaded at:
 gcloud storage cp "${EXECUTION_BENCHMARK_RESULTS_DIR_URL?}/benchmark-results-*.json" .
 
 # Optional: Merge raw results into a single file
-jq '. as $obj | .benchmarks[] | $obj * { benchmarks: [.] }' | \
-  jq -s 'reduce .[] as $item ({}; . * ($item | del(.benchmarks)) | .benchmarks += $item.benchmarks)' \
-  benchmark-results-*.json > benchmark_results.json
+build_tools/benchmarks/benchmark_helper.py merge-results benchmark-results-*.json > benchmark_results.json
 
 # Execution benchmark traces
 gcloud storage cp "${EXECUTION_BENCHMARK_RESULTS_DIR_URL?}/benchmark-traces-*.tar.gz" .

--- a/docs/developers/developing_iree/benchmark_suites.md
+++ b/docs/developers/developing_iree/benchmark_suites.md
@@ -305,6 +305,11 @@ Benchmark raw results and traces can be downloaded at:
 # Execution benchmark raw results
 gcloud storage cp "${EXECUTION_BENCHMARK_RESULTS_DIR_URL?}/benchmark-results-*.json" .
 
+# Optional: Merge raw results into a single file
+jq '. as $obj | .benchmarks[] | $obj * { benchmarks: [.] }' | \
+  jq -s 'reduce .[] as $item ({}; . * ($item | del(.benchmarks)) | .benchmarks += $item.benchmarks)' \
+  benchmark-results-*.json > benchmark_results.json
+
 # Execution benchmark traces
 gcloud storage cp "${EXECUTION_BENCHMARK_RESULTS_DIR_URL?}/benchmark-traces-*.tar.gz" .
 


### PR DESCRIPTION
This is adding sharding support to the benchmark execution. For each benchmark group (a group is defined by the target device) the execution can be split into shards. The default is 1 shard per group (no change to the status quo).

The sharding scheme is currently very simple. We go through the list of run configs and round-robin-like put them into the given number of shards. I guess we want to make this a little smarter in the future, but I believe that's not needed for a first version. Let me know if I'm wrong here.

Note that each shard writes its own benchmark-results-*.json file and there is no step for merging them again. I think that this is not needed since all the code consuming benchmark results is already capable of handling multiple files.

### Open questions:

1. How can I make sure my changes don't break the dashboard upload? I believe this only runs in postsubmit.
2. Are there any consumers of the benchmark execution config and the benchmark results that I'm not aware of and that might break due to this change?

### Implementation Details

As suggested by pzread I extended `export_benchmark_configs.py` to do the sharding. The output is now a map from device name to benchmark-group with each benchmark group having a list of shards. Example:

```json
{
  "c2-standard-16": {
    "host_environment": {
      "platform": "linux",
      "architecture": "x86_64"
    },
    "shards": [
      {
        "index": 0,
        "module_dir_paths": [
          "iree_BertForMaskedLMTF_module_1c7402f88ba881ec6abb39204faa4b5fedb2ffff4a6066555fcff0c7c4b74732",  
          ...
```

In the standard case there is only one shard. The shard index is 0-indexed.

The other big a change is that each shard now creates its own benchmark results and traces file. If there is only 1 shard the name doesn't change, but if there are more, then the filenames get a suffix `-shard<n>of<N>.ext`. Examples:

```
gs://iree-github-actions-presubmit-artifacts/5266674282/2/benchmark-results/benchmark-results-a2-highgpu-1g-00-of-02.json
gs://iree-github-actions-presubmit-artifacts/5266674282/2/benchmark-results/benchmark-results-a2-highgpu-1g-01-of-02.json  
gs://iree-github-actions-presubmit-artifacts/5266674282/2/benchmark-results/benchmark-results-c2-standard-16.json
```