### PR TITLE
Tag CTS tests with the driver they use

### DIFF
--- a/experimental/cuda2/cts/CMakeLists.txt
+++ b/experimental/cuda2/cts/CMakeLists.txt
@@ -24,4 +24,7 @@ iree_hal_cts_test_suite(
     "descriptor_set_layout"
     "driver"
     "pipeline_layout"
+  LABELS
+    driver=cuda2
+    requires-gpu-nvidia
 )

--- a/experimental/metal/cts/CMakeLists.txt
+++ b/experimental/metal/cts/CMakeLists.txt
@@ -20,5 +20,6 @@ iree_hal_cts_test_suite(
   EXCLUDED_TESTS
     # HAL event is unimplemented for Metal right now.
     "event"
+  LABELS
+    driver=metal
 )
-

--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -24,4 +24,6 @@ iree_hal_cts_test_suite(
     # Semaphores are not implemented in the ROCm backend yet.
     "semaphore_submission"
     "semaphore"
+  LABELS
+    driver=rocm
 )

--- a/experimental/webgpu/cts/CMakeLists.txt
+++ b/experimental/webgpu/cts/CMakeLists.txt
@@ -17,4 +17,6 @@ iree_hal_cts_test_suite(
     "\"webgpu-wgsl-fb\""
   DEPS
     iree::experimental::webgpu::registration
+  LABELS
+    driver=webgpu
 )

--- a/runtime/src/iree/hal/drivers/cuda/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/cts/CMakeLists.txt
@@ -20,6 +20,9 @@ iree_hal_cts_test_suite(
   EXCLUDED_TESTS
     # Semaphores are not fully implemented in the CUDA backend yet.
     "semaphore"
+  LABELS
+    driver=cuda
+    requires-gpu-nvidia
 )
 
 # Variant test suite using graph command buffers (--cuda_use_streams=0)
@@ -43,4 +46,7 @@ iree_hal_cts_test_suite(
   INCLUDED_TESTS
     "command_buffer"
     "command_buffer_dispatch"
+  LABELS
+    driver=cuda
+    requires-gpu-nvidia
 )

--- a/runtime/src/iree/hal/drivers/local_sync/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_sync/cts/CMakeLists.txt
@@ -29,6 +29,8 @@ if(IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF)
       iree::hal::drivers::local_sync::registration
     EXCLUDED_TESTS
       "semaphore_submission"  # SubmitWithWait hangs?
+    LABELS
+      driver=local-sync
     )
 endif()
 
@@ -50,5 +52,7 @@ if(IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE)
       iree::hal::drivers::local_sync::registration
     EXCLUDED_TESTS
       "semaphore_submission"  # SubmitWithWait hangs?
+    LABELS
+      driver=local-sync
   )
 endif()

--- a/runtime/src/iree/hal/drivers/local_task/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/cts/CMakeLists.txt
@@ -27,6 +27,8 @@ if(IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF)
       "${NATIVE_EXECUTABLE_FORMAT}"
     DEPS
       iree::hal::drivers::local_task::registration
+    LABELS
+      driver=local-task
   )
 endif()
 
@@ -46,5 +48,7 @@ if(IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE)
       "\"vmvx-bytecode-fb\""
     DEPS
       iree::hal::drivers::local_task::registration
+    LABELS
+      driver=local-task
   )
 endif()

--- a/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
@@ -17,4 +17,6 @@ iree_hal_cts_test_suite(
     "\"SPVE\""
   DEPS
     iree::hal::drivers::vulkan::registration
+  LABELS
+    driver=vulkan
 )


### PR DESCRIPTION
These were missing tags. This makes them get included/excluded
appropriately in CI scripting and human invocation.

Part of https://github.com/openxla/iree/issues/14169