### PR TITLE
In ireeCompilerRegisterDialects, register all global plugin dialects.

### DIFF
--- a/compiler/bindings/python/IREECompilerRegistration.cpp
+++ b/compiler/bindings/python/IREECompilerRegistration.cpp
@@ -11,8 +11,24 @@
 namespace py = pybind11;
 using namespace mlir::python::adaptors;
 
+namespace {
+
+class GlobalInitializer {
+public:
+  GlobalInitializer() { ireeCompilerGlobalInitialize(); }
+  ~GlobalInitializer() { ireeCompilerGlobalShutdown(); }
+};
+
+} // namespace
+
 PYBIND11_MODULE(_site_initialize_0, m) {
   m.doc() = "iree-compile registration";
+
+  // Make sure that GlobalInitialize and GlobalShutdown are called with module
+  // lifetime.
+  py::class_<GlobalInitializer>(m, "_GlobalInitializer");
+  m.attr("_global_init_hook") =
+      py::cast(new GlobalInitializer, py::return_value_policy::take_ownership);
 
   m.def("register_dialects", [](MlirDialectRegistry registry) {
     ireeCompilerRegisterDialects(registry);

--- a/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
+++ b/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
@@ -174,8 +174,9 @@ class Session:
             context_void = _dylib.ireeCompilerSessionStealContext(self._session_p)
             if not context_void:
                 raise RuntimeError(
-                    "Context already released. "
-                    "This is an internal error and likely involves a memory leak (at a minimum)."
+                    "Session context could not be initialized. This either indicated"
+                    "an error setting it up or an attempt to steal the context "
+                    "multiple times (which could indicate a memory leak)."
                 )
             context_cp = PyCapsule_New(context_void, MLIR_PYTHON_CAPSULE_CONTEXT, None)
             self._owned_context = ir.Context._CAPICreate(context_cp)

--- a/compiler/src/iree/compiler/API/Internal/Embed.cpp
+++ b/compiler/src/iree/compiler/API/Internal/Embed.cpp
@@ -1251,8 +1251,7 @@ void ireeCompilerRegisterDialects(MlirDialectRegistry registry) {
   mlir::DialectRegistry *cppRegistry = unwrap(registry);
 
   if (!globalInit) {
-  llvm:
-    errs() << "FATAL ERROR: Not initialized\n";
+    llvm::errs() << "FATAL ERROR: Not initialized\n";
     abort();
   }
   globalInit->registry.appendTo(*cppRegistry);

--- a/compiler/src/iree/compiler/API/Internal/Embed.cpp
+++ b/compiler/src/iree/compiler/API/Internal/Embed.cpp
@@ -1251,7 +1251,8 @@ void ireeCompilerRegisterDialects(MlirDialectRegistry registry) {
   mlir::DialectRegistry *cppRegistry = unwrap(registry);
 
   if (!globalInit) {
-    fprintf(stderr, "FATAL ERROR: Not initialized\n");
+  llvm:
+    errs() << "FATAL ERROR: Not initialized\n";
     abort();
   }
   globalInit->registry.appendTo(*cppRegistry);

--- a/compiler/src/iree/compiler/API/Internal/Embed.cpp
+++ b/compiler/src/iree/compiler/API/Internal/Embed.cpp
@@ -1249,15 +1249,36 @@ ireeCompilerInvocationOutputHALExecutable(iree_compiler_invocation_t *inv,
 
 void ireeCompilerRegisterDialects(MlirDialectRegistry registry) {
   mlir::DialectRegistry *cppRegistry = unwrap(registry);
-  mlir::iree_compiler::registerAllDialects(*cppRegistry);
-  mlir::iree_compiler::registerLLVMIRTranslations(*cppRegistry);
+
+  if (!globalInit) {
+    fprintf(stderr, "FATAL ERROR: Not initialized\n");
+    abort();
+  }
+  globalInit->registry.appendTo(*cppRegistry);
+
+  // The local binder is meant for overriding session-level options, but for
+  // tools like this it is unused.
+  mlir::iree_compiler::PluginManagerOptions pluginManagerOptions;
+  auto localBinder = mlir::iree_compiler::OptionsBinder::local();
+  mlir::iree_compiler::PluginManagerSession pluginSession(
+      globalInit->pluginManager, localBinder, pluginManagerOptions);
+  if (failed(pluginSession.initializePlugins())) {
+    llvm::errs() << "error: Failed to initialize IREE compiler plugins\n";
+  }
+  pluginSession.registerDialects(*cppRegistry);
 }
 
 MlirContext ireeCompilerSessionBorrowContext(iree_compiler_session_t *session) {
+  if (failed(unwrap(session)->activatePluginsOnce())) {
+    return MlirContext{nullptr};
+  }
   return wrap(&unwrap(session)->context);
 }
 
 MlirContext ireeCompilerSessionStealContext(iree_compiler_session_t *session) {
+  if (failed(unwrap(session)->activatePluginsOnce())) {
+    return MlirContext{nullptr};
+  }
   return wrap(unwrap(session)->ownedContext.release());
 }
 

--- a/compiler/src/iree/compiler/API/MLIRInterop.h
+++ b/compiler/src/iree/compiler/API/MLIRInterop.h
@@ -28,6 +28,11 @@ ireeCompilerRegisterDialects(MlirDialectRegistry registry);
 
 // Gets the MlirContext that the session manages. The context is owned by the
 // session and valid until it is destroyed.
+// This implicitly "activates" the session, consuming command line options and
+// diagnostic configuration. Activation is lazy and is usually done on the
+// first use of the context (i.e. for parsing a source in an invocation) but
+// API access like this forces it.
+// Returns a NULL context if it has already been stolen or if activation fails.
 MLIR_CAPI_EXPORTED MlirContext
 ireeCompilerSessionBorrowContext(iree_compiler_session_t *session);
 
@@ -36,6 +41,11 @@ ireeCompilerSessionBorrowContext(iree_compiler_session_t *session);
 // then {nullptr} is returned. Upon return, it is up to the caller to destroy
 // the context and ensure that its lifetime extends at least as long as the
 // session remains in use.
+// This implicitly "activates" the session, consuming command line options and
+// diagnostic configuration. Activation is lazy and is usually done on the
+// first use of the context (i.e. for parsing a source in an invocation) but
+// API access like this forces it.
+// Returns a NULL context if it has already been stolen or if activation fails.
 MLIR_CAPI_EXPORTED MlirContext
 ireeCompilerSessionStealContext(iree_compiler_session_t *session);
 

--- a/compiler/src/iree/compiler/API/MLIRInterop.h
+++ b/compiler/src/iree/compiler/API/MLIRInterop.h
@@ -28,10 +28,10 @@ ireeCompilerRegisterDialects(MlirDialectRegistry registry);
 
 // Gets the MlirContext that the session manages. The context is owned by the
 // session and valid until it is destroyed.
-// This implicitly "activates" the session, consuming command line options and
-// diagnostic configuration. Activation is lazy and is usually done on the
-// first use of the context (i.e. for parsing a source in an invocation) but
-// API access like this forces it.
+// This implicitly "activates" the session: make sure that any configuration
+// (flags, etc) has been done prior. Activation is lazy and is usually done
+// on the first use of the context (i.e. for parsing a source in an
+// invocation) but API access like this forces it.
 // Returns a NULL context if it has already been stolen or if activation fails.
 MLIR_CAPI_EXPORTED MlirContext
 ireeCompilerSessionBorrowContext(iree_compiler_session_t *session);
@@ -41,10 +41,10 @@ ireeCompilerSessionBorrowContext(iree_compiler_session_t *session);
 // then {nullptr} is returned. Upon return, it is up to the caller to destroy
 // the context and ensure that its lifetime extends at least as long as the
 // session remains in use.
-// This implicitly "activates" the session, consuming command line options and
-// diagnostic configuration. Activation is lazy and is usually done on the
-// first use of the context (i.e. for parsing a source in an invocation) but
-// API access like this forces it.
+// This implicitly "activates" the session: make sure that any configuration
+// (flags, etc) has been done prior. Activation is lazy and is usually done
+// on the first use of the context (i.e. for parsing a source in an
+// invocation) but API access like this forces it.
 // Returns a NULL context if it has already been stolen or if activation fails.
 MLIR_CAPI_EXPORTED MlirContext
 ireeCompilerSessionStealContext(iree_compiler_session_t *session);


### PR DESCRIPTION
This matches the behavior of iree-opt and makes API access to iree.compiler.ir match.

Also:
* Updates the Python initializer to bracket execution with `ireeCompilerGlobalInitialize` / `ireeCompilerGlobalShutdown` so that both pure MLIR and IREE compiler API usage can co-exist without stepping on each other.
* Makes `ireeCompilerSessionBorrowContext` and `ireeCompilerSessionStealContext` fully initialize plugins/the context before returning. Previously this was being done lazily and may not have happened, resulting in a context that may not have had all initialization settings applied to it.