### PR TITLE
Use `T4` for main GPU CI instead of A100

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
   ##############################################################################
   build_all:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
     uses: ./.github/workflows/build_all.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -269,7 +268,6 @@ jobs:
 
   test_gpu:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -400,7 +398,6 @@ jobs:
 
   test_tf_integrations_gpu:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,48 @@ jobs:
               ./build_tools/scripts/check_vulkan.sh
               ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
+  test_sm80:
+    needs: [setup, build_all]
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - a100
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          submodules: true
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+      - name: "Downloading build dir archive"
+        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Testing with GPU"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_VULKAN_F16_DISABLE=0 \
+            --env IREE_CUDA_DISABLE=0 \
+            --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+            --env IREE_NVIDIA_SM80_TESTS_DISABLE=0 \
+            --env CTEST_PARALLEL_LEVEL=2 \
+            --env IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$' \
+            --gpus all \
+            --env NVIDIA_DRIVER_CAPABILITIES=all \
+            gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \
+            bash -euo pipefail -c \
+              "./build_tools/scripts/check_cuda.sh
+              ./build_tools/scripts/check_vulkan.sh
+              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
   ##############################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,7 @@ jobs:
             --env IREE_CUDA_DISABLE=0 \
             --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
             --env CTEST_PARALLEL_LEVEL=2 \
+            --env IREE_CTEST_LABEL_REGEX='^requires-gpu' \
             --gpus all \
             --env NVIDIA_DRIVER_CAPABILITIES=all \
             gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,8 +297,9 @@ jobs:
             --env IREE_VULKAN_F16_DISABLE=0 \
             --env IREE_CUDA_DISABLE=0 \
             --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+            --env IREE_NVIDIA_SM80_TESTS_DISABLE=1 \
             --env CTEST_PARALLEL_LEVEL=2 \
-            --env IREE_CTEST_LABEL_REGEX='^requires-gpu' \
+            --env IREE_CTEST_LABEL_REGEX='^requires-gpu|^driver=vulkan$|^driver=cuda$' \
             --gpus all \
             --env NVIDIA_DRIVER_CAPABILITIES=all \
             gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -55,7 +55,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: ${{ steps.configure.outputs.should-run }}
+      should-run: "false"
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}

--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -63,10 +63,10 @@ default_test_tag_filters+=("-vulkan_uses_vk_khr_shader_float16_int8")
 # CUDA CI testing disabled until we setup a target for it.
 default_test_tag_filters+=("-driver=cuda")
 
-if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
+if (( IREE_VULKAN_DISABLE == 1 )); then
   default_test_tag_filters+=("-driver=vulkan")
 fi
-if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE?}" == 1 ]]; then
+if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
   default_test_tag_filters+=("-requires-gpu-nvidia" "-requires-gpu-sm80")
 fi
 

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -110,13 +110,13 @@ for asan_in_bytecode_modules_ON_OFF in OFF ON; do
 
   # IREE_VULKAN_DISABLE is handled separately as we run Vulkan and non-Vulkan
   # tests in separate ctest commands anyway.
-  if [[ "${IREE_CUDA_DISABLE?}" == 1 ]]; then
+  if (( IREE_CUDA_DISABLE == 1 )); then
     label_exclude_args+=("^driver=cuda$")
   fi
-  if [[ "${IREE_VULKAN_F16_DISABLE?}" == 1 ]]; then
+  if (( IREE_VULKAN_F16_DISABLE == 1 )); then
     label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
   fi
-  if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE}" == 1 ]]; then
+  if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
     label_exclude_args+=("^requires-gpu")
   fi
 
@@ -138,7 +138,7 @@ for asan_in_bytecode_modules_ON_OFF in OFF ON; do
   echo "------------------"
   cmake --build . --target check-iree-dialects -- -k 0
 
-  if [[ "${IREE_VULKAN_DISABLE?}" == 0 ]]; then
+  if (( IREE_VULKAN_DISABLE == 0 )); then
     echo "*** Running ctests that use the Vulkan driver, with LSAN disabled (IREE_BYTECODE_MODULE_ENABLE_ASAN=${asan_in_bytecode_modules_ON_OFF}) ***"
     echo "------------------"
     # Disable LeakSanitizer (LSAN) because of a history of issues with Swiftshader

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -67,8 +67,6 @@ declare -a label_exclude_args=(
 )
 
 
-
-
 if (( IREE_VULKAN_DISABLE == 1 )); then
   label_exclude_args+=("^driver=vulkan$")
 fi

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -24,21 +24,25 @@ get_default_parallel_level() {
 }
 
 # Respect the user setting, but default to as many jobs as we have cores.
-export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(get_default_parallel_level)}
+export CTEST_PARALLEL_LEVEL="${CTEST_PARALLEL_LEVEL:-$(get_default_parallel_level)}"
 
 # Respect the user setting, but default to turning on Vulkan.
-export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}
+export IREE_VULKAN_DISABLE="${IREE_VULKAN_DISABLE:-0}"
 # Respect the user setting, but default to turning off CUDA.
-export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
+export IREE_CUDA_DISABLE="${IREE_CUDA_DISABLE:-1}"
 # The VK_KHR_shader_float16_int8 extension is optional prior to Vulkan 1.2.
 # We test on SwiftShader as a baseline, which does not support this extension.
-export IREE_VULKAN_F16_DISABLE=${IREE_VULKAN_F16_DISABLE:-1}
+export IREE_VULKAN_F16_DISABLE="${IREE_VULKAN_F16_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require Nvidia GPU.
-export IREE_NVIDIA_GPU_TESTS_DISABLE=${IREE_NVIDIA_GPU_TESTS_DISABLE:-1}
+export IREE_NVIDIA_GPU_TESTS_DISABLE="${IREE_NVIDIA_GPU_TESTS_DISABLE:-1}"
+# Respect the user setting, but default to skipping tests that require SM80 Nvidia GPU.
+export IREE_NVIDIA_SM80_TESTS_DISABLE="${IREE_NVIDIA_SM80_TESTS_DISABLE:-1}"
 # Respect the user setting, default to no --repeat-until-fail.
-export IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT=${IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT:-}
+export IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT="${IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT:-}"
 # Respect the user setting, default to no --tests-regex.
-export IREE_CTEST_TESTS_REGEX=${IREE_CTEST_TESTS_REGEX:-}
+export IREE_CTEST_TESTS_REGEX="${IREE_CTEST_TESTS_REGEX:-}"
+# Respect the user setting, default to no --label-regex
+export IREE_CTEST_LABEL_REGEX="${IREE_CTEST_LABEL_REGEX:-}"
 
 # Tests to exclude by label. In addition to any custom labels (which are carried
 # over from Bazel tags), every test should be labeled with its directory.
@@ -72,8 +76,12 @@ if [[ "${IREE_VULKAN_F16_DISABLE}" == 1 ]]; then
   label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
 fi
 if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE}" == 1 ]]; then
-  label_exclude_args+=("^requires-gpu$")
+  label_exclude_args+=("^requires-gpu")
 fi
+if [[ "${IREE_NVIDIA_SM80_TESTS_DISABLE}" == 1 ]]; then
+  label_exclude_args+=("^requires-gpu-sm80$")
+fi
+
 
 IFS=',' read -ra extra_label_exclude_args <<< "${IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}"
 label_exclude_args+=(${extra_label_exclude_args[@]})
@@ -127,6 +135,10 @@ ctest_args=(
 
 if [[ -n "${IREE_CTEST_TESTS_REGEX}" ]]; then
   ctest_args+=("--tests-regex ${IREE_CTEST_TESTS_REGEX}")
+fi
+
+if [[ -n "${IREE_CTEST_LABEL_REGEX}" ]]; then
+  ctest_args+=("--label-regex ${IREE_CTEST_LABEL_REGEX}")
 fi
 
 if [[ -n "${IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT}" ]]; then

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -66,6 +66,9 @@ declare -a label_exclude_args=(
   #   ^bindings/
 )
 
+
+
+
 if (( IREE_VULKAN_DISABLE == 1 )); then
   label_exclude_args+=("^driver=vulkan$")
 fi
@@ -91,7 +94,7 @@ label_exclude_args+=(${extra_label_exclude_args[@]})
 # platforms it doesn't support, but that would require editing through layers
 # of CMake functions. Hopefully this list stays very short.
 declare -a excluded_tests=()
-if [[ "$OSTYPE" =~ ^msys ]]; then
+if [[ "${OSTYPE}" =~ ^msys ]]; then
   # These tests are failing on Windows.
   excluded_tests+=(
     # TODO(#11077): INVALID_ARGUMENT: argument/result signature mismatch
@@ -107,7 +110,7 @@ if [[ "$OSTYPE" =~ ^msys ]]; then
     # TODO(#11070): Fix argument/result signature mismatch
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_fully_connected.mlir"
   )
-elif [[ "$OSTYPE" =~ ^darwin ]]; then
+elif [[ "${OSTYPE}" =~ ^darwin ]]; then
   excluded_tests+=(
     #TODO(#12496): Remove after fixing the test on macOS
     "iree/compiler/bindings/c/loader_test"

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -66,19 +66,19 @@ declare -a label_exclude_args=(
   #   ^bindings/
 )
 
-if [[ "${IREE_VULKAN_DISABLE}" == 1 ]]; then
+if (( IREE_VULKAN_DISABLE == 1 )); then
   label_exclude_args+=("^driver=vulkan$")
 fi
-if [[ "${IREE_CUDA_DISABLE}" == 1 ]]; then
+if (( IREE_CUDA_DISABLE == 1 )); then
   label_exclude_args+=("^driver=cuda$")
 fi
-if [[ "${IREE_VULKAN_F16_DISABLE}" == 1 ]]; then
+if (( IREE_VULKAN_F16_DISABLE == 1 )); then
   label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
 fi
-if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE}" == 1 ]]; then
+if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu")
 fi
-if [[ "${IREE_NVIDIA_SM80_TESTS_DISABLE}" == 1 ]]; then
+if (( IREE_NVIDIA_SM80_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-sm80$")
 fi
 

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -47,13 +47,13 @@ declare -a label_exclude_args=(
   #   ^bindings/
 )
 
-if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
+if (( IREE_VULKAN_DISABLE == 1 )); then
   label_exclude_args+=("^driver=vulkan$")
 fi
-if [[ "${IREE_CUDA_DISABLE?}" == 1 ]]; then
+if (( IREE_CUDA_DISABLE == 1 )); then
   label_exclude_args+=("^driver=cuda$")
 fi
-if [[ "${IREE_VULKAN_F16_DISABLE?}" == 1 ]]; then
+if (( IREE_VULKAN_F16_DISABLE == 1 )); then
   label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
 fi
 

--- a/build_tools/github_actions/runner/gcp/create_image.sh
+++ b/build_tools/github_actions/runner/gcp/create_image.sh
@@ -26,7 +26,7 @@ ZONE="${ZONE:-us-central1-a}"
 PROJECT=iree-oss
 BASE_IMAGE="${BASE_IMAGE:-projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20230531}"
 
-GPU_MACHINE_TYPE="a2-highgpu-1g"
+GPU_MACHINE_TYPE="n1-standard-16"
 CPU_MACHINE_TYPE="e2-medium"
 CPU_IMAGE_SIZE_GB=10
 # We need enough space to fetch Docker images that we test with
@@ -145,11 +145,13 @@ function create_image() {
         local machine_type="${CPU_MACHINE_TYPE}"
         local image_size_gb="${CPU_IMAGE_SIZE_GB}"
         local maintenance_policy=MIGRATE
+        local -a extra_args=()
         ;;
       gpu)
         local machine_type="${GPU_MACHINE_TYPE}"
         local image_size_gb="${GPU_IMAGE_SIZE_GB}"
         local maintenance_policy=TERMINATE
+        local -a extra_args=("--accelerator=count=1,type=nvidia-tesla-t4")
         ;;
       *)
         echo "Unrecognized RUNNER_TYPE=${RUNNER_TYPE}"
@@ -182,7 +184,9 @@ function create_image() {
       --metadata="github-runner-type=${RUNNER_TYPE}"
       --machine-type="${machine_type}"
       --create-disk="boot=yes,device-name=${INSTANCE_NAME},image=${BASE_IMAGE},mode=rw,size=${image_size_gb},type=projects/${PROJECT}/zones/${ZONE}/diskTypes/pd-balanced,auto-delete=yes"
+      "${extra_args[@]}"
     )
+
     (set -x; "${create_instance_cmd[@]}")
   fi
 

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -17,7 +17,7 @@ TESTING="${TEMPLATE_TESTING:-0}"
 DRY_RUN="${DRY_RUN:-0}"
 TESTING_SELF_DELETER="${TESTING_SELF_DELETER:-0}"
 
-GPU_IMAGE="${GPU_IMAGE:-github-runner-gpu-2023-06-02-1685724247}"
+GPU_IMAGE="${GPU_IMAGE:-github-runner-gpu-2023-06-14-1686786580}"
 GPU_DISK_SIZE_GB="${GPU_DISK_SIZE_GB:-1000}"
 CPU_IMAGE="${CPU_IMAGE:-github-runner-cpu-2023-06-02-1685725199}"
 CPU_DISK_SIZE_GB="${CPU_DISK_SIZE_GB:-1000}"
@@ -128,9 +128,9 @@ function create_template() {
 
   if [[ "${type}" == gpu ]]; then
     cmd+=(
-      --machine-type=a2-highgpu-1g
+      --machine-type=n1-standard-16
       --maintenance-policy=TERMINATE
-      --accelerator=count=1,type=nvidia-tesla-a100
+      --accelerator=count=1,type=nvidia-tesla-t4
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${GPU_IMAGE},mode=rw,size=${GPU_DISK_SIZE_GB},type=pd-ssd"
     )
   elif [[ "${type}" == cpu ]]; then

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -18,9 +18,8 @@ DRY_RUN="${DRY_RUN:-0}"
 TESTING_SELF_DELETER="${TESTING_SELF_DELETER:-0}"
 
 GPU_IMAGE="${GPU_IMAGE:-github-runner-gpu-2023-06-14-1686786580}"
-GPU_DISK_SIZE_GB="${GPU_DISK_SIZE_GB:-1000}"
 CPU_IMAGE="${CPU_IMAGE:-github-runner-cpu-2023-06-02-1685725199}"
-CPU_DISK_SIZE_GB="${CPU_DISK_SIZE_GB:-1000}"
+DISK_SIZE_GB="${DISK_SIZE_GB:-1000}"
 
 PROD_TEMPLATE_CONFIG_REPO="${PROD_TEMPLATE_CONFIG_REPO:-openxla/iree}"
 GITHUB_RUNNER_SCOPE="${GITHUB_RUNNER_SCOPE:-openxla}"
@@ -131,19 +130,26 @@ function create_template() {
       --machine-type=n1-standard-16
       --maintenance-policy=TERMINATE
       --accelerator=count=1,type=nvidia-tesla-t4
-      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${GPU_IMAGE},mode=rw,size=${GPU_DISK_SIZE_GB},type=pd-ssd"
+      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${GPU_IMAGE},mode=rw,size=${DISK_SIZE_GB},type=pd-ssd"
+    )
+  elif [[ "${type}" == a100 ]]; then
+    cmd+=(
+      --machine-type=a2-highgpu-1g
+      --maintenance-policy=TERMINATE
+      --accelerator=count=1,type=nvidia-tesla-a100
+      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${GPU_IMAGE},mode=rw,size=${DISK_SIZE_GB},type=pd-ssd"
     )
   elif [[ "${type}" == cpu ]]; then
     cmd+=(
       --machine-type=n1-standard-96
       --maintenance-policy=MIGRATE
-      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-ssd"
+      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${DISK_SIZE_GB},type=pd-ssd"
     )
   elif [[ "${type}" == c2s16 ]]; then
     cmd+=(
       --machine-type=c2-standard-16
       --maintenance-policy=MIGRATE
-      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-ssd"
+      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${DISK_SIZE_GB},type=pd-ssd"
     )
   else
     echo "Got unrecognized type '${type}'" >2
@@ -159,7 +165,7 @@ function create_template() {
 }
 
 for group in presubmit postsubmit; do
-  for type in gpu cpu c2s16; do
+  for type in gpu a100 cpu c2s16; do
     create_template "${group}" "${type}"
   done
 done

--- a/experimental/cuda2/cts/CMakeLists.txt
+++ b/experimental/cuda2/cts/CMakeLists.txt
@@ -24,4 +24,7 @@ iree_hal_cts_test_suite(
     "descriptor_set_layout"
     "driver"
     "pipeline_layout"
+  LABELS
+    driver=cuda2
+    requires-gpu-nvidia
 )

--- a/experimental/metal/cts/CMakeLists.txt
+++ b/experimental/metal/cts/CMakeLists.txt
@@ -20,5 +20,6 @@ iree_hal_cts_test_suite(
   EXCLUDED_TESTS
     # HAL event is unimplemented for Metal right now.
     "event"
+  LABELS
+    driver=metal
 )
-

--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -24,4 +24,6 @@ iree_hal_cts_test_suite(
     # Semaphores are not implemented in the ROCm backend yet.
     "semaphore_submission"
     "semaphore"
+  LABELS
+    driver=rocm
 )

--- a/experimental/webgpu/cts/CMakeLists.txt
+++ b/experimental/webgpu/cts/CMakeLists.txt
@@ -17,4 +17,6 @@ iree_hal_cts_test_suite(
     "\"webgpu-wgsl-fb\""
   DEPS
     iree::experimental::webgpu::registration
+  LABELS
+    driver=webgpu
 )

--- a/runtime/src/iree/hal/drivers/cuda/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/cts/CMakeLists.txt
@@ -20,6 +20,9 @@ iree_hal_cts_test_suite(
   EXCLUDED_TESTS
     # Semaphores are not fully implemented in the CUDA backend yet.
     "semaphore"
+  LABELS
+    driver=cuda
+    requires-gpu-nvidia
 )
 
 # Variant test suite using graph command buffers (--cuda_use_streams=0)
@@ -43,4 +46,7 @@ iree_hal_cts_test_suite(
   INCLUDED_TESTS
     "command_buffer"
     "command_buffer_dispatch"
+  LABELS
+    driver=cuda
+    requires-gpu-nvidia
 )

--- a/runtime/src/iree/hal/drivers/local_sync/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_sync/cts/CMakeLists.txt
@@ -29,6 +29,8 @@ if(IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF)
       iree::hal::drivers::local_sync::registration
     EXCLUDED_TESTS
       "semaphore_submission"  # SubmitWithWait hangs?
+    LABELS
+      driver=local-sync
     )
 endif()
 
@@ -50,5 +52,7 @@ if(IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE)
       iree::hal::drivers::local_sync::registration
     EXCLUDED_TESTS
       "semaphore_submission"  # SubmitWithWait hangs?
+    LABELS
+      driver=local-sync
   )
 endif()

--- a/runtime/src/iree/hal/drivers/local_task/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/cts/CMakeLists.txt
@@ -27,6 +27,8 @@ if(IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF)
       "${NATIVE_EXECUTABLE_FORMAT}"
     DEPS
       iree::hal::drivers::local_task::registration
+    LABELS
+      driver=local-task
   )
 endif()
 
@@ -46,5 +48,7 @@ if(IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE)
       "\"vmvx-bytecode-fb\""
     DEPS
       iree::hal::drivers::local_task::registration
+    LABELS
+      driver=local-task
   )
 endif()

--- a/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
@@ -17,4 +17,6 @@ iree_hal_cts_test_suite(
     "\"SPVE\""
   DEPS
     iree::hal::drivers::vulkan::registration
+  LABELS
+    driver=vulkan
 )


### PR DESCRIPTION
These GPUs are much more widely available and cheaper. We can reserve
a100 GPUs for testing that specifically requires them and benchmarking.
This adds another job to run the a100 (sm80) tests. I think we should
consider making it postsubmit only. Unfortunately, a lot of the time in
the CI is spent on things other than running the tests. In fact, the
whole a100 job takes 7 minutes, of which only 8 seconds is spent
actually running tests :-/ So that is something to optimize. Even given
that though, I think it's still worthwhile to split these out. That
huge difference is mostly a result of not having very many
arch-specific tests. The general GPU job spends more like 6 minutes
running tests.

The other advantage is that it tests our GPU code that isn't *supposed*
to be arch specific on something else. We've had a few cases of these
tests not getting correctly tagged, but more importantly this also
prevents accidentally adding an arch-specific dependency. In fact, I
believe it has revealed a number of arch-specific tests on the e2e
matmul (now that https://github.com/openxla/iree/issues/14133 is
fixed).

This is going to require a staged rollout and likely be split into
multiple PRs, but sending for review to start with.

Tested:
Spun up test cluster and ran CI for this PR on the testing runners.

runner-env: testing
