### PR TITLE
Add `vector.fma` to the list of bf16 arith operations

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
@@ -276,9 +276,9 @@ struct ConvertBf16ArithToF32Pass
     target.addDynamicallyLegalDialect<math::MathDialect>(checkOp);
 
     // Some arithmetic operations exist in the vector dialect.
-    target
-        .addDynamicallyLegalOp<vector::ReductionOp, vector::MultiDimReductionOp,
-                               vector::MaskOp, vector::YieldOp>(checkOp);
+    target.addDynamicallyLegalOp<vector::FMAOp, vector::ReductionOp,
+                                 vector::MultiDimReductionOp, vector::MaskOp,
+                                 vector::YieldOp>(checkOp);
 
     // Some ops are always legal.
     target.addLegalOp<arith::BitcastOp>();


### PR DESCRIPTION
When wrapping numerical operations we need to include `vector.fma` to the list. Vectorized convolutions were failing due to this operation missing.