### PR TITLE
Remove old / no longer needed flags from mnist_training notebook.

### DIFF
--- a/samples/colab/mnist_training.ipynb
+++ b/samples/colab/mnist_training.ipynb
@@ -377,13 +377,10 @@
       },
       "source": [
         "# Compile the TrainableDNN module\n",
-        "# Note: extra flags are needed to i64 demotion, see https://github.com/openxla/iree/issues/8644\n",
         "vm_flatbuffer = iree.compiler.tf.compile_module(\n",
         "    TrainableDNN(),\n",
         "    target_backends=[backend_choice],\n",
-        "    exported_names=exported_names,\n",
-        "    extra_args=[\"--iree-stablehlo-demote-i64-to-i32=false\",\n",
-        "                \"--iree-flow-demote-i64-to-i32\"])\n",
+        "    exported_names=exported_names)\n",
         "compiled_model = iree.runtime.load_vm_flatbuffer(\n",
         "    vm_flatbuffer,\n",
         "    backend=backend_choice)"
@@ -441,9 +438,9 @@
           "name": "stdout",
           "text": [
             "Inference latency:\n",
-            "  1.82 ms ± 326 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n",
+            "  1.29 ms ± 219 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n",
             "Training latancy:\n",
-            "  4.9 ms ± 841 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+            "  3.24 ms ± 280 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
           ]
         }
       ]


### PR DESCRIPTION
This fixes the error reported here: https://github.com/openxla/iree/pull/13993#discussion_r1229776695

skip-ci: only covered by nightly 'samples' CI job