### PR TITLE
[CPU] Canonicalize vector masks before they are lowered

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -289,7 +289,7 @@ void GenericVectorizationPass::runOnOperation() {
                                                       funcOp.getContext());
   vector::TransferWriteOp::getCanonicalizationPatterns(vectorizationPatterns,
                                                        funcOp.getContext());
-  vector::populateVectorTransferTensorSliceTransforms(vectorizationPatterns);
+  populateVectorTransferTensorSliceTransforms(vectorizationPatterns);
   (void)applyPatternsAndFoldGreedily(funcOp, std::move(vectorizationPatterns));
 
   // Apply the pad tensor op vectorization separately to avoid running the


### PR DESCRIPTION
This PR adds canonicalization patterns for mask-related op that need to
be applied before such ops are lowered and can no longer be
canonicalized. This is the case of `vector.create_mask` and
`vector.constant_mask`.