### PR TITLE
Add folding arith extension patterns to vectorization post processing.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -271,6 +271,7 @@ void GenericVectorizationPass::runOnOperation() {
   vector::populateVectorTransferPermutationMapLoweringPatterns(
       vectorizationPatterns);
   vector::populateVectorReductionToContractPatterns(vectorizationPatterns);
+  vector::populateFoldArithExtensionPatterns(vectorizationPatterns);
   vectorizationPatterns.add<linalg::LinalgCopyVTRForwardingPattern,
                             linalg::LinalgCopyVTWForwardingPattern>(
       funcOp.getContext(), /*benefit=*/2);


### PR DESCRIPTION
The pattern folds arithmetic extensions on floating point data types into vector contraction operations.