### PR TITLE
Use macOS 13 for x86_64 macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
   build_test_all_macos_x86_64:
     needs: setup
     if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
-    runs-on: macos-12-xl
+    runs-on: macos-13-xl
     env:
       BUILD_DIR: build-macos
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    if: true
+    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
     runs-on: macos-13-xl
     env:
       BUILD_DIR: build-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: true
     runs-on: macos-13-xl
     env:
       BUILD_DIR: build-macos


### PR DESCRIPTION
We'd need macOS 13 Ventura, which supports
Metal 3 by default.