### PR TITLE
Share a `iree_filter_test` helper to conditionally enable tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,7 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(iree_macros)
 include(iree_copts)
+include(iree_filter_test)
 include(iree_cc_binary)
 include(iree_cc_library)
 include(iree_cc_test)

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -6,17 +6,6 @@
 
 include(CMakeParseArguments)
 
-function(iree_is_bytecode_module_test_excluded_by_labels _DST_IS_EXCLUDED_VAR _SRC_LABELS)
-  string(TOLOWER "${CMAKE_BUILD_TYPE}" _LOWERCASE_BUILD_TYPE)
-  if(((IREE_ARCH MARCHES "^riscv_") AND ("noriscv" IN_LIST _SRC_LABELS)) OR
-     (IREE_ENABLE_ASAN AND ("noasan" IN_LIST _SRC_LABELS)) OR
-     (IREE_ENABLE_TSAN AND ("notsan" IN_LIST _SRC_LABELS)) OR
-     (CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _RULE_LABELS) OR
-     ((_LOWERCASE_BUILD_TYPE STREQUAL "debug") AND ( "optonly" IN_LIST _RULE_LABELS)))
-    set("${_DST_IS_EXCLUDED_VAR}" TRUE PARENT_SCOPE)
-  endif()
-endfunction()
-
 # iree_check_test()
 #
 # Creates a test using iree-check-module for the specified source file.
@@ -63,8 +52,17 @@ function(iree_check_test)
     ${ARGN}
   )
 
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    TIMEOUT
+      ${_RULE_TIMEOUT}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 
@@ -175,8 +173,17 @@ function(iree_check_single_backend_test_suite)
     ${ARGN}
   )
 
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    TIMEOUT
+      ${_RULE_TIMEOUT}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 
@@ -346,11 +353,6 @@ function(iree_check_test_suite)
     "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
-
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
-    return()
-  endif()
 
   if(_RULE_TARGET_CPU_FEATURES_VARIANTS)
     set(_TARGET_CPU_FEATURES_VARIANTS "${_RULE_TARGET_CPU_FEATURES_VARIANTS}")

--- a/build_tools/cmake/iree_filter_test.cmake
+++ b/build_tools/cmake/iree_filter_test.cmake
@@ -15,31 +15,29 @@ function(iree_filter_test)
     ${ARGN}
   )
 
-  # Default to excluding; then exclusion cases are implemented as early-returns;
-  # then at the end we will override that to TRUE.
-  set("${_FUNC_RESULT_VAR_ENABLED}" FALSE PARENT_SCOPE)
+  set(_ENABLED TRUE)
 
   # Exclude hostonly tests when cross-compiling.
   if(CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _FUNC_LABELS)
-    return()
+    set(_ENABLED FALSE)
   endif()
 
   # Sanitizer-based exclusions.
   # CUDA is considered incompatible with all sanitizers.
   if(IREE_ENABLE_ASAN)
     if (("noasan" IN_LIST _FUNC_LABELS) OR (_FUNC_DRIVER STREQUAL "cuda"))
-      return()
+      set(_ENABLED FALSE)
     endif()
   endif()
   if(IREE_ENABLE_TSAN)
     if (("notsan" IN_LIST _FUNC_LABELS) OR (_FUNC_DRIVER STREQUAL "cuda"))
-      return()
+      set(_ENABLED FALSE)
     endif()
   endif()
 
   # Architecture-based exclusions.
   if ((IREE_ARCH MATCHES "^riscv_") AND ("noriscv" IN_LIST _FUNC_LABELS))
-    return()
+    set(_ENABLED FALSE)
   endif()
 
   # Timeout-based exclusions.
@@ -63,12 +61,12 @@ function(iree_filter_test)
     set(_EXCLUDE_TIMEOUT_LONG ON)
   endif()
   if(_EXCLUDE_TIMEOUT_MODERATE AND _FUNC_TIMEOUT STREQUAL "moderate")
-    return()
+    set(_ENABLED FALSE)
   endif()
   if(_EXCLUDE_TIMEOUT_LONG AND _FUNC_TIMEOUT STREQUAL "long")
-    return()
+    set(_ENABLED FALSE)
   endif()
 
-  # Test is not excluded, communicate that to the caller.
-  set("${_FUNC_RESULT_VAR_ENABLED}" TRUE PARENT_SCOPE)
+  # Communicate the result to the caller.
+  set("${_FUNC_RESULT_VAR_ENABLED}" "${_ENABLED}" PARENT_SCOPE)
 endfunction()

--- a/build_tools/cmake/iree_filter_test.cmake
+++ b/build_tools/cmake/iree_filter_test.cmake
@@ -1,0 +1,74 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include(CMakeParseArguments)
+
+function(iree_filter_test)
+  cmake_parse_arguments(
+    _FUNC
+    ""
+    "RESULT_VAR_ENABLED;TIMEOUT;DRIVER"
+    "LABELS"
+    ${ARGN}
+  )
+
+  # Default to excluding; then exclusion cases are implemented as early-returns;
+  # then at the end we will override that to TRUE.
+  set("${_FUNC_RESULT_VAR_ENABLED}" FALSE PARENT_SCOPE)
+
+  # Exclude hostonly tests when cross-compiling.
+  if(CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _FUNC_LABELS)
+    return()
+  endif()
+
+  # Sanitizer-based exclusions.
+  # CUDA is considered incompatible with all sanitizers.
+  if(IREE_ENABLE_ASAN)
+    if (("noasan" IN_LIST _FUNC_LABELS) OR (_FUNC_DRIVER STREQUAL "cuda"))
+      return()
+    endif()
+  endif()
+  if(IREE_ENABLE_TSAN)
+    if (("notsan" IN_LIST _FUNC_LABELS) OR (_FUNC_DRIVER STREQUAL "cuda"))
+      return()
+    endif()
+  endif()
+
+  # Architecture-based exclusions.
+  if ((IREE_ARCH MATCHES "^riscv_") AND ("noriscv" IN_LIST _FUNC_LABELS))
+    return()
+  endif()
+
+  # Timeout-based exclusions.
+  #
+  # Tests timeout values are "short", "moderate", "long". The IREE-wide default
+  # is "short".
+  # On very slow configurations, we only run "short" tests (the IREE-wide
+  # default), excluding "moderate" and "long". On other somewhat-slow configs,
+  # we run "short" and "moderate" tests, excluding "long".
+  set(_EXCLUDE_TIMEOUT_MODERATE OFF)
+  set(_EXCLUDE_TIMEOUT_LONG OFF)
+  if (IREE_ARCH MATCHES "^riscv_")
+    # Very slow, because it's emulators on CI. We should have a dedicated
+    # setting for emulators instead of treating all RISC-V as very slow.
+    set(_EXCLUDE_TIMEOUT_MODERATE ON)
+  endif()
+  if (_EXCLUDE_TIMEOUT_MODERATE OR
+      CMAKE_CROSSCOMPILING OR
+      IREE_ENABLE_ASAN OR
+      IREE_ENABLE_TSAN)
+    set(_EXCLUDE_TIMEOUT_LONG ON)
+  endif()
+  if(_EXCLUDE_TIMEOUT_MODERATE AND _FUNC_TIMEOUT STREQUAL "moderate")
+    return()
+  endif()
+  if(_EXCLUDE_TIMEOUT_LONG AND _FUNC_TIMEOUT STREQUAL "long")
+    return()
+  endif()
+
+  # Test is not excluded, communicate that to the caller.
+  set("${_FUNC_RESULT_VAR_ENABLED}" TRUE PARENT_SCOPE)
+endfunction()

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -39,7 +39,17 @@ function(iree_lit_test)
     ${ARGN}
   )
 
-  if(CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _RULE_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    TIMEOUT
+      ${_RULE_TIMEOUT}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -49,8 +49,17 @@ function(iree_trace_runner_test)
     ${ARGN}
   )
 
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    TIMEOUT
+      ${_RULE_TIMEOUT}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 
@@ -164,8 +173,17 @@ function(iree_single_backend_generated_trace_runner_test)
     ${ARGN}
   )
 
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    TIMEOUT
+      ${_RULE_TIMEOUT}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 
@@ -318,11 +336,6 @@ function(iree_generated_trace_runner_test)
     "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
-
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
-    return()
-  endif()
 
   if(_RULE_TARGET_CPU_FEATURES_VARIANTS)
     set(_TARGET_CPU_FEATURES_VARIANTS "${_RULE_TARGET_CPU_FEATURES_VARIANTS}")


### PR DESCRIPTION
This should be NFC, except that the filtering is now applied also to `iree_lit_test`, which was so far omitted from the filtering.

You know that resnet50 outlier test that is always taking an additional 40 seconds to complete with ASAN after everything else is finished? That was it :-)

Some of the logic in `iree_filter_test` is not currently exercised but will be in subsequent PRs as we carry out the fixes for #14152.

The check for the `CMAKE_BUILD_TYPE` to implement `optonly` filtering is dropped: there was apparently no usage of `optonly` in the tree.