### PR TITLE
Strip IREE prefix from tablegen doc files.

### DIFF
--- a/build_tools/cmake/iree_tablegen_doc.cmake
+++ b/build_tools/cmake/iree_tablegen_doc.cmake
@@ -56,8 +56,7 @@ function(iree_tablegen_doc)
   set(LLVM_TARGET_DEFINITIONS ${_INPUTS})
 
   set(_FLAGS
-    # Pass this after https://reviews.llvm.org/D152404
-    # "--strip-prefix=::mlir::iree_compiler::IREE::"
+    "--strip-prefix=::mlir::iree_compiler::IREE::"
   )
 
   set(_OUTPUTS)

--- a/docs/website/generate_extra_files.sh
+++ b/docs/website/generate_extra_files.sh
@@ -31,6 +31,10 @@ cmake -G Ninja \
   -DIREE_BUILD_DOCS=ON
 cmake --build "${BUILD_DIR}" --target iree-doc
 
+if (( IREE_USE_CCACHE == 1 )); then
+  ccache --show-stats
+fi
+
 # Copy from build directory -> source directory (files are .gitignore'd).
 cp -r \
   "${BUILD_DIR}/doc/Dialects/." \


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/5477

Also show ccache stats in the publish workflow.

skip-ci: technically covered by `IREE_BUILD_DOCS` usage in build/test workflows, but I've tested locally and believe this is low enough risk to skip the full builds