### PR TITLE
[LLVMGPU] Harden the legality checks when lowering to cp.async

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
@@ -119,3 +119,39 @@ builtin.module {
     transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!transform.any_op) -> ()
   }
 }
+
+// -----
+
+// Check that pattern skips unaligned and unsupported sizes.
+builtin.module {
+  // CHECK-LABEL: @copies_to_asyncs_load_store
+  func.func @copies_to_asyncs_load_store(%a: memref<1024x1024xf32>, %b: memref<1024x1024xf16>) {
+    %alloc = memref.alloc() : memref<4x32x16xf32, #gpu.address_space<workgroup>>
+    %alloc_1 = memref.alloc() : memref<4x32x16xf16, #gpu.address_space<workgroup>>
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %cst_0 = arith.constant 0.000000e+00 : f32
+
+    // Requires 1-D vector load
+    // CHECK-NOT: nvgpu.device_async_copy
+    //     CHECK: vector.load
+    //     CHECK: vector.store
+    %1 = vector.load %a[%c0, %c4] : memref<1024x1024xf32>, vector<2x2xf32>
+    vector.store %1, %alloc[%c0, %c4, %c0] : memref<4x32x16xf32, #gpu.address_space<workgroup>>, vector<2x2xf32>
+    // CHECK-NOT: nvgpu.device_async_create_group
+
+    // CHECK-NOT: nvgpu.device_async_copy
+    //     CHECK: vector.load    
+    //     CHECK: vector.store
+    %2 = vector.load %b[%c0, %c4] : memref<1024x1024xf16>, vector<1xf16>
+    vector.store %2, %alloc_1[%c0, %c4, %c0] : memref<4x32x16xf16, #gpu.address_space<workgroup>>, vector<1xf16>
+    // CHECK-NOT: nvgpu.device_async_create_group
+    return
+  }
+
+  transform.sequence failures(propagate) {
+  ^bb1(%variant_op: !transform.any_op):
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.create_async_groups %top_level_func {use_mma_sync = false} : (!transform.any_op) -> ()
+  }
+}


### PR DESCRIPTION
This covers two requirements of cp.async:
1) Vector shapes must be 1-D.
2) The number of bytes copied must be 4, 8, or 16.

A third alignment condition is left as future work.

Extracts the simpler conditions from #14184 required for < 32-bit types in unaligned matmul strategies here: #13735