### PR TITLE
Adjust the universal flow-level padding for narrow static-sized dimensions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -83,6 +83,11 @@ struct FoldTrailingUnitTranspose
     }
     if (numDropDims == 0) return failure();
 
+    if (numDropDims == inputTy.getRank()) {
+      rewriter.replaceOp(op, op.getInput());
+      return success();
+    }
+
     Location loc = op.getLoc();
     SmallVector<OpFoldResult> srcMixedSizes =
         tensor::createDimValues(rewriter, loc, op.getInput());

--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_pack_unpack_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_pack_unpack_ops.mlir
@@ -35,6 +35,18 @@ func.func @simple_pad_and_pack(%input: tensor<5x1xf32>, %output: tensor<1x1x8x2x
 
 // -----
 
+func.func @simple_pack_1x1_to_1x1x1x1(%input: tensor<1x1xf32>, %output: tensor<1x1x1x1xf32>, %pad: f32) -> tensor<1x1x1x1xf32> {
+  %0 = tensor.pack %input padding_value(%pad : f32) inner_dims_pos = [0, 1] inner_tiles = [1, 1] into %output : tensor<1x1xf32> -> tensor<1x1x1x1xf32>
+  return %0 : tensor<1x1x1x1xf32>
+}
+// CHECK-LABEL: func.func @simple_pack_1x1_to_1x1x1x1
+// CHECK-SAME:    %[[IN:[A-Za-z0-9]+]]:
+// CHECK-SAME:    %[[OUT:[A-Za-z0-9]+]]:
+// CHECK:         %[[INSERT:.+]] = tensor.insert_slice %[[IN]] into %[[OUT]][0, 0, 0, 0] [1, 1, 1, 1] [1, 1, 1, 1]
+// CHECK:         return %[[INSERT]]
+
+// -----
+
 func.func @simple_NC_to_CNnc(%arg0: tensor<32x8xf32>, %arg1: tensor<1x1x32x8xf32>) -> tensor<1x1x32x8xf32>{
   %0 = tensor.pack %arg0 outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 8] into %arg1 : tensor<32x8xf32> -> tensor<1x1x32x8xf32>
   return %0 : tensor<1x1x32x8xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -6,6 +6,8 @@
 
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 
+#include <iree/compiler/Utils/DataTilingUniversalPadding.h>
+
 #include <memory>
 
 #include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
@@ -262,7 +264,9 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPredicatedPass(clNormalizeInputIndexingMap,
                          createInterchangeTransposeGenericOpsPass)
       // Enable data tiling after all linalg level transformations.
-      .addPredicatedPass(clEnableDataTiling, createSetEncodingPass)
+      .addPredicatedPass(
+          clEnableDataTiling,
+          []() { return createSetEncodingPass(DataTilingUniversalPadding); })
       ////////////////////////////////////////////////////////////////////////
       // Dispatch region formation.
       .addPredicatedPass(!clDispatchTransformFileName.empty(),

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_PASSES_H_
 
 #include <functional>
+#include <optional>
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "llvm/ADT/StringMap.h"
@@ -121,7 +122,8 @@ std::unique_ptr<Pass> createConvertToFlowPass();
 std::unique_ptr<Pass> createOptimizeNumericsPass();
 
 // Sets encoding for tensors to allow tiled execution of operations.
-std::unique_ptr<Pass> createSetEncodingPass();
+std::unique_ptr<Pass> createSetEncodingPass(
+    std::optional<int64_t> padding = std::nullopt);
 
 // Strips the signed/unsigned portion off of tensors.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -251,7 +251,7 @@ def SetEncoding : Pass<"iree-flow-set-encoding", ""> {
   let summary = "Introduce tensor encoding for compute operations";
   let constructor = "mlir::iree_compiler::IREE::Flow::createSetEncodingPass()";
   let options = [
-    Option<"defaultPadding", "default-padding", "int64_t",
+    Option<"optionDefaultPadding", "default-padding", "int64_t",
            /*default=*/"16",
            "Default padding to use so packing can be done without padding during the packing">
   ];

--- a/compiler/src/iree/compiler/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Utils/BUILD.bazel
@@ -29,6 +29,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "ConversionUtils.h",
+        "DataTilingUniversalPadding.h",
         "ElementPackingUtils.h",
         "FlatbufferUtils.h",
         "IndexSet.h",

--- a/compiler/src/iree/compiler/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Utils/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_cc_library(
     Utils
   HDRS
     "ConversionUtils.h"
+    "DataTilingUniversalPadding.h"
     "ElementPackingUtils.h"
     "FlatbufferUtils.h"
     "IndexSet.h"

--- a/compiler/src/iree/compiler/Utils/DataTilingUniversalPadding.h
+++ b/compiler/src/iree/compiler/Utils/DataTilingUniversalPadding.h
@@ -1,0 +1,49 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_UTILS_DATATILINGUNIVERSALPADDING_H_
+#define IREE_COMPILER_UTILS_DATATILINGUNIVERSALPADDING_H_
+
+namespace mlir {
+namespace iree_compiler {
+
+// When using data-tiling, during Flow, the SetEncoding pass must ensure that
+// allocated buffers will be large enough for the eventual padded-and-tiled
+// buffers. Those will only be created in the MaterializeEncoding pass, in HAL.
+// Until then, the exact tile sizes aren't know. Our short-term approach to
+// unblock this is to let SetEncoding pad everything to the next multiple of
+// a "universal" padding size. In order for this to work, this universal padding
+// value must be greater than or equal to any actual tile size that can occur.
+//
+// This widening of tensors is particularly problematic for narrow tensors. For
+// example, it is inefficient to rewrite a tensor<1x1024xf32> into
+// tensor<16x1024xf32>, using only row 0, leaving the other 15 rows unused. To
+// remedy that in the short term until a better solution is found, we have the
+// following contract: for any dimension that is statically sized and whose size
+// is less than DataTilingUniversalPadding, the largest tile size that
+// MaterializeEncoding is allowed to choose is the original dimension size
+// rounded up to the next power of two.
+//
+// Example. If DataTilingUniversalPadding=16, then:
+//
+// For the source tensor type | MaterializeEncoding can choose tile sizes up to
+// -------------------------- | -----------------------------------------------
+// tensor<20x40xf32>          | 16x16
+// tensor<20x1xf32>           | 16x1
+// tensor<1x40xf32>           | 1x16
+// tensor<1x1xf32>            | 1x1
+// tensor<20x2xf32>           | 16x2
+// tensor<20x3xf32>           | 16x4
+// tensor<20x4xf32>           | 16x4
+// tensor<20x5xf32>           | 16x8
+//
+// TODO(#11632) - find a way to do without universal padding.
+const int DataTilingUniversalPadding = 16;
+
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_UTILS_DATATILINGUNIVERSALPADDING_H_

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -590,6 +590,9 @@ IREE_VMVX_ABI_EXPORT(iree_vmvx_mmt4d, mmt4d, v) {
       .K0 = K0,
       .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
   };
+  fprintf(stderr, "M0=%ld N0=%ld K0=%ld\n", M0, N0, K0);
+  fprintf(stderr, "lhs_buffer=%p rhs_buffer=%p out_buffer=%p\n", lhs_buffer,
+          rhs_buffer, out_buffer);
   iree_uk_mmt4d(&ukernel_params);
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();


### PR DESCRIPTION
This is part-solution, part-reframing for #11632. The immediate motivation is that https://github.com/nod-ai/SHARK/issues/1581 is about a model that is all vector-times-matrix matmuls, and at the moment we are padding everything to the next multiple of 16 in Flow (which is the topic of #11632). To get good performance on mat-vec we need to stop doing that.

There was some existing logic in MaterializeEncoding to adjust tile sizes to narrow static dimensions (`adjustTileSizesToNarrowStaticShape`) but it was framed as a local implementation detail, which prevented letting Flow take advantage of it to say: "Since MaterializeEncoding will never generate tiles greater than this along this narrow dimension, I also don't need to pad more than this".

This PR changes that into a real contract between Flow (SetEncoding) and HAL (MaterializeEncoding).

At the moment, there is an e2e matmul test failure specifically only with the VMVX backend with ukernels, with 1x1 matrices: now that they aren't padded anymore to 16x16, the ukernel is being called with the same data pointer for the LHS and RHS matrices. (See printfs intentionally left in for now). @benvanik @stellaraccident any idea?