### PR TITLE
[TransformStrategies] NFC: Harden matmul strategy defaults

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
@@ -67,7 +67,6 @@ static llvm::cl::opt<bool> clPeelPipelineEpilogue(
     llvm::cl::init(false));
 
 using iree_compiler::gpu::AbstractGemmLikeStrategy;
-using iree_compiler::gpu::kCudaWarpSize;
 
 /// Key function for vtable.
 AbstractGemmLikeStrategy::~AbstractGemmLikeStrategy() {}
@@ -112,7 +111,7 @@ AbstractGemmLikeStrategy::getZeroPadAttrFromElementalTypes(OpBuilder &b) const {
 
 LogicalResult
 AbstractGemmLikeStrategy::validate(const GPUModel &gpuModel) const {
-  if (totalNumThreads() != totalNumWarps() * kCudaWarpSize) {
+  if (totalNumThreads() != totalNumWarps() * gpuModel.subgroupSize) {
     llvm::errs() << "Number of threads specified by warps must match total "
                     "number of threads\n";
     return failure();

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
@@ -114,7 +114,6 @@ void AbstractGemmLikeStrategy::initDefaultValues(const GPUModel &gpuModel) {
     numWarps = numThreads;
     numWarps[0] = mlir::ceilDiv(numWarps[0], gpuModel.subgroupSize);
   }
-  /// TODO: Restrict based on hardware support.
   if (clUseAsyncCopies.getNumOccurrences())
     useAsyncCopies = clUseAsyncCopies;
   else

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.cpp
@@ -10,6 +10,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+#include "mlir/Support/MathExtras.h"
 
 using namespace mlir;
 
@@ -22,56 +23,48 @@ static llvm::cl::list<int64_t> clBlockTileSizes(
     "td-matmul-strategy-blk-sizes",
     llvm::cl::desc("block tile size for dims (x,y,z) for the transform "
                    "dialect matmul strategy"),
-    llvm::cl::list_init(ArrayRef<int64_t>{128, 128, 1}),
     llvm::cl::CommaSeparated);
 static llvm::cl::opt<int64_t> clReductionTileSize(
     "td-matmul-strategy-reduc-size",
     llvm::cl::desc(
-        "reduction tile sized for the transform dialect matmul strategy"),
-    llvm::cl::init(16));
+        "reduction tile sized for the transform dialect matmul strategy"));
 static llvm::cl::list<int64_t> clNumThreads(
     "td-matmul-strategy-num-threads",
     llvm::cl::desc("number of threads for dims (x,y,z) for the transform "
                    "dialect matmul strategy"),
-    llvm::cl::list_init(ArrayRef<int64_t>{64, 2, 1}), llvm::cl::CommaSeparated);
+    llvm::cl::CommaSeparated);
 static llvm::cl::list<int64_t> clNumWarps(
     "td-matmul-strategy-num-warps",
     llvm::cl::desc("number of warps for dims (x,y,z) for the transform "
                    "dialect matmul strategy"),
-    llvm::cl::list_init(ArrayRef<int64_t>{2, 2, 1}), llvm::cl::CommaSeparated);
+    llvm::cl::CommaSeparated);
 static llvm::cl::opt<bool> clUseAsyncCopies(
     "td-matmul-strategy-use-async-copies",
     llvm::cl::desc(
-        "use asynchronous copies for the transform dialect matmul strategy"),
-    llvm::cl::init(true));
+        "use asynchronous copies for the transform dialect matmul strategy"));
 static llvm::cl::opt<bool> clUseMmaSync(
     "td-matmul-strategy-use-mma-sync",
-    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"),
-    llvm::cl::init(true));
+    llvm::cl::desc("use mma sync for the transform dialect matmul strategy"));
 static llvm::cl::opt<bool> clUseWmma(
     "td-matmul-strategy-use-wmma",
-    llvm::cl::desc("use wmma for the transform dialect matmul strategy"),
-    llvm::cl::init(false));
+    llvm::cl::desc("use wmma for the transform dialect matmul strategy"));
 static llvm::cl::opt<bool> clUseFma(
     "td-matmul-strategy-use-fma",
-    llvm::cl::desc("use fma for the transform dialect matmul strategy"),
-    llvm::cl::init(false));
+    llvm::cl::desc("use fma for the transform dialect matmul strategy"));
 static llvm::cl::opt<int64_t> clPipelineDepth(
     "td-matmul-strategy-pipeline-depth",
-    llvm::cl::desc("pipeline depth for the transform dialect matmul strategy"),
-    llvm::cl::init(3));
+    llvm::cl::desc("pipeline depth for the transform dialect matmul strategy"));
 static llvm::cl::opt<bool> clPeelPipelineEpilogue(
     "td-matmul-strategy-peel-pipeline-epilogue",
     llvm::cl::desc("whether to peel the pipeline epilogue for the transform "
-                   "dialect matmul strategy"),
-    llvm::cl::init(false));
+                   "dialect matmul strategy"));
 
 using iree_compiler::gpu::AbstractGemmLikeStrategy;
 
 /// Key function for vtable.
 AbstractGemmLikeStrategy::~AbstractGemmLikeStrategy() {}
 
-void AbstractGemmLikeStrategy::initDefaultValues() {
+void AbstractGemmLikeStrategy::initDefaultValues(const GPUModel &gpuModel) {
   blockTileSizes =
       SmallVector<int64_t>{clBlockTileSizes.begin(), clBlockTileSizes.end()};
   numThreads = SmallVector<int64_t>{clNumThreads.begin(), clNumThreads.end()};
@@ -84,16 +77,86 @@ void AbstractGemmLikeStrategy::initDefaultValues() {
   pipelineDepth = clPipelineDepth;
   peelPipelineEpilogue = clPeelPipelineEpilogue;
 
-  if (!clBlockTileSizes.isDefaultAssigned() ||
-      !clNumThreads.isDefaultAssigned() || !clNumWarps.isDefaultAssigned() ||
-      reductionTileSize != clReductionTileSize.getDefault().getValue() ||
-      useAsyncCopies != clUseAsyncCopies.getDefault().getValue() ||
-      useMmaSync != clUseMmaSync.getDefault().getValue() ||
-      useWmma != clUseWmma.getDefault().getValue() ||
-      useFma != clUseFma.getDefault().getValue() ||
-      pipelineDepth != clPipelineDepth.getDefault().getValue() ||
-      peelPipelineEpilogue != clPeelPipelineEpilogue.getDefault().getValue()) {
+  /// cliOptionsSpecified is used to override hard-coded well known good
+  /// defaults when set.
+  if (clBlockTileSizes.getNumOccurrences() ||
+      clNumThreads.getNumOccurrences() || clNumWarps.getNumOccurrences() ||
+      clReductionTileSize.getNumOccurrences() ||
+      clUseAsyncCopies.getNumOccurrences() ||
+      clUseMmaSync.getNumOccurrences() || clUseWmma.getNumOccurrences() ||
+      clUseFma.getNumOccurrences() || clPipelineDepth.getNumOccurrences() ||
+      clPeelPipelineEpilogue.getNumOccurrences()) {
     cliOptionsSpecified = true;
+  }
+
+  /// Default configuration based on hardware properties and problem bit widths.
+  if (clBlockTileSizes.getNumOccurrences()) {
+    blockTileSizes =
+        SmallVector<int64_t>(clBlockTileSizes.begin(), clBlockTileSizes.end());
+  } else {
+    blockTileSizes = SmallVector<int64_t>{128, 128, 1};
+  }
+
+  if (clNumThreads.getNumOccurrences()) {
+    numThreads = SmallVector<int64_t>(clNumThreads.begin(), clNumThreads.end());
+  } else {
+    // Infer from warp counts if present.
+    if (clNumWarps.getNumOccurrences()) {
+      numThreads = SmallVector<int64_t>(clNumWarps.begin(), clNumWarps.end());
+      numThreads[0] *= gpuModel.subgroupSize;
+    } else {
+      numThreads = SmallVector<int64_t>{64, 2, 1};
+    }
+  }
+  if (clNumWarps.getNumOccurrences()) {
+    numWarps = SmallVector<int64_t>(clNumWarps.begin(), clNumWarps.end());
+  } else {
+    numWarps = numThreads;
+    numWarps[0] = mlir::ceilDiv(numWarps[0], gpuModel.subgroupSize);
+  }
+  /// TODO: Restrict based on hardware support.
+  if (clUseAsyncCopies.getNumOccurrences())
+    useAsyncCopies = clUseAsyncCopies;
+  else
+    useAsyncCopies = gpuModel.hasMmaSync;
+  if (clUseMmaSync.getNumOccurrences())
+    useMmaSync = clUseMmaSync;
+  if (clUseWmma.getNumOccurrences())
+    useWmma = clUseWmma;
+  if (clUseFma.getNumOccurrences())
+    useFma = clUseFma;
+  /// If not specified, select instructions to target for compute.
+  if (!useMmaSync && !useWmma && !useFma) {
+    /// First, try to use tensor core.
+    if (getLhsElementalType() == getRhsElementalType()) {
+      /// Currently all supported targets at least have WMMA.
+      /// TODO: Handle targets without tensor core.
+      if (gpuModel.hasMmaSync)
+        useMmaSync = true;
+      else
+        useWmma = true;
+    } else {
+      /// Mixed precision only supported by fma.
+      useFma = true;
+    }
+  }
+  if (clReductionTileSize.getNumOccurrences()) {
+    reductionTileSize = clReductionTileSize;
+  } else {
+    reductionTileSize = 16;
+    if (!useFma) {
+      int64_t maxInputWidth =
+          std::max(lhsElementalBitWidth(), rhsElementalBitWidth());
+      assert(maxInputWidth <= 32 && "requires <= 32-bit types");
+      reductionTileSize *= (32 / maxInputWidth);
+    }
+  }
+  if (clPipelineDepth.getNumOccurrences()) {
+    pipelineDepth = clPipelineDepth;
+  } else {
+    pipelineDepth = 0;
+    if (useAsyncCopies)
+      pipelineDepth = 3;
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -31,7 +31,7 @@ struct AbstractGemmLikeStrategy : GPUStrategy {
 
   /// Initialize values from the CLI. Set cliOptionsSpecified to true if the
   /// default CLI values have been overriden.
-  virtual void initDefaultValues();
+  virtual void initDefaultValues(const GPUModel &gpuModel);
 
   /// Encodes whether the user has specified any CLI options. When true, the
   /// strategy should just run what was specified and is not allowed to
@@ -80,9 +80,19 @@ struct AbstractGemmLikeStrategy : GPUStrategy {
 
   ArrayAttr getZeroPadAttrFromElementalTypes(OpBuilder &b) const;
 
-  int64_t lhsElementalBitWidth = 32;
-  int64_t rhsElementalBitWidth = 32;
-  int64_t resElementalBitWidth = 32;
+  virtual Type getLhsElementalType() const = 0;
+  virtual Type getRhsElementalType() const = 0;
+  virtual Type getResElementalType() const = 0;
+
+  int64_t lhsElementalBitWidth() const {
+    return getLhsElementalType().getIntOrFloatBitWidth();
+  }
+  int64_t rhsElementalBitWidth() const {
+    return getRhsElementalType().getIntOrFloatBitWidth();
+  }
+  int64_t resElementalBitWidth() const {
+    return getResElementalType().getIntOrFloatBitWidth();
+  }
 
   bool alignedLhs() const {
     return m() % blockTileM() == 0 && k() % reductionTileSize == 0;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/AbstractGemmLikeStrategy.h
@@ -9,6 +9,7 @@
 
 #include "iree-dialects/Transforms/TransformMatchers.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/MappingInfo.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 
 namespace llvm {
@@ -19,10 +20,8 @@ namespace mlir {
 namespace iree_compiler {
 namespace gpu {
 
-struct GPUModel;
-
-struct AbstractGemmLikeStrategy {
-  AbstractGemmLikeStrategy() {}
+struct AbstractGemmLikeStrategy : GPUStrategy {
+  AbstractGemmLikeStrategy(const GPUModel &gpuModel) : GPUStrategy(gpuModel) {}
 
   virtual ~AbstractGemmLikeStrategy();
 

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.h
@@ -18,6 +18,8 @@ namespace mlir {
 namespace iree_compiler {
 namespace gpu {
 
+struct GPUModel;
+
 //===----------------------------------------------------------------------===//
 // Base quantities generally useful for all GPU strategies.
 //===----------------------------------------------------------------------===//
@@ -52,8 +54,6 @@ inline Attribute linearIdZ(MLIRContext *ctx) {
 //===----------------------------------------------------------------------===//
 // General helpers.
 //===----------------------------------------------------------------------===//
-static constexpr int64_t kCudaWarpSize = 32;
-static constexpr int64_t kCudaMaxNumThreads = 1024;
 static constexpr int64_t kCudaMaxVectorLoadBitWidth = 128;
 
 /// Return max(1, (value * 32) / bitWidth).
@@ -81,7 +81,7 @@ Value buildMapToBlockAndThreads(ImplicitLocOpBuilder &b, Value funcH,
 /// Takes a handle to a func.func and returns an updated handle to a
 /// func.func.
 Value buildDistributeVectors(ImplicitLocOpBuilder &b, Value variantH,
-                             Value funcH, int64_t warpSize = kCudaWarpSize);
+                             Value funcH, int64_t warpSize);
 
 /// Take care of the last common steps in a GPU strategy (i.e. vectorize,
 /// bufferize, maps to blocks and threads and distribute vectors).
@@ -185,16 +185,6 @@ void buildPipelineSharedMemoryCopies(ImplicitLocOpBuilder &b, Value funcH,
                                      const AbstractGemmLikeStrategy &strategy);
 
 Value buildBufferize(ImplicitLocOpBuilder &b, Value variantH);
-
-//===----------------------------------------------------------------------===//
-// Higher-level problem-specific strategy creation APIs, these should favor
-// user-friendliness.
-//===----------------------------------------------------------------------===//
-
-/// Try to find an exisiting transform dialect strategy for a given entry point.
-LogicalResult matchAndSetTransformStrategy(func::FuncOp entryPoint,
-                                           Operation *op,
-                                           const GPUModel &gpuModel);
 
 } // namespace gpu
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -44,7 +44,6 @@ using iree_compiler::gpu::buildHoistOutputPaddingOp;
 using iree_compiler::gpu::buildMatmulVectorization;
 using iree_compiler::gpu::buildMultiBuffering;
 using iree_compiler::gpu::buildPipelineSharedMemoryCopies;
-using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::MappingInfo;
 using iree_compiler::gpu::MatmulStrategy;
 using iree_compiler::gpu::scaleUpByBitWidth;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h
@@ -30,8 +30,9 @@ struct GPUModel;
 class MatmulStrategy : public AbstractGemmLikeStrategy {
 public:
   MatmulStrategy(MLIRContext *context,
-                 const transform_ext::MatchedMatmulCaptures &captures)
-      : AbstractGemmLikeStrategy(), ctx(context), captures(captures) {
+                 const transform_ext::MatchedMatmulCaptures &captures,
+                 const GPUModel &gpuModel)
+      : AbstractGemmLikeStrategy(gpuModel), ctx(context), captures(captures) {
     initDefaultValues();
   }
 

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.cpp
@@ -39,7 +39,6 @@ using iree_compiler::gpu::buildBufferize;
 using iree_compiler::gpu::buildConvertToAsyncCopies;
 using iree_compiler::gpu::buildDistributeOnePadOrCopyWithNumThreads;
 using iree_compiler::gpu::buildDistributeOnePadOrCopyWithTileSizes;
-using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::PadStrategy;
 using iree_compiler::IREE::transform_dialect::
     IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.h
@@ -11,22 +11,21 @@
 
 #include "iree-dialects/Transforms/TransformMatchers.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace gpu {
 
-struct GPUModel;
-
 struct PadConfig {};
 
 /// Simple padding strategy.
-class PadStrategy {
+class PadStrategy : GPUStrategy {
 public:
   PadStrategy(MLIRContext *context,
               const transform_ext::MatchedPadCaptures &captures,
-              const PadConfig &config)
-      : ctx(context), captures(captures) {
+              const PadConfig &config, const GPUModel &gpuModel)
+      : ctx(context), GPUStrategy(gpuModel), captures(captures) {
     initDefaultValues();
     (void)config;
   }

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.cpp
@@ -39,9 +39,7 @@ using iree_compiler::gpu::adjustNumberOfWarpsForBlockShuffle;
 using iree_compiler::gpu::build1DSplittingStrategyWithOptionalThreadMapping;
 using iree_compiler::gpu::buildCommonTrailingStrategy;
 using iree_compiler::gpu::buildDistributeVectors;
-using iree_compiler::gpu::kCudaMaxNumThreads;
 using iree_compiler::gpu::kCudaMaxVectorLoadBitWidth;
-using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::ReductionConfig;
 using iree_compiler::gpu::scaleUpByBitWidth;
 using iree_compiler::gpu::SmallReductionStrategy;
@@ -51,8 +49,8 @@ using iree_compiler::gpu::threadZ;
 
 mlir::iree_compiler::gpu::SmallReductionStrategy::SmallReductionStrategy(
     const transform_ext::MatchedReductionCaptures &captures,
-    const ReductionConfig &reductionConfig)
-    : AbstractReductionStrategy(captures, {}) {
+    const ReductionConfig &reductionConfig, const GPUModel &gpuModel)
+    : AbstractReductionStrategy(captures, {}), GPUStrategy(gpuModel) {
   configure(reductionConfig);
   LLVM_DEBUG(DBGS() << "use GPU small reduction strategy\n");
   LLVM_DEBUG(llvm::interleaveComma(workgroupTileSizes,
@@ -64,7 +62,7 @@ void mlir::iree_compiler::gpu::SmallReductionStrategy::configure(
     const ReductionConfig &reductionConfig) {
   int64_t maxNumThreadsToUse = reductionConfig.maxNumThreads;
   assert(maxNumThreadsToUse > 0 && "maxNumThreadsToUse must be > 0");
-  assert(maxNumThreadsToUse >= kCudaWarpSize && "not even a warp?");
+  assert(maxNumThreadsToUse >= subgroupSize && "not even a warp?");
 
   // Block-level
   // ===========
@@ -84,13 +82,13 @@ void mlir::iree_compiler::gpu::SmallReductionStrategy::configure(
     maybeDivisor = 1;
 
   // If the captured dimension has no satisfactory divisor, just tile the last
-  // parallel dimension by 2 * kCudaWarpSize.
+  // parallel dimension by 2 * subgroupSize.
   int64_t numParallelLoops = captures.reductionRank - 1;
   workgroupTileSizes.append(numParallelLoops, 1);
   workgroupTileSizes.back() =
       hasTrailingElementwise
           ? *maybeDivisor
-          : std::min((int64_t)maxNumThreadsToUse, (int64_t)(2 * kCudaWarpSize));
+          : std::min((int64_t)maxNumThreadsToUse, (int64_t)(2 * subgroupSize));
 
   // Thread-level
   // ============

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.h
@@ -11,13 +11,11 @@
 
 #include "iree/compiler/Codegen/TransformStrategies/Common/AbstractReductionStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace gpu {
-
-struct GPUModel;
-struct ReductionConfig;
 
 /// Encode a strategy targeted at (very) small reductions, for which other
 /// strategies perform poorly.
@@ -41,11 +39,11 @@ struct ReductionConfig;
 // reductions without catastrophic regressions.
 // TODO: Add another strategy based on segmented scans, which can allow us
 // to force sizes that don't divide properly into warp shuffles.
-class SmallReductionStrategy : public AbstractReductionStrategy {
+class SmallReductionStrategy : public AbstractReductionStrategy, GPUStrategy {
 public:
   SmallReductionStrategy(
       const transform_ext::MatchedReductionCaptures &captures,
-      const ReductionConfig &reductionConfig);
+      const ReductionConfig &reductionConfig, const GPUModel &gpuModel);
 
   SmallReductionStrategy(const SmallReductionStrategy &) = default;
   SmallReductionStrategy &operator=(const SmallReductionStrategy &) = default;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
@@ -421,6 +421,15 @@ static LogicalResult matchAndSetMatmulStrategy(func::FuncOp entryPoint,
     return failure();
   }
 
+  // Limit the types that we choose to support without user intervention for
+  // tensor core.
+  if (!strategy.useFma && !strategy.cliOptionsSpecified &&
+      (!captures.lhsElementType.isF32() || !captures.rhsElementType.isF32() ||
+       !captures.outputElementType.isF32())) {
+    LDBG("--Matmul strategy elemental type check failed\n");
+    return failure();
+  }
+
   // 2. Construct the configuration and the strategy builder.
   // TODO: Generalize along the HW axis.
   auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Codegen/TransformStrategies/Common/Common.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/StagedReductionStrategy.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
@@ -66,9 +67,7 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectPadStrategy(
 // TODO: significantly better namespacing.
 using iree_compiler::gpu::AbstractGemmLikeStrategy;
 using iree_compiler::gpu::GPUModel;
-using iree_compiler::gpu::kCudaMaxNumThreads;
 using iree_compiler::gpu::kCudaMaxVectorLoadBitWidth;
-using iree_compiler::gpu::kCudaWarpSize;
 using iree_compiler::gpu::MatmulStrategy;
 using iree_compiler::gpu::PadConfig;
 using iree_compiler::gpu::PadStrategy;
@@ -146,9 +145,9 @@ getReductionConfig(const transform_ext::MatchedReductionCaptures &captures,
   bool isDynamicReduction = ShapedType::isDynamic(redSize);
   // Otherwise, still only support the small cases for now and fall back to
   // other strategies otherwise.
-  bool isSmallReduction = (redSize < 2 * kCudaWarpSize);
+  bool isSmallReduction = (redSize < 2 * gpuModel.subgroupSize);
   if (!isDynamicReduction && isSmallReduction) {
-    int64_t maxNumThreads = 4 * kCudaWarpSize;
+    int64_t maxNumThreads = 4 * gpuModel.subgroupSize;
     return ReductionConfig{maxNumThreads, 0, ReductionStrategy::Small};
   }
 
@@ -157,37 +156,43 @@ getReductionConfig(const transform_ext::MatchedReductionCaptures &captures,
   //===--------------------------------------------------------------------===//
   int64_t bitWidth = captures.reductionOutputElementalTypeBitWidth;
   int64_t vectorSize = scaleUpByBitWidth(4, bitWidth);
-  int64_t maxNumThreads = 8 * kCudaWarpSize;
+  int64_t maxNumThreads = 8 * gpuModel.subgroupSize;
   // No adjustments in the dynamic case, we need extra information to make a
   // good decision.
   if (ShapedType::isDynamic(redSize))
     return ReductionConfig{maxNumThreads, vectorSize,
                            ReductionStrategy::Staged};
   // Scale down to smaller sizes (4, 8, 16)-warps.
-  if (scaleUpByBitWidth(redSize, bitWidth) <= 4 * kCudaWarpSize) {
+  if (scaleUpByBitWidth(redSize, bitWidth) <= 4 * gpuModel.subgroupSize) {
     vectorSize = scaleUpByBitWidth(1, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
-  } else if (scaleUpByBitWidth(redSize, bitWidth) <= 8 * kCudaWarpSize) {
+    maxNumThreads = 4 * gpuModel.subgroupSize;
+  } else if (scaleUpByBitWidth(redSize, bitWidth) <=
+             8 * gpuModel.subgroupSize) {
     vectorSize = scaleUpByBitWidth(2, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
-  } else if (scaleUpByBitWidth(redSize, bitWidth) <= 8 * 2 * kCudaWarpSize) {
+    maxNumThreads = 4 * gpuModel.subgroupSize;
+  } else if (scaleUpByBitWidth(redSize, bitWidth) <=
+             8 * 2 * gpuModel.subgroupSize) {
     vectorSize = scaleUpByBitWidth(4, bitWidth);
-    maxNumThreads = 4 * kCudaWarpSize;
+    maxNumThreads = 4 * gpuModel.subgroupSize;
   }
   // Scale up to larger sizes (32, 64, 128+)-warps, using vector-4.
   if (!captures.trailingOpSizes.empty()) {
-    if (scaleUpByBitWidth(redSize, bitWidth) >= 128 * 4 * kCudaWarpSize) {
+    if (scaleUpByBitWidth(redSize, bitWidth) >=
+        128 * 4 * gpuModel.subgroupSize) {
       vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 32 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 64 * 4 * kCudaWarpSize) {
+      maxNumThreads = 32 * gpuModel.subgroupSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >=
+               64 * 4 * gpuModel.subgroupSize) {
       vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 16 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 32 * 4 * kCudaWarpSize) {
+      maxNumThreads = 16 * gpuModel.subgroupSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >=
+               32 * 4 * gpuModel.subgroupSize) {
       vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 8 * kCudaWarpSize;
-    } else if (scaleUpByBitWidth(redSize, bitWidth) >= 16 * 4 * kCudaWarpSize) {
+      maxNumThreads = 8 * gpuModel.subgroupSize;
+    } else if (scaleUpByBitWidth(redSize, bitWidth) >=
+               16 * 4 * gpuModel.subgroupSize) {
       vectorSize = scaleUpByBitWidth(4, bitWidth);
-      maxNumThreads = 4 * kCudaWarpSize;
+      maxNumThreads = 4 * gpuModel.subgroupSize;
     }
   }
   return ReductionConfig{maxNumThreads, vectorSize, ReductionStrategy::Staged};
@@ -226,11 +231,11 @@ static LogicalResult matchAndSetReductionStrategy(func::FuncOp entryPoint,
   auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
     ReductionConfig reductionConfig = getReductionConfig(captures, gpuModel);
     if (reductionConfig.strategy == ReductionStrategy::Small) {
-      SmallReductionStrategy strategy(captures, reductionConfig);
+      SmallReductionStrategy strategy(captures, reductionConfig, gpuModel);
       return buildSmallReductionStrategy(b, variant, strategy);
     } else if (reductionConfig.strategy == ReductionStrategy::Staged) {
       // Otherwise, always fallback to the staged strategy.
-      StagedReductionStrategy strategy(captures, reductionConfig);
+      StagedReductionStrategy strategy(captures, reductionConfig, gpuModel);
       return buildStagedReductionStrategy(b, variant, strategy);
     } else {
       return llvm_unreachable("Unknown strategy");
@@ -315,7 +320,7 @@ static MatmulStrategy
 getMatmulConfig(MLIRContext *context,
                 const transform_ext::MatchedMatmulCaptures &captures,
                 const GPUModel &gpuModel) {
-  MatmulStrategy strategy(context, captures);
+  MatmulStrategy strategy(context, captures, gpuModel);
   if (strategy.cliOptionsSpecified)
     return strategy;
 
@@ -485,7 +490,7 @@ static LogicalResult matchAndSetPadStrategy(func::FuncOp entryPoint,
   // 2. Construct the strategy builder.
   PadConfig padConfig = getPadConfig(captures, gpuModel);
   iree_compiler::gpu::PadStrategy strategy(op->getContext(), captures,
-                                           padConfig);
+                                           padConfig, gpuModel);
   if (strategy.useAsyncCopies) {
     LDBG("--Async copies not supported yet\n");
     return failure();

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h
@@ -7,10 +7,8 @@
 #ifndef IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_STRATEGIES_H_
 #define IREE_COMPILER_CODEGEN_TRANSFORM_DIALECT_STRATEGIES_GPU_STRATEGIES_H_
 
-#include "iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.h"
-#include "iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.h"
-#include "iree/compiler/Codegen/TransformStrategies/GPU/SmallReductionStrategy.h"
-#include "iree/compiler/Codegen/TransformStrategies/GPU/StagedReductionStrategy.h"
+#include "llvm/ADT/StringRef.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace mlir {
 class ImplicitLocOpBuilder;
@@ -18,15 +16,43 @@ class Value;
 namespace iree_compiler {
 namespace gpu {
 
+/// Forward declarations of all supported strategies.
+struct MatmulStrategy;
+class PadStrategy;
+class SmallReductionStrategy;
+class StagedReductionStrategy;
+
+static constexpr int64_t kCudaWarpSize = 32;
+static constexpr int64_t kCudaMaxNumThreads = 1024;
+
 /// Placeholder for some hardware model proxy that contains relevant information
-/// to configure the reduction strategy. In the future, this will need to be
+/// to configure the strategies. In the future, this will need to be
 /// driven by some contract with the runtime.
 struct GPUModel {
-  static constexpr StringLiteral kDefaultGPU = "DefaultGPU";
-  StringRef model = kDefaultGPU;
+  static constexpr llvm::StringLiteral kDefaultGPU = "DefaultGPU";
+  llvm::StringRef model = kDefaultGPU;
+  /// TODO: Support a range of subgroup sizes.
+  int64_t subgroupSize = kCudaWarpSize;
+  int64_t maxWorkGroupInvocations = kCudaMaxNumThreads;
+  int64_t maxWorkGroupSize[3] = {1024, 1024, 64};
   bool hasWarpShuffle = false;
   bool hasTF32TensorCore = false;
   bool hasMmaSync = false;
+};
+
+//===--------------------------------------------------------------------===//
+// GPU strategy base.
+//===--------------------------------------------------------------------===//
+/// Basic structure to hold target specific information needed for all gpu
+/// strategies. Certain quantities that can be dynamically selected, such as
+/// subgroup size, will need to be configured with some contract with the
+/// runtime.
+struct GPUStrategy {
+  /// TODO: Configure subgroup size with the strategy and return the selected
+  /// size to the target (i.e. LLVMGPU or SPIR-V).
+  GPUStrategy(const GPUModel &gpuModel) : subgroupSize(gpuModel.subgroupSize) {}
+  /// TODO: Add other quantities relevant to strategy builders.
+  int64_t subgroupSize;
 };
 
 //===--------------------------------------------------------------------===//
@@ -81,6 +107,16 @@ void buildSmallReductionStrategy(ImplicitLocOpBuilder &b, Value variantH,
 /// Supports an optional leading and an optional trailing elementwise operation.
 void buildStagedReductionStrategy(ImplicitLocOpBuilder &b, Value variantH,
                                   const StagedReductionStrategy &strategy);
+
+//===----------------------------------------------------------------------===//
+// Higher-level strategy creation APIs, these should favor
+// user-friendliness.
+//===----------------------------------------------------------------------===//
+
+/// Try to find an exisiting transform dialect strategy for a given entry point.
+LogicalResult matchAndSetTransformStrategy(func::FuncOp entryPoint,
+                                           Operation *op,
+                                           const GPUModel &gpuModel);
 
 } // namespace gpu
 } // namespace iree_compiler


### PR DESCRIPTION
The existing flag approach for configuring matmul strategies from the
command line is difficult to maintain as we generalize to other matmul
shapes/parameters and targets. This moves the default strategy values
from the flag defaults to hard-coded constants while making the flag
defaults represent "optional" values.

This creates seemingly two places where matmul strategies are
configured, but the roles are slightly different. Defaults should be
independent of problem shape and make sense for the compilation target,
while externally configured values are driven by known performance.

Rebased on top of #14221.