### PR TITLE
Mention stable and nightly python releases in more places.

### DIFF
--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -45,9 +45,25 @@ Python packages are regularly published to
 [Python Bindings](../../reference/bindings/python.md) page for more details.
 The core `iree-compiler` package includes the LLVM-based CPU compiler:
 
-``` shell
-python -m pip install iree-compiler
-```
+=== "Stable releases"
+
+    Stable release packages are
+    [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+
+    ``` shell
+    python -m pip install iree-compiler
+    ```
+
+=== ":material-alert: Nightly releases"
+
+    Nightly releases are published on
+    [GitHub releases](https://github.com/openxla/iree/releases).
+
+    ``` shell
+    python -m pip install \
+      --find-links https://openxla.github.io/iree/pip-release-links.html \
+      --upgrade iree-compiler
+    ```
 
 !!! tip
     `iree-compile` is installed to your python module installation path. If you

--- a/docs/website/docs/guides/deployment-configurations/gpu-cuda-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-cuda-rocm.md
@@ -56,9 +56,25 @@ CUDA or ROCm environment. It can be verified by the following steps:
     [Python Bindings](../../reference/bindings/python.md) page for more details.
     The core `iree-compiler` package includes the CUDA compiler:
 
-    ``` shell
-    python -m pip install iree-compiler
-    ```
+    === "Stable releases"
+
+        Stable release packages are
+        [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+
+        ``` shell
+        python -m pip install iree-compiler
+        ```
+
+    === ":material-alert: Nightly releases"
+
+        Nightly releases are published on
+        [GitHub releases](https://github.com/openxla/iree/releases).
+
+        ``` shell
+        python -m pip install \
+          --find-links https://openxla.github.io/iree/pip-release-links.html \
+          --upgrade iree-compiler
+        ```
 
     !!! tip
         `iree-compile` is installed to your python module installation path. If you

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -82,9 +82,25 @@ Python packages are regularly published to
 [Python Bindings](../../reference/bindings/python.md) page for more details.
 The core `iree-compiler` package includes the SPIR-V compiler:
 
-``` shell
-python -m pip install iree-compiler
-```
+=== "Stable releases"
+
+    Stable release packages are
+    [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+
+    ``` shell
+    python -m pip install iree-compiler
+    ```
+
+=== ":material-alert: Nightly releases"
+
+    Nightly releases are published on
+    [GitHub releases](https://github.com/openxla/iree/releases).
+
+    ``` shell
+    python -m pip install \
+      --find-links https://openxla.github.io/iree/pip-release-links.html \
+      --upgrade iree-compiler
+    ```
 
 !!! tip
     `iree-compile` is installed to your python module installation path. If you

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -48,28 +48,47 @@ graph LR
   C --> D
 ```
 
-## Prerequisites
+## :octicons-download-16: Prerequisites
 
-Install IREE pip packages, either from pip or by
-[building from source](../../building-from-source/getting-started.md#python-bindings):
+1. Install IREE packages, either by
+    [building from source](../../building-from-source/getting-started.md#python-bindings)
+    or from pip:
 
-```shell
-pip install \
-  iree-compiler \
-  iree-runtime
-```
+    === "Stable releases"
 
-Install [`torch-mlir`](https://github.com/llvm/torch-mlir), necessary for
-compiling PyTorch models to a format IREE is able to execute:
+        Stable release packages are
+        [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
 
-```shell
-pip install --pre torch-mlir \
-  -f https://llvm.github.io/torch-mlir/package-index/
-  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-```
+        ``` shell
+        python -m pip install \
+          iree-compiler \
+          iree-runtime
+        ```
 
-The command will also install the right version of `torch` that has been tested
-with the version of `torch-mlir` being installed.
+    === ":material-alert: Nightly releases"
+
+        Nightly releases are published on
+        [GitHub releases](https://github.com/openxla/iree/releases).
+
+        ``` shell
+        python -m pip install \
+          --find-links https://openxla.github.io/iree/pip-release-links.html \
+          --upgrade \
+          iree-compiler \
+          iree-runtime
+        ```
+
+2. Install [`torch-mlir`](https://github.com/llvm/torch-mlir), necessary for
+    compiling PyTorch models to a format IREE is able to execute:
+
+    ```shell
+    pip install --pre torch-mlir \
+      -f https://llvm.github.io/torch-mlir/package-index/
+      --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+    ```
+
+    The command will also install the right version of `torch` that has been tested
+    with the version of `torch-mlir` being installed.
 
 ## Running a model
 
@@ -171,7 +190,7 @@ resource-constrained environments. An example illustrating this can be found in
 [this example](https://github.com/iree-org/iree-torch/tree/main/examples/native_training).
 This binary runs a model without a Python interpreter.
 
-## Samples
+## :octicons-code-16: Samples
 
 | Colab notebooks |  |
 | -- | -- |

--- a/docs/website/docs/guides/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/guides/ml-frameworks/tensorflow.md
@@ -43,31 +43,46 @@ graph LR
   C --> D
 ```
 
-## Prerequisites
+## :octicons-download-16: Prerequisites
 
-Install TensorFlow by following the
-[official documentation](https://www.tensorflow.org/install):
+1. Install TensorFlow by following the
+    [official documentation](https://www.tensorflow.org/install):
 
-```shell
-python -m pip install tf-nightly
-```
+    ```shell
+    python -m pip install tf-nightly
+    ```
 
-Install IREE pip packages, either from pip or by
-[building from source](../../building-from-source/getting-started.md#python-bindings):
+2. Install IREE packages, either by
+    [building from source](../../building-from-source/getting-started.md#python-bindings)
+    or from pip:
 
-```shell
-python -m pip install \
-  iree-compiler \
-  iree-runtime \
-  iree-tools-tf
-```
+    === "Stable releases"
 
-!!! Caution
-    The TensorFlow package is currently only available on Linux and macOS. It
-    is not available on Windows yet (see
-    [this issue](https://github.com/openxla/iree/issues/6417)).
+        Stable release packages are
+        [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
 
-## Importing models
+        ``` shell
+        python -m pip install \
+          iree-compiler \
+          iree-runtime \
+          iree-tools-tf
+        ```
+
+    === ":material-alert: Nightly releases"
+
+        Nightly releases are published on
+        [GitHub releases](https://github.com/openxla/iree/releases).
+
+        ``` shell
+        python -m pip install \
+          --find-links https://openxla.github.io/iree/pip-release-links.html \
+          --upgrade \
+          iree-compiler \
+          iree-runtime \
+          iree-tools-tf
+        ```
+
+## :octicons-package-dependents-16: Importing models
 
 IREE compilers transform a model into its final deployable format in several
 sequential steps. The first step for a TensorFlow model is to use either the
@@ -126,7 +141,7 @@ supported targets by following one of the
 
 <!-- TODO(??): overview of APIs available, code snippets (lift from Colab?) -->
 
-## Samples
+## :octicons-code-16: Samples
 
 | Colab notebooks |  |
 | -- | -- |
@@ -139,7 +154,7 @@ End-to-end execution tests can be found in IREE's
 [integrations/tensorflow/e2e/](https://github.com/openxla/iree/tree/main/integrations/tensorflow/e2e)
 directory.
 
-## Troubleshooting
+## :octicons-question-16: Troubleshooting
 
 ### Missing serving signature in SavedModel
 

--- a/docs/website/docs/guides/ml-frameworks/tflite.md
+++ b/docs/website/docs/guides/ml-frameworks/tflite.md
@@ -38,25 +38,46 @@ graph LR
   C --> D
 ```
 
-## Prerequisites
+## :octicons-download-16: Prerequisites
 
-Install TensorFlow by following the
-[official documentation](https://www.tensorflow.org/install):
+1. Install TensorFlow by following the
+    [official documentation](https://www.tensorflow.org/install):
 
-```shell
-python -m pip install tf-nightly
-```
+    ```shell
+    python -m pip install tf-nightly
+    ```
 
-Install TensorFlow-Lite specific dependencies using pip:
+2. Install IREE packages, either by
+    [building from source](../../building-from-source/getting-started.md#python-bindings)
+    or from pip:
 
-```shell
-python -m pip install \
-  iree-compiler \
-  iree-runtime \
-  iree-tools-tflite
-```
+    === "Stable releases"
 
-## Importing and Compiling
+        Stable release packages are
+        [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+
+        ``` shell
+        python -m pip install \
+          iree-compiler \
+          iree-runtime \
+          iree-tools-tflite
+        ```
+
+    === ":material-alert: Nightly releases"
+
+        Nightly releases are published on
+        [GitHub releases](https://github.com/openxla/iree/releases).
+
+        ``` shell
+        python -m pip install \
+          --find-links https://openxla.github.io/iree/pip-release-links.html \
+          --upgrade \
+          iree-compiler \
+          iree-runtime \
+          iree-tools-tflite
+        ```
+
+## :octicons-package-dependents-16: Importing and Compiling
 
 IREE's tooling is divided into two components: import and compilation.
 
@@ -173,15 +194,7 @@ iree_results = invoke(*args)
 print(iree_results)
 ```
 
-## Troubleshooting
-
-Failures during the import step usually indicate a failure to lower from
-TensorFlow Lite's operations to TOSA, the intermediate representation used by
-IREE. Many TensorFlow Lite operations are not fully supported, particularly
-those than use dynamic shapes. File an issue to IREE's TFLite model support
-[project](https://github.com/openxla/iree/projects/42).
-
-## Additional Samples
+## :octicons-code-16: Samples
 
 * The
 [tflitehub folder](https://github.com/iree-org/iree-samples/tree/main/tflitehub)
@@ -198,10 +211,11 @@ is available
 | -- | -- |
 Text classification with TFLite and IREE | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/iree/blob/main/samples/colab/tflite_text_classification.ipynb)
 
-!!! todo
+## :octicons-question-16: Troubleshooting
 
-    [Issue#3954](https://github.com/openxla/iree/issues/3954): Add documentation
-    for an Android demo using the
-    [Java TFLite bindings](https://github.com/openxla/iree/tree/main/runtime/bindings/tflite/java),
-    once it is complete at
-    [not-jenni/iree-android-tflite-demo](https://github.com/not-jenni/iree-android-tflite-demo).
+Failures during the import step usually indicate a failure to lower from
+TensorFlow Lite's operations to TOSA, the intermediate representation used by
+IREE. Many TensorFlow Lite operations are not fully supported, particularly
+those than use dynamic shapes. Please reach out on one of IREE's
+[communication channels](../../index.md#communication-channels) if you notice
+something missing.


### PR DESCRIPTION
I'd been hoping that our stable releases would be frequent enough that most users would be able to use them exclusively, but we've had a number of users report issues going away by upgrading to the nightly releases. This adds the stable/nightly releases content tab to every location on the website that includes pip install instructions: 

![image](https://github.com/openxla/iree/assets/4010439/2ae25cb4-9601-4b26-8a4f-5f0c91d662ad)

![image](https://github.com/openxla/iree/assets/4010439/7727c7f5-3677-422d-b2ac-0704af07f7f4)
