### PR TITLE
[IREEInput] Add top level SCF to CFG conversion to input pipeline

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.cpp
@@ -20,6 +20,8 @@ namespace {
 } // namespace
 
 void buildCommonInputConversionPassPipeline(OpPassManager &passManager) {
+  // Currently we don't handle SCF ops well and have to convert them all to CFG.
+  passManager.addNestedPass<func::FuncOp>(createTopLevelSCFToCFGPass());
   passManager.addPass(createIREEImportPublicPass());
   passManager.addPass(createImportMLProgramPass());
   passManager.addPass(createSanitizeModuleNamesPass());


### PR DESCRIPTION
SCF is not handled well by Flow, and other pipelines (e.g. stablehlo) already include this pass