### PR TITLE
[LLVMGPU] Add a tensor based pipeline for TensorCoreMmaSync codegen. 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
@@ -46,6 +46,8 @@ def LLVMGPU_PackUnPack
     : I32EnumAttrCase<"LLVMGPUPackUnPack", 107>;
 def LLVMGPU_MatmulTensorCoreMmaSync
     : I32EnumAttrCase<"LLVMGPUMatmulTensorCoreMmaSync", 108>;
+def LLVMGPU_MatmulTensorCoreMmaSyncOnTensors
+    : I32EnumAttrCase<"LLVMGPUMatmulTensorCoreMmaSyncOnTensors", 109>;
 
 def SPIRV_BaseLowering
     : I32EnumAttrCase<"SPIRVBaseLowering", 200>;
@@ -86,6 +88,7 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,
     LLVMGPU_TransposeSharedMem, LLVMGPU_WarpReduction,
     LLVMGPU_PackUnPack, LLVMGPU_MatmulTensorCoreMmaSync,
+    LLVMGPU_MatmulTensorCoreMmaSyncOnTensors,
 
     // SPIR-V CodeGen pipelines
     SPIRV_BaseLowering, SPIRV_BaseDistribute, SPIRV_BaseVectorize,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -174,6 +174,12 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
           executableLoweringPipeline,
           translationInfo.value().getSoftwarePipelineDepth());
       break;
+    case IREE::Codegen::DispatchLoweringPassPipeline::
+        LLVMGPUMatmulTensorCoreMmaSyncOnTensors:
+      addGPUMatmulTensorCoreMmaSyncOnTensorsPassPipeline(
+          executableLoweringPipeline,
+          translationInfo.value().getSoftwarePipelineDepth());
+      break;
     case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTransposeSharedMem:
       addGPUTransposePassPipeline(executableLoweringPipeline);
       break;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -340,6 +340,64 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
       createLLVMGPUPackSharedMemoryAlloc());
 }
 
+void addGPUMatmulTensorCoreMmaSyncOnTensorsPassPipeline(
+    OpPassManager &pm, unsigned pipelineDepth) {
+  tileAndDistributeToWorkgroup(pm);
+
+  auto &nestedModulePM = pm.nest<ModuleOp>();
+  nestedModulePM.addNestedPass<func::FuncOp>(createGPUTensorTile(false));
+  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
+
+  // Linalg -> vector
+  nestedModulePM.addNestedPass<func::FuncOp>(createGenericVectorizationPass());
+
+  // tensor to memref
+  addBufferizePasses(nestedModulePM);
+
+  // distribute foreach threads
+  nestedModulePM.addNestedPass<func::FuncOp>(createGPUDistribute());
+
+  // Even though we vectorize before bufferization we are not able to hoist
+  // accumulator load/store out of the K loop until distribution. Therefore we
+  // still rely on buffer level transformations for transfer ops hoisting and
+  // store to load forwarding. This relies on shacky alias analysis and we need
+  // to move this to tensor level once we have better abstractions.
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      memref::createFoldMemRefAliasOpsPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createHoistRedundantVectorTransfersPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createEraseDeadAllocAndStoresPass());
+
+  // Vector -> MMA ops
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMGPUTensorCorePreparationPass(GPUTensorCoreType::MMA_SYNC));
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createHoistUnrolledVectorExtractInsertSlicePass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      memref::createFoldMemRefAliasOpsPass());
+  nestedModulePM.addPass(createCSEPass());
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMGPUVectorToGPU(GPUTensorCoreType::MMA_SYNC));
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+
+  // Hoist loop invariant code to avoid pipelining it.
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLoopInvariantCodeMotionPass());
+  // Pipeline memory operations.
+  nestedModulePM.addNestedPass<func::FuncOp>(createGPUPipeliningPass(
+      /*epiloguePeeling=*/false, pipelineDepth,
+      PipeliningSchedulingStrategy::nvidiaTensorCore));
+  // Optimize shared memory usage.
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMGPUPackSharedMemoryAlloc());
+}
+
 void addGPUTransposePassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -29,6 +29,12 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm);
 void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
                                                unsigned pipelineDepth);
 
+/// Lowering using mma.sync Tensor Core operations on tensor's path. Different
+/// from GPUMatmulTensorCoreMmaSync pipeline, it applies distribution and
+/// vectorization on tensors.
+void addGPUMatmulTensorCoreMmaSyncOnTensorsPassPipeline(OpPassManager &pm,
+                                                        unsigned pipelineDepth);
+
 /// Lowering using wmma Tensor Core operations.
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
                                         unsigned pipelineDepth);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -52,6 +52,8 @@ static LogicalResult getInstructionShape(
     break;
   case IREE::Codegen::DispatchLoweringPassPipeline::
       LLVMGPUMatmulTensorCoreMmaSync:
+  case IREE::Codegen::DispatchLoweringPassPipeline::
+      LLVMGPUMatmulTensorCoreMmaSyncOnTensors:
     // Tensor Core Pipeline / MMA.SYNC
     if (inputElementType.isF16() || inputElementType.isBF16()) {
       instructionShape = {16, 8, 16};
@@ -168,6 +170,11 @@ verifyGPUMatmulPipeline(Operation *op,
   // Return success for SIMT/CUDA cores.
   if (pipeline.getValue() ==
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulSimt)
+    return success();
+
+  // TODO(hanchung): Add a verifier once it's built completely.
+  if (pipeline.getValue() == IREE::Codegen::DispatchLoweringPassPipeline::
+                                 LLVMGPUMatmulTensorCoreMmaSyncOnTensors)
     return success();
 
   //

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -31,6 +31,7 @@ iree_lit_test_suite(
             "nvvm_extract_address_computation.mlir",
             "nvvm_pipeline_test.mlir",
             "nvvm_mma_sync_pipeline_test.mlir",
+            "nvvm_mma_sync_tensor_pipeline_test.mlir",
             "reduction_pipeline_cuda.mlir",
             "reduction_pipeline_rocm.mlir",
             "reduction_pipeline_transform_cuda.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_lit_test_suite(
     "linalg_transform.mlir"
     "nvvm_extract_address_computation.mlir"
     "nvvm_mma_sync_pipeline_test.mlir"
+    "nvvm_mma_sync_tensor_pipeline_test.mlir"
     "nvvm_pipeline_test.mlir"
     "pack_pipeline_test.mlir"
     "pack_shared_memory_alloc.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_tensor_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_tensor_pipeline_test.mlir
@@ -1,0 +1,52 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))" %s | FileCheck %s
+
+#config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 64]]>
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulTensorCoreMmaSyncOnTensors pipeline_depth = 4>
+#compilation = #iree_codegen.compilation_info<lowering_config = #config, translation_info = #translation, workgroup_size = [2, 2, 1]>
+#device_target_cuda = #hal.device.target<"cuda", {executable_targets = [#executable_target_cuda_nvptx_fb], legacy_sync}>
+module attributes {hal.device.targets = [#device_target_cuda]} {
+  hal.executable private @foo_dispatch_0 {
+    hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
+      hal.executable.export public @matmul_f16xf16xf32_to_f16 ordinal(0) layout(#pipeline_layout) {
+      ^bb0(%arg0: !hal.device):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @matmul_f16xf16xf32_to_f16() {
+          %c0 = arith.constant 0 : index
+          %cst = arith.constant 0.000000e+00 : f32
+          %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3456x2048xf16>>
+          %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x1024xf16>>
+          %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<3456x1024xf16>>
+          %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [3456, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<3456x2048xf16>> -> tensor<3456x2048xf16>
+          %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 1024], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x1024xf16>> -> tensor<2048x1024xf16>
+          %5 = tensor.empty() : tensor<3456x1024xf16>
+          %6 = tensor.empty() : tensor<3456x1024xf32>
+          %7 = linalg.fill ins(%cst : f32) outs(%6 : tensor<3456x1024xf32>) -> tensor<3456x1024xf32>
+          %8 = linalg.matmul {compilation_info = #compilation} ins(%3, %4 : tensor<3456x2048xf16>, tensor<2048x1024xf16>) outs(%7 : tensor<3456x1024xf32>) -> tensor<3456x1024xf32>
+          %9 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%8 : tensor<3456x1024xf32>) outs(%5 : tensor<3456x1024xf16>) {
+          ^bb0(%in: f32, %out: f16):
+            %10 = arith.truncf %in : f32 to f16
+            linalg.yield %10 : f16
+          } -> tensor<3456x1024xf16>
+          flow.dispatch.tensor.store %9, %2, offsets = [0, 0], sizes = [3456, 1024], strides = [1, 1] : tensor<3456x1024xf16> -> !flow.dispatch.tensor<writeonly:tensor<3456x1024xf16>>
+          return
+        }
+      }
+    }
+  }
+}
+// CHECK: func.func @matmul_f16xf16xf32_to_f16
+// CHECK-NOT:         memref.alloc
+//
+// After unrolling to mma shapes, there are (64 / 16) * (64 / 8) = 32 results in
+// total.
+//
+// CHECK:             %[[SCF:.+]]:32 = scf.for
+// CHECK-COUNT-31:    %{{.+}} = vector.insert_strided_slice %[[SCF]]#
+// CHECK:             %[[MATMUL_RES:.+]] = vector.insert_strided_slice %[[SCF]]#
+// CHECK:             %[[TRUNCF:.+]] = arith.truncf %[[MATMUL_RES]] : vector<64x64xf32> to vector<64x64xf16>


### PR DESCRIPTION
There are more things will be added to the pipeline, which includes:
  - Allocate shared memory for inputs and outputs
  - Distribution to warps
  - Kick in MultiBuffering transformation
  - etc