### PR TITLE
Having fun with linalg.generic fusion heuristics

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -531,6 +531,12 @@ isFusableWithConsumer(OpOperand &fusedOperand,
   if (!producerLinalgOp || !consumerLinalgOp)
     return false;
 
+  // Check that the producer is all parallel.
+  if (producerLinalgOp.getNumLoops() !=
+      producerLinalgOp.getNumParallelLoops()) {
+    return false;
+  }
+
   // Check that the consumer is all parallel.
   if (consumerLinalgOp.getNumLoops() !=
       consumerLinalgOp.getNumParallelLoops()) {
@@ -654,7 +660,21 @@ isFusableWithProducer(OpOperand &operand,
     return false;
   }
 
+  auto producerLinalgOp = cast<linalg::LinalgOp>(producer);
   auto consumerLinalgOp = cast<linalg::LinalgOp>(consumer);
+
+  // Check that the producer is all parallel.
+  if (producerLinalgOp.getNumLoops() !=
+      producerLinalgOp.getNumParallelLoops()) {
+    return false;
+  }
+
+  // Check that the consumer is all parallel.
+  if (consumerLinalgOp.getNumLoops() !=
+      consumerLinalgOp.getNumParallelLoops()) {
+    return false;
+  }
+
   if (consumerLinalgOp.isDpsInput(&operand)) {
     // Only fuse on inputs if both ops are generic ops.
     if (!isa<linalg::GenericOp>(consumer) ||


### PR DESCRIPTION
Fixes #14414.

Note: CI will fail due to `iree-opt` unit tests which I haven't updated yet, but e2e tests succeed locally. Wanted see if you think that the change makes sense before proceeding with updating tests.

**Note: this PR is now playing with a simple cost model. Original PR description preserved below, referred to the first commit in this PR.**

There is already code in `isFusableWithConsumer` that checks that the consumer is all parallel before fusing. This PR adds a similar check about the producer, and replicates the same logic in `isFusableWithProducer` -- maybe we could let these two functions share a helper.

I think I understand a simple rationale why we should not fuse `reduction` producers: as `reductions` produce an output that is of lower rank than the iteration space (since `reduction` iterators don't participate in the output indexing), _not_ fusing  reductions is a _caching_ optimization. As a toy example, if the producer is a complete sum reduction of a vector down to a scalar, and the consumer is a broadcast of that scalar onto a vector, clearly we don't want to compute the same sum reduction over and over again.

I'm less clear on the rationale for the existing check about not fusing `reduction` consumers. Is it due to some incidental limitation of tile size heuristics? Take for instance a function returning the sum of squares of elements in a vector. So there's a producer that has a parallel iterator and computes `x -> x * x` and there's a consumer with a reduction iterator, computing the sum-reduction. Why not fuse?

Another question, why the existing discrepancy between `isFusableWithConsumer`, which was checking that the producer is all parallel, and `isFusableWithProducer`, which was not checking that? I'm concerned that fusion decisons might hinge on pattern application order etc?