### PR TITLE
Fix scalar degenerate case

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
@@ -49,7 +49,8 @@ static bool isScalarOrTensorOfLinearSizeN(int n, Type type) {
     if (!tensorType.hasStaticShape()) {
       return false;
     }
-    return tensorType.getNumElements() <= n;
+    const auto numElements = tensorType.getNumElements();
+    return numElements <= n && numElements > 0;
   }
   return false;
 }


### PR DESCRIPTION
The 0 element case of FormScalarDispatches fails. Avoid running the pass in these cases.