### PR TITLE
Fix memory effects of transform flow extension ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -588,7 +588,7 @@ transform_dialect::MovePrecedingOpIntoDispatchRegionOp::apply(
 
 void transform_dialect::MovePrecedingOpIntoDispatchRegionOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getTarget(), effects);
+  transform::consumesHandle(getTarget(), effects);
   transform::consumesHandle(getDispatchRegion(), effects);
   transform::producesHandle(getTransformed(), effects);
   transform::modifiesPayload(effects);
@@ -818,7 +818,7 @@ transform_dialect::MoveSucceedingOpIntoDispatchRegionOp::apply(
 
 void transform_dialect::MoveSucceedingOpIntoDispatchRegionOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getTarget(), effects);
+  transform::consumesHandle(getTarget(), effects);
   transform::consumesHandle(getDispatchRegion(), effects);
   transform::producesHandle(getTransformed(), effects);
   transform::modifiesPayload(effects);

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -83,13 +83,12 @@ def RegionToWorkgroupsOp : Op<Transform_Dialect, "iree.region_to_workgroups",
 
 def WrapInDispatchRegionOp : Op<
     Transform_Dialect, "iree.wrap_in_dispatch_region",
-    [FunctionalStyleTransformOpTrait,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      TransformOpInterface,
      TransformEachOpTrait]> {
   let description = [{
     Wrap the `target` op in a new `dispatch.region` op. All uses of target op
-    are replaces with the results of the newly generated `dispach.region` op.
+    are replaces with the results of the newly generated `dispatch.region` op.
 
     The argument `generateWorkload` can be set to generate workload information
     from the given `target` op.


### PR DESCRIPTION
The transform ops in the Flow dialect extension should consume their handles. Their implementaiton uses the confusingly named `move*Op` API that in fact does clone+erase instead of the proper move, which is not guaranteed to preserve operation pointers. This leads to memory corruption.