### PR TITLE
[IREEInput] Add TiedOpInterface to IREEInput dialect

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library", "iree_gentbl_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library", "iree_compiler_cc_test", "iree_gentbl_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -107,5 +107,18 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Transforms",
         "@stablehlo//:stablehlo_ops",
         "@torch-mlir-dialects//:TorchMLIRTMTensorDialect",
+    ],
+)
+
+iree_compiler_cc_test(
+    name = "IREEImportPublicTest",
+    srcs = ["IREEImportPublicTest.cpp"],
+    deps = [
+        "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",
+        "//llvm-external-projects/iree-dialects:IREEInputDialect",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+        "@llvm-project//mlir:IR",
     ],
 )

--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD.bazel
@@ -115,7 +115,6 @@ iree_compiler_cc_test(
     srcs = ["IREEImportPublicTest.cpp"],
     deps = [
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
-        "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",
         "//llvm-external-projects/iree-dialects:IREEInputDialect",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -103,4 +103,18 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    IREEImportPublicTest
+  SRCS
+    "IREEImportPublicTest.cpp"
+  DEPS
+    IREEInputDialect
+    MLIRIR
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::HAL::IR::HALDialect
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublicTest.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublicTest.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/Input/InputDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/testing/gtest.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+
+namespace mlir::iree_compiler {
+
+TEST(IREEImportPublicTest, CheckElementTypeValue) {
+  MLIRContext ctx;
+  OpBuilder b(&ctx);
+
+  auto assert_eq = [&](Type type) {
+    ASSERT_EQ(IREE::HAL::getElementTypeValue(type),
+              IREE::Input::getElementTypeValue(type));
+  };
+
+  assert_eq(b.getIntegerType(1));
+  assert_eq(b.getIntegerType(8));
+  assert_eq(b.getIntegerType(32));
+  assert_eq(b.getIntegerType(64));
+  assert_eq(b.getBF16Type());
+  assert_eq(b.getF16Type());
+  assert_eq(b.getF32Type());
+  assert_eq(b.getF64Type());
+  assert_eq(ComplexType::get(b.getF32Type()));
+  assert_eq(ComplexType::get(b.getF64Type()));
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
@@ -245,7 +245,7 @@ func.func @tensor_slice(%arg0 : tensor<?xf32>, %arg1 : index, %arg2 : index, %ar
 // CHECK-LABEL: func.func @tensor_update
 // CHECK: flow.tensor.update %arg3, %arg0[%arg1] : tensor<?xf32>{%arg2} -> %arg0 as tensor<?xf32>{%arg4}
 func.func @tensor_update(%arg0 : tensor<?xf32>, %arg1 : index, %arg2 : index, %arg3 : tensor<?xf32>, %arg4 : index) -> tensor<?xf32> {
-  %0 = iree_input.tensor.update %arg3, %arg0[%arg1] : tensor<?xf32>{%arg2} -> tensor<?xf32>{%arg4}
+  %0 = iree_input.tensor.update %arg3, %arg0[%arg1] : tensor<?xf32>{%arg2} -> %arg0 as tensor<?xf32>{%arg4}
   return %0 : tensor<?xf32>
 }
 

--- a/llvm-external-projects/iree-dialects/BUILD.bazel
+++ b/llvm-external-projects/iree-dialects/BUILD.bazel
@@ -62,7 +62,7 @@ td_library(
 ################################################################################
 
 gentbl_cc_library(
-    name = "IREEInputInterfacesGen",
+    name = "IREEInputInterfacesIncGen",
     tags = ["manual"],
     tbl_outs = [
         (
@@ -74,7 +74,7 @@ gentbl_cc_library(
             "include/iree-dialects/Dialect/Input/InputOpInterfaces.cpp.inc",
         ),
     ],
-    tblgen = "//third_party/llvm/llvm-project/mlir:mlir-tblgen",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "include/iree-dialects/Dialect/Input/InputInterfaces.td",
     deps = [":TdFiles"],
 )
@@ -122,7 +122,7 @@ cc_library(
     includes = ["include"],
     deps = [
         ":IREEInputIncGen",
-        ":IREEInputInterfacesGen",
+        ":IREEInputInterfacesIncGen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",

--- a/llvm-external-projects/iree-dialects/BUILD.bazel
+++ b/llvm-external-projects/iree-dialects/BUILD.bazel
@@ -62,6 +62,24 @@ td_library(
 ################################################################################
 
 gentbl_cc_library(
+    name = "IREEInputInterfacesGen",
+    tags = ["manual"],
+    tbl_outs = [
+        (
+            ["--gen-op-interface-decls"],
+            "include/iree-dialects/Dialect/Input/InputOpInterfaces.h.inc",
+        ),
+        (
+            ["--gen-op-interface-defs"],
+            "include/iree-dialects/Dialect/Input/InputOpInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "//third_party/llvm/llvm-project/mlir:mlir-tblgen",
+    td_file = "include/iree-dialects/Dialect/Input/InputInterfaces.td",
+    deps = [":TdFiles"],
+)
+
+gentbl_cc_library(
     name = "IREEInputIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
@@ -104,6 +122,7 @@ cc_library(
     includes = ["include"],
     deps = [
         ":IREEInputIncGen",
+        ":IREEInputInterfacesGen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/CMakeLists.txt
@@ -1,3 +1,11 @@
+function(_add_interfaces)
+  set(LLVM_TARGET_DEFINITIONS InputInterfaces.td)
+  mlir_tablegen(InputOpInterfaces.h.inc --gen-op-interface-decls)
+  mlir_tablegen(InputOpInterfaces.cpp.inc --gen-op-interface-defs)
+  add_public_tablegen_target(IREEInputInterfacesIncGen)
+  add_dependencies(mlir-headers IREEInputInterfacesIncGen)
+endfunction()
+
 function(_add_dialect)
   set(LLVM_TARGET_DEFINITIONS InputOps.td)
   mlir_tablegen(InputOps.h.inc -gen-op-decls)
@@ -10,4 +18,5 @@ function(_add_dialect)
   add_dependencies(mlir-headers IREEInputIncGen)
 endfunction()
 
+_add_interfaces()
 _add_dialect()

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
@@ -88,11 +88,6 @@ def IREEInput_ElementTypeParameter : TypeParameter<
 def IREEInput_PtrTargetTypeParameter : TypeParameter<
     "::mlir::Type", "A type suitable as a target type of a pointer">;
 
-def IREEInput_Dim : TypeAlias<Index>;
-def IREEInput_Dims : Variadic<IREEInput_Dim>;
-def IREEInput_Shape : Variadic<IREEInput_Dim>;
-def IREEInput_ShapeDynamicDims : Variadic<IREEInput_Dim>;
-
 def IREEInput_GlobalRefAttr : IREEInput_AliasedSymbolRefAttr;
 def IREEInput_AnyGlobalPtr : IREEInput_AnyPtrOf<[IREEInput_Tensor, IREEInput_PrimitiveType]>;
 
@@ -112,5 +107,22 @@ def IREEInput_TiedOpStorageAttr :
     TypedArrayAttrBase<IREEInput_IndexAttr, "64-bit integer array attribute"> {
   let constBuilderCall = "$_builder.getI64ArrayAttr($0)";
 }
+
+//===----------------------------------------------------------------------===//
+// Type aliases for working with shapes
+//===----------------------------------------------------------------------===//
+
+def IREEInput_Dim : TypeAlias<Index>;
+def IREEInput_Dims : Variadic<IREEInput_Dim>;
+def IREEInput_Shape : Variadic<IREEInput_Dim>;
+def IREEInput_ShapeDynamicDims : Variadic<IREEInput_Dim>;
+
+//===----------------------------------------------------------------------===//
+// Type aliases for working with Buffers and BufferViews
+//===----------------------------------------------------------------------===//
+
+def IREEInput_DeviceSize : TypeAlias<Index>;
+def IREEInput_ElementType : TypeAlias<I32>;
+def IREEInput_EncodingType : TypeAlias<I32>;
 
 #endif // IREE_DIALECTS_DIALECT_INPUT_BASE_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.h
@@ -16,4 +16,20 @@
 #define GET_TYPEDEF_CLASSES
 #include "iree-dialects/Dialect/Input/InputTypes.h.inc"
 
+//===----------------------------------------------------------------------===//
+// IREE ABI helpers for constructing buffer views
+//===----------------------------------------------------------------------===//
+
+namespace mlir::iree_compiler::IREE::Input {
+
+// Returns a stable identifier for the MLIR element type or nullopt if the
+// type is unsupported in the ABI.
+std::optional<int32_t> getElementTypeValue(Type type);
+
+// Returns a stable identifier for the MLIR encoding type or 0 (opaque) if the
+// type is unsupported in the ABI.
+std::optional<int32_t> getEncodingTypeValue(Attribute attr);
+
+} // namespace mlir::iree_compiler::IREE::Input
+
 #endif // IREE_DIALECTS_DIALECT_INPUT_DIALECT_H

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.td
@@ -13,6 +13,19 @@ include "iree-dialects/Dialect/Input/InputBase.td"
 // Types
 //===----------------------------------------------------------------------===//
 
+def IREEInput_BufferType : IREEInput_Type<"Buffer"> {
+  let mnemonic = "buffer";
+
+  let summary = "Buffer is an untyped bag of bits with no shape or dtype";
+
+  let description = [{
+    Buffers represent an untyped bag of bits that can be reinterpreted depending
+    on a use case using `buffer_view` operation. Buffers can be used for packing
+    multiple tensors into the same underlying storage. It is left to higher
+    level code to decide how exactly tensors layed out in the buffer.
+  }];
+}
+
 def IREEInput_BufferViewType : IREEInput_Type<"BufferView"> {
   let mnemonic = "buffer_view";
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputInterfaces.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputInterfaces.td
@@ -1,0 +1,213 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECTS_DIALECT_INPUT_INTERFACES_TD
+#define IREE_DIALECTS_DIALECT_INPUT_INTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// IREE::Input::TiedOpInterface
+//===----------------------------------------------------------------------===//
+
+def IREEInput_TiedOpInterface : OpInterface<"TiedOpInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Input";
+
+  let description = [{
+    An operation that "ties" one or more results to its operands indicating
+    that the result is directly related to the operand in an operation-defined
+    way. Results are still SSA values distinct from the operands and the tie is
+    strictly a relationship relevant to transformations and not something that
+    modifies IR definitions.
+
+    Example:
+      An operation on tensors that wants to indicate that the storage for a
+      result should alias the storage for an operand, performing an "in-place"
+      operation. Since tensors are still used there is no hard requirement that
+      uses of the result SSA value alias the operand; a copy may still be
+      introduced.
+
+    See Util dialect for more documentation and examples.
+
+    The default implementations use an attribute on the op to store the
+    relationship:
+      `OptionalAttr<IREEInput_TiedOpStorageAttr>:$tied_operands`
+
+    Note that `$tied_operands` are indices inside the operand range returned
+    by `getTiedOperandsIndexAndLength`, which may *not* be the full operand
+    range of the op.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the set of operands that results may be tied to as an
+        (index, length) pair ala getODSOperandIndexAndLength.
+
+        By default assumes all operands may be tied. If an op treats some
+        operands as special then the op can override this and specify only the
+        ones it will tie. For example, a cond_branch that has a condition
+        operand as well as the successor operands would return only the range
+        of successor operands.
+      }],
+      /*retTy=*/"std::pair<unsigned, unsigned>",
+      /*methodName=*/"getTiedOperandsIndexAndLength", (ins),
+      /*args=*/[{}],
+      /*defaultImplementation=*/[{
+        return {0, $_op->getNumOperands()};
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the set of results that may be tied to operands as an
+        (index, length) pair ala getODSResultIndexAndLength.
+
+        By default assumes all results may be tied. If an op treats some
+        results as special then the op can override this and specify only the
+        ones it will tie.
+      }],
+      /*retTy=*/"std::pair<unsigned, unsigned>",
+      /*methodName=*/"getTiedResultsIndexAndLength", (ins),
+      /*args=*/[{}],
+      /*defaultImplementation=*/[{
+        return {0, $_op->getNumResults()};
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Walks up the SSA use-def chain to find the first defined value reachable
+        from the given value by traversing tied ops. The returned value may be
+        in another block if that block dominates the one the result is defined
+        in.
+
+        Note that the returned value may be a block argument and have no
+        defining op, and the search will not continue past branches.
+        If the result is untied then the result itself is returned.
+      }],
+      /*retTy=*/"mlir::Value",
+      /*methodName=*/"getTiedResult",
+      /*args=*/(ins "unsigned":$resultIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::TiedOpInterface::findTiedBaseValue(
+          $_op.getResult(resultIndex));
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the operand tied to the given result of the op or nullptr if
+        none.
+      }],
+      /*retTy=*/"mlir::Value",
+      /*methodName=*/"getTiedResultOperand",
+      /*args=*/(ins "Value":$result),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        auto resultIndex = result.cast<mlir::OpResult>().getResultNumber();
+        auto operandIndex = cast<TiedOpInterface>($_op.getOperation())
+            .getTiedResultOperandIndex(resultIndex);
+        return operandIndex.has_value() ?
+            $_op.getOperand(operandIndex.value()) :
+            nullptr;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the operand index tied to the given result index, if any.
+
+        Note that the index returned is into the full range of all operands of
+        the current op.
+      }],
+      /*retTy=*/"::std::optional<unsigned>",
+      /*methodName=*/"getTiedResultOperandIndex",
+      /*args=*/(ins "unsigned":$resultIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::getTiedResultOperandIndex($_op,
+                                                              resultIndex);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Sets the operand index tied to the given result index, if any.
+
+        Note that the index should be into the operand range returned by
+        `getTiedOperandsIndexAndLength`.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"setTiedResultOperandIndex",
+      /*args=*/(ins "unsigned":$resultIndex,
+                    "::std::optional<unsigned>":$operandIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::setTiedResultOperandIndex($_op, resultIndex,
+                                                              operandIndex);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns an array containing the tied result operand indices with -1
+        indicating that a result is not tied.
+
+        Note that the index returned is into the full range of all operands of
+        the current op.
+      }],
+      /*retTy=*/"SmallVector<int64_t>",
+      /*methodName=*/"getTiedResultOperandIndices",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::getTiedResultOperandIndices($_op);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if the given flattened operand index is tied to one or more
+        results.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isOperandTied",
+      /*args=*/(ins "unsigned":$operandIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::isOperandTied($_op, operandIndex);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns a list of result values that are tied to the given operand.
+      }],
+      /*retTy=*/"SmallVector<Value>",
+      /*methodName=*/"getOperandTiedResults",
+      /*args=*/(ins "unsigned":$operandIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::getOperandTiedResults($_op, operandIndex);
+      }]
+    >,
+  ];
+
+  let extraClassDeclaration = [{
+    static StringRef getStorageAttrName() { return "tied_operands"; }
+
+    // Indicates that a result is not tied to any operand.
+    static constexpr int64_t kUntiedIndex = -1;
+
+    // Walks the SSA use-def chain to find the first defined value reachable
+    // from the given value by traversing tied ops. Note that the returned
+    // value may be a block argument and have no defining op.
+    static Value findTiedBaseValue(Value derivedValue);
+
+    // Returns true if any of |value|'s uses have tied it to a result.
+    static bool hasAnyTiedUses(Value value);
+  }];
+
+  let verify = [{
+    return IREE::Input::detail::verifyTiedOp(cast<TiedOpInterface>($_op));
+  }];
+}
+
+#endif // IREE_DIALECTS_DIALECT_INPUT_INTERFACES_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.h
@@ -16,6 +16,35 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+//===----------------------------------------------------------------------===//
+// IREE::Input::TiedOpInterface
+//===----------------------------------------------------------------------===//
+
+namespace mlir::iree_compiler::IREE::Input {
+
+// Forward declare
+class TiedOpInterface;
+
+namespace detail {
+
+std::optional<unsigned> getTiedResultOperandIndex(Operation *op,
+                                                  unsigned resultIndex);
+void setTiedResultOperandIndex(Operation *op, unsigned resultIndex,
+                               std::optional<unsigned> operandIndex);
+SmallVector<int64_t> getTiedResultOperandIndices(Operation *op);
+bool isOperandTied(Operation *tiedOp, unsigned operandIndex);
+SmallVector<Value> getOperandTiedResults(Operation *op, unsigned operandIndex);
+LogicalResult verifyTiedOp(TiedOpInterface tiedOp);
+
+} // namespace detail
+} // namespace mlir::iree_compiler::IREE::Input
+
+//===----------------------------------------------------------------------===//
+
+// Include generated interfaces code (this comment blocks clang-format from
+// clobbering order).
+#include "iree-dialects/Dialect/Input/InputOpInterfaces.h.inc"
+
 #define GET_OP_CLASSES
 #include "iree-dialects/Dialect/Input/InputOps.h.inc"
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -29,16 +29,18 @@ def IREEInput_NullOp : IREEInput_PureOp<"null"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Casts
+// Pseudo ops for conversion support
 //===----------------------------------------------------------------------===//
 
-def IREEInput_TensorToBufferViewOp : IREEInput_PureOp<"cast.tensor_to_buffer_view"> {
-  let summary = "Casts a tensor to a BufferView, capturing dynamic dims";
+def IREEInput_TensorExportOp : IREEInput_PureOp<"tensor.export"> {
+  let summary = "Exports a tensor to a Buffer(View), capturing dynamic dims";
   let arguments = (ins
     IREEInput_Tensor:$source,
     IREEInput_ShapeDynamicDims:$source_dims
   );
-  let results = (outs IREEInput_BufferViewType:$target);
+  let results = (outs
+    AnyTypeOf<[IREEInput_BufferType, IREEInput_BufferViewType]>:$target
+  );
 
   let assemblyFormat = [{
     $source `:` type($source) (`{` $source_dims^ `}`)? `->` type($target)
@@ -46,10 +48,10 @@ def IREEInput_TensorToBufferViewOp : IREEInput_PureOp<"cast.tensor_to_buffer_vie
   }];
 }
 
-def IREEInput_BufferViewToTensorOp : IREEInput_PureOp<"cast.buffer_view_to_tensor"> {
-  let summary = "Casts a BufferView to a tensor, providing dynamic dims";
+def IREEInput_TensorImportOp : IREEInput_PureOp<"tensor.import"> {
+  let summary = "Imports a Buffer(View) to a tensor, providing dynamic dims";
   let arguments = (ins
-    IREEInput_BufferViewType:$source,
+    AnyTypeOf<[IREEInput_BufferType, IREEInput_BufferViewType]>:$source,
     IREEInput_ShapeDynamicDims:$target_dims
   );
   let results = (outs IREEInput_Tensor:$target);
@@ -201,8 +203,60 @@ def IREEInput_GlobalStoreIndirectOp : IREEInput_Op<"global.store.indirect"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Buffer Views
+// Buffers and Buffer Views
 //===----------------------------------------------------------------------===//
+
+def IREEInput_BufferViewCreateOp : IREEInput_PureOp<"buffer_view.create"> {
+  let summary = [{buffer view reference initializer}];
+  let description = [{
+    Creates a reference to a buffer with a particular shape and element type.
+    The buffer is not copied and both the original and view references must be
+    synchronized. This makes it easier to associate commonly-carried metadata
+    along with the contents.
+  }];
+
+  let arguments = (ins
+    IREEInput_BufferType:$source_buffer,
+    IREEInput_DeviceSize:$source_offset,
+    IREEInput_DeviceSize:$source_length,
+    IREEInput_ElementType:$element_type,
+    IREEInput_EncodingType:$encoding_type,
+    IREEInput_Shape:$shape
+  );
+  let results = (outs
+    IREEInput_BufferViewType:$result
+  );
+
+  let assemblyFormat = [{
+    `buffer` `(` $source_buffer `:` type($source_buffer) `)`
+    `` `[` $source_offset `,` $source_length `]`
+    `shape` `(` `[` $shape `]` `)`
+    `type` `(` $element_type `)`
+    `encoding` `(` $encoding_type `)`
+    `:` type($result)
+    attr-dict-with-keyword
+  }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      "Value":$sourceBuffer,
+      "Value":$sourceOffset,
+      "Value":$sourceLength,
+      "int32_t":$elementType,
+      "int32_t":$encodingType,
+      "ValueRange":$shape
+    )>,
+    OpBuilder<(ins
+      "Value":$sourceBuffer,
+      "Value":$sourceOffset,
+      "Value":$sourceLength,
+      "Value":$elementType,
+      "Value":$encodingType,
+      "ValueRange":$shape
+    )>,
+  ];
+}
 
 def IREEInput_BufferViewRankOp : IREEInput_PureOp<"buffer_view.rank"> {
   let summary = [{buffer view rank query}];

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -566,8 +566,7 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
     IREEInput_ShapeDynamicDims:$target_dims,
     Variadic<IREEInput_Dim>:$start_indices,
     IREEInput_Tensor:$update,
-    IREEInput_ShapeDynamicDims:$update_dims,
-    OptionalAttr<IREEInput_TiedOpStorageAttr>:$tied_operands
+    IREEInput_ShapeDynamicDims:$update_dims
   );
   let results = (outs
     IREEInput_Tensor:$result
@@ -576,7 +575,7 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
   let assemblyFormat = [{
     $update `,` $target `[` $start_indices `]` `:`
     type($update) (`{` $update_dims^ `}`)? `->`
-    custom<ShapedTiedResult>(type($result), $target_dims, $tied_operands)
+    custom<ShapedTiedResult>(type($result), $target_dims)
     attr-dict-with-keyword
   }];
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -8,6 +8,7 @@
 #define IREE_DIALECTS_DIALECT_INPUT_OPS_TD
 
 include "iree-dialects/Dialect/Input/InputDialect.td"
+include "iree-dialects/Dialect/Input/InputInterfaces.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -548,6 +549,11 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
     AllTypesMatch<["target", "result"]>,
     AllElementTypesMatch<["update", "target", "result"]>,
     AttrSizedOperandSegments,
+    DeclareOpInterfaceMethods<IREEInput_TiedOpInterface, [
+      "getTiedResult",
+      "getTiedResultOperandIndex",
+      "getTiedResultOperandIndices",
+    ]>,
   ]> {
   let summary = [{updates a tensor with the contents of another tensor}];
   let description = [{
@@ -560,7 +566,8 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
     IREEInput_ShapeDynamicDims:$target_dims,
     Variadic<IREEInput_Dim>:$start_indices,
     IREEInput_Tensor:$update,
-    IREEInput_ShapeDynamicDims:$update_dims
+    IREEInput_ShapeDynamicDims:$update_dims,
+    OptionalAttr<IREEInput_TiedOpStorageAttr>:$tied_operands
   );
   let results = (outs
     IREEInput_Tensor:$result
@@ -569,7 +576,7 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
   let assemblyFormat = [{
     $update `,` $target `[` $start_indices `]` `:`
     type($update) (`{` $update_dims^ `}`)? `->`
-    type($result) (`{` $target_dims^ `}`)?
+    custom<ShapedTiedResult>(type($result), $target_dims, $tied_operands)
     attr-dict-with-keyword
   }];
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_library(IREEInputDialect
 
   DEPENDS
   IREEInputIncGen
+  IREEInputInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputDialect.cpp
@@ -30,12 +30,82 @@ void IREEInputDialect::initialize() {
       >();
 }
 
-namespace mlir {
-namespace iree_compiler {
-namespace IREE {
-namespace Input {
+namespace mlir::iree_compiler::IREE::Input {
 
+//===----------------------------------------------------------------------===//
+// IREE ABI helpers for constructing buffer views
+//===----------------------------------------------------------------------===//
+
+// Keep these in sync with iree/hal/api.h
+namespace {
+enum class NumericalType : uint32_t {
+  kUnknown = 0x00,
+  kInteger = 0x10,
+  kIntegerSigned = kInteger | 0x01,
+  kIntegerUnsigned = kInteger | 0x02,
+  kBoolean = kInteger | 0x03,
+  kFloat = 0x20,
+  kFloatIEEE = kFloat | 0x01,
+  kFloatBrain = kFloat | 0x02,
+  kFloatComplex = kFloat | 0x03,
+};
+} // namespace
+
+static constexpr int32_t makeElementTypeValue(NumericalType numericalType,
+                                              int32_t bitCount) {
+  return (static_cast<uint32_t>(numericalType) << 24) | bitCount;
+}
+
+std::optional<int32_t> getElementTypeValue(Type type) {
+  if (auto intType = llvm::dyn_cast_if_present<IntegerType>(type)) {
+    NumericalType numericalType;
+    if (intType.isInteger(1)) {
+      return makeElementTypeValue(NumericalType::kBoolean, 8);
+    } else if (intType.isSigned()) {
+      numericalType = NumericalType::kIntegerSigned;
+    } else if (intType.isUnsigned()) {
+      numericalType = NumericalType::kIntegerUnsigned;
+    } else {
+      // There's no such thing as a signless integer in machine types but we
+      // need to be able to round-trip the format through the ABI. Exact
+      // numerical type equality comparisons may fail if the frontend assumes
+      // signed/unsigned but the compiler is propagating signless.
+      numericalType = NumericalType::kInteger;
+    }
+    return makeElementTypeValue(numericalType, intType.getWidth());
+  } else if (auto floatType = llvm::dyn_cast_if_present<FloatType>(type)) {
+    switch (APFloat::SemanticsToEnum(floatType.getFloatSemantics())) {
+    case APFloat::S_IEEEhalf:
+    case APFloat::S_IEEEsingle:
+    case APFloat::S_IEEEdouble:
+    case APFloat::S_IEEEquad:
+      return makeElementTypeValue(NumericalType::kFloatIEEE,
+                                  floatType.getWidth());
+    case APFloat::S_BFloat:
+      return makeElementTypeValue(NumericalType::kFloatBrain,
+                                  floatType.getWidth());
+    default:
+      return std::nullopt;
+    }
+  } else if (auto complexType = llvm::dyn_cast_if_present<ComplexType>(type)) {
+    return makeElementTypeValue(
+        NumericalType::kFloatComplex,
+        complexType.getElementType().getIntOrFloatBitWidth() * 2);
+  }
+  return std::nullopt;
+}
+
+std::optional<int32_t> getEncodingTypeValue(Attribute attr) {
+  // TODO(#6762): encoding attribute handling/mapping to enums.
+  assert(!attr && "encoding types other than default not yet supported");
+  // Default to IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR for now.
+  return 1;
+}
+
+//===----------------------------------------------------------------------===//
 // ListType
+//===----------------------------------------------------------------------===//
+
 Type ListType::parse(AsmParser &parser) {
   MLIRContext *ctxt = parser.getContext();
   Type elementType;
@@ -49,7 +119,10 @@ void ListType::print(AsmPrinter &printer) const {
   printer << "<" << getElementType() << ">";
 }
 
+//===----------------------------------------------------------------------===//
 // PtrType
+//===----------------------------------------------------------------------===//
+
 Type PtrType::parse(AsmParser &parser) {
   MLIRContext *ctxt = parser.getContext();
   Type targetType;
@@ -63,7 +136,4 @@ void PtrType::print(AsmPrinter &printer) const {
   printer << "<" << getTargetType() << ">";
 }
 
-} // namespace Input
-} // namespace IREE
-} // namespace iree_compiler
-} // namespace mlir
+} // namespace mlir::iree_compiler::IREE::Input

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -17,6 +17,153 @@
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE::Input;
 
+#include "iree-dialects/Dialect/Input/InputOpInterfaces.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// IREE::Input::TiedOpInterface
+//===----------------------------------------------------------------------===//
+
+namespace mlir::iree_compiler::IREE::Input::detail {
+
+std::optional<unsigned> getTiedResultOperandIndex(Operation *op,
+                                                  unsigned resultIndex) {
+  auto storageAttr =
+      op->getAttrOfType<ArrayAttr>(TiedOpInterface::getStorageAttrName());
+  if (!storageAttr)
+    return std::nullopt;
+  auto valueAttrs = storageAttr.getValue();
+  if (valueAttrs.empty())
+    return std::nullopt;
+  if (auto tiedOp = dyn_cast<TiedOpInterface>(op)) {
+    auto indexAndLength = tiedOp.getTiedResultsIndexAndLength();
+    if (resultIndex < indexAndLength.first)
+      return std::nullopt;
+    resultIndex -= indexAndLength.first;
+    if (resultIndex >= indexAndLength.second)
+      return std::nullopt;
+  }
+  int64_t value = llvm::cast<IntegerAttr>(valueAttrs[resultIndex]).getInt();
+  if (value == TiedOpInterface::kUntiedIndex)
+    return std::nullopt;
+  if (auto tiedOp = dyn_cast<TiedOpInterface>(op)) {
+    unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
+    return tiedOperandsOffset + static_cast<unsigned>(value);
+  } else {
+    return static_cast<unsigned>(value);
+  }
+}
+
+SmallVector<int64_t> getTiedResultOperandIndices(Operation *op) {
+  SmallVector<int64_t> indices;
+  auto storageAttr =
+      op->getAttrOfType<ArrayAttr>(TiedOpInterface::getStorageAttrName());
+  if (!storageAttr)
+    return indices;
+  auto valueAttrs = storageAttr.getValue();
+  if (valueAttrs.empty())
+    return indices;
+  auto tiedOp = cast<TiedOpInterface>(op);
+  auto resultRange = tiedOp.getTiedResultsIndexAndLength();
+  unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
+  indices.resize(resultRange.second);
+  for (unsigned i = 0; i < valueAttrs.size(); ++i) {
+    int64_t index = llvm::cast<IntegerAttr>(valueAttrs[i]).getInt();
+    indices[i] = index != TiedOpInterface::kUntiedIndex
+                     ? tiedOperandsOffset + index
+                     : TiedOpInterface::kUntiedIndex;
+  }
+  return indices;
+}
+
+void setTiedResultOperandIndex(Operation *op, unsigned resultIndex,
+                               std::optional<unsigned> operandIndex) {
+  auto tiedOp = cast<TiedOpInterface>(op);
+  auto resultRange = tiedOp.getTiedResultsIndexAndLength();
+  resultIndex -= resultRange.first;
+
+  auto indices = getTiedResultOperandIndices(op);
+  if (indices.empty()) {
+    indices.resize(resultRange.second, TiedOpInterface::kUntiedIndex);
+  } else {
+    // Well, getTiedResultOperandIndices() returns indices into the full range
+    // of the op, but in the attribute, we expect to store ranges into the range
+    // returned by `getTiedOperandsIndexAndLength`.
+    unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
+    for (auto &index : indices) {
+      if (index != TiedOpInterface::kUntiedIndex)
+        index -= tiedOperandsOffset;
+    }
+  }
+
+  indices[resultIndex] = operandIndex.value_or(TiedOpInterface::kUntiedIndex);
+  op->setAttr(TiedOpInterface::getStorageAttrName(),
+              Builder(op).getIndexArrayAttr(indices));
+}
+
+bool isOperandTied(Operation *op, unsigned operandIndex) {
+  auto tiedOp = dyn_cast<TiedOpInterface>(op);
+  if (!tiedOp)
+    return false;
+  auto tiedIndices = tiedOp.getTiedResultOperandIndices();
+  for (unsigned i = 0; i < tiedIndices.size(); ++i) {
+    if (tiedIndices[i] == operandIndex) {
+      return true;
+    }
+  }
+  return false;
+}
+
+SmallVector<Value> getOperandTiedResults(Operation *op, unsigned operandIndex) {
+  auto tiedOp = dyn_cast<TiedOpInterface>(op);
+  if (!tiedOp)
+    return {};
+  auto resultRange = tiedOp.getTiedResultsIndexAndLength();
+  SmallVector<Value> results;
+  auto tiedIndices = tiedOp.getTiedResultOperandIndices();
+  for (unsigned i = 0; i < tiedIndices.size(); ++i) {
+    if (tiedIndices[i] == operandIndex) {
+      results.push_back(op->getResult(resultRange.first + i));
+    }
+  }
+  return results;
+}
+
+LogicalResult verifyTiedOp(TiedOpInterface tiedOp) {
+  auto tiedOperandIndices = tiedOp.getTiedResultOperandIndices();
+  if (tiedOperandIndices.empty())
+    return success();
+  auto resultRange = tiedOp.getTiedResultsIndexAndLength();
+  if (tiedOperandIndices.size() != resultRange.second) {
+    return tiedOp.emitError("op results/tied operand indices mismatch");
+  }
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::Input::detail
+
+Value TiedOpInterface::findTiedBaseValue(Value derivedValue) {
+  Value baseValue = derivedValue;
+  while (auto definingOp =
+             dyn_cast_or_null<TiedOpInterface>(baseValue.getDefiningOp())) {
+    auto tiedValue = definingOp.getTiedResultOperand(baseValue);
+    if (!tiedValue)
+      break;
+    baseValue = tiedValue;
+  }
+  return baseValue;
+}
+
+bool TiedOpInterface::hasAnyTiedUses(Value value) {
+  for (auto &use : value.getUses()) {
+    auto tiedOp = dyn_cast<TiedOpInterface>(use.getOwner());
+    if (!tiedOp)
+      continue;
+    if (tiedOp.isOperandTied(use.getOperandNumber()))
+      return true;
+  }
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // custom<SymbolVisibility>($sym_visibility)
 //===----------------------------------------------------------------------===//
@@ -90,6 +237,81 @@ static void printTypeOrAttr(OpAsmPrinter &p, Operation *op, TypeAttr type,
     p << " = ";
     p.printAttribute(attr);
   }
+}
+
+//===----------------------------------------------------------------------===//
+// custom<ShapedTiedResult>
+//===----------------------------------------------------------------------===//
+// type{%dim0, %dim1}
+// %arg0 as type{%dim0}
+
+static ParseResult parseShapedTiedResult(
+    OpAsmParser &parser, Type &resultType,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &resultDims,
+    ArrayAttr &tiedOperands) {
+  OpAsmParser::UnresolvedOperand tiedResult;
+  auto res = parser.parseOptionalOperand(tiedResult);
+  int64_t tiedOperandIndex = TiedOpInterface::kUntiedIndex;
+  if (res.has_value() && succeeded(res.value())) {
+    tiedOperandIndex = 0;
+    if (failed(parser.parseKeyword("as")))
+      return failure();
+  }
+  if (failed(parser.parseType(resultType)))
+    return failure();
+  if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
+    if (!shapedType.hasStaticShape()) {
+      SmallVector<OpAsmParser::UnresolvedOperand> dynamicDims;
+      if (failed(parser.parseLBrace()) ||
+          failed(parser.parseOperandList(dynamicDims,
+                                         shapedType.getNumDynamicDims(),
+                                         OpAsmParser::Delimiter::None)) ||
+          failed(parser.parseRBrace())) {
+        return failure();
+      }
+      resultDims.append(dynamicDims);
+    }
+  }
+  tiedOperands = parser.getBuilder().getIndexArrayAttr({tiedOperandIndex});
+  return success();
+}
+
+static ParseResult parseShapedTiedResult(
+    OpAsmParser &parser, Type &resultType,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &resultDims) {
+  ArrayAttr tiedOperands;
+  return parseShapedTiedResult(parser, resultType, resultDims, tiedOperands);
+}
+
+void printShapedTiedResult(OpAsmPrinter &p, TiedOpInterface op, Type resultType,
+                           ValueRange resultDims) {
+  auto tiedOperandIndex = op.getTiedResultOperandIndex(0);
+  if (tiedOperandIndex.has_value()) {
+    auto tiedOperand = op->getOperand(tiedOperandIndex.value());
+    p.printOperand(tiedOperand);
+    p << " as ";
+  }
+  p.printType(resultType);
+  if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
+    if (!shapedType.hasStaticShape()) {
+      if (resultDims.empty()) {
+        p << "{<<INVALID>>}";
+        return;
+      }
+      p << "{";
+      llvm::interleaveComma(
+          resultDims.take_front(shapedType.getNumDynamicDims()), p,
+          [&](Value value) { p.printOperand(value); });
+      p << "}";
+      resultDims = resultDims.drop_front(shapedType.getNumDynamicDims());
+    }
+  }
+}
+
+static void printShapedTiedResult(OpAsmPrinter &p, TiedOpInterface op,
+                                  Type resultType, ValueRange resultDims,
+                                  ArrayAttr tiedOperands) {
+  printShapedTiedResult(p, op, resultType, resultDims);
 }
 
 //===----------------------------------------------------------------------===//
@@ -185,6 +407,23 @@ LogicalResult GlobalStoreIndirectOp::verify() {
                          << globalType << " but store is " << storeType;
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_input.tensor.update
+//===----------------------------------------------------------------------===//
+
+Value TensorUpdateOp::getTiedResult(unsigned resultIndex) {
+  return TiedOpInterface::findTiedBaseValue(getTarget());
+}
+
+std::optional<unsigned>
+TensorUpdateOp::getTiedResultOperandIndex(unsigned resultIndex) {
+  return {0}; // $target
+}
+
+SmallVector<int64_t> TensorUpdateOp::getTiedResultOperandIndices() {
+  return {0}; // $target
 }
 
 #define GET_OP_CLASSES


### PR DESCRIPTION
Tied operands is an important part of the "IREE programming model" and I'll need it in the follow up PR that will add `iree_input.dispatch` operation.

Diffbase: https://github.com/openxla/iree/pull/14278

TrueDiff: https://github.com/ezhulenev/iree/compare/iree-input-0...ezhulenev:iree:iree-input-1