### PR TITLE
Adds support for serialization of sub-byte aligned element types.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
@@ -139,8 +139,7 @@ static bool isConstantInlinable(const ClosureOptimizationOptions &options,
     // Smallish constants are worth moving inside.
     auto shapedType = llvm::cast<ShapedType>(constantType);
     uint64_t estimatedByteLength =
-        shapedType.getNumElements() *
-        getRoundedElementByteWidth(shapedType.getElementType());
+        IREE::Util::getRoundedPhysicalStorageSize(shapedType);
     return denseAttr.isSplat() ||
            estimatedByteLength <= maxInlinedConstantBytes;
   } else if (constantType.isIntOrIndexOrFloat()) {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
@@ -46,8 +46,10 @@ def Util_CompositeAttr : AttrDef<Util_Dialect, "Composite", [
     the full flattened range is required it can be efficiently streamed via the
     SerializableAttrInterface. All values must also be serializable.
 
-    All values are tightly packed. If padding is required it can be inserted as
-    splat elements attributes with the padding value (usually 0).
+    All values are tightly packed to byte boundaries. If padding is required it
+    can be inserted as splat elements attributes with the padding value
+    (usually 0). Sub-byte aligned element types will have their individual
+    components padded to byte alignment.
   }];
 
   let parameters = (ins

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -1099,9 +1099,10 @@ def Util_SerializableAttrInterface : AttrInterface<"SerializableAttrInterface"> 
   let methods = [
     InterfaceMethod<
       /*desc=*/[{
-        Returns the total storage size required by the serialized value.
+        Returns the storage size in bytes required by the serialized value.
         Any of the serialization methods will write precisely this number of
-        bytes.
+        bytes. If the value is sub-byte aligned the storage size will be rounded
+        up to the next whole byte.
       }],
       /*retTy=*/"int64_t",
       /*methodName=*/"getStorageSize",

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir
@@ -10,12 +10,86 @@ vm.module @constants {
 
   // CHECK: "rodata_segments": [{
 
+  // Tests that we densely pack i2 values. Note that the final element (3) is
+  // padded out with zeros.
+  //      CHECK: "embedded_data": [
+  // CHECK-NEXT:   228,
+  // CHECK-NEXT:   26,
+  // CHECK-NEXT:   3
+  // CHECK-NEXT: ]
+  vm.rodata private @dense_i2 dense<[0, 1, 2, 3, 2, 2, 1, 0, 3]> : tensor<9xi2>
+
+  // Tests that we densely pack i3 values and insert the wasted 2-bits of
+  // padding in each byte. Smarter implementations would pack to 16- or 64-bit
+  // physical storage to waste fewer bits.
+  //      CHECK: "embedded_data": [
+  // CHECK-NEXT:   8,
+  // CHECK-NEXT:   26,
+  // CHECK-NEXT:   44,
+  // CHECK-NEXT:   62
+  // CHECK-NEXT: ]
+  vm.rodata private @dense_i3 dense<[0, 1, 2, 3, 4, 5, 6, 7]> : tensor<8xi3>
+
+  // Tests that we densely pack i4 values and handle partial values (14).
+  //      CHECK: "embedded_data": [
+  // CHECK-NEXT:   16,
+  // CHECK-NEXT:   50,
+  // CHECK-NEXT:   84,
+  // CHECK-NEXT:   118,
+  // CHECK-NEXT:   152,
+  // CHECK-NEXT:   186,
+  // CHECK-NEXT:   220,
+  // CHECK-NEXT:   254,
+  // CHECK-NEXT:   14
+  // CHECK-NEXT: ]
+  vm.rodata private @dense_i4 dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 14]> : tensor<17xi4>
+
+  //      CHECK: "embedded_data": [
+  // CHECK-NEXT:   98,
+  // CHECK-NEXT:   16,
+  // CHECK-NEXT:   197,
+  // CHECK-NEXT:   28
+  // CHECK-NEXT: ]
+  vm.rodata private @dense_i5 dense<[2, 3, 4, 5, 6, 7]> : tensor<6xi5>
+
   //      CHECK: "embedded_data": [
   // CHECK-NEXT:   1,
   // CHECK-NEXT:   2,
   // CHECK-NEXT:   3
   // CHECK-NEXT: ]
-  vm.rodata private @dense_i8s dense<[1, 2, 3]> : tensor<3xi8>
+  vm.rodata private @dense_i8 dense<[1, 2, 3]> : tensor<3xi8>
+
+  //      CHECK: "embedded_data": [
+  // CHECK-NEXT:   1,
+  // CHECK-NEXT:   4,
+  // CHECK-NEXT:   12,
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   4,
+  // CHECK-NEXT:   10,
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   0
+  // CHECK-NEXT: ]
+  vm.rodata private @dense_i9 dense<[1, 2, 3, 4, 5]> : tensor<5xi9>
+
+  //      CHECK: "embedded_data": [
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   60,
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   64,
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   66
+  // CHECK-NEXT: ]
+  vm.rodata private @dense_float16 dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf16>
+
+  //      CHECK: "embedded_data": [
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   60,
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   60,
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   60
+  // CHECK-NEXT: ]
+  vm.rodata private @splat_float16 dense<1.000000e+00> : tensor<3xf16>
 
   //      CHECK: "embedded_data": [
   // CHECK-NEXT:   0,
@@ -31,7 +105,7 @@ vm.module @constants {
   // CHECK-NEXT:   64,
   // CHECK-NEXT:   64
   // CHECK-NEXT: ]
-  vm.rodata private @dense_float32s dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>
+  vm.rodata private @dense_float32 dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>
 
   //      CHECK: "embedded_data": [
   // CHECK-NEXT:   0,
@@ -47,16 +121,6 @@ vm.module @constants {
   // CHECK-NEXT:   128,
   // CHECK-NEXT:   63
   // CHECK-NEXT: ]
-  vm.rodata private @splat_float32s dense<1.000000e+00> : tensor<3xf32>
-
-  //      CHECK: "embedded_data": [
-  // CHECK-NEXT:   0,
-  // CHECK-NEXT:   60,
-  // CHECK-NEXT:   0,
-  // CHECK-NEXT:   64,
-  // CHECK-NEXT:   0,
-  // CHECK-NEXT:   66
-  // CHECK-NEXT: ]
-  vm.rodata private @dense_float16s dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf16>
+  vm.rodata private @splat_float32 dense<1.000000e+00> : tensor<3xf32>
 
 }

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -82,6 +82,8 @@ convertDescriptorType(IREE::Input::DescriptorType src) {
     return IREE::HAL::DescriptorType::StorageBuffer;
   case IREE::Input::DescriptorType::UniformBuffer:
     return IREE::HAL::DescriptorType::UniformBuffer;
+  default:
+    llvm_unreachable("Unexpected descriptor type");
   }
 }
 
@@ -95,6 +97,8 @@ convertDescriptorFlags(std::optional<IREE::Input::DescriptorFlags> src) {
     return IREE::HAL::DescriptorFlags::None;
   case IREE::Input::DescriptorFlags::ReadOnly:
     return IREE::HAL::DescriptorFlags::ReadOnly;
+  default:
+    return std::nullopt;
   }
 }
 

--- a/compiler/src/iree/compiler/Utils/ElementPackingUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ElementPackingUtils.cpp
@@ -15,17 +15,17 @@
 namespace mlir {
 namespace iree_compiler {
 
-bool needToPackSubByteElementBitWidth(unsigned bitwidth) {
-  // Require the original bitwidth to be some power of two for now to avoid
+bool needToPackSubByteElementBitWidth(unsigned bitWidth) {
+  // Require the original bit width to be some power of two for now to avoid
   // trickiness and weirdness of packing and cross-byte access.
   // Also disallow boolean values for now--they may require separate interface
   // choices.
-  return bitwidth < 8 && llvm::isPowerOf2_32(bitwidth) && bitwidth != 1;
+  return bitWidth < 8 && llvm::isPowerOf2_32(bitWidth) && bitWidth != 1;
 }
 
 bool needToPackSubByteElements(RankedTensorType shapedType) {
-  unsigned bitwidth = IREE::Util::getTypeBitWidth(shapedType.getElementType());
-  return needToPackSubByteElementBitWidth(bitwidth);
+  unsigned bitWidth = IREE::Util::getTypeBitWidth(shapedType.getElementType());
+  return needToPackSubByteElementBitWidth(bitWidth);
 }
 
 Type legalizeStorageElementType(Type elementType) {
@@ -39,7 +39,7 @@ Type legalizeStorageElementType(Type elementType) {
   if (needToPackSubByteElementBitWidth(bitWidth))
     return elementType;
 
-  // Otherwise, extend them to the next power-of-two bitwidth.
+  // Otherwise, extend them to the next power-of-two bit width.
   unsigned alignedBitWidth =
       IREE::Util::getRoundedElementByteWidth(intType) * 8;
   if (alignedBitWidth == bitWidth)

--- a/compiler/src/iree/compiler/Utils/ElementPackingUtils.h
+++ b/compiler/src/iree/compiler/Utils/ElementPackingUtils.h
@@ -14,9 +14,9 @@
 namespace mlir {
 namespace iree_compiler {
 
-/// Returns true if the given |bitwidth|, if appearing at runtime-kernel
+/// Returns true if the given |bitWidth|, if appearing at runtime-kernel
 /// interface, is less than a byte that should be tightly packed together.
-bool needToPackSubByteElementBitWidth(unsigned bitwidth);
+bool needToPackSubByteElementBitWidth(unsigned bitWidth);
 /// Returns true if the given |shapedType|, if appearing at runtime-kernel
 /// interface, has sub-byte element types that should be tightly packed
 /// together.
@@ -26,7 +26,7 @@ bool needToPackSubByteElements(RankedTensorType shapedType);
 ///
 /// In IREE, if compiling from the same source model, we control both the
 /// runtime and kernel. For such cases, we perform tight packing for supported
-/// sub-byte elements, and expand to the next power-of-two bitwidth for other
+/// sub-byte elements, and expand to the next power-of-two bit width for other
 /// cases.
 Type legalizeStorageElementType(Type elementType);
 


### PR DESCRIPTION
This currently assumes (poorly) that physical storage is always the next power-of-two byte width greater than 2x the logical bit width, so i3 is packed into 2xi3 in i8 (2 wasted bits), i5 is packed into 3xi5 in i16 (1 wasted bit), and i9 is packed into 3xi9 in i32 (5 wasted bits).

When we get proper packed types that let us express the physical and logical bit widths independently we can change the getRoundedPhysicalStorageSize method to use it and most of the code should still work. There's performance improvements to be had when serializing out large arrays of values but that can wait until we know the proper physical sizes.

Progress on #12859.