### PR TITLE
Add `iree-hal-dump-executable-files-to` meta flag.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -42,6 +42,21 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::init(2), llvm::cl::cat(halTargetOptionsCategory));
 
   binder.opt<std::string>(
+      "iree-hal-dump-executable-files-to", executableFilesPath,
+      llvm::cl::desc(
+          "Meta flag for all iree-hal-dump-executable-* options. Path to write "
+          "executable files (sources, benchmarks, intermediates, binaries) "
+          "to."),
+      llvm::cl::callback([&](const std::string &path) {
+        if (executableSourcesPath.empty()) executableSourcesPath = path;
+        if (executableBenchmarksPath.empty()) executableBenchmarksPath = path;
+        if (executableIntermediatesPath.empty())
+          executableIntermediatesPath = path;
+        if (executableBinariesPath.empty()) executableBinariesPath = path;
+      }),
+      llvm::cl::cat(halTargetOptionsCategory));
+
+  binder.opt<std::string>(
       "iree-hal-dump-executable-sources-to", executableSourcesPath,
       llvm::cl::desc("Path to write individual hal.executable input "
                      "source listings into (- for stdout)."),

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -42,7 +42,7 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::init(2), llvm::cl::cat(halTargetOptionsCategory));
 
   binder.opt<std::string>(
-      "iree-hal-dump-executable-sources-to", sourceListingPath,
+      "iree-hal-dump-executable-sources-to", executableSourcesPath,
       llvm::cl::desc("Path to write individual hal.executable input "
                      "source listings into (- for stdout)."),
       llvm::cl::cat(halTargetOptionsCategory));

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -41,7 +41,7 @@ struct TargetOptions {
   int debugLevel;
 
   // A path to write individual executable source listings into.
-  std::string sourceListingPath;
+  std::string executableSourcesPath;
 
   // A path to write standalone executable benchmarks into.
   std::string executableBenchmarksPath;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -40,6 +40,9 @@ struct TargetOptions {
   //   3: maximal debug information
   int debugLevel;
 
+  // Default path to write executable files into.
+  std::string executableFilesPath;
+
   // A path to write individual executable source listings into.
   std::string executableSourcesPath;
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -474,7 +474,7 @@ class DumpExecutableBenchmarksPass
             buildBenchmarkModule(executableOp, variantOp, dispatchParamsMap);
         if (!benchmarkModuleOp) continue;
         auto fileName = (moduleName + "_" + executableOp.getName() + "_" +
-                         variantOp.getName() + ".mlir")
+                         variantOp.getName() + "_benchmark.mlir")
                             .str();
         if (path.empty() || path == "-") {
           dumpModuleToStream(*benchmarkModuleOp, fileName, llvm::outs());

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -179,9 +179,9 @@ void buildHALConfigurationPassPipeline(
   // locations in the IR. This will allow us to easily inspect each executable
   // and give downstream tools that can display source information something
   // more useful and slim than the entire original source model.
-  if (!targetOptions.sourceListingPath.empty()) {
+  if (!targetOptions.executableSourcesPath.empty()) {
     passManager.addPass(
-        createDumpExecutableSourcesPass(targetOptions.sourceListingPath));
+        createDumpExecutableSourcesPass(targetOptions.executableSourcesPath));
   }
 
   // Substitute hal.executables we've generated from earlier phases of


### PR DESCRIPTION
Setting `--iree-hal-dump-executable-files-to=${PATH}` is equivalent to setting
```
--iree-hal-dump-executable-benchmarks-to=${PATH}
--iree-hal-dump-executable-binaries-to=${PATH}
--iree-hal-dump-executable-intermediates-to=${PATH}
--iree-hal-dump-executable-sources-to=${PATH}
```

This is useful when you want to dump _all_ the files to the same path, without needing to type as much.

For example, `iree-compile --iree-hal-target-backends=vulkan-spirv --iree-hal-target-backends=llvm-cpu iree/samples/models/simple_abs.mlir -o /dev/null --iree-hal-dump-executable-files-to=simple_abs_files/` produces:

```
module_abs_dispatch_0.mlir
module_abs_dispatch_0_embedded_elf_x86_64.codegen.bc
module_abs_dispatch_0_embedded_elf_x86_64.linked.bc
module_abs_dispatch_0_embedded_elf_x86_64.optimized.bc
module_abs_dispatch_0_embedded_elf_x86_64.s
module_abs_dispatch_0_embedded_elf_x86_64.so
module_abs_dispatch_0_embedded_elf_x86_64_benchmark.mlir
module_abs_dispatch_0_vulkan_spirv_fb.mlir
module_abs_dispatch_0_vulkan_spirv_fb.spv
module_abs_dispatch_0_vulkan_spirv_fb_benchmark.mlir
```

The new flag is treated as the default for each of those other flags, so you can also set them explicitly (to a path _or_ empty string).

---

Also renamed options and files for consistency.