### PR TITLE
Fix mmperf and sharktank to use A100 runner

### DIFF
--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -17,7 +17,6 @@ on:
   schedule:
     - cron: '0 13 * * *'
   workflow_dispatch:
-  pull_request:
 
 env:
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -144,7 +144,7 @@ jobs:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu
+      - a100
       - os-family=Linux
     env:
       RESULTS_DIR: mmperf-results-cuda

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -144,7 +144,7 @@ jobs:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=${{ needs.setup.outputs.runner-env }}
-      - a100
+      - machine-type=a2-highgpu-1g
       - os-family=Linux
     env:
       RESULTS_DIR: mmperf-results-cuda

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -17,6 +17,7 @@ on:
   schedule:
     - cron: '0 13 * * *'
   workflow_dispatch:
+  pull_request:
 
 env:
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}

--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -7,7 +7,7 @@ on:
   # Uncomment `pull_request` below to test your PR on SHARK.
   # Results will be uploaded to gs://shark-benchmark-artifacts.
   # See the workflow's `SHARK -> generate_report` log output for exact results URL.
-  # pull_request:
+  pull_request:
 
 jobs:
   setup:

--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -7,7 +7,7 @@ on:
   # Uncomment `pull_request` below to test your PR on SHARK.
   # Results will be uploaded to gs://shark-benchmark-artifacts.
   # See the workflow's `SHARK -> generate_report` log output for exact results URL.
-  pull_request:
+  # pull_request:
 
 jobs:
   setup:

--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -93,7 +93,7 @@ jobs:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu
+      - a100
       - os-family=Linux
     env:
       SHARK_SHA: ${{ needs.setup.outputs.shark-sha }}

--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -93,7 +93,7 @@ jobs:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=${{ needs.setup.outputs.runner-env }}
-      - a100
+      - machine-type=a2-highgpu-1g
       - os-family=Linux
     env:
       SHARK_SHA: ${{ needs.setup.outputs.shark-sha }}


### PR DESCRIPTION
Since `- gpu` is will use T4 GPU runner, change MMPerf and SharkTank workflow to use `- machine-type=a2-highgpu-1g` to get the exact spec of A100 GPU runner, as they are doing benchmarking