### PR TITLE
Separate GPU test jobs into general and Ampere-specific

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,121 +241,106 @@ jobs:
             gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:89656f131eb6efc97585f6b71b2cedbaa9ae79b539362d2545b19a9bbaf7501c \
             ./build_tools/bazel/build_core.sh
 
-  test_all:
+  test:
     needs: [setup, build_all]
     if: fromJson(needs.setup.outputs.should-run)
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
     env:
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      DOCKER_ENV_FILE: docker.env
+      DOCKER_ARG_FILE: docker-args.txt
+      EXEC_FILE: run.sh
+      # We could enumerate all the differences in the matrix spec, but for now
+      # there's basically just one split between CPU and GPU and there are two
+      # GPU jobs, so it's annoying to write everything twice. We insted
+      # construct some stuff dynamically in a step that's keyed off of is-gpu.
+      CPU_IMAGE: gcr.io/iree-oss/swiftshader@sha256:beeb2c9853bb41375f5c9ccfb19b1ed35655c4354cc71fbcf124fe9103a7f543
+      GPU_IMAGE: gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02
+    strategy:
+      matrix:
+        target:
+          - runner-type: cpu
+            is-gpu: false
+            docker-env: |
+              IREE_CUDA_DISABLE=1
+          - runner-type: gpu
+            is-gpu: true
+            docker-env: |
+              IREE_CUDA_DISABLE=0
+              IREE_VULKAN_F16_DISABLE=0
+              IREE_NVIDIA_GPU_TESTS_DISABLE=0
+              IREE_NVIDIA_SM80_TESTS_DISABLE=1
+              CTEST_PARALLEL_LEVEL=2
+              IREE_CTEST_LABEL_REGEX='^requires-gpu|^driver=vulkan$|^driver=cuda$'
+              NVIDIA_DRIVER_CAPABILITIES=all
+          - runner-type: a100
+            is-gpu: true
+            docker-env: |
+              IREE_CUDA_DISABLE=0
+              IREE_VULKAN_F16_DISABLE=0
+              IREE_NVIDIA_GPU_TESTS_DISABLE=0
+              IREE_NVIDIA_SM80_TESTS_DISABLE=0
+              CTEST_PARALLEL_LEVEL=2
+              IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$'
+              NVIDIA_DRIVER_CAPABILITIES=all
+    name: test [${{ matrix.runner-type }}]
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - ${{ matrix.target.runner-type }}
+      - os-family=Linux
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
+      - name: Doing GPU-specific setup
+        if: matrix.is-gpu
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+
+          cat <<<EOF >> "${EXEC_FILE}"
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+          EOF
+
+          echo "--gpus=all" >> "${DOCKER_ARG_FILE}"
+
+          echo "CONTAINER_IMAGE=${GPU_IMAGE}" >> "${GITHUB_ENV}"
+      - name: "Setting up docker execution files"
+        run: |
+          echo "./build_tools/cmake/ctest_all.sh ${BUILD_DIR}" >> "${EXEC_FILE}"
+          cat <<<EOF > "${DOCKER_ENV_FILE}"
+          ${{ matrix.docker-env }}
+          EOF
+
+          touch "${DOCKER_ARG_FILE}"
+
+          # Default to CPU image if it wasn't set above
+          CONTAINER_IMAGE="${CONTAINER_IMAGE:-${CPU_IMAGE}}"
+          echo "CONTAINER_IMAGE=${CONTAINER_IMAGE}" >> "${GITHUB_ENV}"
+
+          echo "Docker will run with the following script:"
+          cat "${EXEC_FILE}"
+
+          echo "with the following environment:"
+          cat "${DOCKER_ENV_FILE}"
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Testing all"
         run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env IREE_CUDA_DISABLE=1 \
-            gcr.io/iree-oss/swiftshader@sha256:beeb2c9853bb41375f5c9ccfb19b1ed35655c4354cc71fbcf124fe9103a7f543 \
-            ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+          cat "${DOCKER_ARG_FILE}" | readarray -t DOCKER_ARGS
 
-  test_gpu:
-    needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          submodules: true
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
-      - name: "Downloading build dir archive"
-        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Testing with GPU"
-        run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_F16_DISABLE=0 \
-            --env IREE_CUDA_DISABLE=0 \
-            --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
-            --env IREE_NVIDIA_SM80_TESTS_DISABLE=1 \
-            --env CTEST_PARALLEL_LEVEL=2 \
-            --env IREE_CTEST_LABEL_REGEX='^requires-gpu|^driver=vulkan$|^driver=cuda$' \
-            --gpus all \
-            --env NVIDIA_DRIVER_CAPABILITIES=all \
-            gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \
-            bash -euo pipefail -c \
-              "./build_tools/scripts/check_cuda.sh
-              ./build_tools/scripts/check_vulkan.sh
-              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
-
-  test_nvidia_sm80:
-    needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - a100
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          submodules: true
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
-      - name: "Downloading build dir archive"
-        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Testing with GPU"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_F16_DISABLE=0 \
-            --env IREE_CUDA_DISABLE=0 \
-            --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
-            --env IREE_NVIDIA_SM80_TESTS_DISABLE=0 \
-            --env CTEST_PARALLEL_LEVEL=2 \
-            --env IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$' \
-            --gpus all \
-            --env NVIDIA_DRIVER_CAPABILITIES=all \
-            gcr.io/iree-oss/nvidia@sha256:de6e4453614aa48059fd611d7e7255f4d6ac27ac29a47aabdc04191ec1758533 \
-            bash -euo pipefail -c \
-              "./build_tools/scripts/check_cuda.sh
-              ./build_tools/scripts/check_vulkan.sh
-              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+            --env-file "${DOCKER_ENV_FILE}" \
+            "${DOCKER_ARGS[@]}"
+            "${CONTAINER_IMAGE}" \
+            bash ${EXEC_FILE}"
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
@@ -1048,17 +1033,13 @@ jobs:
 
       # Basic
       - build_all
-      - test_all
       - build_test_all_bazel
-      
+      - test
+
       # Platforms
       - build_test_all_windows
       - build_test_all_macos_arm64
       - build_test_all_macos_x86_64
-      
-      # Accelerators
-      - test_gpu
-      - test_nvidia_sm80
 
       # Subsets
       - build_test_runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
               CTEST_PARALLEL_LEVEL=2
               IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$'
               NVIDIA_DRIVER_CAPABILITIES=all
-    name: test [${{ matrix.runner-type }}]
+    name: test [${{ matrix.target.runner-type }}]
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -297,7 +297,7 @@ jobs:
         with:
           submodules: true
       - name: Doing GPU-specific setup
-        if: matrix.is-gpu
+        if: matrix.target.is-gpu
         run: |
           ./build_tools/scripts/check_cuda.sh
           ./build_tools/scripts/check_vulkan.sh
@@ -314,7 +314,7 @@ jobs:
         run: |
           echo "./build_tools/cmake/ctest_all.sh ${BUILD_DIR}" >> "${EXEC_FILE}"
           cat <<<EOF > "${DOCKER_ENV_FILE}"
-          ${{ matrix.docker-env }}
+          ${{ matrix.target.docker-env }}
           EOF
 
           touch "${DOCKER_ARG_FILE}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
               CTEST_PARALLEL_LEVEL=2
               IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$'
               NVIDIA_DRIVER_CAPABILITIES=all
-    name: test [${{ matrix.target.runner-type }}]
+    name: test [${{ matrix.runner-type }}]
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -297,7 +297,7 @@ jobs:
         with:
           submodules: true
       - name: Doing GPU-specific setup
-        if: matrix.target.is-gpu
+        if: matrix.is-gpu
         run: |
           ./build_tools/scripts/check_cuda.sh
           ./build_tools/scripts/check_vulkan.sh
@@ -314,7 +314,7 @@ jobs:
         run: |
           echo "./build_tools/cmake/ctest_all.sh ${BUILD_DIR}" >> "${EXEC_FILE}"
           cat <<<EOF > "${DOCKER_ENV_FILE}"
-          ${{ matrix.target.docker-env }}
+          ${{ matrix.docker-env }}
           EOF
 
           touch "${DOCKER_ARG_FILE}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,16 +274,26 @@ jobs:
   test_gpu:
     needs: [setup, build_all]
     if: fromJson(needs.setup.outputs.should-run)
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu
-      - os-family=Linux
     env:
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    strategy:
+      matrix:
+        target:
+          - runner-type: gpu
+            iree-ctest-label-regex: ^requires-gpu|^driver=vulkan$|^driver=cuda$
+            iree-nvidia-sm80-tests-disable: 1
+          - runner-type: a100
+            iree-ctest-label-regex: ^requires-gpu-sm80$
+            iree-nvidia-sm80-tests-disable: 0
+    name: test_${{ matrix.target.runner-type }}
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - ${{ matrix.target.runner-type }}
+      - os-family=Linux
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -297,65 +307,26 @@ jobs:
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Testing with GPU"
+      - name: "Testing all"
+        env:
+          IREE_NVIDIA_SM80_TESTS_DISABLE: ${{ matrix.target.iree-nvidia-sm80-tests-disable }}
+          IREE_CTEST_LABEL_REGEX: ${{ matrix.target.iree-ctest-label-regex }}
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_F16_DISABLE=0 \
-            --env IREE_CUDA_DISABLE=0 \
-            --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
-            --env IREE_NVIDIA_SM80_TESTS_DISABLE=1 \
-            --env CTEST_PARALLEL_LEVEL=2 \
-            --env IREE_CTEST_LABEL_REGEX='^requires-gpu|^driver=vulkan$|^driver=cuda$' \
-            --gpus all \
-            --env NVIDIA_DRIVER_CAPABILITIES=all \
-            gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \
-            bash -euo pipefail -c \
-              "./build_tools/scripts/check_cuda.sh
-              ./build_tools/scripts/check_vulkan.sh
-              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
-
-  test_nvidia_sm80:
-    needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - a100
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          submodules: true
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
-      - name: "Downloading build dir archive"
-        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Testing with GPU"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_F16_DISABLE=0 \
-            --env IREE_CUDA_DISABLE=0 \
-            --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
-            --env IREE_NVIDIA_SM80_TESTS_DISABLE=0 \
-            --env CTEST_PARALLEL_LEVEL=2 \
-            --env IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$' \
-            --gpus all \
-            --env NVIDIA_DRIVER_CAPABILITIES=all \
-            gcr.io/iree-oss/nvidia@sha256:de6e4453614aa48059fd611d7e7255f4d6ac27ac29a47aabdc04191ec1758533 \
-            bash -euo pipefail -c \
-              "./build_tools/scripts/check_cuda.sh
-              ./build_tools/scripts/check_vulkan.sh
-              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+              --env-file "${DOCKER_ENV_FILE}" \
+              --env IREE_NVIDIA_SM80_TESTS_DISABLE \
+              --env IREE_CTEST_LABEL_REGEX \
+              --env IREE_VULKAN_F16_DISABLE=0 \
+              --env IREE_CUDA_DISABLE=0 \
+              --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+              --env CTEST_PARALLEL_LEVEL=2 \
+              --env NVIDIA_DRIVER_CAPABILITIES=all \
+              --gpus all \
+              gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \
+              bash -euo pipefail -c \
+                "./build_tools/scripts/check_cuda.sh
+                ./build_tools/scripts/check_vulkan.sh
+                ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
@@ -1050,12 +1021,12 @@ jobs:
       - build_all
       - test_all
       - build_test_all_bazel
-      
+
       # Platforms
       - build_test_all_windows
       - build_test_all_macos_arm64
       - build_test_all_macos_x86_64
-      
+
       # Accelerators
       - test_gpu
       - test_nvidia_sm80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,52 @@ jobs:
             --env IREE_VULKAN_F16_DISABLE=0 \
             --env IREE_CUDA_DISABLE=0 \
             --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+            --env IREE_NVIDIA_SM80_TESTS_DISABLE=1 \
             --env CTEST_PARALLEL_LEVEL=2 \
+            --env IREE_CTEST_LABEL_REGEX='^requires-gpu|^driver=vulkan$|^driver=cuda$' \
+            --gpus all \
+            --env NVIDIA_DRIVER_CAPABILITIES=all \
+            gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \
+            bash -euo pipefail -c \
+              "./build_tools/scripts/check_cuda.sh
+              ./build_tools/scripts/check_vulkan.sh
+              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+
+  test_nvidia_sm80:
+    needs: [setup, build_all]
+    if: fromJson(needs.setup.outputs.should-run)
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - a100
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          submodules: true
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+      - name: "Downloading build dir archive"
+        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Testing with GPU"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_VULKAN_F16_DISABLE=0 \
+            --env IREE_CUDA_DISABLE=0 \
+            --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+            --env IREE_NVIDIA_SM80_TESTS_DISABLE=0 \
+            --env CTEST_PARALLEL_LEVEL=2 \
+            --env IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$' \
             --gpus all \
             --env NVIDIA_DRIVER_CAPABILITIES=all \
             gcr.io/iree-oss/nvidia@sha256:de6e4453614aa48059fd611d7e7255f4d6ac27ac29a47aabdc04191ec1758533 \
@@ -1001,7 +1046,7 @@ jobs:
     needs:
       - setup
 
-      # Basic
+      # Platforms
       - build_all
       - build_test_all_windows
       - build_test_all_macos_arm64
@@ -1009,6 +1054,7 @@ jobs:
       - build_test_all_bazel
       - test_all
       - test_gpu
+      - test_nvidia_sm80
 
       # Subsets
       - build_test_runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,8 @@ jobs:
           - runner-type: a100
             iree-ctest-label-regex: ^requires-gpu-sm80$
             iree-nvidia-sm80-tests-disable: 0
+      # Run other jobs even if one fails.
+      fail-fast: false
     name: test_${{ matrix.target.runner-type }}
     runs-on:
       - self-hosted # must come first

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1046,13 +1046,17 @@ jobs:
     needs:
       - setup
 
-      # Platforms
+      # Basic
       - build_all
+      - test_all
+      - build_test_all_bazel
+      
+      # Platforms
       - build_test_all_windows
       - build_test_all_macos_arm64
       - build_test_all_macos_x86_64
-      - build_test_all_bazel
-      - test_all
+      
+      # Accelerators
       - test_gpu
       - test_nvidia_sm80
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,106 +241,121 @@ jobs:
             gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:89656f131eb6efc97585f6b71b2cedbaa9ae79b539362d2545b19a9bbaf7501c \
             ./build_tools/bazel/build_core.sh
 
-  test:
+  test_all:
     needs: [setup, build_all]
     if: fromJson(needs.setup.outputs.should-run)
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      DOCKER_ENV_FILE: docker.env
-      DOCKER_ARG_FILE: docker-args.txt
-      EXEC_FILE: run.sh
-      # We could enumerate all the differences in the matrix spec, but for now
-      # there's basically just one split between CPU and GPU and there are two
-      # GPU jobs, so it's annoying to write everything twice. We insted
-      # construct some stuff dynamically in a step that's keyed off of is-gpu.
-      CPU_IMAGE: gcr.io/iree-oss/swiftshader@sha256:beeb2c9853bb41375f5c9ccfb19b1ed35655c4354cc71fbcf124fe9103a7f543
-      GPU_IMAGE: gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02
-    strategy:
-      matrix:
-        target:
-          - runner-type: cpu
-            is-gpu: false
-            docker-env: |
-              IREE_CUDA_DISABLE=1
-          - runner-type: gpu
-            is-gpu: true
-            docker-env: |
-              IREE_CUDA_DISABLE=0
-              IREE_VULKAN_F16_DISABLE=0
-              IREE_NVIDIA_GPU_TESTS_DISABLE=0
-              IREE_NVIDIA_SM80_TESTS_DISABLE=1
-              CTEST_PARALLEL_LEVEL=2
-              IREE_CTEST_LABEL_REGEX='^requires-gpu|^driver=vulkan$|^driver=cuda$'
-              NVIDIA_DRIVER_CAPABILITIES=all
-          - runner-type: a100
-            is-gpu: true
-            docker-env: |
-              IREE_CUDA_DISABLE=0
-              IREE_VULKAN_F16_DISABLE=0
-              IREE_NVIDIA_GPU_TESTS_DISABLE=0
-              IREE_NVIDIA_SM80_TESTS_DISABLE=0
-              CTEST_PARALLEL_LEVEL=2
-              IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$'
-              NVIDIA_DRIVER_CAPABILITIES=all
-    name: test [${{ matrix.runner-type }}]
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=${{ needs.setup.outputs.runner-env }}
-      - ${{ matrix.target.runner-type }}
+      - cpu
       - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
-      - name: Doing GPU-specific setup
-        if: matrix.is-gpu
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
-
-          cat <<<EOF >> "${EXEC_FILE}"
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
-          EOF
-
-          echo "--gpus=all" >> "${DOCKER_ARG_FILE}"
-
-          echo "CONTAINER_IMAGE=${GPU_IMAGE}" >> "${GITHUB_ENV}"
-      - name: "Setting up docker execution files"
-        run: |
-          echo "./build_tools/cmake/ctest_all.sh ${BUILD_DIR}" >> "${EXEC_FILE}"
-          cat <<<EOF > "${DOCKER_ENV_FILE}"
-          ${{ matrix.docker-env }}
-          EOF
-
-          touch "${DOCKER_ARG_FILE}"
-
-          # Default to CPU image if it wasn't set above
-          CONTAINER_IMAGE="${CONTAINER_IMAGE:-${CPU_IMAGE}}"
-          echo "CONTAINER_IMAGE=${CONTAINER_IMAGE}" >> "${GITHUB_ENV}"
-
-          echo "Docker will run with the following script:"
-          cat "${EXEC_FILE}"
-
-          echo "with the following environment:"
-          cat "${DOCKER_ENV_FILE}"
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Testing all"
         run: |
-          cat "${DOCKER_ARG_FILE}" | readarray -t DOCKER_ARGS
-
           ./build_tools/github_actions/docker_run.sh \
-            --env-file "${DOCKER_ENV_FILE}" \
-            "${DOCKER_ARGS[@]}"
-            "${CONTAINER_IMAGE}" \
-            bash ${EXEC_FILE}"
+            --env IREE_CUDA_DISABLE=1 \
+            gcr.io/iree-oss/swiftshader@sha256:beeb2c9853bb41375f5c9ccfb19b1ed35655c4354cc71fbcf124fe9103a7f543 \
+            ./build_tools/cmake/ctest_all.sh \
+            "${BUILD_DIR}"
+
+  test_gpu:
+    needs: [setup, build_all]
+    if: fromJson(needs.setup.outputs.should-run)
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - gpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          submodules: true
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+      - name: "Downloading build dir archive"
+        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Testing with GPU"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_VULKAN_F16_DISABLE=0 \
+            --env IREE_CUDA_DISABLE=0 \
+            --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+            --env IREE_NVIDIA_SM80_TESTS_DISABLE=1 \
+            --env CTEST_PARALLEL_LEVEL=2 \
+            --env IREE_CTEST_LABEL_REGEX='^requires-gpu|^driver=vulkan$|^driver=cuda$' \
+            --gpus all \
+            --env NVIDIA_DRIVER_CAPABILITIES=all \
+            gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \
+            bash -euo pipefail -c \
+              "./build_tools/scripts/check_cuda.sh
+              ./build_tools/scripts/check_vulkan.sh
+              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+
+  test_nvidia_sm80:
+    needs: [setup, build_all]
+    if: fromJson(needs.setup.outputs.should-run)
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - a100
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          submodules: true
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+      - name: "Downloading build dir archive"
+        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Testing with GPU"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_VULKAN_F16_DISABLE=0 \
+            --env IREE_CUDA_DISABLE=0 \
+            --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+            --env IREE_NVIDIA_SM80_TESTS_DISABLE=0 \
+            --env CTEST_PARALLEL_LEVEL=2 \
+            --env IREE_CTEST_LABEL_REGEX='^requires-gpu-sm80$' \
+            --gpus all \
+            --env NVIDIA_DRIVER_CAPABILITIES=all \
+            gcr.io/iree-oss/nvidia@sha256:de6e4453614aa48059fd611d7e7255f4d6ac27ac29a47aabdc04191ec1758533 \
+            bash -euo pipefail -c \
+              "./build_tools/scripts/check_cuda.sh
+              ./build_tools/scripts/check_vulkan.sh
+              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
@@ -1033,13 +1048,17 @@ jobs:
 
       # Basic
       - build_all
+      - test_all
       - build_test_all_bazel
-      - test
-
+      
       # Platforms
       - build_test_all_windows
       - build_test_all_macos_arm64
       - build_test_all_macos_x86_64
+      
+      # Accelerators
+      - test_gpu
+      - test_nvidia_sm80
 
       # Subsets
       - build_test_runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,6 @@ jobs:
           IREE_CTEST_LABEL_REGEX: ${{ matrix.target.iree-ctest-label-regex }}
         run: |
           ./build_tools/github_actions/docker_run.sh \
-              --env-file "${DOCKER_ENV_FILE}" \
               --env IREE_NVIDIA_SM80_TESTS_DISABLE \
               --env IREE_CTEST_LABEL_REGEX \
               --env IREE_VULKAN_F16_DISABLE=0 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1029,7 +1029,6 @@ jobs:
 
       # Accelerators
       - test_gpu
-      - test_nvidia_sm80
 
       # Subsets
       - build_test_runtime

--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -63,10 +63,10 @@ default_test_tag_filters+=("-vulkan_uses_vk_khr_shader_float16_int8")
 # CUDA CI testing disabled until we setup a target for it.
 default_test_tag_filters+=("-driver=cuda")
 
-if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
+if (( IREE_VULKAN_DISABLE == 1 )); then
   default_test_tag_filters+=("-driver=vulkan")
 fi
-if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE?}" == 1 ]]; then
+if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
   default_test_tag_filters+=("-requires-gpu-nvidia" "-requires-gpu-sm80")
 fi
 

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -110,13 +110,13 @@ for asan_in_bytecode_modules_ON_OFF in OFF ON; do
 
   # IREE_VULKAN_DISABLE is handled separately as we run Vulkan and non-Vulkan
   # tests in separate ctest commands anyway.
-  if [[ "${IREE_CUDA_DISABLE?}" == 1 ]]; then
+  if (( IREE_CUDA_DISABLE == 1 )); then
     label_exclude_args+=("^driver=cuda$")
   fi
-  if [[ "${IREE_VULKAN_F16_DISABLE?}" == 1 ]]; then
+  if (( IREE_VULKAN_F16_DISABLE == 1 )); then
     label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
   fi
-  if [[ "${IREE_NVIDIA_GPU_TESTS_DISABLE}" == 1 ]]; then
+  if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
     label_exclude_args+=("^requires-gpu")
   fi
 
@@ -138,7 +138,7 @@ for asan_in_bytecode_modules_ON_OFF in OFF ON; do
   echo "------------------"
   cmake --build . --target check-iree-dialects -- -k 0
 
-  if [[ "${IREE_VULKAN_DISABLE?}" == 0 ]]; then
+  if (( IREE_VULKAN_DISABLE == 0 )); then
     echo "*** Running ctests that use the Vulkan driver, with LSAN disabled (IREE_BYTECODE_MODULE_ENABLE_ASAN=${asan_in_bytecode_modules_ON_OFF}) ***"
     echo "------------------"
     # Disable LeakSanitizer (LSAN) because of a history of issues with Swiftshader

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -47,13 +47,13 @@ declare -a label_exclude_args=(
   #   ^bindings/
 )
 
-if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
+if (( IREE_VULKAN_DISABLE == 1 )); then
   label_exclude_args+=("^driver=vulkan$")
 fi
-if [[ "${IREE_CUDA_DISABLE?}" == 1 ]]; then
+if (( IREE_CUDA_DISABLE == 1 )); then
   label_exclude_args+=("^driver=cuda$")
 fi
-if [[ "${IREE_VULKAN_F16_DISABLE?}" == 1 ]]; then
+if (( IREE_VULKAN_F16_DISABLE == 1 )); then
   label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
 fi
 


### PR DESCRIPTION
This will be followed by switching the generic runners to be T4
machines. I think we need to roll things out this way with the extra
job also running on A100.

Part of https://github.com/openxla/iree/issues/14169