### PR TITLE
[IREEInput] Add TiedOpInterface and optimization barrier op

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -365,6 +365,8 @@ void IREEImportPublicPass::runOnOperation() {
   ONE_TO_ONE(IREE::Input::GlobalStoreOp, IREE::Util::GlobalStoreOp);
   ONE_TO_ONE(IREE::Input::GlobalStoreIndirectOp,
              IREE::Util::GlobalStoreIndirectOp);
+  ONE_TO_ONE(IREE::Input::OptimizationBarrierOp,
+             IREE::Util::OptimizationBarrierOp);
 
   if (failed(applyFullConversion(getOperation(), target, std::move(patterns))))
     signalPassFailure();

--- a/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
@@ -329,3 +329,11 @@ builtin.module @global_store_indirect {
     return
   }
 }
+
+// -----
+// CHECK-LABEL: func.func @optimization_barrier
+// CHECK: util.optimization_barrier %arg0 : tensor<f32>
+func.func @optimization_barrier(%arg0 : tensor<f32>) -> tensor<f32> {
+  %0 = iree_input.optimization_barrier %arg0 : tensor<f32>
+  return %0 : tensor<f32>
+}

--- a/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
@@ -245,7 +245,7 @@ func.func @tensor_slice(%arg0 : tensor<?xf32>, %arg1 : index, %arg2 : index, %ar
 // CHECK-LABEL: func.func @tensor_update
 // CHECK: flow.tensor.update %arg3, %arg0[%arg1] : tensor<?xf32>{%arg2} -> %arg0 as tensor<?xf32>{%arg4}
 func.func @tensor_update(%arg0 : tensor<?xf32>, %arg1 : index, %arg2 : index, %arg3 : tensor<?xf32>, %arg4 : index) -> tensor<?xf32> {
-  %0 = iree_input.tensor.update %arg3, %arg0[%arg1] : tensor<?xf32>{%arg2} -> tensor<?xf32>{%arg4}
+  %0 = iree_input.tensor.update %arg3, %arg0[%arg1] : tensor<?xf32>{%arg2} -> %arg0 as tensor<?xf32>{%arg4}
   return %0 : tensor<?xf32>
 }
 

--- a/llvm-external-projects/iree-dialects/BUILD.bazel
+++ b/llvm-external-projects/iree-dialects/BUILD.bazel
@@ -62,7 +62,7 @@ td_library(
 ################################################################################
 
 gentbl_cc_library(
-    name = "IREEInputInterfacesGen",
+    name = "IREEInputInterfacesIncGen",
     tags = ["manual"],
     tbl_outs = [
         (
@@ -74,7 +74,7 @@ gentbl_cc_library(
             "include/iree-dialects/Dialect/Input/InputOpInterfaces.cpp.inc",
         ),
     ],
-    tblgen = "//third_party/llvm/llvm-project/mlir:mlir-tblgen",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "include/iree-dialects/Dialect/Input/InputInterfaces.td",
     deps = [":TdFiles"],
 )
@@ -122,7 +122,7 @@ cc_library(
     includes = ["include"],
     deps = [
         ":IREEInputIncGen",
-        ":IREEInputInterfacesGen",
+        ":IREEInputInterfacesIncGen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",

--- a/llvm-external-projects/iree-dialects/BUILD.bazel
+++ b/llvm-external-projects/iree-dialects/BUILD.bazel
@@ -62,6 +62,24 @@ td_library(
 ################################################################################
 
 gentbl_cc_library(
+    name = "IREEInputInterfacesGen",
+    tags = ["manual"],
+    tbl_outs = [
+        (
+            ["--gen-op-interface-decls"],
+            "include/iree-dialects/Dialect/Input/InputOpInterfaces.h.inc",
+        ),
+        (
+            ["--gen-op-interface-defs"],
+            "include/iree-dialects/Dialect/Input/InputOpInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "//third_party/llvm/llvm-project/mlir:mlir-tblgen",
+    td_file = "include/iree-dialects/Dialect/Input/InputInterfaces.td",
+    deps = [":TdFiles"],
+)
+
+gentbl_cc_library(
     name = "IREEInputIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
@@ -104,6 +122,7 @@ cc_library(
     includes = ["include"],
     deps = [
         ":IREEInputIncGen",
+        ":IREEInputInterfacesGen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/CMakeLists.txt
@@ -1,3 +1,11 @@
+function(_add_interfaces)
+  set(LLVM_TARGET_DEFINITIONS InputInterfaces.td)
+  mlir_tablegen(InputOpInterfaces.h.inc --gen-op-interface-decls)
+  mlir_tablegen(InputOpInterfaces.cpp.inc --gen-op-interface-defs)
+  add_public_tablegen_target(IREEInputInterfacesIncGen)
+  add_dependencies(mlir-headers IREEInputInterfacesIncGen)
+endfunction()
+
 function(_add_dialect)
   set(LLVM_TARGET_DEFINITIONS InputOps.td)
   mlir_tablegen(InputOps.h.inc -gen-op-decls)
@@ -10,4 +18,5 @@ function(_add_dialect)
   add_dependencies(mlir-headers IREEInputIncGen)
 endfunction()
 
+_add_interfaces()
 _add_dialect()

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputInterfaces.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputInterfaces.td
@@ -1,0 +1,213 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECTS_DIALECT_INPUT_INTERFACES_TD
+#define IREE_DIALECTS_DIALECT_INPUT_INTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// IREE::Input::TiedOpInterface
+//===----------------------------------------------------------------------===//
+
+def IREEInput_TiedOpInterface : OpInterface<"TiedOpInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Input";
+
+  let description = [{
+    An operation that "ties" one or more results to its operands indicating
+    that the result is directly related to the operand in an operation-defined
+    way. Results are still SSA values distinct from the operands and the tie is
+    strictly a relationship relevant to transformations and not something that
+    modifies IR definitions.
+
+    Example:
+      An operation on tensors that wants to indicate that the storage for a
+      result should alias the storage for an operand, performing an "in-place"
+      operation. Since tensors are still used there is no hard requirement that
+      uses of the result SSA value alias the operand; a copy may still be
+      introduced.
+
+    See Util dialect for more documentation and examples.
+
+    The default implementations use an attribute on the op to store the
+    relationship:
+      `OptionalAttr<IREEInput_TiedOpStorageAttr>:$tied_operands`
+
+    Note that `$tied_operands` are indices inside the operand range returned
+    by `getTiedOperandsIndexAndLength`, which may *not* be the full operand
+    range of the op.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the set of operands that results may be tied to as an
+        (index, length) pair ala getODSOperandIndexAndLength.
+
+        By default assumes all operands may be tied. If an op treats some
+        operands as special then the op can override this and specify only the
+        ones it will tie. For example, a cond_branch that has a condition
+        operand as well as the successor operands would return only the range
+        of successor operands.
+      }],
+      /*retTy=*/"std::pair<unsigned, unsigned>",
+      /*methodName=*/"getTiedOperandsIndexAndLength", (ins),
+      /*args=*/[{}],
+      /*defaultImplementation=*/[{
+        return {0, $_op->getNumOperands()};
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the set of results that may be tied to operands as an
+        (index, length) pair ala getODSResultIndexAndLength.
+
+        By default assumes all results may be tied. If an op treats some
+        results as special then the op can override this and specify only the
+        ones it will tie.
+      }],
+      /*retTy=*/"std::pair<unsigned, unsigned>",
+      /*methodName=*/"getTiedResultsIndexAndLength", (ins),
+      /*args=*/[{}],
+      /*defaultImplementation=*/[{
+        return {0, $_op->getNumResults()};
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Walks up the SSA use-def chain to find the first defined value reachable
+        from the given value by traversing tied ops. The returned value may be
+        in another block if that block dominates the one the result is defined
+        in.
+
+        Note that the returned value may be a block argument and have no
+        defining op, and the search will not continue past branches.
+        If the result is untied then the result itself is returned.
+      }],
+      /*retTy=*/"mlir::Value",
+      /*methodName=*/"getTiedResult",
+      /*args=*/(ins "unsigned":$resultIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::TiedOpInterface::findTiedBaseValue(
+          $_op.getResult(resultIndex));
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the operand tied to the given result of the op or nullptr if
+        none.
+      }],
+      /*retTy=*/"mlir::Value",
+      /*methodName=*/"getTiedResultOperand",
+      /*args=*/(ins "Value":$result),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        auto resultIndex = result.cast<mlir::OpResult>().getResultNumber();
+        auto operandIndex = cast<TiedOpInterface>($_op.getOperation())
+            .getTiedResultOperandIndex(resultIndex);
+        return operandIndex.has_value() ?
+            $_op.getOperand(operandIndex.value()) :
+            nullptr;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the operand index tied to the given result index, if any.
+
+        Note that the index returned is into the full range of all operands of
+        the current op.
+      }],
+      /*retTy=*/"::std::optional<unsigned>",
+      /*methodName=*/"getTiedResultOperandIndex",
+      /*args=*/(ins "unsigned":$resultIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::getTiedResultOperandIndex($_op,
+                                                              resultIndex);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Sets the operand index tied to the given result index, if any.
+
+        Note that the index should be into the operand range returned by
+        `getTiedOperandsIndexAndLength`.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"setTiedResultOperandIndex",
+      /*args=*/(ins "unsigned":$resultIndex,
+                    "::std::optional<unsigned>":$operandIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::setTiedResultOperandIndex($_op, resultIndex,
+                                                              operandIndex);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns an array containing the tied result operand indices with -1
+        indicating that a result is not tied.
+
+        Note that the index returned is into the full range of all operands of
+        the current op.
+      }],
+      /*retTy=*/"SmallVector<int64_t>",
+      /*methodName=*/"getTiedResultOperandIndices",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::getTiedResultOperandIndices($_op);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if the given flattened operand index is tied to one or more
+        results.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isOperandTied",
+      /*args=*/(ins "unsigned":$operandIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::isOperandTied($_op, operandIndex);
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns a list of result values that are tied to the given operand.
+      }],
+      /*retTy=*/"SmallVector<Value>",
+      /*methodName=*/"getOperandTiedResults",
+      /*args=*/(ins "unsigned":$operandIndex),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return IREE::Input::detail::getOperandTiedResults($_op, operandIndex);
+      }]
+    >,
+  ];
+
+  let extraClassDeclaration = [{
+    static StringRef getStorageAttrName() { return "tied_operands"; }
+
+    // Indicates that a result is not tied to any operand.
+    static constexpr int64_t kUntiedIndex = -1;
+
+    // Walks the SSA use-def chain to find the first defined value reachable
+    // from the given value by traversing tied ops. Note that the returned
+    // value may be a block argument and have no defining op.
+    static Value findTiedBaseValue(Value derivedValue);
+
+    // Returns true if any of |value|'s uses have tied it to a result.
+    static bool hasAnyTiedUses(Value value);
+  }];
+
+  let verify = [{
+    return IREE::Input::detail::verifyTiedOp(cast<TiedOpInterface>($_op));
+  }];
+}
+
+#endif // IREE_DIALECTS_DIALECT_INPUT_INTERFACES_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.h
@@ -16,6 +16,35 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+//===----------------------------------------------------------------------===//
+// IREE::Input::TiedOpInterface
+//===----------------------------------------------------------------------===//
+
+namespace mlir::iree_compiler::IREE::Input {
+
+// Forward declare
+class TiedOpInterface;
+
+namespace detail {
+
+std::optional<unsigned> getTiedResultOperandIndex(Operation *op,
+                                                  unsigned resultIndex);
+void setTiedResultOperandIndex(Operation *op, unsigned resultIndex,
+                               std::optional<unsigned> operandIndex);
+SmallVector<int64_t> getTiedResultOperandIndices(Operation *op);
+bool isOperandTied(Operation *tiedOp, unsigned operandIndex);
+SmallVector<Value> getOperandTiedResults(Operation *op, unsigned operandIndex);
+LogicalResult verifyTiedOp(TiedOpInterface tiedOp);
+
+} // namespace detail
+} // namespace mlir::iree_compiler::IREE::Input
+
+//===----------------------------------------------------------------------===//
+
+// Include generated interfaces code (this comment blocks clang-format from
+// clobbering order).
+#include "iree-dialects/Dialect/Input/InputOpInterfaces.h.inc"
+
 #define GET_OP_CLASSES
 #include "iree-dialects/Dialect/Input/InputOps.h.inc"
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -566,8 +566,7 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
     IREEInput_ShapeDynamicDims:$target_dims,
     Variadic<IREEInput_Dim>:$start_indices,
     IREEInput_Tensor:$update,
-    IREEInput_ShapeDynamicDims:$update_dims,
-    OptionalAttr<IREEInput_TiedOpStorageAttr>:$tied_operands
+    IREEInput_ShapeDynamicDims:$update_dims
   );
   let results = (outs
     IREEInput_Tensor:$result
@@ -576,7 +575,7 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
   let assemblyFormat = [{
     $update `,` $target `[` $start_indices `]` `:`
     type($update) (`{` $update_dims^ `}`)? `->`
-    custom<ShapedTiedResult>(type($result), $target_dims, $tied_operands)
+    custom<ShapedTiedResult>(type($result), $target_dims)
     attr-dict-with-keyword
   }];
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -734,4 +734,35 @@ def IREEInput_AlignOp : IREEInput_PureOp<"align", [
   ];
 }
 
+//===----------------------------------------------------------------------===//
+// Compiler hints
+//===----------------------------------------------------------------------===//
+
+def IREEInput_OptimizationBarrierOp : IREEInput_Op<"optimization_barrier", [
+  SameOperandsAndResultType,
+]> {
+  let summary = "Prevents compiler optimizations across a value.";
+  let description = [{
+    Wraps any operands in an unoptimizable identity to prevent its results from
+    being folded. It will be dropped during the final step in compilation and
+    has no effect at runtime.
+  }];
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let results = (outs Variadic<AnyType>:$results);
+
+  let assemblyFormat = [{
+    attr-dict
+    ($operands^ `:` type($operands))?
+  }];
+
+  let builders = [
+    OpBuilder<(ins
+      "ValueRange":$operands,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes
+    )>,
+  ];
+
+  let hasVerifier = 1;
+}
+
 #endif // IREE_DIALECTS_DIALECT_INPUT_OPS_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -8,6 +8,7 @@
 #define IREE_DIALECTS_DIALECT_INPUT_OPS_TD
 
 include "iree-dialects/Dialect/Input/InputDialect.td"
+include "iree-dialects/Dialect/Input/InputInterfaces.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -548,6 +549,11 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
     AllTypesMatch<["target", "result"]>,
     AllElementTypesMatch<["update", "target", "result"]>,
     AttrSizedOperandSegments,
+    DeclareOpInterfaceMethods<IREEInput_TiedOpInterface, [
+      "getTiedResult",
+      "getTiedResultOperandIndex",
+      "getTiedResultOperandIndices",
+    ]>,
   ]> {
   let summary = [{updates a tensor with the contents of another tensor}];
   let description = [{
@@ -560,7 +566,8 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
     IREEInput_ShapeDynamicDims:$target_dims,
     Variadic<IREEInput_Dim>:$start_indices,
     IREEInput_Tensor:$update,
-    IREEInput_ShapeDynamicDims:$update_dims
+    IREEInput_ShapeDynamicDims:$update_dims,
+    OptionalAttr<IREEInput_TiedOpStorageAttr>:$tied_operands
   );
   let results = (outs
     IREEInput_Tensor:$result
@@ -569,7 +576,7 @@ def IREEInput_TensorUpdateOp : IREEInput_PureOp<"tensor.update", [
   let assemblyFormat = [{
     $update `,` $target `[` $start_indices `]` `:`
     type($update) (`{` $update_dims^ `}`)? `->`
-    type($result) (`{` $target_dims^ `}`)?
+    custom<ShapedTiedResult>(type($result), $target_dims, $tied_operands)
     attr-dict-with-keyword
   }];
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_library(IREEInputDialect
 
   DEPENDS
   IREEInputIncGen
+  IREEInputInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -426,5 +426,39 @@ SmallVector<int64_t> TensorUpdateOp::getTiedResultOperandIndices() {
   return {0}; // $target
 }
 
+//===----------------------------------------------------------------------===//
+// iree_input.optimization_barrier
+//===----------------------------------------------------------------------===//
+
+void OptimizationBarrierOp::build(OpBuilder &builder, OperationState &state,
+                                  ValueRange operands,
+                                  ArrayRef<NamedAttribute> attributes) {
+  state.addOperands(operands);
+  state.addTypes(llvm::to_vector<2>(operands.getTypes()));
+  state.addAttributes(attributes);
+}
+
+LogicalResult OptimizationBarrierOp::verify() {
+  Operation *op = getOperation();
+  if (op->getNumOperands() != op->getNumResults()) {
+    return op->emitOpError()
+           << "must have same number of operands and results, but has "
+           << op->getNumOperands() << " and " << op->getNumResults()
+           << ", respectively";
+  }
+
+  for (int i = 0, e = op->getNumOperands(); i < e; ++i) {
+    if (op->getOperand(i).getType() != op->getResult(i).getType()) {
+      op->emitOpError() << "must have same operand and result types, but they "
+                           "differ at index "
+                        << i;
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+
 #define GET_OP_CLASSES
 #include "iree-dialects/Dialect/Input/InputOps.cpp.inc"

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -17,6 +17,153 @@
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE::Input;
 
+#include "iree-dialects/Dialect/Input/InputOpInterfaces.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// IREE::Input::TiedOpInterface
+//===----------------------------------------------------------------------===//
+
+namespace mlir::iree_compiler::IREE::Input::detail {
+
+std::optional<unsigned> getTiedResultOperandIndex(Operation *op,
+                                                  unsigned resultIndex) {
+  auto storageAttr =
+      op->getAttrOfType<ArrayAttr>(TiedOpInterface::getStorageAttrName());
+  if (!storageAttr)
+    return std::nullopt;
+  auto valueAttrs = storageAttr.getValue();
+  if (valueAttrs.empty())
+    return std::nullopt;
+  if (auto tiedOp = dyn_cast<TiedOpInterface>(op)) {
+    auto indexAndLength = tiedOp.getTiedResultsIndexAndLength();
+    if (resultIndex < indexAndLength.first)
+      return std::nullopt;
+    resultIndex -= indexAndLength.first;
+    if (resultIndex >= indexAndLength.second)
+      return std::nullopt;
+  }
+  int64_t value = llvm::cast<IntegerAttr>(valueAttrs[resultIndex]).getInt();
+  if (value == TiedOpInterface::kUntiedIndex)
+    return std::nullopt;
+  if (auto tiedOp = dyn_cast<TiedOpInterface>(op)) {
+    unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
+    return tiedOperandsOffset + static_cast<unsigned>(value);
+  } else {
+    return static_cast<unsigned>(value);
+  }
+}
+
+SmallVector<int64_t> getTiedResultOperandIndices(Operation *op) {
+  SmallVector<int64_t> indices;
+  auto storageAttr =
+      op->getAttrOfType<ArrayAttr>(TiedOpInterface::getStorageAttrName());
+  if (!storageAttr)
+    return indices;
+  auto valueAttrs = storageAttr.getValue();
+  if (valueAttrs.empty())
+    return indices;
+  auto tiedOp = cast<TiedOpInterface>(op);
+  auto resultRange = tiedOp.getTiedResultsIndexAndLength();
+  unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
+  indices.resize(resultRange.second);
+  for (unsigned i = 0; i < valueAttrs.size(); ++i) {
+    int64_t index = llvm::cast<IntegerAttr>(valueAttrs[i]).getInt();
+    indices[i] = index != TiedOpInterface::kUntiedIndex
+                     ? tiedOperandsOffset + index
+                     : TiedOpInterface::kUntiedIndex;
+  }
+  return indices;
+}
+
+void setTiedResultOperandIndex(Operation *op, unsigned resultIndex,
+                               std::optional<unsigned> operandIndex) {
+  auto tiedOp = cast<TiedOpInterface>(op);
+  auto resultRange = tiedOp.getTiedResultsIndexAndLength();
+  resultIndex -= resultRange.first;
+
+  auto indices = getTiedResultOperandIndices(op);
+  if (indices.empty()) {
+    indices.resize(resultRange.second, TiedOpInterface::kUntiedIndex);
+  } else {
+    // Well, getTiedResultOperandIndices() returns indices into the full range
+    // of the op, but in the attribute, we expect to store ranges into the range
+    // returned by `getTiedOperandsIndexAndLength`.
+    unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
+    for (auto &index : indices) {
+      if (index != TiedOpInterface::kUntiedIndex)
+        index -= tiedOperandsOffset;
+    }
+  }
+
+  indices[resultIndex] = operandIndex.value_or(TiedOpInterface::kUntiedIndex);
+  op->setAttr(TiedOpInterface::getStorageAttrName(),
+              Builder(op).getIndexArrayAttr(indices));
+}
+
+bool isOperandTied(Operation *op, unsigned operandIndex) {
+  auto tiedOp = dyn_cast<TiedOpInterface>(op);
+  if (!tiedOp)
+    return false;
+  auto tiedIndices = tiedOp.getTiedResultOperandIndices();
+  for (unsigned i = 0; i < tiedIndices.size(); ++i) {
+    if (tiedIndices[i] == operandIndex) {
+      return true;
+    }
+  }
+  return false;
+}
+
+SmallVector<Value> getOperandTiedResults(Operation *op, unsigned operandIndex) {
+  auto tiedOp = dyn_cast<TiedOpInterface>(op);
+  if (!tiedOp)
+    return {};
+  auto resultRange = tiedOp.getTiedResultsIndexAndLength();
+  SmallVector<Value> results;
+  auto tiedIndices = tiedOp.getTiedResultOperandIndices();
+  for (unsigned i = 0; i < tiedIndices.size(); ++i) {
+    if (tiedIndices[i] == operandIndex) {
+      results.push_back(op->getResult(resultRange.first + i));
+    }
+  }
+  return results;
+}
+
+LogicalResult verifyTiedOp(TiedOpInterface tiedOp) {
+  auto tiedOperandIndices = tiedOp.getTiedResultOperandIndices();
+  if (tiedOperandIndices.empty())
+    return success();
+  auto resultRange = tiedOp.getTiedResultsIndexAndLength();
+  if (tiedOperandIndices.size() != resultRange.second) {
+    return tiedOp.emitError("op results/tied operand indices mismatch");
+  }
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::Input::detail
+
+Value TiedOpInterface::findTiedBaseValue(Value derivedValue) {
+  Value baseValue = derivedValue;
+  while (auto definingOp =
+             dyn_cast_or_null<TiedOpInterface>(baseValue.getDefiningOp())) {
+    auto tiedValue = definingOp.getTiedResultOperand(baseValue);
+    if (!tiedValue)
+      break;
+    baseValue = tiedValue;
+  }
+  return baseValue;
+}
+
+bool TiedOpInterface::hasAnyTiedUses(Value value) {
+  for (auto &use : value.getUses()) {
+    auto tiedOp = dyn_cast<TiedOpInterface>(use.getOwner());
+    if (!tiedOp)
+      continue;
+    if (tiedOp.isOperandTied(use.getOperandNumber()))
+      return true;
+  }
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // custom<SymbolVisibility>($sym_visibility)
 //===----------------------------------------------------------------------===//
@@ -90,6 +237,81 @@ static void printTypeOrAttr(OpAsmPrinter &p, Operation *op, TypeAttr type,
     p << " = ";
     p.printAttribute(attr);
   }
+}
+
+//===----------------------------------------------------------------------===//
+// custom<ShapedTiedResult>
+//===----------------------------------------------------------------------===//
+// type{%dim0, %dim1}
+// %arg0 as type{%dim0}
+
+static ParseResult parseShapedTiedResult(
+    OpAsmParser &parser, Type &resultType,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &resultDims,
+    ArrayAttr &tiedOperands) {
+  OpAsmParser::UnresolvedOperand tiedResult;
+  auto res = parser.parseOptionalOperand(tiedResult);
+  int64_t tiedOperandIndex = TiedOpInterface::kUntiedIndex;
+  if (res.has_value() && succeeded(res.value())) {
+    tiedOperandIndex = 0;
+    if (failed(parser.parseKeyword("as")))
+      return failure();
+  }
+  if (failed(parser.parseType(resultType)))
+    return failure();
+  if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
+    if (!shapedType.hasStaticShape()) {
+      SmallVector<OpAsmParser::UnresolvedOperand> dynamicDims;
+      if (failed(parser.parseLBrace()) ||
+          failed(parser.parseOperandList(dynamicDims,
+                                         shapedType.getNumDynamicDims(),
+                                         OpAsmParser::Delimiter::None)) ||
+          failed(parser.parseRBrace())) {
+        return failure();
+      }
+      resultDims.append(dynamicDims);
+    }
+  }
+  tiedOperands = parser.getBuilder().getIndexArrayAttr({tiedOperandIndex});
+  return success();
+}
+
+static ParseResult parseShapedTiedResult(
+    OpAsmParser &parser, Type &resultType,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &resultDims) {
+  ArrayAttr tiedOperands;
+  return parseShapedTiedResult(parser, resultType, resultDims, tiedOperands);
+}
+
+void printShapedTiedResult(OpAsmPrinter &p, TiedOpInterface op, Type resultType,
+                           ValueRange resultDims) {
+  auto tiedOperandIndex = op.getTiedResultOperandIndex(0);
+  if (tiedOperandIndex.has_value()) {
+    auto tiedOperand = op->getOperand(tiedOperandIndex.value());
+    p.printOperand(tiedOperand);
+    p << " as ";
+  }
+  p.printType(resultType);
+  if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
+    if (!shapedType.hasStaticShape()) {
+      if (resultDims.empty()) {
+        p << "{<<INVALID>>}";
+        return;
+      }
+      p << "{";
+      llvm::interleaveComma(
+          resultDims.take_front(shapedType.getNumDynamicDims()), p,
+          [&](Value value) { p.printOperand(value); });
+      p << "}";
+      resultDims = resultDims.drop_front(shapedType.getNumDynamicDims());
+    }
+  }
+}
+
+static void printShapedTiedResult(OpAsmPrinter &p, TiedOpInterface op,
+                                  Type resultType, ValueRange resultDims,
+                                  ArrayAttr tiedOperands) {
+  printShapedTiedResult(p, op, resultType, resultDims);
 }
 
 //===----------------------------------------------------------------------===//
@@ -185,6 +407,23 @@ LogicalResult GlobalStoreIndirectOp::verify() {
                          << globalType << " but store is " << storeType;
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_input.tensor.update
+//===----------------------------------------------------------------------===//
+
+Value TensorUpdateOp::getTiedResult(unsigned resultIndex) {
+  return TiedOpInterface::findTiedBaseValue(getTarget());
+}
+
+std::optional<unsigned>
+TensorUpdateOp::getTiedResultOperandIndex(unsigned resultIndex) {
+  return {0}; // $target
+}
+
+SmallVector<int64_t> TensorUpdateOp::getTiedResultOperandIndices() {
+  return {0}; // $target
 }
 
 #define GET_OP_CLASSES


### PR DESCRIPTION
Tied operands is an important part of the "IREE programming model" and I'll need it in the follow up PR that will add iree_input.dispatch operation.

Also added optimization barrier op as a useful compiler hint