### PR TITLE
Remove zero-extent inputs from concat

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/stablehlo_to_stablehlo.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/stablehlo_to_stablehlo.mlir
@@ -462,3 +462,15 @@ func.func @broadcast_iota_sort_slice_incorrect_dims(%in : tensor<16x16x16xf32>) 
 
 // CHECK-LABEL: @broadcast_iota_sort_slice_incorrect_dims
 // CHECK-NOT: chlo.top_k
+
+// -----
+
+// CHECK-LABEL: @concat_remove_zero_extents
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
+// CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
+func.func @concat_remove_zero_extents(%arg0: tensor<2x3xi32>, %arg1 : tensor<2x3xi32>, %arg2 : tensor<2x0xi32>) -> tensor<2x6xi32> {
+  %0 = stablehlo.concatenate %arg0, %arg1, %arg2, dim = 1 : (tensor<2x3xi32>, tensor<2x3xi32>, tensor<2x0xi32>) -> tensor<2x6xi32>
+  // CHECK: [[R0:%.+]] = stablehlo.concatenate  %[[ARG0]], %[[ARG1]], dim = 1 : (tensor<2x3xi32>, tensor<2x3xi32>) -> tensor<2x6xi32>
+  return %0 : tensor<2x6xi32>
+}
+


### PR DESCRIPTION
Removes an input from the `ConcatenationOp` if its dimension is zero along the axis of concatenation.