### PR TITLE
avoid Clang <= 10 bug with -fno-lax-vector-conversions

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -199,7 +199,10 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wunused-comparison"
     "-Wvla"
 
+  CLANG_GTE_12
     # Clang is lax by default on SIMD vector typing. GCC is strict by default.
+    # Some Clang's circa version 10 had incorrect return types for some
+    # intrinsics (#14168).
     "-fno-lax-vector-conversions"
 
   # TODO(#6959): Enable -Werror once we have a presubmit CI.

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -304,7 +304,7 @@ function(iree_select_compiler_opts OPTS)
     _IREE_SELECTS
     ""
     ""
-    "ALL;CLANG;CLANG_GTE_10;CLANG_CL;MSVC;GCC;CLANG_OR_GCC;MSVC_OR_CLANG_CL"
+    "ALL;CLANG;CLANG_GTE_10;CLANG_GTE_12;CLANG_CL;MSVC;GCC;CLANG_OR_GCC;MSVC_OR_CLANG_CL"
   )
   # OPTS is a variable containing the *name* of the variable being populated, so
   # we need to dereference it twice.
@@ -321,6 +321,9 @@ function(iree_select_compiler_opts OPTS)
       list(APPEND _OPTS ${_IREE_SELECTS_CLANG})
       if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
         list(APPEND _OPTS ${_IREE_SELECTS_CLANG_GTE_10})
+      endif()
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
+        list(APPEND _OPTS ${_IREE_SELECTS_CLANG_GTE_12})
       endif()
       list(APPEND _OPTS ${_IREE_SELECTS_CLANG_OR_GCC})
     endif()


### PR DESCRIPTION
Issue reported here: https://discord.com/channels/689900678990135345/689932666505920596/1121124198593609728

```
/home/iree/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c:63:12: error: initializing 'int32x4_t' (vector of 4 'int32_t' values) with an expression of incompatible type '__attribute__((__vector_size__(4 * sizeof(uint32_t)))) uint32_t' (vector of 4 'uint32_t' values) 
    acc0 = vdotq_lane_s32(acc0, rhs0, vget_low_s8(lhs0), 0); 
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
/usr/lib/llvm-10/lib/clang/10.0.0/include/arm_neon.h:37021:11: note: expanded from macro 'vdotq_lane_s32' 
int32x4_t __reint1 = __builtin_shufflevector(*(uint32x2_t *) &__reint, *(uint32x2_t *) &__reint, __p3, __p3, __p3, __p3); \ 
```

The problem is that Clang <= 10 incorrectly thinks that the return type of `vdotq_lane_s32` is `uint32x4_t` when it's really `int32x4_t`.
