### PR TITLE
Add job to sync new IREE fork of StableHLO

### DIFF
--- a/.github/workflows/advance_upstream_forks.yml
+++ b/.github/workflows/advance_upstream_forks.yml
@@ -79,3 +79,14 @@ jobs:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: master
           repository: iree-org/iree-tf-fork
+
+  # Since this is a proper fork we can just use the sync method.
+  advance_stablehlo:
+    name: "Advance StableHLO fork"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Sync Fork
+        env:
+          # The normal GITHUB_TOKEN wouldn't have access to this other repo.
+          GH_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
+        run: gh repo sync iree-org/stablehlo -b main


### PR DESCRIPTION
We'll use this for carrying local patches for integration purposes as
with our other forks. The other forks all have weird names and aren't
proper forks because they're back from when we were in the google/
GitHub organization and we didn't want to create, e.g.
`google/tensorflow`. Now that we have a separate org, we can just use a
normal fork and that makes syncing much more straightforward. Once we
drop the MHLO repo dep (which this is in service of), I think we can
switch the LLVM fork to be a proper fork and archive the TF and MHLO
ones as no longer used.
