### PR TITLE
Remove INTERFACE copts/linkopts from external_cc_library header libraries.

### DIFF
--- a/build_tools/cmake/external_cc_library.cmake
+++ b/build_tools/cmake/external_cc_library.cmake
@@ -158,16 +158,6 @@ function(external_cc_library)
         "$<BUILD_INTERFACE:${IREE_BINARY_DIR}>"
         "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
     )
-    target_compile_options(${_NAME}
-      INTERFACE
-        ${IREE_DEFAULT_COPTS}
-        ${_RULE_COPTS}
-    )
-    target_link_options(${_NAME}
-      INTERFACE
-        ${IREE_DEFAULT_LINKOPTS}
-        ${_RULE_LINKOPTS}
-    )
     target_link_libraries(${_NAME}
       INTERFACE
         ${_RULE_DEPS}


### PR DESCRIPTION
I believe that this is the cause of a lot of option issues in users of header external libraries (happens to include vulkan and cuda hals). Took my quite a bit of hunting to find this being done incorrectly.

Fixes #14211