### PR TITLE
[WIP] Remove `tensor.empty` for fusion cases.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -658,6 +658,14 @@ LogicalResult createTensorEquivalenceClasses(func::FuncOp funcOp,
     plan.dump();
   });
 
+  funcOp.walk([&](linalg::LinalgOp linalgOp) {
+    tieOperandsForOperandFusion(linalgOp, plan);
+  });
+  LLVM_DEBUG({
+    llvm::dbgs() << "After tie-ing operands for fusion";
+    plan.dump();
+  });
+
   if (funcOp
           .walk([&](IREE::Flow::DispatchTensorStoreOp storeOp) -> WalkResult {
             return analyseInterfaceStoreTensorOp(storeOp, plan);

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --iree-codegen-convert-to-destination-passing-style --canonicalize -cse --split-input-file | FileCheck %s
+// RUN: iree-opt %s --iree-codegen-convert-to-destination-passing-style --canonicalize -cse --split-input-file661 | FileCheck %s
 
 func.func @matmul() {
   %m = hal.interface.constant.load[0] : index
@@ -656,10 +656,14 @@ func.func @gemm_gather() {
   return
 }
 // CHECK-LABEL: func @gemm_gather
+//       CHECK:   %[[OUT_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(5)
+//       CHECK:   %[[OUT:.+]] = flow.dispatch.tensor.load %[[OUT_BINDING]]
+//       CHECK:   %[[FILL:.+]] = linalg.fill
+//  CHECK-SAME:       outs(%[[OUT]] :
 //       CHECK:   %[[GEMM:.+]] = linalg.matmul
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       ins(%{{[a-zA-Z0-9]+}} :
-//  CHECK-SAME:       outs(%[[GEMM]] :
+//  CHECK-SAME:       ins(%[[GEMM]], %{{[a-zA-Z0-9]+}} :
+//  CHECK-SAME:       outs(%[[OUT]] :
 
 // -----
 


### PR DESCRIPTION
For a dispatch of the form

`tensor.empty` -> `linalg.fill` -> `linalg.matmul` -> `linalg.generic`

in some cases, the `tensor.empty` can be replaced with using the output of the `linalg.generic` directly if the result of the `linalg.matmul` has the same type as the result of `linalg.generic`. This transformation already existed in the `ConvertToDestinationPassingStyle` pass but was removed since the assumption was that after vectorization the `tensor.empty` would be dead. Adding this back since for non-vectorization cases this will result in an unnecessary stack allocation.

Fixes #14316, #14305