### PR TITLE
Use name instead of ID for benchmark artifacts and targets

### DIFF
--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -48,6 +48,7 @@ function(iree_import_tflite_model)
       DEPENDS
         "${_RULE_SOURCE}"
       COMMENT "Importing TFLite model ${_MODEL_BASENAME}"
+      VERBATIM
     )
     add_custom_target("${_RULE_TARGET_NAME}"
       DEPENDS
@@ -102,6 +103,7 @@ function(iree_import_tf_model)
       DEPENDS
         "${_RULE_SOURCE}"
       COMMENT "Importing TF model ${_MODEL_BASENAME}"
+      VERBATIM
     )
     add_custom_target("${_RULE_TARGET_NAME}"
       DEPENDS

--- a/build_tools/python/e2e_test_artifacts/CMakeLists.txt
+++ b/build_tools/python/e2e_test_artifacts/CMakeLists.txt
@@ -18,5 +18,12 @@ iree_build_tools_py_test(
     "iree_artifacts_test.py"
 )
 
+iree_build_tools_py_test(
+  NAME
+    utils_test
+  SRC
+    "utils_test.py"
+)
+
 
 add_subdirectory(cmake_generator)

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Sequence
 import pathlib
 
 from benchmark_suites.iree import benchmark_presets
-from e2e_test_artifacts import iree_artifacts
+from e2e_test_artifacts import iree_artifacts, utils
 from e2e_test_artifacts.cmake_generator import model_rule_generator
 from e2e_test_framework.definitions import iree_definitions
 import cmake_builder.rules
@@ -66,8 +66,8 @@ class IreeRuleBuilder(object):
                 cmake_rules=[],
             )
 
-        # Import target name: iree-imported-model-<imported_model_id>
-        target_name = f"iree-imported-model-{imported_model.composite_id}"
+        # Import target name: iree-imported-model-<imported_model_name>
+        target_name = utils.get_safe_name(f"iree-imported-model-{imported_model.name}")
 
         import_flags = import_config.materialize_import_flags(model)
         if import_config.tool == iree_definitions.ImportTool.TFLITE_IMPORTER:
@@ -109,8 +109,10 @@ class IreeRuleBuilder(object):
             module_dir_path=output_file_path.parent
         )
 
-        # Module target name: iree-module-<gen_config_id>
-        target_name = f"iree-module-{module_generation_config.composite_id}"
+        # Module target name: iree-module-<gen_config_name>
+        target_name = utils.get_safe_name(
+            f"iree-module-{module_generation_config.name}"
+        )
 
         cmake_rules = [
             cmake_builder.rules.build_iree_bytecode_module(

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
@@ -7,6 +7,7 @@
 import pathlib
 import unittest
 
+from e2e_test_artifacts import utils
 from e2e_test_artifacts.cmake_generator import model_rule_generator, iree_rule_generator
 from e2e_test_framework.definitions import common_definitions, iree_definitions
 
@@ -43,7 +44,7 @@ class IreeRuleBuilderTest(unittest.TestCase):
 
         self.assertEqual(
             rule.target_name,
-            f"iree-imported-model-{tflite_imported_model.composite_id}",
+            utils.get_safe_name(f"iree-imported-model-{tflite_imported_model.name}"),
         )
         self.assertEqual(rule.output_file_path, output_file_path)
 
@@ -114,7 +115,9 @@ class IreeRuleBuilderTest(unittest.TestCase):
             output_file_path=output_file_path,
         )
 
-        self.assertEqual(rule.target_name, f"iree-module-{gen_config.composite_id}")
+        self.assertEqual(
+            rule.target_name, utils.get_safe_name(f"iree-module-{gen_config.name}")
+        )
         self.assertEqual(rule.output_module_path, output_file_path)
 
     def test_build_target_path(self):
@@ -202,8 +205,8 @@ class IreeGeneratorTest(unittest.TestCase):
                 cmake_rules=["abc"],
             ),
             model_b.id: model_rule_generator.ModelRule(
-                target_name="model-y",
-                file_path=pathlib.PurePath("root/model_5678_stablehlo_m.mlir"),
+                target_name=f"model-y",
+                file_path=pathlib.PurePath("root/model_stablehlo_m.mlir"),
                 cmake_rules=["efg"],
             ),
         }
@@ -218,16 +221,20 @@ class IreeGeneratorTest(unittest.TestCase):
 
         concated_cmake_rules = "\n".join(cmake_rules)
         self.assertRegex(
-            concated_cmake_rules, f"iree-imported-model-{imported_model_a.composite_id}"
+            concated_cmake_rules,
+            utils.get_safe_name(f"iree-imported-model-{imported_model_a.name}"),
         )
         self.assertRegex(
-            concated_cmake_rules, f"iree-module-{gen_config_a.composite_id}"
+            concated_cmake_rules,
+            utils.get_safe_name(f"iree-module-{gen_config_a.name}"),
         )
         self.assertRegex(
-            concated_cmake_rules, f"iree-module-{gen_config_b.composite_id}"
+            concated_cmake_rules,
+            utils.get_safe_name(f"iree-module-{gen_config_b.name}"),
         )
         self.assertRegex(
-            concated_cmake_rules, f"iree-module-{gen_config_c.composite_id}"
+            concated_cmake_rules,
+            utils.get_safe_name(f"iree-module-{gen_config_c.name}"),
         )
 
 

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterable, List
 import pathlib
 import urllib.parse
 
-from e2e_test_artifacts import model_artifacts
+from e2e_test_artifacts import model_artifacts, utils
 from e2e_test_framework.definitions import common_definitions
 import cmake_builder.rules
 
@@ -29,8 +29,8 @@ def generate_model_rule_map(
 
     model_rules = {}
     for model in models:
-        # Model target: <package_name>-model-<model_id>
-        target_name = f"model-{model.id}"
+        # Model target: <package_name>-model-<model_name>
+        target_name = utils.get_safe_name(f"model-{model.name}")
         model_path = model_artifacts.get_model_path(model=model, root_path=root_path)
 
         model_url = urllib.parse.urlparse(model.source_url)

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator_test.py
@@ -7,7 +7,7 @@
 import pathlib
 import unittest
 
-from e2e_test_artifacts import model_artifacts
+from e2e_test_artifacts import model_artifacts, utils
 from e2e_test_artifacts.cmake_generator import model_rule_generator
 from e2e_test_framework.definitions import common_definitions
 
@@ -39,12 +39,18 @@ class CommonGeneratorsTest(unittest.TestCase):
         )
 
         self.assertEqual(list(rule_map.keys()), [model_a.id, model_b.id])
-        self.assertEqual(rule_map[model_a.id].target_name, f"model-{model_a.id}")
+        self.assertEqual(
+            rule_map[model_a.id].target_name,
+            utils.get_safe_name(f"model-{model_a.name}"),
+        )
         self.assertEqual(
             rule_map[model_a.id].file_path,
             model_artifacts.get_model_path(model=model_a, root_path=root_path),
         )
-        self.assertEqual(rule_map[model_b.id].target_name, f"model-{model_b.id}")
+        self.assertEqual(
+            rule_map[model_b.id].target_name,
+            utils.get_safe_name(f"model-{model_b.name}"),
+        )
         self.assertEqual(
             rule_map[model_b.id].file_path,
             model_artifacts.get_model_path(model=model_b, root_path=root_path),

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts.py
@@ -3,26 +3,17 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-"""Helpers that generates paths for IREE artifacts."""
+"""Helpers that generate paths for IREE artifacts."""
 
 from typing import Dict, Iterable
 import pathlib
 
-from e2e_test_artifacts import model_artifacts
+from e2e_test_artifacts import model_artifacts, utils
 from e2e_test_framework.definitions import common_definitions, iree_definitions
 
 IREE_ARTIFACT_PREFIX = "iree"
 MODULE_FILENAME = "module.vmfb"
 SCHEDULING_STATS_FILENAME = "scheduling_stats.json"
-
-
-def _get_model_prefix(imported_model: iree_definitions.ImportedModel) -> str:
-    """Returns the model prefix for IREE artifacts. The common prefix helps group
-    artifacts from the same model together for easier navigation.
-    """
-    model = imported_model.model
-    # IREE model prefix: <iree_artifact_prefix>_<model_name>
-    return f"{IREE_ARTIFACT_PREFIX}_{model.name}"
 
 
 def get_imported_model_path(
@@ -47,9 +38,9 @@ def get_imported_model_path(
         # Uses the MLIR model directly.
         return model_artifacts.get_model_path(model=model, root_path=root_path)
 
-    model_prefix = _get_model_prefix(imported_model)
-    # Imported model path: <root_path>/<model_prefix>_<imported_model_id>.mlir
-    return root_path / f"{model_prefix}_{imported_model.composite_id}.mlir"
+    # Imported model path: <root_path>/<iree_artifact_prefix>_<imported_model_name>.mlir
+    filename = utils.get_safe_name(f"{IREE_ARTIFACT_PREFIX}_{imported_model.name}.mlir")
+    return root_path / filename
 
 
 def get_module_dir_path(
@@ -66,9 +57,11 @@ def get_module_dir_path(
     Returns:
       Path of the module directory.
     """
-    model_prefix = _get_model_prefix(module_generation_config.imported_model)
-    # Module dir path: <root_path>/<model_prefix>_module_<gen_config_id>
-    return root_path / f"{model_prefix}_module_{module_generation_config.composite_id}"
+    # Module dir path: <root_path>/<iree_artifact_prefix>_module_<gen_config_name>
+    filename = utils.get_safe_name(
+        f"{IREE_ARTIFACT_PREFIX}_module_{module_generation_config.name}"
+    )
+    return root_path / filename
 
 
 def get_dependent_model_map(

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
@@ -8,7 +8,7 @@ import pathlib
 import unittest
 
 from e2e_test_framework.definitions import common_definitions, iree_definitions
-from e2e_test_artifacts import model_artifacts, iree_artifacts
+from e2e_test_artifacts import model_artifacts, iree_artifacts, utils
 
 
 class IreeArtifactsTest(unittest.TestCase):
@@ -29,10 +29,12 @@ class IreeArtifactsTest(unittest.TestCase):
             imported_model=imported_model, root_path=root_path
         )
 
+        filename = utils.get_safe_name(
+            f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{imported_model.name}.mlir"
+        )
         self.assertEqual(
             path,
-            root_path / f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{model.name}_"
-            f"{imported_model.composite_id}.mlir",
+            root_path / filename,
         )
 
     def test_get_imported_model_path_with_mlir_model(self):
@@ -87,10 +89,12 @@ class IreeArtifactsTest(unittest.TestCase):
             module_generation_config=gen_config, root_path=root_path
         )
 
+        filename = utils.get_safe_name(
+            f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_module_{gen_config.name}"
+        )
         self.assertEqual(
             path,
-            root_path / f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{model.name}_"
-            f"module_{gen_config.composite_id}",
+            root_path / filename,
         )
 
     def test_get_dependent_model_map(self):

--- a/build_tools/python/e2e_test_artifacts/model_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/model_artifacts.py
@@ -3,11 +3,12 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-"""Helpers that generates paths for model artifacts."""
+"""Helpers that generate paths for model artifacts."""
 
 import pathlib
 import urllib.parse
 
+from e2e_test_artifacts import utils
 from e2e_test_framework.definitions import common_definitions
 
 MODEL_ARTIFACT_PREFIX = "model"
@@ -34,5 +35,6 @@ def get_model_path(
         file_exts.pop()
     model_ext = "".join(file_exts)
 
-    # Model path: <root_path>/<model_artifact_prefix>_<model_id>_<model_name><model_ext>
-    return root_path / f"{MODEL_ARTIFACT_PREFIX}_{model.id}_{model.name}{model_ext}"
+    # Model path: <root_path>/<model_artifact_prefix>_<model_name><model_ext>
+    filename = utils.get_safe_name(model.name + model_ext)
+    return root_path / f"{MODEL_ARTIFACT_PREFIX}_{filename}"

--- a/build_tools/python/e2e_test_artifacts/model_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/model_artifacts_test.py
@@ -7,7 +7,7 @@
 import pathlib
 import unittest
 
-from e2e_test_artifacts import model_artifacts
+from e2e_test_artifacts import model_artifacts, utils
 from e2e_test_framework.definitions import common_definitions
 
 
@@ -26,10 +26,12 @@ class ModelArtifactsTest(unittest.TestCase):
 
         path = model_artifacts.get_model_path(model=tflite_model, root_path=root_path)
 
+        filename = utils.get_safe_name(
+            f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tflite_model.name}.tflite"
+        )
         self.assertEqual(
             path,
-            root_path
-            / f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tflite_model.id}_{tflite_model.name}.tflite",
+            root_path / filename,
         )
 
     def test_get_model_path_with_tf_model(self):
@@ -38,7 +40,7 @@ class ModelArtifactsTest(unittest.TestCase):
             name="tf_m",
             tags=[],
             source_type=common_definitions.ModelSourceType.EXPORTED_STABLEHLO_MLIR,
-            source_url="https://example.com/xyz_mlir",
+            source_url="https://example.com/xyz_stablehlo.mlir",
             entry_function="predict",
             input_types=["2xf32"],
         )
@@ -46,10 +48,12 @@ class ModelArtifactsTest(unittest.TestCase):
 
         path = model_artifacts.get_model_path(model=tf_model, root_path=root_path)
 
+        filename = utils.get_safe_name(
+            f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tf_model.name}.mlir"
+        )
         self.assertEqual(
             path,
-            root_path
-            / f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tf_model.id}_{tf_model.name}",
+            root_path / filename,
         )
 
 

--- a/build_tools/python/e2e_test_artifacts/utils.py
+++ b/build_tools/python/e2e_test_artifacts/utils.py
@@ -1,0 +1,16 @@
+## Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Utilities that help generate artifacts."""
+
+import re
+
+# The characters unsafe for CMake and file systems.
+UNSAFE_CHARACTERS = re.compile(r"[^0-9a-zA-Z\-_.]")
+
+
+def get_safe_name(name: str) -> str:
+    """Replace unsafe characters for CMake and file systems with `_`."""
+    return UNSAFE_CHARACTERS.sub("_", name)

--- a/build_tools/python/e2e_test_artifacts/utils.py
+++ b/build_tools/python/e2e_test_artifacts/utils.py
@@ -7,7 +7,10 @@
 
 import re
 
-# The characters unsafe for CMake and file systems.
+# The characters unsafe for CMake and file systems. It's the negation of the
+# allowed list, which is derived from the join of
+# https://cmake.org/cmake/help/v3.27/policy/CMP0037.html and
+# https://www.mtu.edu/umc/services/websites/writing/characters-avoid/.
 UNSAFE_CHARACTERS = re.compile(r"[^0-9a-zA-Z\-_.]")
 
 

--- a/build_tools/python/e2e_test_artifacts/utils_test.py
+++ b/build_tools/python/e2e_test_artifacts/utils_test.py
@@ -1,0 +1,27 @@
+## Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+from e2e_test_artifacts import utils
+
+
+class UtilsTest(unittest.TestCase):
+    def test_get_safe_name_with_disallowed_characters(self):
+        sanitized_name = utils.get_safe_name("test(abc) [x,y,z]")
+
+        self.assertEqual(sanitized_name, "test_abc___x_y_z_")
+
+    def test_get_safe_name_with_all_allowed_characters(self):
+        safe_name = "123_AB-C.test"
+
+        sanitized_name = utils.get_safe_name(safe_name)
+
+        self.assertEqual(sanitized_name, safe_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -9,8 +9,8 @@ iree_benchmark_suite_module_test(
   DRIVER "local-sync"
   EXPECTED_OUTPUT "mobilenet_v1_fp32_expected_output.txt"
   MODULES
-    "riscv_64-Linux=iree_MobileNetV1_fp32_module_e80d71ed8e86c0756226b2323e27e2c7c0fff8eddde59ba69e9222d36ee3eef6/module.vmfb"
-    "x86_64-Linux=iree_MobileNetV1_fp32_module_02cebfbec13685725c5b3c805c6c620ea3f885027bfbb14d17425798e391486f/module.vmfb"
+    "riscv_64-Linux=iree_module_MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
+    "x86_64-Linux=iree_module_MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   RUNNER_ARGS
     "--function=main"
     "--input=1x224x224x3xf32=0"
@@ -22,7 +22,7 @@ iree_benchmark_suite_module_test(
   DRIVER "local-sync"
   EXPECTED_OUTPUT "efficientnet_int8_expected_output.txt"
   MODULES
-    "x86_64-Linux=iree_EfficientNet_int8_module_3926415c1504dfc277674fee17bdfbd68090634b8b52620d8d5755082a89a16d/module.vmfb"
+    "x86_64-Linux=iree_module_EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   RUNNER_ARGS
     "--function=main"
     "--input=1x224x224x3xui8=0"
@@ -34,8 +34,8 @@ iree_benchmark_suite_module_test(
   DRIVER "local-sync"
   EXPECTED_OUTPUT "deeplab_v3_fp32_input_0_expected_output.npy"
   MODULES
-    "arm_64-Android=iree_DeepLabV3_fp32_module_f06fff09f8cebc27d1674045712aaa60afe7aef388c4bc505897f55c3a0d8abb/module.vmfb"
-    "x86_64-Linux=iree_DeepLabV3_fp32_module_87aead729018ce5f114501cecefb6315086eb2a21ae1b30984b1794f619871c6/module.vmfb"
+    "arm_64-Android=iree_module_DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
+    "x86_64-Linux=iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   RUNNER_ARGS
     "--function=main"
     "--input=1x257x257x3xf32=0"
@@ -48,9 +48,9 @@ iree_benchmark_suite_module_test(
   DRIVER "local-sync"
   EXPECTED_OUTPUT "1x2xi8=[72 -72]"
   MODULES
-    "riscv_32-Linux=iree_PersonDetect_int8_module_1ef2da238443010024d69ceb6fe6ab6fa8cf5f4ce7d424dace3a572592043e70/module.vmfb"
-    "riscv_64-Linux=iree_PersonDetect_int8_module_14a15b9072caaee5e2a274a9bbc436a56d095611e5a8e9841f110741d34231f9/module.vmfb"
-    "x86_64-Linux=iree_PersonDetect_int8_module_eb56e91246a131fa41bd335c1c072ffb6e7ffe651ecf65f4eeb171b12848b0ed/module.vmfb"
+    "riscv_32-Linux=iree_module_PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
+    "riscv_64-Linux=iree_module_PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
+    "x86_64-Linux=iree_module_PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   RUNNER_ARGS
     "--function=main"
     "--input=1x96x96x1xi8=0"

--- a/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
@@ -1,727 +1,727 @@
 iree_fetch_artifact(
-  NAME "model-bc1338be-e3df-44fd-82e4-40ba9560a073"
+  NAME "model-PersonDetect_int8"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/person_detect.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-58855e40-eba9-4a71-b878-6b35e3460244"
+  NAME "model-MobileNetV3Small_fp32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/MobileNetV3SmallStaticBatch.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c36c63b0-220a-4d78-8ade-c45ce47d89d3"
+  NAME "model-DeepLabV3_fp32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/deeplabv3.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-4a6f545e-1b4e-41a5-9236-792aa578184b"
+  NAME "model-EfficientNet_int8"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/efficientnet_lite0_int8_2.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-78eab9e5-9ff1-4769-9b55-933c81cc9a0f"
+  NAME "model-MobileNetV1_fp32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v1_224_1.0_float.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.0_float.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32.0_float.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-7d45f8e5-bb5e-48d0-928d-8f125104578f"
+  NAME "model-MobileNetV2_fp32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v2_1.0_224.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.0_224.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32.0_224.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-3dd5a95e-92a9-4486-9062-9a33224f28db"
+  NAME "model-MobileNetV2_int8"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v2_1.0_224_quantized.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_3dd5a95e-92a9-4486-9062-9a33224f28db_MobileNetV2_int8.0_224_quantized.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_int8.0_224_quantized.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-0e466f69-91d6-4e50-b62b-a82b6213a231"
+  NAME "model-MobileSSD_fp32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/mobile_ssd_v2_float_coco.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5afc3014-d29d-4e88-a840-fbaf678acf2b"
+  NAME "model-PoseNet_fp32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/posenet.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-73a0402e-271b-4aa8-a6a5-ac05839ca569"
+  NAME "model-MobileBertSquad_fp16"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/mobilebertsquad.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cc69d69f-6d1f-4a1a-a31e-e021888d0d28"
+  NAME "model-MobileBertSquad_fp32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-float.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-e3997104-a3d2-46b4-9fbf-39069906d123"
+  NAME "model-MobileBertSquad_int8"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-quant.tflite"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.tflite"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-ebe7897f-5613-435b-a330-3cb967704e5e"
+  NAME "model-EfficientNetV2STF"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/manual/EfficientNetV2STF_2023-05-07.timestamp_1683504734.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.timestamp_1683504734.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF.timestamp_1683504734.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-ecf5c970-ee97-49f0-a4ed-df1f34e9d493"
+  NAME "model-MiniLML12H384Uncased"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/manual/MiniLML12H384Uncased_2023-05-07.timestamp_1683504734.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cc474102-7d2f-4ec1-92ae-84e83ba0f390"
+  NAME "model-EfficientNetV2SPT"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230321.784_1679461251/EFFICIENTNET_V2_S/batch_1/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cc474102-7d2f-4ec1-92ae-84e83ba0f390_EfficientNetV2SPT.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2SPT.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-39d157ad-f0ec-4a76-963b-d783beaed60f"
+  NAME "model-BertForMaskedLMTF"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/manual/BertForMaskedLMTF_2023-05-07.timestamp_1683504734.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-8871f602-571c-4eb8-b94d-554cc8ceec5a"
+  NAME "model-BertLargeTF"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/manual/BertLargeTF_2023-05-07.timestamp_1683504734.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.timestamp_1683504734.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF.timestamp_1683504734.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-68caa96e-b8bb-48a2-bb08-a3044981a370"
+  NAME "model-EfficientNetB7PT"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230321.784_1679461251/EFFICIENTNET_B7/batch_1/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_68caa96e-b8bb-48a2-bb08-a3044981a370_EfficientNetB7PT.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_EfficientNetB7PT.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1"
+  NAME "model-BertLargeTFBatch1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_1/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1_BertLargeTFBatch1.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-32"
+  NAME "model-BertLargeTFBatch32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_32/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-32_BertLargeTFBatch32.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch32.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-64"
+  NAME "model-BertLargeTFBatch64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_64/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-64_BertLargeTFBatch64.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch64.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-1"
+  NAME "model-Resnet50TFBatch1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/RESNET50/batch_1/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-1_Resnet50TFBatch1.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch1.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-64"
+  NAME "model-Resnet50TFBatch64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/RESNET50/batch_64/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-64_Resnet50TFBatch64.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch64.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-128"
+  NAME "model-Resnet50TFBatch128"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/RESNET50/batch_128/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-128_Resnet50TFBatch128.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch128.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-587e595d-2adf-4e41-9617-43178a133725-batch-1"
+  NAME "model-T5LargeTFBatch1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/T5_LARGE/batch_1/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-1_T5LargeTFBatch1.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch1.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-587e595d-2adf-4e41-9617-43178a133725-batch-16"
+  NAME "model-T5LargeTFBatch16"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/T5_LARGE/batch_16/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-16_T5LargeTFBatch16.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch16.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-587e595d-2adf-4e41-9617-43178a133725-batch-32"
+  NAME "model-T5LargeTFBatch32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/T5_LARGE/batch_32/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-32_T5LargeTFBatch32.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch32.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8"
+  NAME "model-ClipTextSeqLen64PT"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230307.103_1678163233/SD_CLIP_TEXT_MODEL_SEQLEN64/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8_ClipTextSeqLen64PT.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_ClipTextSeqLen64PT.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-340553d1-e6fe-41b6-b2c7-687c74ccec56"
+  NAME "model-Unet2dPT"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230307.103_1678163233/SD_UNET_MODEL/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_340553d1-e6fe-41b6-b2c7-687c74ccec56_Unet2dPT.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Unet2dPT.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1"
+  NAME "model-BertLargefp16PTBatch1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_1/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1_BertLargefp16PTBatch1.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-271ea7a0-68e7-45b6-91f4-f39d5ce9e29c"
+  NAME "model-EfficientNetV2Sfp16PT"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684831160/EFFICIENTNET_V2_S_FP16/batch_1/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_271ea7a0-68e7-45b6-91f4-f39d5ce9e29c_EfficientNetV2Sfp16PT.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2Sfp16PT.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-50a7aece-73f9-47f4-a93a-4a1178f45407"
+  NAME "model-matmul_3456x1024x2048_f16t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230410_1681181224/matmul_3456x1024x2048_f16t_f16t_f16t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_50a7aece-73f9-47f4-a93a-4a1178f45407_matmul_3456x1024x2048_f16t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_3456x1024x2048_f16t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-a55afe1c-9410-47a6-b417-04b0d75ee5f4"
+  NAME "model-matmul_3456x1024x2048_f32t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230410_1681181224/matmul_3456x1024x2048_f32t_f32t_f32t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_a55afe1c-9410-47a6-b417-04b0d75ee5f4_matmul_3456x1024x2048_f32t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_3456x1024x2048_f32t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-81cebaaf-e23d-4a32-89dc-9fc7adc37a8f"
+  NAME "model-matmul_2560x2560x2560_f16t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230410_1681181224/matmul_2560x2560x2560_f16t_f16t_f16t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_81cebaaf-e23d-4a32-89dc-9fc7adc37a8f_matmul_2560x2560x2560_f16t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_2560x2560x2560_f16t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-579b77ea-76bd-4eb3-bd85-067c25a89eff"
+  NAME "model-matmul_2560x2560x2560_f32t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230410_1681181224/matmul_2560x2560x2560_f32t_f32t_f32t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_579b77ea-76bd-4eb3-bd85-067c25a89eff_matmul_2560x2560x2560_f32t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_2560x2560x2560_f32t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-4e75ff72-f807-49f6-b740-febca1794334"
+  NAME "model-matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230525_1685058259/matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_4e75ff72-f807-49f6-b740-febca1794334_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-8d6be288-9b88-41bd-bc5a-5644df0481bb"
+  NAME "model-matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230525_1685058259/matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_8d6be288-9b88-41bd-bc5a-5644df0481bb_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-0a3d952b-41ca-43d2-9ec3-ccb8dde20ce3"
+  NAME "model-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230525_1685058259/matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_0a3d952b-41ca-43d2-9ec3-ccb8dde20ce3_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-9b81a2f5-bab2-4f6f-b8b5-13cc4b3e9413"
+  NAME "model-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230612_1686563210/matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_9b81a2f5-bab2-4f6f-b8b5-13cc4b3e9413_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-699fd533-02a9-49f0-bf26-1902d8dbb5af"
+  NAME "model-matmul_128x256x8192_f16t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230410_1681181224/matmul_128x256x8192_f16t_f16t_f16t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_699fd533-02a9-49f0-bf26-1902d8dbb5af_matmul_128x256x8192_f16t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_128x256x8192_f16t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-a6c2b812-0a71-45e7-9ea5-f3d8529213ef"
+  NAME "model-matmul_128x256x8192_f32t_tile_config_default"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/microbenchmarks/matmul/20230410_1681181224/matmul_128x256x8192_f32t_f32t_f32t_tile_config_default.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_a6c2b812-0a71-45e7-9ea5-f3d8529213ef_matmul_128x256x8192_f32t_tile_config_default.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_128x256x8192_f32t_tile_config_default.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-8"
+  NAME "model-Resnet50TFBatch8"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/RESNET50/batch_8/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-8_Resnet50TFBatch8.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch8.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-256"
+  NAME "model-Resnet50TFBatch256"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/RESNET50/batch_256/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-256_Resnet50TFBatch256.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch256.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-2048"
+  NAME "model-Resnet50TFBatch2048"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/RESNET50/batch_2048/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-2048_Resnet50TFBatch2048.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch2048.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-16"
+  NAME "model-BertLargeTFBatch16"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_16/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-16_BertLargeTFBatch16.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch16.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-24"
+  NAME "model-BertLargeTFBatch24"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_24/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-24_BertLargeTFBatch24.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch24.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-48"
+  NAME "model-BertLargeTFBatch48"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_48/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-48_BertLargeTFBatch48.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch48.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-512"
+  NAME "model-BertLargeTFBatch512"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_512/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-512_BertLargeTFBatch512.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch512.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024"
+  NAME "model-BertLargeTFBatch1024"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_1024/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024_BertLargeTFBatch1024.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1024.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280"
+  NAME "model-BertLargeTFBatch1280"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/BERT_LARGE/batch_1280/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280_BertLargeTFBatch1280.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1280.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-587e595d-2adf-4e41-9617-43178a133725-batch-24"
+  NAME "model-T5LargeTFBatch24"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/T5_LARGE/batch_24/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-24_T5LargeTFBatch24.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch24.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-587e595d-2adf-4e41-9617-43178a133725-batch-48"
+  NAME "model-T5LargeTFBatch48"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/T5_LARGE/batch_48/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-48_T5LargeTFBatch48.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch48.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-587e595d-2adf-4e41-9617-43178a133725-batch-64"
+  NAME "model-T5LargeTFBatch64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.12.0_1683544084/T5_LARGE/batch_64/hlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-64_T5LargeTFBatch64.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch64.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1"
+  NAME "model-BertLargePTBatch1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_1/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1_BertLargePTBatch1.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-16"
+  NAME "model-BertLargePTBatch16"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_16/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-16_BertLargePTBatch16.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch16.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-24"
+  NAME "model-BertLargePTBatch24"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_24/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-24_BertLargePTBatch24.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch24.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-32"
+  NAME "model-BertLargePTBatch32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_32/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-32_BertLargePTBatch32.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch32.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-48"
+  NAME "model-BertLargePTBatch48"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_48/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-48_BertLargePTBatch48.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch48.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-64"
+  NAME "model-BertLargePTBatch64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_64/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-64_BertLargePTBatch64.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch64.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-512"
+  NAME "model-BertLargePTBatch512"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_512/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-512_BertLargePTBatch512.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch512.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1024"
+  NAME "model-BertLargePTBatch1024"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_1024/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1024_BertLargePTBatch1024.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1024.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1280"
+  NAME "model-BertLargePTBatch1280"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/BERT_LARGE/batch_1280/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1280_BertLargePTBatch1280.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1280.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-1"
+  NAME "model-Resnet50PTBatch1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/RESNET50/batch_1/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-1_Resnet50PTBatch1.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch1.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-8"
+  NAME "model-Resnet50PTBatch8"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/RESNET50/batch_8/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-8_Resnet50PTBatch8.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch8.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-64"
+  NAME "model-Resnet50PTBatch64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/RESNET50/batch_64/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-64_Resnet50PTBatch64.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch64.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-128"
+  NAME "model-Resnet50PTBatch128"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/RESNET50/batch_128/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-128_Resnet50PTBatch128.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch128.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-256"
+  NAME "model-Resnet50PTBatch256"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/RESNET50/batch_256/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-256_Resnet50PTBatch256.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch256.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-2048"
+  NAME "model-Resnet50PTBatch2048"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230401.795_1680469670/RESNET50/batch_2048/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-2048_Resnet50PTBatch2048.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch2048.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-1"
+  NAME "model-Resnet50fp16PTBatch1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/RESNET50_FP16/batch_1/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-1_Resnet50fp16PTBatch1.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch1.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-8"
+  NAME "model-Resnet50fp16PTBatch8"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/RESNET50_FP16/batch_8/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-8_Resnet50fp16PTBatch8.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch8.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-64"
+  NAME "model-Resnet50fp16PTBatch64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/RESNET50_FP16/batch_64/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-64_Resnet50fp16PTBatch64.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch64.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-128"
+  NAME "model-Resnet50fp16PTBatch128"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/RESNET50_FP16/batch_128/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-128_Resnet50fp16PTBatch128.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch128.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-256"
+  NAME "model-Resnet50fp16PTBatch256"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/RESNET50_FP16/batch_256/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-256_Resnet50fp16PTBatch256.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch256.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-2048"
+  NAME "model-Resnet50fp16PTBatch2048"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/RESNET50_FP16/batch_2048/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-2048_Resnet50fp16PTBatch2048.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch2048.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-16"
+  NAME "model-BertLargefp16PTBatch16"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_16/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-16_BertLargefp16PTBatch16.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch16.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-24"
+  NAME "model-BertLargefp16PTBatch24"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_24/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-24_BertLargefp16PTBatch24.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch24.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-32"
+  NAME "model-BertLargefp16PTBatch32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_32/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-32_BertLargefp16PTBatch32.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch32.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-48"
+  NAME "model-BertLargefp16PTBatch48"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_48/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-48_BertLargefp16PTBatch48.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch48.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-64"
+  NAME "model-BertLargefp16PTBatch64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_64/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-64_BertLargefp16PTBatch64.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch64.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-512"
+  NAME "model-BertLargefp16PTBatch512"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_512/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-512_BertLargefp16PTBatch512.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch512.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1024"
+  NAME "model-BertLargefp16PTBatch1024"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_1024/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1024_BertLargefp16PTBatch1024.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1024.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1280"
+  NAME "model-BertLargefp16PTBatch1280"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/pytorch/torch_models_20230522.846_1684830698/BERT_LARGE_FP16/batch_1280/linalg.mlir"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1280_BertLargefp16PTBatch1280.mlir"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1280.mlir"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_1/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1_BERT_LARGE_JAX_384XI32_BATCH1.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch16"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH16"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_16/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch16_BERT_LARGE_JAX_384XI32_BATCH16.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH16.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch24"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH24"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_24/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch24_BERT_LARGE_JAX_384XI32_BATCH24.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH24.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch32"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_32/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch32_BERT_LARGE_JAX_384XI32_BATCH32.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH32.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch48"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH48"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_48/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch48_BERT_LARGE_JAX_384XI32_BATCH48.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH48.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch64"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_64/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch64_BERT_LARGE_JAX_384XI32_BATCH64.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH64.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch512"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH512"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_512/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch512_BERT_LARGE_JAX_384XI32_BATCH512.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH512.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1024"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH1024"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_1024/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1024_BERT_LARGE_JAX_384XI32_BATCH1024.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1024.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1280"
+  NAME "model-BERT_LARGE_JAX_384XI32_BATCH1280"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/BERT_LARGE/batch_1280/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1280_BERT_LARGE_JAX_384XI32_BATCH1280.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1280.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch1"
+  NAME "model-RESNET50_FP32_JAX_3X224X224XF32_BATCH1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/RESNET50/batch_1/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch1_RESNET50_FP32_JAX_3X224X224XF32_BATCH1.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH1.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch8"
+  NAME "model-RESNET50_FP32_JAX_3X224X224XF32_BATCH8"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/RESNET50/batch_8/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch8_RESNET50_FP32_JAX_3X224X224XF32_BATCH8.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH8.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch64"
+  NAME "model-RESNET50_FP32_JAX_3X224X224XF32_BATCH64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/RESNET50/batch_64/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch64_RESNET50_FP32_JAX_3X224X224XF32_BATCH64.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH64.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch128"
+  NAME "model-RESNET50_FP32_JAX_3X224X224XF32_BATCH128"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/RESNET50/batch_128/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch128_RESNET50_FP32_JAX_3X224X224XF32_BATCH128.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH128.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch256"
+  NAME "model-RESNET50_FP32_JAX_3X224X224XF32_BATCH256"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/RESNET50/batch_256/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch256_RESNET50_FP32_JAX_3X224X224XF32_BATCH256.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH256.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch2048"
+  NAME "model-RESNET50_FP32_JAX_3X224X224XF32_BATCH2048"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/RESNET50/batch_2048/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch2048_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch1"
+  NAME "model-T5_LARGE_FP32_JAX_512XI32_BATCH1"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_1/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch1_T5_LARGE_FP32_JAX_512XI32_BATCH1.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH1.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch16"
+  NAME "model-T5_LARGE_FP32_JAX_512XI32_BATCH16"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_16/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch16_T5_LARGE_FP32_JAX_512XI32_BATCH16.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH16.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch24"
+  NAME "model-T5_LARGE_FP32_JAX_512XI32_BATCH24"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_24/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch24_T5_LARGE_FP32_JAX_512XI32_BATCH24.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH24.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch32"
+  NAME "model-T5_LARGE_FP32_JAX_512XI32_BATCH32"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_32/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch32_T5_LARGE_FP32_JAX_512XI32_BATCH32.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH32.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch48"
+  NAME "model-T5_LARGE_FP32_JAX_512XI32_BATCH48"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_48/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch48_T5_LARGE_FP32_JAX_512XI32_BATCH48.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH48.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch64"
+  NAME "model-T5_LARGE_FP32_JAX_512XI32_BATCH64"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_64/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch64_T5_LARGE_FP32_JAX_512XI32_BATCH64.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH64.mlirbc"
   UNPACK
 )
 
 iree_fetch_artifact(
-  NAME "model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch512"
+  NAME "model-T5_LARGE_FP32_JAX_512XI32_BATCH512"
   SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_512/stablehlo.mlirbc"
-  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch512_T5_LARGE_FP32_JAX_512XI32_BATCH512.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH512.mlirbc"
   UNPACK
 )

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -1,79 +1,79 @@
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-a359c8f1e19b6f476e843bdc5566f9554e329cbfb3b4437995ad9cccfb381aee"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.0_float.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_a359c8f1e19b6f476e843bdc5566f9554e329cbfb3b4437995ad9cccfb381aee.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32.0_float.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.0_224.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32.0_224.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_3dd5a95e-92a9-4486-9062-9a33224f28db_MobileNetV2_int8.0_224_quantized.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-MobileNetV2_int8_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_int8.0_224_quantized.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
 )
 
 iree_import_tflite_model(
-  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6"
-  SOURCE "${ROOT_ARTIFACTS_DIR}/model_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.tflite"
-  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
+  TARGET_NAME "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8_tflite_"
+  SOURCE "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8.tflite"
+  OUTPUT_MLIR_FILE "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
 )
 
 iree_bytecode_module(
-  NAME "iree-module-eb56e91246a131fa41bd335c1c072ffb6e7ffe651ecf65f4eeb171b12848b0ed"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_eb56e91246a131fa41bd335c1c072ffb6e7ffe651ecf65f4eeb171b12848b0ed/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -84,9 +84,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-baec9d4086496a94853f349354f87acb8397bf36169134d3269d5803888dcf49"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_baec9d4086496a94853f349354f87acb8397bf36169134d3269d5803888dcf49/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -97,9 +97,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-87aead729018ce5f114501cecefb6315086eb2a21ae1b30984b1794f619871c6"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_87aead729018ce5f114501cecefb6315086eb2a21ae1b30984b1794f619871c6/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -110,9 +110,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3926415c1504dfc277674fee17bdfbd68090634b8b52620d8d5755082a89a16d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_3926415c1504dfc277674fee17bdfbd68090634b8b52620d8d5755082a89a16d/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -123,9 +123,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-02cebfbec13685725c5b3c805c6c620ea3f885027bfbb14d17425798e391486f"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_a359c8f1e19b6f476e843bdc5566f9554e329cbfb3b4437995ad9cccfb381aee.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_module_02cebfbec13685725c5b3c805c6c620ea3f885027bfbb14d17425798e391486f/module.vmfb"
+  NAME "iree-module-MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -136,9 +136,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-429d7055b93250cc19866107e305bef1dc0b7e49e579ef19ea1eeb70eb2fb86d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_429d7055b93250cc19866107e305bef1dc0b7e49e579ef19ea1eeb70eb2fb86d/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -149,9 +149,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-50084c6a5ef433943ae46fbbf852d266d20557be110fff9dea1e4e298040c7c6"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_50084c6a5ef433943ae46fbbf852d266d20557be110fff9dea1e4e298040c7c6/module.vmfb"
+  NAME "iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -162,9 +162,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-737d273c18eb7537e2dde47c4a46391e8657c38f9650032c39bc67fa5f132742"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_737d273c18eb7537e2dde47c4a46391e8657c38f9650032c39bc67fa5f132742/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -175,9 +175,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-92dd923f493f67509a6b54007416f16ac8e6f2023e88f79b3017ea2260ee561a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_92dd923f493f67509a6b54007416f16ac8e6f2023e88f79b3017ea2260ee561a/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -188,9 +188,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-472e6a18344f13d47e89f87670b37eff583ae610c2a1d15ac1cca307ccfc2f4d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_472e6a18344f13d47e89f87670b37eff583ae610c2a1d15ac1cca307ccfc2f4d/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp16_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -201,9 +201,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-95dee09d7f3f9ee36d6c70645585b44b347ea001a1ab9a04b150ca2dc052255f"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_95dee09d7f3f9ee36d6c70645585b44b347ea001a1ab9a04b150ca2dc052255f/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -214,9 +214,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-78154d58dddac432100d656b22fa9bcb45e4207a9ea2bc371bf089a68bad397a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_78154d58dddac432100d656b22fa9bcb45e4207a9ea2bc371bf089a68bad397a/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -227,9 +227,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c8949024e2472bec7b18c4e3757412715c248273005ca6f8d5769656ed425a84"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_c8949024e2472bec7b18c4e3757412715c248273005ca6f8d5769656ed425a84/module.vmfb"
+  NAME "iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -240,9 +240,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a30b64a3d7850881ee9db94e8f75c661af3f76f48d10b3342a6912e1c8879252"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_a30b64a3d7850881ee9db94e8f75c661af3f76f48d10b3342a6912e1c8879252/module.vmfb"
+  NAME "iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -253,9 +253,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-047e75c462648b5fe1133f4ffbc3d1c7bdda154081d3eaa3be0b5445725b272b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cc474102-7d2f-4ec1-92ae-84e83ba0f390_EfficientNetV2SPT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2SPT_module_047e75c462648b5fe1133f4ffbc3d1c7bdda154081d3eaa3be0b5445725b272b/module.vmfb"
+  NAME "iree-module-EfficientNetV2SPT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2SPT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2SPT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=none"
@@ -266,9 +266,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1c7402f88ba881ec6abb39204faa4b5fedb2ffff4a6066555fcff0c7c4b74732"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_module_1c7402f88ba881ec6abb39204faa4b5fedb2ffff4a6066555fcff0c7c4b74732/module.vmfb"
+  NAME "iree-module-BertForMaskedLMTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -279,9 +279,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9c849d0ccfc89c0bca0740949572db8735832012a43c4c9f15c3a8ef0d9cca04"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_9c849d0ccfc89c0bca0740949572db8735832012a43c4c9f15c3a8ef0d9cca04/module.vmfb"
+  NAME "iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -292,9 +292,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-fd5cf4cd75cc1734be3eec2f4396491e9ebb7edd6b9c889cdc29ef72b47d6233"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_68caa96e-b8bb-48a2-bb08-a3044981a370_EfficientNetB7PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetB7PT_module_fd5cf4cd75cc1734be3eec2f4396491e9ebb7edd6b9c889cdc29ef72b47d6233/module.vmfb"
+  NAME "iree-module-EfficientNetB7PT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetB7PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetB7PT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=none"
@@ -305,9 +305,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-711cb4e615cc4e032fe9f198b89e32f4f85c94cab6e9101eb8202b22c97a37b1"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_711cb4e615cc4e032fe9f198b89e32f4f85c94cab6e9101eb8202b22c97a37b1/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -320,9 +320,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c37bfe2bb995b2703170a890bd81e372b687bed57087b1d8a6d8bb16b91c5ad4"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_c37bfe2bb995b2703170a890bd81e372b687bed57087b1d8a6d8bb16b91c5ad4/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -335,9 +335,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3ba167fc59b5959be276b331951c759391d6e158572fc05603981dcc4bd3fc90"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_3ba167fc59b5959be276b331951c759391d6e158572fc05603981dcc4bd3fc90/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -350,9 +350,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-531f99d8bc669343f967598c13ca787c62b01b4dfcd7c4b4ad04a163063a1ddc"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_531f99d8bc669343f967598c13ca787c62b01b4dfcd7c4b4ad04a163063a1ddc/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -365,9 +365,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7e0380f1df059cf6040c12934af4f1c88a469c716a294f383200d5dd5cc69b1d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_7e0380f1df059cf6040c12934af4f1c88a469c716a294f383200d5dd5cc69b1d/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -380,9 +380,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-759fdb2deb885ca5568741853e3497ab3d7037a42a4fdff0af590c803681ec60"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_759fdb2deb885ca5568741853e3497ab3d7037a42a4fdff0af590c803681ec60/module.vmfb"
+  NAME "iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -395,9 +395,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3dbf200159f328bb69c6c5bc79cce408a4ba49d2d07dfb3939786557e63d035c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_3dbf200159f328bb69c6c5bc79cce408a4ba49d2d07dfb3939786557e63d035c/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -410,9 +410,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4b61f532e6cf4e175a7e90cd9418e3c2614176b5253875951f99e52d2621c152"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_4b61f532e6cf4e175a7e90cd9418e3c2614176b5253875951f99e52d2621c152/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -425,9 +425,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8d15dde1c8c2ed90009698c357455dfc94fd96ae877f4892954bef0ec4361de8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_8d15dde1c8c2ed90009698c357455dfc94fd96ae877f4892954bef0ec4361de8/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -440,9 +440,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9a2128d69c5c5a51402e01c4a848e90ec369fa601a3d9fc1ab69dab8db47e6d3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_9a2128d69c5c5a51402e01c4a848e90ec369fa601a3d9fc1ab69dab8db47e6d3/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -455,9 +455,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-aed1ca2855056bcd5b7e51063741685b4a387d9d0574b343e8ddc383b49afc76"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_aed1ca2855056bcd5b7e51063741685b4a387d9d0574b343e8ddc383b49afc76/module.vmfb"
+  NAME "iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -470,9 +470,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-80a2368e148d9605d98060027b9198dea46efbf050a383784ec5df5e85904757"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_80a2368e148d9605d98060027b9198dea46efbf050a383784ec5df5e85904757/module.vmfb"
+  NAME "iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -485,9 +485,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f146632eb124afeb899eeae8aaf5ab6cd9efae22ee9ffb26d34fe1da10049fbe"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_f146632eb124afeb899eeae8aaf5ab6cd9efae22ee9ffb26d34fe1da10049fbe/module.vmfb"
+  NAME "iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -500,9 +500,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a1cdbcd72bb0b7672c5739b372df09aef8d26cf16c58d8da81b45800833a5735"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1_BertLargeTFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1_module_a1cdbcd72bb0b7672c5739b372df09aef8d26cf16c58d8da81b45800833a5735/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -513,9 +513,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-35d83c1c7042590bdda6b704e51c4b2f4af38bd2ed9db75a00632e3f2db1149d"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-32_BertLargeTFBatch32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch32_module_35d83c1c7042590bdda6b704e51c4b2f4af38bd2ed9db75a00632e3f2db1149d/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -526,9 +526,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ba0cb8d4941adfcae0682c84d819555f118b56b7161475386ceeadb7c4b71f09"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-64_BertLargeTFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch64_module_ba0cb8d4941adfcae0682c84d819555f118b56b7161475386ceeadb7c4b71f09/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -539,9 +539,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-10a9a8a00ac0f36f45b5e35a032ca177b68621e3137dc57b9d6e08225301441b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-1_Resnet50TFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch1_module_10a9a8a00ac0f36f45b5e35a032ca177b68621e3137dc57b9d6e08225301441b/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -552,9 +552,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3407fbbc5cb24c7ef432987ec1af9b01dc3626dbe40278bda37c3b3d7c5ac000"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-64_Resnet50TFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch64_module_3407fbbc5cb24c7ef432987ec1af9b01dc3626dbe40278bda37c3b3d7c5ac000/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -565,9 +565,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-780f3809138cfab6b31646debd8b87770f92ccb2ea92e4862801240523f0b573"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-128_Resnet50TFBatch128.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch128_module_780f3809138cfab6b31646debd8b87770f92ccb2ea92e4862801240523f0b573/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch128_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch128.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch128_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -578,9 +578,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1b4cbc14c2735bd4bd2d990f46e6f4843d66a6f688e492e6a02e07d0d4e927ed"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-1_T5LargeTFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch1_module_1b4cbc14c2735bd4bd2d990f46e6f4843d66a6f688e492e6a02e07d0d4e927ed/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -591,9 +591,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0c8eaa0d8238c24ed0c6598e6e713d556697ae695d94d1af142f2f019ead6a31"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-16_T5LargeTFBatch16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch16_module_0c8eaa0d8238c24ed0c6598e6e713d556697ae695d94d1af142f2f019ead6a31/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch16_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch16_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -604,9 +604,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-eadf521de1a4748e1bc771e923e8116aa357b70cb836447757fdbbfc4ad60073"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-32_T5LargeTFBatch32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch32_module_eadf521de1a4748e1bc771e923e8116aa357b70cb836447757fdbbfc4ad60073/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -617,9 +617,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-04ca0a5077b7dd5ace66d803c9b822dff3428b24e7620a61995aff0907af9533"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_04ca0a5077b7dd5ace66d803c9b822dff3428b24e7620a61995aff0907af9533/module.vmfb"
+  NAME "iree-module-EfficientNetV2STF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -629,9 +629,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-deafafd0926321a4b8e4dc73ed4a30b2ed9317d26488246461415be2ee857eb1"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_deafafd0926321a4b8e4dc73ed4a30b2ed9317d26488246461415be2ee857eb1/module.vmfb"
+  NAME "iree-module-MiniLML12H384Uncased_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -641,9 +641,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bdd904cc5614ebf77609c7802a2dfc09f139aee2a247a247d10d320de72b0e28"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_module_bdd904cc5614ebf77609c7802a2dfc09f139aee2a247a247d10d320de72b0e28/module.vmfb"
+  NAME "iree-module-BertForMaskedLMTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -653,9 +653,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-45565cae821666fd34bca97be2e4cce3bd61e71308785728737d89acbb9bc9d2"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_45565cae821666fd34bca97be2e4cce3bd61e71308785728737d89acbb9bc9d2/module.vmfb"
+  NAME "iree-module-BertLargeTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -665,9 +665,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c4b43b31944dbd567e48efacfdb33f707eb248538cf70fa7dcf1085c6c7dbd3f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8_ClipTextSeqLen64PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_c4b43b31944dbd567e48efacfdb33f707eb248538cf70fa7dcf1085c6c7dbd3f/module.vmfb"
+  NAME "iree-module-ClipTextSeqLen64PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_ClipTextSeqLen64PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -677,9 +677,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c8ec2db5ee884e0af17814e61b13d7f7f1f2d4f7028e8c1920d0d968c27de2bb"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_340553d1-e6fe-41b6-b2c7-687c74ccec56_Unet2dPT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_c8ec2db5ee884e0af17814e61b13d7f7f1f2d4f7028e8c1920d0d968c27de2bb/module.vmfb"
+  NAME "iree-module-Unet2dPT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Unet2dPT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -689,9 +689,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9470c46965ea67794da45496454c82eade29b5a519d8037b1314738621e02260"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_68caa96e-b8bb-48a2-bb08-a3044981a370_EfficientNetB7PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetB7PT_module_9470c46965ea67794da45496454c82eade29b5a519d8037b1314738621e02260/module.vmfb"
+  NAME "iree-module-EfficientNetB7PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetB7PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetB7PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -701,9 +701,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-16ec710cdd9921f37f164b180cd3e77db1dc96cce5aabdced6eb3d84382eb02a"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1_BertLargefp16PTBatch1.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1_module_16ec710cdd9921f37f164b180cd3e77db1dc96cce5aabdced6eb3d84382eb02a/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -713,9 +713,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-cb3f9b06f0f2ce3866b286516c88c52e9adb8895044b92c87afa70eb9a4bd440"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_271ea7a0-68e7-45b6-91f4-f39d5ce9e29c_EfficientNetV2Sfp16PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2Sfp16PT_module_cb3f9b06f0f2ce3866b286516c88c52e9adb8895044b92c87afa70eb9a4bd440/module.vmfb"
+  NAME "iree-module-EfficientNetV2Sfp16PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2Sfp16PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2Sfp16PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -725,9 +725,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-44e0517dcee4f94b6f7ea1dd6b5492ee9752b4a7cab27d3e5e5ad38ef23071c6"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_50a7aece-73f9-47f4-a93a-4a1178f45407_matmul_3456x1024x2048_f16t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_3456x1024x2048_f16t_tile_config_default_module_44e0517dcee4f94b6f7ea1dd6b5492ee9752b4a7cab27d3e5e5ad38ef23071c6/module.vmfb"
+  NAME "iree-module-matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_3456x1024x2048_f16t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -738,9 +738,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c0ea83b865fd0c67a3013086ef2250464e2aecfc615a95170ef46128d2e57208"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_a55afe1c-9410-47a6-b417-04b0d75ee5f4_matmul_3456x1024x2048_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_3456x1024x2048_f32t_tile_config_default_module_c0ea83b865fd0c67a3013086ef2250464e2aecfc615a95170ef46128d2e57208/module.vmfb"
+  NAME "iree-module-matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_3456x1024x2048_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -751,9 +751,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c91ccf1fb3086a35cffd2e8bed6be929574a9ba626d9f271f577503ad07e3509"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_81cebaaf-e23d-4a32-89dc-9fc7adc37a8f_matmul_2560x2560x2560_f16t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2560x2560x2560_f16t_tile_config_default_module_c91ccf1fb3086a35cffd2e8bed6be929574a9ba626d9f271f577503ad07e3509/module.vmfb"
+  NAME "iree-module-matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2560x2560x2560_f16t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -764,9 +764,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2502249d103b48bf09a1d8d659fc143f1fb6e9479256e3e621061a2d06dcef2f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_579b77ea-76bd-4eb3-bd85-067c25a89eff_matmul_2560x2560x2560_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2560x2560x2560_f32t_tile_config_default_module_2502249d103b48bf09a1d8d659fc143f1fb6e9479256e3e621061a2d06dcef2f/module.vmfb"
+  NAME "iree-module-matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2560x2560x2560_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -777,9 +777,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2aad29c1743821a6e3b2b946d9fc0b04afc49b5ceeb7ddb721073348a9248eb6"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_4e75ff72-f807-49f6-b740-febca1794334_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_module_2aad29c1743821a6e3b2b946d9fc0b04afc49b5ceeb7ddb721073348a9248eb6/module.vmfb"
+  NAME "iree-module-matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -790,9 +790,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3c564ca58f759968042d8153290be969cc0f6fe9f006fc9050e612d6f5931879"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_8d6be288-9b88-41bd-bc5a-5644df0481bb_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_module_3c564ca58f759968042d8153290be969cc0f6fe9f006fc9050e612d6f5931879/module.vmfb"
+  NAME "iree-module-matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -803,9 +803,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-87ebb308da964e1451c97615c8038b5d2d2ea291fb0e5183404e4d27ec027c3b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_0a3d952b-41ca-43d2-9ec3-ccb8dde20ce3_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_module_87ebb308da964e1451c97615c8038b5d2d2ea291fb0e5183404e4d27ec027c3b/module.vmfb"
+  NAME "iree-module-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -816,9 +816,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bd985950d72dbe45dfcaa1bf4e0a438621642c077226cb42242ec091f8d37b0f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9b81a2f5-bab2-4f6f-b8b5-13cc4b3e9413_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_module_bd985950d72dbe45dfcaa1bf4e0a438621642c077226cb42242ec091f8d37b0f/module.vmfb"
+  NAME "iree-module-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -829,9 +829,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e6503d42c202eff85bcddb53e9869017943e756af09bfe2c05ffc27844ac77e9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_699fd533-02a9-49f0-bf26-1902d8dbb5af_matmul_128x256x8192_f16t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_128x256x8192_f16t_tile_config_default_module_e6503d42c202eff85bcddb53e9869017943e756af09bfe2c05ffc27844ac77e9/module.vmfb"
+  NAME "iree-module-matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_128x256x8192_f16t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -844,9 +844,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-59025e9cf180a4a72de8f609ac9c4e4a3d855a603eedf62d9577e738f1ec12f4"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_a6c2b812-0a71-45e7-9ea5-f3d8529213ef_matmul_128x256x8192_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_128x256x8192_f32t_tile_config_default_module_59025e9cf180a4a72de8f609ac9c4e4a3d855a603eedf62d9577e738f1ec12f4/module.vmfb"
+  NAME "iree-module-matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_128x256x8192_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -859,9 +859,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-58f67edb580a13aa98d3fd05ad31f207d62462c9de990825656b19d2fbacda3c"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-1_Resnet50TFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch1_module_58f67edb580a13aa98d3fd05ad31f207d62462c9de990825656b19d2fbacda3c/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -871,9 +871,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1655ee92ee23748886eef280d7d6f96c8a227fae7d6d78abd3466ce8614f16ba"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-8_Resnet50TFBatch8.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch8_module_1655ee92ee23748886eef280d7d6f96c8a227fae7d6d78abd3466ce8614f16ba/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch8.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -883,9 +883,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-496bdea78d06c9c32d8deae84b088b0eb34f6d1982ac790e2580a50dec4281ae"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-64_Resnet50TFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch64_module_496bdea78d06c9c32d8deae84b088b0eb34f6d1982ac790e2580a50dec4281ae/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -895,9 +895,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5aa3c57b33d354d5ebfe51626e2dac78485a548aa9bf2fba7a3e7a248f8b909e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-128_Resnet50TFBatch128.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch128_module_5aa3c57b33d354d5ebfe51626e2dac78485a548aa9bf2fba7a3e7a248f8b909e/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch128.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -907,9 +907,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a52ef9f5a8c064a4cbf52ea82b694d2c0bb9a0dd43d3576131335ab5453b62a4"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-256_Resnet50TFBatch256.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch256_module_a52ef9f5a8c064a4cbf52ea82b694d2c0bb9a0dd43d3576131335ab5453b62a4/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch256.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -919,9 +919,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a6f73626c6b41d410da11809d66d613293a0e3c298d491d6fb25e3729cf6685e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-2048_Resnet50TFBatch2048.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch2048_module_a6f73626c6b41d410da11809d66d613293a0e3c298d491d6fb25e3729cf6685e/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch2048.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -931,9 +931,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-369f2b1edbd94d2c19cf18be7ee8bb7aa937fe0669fbe6e5fb9a5c06185ebb42"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1_BertLargeTFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1_module_369f2b1edbd94d2c19cf18be7ee8bb7aa937fe0669fbe6e5fb9a5c06185ebb42/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -943,9 +943,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-52f3e54f0a7479eecdae97afb32b90e3952c8be195a861722fd8e8ece857ff40"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-16_BertLargeTFBatch16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch16_module_52f3e54f0a7479eecdae97afb32b90e3952c8be195a861722fd8e8ece857ff40/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -955,9 +955,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-30baf74b5974ab7269c57015554a0fb0447cbde5fb77ab44ed9cf9cd2bc0e351"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-24_BertLargeTFBatch24.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch24_module_30baf74b5974ab7269c57015554a0fb0447cbde5fb77ab44ed9cf9cd2bc0e351/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch24.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -967,9 +967,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-09dd0099b9a0924cc1bcadfb355bccbeea9cb3c29fc48c5181fbb87d80af28a9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-32_BertLargeTFBatch32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch32_module_09dd0099b9a0924cc1bcadfb355bccbeea9cb3c29fc48c5181fbb87d80af28a9/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -979,9 +979,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3385106a53075a52f4ae60523e09ad42cdad60475d97e84695a9c68584d9182a"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-48_BertLargeTFBatch48.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch48_module_3385106a53075a52f4ae60523e09ad42cdad60475d97e84695a9c68584d9182a/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch48.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -991,9 +991,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2021b32a685c21ba21823416591c14fd79075595c101665abe565ff92335c3ef"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-64_BertLargeTFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch64_module_2021b32a685c21ba21823416591c14fd79075595c101665abe565ff92335c3ef/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1003,9 +1003,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-57080e57e3ba061d70d35d8579824a8eab7ee05ef3e0eea02cc251bab87cfd10"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-512_BertLargeTFBatch512.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch512_module_57080e57e3ba061d70d35d8579824a8eab7ee05ef3e0eea02cc251bab87cfd10/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch512.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1015,9 +1015,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-88f03be31249d371d00c63d44d44732ad4c348bf2354bd2b3b042465d86f7183"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024_BertLargeTFBatch1024.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1024_module_88f03be31249d371d00c63d44d44732ad4c348bf2354bd2b3b042465d86f7183/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1024.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1027,9 +1027,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b3f2a0c268a0a8752ccbb56f013455197c466635637b535778a494dab316cf9e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280_BertLargeTFBatch1280.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1280_module_b3f2a0c268a0a8752ccbb56f013455197c466635637b535778a494dab316cf9e/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1280.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1039,9 +1039,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bf4bda91fb17ec7f3402e7b301cb3ab0b7a9b0b00d8cee29fd4cfa46262a5ea1"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-1_T5LargeTFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch1_module_bf4bda91fb17ec7f3402e7b301cb3ab0b7a9b0b00d8cee29fd4cfa46262a5ea1/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1051,9 +1051,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9900b1a0c52b31fc38f1d82ff088102f7131ecbb3fc1b8274929481337d031c5"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-16_T5LargeTFBatch16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch16_module_9900b1a0c52b31fc38f1d82ff088102f7131ecbb3fc1b8274929481337d031c5/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1063,9 +1063,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-25f1a116fad68b01401dfbd8462c7b2729ef2d504df0954509cd488cd5da17a1"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-24_T5LargeTFBatch24.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch24_module_25f1a116fad68b01401dfbd8462c7b2729ef2d504df0954509cd488cd5da17a1/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch24.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1075,9 +1075,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-89643b9db9da0c7b822ba8e2ead4ec12fc3093dbde9b7a8570de1be3d46bd54b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-32_T5LargeTFBatch32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch32_module_89643b9db9da0c7b822ba8e2ead4ec12fc3093dbde9b7a8570de1be3d46bd54b/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1087,9 +1087,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c16715c83936394998fe81f8d33f6e7901f17ff662dfd2941a3982f85c3a9e17"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-48_T5LargeTFBatch48.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch48_module_c16715c83936394998fe81f8d33f6e7901f17ff662dfd2941a3982f85c3a9e17/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch48.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1099,9 +1099,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7ba873f0f155e857b45f991cbb4e8776f8b137d59ddc5f81a7a23ed2a48eecc9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-64_T5LargeTFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch64_module_7ba873f0f155e857b45f991cbb4e8776f8b137d59ddc5f81a7a23ed2a48eecc9/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1111,9 +1111,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-154de838dc7742304c9e27a9f315645a915493bc4f84160e29b15b7fc6dc475e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1_BertLargePTBatch1.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1_module_154de838dc7742304c9e27a9f315645a915493bc4f84160e29b15b7fc6dc475e/module.vmfb"
+  NAME "iree-module-BertLargePTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1123,9 +1123,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-21a83414dc1feb2a3b5fb6afadc36c1022a0ab747380291dbb309637d5f32eab"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-16_BertLargePTBatch16.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch16_module_21a83414dc1feb2a3b5fb6afadc36c1022a0ab747380291dbb309637d5f32eab/module.vmfb"
+  NAME "iree-module-BertLargePTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch16.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1135,9 +1135,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7d93a3e9b342045ed2546960ee3d08f60be237fd8974fe35447a41234f322148"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-24_BertLargePTBatch24.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch24_module_7d93a3e9b342045ed2546960ee3d08f60be237fd8974fe35447a41234f322148/module.vmfb"
+  NAME "iree-module-BertLargePTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch24.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1147,9 +1147,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-995595b7b80370d9c484413e9d06c2de928db32777101c91d3bac0d3797058ec"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-32_BertLargePTBatch32.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch32_module_995595b7b80370d9c484413e9d06c2de928db32777101c91d3bac0d3797058ec/module.vmfb"
+  NAME "iree-module-BertLargePTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch32.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1159,9 +1159,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-45ed9ca2efb9bb645316e856a5c464b76e56902e930ff1d4e54fdef38043b33f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-48_BertLargePTBatch48.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch48_module_45ed9ca2efb9bb645316e856a5c464b76e56902e930ff1d4e54fdef38043b33f/module.vmfb"
+  NAME "iree-module-BertLargePTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch48.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1171,9 +1171,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8c26886533593b666597f8698e33c0e9c98b349bdf8ac01c3d122cc20b741def"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-64_BertLargePTBatch64.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch64_module_8c26886533593b666597f8698e33c0e9c98b349bdf8ac01c3d122cc20b741def/module.vmfb"
+  NAME "iree-module-BertLargePTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch64.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1183,9 +1183,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4df03cf0d71376b43f2e93ca35d252f052733fa8de905af146f25d4216b2b4d2"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-512_BertLargePTBatch512.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch512_module_4df03cf0d71376b43f2e93ca35d252f052733fa8de905af146f25d4216b2b4d2/module.vmfb"
+  NAME "iree-module-BertLargePTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch512.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1195,9 +1195,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c947d0e7889a515a4e58bdbd1688f028ca88351dbd7ec501d9fb13a08c27503f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1024_BertLargePTBatch1024.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1024_module_c947d0e7889a515a4e58bdbd1688f028ca88351dbd7ec501d9fb13a08c27503f/module.vmfb"
+  NAME "iree-module-BertLargePTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1024.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1207,9 +1207,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9c8197e62299f79c373535d91c48acd1b3522264bd7a3d885683570bfc20164c"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1280_BertLargePTBatch1280.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1280_module_9c8197e62299f79c373535d91c48acd1b3522264bd7a3d885683570bfc20164c/module.vmfb"
+  NAME "iree-module-BertLargePTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1280.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1219,9 +1219,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-222490941c581c67f5ce710e9ea141482cd8074294a43a5dc67a01a127037cd4"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-1_Resnet50PTBatch1.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch1_module_222490941c581c67f5ce710e9ea141482cd8074294a43a5dc67a01a127037cd4/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch1.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1231,9 +1231,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-39556c12d84502be71243197b99b0f8c22949093c561c55c01ca906812a86288"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-8_Resnet50PTBatch8.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch8_module_39556c12d84502be71243197b99b0f8c22949093c561c55c01ca906812a86288/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch8.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1243,9 +1243,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9e1870e43977999573defd36f2a4540f70b69acf7a330f5133fd8170265cff23"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-64_Resnet50PTBatch64.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch64_module_9e1870e43977999573defd36f2a4540f70b69acf7a330f5133fd8170265cff23/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch64.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1255,9 +1255,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-99b28083e2bcb855cc6ead27a57d4efbd6a8c54205897ab226fe15bf321e239a"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-128_Resnet50PTBatch128.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch128_module_99b28083e2bcb855cc6ead27a57d4efbd6a8c54205897ab226fe15bf321e239a/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch128.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1267,9 +1267,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0c02fdba447db54fce59698955c728295a98135ef702ce24061834bdea2d1d90"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-256_Resnet50PTBatch256.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch256_module_0c02fdba447db54fce59698955c728295a98135ef702ce24061834bdea2d1d90/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch256.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1279,9 +1279,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e9496836f964df336279914bb907889f071893aac3a0d069f6a318e9a74e4c23"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-2048_Resnet50PTBatch2048.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch2048_module_e9496836f964df336279914bb907889f071893aac3a0d069f6a318e9a74e4c23/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch2048.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1291,9 +1291,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-08e52acdb95ed35139dbf11b82c296d08cdad37909687829b55b1818fce9b0d7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-1_Resnet50fp16PTBatch1.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch1_module_08e52acdb95ed35139dbf11b82c296d08cdad37909687829b55b1818fce9b0d7/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch1.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1303,9 +1303,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9f427ef22efcf4736dda3c87b30a8af80f3071eaba07f6d5e9795c2631effc4e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-8_Resnet50fp16PTBatch8.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch8_module_9f427ef22efcf4736dda3c87b30a8af80f3071eaba07f6d5e9795c2631effc4e/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch8.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1315,9 +1315,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-47edac5a737cd096e898b80a1952d7d448bd3261a765520d79b81d95d9b02375"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-64_Resnet50fp16PTBatch64.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch64_module_47edac5a737cd096e898b80a1952d7d448bd3261a765520d79b81d95d9b02375/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch64.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1327,9 +1327,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f1051eab627311cccb5da9e85ca9ccca9697b8701a004935a9b7f959151cdbd7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-128_Resnet50fp16PTBatch128.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch128_module_f1051eab627311cccb5da9e85ca9ccca9697b8701a004935a9b7f959151cdbd7/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch128.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1339,9 +1339,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b93a8c82dcab5bd300153626e5ae1de06f18ad1a36c25d324204daf654f0fdab"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-256_Resnet50fp16PTBatch256.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch256_module_b93a8c82dcab5bd300153626e5ae1de06f18ad1a36c25d324204daf654f0fdab/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch256.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1351,9 +1351,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b441bdf92d5b74f62726235c0f98e82aa10a21e4092cad147f670484b2d43c7e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-2048_Resnet50fp16PTBatch2048.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch2048_module_b441bdf92d5b74f62726235c0f98e82aa10a21e4092cad147f670484b2d43c7e/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch2048.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1363,9 +1363,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c451b302f020e742b3e66964f5909018fa51d93c753ea337b1bdfea6b69e0901"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-16_BertLargefp16PTBatch16.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch16_module_c451b302f020e742b3e66964f5909018fa51d93c753ea337b1bdfea6b69e0901/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch16.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1375,9 +1375,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-feae531426d546aae8f1c579bfb8183a1315caa6347fe9efa99660a7c7c40947"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-24_BertLargefp16PTBatch24.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch24_module_feae531426d546aae8f1c579bfb8183a1315caa6347fe9efa99660a7c7c40947/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch24.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1387,9 +1387,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-767c1b6faee0eddaca3e01469f49dc355a00f192f1ae5e226839cab3cafbe8d9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-32_BertLargefp16PTBatch32.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch32_module_767c1b6faee0eddaca3e01469f49dc355a00f192f1ae5e226839cab3cafbe8d9/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch32.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1399,9 +1399,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4e879cbb18131becd2cc80ec9d77ef6c40bb1a9288201ee448278fdf2e81b14e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-48_BertLargefp16PTBatch48.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch48_module_4e879cbb18131becd2cc80ec9d77ef6c40bb1a9288201ee448278fdf2e81b14e/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch48.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1411,9 +1411,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-75c29c7da698ad149e4ac580666595c3fbcfe86a50f0b8d8d3a9c737adf685c5"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-64_BertLargefp16PTBatch64.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch64_module_75c29c7da698ad149e4ac580666595c3fbcfe86a50f0b8d8d3a9c737adf685c5/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch64.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1423,9 +1423,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-58a0cb6e5c240493436ae2c1e304a572ff11060233b48dce1bf82f0d3b733a6f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-512_BertLargefp16PTBatch512.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch512_module_58a0cb6e5c240493436ae2c1e304a572ff11060233b48dce1bf82f0d3b733a6f/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch512.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1435,9 +1435,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-454fd6dea6195164691f1bd66e407131bc8ad41cb1ae9a0360ecd4d3fba8a372"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1024_BertLargefp16PTBatch1024.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1024_module_454fd6dea6195164691f1bd66e407131bc8ad41cb1ae9a0360ecd4d3fba8a372/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1024.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1447,9 +1447,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-eaccfeb996e96d52d357fb276b3c864a4050fa8cf77f3f305ac2b64918037a37"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1280_BertLargefp16PTBatch1280.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1280_module_eaccfeb996e96d52d357fb276b3c864a4050fa8cf77f3f305ac2b64918037a37/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1280.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -1459,9 +1459,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-18f35077bfc62e09218dcd1db06f92d04c0698d6eda4999b67a7fe7ba4f31123"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1_BERT_LARGE_JAX_384XI32_BATCH1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1_module_18f35077bfc62e09218dcd1db06f92d04c0698d6eda4999b67a7fe7ba4f31123/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1471,9 +1471,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1078c4ae05bf39833629569966661473dbcfba7a6454301d726e0c0e96115d15"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch16_BERT_LARGE_JAX_384XI32_BATCH16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH16_module_1078c4ae05bf39833629569966661473dbcfba7a6454301d726e0c0e96115d15/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1483,9 +1483,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9a47ca4b87dc126e967d6c9e51894212c20afbae0abddf64c1dbad6a8a0a595a"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch24_BERT_LARGE_JAX_384XI32_BATCH24.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH24_module_9a47ca4b87dc126e967d6c9e51894212c20afbae0abddf64c1dbad6a8a0a595a/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH24.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1495,9 +1495,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-694c3001456d0441c55272d76d1fc4b0e4623bc4875f102a87509ac8382fa029"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch32_BERT_LARGE_JAX_384XI32_BATCH32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH32_module_694c3001456d0441c55272d76d1fc4b0e4623bc4875f102a87509ac8382fa029/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1507,9 +1507,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7ab699651c26607f197f63bdf95842ba4fa92cbe6ffa923b869d5df0ff8830a9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch48_BERT_LARGE_JAX_384XI32_BATCH48.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH48_module_7ab699651c26607f197f63bdf95842ba4fa92cbe6ffa923b869d5df0ff8830a9/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH48.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1519,9 +1519,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3252375798810f175ebda56c63616da1f46954489420549ad219a746867c0c58"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch64_BERT_LARGE_JAX_384XI32_BATCH64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH64_module_3252375798810f175ebda56c63616da1f46954489420549ad219a746867c0c58/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1531,9 +1531,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9f4cafa63a150cabdf61a945dc6a04c9ddac88b75260bb4ce668199cdddbd581"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch512_BERT_LARGE_JAX_384XI32_BATCH512.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH512_module_9f4cafa63a150cabdf61a945dc6a04c9ddac88b75260bb4ce668199cdddbd581/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH512.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1543,9 +1543,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-22c17848ebc029e64b86ac50b5fb28b7198c0ef3b3f7f03ed111d189328ba147"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1024_BERT_LARGE_JAX_384XI32_BATCH1024.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1024_module_22c17848ebc029e64b86ac50b5fb28b7198c0ef3b3f7f03ed111d189328ba147/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1024.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1555,9 +1555,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a28fb3589ad3175aced5b87acb35b791bb71ce005c58f9c3fbadb2df907d7ba6"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1280_BERT_LARGE_JAX_384XI32_BATCH1280.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1280_module_a28fb3589ad3175aced5b87acb35b791bb71ce005c58f9c3fbadb2df907d7ba6/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1280.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1567,9 +1567,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b51439857023ae098fdc5771cad8d554c0f865605270629e76758d962a9e77ef"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch1_RESNET50_FP32_JAX_3X224X224XF32_BATCH1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH1_module_b51439857023ae098fdc5771cad8d554c0f865605270629e76758d962a9e77ef/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1579,9 +1579,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b3da705f46e262d026b6bb01dcf484f35f05ed083ec0319e3b8515f578f02310"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch8_RESNET50_FP32_JAX_3X224X224XF32_BATCH8.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH8_module_b3da705f46e262d026b6bb01dcf484f35f05ed083ec0319e3b8515f578f02310/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH8.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1591,9 +1591,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-814b5155d8c819d65ed0ddac829d3af930ae3b03d2ea34afcd4da6f6b429d4dc"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch64_RESNET50_FP32_JAX_3X224X224XF32_BATCH64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH64_module_814b5155d8c819d65ed0ddac829d3af930ae3b03d2ea34afcd4da6f6b429d4dc/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1603,9 +1603,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-05a6486bab733dfb85e23bc47a9ce384772d2e0c57e3c6ba01b8cb9888db0e2f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch128_RESNET50_FP32_JAX_3X224X224XF32_BATCH128.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH128_module_05a6486bab733dfb85e23bc47a9ce384772d2e0c57e3c6ba01b8cb9888db0e2f/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH128.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1615,9 +1615,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-17a2e53637f4391f741791950b9f5b2c650fc2c97ae00c5e9c60f0d9125ac2c8"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch256_RESNET50_FP32_JAX_3X224X224XF32_BATCH256.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH256_module_17a2e53637f4391f741791950b9f5b2c650fc2c97ae00c5e9c60f0d9125ac2c8/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH256.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1627,9 +1627,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2146e71d7d9f62002c34f2869a60ac58e17d875ba5a8d7b2d170e4de4e342ddc"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch2048_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_module_2146e71d7d9f62002c34f2869a60ac58e17d875ba5a8d7b2d170e4de4e342ddc/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1639,9 +1639,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8b080ab273c07333a503310e33b4bbaa7599319b6b699755b8853ad7ce2fb28e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch1_T5_LARGE_FP32_JAX_512XI32_BATCH1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH1_module_8b080ab273c07333a503310e33b4bbaa7599319b6b699755b8853ad7ce2fb28e/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1651,9 +1651,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d7ff0ce530c700c18dc4704dfcb75ec14540bd0794faee823a3cc1cd62ea53df"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch16_T5_LARGE_FP32_JAX_512XI32_BATCH16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH16_module_d7ff0ce530c700c18dc4704dfcb75ec14540bd0794faee823a3cc1cd62ea53df/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1663,9 +1663,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-129b48d3bbdad4b4333986b8a35fcafa8d4434fead6233154cecfbdab0ca23e6"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch24_T5_LARGE_FP32_JAX_512XI32_BATCH24.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH24_module_129b48d3bbdad4b4333986b8a35fcafa8d4434fead6233154cecfbdab0ca23e6/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH24.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1675,9 +1675,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3dcbc01e07ee34df7e5535dd0be85071685655d51331314b7a17517feb74ed3b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch32_T5_LARGE_FP32_JAX_512XI32_BATCH32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH32_module_3dcbc01e07ee34df7e5535dd0be85071685655d51331314b7a17517feb74ed3b/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1687,9 +1687,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e70546885f5488d986fffccc21a118d82aa7933b7dccfe47b0093591e081231f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch48_T5_LARGE_FP32_JAX_512XI32_BATCH48.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH48_module_e70546885f5488d986fffccc21a118d82aa7933b7dccfe47b0093591e081231f/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH48.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1699,9 +1699,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ba0e837ccb2c4b017df4e2397b3cec6565b2c6b84193ee738a95aef872a39fe7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch64_T5_LARGE_FP32_JAX_512XI32_BATCH64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH64_module_ba0e837ccb2c4b017df4e2397b3cec6565b2c6b84193ee738a95aef872a39fe7/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1711,9 +1711,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d980bb01bd509b62a7610ae2aaa02fcb864582cf9827136a65f2483fd85b5c66"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch512_T5_LARGE_FP32_JAX_512XI32_BATCH512.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH512_module_d980bb01bd509b62a7610ae2aaa02fcb864582cf9827136a65f2483fd85b5c66/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH512.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -1723,9 +1723,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-68f0eb37bb72d0d6605ecdf42691c64125960e122844b0beeae350871a445b1c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_68f0eb37bb72d0d6605ecdf42691c64125960e122844b0beeae350871a445b1c/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1739,9 +1739,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a7a1553d0739151f06bbc00a3ef8b67b0606463eab4b6607069aa94ea0bfd92f"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_a7a1553d0739151f06bbc00a3ef8b67b0606463eab4b6607069aa94ea0bfd92f/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1755,9 +1755,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e80d71ed8e86c0756226b2323e27e2c7c0fff8eddde59ba69e9222d36ee3eef6"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_a359c8f1e19b6f476e843bdc5566f9554e329cbfb3b4437995ad9cccfb381aee.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_module_e80d71ed8e86c0756226b2323e27e2c7c0fff8eddde59ba69e9222d36ee3eef6/module.vmfb"
+  NAME "iree-module-MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1771,9 +1771,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f59cd43a2a2d6e4b3159efa358a6fa0879e72f6f4f0a23af4c8ab550f256986a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_f59cd43a2a2d6e4b3159efa358a6fa0879e72f6f4f0a23af4c8ab550f256986a/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1787,9 +1787,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-14a15b9072caaee5e2a274a9bbc436a56d095611e5a8e9841f110741d34231f9"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_14a15b9072caaee5e2a274a9bbc436a56d095611e5a8e9841f110741d34231f9/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1803,9 +1803,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e850fce2d36ddb09ccc34471641adb77418b93c0949d22ab75806d7cfc489ae3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_e850fce2d36ddb09ccc34471641adb77418b93c0949d22ab75806d7cfc489ae3/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1819,9 +1819,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-93034e879f88475eeeff56dd38297a1d1183f123fbbf5925a07b7c934e5f5d48"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_93034e879f88475eeeff56dd38297a1d1183f123fbbf5925a07b7c934e5f5d48/module.vmfb"
+  NAME "iree-module-MobileNetV2_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1835,9 +1835,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f963d812114af925e0a4b110ee83aeb0e3b41d49fad19b3f449b6a9ccba43b8d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_f963d812114af925e0a4b110ee83aeb0e3b41d49fad19b3f449b6a9ccba43b8d/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1851,9 +1851,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9d909aa679e8c380ff7e93292ef28dbd3bb9e7cc62329f90aef78ce9c7efeff9"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_9d909aa679e8c380ff7e93292ef28dbd3bb9e7cc62329f90aef78ce9c7efeff9/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1867,9 +1867,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1ef2da238443010024d69ceb6fe6ab6fa8cf5f4ce7d424dace3a572592043e70"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_1ef2da238443010024d69ceb6fe6ab6fa8cf5f4ce7d424dace3a572592043e70/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1883,9 +1883,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d399d2540161867967b0590a659d0a86206e145d884bd7afd9abd818713aacd2"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_d399d2540161867967b0590a659d0a86206e145d884bd7afd9abd818713aacd2/module.vmfb"
+  NAME "iree-module-MobileNetV2_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1899,9 +1899,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f06fff09f8cebc27d1674045712aaa60afe7aef388c4bc505897f55c3a0d8abb"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_f06fff09f8cebc27d1674045712aaa60afe7aef388c4bc505897f55c3a0d8abb/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1911,9 +1911,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-91469dce5ace1877a717a8ca5f53c1c8a3ac2f2eb8d116382eb4a5f5ace3a9c8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_91469dce5ace1877a717a8ca5f53c1c8a3ac2f2eb8d116382eb4a5f5ace3a9c8/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1923,9 +1923,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8b6e3f5ddee79e020f1b25ce676d3772dda8cf14f619a3f0649a9f14e0159cd0"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_8b6e3f5ddee79e020f1b25ce676d3772dda8cf14f619a3f0649a9f14e0159cd0/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1935,9 +1935,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-83ef2a35d14b4acf5d569798accc3b5bb693394633d444bdd5c9d55461f549ae"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_83ef2a35d14b4acf5d569798accc3b5bb693394633d444bdd5c9d55461f549ae/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1947,9 +1947,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-244092c4ecd63533f225b0bc16b308e11265ca6b10696f8975866844793e2c4f"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_244092c4ecd63533f225b0bc16b308e11265ca6b10696f8975866844793e2c4f/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1959,9 +1959,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5f46d5bcca6c809578ba7b32829ee4417a67eaa5033b5b58b81e3a8b0b3433ad"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_5f46d5bcca6c809578ba7b32829ee4417a67eaa5033b5b58b81e3a8b0b3433ad/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1971,9 +1971,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-012cc9d71edd7a345ef45d52c630d53ed04ee93523524b417330c644d8f6ce1b"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_012cc9d71edd7a345ef45d52c630d53ed04ee93523524b417330c644d8f6ce1b/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1983,9 +1983,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5eeff62c8ab391e247ede57b226b4be03b81067b8831b13bfa47b62e2dac275a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_5eeff62c8ab391e247ede57b226b4be03b81067b8831b13bfa47b62e2dac275a/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1998,9 +1998,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7d44f561ce87a08f4ed53264b6b95ddd7926263fef781e5135cc696d5a4d3719"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_7d44f561ce87a08f4ed53264b6b95ddd7926263fef781e5135cc696d5a4d3719/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2013,9 +2013,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0d6fed1f6845ce0d70bf81ac2522e9806b4538917cb7ee02a1b6e6a60d6b7115"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_0d6fed1f6845ce0d70bf81ac2522e9806b4538917cb7ee02a1b6e6a60d6b7115/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2028,9 +2028,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2c042cd2ded71abef51933f0466cf58a52de2c67e1a23fde98b1fad1b33e6d7c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_2c042cd2ded71abef51933f0466cf58a52de2c67e1a23fde98b1fad1b33e6d7c/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2043,9 +2043,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-78db72d7b7a1f871a3752c8165cbebc678047f2df5d36b10dd82ee870873b620"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_78db72d7b7a1f871a3752c8165cbebc678047f2df5d36b10dd82ee870873b620/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2058,9 +2058,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0689c824551e3a3650463db3807664420f1033ee1b290fa25e63d04cf1a0a6ef"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_0689c824551e3a3650463db3807664420f1033ee1b290fa25e63d04cf1a0a6ef/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2073,9 +2073,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-69f971c48d4b181ed4a4ec22790dc62fa997aa28ad16e0e176642955ccbbc2f0"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_69f971c48d4b181ed4a4ec22790dc62fa997aa28ad16e0e176642955ccbbc2f0/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_dotprod_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_dotprod_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2089,9 +2089,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-deba344af418957cbd9dc0834a100bc30ba242d7fddb4dc6ba10a87d0af32dc1"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_deba344af418957cbd9dc0834a100bc30ba242d7fddb4dc6ba10a87d0af32dc1/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2101,9 +2101,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-72feea41a0b54e4c9a761933079cba1b2c012e5a5d4b2953ffaa86faaa29a648"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_72feea41a0b54e4c9a761933079cba1b2c012e5a5d4b2953ffaa86faaa29a648/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2113,9 +2113,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b33d5ca3311e31b99daa1c1f13ea5571713538a7889627153ea431debb9b5e2a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_b33d5ca3311e31b99daa1c1f13ea5571713538a7889627153ea431debb9b5e2a/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2125,9 +2125,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-076a1e95f3384b58a77a672c7c36463b091e574b5a6f6eaf78841537b0d1c930"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_076a1e95f3384b58a77a672c7c36463b091e574b5a6f6eaf78841537b0d1c930/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2137,9 +2137,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-05e976592f58a292874d99bd7627e655b15c5460455a08b9ce67e9f7f65b6269"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_05e976592f58a292874d99bd7627e655b15c5460455a08b9ce67e9f7f65b6269/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2149,9 +2149,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-dd4366d716cccdd83b6f777ee966157b92838569f094371b325b926e73c7b1b8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_dd4366d716cccdd83b6f777ee966157b92838569f094371b325b926e73c7b1b8/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2161,9 +2161,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4a1632637ce87fe991848942b028c36732b2bea00920d275ffbcaf2cd9446152"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_4a1632637ce87fe991848942b028c36732b2bea00920d275ffbcaf2cd9446152/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2174,9 +2174,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7f5a7ca6eb12e8ac322d8bb0deb59630d721ab141acc3a941e168d98af507034"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_7f5a7ca6eb12e8ac322d8bb0deb59630d721ab141acc3a941e168d98af507034/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2187,9 +2187,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e3444362e0b630df1b5f70a28089b0764d9ddc886dda852a0ef1300e369aee4d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_e3444362e0b630df1b5f70a28089b0764d9ddc886dda852a0ef1300e369aee4d/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2200,9 +2200,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c95d82463222cf5ea385760eb1f0f0ee28a876620e29fbd59f8f4cb8a5307bc8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_c95d82463222cf5ea385760eb1f0f0ee28a876620e29fbd59f8f4cb8a5307bc8/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2213,9 +2213,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f73d0b9c84ec91b594b00eb3800c372884050fce3e4fb9d80eb407d7b0697412"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_f73d0b9c84ec91b594b00eb3800c372884050fce3e4fb9d80eb407d7b0697412/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2226,9 +2226,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-67ad72cbb9eb9c4746249922e6232b1a17b5d6eeabd9b69ed4d527c1676c77bd"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_67ad72cbb9eb9c4746249922e6232b1a17b5d6eeabd9b69ed4d527c1676c77bd/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2239,9 +2239,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ad38a059079822e7331470e086bc1caca3dbe435878b38e1355229a39d1d25d2"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_ad38a059079822e7331470e086bc1caca3dbe435878b38e1355229a39d1d25d2/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2253,9 +2253,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8eb82c90485cc4281676866b62e6820b60a38ba81068e95254a7d0ddaddc59c3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_8eb82c90485cc4281676866b62e6820b60a38ba81068e95254a7d0ddaddc59c3/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2267,9 +2267,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-cc9b305fb2c95f582d144f1063fc12fd996e757f84738e3de846b0197981bcc2"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_cc9b305fb2c95f582d144f1063fc12fd996e757f84738e3de846b0197981bcc2/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2281,9 +2281,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8930c217bc20a5abf9313fd714a77bf47acefb006e95ba07b5e48caf872541b0"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_8930c217bc20a5abf9313fd714a77bf47acefb006e95ba07b5e48caf872541b0/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2295,9 +2295,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9b6e19b8cab376fffe309f090beeecad08903c0975c9e7ffc480dd46074b97b3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_9b6e19b8cab376fffe309f090beeecad08903c0975c9e7ffc480dd46074b97b3/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2307,9 +2307,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d5ea172c189c6a6a3b61a7e83f7263b9b38cad756d2d5dec1b2db88162eece2a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_d5ea172c189c6a6a3b61a7e83f7263b9b38cad756d2d5dec1b2db88162eece2a/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2319,9 +2319,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bb1cb8e00fd4cee513b2481bd5faf39842ad9c57f80f2e50ddb48763fd030721"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_bb1cb8e00fd4cee513b2481bd5faf39842ad9c57f80f2e50ddb48763fd030721/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2331,9 +2331,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-dc26eca15bb97d42bcfa019de5080da54fb3d7624809aa1c8ac731e710544e18"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_dc26eca15bb97d42bcfa019de5080da54fb3d7624809aa1c8ac731e710544e18/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2343,9 +2343,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-90d4cb308fc14e4832336ebd1e1387a791a20b92af633d0fec9161b807e13427"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_90d4cb308fc14e4832336ebd1e1387a791a20b92af633d0fec9161b807e13427/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2355,9 +2355,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ba322b423888fe93e86180e98668f486afa915565edf3813af3f9da6ad7c9dc9"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_ba322b423888fe93e86180e98668f486afa915565edf3813af3f9da6ad7c9dc9/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2367,9 +2367,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-42bc978e75d5fed90c10d5812a8df7a6153e311b19b9c7faf41a588bdc4da7d8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_42bc978e75d5fed90c10d5812a8df7a6153e311b19b9c7faf41a588bdc4da7d8/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_demote-f32-to-f16_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2380,9 +2380,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-894671e6d7319df243fa8b386b14d5e648fe2ffd66cb95e5a82ad58d7273ada8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_894671e6d7319df243fa8b386b14d5e648fe2ffd66cb95e5a82ad58d7273ada8/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2392,9 +2392,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0af4e7fa84d361d2faa267336c3c090e337f7feff47f0e559337521c07626ba7"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_0af4e7fa84d361d2faa267336c3c090e337f7feff47f0e559337521c07626ba7/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2404,9 +2404,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-138aacc154449b519698bd7ddb4dc9f407cbc1fd86fdbbe901be974058b70319"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_138aacc154449b519698bd7ddb4dc9f407cbc1fd86fdbbe901be974058b70319/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2416,9 +2416,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a47669d662bd18dbd323737d84fd45753c01abaa81b4761eb51b35ce04ee7491"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_a47669d662bd18dbd323737d84fd45753c01abaa81b4761eb51b35ce04ee7491/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2430,9 +2430,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-27c12f520d68a8a754b11ad44cf8ad3ef5c1ec281fc9d84fbc64a7b573cb68b5"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_27c12f520d68a8a754b11ad44cf8ad3ef5c1ec281fc9d84fbc64a7b573cb68b5/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2444,9 +2444,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ec14aafacf15628918390531318a4827d3ac8771b75d60a8239d901dcb4fd898"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_ec14aafacf15628918390531318a4827d3ac8771b75d60a8239d901dcb4fd898/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2458,9 +2458,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-507fabae3d24c2448c8f2af676d68df0a22716a06fa7ffc3b4f865e9272ecdc8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_507fabae3d24c2448c8f2af676d68df0a22716a06fa7ffc3b4f865e9272ecdc8/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2472,9 +2472,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4924918e121a92f802a094de2d67e9c2673c9fdc39faa6a11ac1d38b631a2914"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_4924918e121a92f802a094de2d67e9c2673c9fdc39faa6a11ac1d38b631a2914/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2486,9 +2486,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-383e7567e79adf2178e3d25785855905a4477b6c8daf16bc50d5f9f44d2343d9"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_383e7567e79adf2178e3d25785855905a4477b6c8daf16bc50d5f9f44d2343d9/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2500,9 +2500,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9faad3c50bc64c297531a36bd2ab235b680070d8233ce5ab7d964ac36c7c5563"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_9faad3c50bc64c297531a36bd2ab235b680070d8233ce5ab7d964ac36c7c5563/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_demote-f32-to-f16_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2515,9 +2515,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-90eb882b36d0293eb5b22ffb64f7c395cefa0360b37d4b84854d8b2c52a76358"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_90eb882b36d0293eb5b22ffb64f7c395cefa0360b37d4b84854d8b2c52a76358/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2529,9 +2529,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e1143fcb8d1d262a3b2ac689cf21a1943cc59b2de06192fef185a9bf84994b86"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_e1143fcb8d1d262a3b2ac689cf21a1943cc59b2de06192fef185a9bf84994b86/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2543,9 +2543,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-65aa6dabd0c24dbe48a090db641d82b437d4abd428a6ca0e7b360d3f087a16c8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_65aa6dabd0c24dbe48a090db641d82b437d4abd428a6ca0e7b360d3f087a16c8/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2557,9 +2557,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-131aa61ffcacafc6ae701ff89045cf42d2490ac0c4a1d862bc83c23edb3b92e5"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_131aa61ffcacafc6ae701ff89045cf42d2490ac0c4a1d862bc83c23edb3b92e5/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2572,9 +2572,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-db9784471b47ae8bf55ca7e0821e35a1686256a208df40443c114f1adcdd26f6"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_db9784471b47ae8bf55ca7e0821e35a1686256a208df40443c114f1adcdd26f6/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2587,9 +2587,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-aada5dcefdd361b5227276129e93547a6932a05d380acd342fa33e5b672d498c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_aada5dcefdd361b5227276129e93547a6932a05d380acd342fa33e5b672d498c/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2602,9 +2602,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-887c7a7b540f11ee5e0158143fd46a503a4851211b10b353ec0e00b8b1beb575"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_887c7a7b540f11ee5e0158143fd46a503a4851211b10b353ec0e00b8b1beb575/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2617,9 +2617,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-11766f32ea6a3121d7527bcdf32dead45ab7b3922d72addb46945cfdab784ec0"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_11766f32ea6a3121d7527bcdf32dead45ab7b3922d72addb46945cfdab784ec0/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2632,9 +2632,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0efb794c3a385045fa4d3d086c2a593ce67c4807e9456271f05f4e28490d1c49"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_0efb794c3a385045fa4d3d086c2a593ce67c4807e9456271f05f4e28490d1c49/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2647,9 +2647,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7a3d36d7234ce4abfd833964492631bd81df823e6bde8cd3a1fadfa4faa7c787"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_7a3d36d7234ce4abfd833964492631bd81df823e6bde8cd3a1fadfa4faa7c787/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2663,9 +2663,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e52ef218d6b5b16f35c420fca42ff31c5cf733bc075ed235ce57cf4662824606"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_e52ef218d6b5b16f35c420fca42ff31c5cf733bc075ed235ce57cf4662824606/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2678,9 +2678,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1202e44fbbde0a9581c641d124452363273f0d4395445dc06e60c8e49a27357b"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_1202e44fbbde0a9581c641d124452363273f0d4395445dc06e60c8e49a27357b/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2693,9 +2693,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3c1fbaa12bbd37bf2a17d8a605cdeca75c0e8cc9c6f7e95359d13e47a4270dc3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_3c1fbaa12bbd37bf2a17d8a605cdeca75c0e8cc9c6f7e95359d13e47a4270dc3/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2708,9 +2708,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-63a1dd898daa56fc3a0bff652cb5b2e0483cfe90e9dcd7994b73183b7ce106b2"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8_ClipTextSeqLen64PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_63a1dd898daa56fc3a0bff652cb5b2e0483cfe90e9dcd7994b73183b7ce106b2/module.vmfb"
+  NAME "iree-module-ClipTextSeqLen64PT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_ClipTextSeqLen64PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=none"
@@ -2723,9 +2723,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d0d1a869e3f3901f6f60afaf57160ce888a852f6703efc79756415d43cfcd13e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_340553d1-e6fe-41b6-b2c7-687c74ccec56_Unet2dPT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_d0d1a869e3f3901f6f60afaf57160ce888a852f6703efc79756415d43cfcd13e/module.vmfb"
+  NAME "iree-module-Unet2dPT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Unet2dPT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=none"
@@ -2738,9 +2738,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-337a3ab92a878301dc4bdd2554739b59ebf7925d85af42ee16780ba6c6dee0d8"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8_ClipTextSeqLen64PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_337a3ab92a878301dc4bdd2554739b59ebf7925d85af42ee16780ba6c6dee0d8/module.vmfb"
+  NAME "iree-module-ClipTextSeqLen64PT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_ClipTextSeqLen64PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=none"
@@ -2753,9 +2753,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b5d399322ea7d5e831efb647928974f7f3abce21b2220af9cf9344ccea411545"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_340553d1-e6fe-41b6-b2c7-687c74ccec56_Unet2dPT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_b5d399322ea7d5e831efb647928974f7f3abce21b2220af9cf9344ccea411545/module.vmfb"
+  NAME "iree-module-Unet2dPT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Unet2dPT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=none"
@@ -2768,9 +2768,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-86ce8dfe2979d777a7f9eb0d3b6f8dcd4b594f46e9d610ad8a73edc89a006b26"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_86ce8dfe2979d777a7f9eb0d3b6f8dcd4b594f46e9d610ad8a73edc89a006b26/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -2779,9 +2779,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bd0ea10065a27dea6875ceb70f769e7e0f67a08e857920ca0d0322593441e9ed"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_bd0ea10065a27dea6875ceb70f769e7e0f67a08e857920ca0d0322593441e9ed/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -2790,9 +2790,9 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
-  NAME "iree-module-28e38bd436b036babc0fabe98b6e7c68ca3a7088e73dffff2c538adfa7d6af4c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_28e38bd436b036babc0fabe98b6e7c68ca3a7088e73dffff2c538adfa7d6af4c/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2801,15 +2801,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_28e38bd436b036babc0fabe98b6e7c68ca3a7088e73dffff2c538adfa7d6af4c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PersonDetect_int8(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-439f7c958ce1d3200ea96935174cabde8e8fe6917a007f5e238553e9c2aa7625"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_439f7c958ce1d3200ea96935174cabde8e8fe6917a007f5e238553e9c2aa7625/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2818,15 +2818,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_439f7c958ce1d3200ea96935174cabde8e8fe6917a007f5e238553e9c2aa7625/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2f2e448f73ef190ed35af1b25b6179ce15faba7ee7c12f4956730c441e9a27bd"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_2f2e448f73ef190ed35af1b25b6179ce15faba7ee7c12f4956730c441e9a27bd/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2835,15 +2835,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_2f2e448f73ef190ed35af1b25b6179ce15faba7ee7c12f4956730c441e9a27bd/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c370b55d34f6d3c76aa838ff0a7be520de10a4824c5feaa773e2fb73a588ad8c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_c370b55d34f6d3c76aa838ff0a7be520de10a4824c5feaa773e2fb73a588ad8c/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2852,15 +2852,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_c370b55d34f6d3c76aa838ff0a7be520de10a4824c5feaa773e2fb73a588ad8c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNet_int8(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ef1ba1216f0f304c80b7a5b8bac545a987d04a100d9c1e5e66b75ce88636534c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_a359c8f1e19b6f476e843bdc5566f9554e329cbfb3b4437995ad9cccfb381aee.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_module_ef1ba1216f0f304c80b7a5b8bac545a987d04a100d9c1e5e66b75ce88636534c/module.vmfb"
+  NAME "iree-module-MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2869,15 +2869,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_module_ef1ba1216f0f304c80b7a5b8bac545a987d04a100d9c1e5e66b75ce88636534c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV1_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1c4bc4b5ba3b5862efdbcbb9b3bf4a02f7ff9aa36e852e9b94dbe265d6bfaa99"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_1c4bc4b5ba3b5862efdbcbb9b3bf4a02f7ff9aa36e852e9b94dbe265d6bfaa99/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2886,15 +2886,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_1c4bc4b5ba3b5862efdbcbb9b3bf4a02f7ff9aa36e852e9b94dbe265d6bfaa99/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2cb62cec021aeb2abd869ba5276996e362bae130db7cc2d79389cccee6e372b9"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_2cb62cec021aeb2abd869ba5276996e362bae130db7cc2d79389cccee6e372b9/module.vmfb"
+  NAME "iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2903,15 +2903,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_2cb62cec021aeb2abd869ba5276996e362bae130db7cc2d79389cccee6e372b9/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_int8(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4a3b570ba18c3c9eee458455aaff4aa29293a5c936a19862c698b4b3ddaf06e7"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_4a3b570ba18c3c9eee458455aaff4aa29293a5c936a19862c698b4b3ddaf06e7/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2920,15 +2920,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_4a3b570ba18c3c9eee458455aaff4aa29293a5c936a19862c698b4b3ddaf06e7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a05a2b521a968e99411712e0e5191c3cd1d6295991f3b78acf61faca5d1cf85e"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_a05a2b521a968e99411712e0e5191c3cd1d6295991f3b78acf61faca5d1cf85e/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2937,15 +2937,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_a05a2b521a968e99411712e0e5191c3cd1d6295991f3b78acf61faca5d1cf85e/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5a4c96fc279262ad7d7f1d446d0bd3685b2ca42e06b0167df5be5737c9d42901"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_5a4c96fc279262ad7d7f1d446d0bd3685b2ca42e06b0167df5be5737c9d42901/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp16_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2954,15 +2954,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_5a4c96fc279262ad7d7f1d446d0bd3685b2ca42e06b0167df5be5737c9d42901/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp16(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-27bbe62536a23529b4dd0df3d4913ee18344df9b6e2a32fc834fb7d9bc520e24"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_27bbe62536a23529b4dd0df3d4913ee18344df9b6e2a32fc834fb7d9bc520e24/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2971,15 +2971,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_27bbe62536a23529b4dd0df3d4913ee18344df9b6e2a32fc834fb7d9bc520e24/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-78511a42a50f705b944437a040e1ee3bb5b2595a3b1d4db788586fe48f9a2453"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_78511a42a50f705b944437a040e1ee3bb5b2595a3b1d4db788586fe48f9a2453/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2988,15 +2988,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_78511a42a50f705b944437a040e1ee3bb5b2595a3b1d4db788586fe48f9a2453/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-01d35de2a55b9800e05151455eace0bf4493337ac1210fcc4904d630b075599a"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_01d35de2a55b9800e05151455eace0bf4493337ac1210fcc4904d630b075599a/module.vmfb"
+  NAME "iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3005,15 +3005,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_01d35de2a55b9800e05151455eace0bf4493337ac1210fcc4904d630b075599a/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNetV2STF(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2957930127e9b01e90ccddb7290e1c4b4abf6373cc36929809040e2c144d3fd7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_2957930127e9b01e90ccddb7290e1c4b4abf6373cc36929809040e2c144d3fd7/module.vmfb"
+  NAME "iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3022,15 +3022,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_2957930127e9b01e90ccddb7290e1c4b4abf6373cc36929809040e2c144d3fd7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MiniLML12H384Uncased(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b5078b9d2031b69ec5ce9b775c8701cef73add8ebfb786d9189ca3fb6474cf73"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cc474102-7d2f-4ec1-92ae-84e83ba0f390_EfficientNetV2SPT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2SPT_module_b5078b9d2031b69ec5ce9b775c8701cef73add8ebfb786d9189ca3fb6474cf73/module.vmfb"
+  NAME "iree-module-EfficientNetV2SPT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2SPT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2SPT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=none"
@@ -3039,15 +3039,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2SPT_module_b5078b9d2031b69ec5ce9b775c8701cef73add8ebfb786d9189ca3fb6474cf73/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2SPT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNetV2SPT(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ddd1657bc5433ccca5c8ce562f581626457a793670958cd8b4016c426191a9c4"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_module_ddd1657bc5433ccca5c8ce562f581626457a793670958cd8b4016c426191a9c4/module.vmfb"
+  NAME "iree-module-BertForMaskedLMTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3056,15 +3056,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_module_ddd1657bc5433ccca5c8ce562f581626457a793670958cd8b4016c426191a9c4/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertForMaskedLMTF(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8ee3c7b136703472b53bc8a19d8d28945aca93953612ccc65e55cd1b3dfda6c8"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_8ee3c7b136703472b53bc8a19d8d28945aca93953612ccc65e55cd1b3dfda6c8/module.vmfb"
+  NAME "iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3073,15 +3073,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_8ee3c7b136703472b53bc8a19d8d28945aca93953612ccc65e55cd1b3dfda6c8/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTF(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-63a2a9acdb2dafb66a49487fd7eecb79e49d870ec9b9ef17a1e8e9d50fe5c9ba"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_68caa96e-b8bb-48a2-bb08-a3044981a370_EfficientNetB7PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetB7PT_module_63a2a9acdb2dafb66a49487fd7eecb79e49d870ec9b9ef17a1e8e9d50fe5c9ba/module.vmfb"
+  NAME "iree-module-EfficientNetB7PT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetB7PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetB7PT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=none"
@@ -3090,15 +3090,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNetB7PT_module_63a2a9acdb2dafb66a49487fd7eecb79e49d870ec9b9ef17a1e8e9d50fe5c9ba/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetB7PT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNetB7PT(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9a1d228583ba1e56a19393f6938d16b5d582bb17f89fb5856b8b1c68e34abd45"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_9a1d228583ba1e56a19393f6938d16b5d582bb17f89fb5856b8b1c68e34abd45/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3109,15 +3109,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_9a1d228583ba1e56a19393f6938d16b5d582bb17f89fb5856b8b1c68e34abd45/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PersonDetect_int8(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-00a22e8ada401de8f20895beff9a153585e585c2d686983e27f9d64fdf7d39a8"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_00a22e8ada401de8f20895beff9a153585e585c2d686983e27f9d64fdf7d39a8/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3128,15 +3128,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_00a22e8ada401de8f20895beff9a153585e585c2d686983e27f9d64fdf7d39a8/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-de34105293194986d706823bd3d20ce784506ec5918c4d0efac9839020bb5fdd"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_de34105293194986d706823bd3d20ce784506ec5918c4d0efac9839020bb5fdd/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3147,15 +3147,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_de34105293194986d706823bd3d20ce784506ec5918c4d0efac9839020bb5fdd/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-373b890bed4c0f4828b957e37d319509bf41e39a4e47746285e27101d40f90bd"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_373b890bed4c0f4828b957e37d319509bf41e39a4e47746285e27101d40f90bd/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3166,15 +3166,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_373b890bed4c0f4828b957e37d319509bf41e39a4e47746285e27101d40f90bd/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNet_int8(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-63d75ff4a9998a86855e0e78ab2d782f52b90b58025584f3f03ec3103a81425b"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_63d75ff4a9998a86855e0e78ab2d782f52b90b58025584f3f03ec3103a81425b/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3185,15 +3185,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_63d75ff4a9998a86855e0e78ab2d782f52b90b58025584f3f03ec3103a81425b/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-fdce9dd1dfd20592880fce8969f91ac6abe84eca6922b4df4cbffe512abbfcb6"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_fdce9dd1dfd20592880fce8969f91ac6abe84eca6922b4df4cbffe512abbfcb6/module.vmfb"
+  NAME "iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3204,15 +3204,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_fdce9dd1dfd20592880fce8969f91ac6abe84eca6922b4df4cbffe512abbfcb6/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_int8(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4c74339076df00d23baa17dcb3194043e0472da9d09db4e42a23841ff7bf67b0"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_4c74339076df00d23baa17dcb3194043e0472da9d09db4e42a23841ff7bf67b0/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3223,15 +3223,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_4c74339076df00d23baa17dcb3194043e0472da9d09db4e42a23841ff7bf67b0/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-152d0b6211fff7591df3418c549c979a8144fc34280c22a8b2b5ff8ea3d1b46c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_152d0b6211fff7591df3418c549c979a8144fc34280c22a8b2b5ff8ea3d1b46c/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3242,15 +3242,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_152d0b6211fff7591df3418c549c979a8144fc34280c22a8b2b5ff8ea3d1b46c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e0533bdae79e15707a6eb26eb7f09c4d7dbdbfc40b993a4ad6289cf2bb1f13cb"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_e0533bdae79e15707a6eb26eb7f09c4d7dbdbfc40b993a4ad6289cf2bb1f13cb/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3261,15 +3261,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_e0533bdae79e15707a6eb26eb7f09c4d7dbdbfc40b993a4ad6289cf2bb1f13cb/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ad9a410e86dd9d649de58f5a7dbdc6cd2300fb6b6a363f4483e930d9944d2d07"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_ad9a410e86dd9d649de58f5a7dbdc6cd2300fb6b6a363f4483e930d9944d2d07/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -3280,15 +3280,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_ad9a410e86dd9d649de58f5a7dbdc6cd2300fb6b6a363f4483e930d9944d2d07/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c9a7c5b08db10ed782045b6810cb4ee157da9e95590456d3839c06163ee30fa7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_c9a7c5b08db10ed782045b6810cb4ee157da9e95590456d3839c06163ee30fa7/module.vmfb"
+  NAME "iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3299,15 +3299,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_c9a7c5b08db10ed782045b6810cb4ee157da9e95590456d3839c06163ee30fa7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNetV2STF(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-838cc09b422958a332fd76cf12a6a2a95b8346c8e8d2fe7b15cb5ace4c20581e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_838cc09b422958a332fd76cf12a6a2a95b8346c8e8d2fe7b15cb5ace4c20581e/module.vmfb"
+  NAME "iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3318,15 +3318,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_838cc09b422958a332fd76cf12a6a2a95b8346c8e8d2fe7b15cb5ace4c20581e/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MiniLML12H384Uncased(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8231a286cdc63a48f3f70a12ab5a182142c00cbebaccdc79e35ca552f02422e7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_8231a286cdc63a48f3f70a12ab5a182142c00cbebaccdc79e35ca552f02422e7/module.vmfb"
+  NAME "iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3337,15 +3337,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_8231a286cdc63a48f3f70a12ab5a182142c00cbebaccdc79e35ca552f02422e7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTF(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-26e9fb76ffd5d4ea66e51702b1dce2bc383a6b40e2b2d38d869cc583c58859d9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1_BertLargeTFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1_module_26e9fb76ffd5d4ea66e51702b1dce2bc383a6b40e2b2d38d869cc583c58859d9/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3354,15 +3354,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1_module_26e9fb76ffd5d4ea66e51702b1dce2bc383a6b40e2b2d38d869cc583c58859d9/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch1(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-6d608bf13e06ecee96effcd4ac5934aa039337351f60a1feb59e88ad670ad1f5"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-32_BertLargeTFBatch32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch32_module_6d608bf13e06ecee96effcd4ac5934aa039337351f60a1feb59e88ad670ad1f5/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3371,15 +3371,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch32_module_6d608bf13e06ecee96effcd4ac5934aa039337351f60a1feb59e88ad670ad1f5/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch32(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-37ef777cb4f695d4b87d3291b8d9a4435b03466df03c766c490b5d1830371993"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-64_BertLargeTFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch64_module_37ef777cb4f695d4b87d3291b8d9a4435b03466df03c766c490b5d1830371993/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3388,15 +3388,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch64_module_37ef777cb4f695d4b87d3291b8d9a4435b03466df03c766c490b5d1830371993/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch64(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ee88f7648c08cb775827b3afa89a2aaccd34eff697306c2b35598ba7e4c78df8"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-1_Resnet50TFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch1_module_ee88f7648c08cb775827b3afa89a2aaccd34eff697306c2b35598ba7e4c78df8/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3405,15 +3405,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch1_module_ee88f7648c08cb775827b3afa89a2aaccd34eff697306c2b35598ba7e4c78df8/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch1(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-943dffbfb30f5c423a81911af7a583ffffb0422f9e55a24671232f5f698a689a"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-64_Resnet50TFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch64_module_943dffbfb30f5c423a81911af7a583ffffb0422f9e55a24671232f5f698a689a/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3422,15 +3422,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch64_module_943dffbfb30f5c423a81911af7a583ffffb0422f9e55a24671232f5f698a689a/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch64(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f2d1ab779b6ed6b7e9cddc23ea21d568abb704f6b771159f2571cb76adac8ec5"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-128_Resnet50TFBatch128.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch128_module_f2d1ab779b6ed6b7e9cddc23ea21d568abb704f6b771159f2571cb76adac8ec5/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch128_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch128.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch128_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3439,15 +3439,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch128_module_f2d1ab779b6ed6b7e9cddc23ea21d568abb704f6b771159f2571cb76adac8ec5/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch128_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch128(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0a1b669562cd4cd755ea3ad7bd5042daa0688e8b60de1cf9ee45c227d37ec025"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-1_T5LargeTFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch1_module_0a1b669562cd4cd755ea3ad7bd5042daa0688e8b60de1cf9ee45c227d37ec025/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3456,15 +3456,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch1_module_0a1b669562cd4cd755ea3ad7bd5042daa0688e8b60de1cf9ee45c227d37ec025/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch1(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2139d35085dee09cefbdffc59a0374f1c0274c1ec574815e3277d0129a2089de"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-16_T5LargeTFBatch16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch16_module_2139d35085dee09cefbdffc59a0374f1c0274c1ec574815e3277d0129a2089de/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch16_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch16_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3473,15 +3473,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch16_module_2139d35085dee09cefbdffc59a0374f1c0274c1ec574815e3277d0129a2089de/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch16_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch16(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-dfc624d8a13b1cd8e34b1d14c32eeeb4e2acf6ded9fbda42fd30f3001de972d0"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-32_T5LargeTFBatch32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch32_module_dfc624d8a13b1cd8e34b1d14c32eeeb4e2acf6ded9fbda42fd30f3001de972d0/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=stablehlo"
@@ -3490,15 +3490,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch32_module_dfc624d8a13b1cd8e34b1d14c32eeeb4e2acf6ded9fbda42fd30f3001de972d0/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch32(stablehlo) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-25ad2815eb690276e9c2183aaafaf17a3df734bb6164071ad92dbf1e7faf7509"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_25ad2815eb690276e9c2183aaafaf17a3df734bb6164071ad92dbf1e7faf7509/module.vmfb"
+  NAME "iree-module-EfficientNetV2STF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3506,15 +3506,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_module_25ad2815eb690276e9c2183aaafaf17a3df734bb6164071ad92dbf1e7faf7509/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNetV2STF(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-65586f1e5b51439dd951529c35fa9000a928f90039cc6cfb66d5c81d07a6c62b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_65586f1e5b51439dd951529c35fa9000a928f90039cc6cfb66d5c81d07a6c62b/module.vmfb"
+  NAME "iree-module-MiniLML12H384Uncased_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3522,15 +3522,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_module_65586f1e5b51439dd951529c35fa9000a928f90039cc6cfb66d5c81d07a6c62b/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MiniLML12H384Uncased(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8b19868be1c797cb585551c871c4171e78817e0efc49d30d91b9d722be283de9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_module_8b19868be1c797cb585551c871c4171e78817e0efc49d30d91b9d722be283de9/module.vmfb"
+  NAME "iree-module-BertForMaskedLMTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3538,15 +3538,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_module_8b19868be1c797cb585551c871c4171e78817e0efc49d30d91b9d722be283de9/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertForMaskedLMTF(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c2085883b1f5c767f37508ab998a4bcd17d169fe6a5197d28e4dca8772c90253"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.timestamp_1683504734.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_c2085883b1f5c767f37508ab998a4bcd17d169fe6a5197d28e4dca8772c90253/module.vmfb"
+  NAME "iree-module-BertLargeTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF.timestamp_1683504734.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3554,15 +3554,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_module_c2085883b1f5c767f37508ab998a4bcd17d169fe6a5197d28e4dca8772c90253/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTF(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-88b6b5f712cd2f40d07a136e7f911c05b976c390e07f104c970292dee9a77e9a"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8_ClipTextSeqLen64PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_88b6b5f712cd2f40d07a136e7f911c05b976c390e07f104c970292dee9a77e9a/module.vmfb"
+  NAME "iree-module-ClipTextSeqLen64PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_ClipTextSeqLen64PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3570,15 +3570,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_88b6b5f712cd2f40d07a136e7f911c05b976c390e07f104c970292dee9a77e9a/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "ClipTextSeqLen64PT(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-925cdb19f2aa31a1907c81b5a9e179d91280c77b08a039c1cbf146f71683dde9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_340553d1-e6fe-41b6-b2c7-687c74ccec56_Unet2dPT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_925cdb19f2aa31a1907c81b5a9e179d91280c77b08a039c1cbf146f71683dde9/module.vmfb"
+  NAME "iree-module-Unet2dPT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Unet2dPT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3586,15 +3586,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_925cdb19f2aa31a1907c81b5a9e179d91280c77b08a039c1cbf146f71683dde9/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Unet2dPT(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3c94ab45ad76bd8b2083729b65340b987da3247c854faf7d06431cb05a3b0a23"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_68caa96e-b8bb-48a2-bb08-a3044981a370_EfficientNetB7PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetB7PT_module_3c94ab45ad76bd8b2083729b65340b987da3247c854faf7d06431cb05a3b0a23/module.vmfb"
+  NAME "iree-module-EfficientNetB7PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetB7PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetB7PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3602,15 +3602,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNetB7PT_module_3c94ab45ad76bd8b2083729b65340b987da3247c854faf7d06431cb05a3b0a23/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetB7PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNetB7PT(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5afcbf3d3cd73477dba7cd674d13a936231393835addc705787daa643b051a81"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1_BertLargefp16PTBatch1.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1_module_5afcbf3d3cd73477dba7cd674d13a936231393835addc705787daa643b051a81/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3618,15 +3618,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1_module_5afcbf3d3cd73477dba7cd674d13a936231393835addc705787daa643b051a81/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch1(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-29f80f0856a3f30bb9bc30ed64e2cc9b5fce156fdfd0b829a0acd1e76e0834c7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_271ea7a0-68e7-45b6-91f4-f39d5ce9e29c_EfficientNetV2Sfp16PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2Sfp16PT_module_29f80f0856a3f30bb9bc30ed64e2cc9b5fce156fdfd0b829a0acd1e76e0834c7/module.vmfb"
+  NAME "iree-module-EfficientNetV2Sfp16PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2Sfp16PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2Sfp16PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3634,15 +3634,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2Sfp16PT_module_29f80f0856a3f30bb9bc30ed64e2cc9b5fce156fdfd0b829a0acd1e76e0834c7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2Sfp16PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNetV2Sfp16PT(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9b4e60a06d92bebe93ee7824e1990d10bce55062bd896d3f15604881c446e528"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_50a7aece-73f9-47f4-a93a-4a1178f45407_matmul_3456x1024x2048_f16t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_3456x1024x2048_f16t_tile_config_default_module_9b4e60a06d92bebe93ee7824e1990d10bce55062bd896d3f15604881c446e528/module.vmfb"
+  NAME "iree-module-matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_3456x1024x2048_f16t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3651,15 +3651,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_3456x1024x2048_f16t_tile_config_default_module_9b4e60a06d92bebe93ee7824e1990d10bce55062bd896d3f15604881c446e528/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_3456x1024x2048_f16t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-52ce6f195b382daa71816b068bc1d13541397d6da097276699dbaffa95de35d7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_a55afe1c-9410-47a6-b417-04b0d75ee5f4_matmul_3456x1024x2048_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_3456x1024x2048_f32t_tile_config_default_module_52ce6f195b382daa71816b068bc1d13541397d6da097276699dbaffa95de35d7/module.vmfb"
+  NAME "iree-module-matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_3456x1024x2048_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3668,15 +3668,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_3456x1024x2048_f32t_tile_config_default_module_52ce6f195b382daa71816b068bc1d13541397d6da097276699dbaffa95de35d7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_3456x1024x2048_f32t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-973d25bc365d73084bfa35f317464f59a9b00f67d732733b4eaa476a418ecd95"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_81cebaaf-e23d-4a32-89dc-9fc7adc37a8f_matmul_2560x2560x2560_f16t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2560x2560x2560_f16t_tile_config_default_module_973d25bc365d73084bfa35f317464f59a9b00f67d732733b4eaa476a418ecd95/module.vmfb"
+  NAME "iree-module-matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2560x2560x2560_f16t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3685,15 +3685,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_2560x2560x2560_f16t_tile_config_default_module_973d25bc365d73084bfa35f317464f59a9b00f67d732733b4eaa476a418ecd95/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_2560x2560x2560_f16t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f9df9c8ecc1b369ddc960f07ab7097a9c1dd8587441cbd9cf91e443e2639bf28"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_579b77ea-76bd-4eb3-bd85-067c25a89eff_matmul_2560x2560x2560_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2560x2560x2560_f32t_tile_config_default_module_f9df9c8ecc1b369ddc960f07ab7097a9c1dd8587441cbd9cf91e443e2639bf28/module.vmfb"
+  NAME "iree-module-matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2560x2560x2560_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3702,15 +3702,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_2560x2560x2560_f32t_tile_config_default_module_f9df9c8ecc1b369ddc960f07ab7097a9c1dd8587441cbd9cf91e443e2639bf28/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_2560x2560x2560_f32t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f93f9c93aaa7cf3f771a421d1f4488d840a775063dd2b8d7971c94b9d18ace59"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_4e75ff72-f807-49f6-b740-febca1794334_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_module_f93f9c93aaa7cf3f771a421d1f4488d840a775063dd2b8d7971c94b9d18ace59/module.vmfb"
+  NAME "iree-module-matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3719,15 +3719,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_module_f93f9c93aaa7cf3f771a421d1f4488d840a775063dd2b8d7971c94b9d18ace59/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-aa51110b0fb3f96c5d3ce6f22b445b0be96a54789754fcd8309de707ab8f5a1c"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_8d6be288-9b88-41bd-bc5a-5644df0481bb_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_module_aa51110b0fb3f96c5d3ce6f22b445b0be96a54789754fcd8309de707ab8f5a1c/module.vmfb"
+  NAME "iree-module-matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3736,15 +3736,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_module_aa51110b0fb3f96c5d3ce6f22b445b0be96a54789754fcd8309de707ab8f5a1c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-67e643dea7f2cf9e5e90ec74746ecc52c487747966a95b8140c3c0cd6f90b709"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_0a3d952b-41ca-43d2-9ec3-ccb8dde20ce3_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_module_67e643dea7f2cf9e5e90ec74746ecc52c487747966a95b8140c3c0cd6f90b709/module.vmfb"
+  NAME "iree-module-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3753,15 +3753,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_module_67e643dea7f2cf9e5e90ec74746ecc52c487747966a95b8140c3c0cd6f90b709/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4d3bfb94dfe03a269350ad28fb9b1fa8db8c88ff19e2535cef09aafdbdfd83f5"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9b81a2f5-bab2-4f6f-b8b5-13cc4b3e9413_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_module_4d3bfb94dfe03a269350ad28fb9b1fa8db8c88ff19e2535cef09aafdbdfd83f5/module.vmfb"
+  NAME "iree-module-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3770,15 +3770,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_module_4d3bfb94dfe03a269350ad28fb9b1fa8db8c88ff19e2535cef09aafdbdfd83f5/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-371a68ee85e41abf2d2a2847fe6c9f85fdc51f76516d74e3576b9d72670c1a0b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_699fd533-02a9-49f0-bf26-1902d8dbb5af_matmul_128x256x8192_f16t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_128x256x8192_f16t_tile_config_default_module_371a68ee85e41abf2d2a2847fe6c9f85fdc51f76516d74e3576b9d72670c1a0b/module.vmfb"
+  NAME "iree-module-matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_128x256x8192_f16t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3789,15 +3789,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_128x256x8192_f16t_tile_config_default_module_371a68ee85e41abf2d2a2847fe6c9f85fdc51f76516d74e3576b9d72670c1a0b/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_128x256x8192_f16t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,splitk,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1af884e597c283d319b14e8d55156eac66a86045fcb7e521c3f50aa8a6c04126"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_a6c2b812-0a71-45e7-9ea5-f3d8529213ef_matmul_128x256x8192_f32t_tile_config_default.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_matmul_128x256x8192_f32t_tile_config_default_module_1af884e597c283d319b14e8d55156eac66a86045fcb7e521c3f50aa8a6c04126/module.vmfb"
+  NAME "iree-module-matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_128x256x8192_f32t_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -3808,15 +3808,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_matmul_128x256x8192_f32t_tile_config_default_module_1af884e597c283d319b14e8d55156eac66a86045fcb7e521c3f50aa8a6c04126/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_128x256x8192_f32t_tile_config_default(linalg) [cuda-sm_80-linux_gnu-cuda][ukernel,matmul,splitk,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2fe6a4ac93d74732ebabbd87e84e6ec56d2aeb9f6a94f5b595f74f947498c579"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-1_Resnet50TFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch1_module_2fe6a4ac93d74732ebabbd87e84e6ec56d2aeb9f6a94f5b595f74f947498c579/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3824,15 +3824,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch1_module_2fe6a4ac93d74732ebabbd87e84e6ec56d2aeb9f6a94f5b595f74f947498c579/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch1(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-32dfb79e574ef282dd352a156620d44d545dda0f49ea1ac27394028d2ced46a8"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-8_Resnet50TFBatch8.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch8_module_32dfb79e574ef282dd352a156620d44d545dda0f49ea1ac27394028d2ced46a8/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch8.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3840,15 +3840,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch8_module_32dfb79e574ef282dd352a156620d44d545dda0f49ea1ac27394028d2ced46a8/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch8(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3421bd5d457a3ed62e7aa74559afb7199105c1f60b65090a247ee3e6d9aec69c"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-64_Resnet50TFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch64_module_3421bd5d457a3ed62e7aa74559afb7199105c1f60b65090a247ee3e6d9aec69c/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3856,15 +3856,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch64_module_3421bd5d457a3ed62e7aa74559afb7199105c1f60b65090a247ee3e6d9aec69c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch64(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5663bccd89aa0616691d5b804b337c8989a2ca94c1bf2673d41dbbab9e511f20"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-128_Resnet50TFBatch128.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch128_module_5663bccd89aa0616691d5b804b337c8989a2ca94c1bf2673d41dbbab9e511f20/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch128.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3872,15 +3872,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch128_module_5663bccd89aa0616691d5b804b337c8989a2ca94c1bf2673d41dbbab9e511f20/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch128(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-353a915204b8eb401d0caac543588920cfab76f826463394cc1e99546cab13bb"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-256_Resnet50TFBatch256.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch256_module_353a915204b8eb401d0caac543588920cfab76f826463394cc1e99546cab13bb/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch256.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3888,15 +3888,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch256_module_353a915204b8eb401d0caac543588920cfab76f826463394cc1e99546cab13bb/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch256(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c5f0532455c22436b0fce487797b957939acb0d1f235644187d63bca29a70654"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-2048_Resnet50TFBatch2048.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch2048_module_c5f0532455c22436b0fce487797b957939acb0d1f235644187d63bca29a70654/module.vmfb"
+  NAME "iree-module-Resnet50TFBatch2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50TFBatch2048.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3904,15 +3904,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50TFBatch2048_module_c5f0532455c22436b0fce487797b957939acb0d1f235644187d63bca29a70654/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TFBatch2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50TFBatch2048(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1bac11dad2160652ffcfb201d96418f4c044fcd79771cf6a783f311998850a2e"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1_BertLargeTFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1_module_1bac11dad2160652ffcfb201d96418f4c044fcd79771cf6a783f311998850a2e/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3920,15 +3920,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1_module_1bac11dad2160652ffcfb201d96418f4c044fcd79771cf6a783f311998850a2e/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch1(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3edb70502ef7a26db736a64e24a677ff085fb800a8475e750dd2a9d119baf407"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-16_BertLargeTFBatch16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch16_module_3edb70502ef7a26db736a64e24a677ff085fb800a8475e750dd2a9d119baf407/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3936,15 +3936,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch16_module_3edb70502ef7a26db736a64e24a677ff085fb800a8475e750dd2a9d119baf407/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch16(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7f45c4f644d293bb984007aa1a91c919c5a75d01bf38f70ba7257c0b21c654f3"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-24_BertLargeTFBatch24.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch24_module_7f45c4f644d293bb984007aa1a91c919c5a75d01bf38f70ba7257c0b21c654f3/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch24.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3952,15 +3952,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch24_module_7f45c4f644d293bb984007aa1a91c919c5a75d01bf38f70ba7257c0b21c654f3/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch24(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bb96ff5237b0ad603b1ee7c59601a1c957a2ed5c95cbfd94f7ec6d707aad3660"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-32_BertLargeTFBatch32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch32_module_bb96ff5237b0ad603b1ee7c59601a1c957a2ed5c95cbfd94f7ec6d707aad3660/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3968,15 +3968,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch32_module_bb96ff5237b0ad603b1ee7c59601a1c957a2ed5c95cbfd94f7ec6d707aad3660/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch32(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5b499a05fc60f78b5b11b1e9ba89ba797450e5b49b0613b3c23d996c6f767c64"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-48_BertLargeTFBatch48.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch48_module_5b499a05fc60f78b5b11b1e9ba89ba797450e5b49b0613b3c23d996c6f767c64/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch48.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -3984,15 +3984,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch48_module_5b499a05fc60f78b5b11b1e9ba89ba797450e5b49b0613b3c23d996c6f767c64/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch48(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-40b0bd95d986d079ae0fc8cd57b473a150289a5f3ee6029b388ebc86edd4a60c"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-64_BertLargeTFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch64_module_40b0bd95d986d079ae0fc8cd57b473a150289a5f3ee6029b388ebc86edd4a60c/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4000,15 +4000,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch64_module_40b0bd95d986d079ae0fc8cd57b473a150289a5f3ee6029b388ebc86edd4a60c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch64(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-03736c12afe2b27f77101146eddaa80c8911cdbc2120ab574225c08b088e14f3"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-512_BertLargeTFBatch512.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch512_module_03736c12afe2b27f77101146eddaa80c8911cdbc2120ab574225c08b088e14f3/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch512.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4016,15 +4016,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch512_module_03736c12afe2b27f77101146eddaa80c8911cdbc2120ab574225c08b088e14f3/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch512(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b180d82d1a87fe29e414ecd55bf8a82ff92b80d7c644d31769729160b27aa467"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024_BertLargeTFBatch1024.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1024_module_b180d82d1a87fe29e414ecd55bf8a82ff92b80d7c644d31769729160b27aa467/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1024.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4032,15 +4032,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1024_module_b180d82d1a87fe29e414ecd55bf8a82ff92b80d7c644d31769729160b27aa467/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch1024(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-6265e9506389bb29c551ad62f4ea05f54bd0e549c2d29bf425bac9d56aa55ef6"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280_BertLargeTFBatch1280.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1280_module_6265e9506389bb29c551ad62f4ea05f54bd0e549c2d29bf425bac9d56aa55ef6/module.vmfb"
+  NAME "iree-module-BertLargeTFBatch1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargeTFBatch1280.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4048,15 +4048,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargeTFBatch1280_module_6265e9506389bb29c551ad62f4ea05f54bd0e549c2d29bf425bac9d56aa55ef6/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTFBatch1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargeTFBatch1280(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1ee530ad72c5711ee3abf11b27eed04e11d261fb6c0d23a6cb68c80c1a42580b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-1_T5LargeTFBatch1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch1_module_1ee530ad72c5711ee3abf11b27eed04e11d261fb6c0d23a6cb68c80c1a42580b/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4064,15 +4064,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch1_module_1ee530ad72c5711ee3abf11b27eed04e11d261fb6c0d23a6cb68c80c1a42580b/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch1(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-38e99a06cd01399fe48cd9d860f65474e4fd7df1b3aca491766ff5f825315a79"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-16_T5LargeTFBatch16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch16_module_38e99a06cd01399fe48cd9d860f65474e4fd7df1b3aca491766ff5f825315a79/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4080,15 +4080,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch16_module_38e99a06cd01399fe48cd9d860f65474e4fd7df1b3aca491766ff5f825315a79/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch16(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-db86dfb7ef5e59b31bf513df65fffd397f49e3fe3b5c03149140ccf3b6b2f821"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-24_T5LargeTFBatch24.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch24_module_db86dfb7ef5e59b31bf513df65fffd397f49e3fe3b5c03149140ccf3b6b2f821/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch24.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4096,15 +4096,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch24_module_db86dfb7ef5e59b31bf513df65fffd397f49e3fe3b5c03149140ccf3b6b2f821/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch24(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-89966a2ac764b543e721d822acdbe015526866e0a8d56a6782f240eeb3cddea1"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-32_T5LargeTFBatch32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch32_module_89966a2ac764b543e721d822acdbe015526866e0a8d56a6782f240eeb3cddea1/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4112,15 +4112,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch32_module_89966a2ac764b543e721d822acdbe015526866e0a8d56a6782f240eeb3cddea1/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch32(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-6da0542e65f9e5eff1bc142506866aec435b931b36eb8e86139f79b4945863fd"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-48_T5LargeTFBatch48.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch48_module_6da0542e65f9e5eff1bc142506866aec435b931b36eb8e86139f79b4945863fd/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch48.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4128,15 +4128,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch48_module_6da0542e65f9e5eff1bc142506866aec435b931b36eb8e86139f79b4945863fd/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch48(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f55259e9c9778885d48b20cfb18242984fa9dde9840fa0f92c7de379c88c8230"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_587e595d-2adf-4e41-9617-43178a133725-batch-64_T5LargeTFBatch64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch64_module_f55259e9c9778885d48b20cfb18242984fa9dde9840fa0f92c7de379c88c8230/module.vmfb"
+  NAME "iree-module-T5LargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5LargeTFBatch64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4144,15 +4144,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5LargeTFBatch64_module_f55259e9c9778885d48b20cfb18242984fa9dde9840fa0f92c7de379c88c8230/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5LargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5LargeTFBatch64(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-999f2edcdf9fbc84e0969923f8605e9069810a63849973a5b74488f83d14a2fe"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1_BertLargePTBatch1.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1_module_999f2edcdf9fbc84e0969923f8605e9069810a63849973a5b74488f83d14a2fe/module.vmfb"
+  NAME "iree-module-BertLargePTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4160,15 +4160,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1_module_999f2edcdf9fbc84e0969923f8605e9069810a63849973a5b74488f83d14a2fe/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch1(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5176d0f5fa331fa047395186a866870fe4210f637472ef4bb0a3f1ba3a62a749"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-16_BertLargePTBatch16.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch16_module_5176d0f5fa331fa047395186a866870fe4210f637472ef4bb0a3f1ba3a62a749/module.vmfb"
+  NAME "iree-module-BertLargePTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch16.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4176,15 +4176,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch16_module_5176d0f5fa331fa047395186a866870fe4210f637472ef4bb0a3f1ba3a62a749/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch16(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e67816e321544bb61b63ed8cd8b7faa8ff7d35cca15832b5fbc117f4693b3e78"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-24_BertLargePTBatch24.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch24_module_e67816e321544bb61b63ed8cd8b7faa8ff7d35cca15832b5fbc117f4693b3e78/module.vmfb"
+  NAME "iree-module-BertLargePTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch24.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4192,15 +4192,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch24_module_e67816e321544bb61b63ed8cd8b7faa8ff7d35cca15832b5fbc117f4693b3e78/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch24(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d746ecf3d747f18306b6dea4cb6b9e9dbf987fe7fd4d0b27b39a57a213e75dd9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-32_BertLargePTBatch32.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch32_module_d746ecf3d747f18306b6dea4cb6b9e9dbf987fe7fd4d0b27b39a57a213e75dd9/module.vmfb"
+  NAME "iree-module-BertLargePTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch32.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4208,15 +4208,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch32_module_d746ecf3d747f18306b6dea4cb6b9e9dbf987fe7fd4d0b27b39a57a213e75dd9/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch32(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-439dab16cd6df449fc83eb3e1603fa86ad811e749bcad2c3e3176976c56848e5"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-48_BertLargePTBatch48.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch48_module_439dab16cd6df449fc83eb3e1603fa86ad811e749bcad2c3e3176976c56848e5/module.vmfb"
+  NAME "iree-module-BertLargePTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch48.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4224,15 +4224,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch48_module_439dab16cd6df449fc83eb3e1603fa86ad811e749bcad2c3e3176976c56848e5/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch48(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-815e44d1ac31402e86d0fef72e79474a25dfad3a5c15b8cdd3642e101274342d"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-64_BertLargePTBatch64.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch64_module_815e44d1ac31402e86d0fef72e79474a25dfad3a5c15b8cdd3642e101274342d/module.vmfb"
+  NAME "iree-module-BertLargePTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch64.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4240,15 +4240,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch64_module_815e44d1ac31402e86d0fef72e79474a25dfad3a5c15b8cdd3642e101274342d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch64(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-fd0f6049f3cd4fee97c182e824f8e65eeabef47ef86a3797ae278ae1fc101705"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-512_BertLargePTBatch512.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch512_module_fd0f6049f3cd4fee97c182e824f8e65eeabef47ef86a3797ae278ae1fc101705/module.vmfb"
+  NAME "iree-module-BertLargePTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch512.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4256,15 +4256,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch512_module_fd0f6049f3cd4fee97c182e824f8e65eeabef47ef86a3797ae278ae1fc101705/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch512(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-48ad70710c3602b589431df74468589c74f2a5b54f56d8f86af86c70408ae36d"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1024_BertLargePTBatch1024.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1024_module_48ad70710c3602b589431df74468589c74f2a5b54f56d8f86af86c70408ae36d/module.vmfb"
+  NAME "iree-module-BertLargePTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1024.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4272,15 +4272,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1024_module_48ad70710c3602b589431df74468589c74f2a5b54f56d8f86af86c70408ae36d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch1024(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-07014af4305cf75cd094171519987b1ed1a6a6b70e489d2770301b623b7afe0c"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1280_BertLargePTBatch1280.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1280_module_07014af4305cf75cd094171519987b1ed1a6a6b70e489d2770301b623b7afe0c/module.vmfb"
+  NAME "iree-module-BertLargePTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargePTBatch1280.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4288,15 +4288,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargePTBatch1280_module_07014af4305cf75cd094171519987b1ed1a6a6b70e489d2770301b623b7afe0c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargePTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargePTBatch1280(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-681f456f27dbb79e7d8d0266bf835866d9f29f87eafad7e867ac13c84602742f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-1_Resnet50PTBatch1.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch1_module_681f456f27dbb79e7d8d0266bf835866d9f29f87eafad7e867ac13c84602742f/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch1.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4304,15 +4304,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch1_module_681f456f27dbb79e7d8d0266bf835866d9f29f87eafad7e867ac13c84602742f/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50PTBatch1(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3b0ae1403ef444d812f0c7b37fda7311e2cc4ea407850ee7b91e6984b9c86100"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-8_Resnet50PTBatch8.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch8_module_3b0ae1403ef444d812f0c7b37fda7311e2cc4ea407850ee7b91e6984b9c86100/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch8.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4320,15 +4320,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch8_module_3b0ae1403ef444d812f0c7b37fda7311e2cc4ea407850ee7b91e6984b9c86100/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50PTBatch8(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ff26aa2d1b8f0d80a8ab10aab0a87ae89e36c141dc6c758da61c339d51e2db8d"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-64_Resnet50PTBatch64.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch64_module_ff26aa2d1b8f0d80a8ab10aab0a87ae89e36c141dc6c758da61c339d51e2db8d/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch64.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4336,15 +4336,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch64_module_ff26aa2d1b8f0d80a8ab10aab0a87ae89e36c141dc6c758da61c339d51e2db8d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50PTBatch64(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-666922620019ce61f2ffa56e9e141fc3ef2736a04eab3d7c6d3b0fbeeaef4275"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-128_Resnet50PTBatch128.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch128_module_666922620019ce61f2ffa56e9e141fc3ef2736a04eab3d7c6d3b0fbeeaef4275/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch128.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4352,15 +4352,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch128_module_666922620019ce61f2ffa56e9e141fc3ef2736a04eab3d7c6d3b0fbeeaef4275/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50PTBatch128(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b36c4a1b93f09dee52b255982410f5b9e8e351010fe22eadb3f5afb6719f6873"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-256_Resnet50PTBatch256.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch256_module_b36c4a1b93f09dee52b255982410f5b9e8e351010fe22eadb3f5afb6719f6873/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch256.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4368,15 +4368,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch256_module_b36c4a1b93f09dee52b255982410f5b9e8e351010fe22eadb3f5afb6719f6873/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50PTBatch256(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-50c0cb0ea6df2e4c1c1337a607252366fb8cd17ffe72cd8aeb76a9f9a8d6712f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-2048_Resnet50PTBatch2048.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch2048_module_50c0cb0ea6df2e4c1c1337a607252366fb8cd17ffe72cd8aeb76a9f9a8d6712f/module.vmfb"
+  NAME "iree-module-Resnet50PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50PTBatch2048.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4384,15 +4384,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50PTBatch2048_module_50c0cb0ea6df2e4c1c1337a607252366fb8cd17ffe72cd8aeb76a9f9a8d6712f/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50PTBatch2048(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ebd2ba823bb384984a3b574bb27f9548e90ea7ab22267cc945211b05ff35dd96"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-1_Resnet50fp16PTBatch1.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch1_module_ebd2ba823bb384984a3b574bb27f9548e90ea7ab22267cc945211b05ff35dd96/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch1.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4400,15 +4400,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch1_module_ebd2ba823bb384984a3b574bb27f9548e90ea7ab22267cc945211b05ff35dd96/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50fp16PTBatch1(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-371a2c6fa2e0b6ae8aecaac605ed5e6bc16202b5bf5c12d3d47d270eac205de6"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-8_Resnet50fp16PTBatch8.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch8_module_371a2c6fa2e0b6ae8aecaac605ed5e6bc16202b5bf5c12d3d47d270eac205de6/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch8.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4416,15 +4416,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch8_module_371a2c6fa2e0b6ae8aecaac605ed5e6bc16202b5bf5c12d3d47d270eac205de6/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50fp16PTBatch8(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-af8ef7bef409aeae3f1205a04c94c87d042187424d0f8df009a1aa8a986b6709"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-64_Resnet50fp16PTBatch64.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch64_module_af8ef7bef409aeae3f1205a04c94c87d042187424d0f8df009a1aa8a986b6709/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch64.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4432,15 +4432,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch64_module_af8ef7bef409aeae3f1205a04c94c87d042187424d0f8df009a1aa8a986b6709/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50fp16PTBatch64(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-665c507d3681ab53586a2ee493cd409684a32c6b553e194d2777f7560b07fbaf"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-128_Resnet50fp16PTBatch128.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch128_module_665c507d3681ab53586a2ee493cd409684a32c6b553e194d2777f7560b07fbaf/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch128.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4448,15 +4448,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch128_module_665c507d3681ab53586a2ee493cd409684a32c6b553e194d2777f7560b07fbaf/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50fp16PTBatch128(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4e69d30862f6dff4ed53e4ae462e670b4a2f6168a0d5bf1927b473f6713a5bde"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-256_Resnet50fp16PTBatch256.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch256_module_4e69d30862f6dff4ed53e4ae462e670b4a2f6168a0d5bf1927b473f6713a5bde/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch256.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4464,15 +4464,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch256_module_4e69d30862f6dff4ed53e4ae462e670b4a2f6168a0d5bf1927b473f6713a5bde/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50fp16PTBatch256(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1d4e4d30cb34199b1f451d2c43857270a4be48110a4f0bbb0f1db9b476820ac4"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-2048_Resnet50fp16PTBatch2048.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch2048_module_1d4e4d30cb34199b1f451d2c43857270a4be48110a4f0bbb0f1db9b476820ac4/module.vmfb"
+  NAME "iree-module-Resnet50fp16PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Resnet50fp16PTBatch2048.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4480,15 +4480,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Resnet50fp16PTBatch2048_module_1d4e4d30cb34199b1f451d2c43857270a4be48110a4f0bbb0f1db9b476820ac4/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50fp16PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Resnet50fp16PTBatch2048(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c42debd998a5a6b00a9f3b5a1087e17909498038cb9c24d0ff87a5761a4962f1"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-16_BertLargefp16PTBatch16.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch16_module_c42debd998a5a6b00a9f3b5a1087e17909498038cb9c24d0ff87a5761a4962f1/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch16.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4496,15 +4496,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch16_module_c42debd998a5a6b00a9f3b5a1087e17909498038cb9c24d0ff87a5761a4962f1/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch16(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-edd2270e3119ce3d52a3752532cdcb4ee08420837cbdcac42025b46e7c196230"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-24_BertLargefp16PTBatch24.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch24_module_edd2270e3119ce3d52a3752532cdcb4ee08420837cbdcac42025b46e7c196230/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch24.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4512,15 +4512,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch24_module_edd2270e3119ce3d52a3752532cdcb4ee08420837cbdcac42025b46e7c196230/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch24(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-57205a38cd8970cedf207e4d0c02d14103668a635dd341d6bf4ce12f6d1fd56c"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-32_BertLargefp16PTBatch32.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch32_module_57205a38cd8970cedf207e4d0c02d14103668a635dd341d6bf4ce12f6d1fd56c/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch32.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4528,15 +4528,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch32_module_57205a38cd8970cedf207e4d0c02d14103668a635dd341d6bf4ce12f6d1fd56c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch32(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-88490c7b469b6be6ae374fbdd1f3b9e3d4a998dee5629741ab22f449cefaa1d8"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-48_BertLargefp16PTBatch48.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch48_module_88490c7b469b6be6ae374fbdd1f3b9e3d4a998dee5629741ab22f449cefaa1d8/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch48.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4544,15 +4544,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch48_module_88490c7b469b6be6ae374fbdd1f3b9e3d4a998dee5629741ab22f449cefaa1d8/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch48(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-218daf4b21025dfcd8d446934c80b999ea21d0e0202fce7e87604c52f9224f66"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-64_BertLargefp16PTBatch64.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch64_module_218daf4b21025dfcd8d446934c80b999ea21d0e0202fce7e87604c52f9224f66/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch64.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4560,15 +4560,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch64_module_218daf4b21025dfcd8d446934c80b999ea21d0e0202fce7e87604c52f9224f66/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch64(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c838ded21eebe38f16ac159822b41648625ff507ae49f35845e9bfdc93732cd3"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-512_BertLargefp16PTBatch512.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch512_module_c838ded21eebe38f16ac159822b41648625ff507ae49f35845e9bfdc93732cd3/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch512.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4576,15 +4576,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch512_module_c838ded21eebe38f16ac159822b41648625ff507ae49f35845e9bfdc93732cd3/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch512(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-dfdfa87bbaf9931a0e4c47c02866e103872cb20b30899b2358c9d7e59101d5a9"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1024_BertLargefp16PTBatch1024.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1024_module_dfdfa87bbaf9931a0e4c47c02866e103872cb20b30899b2358c9d7e59101d5a9/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1024.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4592,15 +4592,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1024_module_dfdfa87bbaf9931a0e4c47c02866e103872cb20b30899b2358c9d7e59101d5a9/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch1024(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c480fe46ed6eef2a12e453924f953d7d0ad1a5178e11e2948b7d0223d0c0d9f5"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1280_BertLargefp16PTBatch1280.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1280_module_c480fe46ed6eef2a12e453924f953d7d0ad1a5178e11e2948b7d0223d0c0d9f5/module.vmfb"
+  NAME "iree-module-BertLargefp16PTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BertLargefp16PTBatch1280.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=none"
@@ -4608,15 +4608,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BertLargefp16PTBatch1280_module_c480fe46ed6eef2a12e453924f953d7d0ad1a5178e11e2948b7d0223d0c0d9f5/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BertLargefp16PTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BertLargefp16PTBatch1280(linalg) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f467fd6a4898fc695217f5e9fb245da17e005453f25e83accdc183c16e270c11"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1_BERT_LARGE_JAX_384XI32_BATCH1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1_module_f467fd6a4898fc695217f5e9fb245da17e005453f25e83accdc183c16e270c11/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4624,15 +4624,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1_module_f467fd6a4898fc695217f5e9fb245da17e005453f25e83accdc183c16e270c11/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH1(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d1e4f85096576419ec92da3a1216146291a17b2a42dd2b3f635401308f7c20b7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch16_BERT_LARGE_JAX_384XI32_BATCH16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH16_module_d1e4f85096576419ec92da3a1216146291a17b2a42dd2b3f635401308f7c20b7/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4640,15 +4640,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH16_module_d1e4f85096576419ec92da3a1216146291a17b2a42dd2b3f635401308f7c20b7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH16(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2d4049a9ca6a95ab7169f046f382bcb91ecacee29ecee3256570db0158372fcf"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch24_BERT_LARGE_JAX_384XI32_BATCH24.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH24_module_2d4049a9ca6a95ab7169f046f382bcb91ecacee29ecee3256570db0158372fcf/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH24.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4656,15 +4656,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH24_module_2d4049a9ca6a95ab7169f046f382bcb91ecacee29ecee3256570db0158372fcf/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH24(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-620619c21b56a577b155f19b8efb4bdec8f640f76b1c3dae8e4397bdf1d04aee"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch32_BERT_LARGE_JAX_384XI32_BATCH32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH32_module_620619c21b56a577b155f19b8efb4bdec8f640f76b1c3dae8e4397bdf1d04aee/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4672,15 +4672,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH32_module_620619c21b56a577b155f19b8efb4bdec8f640f76b1c3dae8e4397bdf1d04aee/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH32(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d25741e6366c1c2552eaf930f99dd3362c0e2dbc55035e0f14e3a562f005245f"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch48_BERT_LARGE_JAX_384XI32_BATCH48.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH48_module_d25741e6366c1c2552eaf930f99dd3362c0e2dbc55035e0f14e3a562f005245f/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH48.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4688,15 +4688,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH48_module_d25741e6366c1c2552eaf930f99dd3362c0e2dbc55035e0f14e3a562f005245f/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH48(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ed46d4ed1910589e121e64cdf08c2d3cc72a1bfe24ae41cf78bfc98c7b7fc4c2"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch64_BERT_LARGE_JAX_384XI32_BATCH64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH64_module_ed46d4ed1910589e121e64cdf08c2d3cc72a1bfe24ae41cf78bfc98c7b7fc4c2/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4704,15 +4704,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH64_module_ed46d4ed1910589e121e64cdf08c2d3cc72a1bfe24ae41cf78bfc98c7b7fc4c2/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH64(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e73380cafbdf91e5fa9867a399562b4b5136864fa8d887cd1580d5d3154a71eb"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch512_BERT_LARGE_JAX_384XI32_BATCH512.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH512_module_e73380cafbdf91e5fa9867a399562b4b5136864fa8d887cd1580d5d3154a71eb/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH512.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4720,15 +4720,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH512_module_e73380cafbdf91e5fa9867a399562b4b5136864fa8d887cd1580d5d3154a71eb/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH512(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-cf5560593dbc526d065894226429652670c5f24a8fb0828bd298921d137a17d4"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1024_BERT_LARGE_JAX_384XI32_BATCH1024.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1024_module_cf5560593dbc526d065894226429652670c5f24a8fb0828bd298921d137a17d4/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1024.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4736,15 +4736,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1024_module_cf5560593dbc526d065894226429652670c5f24a8fb0828bd298921d137a17d4/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH1024(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-dde92ea004e3c30ffbe82139e2cdf371c9bf78d05660fd952720ddb110bd9724"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1280_BERT_LARGE_JAX_384XI32_BATCH1280.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1280_module_dde92ea004e3c30ffbe82139e2cdf371c9bf78d05660fd952720ddb110bd9724/module.vmfb"
+  NAME "iree-module-BERT_LARGE_JAX_384XI32_BATCH1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_BERT_LARGE_JAX_384XI32_BATCH1280.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4752,15 +4752,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_BERT_LARGE_JAX_384XI32_BATCH1280_module_dde92ea004e3c30ffbe82139e2cdf371c9bf78d05660fd952720ddb110bd9724/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_BERT_LARGE_JAX_384XI32_BATCH1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "BERT_LARGE_JAX_384XI32_BATCH1280(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-acc8bb1b4e349461110585d461d06457f4139d62f0f1a5bfbf0afc356a070ae2"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch1_RESNET50_FP32_JAX_3X224X224XF32_BATCH1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH1_module_acc8bb1b4e349461110585d461d06457f4139d62f0f1a5bfbf0afc356a070ae2/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4768,15 +4768,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH1_module_acc8bb1b4e349461110585d461d06457f4139d62f0f1a5bfbf0afc356a070ae2/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "RESNET50_FP32_JAX_3X224X224XF32_BATCH1(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9453f508befcf3fdb82b3576484b5bbe4e199d26058d668f7741964e8755cbdd"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch8_RESNET50_FP32_JAX_3X224X224XF32_BATCH8.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH8_module_9453f508befcf3fdb82b3576484b5bbe4e199d26058d668f7741964e8755cbdd/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH8.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4784,15 +4784,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH8_module_9453f508befcf3fdb82b3576484b5bbe4e199d26058d668f7741964e8755cbdd/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "RESNET50_FP32_JAX_3X224X224XF32_BATCH8(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7633e088c3e1f7284944fa464c01a783cf45ba19498588bde13e3a675001eaa0"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch64_RESNET50_FP32_JAX_3X224X224XF32_BATCH64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH64_module_7633e088c3e1f7284944fa464c01a783cf45ba19498588bde13e3a675001eaa0/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4800,15 +4800,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH64_module_7633e088c3e1f7284944fa464c01a783cf45ba19498588bde13e3a675001eaa0/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "RESNET50_FP32_JAX_3X224X224XF32_BATCH64(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b54917aaf09c743ce6db08f24b0103f903763d3d73a953fd90b48d992b8e313b"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch128_RESNET50_FP32_JAX_3X224X224XF32_BATCH128.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH128_module_b54917aaf09c743ce6db08f24b0103f903763d3d73a953fd90b48d992b8e313b/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH128.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4816,15 +4816,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH128_module_b54917aaf09c743ce6db08f24b0103f903763d3d73a953fd90b48d992b8e313b/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "RESNET50_FP32_JAX_3X224X224XF32_BATCH128(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a71d327d1732c9c8f620b3ae2082cbe22c469d0375452a3245fa038cd4a6e7d7"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch256_RESNET50_FP32_JAX_3X224X224XF32_BATCH256.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH256_module_a71d327d1732c9c8f620b3ae2082cbe22c469d0375452a3245fa038cd4a6e7d7/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH256.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4832,15 +4832,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH256_module_a71d327d1732c9c8f620b3ae2082cbe22c469d0375452a3245fa038cd4a6e7d7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "RESNET50_FP32_JAX_3X224X224XF32_BATCH256(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a9ce4102685085f444f446b79493a8863dcb8f00678c98a0e2a04d26b286626d"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch2048_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_module_a9ce4102685085f444f446b79493a8863dcb8f00678c98a0e2a04d26b286626d/module.vmfb"
+  NAME "iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4848,15 +4848,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_module_a9ce4102685085f444f446b79493a8863dcb8f00678c98a0e2a04d26b286626d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "RESNET50_FP32_JAX_3X224X224XF32_BATCH2048(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0e7d8192ccb37cbe6b55c35e8e0cbaabce859ed9b8e62c822e835a60733c66d8"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch1_T5_LARGE_FP32_JAX_512XI32_BATCH1.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH1_module_0e7d8192ccb37cbe6b55c35e8e0cbaabce859ed9b8e62c822e835a60733c66d8/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH1.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4864,15 +4864,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH1_module_0e7d8192ccb37cbe6b55c35e8e0cbaabce859ed9b8e62c822e835a60733c66d8/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5_LARGE_FP32_JAX_512XI32_BATCH1(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3d2ee887cbcf8499dfddfcf629106072a067d27b789b620d76e74749151e86a2"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch16_T5_LARGE_FP32_JAX_512XI32_BATCH16.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH16_module_3d2ee887cbcf8499dfddfcf629106072a067d27b789b620d76e74749151e86a2/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH16.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4880,15 +4880,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH16_module_3d2ee887cbcf8499dfddfcf629106072a067d27b789b620d76e74749151e86a2/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5_LARGE_FP32_JAX_512XI32_BATCH16(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c13a2bb43eafea303949f6bb48fe7eba78782f7ca8ae52eecff03d5b2069a178"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch24_T5_LARGE_FP32_JAX_512XI32_BATCH24.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH24_module_c13a2bb43eafea303949f6bb48fe7eba78782f7ca8ae52eecff03d5b2069a178/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH24.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4896,15 +4896,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH24_module_c13a2bb43eafea303949f6bb48fe7eba78782f7ca8ae52eecff03d5b2069a178/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5_LARGE_FP32_JAX_512XI32_BATCH24(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4c0fe9013ea11c0c0e2214d06fd2088f33127a9431acfe24cca1a7f475425f06"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch32_T5_LARGE_FP32_JAX_512XI32_BATCH32.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH32_module_4c0fe9013ea11c0c0e2214d06fd2088f33127a9431acfe24cca1a7f475425f06/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH32.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4912,15 +4912,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH32_module_4c0fe9013ea11c0c0e2214d06fd2088f33127a9431acfe24cca1a7f475425f06/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5_LARGE_FP32_JAX_512XI32_BATCH32(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-656c20012d1675da118d78c6bbb3256b186156d52e8f423039d1deb1c103ccf0"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch48_T5_LARGE_FP32_JAX_512XI32_BATCH48.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH48_module_656c20012d1675da118d78c6bbb3256b186156d52e8f423039d1deb1c103ccf0/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH48.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4928,15 +4928,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH48_module_656c20012d1675da118d78c6bbb3256b186156d52e8f423039d1deb1c103ccf0/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5_LARGE_FP32_JAX_512XI32_BATCH48(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8a9816fe878d3d0d1dbe1cddb3f4bef09cce39f390b3e1f2c7bc8ebd93a9caa0"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch64_T5_LARGE_FP32_JAX_512XI32_BATCH64.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH64_module_8a9816fe878d3d0d1dbe1cddb3f4bef09cce39f390b3e1f2c7bc8ebd93a9caa0/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH64.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4944,15 +4944,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH64_module_8a9816fe878d3d0d1dbe1cddb3f4bef09cce39f390b3e1f2c7bc8ebd93a9caa0/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5_LARGE_FP32_JAX_512XI32_BATCH64(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-121352e7a870ce9da0b3494ec7882270dd8b2d0b87ee33eb3211579c737797ed"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch512_T5_LARGE_FP32_JAX_512XI32_BATCH512.mlirbc"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH512_module_121352e7a870ce9da0b3494ec7882270dd8b2d0b87ee33eb3211579c737797ed/module.vmfb"
+  NAME "iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_T5_LARGE_FP32_JAX_512XI32_BATCH512.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=stablehlo"
@@ -4960,15 +4960,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_T5_LARGE_FP32_JAX_512XI32_BATCH512_module_121352e7a870ce9da0b3494ec7882270dd8b2d0b87ee33eb3211579c737797ed/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_T5_LARGE_FP32_JAX_512XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "T5_LARGE_FP32_JAX_512XI32_BATCH512(stablehlo) [cuda-sm_80-linux_gnu-cuda][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-16b5b80aaf1271b5ad782570340cc0c7c1c97e10b7e6c6cc6e5f3ede8393cb6c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_16b5b80aaf1271b5ad782570340cc0c7c1c97e10b7e6c6cc6e5f3ede8393cb6c/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -4980,15 +4980,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_16b5b80aaf1271b5ad782570340cc0c7c1c97e10b7e6c6cc6e5f3ede8393cb6c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [riscv_64-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-65fa033050b916e8143d44b5081ee45db3b1946a5d77de223328a7fe92a1cc66"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_65fa033050b916e8143d44b5081ee45db3b1946a5d77de223328a7fe92a1cc66/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5000,15 +5000,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_65fa033050b916e8143d44b5081ee45db3b1946a5d77de223328a7fe92a1cc66/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [riscv_64-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-16ef56b6869d10b17e983fec62e9f48e6bb87e9a348ab52a0b2faabca2b03578"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_a359c8f1e19b6f476e843bdc5566f9554e329cbfb3b4437995ad9cccfb381aee.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_module_16ef56b6869d10b17e983fec62e9f48e6bb87e9a348ab52a0b2faabca2b03578/module.vmfb"
+  NAME "iree-module-MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5020,15 +5020,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_module_16ef56b6869d10b17e983fec62e9f48e6bb87e9a348ab52a0b2faabca2b03578/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV1_fp32(tflite) [riscv_64-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-56bc9128e294585d749b8ebe34fd03060ba34d200eef185837b6002d0dcbfccb"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_56bc9128e294585d749b8ebe34fd03060ba34d200eef185837b6002d0dcbfccb/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5040,15 +5040,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_56bc9128e294585d749b8ebe34fd03060ba34d200eef185837b6002d0dcbfccb/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [riscv_64-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-eb1b1732e5d30ce4689b871f8ec18c50b30eedd418eb80330807fe505bb78f7e"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_eb1b1732e5d30ce4689b871f8ec18c50b30eedd418eb80330807fe505bb78f7e/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5060,15 +5060,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_eb1b1732e5d30ce4689b871f8ec18c50b30eedd418eb80330807fe505bb78f7e/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PersonDetect_int8(tflite) [riscv_64-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bd32992875a8fc7a494c75933b1693d6d8b845fccf2b12504a8cba64d80ad110"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_bd32992875a8fc7a494c75933b1693d6d8b845fccf2b12504a8cba64d80ad110/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5080,15 +5080,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_bd32992875a8fc7a494c75933b1693d6d8b845fccf2b12504a8cba64d80ad110/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNet_int8(tflite) [riscv_64-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5e966f45b952e5406271a1a23edd5d9ffab75524b450b7cf4ee35263bb0830f3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_5e966f45b952e5406271a1a23edd5d9ffab75524b450b7cf4ee35263bb0830f3/module.vmfb"
+  NAME "iree-module-MobileNetV2_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5100,15 +5100,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_5e966f45b952e5406271a1a23edd5d9ffab75524b450b7cf4ee35263bb0830f3/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_int8(tflite) [riscv_64-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-ff7ed59e05efe8b9a397a179726f63da68a8a1ac3ea731924b4bd24dab491b34"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_ff7ed59e05efe8b9a397a179726f63da68a8a1ac3ea731924b4bd24dab491b34/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5120,15 +5120,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_ff7ed59e05efe8b9a397a179726f63da68a8a1ac3ea731924b4bd24dab491b34/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNet_int8(tflite) [riscv_32-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-8e2d1286ad9a7e360b0c26019146a22ec9188f8bdf8ad99341eb5531cdea2417"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_8e2d1286ad9a7e360b0c26019146a22ec9188f8bdf8ad99341eb5531cdea2417/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5140,15 +5140,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_8e2d1286ad9a7e360b0c26019146a22ec9188f8bdf8ad99341eb5531cdea2417/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [riscv_32-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d967e293594998e48355d30d900dbdf77dbd6eedbff768112dbe8e7ec332b9eb"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_d967e293594998e48355d30d900dbdf77dbd6eedbff768112dbe8e7ec332b9eb/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5160,15 +5160,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_d967e293594998e48355d30d900dbdf77dbd6eedbff768112dbe8e7ec332b9eb/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PersonDetect_int8(tflite) [riscv_32-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-94a5cba0f45ffc2dc028a5f9fa5780fa61ed91b27382c86c4d96de0e2cd002f3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_94a5cba0f45ffc2dc028a5f9fa5780fa61ed91b27382c86c4d96de0e2cd002f3/module.vmfb"
+  NAME "iree-module-MobileNetV2_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5180,15 +5180,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_int8_module_94a5cba0f45ffc2dc028a5f9fa5780fa61ed91b27382c86c4d96de0e2cd002f3/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_int8(tflite) [riscv_32-generic-linux_gnu-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-91a35228ead480e04b85998ccf3edfc891f44b5f79017b7fcab72cb66a812b07"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_91a35228ead480e04b85998ccf3edfc891f44b5f79017b7fcab72cb66a812b07/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5196,15 +5196,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_91a35228ead480e04b85998ccf3edfc891f44b5f79017b7fcab72cb66a812b07/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-f58c00ccab797ad4dbca3de3b50633588a68db0122aa011bdf81a9aca5ea692b"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_f58c00ccab797ad4dbca3de3b50633588a68db0122aa011bdf81a9aca5ea692b/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5212,15 +5212,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_f58c00ccab797ad4dbca3de3b50633588a68db0122aa011bdf81a9aca5ea692b/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bfb6239769f044d2228f2efb5ce6aa51132455d9a8178e5a5ec8525ff5836e0d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_bfb6239769f044d2228f2efb5ce6aa51132455d9a8178e5a5ec8525ff5836e0d/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5228,15 +5228,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_bfb6239769f044d2228f2efb5ce6aa51132455d9a8178e5a5ec8525ff5836e0d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-469056c2ca5935d7c63d5424c635a439f94593a307e96483e4db16af1c15186e"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_469056c2ca5935d7c63d5424c635a439f94593a307e96483e4db16af1c15186e/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5244,15 +5244,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_469056c2ca5935d7c63d5424c635a439f94593a307e96483e4db16af1c15186e/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3aab34d7c719c9d828a741a7900b4794302a587927c462b4ec8feec3f7d43e99"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_3aab34d7c719c9d828a741a7900b4794302a587927c462b4ec8feec3f7d43e99/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5260,15 +5260,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_3aab34d7c719c9d828a741a7900b4794302a587927c462b4ec8feec3f7d43e99/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-11a9de4ea6e17feff81429ed53e52a70e89c1cfeef0a73f10740c8420341b81d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_11a9de4ea6e17feff81429ed53e52a70e89c1cfeef0a73f10740c8420341b81d/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5276,15 +5276,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_11a9de4ea6e17feff81429ed53e52a70e89c1cfeef0a73f10740c8420341b81d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9c01136785f28f0d2c969cee8ce87bde3267d63425c5d86d39137abdf7f0f196"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_9c01136785f28f0d2c969cee8ce87bde3267d63425c5d86d39137abdf7f0f196/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5292,15 +5292,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_9c01136785f28f0d2c969cee8ce87bde3267d63425c5d86d39137abdf7f0f196/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3160a297a2c9d3d21caeec097b6fe19150c3feae5fa872e21817af0be8a8176a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_3160a297a2c9d3d21caeec097b6fe19150c3feae5fa872e21817af0be8a8176a/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5311,15 +5311,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_3160a297a2c9d3d21caeec097b6fe19150c3feae5fa872e21817af0be8a8176a/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0bf641c301b26975b8919a18de98d9dfd6444d6542085dd2d8e8155ea6bc8efe"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_0bf641c301b26975b8919a18de98d9dfd6444d6542085dd2d8e8155ea6bc8efe/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5330,15 +5330,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_0bf641c301b26975b8919a18de98d9dfd6444d6542085dd2d8e8155ea6bc8efe/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-058ea3aae7385269d001efd9eb2303887614d138ff69150b20a703fc7b97c2c6"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_058ea3aae7385269d001efd9eb2303887614d138ff69150b20a703fc7b97c2c6/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5349,15 +5349,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_058ea3aae7385269d001efd9eb2303887614d138ff69150b20a703fc7b97c2c6/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-fdff4caa105318036534bd28b76a6fe34e6e2412752c1a000f50fafe7f01ef07"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_fdff4caa105318036534bd28b76a6fe34e6e2412752c1a000f50fafe7f01ef07/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5368,15 +5368,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_fdff4caa105318036534bd28b76a6fe34e6e2412752c1a000f50fafe7f01ef07/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-14ce4459cb4ea8aa84b5315222e9cfe00fe8a3b456b2ae75a5eb943036279d68"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_14ce4459cb4ea8aa84b5315222e9cfe00fe8a3b456b2ae75a5eb943036279d68/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5387,15 +5387,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_14ce4459cb4ea8aa84b5315222e9cfe00fe8a3b456b2ae75a5eb943036279d68/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0b2b90bac148aa9f7c2ee34db723a002823dbc0d5981e47511f09cafa3693101"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_0b2b90bac148aa9f7c2ee34db723a002823dbc0d5981e47511f09cafa3693101/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5406,15 +5406,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_0b2b90bac148aa9f7c2ee34db723a002823dbc0d5981e47511f09cafa3693101/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-bd015dc23ff2f9bf5d681039cbb0f6418cd3d09d09124c0238d8c2caf01dba24"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_bd015dc23ff2f9bf5d681039cbb0f6418cd3d09d09124c0238d8c2caf01dba24/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_dotprod_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_dotprod_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -5426,15 +5426,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_bd015dc23ff2f9bf5d681039cbb0f6418cd3d09d09124c0238d8c2caf01dba24/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_dotprod_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,mmt4d,dotprod,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e02e0460e54ee222b46c25e876f937eed5582b0823cad1b1d009fe406b160c33"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_e02e0460e54ee222b46c25e876f937eed5582b0823cad1b1d009fe406b160c33/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5442,15 +5442,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_e02e0460e54ee222b46c25e876f937eed5582b0823cad1b1d009fe406b160c33/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d6590e27e94d8aac1b2bfb1e7c60e31dcddacd3a10687cdae998979fc31720fc"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_d6590e27e94d8aac1b2bfb1e7c60e31dcddacd3a10687cdae998979fc31720fc/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5458,15 +5458,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_d6590e27e94d8aac1b2bfb1e7c60e31dcddacd3a10687cdae998979fc31720fc/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-50567a33e0bd9aa5a32a6f61fca9ef8a70ac4d94313024f2c4ec92d9c543c599"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_50567a33e0bd9aa5a32a6f61fca9ef8a70ac4d94313024f2c4ec92d9c543c599/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5474,15 +5474,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_50567a33e0bd9aa5a32a6f61fca9ef8a70ac4d94313024f2c4ec92d9c543c599/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-6b9353f591f5044f661ecbbaafee502d710cf263527525d4f843b26cd43f11f7"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_6b9353f591f5044f661ecbbaafee502d710cf263527525d4f843b26cd43f11f7/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5490,15 +5490,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_6b9353f591f5044f661ecbbaafee502d710cf263527525d4f843b26cd43f11f7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5f03fee30980d1fb1074b82d329a1fa63b365858539743e672ad56c039dd732a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_5f03fee30980d1fb1074b82d329a1fa63b365858539743e672ad56c039dd732a/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5506,15 +5506,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_5f03fee30980d1fb1074b82d329a1fa63b365858539743e672ad56c039dd732a/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-611a54141f98b17aa94abdba55d8a0487aa722bba4da6853c090f786975c5884"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_611a54141f98b17aa94abdba55d8a0487aa722bba4da6853c090f786975c5884/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5522,15 +5522,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_611a54141f98b17aa94abdba55d8a0487aa722bba4da6853c090f786975c5884/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0d524f6ce80da6d1998eb8978623a2f6efd413e0b973c6f2dddf52a46b19907e"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_0d524f6ce80da6d1998eb8978623a2f6efd413e0b973c6f2dddf52a46b19907e/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5539,15 +5539,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_0d524f6ce80da6d1998eb8978623a2f6efd413e0b973c6f2dddf52a46b19907e/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-dd2a6a43dceabe7a807e280b43177cdf892d4ad20fdef4e3d3b6e39be7b9b09d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_dd2a6a43dceabe7a807e280b43177cdf892d4ad20fdef4e3d3b6e39be7b9b09d/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5556,15 +5556,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_dd2a6a43dceabe7a807e280b43177cdf892d4ad20fdef4e3d3b6e39be7b9b09d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-823ec09bcc061f124fa9229747054945cedf352e11d661a68785cb26af5f83b6"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_823ec09bcc061f124fa9229747054945cedf352e11d661a68785cb26af5f83b6/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5573,15 +5573,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_823ec09bcc061f124fa9229747054945cedf352e11d661a68785cb26af5f83b6/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-899c2de5e339b7e19528e80de1129a38511948ba3331932c22e23223707af4ca"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_899c2de5e339b7e19528e80de1129a38511948ba3331932c22e23223707af4ca/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5590,15 +5590,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_899c2de5e339b7e19528e80de1129a38511948ba3331932c22e23223707af4ca/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c3cb44c1331872dc53919d0d8b2cab4c256dcdf8b0038f9b6a692a5c874f855b"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_c3cb44c1331872dc53919d0d8b2cab4c256dcdf8b0038f9b6a692a5c874f855b/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5607,15 +5607,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_c3cb44c1331872dc53919d0d8b2cab4c256dcdf8b0038f9b6a692a5c874f855b/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-dc81a08fe0e5140f22f328d9dfea1828e7318d67899a2534d3b02ff36032cb61"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_dc81a08fe0e5140f22f328d9dfea1828e7318d67899a2534d3b02ff36032cb61/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5624,15 +5624,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_dc81a08fe0e5140f22f328d9dfea1828e7318d67899a2534d3b02ff36032cb61/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1171fb017e88de21814d71ea2d35564de6904d3d2359ef53e0fa2c67ea6e9914"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_1171fb017e88de21814d71ea2d35564de6904d3d2359ef53e0fa2c67ea6e9914/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5642,15 +5642,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_1171fb017e88de21814d71ea2d35564de6904d3d2359ef53e0fa2c67ea6e9914/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-9b9a47b0a97a0bd002bd7fd1f104caaa94b8bf60cf02ffcc2b50129679e4c6f3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_9b9a47b0a97a0bd002bd7fd1f104caaa94b8bf60cf02ffcc2b50129679e4c6f3/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5660,15 +5660,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_9b9a47b0a97a0bd002bd7fd1f104caaa94b8bf60cf02ffcc2b50129679e4c6f3/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4f5ab4bfb26a82d0f83133b9e85585f0c5b97cdb00143de31675158a5a71b457"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_4f5ab4bfb26a82d0f83133b9e85585f0c5b97cdb00143de31675158a5a71b457/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5678,15 +5678,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_4f5ab4bfb26a82d0f83133b9e85585f0c5b97cdb00143de31675158a5a71b457/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-480b59f233af720e16db8e5da1988a8d69bd61169bf5b5899f425ff98dc0dc19"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_480b59f233af720e16db8e5da1988a8d69bd61169bf5b5899f425ff98dc0dc19/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5696,15 +5696,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_480b59f233af720e16db8e5da1988a8d69bd61169bf5b5899f425ff98dc0dc19/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [qualcomm-adreno-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7731488e1eb90da5480e76b4cd98b12c16b83d7c7011b0aa9ef3a5d6d2059a3c"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_7731488e1eb90da5480e76b4cd98b12c16b83d7c7011b0aa9ef3a5d6d2059a3c/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5712,15 +5712,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_7731488e1eb90da5480e76b4cd98b12c16b83d7c7011b0aa9ef3a5d6d2059a3c/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-61decb77e61b184a2c353fac3d60af1cd7c73abc867c23e9519f5e398265a728"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_61decb77e61b184a2c353fac3d60af1cd7c73abc867c23e9519f5e398265a728/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5728,15 +5728,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_61decb77e61b184a2c353fac3d60af1cd7c73abc867c23e9519f5e398265a728/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-4ec47dd2b4a43dd434d041d4d9db548076b70cfd63a2fec2971035394954f1d5"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_4ec47dd2b4a43dd434d041d4d9db548076b70cfd63a2fec2971035394954f1d5/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5744,15 +5744,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_4ec47dd2b4a43dd434d041d4d9db548076b70cfd63a2fec2971035394954f1d5/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b0309994482c31c79242ee8ef3902b4cc54c1479688824734b33d2f554d6aff6"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_b0309994482c31c79242ee8ef3902b4cc54c1479688824734b33d2f554d6aff6/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5760,15 +5760,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_b0309994482c31c79242ee8ef3902b4cc54c1479688824734b33d2f554d6aff6/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-113994770711e5784a73ac623cbde328267c94b6341e001328b053c02b8bc08f"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_113994770711e5784a73ac623cbde328267c94b6341e001328b053c02b8bc08f/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5776,15 +5776,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_113994770711e5784a73ac623cbde328267c94b6341e001328b053c02b8bc08f/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-954bc3dc1fd0c22768ebfe898a67c0db3743d74e8fb776fced75eafb0421058f"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_954bc3dc1fd0c22768ebfe898a67c0db3743d74e8fb776fced75eafb0421058f/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5792,15 +5792,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_954bc3dc1fd0c22768ebfe898a67c0db3743d74e8fb776fced75eafb0421058f/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-6bb61b9c7107a9a30ad20c154321e7e9b14aefc407a8aeda41ac6df5eac757c4"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_6bb61b9c7107a9a30ad20c154321e7e9b14aefc407a8aeda41ac6df5eac757c4/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_demote-f32-to-f16_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5809,15 +5809,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_6bb61b9c7107a9a30ad20c154321e7e9b14aefc407a8aeda41ac6df5eac757c4/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_demote-f32-to-f16_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp16(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,demote-f32-to-f16,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-2a38d4c2e9ce2c3f9a78f5dce9e889145a1d4ec821d5776f15d6d6e679901474"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_2a38d4c2e9ce2c3f9a78f5dce9e889145a1d4ec821d5776f15d6d6e679901474/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5825,15 +5825,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_2a38d4c2e9ce2c3f9a78f5dce9e889145a1d4ec821d5776f15d6d6e679901474/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-660bd6b0861f368e51c6ecac52d6dce2998d863bc0a4bbd9dbdd77508ea761d4"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_660bd6b0861f368e51c6ecac52d6dce2998d863bc0a4bbd9dbdd77508ea761d4/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5841,15 +5841,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_660bd6b0861f368e51c6ecac52d6dce2998d863bc0a4bbd9dbdd77508ea761d4/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNet_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-224bd124c8446c300caa77db186ca926e71e79cf187980db5dea593d6f29d434"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_224bd124c8446c300caa77db186ca926e71e79cf187980db5dea593d6f29d434/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5857,15 +5857,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_224bd124c8446c300caa77db186ca926e71e79cf187980db5dea593d6f29d434/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PersonDetect_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7bec578c7016cb7e017057c227a9b677901d14c0fff35e31c4a5cf12692db105"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_7bec578c7016cb7e017057c227a9b677901d14c0fff35e31c4a5cf12692db105/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5875,15 +5875,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_7bec578c7016cb7e017057c227a9b677901d14c0fff35e31c4a5cf12692db105/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-89a91c770dfce869ecb04e4b37e3b4d7da508a240da395cf240cc20ee8573857"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_89a91c770dfce869ecb04e4b37e3b4d7da508a240da395cf240cc20ee8573857/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5893,15 +5893,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_89a91c770dfce869ecb04e4b37e3b4d7da508a240da395cf240cc20ee8573857/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e6049d40d7925bccce4859e5408f2ad53eb68309aa38b46b8a7e47c94a2cd8a3"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_e6049d40d7925bccce4859e5408f2ad53eb68309aa38b46b8a7e47c94a2cd8a3/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5911,15 +5911,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_e6049d40d7925bccce4859e5408f2ad53eb68309aa38b46b8a7e47c94a2cd8a3/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-a4194c053541ebc49b4912bbdf3ca211331fdca5d157440837144e59d279bf1f"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_a4194c053541ebc49b4912bbdf3ca211331fdca5d157440837144e59d279bf1f/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5929,15 +5929,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_a4194c053541ebc49b4912bbdf3ca211331fdca5d157440837144e59d279bf1f/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-599701d7114956cf64777412899cff57ea5be0478f9a2331377770beaad8f923"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_599701d7114956cf64777412899cff57ea5be0478f9a2331377770beaad8f923/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5947,15 +5947,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_599701d7114956cf64777412899cff57ea5be0478f9a2331377770beaad8f923/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-1d26fcfdb7387659356dd99ce7e10907c8560b0925ad839334b0a6155d25167a"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_1d26fcfdb7387659356dd99ce7e10907c8560b0925ad839334b0a6155d25167a/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5965,15 +5965,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_1d26fcfdb7387659356dd99ce7e10907c8560b0925ad839334b0a6155d25167a/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b74ccbdce4ec07bb65313ee96b67c1b946a6c959158714706209a9df2b93ab0d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_b74ccbdce4ec07bb65313ee96b67c1b946a6c959158714706209a9df2b93ab0d/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_demote-f32-to-f16_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -5984,15 +5984,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_b74ccbdce4ec07bb65313ee96b67c1b946a6c959158714706209a9df2b93ab0d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_demote-f32-to-f16_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp16(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,demote-f32-to-f16,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b8ee6e3d12e6662f0c78b851876a0759da23967e71ae1a2b5569d0ec3101b43b"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_b8ee6e3d12e6662f0c78b851876a0759da23967e71ae1a2b5569d0ec3101b43b/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6002,15 +6002,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_b8ee6e3d12e6662f0c78b851876a0759da23967e71ae1a2b5569d0ec3101b43b/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-96e2ebf26260627484f375448ef478c35608ada2d2a0f81c0bec697db9ea3105"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_96e2ebf26260627484f375448ef478c35608ada2d2a0f81c0bec697db9ea3105/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6020,15 +6020,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_96e2ebf26260627484f375448ef478c35608ada2d2a0f81c0bec697db9ea3105/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNet_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-0ee6c4e8f636f98e5443974526d95e057d5a62bb311bb6dbadd87d50b395a373"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_0ee6c4e8f636f98e5443974526d95e057d5a62bb311bb6dbadd87d50b395a373/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6038,15 +6038,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_0ee6c4e8f636f98e5443974526d95e057d5a62bb311bb6dbadd87d50b395a373/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PersonDetect_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-178907b155b6322dedfa947937f9caca5158ff3af167470f2de90347dba357f4"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_178907b155b6322dedfa947937f9caca5158ff3af167470f2de90347dba357f4/module.vmfb"
+  NAME "iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6057,15 +6057,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_module_178907b155b6322dedfa947937f9caca5158ff3af167470f2de90347dba357f4/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "DeepLabV3_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-7dcabfd6caa769a75657e07e7315dd42f52b3d4cbc37d75098aca446d3ff4066"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_7dcabfd6caa769a75657e07e7315dd42f52b3d4cbc37d75098aca446d3ff4066/module.vmfb"
+  NAME "iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6076,15 +6076,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_module_7dcabfd6caa769a75657e07e7315dd42f52b3d4cbc37d75098aca446d3ff4066/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileSSD_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-247b38beca9631678d80755b0b4db2b323ddc4d95772617889a6a4bb813c6b74"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_247b38beca9631678d80755b0b4db2b323ddc4d95772617889a6a4bb813c6b74/module.vmfb"
+  NAME "iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6095,15 +6095,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_module_247b38beca9631678d80755b0b4db2b323ddc4d95772617889a6a4bb813c6b74/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PoseNet_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d39340f50384e970b103694a38d7d21d5b1171d7304630d25e925c5c2486bf10"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_d39340f50384e970b103694a38d7d21d5b1171d7304630d25e925c5c2486bf10/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6114,15 +6114,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_module_d39340f50384e970b103694a38d7d21d5b1171d7304630d25e925c5c2486bf10/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-d8f22b5a700abdef68fe791ad08acdfc6d238d82e00f264367d922b99b369ff7"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_d8f22b5a700abdef68fe791ad08acdfc6d238d82e00f264367d922b99b369ff7/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6133,15 +6133,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_d8f22b5a700abdef68fe791ad08acdfc6d238d82e00f264367d922b99b369ff7/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-c6a4903d1769d721782cf2b6e84837aca21f87fcf8759912a86ae2f572e8440d"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_c6a4903d1769d721782cf2b6e84837aca21f87fcf8759912a86ae2f572e8440d/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6152,15 +6152,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_c6a4903d1769d721782cf2b6e84837aca21f87fcf8759912a86ae2f572e8440d/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-3c43472d6cb0f74a1c08920e3f580b701e995a85305fd4b2e370542b4d449b18"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_3c43472d6cb0f74a1c08920e3f580b701e995a85305fd4b2e370542b4d449b18/module.vmfb"
+  NAME "iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6172,15 +6172,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_module_3c43472d6cb0f74a1c08920e3f580b701e995a85305fd4b2e370542b4d449b18/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_fp16(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,demote-f32-to-f16,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-6e207112c3da58908537a07d168c78e7d166fe6803659d4b9f07848c968d6d12"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_6e207112c3da58908537a07d168c78e7d166fe6803659d4b9f07848c968d6d12/module.vmfb"
+  NAME "iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6191,15 +6191,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_module_6e207112c3da58908537a07d168c78e7d166fe6803659d4b9f07848c968d6d12/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileBertSquad_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-75259bfdbf7eb331691860ffb18e04a146168a72b7b10cf070d5db7f67dd2378"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_75259bfdbf7eb331691860ffb18e04a146168a72b7b10cf070d5db7f67dd2378/module.vmfb"
+  NAME "iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6210,15 +6210,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_module_75259bfdbf7eb331691860ffb18e04a146168a72b7b10cf070d5db7f67dd2378/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "EfficientNet_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-5ef6657fb694df545b7f87fbb78dfa99af891778790ac0924c08a87d335c1bf9"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_5ef6657fb694df545b7f87fbb78dfa99af891778790ac0924c08a87d335c1bf9/module.vmfb"
+  NAME "iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -6229,15 +6229,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_module_5ef6657fb694df545b7f87fbb78dfa99af891778790ac0924c08a87d335c1bf9/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "PersonDetect_int8(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-b975b6877510291f2ee4ca814bd9b6a5cd2a2bf90c506627eb69b305835f1197"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8_ClipTextSeqLen64PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_b975b6877510291f2ee4ca814bd9b6a5cd2a2bf90c506627eb69b305835f1197/module.vmfb"
+  NAME "iree-module-ClipTextSeqLen64PT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_ClipTextSeqLen64PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=none"
@@ -6248,15 +6248,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_b975b6877510291f2ee4ca814bd9b6a5cd2a2bf90c506627eb69b305835f1197/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "ClipTextSeqLen64PT(linalg) [nvidia-ampere-vulkan_linux-vulkan_spirv][experimental-flags,tensorcore,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-6dd24b8caef78a32f9aaa8d86557e7fff7feca016887de56c20d89d5e6e466f6"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_340553d1-e6fe-41b6-b2c7-687c74ccec56_Unet2dPT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_6dd24b8caef78a32f9aaa8d86557e7fff7feca016887de56c20d89d5e6e466f6/module.vmfb"
+  NAME "iree-module-Unet2dPT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Unet2dPT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=none"
@@ -6267,15 +6267,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_6dd24b8caef78a32f9aaa8d86557e7fff7feca016887de56c20d89d5e6e466f6/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Unet2dPT(linalg) [nvidia-ampere-vulkan_linux-vulkan_spirv][experimental-flags,tensorcore,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-85216f0b904906cd9508018c3644350882b72bc4702e875d9e31f33cc751de06"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8_ClipTextSeqLen64PT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_85216f0b904906cd9508018c3644350882b72bc4702e875d9e31f33cc751de06/module.vmfb"
+  NAME "iree-module-ClipTextSeqLen64PT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_ClipTextSeqLen64PT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=none"
@@ -6286,15 +6286,15 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_ClipTextSeqLen64PT_module_85216f0b904906cd9508018c3644350882b72bc4702e875d9e31f33cc751de06/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_ClipTextSeqLen64PT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "ClipTextSeqLen64PT(linalg) [nvidia-pascal-vulkan_linux-vulkan_spirv][experimental-flags,simt,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-824ac4e9e8621e344eca176c4c3e066acf8e460cff9337f94701de3e37c86e1a"
-  SRC "${ROOT_ARTIFACTS_DIR}/model_340553d1-e6fe-41b6-b2c7-687c74ccec56_Unet2dPT.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_824ac4e9e8621e344eca176c4c3e066acf8e460cff9337f94701de3e37c86e1a/module.vmfb"
+  NAME "iree-module-Unet2dPT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_Unet2dPT.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=none"
@@ -6305,807 +6305,807 @@ iree_bytecode_module(
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_Unet2dPT_module_824ac4e9e8621e344eca176c4c3e066acf8e460cff9337f94701de3e37c86e1a/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_Unet2dPT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "Unet2dPT(linalg) [nvidia-pascal-vulkan_linux-vulkan_spirv][experimental-flags,simt,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-02b72f9538e4dfc9c789e63d722d5eab4333f3f55f8375503f433a790da119cc"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_02b72f9538e4dfc9c789e63d722d5eab4333f3f55f8375503f433a790da119cc/module.vmfb"
+  NAME "iree-module-MobileNetV2_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_module_02b72f9538e4dfc9c789e63d722d5eab4333f3f55f8375503f433a790da119cc/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV2_fp32(tflite) [vmvx-generic-vmvx-vmvx][experimental-flags,compile-stats]"
   PUBLIC
 )
 
 iree_bytecode_module(
-  NAME "iree-module-e7bd41e564750501f39ac9690c18d1a2e77dc7999da710d0c0bf80751dda84a0"
-  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337.mlir"
-  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_e7bd41e564750501f39ac9690c18d1a2e77dc7999da710d0c0bf80751dda84a0/module.vmfb"
+  NAME "iree-module-MobileNetV3Small_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_tflite_.mlir"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
-    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_module_e7bd41e564750501f39ac9690c18d1a2e77dc7999da710d0c0bf80751dda84a0/scheduling_stats.json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "MobileNetV3Small_fp32(tflite) [vmvx-generic-vmvx-vmvx][experimental-flags,compile-stats]"
   PUBLIC
 )
 
 add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d
-  ${PACKAGE_NAME}_iree-imported-model-2b9d79769b2b1ece7dd4a4bccd146a99fc3c38c4427a179d37308146adfc5c0e
-  ${PACKAGE_NAME}_iree-imported-model-394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337
-  ${PACKAGE_NAME}_iree-imported-model-3bda9f3a5eb6a0fd3adc80187495d7ab840e409f379c70e3fd687934fafdd3b6
-  ${PACKAGE_NAME}_iree-imported-model-3ea5b376aec708e6c6827b0a9da7135fc50f20400dc0d55f16a3378a08fa5cf4
-  ${PACKAGE_NAME}_iree-imported-model-3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025
-  ${PACKAGE_NAME}_iree-imported-model-4afb465f351db6dbf3d06a03d98f0e77c9cc1e284d89f6db6367969793e44a59
-  ${PACKAGE_NAME}_iree-imported-model-7f3f1c653a612b1a7c13af9e9e6a3b0d0d12ae159e5e4e619d00717b0686bc9a
-  ${PACKAGE_NAME}_iree-imported-model-93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850
-  ${PACKAGE_NAME}_iree-imported-model-a359c8f1e19b6f476e843bdc5566f9554e329cbfb3b4437995ad9cccfb381aee
-  ${PACKAGE_NAME}_iree-imported-model-a56388db344366834963ce4295c7695bd3f75b6840962c0b4aec857f34575ded
-  ${PACKAGE_NAME}_iree-imported-model-af95be67ed750381753ca4fe4341853e7e2884d4c4bd1dd9a17d8ceab3ee8882
-  ${PACKAGE_NAME}_model-0a3d952b-41ca-43d2-9ec3-ccb8dde20ce3
-  ${PACKAGE_NAME}_model-271ea7a0-68e7-45b6-91f4-f39d5ce9e29c
-  ${PACKAGE_NAME}_model-340553d1-e6fe-41b6-b2c7-687c74ccec56
-  ${PACKAGE_NAME}_model-39d157ad-f0ec-4a76-963b-d783beaed60f
-  ${PACKAGE_NAME}_model-4e75ff72-f807-49f6-b740-febca1794334
-  ${PACKAGE_NAME}_model-50a7aece-73f9-47f4-a93a-4a1178f45407
-  ${PACKAGE_NAME}_model-579b77ea-76bd-4eb3-bd85-067c25a89eff
-  ${PACKAGE_NAME}_model-68caa96e-b8bb-48a2-bb08-a3044981a370
-  ${PACKAGE_NAME}_model-699fd533-02a9-49f0-bf26-1902d8dbb5af
-  ${PACKAGE_NAME}_model-81cebaaf-e23d-4a32-89dc-9fc7adc37a8f
-  ${PACKAGE_NAME}_model-8871f602-571c-4eb8-b94d-554cc8ceec5a
-  ${PACKAGE_NAME}_model-8d6be288-9b88-41bd-bc5a-5644df0481bb
-  ${PACKAGE_NAME}_model-9a9515c7-cb68-4c34-b1d2-0e8c0a3620b8
-  ${PACKAGE_NAME}_model-9b81a2f5-bab2-4f6f-b8b5-13cc4b3e9413
-  ${PACKAGE_NAME}_model-a55afe1c-9410-47a6-b417-04b0d75ee5f4
-  ${PACKAGE_NAME}_model-a6c2b812-0a71-45e7-9ea5-f3d8529213ef
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1
-  ${PACKAGE_NAME}_model-cc474102-7d2f-4ec1-92ae-84e83ba0f390
-  ${PACKAGE_NAME}_model-ebe7897f-5613-435b-a330-3cb967704e5e
-  ${PACKAGE_NAME}_model-ecf5c970-ee97-49f0-a4ed-df1f34e9d493
+  ${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV2_int8_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8_tflite_
+  ${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32_tflite_
+  ${PACKAGE_NAME}_model-BertForMaskedLMTF
+  ${PACKAGE_NAME}_model-BertLargeTF
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch1
+  ${PACKAGE_NAME}_model-ClipTextSeqLen64PT
+  ${PACKAGE_NAME}_model-EfficientNetB7PT
+  ${PACKAGE_NAME}_model-EfficientNetV2SPT
+  ${PACKAGE_NAME}_model-EfficientNetV2STF
+  ${PACKAGE_NAME}_model-EfficientNetV2Sfp16PT
+  ${PACKAGE_NAME}_model-MiniLML12H384Uncased
+  ${PACKAGE_NAME}_model-Unet2dPT
+  ${PACKAGE_NAME}_model-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_128x256x8192_f16t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_128x256x8192_f32t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_2560x2560x2560_f16t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_2560x2560x2560_f32t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_3456x1024x2048_f16t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_3456x1024x2048_f32t_tile_config_default
 )
 
 add_dependencies(iree-benchmark-import-models-large
-  ${PACKAGE_NAME}_model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch1
-  ${PACKAGE_NAME}_model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch16
-  ${PACKAGE_NAME}_model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch24
-  ${PACKAGE_NAME}_model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch32
-  ${PACKAGE_NAME}_model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch48
-  ${PACKAGE_NAME}_model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch512
-  ${PACKAGE_NAME}_model-173c7180-bad4-4b91-8423-4beeb13d2b0a-MODEL_T5_LARGE-fp32-JAX-512xi32-batch64
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1024
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch1280
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch16
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch24
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch32
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch48
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch512
-  ${PACKAGE_NAME}_model-47cb0d3a-5eb7-41c7-9d7c-97aae7023ecf-MODEL_BERT_LARGE-fp32-JAX-384xi32-batch64
-  ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-1
-  ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-16
-  ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-24
-  ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-32
-  ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-48
-  ${PACKAGE_NAME}_model-587e595d-2adf-4e41-9617-43178a133725-batch-64
-  ${PACKAGE_NAME}_model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-1
-  ${PACKAGE_NAME}_model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-128
-  ${PACKAGE_NAME}_model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-2048
-  ${PACKAGE_NAME}_model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-256
-  ${PACKAGE_NAME}_model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-64
-  ${PACKAGE_NAME}_model-5e779dd2-f115-4a1c-9aab-87b7ae4a568d-batch-8
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1024
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-1280
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-16
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-24
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-32
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-48
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-512
-  ${PACKAGE_NAME}_model-5f3de3b3-fd00-4582-a97e-b70ff5edab07-batch-64
-  ${PACKAGE_NAME}_model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-1
-  ${PACKAGE_NAME}_model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-128
-  ${PACKAGE_NAME}_model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-2048
-  ${PACKAGE_NAME}_model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-256
-  ${PACKAGE_NAME}_model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-64
-  ${PACKAGE_NAME}_model-9a5a8b8c-6e7a-4b51-bb4f-84e738957238-batch-8
-  ${PACKAGE_NAME}_model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch1
-  ${PACKAGE_NAME}_model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch128
-  ${PACKAGE_NAME}_model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch2048
-  ${PACKAGE_NAME}_model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch256
-  ${PACKAGE_NAME}_model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch64
-  ${PACKAGE_NAME}_model-aff75509-4420-40a8-844e-dbfc48494fe6-MODEL_RESNET50-fp32-JAX-3x224x224xf32-batch8
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1024
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-1280
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-16
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-24
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-32
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-48
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-512
-  ${PACKAGE_NAME}_model-c1be9a9d-64c3-4d88-8551-89a8b4f305ba-batch-64
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1024
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-1280
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-16
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-24
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-32
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-48
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-512
-  ${PACKAGE_NAME}_model-cbc5e400-7c93-4844-aca8-bce8f1bf9948-batch-64
-  ${PACKAGE_NAME}_model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-1
-  ${PACKAGE_NAME}_model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-128
-  ${PACKAGE_NAME}_model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-2048
-  ${PACKAGE_NAME}_model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-256
-  ${PACKAGE_NAME}_model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-64
-  ${PACKAGE_NAME}_model-fd05da43-5e37-4fa0-88f8-3ceec1682345-batch-8
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH1
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH1024
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH1280
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH16
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH24
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH32
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH48
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH512
+  ${PACKAGE_NAME}_model-BERT_LARGE_JAX_384XI32_BATCH64
+  ${PACKAGE_NAME}_model-BertLargePTBatch1
+  ${PACKAGE_NAME}_model-BertLargePTBatch1024
+  ${PACKAGE_NAME}_model-BertLargePTBatch1280
+  ${PACKAGE_NAME}_model-BertLargePTBatch16
+  ${PACKAGE_NAME}_model-BertLargePTBatch24
+  ${PACKAGE_NAME}_model-BertLargePTBatch32
+  ${PACKAGE_NAME}_model-BertLargePTBatch48
+  ${PACKAGE_NAME}_model-BertLargePTBatch512
+  ${PACKAGE_NAME}_model-BertLargePTBatch64
+  ${PACKAGE_NAME}_model-BertLargeTFBatch1
+  ${PACKAGE_NAME}_model-BertLargeTFBatch1024
+  ${PACKAGE_NAME}_model-BertLargeTFBatch1280
+  ${PACKAGE_NAME}_model-BertLargeTFBatch16
+  ${PACKAGE_NAME}_model-BertLargeTFBatch24
+  ${PACKAGE_NAME}_model-BertLargeTFBatch32
+  ${PACKAGE_NAME}_model-BertLargeTFBatch48
+  ${PACKAGE_NAME}_model-BertLargeTFBatch512
+  ${PACKAGE_NAME}_model-BertLargeTFBatch64
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch1024
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch1280
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch16
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch24
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch32
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch48
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch512
+  ${PACKAGE_NAME}_model-BertLargefp16PTBatch64
+  ${PACKAGE_NAME}_model-RESNET50_FP32_JAX_3X224X224XF32_BATCH1
+  ${PACKAGE_NAME}_model-RESNET50_FP32_JAX_3X224X224XF32_BATCH128
+  ${PACKAGE_NAME}_model-RESNET50_FP32_JAX_3X224X224XF32_BATCH2048
+  ${PACKAGE_NAME}_model-RESNET50_FP32_JAX_3X224X224XF32_BATCH256
+  ${PACKAGE_NAME}_model-RESNET50_FP32_JAX_3X224X224XF32_BATCH64
+  ${PACKAGE_NAME}_model-RESNET50_FP32_JAX_3X224X224XF32_BATCH8
+  ${PACKAGE_NAME}_model-Resnet50PTBatch1
+  ${PACKAGE_NAME}_model-Resnet50PTBatch128
+  ${PACKAGE_NAME}_model-Resnet50PTBatch2048
+  ${PACKAGE_NAME}_model-Resnet50PTBatch256
+  ${PACKAGE_NAME}_model-Resnet50PTBatch64
+  ${PACKAGE_NAME}_model-Resnet50PTBatch8
+  ${PACKAGE_NAME}_model-Resnet50TFBatch1
+  ${PACKAGE_NAME}_model-Resnet50TFBatch128
+  ${PACKAGE_NAME}_model-Resnet50TFBatch2048
+  ${PACKAGE_NAME}_model-Resnet50TFBatch256
+  ${PACKAGE_NAME}_model-Resnet50TFBatch64
+  ${PACKAGE_NAME}_model-Resnet50TFBatch8
+  ${PACKAGE_NAME}_model-Resnet50fp16PTBatch1
+  ${PACKAGE_NAME}_model-Resnet50fp16PTBatch128
+  ${PACKAGE_NAME}_model-Resnet50fp16PTBatch2048
+  ${PACKAGE_NAME}_model-Resnet50fp16PTBatch256
+  ${PACKAGE_NAME}_model-Resnet50fp16PTBatch64
+  ${PACKAGE_NAME}_model-Resnet50fp16PTBatch8
+  ${PACKAGE_NAME}_model-T5LargeTFBatch1
+  ${PACKAGE_NAME}_model-T5LargeTFBatch16
+  ${PACKAGE_NAME}_model-T5LargeTFBatch24
+  ${PACKAGE_NAME}_model-T5LargeTFBatch32
+  ${PACKAGE_NAME}_model-T5LargeTFBatch48
+  ${PACKAGE_NAME}_model-T5LargeTFBatch64
+  ${PACKAGE_NAME}_model-T5_LARGE_FP32_JAX_512XI32_BATCH1
+  ${PACKAGE_NAME}_model-T5_LARGE_FP32_JAX_512XI32_BATCH16
+  ${PACKAGE_NAME}_model-T5_LARGE_FP32_JAX_512XI32_BATCH24
+  ${PACKAGE_NAME}_model-T5_LARGE_FP32_JAX_512XI32_BATCH32
+  ${PACKAGE_NAME}_model-T5_LARGE_FP32_JAX_512XI32_BATCH48
+  ${PACKAGE_NAME}_model-T5_LARGE_FP32_JAX_512XI32_BATCH512
+  ${PACKAGE_NAME}_model-T5_LARGE_FP32_JAX_512XI32_BATCH64
 )
 
 add_dependencies(iree-benchmark-suites-android-cpu
-  ${PACKAGE_NAME}_iree-module-86ce8dfe2979d777a7f9eb0d3b6f8dcd4b594f46e9d610ad8a73edc89a006b26
-  ${PACKAGE_NAME}_iree-module-bd0ea10065a27dea6875ceb70f769e7e0f67a08e857920ca0d0322593441e9ed
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_
 )
 
 add_dependencies(iree-benchmark-suites-android-gpu
-  ${PACKAGE_NAME}_iree-module-012cc9d71edd7a345ef45d52c630d53ed04ee93523524b417330c644d8f6ce1b
-  ${PACKAGE_NAME}_iree-module-05e976592f58a292874d99bd7627e655b15c5460455a08b9ce67e9f7f65b6269
-  ${PACKAGE_NAME}_iree-module-0689c824551e3a3650463db3807664420f1033ee1b290fa25e63d04cf1a0a6ef
-  ${PACKAGE_NAME}_iree-module-076a1e95f3384b58a77a672c7c36463b091e574b5a6f6eaf78841537b0d1c930
-  ${PACKAGE_NAME}_iree-module-0af4e7fa84d361d2faa267336c3c090e337f7feff47f0e559337521c07626ba7
-  ${PACKAGE_NAME}_iree-module-0d6fed1f6845ce0d70bf81ac2522e9806b4538917cb7ee02a1b6e6a60d6b7115
-  ${PACKAGE_NAME}_iree-module-0efb794c3a385045fa4d3d086c2a593ce67c4807e9456271f05f4e28490d1c49
-  ${PACKAGE_NAME}_iree-module-11766f32ea6a3121d7527bcdf32dead45ab7b3922d72addb46945cfdab784ec0
-  ${PACKAGE_NAME}_iree-module-1202e44fbbde0a9581c641d124452363273f0d4395445dc06e60c8e49a27357b
-  ${PACKAGE_NAME}_iree-module-131aa61ffcacafc6ae701ff89045cf42d2490ac0c4a1d862bc83c23edb3b92e5
-  ${PACKAGE_NAME}_iree-module-138aacc154449b519698bd7ddb4dc9f407cbc1fd86fdbbe901be974058b70319
-  ${PACKAGE_NAME}_iree-module-244092c4ecd63533f225b0bc16b308e11265ca6b10696f8975866844793e2c4f
-  ${PACKAGE_NAME}_iree-module-27c12f520d68a8a754b11ad44cf8ad3ef5c1ec281fc9d84fbc64a7b573cb68b5
-  ${PACKAGE_NAME}_iree-module-2c042cd2ded71abef51933f0466cf58a52de2c67e1a23fde98b1fad1b33e6d7c
-  ${PACKAGE_NAME}_iree-module-383e7567e79adf2178e3d25785855905a4477b6c8daf16bc50d5f9f44d2343d9
-  ${PACKAGE_NAME}_iree-module-3c1fbaa12bbd37bf2a17d8a605cdeca75c0e8cc9c6f7e95359d13e47a4270dc3
-  ${PACKAGE_NAME}_iree-module-42bc978e75d5fed90c10d5812a8df7a6153e311b19b9c7faf41a588bdc4da7d8
-  ${PACKAGE_NAME}_iree-module-4924918e121a92f802a094de2d67e9c2673c9fdc39faa6a11ac1d38b631a2914
-  ${PACKAGE_NAME}_iree-module-4a1632637ce87fe991848942b028c36732b2bea00920d275ffbcaf2cd9446152
-  ${PACKAGE_NAME}_iree-module-507fabae3d24c2448c8f2af676d68df0a22716a06fa7ffc3b4f865e9272ecdc8
-  ${PACKAGE_NAME}_iree-module-5eeff62c8ab391e247ede57b226b4be03b81067b8831b13bfa47b62e2dac275a
-  ${PACKAGE_NAME}_iree-module-5f46d5bcca6c809578ba7b32829ee4417a67eaa5033b5b58b81e3a8b0b3433ad
-  ${PACKAGE_NAME}_iree-module-65aa6dabd0c24dbe48a090db641d82b437d4abd428a6ca0e7b360d3f087a16c8
-  ${PACKAGE_NAME}_iree-module-67ad72cbb9eb9c4746249922e6232b1a17b5d6eeabd9b69ed4d527c1676c77bd
-  ${PACKAGE_NAME}_iree-module-69f971c48d4b181ed4a4ec22790dc62fa997aa28ad16e0e176642955ccbbc2f0
-  ${PACKAGE_NAME}_iree-module-72feea41a0b54e4c9a761933079cba1b2c012e5a5d4b2953ffaa86faaa29a648
-  ${PACKAGE_NAME}_iree-module-78db72d7b7a1f871a3752c8165cbebc678047f2df5d36b10dd82ee870873b620
-  ${PACKAGE_NAME}_iree-module-7a3d36d7234ce4abfd833964492631bd81df823e6bde8cd3a1fadfa4faa7c787
-  ${PACKAGE_NAME}_iree-module-7d44f561ce87a08f4ed53264b6b95ddd7926263fef781e5135cc696d5a4d3719
-  ${PACKAGE_NAME}_iree-module-7f5a7ca6eb12e8ac322d8bb0deb59630d721ab141acc3a941e168d98af507034
-  ${PACKAGE_NAME}_iree-module-83ef2a35d14b4acf5d569798accc3b5bb693394633d444bdd5c9d55461f549ae
-  ${PACKAGE_NAME}_iree-module-887c7a7b540f11ee5e0158143fd46a503a4851211b10b353ec0e00b8b1beb575
-  ${PACKAGE_NAME}_iree-module-8930c217bc20a5abf9313fd714a77bf47acefb006e95ba07b5e48caf872541b0
-  ${PACKAGE_NAME}_iree-module-894671e6d7319df243fa8b386b14d5e648fe2ffd66cb95e5a82ad58d7273ada8
-  ${PACKAGE_NAME}_iree-module-8b6e3f5ddee79e020f1b25ce676d3772dda8cf14f619a3f0649a9f14e0159cd0
-  ${PACKAGE_NAME}_iree-module-8eb82c90485cc4281676866b62e6820b60a38ba81068e95254a7d0ddaddc59c3
-  ${PACKAGE_NAME}_iree-module-90d4cb308fc14e4832336ebd1e1387a791a20b92af633d0fec9161b807e13427
-  ${PACKAGE_NAME}_iree-module-90eb882b36d0293eb5b22ffb64f7c395cefa0360b37d4b84854d8b2c52a76358
-  ${PACKAGE_NAME}_iree-module-91469dce5ace1877a717a8ca5f53c1c8a3ac2f2eb8d116382eb4a5f5ace3a9c8
-  ${PACKAGE_NAME}_iree-module-9b6e19b8cab376fffe309f090beeecad08903c0975c9e7ffc480dd46074b97b3
-  ${PACKAGE_NAME}_iree-module-9faad3c50bc64c297531a36bd2ab235b680070d8233ce5ab7d964ac36c7c5563
-  ${PACKAGE_NAME}_iree-module-a47669d662bd18dbd323737d84fd45753c01abaa81b4761eb51b35ce04ee7491
-  ${PACKAGE_NAME}_iree-module-aada5dcefdd361b5227276129e93547a6932a05d380acd342fa33e5b672d498c
-  ${PACKAGE_NAME}_iree-module-ad38a059079822e7331470e086bc1caca3dbe435878b38e1355229a39d1d25d2
-  ${PACKAGE_NAME}_iree-module-b33d5ca3311e31b99daa1c1f13ea5571713538a7889627153ea431debb9b5e2a
-  ${PACKAGE_NAME}_iree-module-ba322b423888fe93e86180e98668f486afa915565edf3813af3f9da6ad7c9dc9
-  ${PACKAGE_NAME}_iree-module-bb1cb8e00fd4cee513b2481bd5faf39842ad9c57f80f2e50ddb48763fd030721
-  ${PACKAGE_NAME}_iree-module-c95d82463222cf5ea385760eb1f0f0ee28a876620e29fbd59f8f4cb8a5307bc8
-  ${PACKAGE_NAME}_iree-module-cc9b305fb2c95f582d144f1063fc12fd996e757f84738e3de846b0197981bcc2
-  ${PACKAGE_NAME}_iree-module-d5ea172c189c6a6a3b61a7e83f7263b9b38cad756d2d5dec1b2db88162eece2a
-  ${PACKAGE_NAME}_iree-module-db9784471b47ae8bf55ca7e0821e35a1686256a208df40443c114f1adcdd26f6
-  ${PACKAGE_NAME}_iree-module-dc26eca15bb97d42bcfa019de5080da54fb3d7624809aa1c8ac731e710544e18
-  ${PACKAGE_NAME}_iree-module-dd4366d716cccdd83b6f777ee966157b92838569f094371b325b926e73c7b1b8
-  ${PACKAGE_NAME}_iree-module-deba344af418957cbd9dc0834a100bc30ba242d7fddb4dc6ba10a87d0af32dc1
-  ${PACKAGE_NAME}_iree-module-e1143fcb8d1d262a3b2ac689cf21a1943cc59b2de06192fef185a9bf84994b86
-  ${PACKAGE_NAME}_iree-module-e3444362e0b630df1b5f70a28089b0764d9ddc886dda852a0ef1300e369aee4d
-  ${PACKAGE_NAME}_iree-module-e52ef218d6b5b16f35c420fca42ff31c5cf733bc075ed235ce57cf4662824606
-  ${PACKAGE_NAME}_iree-module-ec14aafacf15628918390531318a4827d3ac8771b75d60a8239d901dcb4fd898
-  ${PACKAGE_NAME}_iree-module-f06fff09f8cebc27d1674045712aaa60afe7aef388c4bc505897f55c3a0d8abb
-  ${PACKAGE_NAME}_iree-module-f73d0b9c84ec91b594b00eb3800c372884050fce3e4fb9d80eb407d7b0697412
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_dotprod_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_
 )
 
 add_dependencies(iree-benchmark-suites-comp-stats
-  ${PACKAGE_NAME}_iree-module-00a22e8ada401de8f20895beff9a153585e585c2d686983e27f9d64fdf7d39a8
-  ${PACKAGE_NAME}_iree-module-01d35de2a55b9800e05151455eace0bf4493337ac1210fcc4904d630b075599a
-  ${PACKAGE_NAME}_iree-module-02b72f9538e4dfc9c789e63d722d5eab4333f3f55f8375503f433a790da119cc
-  ${PACKAGE_NAME}_iree-module-058ea3aae7385269d001efd9eb2303887614d138ff69150b20a703fc7b97c2c6
-  ${PACKAGE_NAME}_iree-module-0b2b90bac148aa9f7c2ee34db723a002823dbc0d5981e47511f09cafa3693101
-  ${PACKAGE_NAME}_iree-module-0bf641c301b26975b8919a18de98d9dfd6444d6542085dd2d8e8155ea6bc8efe
-  ${PACKAGE_NAME}_iree-module-0d524f6ce80da6d1998eb8978623a2f6efd413e0b973c6f2dddf52a46b19907e
-  ${PACKAGE_NAME}_iree-module-0ee6c4e8f636f98e5443974526d95e057d5a62bb311bb6dbadd87d50b395a373
-  ${PACKAGE_NAME}_iree-module-113994770711e5784a73ac623cbde328267c94b6341e001328b053c02b8bc08f
-  ${PACKAGE_NAME}_iree-module-1171fb017e88de21814d71ea2d35564de6904d3d2359ef53e0fa2c67ea6e9914
-  ${PACKAGE_NAME}_iree-module-11a9de4ea6e17feff81429ed53e52a70e89c1cfeef0a73f10740c8420341b81d
-  ${PACKAGE_NAME}_iree-module-14ce4459cb4ea8aa84b5315222e9cfe00fe8a3b456b2ae75a5eb943036279d68
-  ${PACKAGE_NAME}_iree-module-152d0b6211fff7591df3418c549c979a8144fc34280c22a8b2b5ff8ea3d1b46c
-  ${PACKAGE_NAME}_iree-module-16b5b80aaf1271b5ad782570340cc0c7c1c97e10b7e6c6cc6e5f3ede8393cb6c
-  ${PACKAGE_NAME}_iree-module-16ef56b6869d10b17e983fec62e9f48e6bb87e9a348ab52a0b2faabca2b03578
-  ${PACKAGE_NAME}_iree-module-178907b155b6322dedfa947937f9caca5158ff3af167470f2de90347dba357f4
-  ${PACKAGE_NAME}_iree-module-1af884e597c283d319b14e8d55156eac66a86045fcb7e521c3f50aa8a6c04126
-  ${PACKAGE_NAME}_iree-module-1c4bc4b5ba3b5862efdbcbb9b3bf4a02f7ff9aa36e852e9b94dbe265d6bfaa99
-  ${PACKAGE_NAME}_iree-module-1d26fcfdb7387659356dd99ce7e10907c8560b0925ad839334b0a6155d25167a
-  ${PACKAGE_NAME}_iree-module-224bd124c8446c300caa77db186ca926e71e79cf187980db5dea593d6f29d434
-  ${PACKAGE_NAME}_iree-module-247b38beca9631678d80755b0b4db2b323ddc4d95772617889a6a4bb813c6b74
-  ${PACKAGE_NAME}_iree-module-25ad2815eb690276e9c2183aaafaf17a3df734bb6164071ad92dbf1e7faf7509
-  ${PACKAGE_NAME}_iree-module-27bbe62536a23529b4dd0df3d4913ee18344df9b6e2a32fc834fb7d9bc520e24
-  ${PACKAGE_NAME}_iree-module-28e38bd436b036babc0fabe98b6e7c68ca3a7088e73dffff2c538adfa7d6af4c
-  ${PACKAGE_NAME}_iree-module-2957930127e9b01e90ccddb7290e1c4b4abf6373cc36929809040e2c144d3fd7
-  ${PACKAGE_NAME}_iree-module-29f80f0856a3f30bb9bc30ed64e2cc9b5fce156fdfd0b829a0acd1e76e0834c7
-  ${PACKAGE_NAME}_iree-module-2a38d4c2e9ce2c3f9a78f5dce9e889145a1d4ec821d5776f15d6d6e679901474
-  ${PACKAGE_NAME}_iree-module-2cb62cec021aeb2abd869ba5276996e362bae130db7cc2d79389cccee6e372b9
-  ${PACKAGE_NAME}_iree-module-2f2e448f73ef190ed35af1b25b6179ce15faba7ee7c12f4956730c441e9a27bd
-  ${PACKAGE_NAME}_iree-module-3160a297a2c9d3d21caeec097b6fe19150c3feae5fa872e21817af0be8a8176a
-  ${PACKAGE_NAME}_iree-module-371a68ee85e41abf2d2a2847fe6c9f85fdc51f76516d74e3576b9d72670c1a0b
-  ${PACKAGE_NAME}_iree-module-373b890bed4c0f4828b957e37d319509bf41e39a4e47746285e27101d40f90bd
-  ${PACKAGE_NAME}_iree-module-3aab34d7c719c9d828a741a7900b4794302a587927c462b4ec8feec3f7d43e99
-  ${PACKAGE_NAME}_iree-module-3c43472d6cb0f74a1c08920e3f580b701e995a85305fd4b2e370542b4d449b18
-  ${PACKAGE_NAME}_iree-module-3c94ab45ad76bd8b2083729b65340b987da3247c854faf7d06431cb05a3b0a23
-  ${PACKAGE_NAME}_iree-module-439f7c958ce1d3200ea96935174cabde8e8fe6917a007f5e238553e9c2aa7625
-  ${PACKAGE_NAME}_iree-module-469056c2ca5935d7c63d5424c635a439f94593a307e96483e4db16af1c15186e
-  ${PACKAGE_NAME}_iree-module-480b59f233af720e16db8e5da1988a8d69bd61169bf5b5899f425ff98dc0dc19
-  ${PACKAGE_NAME}_iree-module-4a3b570ba18c3c9eee458455aaff4aa29293a5c936a19862c698b4b3ddaf06e7
-  ${PACKAGE_NAME}_iree-module-4c74339076df00d23baa17dcb3194043e0472da9d09db4e42a23841ff7bf67b0
-  ${PACKAGE_NAME}_iree-module-4d3bfb94dfe03a269350ad28fb9b1fa8db8c88ff19e2535cef09aafdbdfd83f5
-  ${PACKAGE_NAME}_iree-module-4ec47dd2b4a43dd434d041d4d9db548076b70cfd63a2fec2971035394954f1d5
-  ${PACKAGE_NAME}_iree-module-4f5ab4bfb26a82d0f83133b9e85585f0c5b97cdb00143de31675158a5a71b457
-  ${PACKAGE_NAME}_iree-module-50567a33e0bd9aa5a32a6f61fca9ef8a70ac4d94313024f2c4ec92d9c543c599
-  ${PACKAGE_NAME}_iree-module-52ce6f195b382daa71816b068bc1d13541397d6da097276699dbaffa95de35d7
-  ${PACKAGE_NAME}_iree-module-56bc9128e294585d749b8ebe34fd03060ba34d200eef185837b6002d0dcbfccb
-  ${PACKAGE_NAME}_iree-module-599701d7114956cf64777412899cff57ea5be0478f9a2331377770beaad8f923
-  ${PACKAGE_NAME}_iree-module-5a4c96fc279262ad7d7f1d446d0bd3685b2ca42e06b0167df5be5737c9d42901
-  ${PACKAGE_NAME}_iree-module-5afcbf3d3cd73477dba7cd674d13a936231393835addc705787daa643b051a81
-  ${PACKAGE_NAME}_iree-module-5e966f45b952e5406271a1a23edd5d9ffab75524b450b7cf4ee35263bb0830f3
-  ${PACKAGE_NAME}_iree-module-5ef6657fb694df545b7f87fbb78dfa99af891778790ac0924c08a87d335c1bf9
-  ${PACKAGE_NAME}_iree-module-5f03fee30980d1fb1074b82d329a1fa63b365858539743e672ad56c039dd732a
-  ${PACKAGE_NAME}_iree-module-611a54141f98b17aa94abdba55d8a0487aa722bba4da6853c090f786975c5884
-  ${PACKAGE_NAME}_iree-module-61decb77e61b184a2c353fac3d60af1cd7c73abc867c23e9519f5e398265a728
-  ${PACKAGE_NAME}_iree-module-63a2a9acdb2dafb66a49487fd7eecb79e49d870ec9b9ef17a1e8e9d50fe5c9ba
-  ${PACKAGE_NAME}_iree-module-63d75ff4a9998a86855e0e78ab2d782f52b90b58025584f3f03ec3103a81425b
-  ${PACKAGE_NAME}_iree-module-65586f1e5b51439dd951529c35fa9000a928f90039cc6cfb66d5c81d07a6c62b
-  ${PACKAGE_NAME}_iree-module-65fa033050b916e8143d44b5081ee45db3b1946a5d77de223328a7fe92a1cc66
-  ${PACKAGE_NAME}_iree-module-660bd6b0861f368e51c6ecac52d6dce2998d863bc0a4bbd9dbdd77508ea761d4
-  ${PACKAGE_NAME}_iree-module-67e643dea7f2cf9e5e90ec74746ecc52c487747966a95b8140c3c0cd6f90b709
-  ${PACKAGE_NAME}_iree-module-6b9353f591f5044f661ecbbaafee502d710cf263527525d4f843b26cd43f11f7
-  ${PACKAGE_NAME}_iree-module-6bb61b9c7107a9a30ad20c154321e7e9b14aefc407a8aeda41ac6df5eac757c4
-  ${PACKAGE_NAME}_iree-module-6dd24b8caef78a32f9aaa8d86557e7fff7feca016887de56c20d89d5e6e466f6
-  ${PACKAGE_NAME}_iree-module-6e207112c3da58908537a07d168c78e7d166fe6803659d4b9f07848c968d6d12
-  ${PACKAGE_NAME}_iree-module-75259bfdbf7eb331691860ffb18e04a146168a72b7b10cf070d5db7f67dd2378
-  ${PACKAGE_NAME}_iree-module-7731488e1eb90da5480e76b4cd98b12c16b83d7c7011b0aa9ef3a5d6d2059a3c
-  ${PACKAGE_NAME}_iree-module-78511a42a50f705b944437a040e1ee3bb5b2595a3b1d4db788586fe48f9a2453
-  ${PACKAGE_NAME}_iree-module-7bec578c7016cb7e017057c227a9b677901d14c0fff35e31c4a5cf12692db105
-  ${PACKAGE_NAME}_iree-module-7dcabfd6caa769a75657e07e7315dd42f52b3d4cbc37d75098aca446d3ff4066
-  ${PACKAGE_NAME}_iree-module-8231a286cdc63a48f3f70a12ab5a182142c00cbebaccdc79e35ca552f02422e7
-  ${PACKAGE_NAME}_iree-module-823ec09bcc061f124fa9229747054945cedf352e11d661a68785cb26af5f83b6
-  ${PACKAGE_NAME}_iree-module-824ac4e9e8621e344eca176c4c3e066acf8e460cff9337f94701de3e37c86e1a
-  ${PACKAGE_NAME}_iree-module-838cc09b422958a332fd76cf12a6a2a95b8346c8e8d2fe7b15cb5ace4c20581e
-  ${PACKAGE_NAME}_iree-module-85216f0b904906cd9508018c3644350882b72bc4702e875d9e31f33cc751de06
-  ${PACKAGE_NAME}_iree-module-88b6b5f712cd2f40d07a136e7f911c05b976c390e07f104c970292dee9a77e9a
-  ${PACKAGE_NAME}_iree-module-899c2de5e339b7e19528e80de1129a38511948ba3331932c22e23223707af4ca
-  ${PACKAGE_NAME}_iree-module-89a91c770dfce869ecb04e4b37e3b4d7da508a240da395cf240cc20ee8573857
-  ${PACKAGE_NAME}_iree-module-8b19868be1c797cb585551c871c4171e78817e0efc49d30d91b9d722be283de9
-  ${PACKAGE_NAME}_iree-module-8e2d1286ad9a7e360b0c26019146a22ec9188f8bdf8ad99341eb5531cdea2417
-  ${PACKAGE_NAME}_iree-module-8ee3c7b136703472b53bc8a19d8d28945aca93953612ccc65e55cd1b3dfda6c8
-  ${PACKAGE_NAME}_iree-module-91a35228ead480e04b85998ccf3edfc891f44b5f79017b7fcab72cb66a812b07
-  ${PACKAGE_NAME}_iree-module-925cdb19f2aa31a1907c81b5a9e179d91280c77b08a039c1cbf146f71683dde9
-  ${PACKAGE_NAME}_iree-module-94a5cba0f45ffc2dc028a5f9fa5780fa61ed91b27382c86c4d96de0e2cd002f3
-  ${PACKAGE_NAME}_iree-module-954bc3dc1fd0c22768ebfe898a67c0db3743d74e8fb776fced75eafb0421058f
-  ${PACKAGE_NAME}_iree-module-96e2ebf26260627484f375448ef478c35608ada2d2a0f81c0bec697db9ea3105
-  ${PACKAGE_NAME}_iree-module-973d25bc365d73084bfa35f317464f59a9b00f67d732733b4eaa476a418ecd95
-  ${PACKAGE_NAME}_iree-module-9a1d228583ba1e56a19393f6938d16b5d582bb17f89fb5856b8b1c68e34abd45
-  ${PACKAGE_NAME}_iree-module-9b4e60a06d92bebe93ee7824e1990d10bce55062bd896d3f15604881c446e528
-  ${PACKAGE_NAME}_iree-module-9b9a47b0a97a0bd002bd7fd1f104caaa94b8bf60cf02ffcc2b50129679e4c6f3
-  ${PACKAGE_NAME}_iree-module-9c01136785f28f0d2c969cee8ce87bde3267d63425c5d86d39137abdf7f0f196
-  ${PACKAGE_NAME}_iree-module-a05a2b521a968e99411712e0e5191c3cd1d6295991f3b78acf61faca5d1cf85e
-  ${PACKAGE_NAME}_iree-module-a4194c053541ebc49b4912bbdf3ca211331fdca5d157440837144e59d279bf1f
-  ${PACKAGE_NAME}_iree-module-aa51110b0fb3f96c5d3ce6f22b445b0be96a54789754fcd8309de707ab8f5a1c
-  ${PACKAGE_NAME}_iree-module-ad9a410e86dd9d649de58f5a7dbdc6cd2300fb6b6a363f4483e930d9944d2d07
-  ${PACKAGE_NAME}_iree-module-b0309994482c31c79242ee8ef3902b4cc54c1479688824734b33d2f554d6aff6
-  ${PACKAGE_NAME}_iree-module-b5078b9d2031b69ec5ce9b775c8701cef73add8ebfb786d9189ca3fb6474cf73
-  ${PACKAGE_NAME}_iree-module-b74ccbdce4ec07bb65313ee96b67c1b946a6c959158714706209a9df2b93ab0d
-  ${PACKAGE_NAME}_iree-module-b8ee6e3d12e6662f0c78b851876a0759da23967e71ae1a2b5569d0ec3101b43b
-  ${PACKAGE_NAME}_iree-module-b975b6877510291f2ee4ca814bd9b6a5cd2a2bf90c506627eb69b305835f1197
-  ${PACKAGE_NAME}_iree-module-bd015dc23ff2f9bf5d681039cbb0f6418cd3d09d09124c0238d8c2caf01dba24
-  ${PACKAGE_NAME}_iree-module-bd32992875a8fc7a494c75933b1693d6d8b845fccf2b12504a8cba64d80ad110
-  ${PACKAGE_NAME}_iree-module-bfb6239769f044d2228f2efb5ce6aa51132455d9a8178e5a5ec8525ff5836e0d
-  ${PACKAGE_NAME}_iree-module-c2085883b1f5c767f37508ab998a4bcd17d169fe6a5197d28e4dca8772c90253
-  ${PACKAGE_NAME}_iree-module-c370b55d34f6d3c76aa838ff0a7be520de10a4824c5feaa773e2fb73a588ad8c
-  ${PACKAGE_NAME}_iree-module-c3cb44c1331872dc53919d0d8b2cab4c256dcdf8b0038f9b6a692a5c874f855b
-  ${PACKAGE_NAME}_iree-module-c6a4903d1769d721782cf2b6e84837aca21f87fcf8759912a86ae2f572e8440d
-  ${PACKAGE_NAME}_iree-module-c9a7c5b08db10ed782045b6810cb4ee157da9e95590456d3839c06163ee30fa7
-  ${PACKAGE_NAME}_iree-module-d39340f50384e970b103694a38d7d21d5b1171d7304630d25e925c5c2486bf10
-  ${PACKAGE_NAME}_iree-module-d6590e27e94d8aac1b2bfb1e7c60e31dcddacd3a10687cdae998979fc31720fc
-  ${PACKAGE_NAME}_iree-module-d8f22b5a700abdef68fe791ad08acdfc6d238d82e00f264367d922b99b369ff7
-  ${PACKAGE_NAME}_iree-module-d967e293594998e48355d30d900dbdf77dbd6eedbff768112dbe8e7ec332b9eb
-  ${PACKAGE_NAME}_iree-module-dc81a08fe0e5140f22f328d9dfea1828e7318d67899a2534d3b02ff36032cb61
-  ${PACKAGE_NAME}_iree-module-dd2a6a43dceabe7a807e280b43177cdf892d4ad20fdef4e3d3b6e39be7b9b09d
-  ${PACKAGE_NAME}_iree-module-ddd1657bc5433ccca5c8ce562f581626457a793670958cd8b4016c426191a9c4
-  ${PACKAGE_NAME}_iree-module-de34105293194986d706823bd3d20ce784506ec5918c4d0efac9839020bb5fdd
-  ${PACKAGE_NAME}_iree-module-e02e0460e54ee222b46c25e876f937eed5582b0823cad1b1d009fe406b160c33
-  ${PACKAGE_NAME}_iree-module-e0533bdae79e15707a6eb26eb7f09c4d7dbdbfc40b993a4ad6289cf2bb1f13cb
-  ${PACKAGE_NAME}_iree-module-e6049d40d7925bccce4859e5408f2ad53eb68309aa38b46b8a7e47c94a2cd8a3
-  ${PACKAGE_NAME}_iree-module-e7bd41e564750501f39ac9690c18d1a2e77dc7999da710d0c0bf80751dda84a0
-  ${PACKAGE_NAME}_iree-module-eb1b1732e5d30ce4689b871f8ec18c50b30eedd418eb80330807fe505bb78f7e
-  ${PACKAGE_NAME}_iree-module-ef1ba1216f0f304c80b7a5b8bac545a987d04a100d9c1e5e66b75ce88636534c
-  ${PACKAGE_NAME}_iree-module-f58c00ccab797ad4dbca3de3b50633588a68db0122aa011bdf81a9aca5ea692b
-  ${PACKAGE_NAME}_iree-module-f93f9c93aaa7cf3f771a421d1f4488d840a775063dd2b8d7971c94b9d18ace59
-  ${PACKAGE_NAME}_iree-module-f9df9c8ecc1b369ddc960f07ab7097a9c1dd8587441cbd9cf91e443e2639bf28
-  ${PACKAGE_NAME}_iree-module-fdce9dd1dfd20592880fce8969f91ac6abe84eca6922b4df4cbffe512abbfcb6
-  ${PACKAGE_NAME}_iree-module-fdff4caa105318036534bd28b76a6fe34e6e2412752c1a000f50fafe7f01ef07
-  ${PACKAGE_NAME}_iree-module-ff7ed59e05efe8b9a397a179726f63da68a8a1ac3ea731924b4bd24dab491b34
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_compile-stats_
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetB7PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetB7PT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2SPT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2Sfp16PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_dotprod_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
 )
 
 add_dependencies(iree-benchmark-suites-comp-stats-large
-  ${PACKAGE_NAME}_iree-module-03736c12afe2b27f77101146eddaa80c8911cdbc2120ab574225c08b088e14f3
-  ${PACKAGE_NAME}_iree-module-07014af4305cf75cd094171519987b1ed1a6a6b70e489d2770301b623b7afe0c
-  ${PACKAGE_NAME}_iree-module-0a1b669562cd4cd755ea3ad7bd5042daa0688e8b60de1cf9ee45c227d37ec025
-  ${PACKAGE_NAME}_iree-module-0e7d8192ccb37cbe6b55c35e8e0cbaabce859ed9b8e62c822e835a60733c66d8
-  ${PACKAGE_NAME}_iree-module-121352e7a870ce9da0b3494ec7882270dd8b2d0b87ee33eb3211579c737797ed
-  ${PACKAGE_NAME}_iree-module-1bac11dad2160652ffcfb201d96418f4c044fcd79771cf6a783f311998850a2e
-  ${PACKAGE_NAME}_iree-module-1d4e4d30cb34199b1f451d2c43857270a4be48110a4f0bbb0f1db9b476820ac4
-  ${PACKAGE_NAME}_iree-module-1ee530ad72c5711ee3abf11b27eed04e11d261fb6c0d23a6cb68c80c1a42580b
-  ${PACKAGE_NAME}_iree-module-2139d35085dee09cefbdffc59a0374f1c0274c1ec574815e3277d0129a2089de
-  ${PACKAGE_NAME}_iree-module-218daf4b21025dfcd8d446934c80b999ea21d0e0202fce7e87604c52f9224f66
-  ${PACKAGE_NAME}_iree-module-26e9fb76ffd5d4ea66e51702b1dce2bc383a6b40e2b2d38d869cc583c58859d9
-  ${PACKAGE_NAME}_iree-module-2d4049a9ca6a95ab7169f046f382bcb91ecacee29ecee3256570db0158372fcf
-  ${PACKAGE_NAME}_iree-module-2fe6a4ac93d74732ebabbd87e84e6ec56d2aeb9f6a94f5b595f74f947498c579
-  ${PACKAGE_NAME}_iree-module-32dfb79e574ef282dd352a156620d44d545dda0f49ea1ac27394028d2ced46a8
-  ${PACKAGE_NAME}_iree-module-3421bd5d457a3ed62e7aa74559afb7199105c1f60b65090a247ee3e6d9aec69c
-  ${PACKAGE_NAME}_iree-module-353a915204b8eb401d0caac543588920cfab76f826463394cc1e99546cab13bb
-  ${PACKAGE_NAME}_iree-module-371a2c6fa2e0b6ae8aecaac605ed5e6bc16202b5bf5c12d3d47d270eac205de6
-  ${PACKAGE_NAME}_iree-module-37ef777cb4f695d4b87d3291b8d9a4435b03466df03c766c490b5d1830371993
-  ${PACKAGE_NAME}_iree-module-38e99a06cd01399fe48cd9d860f65474e4fd7df1b3aca491766ff5f825315a79
-  ${PACKAGE_NAME}_iree-module-3b0ae1403ef444d812f0c7b37fda7311e2cc4ea407850ee7b91e6984b9c86100
-  ${PACKAGE_NAME}_iree-module-3d2ee887cbcf8499dfddfcf629106072a067d27b789b620d76e74749151e86a2
-  ${PACKAGE_NAME}_iree-module-3edb70502ef7a26db736a64e24a677ff085fb800a8475e750dd2a9d119baf407
-  ${PACKAGE_NAME}_iree-module-40b0bd95d986d079ae0fc8cd57b473a150289a5f3ee6029b388ebc86edd4a60c
-  ${PACKAGE_NAME}_iree-module-439dab16cd6df449fc83eb3e1603fa86ad811e749bcad2c3e3176976c56848e5
-  ${PACKAGE_NAME}_iree-module-48ad70710c3602b589431df74468589c74f2a5b54f56d8f86af86c70408ae36d
-  ${PACKAGE_NAME}_iree-module-4c0fe9013ea11c0c0e2214d06fd2088f33127a9431acfe24cca1a7f475425f06
-  ${PACKAGE_NAME}_iree-module-4e69d30862f6dff4ed53e4ae462e670b4a2f6168a0d5bf1927b473f6713a5bde
-  ${PACKAGE_NAME}_iree-module-50c0cb0ea6df2e4c1c1337a607252366fb8cd17ffe72cd8aeb76a9f9a8d6712f
-  ${PACKAGE_NAME}_iree-module-5176d0f5fa331fa047395186a866870fe4210f637472ef4bb0a3f1ba3a62a749
-  ${PACKAGE_NAME}_iree-module-5663bccd89aa0616691d5b804b337c8989a2ca94c1bf2673d41dbbab9e511f20
-  ${PACKAGE_NAME}_iree-module-57205a38cd8970cedf207e4d0c02d14103668a635dd341d6bf4ce12f6d1fd56c
-  ${PACKAGE_NAME}_iree-module-5b499a05fc60f78b5b11b1e9ba89ba797450e5b49b0613b3c23d996c6f767c64
-  ${PACKAGE_NAME}_iree-module-620619c21b56a577b155f19b8efb4bdec8f640f76b1c3dae8e4397bdf1d04aee
-  ${PACKAGE_NAME}_iree-module-6265e9506389bb29c551ad62f4ea05f54bd0e549c2d29bf425bac9d56aa55ef6
-  ${PACKAGE_NAME}_iree-module-656c20012d1675da118d78c6bbb3256b186156d52e8f423039d1deb1c103ccf0
-  ${PACKAGE_NAME}_iree-module-665c507d3681ab53586a2ee493cd409684a32c6b553e194d2777f7560b07fbaf
-  ${PACKAGE_NAME}_iree-module-666922620019ce61f2ffa56e9e141fc3ef2736a04eab3d7c6d3b0fbeeaef4275
-  ${PACKAGE_NAME}_iree-module-681f456f27dbb79e7d8d0266bf835866d9f29f87eafad7e867ac13c84602742f
-  ${PACKAGE_NAME}_iree-module-6d608bf13e06ecee96effcd4ac5934aa039337351f60a1feb59e88ad670ad1f5
-  ${PACKAGE_NAME}_iree-module-6da0542e65f9e5eff1bc142506866aec435b931b36eb8e86139f79b4945863fd
-  ${PACKAGE_NAME}_iree-module-7633e088c3e1f7284944fa464c01a783cf45ba19498588bde13e3a675001eaa0
-  ${PACKAGE_NAME}_iree-module-7f45c4f644d293bb984007aa1a91c919c5a75d01bf38f70ba7257c0b21c654f3
-  ${PACKAGE_NAME}_iree-module-815e44d1ac31402e86d0fef72e79474a25dfad3a5c15b8cdd3642e101274342d
-  ${PACKAGE_NAME}_iree-module-88490c7b469b6be6ae374fbdd1f3b9e3d4a998dee5629741ab22f449cefaa1d8
-  ${PACKAGE_NAME}_iree-module-89966a2ac764b543e721d822acdbe015526866e0a8d56a6782f240eeb3cddea1
-  ${PACKAGE_NAME}_iree-module-8a9816fe878d3d0d1dbe1cddb3f4bef09cce39f390b3e1f2c7bc8ebd93a9caa0
-  ${PACKAGE_NAME}_iree-module-943dffbfb30f5c423a81911af7a583ffffb0422f9e55a24671232f5f698a689a
-  ${PACKAGE_NAME}_iree-module-9453f508befcf3fdb82b3576484b5bbe4e199d26058d668f7741964e8755cbdd
-  ${PACKAGE_NAME}_iree-module-999f2edcdf9fbc84e0969923f8605e9069810a63849973a5b74488f83d14a2fe
-  ${PACKAGE_NAME}_iree-module-a71d327d1732c9c8f620b3ae2082cbe22c469d0375452a3245fa038cd4a6e7d7
-  ${PACKAGE_NAME}_iree-module-a9ce4102685085f444f446b79493a8863dcb8f00678c98a0e2a04d26b286626d
-  ${PACKAGE_NAME}_iree-module-acc8bb1b4e349461110585d461d06457f4139d62f0f1a5bfbf0afc356a070ae2
-  ${PACKAGE_NAME}_iree-module-af8ef7bef409aeae3f1205a04c94c87d042187424d0f8df009a1aa8a986b6709
-  ${PACKAGE_NAME}_iree-module-b180d82d1a87fe29e414ecd55bf8a82ff92b80d7c644d31769729160b27aa467
-  ${PACKAGE_NAME}_iree-module-b36c4a1b93f09dee52b255982410f5b9e8e351010fe22eadb3f5afb6719f6873
-  ${PACKAGE_NAME}_iree-module-b54917aaf09c743ce6db08f24b0103f903763d3d73a953fd90b48d992b8e313b
-  ${PACKAGE_NAME}_iree-module-bb96ff5237b0ad603b1ee7c59601a1c957a2ed5c95cbfd94f7ec6d707aad3660
-  ${PACKAGE_NAME}_iree-module-c13a2bb43eafea303949f6bb48fe7eba78782f7ca8ae52eecff03d5b2069a178
-  ${PACKAGE_NAME}_iree-module-c42debd998a5a6b00a9f3b5a1087e17909498038cb9c24d0ff87a5761a4962f1
-  ${PACKAGE_NAME}_iree-module-c480fe46ed6eef2a12e453924f953d7d0ad1a5178e11e2948b7d0223d0c0d9f5
-  ${PACKAGE_NAME}_iree-module-c5f0532455c22436b0fce487797b957939acb0d1f235644187d63bca29a70654
-  ${PACKAGE_NAME}_iree-module-c838ded21eebe38f16ac159822b41648625ff507ae49f35845e9bfdc93732cd3
-  ${PACKAGE_NAME}_iree-module-cf5560593dbc526d065894226429652670c5f24a8fb0828bd298921d137a17d4
-  ${PACKAGE_NAME}_iree-module-d1e4f85096576419ec92da3a1216146291a17b2a42dd2b3f635401308f7c20b7
-  ${PACKAGE_NAME}_iree-module-d25741e6366c1c2552eaf930f99dd3362c0e2dbc55035e0f14e3a562f005245f
-  ${PACKAGE_NAME}_iree-module-d746ecf3d747f18306b6dea4cb6b9e9dbf987fe7fd4d0b27b39a57a213e75dd9
-  ${PACKAGE_NAME}_iree-module-db86dfb7ef5e59b31bf513df65fffd397f49e3fe3b5c03149140ccf3b6b2f821
-  ${PACKAGE_NAME}_iree-module-dde92ea004e3c30ffbe82139e2cdf371c9bf78d05660fd952720ddb110bd9724
-  ${PACKAGE_NAME}_iree-module-dfc624d8a13b1cd8e34b1d14c32eeeb4e2acf6ded9fbda42fd30f3001de972d0
-  ${PACKAGE_NAME}_iree-module-dfdfa87bbaf9931a0e4c47c02866e103872cb20b30899b2358c9d7e59101d5a9
-  ${PACKAGE_NAME}_iree-module-e67816e321544bb61b63ed8cd8b7faa8ff7d35cca15832b5fbc117f4693b3e78
-  ${PACKAGE_NAME}_iree-module-e73380cafbdf91e5fa9867a399562b4b5136864fa8d887cd1580d5d3154a71eb
-  ${PACKAGE_NAME}_iree-module-ebd2ba823bb384984a3b574bb27f9548e90ea7ab22267cc945211b05ff35dd96
-  ${PACKAGE_NAME}_iree-module-ed46d4ed1910589e121e64cdf08c2d3cc72a1bfe24ae41cf78bfc98c7b7fc4c2
-  ${PACKAGE_NAME}_iree-module-edd2270e3119ce3d52a3752532cdcb4ee08420837cbdcac42025b46e7c196230
-  ${PACKAGE_NAME}_iree-module-ee88f7648c08cb775827b3afa89a2aaccd34eff697306c2b35598ba7e4c78df8
-  ${PACKAGE_NAME}_iree-module-f2d1ab779b6ed6b7e9cddc23ea21d568abb704f6b771159f2571cb76adac8ec5
-  ${PACKAGE_NAME}_iree-module-f467fd6a4898fc695217f5e9fb245da17e005453f25e83accdc183c16e270c11
-  ${PACKAGE_NAME}_iree-module-f55259e9c9778885d48b20cfb18242984fa9dde9840fa0f92c7de379c88c8230
-  ${PACKAGE_NAME}_iree-module-fd0f6049f3cd4fee97c182e824f8e65eeabef47ef86a3797ae278ae1fc101705
-  ${PACKAGE_NAME}_iree-module-ff26aa2d1b8f0d80a8ab10aab0a87ae89e36c141dc6c758da61c339d51e2db8d
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch128_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch16_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_compile-stats_
 )
 
 add_dependencies(iree-benchmark-suites-cuda
-  ${PACKAGE_NAME}_iree-module-04ca0a5077b7dd5ace66d803c9b822dff3428b24e7620a61995aff0907af9533
-  ${PACKAGE_NAME}_iree-module-16ec710cdd9921f37f164b180cd3e77db1dc96cce5aabdced6eb3d84382eb02a
-  ${PACKAGE_NAME}_iree-module-2502249d103b48bf09a1d8d659fc143f1fb6e9479256e3e621061a2d06dcef2f
-  ${PACKAGE_NAME}_iree-module-2aad29c1743821a6e3b2b946d9fc0b04afc49b5ceeb7ddb721073348a9248eb6
-  ${PACKAGE_NAME}_iree-module-3c564ca58f759968042d8153290be969cc0f6fe9f006fc9050e612d6f5931879
-  ${PACKAGE_NAME}_iree-module-44e0517dcee4f94b6f7ea1dd6b5492ee9752b4a7cab27d3e5e5ad38ef23071c6
-  ${PACKAGE_NAME}_iree-module-45565cae821666fd34bca97be2e4cce3bd61e71308785728737d89acbb9bc9d2
-  ${PACKAGE_NAME}_iree-module-59025e9cf180a4a72de8f609ac9c4e4a3d855a603eedf62d9577e738f1ec12f4
-  ${PACKAGE_NAME}_iree-module-87ebb308da964e1451c97615c8038b5d2d2ea291fb0e5183404e4d27ec027c3b
-  ${PACKAGE_NAME}_iree-module-9470c46965ea67794da45496454c82eade29b5a519d8037b1314738621e02260
-  ${PACKAGE_NAME}_iree-module-bd985950d72dbe45dfcaa1bf4e0a438621642c077226cb42242ec091f8d37b0f
-  ${PACKAGE_NAME}_iree-module-bdd904cc5614ebf77609c7802a2dfc09f139aee2a247a247d10d320de72b0e28
-  ${PACKAGE_NAME}_iree-module-c0ea83b865fd0c67a3013086ef2250464e2aecfc615a95170ef46128d2e57208
-  ${PACKAGE_NAME}_iree-module-c4b43b31944dbd567e48efacfdb33f707eb248538cf70fa7dcf1085c6c7dbd3f
-  ${PACKAGE_NAME}_iree-module-c8ec2db5ee884e0af17814e61b13d7f7f1f2d4f7028e8c1920d0d968c27de2bb
-  ${PACKAGE_NAME}_iree-module-c91ccf1fb3086a35cffd2e8bed6be929574a9ba626d9f271f577503ad07e3509
-  ${PACKAGE_NAME}_iree-module-cb3f9b06f0f2ce3866b286516c88c52e9adb8895044b92c87afa70eb9a4bd440
-  ${PACKAGE_NAME}_iree-module-deafafd0926321a4b8e4dc73ed4a30b2ed9317d26488246461415be2ee857eb1
-  ${PACKAGE_NAME}_iree-module-e6503d42c202eff85bcddb53e9869017943e756af09bfe2c05ffc27844ac77e9
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetB7PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2Sfp16PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_
+  ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_
+  ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
 )
 
 add_dependencies(iree-benchmark-suites-cuda-large
-  ${PACKAGE_NAME}_iree-module-05a6486bab733dfb85e23bc47a9ce384772d2e0c57e3c6ba01b8cb9888db0e2f
-  ${PACKAGE_NAME}_iree-module-08e52acdb95ed35139dbf11b82c296d08cdad37909687829b55b1818fce9b0d7
-  ${PACKAGE_NAME}_iree-module-09dd0099b9a0924cc1bcadfb355bccbeea9cb3c29fc48c5181fbb87d80af28a9
-  ${PACKAGE_NAME}_iree-module-0c02fdba447db54fce59698955c728295a98135ef702ce24061834bdea2d1d90
-  ${PACKAGE_NAME}_iree-module-1078c4ae05bf39833629569966661473dbcfba7a6454301d726e0c0e96115d15
-  ${PACKAGE_NAME}_iree-module-129b48d3bbdad4b4333986b8a35fcafa8d4434fead6233154cecfbdab0ca23e6
-  ${PACKAGE_NAME}_iree-module-154de838dc7742304c9e27a9f315645a915493bc4f84160e29b15b7fc6dc475e
-  ${PACKAGE_NAME}_iree-module-1655ee92ee23748886eef280d7d6f96c8a227fae7d6d78abd3466ce8614f16ba
-  ${PACKAGE_NAME}_iree-module-17a2e53637f4391f741791950b9f5b2c650fc2c97ae00c5e9c60f0d9125ac2c8
-  ${PACKAGE_NAME}_iree-module-18f35077bfc62e09218dcd1db06f92d04c0698d6eda4999b67a7fe7ba4f31123
-  ${PACKAGE_NAME}_iree-module-2021b32a685c21ba21823416591c14fd79075595c101665abe565ff92335c3ef
-  ${PACKAGE_NAME}_iree-module-2146e71d7d9f62002c34f2869a60ac58e17d875ba5a8d7b2d170e4de4e342ddc
-  ${PACKAGE_NAME}_iree-module-21a83414dc1feb2a3b5fb6afadc36c1022a0ab747380291dbb309637d5f32eab
-  ${PACKAGE_NAME}_iree-module-222490941c581c67f5ce710e9ea141482cd8074294a43a5dc67a01a127037cd4
-  ${PACKAGE_NAME}_iree-module-22c17848ebc029e64b86ac50b5fb28b7198c0ef3b3f7f03ed111d189328ba147
-  ${PACKAGE_NAME}_iree-module-25f1a116fad68b01401dfbd8462c7b2729ef2d504df0954509cd488cd5da17a1
-  ${PACKAGE_NAME}_iree-module-30baf74b5974ab7269c57015554a0fb0447cbde5fb77ab44ed9cf9cd2bc0e351
-  ${PACKAGE_NAME}_iree-module-3252375798810f175ebda56c63616da1f46954489420549ad219a746867c0c58
-  ${PACKAGE_NAME}_iree-module-3385106a53075a52f4ae60523e09ad42cdad60475d97e84695a9c68584d9182a
-  ${PACKAGE_NAME}_iree-module-369f2b1edbd94d2c19cf18be7ee8bb7aa937fe0669fbe6e5fb9a5c06185ebb42
-  ${PACKAGE_NAME}_iree-module-39556c12d84502be71243197b99b0f8c22949093c561c55c01ca906812a86288
-  ${PACKAGE_NAME}_iree-module-3dcbc01e07ee34df7e5535dd0be85071685655d51331314b7a17517feb74ed3b
-  ${PACKAGE_NAME}_iree-module-454fd6dea6195164691f1bd66e407131bc8ad41cb1ae9a0360ecd4d3fba8a372
-  ${PACKAGE_NAME}_iree-module-45ed9ca2efb9bb645316e856a5c464b76e56902e930ff1d4e54fdef38043b33f
-  ${PACKAGE_NAME}_iree-module-47edac5a737cd096e898b80a1952d7d448bd3261a765520d79b81d95d9b02375
-  ${PACKAGE_NAME}_iree-module-496bdea78d06c9c32d8deae84b088b0eb34f6d1982ac790e2580a50dec4281ae
-  ${PACKAGE_NAME}_iree-module-4df03cf0d71376b43f2e93ca35d252f052733fa8de905af146f25d4216b2b4d2
-  ${PACKAGE_NAME}_iree-module-4e879cbb18131becd2cc80ec9d77ef6c40bb1a9288201ee448278fdf2e81b14e
-  ${PACKAGE_NAME}_iree-module-52f3e54f0a7479eecdae97afb32b90e3952c8be195a861722fd8e8ece857ff40
-  ${PACKAGE_NAME}_iree-module-57080e57e3ba061d70d35d8579824a8eab7ee05ef3e0eea02cc251bab87cfd10
-  ${PACKAGE_NAME}_iree-module-58a0cb6e5c240493436ae2c1e304a572ff11060233b48dce1bf82f0d3b733a6f
-  ${PACKAGE_NAME}_iree-module-58f67edb580a13aa98d3fd05ad31f207d62462c9de990825656b19d2fbacda3c
-  ${PACKAGE_NAME}_iree-module-5aa3c57b33d354d5ebfe51626e2dac78485a548aa9bf2fba7a3e7a248f8b909e
-  ${PACKAGE_NAME}_iree-module-694c3001456d0441c55272d76d1fc4b0e4623bc4875f102a87509ac8382fa029
-  ${PACKAGE_NAME}_iree-module-75c29c7da698ad149e4ac580666595c3fbcfe86a50f0b8d8d3a9c737adf685c5
-  ${PACKAGE_NAME}_iree-module-767c1b6faee0eddaca3e01469f49dc355a00f192f1ae5e226839cab3cafbe8d9
-  ${PACKAGE_NAME}_iree-module-7ab699651c26607f197f63bdf95842ba4fa92cbe6ffa923b869d5df0ff8830a9
-  ${PACKAGE_NAME}_iree-module-7ba873f0f155e857b45f991cbb4e8776f8b137d59ddc5f81a7a23ed2a48eecc9
-  ${PACKAGE_NAME}_iree-module-7d93a3e9b342045ed2546960ee3d08f60be237fd8974fe35447a41234f322148
-  ${PACKAGE_NAME}_iree-module-814b5155d8c819d65ed0ddac829d3af930ae3b03d2ea34afcd4da6f6b429d4dc
-  ${PACKAGE_NAME}_iree-module-88f03be31249d371d00c63d44d44732ad4c348bf2354bd2b3b042465d86f7183
-  ${PACKAGE_NAME}_iree-module-89643b9db9da0c7b822ba8e2ead4ec12fc3093dbde9b7a8570de1be3d46bd54b
-  ${PACKAGE_NAME}_iree-module-8b080ab273c07333a503310e33b4bbaa7599319b6b699755b8853ad7ce2fb28e
-  ${PACKAGE_NAME}_iree-module-8c26886533593b666597f8698e33c0e9c98b349bdf8ac01c3d122cc20b741def
-  ${PACKAGE_NAME}_iree-module-9900b1a0c52b31fc38f1d82ff088102f7131ecbb3fc1b8274929481337d031c5
-  ${PACKAGE_NAME}_iree-module-995595b7b80370d9c484413e9d06c2de928db32777101c91d3bac0d3797058ec
-  ${PACKAGE_NAME}_iree-module-99b28083e2bcb855cc6ead27a57d4efbd6a8c54205897ab226fe15bf321e239a
-  ${PACKAGE_NAME}_iree-module-9a47ca4b87dc126e967d6c9e51894212c20afbae0abddf64c1dbad6a8a0a595a
-  ${PACKAGE_NAME}_iree-module-9c8197e62299f79c373535d91c48acd1b3522264bd7a3d885683570bfc20164c
-  ${PACKAGE_NAME}_iree-module-9e1870e43977999573defd36f2a4540f70b69acf7a330f5133fd8170265cff23
-  ${PACKAGE_NAME}_iree-module-9f427ef22efcf4736dda3c87b30a8af80f3071eaba07f6d5e9795c2631effc4e
-  ${PACKAGE_NAME}_iree-module-9f4cafa63a150cabdf61a945dc6a04c9ddac88b75260bb4ce668199cdddbd581
-  ${PACKAGE_NAME}_iree-module-a28fb3589ad3175aced5b87acb35b791bb71ce005c58f9c3fbadb2df907d7ba6
-  ${PACKAGE_NAME}_iree-module-a52ef9f5a8c064a4cbf52ea82b694d2c0bb9a0dd43d3576131335ab5453b62a4
-  ${PACKAGE_NAME}_iree-module-a6f73626c6b41d410da11809d66d613293a0e3c298d491d6fb25e3729cf6685e
-  ${PACKAGE_NAME}_iree-module-b3da705f46e262d026b6bb01dcf484f35f05ed083ec0319e3b8515f578f02310
-  ${PACKAGE_NAME}_iree-module-b3f2a0c268a0a8752ccbb56f013455197c466635637b535778a494dab316cf9e
-  ${PACKAGE_NAME}_iree-module-b441bdf92d5b74f62726235c0f98e82aa10a21e4092cad147f670484b2d43c7e
-  ${PACKAGE_NAME}_iree-module-b51439857023ae098fdc5771cad8d554c0f865605270629e76758d962a9e77ef
-  ${PACKAGE_NAME}_iree-module-b93a8c82dcab5bd300153626e5ae1de06f18ad1a36c25d324204daf654f0fdab
-  ${PACKAGE_NAME}_iree-module-ba0e837ccb2c4b017df4e2397b3cec6565b2c6b84193ee738a95aef872a39fe7
-  ${PACKAGE_NAME}_iree-module-bf4bda91fb17ec7f3402e7b301cb3ab0b7a9b0b00d8cee29fd4cfa46262a5ea1
-  ${PACKAGE_NAME}_iree-module-c16715c83936394998fe81f8d33f6e7901f17ff662dfd2941a3982f85c3a9e17
-  ${PACKAGE_NAME}_iree-module-c451b302f020e742b3e66964f5909018fa51d93c753ea337b1bdfea6b69e0901
-  ${PACKAGE_NAME}_iree-module-c947d0e7889a515a4e58bdbd1688f028ca88351dbd7ec501d9fb13a08c27503f
-  ${PACKAGE_NAME}_iree-module-d7ff0ce530c700c18dc4704dfcb75ec14540bd0794faee823a3cc1cd62ea53df
-  ${PACKAGE_NAME}_iree-module-d980bb01bd509b62a7610ae2aaa02fcb864582cf9827136a65f2483fd85b5c66
-  ${PACKAGE_NAME}_iree-module-e70546885f5488d986fffccc21a118d82aa7933b7dccfe47b0093591e081231f
-  ${PACKAGE_NAME}_iree-module-e9496836f964df336279914bb907889f071893aac3a0d069f6a318e9a74e4c23
-  ${PACKAGE_NAME}_iree-module-eaccfeb996e96d52d357fb276b3c864a4050fa8cf77f3f305ac2b64918037a37
-  ${PACKAGE_NAME}_iree-module-f1051eab627311cccb5da9e85ca9ccca9697b8701a004935a9b7f959151cdbd7
-  ${PACKAGE_NAME}_iree-module-feae531426d546aae8f1c579bfb8183a1315caa6347fe9efa99660a7c7c40947
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
 )
 
 add_dependencies(iree-benchmark-suites-default
-  ${PACKAGE_NAME}_iree-module-012cc9d71edd7a345ef45d52c630d53ed04ee93523524b417330c644d8f6ce1b
-  ${PACKAGE_NAME}_iree-module-02cebfbec13685725c5b3c805c6c620ea3f885027bfbb14d17425798e391486f
-  ${PACKAGE_NAME}_iree-module-047e75c462648b5fe1133f4ffbc3d1c7bdda154081d3eaa3be0b5445725b272b
-  ${PACKAGE_NAME}_iree-module-04ca0a5077b7dd5ace66d803c9b822dff3428b24e7620a61995aff0907af9533
-  ${PACKAGE_NAME}_iree-module-05e976592f58a292874d99bd7627e655b15c5460455a08b9ce67e9f7f65b6269
-  ${PACKAGE_NAME}_iree-module-0689c824551e3a3650463db3807664420f1033ee1b290fa25e63d04cf1a0a6ef
-  ${PACKAGE_NAME}_iree-module-076a1e95f3384b58a77a672c7c36463b091e574b5a6f6eaf78841537b0d1c930
-  ${PACKAGE_NAME}_iree-module-0af4e7fa84d361d2faa267336c3c090e337f7feff47f0e559337521c07626ba7
-  ${PACKAGE_NAME}_iree-module-0d6fed1f6845ce0d70bf81ac2522e9806b4538917cb7ee02a1b6e6a60d6b7115
-  ${PACKAGE_NAME}_iree-module-0efb794c3a385045fa4d3d086c2a593ce67c4807e9456271f05f4e28490d1c49
-  ${PACKAGE_NAME}_iree-module-11766f32ea6a3121d7527bcdf32dead45ab7b3922d72addb46945cfdab784ec0
-  ${PACKAGE_NAME}_iree-module-1202e44fbbde0a9581c641d124452363273f0d4395445dc06e60c8e49a27357b
-  ${PACKAGE_NAME}_iree-module-131aa61ffcacafc6ae701ff89045cf42d2490ac0c4a1d862bc83c23edb3b92e5
-  ${PACKAGE_NAME}_iree-module-138aacc154449b519698bd7ddb4dc9f407cbc1fd86fdbbe901be974058b70319
-  ${PACKAGE_NAME}_iree-module-14a15b9072caaee5e2a274a9bbc436a56d095611e5a8e9841f110741d34231f9
-  ${PACKAGE_NAME}_iree-module-16ec710cdd9921f37f164b180cd3e77db1dc96cce5aabdced6eb3d84382eb02a
-  ${PACKAGE_NAME}_iree-module-1c7402f88ba881ec6abb39204faa4b5fedb2ffff4a6066555fcff0c7c4b74732
-  ${PACKAGE_NAME}_iree-module-1ef2da238443010024d69ceb6fe6ab6fa8cf5f4ce7d424dace3a572592043e70
-  ${PACKAGE_NAME}_iree-module-244092c4ecd63533f225b0bc16b308e11265ca6b10696f8975866844793e2c4f
-  ${PACKAGE_NAME}_iree-module-2502249d103b48bf09a1d8d659fc143f1fb6e9479256e3e621061a2d06dcef2f
-  ${PACKAGE_NAME}_iree-module-27c12f520d68a8a754b11ad44cf8ad3ef5c1ec281fc9d84fbc64a7b573cb68b5
-  ${PACKAGE_NAME}_iree-module-2aad29c1743821a6e3b2b946d9fc0b04afc49b5ceeb7ddb721073348a9248eb6
-  ${PACKAGE_NAME}_iree-module-2c042cd2ded71abef51933f0466cf58a52de2c67e1a23fde98b1fad1b33e6d7c
-  ${PACKAGE_NAME}_iree-module-337a3ab92a878301dc4bdd2554739b59ebf7925d85af42ee16780ba6c6dee0d8
-  ${PACKAGE_NAME}_iree-module-383e7567e79adf2178e3d25785855905a4477b6c8daf16bc50d5f9f44d2343d9
-  ${PACKAGE_NAME}_iree-module-3926415c1504dfc277674fee17bdfbd68090634b8b52620d8d5755082a89a16d
-  ${PACKAGE_NAME}_iree-module-3ba167fc59b5959be276b331951c759391d6e158572fc05603981dcc4bd3fc90
-  ${PACKAGE_NAME}_iree-module-3c1fbaa12bbd37bf2a17d8a605cdeca75c0e8cc9c6f7e95359d13e47a4270dc3
-  ${PACKAGE_NAME}_iree-module-3c564ca58f759968042d8153290be969cc0f6fe9f006fc9050e612d6f5931879
-  ${PACKAGE_NAME}_iree-module-3dbf200159f328bb69c6c5bc79cce408a4ba49d2d07dfb3939786557e63d035c
-  ${PACKAGE_NAME}_iree-module-429d7055b93250cc19866107e305bef1dc0b7e49e579ef19ea1eeb70eb2fb86d
-  ${PACKAGE_NAME}_iree-module-42bc978e75d5fed90c10d5812a8df7a6153e311b19b9c7faf41a588bdc4da7d8
-  ${PACKAGE_NAME}_iree-module-44e0517dcee4f94b6f7ea1dd6b5492ee9752b4a7cab27d3e5e5ad38ef23071c6
-  ${PACKAGE_NAME}_iree-module-45565cae821666fd34bca97be2e4cce3bd61e71308785728737d89acbb9bc9d2
-  ${PACKAGE_NAME}_iree-module-472e6a18344f13d47e89f87670b37eff583ae610c2a1d15ac1cca307ccfc2f4d
-  ${PACKAGE_NAME}_iree-module-4924918e121a92f802a094de2d67e9c2673c9fdc39faa6a11ac1d38b631a2914
-  ${PACKAGE_NAME}_iree-module-4a1632637ce87fe991848942b028c36732b2bea00920d275ffbcaf2cd9446152
-  ${PACKAGE_NAME}_iree-module-4b61f532e6cf4e175a7e90cd9418e3c2614176b5253875951f99e52d2621c152
-  ${PACKAGE_NAME}_iree-module-50084c6a5ef433943ae46fbbf852d266d20557be110fff9dea1e4e298040c7c6
-  ${PACKAGE_NAME}_iree-module-507fabae3d24c2448c8f2af676d68df0a22716a06fa7ffc3b4f865e9272ecdc8
-  ${PACKAGE_NAME}_iree-module-531f99d8bc669343f967598c13ca787c62b01b4dfcd7c4b4ad04a163063a1ddc
-  ${PACKAGE_NAME}_iree-module-59025e9cf180a4a72de8f609ac9c4e4a3d855a603eedf62d9577e738f1ec12f4
-  ${PACKAGE_NAME}_iree-module-5eeff62c8ab391e247ede57b226b4be03b81067b8831b13bfa47b62e2dac275a
-  ${PACKAGE_NAME}_iree-module-5f46d5bcca6c809578ba7b32829ee4417a67eaa5033b5b58b81e3a8b0b3433ad
-  ${PACKAGE_NAME}_iree-module-63a1dd898daa56fc3a0bff652cb5b2e0483cfe90e9dcd7994b73183b7ce106b2
-  ${PACKAGE_NAME}_iree-module-65aa6dabd0c24dbe48a090db641d82b437d4abd428a6ca0e7b360d3f087a16c8
-  ${PACKAGE_NAME}_iree-module-67ad72cbb9eb9c4746249922e6232b1a17b5d6eeabd9b69ed4d527c1676c77bd
-  ${PACKAGE_NAME}_iree-module-68f0eb37bb72d0d6605ecdf42691c64125960e122844b0beeae350871a445b1c
-  ${PACKAGE_NAME}_iree-module-69f971c48d4b181ed4a4ec22790dc62fa997aa28ad16e0e176642955ccbbc2f0
-  ${PACKAGE_NAME}_iree-module-711cb4e615cc4e032fe9f198b89e32f4f85c94cab6e9101eb8202b22c97a37b1
-  ${PACKAGE_NAME}_iree-module-72feea41a0b54e4c9a761933079cba1b2c012e5a5d4b2953ffaa86faaa29a648
-  ${PACKAGE_NAME}_iree-module-737d273c18eb7537e2dde47c4a46391e8657c38f9650032c39bc67fa5f132742
-  ${PACKAGE_NAME}_iree-module-759fdb2deb885ca5568741853e3497ab3d7037a42a4fdff0af590c803681ec60
-  ${PACKAGE_NAME}_iree-module-78154d58dddac432100d656b22fa9bcb45e4207a9ea2bc371bf089a68bad397a
-  ${PACKAGE_NAME}_iree-module-78db72d7b7a1f871a3752c8165cbebc678047f2df5d36b10dd82ee870873b620
-  ${PACKAGE_NAME}_iree-module-7a3d36d7234ce4abfd833964492631bd81df823e6bde8cd3a1fadfa4faa7c787
-  ${PACKAGE_NAME}_iree-module-7d44f561ce87a08f4ed53264b6b95ddd7926263fef781e5135cc696d5a4d3719
-  ${PACKAGE_NAME}_iree-module-7e0380f1df059cf6040c12934af4f1c88a469c716a294f383200d5dd5cc69b1d
-  ${PACKAGE_NAME}_iree-module-7f5a7ca6eb12e8ac322d8bb0deb59630d721ab141acc3a941e168d98af507034
-  ${PACKAGE_NAME}_iree-module-80a2368e148d9605d98060027b9198dea46efbf050a383784ec5df5e85904757
-  ${PACKAGE_NAME}_iree-module-83ef2a35d14b4acf5d569798accc3b5bb693394633d444bdd5c9d55461f549ae
-  ${PACKAGE_NAME}_iree-module-86ce8dfe2979d777a7f9eb0d3b6f8dcd4b594f46e9d610ad8a73edc89a006b26
-  ${PACKAGE_NAME}_iree-module-87aead729018ce5f114501cecefb6315086eb2a21ae1b30984b1794f619871c6
-  ${PACKAGE_NAME}_iree-module-87ebb308da964e1451c97615c8038b5d2d2ea291fb0e5183404e4d27ec027c3b
-  ${PACKAGE_NAME}_iree-module-887c7a7b540f11ee5e0158143fd46a503a4851211b10b353ec0e00b8b1beb575
-  ${PACKAGE_NAME}_iree-module-8930c217bc20a5abf9313fd714a77bf47acefb006e95ba07b5e48caf872541b0
-  ${PACKAGE_NAME}_iree-module-894671e6d7319df243fa8b386b14d5e648fe2ffd66cb95e5a82ad58d7273ada8
-  ${PACKAGE_NAME}_iree-module-8b6e3f5ddee79e020f1b25ce676d3772dda8cf14f619a3f0649a9f14e0159cd0
-  ${PACKAGE_NAME}_iree-module-8d15dde1c8c2ed90009698c357455dfc94fd96ae877f4892954bef0ec4361de8
-  ${PACKAGE_NAME}_iree-module-8eb82c90485cc4281676866b62e6820b60a38ba81068e95254a7d0ddaddc59c3
-  ${PACKAGE_NAME}_iree-module-90d4cb308fc14e4832336ebd1e1387a791a20b92af633d0fec9161b807e13427
-  ${PACKAGE_NAME}_iree-module-90eb882b36d0293eb5b22ffb64f7c395cefa0360b37d4b84854d8b2c52a76358
-  ${PACKAGE_NAME}_iree-module-91469dce5ace1877a717a8ca5f53c1c8a3ac2f2eb8d116382eb4a5f5ace3a9c8
-  ${PACKAGE_NAME}_iree-module-92dd923f493f67509a6b54007416f16ac8e6f2023e88f79b3017ea2260ee561a
-  ${PACKAGE_NAME}_iree-module-93034e879f88475eeeff56dd38297a1d1183f123fbbf5925a07b7c934e5f5d48
-  ${PACKAGE_NAME}_iree-module-9470c46965ea67794da45496454c82eade29b5a519d8037b1314738621e02260
-  ${PACKAGE_NAME}_iree-module-95dee09d7f3f9ee36d6c70645585b44b347ea001a1ab9a04b150ca2dc052255f
-  ${PACKAGE_NAME}_iree-module-9a2128d69c5c5a51402e01c4a848e90ec369fa601a3d9fc1ab69dab8db47e6d3
-  ${PACKAGE_NAME}_iree-module-9b6e19b8cab376fffe309f090beeecad08903c0975c9e7ffc480dd46074b97b3
-  ${PACKAGE_NAME}_iree-module-9c849d0ccfc89c0bca0740949572db8735832012a43c4c9f15c3a8ef0d9cca04
-  ${PACKAGE_NAME}_iree-module-9d909aa679e8c380ff7e93292ef28dbd3bb9e7cc62329f90aef78ce9c7efeff9
-  ${PACKAGE_NAME}_iree-module-9faad3c50bc64c297531a36bd2ab235b680070d8233ce5ab7d964ac36c7c5563
-  ${PACKAGE_NAME}_iree-module-a30b64a3d7850881ee9db94e8f75c661af3f76f48d10b3342a6912e1c8879252
-  ${PACKAGE_NAME}_iree-module-a47669d662bd18dbd323737d84fd45753c01abaa81b4761eb51b35ce04ee7491
-  ${PACKAGE_NAME}_iree-module-a7a1553d0739151f06bbc00a3ef8b67b0606463eab4b6607069aa94ea0bfd92f
-  ${PACKAGE_NAME}_iree-module-aada5dcefdd361b5227276129e93547a6932a05d380acd342fa33e5b672d498c
-  ${PACKAGE_NAME}_iree-module-ad38a059079822e7331470e086bc1caca3dbe435878b38e1355229a39d1d25d2
-  ${PACKAGE_NAME}_iree-module-aed1ca2855056bcd5b7e51063741685b4a387d9d0574b343e8ddc383b49afc76
-  ${PACKAGE_NAME}_iree-module-b33d5ca3311e31b99daa1c1f13ea5571713538a7889627153ea431debb9b5e2a
-  ${PACKAGE_NAME}_iree-module-b5d399322ea7d5e831efb647928974f7f3abce21b2220af9cf9344ccea411545
-  ${PACKAGE_NAME}_iree-module-ba322b423888fe93e86180e98668f486afa915565edf3813af3f9da6ad7c9dc9
-  ${PACKAGE_NAME}_iree-module-baec9d4086496a94853f349354f87acb8397bf36169134d3269d5803888dcf49
-  ${PACKAGE_NAME}_iree-module-bb1cb8e00fd4cee513b2481bd5faf39842ad9c57f80f2e50ddb48763fd030721
-  ${PACKAGE_NAME}_iree-module-bd0ea10065a27dea6875ceb70f769e7e0f67a08e857920ca0d0322593441e9ed
-  ${PACKAGE_NAME}_iree-module-bd985950d72dbe45dfcaa1bf4e0a438621642c077226cb42242ec091f8d37b0f
-  ${PACKAGE_NAME}_iree-module-bdd904cc5614ebf77609c7802a2dfc09f139aee2a247a247d10d320de72b0e28
-  ${PACKAGE_NAME}_iree-module-c0ea83b865fd0c67a3013086ef2250464e2aecfc615a95170ef46128d2e57208
-  ${PACKAGE_NAME}_iree-module-c37bfe2bb995b2703170a890bd81e372b687bed57087b1d8a6d8bb16b91c5ad4
-  ${PACKAGE_NAME}_iree-module-c4b43b31944dbd567e48efacfdb33f707eb248538cf70fa7dcf1085c6c7dbd3f
-  ${PACKAGE_NAME}_iree-module-c8949024e2472bec7b18c4e3757412715c248273005ca6f8d5769656ed425a84
-  ${PACKAGE_NAME}_iree-module-c8ec2db5ee884e0af17814e61b13d7f7f1f2d4f7028e8c1920d0d968c27de2bb
-  ${PACKAGE_NAME}_iree-module-c91ccf1fb3086a35cffd2e8bed6be929574a9ba626d9f271f577503ad07e3509
-  ${PACKAGE_NAME}_iree-module-c95d82463222cf5ea385760eb1f0f0ee28a876620e29fbd59f8f4cb8a5307bc8
-  ${PACKAGE_NAME}_iree-module-cb3f9b06f0f2ce3866b286516c88c52e9adb8895044b92c87afa70eb9a4bd440
-  ${PACKAGE_NAME}_iree-module-cc9b305fb2c95f582d144f1063fc12fd996e757f84738e3de846b0197981bcc2
-  ${PACKAGE_NAME}_iree-module-d0d1a869e3f3901f6f60afaf57160ce888a852f6703efc79756415d43cfcd13e
-  ${PACKAGE_NAME}_iree-module-d399d2540161867967b0590a659d0a86206e145d884bd7afd9abd818713aacd2
-  ${PACKAGE_NAME}_iree-module-d5ea172c189c6a6a3b61a7e83f7263b9b38cad756d2d5dec1b2db88162eece2a
-  ${PACKAGE_NAME}_iree-module-db9784471b47ae8bf55ca7e0821e35a1686256a208df40443c114f1adcdd26f6
-  ${PACKAGE_NAME}_iree-module-dc26eca15bb97d42bcfa019de5080da54fb3d7624809aa1c8ac731e710544e18
-  ${PACKAGE_NAME}_iree-module-dd4366d716cccdd83b6f777ee966157b92838569f094371b325b926e73c7b1b8
-  ${PACKAGE_NAME}_iree-module-deafafd0926321a4b8e4dc73ed4a30b2ed9317d26488246461415be2ee857eb1
-  ${PACKAGE_NAME}_iree-module-deba344af418957cbd9dc0834a100bc30ba242d7fddb4dc6ba10a87d0af32dc1
-  ${PACKAGE_NAME}_iree-module-e1143fcb8d1d262a3b2ac689cf21a1943cc59b2de06192fef185a9bf84994b86
-  ${PACKAGE_NAME}_iree-module-e3444362e0b630df1b5f70a28089b0764d9ddc886dda852a0ef1300e369aee4d
-  ${PACKAGE_NAME}_iree-module-e52ef218d6b5b16f35c420fca42ff31c5cf733bc075ed235ce57cf4662824606
-  ${PACKAGE_NAME}_iree-module-e6503d42c202eff85bcddb53e9869017943e756af09bfe2c05ffc27844ac77e9
-  ${PACKAGE_NAME}_iree-module-e80d71ed8e86c0756226b2323e27e2c7c0fff8eddde59ba69e9222d36ee3eef6
-  ${PACKAGE_NAME}_iree-module-e850fce2d36ddb09ccc34471641adb77418b93c0949d22ab75806d7cfc489ae3
-  ${PACKAGE_NAME}_iree-module-eb56e91246a131fa41bd335c1c072ffb6e7ffe651ecf65f4eeb171b12848b0ed
-  ${PACKAGE_NAME}_iree-module-ec14aafacf15628918390531318a4827d3ac8771b75d60a8239d901dcb4fd898
-  ${PACKAGE_NAME}_iree-module-f06fff09f8cebc27d1674045712aaa60afe7aef388c4bc505897f55c3a0d8abb
-  ${PACKAGE_NAME}_iree-module-f146632eb124afeb899eeae8aaf5ab6cd9efae22ee9ffb26d34fe1da10049fbe
-  ${PACKAGE_NAME}_iree-module-f59cd43a2a2d6e4b3159efa358a6fa0879e72f6f4f0a23af4c8ab550f256986a
-  ${PACKAGE_NAME}_iree-module-f73d0b9c84ec91b594b00eb3800c372884050fce3e4fb9d80eb407d7b0697412
-  ${PACKAGE_NAME}_iree-module-f963d812114af925e0a4b110ee83aeb0e3b41d49fad19b3f449b6a9ccba43b8d
-  ${PACKAGE_NAME}_iree-module-fd5cf4cd75cc1734be3eec2f4396491e9ebb7edd6b9c889cdc29ef72b47d6233
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNetB7PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetB7PT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2SPT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2Sfp16PT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_dotprod_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___vmvx-generic-vmvx-vmvx__experimental-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___qualcomm-adreno-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_
+  ${PACKAGE_NAME}_iree-module-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_
+  ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_
+  ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
+  ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
 )
 
 add_dependencies(iree-benchmark-suites-large
-  ${PACKAGE_NAME}_iree-module-05a6486bab733dfb85e23bc47a9ce384772d2e0c57e3c6ba01b8cb9888db0e2f
-  ${PACKAGE_NAME}_iree-module-08e52acdb95ed35139dbf11b82c296d08cdad37909687829b55b1818fce9b0d7
-  ${PACKAGE_NAME}_iree-module-09dd0099b9a0924cc1bcadfb355bccbeea9cb3c29fc48c5181fbb87d80af28a9
-  ${PACKAGE_NAME}_iree-module-0c02fdba447db54fce59698955c728295a98135ef702ce24061834bdea2d1d90
-  ${PACKAGE_NAME}_iree-module-0c8eaa0d8238c24ed0c6598e6e713d556697ae695d94d1af142f2f019ead6a31
-  ${PACKAGE_NAME}_iree-module-1078c4ae05bf39833629569966661473dbcfba7a6454301d726e0c0e96115d15
-  ${PACKAGE_NAME}_iree-module-10a9a8a00ac0f36f45b5e35a032ca177b68621e3137dc57b9d6e08225301441b
-  ${PACKAGE_NAME}_iree-module-129b48d3bbdad4b4333986b8a35fcafa8d4434fead6233154cecfbdab0ca23e6
-  ${PACKAGE_NAME}_iree-module-154de838dc7742304c9e27a9f315645a915493bc4f84160e29b15b7fc6dc475e
-  ${PACKAGE_NAME}_iree-module-1655ee92ee23748886eef280d7d6f96c8a227fae7d6d78abd3466ce8614f16ba
-  ${PACKAGE_NAME}_iree-module-17a2e53637f4391f741791950b9f5b2c650fc2c97ae00c5e9c60f0d9125ac2c8
-  ${PACKAGE_NAME}_iree-module-18f35077bfc62e09218dcd1db06f92d04c0698d6eda4999b67a7fe7ba4f31123
-  ${PACKAGE_NAME}_iree-module-1b4cbc14c2735bd4bd2d990f46e6f4843d66a6f688e492e6a02e07d0d4e927ed
-  ${PACKAGE_NAME}_iree-module-2021b32a685c21ba21823416591c14fd79075595c101665abe565ff92335c3ef
-  ${PACKAGE_NAME}_iree-module-2146e71d7d9f62002c34f2869a60ac58e17d875ba5a8d7b2d170e4de4e342ddc
-  ${PACKAGE_NAME}_iree-module-21a83414dc1feb2a3b5fb6afadc36c1022a0ab747380291dbb309637d5f32eab
-  ${PACKAGE_NAME}_iree-module-222490941c581c67f5ce710e9ea141482cd8074294a43a5dc67a01a127037cd4
-  ${PACKAGE_NAME}_iree-module-22c17848ebc029e64b86ac50b5fb28b7198c0ef3b3f7f03ed111d189328ba147
-  ${PACKAGE_NAME}_iree-module-25f1a116fad68b01401dfbd8462c7b2729ef2d504df0954509cd488cd5da17a1
-  ${PACKAGE_NAME}_iree-module-30baf74b5974ab7269c57015554a0fb0447cbde5fb77ab44ed9cf9cd2bc0e351
-  ${PACKAGE_NAME}_iree-module-3252375798810f175ebda56c63616da1f46954489420549ad219a746867c0c58
-  ${PACKAGE_NAME}_iree-module-3385106a53075a52f4ae60523e09ad42cdad60475d97e84695a9c68584d9182a
-  ${PACKAGE_NAME}_iree-module-3407fbbc5cb24c7ef432987ec1af9b01dc3626dbe40278bda37c3b3d7c5ac000
-  ${PACKAGE_NAME}_iree-module-35d83c1c7042590bdda6b704e51c4b2f4af38bd2ed9db75a00632e3f2db1149d
-  ${PACKAGE_NAME}_iree-module-369f2b1edbd94d2c19cf18be7ee8bb7aa937fe0669fbe6e5fb9a5c06185ebb42
-  ${PACKAGE_NAME}_iree-module-39556c12d84502be71243197b99b0f8c22949093c561c55c01ca906812a86288
-  ${PACKAGE_NAME}_iree-module-3dcbc01e07ee34df7e5535dd0be85071685655d51331314b7a17517feb74ed3b
-  ${PACKAGE_NAME}_iree-module-454fd6dea6195164691f1bd66e407131bc8ad41cb1ae9a0360ecd4d3fba8a372
-  ${PACKAGE_NAME}_iree-module-45ed9ca2efb9bb645316e856a5c464b76e56902e930ff1d4e54fdef38043b33f
-  ${PACKAGE_NAME}_iree-module-47edac5a737cd096e898b80a1952d7d448bd3261a765520d79b81d95d9b02375
-  ${PACKAGE_NAME}_iree-module-496bdea78d06c9c32d8deae84b088b0eb34f6d1982ac790e2580a50dec4281ae
-  ${PACKAGE_NAME}_iree-module-4df03cf0d71376b43f2e93ca35d252f052733fa8de905af146f25d4216b2b4d2
-  ${PACKAGE_NAME}_iree-module-4e879cbb18131becd2cc80ec9d77ef6c40bb1a9288201ee448278fdf2e81b14e
-  ${PACKAGE_NAME}_iree-module-52f3e54f0a7479eecdae97afb32b90e3952c8be195a861722fd8e8ece857ff40
-  ${PACKAGE_NAME}_iree-module-57080e57e3ba061d70d35d8579824a8eab7ee05ef3e0eea02cc251bab87cfd10
-  ${PACKAGE_NAME}_iree-module-58a0cb6e5c240493436ae2c1e304a572ff11060233b48dce1bf82f0d3b733a6f
-  ${PACKAGE_NAME}_iree-module-58f67edb580a13aa98d3fd05ad31f207d62462c9de990825656b19d2fbacda3c
-  ${PACKAGE_NAME}_iree-module-5aa3c57b33d354d5ebfe51626e2dac78485a548aa9bf2fba7a3e7a248f8b909e
-  ${PACKAGE_NAME}_iree-module-694c3001456d0441c55272d76d1fc4b0e4623bc4875f102a87509ac8382fa029
-  ${PACKAGE_NAME}_iree-module-75c29c7da698ad149e4ac580666595c3fbcfe86a50f0b8d8d3a9c737adf685c5
-  ${PACKAGE_NAME}_iree-module-767c1b6faee0eddaca3e01469f49dc355a00f192f1ae5e226839cab3cafbe8d9
-  ${PACKAGE_NAME}_iree-module-780f3809138cfab6b31646debd8b87770f92ccb2ea92e4862801240523f0b573
-  ${PACKAGE_NAME}_iree-module-7ab699651c26607f197f63bdf95842ba4fa92cbe6ffa923b869d5df0ff8830a9
-  ${PACKAGE_NAME}_iree-module-7ba873f0f155e857b45f991cbb4e8776f8b137d59ddc5f81a7a23ed2a48eecc9
-  ${PACKAGE_NAME}_iree-module-7d93a3e9b342045ed2546960ee3d08f60be237fd8974fe35447a41234f322148
-  ${PACKAGE_NAME}_iree-module-814b5155d8c819d65ed0ddac829d3af930ae3b03d2ea34afcd4da6f6b429d4dc
-  ${PACKAGE_NAME}_iree-module-88f03be31249d371d00c63d44d44732ad4c348bf2354bd2b3b042465d86f7183
-  ${PACKAGE_NAME}_iree-module-89643b9db9da0c7b822ba8e2ead4ec12fc3093dbde9b7a8570de1be3d46bd54b
-  ${PACKAGE_NAME}_iree-module-8b080ab273c07333a503310e33b4bbaa7599319b6b699755b8853ad7ce2fb28e
-  ${PACKAGE_NAME}_iree-module-8c26886533593b666597f8698e33c0e9c98b349bdf8ac01c3d122cc20b741def
-  ${PACKAGE_NAME}_iree-module-9900b1a0c52b31fc38f1d82ff088102f7131ecbb3fc1b8274929481337d031c5
-  ${PACKAGE_NAME}_iree-module-995595b7b80370d9c484413e9d06c2de928db32777101c91d3bac0d3797058ec
-  ${PACKAGE_NAME}_iree-module-99b28083e2bcb855cc6ead27a57d4efbd6a8c54205897ab226fe15bf321e239a
-  ${PACKAGE_NAME}_iree-module-9a47ca4b87dc126e967d6c9e51894212c20afbae0abddf64c1dbad6a8a0a595a
-  ${PACKAGE_NAME}_iree-module-9c8197e62299f79c373535d91c48acd1b3522264bd7a3d885683570bfc20164c
-  ${PACKAGE_NAME}_iree-module-9e1870e43977999573defd36f2a4540f70b69acf7a330f5133fd8170265cff23
-  ${PACKAGE_NAME}_iree-module-9f427ef22efcf4736dda3c87b30a8af80f3071eaba07f6d5e9795c2631effc4e
-  ${PACKAGE_NAME}_iree-module-9f4cafa63a150cabdf61a945dc6a04c9ddac88b75260bb4ce668199cdddbd581
-  ${PACKAGE_NAME}_iree-module-a1cdbcd72bb0b7672c5739b372df09aef8d26cf16c58d8da81b45800833a5735
-  ${PACKAGE_NAME}_iree-module-a28fb3589ad3175aced5b87acb35b791bb71ce005c58f9c3fbadb2df907d7ba6
-  ${PACKAGE_NAME}_iree-module-a52ef9f5a8c064a4cbf52ea82b694d2c0bb9a0dd43d3576131335ab5453b62a4
-  ${PACKAGE_NAME}_iree-module-a6f73626c6b41d410da11809d66d613293a0e3c298d491d6fb25e3729cf6685e
-  ${PACKAGE_NAME}_iree-module-b3da705f46e262d026b6bb01dcf484f35f05ed083ec0319e3b8515f578f02310
-  ${PACKAGE_NAME}_iree-module-b3f2a0c268a0a8752ccbb56f013455197c466635637b535778a494dab316cf9e
-  ${PACKAGE_NAME}_iree-module-b441bdf92d5b74f62726235c0f98e82aa10a21e4092cad147f670484b2d43c7e
-  ${PACKAGE_NAME}_iree-module-b51439857023ae098fdc5771cad8d554c0f865605270629e76758d962a9e77ef
-  ${PACKAGE_NAME}_iree-module-b93a8c82dcab5bd300153626e5ae1de06f18ad1a36c25d324204daf654f0fdab
-  ${PACKAGE_NAME}_iree-module-ba0cb8d4941adfcae0682c84d819555f118b56b7161475386ceeadb7c4b71f09
-  ${PACKAGE_NAME}_iree-module-ba0e837ccb2c4b017df4e2397b3cec6565b2c6b84193ee738a95aef872a39fe7
-  ${PACKAGE_NAME}_iree-module-bf4bda91fb17ec7f3402e7b301cb3ab0b7a9b0b00d8cee29fd4cfa46262a5ea1
-  ${PACKAGE_NAME}_iree-module-c16715c83936394998fe81f8d33f6e7901f17ff662dfd2941a3982f85c3a9e17
-  ${PACKAGE_NAME}_iree-module-c451b302f020e742b3e66964f5909018fa51d93c753ea337b1bdfea6b69e0901
-  ${PACKAGE_NAME}_iree-module-c947d0e7889a515a4e58bdbd1688f028ca88351dbd7ec501d9fb13a08c27503f
-  ${PACKAGE_NAME}_iree-module-d7ff0ce530c700c18dc4704dfcb75ec14540bd0794faee823a3cc1cd62ea53df
-  ${PACKAGE_NAME}_iree-module-d980bb01bd509b62a7610ae2aaa02fcb864582cf9827136a65f2483fd85b5c66
-  ${PACKAGE_NAME}_iree-module-e70546885f5488d986fffccc21a118d82aa7933b7dccfe47b0093591e081231f
-  ${PACKAGE_NAME}_iree-module-e9496836f964df336279914bb907889f071893aac3a0d069f6a318e9a74e4c23
-  ${PACKAGE_NAME}_iree-module-eaccfeb996e96d52d357fb276b3c864a4050fa8cf77f3f305ac2b64918037a37
-  ${PACKAGE_NAME}_iree-module-eadf521de1a4748e1bc771e923e8116aa357b70cb836447757fdbbfc4ad60073
-  ${PACKAGE_NAME}_iree-module-f1051eab627311cccb5da9e85ca9ccca9697b8701a004935a9b7f959151cdbd7
-  ${PACKAGE_NAME}_iree-module-feae531426d546aae8f1c579bfb8183a1315caa6347fe9efa99660a7c7c40947
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BERT_LARGE_JAX_384XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargePTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1024_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1280_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1024_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch1280_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch16_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch24_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch32_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch48_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch512_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargefp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-RESNET50_FP32_JAX_3X224X224XF32_BATCH8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch128_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch128_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch2048_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch256_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch8_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch128_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch1_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch2048_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch256_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch64_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50fp16PTBatch8_linalg___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch16_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH16_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH1_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH24_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH32_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH48_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH512_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5_LARGE_FP32_JAX_512XI32_BATCH64_stablehlo___cuda-sm_80-linux_gnu-cuda__default-flags_
 )
 
 add_dependencies(iree-benchmark-suites-riscv
-  ${PACKAGE_NAME}_iree-module-14a15b9072caaee5e2a274a9bbc436a56d095611e5a8e9841f110741d34231f9
-  ${PACKAGE_NAME}_iree-module-1ef2da238443010024d69ceb6fe6ab6fa8cf5f4ce7d424dace3a572592043e70
-  ${PACKAGE_NAME}_iree-module-68f0eb37bb72d0d6605ecdf42691c64125960e122844b0beeae350871a445b1c
-  ${PACKAGE_NAME}_iree-module-93034e879f88475eeeff56dd38297a1d1183f123fbbf5925a07b7c934e5f5d48
-  ${PACKAGE_NAME}_iree-module-9d909aa679e8c380ff7e93292ef28dbd3bb9e7cc62329f90aef78ce9c7efeff9
-  ${PACKAGE_NAME}_iree-module-a7a1553d0739151f06bbc00a3ef8b67b0606463eab4b6607069aa94ea0bfd92f
-  ${PACKAGE_NAME}_iree-module-d399d2540161867967b0590a659d0a86206e145d884bd7afd9abd818713aacd2
-  ${PACKAGE_NAME}_iree-module-e80d71ed8e86c0756226b2323e27e2c7c0fff8eddde59ba69e9222d36ee3eef6
-  ${PACKAGE_NAME}_iree-module-e850fce2d36ddb09ccc34471641adb77418b93c0949d22ab75806d7cfc489ae3
-  ${PACKAGE_NAME}_iree-module-f59cd43a2a2d6e4b3159efa358a6fa0879e72f6f4f0a23af4c8ab550f256986a
-  ${PACKAGE_NAME}_iree-module-f963d812114af925e0a4b110ee83aeb0e3b41d49fad19b3f449b6a9ccba43b8d
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___riscv_32-generic-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___riscv_64-generic-linux_gnu-llvm_cpu__default-flags_
 )
 
 add_dependencies(iree-benchmark-suites-vulkan-nvidia
-  ${PACKAGE_NAME}_iree-module-337a3ab92a878301dc4bdd2554739b59ebf7925d85af42ee16780ba6c6dee0d8
-  ${PACKAGE_NAME}_iree-module-63a1dd898daa56fc3a0bff652cb5b2e0483cfe90e9dcd7994b73183b7ce106b2
-  ${PACKAGE_NAME}_iree-module-b5d399322ea7d5e831efb647928974f7f3abce21b2220af9cf9344ccea411545
-  ${PACKAGE_NAME}_iree-module-d0d1a869e3f3901f6f60afaf57160ce888a852f6703efc79756415d43cfcd13e
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_
+  ${PACKAGE_NAME}_iree-module-ClipTextSeqLen64PT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___nvidia-ampere-vulkan_linux-vulkan_spirv__experimental-flags_tensorcore_
+  ${PACKAGE_NAME}_iree-module-Unet2dPT_linalg___nvidia-pascal-vulkan_linux-vulkan_spirv__experimental-flags_simt_
 )
 
 add_dependencies(iree-benchmark-suites-x86_64
-  ${PACKAGE_NAME}_iree-module-02cebfbec13685725c5b3c805c6c620ea3f885027bfbb14d17425798e391486f
-  ${PACKAGE_NAME}_iree-module-047e75c462648b5fe1133f4ffbc3d1c7bdda154081d3eaa3be0b5445725b272b
-  ${PACKAGE_NAME}_iree-module-1c7402f88ba881ec6abb39204faa4b5fedb2ffff4a6066555fcff0c7c4b74732
-  ${PACKAGE_NAME}_iree-module-3926415c1504dfc277674fee17bdfbd68090634b8b52620d8d5755082a89a16d
-  ${PACKAGE_NAME}_iree-module-3ba167fc59b5959be276b331951c759391d6e158572fc05603981dcc4bd3fc90
-  ${PACKAGE_NAME}_iree-module-3dbf200159f328bb69c6c5bc79cce408a4ba49d2d07dfb3939786557e63d035c
-  ${PACKAGE_NAME}_iree-module-429d7055b93250cc19866107e305bef1dc0b7e49e579ef19ea1eeb70eb2fb86d
-  ${PACKAGE_NAME}_iree-module-472e6a18344f13d47e89f87670b37eff583ae610c2a1d15ac1cca307ccfc2f4d
-  ${PACKAGE_NAME}_iree-module-4b61f532e6cf4e175a7e90cd9418e3c2614176b5253875951f99e52d2621c152
-  ${PACKAGE_NAME}_iree-module-50084c6a5ef433943ae46fbbf852d266d20557be110fff9dea1e4e298040c7c6
-  ${PACKAGE_NAME}_iree-module-531f99d8bc669343f967598c13ca787c62b01b4dfcd7c4b4ad04a163063a1ddc
-  ${PACKAGE_NAME}_iree-module-711cb4e615cc4e032fe9f198b89e32f4f85c94cab6e9101eb8202b22c97a37b1
-  ${PACKAGE_NAME}_iree-module-737d273c18eb7537e2dde47c4a46391e8657c38f9650032c39bc67fa5f132742
-  ${PACKAGE_NAME}_iree-module-759fdb2deb885ca5568741853e3497ab3d7037a42a4fdff0af590c803681ec60
-  ${PACKAGE_NAME}_iree-module-78154d58dddac432100d656b22fa9bcb45e4207a9ea2bc371bf089a68bad397a
-  ${PACKAGE_NAME}_iree-module-7e0380f1df059cf6040c12934af4f1c88a469c716a294f383200d5dd5cc69b1d
-  ${PACKAGE_NAME}_iree-module-80a2368e148d9605d98060027b9198dea46efbf050a383784ec5df5e85904757
-  ${PACKAGE_NAME}_iree-module-87aead729018ce5f114501cecefb6315086eb2a21ae1b30984b1794f619871c6
-  ${PACKAGE_NAME}_iree-module-8d15dde1c8c2ed90009698c357455dfc94fd96ae877f4892954bef0ec4361de8
-  ${PACKAGE_NAME}_iree-module-92dd923f493f67509a6b54007416f16ac8e6f2023e88f79b3017ea2260ee561a
-  ${PACKAGE_NAME}_iree-module-95dee09d7f3f9ee36d6c70645585b44b347ea001a1ab9a04b150ca2dc052255f
-  ${PACKAGE_NAME}_iree-module-9a2128d69c5c5a51402e01c4a848e90ec369fa601a3d9fc1ab69dab8db47e6d3
-  ${PACKAGE_NAME}_iree-module-9c849d0ccfc89c0bca0740949572db8735832012a43c4c9f15c3a8ef0d9cca04
-  ${PACKAGE_NAME}_iree-module-a30b64a3d7850881ee9db94e8f75c661af3f76f48d10b3342a6912e1c8879252
-  ${PACKAGE_NAME}_iree-module-aed1ca2855056bcd5b7e51063741685b4a387d9d0574b343e8ddc383b49afc76
-  ${PACKAGE_NAME}_iree-module-baec9d4086496a94853f349354f87acb8397bf36169134d3269d5803888dcf49
-  ${PACKAGE_NAME}_iree-module-c37bfe2bb995b2703170a890bd81e372b687bed57087b1d8a6d8bb16b91c5ad4
-  ${PACKAGE_NAME}_iree-module-c8949024e2472bec7b18c4e3757412715c248273005ca6f8d5769656ed425a84
-  ${PACKAGE_NAME}_iree-module-eb56e91246a131fa41bd335c1c072ffb6e7ffe651ecf65f4eeb171b12848b0ed
-  ${PACKAGE_NAME}_iree-module-f146632eb124afeb899eeae8aaf5ab6cd9efae22ee9ffb26d34fe1da10049fbe
-  ${PACKAGE_NAME}_iree-module-fd5cf4cd75cc1734be3eec2f4396491e9ebb7edd6b9c889cdc29ef72b47d6233
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNetB7PT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2SPT_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_fuse-padding_
 )
 
 add_dependencies(iree-benchmark-suites-x86_64-large
-  ${PACKAGE_NAME}_iree-module-0c8eaa0d8238c24ed0c6598e6e713d556697ae695d94d1af142f2f019ead6a31
-  ${PACKAGE_NAME}_iree-module-10a9a8a00ac0f36f45b5e35a032ca177b68621e3137dc57b9d6e08225301441b
-  ${PACKAGE_NAME}_iree-module-1b4cbc14c2735bd4bd2d990f46e6f4843d66a6f688e492e6a02e07d0d4e927ed
-  ${PACKAGE_NAME}_iree-module-3407fbbc5cb24c7ef432987ec1af9b01dc3626dbe40278bda37c3b3d7c5ac000
-  ${PACKAGE_NAME}_iree-module-35d83c1c7042590bdda6b704e51c4b2f4af38bd2ed9db75a00632e3f2db1149d
-  ${PACKAGE_NAME}_iree-module-780f3809138cfab6b31646debd8b87770f92ccb2ea92e4862801240523f0b573
-  ${PACKAGE_NAME}_iree-module-a1cdbcd72bb0b7672c5739b372df09aef8d26cf16c58d8da81b45800833a5735
-  ${PACKAGE_NAME}_iree-module-ba0cb8d4941adfcae0682c84d819555f118b56b7161475386ceeadb7c4b71f09
-  ${PACKAGE_NAME}_iree-module-eadf521de1a4748e1bc771e923e8116aa357b70cb836447757fdbbfc4ad60073
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch128_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TFBatch64_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch16_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch1_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-T5LargeTFBatch32_stablehlo___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_
 )


### PR DESCRIPTION
Initially we think using artificial benchmark ID (UUID, SHA) for artifacts and targets because:
1. Conflict free and no special characters for build and CI system (for example, gcloud cli doesn't accept `[]` because [they're the wildcards](https://github.com/GoogleCloudPlatform/gsutil/issues/290)).
2. Artifact filenames are fixed length, no need to worry about the limits of path length on file systems.

And the human-readable `benchmark-flags.txt` should provide enough information for navigating in the artifacts.

This is not so true because it's very intuitive to simply browser the artifact directories to find the needed artifacts. So this change reverts the previous decision and use the sanitized config name for artifacts and build targets.

To avoid conflict, before sanitization, all config names are verified to be unique. There is a chance that conflict happens after the sanitization (after repalcing disallowed characters with `_`) but I think the chance is low. If there is a conflict in build targets, CMake will let users now. We can also consider to use `__` as replacements to further reduce the chance of conflict.

Here is an example of the build rule with the longest name:

```
iree_bytecode_module(
  NAME "iree-module-MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_compile-stats_"
  SRC "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_tflite_.mlir"
  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_compile-stats_/module.vmfb"
  FLAGS
    "--iree-hal-target-backends=vulkan-spirv"
    "--iree-input-type=tosa"
    "--iree-vulkan-target-triple=valhall-unknown-android31"
    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
    "--iree-stream-partitioning-favor=max-concurrency"
    "--iree-hal-benchmark-dispatch-repeat-count=32"
    "--iree-flow-demote-f32-to-f16"
    "--iree-vm-emit-polyglot-zip=true"
    "--iree-llvmcpu-debug-symbols=false"
    "--iree-scheduling-dump-statistics-format=json"
    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_compile-stats_/scheduling_stats.json"
  FRIENDLY_NAME "MobileBertSquad_fp16(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,demote-f32-to-f16,compile-stats]"
  PUBLIC
)
```

The longest filename `iree_module_MobileBertSquad_fp16_tflite___arm-valhall-vulkan_android31-vulkan_spirv__experimental-flags_fuse-padding_max-concurrency_repeated-kernel_demote-f32-to-f16_compile-stats_/scheduling_stats.json` is 203 characters, which is not ideal. But we can think about shortening the name (e.g. not directly using the concatenation of tags in the name)