### PR TITLE
Ignore deleted files in python format checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,7 +64,9 @@ jobs:
           python3 -m pip install black==23.3
       - name: Check if modified files are formatted
         run: |
-          git diff "${GITHUB_BASE_REF?}" --name-only -- '*.py' ':!third_party' \
+          # The filter lowercase `d` means to exclude deleted files.
+          git diff "${GITHUB_BASE_REF?}" --name-only --diff-filter=d \
+            -- '*.py' ':!third_party' \
             | xargs --no-run-if-empty black --check --diff --verbose
       - name: Instructions for fixing the above linting errors
         if: failure()

--- a/build_tools/scripts/lint.sh
+++ b/build_tools/scripts/lint.sh
@@ -55,7 +55,9 @@ ${scripts_dir}/run_buildifier.sh
 git diff --exit-code
 
 echo "***** black *****"
-git diff main --name-only -- '*.py' ':!third_party' | xargs -r black
+# The filter lowercase `d` means to exclude deleted files.
+git diff main --name-only --diff-filter=d -- '*.py' ':!third_party' \
+  | xargs -r black
 
 echo "***** pytype *****"
 ./build_tools/pytype/check_diff.sh


### PR DESCRIPTION
Add `--diff-filter=d` in `git diff` to ignore deleted files when checking formats; otherwise `black` will fail to find the deleted files.

`d` means deleted and lowercase means to exclude.

skip-ci: Not run in CI workflow