### PR TITLE
Cleaning up the iree/base/tracing.h header a bit.

### DIFF
--- a/experimental/cuda2/cuda_allocator.c
+++ b/experimental/cuda2/cuda_allocator.c
@@ -360,7 +360,7 @@ static iree_status_t iree_hal_cuda2_allocator_allocate_buffer(
   void* host_ptr = NULL;
   CUdeviceptr device_ptr = 0;
   IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_hal_cuda2_buffer_allocate");
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, allocation_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, allocation_size);
   if (iree_all_bits_set(compat_params.type,
                         IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
     if (iree_all_bits_set(compat_params.type,

--- a/experimental/cuda2/memory_pools.c
+++ b/experimental/cuda2/memory_pools.c
@@ -214,7 +214,7 @@ iree_status_t iree_hal_cuda2_memory_pools_alloca(
     iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)allocation_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)allocation_size);
 
   iree_hal_buffer_params_canonicalize(&params);
 
@@ -272,7 +272,7 @@ iree_status_t iree_hal_cuda2_memory_pools_dealloca(
     iree_hal_cuda2_memory_pools_t* pools, CUstream stream,
     iree_hal_buffer_t* buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(
       z0, (int64_t)iree_hal_buffer_allocation_size(buffer));
 
   // Only process the request if the buffer came from an async pool.

--- a/experimental/webgpu/simple_allocator.c
+++ b/experimental/webgpu/simple_allocator.c
@@ -201,7 +201,7 @@ static iree_status_t iree_hal_webgpu_simple_allocator_allocate_buffer(
   // mappedAtCreation and populating it before unmapping.
   if (has_initial_data) {
     IREE_TRACE_ZONE_BEGIN(z1);
-    IREE_TRACE_ZONE_APPEND_VALUE(z1, (uint64_t)initial_data.data_length);
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z1, (uint64_t)initial_data.data_length);
     void* mapped_ptr =
         wgpuBufferGetMappedRange(buffer_handle, 0, initial_data.data_length);
     memcpy(mapped_ptr, initial_data.data, initial_data.data_length);

--- a/runtime/bindings/tflite/interpreter.c
+++ b/runtime/bindings/tflite/interpreter.c
@@ -393,7 +393,7 @@ TFL_CAPI_EXPORT extern TfLiteInterpreter* TfLiteInterpreterCreate(
       _TfLiteInterpreterCreate(model, optional_options, &interpreter);
   if (iree_status_is_ok(iree_status_consume_code(status))) {
     IREE_TRACE_ZONE_APPEND_TEXT(z0, "num_threads=", strlen("num_threads="));
-    IREE_TRACE_ZONE_APPEND_VALUE(z0, interpreter->options.num_threads);
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, interpreter->options.num_threads);
   } else {
     IREE_TRACE_MESSAGE(ERROR, "failed interpreter creation");
     TfLiteInterpreterDelete(interpreter);
@@ -563,7 +563,7 @@ TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterAllocateTensors(
     total_input_size +=
         iree_hal_buffer_byte_length(interpreter->input_tensors[i].buffer);
   }
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, total_input_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, total_input_size);
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
   IREE_TRACE_ZONE_END(z0);
@@ -608,7 +608,7 @@ TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterInvoke(
     total_output_size +=
         iree_hal_buffer_byte_length(interpreter->output_tensors[i].buffer);
   }
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, total_output_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, total_output_size);
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/bindings/tflite/options.c
+++ b/runtime/bindings/tflite/options.c
@@ -43,7 +43,7 @@ TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsDelete(
 TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetNumThreads(
     TfLiteInterpreterOptions* options, int32_t num_threads) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, num_threads);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, num_threads);
   options->num_threads = num_threads;
   IREE_TRACE_ZONE_END(z0);
 }

--- a/runtime/bindings/tflite/tensor.c
+++ b/runtime/bindings/tflite/tensor.c
@@ -245,7 +245,8 @@ TFL_CAPI_EXPORT extern TfLiteStatus TfLiteTensorCopyFromBuffer(
     return kTfLiteApplicationError;
   }
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, tensor->buffer_mapping.contents.data_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0,
+                                   tensor->buffer_mapping.contents.data_length);
 
   // NOTE: we could use a iree_hal_buffer_map_write here but we already
   // have the buffer mapped. If we knew the user would never use
@@ -264,7 +265,7 @@ TFL_CAPI_EXPORT extern TfLiteStatus TfLiteTensorCopyToBuffer(
     return kTfLiteApplicationError;
   }
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(
       z0, output_tensor->buffer_mapping.contents.data_length);
 
   // NOTE: as with above we should use an iree_hal_buffer_map_read here.

--- a/runtime/src/iree/base/internal/wait_handle_inproc.c
+++ b/runtime/src/iree/base/internal/wait_handle_inproc.c
@@ -118,7 +118,7 @@ iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)capacity);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)capacity);
   *out_set = NULL;
 
   iree_wait_set_t* set = NULL;

--- a/runtime/src/iree/base/loop.c
+++ b/runtime/src/iree/base/loop.c
@@ -44,9 +44,9 @@ IREE_API_EXPORT iree_status_t iree_loop_dispatch(
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
   }
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)workgroup_count_xyz[0]);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)workgroup_count_xyz[1]);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)workgroup_count_xyz[2]);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)workgroup_count_xyz[0]);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)workgroup_count_xyz[1]);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)workgroup_count_xyz[2]);
 
   const iree_loop_dispatch_params_t params = {
       .callback =
@@ -159,7 +159,7 @@ IREE_API_EXPORT iree_status_t iree_loop_wait_any(
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
   }
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)count);
   iree_status_t status =
       iree_loop_wait_multi(IREE_LOOP_COMMAND_WAIT_ANY, loop, count,
                            wait_sources, timeout, callback, user_data);
@@ -174,7 +174,7 @@ IREE_API_EXPORT iree_status_t iree_loop_wait_all(
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
   }
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)count);
   iree_status_t status =
       iree_loop_wait_multi(IREE_LOOP_COMMAND_WAIT_ALL, loop, count,
                            wait_sources, timeout, callback, user_data);

--- a/runtime/src/iree/base/loop_sync.c
+++ b/runtime/src/iree/base/loop_sync.c
@@ -576,7 +576,7 @@ static void iree_loop_wait_list_handle_wake(iree_loop_wait_list_t* wait_list,
   int woken_tasks = 0;
 
   (void)woken_tasks;
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, woken_tasks);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, woken_tasks);
   IREE_TRACE_ZONE_END(z0);
 }
 
@@ -647,7 +647,7 @@ static iree_status_t iree_loop_wait_list_commit(
 
   // Real system wait.
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)wait_list->count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)wait_list->count);
 
   // Enter the system wait API.
   iree_wait_handle_t wake_handle = iree_wait_handle_immediate();

--- a/runtime/src/iree/base/time.c
+++ b/runtime/src/iree/base/time.c
@@ -169,7 +169,7 @@ bool iree_wait_until(iree_time_t deadline_ns) {
   if (deadline_ns == IREE_TIME_INFINITE_PAST) return true;
 
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(
       z0, (uint64_t)iree_absolute_deadline_to_timeout_ns(deadline_ns));
 
   // NOTE: we want to use sleep APIs with absolute times as that makes retrying

--- a/runtime/src/iree/hal/allocator.c
+++ b/runtime/src/iree/hal/allocator.c
@@ -182,7 +182,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
   IREE_ASSERT_ARGUMENT(out_buffer);
   *out_buffer = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)allocation_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)allocation_size);
   iree_hal_buffer_params_canonicalize(&params);
   iree_status_t status = _VTABLE_DISPATCH(allocator, allocate_buffer)(
       allocator, &params, allocation_size, initial_data, out_buffer);
@@ -195,7 +195,7 @@ IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(
       z0, (int64_t)iree_hal_buffer_allocation_size(buffer));
   _VTABLE_DISPATCH(allocator, deallocate_buffer)(allocator, buffer);
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -680,7 +680,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_map_read(
   IREE_ASSERT_ARGUMENT(target_buffer);
 
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, data_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, data_length);
   iree_hal_buffer_mapping_t source_mapping = {{0}};
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_buffer_map_range(source_buffer, IREE_HAL_MAPPING_MODE_SCOPED,
@@ -704,7 +704,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_map_write(
   IREE_ASSERT_ARGUMENT(source_buffer);
 
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, data_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, data_length);
   iree_hal_buffer_mapping_t target_mapping;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
@@ -747,7 +747,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_map_copy(
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, data_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, data_length);
 
   // Map source, which may have IREE_WHOLE_BUFFER length.
   iree_hal_buffer_mapping_t source_mapping;

--- a/runtime/src/iree/hal/channel.c
+++ b/runtime/src/iree/hal/channel.c
@@ -42,9 +42,9 @@ IREE_API_EXPORT iree_status_t iree_hal_channel_split(
   IREE_ASSERT_ARGUMENT(out_split_channel);
   *out_split_channel = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, color);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, key);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, flags);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, color);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, key);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, flags);
   iree_status_t status = _VTABLE_DISPATCH(base_channel, split)(
       base_channel, color, key, flags, out_split_channel);
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -119,7 +119,7 @@ IREE_API_EXPORT iree_status_t iree_hal_device_transfer_range(
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_TEXT(
       z0, is_source_host ? "h2d" : (is_target_host ? "d2h" : "d2d"));
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, data_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, data_length);
 
   // Defer to the backing implementation.
   iree_status_t status = _VTABLE_DISPATCH(device, transfer_range)(

--- a/runtime/src/iree/hal/driver.c
+++ b/runtime/src/iree/hal/driver.c
@@ -53,7 +53,7 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_create_device_by_ordinal(
   IREE_ASSERT_ARGUMENT(out_device);
   *out_device = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)device_ordinal);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)device_ordinal);
 
   // Query the devices from the driver.
   iree_host_size_t device_info_count = 0;
@@ -98,7 +98,7 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_create_device_by_id(
   IREE_ASSERT_ARGUMENT(out_device);
   *out_device = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)device_id);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)device_id);
   iree_status_t status = _VTABLE_DISPATCH(driver, create_device_by_id)(
       driver, device_id, param_count, params, host_allocator, out_device);
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -334,7 +334,7 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
   void* host_ptr = NULL;
   CUdeviceptr device_ptr = 0;
   IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_hal_cuda_buffer_allocate");
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, allocation_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, allocation_size);
   if (iree_all_bits_set(compat_params.type,
                         IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
     // Device local case.

--- a/runtime/src/iree/hal/drivers/cuda/memory_pools.c
+++ b/runtime/src/iree/hal/drivers/cuda/memory_pools.c
@@ -210,7 +210,7 @@ iree_status_t iree_hal_cuda_memory_pools_alloca(
     iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)allocation_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)allocation_size);
 
   iree_hal_buffer_params_canonicalize(&params);
 
@@ -267,7 +267,7 @@ iree_status_t iree_hal_cuda_memory_pools_dealloca(
     iree_hal_cuda_memory_pools_t* pools, CUstream stream,
     iree_hal_buffer_t* buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(
       z0, (int64_t)iree_hal_buffer_allocation_size(buffer));
 
   // Only process the request if the buffer came from an async pool.

--- a/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
+++ b/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
@@ -91,9 +91,9 @@ iree_status_t iree_hal_cuda_nccl_channel_create(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   IREE_TRACE(const uint64_t id_hash = iree_hal_cuda_nccl_hash_id(id));
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, id_hash);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, rank);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, id_hash);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, rank);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count);
 
   ncclComm_t comm = NULL;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
@@ -128,9 +128,9 @@ static void iree_hal_cuda_nccl_channel_destroy(
       iree_hal_cuda_nccl_channel_cast(base_channel);
   iree_allocator_t host_allocator = channel->context_wrapper->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, channel->id_hash);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, channel->rank);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, channel->count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, channel->id_hash);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, channel->rank);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, channel->count);
 
   // TODO(#9580): support async tear down
   // We could be smarter about starting finalization of all channels async and

--- a/runtime/src/iree/hal/drivers/cuda/tracing.c
+++ b/runtime/src/iree/hal/drivers/cuda/tracing.c
@@ -95,8 +95,8 @@ iree_status_t iree_hal_cuda_tracing_context_allocate(
   if (iree_status_is_ok(status)) {
     IREE_TRACE_ZONE_BEGIN_NAMED(
         z_event_pool, "iree_hal_cuda_tracing_context_allocate_event_pool");
-    IREE_TRACE_ZONE_APPEND_VALUE(z_event_pool,
-                                 (int64_t)context->query_capacity);
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z_event_pool,
+                                     (int64_t)context->query_capacity);
     for (iree_host_size_t i = 0; i < context->query_capacity; ++i) {
       status = CU_RESULT_TO_STATUS(
           cuda_context->syms,
@@ -185,7 +185,7 @@ void iree_hal_cuda_tracing_context_collect(
         context->query_head < context->query_tail
             ? context->query_capacity - context->query_tail
             : context->query_head - context->query_tail;
-    IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)try_query_count);
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)try_query_count);
 
     // Scan and feed the times to tracy, stopping when we hit the first
     // unavailable query.
@@ -209,7 +209,7 @@ void iree_hal_cuda_tracing_context_collect(
 
       read_query_count = i + 1;
     }
-    IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)read_query_count);
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)read_query_count);
 
     context->query_tail += read_query_count;
     if (context->query_tail >= context->query_capacity) {

--- a/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
@@ -506,7 +506,7 @@ static iree_status_t iree_hal_cmd_fill_tile(
   iree_device_size_t remaining_length = cmd->length - slice_offset;
   iree_device_size_t slice_length =
       iree_min(length_per_slice, remaining_length);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)slice_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)slice_length);
 
   iree_status_t status = iree_hal_buffer_map_fill(
       cmd->target_buffer, cmd->target_offset + slice_offset, slice_length,
@@ -645,7 +645,7 @@ static iree_status_t iree_hal_cmd_copy_tile(
   iree_device_size_t remaining_length = cmd->length - slice_offset;
   iree_device_size_t slice_length =
       iree_min(length_per_slice, remaining_length);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)slice_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)slice_length);
 
   iree_status_t status = iree_hal_buffer_map_copy(
       cmd->source_buffer, cmd->source_offset + slice_offset, cmd->target_buffer,

--- a/runtime/src/iree/hal/drivers/vulkan/tracing.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/tracing.cc
@@ -321,13 +321,13 @@ static void iree_hal_vulkan_tracing_prepare_query_pool(
   pool_info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
   pool_info.queryCount = IREE_HAL_VULKAN_TRACING_DEFAULT_QUERY_CAPACITY;
   pool_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, pool_info.queryCount);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, pool_info.queryCount);
   while (context->logical_device->syms()->vkCreateQueryPool(
              *context->logical_device, &pool_info,
              context->logical_device->allocator(),
              &context->query_pool) != VK_SUCCESS) {
     pool_info.queryCount /= 2;
-    IREE_TRACE_ZONE_APPEND_VALUE(z0, pool_info.queryCount);
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, pool_info.queryCount);
   }
   context->query_capacity = pool_info.queryCount;
 

--- a/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
@@ -245,15 +245,15 @@ static iree_status_t iree_hal_vulkan_populate_memory_types(
   // let us correlate the memory types with vulkan-info and see if we got the
   // "right" ones.
   IREE_TRACE_ZONE_APPEND_TEXT(z0, "dispatch:");
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->dispatch_idx);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, out_memory_types->dispatch_idx);
   IREE_TRACE_ZONE_APPEND_TEXT(z0, "bulk-upload:");
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->bulk_upload_idx);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, out_memory_types->bulk_upload_idx);
   IREE_TRACE_ZONE_APPEND_TEXT(z0, "bulk-download:");
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->bulk_download_idx);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, out_memory_types->bulk_download_idx);
   IREE_TRACE_ZONE_APPEND_TEXT(z0, "staging-upload:");
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->staging_upload_idx);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, out_memory_types->staging_upload_idx);
   IREE_TRACE_ZONE_APPEND_TEXT(z0, "staging-download:");
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->staging_download_idx);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, out_memory_types->staging_download_idx);
   IREE_TRACE_ZONE_END(z0);
 
   // Check to make sure all memory types were found. If we didn't find any
@@ -567,7 +567,7 @@ static iree_status_t iree_hal_vulkan_vma_allocator_query_memory_heaps(
   }
 
   if (out_count) *out_count = count;
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count);
   IREE_TRACE_ZONE_END(z0);
   if (capacity < count) {
     // NOTE: lightweight as this is hit in normal pre-sizing usage.

--- a/runtime/src/iree/hal/drivers/vulkan/vma_buffer.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_buffer.cc
@@ -49,7 +49,7 @@ iree_status_t iree_hal_vulkan_vma_buffer_wrap(
   IREE_ASSERT_ARGUMENT(allocation);
   IREE_ASSERT_ARGUMENT(out_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)allocation_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)allocation_size);
 
   iree_allocator_t host_allocator =
       iree_hal_allocator_host_allocator(allocator);
@@ -87,7 +87,7 @@ static void iree_hal_vulkan_vma_buffer_destroy(iree_hal_buffer_t* base_buffer) {
       iree_hal_vulkan_vma_buffer_cast(base_buffer);
   iree_allocator_t host_allocator = base_buffer->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(
       z0, (int64_t)iree_hal_buffer_allocation_size(base_buffer));
 
   IREE_TRACE_FREE_NAMED(IREE_HAL_VULKAN_VMA_ALLOCATOR_ID,

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -492,7 +492,7 @@ static iree_status_t iree_hal_vulkan_driver_find_device_by_index(
     iree_hal_driver_t* base_driver, uint32_t device_index,
     iree_allocator_t host_allocator, VkPhysicalDevice* found_physical_device) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)device_index);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)device_index);
 
   iree_hal_vulkan_driver_t* driver = iree_hal_vulkan_driver_cast(base_driver);
 

--- a/runtime/src/iree/hal/local/executable_library_util.c
+++ b/runtime/src/iree/hal/local/executable_library_util.c
@@ -52,7 +52,7 @@ iree_status_t iree_hal_executable_library_initialize_imports(
   IREE_ASSERT_ARGUMENT(import_thunk);
   if (!import_table || !import_table->count) return iree_ok_status();
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, import_table->count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, import_table->count);
 
   // The thunk is used to give the loader a chance to intercept import calls
   // in cases where it needs to JIT, perform FFI/ABI conversion, etc.

--- a/runtime/src/iree/hal/local/executable_loader.c
+++ b/runtime/src/iree/hal/local/executable_loader.c
@@ -17,7 +17,7 @@ iree_status_t iree_hal_executable_import_provider_try_resolve(
   IREE_ASSERT_ARGUMENT(out_fn_contexts);
   if (out_resolution) *out_resolution = 0;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count);
 
   // It's fine for there to be no registered provider if all symbols are
   // optional. This is a special case for NULL import providers.

--- a/runtime/src/iree/hal/local/executable_plugin_manager.c
+++ b/runtime/src/iree/hal/local/executable_plugin_manager.c
@@ -499,7 +499,7 @@ static iree_status_t iree_hal_executable_plugin_manager_resolve(
   IREE_ASSERT_ARGUMENT(out_fn_contexts);
   if (out_resolution) *out_resolution = 0;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count);
 
   // Fetch the valid provider count.
   // This may end up missing providers that get registered during/after we scan

--- a/runtime/src/iree/hal/semaphore.c
+++ b/runtime/src/iree/hal/semaphore.c
@@ -28,7 +28,7 @@ iree_hal_semaphore_create(iree_hal_device_t* device, uint64_t initial_value,
   IREE_ASSERT_ARGUMENT(out_semaphore);
   *out_semaphore = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, initial_value);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, initial_value);
   iree_status_t status =
       IREE_HAL_VTABLE_DISPATCH(device, iree_hal_device, create_semaphore)(
           device, initial_value, out_semaphore);
@@ -44,7 +44,7 @@ iree_hal_semaphore_query(iree_hal_semaphore_t* semaphore, uint64_t* out_value) {
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status =
       _VTABLE_DISPATCH(semaphore, query)(semaphore, out_value);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, *out_value);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, *out_value);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
@@ -53,7 +53,7 @@ IREE_API_EXPORT iree_status_t
 iree_hal_semaphore_signal(iree_hal_semaphore_t* semaphore, uint64_t new_value) {
   IREE_ASSERT_ARGUMENT(semaphore);
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, new_value);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, new_value);
   iree_status_t status =
       _VTABLE_DISPATCH(semaphore, signal)(semaphore, new_value);
   IREE_TRACE_ZONE_END(z0);
@@ -64,7 +64,7 @@ IREE_API_EXPORT void iree_hal_semaphore_fail(iree_hal_semaphore_t* semaphore,
                                              iree_status_t status) {
   IREE_ASSERT_ARGUMENT(semaphore);
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, iree_status_code(status));
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, iree_status_code(status));
   _VTABLE_DISPATCH(semaphore, fail)(semaphore, status);
   IREE_TRACE_ZONE_END(z0);
 }
@@ -73,7 +73,7 @@ IREE_API_EXPORT iree_status_t iree_hal_semaphore_wait(
     iree_hal_semaphore_t* semaphore, uint64_t value, iree_timeout_t timeout) {
   IREE_ASSERT_ARGUMENT(semaphore);
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, value);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, value);
   iree_status_t status =
       _VTABLE_DISPATCH(semaphore, wait)(semaphore, value, timeout);
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/utils/buffer_transfer.c
+++ b/runtime/src/iree/hal/utils/buffer_transfer.c
@@ -331,7 +331,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_emulated_map_range(
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)local_byte_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)local_byte_length);
 
   // NOTE: this is assuming that the host is going to be doing a lot of work
   // on the mapped memory and wants read/write caching and such. If the user
@@ -410,7 +410,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_emulated_unmap_range(
   IREE_ASSERT_ARGUMENT(buffer);
   IREE_ASSERT_ARGUMENT(mapping);
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)local_byte_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)local_byte_length);
   iree_hal_emulated_buffer_mapping_t* emulation_state =
       (iree_hal_emulated_buffer_mapping_t*)((uintptr_t)
                                                 mapping->impl.reserved[0]);

--- a/runtime/src/iree/hal/utils/caching_allocator.c
+++ b/runtime/src/iree/hal/utils/caching_allocator.c
@@ -192,7 +192,7 @@ static iree_hal_buffer_t* iree_hal_caching_allocator_pool_find_and_take_buffer(
 static void iree_hal_caching_allocator_pool_trim_to_size(
     iree_hal_caching_allocator_pool_t* pool, iree_device_size_t target_size) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)target_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)target_size);
 
   iree_slim_mutex_lock(&pool->mutex);
 
@@ -242,7 +242,7 @@ static iree_status_t iree_hal_caching_allocator_pool_acquire(
     const iree_hal_buffer_params_t* params, iree_device_size_t allocation_size,
     iree_const_byte_span_t initial_data, iree_hal_buffer_t** out_buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)allocation_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)allocation_size);
 
   // Scan the free list to find an appropriate block.
   // If found we pop it off the list and return it without needing to allocate.
@@ -308,7 +308,7 @@ static iree_status_t iree_hal_caching_allocator_pool_acquire(
 static void iree_hal_caching_allocator_pool_release(
     iree_hal_caching_allocator_pool_t* pool, iree_hal_buffer_t* buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(
       z0, (int64_t)iree_hal_buffer_allocation_size(buffer));
 
   // Try to add the buffer to the pool. If the pool is at capacity we'll just

--- a/runtime/src/iree/hal/utils/collective_batch.c
+++ b/runtime/src/iree/hal/utils/collective_batch.c
@@ -55,7 +55,7 @@ static iree_status_t iree_hal_collective_batch_grow(
   iree_host_size_t new_capacity =
       batch->capacity == 0 ? IREE_HAL_COLLECTIVE_BATCH_INITIAL_CAPACITY
                            : batch->capacity * 2;
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, new_capacity);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, new_capacity);
 
   // Allocate new storage - this may fail if the system (or block pool) is over
   // capacity.

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -59,7 +59,8 @@ iree_status_t iree_task_executor_create(iree_task_executor_options_t options,
   options.worker_local_memory_size =
       iree_host_align(options.worker_local_memory_size,
                       iree_hardware_destructive_interference_size);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)options.worker_local_memory_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0,
+                                   (int64_t)options.worker_local_memory_size);
   iree_host_size_t executor_base_size =
       iree_host_align(sizeof(iree_task_executor_t),
                       iree_hardware_destructive_interference_size);

--- a/runtime/src/iree/task/poller.c
+++ b/runtime/src/iree/task/poller.c
@@ -267,8 +267,8 @@ static iree_task_poller_prepare_result_t iree_task_poller_prepare_task(
     // An actual wait. Ensure that the deadline has not been exceeded yet.
     // If it hasn't yet been hit we'll propagate the deadline to the system wait
     // API - then on the next pump we'll hit this case and retire the task.
-    IREE_TRACE_ZONE_APPEND_VALUE(z0, task->deadline_ns);
-    IREE_TRACE_ZONE_APPEND_VALUE(z0, now_ns);
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, task->deadline_ns);
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, now_ns);
     if (task->deadline_ns <= now_ns) {
       wait_status_code = IREE_STATUS_DEADLINE_EXCEEDED;
     } else {
@@ -420,7 +420,7 @@ static void iree_task_poller_wake_task(iree_task_poller_t* poller,
   int woken_tasks = 0;
 
   (void)woken_tasks;
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, woken_tasks);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, woken_tasks);
   IREE_TRACE_ZONE_END(z0);
 }
 

--- a/runtime/src/iree/task/pool.c
+++ b/runtime/src/iree/task/pool.c
@@ -116,8 +116,8 @@ iree_status_t iree_task_pool_initialize(iree_allocator_t allocator,
                                         iree_host_size_t initial_capacity,
                                         iree_task_pool_t* out_pool) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, task_size);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, initial_capacity);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, task_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, initial_capacity);
 
   out_pool->allocator = allocator;
   out_pool->task_size = task_size;

--- a/runtime/src/iree/task/post_batch.c
+++ b/runtime/src/iree/task/post_batch.c
@@ -97,7 +97,7 @@ void iree_task_post_batch_enqueue(iree_task_post_batch_t* post_batch,
 static void iree_task_post_batch_wake_workers(
     iree_task_post_batch_t* post_batch, iree_task_affinity_set_t wake_mask) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, iree_math_count_ones_u64(wake_mask));
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, iree_math_count_ones_u64(wake_mask));
 
   // TODO(#4016): use a FUTEX_WAKE_BITSET here to wake all of the workers that
   // have pending work in a single syscall (vs. popcnt(worker_pending_mask)

--- a/runtime/src/iree/task/task.c
+++ b/runtime/src/iree/task/task.c
@@ -564,7 +564,7 @@ void iree_task_dispatch_issue(iree_task_dispatch_t* dispatch_task,
                               iree_task_submission_t* pending_submission,
                               iree_task_post_batch_t* post_batch) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, dispatch_task->dispatch_id);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, dispatch_task->dispatch_id);
 
   // Mark the dispatch as having been issued; the next time it retires it'll be
   // because all work has completed.
@@ -653,7 +653,7 @@ void iree_task_dispatch_issue(iree_task_dispatch_t* dispatch_task,
 void iree_task_dispatch_retire(iree_task_dispatch_t* dispatch_task,
                                iree_task_submission_t* pending_submission) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, dispatch_task->dispatch_id);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, dispatch_task->dispatch_id);
 
   // TODO(benvanik): attach statistics to the tracy zone.
 
@@ -716,7 +716,7 @@ void iree_task_dispatch_shard_execute(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_task_dispatch_t* dispatch_task = iree_task_dispatch_shard_parent(task);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, dispatch_task->dispatch_id);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, dispatch_task->dispatch_id);
   IREE_TRACE_ZONE_SET_COLOR(
       z0, iree_math_ptr_to_xrgb(dispatch_task->closure.user_context));
 
@@ -789,10 +789,10 @@ void iree_task_dispatch_shard_execute(
 #ifndef NDEBUG
       // NOTE: these are useful for debugging but dramatically increase our
       // cost here; only enable if needed for tracking work distribution:
-      IREE_TRACE_ZONE_APPEND_VALUE(z_tile, tile_context.workgroup_xyz[0]);
-      IREE_TRACE_ZONE_APPEND_VALUE(z_tile, tile_context.workgroup_xyz[1]);
-      IREE_TRACE_ZONE_APPEND_VALUE(z_tile, tile_context.workgroup_xyz[2]);
-      // IREE_TRACE_ZONE_APPEND_VALUE(z_tile, (uint64_t)task->closure.fn);
+      IREE_TRACE_ZONE_APPEND_VALUE_I64(z_tile, tile_context.workgroup_xyz[0]);
+      IREE_TRACE_ZONE_APPEND_VALUE_I64(z_tile, tile_context.workgroup_xyz[1]);
+      IREE_TRACE_ZONE_APPEND_VALUE_I64(z_tile, tile_context.workgroup_xyz[2]);
+      // IREE_TRACE_ZONE_APPEND_VALUE_I64(z_tile, (uint64_t)task->closure.fn);
 #endif  // !NDEBUG
 
       iree_status_t status =

--- a/runtime/src/iree/task/topology.c
+++ b/runtime/src/iree/task/topology.c
@@ -79,7 +79,7 @@ iree_status_t iree_task_topology_push_group(
 void iree_task_topology_initialize_from_group_count(
     iree_host_size_t group_count, iree_task_topology_t* out_topology) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, group_count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, group_count);
 
   iree_task_topology_initialize(out_topology);
   for (iree_host_size_t i = 0; i < group_count; ++i) {

--- a/runtime/src/iree/task/topology_cpuinfo.c
+++ b/runtime/src/iree/task/topology_cpuinfo.c
@@ -15,7 +15,7 @@
 static void iree_task_topology_initialize_fallback(
     iree_host_size_t max_group_count, iree_task_topology_t* out_topology) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, max_group_count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, max_group_count);
   // TODO(benvanik): implement our own query... but that seems not so great.
   // For now we default to a single group: if a user wants more then they can
   // either get cpuinfo working for their platform or manually construct the
@@ -241,7 +241,7 @@ static void iree_task_topology_initialize_from_physical_cores_with_filter(
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, max_core_count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, max_core_count);
 
   // Count cores that match the filter.
   iree_host_size_t core_count = 0;

--- a/runtime/src/iree/tooling/instrument_util.c
+++ b/runtime/src/iree/tooling/instrument_util.c
@@ -25,13 +25,14 @@ static iree_status_t iree_tooling_write_iovec(iree_vm_ref_t iovec, FILE* file) {
   bool write_ok = false;
   if (iree_vm_buffer_isa(iovec)) {
     iree_vm_buffer_t* buffer = iree_vm_buffer_deref(iovec);
-    IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)iree_vm_buffer_length(buffer));
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z0,
+                                     (int64_t)iree_vm_buffer_length(buffer));
     write_ok =
         fwrite(iree_vm_buffer_data(buffer), 1, iree_vm_buffer_length(buffer),
                file) == iree_vm_buffer_length(buffer);
   } else if (iree_hal_buffer_view_isa(iovec)) {
     iree_hal_buffer_view_t* buffer_view = iree_hal_buffer_view_deref(iovec);
-    IREE_TRACE_ZONE_APPEND_VALUE(
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(
         z0, (int64_t)iree_hal_buffer_view_byte_length(buffer_view));
     iree_hal_buffer_mapping_t mapping;
     IREE_RETURN_AND_END_ZONE_IF_ERROR(

--- a/runtime/src/iree/vm/context.c
+++ b/runtime/src/iree/vm/context.c
@@ -697,7 +697,7 @@ static iree_status_t iree_vm_context_notify_reverse(iree_vm_stack_t* stack,
 IREE_API_EXPORT iree_status_t iree_vm_context_notify(iree_vm_context_t* context,
                                                      iree_vm_signal_t signal) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)signal);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (uint64_t)signal);
 
   // VM stack used to call into module __init methods.
   IREE_VM_INLINE_STACK_INITIALIZE(

--- a/runtime/src/iree/vm/stack.c
+++ b/runtime/src/iree/vm/stack.c
@@ -411,12 +411,12 @@ static iree_zone_id_t iree_vm_stack_trace_wait_zone_begin(
     }
     case IREE_VM_WAIT_ANY: {
       IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_vm_stack_wait_any");
-      IREE_TRACE_ZONE_APPEND_VALUE(z0, wait_count);
+      IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, wait_count);
       return z0;
     }
     case IREE_VM_WAIT_ALL: {
       IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_vm_stack_wait_all");
-      IREE_TRACE_ZONE_APPEND_VALUE(z0, wait_count);
+      IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, wait_count);
       return z0;
     }
   }
@@ -589,7 +589,8 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_function_enter(
     frame_header->trace_zone =
         iree_vm_stack_trace_function_zone_begin(frame_type, function);
     if (frame_header->trace_zone) {
-      IREE_TRACE_ZONE_APPEND_VALUE(frame_header->trace_zone, (uint64_t)stack);
+      IREE_TRACE_ZONE_APPEND_VALUE_I64(frame_header->trace_zone,
+                                       (uint64_t)stack);
     }
   });
 
@@ -752,7 +753,8 @@ static void iree_vm_stack_resume_trace_zones_recursive(
     frame_header->trace_zone = iree_vm_stack_trace_function_zone_begin(
         frame_header->frame.type, &frame_header->frame.function);
     if (frame_header->trace_zone) {
-      IREE_TRACE_ZONE_APPEND_VALUE(frame_header->trace_zone, (uint64_t)stack);
+      IREE_TRACE_ZONE_APPEND_VALUE_I64(frame_header->trace_zone,
+                                       (uint64_t)stack);
     }
   }
 }

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -589,7 +589,7 @@ class IREEBenchmark {
 }  // namespace iree
 
 int main(int argc, char** argv) {
-  IREE_TRACE_SCOPE_NAMED("main");
+  IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree-benchmark-module");
 
   // Pass through flags to benchmark (allowing --help to fall through).
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_UNDEFINED_OK |
@@ -600,12 +600,17 @@ int main(int argc, char** argv) {
   iree::IREEBenchmark iree_benchmark;
   iree_status_t status = iree_benchmark.Register();
   if (!iree_status_is_ok(status)) {
-    int ret = static_cast<int>(iree_status_code(status));
+    int exit_code = static_cast<int>(iree_status_code(status));
     printf("%s\n", iree::Status(std::move(status)).ToString().c_str());
-    return ret;
+    IREE_TRACE_ZONE_END(z0);
+    IREE_TRACE_APP_EXIT(exit_code);
+    return exit_code;
   }
   IREE_CHECK_OK(iree_hal_begin_profiling_from_flags(iree_benchmark.device()));
   ::benchmark::RunSpecifiedBenchmarks();
   IREE_CHECK_OK(iree_hal_end_profiling_from_flags(iree_benchmark.device()));
-  return 0;
+
+  IREE_TRACE_ZONE_END(z0);
+  IREE_TRACE_APP_EXIT(EXIT_SUCCESS);
+  return EXIT_SUCCESS;
 }

--- a/tools/iree-benchmark-trace-main.c
+++ b/tools/iree-benchmark-trace-main.c
@@ -267,7 +267,8 @@ int main(int argc, char** argv) {
   if (argc <= 1) {
     fprintf(stderr,
             "no trace files provided; pass one or more yaml file paths");
-    return 1;
+    IREE_TRACE_APP_EXIT(EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   // Used when tracing to display benchmark state.
@@ -302,5 +303,6 @@ int main(int argc, char** argv) {
 
   iree_file_contents_free(stdin_contents);
   iree_vm_instance_release(instance);
-  return 0;
+  IREE_TRACE_APP_EXIT(EXIT_SUCCESS);
+  return EXIT_SUCCESS;
 }

--- a/tools/iree-check-module-main.cc
+++ b/tools/iree-check-module-main.cc
@@ -158,11 +158,12 @@ extern "C" int main(int argc, char** argv) {
   IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree-check-module");
   int exit_code = 1;
   iree_status_t status = Run(iree_allocator_system(), &exit_code);
-  int ret = iree_status_is_ok(status) ? exit_code : 1;
+  exit_code = iree_status_is_ok(status) ? exit_code : EXIT_FAILURE;
   IREE_TRACE_ZONE_END(z0);
+  IREE_TRACE_APP_EXIT(exit_code);
 
   if (FLAG_expect_failure) {
-    if (ret == 0) {
+    if (exit_code == 0) {
       printf("Test passed but expected failure\n");
       return 1;
     }
@@ -170,11 +171,11 @@ extern "C" int main(int argc, char** argv) {
     return 0;
   }
 
-  if (ret != 0) {
+  if (exit_code != 0) {
     printf("Test failed\n%s\n", Status(std::move(status)).ToString().c_str());
   }
 
-  return ret;
+  return exit_code;
 }
 
 }  // namespace iree

--- a/tools/iree-e2e-matmul-test.c
+++ b/tools/iree-e2e-matmul-test.c
@@ -1222,6 +1222,7 @@ int main(int argc, char** argv) {
   if (argc <= 1) {
     fprintf(stderr,
             "no trace files provided; pass one or more yaml file paths\n");
+    IREE_TRACE_APP_EXIT(1);
     return 1;
   }
 
@@ -1232,11 +1233,13 @@ int main(int argc, char** argv) {
     status = run_trace_files(argc - 1, argv + 1, instance);
   }
   iree_vm_instance_release(instance);
+  int exit_code = EXIT_SUCCESS;
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     bool is_unavailable = iree_status_is_unavailable(status);
     iree_status_free(status);
-    return is_unavailable ? EXIT_SUCCESS : EXIT_FAILURE;
+    exit_code = is_unavailable ? EXIT_SUCCESS : EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+  IREE_TRACE_APP_EXIT(exit_code);
+  return exit_code;
 }

--- a/tools/iree-run-mlir-main.cc
+++ b/tools/iree-run-mlir-main.cc
@@ -465,7 +465,7 @@ class ArgParser {
 }  // namespace
 
 extern "C" int main(int argc, char** argv) {
-  IREE_TRACE_SCOPE_NAMED("iree-run-mlir");
+  IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree-run-mlir");
 
   // Initialize the compiler once on startup before using any other APIs.
   ireeCompilerGlobalInitialize();
@@ -474,7 +474,9 @@ extern "C" int main(int argc, char** argv) {
   ArgParser arg_parser;
   if (!arg_parser.Parse(argc, argv)) {
     ireeCompilerGlobalShutdown();
-    return 1;
+    IREE_TRACE_ZONE_END(z0);
+    IREE_TRACE_APP_EXIT(EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   // Pass along compiler flags.
@@ -506,7 +508,9 @@ extern "C" int main(int argc, char** argv) {
             "Pass either the path to a .mlir/mlirbc file or `-` to read from "
             "stdin.\n");
     fflush(stderr);
-    return 1;
+    IREE_TRACE_ZONE_END(z0);
+    IREE_TRACE_APP_EXIT(EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
   const char* source_filename = runtime_argv[1];
 
@@ -516,15 +520,15 @@ extern "C" int main(int argc, char** argv) {
   // The process return code is 0 for success and non-zero otherwise.
   // We don't differentiate between compiler or runtime error codes here but
   // could if someone found it useful.
-  int rc = EXIT_SUCCESS;
+  int exit_code = EXIT_SUCCESS;
 
   // Compile and run the provided source file and get the exit code determined
   // based on the run mode.
   auto status_or = CompileAndRunFile(session, source_filename);
   if (status_or.ok()) {
-    rc = status_or.value();
+    exit_code = status_or.value();
   } else {
-    rc = 2;
+    exit_code = 2;
     iree_status_fprint(stderr, status_or.status().get());
     fflush(stderr);
   }
@@ -533,7 +537,10 @@ extern "C" int main(int argc, char** argv) {
 
   // No more compiler APIs can be called after this point.
   ireeCompilerGlobalShutdown();
-  return rc;
+
+  IREE_TRACE_ZONE_END(z0);
+  IREE_TRACE_APP_EXIT(exit_code);
+  return exit_code;
 }
 
 }  // namespace iree

--- a/tools/iree-run-module-main.c
+++ b/tools/iree-run-module-main.c
@@ -52,5 +52,6 @@ int main(int argc, char** argv) {
   }
 
   IREE_TRACE_ZONE_END(z0);
+  IREE_TRACE_APP_EXIT(exit_code);
   return exit_code;
 }

--- a/tools/iree-run-trace-main.c
+++ b/tools/iree-run-trace-main.c
@@ -359,7 +359,8 @@ int main(int argc, char** argv) {
   if (argc <= 1) {
     fprintf(stderr,
             "no trace files provided; pass one or more yaml file paths");
-    return 1;
+    IREE_TRACE_APP_EXIT(EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   iree_vm_instance_t* instance = NULL;
@@ -369,10 +370,12 @@ int main(int argc, char** argv) {
     status = iree_run_trace_files(argc - 1, argv + 1, instance);
   }
   iree_vm_instance_release(instance);
+  int exit_code = EXIT_SUCCESS;
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);
-    return 1;
+    exit_code = EXIT_FAILURE;
   }
-  return 0;
+  IREE_TRACE_APP_EXIT(exit_code);
+  return exit_code;
 }


### PR DESCRIPTION
There's more work to generalize out some tracy-isms we may not want to enforce on other implementations. GPU and mutex tracing is still behind the tracy wall today.