### PR TITLE
Tag `e2e_matmul_direct_f16_gpu_large_unaligned` as requiring sm80

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -307,7 +307,7 @@ iree_generated_trace_runner_test(
         "nomsan",
         "notsan",
         "noubsan",
-        "requires-gpu-nvidia",
+        "requires-gpu-sm80",
     ],
     target_backends_and_drivers = [
         ("cuda", "cuda"),

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -455,7 +455,7 @@ iree_generated_trace_runner_test(
     "nomsan"
     "notsan"
     "noubsan"
-    "requires-gpu-nvidia"
+    "requires-gpu-sm80"
 )
 
 iree_generated_trace_runner_test(


### PR DESCRIPTION
Part of https://github.com/openxla/iree/issues/14169

runner-env: testing