### PR TITLE
Integrate llvm-project at d179421099314431a91b85c01977ba0086ffd6db

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -85,7 +85,7 @@ struct FoldTrailingUnitTranspose
 
     Location loc = op.getLoc();
     SmallVector<OpFoldResult> srcMixedSizes =
-        tensor::createDimValues(rewriter, loc, op.getInput());
+        tensor::getMixedSizes(rewriter, loc, op.getInput());
     SmallVector<OpFoldResult> mixedStride(inputTy.getRank(),
                                           rewriter.getIndexAttr(1));
     SmallVector<OpFoldResult> mixedOffsets(inputTy.getRank(),
@@ -97,7 +97,7 @@ struct FoldTrailingUnitTranspose
         op.getInput(), mixedOffsets, srcMixedSizes, mixedStride);
 
     SmallVector<OpFoldResult> destMixedSizes =
-        tensor::createDimValues(rewriter, loc, op.getInit());
+        tensor::getMixedSizes(rewriter, loc, op.getInit());
     auto initTy = llvm::cast<ShapedType>(op.getInit().getType());
     destMixedSizes.resize(initTy.getRank() - numDropDims);
     auto dest = rewriter.create<tensor::EmptyOp>(loc, destMixedSizes,

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -119,25 +119,27 @@ struct FlattenMemRefTypeConverter final : public TypeConverter {
 static Value createTotalElementCountValue(ShapedType type,
                                           ValueRange dynamicDims, Location loc,
                                           OpBuilder &builder) {
-  MLIRContext *context = builder.getContext();
-
   if (type.hasStaticShape()) {
     assert(dynamicDims.empty());
     return builder.create<arith::ConstantIndexOp>(loc, type.getNumElements());
   }
 
-  int dynamicDimIndex = 0;
+  int64_t numSymbols = 0;
+  int64_t constantIntValue = 1;
+
   SmallVector<OpFoldResult> dims;
   auto shape = type.getShape();
-  AffineExpr sizeExpr = getAffineConstantExpr(1, context);
   for (int i = 0; i < shape.size(); ++i) {
-    sizeExpr = sizeExpr * getAffineSymbolExpr(i, context);
     if (ShapedType::isDynamic(shape[i])) {
-      dims.push_back(dynamicDims[dynamicDimIndex++]);
+      dims.push_back(dynamicDims[numSymbols]);
+      numSymbols++;
     } else {
-      dims.push_back(
-          builder.create<arith::ConstantIndexOp>(loc, shape[i]).getValue());
+      constantIntValue *= shape[i];
     }
+  }
+  AffineExpr sizeExpr = builder.getAffineConstantExpr(constantIntValue);
+  for (int i = 0; i < numSymbols; i++) {
+    sizeExpr = sizeExpr * builder.getAffineSymbolExpr(i);
   }
   return affine::makeComposedAffineApply(builder, loc, sizeExpr, dims);
 }
@@ -351,10 +353,7 @@ static Value linearizeIndices(Value sourceValue, ValueRange indices,
         makeStridedLinearLayoutMap(strides, 0, builder.getContext());
     // Dynamic strides/offset will create symbols. There should be none for the
     // static case.
-    SmallVector<OpFoldResult> opFoldIndicies;
-    for (Value value : indices) {
-      opFoldIndicies.push_back(value);
-    }
+    SmallVector<OpFoldResult> opFoldIndicies = getAsOpFoldResult(indices);
     if (linearLayoutMap.getNumSymbols() == 0) {
       return affine::makeComposedAffineApply(builder, loc, linearLayoutMap,
                                              opFoldIndicies);

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -65,9 +65,9 @@ static std::tuple<Value, Value> getDistributeLBAndStep(OpBuilder &b,
   auto offsetMap = AffineMap::get(0, 3, {s0 + s1 * s2});
   auto stepMap = AffineMap::get(0, 2, {s0 * s1});
   Value distributeLB = affine::makeComposedAffineApply(
-      b, loc, offsetMap, ValueRange{lb, procId, step});
+      b, loc, offsetMap, ArrayRef<OpFoldResult>{lb, procId, step});
   Value distributeStep = affine::makeComposedAffineApply(
-      b, loc, stepMap, ValueRange{step, nprocs});
+      b, loc, stepMap, ArrayRef<OpFoldResult>{step, nprocs});
   return {distributeLB, distributeStep};
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DetachElementwiseFromNamedOps.cpp
@@ -68,7 +68,7 @@ struct DetachElementwisePattern
     // Create a zero tensor as the new output tensor operand to the Linalg
     // contraction op.
     SmallVector<OpFoldResult> mixedSizes =
-        tensor::createDimValues(rewriter, loc, outputOperand);
+        tensor::getMixedSizes(rewriter, loc, outputOperand);
     auto initOp =
         rewriter.create<tensor::EmptyOp>(loc, mixedSizes, elementType);
     Value zero = rewriter.create<arith::ConstantOp>(

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -62,7 +62,7 @@ static SmallVector<Range> getLoopRangesImpl(TilingInterface tilableOp,
 static SmallVector<Range> getLoopRangesFromValue(Value source, Location loc,
                                                  OpBuilder &builder) {
   SmallVector<OpFoldResult> dimValues =
-      tensor::createDimValues(builder, loc, source);
+      tensor::getMixedSizes(builder, loc, source);
   OpFoldResult zero = builder.getIndexAttr(0);
   OpFoldResult one = builder.getIndexAttr(1);
   return llvm::map_to_vector(dimValues, [&](OpFoldResult dimValue) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SetEncoding.cpp
@@ -248,7 +248,7 @@ struct FoldFillWithSetEncoding
     RankedTensorType encodingType = encodingOp.getResultType();
     Location loc = fillOp.getLoc();
     SmallVector<OpFoldResult> dimValues =
-        tensor::createDimValues(rewriter, loc, fillOp.getOutputs()[0]);
+        tensor::getMixedSizes(rewriter, loc, fillOp.getOutputs()[0]);
     auto newEmptyOp = rewriter.create<tensor::EmptyOp>(
         loc, dimValues, encodingType.getElementType(),
         encodingType.getEncoding());

--- a/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
@@ -31,7 +31,7 @@ namespace {
 Value emptyCopy(ImplicitLocOpBuilder &rewriter, Value value) {
   Type eTy = getElementTypeOrSelf(value.getType());
   SmallVector<OpFoldResult> mixedSizes =
-      tensor::createDimValues(rewriter, rewriter.getLoc(), value);
+      tensor::getMixedSizes(rewriter, rewriter.getLoc(), value);
   return rewriter.create<tensor::EmptyOp>(mixedSizes, eTy);
 }
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgExt.cpp
@@ -301,7 +301,7 @@ struct FftOpConversion final : OpConversionPattern<mlir::stablehlo::FftOp> {
     auto rank = realType.getRank();
 
     SmallVector<OpFoldResult> mixedSizes =
-        tensor::createDimValues(b, b.getLoc(), real);
+        tensor::getMixedSizes(b, b.getLoc(), real);
     Value emptyTensor =
         b.create<tensor::EmptyOp>(mixedSizes, realType.getElementType());
 
@@ -386,7 +386,7 @@ struct FftOpConversion final : OpConversionPattern<mlir::stablehlo::FftOp> {
     SmallVector<OpFoldResult> offsets(ty.getRank(), b.getIndexAttr(0));
     SmallVector<OpFoldResult> strides(ty.getRank(), b.getIndexAttr(1));
     SmallVector<OpFoldResult> sizes =
-        tensor::createDimValues(b, b.getLoc(), adaptor.getOperand());
+        tensor::getMixedSizes(b, b.getLoc(), adaptor.getOperand());
     sizes.back() = b.getIndexAttr(shape.back());
     auto real = b.create<tensor::ExtractSliceOp>(ty, results[0], offsets, sizes,
                                                  strides);
@@ -414,7 +414,7 @@ struct ReverseOpConversion final
 
     Location loc = op.getLoc();
     SmallVector<OpFoldResult> mixedSizes =
-        tensor::createDimValues(rewriter, loc, adaptor.getOperands()[0]);
+        tensor::getMixedSizes(rewriter, loc, adaptor.getOperands()[0]);
     Value emptyTensor =
         rewriter.create<tensor::EmptyOp>(loc, mixedSizes, ty.getElementType());
     rewriter.replaceOpWithNewOp<IREE::LinalgExt::ReverseOp>(
@@ -457,7 +457,7 @@ struct TopkOpConversion final : OpConversionPattern<chlo::TopKOp> {
     // Create and initialize output tensors for LinalgExt TopK results
     // Define the output types based on the results of CHLO TopK
     SmallVector<OpFoldResult> mixedSizes =
-        tensor::createDimValues(rewriter, loc, adaptor.getOperand());
+        tensor::getMixedSizes(rewriter, loc, adaptor.getOperand());
     mixedSizes.back() = rewriter.getIndexAttr(adaptor.getK());
     Value emptyTensorOutputValues = rewriter.create<mlir::tensor::EmptyOp>(
         loc, mixedSizes, valueElementType);

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1811,7 +1811,7 @@ SmallVector<OpFoldResult> PackOp::getResultShape(
 }
 
 SmallVector<OpFoldResult> PackOp::getResultShape(OpBuilder &builder) {
-  return tensor::createDimValues(builder, getLoc(), getOutput());
+  return tensor::getMixedSizes(builder, getLoc(), getOutput());
 }
 
 ShapedType PackOp::getPackedType(ShapedType sourceType,

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/DecomposeSoftmax.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/DecomposeSoftmax.cpp
@@ -128,7 +128,7 @@ LogicalResult convertSoftmaxToGenerics(func::FuncOp funcOp) {
     Type elementType = inputType.getElementType();
     int64_t reductionDim = softmaxOp.getDimension();
     SmallVector<OpFoldResult> dims =
-        tensor::createDimValues(rewriter, loc, input);
+        tensor::getMixedSizes(rewriter, loc, input);
     Value outputNd = rewriter.create<tensor::EmptyOp>(loc, dims, elementType);
     dims.erase(dims.begin() + reductionDim);
     // Compute max along dim

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/PadContractionToBlockSize.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/PadContractionToBlockSize.cpp
@@ -23,7 +23,7 @@ using namespace IREE::LinalgExt;
 static Operation *sliceTensor(Location loc, Value expanded, Value original,
                               OpBuilder &builder) {
   SmallVector<OpFoldResult> sizes =
-      tensor::createDimValues(builder, loc, original);
+      tensor::getMixedSizes(builder, loc, original);
   SmallVector<OpFoldResult> offsets(sizes.size(), builder.getI64IntegerAttr(0));
   SmallVector<OpFoldResult> strides(sizes.size(), builder.getI64IntegerAttr(1));
   return builder.create<tensor::ExtractSliceOp>(loc, expanded, offsets, sizes,

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeAttention.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeAttention.cpp
@@ -278,7 +278,7 @@ tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
   Type elementType = queryType.getElementType();
   ArrayRef<int64_t> queryShape = queryType.getShape();
   SmallVector<OpFoldResult> queryDimValues =
-      tensor::createDimValues(rewriter, loc, query);
+      tensor::getMixedSizes(rewriter, loc, query);
   OpFoldResult headDimension = queryDimValues[2];
   OpFoldResult sequenceTileLength = queryDimValues[1];
   OpFoldResult batchTileLength = queryDimValues[0];
@@ -286,7 +286,7 @@ tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
   Value key = attnOp.getKey();
   Value value = attnOp.getValue();
   SmallVector<OpFoldResult> keyDimValues =
-      tensor::createDimValues(rewriter, loc, key);
+      tensor::getMixedSizes(rewriter, loc, key);
   OpFoldResult sequenceLength = keyDimValues[1];
 
   // Construct first loop

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
@@ -36,7 +36,7 @@ static void computeLoopParams(SmallVectorImpl<Value> &lbs,
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
   SmallVector<OpFoldResult> dimValues =
-      tensor::createDimValues(builder, loc, tensor);
+      tensor::getMixedSizes(builder, loc, tensor);
   for (int i = numImageDims; i < dimValues.size(); i++) {
     lbs.push_back(zero);
     ubs.push_back(getValueOrCreateConstantIndexOp(builder, loc, dimValues[i]));


### PR DESCRIPTION
* Reset third_party/llvm-project: d179421099314431a91b85c01977ba0086ffd6db (2023-06-22 16:56:08 +0200): [LoopUnroll] Avoid undef indices in test (NFC)