### PR TITLE
Check timestamp instead of canceling benchmark trigger

### DIFF
--- a/.github/workflows/benchmark_trigger.yml
+++ b/.github/workflows/benchmark_trigger.yml
@@ -57,9 +57,11 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     concurrency:
-      # This cancels queued and in-progress trigger runs for the same PR.
+      # Only allows a single trigger runs for a PR at the same time.
+      # Timestamp-based check below makes sure we don't trigger benchmark twice.
+      # We don't use `cancel-in-progress` because cancelled jobs are always
+      # considered as failures and show red on Github CI.
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     steps:
       - name: "Checking out repository"
         # This checkouts from the base branch instead of the pull request. See
@@ -75,6 +77,19 @@ jobs:
             > "${RUN_JSON}"
           echo "workflow-url=$(jq '.url' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
           echo "run-status=$(jq --raw-output '.status' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
+          echo "created-at=$(jq --raw-output '.created_at' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
+          echo "updated-at=$(jq --raw-output '.updated_at' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
+          echo "run-started-at=$(jq --raw-output '.run_started_at' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
+      - name: "Checking if the workflow has been restarted"
+        id: should-run
+        env:
+          CREATED_AT: ${{ steps.find-workflow.outputs.created-at }}
+          UPDATED_AT: ${{ steps.find-workflow.outputs.updated-at }}
+          RUN_STARTED_AT: ${{ steps.find-workflow.outputs.run-started-at }}
+        run: |
+          echo "${CREATED_AT}"
+          echo "${UPDATED_AT}"
+          echo "${RUN_STARTED_AT}"
       - name: "Cancelling the previous workflow run"
         # If the workflow isn't completed, we need to cancel it first; otherwise
         # the API can't rerun it.

--- a/.github/workflows/benchmark_trigger.yml
+++ b/.github/workflows/benchmark_trigger.yml
@@ -35,21 +35,23 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     outputs:
-      should-rerun: ${{ steps.precondition.outputs.should-rerun }}
+      label-found: ${{ steps.precondition.outputs.label-found }}
+      triggered-at: ${{ steps.precondition.outputs.triggered-at }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: "Checking labels"
         id: precondition
         run: |
-          echo "should-rerun=$(jq --raw-output \
+          echo "label-found=$(jq \
             --arg label_prefix ${BENCHMARK_LABEL_PREFIX} \
             '.label.name | startswith($label_prefix)' \
             ${GITHUB_EVENT_PATH})" >> "${GITHUB_OUTPUT}"
+          echo "triggered-at=$(date +%s)" >> "${GITHUB_OUTPUT}"
 
   trigger:
     needs: check
-    if: needs.check.outputs.should-rerun == 'true'
+    if: fromJSON(needs.check.outputs.label-found)
     runs-on: ubuntu-20.04
     # Required for cancel and rerun APIs.
     permissions:
@@ -81,21 +83,28 @@ jobs:
           echo "updated-at=$(jq --raw-output '.updated_at' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
           echo "run-started-at=$(jq --raw-output '.run_started_at' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
       - name: "Checking if the workflow has been restarted"
-        id: should-run
+        id: check
+        if: fromJSON(steps.find-workflow.outputs.workflow-url) != null
         env:
           CREATED_AT: ${{ steps.find-workflow.outputs.created-at }}
           UPDATED_AT: ${{ steps.find-workflow.outputs.updated-at }}
           RUN_STARTED_AT: ${{ steps.find-workflow.outputs.run-started-at }}
+          TRIGGERED_AT: ${{ needs.check.outputs.triggered-at }}
         run: |
           echo "${CREATED_AT}"
           echo "${UPDATED_AT}"
-          echo "${RUN_STARTED_AT}"
-          cat "${GITHUB_EVENT_PATH}"
+          RUN_STARTED_AT_EPOCH="$(date --date="${RUN_STARTED_AT}" +%s)"
+          if (( "${RUN_STARTED_AT_EPOCH}" < "${TRIGGERED_AT}" )); then
+            SHOULD_RERUN="true"
+          else
+            SHOULD_RERUN="false"
+          fi
+          echo "should-rerun=${SHOULD_RERUN}" >> "${GITHUB_OUTPUT}"
       - name: "Cancelling the previous workflow run"
         # If the workflow isn't completed, we need to cancel it first; otherwise
         # the API can't rerun it.
         if: |
-          fromJSON(steps.find-workflow.outputs.workflow-url) != null &&
+          fromJSON(steps.check.outputs.should-rerun) &&
           steps.find-workflow.outputs.run-status != 'completed'
         env:
           IREE_WORKFLOW_RUN_URL: ${{ fromJSON(steps.find-workflow.outputs.workflow-url) }}
@@ -109,14 +118,14 @@ jobs:
         # commit. Even if that happens, users will see their CI run fails and
         # can rerun it manually from the UI.
         id: get-sha
-        if: fromJSON(steps.find-workflow.outputs.workflow-url) != null
+        if: fromJSON(steps.check.outputs.should-rerun)
         run: |
           echo "latest-sha=$(gh api /repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER} \
             | jq --raw-output '.head.sha')" \
             >> "${GITHUB_OUTPUT}"
       - name: "Rerequesting the workflow"
         if: |
-          fromJSON(steps.find-workflow.outputs.workflow-url) != null &&
+          fromJSON(steps.check.outputs.should-rerun) &&
           steps.get-sha.outputs.latest-sha == env.HEAD_SHA
         env:
           WORKFLOW_RUN_URL: ${{ fromJSON(steps.find-workflow.outputs.workflow-url) }}

--- a/.github/workflows/benchmark_trigger.yml
+++ b/.github/workflows/benchmark_trigger.yml
@@ -90,6 +90,7 @@ jobs:
           echo "${CREATED_AT}"
           echo "${UPDATED_AT}"
           echo "${RUN_STARTED_AT}"
+          cat "${GITHUB_EVENT_PATH}"
       - name: "Cancelling the previous workflow run"
         # If the workflow isn't completed, we need to cancel it first; otherwise
         # the API can't rerun it.

--- a/.github/workflows/benchmark_trigger.yml
+++ b/.github/workflows/benchmark_trigger.yml
@@ -96,7 +96,7 @@ jobs:
           # the workflow has been rerun and picked up the new labels. Skip rerun
           # in this case.
           RUN_STARTED_AT_EPOCH="$(date --date="${RUN_STARTED_AT}" +%s)"
-          if (( "${RUN_STARTED_AT_EPOCH}" < "${TRIGGERED_AT}" )); then
+          if (( RUN_STARTED_AT_EPOCH < TRIGGERED_AT )); then
             SHOULD_RERUN="true"
           else
             SHOULD_RERUN="false"

--- a/.github/workflows/benchmark_trigger.yml
+++ b/.github/workflows/benchmark_trigger.yml
@@ -32,10 +32,10 @@ jobs:
   # constraint on it; otherwise the irrelevant labeling events will cancel the
   # events that meet the preconditions. Even with cancel-in-progress = false,
   # the queued events will still be cancelled.
-  check:
+  precondition:
     runs-on: ubuntu-20.04
     outputs:
-      label-found: ${{ steps.precondition.outputs.label-found }}
+      found-label: ${{ steps.precondition.outputs.found-label }}
       triggered-at: ${{ steps.precondition.outputs.triggered-at }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,15 +43,17 @@ jobs:
       - name: "Checking labels"
         id: precondition
         run: |
-          echo "label-found=$(jq \
+          echo "found-label=$(jq \
             --arg label_prefix ${BENCHMARK_LABEL_PREFIX} \
             '.label.name | startswith($label_prefix)' \
             ${GITHUB_EVENT_PATH})" >> "${GITHUB_OUTPUT}"
+          # pull_request_target event doesn't have the workflow start time. Get
+          # the approximate start time at the beginning.
           echo "triggered-at=$(date +%s)" >> "${GITHUB_OUTPUT}"
 
   trigger:
-    needs: check
-    if: fromJSON(needs.check.outputs.label-found)
+    needs: precondition
+    if: fromJSON(needs.precondition.outputs.found-label)
     runs-on: ubuntu-20.04
     # Required for cancel and rerun APIs.
     permissions:
@@ -59,16 +61,18 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     concurrency:
-      # Only allows a single trigger runs for a PR at the same time.
-      # Timestamp-based check below makes sure we don't trigger benchmark twice.
-      # We don't use `cancel-in-progress` because cancelled jobs are always
-      # considered as failures and show red on Github CI.
+      # Only allows a single trigger to run for a PR concurrently.
+      # Timestamp-based check below makes sure we don't rerun benchmark twice
+      # when multiple label events happen the same time. We don't use
+      # `cancel-in-progress` to avoid that because cancelled jobs are
+      # considered as failures and show red on Github UI.
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
     steps:
       - name: "Checking out repository"
         # This checkouts from the base branch instead of the pull request. See
         # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+
       - name: "Finding the previous workflow run"
         id: find-workflow
         env:
@@ -79,20 +83,18 @@ jobs:
             > "${RUN_JSON}"
           echo "workflow-url=$(jq '.url' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
           echo "run-status=$(jq --raw-output '.status' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
-          echo "created-at=$(jq --raw-output '.created_at' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
-          echo "updated-at=$(jq --raw-output '.updated_at' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
           echo "run-started-at=$(jq --raw-output '.run_started_at' ${RUN_JSON})" >> "${GITHUB_OUTPUT}"
-      - name: "Checking if the workflow has been restarted"
+
+      - name: "Checking if the workflow has been rerun"
         id: check
         if: fromJSON(steps.find-workflow.outputs.workflow-url) != null
         env:
-          CREATED_AT: ${{ steps.find-workflow.outputs.created-at }}
-          UPDATED_AT: ${{ steps.find-workflow.outputs.updated-at }}
           RUN_STARTED_AT: ${{ steps.find-workflow.outputs.run-started-at }}
-          TRIGGERED_AT: ${{ needs.check.outputs.triggered-at }}
+          TRIGGERED_AT: ${{ needs.precondition.outputs.triggered-at }}
         run: |
-          echo "${CREATED_AT}"
-          echo "${UPDATED_AT}"
+          # If the latest workflow run started after the trigger event, it means
+          # the workflow has been rerun and picked up the new labels. Skip rerun
+          # in this case.
           RUN_STARTED_AT_EPOCH="$(date --date="${RUN_STARTED_AT}" +%s)"
           if (( "${RUN_STARTED_AT_EPOCH}" < "${TRIGGERED_AT}" )); then
             SHOULD_RERUN="true"
@@ -100,6 +102,13 @@ jobs:
             SHOULD_RERUN="false"
           fi
           echo "should-rerun=${SHOULD_RERUN}" >> "${GITHUB_OUTPUT}"
+
+          cat <<EOF
+          Workflow run started at $(date --utc --date="${RUN_STARTED_AT}")
+          Trigger event started at $(date --utc --date="@${TRIGGERED_AT}")
+          Should rerun: "${SHOULD_RERUN}"
+          EOF
+
       - name: "Cancelling the previous workflow run"
         # If the workflow isn't completed, we need to cancel it first; otherwise
         # the API can't rerun it.
@@ -109,6 +118,7 @@ jobs:
         env:
           IREE_WORKFLOW_RUN_URL: ${{ fromJSON(steps.find-workflow.outputs.workflow-url) }}
         run: build_tools/github_actions/cancel_workflow_and_wait.sh
+
       - name: "Getting the latest commit SHA"
         # A push might have happened to trigger a new workflow run. Check the
         # PR's latest commit SHA and only rerun if there is no new push.
@@ -123,6 +133,7 @@ jobs:
           echo "latest-sha=$(gh api /repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER} \
             | jq --raw-output '.head.sha')" \
             >> "${GITHUB_OUTPUT}"
+
       - name: "Rerequesting the workflow"
         if: |
           fromJSON(steps.check.outputs.should-rerun) &&


### PR DESCRIPTION
Instead of cancelling concurrent `trigger` jobs when multiple labeling events trigger them, let them run one by one and skip if the workflow has been rerun based on timestamp. By not cancelling the jobs, this should avoid red failures on Github UI.

### Explanation
When multiple labeling events happen at the same time (e.g. When adding multiple labels in a single action, Github will send a labeling event for each label), we will see:

1. CI (benchmark) workflow is running (or completed)
2. Add multiple labels
3. `benchmark_trigger 1` starts, `benchmark_trigger 2, benchmark_trigger 3, ...` are pending (due to concurrency control)
4. `benchmark_trigger 1` reruns the CI workflow (so CI picks up the new benchmark labels) and finishes
5. `benchmark_trigger 2` is unblocked

After step 5, we don't want `benchmark_trigger 2` to rerun the CI workflow again. Previously we used `cancel-in-progress` to cancel other `benchmark_trigger` at step 3, but that leads to Github UI race conditions and show red cancelled jobs.

In this change, we let all `benchmark_trigger` stay in the queue. And after step 5, `benchmark_trigger` will check the CI workflow status and skip the rerun if the CI workflow start time is later than its start time (the time `benchmark_trigger` is created, before joining the queue). Because that means the CI workflow has been rerun by someone else.

skip-ci: Manually tested on https://github.com/openxla/iree/pull/14148