### PR TITLE
Rationalize classification and enabling of long-running tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,7 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(iree_macros)
 include(iree_copts)
+include(iree_filter_test)
 include(iree_cc_binary)
 include(iree_cc_library)
 include(iree_cc_test)

--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -22,9 +22,9 @@ def iree_check_test(
         driver = None,
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features = None,
-        timeout = None,
         **kwargs):
     """Creates an iree-check-module test for the specified source file.
 
@@ -39,11 +39,13 @@ def iree_check_test(
           format and backend flags are passed automatically.
       runner_args: additional runner_args to pass to iree-check-module. The
           driver and input file are passed automatically.
+      size: Optional value identifying heavy tests. Allowed values are
+          like in Bazel but the focus is less in controlling test timeouts
+          and more on altogether skipping heavy tests in slow configs.
       tags: additional tags to apply to the generated test. A tag
           "driver=DRIVER" is added automatically.
       target_cpu_features: currently unimplemented (must be empty), will
           eventually allow specifying target CPU features.
-      timeout: timeout for the generated tests.
       **kwargs: any additional attributes to pass to the underlying native_test.
     """
 
@@ -72,7 +74,7 @@ def iree_check_test(
         data = [":%s" % bytecode_module_name],
         src = "//tools:iree-check-module",
         tags = tags + ["driver=%s" % driver],
-        timeout = timeout,
+        size = size,
         **kwargs
     )
 
@@ -83,9 +85,9 @@ def iree_check_single_backend_test_suite(
         driver = None,
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features = None,
-        timeout = None,
         **kwargs):
     """Creates a test suite of iree-check-module tests for a single backend/driver pair.
 
@@ -106,10 +108,12 @@ def iree_check_single_backend_test_suite(
           separate suite or iree_check_test.
       target_cpu_features: currently unimplemented (must be empty), will
           eventually allow specifying target CPU features.
+      size: Optional value identifying heavy tests. Allowed values are
+          like in Bazel but the focus is less in controlling test timeouts
+          and more on altogether skipping heavy tests in slow configs.
       tags: tags to apply to the generated tests. Note that as in standard test
           suites, manual is treated specially and will also apply to the test
           suite itself.
-      timeout: timeout for the generated tests.
       **kwargs: any additional attributes to pass to the underlying tests and
           test suite.
     """
@@ -132,7 +136,7 @@ def iree_check_single_backend_test_suite(
             compiler_flags = compiler_flags,
             runner_args = runner_args,
             tags = tags,
-            timeout = timeout,
+            size = size,
             **kwargs
         )
         tests.append(test_name)
@@ -158,6 +162,7 @@ def iree_check_test_suite(
         target_backends_and_drivers = ALL_TARGET_BACKENDS_AND_DRIVERS,
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features_variants = [],
         **kwargs):
@@ -176,6 +181,9 @@ def iree_check_test_suite(
           iree-check-module tests. The driver and input file are passed
           automatically. To use different runner_args per test, create a
           separate suite or iree_check_test.
+      size: Optional value identifying heavy tests. Allowed values are
+          like in Bazel but the focus is less in controlling test timeouts
+          and more on altogether skipping heavy tests in slow configs.
       tags: tags to apply to the generated tests. Note that as in standard test
           suites, manual is treated specially and will also apply to the test
           suite itself.
@@ -210,6 +218,7 @@ def iree_check_test_suite(
             compiler_flags = compiler_flags,
             runner_args = runner_args,
             tags = tags,
+            size = size,
             **kwargs
         )
         tests.append(suite_name)

--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -19,9 +19,9 @@ def iree_trace_runner_test(
         trace,
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features = None,
-        timeout = None,
         **kwargs):
     """Creates a test running a custom trace-runner on a trace file (yaml).
 
@@ -34,6 +34,9 @@ def iree_trace_runner_test(
             output format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The
             driver and input file flags are passed automatically.
+        size: Optional value identifying heavy tests. Allowed values are
+            like in Bazel but the focus is less in controlling test timeouts
+            and more on altogether skipping heavy tests in slow configs.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is
             added automatically.
         trace_runner: trace-runner program to run.
@@ -41,7 +44,6 @@ def iree_trace_runner_test(
         module_name: specifies the  path to use for the enerated IREE module
             (.vmfb). Mandatory, unlike in iree_check_test, because trace files
             (.yaml) reference a specific module file path.
-        timeout: timeout for the generated tests.
         target_cpu_features: target CPU features. Only for llvm-cpu backend.
         **kwargs: any additional attributes to pass to the underlying tests and
             test suite.
@@ -77,7 +79,7 @@ def iree_trace_runner_test(
         ],
         src = trace_runner,
         tags = tags + ["driver=%s" % driver],
-        timeout = timeout,
+        size = size,
         **kwargs
     )
 
@@ -90,9 +92,9 @@ def iree_single_backend_generated_trace_runner_test(
         generator_args = [],
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
         target_cpu_features = None,
-        timeout = None,
         **kwargs):
     """Generates an iree_trace_runner_test using a custom python generator script.
 
@@ -114,10 +116,12 @@ def iree_single_backend_generated_trace_runner_test(
             output format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The
             driver and input file flags are passed automatically.
+        size: Optional value identifying heavy tests. Allowed values are
+            like in Bazel but the focus is less in controlling test timeouts
+            and more on altogether skipping heavy tests in slow configs.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is
             added automatically.
         trace_runner: trace-runner program to run.
-        timeout: timeout for the generated tests.
         target_cpu_features: target CPU features. Only for llvm-cpu backend.
         **kwargs: any additional attributes to pass to the underlying tests and
             test suite.
@@ -156,7 +160,7 @@ def iree_single_backend_generated_trace_runner_test(
         compiler_flags = compiler_flags,
         runner_args = runner_args,
         tags = tags,
-        timeout = timeout,
+        size = size,
         target_cpu_features = target_cpu_features,
         **kwargs
     )
@@ -169,8 +173,8 @@ def iree_generated_trace_runner_test(
         generator_args = [],
         compiler_flags = [],
         runner_args = [],
+        size = None,
         tags = [],
-        timeout = None,
         target_cpu_features_variants = [],
         **kwargs):
     """Generates a suite of iree_trace_runner_test on multiple backends/drivers.
@@ -190,10 +194,12 @@ def iree_generated_trace_runner_test(
             output format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The
             driver and input file flags are passed automatically.
+        size: Optional value identifying heavy tests. Allowed values are
+            like in Bazel but the focus is less in controlling test timeouts
+            and more on altogether skipping heavy tests in slow configs.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is
             added automatically.
         trace_runner: trace-runner program to run.
-        timeout: timeout for the generated tests.
         target_cpu_features_variants: list of target cpu features variants.
             Currently unimplemented in Bazel due to difficulty of specializing
             to target architecture in Bazel. The following describes the
@@ -224,7 +230,7 @@ def iree_generated_trace_runner_test(
             compiler_flags = compiler_flags,
             runner_args = runner_args,
             tags = tags,
-            timeout = timeout,
+            size = size,
             **kwargs
         )
         tests.append(suite_entry_name)

--- a/build_tools/bazel/lit_test.bzl
+++ b/build_tools/bazel/lit_test.bzl
@@ -61,7 +61,7 @@ def lit_test(
         data = None,
         visibility = None,
         env = None,
-        timeout = None,
+        size = None,
         **kwargs):
     """Runs a single test file with LLVM's lit tool.
 
@@ -83,7 +83,9 @@ def lit_test(
       visibility: visibility of the generated test target.
       env: string_dict. Environment variables available during test execution.
         See the common Bazel test attribute.
-      timeout: bazel test timeout string, as per common bazel definitions.
+      size: Optional value identifying heavy tests. Allowed values are
+        like in Bazel but the focus is less in controlling test timeouts
+        and more on altogether skipping heavy tests in slow configs.
       **kwargs: additional keyword arguments to pass to all generated rules.
 
     See https://llvm.org/docs/CommandGuide/lit.html for details on lit
@@ -122,7 +124,7 @@ def lit_test(
         data = [test_file, cfg, tools_on_path_target_name] + data,
         visibility = visibility,
         env = env,
-        timeout = timeout,
+        size = size,
         **kwargs
     )
 
@@ -134,9 +136,8 @@ def lit_test_suite(
         args = None,
         data = None,
         visibility = None,
-        size = "small",
+        size = None,
         env = None,
-        timeout = None,
         **kwargs):
     """Creates one lit test per source file and a test suite that bundles them.
 
@@ -156,10 +157,11 @@ def lit_test_suite(
         targets in `cfg` and `tools`, as well as their data dependencies, are
         added automatically.
       visibility: visibility of the generated test targets and test suite.
-      size: string. size of the generated tests.
+      size: Optional value identifying heavy tests. Allowed values are
+        like in Bazel but the focus is less in controlling test timeouts
+        and more on altogether skipping heavy tests in slow configs.
       env: string_dict. Environment variables available during test execution.
         See the common Bazel test attribute.
-      timeout: timeout argument passed to the individual tests.
       **kwargs: additional keyword arguments to pass to all generated rules.
 
     See https://llvm.org/docs/CommandGuide/lit.html for details on lit
@@ -187,7 +189,7 @@ def lit_test_suite(
             data = data,
             visibility = visibility,
             env = env,
-            timeout = timeout,
+            size = size,
             **kwargs
         )
 

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -6,17 +6,6 @@
 
 include(CMakeParseArguments)
 
-function(iree_is_bytecode_module_test_excluded_by_labels _DST_IS_EXCLUDED_VAR _SRC_LABELS)
-  string(TOLOWER "${CMAKE_BUILD_TYPE}" _LOWERCASE_BUILD_TYPE)
-  if(((IREE_ARCH MARCHES "^riscv_") AND ("noriscv" IN_LIST _SRC_LABELS)) OR
-     (IREE_ENABLE_ASAN AND ("noasan" IN_LIST _SRC_LABELS)) OR
-     (IREE_ENABLE_TSAN AND ("notsan" IN_LIST _SRC_LABELS)) OR
-     (CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _RULE_LABELS) OR
-     ((_LOWERCASE_BUILD_TYPE STREQUAL "debug") AND ( "optonly" IN_LIST _RULE_LABELS)))
-    set("${_DST_IS_EXCLUDED_VAR}" TRUE PARENT_SCOPE)
-  endif()
-endfunction()
-
 # iree_check_test()
 #
 # Creates a test using iree-check-module for the specified source file.
@@ -61,8 +50,17 @@ function(iree_check_test)
     ${ARGN}
   )
 
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    SIZE
+      ${_RULE_SIZE}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 
@@ -171,8 +169,17 @@ function(iree_check_single_backend_test_suite)
     ${ARGN}
   )
 
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    SIZE
+      ${_RULE_SIZE}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 
@@ -340,11 +347,6 @@ function(iree_check_test_suite)
     "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
-
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
-    return()
-  endif()
 
   if(_RULE_TARGET_CPU_FEATURES_VARIANTS)
     set(_TARGET_CPU_FEATURES_VARIANTS "${_RULE_TARGET_CPU_FEATURES_VARIANTS}")

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -56,8 +56,8 @@ function(iree_check_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;TARGET_BACKEND;DRIVER;MODULE_FILE_NAME"
-    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES;TIMEOUT"
+    "NAME;SRC;TARGET_BACKEND;DRIVER;MODULE_FILE_NAME;SIZE"
+    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -126,8 +126,8 @@ function(iree_check_test)
       ${_RULE_RUNNER_ARGS}
     LABELS
       ${_RULE_LABELS}
-    TIMEOUT
-      ${_RULE_TIMEOUT}
+    SIZE
+      ${_RULE_SIZE}
   )
 endfunction()
 
@@ -166,8 +166,8 @@ function(iree_check_single_backend_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TARGET_BACKEND;DRIVER"
-    "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES;TIMEOUT"
+    "NAME;TARGET_BACKEND;DRIVER;SIZE"
+    "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -239,8 +239,8 @@ function(iree_check_single_backend_test_suite)
         ${_RULE_LABELS}
       TARGET_CPU_FEATURES
         ${_RULE_TARGET_CPU_FEATURES}
-      TIMEOUT
-        ${_RULE_TIMEOUT}
+      SIZE
+        ${_RULE_SIZE}
     )
   endforeach()
 endfunction()
@@ -336,8 +336,8 @@ function(iree_check_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME"
-    "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS;TIMEOUT"
+    "NAME;SIZE"
+    "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
 
@@ -399,8 +399,8 @@ function(iree_check_test_suite)
           ${_LABELS}
         TARGET_CPU_FEATURES
           ${_TARGET_CPU_FEATURES}
-        TIMEOUT
-          ${_RULE_TIMEOUT}
+        SIZE
+          ${_RULE_SIZE}
       )
     endforeach()
   endforeach()

--- a/build_tools/cmake/iree_filter_test.cmake
+++ b/build_tools/cmake/iree_filter_test.cmake
@@ -1,0 +1,65 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include(CMakeParseArguments)
+
+function(iree_filter_test)
+  cmake_parse_arguments(
+    _FUNC
+    ""
+    "RESULT_VAR_ENABLED;SIZE;DRIVER"
+    "LABELS"
+    ${ARGN}
+  )
+  # Default to excluding; then exclusion cases are implemented as early-returns;
+  # then at the end we will override that to TRUE.
+  set("${_FUNC_RESULT_VAR_ENABLED}" FALSE PARENT_SCOPE)
+  # Exclude hostonly tests when cross-compiling.
+  if(CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _FUNC_LABELS)
+    return()
+  endif()
+  # Sanitizer-based exclusions.
+  # CUDA is considered incompatible with all sanitizers.
+  if(IREE_ENABLE_ASAN)
+    if (("noasan" IN_LIST _FUNC_LABELS) OR (_FUNC_DRIVER STREQUAL "cuda"))
+      return()
+    endif()
+  endif()
+  if(IREE_ENABLE_TSAN)
+    if (("notsan" IN_LIST _FUNC_LABELS) OR (_FUNC_DRIVER STREQUAL "cuda"))
+      return()
+    endif()
+  endif()
+  # Architecture-based exclusions.
+  if ((IREE_ARCH MATCHES "^riscv_") AND ("noriscv" IN_LIST _FUNC_LABELS))
+    return()
+  endif()
+  # Size-based exclusions.
+  set(_EXCLUDE_SIZE_LARGE OFF)
+  set(_EXCLUDE_SIZE_ENORMOUS OFF)
+  # On very slow configurations, exclude "large" tests.
+  # Note: RISC-V is treated very slow because at the moment it's emulators on
+  # CI. We should have a dedicated emulator setting instead.
+  if (IREE_ARCH MATCHES "^riscv_")
+    set(_EXCLUDE_SIZE_LARGE ON)
+  endif()
+  # On somewhat slow configurations, such as sanitizers, exclude only
+  # "enormous" tests.
+  if (_EXCLUDE_SIZE_LARGE OR
+      CMAKE_CROSSCOMPILING OR
+      IREE_ENABLE_ASAN OR
+      IREE_ENABLE_TSAN)
+    set(_EXCLUDE_SIZE_ENORMOUS ON)
+  endif()
+  if(_EXCLUDE_SIZE_LARGE AND _FUNC_SIZE STREQUAL "large")
+    return()
+  endif()
+  if(_EXCLUDE_SIZE_ENORMOUS AND _FUNC_SIZE STREQUAL "enormous")
+    return()
+  endif()
+  # Test is not excluded, communicate that to the caller.
+  set("${_FUNC_RESULT_VAR_ENABLED}" TRUE PARENT_SCOPE)
+endfunction()

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -34,8 +34,8 @@ function(iree_lit_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_FILE"
-    "DATA;TOOLS;LABELS;TIMEOUT"
+    "NAME;TEST_FILE;SIZE"
+    "DATA;TOOLS;LABELS"
     ${ARGN}
   )
 
@@ -80,7 +80,6 @@ function(iree_lit_test)
   set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT
     "LIT_OPTS=-v"
     "FILECHECK_OPTS=--enable-var-scope")
-  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
   iree_configure_test(${_NAME_PATH})
 
   # TODO(gcmn): Figure out how to indicate a dependency on _RULE_DATA being built
@@ -112,14 +111,10 @@ function(iree_lit_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME"
-    "SRCS;DATA;TOOLS;LABELS;TIMEOUT"
+    "NAME;SIZE"
+    "SRCS;DATA;TOOLS;LABELS"
     ${ARGN}
   )
-
-  if (NOT DEFINED _RULE_TIMEOUT)
-    set(_RULE_TIMEOUT 60)
-  endif()
 
   foreach(_TEST_FILE ${_RULE_SRCS})
     get_filename_component(_TEST_BASENAME ${_TEST_FILE} NAME)
@@ -134,8 +129,8 @@ function(iree_lit_test_suite)
         "${_RULE_TOOLS}"
       LABELS
         "${_RULE_LABELS}"
-      TIMEOUT
-        ${_RULE_TIMEOUT}
+      SIZE
+        ${_RULE_SIZE}
     )
   endforeach()
 endfunction()

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -39,7 +39,17 @@ function(iree_lit_test)
     ${ARGN}
   )
 
-  if(CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _RULE_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    SIZE
+      ${_RULE_SIZE}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -56,7 +56,7 @@ function(iree_native_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;DRIVER;WILL_FAIL"
+    "NAME;SRC;DRIVER;WILL_FAIL;SIZE"
     "ARGS;LABELS;DATA;TIMEOUT"
     ${ARGN}
   )

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -42,7 +42,7 @@ function(iree_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;TRACE;TARGET_BACKEND;DRIVER;TRACE_RUNNER;MODULE_FILE_NAME"
+    "NAME;SRC;TRACE;TARGET_BACKEND;DRIVER;TRACE_RUNNER;MODULE_FILE_NAME;SIZE"
     "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
@@ -102,6 +102,8 @@ function(iree_trace_runner_test)
       ${_RULE_RUNNER_ARGS}
     LABELS
       ${_RULE_LABELS}
+    SIZE
+      ${_RULE_SIZE}
   )
 endfunction()
 
@@ -153,7 +155,7 @@ function(iree_single_backend_generated_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;GENERATOR;TARGET_BACKEND;DRIVER;TRACE_RUNNER"
+    "NAME;GENERATOR;TARGET_BACKEND;DRIVER;TRACE_RUNNER;SIZE"
     "GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
@@ -247,6 +249,8 @@ function(iree_single_backend_generated_trace_runner_test)
       ${_RULE_LABELS}
     TARGET_CPU_FEATURES
       ${_RULE_TARGET_CPU_FEATURES}
+    SIZE
+      ${_RULE_SIZE}
   )
 
   # Note we are relying on the fact that the target created by
@@ -304,7 +308,7 @@ function(iree_generated_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;GENERATOR;TRACE_RUNNER"
+    "NAME;GENERATOR;TRACE_RUNNER;SIZE"
     "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
@@ -371,6 +375,8 @@ function(iree_generated_trace_runner_test)
           ${_LABELS}
         TARGET_CPU_FEATURES
           ${_TARGET_CPU_FEATURES}
+        SIZE
+          ${_RULE_SIZE}
       )
     endforeach()
   endforeach()

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -47,8 +47,17 @@ function(iree_trace_runner_test)
     ${ARGN}
   )
 
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    SIZE
+      ${_RULE_SIZE}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 
@@ -160,8 +169,17 @@ function(iree_single_backend_generated_trace_runner_test)
     ${ARGN}
   )
 
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
+  iree_filter_test(
+    RESULT_VAR_ENABLED
+      _ENABLED
+    LABELS
+      ${_RULE_LABELS}
+    SIZE
+      ${_RULE_SIZE}
+    DRIVER
+      ${_RULE_DRIVER}
+  )
+  if(NOT _ENABLED)
     return()
   endif()
 
@@ -312,11 +330,6 @@ function(iree_generated_trace_runner_test)
     "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
-
-  iree_is_bytecode_module_test_excluded_by_labels(_EXCLUDED_BY_LABELS "${_RULE_LABELS}")
-  if(_EXCLUDED_BY_LABELS)
-    return()
-  endif()
 
   if(_RULE_TARGET_CPU_FEATURES_VARIANTS)
     set(_TARGET_CPU_FEATURES_VARIANTS "${_RULE_TARGET_CPU_FEATURES_VARIANTS}")

--- a/runtime/src/iree/hal/drivers/vulkan/util/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/util/CMakeLists.txt
@@ -76,8 +76,6 @@ iree_cc_test(
     ::ref_ptr
     iree::testing::gtest
     iree::testing::gtest_main
-  TIMEOUT
-    60
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -92,11 +92,6 @@ iree_check_single_backend_test_suite(
         ],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -79,10 +79,6 @@ iree_check_single_backend_test_suite(
   DRIVER
     "cuda"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -33,11 +33,6 @@ iree_check_single_backend_test_suite(
     ),
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
@@ -51,11 +46,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-flow-topk-split-reduction=2"],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
@@ -69,11 +59,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-flow-topk-split-reduction=3,2"],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -25,10 +25,6 @@ iree_check_single_backend_test_suite(
   DRIVER
     "cuda"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -44,10 +40,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-flow-topk-split-reduction=2"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -63,10 +55,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-flow-topk-split-reduction=3,2"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -227,11 +227,6 @@ X86_64_AVX512_VNNI = X86_64_AVX512_BASE + [
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -256,11 +251,6 @@ X86_64_AVX512_VNNI = X86_64_AVX512_BASE + [
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -282,11 +272,6 @@ iree_generated_trace_runner_test(
         "--shapes=gpu_large",
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -308,11 +293,6 @@ iree_generated_trace_runner_test(
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -336,11 +316,6 @@ iree_generated_trace_runner_test(
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -364,11 +339,6 @@ iree_generated_trace_runner_test(
         "--compilation_info=%s" % compilation_info,
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
@@ -390,11 +360,6 @@ iree_generated_trace_runner_test(
         "--shapes=large",
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
         # "--shapes=large" can cause timeouts on riscv emulator.
         "noriscv",

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -61,6 +61,8 @@ py_binary(
 
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_mmt4d_%s_large" % lhs_rhs_type,
+    # "--shapes=large" can cause timeouts on riscv emulator.
+    size = "large",
     compiler_flags = [
         "--iree-flow-enable-data-tiling",
     ],
@@ -70,9 +72,9 @@ py_binary(
         "--shapes=large",
     ],
     tags = [
-        # "--shapes=large" can cause timeouts on riscv emulator and sanitizers.
-        "noriscv",
-        "noasan",
+        # "--shapes=large" can cause timeouts on TSAN CI.
+        # Revisit when the CI build hosts get an upgraded toolchain,
+        # as that seems to be fine locally with a recent Clang.
         "notsan",
     ],
     target_backends_and_drivers = [
@@ -182,6 +184,8 @@ X86_64_AVX512_VNNI = X86_64_AVX512_BASE + [
 # Test mmt4d with --iree-llvmcpu-enable-microkernels.
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_mmt4d_%s_%s_ukernel" % (lhs_rhs_type, size),
+    # "--shapes=large" can cause timeouts on riscv emulator.
+    size = "large" if size == "large" else None,
     compiler_flags = [
         "--iree-llvmcpu-enable-microkernels",
         "--iree-flow-enable-data-tiling",
@@ -192,9 +196,9 @@ X86_64_AVX512_VNNI = X86_64_AVX512_BASE + [
         "--shapes=%s" % size,
     ],
     tags = [
-        # "--shapes=large" can cause timeouts on riscv emulator and sanitizers.
-        "noriscv",
-        "noasan",
+        # "--shapes=large" can cause timeouts on TSAN CI.
+        # Revisit when the CI build hosts get an upgraded toolchain,
+        # as that seems to be fine locally with a recent Clang.
         "notsan",
     ] if size == "large" else [],
     target_backends_and_drivers = [
@@ -351,6 +355,8 @@ iree_generated_trace_runner_test(
 
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_%s_large_split_k" % lhs_rhs_type,
+    # "--shapes=large" can cause timeouts on riscv emulator.
+    size = "large",
     compiler_flags = [
         "--iree-flow-split-matmul-reduction=4",
     ],
@@ -361,8 +367,6 @@ iree_generated_trace_runner_test(
     ],
     tags = [
         "requires-gpu-nvidia",
-        # "--shapes=large" can cause timeouts on riscv emulator.
-        "noriscv",
     ],
     target_backends_and_drivers = [
         ("cuda", "cuda"),

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -101,13 +101,13 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-flow-enable-data-tiling"
   LABELS
-    "noriscv"
-    "noasan"
     "notsan"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "arm_64:dotprod:+dotprod"
     "arm_64:i8mm:+i8mm"
+  SIZE
+    "large"
 )
 
 iree_generated_trace_runner_test(
@@ -127,11 +127,11 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-flow-enable-data-tiling"
   LABELS
-    "noriscv"
-    "noasan"
     "notsan"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
+  SIZE
+    "large"
 )
 
 iree_generated_trace_runner_test(
@@ -298,8 +298,6 @@ iree_generated_trace_runner_test(
     "--iree-llvmcpu-enable-microkernels"
     "--iree-flow-enable-data-tiling"
   LABELS
-    "noriscv"
-    "noasan"
     "notsan"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
@@ -308,6 +306,8 @@ iree_generated_trace_runner_test(
     "x86_64:avx512_vnni:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
     "arm_64:dotprod:+dotprod"
     "arm_64:i8mm:+i8mm"
+  SIZE
+    "large"
 )
 
 iree_generated_trace_runner_test(
@@ -353,13 +353,13 @@ iree_generated_trace_runner_test(
     "--iree-llvmcpu-enable-microkernels"
     "--iree-flow-enable-data-tiling"
   LABELS
-    "noriscv"
-    "noasan"
     "notsan"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "x86_64:avx2_fma:+avx,+avx2,+fma"
     "x86_64:avx512_base:+avx,+avx2,+fma,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+  SIZE
+    "large"
 )
 
 iree_generated_trace_runner_test(
@@ -505,7 +505,8 @@ iree_generated_trace_runner_test(
     "--iree-flow-split-matmul-reduction=4"
   LABELS
     "requires-gpu-nvidia"
-    "noriscv"
+  SIZE
+    "large"
 )
 
 iree_generated_trace_runner_test(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -378,10 +378,6 @@ iree_generated_trace_runner_test(
   DRIVERS
     "cuda"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -403,10 +399,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -427,10 +419,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -452,10 +440,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -477,10 +461,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -502,10 +482,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -528,10 +504,6 @@ iree_generated_trace_runner_test(
   COMPILER_FLAGS
     "--iree-flow-split-matmul-reduction=4"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
     "noriscv"
 )

--- a/tests/e2e/models/BUILD.bazel
+++ b/tests/e2e/models/BUILD.bazel
@@ -112,11 +112,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/models/BUILD.bazel
+++ b/tests/e2e/models/BUILD.bazel
@@ -98,7 +98,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_vulkan-spirv_vulkan",
-    timeout = "long",
+    size = "large",
     srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "vulkan",
@@ -107,7 +107,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_cuda_cuda",
-    timeout = "long",
+    size = "large",
     srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "cuda",

--- a/tests/e2e/models/BUILD.bazel
+++ b/tests/e2e/models/BUILD.bazel
@@ -21,7 +21,9 @@ CHECK_FRAMEWORK_TESTS = [
 ]
 
 iree_lit_test_suite(
-    name = "lit",
+    name = "lit_large",
+    # These tests are too large for some slow configurations (emulators...).
+    size = "large",
     srcs = enforce_glob(
         [
             "collatz.mlir",
@@ -34,16 +36,17 @@ iree_lit_test_suite(
         include =
             ["*.mlir"],
         exclude = CHECK_FRAMEWORK_TESTS + [
-            # Part of lit_large below.
+            # Part of lit_enormous below.
             "resnet50_fake_weights.mlir",
         ],
     ),
     cfg = "//tests:lit.cfg.py",
     tags = [
+        # These tests use `iree-run-mlir`, so they require the `hostonly` tag.
+        "hostonly",
+        # These tests explicitly use these drivers.
         "driver=local-task",
         "driver=vulkan",
-        "hostonly",
-        "optonly",  # swiftshader is too slow in dbg
     ],
     tools = [
         "//tools:iree-run-mlir",
@@ -52,19 +55,17 @@ iree_lit_test_suite(
     ],
 )
 
-# Larger tests requiring tags skipping them in slow configurations such as
-# sanitizers.
 iree_lit_test_suite(
-    name = "lit_large",
+    name = "lit_enormous",
+    size = "enormous",
     srcs = ["resnet50_fake_weights.mlir"],
     cfg = "//tests:lit.cfg.py",
     tags = [
+        # These tests use `iree-run-mlir`, so they require the `hostonly` tag.
+        "hostonly",
+        # These tests explicitly use these drivers.
         "driver=local-task",
         "driver=vulkan",
-        "hostonly",
-        "noasan",
-        "notsan",
-        "optonly",  # swiftshader is too slow in dbg
     ],
     tools = [
         "//tools:iree-run-mlir",
@@ -75,16 +76,10 @@ iree_lit_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_llvm-cpu_local-task",
+    size = "large",
     srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "local-task",
-    tags = [
-        # Large models, skip on slow targets.
-        "hostonly",
-        "noasan",
-        "notsan",
-        "optonly",  # swiftshader is too slow in dbg
-    ],
     target_backend = "llvm-cpu",
 )
 

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -97,10 +97,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
   SIZE
     "large"

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -80,8 +80,8 @@ iree_check_single_backend_test_suite(
     "vulkan"
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
-  TIMEOUT
-    900
+  SIZE
+    "large"
 )
 
 iree_check_single_backend_test_suite(
@@ -102,8 +102,8 @@ iree_check_single_backend_test_suite(
     "notsan"
     "noubsan"
     "requires-gpu-nvidia"
-  TIMEOUT
-    900
+  SIZE
+    "large"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -12,7 +12,7 @@ iree_add_all_subdirs()
 
 iree_lit_test_suite(
   NAME
-    lit
+    lit_large
   SRCS
     "collatz.mlir"
     "edge_detection.mlir"
@@ -25,15 +25,16 @@ iree_lit_test_suite(
     FileCheck
     iree-run-mlir
   LABELS
+    "hostonly"
     "driver=local-task"
     "driver=vulkan"
-    "hostonly"
-    "optonly"
+  SIZE
+    "large"
 )
 
 iree_lit_test_suite(
   NAME
-    lit_large
+    lit_enormous
   SRCS
     "resnet50_fake_weights.mlir"
   TOOLS
@@ -41,12 +42,11 @@ iree_lit_test_suite(
     FileCheck
     iree-run-mlir
   LABELS
+    "hostonly"
     "driver=local-task"
     "driver=vulkan"
-    "hostonly"
-    "noasan"
-    "notsan"
-    "optonly"
+  SIZE
+    "enormous"
 )
 
 iree_check_single_backend_test_suite(
@@ -61,11 +61,8 @@ iree_check_single_backend_test_suite(
     "local-task"
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
-  LABELS
-    "hostonly"
-    "noasan"
-    "notsan"
-    "optonly"
+  SIZE
+    "large"
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -111,11 +111,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
@@ -132,11 +127,6 @@ iree_check_single_backend_test_suite(
     ],
     driver = "cuda",
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -45,8 +45,10 @@ iree_lit_test_suite(
     ],
     cfg = "//tests:lit.cfg.py",
     tags = [
+        # Some of these tests explicitly use these drivers.
         "driver=local-task",
         "driver=vulkan",
+        # Some of these tests run iree-run-mlir, requiring `hostonly`.
         "hostonly",
     ],
     tools = [

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -154,10 +154,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -174,10 +170,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-flow-fuse-multi-use"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/e2e/stablehlo_ops/BUILD.bazel
+++ b/tests/e2e/stablehlo_ops/BUILD.bazel
@@ -413,11 +413,6 @@ iree_check_single_backend_test_suite(
     driver = "cuda",
     runner_args = ["--cuda_use_streams=false"],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
@@ -497,11 +492,6 @@ iree_check_single_backend_test_suite(
     driver = "cuda",
     runner_args = ["--cuda_use_streams=true"],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -371,10 +371,6 @@ iree_check_single_backend_test_suite(
   RUNNER_ARGS
     "--cuda_use_streams=false"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 
@@ -451,10 +447,6 @@ iree_check_single_backend_test_suite(
   RUNNER_ARGS
     "--cuda_use_streams=true"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/e2e/tensor_ops/BUILD.bazel
+++ b/tests/e2e/tensor_ops/BUILD.bazel
@@ -111,10 +111,6 @@ iree_check_single_backend_test_suite(
     ),
     driver = "cuda",
     tags = [
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",

--- a/tests/e2e/tensor_ops/CMakeLists.txt
+++ b/tests/e2e/tensor_ops/CMakeLists.txt
@@ -84,10 +84,6 @@ iree_check_single_backend_test_suite(
   DRIVER
     "cuda"
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
     "requires-gpu-nvidia"
 )
 

--- a/tests/transform_dialect/cpu/BUILD.bazel
+++ b/tests/transform_dialect/cpu/BUILD.bazel
@@ -15,6 +15,7 @@ package(
 
 iree_lit_test_suite(
     name = "lit",
+    size = "large",
     srcs = [
         "attention.mlir",
         "contraction-packing.mlir",
@@ -29,12 +30,6 @@ iree_lit_test_suite(
         "attention_codegen_spec.mlir",
         "matmul_codegen_custom_dispatch_formation_spec.mlir",
         "matmul_codegen_default_spec.mlir",
-    ],
-    tags = [
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
     ],
     tools = [
         "//tools:iree-benchmark-module",

--- a/tests/transform_dialect/cpu/CMakeLists.txt
+++ b/tests/transform_dialect/cpu/CMakeLists.txt
@@ -30,11 +30,8 @@ iree_lit_test_suite(
     attention_codegen_spec.mlir
     matmul_codegen_custom_dispatch_formation_spec.mlir
     matmul_codegen_default_spec.mlir
-  LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
+  SIZE
+    "large"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/transform_dialect/cuda/BUILD.bazel
+++ b/tests/transform_dialect/cuda/BUILD.bazel
@@ -63,13 +63,8 @@ iree_lit_test_suite(
         "vecadd2d_codegen_spec_partial_tile.mlir",
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
-        "requires-gpu-nvidia",
         "driver=cuda",
+        "requires-gpu-nvidia",
     ],
     tools = [
         "//tools:iree-compile",
@@ -99,13 +94,8 @@ iree_lit_test_suite(
         "mma_using_layout_analysis_codegen_spec.mlir",
     ],
     tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
-        "requires-gpu-sm80",
         "driver=cuda",
+        "requires-gpu-sm80",
     ],
     tools = [
         "//tools:iree-compile",

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -48,12 +48,8 @@ iree_lit_test_suite(
     vecadd2d_codegen_spec.mlir
     vecadd2d_codegen_spec_partial_tile.mlir
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-nvidia"
     "driver=cuda"
+    "requires-gpu-nvidia"
 )
 
 iree_lit_test_suite(
@@ -77,12 +73,8 @@ iree_lit_test_suite(
     mma_reduction_layout_analysis_dispatch_spec.mlir
     mma_using_layout_analysis_codegen_spec.mlir
   LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-sm80"
     "driver=cuda"
+    "requires-gpu-sm80"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tools/test/BUILD.bazel
+++ b/tools/test/BUILD.bazel
@@ -43,8 +43,10 @@ iree_lit_test_suite(
         "iree-run-trace.yml",
     ],
     tags = [
+        # These tests explicitly use these drivers.
         "driver=local-task",
         "driver=vulkan",
+        # These tests explicitly run `iree-compile`, so they need `hostonly`.
         "hostonly",
     ],
     tools = [
@@ -66,6 +68,7 @@ iree_lit_test_suite(
     srcs = ["benchmark_flags.txt"],
     cfg = "//tools:lit.cfg.py",
     tags = [
+        # These tests explicitly run `iree-compile`, so they need `hostonly`.
         "hostonly",
     ],
     tools = [


### PR DESCRIPTION
Fixes #14152 (Last PR in a chain of 4, following #14156, #14157, #14158).

This annotates larger tests with a `size` parameter, rather than ad-hoc sanitizer-excluding, riscv-excluding tags. This also adds comments justifying remaining tags.