### PR TITLE
Refresh website glossary with entries for StableHLO + OpenXLA.

### DIFF
--- a/docs/website/docs/guides/ml-frameworks/index.md
+++ b/docs/website/docs/guides/ml-frameworks/index.md
@@ -49,4 +49,4 @@ executed on the specified devices using IREE's runtime.
 The final stage is executing the now compiled module. This involves selecting
 what compute devices should be used, loading the module, and executing the
 module with the intended inputs. IREE provides several
-[language bindings](../../reference/bindings/index.md) for it's runtime API.
+[language bindings](../../reference/bindings/index.md) for its runtime API.

--- a/docs/website/docs/reference/glossary.md
+++ b/docs/website/docs/reference/glossary.md
@@ -1,26 +1,44 @@
+---
+hide:
+  - tags
+tags:
+  - JAX
+  - PyTorch
+  - TensorFlow
+---
+
 # Glossary
 
-IREE exists in an ecosystem of projects, each using their own terminology
-and interacting in various ways. Below is a summation of these projects
-with the problems they are built to address.
+IREE exists in an ecosystem of projects and acts as a bridge between machine
+learning frameworks and a variety of hardware platforms. This glossary outlines
+some of those projects and technologies.
+
+!!! question - "Something missing?"
+
+    Don't see a project of technology here that you think should be? We welcome
+    contributions on [our GitHub page](https://github.com/openxla/iree)!
 
 ## JAX
 
-[JAX](https://github.com/google/jax) is a front-end for writing and
-executing Machine Learning models, including support for Google
-Cloud TPUs.
+[JAX](https://github.com/google/jax) is Python framework supporting
+high-performance machine learning research by bridging automatic differentiation
+and ML compilers like [XLA](https://github.com/openxla/xla) and IREE.
+
+See the
+[JAX Integration guide](../guides/ml-frameworks/jax.md) for details on how to
+use JAX programs with IREE.
 
 ## MLIR
 
-[Multi Level Intermediate Representation](https://mlir.llvm.org/) is
+[Multi-Level Intermediate Representation (MLIR)](https://mlir.llvm.org/) is
 the compiler framework that IREE is built around. Beyond the tooling
 this includes a set of common dialects and transformations that IREE
 utilizes for its code generation system.
 
 For general discussion on MLIR see the project's
-[discourse](https://discourse.llvm.org/c/mlir/31) group.
+[discourse](https://discourse.llvm.org/c/mlir/31) forum.
 
-## LinAlg
+## Linalg
 
 [Linalg](https://mlir.llvm.org/docs/Dialects/Linalg/) is an MLIR dialect
 that defines how Linear Algebra operations can be described in a
@@ -29,31 +47,72 @@ IREE's code generation defines tensor operations using the Linalg
 dialect, then uses it to generate the loop structures for the CPU and
 GPU backends.
 
+## OpenXLA
+
+[OpenXLA](https://github.com/openxla/community) is a community-driven, open
+source ML compiler ecosystem.
+
+IREE is one project under the
+[OpenXLA GitHub Organization](https://github.com/openxla), and it interfaces
+with many of the other projects, such as [StableHLO](#stablehlo).
+
+## PyTorch
+
+[PyTorch](https://pytorch.org/) is an optimized tensor library for deep
+learning.
+
+PyTorch uses the [Torch-MLIR](https://github.com/llvm/torch-mlir) project to
+interface with projects like IREE. See the
+[PyTorch Integration guide](../guides/ml-frameworks/pytorch.md) for details on
+how to use PyTorch programs with IREE.
+
 ## SPIR-V
 
 [SPIR-V](https://www.khronos.org/spir/) is a shader and kernel intermediate
 language for expressing parallel computation typically used for GPUs. It serves
 as a hardware agnostic assembly format for distributing complex,
-computationally intensive programs. It is the preferred method for
-shipping platform agnostic binaries to run on GPUs.
+computationally intensive programs.
+
+IREE uses the
+[SPIR-V MLIR Dialect](https://mlir.llvm.org/docs/Dialects/SPIR-V/) in it's code
+generation pipeline for Vulkan and other compute APIs.
+
+## StableHLO
+
+[StableHLO](https://github.com/openxla/stablehlo) is a set of versioned
+high-level operations (HLOs) for ML models with backward and forward
+compatibility guarantees. StableHLO aims to improve interoperability between
+frameworks (such as TensorFlow, JAX, and PyTorch) and ML compilers.
+
+StableHLO has both a
+[specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md)
+and an MLIR dialect.
+
+IREE uses the StableHLO MLIR Dialect as one of it's input formats.
 
 ## TOSA
 
-The [TOSA](https://developer.mlplatform.org/w/tosa/) specification defines a
-set of common tensor operations to most machine learning frameworks.
-This simplifies model compilation as separate front-end frameworks can target
-TOSA's intermediate representation without compromising on the ability to
-achieve efficient execution across multiple device types.
+[Tensor Operator Set Architecture (TOSA)](https://www.mlplatform.org/tosa)
+provides a set of tensor operations commonly employed by Deep Neural Networks.
+TOSA defines accuracy and compatibility constraints so frameworks that use it
+can trust that applications will produce similar results on a variety of
+hardware targets.
 
-IREE uses the TOSA MLIR dialect as a prioritized ingestion format, transforming
-multiple ML-platform ingestion formats into a TOSA compatible set of operations.
+TOSA has both a [specification](https://www.mlplatform.org/tosa/tosa_spec.html)
+and an [MLIR dialect](https://mlir.llvm.org/docs/Dialects/TOSA/).
 
-Changes to the TOSA specification require submitting a proposal on TOSA's
-[platform development page](https://developer.mlplatform.org/w/tosa/#:~:text=Specification%20Contributions)
+IREE uses the TOSA MLIR dialect as one of it's input formats.
 
 ## TFLite
 
-[TensorFlow lite](https://www.tensorflow.org/lite) is a model format and
-execution system for performing on device inference. IREE supports TFLite
-FlatBuffers translation into [TOSA](#tosa) operations and compilation
-into the LinAlg dialect.
+[TensorFlow Lite (TFLite)](https://www.tensorflow.org/lite) is a library
+for deploying models on mobile and other edge devices.
+
+IREE supports running TFLite programs that have been imported into MLIR using
+the TOSA dialect. See the
+[TFLite Integration guide](../guides/ml-frameworks/tflite.md) for details on how
+to use TFLite programs with IREE.
+
+IREE also provides runtime bindings for the
+[TFLite C API](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/c),
+see the [TensorFlow Lite bindings](./bindings/tensorflow-lite.md) page.

--- a/docs/website/docs/reference/glossary.md
+++ b/docs/website/docs/reference/glossary.md
@@ -74,7 +74,7 @@ as a hardware agnostic assembly format for distributing complex,
 computationally intensive programs.
 
 IREE uses the
-[SPIR-V MLIR Dialect](https://mlir.llvm.org/docs/Dialects/SPIR-V/) in it's code
+[SPIR-V MLIR Dialect](https://mlir.llvm.org/docs/Dialects/SPIR-V/) in its code
 generation pipeline for Vulkan and other compute APIs.
 
 ## StableHLO
@@ -88,7 +88,7 @@ StableHLO has both a
 [specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md)
 and an MLIR dialect.
 
-IREE uses the StableHLO MLIR Dialect as one of it's input formats.
+IREE uses the StableHLO MLIR Dialect as one of its input formats.
 
 ## TOSA
 
@@ -101,7 +101,7 @@ hardware targets.
 TOSA has both a [specification](https://www.mlplatform.org/tosa/tosa_spec.html)
 and an [MLIR dialect](https://mlir.llvm.org/docs/Dialects/TOSA/).
 
-IREE uses the TOSA MLIR dialect as one of it's input formats.
+IREE uses the TOSA MLIR dialect as one of its input formats.
 
 ## TFLite
 

--- a/docs/website/docs/reference/glossary.md
+++ b/docs/website/docs/reference/glossary.md
@@ -41,11 +41,12 @@ For general discussion on MLIR see the project's
 ## Linalg
 
 [Linalg](https://mlir.llvm.org/docs/Dialects/Linalg/) is an MLIR dialect
-that defines how Linear Algebra operations can be described in a
-generalized fashion, including a set of commonly used operations.
-IREE's code generation defines tensor operations using the Linalg
-dialect, then uses it to generate the loop structures for the CPU and
-GPU backends.
+that defines Linear Algebra operations in a generalized fashion by modeling
+iteration spaces together with compute payloads. Linalg includes a set of
+commonly used operations as well as generic interfaces.
+
+IREE uses the Linalg dialect during its code generation pipeline to define
+tensor operations then generate loop structures for its various backend targets.
 
 ## OpenXLA
 


### PR DESCRIPTION
I also rewrote most entries, updated URLs, and added more cross references to other pages on the website.

|  |  |
|--------|--------|
| Current page | https://openxla.github.io/iree/reference/glossary/ |
| Preview page | https://scotttodd.github.io/iree/reference/glossary/ | 