### PR TITLE
Keep `(pad + set_encoding)` pairs as-is to be later folded into `tensor.pack`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/tensor_pad_to_tensor_insert_slice.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/tensor_pad_to_tensor_insert_slice.mlir
@@ -80,3 +80,30 @@ func.func @_main(%arg0: tensor<1x33x33x480xf32>, %arg1: tensor<3x3x480x1xf32>) -
 }
 // CHECK-NOT: tensor.pad
 // SKIP: tensor.pad
+
+// ----
+
+func.func @dispatch_dispatch_0_generic_512x1024_f32(
+    %arg0: !flow.dispatch.tensor<readonly:tensor<512x1024xf32>>,
+    %arg1: index, %arg2: index, %arg3: index, %arg4: index,
+    %arg5: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<512x1024xf32>>>>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = flow.dispatch.workload.ordinal %arg3, 2 : index
+  %1 = flow.dispatch.workload.ordinal %arg4, 3 : index
+  %2 = flow.dispatch.tie_shape %arg5 : !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<512x1024xf32>>>>{%0, %1}
+  %3 = flow.dispatch.workload.ordinal %arg1, 0 : index
+  %4 = flow.dispatch.workload.ordinal %arg2, 1 : index
+  %5 = flow.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [512, 1024], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x1024xf32>> -> tensor<512x1024xf32>
+  %padded = tensor.pad %5 low[0, 0] high[%3, %4] {
+  ^bb0(%arg6: index, %arg7: index):
+    tensor.yield %cst : f32
+  } : tensor<512x1024xf32> to tensor<?x?xf32>
+  %11 = iree_linalg_ext.set_encoding %padded : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<512x1024xf32>>>
+  flow.dispatch.tensor.store %11, %2, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1] : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<512x1024xf32>>> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<512x1024xf32>>>>{%0, %1}
+  return
+}
+
+// CHECK:  %[[LOAD:.+]] = flow.dispatch.tensor.load
+// CHECK:  %[[PAD:.+]] = tensor.pad %[[LOAD]] low
+// CHECK:  %[[ENCODE:.+]] = iree_linalg_ext.set_encoding %[[PAD]] : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding
+// CHECK:  flow.dispatch.tensor.store %[[ENCODE]],


### PR DESCRIPTION
(`pad` + `set_encoding`) is a special pattern that we want to preserve, because ultimately they get folded into tensor.pack.
