### PR TITLE
Relax the Matmul transform strategy to allow using fmas for smaller cases.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -779,7 +779,10 @@ transform_dialect::PipelineSharedMemoryCopiesOp::applyToOne(
                       : PipeliningSchedulingStrategy::loadGlobalStage0;
   FailureOr<scf::ForOp> pipelinedFor = iree_compiler::pipelineSharedMemoryCopy(
       rewriter, forOp, schedule, false, depth);
-  if (failed(pipelinedFor)) return emitDefaultSilenceableFailure(forOp);
+  if (failed(pipelinedFor)) {
+    results.push_back(forOp);
+    return DiagnosedSilenceableFailure::success();
+  }
   results.push_back(pipelinedFor.value());
   return DiagnosedSilenceableFailure::success();
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -424,8 +424,8 @@ def PipelineSharedMemoryCopiesOp : Op<
 
     #### Return modes
     This transform consumes the scf.for handle and produces a result handle
-    which points to the new scf.for loop generated. It will fail if the loop
-    cannot be pipelined or if there are no shared memory copies.
+    which points to a) the new scf.for loop generated (success case) or b) the
+    existing scf.for loop (failure case).
   }];
 
   let arguments = (
@@ -497,8 +497,8 @@ def CreateAsyncGroupsOp :
     of consecutive copies and emit wait operation right after.
     The input operation is a `func.func`.
 
-    `use_mma_sync` specifies whether or not `bypassL1` attributes should be
-    added to the async copies.
+    `use_mma_sync` specifies whether `bypassL1` attributes should be added to the
+    async copies.
 
     #### Return modes
     This op returns a handle to the transformed function, even if nothing
@@ -506,7 +506,7 @@ def CreateAsyncGroupsOp :
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-                   BoolAttr:$use_mma_sync);
+                   UnitAttr:$use_mma_sync);
   let results = (outs);
 
   let assemblyFormat = [{ 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
@@ -25,7 +25,7 @@ builtin.module {
   transform.sequence failures(propagate) {
   ^bb1(%variant_op: !transform.any_op):
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.create_async_groups %top_level_func {use_mma_sync = true} : (!transform.any_op) -> ()
+    transform.iree.create_async_groups %top_level_func {use_mma_sync} : (!transform.any_op) -> ()
   }
 }
 
@@ -57,7 +57,7 @@ builtin.module {
   transform.sequence failures(propagate) {
   ^bb1(%variant_op: !transform.any_op):
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!transform.any_op) -> ()
+    transform.iree.create_async_groups %top_level_func : (!transform.any_op) -> ()
   }
 }
 
@@ -86,7 +86,7 @@ builtin.module {
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     %vector_transfer = transform.structured.match ops{["memref.alloc"]} in %top_level_func : (!transform.any_op) -> !transform.any_op
     // expected-error@below {{transform applied to the wrong op kind}}
-    transform.iree.create_async_groups %vector_transfer {use_mma_sync = false} : (!transform.any_op) -> ()
+    transform.iree.create_async_groups %vector_transfer : (!transform.any_op) -> ()
   }
 }
 
@@ -116,7 +116,7 @@ builtin.module {
   transform.sequence failures(propagate) {
   ^bb1(%variant_op: !transform.any_op):
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!transform.any_op) -> ()
+    transform.iree.create_async_groups %top_level_func : (!transform.any_op) -> ()
   }
 }
 
@@ -152,6 +152,6 @@ builtin.module {
   transform.sequence failures(propagate) {
   ^bb1(%variant_op: !transform.any_op):
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!transform.any_op) -> ()
+    transform.iree.create_async_groups %top_level_func : (!transform.any_op) -> ()
   }
 }

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -86,6 +86,8 @@ struct AbstractGemmLikeStrategy {
   //===--------------------------------------------------------------------===//
   bool useAsyncCopies;
   bool useMmaSync;
+  bool useWmma;
+  bool useFma;
   int64_t pipelineDepth;
   virtual MappingInfo computeMapping() const = 0;
 

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -86,6 +86,14 @@ static llvm::cl::opt<bool> clUseMmaSync(
     "td-matmul-strategy-use-mma-sync",
     llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
     llvm::cl::init(true));
+static llvm::cl::opt<bool> clUseWmma(
+    "td-matmul-strategy-use-wmma",
+    llvm::cl::desc("use wmma for the transform dialect matmul strategy"),
+    llvm::cl::init(false));
+static llvm::cl::opt<bool> clUseFma(
+    "td-matmul-strategy-use-fma",
+    llvm::cl::desc("use fma for the transform dialect matmul strategy"),
+    llvm::cl::init(false));
 static llvm::cl::opt<int64_t> clPipelineDepth(
     "td-matmul-strategy-pipeline-depth",
     llvm::cl::desc("pipeline depth for the transform dialect matmul strategy"),
@@ -99,6 +107,8 @@ void MatmulStrategy::initDefaultValues() {
   reductionTileSize = clReductionTileSize;
   useAsyncCopies = clUseAsyncCopies;
   useMmaSync = clUseMmaSync;
+  useWmma = clUseWmma;
+  useFma = clUseFma;
   pipelineDepth = clPipelineDepth;
 
   // TODO: Capture input/output element types properly for configuring the
@@ -112,6 +122,8 @@ void MatmulStrategy::initDefaultValues() {
       reductionTileSize != clReductionTileSize.getDefault().getValue() ||
       useAsyncCopies != clUseAsyncCopies.getDefault().getValue() ||
       useMmaSync != clUseMmaSync.getDefault().getValue() ||
+      useWmma != clUseWmma.getDefault().getValue() ||
+      useFma != clUseFma.getDefault().getValue() ||
       pipelineDepth != clPipelineDepth.getDefault().getValue()) {
     cliOptionsSpecified = true;
   }
@@ -151,6 +163,8 @@ void MatmulStrategy::print(llvm::raw_ostream &os) const {
   }
   os << "}\n";
   os << "- use async copies: " << useAsyncCopies << '\n';
+  os << "- use fma: " << useFma << '\n';
+  os << "- use wmma: " << useWmma << '\n';
   os << "- use mma sync: " << useMmaSync << '\n';
   os << "- pipeline depth: " << pipelineDepth << '\n';
 

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
@@ -54,6 +54,11 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectAlignedMatmul(
     llvm::cl::desc(
         "activate the matmul tensorcore strategy for tile aligned shapes"),
     llvm::cl::init(false));
+llvm::cl::opt<bool> clGPUEnableTransformDialectSmallMatmul(
+    "iree-codegen-llvmgpu-enable-transform-dialect-small-matmul",
+    llvm::cl::desc("activate the matmul tensorcore strategy for small shapes "
+                   "(< 16) in at least a dimension"),
+    llvm::cl::init(false));
 llvm::cl::opt<bool> clGPUEnableTransformDialectPadStrategy(
     "iree-codegen-llvmgpu-enable-transform-dialect-pad-strategy",
     llvm::cl::desc("activate the pad strategy"), llvm::cl::init(false));
@@ -265,16 +270,30 @@ static void failSafeOverrides(MatmulStrategy &strategy,
                               const GPUModel &gpuModel) {
   // Failsafe for blockTileM to avoid tiling by > size (i.e. no tiling).
   int64_t blockTileM = selectLargestFailsafeValueIfNeeded(
-      strategy.blockTileM(), strategy.m(), {16, 32, 64, 128}, {1, 16, 32, 64});
+      strategy.blockTileM(), strategy.m(), {2, 4, 8, 16, 32, 64, 128},
+      {1, 2, 4, 8, 16, 32, 64});
   // Failsafe for blockTileN to avoid tiling by > size (i.e. no tiling).
   int64_t blockTileN = selectLargestFailsafeValueIfNeeded(
-      strategy.blockTileN(), strategy.n(), {16, 32, 64, 128}, {1, 16, 32, 64});
+      strategy.blockTileN(), strategy.n(), {2, 4, 8, 16, 32, 64, 128},
+      {1, 2, 4, 8, 16, 32, 64});
   // Failsafe for reductionSize to avoid tiling by > size (i.e. no tiling).
   int64_t reductionTileSize = selectLargestFailsafeValueIfNeeded(
-      strategy.reductionTileSize, strategy.k(), {8, 16, 24, 32, 40, 48, 56, 64},
-      {1, 8, 16, 24, 32, 40, 48, 56});
+      strategy.reductionTileSize, strategy.k(),
+      {2, 4, 8, 16, 24, 32, 40, 48, 56, 64},
+      {1, 2, 4, 8, 16, 24, 32, 40, 48, 56});
+
+  // If some dimension is small, use fmas.
+  // TODO: more parallelism by locally splitting the K-loop and reducing in the
+  // fma case.
+  if (blockTileM < 16 || blockTileN < 16 || reductionTileSize < 16) {
+    strategy.useMmaSync = false;
+    strategy.useWmma = false;
+    strategy.useFma = true;
+  }
+
   strategy.blockTileSizes = {blockTileM, blockTileN};
   strategy.reductionTileSize = reductionTileSize;
+
   // Avoid too deep pipelines. This should also look at shared memory usage in
   // the future.
   if (strategy.pipelineDepth * strategy.reductionTileSize > strategy.k()) {
@@ -354,6 +373,20 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
     return failure();
   }
 
+  // Currently the unaligned transform strategy does not properly handle
+  // degenerate dimensions that should have been rank-reduced (e.g. `1`).
+  // Also, it is unprofitable to force small matmuls through a high latency
+  // tensorcore path, we are better off with a simple simt strategy.
+  // TODO: profitability details can be ironed out in the future when we have a
+  // heuristic to better select strategy parameters.
+  bool smallCases = (matmulSize[0] > 0 && matmulSize[0] < 16) ||
+                    (matmulSize[1] > 0 && matmulSize[1] < 16) ||
+                    (matmulSize[2] > 0 && matmulSize[2] < 16);
+  if (smallCases && !clGPUEnableTransformDialectSmallMatmul) {
+    LDBG("--Matmul strategy small size check failed\n");
+    return failure();
+  }
+
   // Currently the fully aligned case still lags behind the current default
   // pipeline and thus is guarded by a flag. This is the case when at least one
   // of the following holds
@@ -363,22 +396,9 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
   bool guardedAlignedCases = matmulSize[0] % 64 == 0 ||
                              matmulSize[1] % 64 == 0 || matmulSize[2] % 16 == 0;
 
-  if (guardedAlignedCases && !clGPUEnableTransformDialectAlignedMatmul) {
+  if (!smallCases && guardedAlignedCases &&
+      !clGPUEnableTransformDialectAlignedMatmul) {
     LDBG("--Matmul strategy alignment check failed\n");
-    return failure();
-  }
-
-  // Currently the unaligned transform strategy does not properly handle
-  // degenerate dimensions that should have been rank-reduced (e.g. `1`).
-  // Also, it is unprofitable to force small matmuls through a high latency
-  // tensorcore path, we are better off with a simple simt strategy.
-  // TODO: profitability details can be ironed out in the future when we have a
-  // heuristic to better select strategy parameters.
-  bool unsupportedSmallCases = (matmulSize[0] > 0 && matmulSize[0] < 16) ||
-                               (matmulSize[1] > 0 && matmulSize[1] < 16) ||
-                               (matmulSize[2] > 0 && matmulSize[2] < 16);
-  if (unsupportedSmallCases) {
-    LDBG("--Matmul strategy small size check failed\n");
     return failure();
   }
 


### PR DESCRIPTION
This PR generalizes the matmul strategy to degrade to non-tensorcore operations.
This is particularly useful for matmuls with some small dimension(s) that can
benefit from more aggressive schedule of copies that don't match tensorcore operations.
    
This was tested to high fraction of bandwidth peak for such cases of small dimension(s).