### PR TITLE
Link to website overview slides in docs/README.md.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,7 @@ instructions.
 
 Developer documentation _can_ compromise on each of these points. Pages may
 also be promoted to website/ after some refinement.
+
+For more details on how this is set up, see
+
+* [IREE Website Overview - July 10, 2023](https://docs.google.com/presentation/d/116TyW_aCsPXmmjRYI2tRqpOwDaGNoV8LDC_j9hsMrDk/edit?usp=sharing)


### PR DESCRIPTION
I presented these slides at an internal team meeting and may repeat the presentation for the broader community if there is interest and a time slot.

The slides should be world-readable (except where `docs.google.com` is blocked). I tried exporting to .pdf but don't want to commit a 1.3MB file to the repo (lots of screenshots, even with good compression).