### PR TITLE
[Flow] NFC: Remove redundant tied_operands attribte from tensor.update op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
@@ -132,9 +132,9 @@ convertInsertSliceOpToFlowUpdateOp(RewriterBase &rewriter,
                                                     insertOp.getMixedOffsets());
   Value dest = insertOp.getDest();
   auto destDynamicDims = tensor::createDynamicDimValues(rewriter, loc, dest);
-  rewriter.replaceOpWithNewOp<TensorUpdateOp>(
-      insertOp, insertOp.getType(), dest, destDynamicDims, offsetVals, source,
-      sourceDynamicDims, rewriter.getIndexArrayAttr({0}));
+  rewriter.replaceOpWithNewOp<TensorUpdateOp>(insertOp, insertOp.getType(),
+                                              dest, destDynamicDims, offsetVals,
+                                              source, sourceDynamicDims);
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -1228,8 +1228,7 @@ struct FoldTensorUpdateOpWithCasts : public OpRewritePattern<TensorUpdateOp> {
         updateOp.getStartIndices(), update,
         refreshDimsOnTypeChange(updateOp, updateOp.getUpdate().getType(),
                                 update.getType(), updateOp.getUpdateDims(),
-                                rewriter),
-        updateOp.getTiedOperandsAttr());
+                                rewriter));
     rewriter.replaceOpWithNewOp<tensor::CastOp>(
         updateOp, updateOp.getResult().getType(), newOp.getResult());
     return success();

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1599,7 +1599,7 @@ void TensorUpdateOp::build(OpBuilder &builder, OperationState &state,
   auto updateDims =
       IREE::Util::buildDynamicDimsForValue(state.location, update, builder);
   build(builder, state, target.getType(), target, targetDims, startIndices,
-        update, updateDims, builder.getIndexArrayAttr({0}));
+        update, updateDims);
 }
 
 LogicalResult TensorUpdateOp::verify() {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1468,8 +1468,7 @@ def FLOW_TensorUpdateOp : FLOW_PureOp<"tensor.update", [
     FLOW_ShapeDynamicDims:$target_dims,
     Variadic<FLOW_Dim>:$start_indices,
     FLOW_Tensor:$update,
-    FLOW_ShapeDynamicDims:$update_dims,
-    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands
+    FLOW_ShapeDynamicDims:$update_dims
   );
   let results = (outs
     FLOW_Tensor:$result
@@ -1478,7 +1477,7 @@ def FLOW_TensorUpdateOp : FLOW_PureOp<"tensor.update", [
   let assemblyFormat = [{
     $update `,` $target `[` $start_indices `]` `:`
     type($update) (`{` $update_dims^ `}`)? `->`
-    custom<ShapedTiedResult>(type($result), $target_dims, $tied_operands)
+    custom<ShapedTiedResult>(type($result), $target_dims)
     attr-dict-with-keyword
   }];
 


### PR DESCRIPTION
Tied operand hardcoded to `0` and attribute only adds confusion