### PR TITLE
Fix clone producers for use in count region

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -359,8 +359,9 @@ Flow::clonePrecedingOpIntoDispatchRegion(RewriterBase &rewriter,
       parentRegion = parentOperation->getParentRegion();
     }
 
-    if (parentOperation && &parentRegion->front() == &body)
+    if (parentOperation && &parentRegion->front() == &body) {
       usesInsideOfRegion.push_back(&use);
+    }
   }
 
   // Clone op into dispatch region.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -350,7 +350,16 @@ Flow::clonePrecedingOpIntoDispatchRegion(RewriterBase &rewriter,
   // Gather all uses of `target`.
   SmallVector<OpOperand *> usesInsideOfRegion;
   for (OpOperand &use : target->getUses()) {
-    if (regionOp->isProperAncestor(use.getOwner()))
+    Operation *parentOperation = use.getOwner();
+    Region *parentRegion = parentOperation->getParentRegion();
+
+    while ((parentOperation = parentOperation->getParentOp())) {
+      if (regionOp.getOperation() == parentOperation)
+        break;
+      parentRegion = parentOperation->getParentRegion();
+    }
+
+    if (parentOperation && &parentRegion->front() == &body)
       usesInsideOfRegion.push_back(&use);
   }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -19,7 +19,7 @@ iree_lit_test_suite(
             "capture_dispatch_dynamic_dims.mlir",
             "cleanup_numeric_narrowing.mlir",
             "cleanup_tensor_shapes.mlir",
-            "clone_producers_into_dispath_regions.mlir",
+            "clone_producers_into_dispatch_regions.mlir",
             "collapse_reduction.mlir",
             "conv1x1_to_matmul.mlir",
             "convert_region_to_workgroups.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -17,7 +17,7 @@ iree_lit_test_suite(
     "capture_dispatch_dynamic_dims.mlir"
     "cleanup_numeric_narrowing.mlir"
     "cleanup_tensor_shapes.mlir"
-    "clone_producers_into_dispath_regions.mlir"
+    "clone_producers_into_dispatch_regions.mlir"
     "collapse_linalg_generic_on_tensors.mlir"
     "collapse_reduction.mlir"
     "conv1x1_to_matmul.mlir"


### PR DESCRIPTION
Use of cloned values in the `count` region were cloned into the dispatch region. We should check that their use is in the correct region before cloning.