### PR TITLE
Disable Bit-width change for modules with external functions.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir
@@ -94,3 +94,4 @@ func.func @main(%x : tensor<2xi64>, %y : tensor<2xf64>) -> tensor<2xf64> {
   %1 = func.call @extern_func(%y, %x) : (tensor<2xf64>, tensor<2xi64>) -> tensor<2xf64>
   return %1 : tensor<2xf64>
 }
+

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir
@@ -82,3 +82,15 @@ func.func @complexTypesF64(%arg0 : complex<f64>) -> complex<f64> {
   return %arg0 : complex<f64>
 }
 
+// -----
+
+// Check if Demotion is disabled for external functions.
+
+func.func private @extern_func(tensor<2xf64>, tensor<2xi64>) -> tensor<2xf64>
+// CHECK-LABEL: func.func @main
+// CHECK-SAME: (%[[ARG0:.*]]: tensor<2xi64>, %[[ARG1:.*]]: tensor<2xf64>) -> tensor<2xf64>
+func.func @main(%x : tensor<2xi64>, %y : tensor<2xf64>) -> tensor<2xf64> {
+  // CHECK-DAG: call @extern_func(%[[ARG1]], %[[ARG0]]) : (tensor<2xf64>, tensor<2xi64>) -> tensor<2xf64>
+  %1 = func.call @extern_func(%y, %x) : (tensor<2xf64>, tensor<2xi64>) -> tensor<2xf64>
+  return %1 : tensor<2xf64>
+}

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
@@ -158,13 +158,13 @@ func.func @foo(%arg0 : tensor<i64>) {
 // CHECK: util.global private @{{.+}} : tensor<4xi32>
 util.global private @v_initializer : tensor<4xi64>
 util.initializer {
-  // CHECK: %[[VALUE:.+]] = func.call @initializer() : () -> tensor<4xi32>
+  // CHECK: %[[VALUE:.+]] = func.call @initializer() : () -> tensor<4xi64>
   %0 = func.call @initializer() : () -> tensor<4xi64>
-  // CHECK: util.global.store %[[VALUE]], @v_initializer : tensor<4xi32>
+  // CHECK: util.global.store %[[VALUE]], @v_initializer : tensor<4xi64>
   util.global.store %0, @v_initializer : tensor<4xi64>
   util.initializer.return
 }
-// CHECK: func.func private @initializer() -> tensor<4xi32>
+// CHECK: func.func private @initializer() -> tensor<4xi64>
 func.func private @initializer() -> tensor<4xi64>
 
 // -----


### PR DESCRIPTION
This patch will disable bit-width changes for modules that have external functions. Since the body of the function is compiled elsewhere and just linked, any modification will cause linker issues.

Fixes: #12987