### PR TITLE
[spirv] Add basic lowering pipeline without tiling and distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
@@ -38,20 +38,22 @@ def LLVMGPU_WarpReduction : I32EnumAttrCase<"LLVMGPUWarpReduction", 14>;
 def LLVMGPU_PackUnPack : I32EnumAttrCase<"LLVMGPUPackUnPack", 15>;
 def LLVMGPU_MatmulTensorCoreMmaSync : I32EnumAttrCase<"LLVMGPUMatmulTensorCoreMmaSync", 16>;
 
+def SPIRV_BaseLowering
+    : I32EnumAttrCase<"SPIRVBaseLowering", 17>;
 def SPIRV_BaseDistribute
-    : I32EnumAttrCase<"SPIRVBaseDistribute", 17>;
+    : I32EnumAttrCase<"SPIRVBaseDistribute", 18>;
 def SPIRV_BaseVectorize
-    : I32EnumAttrCase<"SPIRVBaseVectorize", 18>;
+    : I32EnumAttrCase<"SPIRVBaseVectorize", 19>;
 def SPIRV_MatmulPromoteVectorize
-    : I32EnumAttrCase<"SPIRVMatmulPromoteVectorize", 19>;
+    : I32EnumAttrCase<"SPIRVMatmulPromoteVectorize", 20>;
 def SPIRV_CooperativeMatrixVectorize
-    : I32EnumAttrCase<"SPIRVCooperativeMatrixVectorize", 20>;
+    : I32EnumAttrCase<"SPIRVCooperativeMatrixVectorize", 21>;
 def SPIRV_SubgroupReduce
-    : I32EnumAttrCase<"SPIRVSubgroupReduce", 21>;
+    : I32EnumAttrCase<"SPIRVSubgroupReduce", 22>;
 def SPIRV_WinogradVectorize
-    : I32EnumAttrCase<"SPIRVWinogradVectorize", 22>;
+    : I32EnumAttrCase<"SPIRVWinogradVectorize", 23>;
 
-def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 23>;
+def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 24>;
 
 
 def Linalg_TransformDialectCodegen
@@ -72,7 +74,7 @@ def DispatchLoweringPassPipelineEnum
             LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,
             LLVMGPU_TransposeSharedMem, LLVMGPU_WarpReduction,
             LLVMGPU_PackUnPack, LLVMGPU_MatmulTensorCoreMmaSync,
-            SPIRV_BaseDistribute, SPIRV_BaseVectorize,
+            SPIRV_BaseLowering, SPIRV_BaseDistribute, SPIRV_BaseVectorize,
             SPIRV_MatmulPromoteVectorize, SPIRV_CooperativeMatrixVectorize,
             SPIRV_SubgroupReduce, SPIRV_WinogradVectorize, VMVX_Default,
             // Transform dialect based codegen

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1632,6 +1632,23 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
 static LogicalResult setConfigForKernel(const spirv::TargetEnv &targetEnv,
                                         IREE::HAL::ExecutableExportOp exportOp,
                                         func::FuncOp funcOp) {
+  // First check whether we already have workgroup count set--it's a "contract"
+  // to indicate that we should bypass all tiling and distribution to go down
+  // just the most basic lowering flow.
+  if (Block *body = exportOp.getWorkgroupCountBody()) {
+    auto retOp = cast<IREE::HAL::ReturnOp>(body->getTerminator());
+    // For scalar dispatch cases--using just one thread of one workgroup.
+    auto isOne = [](Value value) { return matchPattern(value, m_One()); };
+    if (llvm::all_of(retOp.getOperands(), isOne)) {
+      std::array<int64_t, 3> workgroupSize = {1, 1, 1};
+      if (failed(setDispatchConfig(funcOp, workgroupSize, std::nullopt)))
+        return failure();
+      auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
+          funcOp.getContext(), CodeGenPipeline::SPIRVBaseLowering);
+      return setTranslationInfo(funcOp, translationInfo);
+    }
+  }
+
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   if (computeOps.empty()) {
     // No compute operations found. Allow to pass through without a config.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -18,6 +18,10 @@
 namespace mlir {
 namespace iree_compiler {
 
+/// Pass pipeline to lower IREE HAL executables without any tiling and
+/// distribution.
+void addSPIRVBaseLoweringPassPipeline(OpPassManager &pm);
+
 /// Pass pipeline to lower IREE HAL executables by tiling and distributing to
 /// workgroups and invocations. Each invocation handles a scalar.
 void addSPIRVBaseDistributePassPipeline(OpPassManager &pm);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -166,6 +166,9 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
 
   if (!testLoweringConfiguration && translationInfo.has_value()) {
     switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
+    case CodeGenPipeline::SPIRVBaseLowering:
+      addSPIRVBaseLoweringPassPipeline(pipeline);
+      break;
     case CodeGenPipeline::SPIRVBaseDistribute:
       addSPIRVBaseDistributePassPipeline(pipeline);
       break;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -43,6 +43,7 @@ iree_lit_test_suite(
             "illegal_configuration.mlir",
             "lowering_matmul_fusion.mlir",
             "lowering_matmul_promotion.mlir",
+            "lowering_scalar_dispatch.mlir",
             "lowering_reduction.mlir",
             "map_memref_storage_class.mlir",
             "pipeline_matmul_cooperative_ops.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_lit_test_suite(
     "lowering_matmul_fusion.mlir"
     "lowering_matmul_promotion.mlir"
     "lowering_reduction.mlir"
+    "lowering_scalar_dispatch.mlir"
     "map_memref_storage_class.mlir"
     "pipeline_matmul_cooperative_ops.mlir"
     "pipeline_matmul_promotion.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_scalar_dispatch.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_scalar_dispatch.mlir
@@ -1,0 +1,45 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-spirv-lower-executable-target-pass)))' -mlir-print-local-scope %s | FileCheck %s
+
+#executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.5, [Shader], []>, Unknown:Unknown,
+    #spirv.resource_limits<max_compute_workgroup_size = [128, 128, 64], subgroup_size = 32>>}>
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>
+
+hal.executable @scalar_dispatch {
+  hal.executable.variant public @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
+    hal.executable.export public @scalar_dispatch ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      func.func @scalar_dispatch() {
+        %c0 = arith.constant 0 : index
+        %c6364136223846793005_i64 = arith.constant 6364136223846793005 : i64
+        %c1442695040888963407_i64 = arith.constant 1442695040888963407 : i64
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<i64>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<i64>>
+        %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:tensor<i64>> -> tensor<i64>
+        %extracted = tensor.extract %2[] : tensor<i64>
+        %3 = arith.muli %extracted, %c6364136223846793005_i64 : i64
+        %4 = arith.addi %3, %c1442695040888963407_i64 : i64
+        %inserted = tensor.insert %4 into %2[] : tensor<i64>
+        flow.dispatch.tensor.store %inserted, %1, offsets = [], sizes = [], strides = [] : tensor<i64> -> !flow.dispatch.tensor<writeonly:tensor<i64>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable.export public @scalar_dispatch
+//  CHECK-SAME: translation_info = #iree_codegen.translation_info<SPIRVBaseLowering>
+//  CHECK-SAME: workgroup_size = [1 : index, 1 : index, 1 : index]
+
+//       CHECK: func.func @scalar_dispatch()
+//       CHECK:   %[[SPAN0:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//       CHECK:   %[[SPAN1:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//       CHECK:   memref.load %[[SPAN0]][] : memref<i64, #hal.descriptor_type<storage_buffer>>
+//       CHECK:   arith.muli {{.+}} : i64
+//       CHECK:   arith.addi {{.+}} : i64
+//       CHECK:   memref.store %{{.+}}, %[[SPAN1]][] : memref<i64, #hal.descriptor_type<storage_buffer>>


### PR DESCRIPTION
This pipeline just performs bufferization and additional loop and SPIR-V lowering. Immediately this is to support dispatch containing only scalar values.

Fixes https://github.com/openxla/iree/issues/14348