### PR TITLE
[NFC] Move LLVMCPUVectorization pass to common GenericVectorization pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -162,6 +162,7 @@ iree_compiler_cc_library(
         "FoldTensorExtractOpPass.cpp",
         "ForOpCanonicalizationPass.cpp",
         "FuseTensorPadWithConsumer.cpp",
+        "GenericVectorization.cpp",
         "HoistStaticallyBoundAllocations.cpp",
         "IREEComprehensiveBufferizePass.cpp",
         "IREEExpandStridedMetadata.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -137,6 +137,7 @@ iree_cc_library(
     "FoldTensorExtractOpPass.cpp"
     "ForOpCanonicalizationPass.cpp"
     "FuseTensorPadWithConsumer.cpp"
+    "GenericVectorization.cpp"
     "HoistStaticallyBoundAllocations.cpp"
     "IREEComprehensiveBufferizePass.cpp"
     "IREEExpandStridedMetadata.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
-#include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Codegen/Common/PassDetail.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
@@ -21,7 +21,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#define DEBUG_TYPE "iree-llvmcpu-vectorization"
+#define DEBUG_TYPE "iree-codegen-generic-vectorization"
 #define VEC_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 
 namespace mlir {
@@ -211,11 +211,11 @@ getVectorSizes(linalg::LinalgOp linalgOp,
   return vecSize;
 }
 
-class LLVMCPUVectorizationPass
-    : public LLVMCPUVectorizationBase<LLVMCPUVectorizationPass> {
+class GenericVectorizationPass
+    : public GenericVectorizationBase<GenericVectorizationPass> {
 public:
-  using LLVMCPUVectorizationBase::LLVMCPUVectorizationBase;
-  LLVMCPUVectorizationPass(const LLVMCPUVectorizationPassOptions &options) {
+  using GenericVectorizationBase::GenericVectorizationBase;
+  GenericVectorizationPass(const GenericVectorizationPassOptions &options) {
     this->enableVectorMasking.setValue(options.enableVectorMasking);
     this->vectorizePadding.setValue(options.vectorizePadding);
     this->vectorizeGatherAccesses.setValue(options.vectorizeGatherAccesses);
@@ -228,7 +228,7 @@ public:
   void runOnOperation() override;
 };
 
-void LLVMCPUVectorizationPass::runOnOperation() {
+void GenericVectorizationPass::runOnOperation() {
   MLIRContext *context = &getContext();
   auto funcOp = getOperation();
   SmallVector<int64_t> canonicalVectorShape;
@@ -303,12 +303,12 @@ void LLVMCPUVectorizationPass::runOnOperation() {
 }
 } // namespace
 
-std::unique_ptr<OperationPass<func::FuncOp>> createLLVMCPUVectorizationPass() {
-  return std::make_unique<LLVMCPUVectorizationPass>();
+std::unique_ptr<OperationPass<func::FuncOp>> createGenericVectorizationPass() {
+  return std::make_unique<GenericVectorizationPass>();
 }
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLLVMCPUVectorizationPass(const LLVMCPUVectorizationPassOptions &options) {
-  return std::make_unique<LLVMCPUVectorizationPass>(options);
+createGenericVectorizationPass(const GenericVectorizationPassOptions &options) {
+  return std::make_unique<GenericVectorizationPass>(options);
 }
 } // namespace iree_compiler
 } // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -130,6 +130,7 @@ struct GenericVectorizationPassOptions {
   bool vectorizePadding = false;
   bool vectorizeGatherAccesses = false;
 };
+/// Creates a pass to perform vectorization on LinAlg and tensor ops.
 std::unique_ptr<OperationPass<func::FuncOp>> createGenericVectorizationPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createGenericVectorizationPass(const GenericVectorizationPassOptions &options);

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -125,6 +125,15 @@ std::unique_ptr<OperationPass<func::FuncOp>> createForOpCanonicalizationPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createFuseTensorPadWithConsumerPass();
 
+struct GenericVectorizationPassOptions {
+  bool enableVectorMasking = false;
+  bool vectorizePadding = false;
+  bool vectorizeGatherAccesses = false;
+};
+std::unique_ptr<OperationPass<func::FuncOp>> createGenericVectorizationPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createGenericVectorizationPass(const GenericVectorizationPassOptions &options);
+
 std::unique_ptr<OperationPass<func::FuncOp>>
 createHoistStaticallyBoundAllocationsPass();
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -212,6 +212,21 @@ def FuseTensorPadWithConsumer :
   let constructor = "mlir::iree_compiler::createFuseTensorPadWithConsumerPass()";
 }
 
+def GenericVectorization :
+    Pass<"iree-codegen-generic-vectorization", "func::FuncOp"> {
+  let summary = "Pass to perform vectorization on tensor/linalg ops.";
+  let options = [
+    Option<"enableVectorMasking", "enable-vector-masking", "bool",/*default=*/"false",
+      "Enable vector masking during vectorization.">,
+    Option<"vectorizePadding", "vectorize-padding", "bool", /*default=*/"false",
+      "Rewrite all tensor.pad ops in the function to vector form.">,
+    Option<"vectorizeGatherAccesses", "vectorize-gather-accesses", "bool", /*default=*/"false",
+      "Enable vectorizaiton of operations that may generate vector.gather operations.">,
+  ];
+  let constructor =
+      "mlir::iree_compiler::createGenericVectorizationPass()";
+}
+
 def HoistStaticallyBoundAllocations :
     Pass<"iree-hoist-statically-bound-allocations", "func::FuncOp"> {
   let summary = "Hoist statically bound alloca ops to the entry block of functions";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -68,7 +68,6 @@ iree_compiler_cc_library(
         "LLVMCPUTileAndFuse.cpp",
         "LLVMCPUUnfuseFMAOps.cpp",
         "LLVMCPUVectorLowering.cpp",
-        "LLVMCPUVectorization.cpp",
         "Passes.cpp",
         "TargetMLTransformInfo.cpp",
         "TileSizeSelection.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -70,7 +70,6 @@ iree_cc_library(
     "LLVMCPUTileAndFuse.cpp"
     "LLVMCPUUnfuseFMAOps.cpp"
     "LLVMCPUVectorLowering.cpp"
-    "LLVMCPUVectorization.cpp"
     "Passes.cpp"
     "TargetMLTransformInfo.cpp"
     "TileSizeSelection.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -334,11 +334,11 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager,
       createLLVMCPUTilePass(tilingConfig.getVectorParallelLevel()));
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMCPUPeelPass());
   {
-    LLVMCPUVectorizationPassOptions options;
+    GenericVectorizationPassOptions options;
     options.enableVectorMasking = enableVectorMasking;
     options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
-        createLLVMCPUVectorizationPass(options));
+        createGenericVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
@@ -377,12 +377,12 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager,
       createLLVMCPUTensorPadPass(LLVMCPUTensorPadOption::ReductionDims));
 
   {
-    LLVMCPUVectorizationPassOptions options;
+    GenericVectorizationPassOptions options;
     options.enableVectorMasking = enableVectorMasking;
     options.vectorizePadding = true;
     options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
-        createLLVMCPUVectorizationPass(options));
+        createGenericVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
@@ -485,12 +485,12 @@ void addMultiTilingExpertPassPipeline(
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
 
-    LLVMCPUVectorizationPassOptions options;
+    GenericVectorizationPassOptions options;
     options.enableVectorMasking = enableVectorMasking;
     options.vectorizePadding = true;
     options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
-        createLLVMCPUVectorizationPass(options));
+        createGenericVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
@@ -546,12 +546,12 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager,
 
   {
     nestedModulePM.addNestedPass<func::FuncOp>(createVectorizePadPass());
-    LLVMCPUVectorizationPassOptions options;
+    GenericVectorizationPassOptions options;
     options.enableVectorMasking = enableVectorMasking;
     options.vectorizePadding = true;
     options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
-        createLLVMCPUVectorizationPass(options));
+        createGenericVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
@@ -598,7 +598,7 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager,
     nestedModulePM.addNestedPass<func::FuncOp>(createLLVMCPUTilePass(
         static_cast<int64_t>(tilingConfig.getVectorReductionLevel())));
     nestedModulePM.addNestedPass<func::FuncOp>(
-        createLLVMCPUVectorizationPass());
+        createGenericVectorizationPass());
   }
 
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -622,10 +622,10 @@ void addCPUDataTilingPipeline(OpPassManager &passManager,
       createDecomposePackUnPackOpsPass());
 
   {
-    LLVMCPUVectorizationPassOptions options;
+    GenericVectorizationPassOptions options;
     options.vectorizePadding = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
-        createLLVMCPUVectorizationPass(options));
+        createGenericVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -91,15 +91,6 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMCPUVectorLoweringPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMCPUVectorLoweringPass(
     const LLVMCPUVectorLoweringPassOptions &options);
 
-struct LLVMCPUVectorizationPassOptions {
-  bool enableVectorMasking = false;
-  bool vectorizePadding = false;
-  bool vectorizeGatherAccesses = false;
-};
-std::unique_ptr<OperationPass<func::FuncOp>> createLLVMCPUVectorizationPass();
-std::unique_ptr<OperationPass<func::FuncOp>>
-createLLVMCPUVectorizationPass(const LLVMCPUVectorizationPassOptions &options);
-
 /// A pass that converts certain vector.contract ops to custom kernels.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createVectorContractCustomKernelsPass();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -152,21 +152,6 @@ def LLVMCPUUnfuseFMAOps :
   let constructor = "mlir::iree_compiler::createLLVMCPUUnfuseFMAOpsPass()";
 }
 
-def LLVMCPUVectorization :
-    Pass<"iree-llvmcpu-vectorization", "func::FuncOp"> {
-  let summary = "Pass to perform vectorization on tensor/linalg ops.";
-  let options = [
-    Option<"enableVectorMasking", "enable-vector-masking", "bool",/*default=*/"false",
-      "Enable vector masking during vectorization.">,
-    Option<"vectorizePadding", "vectorize-padding", "bool", /*default=*/"false",
-      "Rewrite all tensor.pad ops in the function to vector form.">,
-    Option<"vectorizeGatherAccesses", "vectorize-gather-accesses", "bool", /*default=*/"false",
-      "Enable vectorizaiton of operations that may generate vector.gather operations.">,
-  ];
-  let constructor =
-      "mlir::iree_compiler::createLLVMCPUVectorizationPass()";
-}
-
 def LLVMCPUVectorLowering :
     Pass<"iree-llvmcpu-vector-lowering", "func::FuncOp"> {
   let summary = "Pass to lower Vector ops before conversion to LLVM.";


### PR DESCRIPTION
There are nothing CPU specifics in the pass. It is just a pass that converts LinAlg ops and tensor ops to vector ops. Move it to Common/ then we can reuse it for other backends.