### PR TITLE
Drop sanitizer-disabling tags in CUDA tests.

### DIFF
--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -92,11 +92,6 @@ iree_check_single_backend_test_suite(
         ],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -79,10 +79,6 @@ iree_check_single_backend_test_suite(
   DRIVER
     "cuda"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -33,11 +33,6 @@ iree_check_single_backend_test_suite(
     ),
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
@@ -51,11 +46,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-flow-topk-split-reduction=2"],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
@@ -69,11 +59,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-flow-topk-split-reduction=3,2"],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -25,10 +25,6 @@ iree_check_single_backend_test_suite(
   DRIVER
     "cuda"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -44,10 +40,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-flow-topk-split-reduction=2"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -63,10 +55,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-flow-topk-split-reduction=3,2"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -227,11 +227,6 @@ X86_64_AVX512_VNNI = X86_64_AVX512_BASE + [
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -256,11 +251,6 @@ X86_64_AVX512_VNNI = X86_64_AVX512_BASE + [
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -282,11 +272,6 @@ iree_generated_trace_runner_test(
         "--shapes=gpu_large",
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -308,11 +293,6 @@ iree_generated_trace_runner_test(
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -336,11 +316,6 @@ iree_generated_trace_runner_test(
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -364,11 +339,6 @@ iree_generated_trace_runner_test(
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -390,11 +360,6 @@ iree_generated_trace_runner_test(
         "--shapes=large",
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
         # "--shapes=large" can cause timeouts on riscv emulator.
         "noriscv",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -378,10 +378,6 @@ iree_generated_trace_runner_test(
   DRIVERS
     "cuda"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -403,10 +399,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -427,10 +419,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -452,10 +440,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -477,10 +461,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -502,10 +482,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -528,10 +504,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-flow-split-matmul-reduction=4"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
     "noriscv"
 )

--- a/tests/e2e/models/BUILD.bazel
+++ b/tests/e2e/models/BUILD.bazel
@@ -112,11 +112,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -97,10 +97,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
   TIMEOUT
     "long"

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -111,11 +111,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
@@ -132,11 +127,6 @@ iree_check_single_backend_test_suite(
     ],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -154,10 +154,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -174,10 +170,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-flow-fuse-multi-use"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/e2e/stablehlo_ops/BUILD.bazel
+++ b/tests/e2e/stablehlo_ops/BUILD.bazel
@@ -413,11 +413,6 @@ iree_check_single_backend_test_suite(
     driver = "cuda",
     runner_args = ["--cuda_use_streams=false"],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
@@ -497,11 +492,6 @@ iree_check_single_backend_test_suite(
     driver = "cuda",
     runner_args = ["--cuda_use_streams=true"],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -371,10 +371,6 @@ iree_check_single_backend_test_suite(
   RUNNER_ARGS
     "--cuda_use_streams=false"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -451,10 +447,6 @@ iree_check_single_backend_test_suite(
   RUNNER_ARGS
     "--cuda_use_streams=true"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/e2e/tensor_ops/BUILD.bazel
+++ b/tests/e2e/tensor_ops/BUILD.bazel
@@ -111,10 +111,6 @@ iree_check_single_backend_test_suite(
     ),
     driver = "cuda",
     tags = [
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/tensor_ops/CMakeLists.txt
+++ b/tests/e2e/tensor_ops/CMakeLists.txt
@@ -84,10 +84,6 @@ iree_check_single_backend_test_suite(
   DRIVER
     "cuda"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/transform_dialect/cuda/BUILD.bazel
+++ b/tests/transform_dialect/cuda/BUILD.bazel
@@ -63,13 +63,8 @@ iree_lit_test_suite(
         "vecadd2d_codegen_spec_partial_tile.mlir",
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
-        "requires-gpu-nvidia",
         "driver=cuda",
+        "requires-gpu-nvidia",
     ],
     tools = [
         "//tools:iree-compile",
@@ -99,13 +94,8 @@ iree_lit_test_suite(
         "mma_using_layout_analysis_codegen_spec.mlir",
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
-        "requires-gpu-sm80",
         "driver=cuda",
+        "requires-gpu-sm80",
     ],
     tools = [
         "//tools:iree-compile",

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -48,12 +48,8 @@ iree_lit_test_suite(
     vecadd2d_codegen_spec.mlir
     vecadd2d_codegen_spec_partial_tile.mlir
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-nvidia"
     "driver=cuda"
+    "requires-gpu-nvidia"
 )
 
 iree_lit_test_suite(
@@ -77,12 +73,8 @@ iree_lit_test_suite(
     mma_reduction_layout_analysis_dispatch_spec.mlir
     mma_using_layout_analysis_codegen_spec.mlir
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-sm80"
     "driver=cuda"
+    "requires-gpu-sm80"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
As of #14157, `iree_filter_test` already skips CUDA tests in sanitizer configs, so these flags are not needed anymore. This is another step towards fixing #14152.