### PR TITLE
Make iree-lld tool optional in python bindings

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/core.py
+++ b/compiler/bindings/python/iree/compiler/tools/core.py
@@ -185,8 +185,9 @@ def build_compile_command_line(input_file: str, tfs: TempFileSaver,
     cl.append(f"-o={options.output_file}")
 
   # Tool paths.
-  lld_path = find_tool("iree-lld")
-  cl.append(f"--iree-llvmcpu-embedded-linker-path={lld_path}")
+  if "llvm-cpu" in options.target_backends:
+    lld_path = find_tool("iree-lld")
+    cl.append(f"--iree-llvmcpu-embedded-linker-path={lld_path}")
 
   # MLIR flags.
   if options.output_mlir_debuginfo:


### PR DESCRIPTION
In `openxla-nvgpu` we are building IREE with only CUDA backend, and it doesn't require `iree-lld` tool