### PR TITLE
[CodeGen] Remove IREE folding patterns from ConcretizePadResultShape.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
@@ -168,9 +168,6 @@ void populateConcretizePadResultShapePatterns(RewritePatternSet &patterns,
   // Pulling in upstream scf.for and affine.min canonicalization patterns.
   // They work on tiled (but not distributed) loops.
   scf::populateSCFForLoopCanonicalizationPatterns(patterns);
-  // Pulling in IREE scf.for and affine.min canonicalization patterns.
-  // They work on tiled and distributed loops.
-  populateFoldAffineMinInDistributedLoopsPatterns(patterns, numWorkgroups);
   // Pulling in flow.dispatch.tensor.load op canonicalization patterns.
   // Tiling can generate dim ops taking them as operands.
   IREE::Flow::DispatchTensorLoadOp::getCanonicalizationPatterns(patterns,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -227,6 +227,7 @@ static void concretizePadShape(func::FuncOp funcOp) {
   RewritePatternSet patterns(context);
   SmallVector<int64_t> numWorkgroups = getStaticNumWorkgroups(funcOp);
   populateConcretizePadResultShapePatterns(patterns, numWorkgroups);
+  populateFoldAffineMinInDistributedLoopsPatterns(patterns, numWorkgroups);
   (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
 
   LLVM_DEBUG({


### PR DESCRIPTION
The patterns are expected to be used right after distribution. User should call them explicitly, not including them in the pass.

Fixes https://github.com/openxla/iree/issues/14406