### PR TITLE
Implement CI job optionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
   ##############################################################################
   build_all:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_all')
     uses: ./.github/workflows/build_all.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -74,7 +74,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
     runs-on: windows-2022-64core
     defaults:
       run:
@@ -132,7 +132,7 @@ jobs:
 
   build_test_all_macos_arm64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_macos_arm64')
     runs-on:
       - ${{ github.repository == 'openxla/iree' && 'self-hosted' || 'macos-11' }} # must come first
       - runner-group=postsubmit
@@ -169,7 +169,7 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_macos_x86_64')
     runs-on: macos-13-xl
     env:
       BUILD_DIR: build-macos
@@ -220,7 +220,7 @@ jobs:
 
   build_test_all_bazel:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_bazel')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -243,7 +243,7 @@ jobs:
 
   test_all:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_all')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -273,7 +273,7 @@ jobs:
 
   test_gpu:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_gpu')
     env:
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
@@ -334,7 +334,7 @@ jobs:
   ##############################################################################
   build_test_runtime:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_runtime')
     runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
@@ -362,7 +362,7 @@ jobs:
 
   build_test_runtime_windows:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_runtime_windows')
     runs-on: windows-2022-64core
     defaults:
       run:
@@ -391,7 +391,7 @@ jobs:
   ##############################################################################
   test_tf_integrations:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_tf_integrations')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -421,7 +421,7 @@ jobs:
 
   test_tf_integrations_gpu:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_tf_integrations_gpu')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -459,7 +459,7 @@ jobs:
   ##############################################################################
   python_release_packages:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'python_release_packages')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -498,7 +498,7 @@ jobs:
 
   asan:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'asan')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -526,7 +526,7 @@ jobs:
 
   tsan:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'tsan')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -551,7 +551,7 @@ jobs:
 
   small_runtime:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'small_runtime')
     runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
@@ -578,7 +578,7 @@ jobs:
 
   gcc:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'gcc')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -610,7 +610,7 @@ jobs:
 
   tracing:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'tracing')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -639,7 +639,7 @@ jobs:
 
   debug:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'debug')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -668,7 +668,7 @@ jobs:
 
   byo_llvm:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'byo_llvm')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -697,7 +697,7 @@ jobs:
 
   build_benchmark_tools:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_benchmark_tools')
     uses: ./.github/workflows/build_benchmark_tools.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -708,7 +708,7 @@ jobs:
 
   build_e2e_test_artifacts:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_e2e_test_artifacts')
     uses: ./.github/workflows/build_e2e_test_artifacts.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -720,7 +720,7 @@ jobs:
 
   compilation_benchmarks:
     needs: [setup, build_e2e_test_artifacts]
-    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'compilation_benchmarks') && needs.setup.outputs.benchmark-presets != ''
     uses: ./.github/workflows/benchmark_compilation.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -732,7 +732,7 @@ jobs:
 
   execution_benchmarks:
     needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]
-    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'execution_benchmarks') && needs.setup.outputs.benchmark-presets != ''
     uses: ./.github/workflows/benchmark_execution.yml
     with:
       # env.GCS_DIR is also duplicated in this workflow. See the note there on
@@ -745,7 +745,7 @@ jobs:
 
   process_benchmark_results:
     needs: [setup, compilation_benchmarks, execution_benchmarks]
-    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'process_benchmark_results') && needs.setup.outputs.benchmark-presets != ''
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -837,7 +837,7 @@ jobs:
 
   cross_compile_and_test:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'cross_compile_and_test')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -926,7 +926,7 @@ jobs:
   # can't access matrix variable to skip certain matrix jobs for presubmit).
   build_and_test_android:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_and_test_android')
     uses: ./.github/workflows/build_and_test_android.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -939,7 +939,7 @@ jobs:
 
   test_benchmark_suites:
     needs: [setup, build_all, build_e2e_test_artifacts]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_benchmark_suites')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -111,9 +111,12 @@ jobs:
 
           ./build_tools/github_actions/configure_ci.py
 
-      - name: "Show benchmark presets"
+      - name: "Show enabled options"
         env:
           BENCHMARK_PRESETS: ${{ steps.configure.outputs.benchmark-presets }}
+          ENABLED_JOBS: ${{ join(fromJson(steps.configure.outputs.enabled-jobs)) }}
         run: |
+          echo ":green_circle: Enabled jobs: \`${ENABLED_JOBS}\`" \
+              >> "${GITHUB_STEP_SUMMARY}"
           echo ":stopwatch: Enabled benchmarks: \`${BENCHMARK_PRESETS}\`" \
             >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -13,10 +13,10 @@ name: Setup
 on:
   workflow_call:
     outputs:
-      should-run:
+      enabled-jobs:
         description: |
-          Whether CI should run.
-        value: ${{ jobs.setup.outputs.should-run }}
+          Which jobs should run.
+        value: ${{ jobs.setup.outputs.enabled-jobs }}
       is-pr:
         description: |
           Whether the workflow has been triggered by a pull request.
@@ -55,7 +55,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: ${{ steps.configure.outputs.should-run }}
+      enabled-jobs: ${{ steps.configure.outputs.enabled-jobs }}
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,11 @@ later culprit-finding. It is assumed that the PR author will merge their change
 unless they ask someone else to merge it for them (e.g. because they don't have
 write access).
 
-## Peculiarities
+## Details
 
-Our documentation on
-[repository management](https://github.com/openxla/iree/blob/main/docs/developers/developing_iree/repository_management.md)
-has more information on some of the oddities in our repository setup and
-workflows. For the most part, these should be transparent to normal developer
-workflows.
+For further details, see our
+[detailed contributing guide](/docs/developers/contributing.md), which is
+separate to avoid notifying everyone every time it changes.
 
 ## Community Guidelines
 

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -239,8 +239,8 @@ def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
 
     # PR information can be fetched from API for the latest updates. If
     # ORIGINAL_PR_TITLE is set, compare the current and original description and
-    # show a notice if they are different. This is mostly to inform users that the
-    # workflow might not parse the PR description they expect.
+    # show a notice if they are different. This is mostly to inform users that
+    # the workflow might not parse the PR description they expect.
     if original_title is not None:
         original_description = PR_DESCRIPTION_TEMPLATE.substitute(
             title=original_title, body=original_body
@@ -377,7 +377,8 @@ def get_enabled_jobs(
         ):
             raise ValueError(
                 f"Cannot specify both '{Trailer.SKIP_JOBS}' and any of"
-                f" '{Trailer.EXACTLY_JOBS}', '{Trailer.EXTRA_JOBS}', '{Trailer.SKIP_JOBS}'"
+                f" '{Trailer.EXACTLY_JOBS}', '{Trailer.EXTRA_JOBS}',"
+                f" '{Trailer.SKIP_JOBS}'"
             )
         print(
             f"Skipping all jobs because PR description has"
@@ -392,7 +393,11 @@ def get_enabled_jobs(
                 f" '{Trailer.EXTRA_JOBS}' or '{Trailer.SKIP_JOBS}'"
             )
 
-        exactly_jobs = parse_jobs_trailer(trailers, Trailer.EXACTLY_JOBS, all_jobs)
+        exactly_jobs = parse_jobs_trailer(
+            trailers,
+            Trailer.EXACTLY_JOBS,
+            all_jobs,
+        )
         return exactly_jobs
 
     skip_jobs = parse_jobs_trailer(trailers, Trailer.SKIP_JOBS, all_jobs)
@@ -439,8 +444,9 @@ def get_benchmark_presets(
     skip_llvm_integrate_benchmark = Trailer.SKIP_LLVM_INTEGRATE_BENCHMARK in trailers
     if skip_llvm_integrate_benchmark:
         print(
-            "Skipping default benchmarking on LLVM integration because PR "
-            f"description has '{Trailer.SKIP_LLVM_INTEGRATE_BENCHMARK}' trailer."
+            f"Skipping default benchmarking on LLVM integration because PR "
+            f"description has '{Trailer.SKIP_LLVM_INTEGRATE_BENCHMARK}'"
+            f" trailer."
         )
 
     if not is_pr:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -8,23 +8,23 @@
 """Determines whether CI should run on a given PR.
 
 The following environment variables are required:
-"GITHUB_EVENT_NAME",: GitHub event name, e.g. pull_request.
-"GITHUB_OUTPUT",: path to write workflow output variables.
-"GITHUB_STEP_SUMMARY",: path to write workflow summary output.
+- GITHUB_EVENT_NAME: GitHub event name, e.g. pull_request.
+- GITHUB_OUTPUT: path to write workflow output variables.
+- GITHUB_STEP_SUMMARY: path to write workflow summary output.
 
 When GITHUB_EVENT_NAME is "pull_request", there are additional environment
 variables to be set:
-"PR_BRANCH", (required): PR source branch.
-"PR_TITLE", (required): PR title.
-"PR_BODY", (optional): PR description.
-"PR_LABELS", (optional): JSON list of PR label names.
-"BASE_REF", (required): base commit SHA of the PR.
-"ORIGINAL_PR_TITLE", (optional): PR title from the original PR event, showing a
+- PR_BRANCH (required): PR source branch.
+- PR_TITLE (required): PR title.
+- PR_BODY (optional): PR description.
+- PR_LABELS (optional): JSON list of PR label names.
+- BASE_REF (required): base commit SHA of the PR.
+- ORIGINAL_PR_TITLE (optional): PR title from the original PR event, showing a
     notice if PR_TITLE is different.
-"ORIGINAL_PR_BODY", (optional): PR description from the original PR event,
+- ORIGINAL_PR_BODY (optional): PR description from the original PR event,
     showing a notice if PR_BODY is different. ORIGINAL_PR_TITLE must also be
     set.
-"ORIGINAL_PR_LABELS", (optional): PR labels from the original PR event, showing a
+- ORIGINAL_PR_LABELS (optional): PR labels from the original PR event, showing a
     notice if PR_LABELS is different. ORIGINAL_PR_TITLE must also be set.
 
 Exit code 0 indicates that it should and exit code 2 indicates that it should

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -41,7 +41,7 @@ import string
 import subprocess
 import sys
 import textwrap
-from typing import Iterable, List, Mapping, Sequence, Tuple
+from typing import Iterable, List, Mapping, Sequence, Set, Tuple
 
 import yaml
 
@@ -49,6 +49,8 @@ import yaml
 # We don't get StrEnum till Python 3.11
 @enum.unique
 class Trailer(str, enum.Enum):
+    __str__ = str.__str__
+
     SKIP_CI = "skip-ci"
     SKIP_JOBS = "ci-skip"
     EXTRA_JOBS = "ci-extra"
@@ -59,7 +61,7 @@ class Trailer(str, enum.Enum):
     SKIP_LLVM_INTEGRATE_BENCHMARK = "skip-llvm-integrate-benchmark"
 
     # Before Python 3.12, it the native __contains__ doesn't work for checking
-    # member values like this:
+    # member values like this and it's not possible to easily override this.
     # https://docs.python.org/3/library/enum.html#enum.EnumType.__contains__
     @classmethod
     def contains(cls, val):
@@ -68,6 +70,7 @@ class Trailer(str, enum.Enum):
         except ValueError:
             return False
         return True
+
 
 
 # This is to help prevent typos. For now we hard error on any trailer that
@@ -302,7 +305,7 @@ def get_runner_env(trailers: Mapping[str, str]) -> str:
 
 
 def parse_jobs_trailer(trailers: Mapping[str, str], key: str,
-                       all_jobs: set[str]) -> set[str]:
+                       all_jobs: Set[str]) -> Set[str]:
     jobs_text = trailers.get(key)
     if jobs_text is None:
         return set()
@@ -326,7 +329,7 @@ def parse_jobs_trailer(trailers: Mapping[str, str], key: str,
     return jobs
 
 
-def get_enabled_jobs(is_pr: bool, trailers: Mapping[str, str]) -> set[str]:
+def get_enabled_jobs(is_pr: bool, trailers: Mapping[str, str]) -> Set[str]:
     with open(CI_WORKFLOW_FILE) as f:
         workflow = yaml.load(f.read(), Loader=yaml.SafeLoader)
     all_jobs = set(workflow["jobs"].keys())

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -8,23 +8,23 @@
 """Determines whether CI should run on a given PR.
 
 The following environment variables are required:
-- GITHUB_EVENT_NAME: GitHub event name, e.g. pull_request.
-- GITHUB_OUTPUT: path to write workflow output variables.
-- GITHUB_STEP_SUMMARY: path to write workflow summary output.
+"GITHUB_EVENT_NAME",: GitHub event name, e.g. pull_request.
+"GITHUB_OUTPUT",: path to write workflow output variables.
+"GITHUB_STEP_SUMMARY",: path to write workflow summary output.
 
 When GITHUB_EVENT_NAME is "pull_request", there are additional environment
 variables to be set:
-- PR_BRANCH (required): PR source branch.
-- PR_TITLE (required): PR title.
-- PR_BODY (optional): PR description.
-- PR_LABELS (optional): JSON list of PR label names.
-- BASE_REF (required): base commit SHA of the PR.
-- ORIGINAL_PR_TITLE (optional): PR title from the original PR event, showing a
+"PR_BRANCH", (required): PR source branch.
+"PR_TITLE", (required): PR title.
+"PR_BODY", (optional): PR description.
+"PR_LABELS", (optional): JSON list of PR label names.
+"BASE_REF", (required): base commit SHA of the PR.
+"ORIGINAL_PR_TITLE", (optional): PR title from the original PR event, showing a
     notice if PR_TITLE is different.
-- ORIGINAL_PR_BODY (optional): PR description from the original PR event,
+"ORIGINAL_PR_BODY", (optional): PR description from the original PR event,
     showing a notice if PR_BODY is different. ORIGINAL_PR_TITLE must also be
     set.
-- ORIGINAL_PR_LABELS (optional): PR labels from the original PR event, showing a
+"ORIGINAL_PR_LABELS", (optional): PR labels from the original PR event, showing a
     notice if PR_LABELS is different. ORIGINAL_PR_TITLE must also be set.
 
 Exit code 0 indicates that it should and exit code 2 indicates that it should
@@ -32,19 +32,49 @@ not.
 """
 
 import difflib
+import enum
 import fnmatch
 import json
 import os
 import re
+import string
 import subprocess
+import sys
 import textwrap
 from typing import Iterable, List, Mapping, Sequence, Tuple
 
-SKIP_CI_KEY = "skip-ci"
-RUNNER_ENV_KEY = "runner-env"
-BENCHMARK_EXTRA_KEY = "benchmark-extra"
-# Trailer to prevent benchmarks from always running on LLVM integration PRs.
-SKIP_LLVM_INTEGRATE_BENCHMARK_KEY = "skip-llvm-integrate-benchmark"
+import yaml
+
+
+@enum.unique
+class Trailer(enum.StrEnum):
+    SKIP_CI = "skip-ci"
+    SKIP_JOBS = "ci-skip"
+    EXTRA_JOBS = "ci-extra"
+    EXACTLY_JOBS = "ci-exactly"
+    RUNNER_ENV = "runner-env"
+    BENCHMARK_EXTRA = "benchmark-extra"
+    # Trailer to prevent benchmarks from always running on LLVM integration PRs.
+    SKIP_LLVM_INTEGRATE_BENCHMARK = "skip-llvm-integrate-benchmark"
+
+    # Before Python 3.12, it the native __contains__ doesn't work for checking
+    # member values like this:
+    # https://docs.python.org/3/library/enum.html#enum.EnumType.__contains__
+    @classmethod
+    def contains(cls, val):
+        try:
+            cls(val)
+        except ValueError:
+            return False
+        return True
+
+
+# This is to help prevent typos. For now we hard error on any trailer that
+# starts with this prefix but isn't in our list. We can add known commonly used
+# trailers to our list or we might consider relaxing this.
+RESERVED_TRAILER_PREFIXES = ["ci-", "bewnchmark-", "skip-"]
+CI_WORKFLOW_FILE = ".github/workflows/ci.yml"
+ALL_KEY = "all"
 
 # Note that these are fnmatch patterns, which are not the same as gitignore
 # patterns because they don't treat '/' specially. The standard library doesn't
@@ -77,6 +107,14 @@ SKIP_PATH_PATTERNS = [
 RUNNER_ENV_DEFAULT = "prod"
 RUNNER_ENV_OPTIONS = [RUNNER_ENV_DEFAULT, "testing"]
 
+CONTROL_JOBS = frozenset(["setup", "summary"])
+
+POSTSUBMIT_ONLY_JOBS = frozenset([
+    "build_test_all_windows",
+    "build_test_all_macos_arm64",
+    "build_test_all_macos_x86_64",
+])
+
 DEFAULT_BENCHMARK_PRESET_GROUP = [
     "cuda",
     "x86_64",
@@ -91,27 +129,30 @@ LARGE_BENCHMARK_PRESET_GROUP = ["cuda-large", "x86_64-large"]
 BENCHMARK_PRESET_OPTIONS = DEFAULT_BENCHMARK_PRESET_GROUP + LARGE_BENCHMARK_PRESET_GROUP
 BENCHMARK_LABEL_PREFIX = "benchmarks"
 
-PR_DESCRIPTION_TEMPLATE = "{title}" "\n\n" "{body}"
+PR_DESCRIPTION_TEMPLATE = string.Template("${title}\n\n${body}")
 
 # Patterns to detect "LLVM integration" PRs, i.e. changes that update the
 # third_party/llvm-project submodule. This should only include PRs
 # intended to be merged and should exclude test/draft PRs as well as
 # PRs that include temporary patches to the submodule during review.
 # See also: https://github.com/openxla/iree/issues/12268
-LLVM_INTEGRATE_TITLE_PATTERN = re.compile("^integrate.+llvm-project", re.IGNORECASE)
-LLVM_INTEGRATE_BRANCH_PATTERN = re.compile("bump-llvm|llvm-bump", re.IGNORECASE)
+LLVM_INTEGRATE_TITLE_PATTERN = re.compile("^integrate.+llvm-project",
+                                          re.IGNORECASE)
+LLVM_INTEGRATE_BRANCH_PATTERN = re.compile("bump-llvm|llvm-bump",
+                                           re.IGNORECASE)
 LLVM_INTEGRATE_LABEL = "llvm-integrate"
 
 
 def skip_path(path: str) -> bool:
-    return any(fnmatch.fnmatch(path, pattern) for pattern in SKIP_PATH_PATTERNS)
+    return any(
+        fnmatch.fnmatch(path, pattern) for pattern in SKIP_PATH_PATTERNS)
 
 
 def set_output(d: Mapping[str, str]):
     print(f"Setting outputs: {d}")
     step_output_file = os.environ["GITHUB_OUTPUT"]
     with open(step_output_file, "a") as f:
-        f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
+        f.writelines(f"{k}={json.dumps(v)}" + "\n" for k, v in d.items())
 
 
 def write_job_summary(summary: str):
@@ -132,10 +173,8 @@ def check_description_and_show_diff(
 ):
     original_labels = sorted(original_labels)
     current_labels = sorted(current_labels)
-    if (
-        original_description == current_description
-        and original_labels == current_labels
-    ):
+    if (original_description == current_description
+            and original_labels == current_labels):
         return
 
     description_diffs = difflib.unified_diff(
@@ -145,29 +184,24 @@ def check_description_and_show_diff(
     description_diffs = "".join(description_diffs)
 
     if description_diffs != "":
-        description_diffs = textwrap.dedent(
-            """\
+        description_diffs = textwrap.dedent("""\
     ```diff
     {}
     ```
-    """
-        ).format(description_diffs)
+    """).format(description_diffs)
 
     if original_labels == current_labels:
         label_diffs = ""
     else:
-        label_diffs = textwrap.dedent(
-            """\
+        label_diffs = textwrap.dedent("""\
     ```
     Original labels: {original_labels}
     Current labels: {current_labels}
     ```
-    """
-        ).format(original_labels=original_labels, current_labels=current_labels)
+    """).format(original_labels=original_labels, current_labels=current_labels)
 
     write_job_summary(
-        textwrap.dedent(
-            """\
+        textwrap.dedent("""\
   :pushpin: Using the PR description and labels different from the original PR event that started this workflow.
 
   <details>
@@ -176,12 +210,12 @@ def check_description_and_show_diff(
   {description_diffs}
 
   {label_diffs}
-  </details>"""
-        ).format(description_diffs=description_diffs, label_diffs=label_diffs)
-    )
+  </details>""").format(description_diffs=description_diffs,
+                        label_diffs=label_diffs))
 
 
-def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
+def get_trailers_and_labels(
+        is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
     if not is_pr:
         return ({}, [])
 
@@ -192,16 +226,15 @@ def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
     original_body = os.environ.get("ORIGINAL_PR_BODY", "")
     original_labels = json.loads(os.environ.get("ORIGINAL_PR_LABELS", "[]"))
 
-    description = PR_DESCRIPTION_TEMPLATE.format(title=title, body=body)
+    description = PR_DESCRIPTION_TEMPLATE.substitute(title=title, body=body)
 
     # PR information can be fetched from API for the latest updates. If
     # ORIGINAL_PR_TITLE is set, compare the current and original description and
     # show a notice if they are different. This is mostly to inform users that the
     # workflow might not parse the PR description they expect.
     if original_title is not None:
-        original_description = PR_DESCRIPTION_TEMPLATE.format(
-            title=original_title, body=original_body
-        )
+        original_description = PR_DESCRIPTION_TEMPLATE.substitute(
+            title=original_title, body=original_body)
         print(
             "Original PR description and labels:",
             original_description,
@@ -229,6 +262,15 @@ def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
         k.lower().strip(): v.strip()
         for k, v in (line.split(":", maxsplit=1) for line in trailer_lines)
     }
+
+    for key in trailer_map:
+        if not Trailer.contains(key):
+            for prefix in RESERVED_TRAILER_PREFIXES:
+                if key.startswith(prefix):
+                    print(f"Trailer '{key}' starts with reserved prefix"
+                          f"'{prefix}' but is unknown.")
+            print(f"Skipping unknown trailer '{key}'", file=sys.stderr)
+
     return (trailer_map, labels)
 
 
@@ -246,44 +288,106 @@ def modifies_included_path(base_ref: str) -> bool:
     return any(not skip_path(p) for p in get_modified_paths(base_ref))
 
 
-def should_run_ci(is_pr: bool, trailers: Mapping[str, str]) -> bool:
-    if not is_pr:
-        print(
-            "Running CI independent of diff because run was not triggered by a"
-            " pull request event."
-        )
-        return True
+def get_runner_env(trailers: Mapping[str, str]) -> str:
+    runner_env = trailers.get(Trailer.RUNNER_ENV)
+    if runner_env is None:
+        print(f"Using '{RUNNER_ENV_DEFAULT}' runners because"
+              f" '{Trailer.RUNNER_ENV}' not found in {trailers}")
+        runner_env = RUNNER_ENV_DEFAULT
+    else:
+        print(f"Using runner environment '{runner_env}' from PR description"
+              f" trailers")
+    return runner_env
 
-    if SKIP_CI_KEY in trailers:
-        print(f"Not running CI because PR description has '{SKIP_CI_KEY}' trailer.")
-        return False
+
+def parse_jobs_trailer(trailers: Mapping[str, str], key: str,
+                       all_jobs: set[str]) -> set[str]:
+    jobs_text = trailers.get(key)
+    if jobs_text is None:
+        return set()
+    jobs = set(jobs_text.split(","))
+    if ALL_KEY in jobs:
+        if len(jobs) != 1:
+            print(f"'{ALL_KEY}' must be alone in job specification"
+                  f" trailer, but got '{key}: {jobs_text}'")
+            sys.exit(1)
+        print(f"Expanded trailer '{key}: {jobs_text}' to all jobs")
+        return all_jobs
+
+    jobs = set(jobs)
+    unknown_jobs = jobs - all_jobs
+    if unknown_jobs:
+        print(
+            f"Received unknown jobs '{','.join(unknown_jobs)}' in"
+            f" trailer '{key}'",
+            file=sys.stderr)
+        sys.exit(1)
+    return jobs
+
+
+def get_enabled_jobs(is_pr: bool, trailers: Mapping[str, str]) -> set[str]:
+    with open(CI_WORKFLOW_FILE) as f:
+        workflow = yaml.load(f.read(), Loader=yaml.SafeLoader)
+    all_jobs = set(workflow["jobs"].keys())
+    all_jobs -= CONTROL_JOBS
+
+    if ALL_KEY in all_jobs:
+        print(f"Workflow has job with reserved name '{ALL_KEY}'")
+
+    if not is_pr:
+        print("Running all jobs because run was not triggered by a"
+              " pull request event.")
+        return all_jobs
+
+    if Trailer.SKIP_CI in trailers:
+        if (Trailer.EXACTLY_JOBS in trailers or Trailer.EXTRA_JOBS in trailers
+                or Trailer.SKIP_JOBS in trailers):
+            print(
+                f"Cannot specify both '{Trailer.SKIP_JOBS}' and any of"
+                f" '{Trailer.EXACTLY_JOBS}', '{Trailer.EXTRA_JOBS}', '{Trailer.SKIP_JOBS}'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"Skipping all jobs because PR description has"
+              f" '{Trailer.SKIP_CI}' trailer.")
+        return set()
+
+    if Trailer.EXACTLY_JOBS in trailers:
+        if Trailer.EXTRA_JOBS in trailers or Trailer.SKIP_JOBS in trailers:
+            print(
+                f"Cannot mix trailer '{Trailer.EXACTLY_JOBS}' with"
+                f" '{Trailer.EXTRA_JOBS}' or '{Trailer.SKIP_JOBS}'",
+                file=sys.stderr)
+            sys.exit(1)
+
+        exactly_jobs = parse_jobs_trailer(trailers, Trailer.EXACTLY_JOBS,
+                                          all_jobs)
+        return exactly_jobs
+
+    skip_jobs = parse_jobs_trailer(trailers, Trailer.SKIP_JOBS, all_jobs)
+    extra_jobs = parse_jobs_trailer(trailers, Trailer.EXTRA_JOBS, all_jobs)
+
+    ambiguous_jobs = skip_jobs & extra_jobs
+    if ambiguous_jobs:
+        print(f"Jobs cannot be specified in both '{Trailer.SKIP_JOBS}' and"
+              f" '{Trailer.EXTRA_JOBS}', but found {ambiguous_jobs}")
+        sys.exit(1)
+
+    default_jobs = all_jobs - POSTSUBMIT_ONLY_JOBS
 
     base_ref = os.environ["BASE_REF"]
     try:
         modifies = modifies_included_path(base_ref)
     except TimeoutError as e:
-        print("Computing modified files timed out. Running the CI")
-        return True
+        print("Computing modified files timed out. Not using PR diff to"
+              " determine jobs to run.")
 
     if not modifies:
-        print("Skipping CI because all modified files are marked as excluded.")
-        return False
+        print("Not including any jobs by default because all modified files"
+              " are marked as excluded.")
+        default_jobs = frozenset()
 
-    print("CI should run")
-    return True
-
-
-def get_runner_env(trailers: Mapping[str, str]) -> str:
-    runner_env = trailers.get(RUNNER_ENV_KEY)
-    if runner_env is None:
-        print(
-            f"Using '{RUNNER_ENV_DEFAULT}' runners because '{RUNNER_ENV_KEY}'"
-            f" not found in {trailers}"
-        )
-        runner_env = RUNNER_ENV_DEFAULT
-    else:
-        print(f"Using runner environment '{runner_env}' from PR description trailers")
-    return runner_env
+    return (default_jobs | extra_jobs) - skip_jobs
 
 
 def get_benchmark_presets(
@@ -305,11 +409,11 @@ def get_benchmark_presets(
       build_tools/benchmarks/export_benchmark_config.py.
     """
 
-    skip_llvm_integrate_benchmark = SKIP_LLVM_INTEGRATE_BENCHMARK_KEY in trailers
+    skip_llvm_integrate_benchmark = Trailer.SKIP_LLVM_INTEGRATE_BENCHMARK in trailers
     if skip_llvm_integrate_benchmark:
         print(
             "Skipping default benchmarking on LLVM integration because PR "
-            f"description has '{SKIP_LLVM_INTEGRATE_BENCHMARK_KEY}' trailer."
+            f"description has '{Trailer.SKIP_LLVM_INTEGRATE_BENCHMARK}' trailer."
         )
 
     if not is_pr:
@@ -318,19 +422,19 @@ def get_benchmark_presets(
     elif is_llvm_integrate_pr and not skip_llvm_integrate_benchmark:
         # Run all benchmark presets for LLVM integration PRs.
         preset_options = {DEFAULT_BENCHMARK_PRESET}
-        print(f"Using benchmark preset '{preset_options}' for LLVM integration PR")
+        print(
+            f"Using benchmark preset '{preset_options}' for LLVM integration PR"
+        )
     else:
         preset_options = set(
-            label.split(":", maxsplit=1)[1]
-            for label in labels
-            if label.startswith(BENCHMARK_LABEL_PREFIX + ":")
-        )
-        trailer = trailers.get(BENCHMARK_EXTRA_KEY)
+            label.split(":", maxsplit=1)[1] for label in labels
+            if label.startswith(BENCHMARK_LABEL_PREFIX + ":"))
+        trailer = trailers.get(Trailer.BENCHMARK_EXTRA)
         if trailer is not None:
             preset_options = preset_options.union(
-                option.strip() for option in trailer.split(",")
-            )
-        print(f"Using benchmark preset '{preset_options}' from trailers and labels")
+                option.strip() for option in trailer.split(","))
+            print(f"Using benchmark preset '{preset_options}' from trailers"
+                  f" and labels")
 
     if DEFAULT_BENCHMARK_PRESET in preset_options:
         preset_options.remove(DEFAULT_BENCHMARK_PRESET)
@@ -346,8 +450,7 @@ def get_benchmark_presets(
         if preset_option not in BENCHMARK_PRESET_OPTIONS:
             raise ValueError(
                 f"Unknown benchmark preset option: '{preset_option}'.\n"
-                f"Available options: '{BENCHMARK_PRESET_OPTIONS}'."
-            )
+                f"Available options: '{BENCHMARK_PRESET_OPTIONS}'.")
 
     return ",".join(preset_options)
 
@@ -357,18 +460,17 @@ def main():
     trailers, labels = get_trailers_and_labels(is_pr)
     is_llvm_integrate_pr = bool(
         LLVM_INTEGRATE_TITLE_PATTERN.search(os.environ.get("PR_TITLE", ""))
-        or LLVM_INTEGRATE_BRANCH_PATTERN.search(os.environ.get("PR_BRANCH", ""))
-        or LLVM_INTEGRATE_LABEL in labels
-    )
+        or LLVM_INTEGRATE_BRANCH_PATTERN.search(os.environ.get(
+            "PR_BRANCH", "")) or LLVM_INTEGRATE_LABEL in labels)
+    benchmark_presets = get_benchmark_presets(trailers, labels, is_pr,
+                                              is_llvm_integrate_pr)
     output = {
-        "should-run": json.dumps(should_run_ci(is_pr, trailers)),
-        "is-pr": json.dumps(is_pr),
+        "enabled-jobs": sorted(get_enabled_jobs(is_pr, trailers)),
+        "is-pr": is_pr,
         "runner-env": get_runner_env(trailers),
         "runner-group": "presubmit" if is_pr else "postsubmit",
         "write-caches": "0" if is_pr else "1",
-        "benchmark-presets": get_benchmark_presets(
-            trailers, labels, is_pr, is_llvm_integrate_pr
-        ),
+        "benchmark-presets": benchmark_presets,
     }
 
     set_output(output)

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -46,8 +46,9 @@ from typing import Iterable, List, Mapping, Sequence, Tuple
 import yaml
 
 
+# We don't get StrEnum till Python 3.11
 @enum.unique
-class Trailer(enum.StrEnum):
+class Trailer(str, enum.Enum):
     SKIP_CI = "skip-ci"
     SKIP_JOBS = "ci-skip"
     EXTRA_JOBS = "ci-extra"

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -321,7 +321,7 @@ def parse_jobs_trailer(
     jobs_text = trailers.get(key)
     if jobs_text is None:
         return set()
-    jobs = set(jobs_text.split(","))
+    jobs = set(name.strip() for name in jobs_text.split(","))
     if ALL_KEY in jobs:
         if len(jobs) != 1:
             print(

--- a/docs/developers/developing_iree/contributing.md
+++ b/docs/developers/developing_iree/contributing.md
@@ -1,0 +1,98 @@
+# Contributing
+
+This is a more detailed version of the top-level
+[CONTRIBUTING.md](/CONTRIBUTING.md) file. We keep it separate to avoid everyone
+getting a pop-up when creating a PR after each time it changes.
+
+## Downstream Integrations
+
+Due to the process by which we synchronize this GitHub project with our internal
+Google source code repository, there are some oddities in our workflows and
+processes. We aim to minimize these, and especially to mitigate their impact on
+external contributors, but when they come up, they are documented here for
+clarity and transparency. If any of these things are particularly troublesome or
+painful for your workflow, please reach out to us so we can prioritize a fix.
+
+Hopefully these quirks actually make usage in other downstream projects easier,
+but integrators may need to look past some details (like the Bazel build system,
+Android support, etc.) based on their specific requirements.
+
+## Build Systems
+
+IREE supports building from source with both Bazel and CMake. CMake is the
+preferred build system for open source users and offers the most flexible
+configuration options. Bazel is a stricter build system and helps with usage in
+the Google internal source repository. Certain dependencies (think large/complex
+projects like CUDA, TensorFlow, PyTorch, etc.) may be difficult to support with
+one build system or the other, so the project may configure these as optional.
+
+## CI
+
+IREE uses [GitHub Actions](https://docs.github.com/en/actions) for CI. The
+primary CI is configured in the
+[ci.yml workflow file](/.github/workflows/ci.yml).
+
+### Self-Hosted Runners
+
+In addition to the default runners GitHub provides, IREE uses
+[self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners)
+to run many of its workflow jobs. These enable access to additional compute and
+custom configurations such as accelarators. Configuration scripting is checked
+in to this repository (see the
+[README for that directory](/build_tools/github_actions/runner/README.md)).
+
+### Custom Managed Runners
+
+In addition to our self-hosted runners, we use GitHub's
+[large managed runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners)
+for some platforms that are more trouble to configure ourselves (e.g. Mac).
+
+### CI Behavior Manipulation
+
+The setup step of the CI determines which CI jobs to run. This is controlled by
+the [configure_ci.py](/build_tools/github_actions/configure_ci.py) script. It
+will generally run a pre-determined set of jobs on presubmit with some jobs kept
+as post-submit only. If changes are only to a certain set of excluded files that
+we know don't affect CI (e.g. docs), then it will skip the jobs. You can
+customize which jobs run using
+[git trailers](https://git-scm.com/docs/git-interpret-trailers) in the PR
+description. The available options are
+
+```
+ci-skip: jobs,to,skip
+ci-extra: extra,jobs,to,run
+ci-exactly: exact,set,of,jobs,to,run
+skip-ci: free form reason
+skip-llvm-integrate-benchmark: free form reason
+benchmark-extra: extra,benchmarks,to,run
+runner-env: [testing|prod]
+```
+
+The first three follow the same format and instruct the setup script on which
+jobs to include or exclude from its run. They take a comma-separated list of
+jobs which must be from the set of top-level job identifiers in ci.yml file or
+the special keyword "all" to indicate all jobs. `ci-skip` removes jobs that
+would otherwise be included, though it is not an error to list jobs that would
+not be included by default. `ci-extra` adds additional jobs that would not have
+otherwise been run, though it is not an error to list jobs that would have been
+included anyway. It *is* an error to list a job in both of these fields.
+`ci-exactly` provides an exact list of jobs that should run. It is mutually
+exclusive with both `ci-skip` and `ci-extra`. In all these cases, the setup does
+not make any effort to ensure that job dependencies are satisfied. Thus, if you
+request skipping the `build_all` job, all the jobs that depend on it will fail,
+not be skipped. `skip-ci` is an older option that simply skips all jobs. Its
+usage is deprecated and it is mutually exclusive with all of the other `ci-*`
+options. Prefer `ci-skip: all`.
+
+Benchmarks don't run by default on PRs, and must be specifically requested. They
+*do* run by default on PRs detected to be an integration of LLVM into IREE, but
+this behavior can be disabled with `skip-llvm-integrate-benchmark`. The
+`benchmark-extra` option allows specifying additional benchmark presets to run
+as part of benchmarking. It accepts a comma-separated list of benchmark presets.
+This combines with labels added to the PR (which are a more limited set of
+options). See the [benchmark suites documentation](./benchmark_suites.md).
+
+The `runner-env` option controls which runner environment to target for our
+self-hosted runners. We maintain a test environment to allow testing out new
+configurations prior to rolling them out. This trailer is for advanced users who
+are working on the CI infrastructure itself.


### PR DESCRIPTION
With an increasing number of CI jobs and more resource issues, I think
it's useful for people to be able to specify which jobs they actually
want to run. In particular, I think it would be beneficial to make some
jobs, such as Windows, Mac, and A100, available for opt-in. Personally,
when adding new jobs, I am routinely hacking the ci.yml file to only
run specific jobs and I think I am probably better able to do that: I
see other people running the entire workflow repeatedly just to test
one job.

Now that we re-evaluate the PR description when rerunning the job,
people don't need to push another commit or anything after editing the
description: they can 'just' cancel and rerun the job (still not ideal).

I know people have struggled with the ergonomics of trailers for CI
control in the past. I tried to make the tag names follow a consistent
format and also added additional error checking like looking for
unknown usage of reserved prefixes. Weird tag combinations provide
immediate errors. The lack of correspondence between `skip-ci` and
`ci-skip` is a bit unfortunate. I'm open to other names, but I don't
think we should choose something less natural just to avoid this. We
should probably drop `skip-ci` entirely with this because you would
spell that `ci-skip: all`. That does have the disadvantage of not being
able to provide justification as part of the trailer, but that can be
done free-form in the PR description without losing much IMO.

One thing this doesn't do is any kind of dependency analysis. That is,
if you specify `ci-exactly: test_all`, it's not going to run
`build_all` and then the `test_all` job will just fail. This is
theoretically something it could do, since it's already parsing the
workflow file, but I'm not sure if that actually makes things less
confusing.

This also perhaps prompts cleaning up the job names so they're a bit
pithier and more intuitive. I think `build_test_all_windows` could just
be called `windows` for instance: this is a case where very structured
names actually get in the way IMO.

Fixes https://github.com/openxla/iree/issues/10042

Tested running locally with various env variable settings. Tested a
few different options in this PR also.

ci-skip: all
