### PR TITLE
Add compiler code reformatting to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,6 @@
 
 # Use Black to format Python files (#14161)
 be24f0258a520a48555c9baec9d2f737ba1c2ca0
+
+# Switch compiler to LLVM/MLIR formatting style (#14181)
+3b652d46e86cd82cc81922a964327b12dc914428


### PR DESCRIPTION
With this added the reformatting change will not show up in line history. This is supported by both `git blame` and GitHub web ui.

If you haven't already, add this file to your git config with:
```shell
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Issue: https://github.com/openxla/iree/issues/12866

skip-ci: Dotfile change only.