### PR TITLE
Reland "Implement CI job optionality (#14312)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
   ##############################################################################
   build_all:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_all')
     uses: ./.github/workflows/build_all.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -74,7 +74,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
     runs-on: windows-2022-64core
     defaults:
       run:
@@ -132,7 +132,7 @@ jobs:
 
   build_test_all_macos_arm64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_macos_arm64')
     runs-on:
       - ${{ github.repository == 'openxla/iree' && 'self-hosted' || 'macos-11' }} # must come first
       - runner-group=postsubmit
@@ -169,7 +169,7 @@ jobs:
 
   build_test_all_macos_x86_64:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_macos_x86_64')
     runs-on: macos-13-xl
     env:
       BUILD_DIR: build-macos
@@ -220,7 +220,7 @@ jobs:
 
   build_test_all_bazel:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_bazel')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -243,7 +243,7 @@ jobs:
 
   test_all:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_all')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -273,7 +273,7 @@ jobs:
 
   test_gpu:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_gpu')
     env:
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
@@ -334,7 +334,7 @@ jobs:
   ##############################################################################
   build_test_runtime:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_runtime')
     runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
@@ -362,7 +362,7 @@ jobs:
 
   build_test_runtime_windows:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_runtime_windows')
     runs-on: windows-2022-64core
     defaults:
       run:
@@ -391,7 +391,7 @@ jobs:
   ##############################################################################
   test_tf_integrations:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_tf_integrations')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -421,7 +421,7 @@ jobs:
 
   test_tf_integrations_gpu:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_tf_integrations_gpu')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -459,7 +459,7 @@ jobs:
   ##############################################################################
   python_release_packages:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'python_release_packages')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -498,7 +498,7 @@ jobs:
 
   asan:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'asan')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -526,7 +526,7 @@ jobs:
 
   tsan:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'tsan')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -551,7 +551,7 @@ jobs:
 
   small_runtime:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'small_runtime')
     runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
@@ -578,7 +578,7 @@ jobs:
 
   gcc:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'gcc')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -610,7 +610,7 @@ jobs:
 
   tracing:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'tracing')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -639,7 +639,7 @@ jobs:
 
   debug:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'debug')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -668,7 +668,7 @@ jobs:
 
   byo_llvm:
     needs: setup
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'byo_llvm')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -697,7 +697,7 @@ jobs:
 
   build_benchmark_tools:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_benchmark_tools')
     uses: ./.github/workflows/build_benchmark_tools.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -708,7 +708,7 @@ jobs:
 
   build_e2e_test_artifacts:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_e2e_test_artifacts')
     uses: ./.github/workflows/build_e2e_test_artifacts.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -720,7 +720,7 @@ jobs:
 
   compilation_benchmarks:
     needs: [setup, build_e2e_test_artifacts]
-    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'compilation_benchmarks') && needs.setup.outputs.benchmark-presets != ''
     uses: ./.github/workflows/benchmark_compilation.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -732,7 +732,7 @@ jobs:
 
   execution_benchmarks:
     needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]
-    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'execution_benchmarks') && needs.setup.outputs.benchmark-presets != ''
     uses: ./.github/workflows/benchmark_execution.yml
     with:
       # env.GCS_DIR is also duplicated in this workflow. See the note there on
@@ -745,7 +745,7 @@ jobs:
 
   process_benchmark_results:
     needs: [setup, compilation_benchmarks, execution_benchmarks]
-    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'process_benchmark_results') && needs.setup.outputs.benchmark-presets != ''
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -837,7 +837,7 @@ jobs:
 
   cross_compile_and_test:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'cross_compile_and_test')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -926,7 +926,7 @@ jobs:
   # can't access matrix variable to skip certain matrix jobs for presubmit).
   build_and_test_android:
     needs: [setup, build_all]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_and_test_android')
     uses: ./.github/workflows/build_and_test_android.yml
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
@@ -939,7 +939,7 @@ jobs:
 
   test_benchmark_suites:
     needs: [setup, build_all, build_e2e_test_artifacts]
-    if: fromJson(needs.setup.outputs.should-run)
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_benchmark_suites')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -13,10 +13,10 @@ name: Setup
 on:
   workflow_call:
     outputs:
-      should-run:
+      enabled-jobs:
         description: |
-          Whether CI should run.
-        value: ${{ jobs.setup.outputs.should-run }}
+          Which jobs should run.
+        value: ${{ jobs.setup.outputs.enabled-jobs }}
       is-pr:
         description: |
           Whether the workflow has been triggered by a pull request.
@@ -55,7 +55,7 @@ jobs:
       # parent will be the tip of main.
       BASE_REF: HEAD^
     outputs:
-      should-run: ${{ steps.configure.outputs.should-run }}
+      enabled-jobs: ${{ steps.configure.outputs.enabled-jobs }}
       is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
@@ -111,9 +111,12 @@ jobs:
 
           ./build_tools/github_actions/configure_ci.py
 
-      - name: "Show benchmark presets"
+      - name: "Show enabled options"
         env:
           BENCHMARK_PRESETS: ${{ steps.configure.outputs.benchmark-presets }}
+          ENABLED_JOBS: ${{ join(fromJson(steps.configure.outputs.enabled-jobs)) }}
         run: |
+          echo ":green_circle: Enabled jobs: \`${ENABLED_JOBS}\`" \
+              >> "${GITHUB_STEP_SUMMARY}"
           echo ":stopwatch: Enabled benchmarks: \`${BENCHMARK_PRESETS}\`" \
             >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -110,6 +110,7 @@ jobs:
           git log --oneline --graph --max-count=3
 
           ./build_tools/github_actions/configure_ci.py
+          cat "${GITHUB_OUTPUT}"
 
       - name: "Show enabled options"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -110,7 +110,6 @@ jobs:
           git log --oneline --graph --max-count=3
 
           ./build_tools/github_actions/configure_ci.py
-          cat "${GITHUB_OUTPUT}"
 
       - name: "Show enabled options"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -113,8 +113,8 @@ jobs:
 
       - name: "Show enabled options"
         env:
-          BENCHMARK_PRESETS: ${{ steps.configure.outputs.benchmark-presets }}
-          ENABLED_JOBS: ${{ join(fromJson(steps.configure.outputs.enabled-jobs)) }}
+          BENCHMARK_PRESETS: ${{ steps.configure.outputs.benchmark-presets || 'None' }}
+          ENABLED_JOBS: ${{ join(fromJson(steps.configure.outputs.enabled-jobs)) || 'None' }}
         run: |
           echo ":green_circle: Enabled jobs: \`${ENABLED_JOBS}\`" \
               >> "${GITHUB_STEP_SUMMARY}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,11 @@ later culprit-finding. It is assumed that the PR author will merge their change
 unless they ask someone else to merge it for them (e.g. because they don't have
 write access).
 
-## Peculiarities
+## Details
 
-Our documentation on
-[repository management](https://github.com/openxla/iree/blob/main/docs/developers/developing_iree/repository_management.md)
-has more information on some of the oddities in our repository setup and
-workflows. For the most part, these should be transparent to normal developer
-workflows.
+For further details, see our
+[detailed contributing guide](/docs/developers/contributing.md), which is
+separate to avoid notifying everyone every time it changes.
 
 ## Community Guidelines
 

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -32,19 +32,52 @@ not.
 """
 
 import difflib
+import enum
 import fnmatch
 import json
 import os
 import re
+import string
 import subprocess
+import sys
 import textwrap
-from typing import Iterable, List, Mapping, Sequence, Tuple
+from typing import Iterable, List, Mapping, Sequence, Set, Tuple
 
-SKIP_CI_KEY = "skip-ci"
-RUNNER_ENV_KEY = "runner-env"
-BENCHMARK_EXTRA_KEY = "benchmark-extra"
-# Trailer to prevent benchmarks from always running on LLVM integration PRs.
-SKIP_LLVM_INTEGRATE_BENCHMARK_KEY = "skip-llvm-integrate-benchmark"
+import yaml
+
+
+# We don't get StrEnum till Python 3.11
+@enum.unique
+class Trailer(str, enum.Enum):
+    __str__ = str.__str__
+
+    SKIP_CI = "skip-ci"
+    SKIP_JOBS = "ci-skip"
+    EXTRA_JOBS = "ci-extra"
+    EXACTLY_JOBS = "ci-exactly"
+    RUNNER_ENV = "runner-env"
+    BENCHMARK_EXTRA = "benchmark-extra"
+    # Trailer to prevent benchmarks from always running on LLVM integration PRs.
+    SKIP_LLVM_INTEGRATE_BENCHMARK = "skip-llvm-integrate-benchmark"
+
+    # Before Python 3.12, it the native __contains__ doesn't work for checking
+    # member values like this and it's not possible to easily override this.
+    # https://docs.python.org/3/library/enum.html#enum.EnumType.__contains__
+    @classmethod
+    def contains(cls, val):
+        try:
+            cls(val)
+        except ValueError:
+            return False
+        return True
+
+
+# This is to help prevent typos. For now we hard error on any trailer that
+# starts with this prefix but isn't in our list. We can add known commonly used
+# trailers to our list or we might consider relaxing this.
+RESERVED_TRAILER_PREFIXES = ["ci-", "bewnchmark-", "skip-"]
+CI_WORKFLOW_FILE = ".github/workflows/ci.yml"
+ALL_KEY = "all"
 
 # Note that these are fnmatch patterns, which are not the same as gitignore
 # patterns because they don't treat '/' specially. The standard library doesn't
@@ -77,6 +110,16 @@ SKIP_PATH_PATTERNS = [
 RUNNER_ENV_DEFAULT = "prod"
 RUNNER_ENV_OPTIONS = [RUNNER_ENV_DEFAULT, "testing"]
 
+CONTROL_JOBS = frozenset(["setup", "summary"])
+
+POSTSUBMIT_ONLY_JOBS = frozenset(
+    [
+        "build_test_all_windows",
+        "build_test_all_macos_arm64",
+        "build_test_all_macos_x86_64",
+    ]
+)
+
 DEFAULT_BENCHMARK_PRESET_GROUP = [
     "cuda",
     "x86_64",
@@ -91,7 +134,7 @@ LARGE_BENCHMARK_PRESET_GROUP = ["cuda-large", "x86_64-large"]
 BENCHMARK_PRESET_OPTIONS = DEFAULT_BENCHMARK_PRESET_GROUP + LARGE_BENCHMARK_PRESET_GROUP
 BENCHMARK_LABEL_PREFIX = "benchmarks"
 
-PR_DESCRIPTION_TEMPLATE = "{title}" "\n\n" "{body}"
+PR_DESCRIPTION_TEMPLATE = string.Template("${title}\n\n${body}")
 
 # Patterns to detect "LLVM integration" PRs, i.e. changes that update the
 # third_party/llvm-project submodule. This should only include PRs
@@ -111,7 +154,7 @@ def set_output(d: Mapping[str, str]):
     print(f"Setting outputs: {d}")
     step_output_file = os.environ["GITHUB_OUTPUT"]
     with open(step_output_file, "a") as f:
-        f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
+        f.writelines(f"{k}={json.dumps(v)}" + "\n" for k, v in d.items())
 
 
 def write_job_summary(summary: str):
@@ -192,14 +235,14 @@ def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
     original_body = os.environ.get("ORIGINAL_PR_BODY", "")
     original_labels = json.loads(os.environ.get("ORIGINAL_PR_LABELS", "[]"))
 
-    description = PR_DESCRIPTION_TEMPLATE.format(title=title, body=body)
+    description = PR_DESCRIPTION_TEMPLATE.substitute(title=title, body=body)
 
     # PR information can be fetched from API for the latest updates. If
     # ORIGINAL_PR_TITLE is set, compare the current and original description and
-    # show a notice if they are different. This is mostly to inform users that the
-    # workflow might not parse the PR description they expect.
+    # show a notice if they are different. This is mostly to inform users that
+    # the workflow might not parse the PR description they expect.
     if original_title is not None:
-        original_description = PR_DESCRIPTION_TEMPLATE.format(
+        original_description = PR_DESCRIPTION_TEMPLATE.substitute(
             title=original_title, body=original_body
         )
         print(
@@ -229,6 +272,17 @@ def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
         k.lower().strip(): v.strip()
         for k, v in (line.split(":", maxsplit=1) for line in trailer_lines)
     }
+
+    for key in trailer_map:
+        if not Trailer.contains(key):
+            for prefix in RESERVED_TRAILER_PREFIXES:
+                if key.startswith(prefix):
+                    print(
+                        f"Trailer '{key}' starts with reserved prefix"
+                        f"'{prefix}' but is unknown."
+                    )
+            print(f"Skipping unknown trailer '{key}'", file=sys.stderr)
+
     return (trailer_map, labels)
 
 
@@ -242,48 +296,130 @@ def get_modified_paths(base_ref: str) -> Iterable[str]:
     ).stdout.splitlines()
 
 
-def modifies_included_path(base_ref: str) -> bool:
-    return any(not skip_path(p) for p in get_modified_paths(base_ref))
-
-
-def should_run_ci(is_pr: bool, trailers: Mapping[str, str]) -> bool:
-    if not is_pr:
+def modifies_included_path() -> bool:
+    base_ref = os.environ["BASE_REF"]
+    try:
+        return any(not skip_path(p) for p in get_modified_paths(base_ref))
+    except TimeoutError as e:
         print(
-            "Running CI independent of diff because run was not triggered by a"
-            " pull request event."
+            "Computing modified files timed out. Not using PR diff to determine"
+            " jobs to run.",
+            file=sys.stderr,
         )
         return True
 
-    if SKIP_CI_KEY in trailers:
-        print(f"Not running CI because PR description has '{SKIP_CI_KEY}' trailer.")
-        return False
-
-    base_ref = os.environ["BASE_REF"]
-    try:
-        modifies = modifies_included_path(base_ref)
-    except TimeoutError as e:
-        print("Computing modified files timed out. Running the CI")
-        return True
-
-    if not modifies:
-        print("Skipping CI because all modified files are marked as excluded.")
-        return False
-
-    print("CI should run")
-    return True
-
 
 def get_runner_env(trailers: Mapping[str, str]) -> str:
-    runner_env = trailers.get(RUNNER_ENV_KEY)
+    runner_env = trailers.get(Trailer.RUNNER_ENV)
     if runner_env is None:
         print(
-            f"Using '{RUNNER_ENV_DEFAULT}' runners because '{RUNNER_ENV_KEY}'"
-            f" not found in {trailers}"
+            f"Using '{RUNNER_ENV_DEFAULT}' runners because"
+            f" '{Trailer.RUNNER_ENV}' not found in {trailers}"
         )
         runner_env = RUNNER_ENV_DEFAULT
     else:
         print(f"Using runner environment '{runner_env}' from PR description trailers")
     return runner_env
+
+
+def parse_jobs_trailer(
+    trailers: Mapping[str, str], key: str, all_jobs: Set[str]
+) -> Set[str]:
+    jobs_text = trailers.get(key)
+    if jobs_text is None:
+        return set()
+    jobs = set(name.strip() for name in jobs_text.split(","))
+    if ALL_KEY in jobs:
+        if len(jobs) != 1:
+            raise ValueError(
+                f"'{ALL_KEY}' must be alone in job specification"
+                f" trailer, but got '{key}: {jobs_text}'"
+            )
+        print(f"Expanded trailer '{key}: {jobs_text}' to all jobs")
+        return all_jobs
+
+    jobs = set(jobs)
+    unknown_jobs = jobs - all_jobs
+    if unknown_jobs:
+        raise ValueError(
+            f"Received unknown jobs '{','.join(unknown_jobs)}' in trailer '{key}'"
+        )
+    return jobs
+
+
+def parse_jobs_from_workflow_file() -> Set[str]:
+    with open(CI_WORKFLOW_FILE) as f:
+        workflow = yaml.load(f.read(), Loader=yaml.SafeLoader)
+    all_jobs = set(workflow["jobs"].keys())
+    all_jobs -= CONTROL_JOBS
+
+    if ALL_KEY in all_jobs:
+        raise ValueError(f"Workflow has job with reserved name '{ALL_KEY}'")
+    return all_jobs
+
+
+def get_enabled_jobs(
+    is_pr: bool, modifies: bool, trailers: Mapping[str, str], all_jobs: Set[str]
+) -> Set[str]:
+    if not is_pr:
+        print(
+            "Running all jobs because run was not triggered by a pull request"
+            " event.",
+            file=sys.stderr,
+        )
+        return all_jobs
+
+    if Trailer.SKIP_CI in trailers:
+        if (
+            Trailer.EXACTLY_JOBS in trailers
+            or Trailer.EXTRA_JOBS in trailers
+            or Trailer.SKIP_JOBS in trailers
+        ):
+            raise ValueError(
+                f"Cannot specify both '{Trailer.SKIP_JOBS}' and any of"
+                f" '{Trailer.EXACTLY_JOBS}', '{Trailer.EXTRA_JOBS}',"
+                f" '{Trailer.SKIP_JOBS}'"
+            )
+        print(
+            f"Skipping all jobs because PR description has"
+            f" '{Trailer.SKIP_CI}' trailer."
+        )
+        return set()
+
+    if Trailer.EXACTLY_JOBS in trailers:
+        if Trailer.EXTRA_JOBS in trailers or Trailer.SKIP_JOBS in trailers:
+            raise ValueError(
+                f"Cannot mix trailer '{Trailer.EXACTLY_JOBS}' with"
+                f" '{Trailer.EXTRA_JOBS}' or '{Trailer.SKIP_JOBS}'"
+            )
+
+        exactly_jobs = parse_jobs_trailer(
+            trailers,
+            Trailer.EXACTLY_JOBS,
+            all_jobs,
+        )
+        return exactly_jobs
+
+    skip_jobs = parse_jobs_trailer(trailers, Trailer.SKIP_JOBS, all_jobs)
+    extra_jobs = parse_jobs_trailer(trailers, Trailer.EXTRA_JOBS, all_jobs)
+
+    ambiguous_jobs = skip_jobs & extra_jobs
+    if ambiguous_jobs:
+        raise ValueError(
+            f"Jobs cannot be specified in both '{Trailer.SKIP_JOBS}' and"
+            f" '{Trailer.EXTRA_JOBS}', but found {ambiguous_jobs}"
+        )
+
+    default_jobs = all_jobs - POSTSUBMIT_ONLY_JOBS
+
+    if not modifies:
+        print(
+            "Not including any jobs by default because all modified files"
+            " are marked as excluded."
+        )
+        default_jobs = frozenset()
+
+    return (default_jobs | extra_jobs) - skip_jobs
 
 
 def get_benchmark_presets(
@@ -305,11 +441,12 @@ def get_benchmark_presets(
       build_tools/benchmarks/export_benchmark_config.py.
     """
 
-    skip_llvm_integrate_benchmark = SKIP_LLVM_INTEGRATE_BENCHMARK_KEY in trailers
+    skip_llvm_integrate_benchmark = Trailer.SKIP_LLVM_INTEGRATE_BENCHMARK in trailers
     if skip_llvm_integrate_benchmark:
         print(
-            "Skipping default benchmarking on LLVM integration because PR "
-            f"description has '{SKIP_LLVM_INTEGRATE_BENCHMARK_KEY}' trailer."
+            f"Skipping default benchmarking on LLVM integration because PR "
+            f"description has '{Trailer.SKIP_LLVM_INTEGRATE_BENCHMARK}'"
+            f" trailer."
         )
 
     if not is_pr:
@@ -325,12 +462,15 @@ def get_benchmark_presets(
             for label in labels
             if label.startswith(BENCHMARK_LABEL_PREFIX + ":")
         )
-        trailer = trailers.get(BENCHMARK_EXTRA_KEY)
+        trailer = trailers.get(Trailer.BENCHMARK_EXTRA)
         if trailer is not None:
             preset_options = preset_options.union(
                 option.strip() for option in trailer.split(",")
             )
-        print(f"Using benchmark preset '{preset_options}' from trailers and labels")
+            print(
+                f"Using benchmark preset '{preset_options}' from trailers"
+                f" and labels"
+            )
 
     if DEFAULT_BENCHMARK_PRESET in preset_options:
         preset_options.remove(DEFAULT_BENCHMARK_PRESET)
@@ -360,15 +500,24 @@ def main():
         or LLVM_INTEGRATE_BRANCH_PATTERN.search(os.environ.get("PR_BRANCH", ""))
         or LLVM_INTEGRATE_LABEL in labels
     )
+
+    modifies = modifies_included_path()
+    try:
+        benchmark_presets = get_benchmark_presets(
+            trailers, labels, is_pr, is_llvm_integrate_pr
+        )
+        all_jobs = parse_jobs_from_workflow_file()
+        enabled_jobs = get_enabled_jobs(modifies, is_pr, trailers, all_jobs)
+    except ValueError as e:
+        print(e)
+        sys.exit(1)
     output = {
-        "should-run": json.dumps(should_run_ci(is_pr, trailers)),
-        "is-pr": json.dumps(is_pr),
+        "enabled-jobs": sorted(enabled_jobs),
+        "is-pr": is_pr,
         "runner-env": get_runner_env(trailers),
         "runner-group": "presubmit" if is_pr else "postsubmit",
         "write-caches": "0" if is_pr else "1",
-        "benchmark-presets": get_benchmark_presets(
-            trailers, labels, is_pr, is_llvm_integrate_pr
-        ),
+        "benchmark-presets": benchmark_presets,
     }
 
     set_output(output)

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -359,7 +359,11 @@ def parse_jobs_from_workflow_file() -> Set[str]:
 
 
 def get_enabled_jobs(
-    is_pr: bool, modifies: bool, trailers: Mapping[str, str], all_jobs: Set[str]
+    *,
+    is_pr: bool,
+    modifies: bool,
+    trailers: Mapping[str, str],
+    all_jobs: Set[str],
 ) -> Set[str]:
     if not is_pr:
         print(
@@ -507,7 +511,9 @@ def main():
             trailers, labels, is_pr, is_llvm_integrate_pr
         )
         all_jobs = parse_jobs_from_workflow_file()
-        enabled_jobs = get_enabled_jobs(modifies, is_pr, trailers, all_jobs)
+        enabled_jobs = get_enabled_jobs(
+            modifies=modifies, is_pr=is_pr, trailers=trailers, all_jobs=all_jobs
+        )
     except ValueError as e:
         print(e)
         sys.exit(1)

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -154,7 +154,7 @@ def set_output(d: Mapping[str, str]):
     print(f"Setting outputs: {d}")
     step_output_file = os.environ["GITHUB_OUTPUT"]
     with open(step_output_file, "a") as f:
-        f.writelines(f"{k}=v" + "\n" for k, v in d.items())
+        f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
 
 
 def write_job_summary(summary: str):

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -154,7 +154,7 @@ def set_output(d: Mapping[str, str]):
     print(f"Setting outputs: {d}")
     step_output_file = os.environ["GITHUB_OUTPUT"]
     with open(step_output_file, "a") as f:
-        f.writelines(f"{k}={json.dumps(v)}" + "\n" for k, v in d.items())
+        f.writelines(f"{k}=v" + "\n" for k, v in d.items())
 
 
 def write_job_summary(summary: str):
@@ -512,8 +512,8 @@ def main():
         print(e)
         sys.exit(1)
     output = {
-        "enabled-jobs": sorted(enabled_jobs),
-        "is-pr": is_pr,
+        "enabled-jobs": json.dumps(sorted(enabled_jobs)),
+        "is-pr": json.dumps(is_pr),
         "runner-env": get_runner_env(trailers),
         "runner-group": "presubmit" if is_pr else "postsubmit",
         "write-caches": "0" if is_pr else "1",

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -359,11 +359,11 @@ def parse_jobs_from_workflow_file() -> Set[str]:
 
 
 def get_enabled_jobs(
+    trailers: Mapping[str, str],
+    all_jobs: Set[str],
     *,
     is_pr: bool,
     modifies: bool,
-    trailers: Mapping[str, str],
-    all_jobs: Set[str],
 ) -> Set[str]:
     if not is_pr:
         print(
@@ -512,7 +512,10 @@ def main():
         )
         all_jobs = parse_jobs_from_workflow_file()
         enabled_jobs = get_enabled_jobs(
-            modifies=modifies, is_pr=is_pr, trailers=trailers, all_jobs=all_jobs
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
         )
     except ValueError as e:
         print(e)

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -147,7 +147,12 @@ class ConfigureCITest(unittest.TestCase):
         all_jobs = {"job1", "job2", "job3"}
         is_pr = True
         modifies = True
-        jobs = configure_ci.get_enabled_jobs(is_pr, modifies, trailers, all_jobs)
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
+        )
         self.assertCountEqual(jobs, all_jobs)
 
     def test_get_enabled_jobs_postsubmit(self):
@@ -157,7 +162,12 @@ class ConfigureCITest(unittest.TestCase):
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = False
         modifies = True
-        jobs = configure_ci.get_enabled_jobs(is_pr, modifies, trailers, all_jobs)
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
+        )
         self.assertCountEqual(jobs, all_jobs)
 
     def test_get_enabled_jobs_no_postsubmit(self):
@@ -167,7 +177,12 @@ class ConfigureCITest(unittest.TestCase):
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
         modifies = True
-        jobs = configure_ci.get_enabled_jobs(is_pr, modifies, trailers, all_jobs)
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
+        )
         self.assertCountEqual(jobs, default_jobs)
 
     def test_get_enabled_jobs_no_modifies(self):
@@ -177,7 +192,12 @@ class ConfigureCITest(unittest.TestCase):
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
         modifies = False
-        jobs = configure_ci.get_enabled_jobs(is_pr, modifies, trailers, all_jobs)
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
+        )
         self.assertCountEqual(jobs, {})
 
     def test_get_enabled_jobs_skip(self):
@@ -187,7 +207,12 @@ class ConfigureCITest(unittest.TestCase):
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
         modifies = True
-        jobs = configure_ci.get_enabled_jobs(is_pr, modifies, trailers, all_jobs)
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
+        )
         self.assertCountEqual(jobs, {"job3"})
 
     def test_get_enabled_jobs_skip_all(self):
@@ -197,7 +222,12 @@ class ConfigureCITest(unittest.TestCase):
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
         modifies = True
-        jobs = configure_ci.get_enabled_jobs(is_pr, modifies, trailers, all_jobs)
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
+        )
         self.assertCountEqual(jobs, {})
 
     def test_get_enabled_jobs_extra(self):
@@ -207,7 +237,12 @@ class ConfigureCITest(unittest.TestCase):
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
         modifies = True
-        jobs = configure_ci.get_enabled_jobs(is_pr, modifies, trailers, all_jobs)
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
+        )
         self.assertCountEqual(jobs, all_jobs)
 
     def test_get_enabled_jobs_exactly(self):
@@ -217,7 +252,12 @@ class ConfigureCITest(unittest.TestCase):
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
         modifies = True
-        jobs = configure_ci.get_enabled_jobs(is_pr, modifies, trailers, all_jobs)
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modifies=modifies,
+            is_pr=is_pr,
+        )
         self.assertCountEqual(jobs, {postsubmit_job})
 
 

--- a/docs/developers/developing_iree/contributing.md
+++ b/docs/developers/developing_iree/contributing.md
@@ -1,0 +1,98 @@
+# Contributing
+
+This is a more detailed version of the top-level
+[CONTRIBUTING.md](/CONTRIBUTING.md) file. We keep it separate to avoid everyone
+getting a pop-up when creating a PR after each time it changes.
+
+## Downstream Integrations
+
+Due to the process by which we synchronize this GitHub project with our internal
+Google source code repository, there are some oddities in our workflows and
+processes. We aim to minimize these, and especially to mitigate their impact on
+external contributors, but when they come up, they are documented here for
+clarity and transparency. If any of these things are particularly troublesome or
+painful for your workflow, please reach out to us so we can prioritize a fix.
+
+Hopefully these quirks actually make usage in other downstream projects easier,
+but integrators may need to look past some details (like the Bazel build system,
+Android support, etc.) based on their specific requirements.
+
+## Build Systems
+
+IREE supports building from source with both Bazel and CMake. CMake is the
+preferred build system for open source users and offers the most flexible
+configuration options. Bazel is a stricter build system and helps with usage in
+the Google internal source repository. Certain dependencies (think large/complex
+projects like CUDA, TensorFlow, PyTorch, etc.) may be difficult to support with
+one build system or the other, so the project may configure these as optional.
+
+## CI
+
+IREE uses [GitHub Actions](https://docs.github.com/en/actions) for CI. The
+primary CI is configured in the
+[ci.yml workflow file](/.github/workflows/ci.yml).
+
+### Self-Hosted Runners
+
+In addition to the default runners GitHub provides, IREE uses
+[self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners)
+to run many of its workflow jobs. These enable access to additional compute and
+custom configurations such as accelarators. Configuration scripting is checked
+in to this repository (see the
+[README for that directory](/build_tools/github_actions/runner/README.md)).
+
+### Custom Managed Runners
+
+In addition to our self-hosted runners, we use GitHub's
+[large managed runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners)
+for some platforms that are more trouble to configure ourselves (e.g. Mac).
+
+### CI Behavior Manipulation
+
+The setup step of the CI determines which CI jobs to run. This is controlled by
+the [configure_ci.py](/build_tools/github_actions/configure_ci.py) script. It
+will generally run a pre-determined set of jobs on presubmit with some jobs kept
+as post-submit only. If changes are only to a certain set of excluded files that
+we know don't affect CI (e.g. docs), then it will skip the jobs. You can
+customize which jobs run using
+[git trailers](https://git-scm.com/docs/git-interpret-trailers) in the PR
+description. The available options are
+
+```
+ci-skip: jobs,to,skip
+ci-extra: extra,jobs,to,run
+ci-exactly: exact,set,of,jobs,to,run
+skip-ci: free form reason
+skip-llvm-integrate-benchmark: free form reason
+benchmark-extra: extra,benchmarks,to,run
+runner-env: [testing|prod]
+```
+
+The first three follow the same format and instruct the setup script on which
+jobs to include or exclude from its run. They take a comma-separated list of
+jobs which must be from the set of top-level job identifiers in ci.yml file or
+the special keyword "all" to indicate all jobs. `ci-skip` removes jobs that
+would otherwise be included, though it is not an error to list jobs that would
+not be included by default. `ci-extra` adds additional jobs that would not have
+otherwise been run, though it is not an error to list jobs that would have been
+included anyway. It *is* an error to list a job in both of these fields.
+`ci-exactly` provides an exact list of jobs that should run. It is mutually
+exclusive with both `ci-skip` and `ci-extra`. In all these cases, the setup does
+not make any effort to ensure that job dependencies are satisfied. Thus, if you
+request skipping the `build_all` job, all the jobs that depend on it will fail,
+not be skipped. `skip-ci` is an older option that simply skips all jobs. Its
+usage is deprecated and it is mutually exclusive with all of the other `ci-*`
+options. Prefer `ci-skip: all`.
+
+Benchmarks don't run by default on PRs, and must be specifically requested. They
+*do* run by default on PRs detected to be an integration of LLVM into IREE, but
+this behavior can be disabled with `skip-llvm-integrate-benchmark`. The
+`benchmark-extra` option allows specifying additional benchmark presets to run
+as part of benchmarking. It accepts a comma-separated list of benchmark presets.
+This combines with labels added to the PR (which are a more limited set of
+options). See the [benchmark suites documentation](./benchmark_suites.md).
+
+The `runner-env` option controls which runner environment to target for our
+self-hosted runners. We maintain a test environment to allow testing out new
+configurations prior to rolling them out. This trailer is for advanced users who
+are working on the CI infrastructure itself.


### PR DESCRIPTION
I tried to be consistent about json-encoding everything in `set_output`,
so the caller didn't need to worry about that, but it turns out that
wraps things that are already strings in an extra set of quotes,
breaking ~everything.

Additionally, I wrote a function with two positional boolean args
(bad!) and swapped the order they were passed (which is why those are
bad). Changed them to keyword args.