### PR TITLE
Add .git-blame-ignore-revs file for large-scale changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# This file contains the list of commits to exclude from 'git blame'.
+# Such commits do not meaningfully contribute to git history, and include
+# large-scale mechanical changes like code formatting style changes.
+#
+# To set this file as the default ignore file for 'git blame', run:
+# ```shell
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# ```
+
+# Use Black to format Python files (#14161)
+be24f0258a520a48555c9baec9d2f737ba1c2ca0


### PR DESCRIPTION
This file tell git blame to look through commits that do not meaningfully contribute to git history, e.g., mass formatting changes.

Pre-populate this file with the Black python formatting commit.

To use this configuration file, run:
```shell
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Fixes: https://github.com/openxla/iree/issues/14135

skip-ci: Dotfile change only.