### PR TITLE
Switch CMake to build libIREECompiler.so without explicit export lists.

### DIFF
--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -299,6 +299,7 @@ function(iree_cc_library)
     message(STATUS "  + alias ${_PACKAGE_NS}::${_RULE_NAME}")
   endif()
   add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
+
   if(NOT "${_PACKAGE_NS}" STREQUAL "")
     # If the library name matches the final component of the package then treat
     # it as a default. For example, foo/bar/ library 'bar' would end up as

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -299,9 +299,6 @@ function(iree_cc_library)
     message(STATUS "  + alias ${_PACKAGE_NS}::${_RULE_NAME}")
   endif()
   add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
-  # if(TARGET ${_OBJECTS_NAME})
-  #   add_library(${_PACKAGE_NS}::${_RULE_NAME}.objects ALIAS ${_OBJECTS_NAME})
-  # endif()
   if(NOT "${_PACKAGE_NS}" STREQUAL "")
     # If the library name matches the final component of the package then treat
     # it as a default. For example, foo/bar/ library 'bar' would end up as

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -299,7 +299,9 @@ function(iree_cc_library)
     message(STATUS "  + alias ${_PACKAGE_NS}::${_RULE_NAME}")
   endif()
   add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
-
+  # if(TARGET ${_OBJECTS_NAME})
+  #   add_library(${_PACKAGE_NS}::${_RULE_NAME}.objects ALIAS ${_OBJECTS_NAME})
+  # endif()
   if(NOT "${_PACKAGE_NS}" STREQUAL "")
     # If the library name matches the final component of the package then treat
     # it as a default. For example, foo/bar/ library 'bar' would end up as

--- a/compiler/bindings/c/iree/compiler/api_support.h
+++ b/compiler/bindings/c/iree/compiler/api_support.h
@@ -7,8 +7,8 @@
 #ifndef IREE_COMPILER_API_SUPPORT_H
 #define IREE_COMPILER_API_SUPPORT_H
 
-#if (defined(_WIN32) || defined(__CYGWIN__))
-// Visibility annotations disabled.
+#if (defined(_WIN32) || defined(__CYGWIN__)) && \
+  !defined(IREE_EMBED_ENABLE_WINDOWS_DLL_DECLSPEC)
 #define IREE_EMBED_EXPORTED
 #elif defined(_WIN32) || defined(__CYGWIN__)
 // Windows visibility declarations.

--- a/compiler/bindings/c/iree/compiler/api_support.h
+++ b/compiler/bindings/c/iree/compiler/api_support.h
@@ -7,8 +7,8 @@
 #ifndef IREE_COMPILER_API_SUPPORT_H
 #define IREE_COMPILER_API_SUPPORT_H
 
-#if (defined(_WIN32) || defined(__CYGWIN__)) && \
-  !defined(IREE_EMBED_ENABLE_WINDOWS_DLL_DECLSPEC)
+#if (defined(_WIN32) || defined(__CYGWIN__)) &&                                \
+    !defined(IREE_EMBED_ENABLE_WINDOWS_DLL_DECLSPEC)
 #define IREE_EMBED_EXPORTED
 #elif defined(_WIN32) || defined(__CYGWIN__)
 // Windows visibility declarations.

--- a/compiler/bindings/c/iree/compiler/loader/loader.cpp
+++ b/compiler/bindings/c/iree/compiler/loader/loader.cpp
@@ -260,9 +260,8 @@ void ireeCompilerInvocationSetCompileToPhase(iree_compiler_invocation_t *run,
   __ireeCompilerInvocationSetCompileToPhase(run, phase);
 }
 
-void
-ireeCompilerInvocationSetVerifyIR(iree_compiler_invocation_t *run,
-                                  bool enable) {
+void ireeCompilerInvocationSetVerifyIR(iree_compiler_invocation_t *run,
+                                       bool enable) {
   __ireeCompilerInvocationSetVerifyIR(run, enable);
 }
 

--- a/compiler/bindings/c/iree/compiler/loader/loader.cpp
+++ b/compiler/bindings/c/iree/compiler/loader/loader.cpp
@@ -260,7 +260,7 @@ void ireeCompilerInvocationSetCompileToPhase(iree_compiler_invocation_t *run,
   __ireeCompilerInvocationSetCompileToPhase(run, phase);
 }
 
-IREE_EMBED_EXPORTED void
+void
 ireeCompilerInvocationSetVerifyIR(iree_compiler_invocation_t *run,
                                   bool enable) {
   __ireeCompilerInvocationSetVerifyIR(run, enable);

--- a/compiler/src/iree/compiler/API/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/BUILD.bazel
@@ -32,6 +32,11 @@ iree_compiler_cc_library(
     ],
 )
 
+# IMPORTANT: If modifying the list of dependencies, mirror the changes
+# manually into:
+#   1. CMakeLists.txt _EXPORT_OBJECT_LIBS
+#   2. TODO: Something for bazel.
+# The CI will complain if you get it wrong.
 iree_compiler_cc_library(
     name = "StaticImpl",
     deps = [

--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -42,21 +42,130 @@ iree_cc_library(
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
+################################################################################
+# libIREECompiler.so building
+# It's 2023. We were supposed to have sane ways to build shared libraries.
+# We were promised.
+#
+# Anyway, the shared library must be explicitly assembled from the *object
+# libraries* that make up its public interface. We could use the new
+# $<LINK_LIBRARY:WHOLE_ARCHIVE> feature to bypass this old way of doing it,
+# but that interacts badly with BUILD_SHARED_LIBS mode (since it would then
+# not be linking the static libraries *into* a composite shared library).
+#
+# Therefore, we duplicate the object libs from above. They are lexically
+# related:
+#   1. LLVM derived object libraries are named with an "obj." prefix.
+#   2. IREE derived object libraries are named with an ".objects" suffix.
+#   3. Alias libraries don't work, so we need to use the "_" vs "::" form.
+#
+# Given this variance, we opt for simple duplication. Make sure that the list
+# below is always kept in sync with the list above for StaticImpl.
+#
+# Further, we have to separate out the LINK_LIBRARIES dependencies of the
+# OBJECTS libraries and include them manually as PRIVATE deps of the shared
+# library. This involves some generator shenanigans.
+#
+# Finally, we allow super-projects to export additional API from our shared
+# library by populating the IREE_COMPILER_API_ADDL_EXPORT_OBJECTS.
+################################################################################
+
+set(_EXPORT_OBJECT_LIBS
+  obj.IREEDialectsCAPI
+  obj.MLIRCAPIDebug
+  obj.MLIRCAPIIR
+  obj.MLIRCAPIInterfaces
+  obj.MLIRCAPILinalg
+  obj.MLIRCAPIPDL
+  obj.MLIRCAPITransformDialect
+  iree_compiler_API_Internal_Embed.objects
+  iree_compiler_API_Internal_IREECompileToolEntryPoint.objects
+  iree_compiler_API_Internal_IREEMLIRLSPServerToolEntryPoint.objects
+  iree_compiler_API_Internal_IREEOptToolEntryPoint.objects
+  iree_compiler_API_Internal_LLDToolEntryPoint.objects
+)
+
+if(DEFINED IREE_COMPILER_API_ADDL_EXPORT_OBJECTS)
+  message(STATUS "Bundling additional exports into libIREECompiler.so: ${IREE_COMPILER_API_ADDL_EXPORT_OBJECTS}")
+  list(APPEND _EXPORT_OBJECT_LIBS ${IREE_COMPILER_API_ADDL_EXPORT_OBJECTS})
+endif()
+
+set(_EXPORT_OBJECT_SRCS)
+set(_EXPORT_OBJECT_DEPS)
+foreach(_object_lib ${_EXPORT_OBJECT_LIBS})
+  # On MSVC, source level __declspec(dllexport) remain the most precise
+  # way to control DLL API availability. All of the MLIR and IREE CAPI
+  # are annotated this way, which approximates the same behavior we get if
+  # building the overall project with visibility=hidden on POSIX.
+  # Emission of these annotations is guarded by two macros in each
+  # codebase: one to enable DECLSPEC emission at all and another
+  # to indicate that we are building a library and the symbols should be
+  # exported (vs imported). Note that with CMake controlling linking,
+  # it is not necessary to emit dllimport annotations, since CMake will
+  # link against the import library, which is sufficient for functions.
+  # The alternative is to export everything by setting (on the SharedImpl):
+  #   WINDOWS_EXPORT_ALL_SYMBOLS ON
+  # This, however, produces on the order of 6-10k exported symbols, whereas
+  # the focused API is 1/10 of that.
+  #
+  # It isn't super polite to be poking at other people's library definitions
+  # like this, but MSVC is weird and given the structure of the projects, this
+  # isn't so bad.
+  if(MSVC)
+    target_compile_definitions(${_object_lib} PRIVATE
+      # See compiler/bindings/c/iree/compiler/api_support.h.
+      # IREE embedded CAPI uses its own macros to enable
+      # declaration specs.
+      IREE_EMBED_ENABLE_WINDOWS_DLL_DECLSPEC
+      IREE_EMBED_BUILDING_LIBRARY
+
+      # See mlir-c/Support.h for the annotation selection.
+      MLIR_CAPI_ENABLE_WINDOWS_DLL_DECLSPEC
+      MLIR_CAPI_BUILDING_LIBRARY
+    )
+  endif()
+
+  list(APPEND _EXPORT_OBJECT_SRCS "$<TARGET_OBJECTS:${_object_lib}>")
+  # Ugh. CMake. GENEX_EVAL is not recursive: it evaluates one level of generator
+  # expressions. There is a way to hold it just right so that GENEX_EVAL is
+  # used at the call site, but it is really tricky and people can't be expected
+  # to get it right. In fact, at the time of this writing, some misc usage
+  # in LLVM causes a second level of generator expressions in some base
+  # libraries. For good measure, we do GENEX_EVAL four times. If you get errors
+  # that show like generator expressions are showing up in link lines, this is
+  # the culprit. Look at the export_objects_debug.txt to confirm. Then, add
+  # another level of fix upstream if you like pain.
+  list(APPEND _EXPORT_OBJECT_DEPS "$<GENEX_EVAL:$<GENEX_EVAL:$<GENEX_EVAL:$<GENEX_EVAL:$<TARGET_PROPERTY:${_object_lib},LINK_LIBRARIES>>>>>")
+endforeach()
+file(GENERATE OUTPUT export_objects_debug.txt CONTENT "OBJECTS:${_EXPORT_OBJECT_SRCS}\n\nDEPS:${_EXPORT_OBJECT_DEPS}")
 iree_cc_library(
   SHARED
   NAME
     SharedImpl
-  WINDOWS_DEF_FILE
-    # On Windows, include the generated def file.
-    ${CMAKE_CURRENT_SOURCE_DIR}/api_exports.def
   SRCS
-    api_exports.c
+     # Force this to be a regular library with an empty source file.
+     empty.c
   LINKOPTS
-    # Linux uses a linker script.
-    $<$<PLATFORM_ID:Linux>:-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/api_exports.ld>
-    # MacOS uses a symbol list. Note that this option is only accepted
-    # with a single dash.
-    $<$<PLATFORM_ID:Darwin>:-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/api_exports.macos.lst>
+    # Linux uses a linker script to version symbols.
+    $<$<PLATFORM_ID:Linux>:-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/api_version.ld>
+)
+
+# Make sure that re-link if extra linker inputs change.
+set_target_properties(iree_compiler_API_SharedImpl PROPERTIES
+  LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/api_version.ld
+)
+
+# We need to add the object sources directly to the SHARED sub-target, not
+# the .objects sub-target, which is what would happen if added to SRCS.
+target_sources(iree_compiler_API_SharedImpl PRIVATE
+  ${_EXPORT_OBJECT_SRCS}
+)
+
+# Explicitly link deps as PRIVATE (the default rule uses PUBLIC) so that usage
+# requirements do not cascade: The shared library is intended to be used as an
+# isolated boundary for C consumers.
+target_link_libraries(iree_compiler_API_SharedImpl PRIVATE
+  ${_EXPORT_OBJECT_DEPS}
 )
 
 # If not using sanitizers, ask linkers to error on undefined symbols.
@@ -70,19 +179,6 @@ if(NOT IREE_ENABLE_ASAN
     $<$<PLATFORM_ID:Darwin>:-Wl,-undefined,error>
   )
 endif()
-
-# DANGER: iree_cc_library links its deps with PUBLIC scope, which causes
-# usage requirements to propagate from dependents to users of the shared
-# library. The shared library is intended to be used as an isolated boundary
-# for C consumers. Therefore, we depend on the backing static library with
-# PRIVATE scope explicitly here vs using a DEPS above. This kind of "boundary
-# shared library" seems to be the only place this happens, so we special
-# case vs generalizing.
-target_link_libraries(
-  iree_compiler_API_SharedImpl
-  PRIVATE
-    iree_compiler_API_StaticImpl
-)
 
 set_target_properties(
   iree_compiler_API_SharedImpl

--- a/compiler/src/iree/compiler/API/api_version.ld
+++ b/compiler/src/iree/compiler/API/api_version.ld
@@ -1,0 +1,5 @@
+IREE_API_0.0 {
+  /* Deployed versions are compiled with visibility hidden and source level
+     export annotations. */
+  global: *;
+};

--- a/compiler/src/iree/compiler/API/empty.c
+++ b/compiler/src/iree/compiler/API/empty.c
@@ -1,0 +1,1 @@
+typedef int dummy;


### PR DESCRIPTION
The need to run generate_exports.py was always a hack that we didn't want to carry forward. This patch does the CMake plumbing needed to build the compiler shared library without such a workaround.

It relies on the source level annotations to control what gets exported in deployment builds (in dev builds, everything is exported on Posix). This also adds a mechanism for super-projects to extend what gets exported (which was the motivating use case to fix this).

There is a similar-effect (but different mechanism) way to achieve this on Bazel, but it requires a Bazel upgrade to use. I'll do that separately. Until then, the old export lists will be used for Bazel.