### PR TITLE
Avoid performing fusion on operations with `flow.dispatch.region` or `flow.dispatch.workgroups` operations.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -103,6 +103,26 @@ SmallVector<Range> Flow::getLoopRanges(Operation *op, Location loc,
       });
 }
 
+/// Return `true` if an operation is within a `flow.dispatch.region` or
+/// `flow.dispatch.workgroups` op.
+bool Flow::isNonNullAndOutsideDispatch(Operation *op) {
+  if (!op)
+    return false;
+  Operation *parentOp = op->getParentOp();
+  while (parentOp) {
+    if (isa<Flow::DispatchRegionOp, Flow::DispatchWorkgroupsOp>(parentOp)) {
+      return false;
+    }
+    parentOp = parentOp->getParentOp();
+  }
+  return true;
+}
+bool Flow::isNonNullAndOutsideDispatch(ArrayRef<Operation *> operations) {
+  return llvm::all_of(operations, [](Operation *op) {
+    return isNonNullAndOutsideDispatch(op);
+  });
+}
+
 /// Compute the workload to use for the workgroup based on the root op.
 static SmallVector<Value> getWorkloadForRootOp(OpBuilder &builder,
                                                Operation *rootOp) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
@@ -22,6 +22,11 @@ namespace IREE {
 namespace Flow {
 class DispatchRegionOp;
 
+/// Check if an operation is not null and is not nested within
+/// `flow.dispatch.region` or `flow.dispatch.workgroups` op.
+bool isNonNullAndOutsideDispatch(Operation *op);
+bool isNonNullAndOutsideDispatch(ArrayRef<Operation *> operations);
+
 /// For a given operation returns the loop ranges needed to compute the op.
 SmallVector<Range> getLoopRanges(Operation *op, Location loc,
                                  OpBuilder &builder);


### PR DESCRIPTION
Towards #14337