### PR TITLE
[Transform] Add subgroup size setting when mapping to gpu threads

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -109,8 +109,26 @@ transform_dialect::MapNestedForallToGpuThreadsOp::applyToOne(
   auto newAttr = rewriter.getIndexArrayAttr(getWorkgroupDims());
   rewriter.startRootUpdate(exportOp);
   exportOp->setAttr(exportOp.getWorkgroupSizeAttrName(), newAttr);
+  if (std::optional<int64_t> subgroupSize = getSubgroupSize()) {
+    auto subgroupSizeAttr = rewriter.getIndexAttr(*subgroupSize);
+    exportOp->setAttr(exportOp.getSubgroupSizeAttrName(), subgroupSizeAttr);
+  }
   rewriter.finalizeRootUpdate(exportOp);
   return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::MapNestedForallToGpuThreadsOp::build(
+    OpBuilder &builder, OperationState &state, Value target,
+    ArrayRef<int64_t> workgroupDims, ArrayRef<int64_t> warpDims) {
+  build(builder, state, {}, target, workgroupDims, warpDims, IntegerAttr());
+}
+
+void transform_dialect::MapNestedForallToGpuThreadsOp::build(
+    OpBuilder &builder, OperationState &state, Value target,
+    ArrayRef<int64_t> workgroupDims, ArrayRef<int64_t> warpDims,
+    int64_t subgroupSize) {
+  build(builder, state, {}, target, workgroupDims, warpDims,
+        builder.getI64IntegerAttr(subgroupSize));
 }
 
 void transform_dialect::MapNestedForallToGpuThreadsOp::getEffects(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -89,18 +89,29 @@ def MapNestedForallToGpuThreadsOp :
 
   let arguments = (ins TransformHandleTypeInterface:$target,
                    DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_dims,
-                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$warp_dims);
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$warp_dims,
+                   OptionalAttr<I64Attr>:$subgroup_size);
   let results = (outs);
 
   let assemblyFormat = [{
     $target
     `workgroup_dims` `=` $workgroup_dims
     (`warp_dims` `=` $warp_dims^)?
+    (`subgroup_size` `=` $subgroup_size^)?
     attr-dict
     `:` functional-type($target, results)
   }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
+  let builders = [
+    OpBuilder<(ins "Value":$target,
+                   "ArrayRef<int64_t>":$workgroup_dims,
+                   "ArrayRef<int64_t>":$warp_dims)>,
+    OpBuilder<(ins "Value":$target,
+                   "ArrayRef<int64_t>":$workgroup_dims,
+                   "ArrayRef<int64_t>":$warp_dims,
+                   "int64_t":$subgroupSize)>
+  ];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,


### PR DESCRIPTION
For targets with support for configurable subgroup size, this is passed down to the runtime through a `subgroup_size` attribute similar to the way `workgroup_size` is specified. This allows setting subgroup size in transform dialect based strategies by assigning it at the same time as workgroup size.