### PR TITLE
Test `timeout` parameters: consistent support

### DIFF
--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -160,6 +160,7 @@ def iree_check_test_suite(
         runner_args = [],
         tags = [],
         target_cpu_features_variants = [],
+        timeout = None,
         **kwargs):
     """Creates a test suite of iree-check-module tests.
 
@@ -190,6 +191,7 @@ def iree_check_test_suite(
           and cpu_features is a comma-separated list of LLVM target attributes
           to enable. Example:
             x86_64:avx2_fma:+avx,+avx2,+fma
+      timeout: timeout for the generated tests.
       **kwargs: any additional attributes to pass to the underlying tests and
           test suite.
     """
@@ -210,6 +212,7 @@ def iree_check_test_suite(
             compiler_flags = compiler_flags,
             runner_args = runner_args,
             tags = tags,
+            timeout = timeout,
             **kwargs
         )
         tests.append(suite_name)

--- a/build_tools/bazel/native_binary.bzl
+++ b/build_tools/bazel/native_binary.bzl
@@ -53,7 +53,7 @@ def _native_binary_impl(ctx):
 
 def _native_test_impl(ctx):
     if not ctx.attr.timeout:
-      ctx.attr.timeout = "short"
+        ctx.attr.timeout = "short"
     default_info = _shared_impl(ctx)
     return [default_info, testing.TestEnvironment(ctx.attr.env)]
 

--- a/build_tools/bazel/native_binary.bzl
+++ b/build_tools/bazel/native_binary.bzl
@@ -52,6 +52,8 @@ def _native_binary_impl(ctx):
     return [default_info]
 
 def _native_test_impl(ctx):
+    if not ctx.attr.timeout:
+      ctx.attr.timeout = "short"
     default_info = _shared_impl(ctx)
     return [default_info, testing.TestEnvironment(ctx.attr.env)]
 

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -49,25 +49,10 @@ class BuildFileFunctions(object):
     else:
       return f"  {name}\n    {value}\n"
 
-  # Match Bazel's timeout values
-  # https://docs.bazel.build/versions/main/test-encyclopedia.html
-  _timeout_map = {
-      "short": 60,
-      "moderate": 300,
-      "long": 900,
-      "eternal": 3600,
-  }
-
   def _should_skip_target(self, tags=None, **kwargs):
     if tags and "skip-bazel_to_cmake" in tags:
       return True
     return False
-
-  def _convert_timeout_arg_block(self, name, value):
-    if value is None:
-      return ""
-    value = self._timeout_map[value]
-    return f"  {name}\n    {value}\n"
 
   def _convert_string_list_block(self, name, values, quote=True, sort=False):
     # Note this deliberately distinguishes between an empty list (argument
@@ -395,7 +380,7 @@ class BuildFileFunctions(object):
     deps_block = self._convert_target_list_block("DEPS", deps)
     args_block = self._convert_string_list_block("ARGS", args)
     labels_block = self._convert_string_list_block("LABELS", tags)
-    timeout_block = self._convert_timeout_arg_block("TIMEOUT", timeout)
+    timeout_block = self._convert_string_arg_block("TIMEOUT", timeout)
     includes_block = self._convert_includes_block(includes)
 
     self._converter.body += (f"iree_cc_test(\n"
@@ -623,7 +608,7 @@ class BuildFileFunctions(object):
     tools_block = self._convert_target_list_block("TOOLS", tools)
     data_block = self._convert_target_list_block("DATA", data)
     labels_block = self._convert_string_list_block("LABELS", tags)
-    timeout_block = self._convert_timeout_arg_block("TIMEOUT", timeout)
+    timeout_block = self._convert_string_arg_block("TIMEOUT", timeout)
 
     self._converter.body += (f"iree_lit_test_suite(\n"
                              f"{name_block}"
@@ -660,7 +645,7 @@ class BuildFileFunctions(object):
     labels_block = self._convert_string_list_block("LABELS", tags)
     target_cpu_features_block = self._convert_string_arg_block(
         "TARGET_CPU_FEATURES", target_cpu_features)
-    timeout_block = self._convert_timeout_arg_block("TIMEOUT", timeout)
+    timeout_block = self._convert_string_arg_block("TIMEOUT", timeout)
 
     self._converter.body += (f"iree_check_single_backend_test_suite(\n"
                              f"{name_block}"
@@ -704,7 +689,7 @@ class BuildFileFunctions(object):
     labels_block = self._convert_string_list_block("LABELS", tags)
     target_cpu_features_variants_block = self._convert_string_list_block(
         "TARGET_CPU_FEATURES_VARIANTS", target_cpu_features_variants)
-    timeout_block = self._convert_timeout_arg_block("TIMEOUT", timeout)
+    timeout_block = self._convert_string_arg_block("TIMEOUT", timeout)
 
     self._converter.body += (f"iree_check_test_suite(\n"
                              f"{name_block}"
@@ -728,6 +713,7 @@ class BuildFileFunctions(object):
                                        runner_args=None,
                                        tags=None,
                                        target_cpu_features_variants=None,
+                                       timeout=None,
                                        **kwargs):
     if self._should_skip_target(tags=tags, **kwargs):
       return
@@ -758,6 +744,7 @@ class BuildFileFunctions(object):
     labels_block = self._convert_string_list_block("LABELS", tags)
     target_cpu_features_variants_block = self._convert_string_list_block(
         "TARGET_CPU_FEATURES_VARIANTS", target_cpu_features_variants)
+    timeout_block = self._convert_string_arg_block("TIMEOUT", timeout)
 
     self._converter.body += (f"iree_generated_trace_runner_test(\n"
                              f"{name_block}"
@@ -770,6 +757,7 @@ class BuildFileFunctions(object):
                              f"{runner_args_block}"
                              f"{labels_block}"
                              f"{target_cpu_features_variants_block}"
+                             f"{timeout_block}"
                              f")\n\n")
 
   def native_test(self,
@@ -788,7 +776,7 @@ class BuildFileFunctions(object):
     test_binary_block = self._convert_single_target_block("SRC", src)
     args_block = self._convert_string_list_block("ARGS", args)
     labels_block = self._convert_string_list_block("LABELS", tags)
-    timeout_block = self._convert_timeout_arg_block("TIMEOUT", timeout)
+    timeout_block = self._convert_string_arg_block("TIMEOUT", timeout)
 
     self._converter.body += (f"iree_native_test(\n"
                              f"{name_block}"

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -190,11 +190,8 @@ function(iree_cc_test)
     iree_configure_test(${_NAME_PATH})
   endif(ANDROID)
 
-  if (NOT DEFINED _RULE_TIMEOUT)
-    set(_RULE_TIMEOUT 60)
-  endif()
-
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
   set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
-  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
+  iree_get_timeout_seconds(_TIMEOUT_SECONDS "${_RULE_TIMEOUT}")
+  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_TIMEOUT_SECONDS})
 endfunction()

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -40,6 +40,8 @@ endfunction()
 #       to use for the generated IREE module (.vmfb).
 #   TARGET_CPU_FEATURES: If specified, a string passed as argument to
 #       --iree-llvmcpu-target-cpu-features.
+#   TIMEOUT: Test target timeout. Allowed values: "short", "moderate", "long".
+#       Default: "short". See iree_get_timeout_seconds().
 function(iree_check_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -56,8 +58,8 @@ function(iree_check_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;TARGET_BACKEND;DRIVER;MODULE_FILE_NAME"
-    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES;TIMEOUT"
+    "NAME;SRC;TARGET_BACKEND;DRIVER;MODULE_FILE_NAME;TIMEOUT"
+    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -154,6 +156,8 @@ endfunction()
 #       is added automatically.
 #   TARGET_CPU_FEATURES: If specified, a string passed as argument to
 #       --iree-llvmcpu-target-cpu-features.
+#   TIMEOUT: Test target timeout. Allowed values: "short", "moderate", "long".
+#       Default: "short". See iree_get_timeout_seconds().
 function(iree_check_single_backend_test_suite)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -166,8 +170,8 @@ function(iree_check_single_backend_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TARGET_BACKEND;DRIVER"
-    "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES;TIMEOUT"
+    "NAME;TARGET_BACKEND;DRIVER;TIMEOUT"
+    "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -328,6 +332,8 @@ endfunction()
 #       and cpu_features is a comma-separated list of LLVM target attributes
 #       to enable. Example:
 #         x86_64:avx2_fma:+avx,+avx2,+fma
+#   TIMEOUT: Test target timeout. Allowed values: "short", "moderate", "long".
+#       Default: "short". See iree_get_timeout_seconds().
 function(iree_check_test_suite)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -336,8 +342,8 @@ function(iree_check_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME"
-    "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS;TIMEOUT"
+    "NAME;TIMEOUT"
+    "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
 

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -34,8 +34,8 @@ function(iree_lit_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_FILE"
-    "DATA;TOOLS;LABELS;TIMEOUT"
+    "NAME;TEST_FILE;TIMEOUT"
+    "DATA;TOOLS;LABELS"
     ${ARGN}
   )
 
@@ -80,7 +80,10 @@ function(iree_lit_test)
   set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT
     "LIT_OPTS=-v"
     "FILECHECK_OPTS=--enable-var-scope")
-  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
+
+  iree_get_timeout_seconds(_TIMEOUT_SECONDS "${_RULE_TIMEOUT}")
+  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_TIMEOUT_SECONDS})
+
   iree_configure_test(${_NAME_PATH})
 
   # TODO(gcmn): Figure out how to indicate a dependency on _RULE_DATA being built
@@ -112,14 +115,10 @@ function(iree_lit_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME"
-    "SRCS;DATA;TOOLS;LABELS;TIMEOUT"
+    "NAME;TIMEOUT"
+    "SRCS;DATA;TOOLS;LABELS"
     ${ARGN}
   )
-
-  if (NOT DEFINED _RULE_TIMEOUT)
-    set(_RULE_TIMEOUT 60)
-  endif()
 
   foreach(_TEST_FILE ${_RULE_SRCS})
     get_filename_component(_TEST_BASENAME ${_TEST_FILE} NAME)

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -514,6 +514,37 @@ function(iree_symlink_tool)
   )
 endfunction()
 
+#-------------------------------------------------------------------------------
+# Test timeout values
+#-------------------------------------------------------------------------------
+
+# iree_get_timeout_seconds()
+#
+# Evaluates a Bazel-like timeout string to a number of seconds.
+# Allowed timeout values:  "short", "moderate", "long".
+# Default is "short".
+#
+# This is aligned with our `native_test` function in Bazel. This differs from
+# general Bazel rules in two ways: they default to "moderate" and they allow an
+# additional timeout value "eternal".
+#
+# Note: the current numbers of seconds are just the Bazel standard values.
+# They could change in the future. We don't actually want "short" tests that
+# run for 60 seconds, and we might never want any test to run for 900 seconds.
+# The main purpose of these timeout enumeration values is to filter and skip
+# certain tests on slow configurations, not to allow tests to run for a long
+# time.
+function(iree_get_timeout_seconds DST_VAR SRC_TIMEOUT_STRING)
+  if(SRC_TIMEOUT_STRING STREQUAL "short" OR NOT SRC_TIMEOUT_STRING)
+    set(${DST_VAR} 60 PARENT_SCOPE)
+  elseif(SRC_TIMEOUT_STRING STREQUAL "moderate")
+    set(${DST_VAR} 300 PARENT_SCOPE)
+  elseif(SRC_TIMEOUT_STRING STREQUAL "long")
+    set(${DST_VAR} 900 PARENT_SCOPE)
+  else()
+    message(SEND_ERROR "Unhandled timeout value \"${SRC_TIMEOUT_STRING}\"")
+  endif()
+endfunction()
 
 #-------------------------------------------------------------------------------
 # Tests

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -28,7 +28,11 @@ include(CMakeParseArguments)
 # WILL_FAIL: The target will run, but its pass/fail status will be inverted.
 # LABELS: Additional labels to apply to the test. The package path is added
 #     automatically.
-# TIMEOUT: Test target timeout in seconds.
+# TIMEOUT: Test target timeout. String, as in Bazel rules. Allowed values:
+#     "short", "moderate", "long". Default is "short". This is aligned with our
+#     `native_test` function in Bazel. This differs from general Bazel rules in
+#     two ways: they default to "moderate" and they allow an additional timeout
+#     value "eternal".
 #
 # Note: the DATA argument is not actually adding dependencies because CMake
 # doesn't have a good way to specify a data dependency for a test.
@@ -148,14 +152,12 @@ function(iree_native_test)
     iree_configure_test(${_TEST_NAME})
   endif()
 
-  if (NOT DEFINED _RULE_TIMEOUT)
-    set(_RULE_TIMEOUT 60)
-  endif()
+  iree_get_timeout_seconds(_TIMEOUT_SECONDS "${_RULE_TIMEOUT}")
 
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
   set_property(TEST ${_TEST_NAME} PROPERTY LABELS "${_RULE_LABELS}")
   set_property(TEST "${_TEST_NAME}" PROPERTY REQUIRED_FILES "${_RULE_DATA}")
-  set_property(TEST ${_TEST_NAME} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
+  set_property(TEST ${_TEST_NAME} PROPERTY TIMEOUT ${_TIMEOUT_SECONDS})
   if(_RULE_WILL_FAIL)
     set_property(TEST ${_TEST_NAME} PROPERTY WILL_FAIL ${_RULE_WILL_FAIL})
   endif()

--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -249,9 +249,8 @@ function(iree_local_py_test)
       "PYTHONPATH=${_PYTHONPATH}"
   )
 
-  if (NOT DEFINED _RULE_TIMEOUT)
-    set(_RULE_TIMEOUT 60)
-  endif()
+  iree_get_timeout_seconds(_TIMEOUT_SECONDS "${_RULE_TIMEOUT}")
+  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_TIMEOUT_SECONDS})
 
   iree_configure_test(${_NAME_PATH})
 

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -29,6 +29,8 @@ include(CMakeParseArguments)
 #       because trace files (.yaml) reference a specific module file path.
 #   TARGET_CPU_FEATURES: If specified, a string passed as argument to
 #       --iree-llvmcpu-target-cpu-features.
+#   TIMEOUT: Test target timeout. Allowed values: "short", "moderate", "long".
+#       Default: "short". See iree_get_timeout_seconds().
 function(iree_trace_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -42,7 +44,7 @@ function(iree_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;TRACE;TARGET_BACKEND;DRIVER;TRACE_RUNNER;MODULE_FILE_NAME"
+    "NAME;SRC;TRACE;TARGET_BACKEND;DRIVER;TRACE_RUNNER;MODULE_FILE_NAME;TIMEOUT"
     "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
@@ -102,6 +104,8 @@ function(iree_trace_runner_test)
       ${_RULE_RUNNER_ARGS}
     LABELS
       ${_RULE_LABELS}
+    TIMEOUT
+      ${_RULE_TIMEOUT}
   )
 endfunction()
 
@@ -133,6 +137,8 @@ endfunction()
 #   TRACE_RUNNER: trace-runner program to run.
 #   TARGET_CPU_FEATURES: If specified, a string passed as argument to
 #       --iree-llvmcpu-target-cpu-features.
+#   TIMEOUT: Test target timeout. Allowed values: "short", "moderate", "long".
+#       Default: "short". See iree_get_timeout_seconds().
 function(iree_single_backend_generated_trace_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -153,7 +159,7 @@ function(iree_single_backend_generated_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;GENERATOR;TARGET_BACKEND;DRIVER;TRACE_RUNNER"
+    "NAME;GENERATOR;TARGET_BACKEND;DRIVER;TRACE_RUNNER;TIMEOUT"
     "GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
@@ -247,6 +253,8 @@ function(iree_single_backend_generated_trace_runner_test)
       ${_RULE_LABELS}
     TARGET_CPU_FEATURES
       ${_RULE_TARGET_CPU_FEATURES}
+    TIMEOUT
+      ${_RULE_TIMEOUT}
   )
 
   # Note we are relying on the fact that the target created by
@@ -296,6 +304,8 @@ endfunction()
 #       and cpu_features is a comma-separated list of LLVM target attributes
 #       to enable. Example:
 #         x86_64:avx2_fma:+avx,+avx2,+fma
+#   TIMEOUT: Test target timeout. Allowed values: "short", "moderate", "long".
+#       Default: "short". See iree_get_timeout_seconds().
 function(iree_generated_trace_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -304,7 +314,7 @@ function(iree_generated_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;GENERATOR;TRACE_RUNNER"
+    "NAME;GENERATOR;TRACE_RUNNER;TIMEOUT"
     "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
@@ -371,6 +381,8 @@ function(iree_generated_trace_runner_test)
           ${_LABELS}
         TARGET_CPU_FEATURES
           ${_TARGET_CPU_FEATURES}
+        TIMEOUT
+          ${_RULE_TIMEOUT}
       )
     endforeach()
   endforeach()

--- a/runtime/src/iree/hal/drivers/vulkan/util/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/util/BUILD.bazel
@@ -66,7 +66,6 @@ iree_runtime_cc_library(
 
 iree_runtime_cc_test(
     name = "ref_ptr_test",
-    timeout = "short",
     srcs = ["ref_ptr_test.cc"],
     deps = [
         ":ref_ptr",

--- a/runtime/src/iree/hal/drivers/vulkan/util/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/util/CMakeLists.txt
@@ -76,8 +76,6 @@ iree_cc_test(
     ::ref_ptr
     iree::testing::gtest
     iree::testing::gtest_main
-  TIMEOUT
-    60
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -81,7 +81,7 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
   TIMEOUT
-    900
+    "long"
 )
 
 iree_check_single_backend_test_suite(
@@ -103,7 +103,7 @@ iree_check_single_backend_test_suite(
     "noubsan"
     "requires-gpu-nvidia"
   TIMEOUT
-    900
+    "long"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
This aligns both our Bazel and CMake builds on the following, essentially Bazel standard but with a twist, concept of `timeout` parameters:

* `timeout` is a string (not an integer number of seconds).
* Allowed values: `short`, `moderate`, `long`.
    * Like standard Bazel, except we don't currently allow `eternal`.
* Default value: `short`.
    * That's unlike standard Bazel where the default is effectively `moderate`, after an indirection via the `size` parameter which we don't have here.

The mapping for `timeout` enumeration values to numbers of seconds used to be done in `bazel_to_cmake_converter`. Now it's moved to the CMake side. Keeping symbolic constants in CMake is a better fit for filtering long tests on slow configurations.

The existing support for `TIMEOUT` parameters in CMake rules was spotty. Some rules had it implemented, though `TIMEOUT` was sometimes incorrectly parsed as a multi-value parameter. Some rules just didn't have it. `iree_python.cmake` had logic to set a default value 60 to a timeout variable, then didn't actually use that variable.

This is a step in #14152 and, as discussed there, this supersedes #14156.