### PR TITLE
Create empty files without unnecessary timestamp updates.

### DIFF
--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -101,7 +101,7 @@ function(iree_cc_binary)
     )
   else()
     set(_DUMMY_SRC "${CMAKE_CURRENT_BINARY_DIR}/${_NAME}_dummy.cc")
-    file(WRITE ${_DUMMY_SRC} "")
+    iree_make_empty_file("${_DUMMY_SRC}")
     target_sources(${_NAME}
       PRIVATE
         ${_DUMMY_SRC}

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -382,6 +382,17 @@ function(iree_add_data_dependencies)
 endfunction()
 
 #-------------------------------------------------------------------------------
+# iree_make_empty_file
+#-------------------------------------------------------------------------------
+
+# Creates an empty file by copying an in-tree empty file. Unlike `file(WRITE)`
+# or `file(TOUCH)`, this does not update the timestamp every time CMake is run,
+# avoiding unnecessary rebuilds when the empty file is used as a rule input.
+function(iree_make_empty_file _FILENAME)
+  configure_file("${PROJECT_SOURCE_DIR}/build_tools/cmake/empty_file" "${_FILENAME}" COPYONLY)
+endfunction()
+
+#-------------------------------------------------------------------------------
 # Emscripten
 #-------------------------------------------------------------------------------
 

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/BUILD.bazel
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/BUILD.bazel
@@ -74,7 +74,7 @@ iree_link_bitcode(
 iree_cmake_extra_content(
     content = """
 elseif(IREE_BUILD_COMPILER AND IREE_TARGET_BACKEND_LLVM_CPU)
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_arm_64.bc" "")
+iree_make_empty_file("${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_arm_64.bc")
 endif()  # _IREE_UKERNEL_BITCODE_BUILD_ARM_64
 """,
     inline = True,

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
@@ -58,7 +58,7 @@ iree_link_bitcode(
 )
 
 elseif(IREE_BUILD_COMPILER AND IREE_TARGET_BACKEND_LLVM_CPU)
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_arm_64.bc" "")
+iree_make_empty_file("${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_arm_64.bc")
 endif()  # _IREE_UKERNEL_BITCODE_BUILD_ARM_64
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/BUILD.bazel
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/BUILD.bazel
@@ -117,7 +117,7 @@ iree_link_bitcode(
 iree_cmake_extra_content(
     content = """
 elseif(IREE_BUILD_COMPILER AND IREE_TARGET_BACKEND_LLVM_CPU)
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_x86_64.bc" "")
+iree_make_empty_file("${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_x86_64.bc")
 endif()  # _IREE_UKERNEL_BITCODE_BUILD_X86_64
 """,
     inline = True,

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
@@ -91,7 +91,7 @@ iree_link_bitcode(
 )
 
 elseif(IREE_BUILD_COMPILER AND IREE_TARGET_BACKEND_LLVM_CPU)
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_x86_64.bc" "")
+iree_make_empty_file("${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_x86_64.bc")
 endif()  # _IREE_UKERNEL_BITCODE_BUILD_X86_64
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
This fixes the mysterious re-linking of `libIREECompiler` every time CMake was re-run.  The problem was that `file(WRITE)` updates timestamps every time, even if contents does not change. CMake documentation actually had a note about exactly this:

https://cmake.org/cmake/help/latest/command/file.html#write

> If the file is a build input, use the [configure_file()](https://cmake.org/cmake/help/latest/command/configure_file.html#command:configure_file) command to update the file only when its content changes.

For the record, the tool that helped debug that was `ninja -d explain`. It outputs things like:
```
ninja explain: restat of output runtime/src/iree/builtins/ukernel/ukernel_bitcode.h older than most recent input runtime/src/iree/builtins/ukernel/arch/arm_64/ukernel_bitcode_arm_64.bc (1686679813375596068 vs 1686679898087480062)
```