### PR TITLE
Use always-enabled vmvx targets in assign_target_devices test.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_target_devices.mlir
@@ -1,18 +1,18 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices)' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-0
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vulkan-spirv})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vulkan-spirv,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vmvx,vmvx-inline})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
 
-// TARGET-1: #device_target_vulkan = #hal.device.target<"vulkan"
+// TARGET-1: #device_target_vmvx = #hal.device.target<"vmvx"
 
 // TARGET-2: #device_target_vmvx = #hal.device.target<"vmvx"
-// TARGET-2: #device_target_vulkan = #hal.device.target<"vulkan"
+// TARGET-2: #device_target_vmvx_inline = #hal.device.target<"vmvx-inline"
 
 // CHECK: module
 // TARGET-0: @module {
 // TARGET-1: @module attributes {
-// TARGET-1-SAME: hal.device.targets = [#device_target_vulkan]
+// TARGET-1-SAME: hal.device.targets = [#device_target_vmvx]
 // TARGET-2: @module attributes {
-// TARGET-2-SAME: hal.device.targets = [#device_target_vulkan, #device_target_vmvx]}
+// TARGET-2-SAME: hal.device.targets = [#device_target_vmvx, #device_target_vmvx_inline]}
 module @module {}
 
 // -----


### PR DESCRIPTION
This test now passes when you configure CMake with just `-DIREE_TARGET_BACKEND_DEFAULTS=OFF" -DIREE_TARGET_BACKEND_VMVX=ON`. Otherwise, we'd want to filter this test if `IREE_TARGET_BACKEND_VULKAN_SPIRV` is false, as in https://github.com/openxla/iree/pull/14035#discussion_r1227114504.

I verified my CMake config with this:
```console
$ iree-compile --iree-hal-list-target-backends

Registered target backends:
  vmvx
  vmvx-inline
```