### PR TITLE
Fold tensor.extract operations on linalg.fill populated tensors

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -160,6 +160,7 @@ iree_compiler_cc_library(
         "ExtractAddressComputation.cpp",
         "FlattenMemRefSubspanPass.cpp",
         "FoldAffineMinInDistributedLoops.cpp",
+        "FoldTensorExtractFillPass.cpp",
         "FoldTensorExtractOpPass.cpp",
         "FoldTensorSubsetIntoVectorTransferOps.cpp",
         "ForOpCanonicalizationPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -135,6 +135,7 @@ iree_cc_library(
     "ExtractAddressComputation.cpp"
     "FlattenMemRefSubspanPass.cpp"
     "FoldAffineMinInDistributedLoops.cpp"
+    "FoldTensorExtractFillPass.cpp"
     "FoldTensorExtractOpPass.cpp"
     "FoldTensorSubsetIntoVectorTransferOps.cpp"
     "ForOpCanonicalizationPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/FoldTensorExtractFillPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldTensorExtractFillPass.cpp
@@ -1,0 +1,65 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/PassDetail.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+struct FoldTensorExtractFillPattern : public OpRewritePattern<tensor::ExtractOp> {
+public:
+  using OpRewritePattern<tensor::ExtractOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractOp extractOp,
+                                PatternRewriter &rewriter) const override {
+    // see if tensor input of tensor.extract op is result of linalg.fill op
+    auto tensorFill = extractOp.getTensor().getDefiningOp<linalg::FillOp>();
+    if (!tensorFill) {
+      return failure();
+    }
+
+    // get scalar input operand of linalg.fill
+    Value extractedScalar = tensorFill.getInputs()[0];
+
+    // replace tensor.extract op with op that simply produces the scalar
+    rewriter.replaceOpWithNewOp<arith::ExtFOp>(
+        extractOp, extractedScalar.getType(), extractedScalar);
+    return success();
+  }
+};
+
+struct FoldTensorExtractFillPass
+    : public FoldTensorExtractFillBase<FoldTensorExtractFillPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<FoldTensorExtractFillPattern>(context);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> createFoldTensorExtractFillPass() {
+  return std::make_unique<FoldTensorExtractFillPass>();
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -115,6 +115,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createFlattenMemRefSubspanPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createFoldAffineMinInDistributedLoopsPass();
 
+// folds tensor.extract(linalg.fill(%x)) to %x
+std::unique_ptr<Pass> createFoldTensorExtractFillPass();
+
 /// After running the upstream TensorConstantBufferize pass, remove
 /// tensor_loads introduced for use only in tensor_extract. These can be
 /// folded to use a load of the created memref object that holds the constant

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -200,6 +200,12 @@ def FoldAffineMinInDistributedLoops :
   let constructor = "mlir::iree_compiler::createFoldAffineMinInDistributedLoopsPass()";
 }
 
+def FoldTensorExtractFill :
+  Pass<"iree-codegen-fold-tensor-extract-fill", ""> {
+  let summary = "Fold `tensor.extract(linalg.fill)` operations prior to lowering to LLVM";
+  let constructor = "mlir::iree_compiler::createFoldTensorExtractFillPass()";
+}
+
 def FoldTensorExtractOp :
   Pass<"iree-codegen-fold-tensor-extract-op", ""> {
   let summary = "Fold `tensor.extract` operations prior to lowering to LLVM";


### PR DESCRIPTION
Added a compiler pass to fold tensor.extract operations on tensors populated by linalg.fill operations to address memref error with SPIRV lowering (folds `tensor.extract(linalg.fill(%x))` into `%x`. 

Fixes #14314.