### PR TITLE
Remove `configure_ci.py` from `post_benchmark_comment.yaml`

### DIFF
--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -17,33 +17,9 @@ env:
   PR_CI_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
 
 jobs:
-  setup:
+  post_comment:
     # Only run the workflow if it's triggered from a pull request.
     if: github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-20.04
-    outputs:
-      should-run: ${{ steps.configure.outputs.should-run }}
-      runner-env: ${{ steps.configure.outputs.runner-env }}
-      runner-group: ${{ steps.configure.outputs.runner-group }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-        with:
-          # We need the parent commit to do a diff
-          fetch-depth: 2
-      - name: "Configuring CI options"
-        id: configure
-        run: |
-          # Just informative logging. There should only be two commits in the
-          # history here, but limiting the depth helps when copying from a local
-          # repo instead of using checkout, e.g. with
-          # https://github.com/nektos/act where there will be more.
-          git log --oneline --graph --max-count=3
-          ./build_tools/github_actions/configure_ci.py
-
-  post_comment:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
     runs-on: ubuntu-20.04
     permissions:
       issues: write

--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -10,6 +10,7 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  pull_request:
 
 env:
   PR_CI_STAGE: ${{ github.event.workflow_run.event == 'pull_request' && 'presubmit' || 'postsubmit' }}

--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -10,7 +10,6 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-  pull_request:
 
 env:
   PR_CI_STAGE: ${{ github.event.workflow_run.event == 'pull_request' && 'presubmit' || 'postsubmit' }}


### PR DESCRIPTION
Jobs in `post_benchmark_comment.yaml` has no dependency on the outputs of `configure_ci.py`. Remove the configure job.

This should also solve the current issues due to the recent change in `configure_ci.py` (https://github.com/openxla/iree/actions/runs/5490581110/jobs/10006200922)

skip-ci: Not run in presubmit