### PR TITLE
Makes --iree-input-type an open namespace and adds a plugin extension for it.

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/Embed.cpp
+++ b/compiler/src/iree/compiler/API/Internal/Embed.cpp
@@ -613,6 +613,30 @@ bool Invocation::initializeInvocation() {
     return false;
   }
 
+  // Validate flags.
+  // Validate inputTypeMnemonic.
+  if (session.inputOptions.parseInputTypeMnemonic() ==
+      InputDialectOptions::Type::plugin) {
+    llvm::StringSet<> inputTypeMnemonics;
+    session.pluginSession.populateCustomInputConversionTypes(
+        inputTypeMnemonics);
+    if (!inputTypeMnemonics.contains(session.inputOptions.inputTypeMnemonic)) {
+      auto diag = emitError(UnknownLoc::get(&session.context))
+                  << "unknown custom value for --input-input-type='"
+                  << session.inputOptions.inputTypeMnemonic << "'";
+      if (inputTypeMnemonics.empty()) {
+        diag << " (none registered)";
+      } else {
+        diag << " (available:";
+        for (auto &s : inputTypeMnemonics) {
+          diag << " '" << s.first() << "'";
+        }
+        diag << ")";
+      }
+      return false;
+    }
+  }
+
   return true;
 }
 

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -30,12 +30,16 @@ struct BindingOptions {
 // needs to be created in order to represent whole-module level framework
 // quirks. These are just about the ops in the functions.
 struct InputDialectOptions {
+  // Built-in input types, represented by an enum.
   enum class Type {
     // Applies no input transformation. Only supported core and extension ops
     // are supported.
     none,
     // Analyses the input to determine what input dialect pipeline to use.
     auto_detect,
+    // A named input pipeline from a plugin. If set, then 'pluginInputPipeline'
+    // must be set.
+    plugin,
 #ifdef IREE_HAVE_STABLEHLO_INPUT
     // Legalizes input defined over StableHLO ops.
     stablehlo,
@@ -52,7 +56,15 @@ struct InputDialectOptions {
     tosa,
 #endif // IREE_HAVE_TOSA_INPUT
   };
-  Type type = Type::auto_detect;
+  // The flag value is captured into spec by the CL system and it must be
+  // interpreted by parseInputTypeSpec.
+  std::string inputTypeMnemonic{"auto"};
+
+  // Parses the user-provided inputTypeMnemonic, returning a recognized Type
+  // enumeration as appropriate. If the returned type is `plugin`, then it is
+  // a custom input type and the raw inputTypeMnemonic should be passed to the
+  // plugin system for resolution.
+  Type parseInputTypeMnemonic();
 
   bool demoteI64ToI32 = true;
   bool demoteF64ToF32 = true;

--- a/compiler/src/iree/compiler/PluginAPI/Client.h
+++ b/compiler/src/iree/compiler/PluginAPI/Client.h
@@ -7,12 +7,14 @@
 #ifndef IREE_COMPILER_PLUGINAPI_CLIENT_H_
 #define IREE_COMPILER_PLUGINAPI_CLIENT_H_
 
+#include <functional>
 #include <optional>
 #include <string_view>
 
 #include "iree/compiler/Pipelines/Options.h"
 #include "iree/compiler/Utils/OptionUtils.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
 
 namespace mlir {
 class DialectRegistry;
@@ -47,9 +49,23 @@ public:
   virtual ~PipelineExtensions();
 
   // Add passes to the input preprocessing pipeline, which allows to process the
-  // raw input to IREE.
+  // raw input to IREE. This applies to builtin Type enum input pipelines.
   virtual void extendInputConversionPreprocessingPassPipeline(
       OpPassManager &passManager, InputDialectOptions::Type inputType) {}
+
+  // Adds input type mnemonics that this instance supports. At least one plugin
+  // must advertise support for a custom input type in order for it to be
+  // considered valid.
+  virtual void populateCustomInputConversionTypes(StringSet<> &typeMnemonics) {}
+
+  // Adds passes to the input preprocessing pipeline for the given
+  // InputDialectOptions::Type::plugin type with the given mnemonic.
+  // Returns true if extensions were made.
+  virtual bool
+  extendCustomInputConversionPassPipeline(OpPassManager &passManager,
+                                          std::string_view typeMnemonic) {
+    return false;
+  }
 
   // Adds passes to the |buildPreprocessingPassPipeline| pipeline at the end.
   virtual void extendPreprocessingPassPipeline(OpPassManager &passManager) {}

--- a/compiler/src/iree/compiler/PluginAPI/PluginManager.h
+++ b/compiler/src/iree/compiler/PluginAPI/PluginManager.h
@@ -102,7 +102,24 @@ public:
     }
   }
 
-  // Forward pipeline extensions.
+  void populateCustomInputConversionTypes(StringSet<> &typeMnemonics) override {
+    for (auto *s : initializedSessions) {
+      s->populateCustomInputConversionTypes(typeMnemonics);
+    }
+  }
+
+  bool extendCustomInputConversionPassPipeline(
+      OpPassManager &passManager, std::string_view typeMnemonic) override {
+    bool matched = false;
+    for (auto *s : initializedSessions) {
+      if (s->extendCustomInputConversionPassPipeline(passManager,
+                                                     typeMnemonic)) {
+        matched = true;
+      }
+    }
+    return matched;
+  }
+
   void extendPreprocessingPassPipeline(OpPassManager &passManager) override {
     for (auto *s : initializedSessions) {
       s->extendPreprocessingPassPipeline(passManager);


### PR DESCRIPTION
This lets plugins define their own input types. The plumbing on the plugin manager side is a bit awkward since typical pipeline construction constructors don't have access to the context for error reporting. We may need to revisit a better error reporting option later if this gets any more complicated. However, there is only one use, so it is unlikely to spider.