### PR TITLE
Do not rematerialize scalar-like ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -34,9 +34,11 @@ struct MergeElementwiseOps : public OpRewritePattern<linalg::GenericOp> {
     // Avoid doing this for scalar operations. This is a temporary solution
     // to address #14258. Ideally we should apply this pass more prescriptively
     // instead of default always.
-    if (llvm::all_of(genericOp.getResults(), [](Value v) {
-          return isScalarOrTensorOfSizeOne(v.getType());
-        })) {
+    auto isScalarValue = [](Value v) {
+      return isScalarOrTensorOfSizeOne(v.getType());
+    };
+    if (llvm::all_of(genericOp.getOperands(), isScalarValue) &&
+        llvm::all_of(genericOp.getResults(), isScalarValue)) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -18,12 +18,28 @@ namespace iree_compiler {
 
 namespace {
 
+static bool isScalarOrTensorOfSizeOne(Type t) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(t)) {
+    return tensorType.hasStaticShape() && tensorType.getNumElements() == 1;
+  }
+  return t.isIntOrIndexOrFloat();
+}
+
 /// Merge elementwise operations into their consumers.
 struct MergeElementwiseOps : public OpRewritePattern<linalg::GenericOp> {
   using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
+    // Avoid doing this for scalar operations. This is a temporary solution
+    // to address #14258. Ideally we should apply this pass more prescriptively
+    // instead of default always.
+    if (llvm::all_of(genericOp.getResults(), [](Value v) {
+          return isScalarOrTensorOfSizeOne(v.getType());
+        })) {
+      return failure();
+    }
+
     // Find the first operand that is defined by another generic op on tensors.
     for (OpOperand &opOperand : genericOp->getOpOperands()) {
       if (!linalg::areElementwiseOpsFusable(&opOperand))


### PR DESCRIPTION
For scalar dispatches it is unnecessary to rematerialize these operations. Avoid rematerialization for ops with scalar-like returns. This is a WAR the real issue where `RematerializeParallelOps` should not be run by default.

Fixes #14258