### PR TITLE
Fix CUDA bitcode builds on Windows.

### DIFF
--- a/build_tools/cmake/iree_bitcode_library.cmake
+++ b/build_tools/cmake/iree_bitcode_library.cmake
@@ -132,18 +132,23 @@ function(iree_cuda_bitcode_library)
   endif()
 
   set(_CUDA_ARCH "${_RULE_CUDA_ARCH}")
-  
+
   set(_COPTS
     "-x" "cuda"
-    
+
     # Target architecture.
     "--cuda-gpu-arch=${_CUDA_ARCH}"
+
+    "--cuda-path=${CUDAToolkit_ROOT}"
 
     # Suppress warnings about missing path to cuda lib,
     # and benign warning about CUDA version.
     "-Wno-unknown-cuda-version"
     "-nocudalib"
     "--cuda-device-only"
+
+    # https://github.com/llvm/llvm-project/issues/54609
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
 
     # Optimized and unstamped.
     "-O3"

--- a/build_tools/third_party/cuda/CMakeLists.txt
+++ b/build_tools/third_party/cuda/CMakeLists.txt
@@ -35,6 +35,7 @@ else()
     if(CUDAToolkit_FOUND)
       # Found on the system somewhere, no need to install our own copy.
       cmake_path(GET CUDAToolkit_BIN_DIR PARENT_PATH CUDAToolkit_ROOT)
+      set(CUDAToolkit_ROOT "${CUDAToolkit_ROOT}" PARENT_SCOPE)
       message(STATUS "Using found CUDA toolkit: ${CUDAToolkit_ROOT}")
     else()
       # Download a copy of the CUDA toolkit into the build directory if needed.

--- a/samples/custom_dispatch/cuda/kernels/CMakeLists.txt
+++ b/samples/custom_dispatch/cuda/kernels/CMakeLists.txt
@@ -134,7 +134,7 @@ iree_cuda_bitcode_library(
   CUDA_ARCH
     sm_60
   SRCS
-    "ukernel.cu" 
+    "ukernel.cu"
 )
 
 iree_check_single_backend_test_suite(


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/14264 (see that issue and https://github.com/llvm/llvm-project/issues/54609 for the specific errors I was seeing)

Unfortunately, using clang to compile for CUDA on Windows (and macOS) is generally unstable/unsupported: https://llvm.org/docs/CompileCudaWithLLVM.html#prerequisites
> CUDA compilation is supported on Linux. Compilation on MacOS and Windows may or may not work and currently have no maintainers.