### PR TITLE
Remove explicit Bazel public visibility from targets.

### DIFF
--- a/experimental/webgpu/BUILD.bazel
+++ b/experimental/webgpu/BUILD.bazel
@@ -44,7 +44,6 @@ iree_runtime_cc_library(
     hdrs = [
         "api.h",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",

--- a/experimental/webgpu/platform/BUILD.bazel
+++ b/experimental/webgpu/platform/BUILD.bazel
@@ -17,7 +17,6 @@ iree_runtime_cc_library(
     hdrs = [
         "webgpu.h",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",

--- a/runtime/bindings/tflite/BUILD.bazel
+++ b/runtime/bindings/tflite/BUILD.bazel
@@ -38,7 +38,6 @@ iree_runtime_cc_library(
         "include/tensorflow/lite/c/c_api_experimental.h",
         "include/tensorflow/lite/c/common.h",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",

--- a/runtime/src/iree/base/BUILD.bazel
+++ b/runtime/src/iree/base/BUILD.bazel
@@ -42,7 +42,6 @@ iree_runtime_cc_library(
         "wait_source.h",
     ],
     hdrs = ["api.h"],
-    visibility = ["//visibility:public"],
     deps = [
         ":core_headers",
         "//runtime/src/iree/base/tracing:provider",

--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -68,7 +68,6 @@ iree_runtime_cc_library(
         "vulkan_device.h",
         "vulkan_driver.h",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         ":dynamic_symbols",
         "//runtime/src/iree/base",

--- a/runtime/src/iree/hal/utils/BUILD.bazel
+++ b/runtime/src/iree/hal/utils/BUILD.bazel
@@ -17,7 +17,6 @@ iree_runtime_cc_library(
     name = "allocators",
     srcs = ["allocators.c"],
     hdrs = ["allocators.h"],
-    visibility = ["//visibility:public"],
     deps = [
         ":caching_allocator",
         ":debug_allocator",
@@ -30,7 +29,6 @@ iree_runtime_cc_library(
     name = "buffer_transfer",
     srcs = ["buffer_transfer.c"],
     hdrs = ["buffer_transfer.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",
@@ -41,7 +39,6 @@ iree_runtime_cc_library(
     name = "debug_allocator",
     srcs = ["debug_allocator.c"],
     hdrs = ["debug_allocator.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",
@@ -52,7 +49,6 @@ iree_runtime_cc_library(
     name = "collective_batch",
     srcs = ["collective_batch.c"],
     hdrs = ["collective_batch.h"],
-    visibility = ["//visibility:public"],
     deps = [
         ":resource_set",
         "//runtime/src/iree/base",
@@ -65,7 +61,6 @@ iree_runtime_cc_library(
     name = "caching_allocator",
     srcs = ["caching_allocator.c"],
     hdrs = ["caching_allocator.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:synchronization",
@@ -77,7 +72,6 @@ iree_runtime_cc_library(
     name = "deferred_command_buffer",
     srcs = ["deferred_command_buffer.c"],
     hdrs = ["deferred_command_buffer.h"],
-    visibility = ["//visibility:public"],
     deps = [
         ":resource_set",
         "//runtime/src/iree/base",
@@ -93,7 +87,6 @@ iree_runtime_cc_library(
         "libmpi.h",
         "libmpi_dynamic_symbols.h",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:dynamic_library",
@@ -116,7 +109,6 @@ iree_runtime_cc_library(
     name = "mpi_channel_provider",
     srcs = ["mpi_channel_provider.c"],
     hdrs = ["mpi_channel_provider.h"],
-    visibility = ["//visibility:public"],
     deps = [
         ":libmpi",
         "//runtime/src/iree/base",
@@ -128,7 +120,6 @@ iree_runtime_cc_library(
     name = "resource_set",
     srcs = ["resource_set.c"],
     hdrs = ["resource_set.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",
@@ -165,7 +156,6 @@ iree_runtime_cc_library(
     name = "semaphore_base",
     srcs = ["semaphore_base.c"],
     hdrs = ["semaphore_base.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:synchronization",


### PR DESCRIPTION
These are already granted public visibility by their package defaults.

Visibility doesn't really mean much in the Bazel world of distributed repositories. Downstream in the Google monorepo we care much more, so we set fine grained visibility groups for access to specific components and APIs.