### PR TITLE
Add explicit homepage to website extra section.

### DIFF
--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -54,6 +54,8 @@ extra:
   community_homepage: https://github.com/openxla/community
   community_site_name: OpenXLA
 
+  homepage: https://openxla.github.io/iree/
+
   # TODO(scotttodd): join mkdocs-material insiders and remove notice?
   #   (we *can* remove the notice without joining)
   # generator: false


### PR DESCRIPTION
This fixes the "IREE" header link to point to the homepage instead of the current page: 
![image](https://github.com/openxla/iree/assets/4010439/cff35c6b-f0ab-41d8-8121-134872c598b7)

It's not _quite_ what you want for local development, but I don't really understand the other available values in https://github.com/openxla/iree/blob/6867577a5d3d0b551ecc5256d5def2c739da64ec/third_party/mkdocs-material/overrides/partials/header.html#L47-L49