### PR TITLE
Tweak zero-extent removal for multi-return operations

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1023,9 +1023,9 @@ struct ZeroExtentTensorCanon final : RewritePattern {
       if (!resultType) {
         continue;
       }
-      rewriter.replaceAllUsesWith(result,
-          rewriter.create<tensor::EmptyOp>(
-          loc, resultType->getShape(), resultType->getElementType()));
+      rewriter.replaceAllUsesWith(result, rewriter.create<tensor::EmptyOp>(
+                                              loc, resultType->getShape(),
+                                              resultType->getElementType()));
       didUpdate = true;
     }
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1017,19 +1017,20 @@ struct ZeroExtentTensorCanon final : RewritePattern {
 
     // If the result is a zero-extent tensor, replace the whole op with an empty
     // tensor.
+    bool didUpdate = false;
     for (auto result : op->getResults()) {
       auto resultType = isZeroExtent(result.getType());
       if (!resultType) {
         continue;
       }
-      result.replaceAllUsesWith(rewriter.create<tensor::EmptyOp>(
+      rewriter.replaceAllUsesWith(result,
+          rewriter.create<tensor::EmptyOp>(
           loc, resultType->getShape(), resultType->getElementType()));
-      return success();
+      didUpdate = true;
     }
 
     // If one of the operands is a zero-extent tensor, replace the operand with
     // an empty tensor.
-    bool didUpdate = false;
     for (OpOperand &operand : op->getOpOperands()) {
       auto operandType = isZeroExtent(operand.get().getType());
       if (!operandType || operand.get().getDefiningOp<tensor::EmptyOp>()) {

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
@@ -663,3 +663,19 @@ func.func @scatter_zero_ext(%arg0 : tensor<f32>, %arg1 : tensor<1x0xi32>, %arg2 
 // CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<1x0xi32>
 // CHECK:   %[[SCATTER:.+]] = "stablehlo.scatter"(%arg0, %0, %arg2)
 // CHECK:   return %[[SCATTER]] 
+
+// -----
+
+  func.func public @sort_zero_extent(%arg0: tensor<0xi16> {jax.arg_info = "a", mhlo.sharding = "{replicated}"}) -> (tensor<0xi32> {jax.result_info = ""}) {
+    %0 = stablehlo.iota dim = 0 : tensor<0xi32>
+    %1:2 = "stablehlo.sort"(%arg0, %0) ({
+    ^bb0(%arg1: tensor<i16>, %arg2: tensor<i16>, %arg3: tensor<i32>, %arg4: tensor<i32>):
+      %2 = stablehlo.compare  LT, %arg1, %arg2,  SIGNED : (tensor<i16>, tensor<i16>) -> tensor<i1>
+      stablehlo.return %2 : tensor<i1>
+    }) {dimension = 0 : i64, is_stable = true} : (tensor<0xi16>, tensor<0xi32>) -> (tensor<0xi16>, tensor<0xi32>)
+    return %1#1 : tensor<0xi32>
+  }
+
+// CHECK-LABEL: @sort_zero_extent
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<0xi32>
+// CHECK: return %[[EMPTY]]


### PR DESCRIPTION
If an operation returned multiple values we could fail to perform the replacement.