### PR TITLE
Update lint script to run black

### DIFF
--- a/build_tools/scripts/lint.sh
+++ b/build_tools/scripts/lint.sh
@@ -54,9 +54,8 @@ echo "***** buildifier *****"
 ${scripts_dir}/run_buildifier.sh
 git diff --exit-code
 
-echo "***** yapf *****"
-# Don't fail script if condition is false
-git diff -U0 main | ./third_party/format_diff/format_diff.py yapf -i
+echo "***** black *****"
+git diff main --name-only -- '*.py' ':!third_party' | xargs -r black
 
 echo "***** pytype *****"
 ./build_tools/pytype/check_diff.sh


### PR DESCRIPTION
I missed this in the original PR that switched from yapf to black: https://github.com/openxla/iree/pull/14161.

Issue: https://github.com/openxla/iree/issues/14135

skip-ci: Script change only.