### PR TITLE
NFC: Thread subgroup size through transform dialect based GPU strategies

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
@@ -62,7 +62,6 @@ static llvm::cl::opt<int64_t> clPipelineDepth(
     llvm::cl::init(3));
 
 using iree_compiler::gpu::AbstractGemmLikeStrategy;
-using iree_compiler::gpu::kCudaWarpSize;
 
 /// Key function for vtable.
 AbstractGemmLikeStrategy::~AbstractGemmLikeStrategy() {}
@@ -105,7 +104,7 @@ AbstractGemmLikeStrategy::getZeroPadAttrFromElementalTypes(OpBuilder &b) const {
 
 LogicalResult
 AbstractGemmLikeStrategy::validate(const GPUModel &gpuModel) const {
-  if (totalNumThreads() != totalNumWarps() * kCudaWarpSize) {
+  if (totalNumThreads() != totalNumWarps() * gpuModel.subgroupSize) {
     llvm::errs() << "Number of threads specified by warps must match total "
                     "number of threads\n";
     return failure();

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -9,6 +9,7 @@
 
 #include "iree-dialects/Transforms/TransformMatchers.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/MappingInfo.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 
 namespace llvm {
@@ -19,10 +20,8 @@ namespace mlir {
 namespace iree_compiler {
 namespace gpu {
 
-struct GPUModel;
-
-struct AbstractGemmLikeStrategy {
-  AbstractGemmLikeStrategy() {}
+struct AbstractGemmLikeStrategy : GPUStrategy {
+  AbstractGemmLikeStrategy(const GPUModel &gpuModel) : GPUStrategy(gpuModel) {}
 
   virtual ~AbstractGemmLikeStrategy();
 

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.h
@@ -18,6 +18,8 @@ namespace mlir {
 namespace iree_compiler {
 namespace gpu {
 
+struct GPUModel;
+
 //===----------------------------------------------------------------------===//
 // Base quantities generally useful for all GPU strategies.
 //===----------------------------------------------------------------------===//
@@ -52,8 +54,6 @@ inline Attribute linearIdZ(MLIRContext *ctx) {
 //===----------------------------------------------------------------------===//
 // General helpers.
 //===----------------------------------------------------------------------===//
-static constexpr int64_t kCudaWarpSize = 32;
-static constexpr int64_t kCudaMaxNumThreads = 1024;
 static constexpr int64_t kCudaMaxVectorLoadBitWidth = 128;
 
 /// Return max(1, (value * 32) / bitWidth).
@@ -81,7 +81,7 @@ Value buildMapToBlockAndThreads(ImplicitLocOpBuilder &b, Value funcH,
 /// Takes a handle to a func.func and returns an updated handle to a
 /// func.func.
 Value buildDistributeVectors(ImplicitLocOpBuilder &b, Value variantH,
-                             Value funcH, int64_t warpSize = kCudaWarpSize);
+                             Value funcH, int64_t warpSize);
 
 /// Take care of the last common steps in a GPU strategy (i.e. vectorize,
 /// bufferize, maps to blocks and threads and distribute vectors).
@@ -185,16 +185,6 @@ void buildPipelineSharedMemoryCopies(ImplicitLocOpBuilder &b, Value funcH,
                                      const AbstractGemmLikeStrategy &strategy);
 
 Value buildBufferize(ImplicitLocOpBuilder &b, Value variantH);
-
-//===----------------------------------------------------------------------===//
-// Higher-level problem-specific strategy creation APIs, these should favor
-// user-friendliness.
-//===----------------------------------------------------------------------===//
-
-/// Try to find an exisiting transform dialect strategy for a given entry point.
-LogicalResult matchAndSetTransformStrategy(func::FuncOp entryPoint,
-                                           Operation *op,
-                                           const GPUModel &gpuModel);
 
 } // namespace gpu
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -44,7 +44,6 @@ using iree_compiler::gpu::buildHoistOutputPaddingOp;
 using iree_compiler::gpu::buildMatmulVectorization;
 using iree_compiler::gpu::buildMultiBuffering;
 using iree_compiler::gpu::buildPipelineSharedMemoryCopies;
-using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::MappingInfo;
 using iree_compiler::gpu::MatmulStrategy;
 using iree_compiler::gpu::scaleUpByBitWidth;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -30,8 +30,9 @@ struct GPUModel;
 class MatmulStrategy : public AbstractGemmLikeStrategy {
 public:
   MatmulStrategy(MLIRContext *context,
-                 const transform_ext::MatchedMatmulCaptures &captures)
-      : AbstractGemmLikeStrategy(), ctx(context), captures(captures) {
+                 const transform_ext::MatchedMatmulCaptures &captures,
+                 const GPUModel &gpuModel)
+      : AbstractGemmLikeStrategy(gpuModel), ctx(context), captures(captures) {
     initDefaultValues();
   }
 

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.cpp
@@ -39,7 +39,6 @@ using iree_compiler::gpu::buildBufferize;
 using iree_compiler::gpu::buildConvertToAsyncCopies;
 using iree_compiler::gpu::buildDistributeOnePadOrCopyWithNumThreads;
 using iree_compiler::gpu::buildDistributeOnePadOrCopyWithTileSizes;
-using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::PadStrategy;
 using iree_compiler::IREE::transform_dialect::
     IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.h
@@ -11,22 +11,21 @@
 
 #include "iree-dialects/Transforms/TransformMatchers.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace gpu {
 
-struct GPUModel;
-
 struct PadConfig {};
 
 /// Simple padding strategy.
-class PadStrategy {
+class PadStrategy : GPUStrategy {
 public:
   PadStrategy(MLIRContext *context,
               const transform_ext::MatchedPadCaptures &captures,
-              const PadConfig &config)
-      : ctx(context), captures(captures) {
+              const PadConfig &config, const GPUModel &gpuModel)
+      : ctx(context), GPUStrategy(gpuModel), captures(captures) {
     initDefaultValues();
     (void)config;
   }

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.cpp
@@ -39,9 +39,7 @@ using iree_compiler::gpu::adjustNumberOfWarpsForBlockShuffle;
 using iree_compiler::gpu::build1DSplittingStrategyWithOptionalThreadMapping;
 using iree_compiler::gpu::buildCommonTrailingStrategy;
 using iree_compiler::gpu::buildDistributeVectors;
-using iree_compiler::gpu::kCudaMaxNumThreads;
 using iree_compiler::gpu::kCudaMaxVectorLoadBitWidth;
-using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::ReductionConfig;
 using iree_compiler::gpu::scaleUpByBitWidth;
 using iree_compiler::gpu::SmallReductionStrategy;
@@ -51,8 +49,8 @@ using iree_compiler::gpu::threadZ;
 
 mlir::iree_compiler::gpu::SmallReductionStrategy::SmallReductionStrategy(
     const transform_ext::MatchedReductionCaptures &captures,
-    const ReductionConfig &reductionConfig)
-    : AbstractReductionStrategy(captures, {}) {
+    const ReductionConfig &reductionConfig, const GPUModel &gpuModel)
+    : AbstractReductionStrategy(captures, {}), GPUStrategy(gpuModel) {
   configure(reductionConfig);
   LLVM_DEBUG(DBGS() << "use GPU small reduction strategy\n");
   LLVM_DEBUG(llvm::interleaveComma(workgroupTileSizes,
@@ -64,7 +62,7 @@ void mlir::iree_compiler::gpu::SmallReductionStrategy::configure(
     const ReductionConfig &reductionConfig) {
   int64_t maxNumThreadsToUse = reductionConfig.maxNumThreads;
   assert(maxNumThreadsToUse > 0 && "maxNumThreadsToUse must be > 0");
-  assert(maxNumThreadsToUse >= kCudaWarpSize && "not even a warp?");
+  assert(maxNumThreadsToUse >= subgroupSize && "not even a warp?");
 
   // Block-level
   // ===========
@@ -84,13 +82,13 @@ void mlir::iree_compiler::gpu::SmallReductionStrategy::configure(
     maybeDivisor = 1;
 
   // If the captured dimension has no satisfactory divisor, just tile the last
-  // parallel dimension by 2 * kCudaWarpSize.
+  // parallel dimension by 2 * subgroupSize.
   int64_t numParallelLoops = captures.reductionRank - 1;
   workgroupTileSizes.append(numParallelLoops, 1);
   workgroupTileSizes.back() =
       hasTrailingElementwise
           ? *maybeDivisor
-          : std::min((int64_t)maxNumThreadsToUse, (int64_t)(2 * kCudaWarpSize));
+          : std::min((int64_t)maxNumThreadsToUse, (int64_t)(2 * subgroupSize));
 
   // Thread-level
   // ============

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.h
@@ -11,13 +11,11 @@
 
 #include "iree/compiler/Codegen/TransformStrategies/Common/AbstractReductionStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace gpu {
-
-struct GPUModel;
-struct ReductionConfig;
 
 /// Encode a strategy targeted at (very) small reductions, for which other
 /// strategies perform poorly.
@@ -41,11 +39,11 @@ struct ReductionConfig;
 // reductions without catastrophic regressions.
 // TODO: Add another strategy based on segmented scans, which can allow us
 // to force sizes that don't divide properly into warp shuffles.
-class SmallReductionStrategy : public AbstractReductionStrategy {
+class SmallReductionStrategy : public AbstractReductionStrategy, GPUStrategy {
 public:
   SmallReductionStrategy(
       const transform_ext::MatchedReductionCaptures &captures,
-      const ReductionConfig &reductionConfig);
+      const ReductionConfig &reductionConfig, const GPUModel &gpuModel);
 
   SmallReductionStrategy(const SmallReductionStrategy &) = default;
   SmallReductionStrategy &operator=(const SmallReductionStrategy &) = default;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Codegen/TransformStrategies/Common/Common.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/StagedReductionStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
@@ -66,9 +67,7 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectPadStrategy(
 // TODO: significantly better namespacing.
 using iree_compiler::gpu::AbstractGemmLikeStrategy;
 using iree_compiler::gpu::GPUModel;
-using iree_compiler::gpu::kCudaMaxNumThreads;
 using iree_compiler::gpu::kCudaMaxVectorLoadBitWidth;
-using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::MatmulStrategy;
 using iree_compiler::gpu::PadConfig;
 using iree_compiler::gpu::PadStrategy;
@@ -146,9 +145,9 @@ getReductionConfig(const transform_ext::MatchedReductionCaptures &captures,
   bool isDynamicReduction = ShapedType::isDynamic(redSize);
   // Otherwise, still only support the small cases for now and fall back to
   // other strategies otherwise.
-  bool isSmallReduction = (redSize < 2 * kCudaWarpSize);
+  bool isSmallReduction = (redSize < 2 * gpuModel.subgroupSize);
   if (!isDynamicReduction && isSmallReduction) {
-    int64_t maxNumThreads = 4 * kCudaWarpSize;
+    int64_t maxNumThreads = 4 * gpuModel.subgroupSize;
     return ReductionConfig{maxNumThreads, 0, ReductionStrategy::Small};
   }
 
@@ -157,37 +156,43 @@ getReductionConfig(const transform_ext::MatchedReductionCaptures &captures,
   //===--------------------------------------------------------------------===//
   int64_t bitWidth = captures.reductionOutputElementalTypeBitWidth;
   int64_t vectorSize = scaleUpByBitWidth(4, bitWidth);
-  int64_t maxNumThreads = 8 * kCudaWarpSize;
+  int64_t maxNumThreads = 8 * gpuModel.subgroupSize;
   // No adjustments in the dynamic case, we need extra information to make a
   // good decision.
   if (ShapedType::isDynamic(redSize))
     return ReductionConfig{maxNumThreads, vectorSize,
                            ReductionStrategy::Staged};
   // Scale down to smaller sizes (4, 8, 16)-warps.
-  if (scaleUpByBitWidth(redSize, bitWidth) <= 4 * kCudaWarpSize) {
+  if (scaleUpByBitWidth(redSize, bitWidth) <= 4 * gpuModel.subgroupSize) {
     vectorSize = scaleUpByBitWidth(1, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
-  } else if (scaleUpByBitWidth(redSize, bitWidth) <= 8 * kCudaWarpSize) {
+    maxNumThreads = 4 * gpuModel.subgroupSize;
+  } else if (scaleUpByBitWidth(redSize, bitWidth) <=
+             8 * gpuModel.subgroupSize) {
     vectorSize = scaleUpByBitWidth(2, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
-  } else if (scaleUpByBitWidth(redSize, bitWidth) <= 8 * 2 * kCudaWarpSize) {
+    maxNumThreads = 4 * gpuModel.subgroupSize;
+  } else if (scaleUpByBitWidth(redSize, bitWidth) <=
+             8 * 2 * gpuModel.subgroupSize) {
     vectorSize = scaleUpByBitWidth(4, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
+    maxNumThreads = 4 * gpuModel.subgroupSize;
   }
   // Scale up to larger sizes (32, 64, 128+)-warps, using vector-4.
   if (!captures.trailingOpSizes.empty()) {
-    if (scaleUpByBitWidth(redSize, bitWidth) >= 128 * 4 * kCudaWarpSize) {
+    if (scaleUpByBitWidth(redSize, bitWidth) >=
+        128 * 4 * gpuModel.subgroupSize) {
       vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 32 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 64 * 4 * kCudaWarpSize) {
+      maxNumThreads = 32 * gpuModel.subgroupSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >=
+               64 * 4 * gpuModel.subgroupSize) {
       vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 16 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 32 * 4 * kCudaWarpSize) {
+      maxNumThreads = 16 * gpuModel.subgroupSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >=
+               32 * 4 * gpuModel.subgroupSize) {
       vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 8 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 16 * 4 * kCudaWarpSize) {
+      maxNumThreads = 8 * gpuModel.subgroupSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >=
+               16 * 4 * gpuModel.subgroupSize) {
       vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 4 * kCudaWarpSize;
+      maxNumThreads = 4 * gpuModel.subgroupSize;
     }
   }
   return ReductionConfig{maxNumThreads, vectorSize, ReductionStrategy::Staged};
@@ -226,11 +231,11 @@ static LogicalResult matchAndSetReductionStrategy(func::FuncOp entryPoint,
   auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
     ReductionConfig reductionConfig = getReductionConfig(captures, gpuModel);
     if (reductionConfig.strategy == ReductionStrategy::Small) {
-      SmallReductionStrategy strategy(captures, reductionConfig);
+      SmallReductionStrategy strategy(captures, reductionConfig, gpuModel);
       return buildSmallReductionStrategy(b, variant, strategy);
     } else if (reductionConfig.strategy == ReductionStrategy::Staged) {
       // Otherwise, always fallback to the staged strategy.
-      StagedReductionStrategy strategy(captures, reductionConfig);
+      StagedReductionStrategy strategy(captures, reductionConfig, gpuModel);
       return buildStagedReductionStrategy(b, variant, strategy);
     } else {
       return llvm_unreachable("Unknown strategy");
@@ -315,7 +320,7 @@ static MatmulStrategy
 getMatmulConfig(MLIRContext *context,
                 const transform_ext::MatchedMatmulCaptures &captures,
                 const GPUModel &gpuModel) {
-  MatmulStrategy strategy(context, captures);
+  MatmulStrategy strategy(context, captures, gpuModel);
   if (strategy.cliOptionsSpecified)
     return strategy;
 
@@ -492,7 +497,7 @@ static LogicalResult matchAndSetPadStrategy(func::FuncOp entryPoint,
   // 2. Construct the strategy builder.
   PadConfig padConfig = getPadConfig(captures, gpuModel);
   iree_compiler::gpu::PadStrategy strategy(op->getContext(), captures,
-                                           padConfig);
+                                           padConfig, gpuModel);
   if (strategy.useAsyncCopies) {
     LDBG("--Async copies not supported yet\n");
     return failure();

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h
@@ -7,10 +7,8 @@
 #ifndef IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_STRATEGIES_H_
 #define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_STRATEGIES_H_
 
-#include "iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h"
-#include "iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.h"
-#include "iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.h"
-#include "iree/compiler/Codegen/TransformStrategies/GPU/StagedReductionStrategy.h"
+#include "llvm/ADT/StringRef.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace mlir {
 class ImplicitLocOpBuilder;
@@ -18,15 +16,43 @@ class Value;
 namespace iree_compiler {
 namespace gpu {
 
+/// Forward declarations of all supported strategies.
+struct MatmulStrategy;
+class PadStrategy;
+class SmallReductionStrategy;
+class StagedReductionStrategy;
+
+static constexpr int64_t kCudaWarpSize = 32;
+static constexpr int64_t kCudaMaxNumThreads = 1024;
+
 /// Placeholder for some hardware model proxy that contains relevant information
-/// to configure the reduction strategy. In the future, this will need to be
+/// to configure the strategies. In the future, this will need to be
 /// driven by some contract with the runtime.
 struct GPUModel {
-  static constexpr StringLiteral kDefaultGPU = "DefaultGPU";
-  StringRef model = kDefaultGPU;
+  static constexpr llvm::StringLiteral kDefaultGPU = "DefaultGPU";
+  llvm::StringRef model = kDefaultGPU;
+  /// TODO: Support a range of subgroup sizes.
+  int64_t subgroupSize = kCudaWarpSize;
+  int64_t maxWorkGroupInvocations = kCudaMaxNumThreads;
+  int64_t maxWorkGroupSize[3] = {1024, 1024, 64};
   bool hasWarpShuffle = false;
   bool hasTF32TensorCore = false;
   bool hasMmaSync = false;
+};
+
+//===--------------------------------------------------------------------===//
+// GPU strategy base.
+//===--------------------------------------------------------------------===//
+/// Basic structure to hold target specific information needed for all gpu
+/// strategies. Certain quantities that can be dynamically selected, such as
+/// subgroup size, will need to be configured with some contract with the
+/// runtime.
+struct GPUStrategy {
+  /// TODO: Configure subgroup size with the strategy and return the selected
+  /// size to the target (i.e. LLVMGPU or SPIR-V).
+  GPUStrategy(const GPUModel &gpuModel) : subgroupSize(gpuModel.subgroupSize) {}
+  /// TODO: Add other quantities relevant to strategy builders.
+  int64_t subgroupSize;
 };
 
 //===--------------------------------------------------------------------===//
@@ -81,6 +107,16 @@ void buildSmallReductionStrategy(ImplicitLocOpBuilder &b, Value variantH,
 /// Supports an optional leading and an optional trailing elementwise operation.
 void buildStagedReductionStrategy(ImplicitLocOpBuilder &b, Value variantH,
                                   const StagedReductionStrategy &strategy);
+
+//===----------------------------------------------------------------------===//
+// Higher-level strategy creation APIs, these should favor
+// user-friendliness.
+//===----------------------------------------------------------------------===//
+
+/// Try to find an exisiting transform dialect strategy for a given entry point.
+LogicalResult matchAndSetTransformStrategy(func::FuncOp entryPoint,
+                                           Operation *op,
+                                           const GPUModel &gpuModel);
 
 } // namespace gpu
 } // namespace iree_compiler


### PR DESCRIPTION
In preparation for generalizing along the hardware axis (in particular SPIR-V), this tries to decouple some hard-coded CUDA elements from GPU strategies. Subgroup size is somewhat unique in that some targets support variable sizes.