### PR TITLE
Add service to preload docker images on runner startup

### DIFF
--- a/build_tools/github_actions/runner/config/systemd/scripts/preload_docker.sh
+++ b/build_tools/github_actions/runner/config/systemd/scripts/preload_docker.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Pre-fetches docker images so we don't have to wait for docker to fetch them as
+# part of `docker run` in the CI jobs. This isn't comprehensive but pre-fetches
+# things we think are pretty likely to be useful to pre-fetch. It runs in the
+# background so shouldn't have a significant impact on other startup tasks. It
+# also won't block fetches being done by the job itself. It could compete for
+# network bandwidth though, so we don't want to just always try to fetch
+# everything.
+
+set -euo pipefail
+
+source /runner-root/config/functions.sh
+
+nice_curl https://raw.githubusercontent.com/openxla/iree/main/build_tools/docker/prod_digests.txt \
+  --output /tmp/prod_digests.txt
+
+# Basically everything uses a derivative of one of these
+grep 'gcr.io/iree-oss/base@' /tmp/prod_digests.txt | xargs docker pull
+grep 'gcr.io/iree-oss/base-bleeding-edge@' /tmp/prod_digests.txt | xargs docker pull
+
+RUNNER_TYPE="$(get_attribute github-runner-type)"
+
+if [[ "${RUNNER_TYPE}" == gpu || "${RUNNER_TYPE}" == a100 ]]; then
+  grep 'gcr.io/iree-oss/nvidia@' /tmp/prod_digests.txt | xargs docker pull
+fi
+
+if [[ "${RUNNER_TYPE}" == a100 ]]; then
+  grep 'gcr.io/iree-oss/nvidia-bleeding-edge@' /tmp/prod_digests.txt | xargs docker pull
+fi

--- a/build_tools/github_actions/runner/config/systemd/system/preload-docker.service
+++ b/build_tools/github_actions/runner/config/systemd/system/preload-docker.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=GitHub Actions Runner
+After=docker.target
+
+[Service]
+User=runner
+Group=runner
+Type=oneshot
+EnvironmentFile=/etc/environment
+ExecStart=/runner-root/config/systemd/scripts/preload_docker.sh
+Restart=no
+RemainAfterExit=yes
+
+[Install]
+WantedBy=runner-setup.target


### PR DESCRIPTION
This should reduce job latency by pre-fetching some work that would
otherwise be done when we call `docker run`. The disadvantage is that
it will be fetching unnecessary things, so we try to keep the set of
images limited.

This won't reduce resource usage, but should reduce job latency on
average.