### PR TITLE
Let test rules consistently have a size parameter, not a timeout.

### DIFF
--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -22,9 +22,9 @@ def iree_check_test(
         driver = None,
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features = None,
-        timeout = None,
         **kwargs):
     """Creates an iree-check-module test for the specified source file.
 
@@ -39,11 +39,13 @@ def iree_check_test(
           format and backend flags are passed automatically.
       runner_args: additional runner_args to pass to iree-check-module. The
           driver and input file are passed automatically.
+      size: Optional value identifying heavy tests. Allowed values are
+          like in Bazel but the focus is less in controlling test timeouts
+          and more on altogether skipping heavy tests in slow configs.
       tags: additional tags to apply to the generated test. A tag
           "driver=DRIVER" is added automatically.
       target_cpu_features: currently unimplemented (must be empty), will
           eventually allow specifying target CPU features.
-      timeout: timeout for the generated tests.
       **kwargs: any additional attributes to pass to the underlying native_test.
     """
 
@@ -72,7 +74,7 @@ def iree_check_test(
         data = [":%s" % bytecode_module_name],
         src = "//tools:iree-check-module",
         tags = tags + ["driver=%s" % driver],
-        timeout = timeout,
+        size = size,
         **kwargs
     )
 
@@ -83,9 +85,9 @@ def iree_check_single_backend_test_suite(
         driver = None,
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features = None,
-        timeout = None,
         **kwargs):
     """Creates a test suite of iree-check-module tests for a single backend/driver pair.
 
@@ -106,10 +108,12 @@ def iree_check_single_backend_test_suite(
           separate suite or iree_check_test.
       target_cpu_features: currently unimplemented (must be empty), will
           eventually allow specifying target CPU features.
+      size: Optional value identifying heavy tests. Allowed values are
+          like in Bazel but the focus is less in controlling test timeouts
+          and more on altogether skipping heavy tests in slow configs.
       tags: tags to apply to the generated tests. Note that as in standard test
           suites, manual is treated specially and will also apply to the test
           suite itself.
-      timeout: timeout for the generated tests.
       **kwargs: any additional attributes to pass to the underlying tests and
           test suite.
     """
@@ -132,7 +136,7 @@ def iree_check_single_backend_test_suite(
             compiler_flags = compiler_flags,
             runner_args = runner_args,
             tags = tags,
-            timeout = timeout,
+            size = size,
             **kwargs
         )
         tests.append(test_name)
@@ -158,6 +162,7 @@ def iree_check_test_suite(
         target_backends_and_drivers = ALL_TARGET_BACKENDS_AND_DRIVERS,
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features_variants = [],
         **kwargs):
@@ -176,6 +181,9 @@ def iree_check_test_suite(
           iree-check-module tests. The driver and input file are passed
           automatically. To use different runner_args per test, create a
           separate suite or iree_check_test.
+      size: Optional value identifying heavy tests. Allowed values are
+          like in Bazel but the focus is less in controlling test timeouts
+          and more on altogether skipping heavy tests in slow configs.
       tags: tags to apply to the generated tests. Note that as in standard test
           suites, manual is treated specially and will also apply to the test
           suite itself.
@@ -210,6 +218,7 @@ def iree_check_test_suite(
             compiler_flags = compiler_flags,
             runner_args = runner_args,
             tags = tags,
+            size = size,
             **kwargs
         )
         tests.append(suite_name)

--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -19,9 +19,9 @@ def iree_trace_runner_test(
         trace,
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features = None,
-        timeout = None,
         **kwargs):
     """Creates a test running a custom trace-runner on a trace file (yaml).
 
@@ -34,6 +34,9 @@ def iree_trace_runner_test(
             output format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The
             driver and input file flags are passed automatically.
+        size: Optional value identifying heavy tests. Allowed values are
+            like in Bazel but the focus is less in controlling test timeouts
+            and more on altogether skipping heavy tests in slow configs.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is
             added automatically.
         trace_runner: trace-runner program to run.
@@ -41,7 +44,6 @@ def iree_trace_runner_test(
         module_name: specifies the  path to use for the enerated IREE module
             (.vmfb). Mandatory, unlike in iree_check_test, because trace files
             (.yaml) reference a specific module file path.
-        timeout: timeout for the generated tests.
         target_cpu_features: target CPU features. Only for llvm-cpu backend.
         **kwargs: any additional attributes to pass to the underlying tests and
             test suite.
@@ -77,7 +79,7 @@ def iree_trace_runner_test(
         ],
         src = trace_runner,
         tags = tags + ["driver=%s" % driver],
-        timeout = timeout,
+        size = size,
         **kwargs
     )
 
@@ -90,9 +92,9 @@ def iree_single_backend_generated_trace_runner_test(
         generator_args = [],
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features = None,
-        timeout = None,
         **kwargs):
     """Generates an iree_trace_runner_test using a custom python generator script.
 
@@ -114,10 +116,12 @@ def iree_single_backend_generated_trace_runner_test(
             output format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The
             driver and input file flags are passed automatically.
+        size: Optional value identifying heavy tests. Allowed values are
+            like in Bazel but the focus is less in controlling test timeouts
+            and more on altogether skipping heavy tests in slow configs.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is
             added automatically.
         trace_runner: trace-runner program to run.
-        timeout: timeout for the generated tests.
         target_cpu_features: target CPU features. Only for llvm-cpu backend.
         **kwargs: any additional attributes to pass to the underlying tests and
             test suite.
@@ -156,7 +160,7 @@ def iree_single_backend_generated_trace_runner_test(
         compiler_flags = compiler_flags,
         runner_args = runner_args,
         tags = tags,
-        timeout = timeout,
+        size = size,
         target_cpu_features = target_cpu_features,
         **kwargs
     )
@@ -169,8 +173,8 @@ def iree_generated_trace_runner_test(
         generator_args = [],
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
-        timeout = None,
         target_cpu_features_variants = [],
         **kwargs):
     """Generates a suite of iree_trace_runner_test on multiple backends/drivers.
@@ -190,10 +194,12 @@ def iree_generated_trace_runner_test(
             output format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The
             driver and input file flags are passed automatically.
+        size: Optional value identifying heavy tests. Allowed values are
+            like in Bazel but the focus is less in controlling test timeouts
+            and more on altogether skipping heavy tests in slow configs.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is
             added automatically.
         trace_runner: trace-runner program to run.
-        timeout: timeout for the generated tests.
         target_cpu_features_variants: list of target cpu features variants.
             Currently unimplemented in Bazel due to difficulty of specializing
             to target architecture in Bazel. The following describes the
@@ -224,7 +230,7 @@ def iree_generated_trace_runner_test(
             compiler_flags = compiler_flags,
             runner_args = runner_args,
             tags = tags,
-            timeout = timeout,
+            size = size,
             **kwargs
         )
         tests.append(suite_entry_name)

--- a/build_tools/bazel/lit_test.bzl
+++ b/build_tools/bazel/lit_test.bzl
@@ -61,7 +61,7 @@ def lit_test(
         data = None,
         visibility = None,
         env = None,
-        timeout = None,
+        size = None,
         **kwargs):
     """Runs a single test file with LLVM's lit tool.
 
@@ -83,7 +83,9 @@ def lit_test(
       visibility: visibility of the generated test target.
       env: string_dict. Environment variables available during test execution.
         See the common Bazel test attribute.
-      timeout: bazel test timeout string, as per common bazel definitions.
+      size: Optional value identifying heavy tests. Allowed values are
+        like in Bazel but the focus is less in controlling test timeouts
+        and more on altogether skipping heavy tests in slow configs.
       **kwargs: additional keyword arguments to pass to all generated rules.
 
     See https://llvm.org/docs/CommandGuide/lit.html for details on lit
@@ -122,7 +124,7 @@ def lit_test(
         data = [test_file, cfg, tools_on_path_target_name] + data,
         visibility = visibility,
         env = env,
-        timeout = timeout,
+        size = size,
         **kwargs
     )
 
@@ -134,9 +136,8 @@ def lit_test_suite(
         args = None,
         data = None,
         visibility = None,
-        size = "small",
+        size = None,
         env = None,
-        timeout = None,
         **kwargs):
     """Creates one lit test per source file and a test suite that bundles them.
 
@@ -156,10 +157,11 @@ def lit_test_suite(
         targets in `cfg` and `tools`, as well as their data dependencies, are
         added automatically.
       visibility: visibility of the generated test targets and test suite.
-      size: string. size of the generated tests.
+      size: Optional value identifying heavy tests. Allowed values are
+        like in Bazel but the focus is less in controlling test timeouts
+        and more on altogether skipping heavy tests in slow configs.
       env: string_dict. Environment variables available during test execution.
         See the common Bazel test attribute.
-      timeout: timeout argument passed to the individual tests.
       **kwargs: additional keyword arguments to pass to all generated rules.
 
     See https://llvm.org/docs/CommandGuide/lit.html for details on lit
@@ -187,7 +189,7 @@ def lit_test_suite(
             data = data,
             visibility = visibility,
             env = env,
-            timeout = timeout,
+            size = size,
             **kwargs
         )
 

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -56,8 +56,8 @@ function(iree_check_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;TARGET_BACKEND;DRIVER;MODULE_FILE_NAME"
-    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES;TIMEOUT"
+    "NAME;SRC;TARGET_BACKEND;DRIVER;MODULE_FILE_NAME;SIZE"
+    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -126,8 +126,8 @@ function(iree_check_test)
       ${_RULE_RUNNER_ARGS}
     LABELS
       ${_RULE_LABELS}
-    TIMEOUT
-      ${_RULE_TIMEOUT}
+    SIZE
+      ${_RULE_SIZE}
   )
 endfunction()
 
@@ -166,8 +166,8 @@ function(iree_check_single_backend_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TARGET_BACKEND;DRIVER"
-    "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES;TIMEOUT"
+    "NAME;TARGET_BACKEND;DRIVER;SIZE"
+    "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -239,8 +239,8 @@ function(iree_check_single_backend_test_suite)
         ${_RULE_LABELS}
       TARGET_CPU_FEATURES
         ${_RULE_TARGET_CPU_FEATURES}
-      TIMEOUT
-        ${_RULE_TIMEOUT}
+      SIZE
+        ${_RULE_SIZE}
     )
   endforeach()
 endfunction()
@@ -336,8 +336,8 @@ function(iree_check_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME"
-    "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS;TIMEOUT"
+    "NAME;SIZE"
+    "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
 
@@ -399,8 +399,8 @@ function(iree_check_test_suite)
           ${_LABELS}
         TARGET_CPU_FEATURES
           ${_TARGET_CPU_FEATURES}
-        TIMEOUT
-          ${_RULE_TIMEOUT}
+        SIZE
+          ${_RULE_SIZE}
       )
     endforeach()
   endforeach()

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -34,8 +34,8 @@ function(iree_lit_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_FILE"
-    "DATA;TOOLS;LABELS;TIMEOUT"
+    "NAME;TEST_FILE;SIZE"
+    "DATA;TOOLS;LABELS"
     ${ARGN}
   )
 
@@ -80,7 +80,6 @@ function(iree_lit_test)
   set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT
     "LIT_OPTS=-v"
     "FILECHECK_OPTS=--enable-var-scope")
-  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
   iree_configure_test(${_NAME_PATH})
 
   # TODO(gcmn): Figure out how to indicate a dependency on _RULE_DATA being built
@@ -112,14 +111,10 @@ function(iree_lit_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME"
-    "SRCS;DATA;TOOLS;LABELS;TIMEOUT"
+    "NAME;SIZE"
+    "SRCS;DATA;TOOLS;LABELS"
     ${ARGN}
   )
-
-  if (NOT DEFINED _RULE_TIMEOUT)
-    set(_RULE_TIMEOUT 60)
-  endif()
 
   foreach(_TEST_FILE ${_RULE_SRCS})
     get_filename_component(_TEST_BASENAME ${_TEST_FILE} NAME)
@@ -134,8 +129,8 @@ function(iree_lit_test_suite)
         "${_RULE_TOOLS}"
       LABELS
         "${_RULE_LABELS}"
-      TIMEOUT
-        ${_RULE_TIMEOUT}
+      SIZE
+        ${_RULE_SIZE}
     )
   endforeach()
 endfunction()

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -56,7 +56,7 @@ function(iree_native_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;DRIVER;WILL_FAIL"
+    "NAME;SRC;DRIVER;WILL_FAIL;SIZE"
     "ARGS;LABELS;DATA;TIMEOUT"
     ${ARGN}
   )

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -42,7 +42,7 @@ function(iree_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;TRACE;TARGET_BACKEND;DRIVER;TRACE_RUNNER;MODULE_FILE_NAME"
+    "NAME;SRC;TRACE;TARGET_BACKEND;DRIVER;TRACE_RUNNER;MODULE_FILE_NAME;SIZE"
     "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
@@ -102,6 +102,8 @@ function(iree_trace_runner_test)
       ${_RULE_RUNNER_ARGS}
     LABELS
       ${_RULE_LABELS}
+    SIZE
+      ${_RULE_SIZE}
   )
 endfunction()
 
@@ -153,7 +155,7 @@ function(iree_single_backend_generated_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;GENERATOR;TARGET_BACKEND;DRIVER;TRACE_RUNNER"
+    "NAME;GENERATOR;TARGET_BACKEND;DRIVER;TRACE_RUNNER;SIZE"
     "GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
@@ -247,6 +249,8 @@ function(iree_single_backend_generated_trace_runner_test)
       ${_RULE_LABELS}
     TARGET_CPU_FEATURES
       ${_RULE_TARGET_CPU_FEATURES}
+    SIZE
+      ${_RULE_SIZE}
   )
 
   # Note we are relying on the fact that the target created by
@@ -304,7 +308,7 @@ function(iree_generated_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;GENERATOR;TRACE_RUNNER"
+    "NAME;GENERATOR;TRACE_RUNNER;SIZE"
     "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
@@ -371,6 +375,8 @@ function(iree_generated_trace_runner_test)
           ${_LABELS}
         TARGET_CPU_FEATURES
           ${_TARGET_CPU_FEATURES}
+        SIZE
+          ${_RULE_SIZE}
       )
     endforeach()
   endforeach()

--- a/runtime/src/iree/hal/drivers/vulkan/util/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/util/CMakeLists.txt
@@ -76,8 +76,6 @@ iree_cc_test(
     ::ref_ptr
     iree::testing::gtest
     iree::testing::gtest_main
-  TIMEOUT
-    60
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/models/BUILD.bazel
+++ b/tests/e2e/models/BUILD.bazel
@@ -98,7 +98,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_vulkan-spirv_vulkan",
-    timeout = "long",
+    size = "large",
     srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "vulkan",
@@ -107,7 +107,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_cuda_cuda",
-    timeout = "long",
+    size = "large",
     srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "cuda",

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -80,8 +80,8 @@ iree_check_single_backend_test_suite(
     "vulkan"
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
-  TIMEOUT
-    900
+  SIZE
+    "large"
 )
 
 iree_check_single_backend_test_suite(
@@ -102,8 +102,8 @@ iree_check_single_backend_test_suite(
     "notsan"
     "noubsan"
     "requires-gpu-nvidia"
-  TIMEOUT
-    900
+  SIZE
+    "large"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
Bazel test rules have both `size` and `timeout` parameters, largely redundant as each `size` implies a corresponding timeout.

In some of our CMake test rules, we had a `TIMEOUT` parameter, mirroring the Bazel timeout. We made nearly no use of it at all. As a result, the mechanics were largely untested and not always consistently implemented. I believe that reflects the fact that we care about test latencies, so if a test takes a long time in some slow configuration, we typically want to disable it there, rather than allow it to run for a long time thanks to an increased timeout. I think this tells us that of the two Bazel parameters, `size` and `timeout`, it is `size` that is more relevant to us. We want to annotate tests as being "large", so we may decide to skip them in certain configurations.

The immediate motivation is #14152: I want to consistently start using `size` parameters to annotate large tests to be skipped in slow configurations, rather than the current collection of ad-hoc labels.