### PR TITLE
Register Arm SME passes in mlir::registerMlirPasses()

### DIFF
--- a/compiler/src/iree/compiler/Tools/init_mlir_passes.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_passes.h
@@ -16,6 +16,7 @@
 
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Dialect/ArmSME/Transforms/Passes.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
@@ -78,6 +79,9 @@ inline void registerMlirPasses() {
   registerConvertGPUToSPIRVPass();
   registerConvertControlFlowToSPIRVPass();
   registerConvertFuncToSPIRVPass();
+
+  // Arm SME
+  arm_sme::registerArmSMEPasses();
 }
 
 } // namespace mlir


### PR DESCRIPTION
This allows these passes to be used in CLI options (e.g. `--mlir-print-ir-after=<pass>`).