### PR TITLE
Add VmModule.mmap() to Python API.

### DIFF
--- a/runtime/bindings/python/tests/vm_test.py
+++ b/runtime/bindings/python/tests/vm_test.py
@@ -8,6 +8,7 @@
 
 import logging
 import numpy as np
+import tempfile
 import unittest
 
 import iree.compiler
@@ -105,6 +106,28 @@ class VmTest(unittest.TestCase):
     result = finv(5, 6)
     logging.info("result: %s", result)
     self.assertEqual(result, 11)
+
+  def test_mmap(self):
+    binary = iree.compiler.compile_str(
+        """
+        func.func @add_scalar(%arg0: i32, %arg1: i32) -> i32 {
+          %0 = arith.addi %arg0, %arg1 : i32
+          return %0 : i32
+        }
+        """,
+        target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS
+    )
+    with tempfile.NamedTemporaryFile() as tf:
+      tf.write(binary)
+      tf.flush()
+      m = iree.runtime.VmModule.mmap(self.instance, tf.name)
+      context = iree.runtime.VmContext(self.instance,
+                                      modules=[self.hal_module, m])
+      f = m.lookup_function("add_scalar")
+      finv = iree.runtime.FunctionInvoker(context, self.device, f, tracer=None)
+      result = finv(5, 6)
+      logging.info("result: %s", result)
+      self.assertEqual(result, 11)
 
   def test_synchronous_dynamic_shape_invoke_function_new_abi(self):
     m = create_simple_dynamic_abs_module(self.instance)

--- a/runtime/bindings/python/tests/vm_test.py
+++ b/runtime/bindings/python/tests/vm_test.py
@@ -115,14 +115,13 @@ class VmTest(unittest.TestCase):
           return %0 : i32
         }
         """,
-        target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS
-    )
+        target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS)
     with tempfile.NamedTemporaryFile() as tf:
       tf.write(binary)
       tf.flush()
       m = iree.runtime.VmModule.mmap(self.instance, tf.name)
       context = iree.runtime.VmContext(self.instance,
-                                      modules=[self.hal_module, m])
+                                       modules=[self.hal_module, m])
       f = m.lookup_function("add_scalar")
       finv = iree.runtime.FunctionInvoker(context, self.device, f, tracer=None)
       result = finv(5, 6)

--- a/runtime/bindings/python/vm.h
+++ b/runtime/bindings/python/vm.h
@@ -133,6 +133,7 @@ class VmModule : public ApiRefCounted<VmModule, iree_vm_module_t> {
                                           const std::string& name,
                                           uint32_t minimum_version);
 
+  static VmModule MMap(VmInstance* instance, std::string filepath);
   static VmModule FromFlatbufferBlob(VmInstance* instance,
                                      py::object flatbuffer_blob_object);
 


### PR DESCRIPTION
We really need page aligned flatbuffer blobs vs normal malloc alignment. The best way to be loading a file is via mmap, so just make that available as an API.

This could be done in Python by the caller but is error-prone. The public API will make this more robust.

Provides the mechanism to fix #13887