### PR TITLE
[iree-dialects][test] Remove dead code from the transfrom script

### DIFF
--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -23,9 +23,6 @@ transform.sequence failures(propagate) {
   transform.structured.vectorize %2 { vectorize_padding } : (!transform.any_op) -> !transform.any_op
   %module_op1 = transform.bufferization.one_shot_bufferize layout{IdentityLayoutMap} %module_op
     {bufferize_function_boundaries = true} : (!transform.any_op) -> !transform.any_op
-  %3 = transform.structured.match ops{["func.func"]} in %module_op1
-    : (!transform.any_op) -> !transform.any_op
-
 
   %func = transform.structured.match ops{["func.func"]} in %module_op1
     : (!transform.any_op) -> !transform.any_op


### PR DESCRIPTION
Dead code in the transform script can currently trigger a bug in the interpreter. The issue is the transforms are applied to the transform script as well.
For this particular test, we have a dead matcher that gets removed by dce and this crashes the interpreter because it tries to access a transform op that doesn't exist anymore (use-after-free).

While the interpreter is being fixed (upstream), remove the dead code to avoid the crash.