### PR TITLE
Make barrier elimination more aggressive

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -1424,36 +1424,17 @@ public:
     LLVM_DEBUG(DBGS() << "checking the necessity of: " << barrier << " "
                       << barrier.getLoc() << "\n");
 
-    {
-      LLVM_DEBUG(DBGS() << "with respect to the barrier(s) before\n");
-      SmallVector<MemoryEffects::EffectInstance> beforeEffects;
-      getEffectsBefore(barrier, beforeEffects, /*stopAtBarrier=*/true);
+    SmallVector<MemoryEffects::EffectInstance> beforeEffects;
+    getEffectsBefore(barrier, beforeEffects, /*stopAtBarrier=*/true);
 
-      SmallVector<MemoryEffects::EffectInstance> afterEffects;
-      getEffectsAfter(barrier, afterEffects, /*stopAtBarrier=*/false);
+    SmallVector<MemoryEffects::EffectInstance> afterEffects;
+    getEffectsAfter(barrier, afterEffects, /*stopAtBarrier=*/true);
 
-      if (!haveConflictingEffects(beforeEffects, afterEffects)) {
-        LLVM_DEBUG(DBGS() << "the barrier(s) before is sufficient, removing "
-                          << barrier << "\n");
-        rewriter.eraseOp(barrier);
-        return success();
-      }
-    }
-
-    {
-      LLVM_DEBUG(DBGS() << "with respect to the barrier(s) after\n");
-      SmallVector<MemoryEffects::EffectInstance> beforeEffects;
-      getEffectsBefore(barrier, beforeEffects, /*stopAtBarrier*/ false);
-
-      SmallVector<MemoryEffects::EffectInstance> afterEffects;
-      getEffectsAfter(barrier, afterEffects, /*stopAtBarrier*/ true);
-
-      if (!haveConflictingEffects(beforeEffects, afterEffects)) {
-        LLVM_DEBUG(DBGS() << "the barrier(s) after is sufficient, removing "
-                          << barrier << "\n");
-        rewriter.eraseOp(barrier);
-        return success();
-      }
+    if (!haveConflictingEffects(beforeEffects, afterEffects)) {
+      LLVM_DEBUG(DBGS() << "the surrounding barriers are sufficient, removing "
+                        << barrier << "\n");
+      rewriter.eraseOp(barrier);
+      return success();
     }
 
     LLVM_DEBUG(DBGS() << "barrier is necessary: " << barrier << " "


### PR DESCRIPTION
Contrary to the conceptual description of the barrier elimination technique in the paper by Moses et.al., barrier elimination in IREE is performed by the greedy rewriter. Thus a redundant barrier is erased immediately and the updated IR is considered after for the next barrier. Therefore, there it is sufficient to consider the effects before and after each barrier until hitting the next barrier, rather than pairwise extending those until the end of the parallel region boundary.

Specifically, the case that wouldn't be handled correctly with non-eager rewriting,

```mlir
  store %A
  barrier  // useless because no effects after
  // nothing
  barrier  // useless because no effects before
  load %A
```

is handled correctly in IREE that removes one of the barriers and sees the second as required when re-analyzing the eagerly rewrtitten IR.

This change lets us eliminate more barriers.