### PR TITLE
Add missing concurrency control in workflows

### DIFF
--- a/.github/workflows/benchmark_large.yml
+++ b/.github/workflows/benchmark_large.yml
@@ -14,6 +14,13 @@ on:
     - cron: '0 09,21 * * *'
   workflow_dispatch:
 
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   # This needs to be in env instead of the outputs of setup because it contains
   # the run attempt and we want that to be the current attempt, not whatever

--- a/.github/workflows/run_convperf.yml
+++ b/.github/workflows/run_convperf.yml
@@ -18,6 +18,13 @@ on:
     - cron: '0 16 * * *'
   workflow_dispatch:
 
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
 

--- a/.github/workflows/run_iree_dispatch_profiler.yml
+++ b/.github/workflows/run_iree_dispatch_profiler.yml
@@ -21,6 +21,13 @@ on:
     - cron: "0 14 * * 1-5"
   workflow_dispatch:
 
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     uses: ./.github/workflows/setup.yml

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -18,6 +18,13 @@ on:
     - cron: '0 13 * * *'
   workflow_dispatch:
 
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
 

--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -9,6 +9,13 @@ on:
   # See the workflow's `SHARK -> generate_report` log output for exact results URL.
   # pull_request:
 
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     runs-on: ubuntu-20.04

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -15,6 +15,13 @@ on:
     - cron: "5 4 * * 1-5"
   workflow_dispatch:
 
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   colab:
     runs-on: ubuntu-20.04-64core


### PR DESCRIPTION
There are several workflows don't set concurrency control to cancel duplicate jobs.

Add concurrency control for them as it saves resources when people test them in presubmit by adding `pull_request:`, even though they are usually run by schedule.

For now only add test/benchmark workflows and skip release workflows the interruption on them might be undesirable. 

skip-ci: Not related to ci.yml