### PR TITLE
Improve buffer handling in WebGPU sample.

### DIFF
--- a/experimental/web/sample_webgpu/index.html
+++ b/experimental/web/sample_webgpu/index.html
@@ -300,7 +300,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       ireeCallFunction(loadedProgram, functionName, inputs)
           .then((resultObject) => {
             functionOutputsElement.value =
-                resultObject['outputs'].replace(";", "\n");
+                resultObject['outputs'].replaceAll(";", "\n");
 
             const endJsTime = performance.now();
             const totalJsTime = endJsTime - startJsTime;

--- a/experimental/webgpu/buffer.c
+++ b/experimental/webgpu/buffer.c
@@ -82,8 +82,10 @@ static void iree_hal_webgpu_buffer_destroy(iree_hal_buffer_t* base_buffer) {
 }
 
 WGPUBuffer iree_hal_webgpu_buffer_handle(const iree_hal_buffer_t* base_buffer) {
+  iree_hal_buffer_t* allocated_buffer =
+      iree_hal_buffer_allocated_buffer(base_buffer);
   iree_hal_webgpu_buffer_t* buffer =
-      iree_hal_webgpu_buffer_cast((iree_hal_buffer_t*)base_buffer);
+      iree_hal_webgpu_buffer_cast((iree_hal_buffer_t*)allocated_buffer);
   IREE_ASSERT_ARGUMENT(buffer);
   return buffer->handle;
 }


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/13809

* Some errors were not being fully propagated
* Some code attempted to access handles without going through `iree_hal_buffer_allocated_buffer()`

__This code still has bugs:__

* multiple_results.mlir: `absf(-1.23, -4.56)` returns `(4.56, 0)` at first, then `(1.23, 4.56)` on future calls with the same loaded program state
* mobilebert, posenet, mobilessd: no errors, correct number of outputs, incorrect numerical results (way off `llvm-cpu`/`local-task`, stable across runs)