### PR TITLE
[CPU] Early lowering of high-level vector mask operations

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -977,8 +977,6 @@ void ConvertToLLVMPass::runOnOperation() {
     // better to use outerproduct.
     vector::populateVectorContractLoweringPatterns(
         patterns, vector::VectorTransformsOptions());
-    vector::populateVectorMaskMaterializationPatterns(
-        patterns, /*force32BitVectorIndices=*/false);
     vector::populateVectorMaskOpLoweringPatterns(patterns);
     vector::populateVectorShapeCastLoweringPatterns(patterns);
     // TODO: doubtful that the "default" does what one want here, it is likely

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorLowering.cpp
@@ -167,6 +167,17 @@ void LLVMCPUVectorLoweringPass::runOnOperation() {
     vector::populateVectorShapeCastLoweringPatterns(patterns);
     (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
   }
+
+  // Lower high-level vector mask operations, such as `vector.create_mask` and
+  // `vector.constant_mask`, to simpler ops. The resulting code needs a go
+  // through a canonicalization pass before it's lowered to LLVM.
+  {
+    RewritePatternSet patterns(ctx);
+    vector::populateVectorMaskMaterializationPatterns(
+        patterns, /*force32BitVectorIndices=*/false);
+    vector::populateVectorMaskOpLoweringPatterns(patterns);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  }
 }
 } // namespace
 


### PR DESCRIPTION
This PR moves the lowering of high-level mask-related ops from `ConvertToLLVM` to `LLVMCPUVectorLowering`. We need this lowering to run earlier followed by a canonicalization pass before the final lowering to LLVM.