### PR TITLE
Make HoistRedundantVectorTransfers be an individual pass.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -163,6 +163,7 @@ iree_compiler_cc_library(
         "ForOpCanonicalizationPass.cpp",
         "FuseTensorPadWithConsumer.cpp",
         "GenericVectorization.cpp",
+        "HoistRedundantVectorTransfers.cpp",
         "HoistStaticallyBoundAllocations.cpp",
         "IREEComprehensiveBufferizePass.cpp",
         "IREEExpandStridedMetadata.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -138,6 +138,7 @@ iree_cc_library(
     "ForOpCanonicalizationPass.cpp"
     "FuseTensorPadWithConsumer.cpp"
     "GenericVectorization.cpp"
+    "HoistRedundantVectorTransfers.cpp"
     "HoistStaticallyBoundAllocations.cpp"
     "IREEComprehensiveBufferizePass.cpp"
     "IREEExpandStridedMetadata.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -290,16 +290,6 @@ void GenericVectorizationPass::runOnOperation() {
     linalg::populatePadOpVectorizationPatterns(patterns);
     (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
   }
-
-  // Gathers all innermost loops through a post order pruned walk.
-  funcOp.walk([](Operation *op) {
-    if (auto forOp = dyn_cast<affine::AffineForOp>(op))
-      (void)promoteIfSingleIteration(forOp);
-    else if (auto forOp = dyn_cast<scf::ForOp>(op))
-      (void)promoteIfSingleIteration(forOp);
-  });
-  linalg::hoistRedundantVectorTransfers(funcOp);
-  linalg::hoistRedundantVectorTransfersOnTensor(funcOp);
 }
 } // namespace
 

--- a/compiler/src/iree/compiler/Codegen/Common/HoistRedundantVectorTransfers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/HoistRedundantVectorTransfers.cpp
@@ -1,0 +1,46 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/PassDetail.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace {
+
+class HoistRedundantVectorTransfersPass
+    : public HoistRedundantVectorTransfersBase<
+          HoistRedundantVectorTransfersPass> {
+public:
+  using HoistRedundantVectorTransfersBase::HoistRedundantVectorTransfersBase;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<scf::SCFDialect, vector::VectorDialect>();
+  }
+  void runOnOperation() override;
+};
+
+void HoistRedundantVectorTransfersPass::runOnOperation() {
+  auto funcOp = getOperation();
+  linalg::hoistRedundantVectorTransfers(funcOp);
+  linalg::hoistRedundantVectorTransfersOnTensor(funcOp);
+  IRRewriter rewriter(funcOp->getContext());
+  vector::transferOpflowOpt(rewriter, funcOp);
+}
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createHoistRedundantVectorTransfersPass() {
+  return std::make_unique<HoistRedundantVectorTransfersPass>();
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -136,6 +136,9 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createGenericVectorizationPass(const GenericVectorizationPassOptions &options);
 
 std::unique_ptr<OperationPass<func::FuncOp>>
+createHoistRedundantVectorTransfersPass();
+
+std::unique_ptr<OperationPass<func::FuncOp>>
 createHoistStaticallyBoundAllocationsPass();
 
 /// Pass to perform linalg on tensor bufferization. The function passed into

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -227,6 +227,12 @@ def GenericVectorization :
       "mlir::iree_compiler::createGenericVectorizationPass()";
 }
 
+def HoistRedundantVectorTransfers :
+    Pass<"iree-codegen-hoist-redundant-vector-transfers", "func::FuncOp"> {
+  let summary = "Hoist redundant vector transfers";
+  let constructor = "mlir::iree_compiler::createHoistRedundantVectorTransfersPass()";
+}
+
 def HoistStaticallyBoundAllocations :
     Pass<"iree-hoist-statically-bound-allocations", "func::FuncOp"> {
   let summary = "Hoist statically bound alloca ops to the entry block of functions";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -339,6 +339,8 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager,
     options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createGenericVectorizationPass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createHoistRedundantVectorTransfersPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
@@ -383,6 +385,8 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager,
     options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createGenericVectorizationPass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createHoistRedundantVectorTransfersPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
@@ -491,6 +495,8 @@ void addMultiTilingExpertPassPipeline(
     options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createGenericVectorizationPass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createHoistRedundantVectorTransfersPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
@@ -552,6 +558,8 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager,
     options.vectorizeGatherAccesses = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createGenericVectorizationPass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createHoistRedundantVectorTransfersPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
@@ -599,6 +607,8 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager,
         static_cast<int64_t>(tilingConfig.getVectorReductionLevel())));
     nestedModulePM.addNestedPass<func::FuncOp>(
         createGenericVectorizationPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createHoistRedundantVectorTransfersPass());
   }
 
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -626,6 +636,8 @@ void addCPUDataTilingPipeline(OpPassManager &passManager,
     options.vectorizePadding = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createGenericVectorizationPass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createHoistRedundantVectorTransfersPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -153,6 +153,8 @@ void addGPUVectorizationPassPipeline(OpPassManager &pm) {
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createHoistRedundantVectorTransfersPass());
 }
 
 void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
@@ -204,7 +206,7 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
   // store to load forwarding. This relies on shacky alias analysis and we need
   // to move this to tensor level once we have better abstractions.
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createOptimizeVectorTransferPass());
+      createHoistRedundantVectorTransfersPass());
 
   // Hoist loop invariant code to avoid pipelining it.
   nestedModulePM.addNestedPass<func::FuncOp>(
@@ -243,6 +245,8 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createHoistRedundantVectorTransfersPass());
 
   // Distribute shared memory copies.
   nestedModulePM.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
@@ -304,6 +308,8 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createHoistRedundantVectorTransfersPass());
 
   // Distribute shared memory copies.
   nestedModulePM.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
@@ -354,6 +360,8 @@ void addGPUTransposePassPipeline(OpPassManager &pm) {
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createHoistRedundantVectorTransfersPass());
 
   // tensor to memref
   addBufferizePasses(nestedModulePM);
@@ -395,10 +403,11 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
   addBufferizePasses(nestedModulePM);
 
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createOptimizeVectorTransferPass());
-
-  nestedModulePM.addNestedPass<func::FuncOp>(
       memref::createFoldMemRefAliasOpsPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createOptimizeVectorTransferPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createHoistRedundantVectorTransfersPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createLoopInvariantCodeMotionPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -428,7 +437,7 @@ void addGPUPackUnPackPasses(OpPassManager &pm) {
       createDecomposePackUnPackOpsPass(/*tileOuterToOne=*/true));
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUVectorizationPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createOptimizeVectorTransferPass());
+      createHoistRedundantVectorTransfersPass());
 
   addBufferizePasses(nestedModulePM);
 


### PR DESCRIPTION
It also replaces two OptimizeVectorTransferPass with the new pass, which simplifies some GPU pipeline a bit.

The `promoteIfSingleIteration` is removed from vectorization because they are really not part of vectorization.