### PR TITLE
Move fixupVisibility before optimization passes

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -522,6 +522,12 @@ public:
                         variantOp.getName(), ".linked.bc", *llvmModule);
     }
 
+    // Fixup visibility from any symbols we may link in - we want to hide all
+    // but the query entry point.
+    SetVector<llvm::Function *> preservedFuncs;
+    preservedFuncs.insert(queryLibraryFunc);
+    fixupVisibility(*llvmModule, preservedFuncs);
+
     // LLVM opt passes that perform code generation optimizations/transformation
     // similar to what a frontend would do.
     if (failed(
@@ -531,12 +537,6 @@ public:
                 "targeting '"
              << targetTriple.str() << "'";
     }
-
-    // Fixup visibility from any symbols we may link in - we want to hide all
-    // but the query entry point.
-    SetVector<llvm::Function *> preservedFuncs;
-    preservedFuncs.insert(queryLibraryFunc);
-    fixupVisibility(*llvmModule, preservedFuncs);
 
     // Dump bitcode post-linking and optimization.
     if (!options.dumpIntermediatesPath.empty()) {


### PR DESCRIPTION
This fixes the general issue that IREE bytecode modules tend to contain code for things like math functions (`roundf`, `powf` etc) even if they don't reference them. It was also key to fixing dead code elimination (DCE) for ukernel code paths (next PR xxx), which is how I found this.

`fixupVisibility` sets most symbols to have `InternalLinkage`, which is key to DCE. The actual DCE passes run in `runLLVMIRPasses`. So it's important that `fixupVisibility` is called before `runLLVMIRPasses`, not after.