### PR TITLE
Start LLVM integrate (64 commits behind)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -205,7 +205,8 @@ struct FoldFillIntoPad : public OpRewritePattern<tensor::PadOp> {
 
     Location loc = padOp.getLoc();
     auto emptyOp = rewriter.create<tensor::EmptyOp>(
-        loc, resultType, tensor::getMixedSizes(rewriter, loc, padOp));
+        loc, tensor::getMixedSizes(rewriter, loc, padOp),
+        resultType.getElementType());
     rewriter.replaceOpWithNewOp<linalg::FillOp>(padOp, padValue,
                                                 emptyOp.getResult());
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -33,7 +33,6 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Dialect/Linalg/Utils/IndexingUtils.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
@@ -206,8 +205,7 @@ struct FoldFillIntoPad : public OpRewritePattern<tensor::PadOp> {
 
     Location loc = padOp.getLoc();
     auto emptyOp = rewriter.create<tensor::EmptyOp>(
-        loc, resultType,
-        linalg::createDynamicDimensions(rewriter, loc, padOp.getResult()));
+        loc, resultType, tensor::getMixedSizes(rewriter, loc, padOp));
     rewriter.replaceOpWithNewOp<linalg::FillOp>(padOp, padValue,
                                                 emptyOp.getResult());
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -359,11 +359,10 @@ transform_dialect::ApplyLoopIndependentCodeMotionOp::applyToOne(
     // tracking.
     // TODO: confirm / revisit this assumption and plumb a rewriter through
     // upstream moveLoopInvariantCode if necessary.
-    funcOp->walk([&](Operation *op) {
+    funcOp->walk([](Operation *op) {
       (void)llvm::TypeSwitch<Operation *, LogicalResult>(op)
-          .Case<affine::AffineForOp, scf::ForOp>([&](auto loop) {
-            return loop.promoteIfSingleIteration(rewriter);
-          })
+          .Case<affine::AffineForOp, scf::ForOp>(
+              [](auto loop) { return promoteIfSingleIteration(loop); })
           .Default([](Operation *) { return success(); });
     });
   });

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -358,10 +358,11 @@ transform_dialect::ApplyLoopIndependentCodeMotionOp::applyToOne(
     // tracking.
     // TODO: confirm / revisit this assumption and plumb a rewriter through
     // upstream moveLoopInvariantCode if necessary.
-    funcOp->walk([](Operation *op) {
+    funcOp->walk([&](Operation *op) {
       (void)llvm::TypeSwitch<Operation *, LogicalResult>(op)
-          .Case<affine::AffineForOp, scf::ForOp>(
-              [](auto loop) { return promoteIfSingleIteration(loop); })
+          .Case<affine::AffineForOp, scf::ForOp>([&](auto loop) {
+            return loop.promoteIfSingleIteration(rewriter);
+          })
           .Default([](Operation *) { return success(); });
     });
   });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -364,7 +364,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
 
-//         CHECK: %[[ALLOC0:.+]] = memref.alloc() {alignment = 64 : i64} : memref<1xi8, #gpu.address_space<workgroup>>
+//     CHECK-DAG: %[[ALLOC0:.+]] = memref.alloc() {alignment = 64 : i64} : memref<1xi8, #gpu.address_space<workgroup>>
 // Local per-thread scf.for-based reduction.
 //         CHECK: %[[TIDX:.]] = gpu.thread_id  x
 //         CHECK: scf.for {{.*}} -> (vector<1xi8>)

--- a/compiler/src/iree/compiler/InputConversion/Common/QuantizedMatmulToMatmul.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/QuantizedMatmulToMatmul.cpp
@@ -9,7 +9,6 @@
 #include "iree/compiler/InputConversion/Common/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Linalg/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -65,9 +64,8 @@ struct QuantizedMatmulToMatmul
     }
     // Create the result. No need to zero-fill it as we will overwrite it.
     ShapedType accType = llvm::cast<ShapedType>(acc.getType());
-    auto accDynShape = linalg::createDynamicDimensions(rewriter, loc, acc);
     Value initResult = builder.create<tensor::EmptyOp>(
-        accType.getShape(), accType.getElementType(), accDynShape);
+        tensor::getMixedSizes(builder, loc, acc), accType.getElementType());
     // Create the indexing maps for the generic.
     MLIRContext *context = rewriter.getContext();
     AffineExpr m, n;


### PR DESCRIPTION
Advance LLVM to cb7bda2ace81226c5b33165411dd0316f93fa57e: [mlir][NFC] Use `getConstantIntValue` instead of casting to `ConstantIndexOp` (Matthias Springer on 2023-07-04 14:08:37 +0200)