### PR TITLE
[IREEInput] Add support for buffers and constructing buffer views

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library", "iree_gentbl_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library", "iree_compiler_cc_test", "iree_gentbl_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -107,5 +107,18 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Transforms",
         "@stablehlo//:stablehlo_ops",
         "@torch-mlir-dialects//:TorchMLIRTMTensorDialect",
+    ],
+)
+
+iree_compiler_cc_test(
+    name = "IREEImportPublicTest",
+    srcs = ["IREEImportPublicTest.cpp"],
+    deps = [
+        "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",
+        "//llvm-external-projects/iree-dialects:IREEInputDialect",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+        "@llvm-project//mlir:IR",
     ],
 )

--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
@@ -115,7 +115,6 @@ iree_compiler_cc_test(
     srcs = ["IREEImportPublicTest.cpp"],
     deps = [
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
-        "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",
         "//llvm-external-projects/iree-dialects:IREEInputDialect",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -103,4 +103,18 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    IREEImportPublicTest
+  SRCS
+    "IREEImportPublicTest.cpp"
+  DEPS
+    IREEInputDialect
+    MLIRIR
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::HAL::IR::HALDialect
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublicTest.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublicTest.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/Input/InputDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/testing/gtest.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+
+namespace mlir::iree_compiler {
+
+TEST(IREEImportPublicTest, CheckElementTypeValue) {
+  MLIRContext ctx;
+  OpBuilder b(&ctx);
+
+  auto assert_eq = [&](Type type) {
+    ASSERT_EQ(IREE::HAL::getElementTypeValue(type),
+              IREE::Input::getElementTypeValue(type));
+  };
+
+  assert_eq(b.getIntegerType(1));
+  assert_eq(b.getIntegerType(8));
+  assert_eq(b.getIntegerType(32));
+  assert_eq(b.getIntegerType(64));
+  assert_eq(b.getBF16Type());
+  assert_eq(b.getF16Type());
+  assert_eq(b.getF32Type());
+  assert_eq(b.getF64Type());
+  assert_eq(ComplexType::get(b.getF32Type()));
+  assert_eq(ComplexType::get(b.getF64Type()));
+}
+
+} // namespace mlir::iree_compiler

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
@@ -88,11 +88,6 @@ def IREEInput_ElementTypeParameter : TypeParameter<
 def IREEInput_PtrTargetTypeParameter : TypeParameter<
     "::mlir::Type", "A type suitable as a target type of a pointer">;
 
-def IREEInput_Dim : TypeAlias<Index>;
-def IREEInput_Dims : Variadic<IREEInput_Dim>;
-def IREEInput_Shape : Variadic<IREEInput_Dim>;
-def IREEInput_ShapeDynamicDims : Variadic<IREEInput_Dim>;
-
 def IREEInput_GlobalRefAttr : IREEInput_AliasedSymbolRefAttr;
 def IREEInput_AnyGlobalPtr : IREEInput_AnyPtrOf<[IREEInput_Tensor, IREEInput_PrimitiveType]>;
 
@@ -112,5 +107,22 @@ def IREEInput_TiedOpStorageAttr :
     TypedArrayAttrBase<IREEInput_IndexAttr, "64-bit integer array attribute"> {
   let constBuilderCall = "$_builder.getI64ArrayAttr($0)";
 }
+
+//===----------------------------------------------------------------------===//
+// Type aliases for working with shapes
+//===----------------------------------------------------------------------===//
+
+def IREEInput_Dim : TypeAlias<Index>;
+def IREEInput_Dims : Variadic<IREEInput_Dim>;
+def IREEInput_Shape : Variadic<IREEInput_Dim>;
+def IREEInput_ShapeDynamicDims : Variadic<IREEInput_Dim>;
+
+//===----------------------------------------------------------------------===//
+// Type aliases for working with Buffers and BufferViews
+//===----------------------------------------------------------------------===//
+
+def IREEInput_DeviceSize : TypeAlias<Index>;
+def IREEInput_ElementType : TypeAlias<I32>;
+def IREEInput_EncodingType : TypeAlias<I32>;
 
 #endif // IREE_DIALECTS_DIALECT_INPUT_BASE_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.h
@@ -16,4 +16,20 @@
 #define GET_TYPEDEF_CLASSES
 #include "iree-dialects/Dialect/Input/InputTypes.h.inc"
 
+//===----------------------------------------------------------------------===//
+// IREE ABI helpers for constructing buffer views
+//===----------------------------------------------------------------------===//
+
+namespace mlir::iree_compiler::IREE::Input {
+
+// Returns a stable identifier for the MLIR element type or nullopt if the
+// type is unsupported in the ABI.
+std::optional<int32_t> getElementTypeValue(Type type);
+
+// Returns a stable identifier for the MLIR encoding type or 0 (opaque) if the
+// type is unsupported in the ABI.
+std::optional<int32_t> getEncodingTypeValue(Attribute attr);
+
+} // namespace mlir::iree_compiler::IREE::Input
+
 #endif // IREE_DIALECTS_DIALECT_INPUT_DIALECT_H

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.h
@@ -26,8 +26,8 @@ namespace mlir::iree_compiler::IREE::Input {
 // type is unsupported in the ABI.
 std::optional<int32_t> getElementTypeValue(Type type);
 
-// Returns a stable identifier for the MLIR encoding type or 0 (opaque) if the
-// type is unsupported in the ABI.
+// Returns a stable identifier for the MLIR encoding type or empty optional
+// (opaque) if the type is unsupported in the ABI.
 std::optional<int32_t> getEncodingTypeValue(Attribute attr);
 
 } // namespace mlir::iree_compiler::IREE::Input

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.td
@@ -13,6 +13,19 @@ include "iree-dialects/Dialect/Input/InputBase.td"
 // Types
 //===----------------------------------------------------------------------===//
 
+def IREEInput_BufferType : IREEInput_Type<"Buffer"> {
+  let mnemonic = "buffer";
+
+  let summary = "Buffer is an untyped bag of bits with no shape or dtype";
+
+  let description = [{
+    Buffers represent an untyped bag of bits that can be reinterpreted depending
+    on a use case using `buffer_view` operation. Buffers can be used for packing
+    multiple tensors into the same underlying storage. It is left to higher
+    level code to decide how exactly tensors layed out in the buffer.
+  }];
+}
+
 def IREEInput_BufferViewType : IREEInput_Type<"BufferView"> {
   let mnemonic = "buffer_view";
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -29,16 +29,18 @@ def IREEInput_NullOp : IREEInput_PureOp<"null"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Casts
+// Pseudo ops for conversion support
 //===----------------------------------------------------------------------===//
 
-def IREEInput_TensorToBufferViewOp : IREEInput_PureOp<"cast.tensor_to_buffer_view"> {
-  let summary = "Casts a tensor to a BufferView, capturing dynamic dims";
+def IREEInput_TensorExportOp : IREEInput_PureOp<"tensor.export"> {
+  let summary = "Exports a tensor to a Buffer(View), capturing dynamic dims";
   let arguments = (ins
     IREEInput_Tensor:$source,
     IREEInput_ShapeDynamicDims:$source_dims
   );
-  let results = (outs IREEInput_BufferViewType:$target);
+  let results = (outs
+    AnyTypeOf<[IREEInput_BufferType, IREEInput_BufferViewType]>:$target
+  );
 
   let assemblyFormat = [{
     $source `:` type($source) (`{` $source_dims^ `}`)? `->` type($target)
@@ -46,10 +48,10 @@ def IREEInput_TensorToBufferViewOp : IREEInput_PureOp<"cast.tensor_to_buffer_vie
   }];
 }
 
-def IREEInput_BufferViewToTensorOp : IREEInput_PureOp<"cast.buffer_view_to_tensor"> {
-  let summary = "Casts a BufferView to a tensor, providing dynamic dims";
+def IREEInput_TensorImportOp : IREEInput_PureOp<"tensor.import"> {
+  let summary = "Imports a Buffer(View) to a tensor, providing dynamic dims";
   let arguments = (ins
-    IREEInput_BufferViewType:$source,
+    AnyTypeOf<[IREEInput_BufferType, IREEInput_BufferViewType]>:$source,
     IREEInput_ShapeDynamicDims:$target_dims
   );
   let results = (outs IREEInput_Tensor:$target);
@@ -201,8 +203,60 @@ def IREEInput_GlobalStoreIndirectOp : IREEInput_Op<"global.store.indirect"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Buffer Views
+// Buffers and Buffer Views
 //===----------------------------------------------------------------------===//
+
+def IREEInput_BufferViewCreateOp : IREEInput_PureOp<"buffer_view.create"> {
+  let summary = [{buffer view reference initializer}];
+  let description = [{
+    Creates a reference to a buffer with a particular shape and element type.
+    The buffer is not copied and both the original and view references must be
+    synchronized. This makes it easier to associate commonly-carried metadata
+    along with the contents.
+  }];
+
+  let arguments = (ins
+    IREEInput_BufferType:$source_buffer,
+    IREEInput_DeviceSize:$source_offset,
+    IREEInput_DeviceSize:$source_length,
+    IREEInput_ElementType:$element_type,
+    IREEInput_EncodingType:$encoding_type,
+    IREEInput_Shape:$shape
+  );
+  let results = (outs
+    IREEInput_BufferViewType:$result
+  );
+
+  let assemblyFormat = [{
+    `buffer` `(` $source_buffer `:` type($source_buffer) `)`
+    `` `[` $source_offset `,` $source_length `]`
+    `shape` `(` `[` $shape `]` `)`
+    `type` `(` $element_type `)`
+    `encoding` `(` $encoding_type `)`
+    `:` type($result)
+    attr-dict-with-keyword
+  }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      "Value":$sourceBuffer,
+      "Value":$sourceOffset,
+      "Value":$sourceLength,
+      "int32_t":$elementType,
+      "int32_t":$encodingType,
+      "ValueRange":$shape
+    )>,
+    OpBuilder<(ins
+      "Value":$sourceBuffer,
+      "Value":$sourceOffset,
+      "Value":$sourceLength,
+      "Value":$elementType,
+      "Value":$encodingType,
+      "ValueRange":$shape
+    )>,
+  ];
+}
 
 def IREEInput_BufferViewRankOp : IREEInput_PureOp<"buffer_view.rank"> {
   let summary = [{buffer view rank query}];

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputDialect.cpp
@@ -30,12 +30,82 @@ void IREEInputDialect::initialize() {
       >();
 }
 
-namespace mlir {
-namespace iree_compiler {
-namespace IREE {
-namespace Input {
+namespace mlir::iree_compiler::IREE::Input {
 
+//===----------------------------------------------------------------------===//
+// IREE ABI helpers for constructing buffer views
+//===----------------------------------------------------------------------===//
+
+// Keep these in sync with iree/hal/api.h
+namespace {
+enum class NumericalType : uint32_t {
+  kUnknown = 0x00,
+  kInteger = 0x10,
+  kIntegerSigned = kInteger | 0x01,
+  kIntegerUnsigned = kInteger | 0x02,
+  kBoolean = kInteger | 0x03,
+  kFloat = 0x20,
+  kFloatIEEE = kFloat | 0x01,
+  kFloatBrain = kFloat | 0x02,
+  kFloatComplex = kFloat | 0x03,
+};
+} // namespace
+
+static constexpr int32_t makeElementTypeValue(NumericalType numericalType,
+                                              int32_t bitCount) {
+  return (static_cast<uint32_t>(numericalType) << 24) | bitCount;
+}
+
+std::optional<int32_t> getElementTypeValue(Type type) {
+  if (auto intType = llvm::dyn_cast_if_present<IntegerType>(type)) {
+    NumericalType numericalType;
+    if (intType.isInteger(1)) {
+      return makeElementTypeValue(NumericalType::kBoolean, 8);
+    } else if (intType.isSigned()) {
+      numericalType = NumericalType::kIntegerSigned;
+    } else if (intType.isUnsigned()) {
+      numericalType = NumericalType::kIntegerUnsigned;
+    } else {
+      // There's no such thing as a signless integer in machine types but we
+      // need to be able to round-trip the format through the ABI. Exact
+      // numerical type equality comparisons may fail if the frontend assumes
+      // signed/unsigned but the compiler is propagating signless.
+      numericalType = NumericalType::kInteger;
+    }
+    return makeElementTypeValue(numericalType, intType.getWidth());
+  } else if (auto floatType = llvm::dyn_cast_if_present<FloatType>(type)) {
+    switch (APFloat::SemanticsToEnum(floatType.getFloatSemantics())) {
+    case APFloat::S_IEEEhalf:
+    case APFloat::S_IEEEsingle:
+    case APFloat::S_IEEEdouble:
+    case APFloat::S_IEEEquad:
+      return makeElementTypeValue(NumericalType::kFloatIEEE,
+                                  floatType.getWidth());
+    case APFloat::S_BFloat:
+      return makeElementTypeValue(NumericalType::kFloatBrain,
+                                  floatType.getWidth());
+    default:
+      return std::nullopt;
+    }
+  } else if (auto complexType = llvm::dyn_cast_if_present<ComplexType>(type)) {
+    return makeElementTypeValue(
+        NumericalType::kFloatComplex,
+        complexType.getElementType().getIntOrFloatBitWidth() * 2);
+  }
+  return std::nullopt;
+}
+
+std::optional<int32_t> getEncodingTypeValue(Attribute attr) {
+  // TODO(#6762): encoding attribute handling/mapping to enums.
+  assert(!attr && "encoding types other than default not yet supported");
+  // Default to IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR for now.
+  return 1;
+}
+
+//===----------------------------------------------------------------------===//
 // ListType
+//===----------------------------------------------------------------------===//
+
 Type ListType::parse(AsmParser &parser) {
   MLIRContext *ctxt = parser.getContext();
   Type elementType;
@@ -49,7 +119,10 @@ void ListType::print(AsmPrinter &printer) const {
   printer << "<" << getElementType() << ">";
 }
 
+//===----------------------------------------------------------------------===//
 // PtrType
+//===----------------------------------------------------------------------===//
+
 Type PtrType::parse(AsmParser &parser) {
   MLIRContext *ctxt = parser.getContext();
   Type targetType;
@@ -63,7 +136,4 @@ void PtrType::print(AsmPrinter &printer) const {
   printer << "<" << getTargetType() << ">";
 }
 
-} // namespace Input
-} // namespace IREE
-} // namespace iree_compiler
-} // namespace mlir
+} // namespace mlir::iree_compiler::IREE::Input


### PR DESCRIPTION
1. Add `iree_input.buffer` type
2. Rename cast operations to `tensor.export` and `tensor.import` for consistency with `HAL`
3. Add `buffer_view.create` operation
4. Add functions for computing buffer view type end encoding to `IREEInput` dialect to break a dependency on `HALTypes`