### PR TITLE
[CI] Do not run black when no files changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Check if modified files are formatted
         run: |
           git diff "${GITHUB_BASE_REF?}" --name-only -- '*.py' ':!third_party' \
-            | xargs black --check --diff --verbose
+            | xargs --no-run-if-empty black --check --diff --verbose
       - name: Instructions for fixing the above linting errors
         if: failure()
         run: |


### PR DESCRIPTION
Black expects at least one file or dir to format, so we need to handle the case when no python files were modified.

Issue: https://github.com/openxla/iree/issues/14135