### PR TITLE
Fix integrate scripts to throw an error if bump-branch already exists.

### DIFF
--- a/build_tools/scripts/integrate/bump_llvm.py
+++ b/build_tools/scripts/integrate/bump_llvm.py
@@ -64,6 +64,7 @@ def main(args):
         branch_name,
         checkout=True,
         ref=f"{args.upstream_remote}/main",
+        remote=f"{args.upstream_remote}",
         force=args.reuse_branch,
     )
 

--- a/build_tools/scripts/integrate/iree_utils.py
+++ b/build_tools/scripts/integrate/iree_utils.py
@@ -102,22 +102,19 @@ def git_checkout(ref, *, repo_dir=None):
 
 
 def git_check_if_branch_exists(branch_name, remote=None):
-    args=["branch", "--all", "-l"]
-    full_name=branch_name
+    args = ["branch", "--all", "-l"]
+    full_name = branch_name
     if remote is not None:
         args.append("--remote")
-        full_name=f"{remote}/{full_name}"
+        full_name = f"{remote}/{full_name}"
     args.append(full_name)
     output = git_exec(args, capture_output=True, quiet=True).strip()
     if output:
-        raise SystemExit(
-            f"ERROR: {full_name} already exists.\n"
-        )
+	raise SystemExit( f"ERROR: {full_name} already exists.\n")
 
 
 def git_create_branch(
-    branch_name, *, checkout=True, ref=None, force=False, repo_dir=None,
-    remote=None
+    branch_name, *, checkout=True, ref=None, force=False, repo_dir=None, remote=None
 ):
     git_check_if_branch_exists(branch_name)
     git_check_if_branch_exists(branch_name, remote=remote)

--- a/build_tools/scripts/integrate/iree_utils.py
+++ b/build_tools/scripts/integrate/iree_utils.py
@@ -110,7 +110,7 @@ def git_check_if_branch_exists(branch_name, remote=None):
     args.append(full_name)
     output = git_exec(args, capture_output=True, quiet=True).strip()
     if output:
-	raise SystemExit(f"ERROR: {full_name} already exists.\n")
+        raise SystemExit(f"ERROR: {full_name} already exists.\n")
 
 
 def git_create_branch(

--- a/build_tools/scripts/integrate/iree_utils.py
+++ b/build_tools/scripts/integrate/iree_utils.py
@@ -75,7 +75,7 @@ def git_is_porcelain(*, repo_dir=None):
 
 def git_check_porcelain(*, repo_dir=None):
     output = git_exec(
-        ["status", "--porcelain", "--untracked-files=no"],
+        ["status", "--porcelain"],
         capture_output=True,
         quiet=True,
         repo_dir=repo_dir,
@@ -101,9 +101,26 @@ def git_checkout(ref, *, repo_dir=None):
     git_exec(["checkout", ref], repo_dir=repo_dir)
 
 
+def git_check_if_branch_exists(branch_name, remote=None):
+    args=["branch", "--all", "-l"]
+    full_name=branch_name
+    if remote is not None:
+        args.append("--remote")
+        full_name=f"{remote}/{full_name}"
+    args.append(full_name)
+    output = git_exec(args, capture_output=True, quiet=True).strip()
+    if output:
+        raise SystemExit(
+            f"ERROR: {full_name} already exists.\n"
+        )
+
+
 def git_create_branch(
-    branch_name, *, checkout=True, ref=None, force=False, repo_dir=None
+    branch_name, *, checkout=True, ref=None, force=False, repo_dir=None,
+    remote=None
 ):
+    git_check_if_branch_exists(branch_name)
+    git_check_if_branch_exists(branch_name, remote=remote)
     branch_args = ["branch"]
     if force:
         branch_args.append("-f")

--- a/build_tools/scripts/integrate/iree_utils.py
+++ b/build_tools/scripts/integrate/iree_utils.py
@@ -110,7 +110,7 @@ def git_check_if_branch_exists(branch_name, remote=None):
     args.append(full_name)
     output = git_exec(args, capture_output=True, quiet=True).strip()
     if output:
-	raise SystemExit( f"ERROR: {full_name} already exists.\n")
+	raise SystemExit(f"ERROR: {full_name} already exists.\n")
 
 
 def git_create_branch(


### PR DESCRIPTION
Previously it was silently reusing the same branch locally as well as remotely. Now it's an error.