### PR TITLE
Fix GPUReduceBankConflictsPass for zero rank memref.alloc

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
@@ -17,7 +17,10 @@ namespace iree_compiler {
 /// have bank conflicts when reading 2D shapes within shared memory.
 static void padAlloc(MLIRContext *context, memref::AllocOp allocOp,
                      int64_t paddingSizeBits) {
-  int64_t innerDim = allocOp.getType().getShape().back();
+  auto allocOpShape = allocOp.getType().getShape();
+  if (allocOpShape.empty())
+    return;
+  int64_t innerDim = allocOpShape.back();
   if (ShapedType::isDynamic(innerDim))
     return;
   Type elType = allocOp.getType().getElementType();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
@@ -31,3 +31,14 @@ func.func @pad_alloc_negative(%a: memref<1024x1024xf32>, %i: index, %v: vector<4
     vector<4xf32>, memref<?x32x64xf32, #gpu.address_space<workgroup>>
   return
 }
+
+// -----
+
+// CHECK-LABEL: func.func @pad_alloc_rank_zero
+func.func @pad_alloc_rank_zero() {
+  %cst = arith.constant dense<-3.40282347E+38> : vector<f32>
+// CHECK: memref.alloc() : memref<f32, #gpu.address_space<workgroup>
+  %0 = memref.alloc() : memref<f32, #gpu.address_space<workgroup>>
+  vector.transfer_write %cst, %0[] : vector<f32>, memref<f32, #gpu.address_space<workgroup>>
+  return
+}


### PR DESCRIPTION
-- This commit fixes GPUReduceBankConflictsPass for zero rank
   memref.alloc op.
   
Fixes this [dispatch](https://gist.github.com/Abhishek-Varma/1dee186ce3b1b1ca1846d94ac41c44af) which we get during int8 quantization of a LLM.

Repro command :
```
iree-compile --iree-input-type=tm_tensor --iree-vm-bytecode-module-output-format=flatbuffer-binary --iree-hal-target-backends=cuda --mlir-print-debuginfo --mlir-print-op-on-diagnostic=false --iree-llvmcpu-target-cpu-features=host --iree-hal-cuda-llvm-target-arch=sm_80 --iree-stream-resource-index-bits=64 --iree-vm-target-index-bits=64 --iree-vm-bytecode-module-strip-source-map=true --iree-util-zero-fill-elided-attrs --iree-hal-dump-executable-sources-to=ies --iree-vm-target-truncate-unsupported-floats --iree-codegen-check-ir-before-llvm-conversion=false --iree-vm-bytecode-module-output-format=flatbuffer-binary
```
Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>