### PR TITLE
Integrate llvm-project at 6c30b7886919

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -82,9 +82,9 @@ SmallVector<int64_t> getNativeVectorShapeImpl(VectorTransferOpInterface op) {
   auto vecType = op.getVectorType();
   SmallVector<int64_t> nativeSize(vecType.getRank(), 1);
   for (const auto &[index, dim] :
-       llvm::enumerate(op.permutation_map().getResults())) {
+       llvm::enumerate(op.getPermutationMap().getResults())) {
     if (auto dimExpr = dim.dyn_cast<AffineDimExpr>()) {
-      if (dimExpr.getPosition() == op.permutation_map().getNumDims() - 1) {
+      if (dimExpr.getPosition() == op.getPermutationMap().getNumDims() - 1) {
         nativeSize[index] = getMemoryVectorSize(
             op.source(), vecType.getElementType(), vecType.getShape()[index]);
       }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -57,7 +57,7 @@ static bool getUsesIfAllTransferOp(Value value,
     }
 
     if (auto transferOp = dyn_cast<VectorTransferOpInterface>(userOp)) {
-      if (!transferOp.permutation_map().isMinorIdentity()) {
+      if (!transferOp.getPermutationMap().isMinorIdentity()) {
         uses.clear();
         LLVM_DEBUG(llvm::dbgs() << "failed: non-minor-identity transfer user: "
                                 << *userOp << "\n");

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/AndroidLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/AndroidLinkerTool.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/FormatVariadic.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/EmbeddedLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/EmbeddedLinkerTool.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.h"
 #include "iree/compiler/Utils/ToolUtils.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/FileSystem.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/UnixLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/UnixLinkerTool.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.h"
 #include "iree/compiler/Utils/ToolUtils.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/FileSystem.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WasmLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WasmLinkerTool.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.h"
 #include "iree/compiler/Utils/ToolUtils.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/FormatVariadic.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WindowsLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WindowsLinkerTool.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.h"
 #include "iree/compiler/Utils/ToolUtils.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/FormatVariadic.h"


### PR DESCRIPTION
* Reset third_party/llvm-project: 6c30b7886919eb19289f5ed9216e72de9700c9fb (2023-07-17 13:57:08 -0700): Reland "[PS4/PS5] Tidy up driver warnings finding the SDK"