### PR TITLE
[HAL] Fix a bug in buffer_view.buffer folder

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -176,9 +176,7 @@ struct SkipBufferViewBufferOp : public OpRewritePattern<BufferViewBufferOp> {
     if (!createOp)
       return failure();
 
-    APInt offset;
-    if (matchPattern(createOp.getSourceOffset(), m_ConstantInt(&offset)) &&
-        offset.isZero()) {
+    if (matchPattern(createOp.getSourceOffset(), m_Zero())) {
       rewriter.replaceOp(op, createOp.getSourceBuffer());
       return success();
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -165,17 +165,24 @@ void BufferViewCreateOp::getCanonicalizationPatterns(RewritePatternSet &results,
 namespace {
 
 /// Skips a hal.buffer_view.buffer accessor when the buffer view was created in
-/// the same scope and we know the origin buffer.
+/// the same scope at zero offset and we know the origin buffer.
 struct SkipBufferViewBufferOp : public OpRewritePattern<BufferViewBufferOp> {
   using OpRewritePattern<BufferViewBufferOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(BufferViewBufferOp op,
                                 PatternRewriter &rewriter) const override {
-    if (auto createOp = dyn_cast_or_null<BufferViewCreateOp>(
-            op.getBufferView().getDefiningOp())) {
+    auto createOp = dyn_cast_or_null<BufferViewCreateOp>(
+        op.getBufferView().getDefiningOp());
+    if (!createOp)
+      return failure();
+
+    APInt offset;
+    if (matchPattern(createOp.getSourceOffset(), m_ConstantInt(&offset)) &&
+        offset.isZero()) {
       rewriter.replaceOp(op, createOp.getSourceBuffer());
       return success();
     }
+
     return failure();
   }
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
@@ -39,3 +39,21 @@ func.func @SkipBufferViewBufferOp(%buffer : !hal.buffer) -> !hal.buffer {
   // CHECK: return %[[BUFFER]]
   return %view_buffer : !hal.buffer
 }
+
+// -----
+
+// CHECK-LABEL: func.func @DoNotSkipBufferViewBufferOp
+func.func @DoNotSkipBufferViewBufferOp(%buffer : !hal.buffer) -> !hal.buffer {
+  %c1 = arith.constant 1 : i32
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
+  %c32 = arith.constant 32 : i32
+  %view = hal.buffer_view.create buffer(%buffer : !hal.buffer)[%c1, %c10]
+                                 shape([%c10, %c11])
+                                 type(%c32)
+                                 encoding(%c1) : !hal.buffer_view
+  // CHECK: %[[BUFFER:.+]] = hal.buffer_view.buffer
+  %view_buffer = hal.buffer_view.buffer<%view : !hal.buffer_view> : !hal.buffer
+  // CHECK: return %[[BUFFER]]
+  return %view_buffer : !hal.buffer
+}

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
@@ -26,11 +26,11 @@ func.func @FoldBufferViewCreateSubspan(%base_buffer: !hal.buffer, %subspan_offse
 // CHECK-LABEL: func.func @SkipBufferViewBufferOp
 // CHECK-SAME: %[[BUFFER:.+]]: !hal.buffer
 func.func @SkipBufferViewBufferOp(%buffer : !hal.buffer) -> !hal.buffer {
-  %encoding = arith.constant 1 : i32
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index
   %c11 = arith.constant 11 : index
   %c32 = arith.constant 32 : i32
+  %encoding = arith.constant 1 : i32
   %view = hal.buffer_view.create buffer(%buffer : !hal.buffer)[%c0, %c10]
                                  shape([%c10, %c11])
                                  type(%c32)
@@ -44,11 +44,11 @@ func.func @SkipBufferViewBufferOp(%buffer : !hal.buffer) -> !hal.buffer {
 
 // CHECK-LABEL: func.func @DoNotSkipBufferViewBufferOp
 func.func @DoNotSkipBufferViewBufferOp(%buffer : !hal.buffer) -> !hal.buffer {
-  %encoding = arith.constant 1 : i32
   %c5 = arith.constant 5 : index
   %c10 = arith.constant 10 : index
   %c11 = arith.constant 11 : index
   %c32 = arith.constant 32 : i32
+  %encoding = arith.constant 1 : i32
   %view = hal.buffer_view.create buffer(%buffer : !hal.buffer)[%c5, %c10]
                                  shape([%c10, %c11])
                                  type(%c32)

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
@@ -26,15 +26,15 @@ func.func @FoldBufferViewCreateSubspan(%base_buffer: !hal.buffer, %subspan_offse
 // CHECK-LABEL: func.func @SkipBufferViewBufferOp
 // CHECK-SAME: %[[BUFFER:.+]]: !hal.buffer
 func.func @SkipBufferViewBufferOp(%buffer : !hal.buffer) -> !hal.buffer {
+  %encoding = arith.constant 1 : i32
   %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : i32
   %c10 = arith.constant 10 : index
   %c11 = arith.constant 11 : index
   %c32 = arith.constant 32 : i32
   %view = hal.buffer_view.create buffer(%buffer : !hal.buffer)[%c0, %c10]
                                  shape([%c10, %c11])
                                  type(%c32)
-                                 encoding(%c1) : !hal.buffer_view
+                                 encoding(%encoding) : !hal.buffer_view
   %view_buffer = hal.buffer_view.buffer<%view : !hal.buffer_view> : !hal.buffer
   // CHECK: return %[[BUFFER]]
   return %view_buffer : !hal.buffer
@@ -44,14 +44,15 @@ func.func @SkipBufferViewBufferOp(%buffer : !hal.buffer) -> !hal.buffer {
 
 // CHECK-LABEL: func.func @DoNotSkipBufferViewBufferOp
 func.func @DoNotSkipBufferViewBufferOp(%buffer : !hal.buffer) -> !hal.buffer {
-  %c1 = arith.constant 1 : i32
+  %encoding = arith.constant 1 : i32
+  %c5 = arith.constant 5 : index
   %c10 = arith.constant 10 : index
   %c11 = arith.constant 11 : index
   %c32 = arith.constant 32 : i32
-  %view = hal.buffer_view.create buffer(%buffer : !hal.buffer)[%c1, %c10]
+  %view = hal.buffer_view.create buffer(%buffer : !hal.buffer)[%c5, %c10]
                                  shape([%c10, %c11])
                                  type(%c32)
-                                 encoding(%c1) : !hal.buffer_view
+                                 encoding(%encoding) : !hal.buffer_view
   // CHECK: %[[BUFFER:.+]] = hal.buffer_view.buffer
   %view_buffer = hal.buffer_view.buffer<%view : !hal.buffer_view> : !hal.buffer
   // CHECK: return %[[BUFFER]]


### PR DESCRIPTION
It's incorrect to skip `hal.buffer_view.buffer` accessor if buffer view was constructed at non-zero offset

Fix for: https://github.com/openxla/iree/issues/14215