### PR TITLE
[Flow] Generalize named ops that are better handled as `linalg.generic`.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -50,6 +50,7 @@ iree_compiler_cc_library(
         "FormDispatchWorkgroups.cpp",
         "FormScalarDispatches.cpp",
         "FusionOfTensorOps.cpp",
+        "GeneralizeLinalgNamedOps.cpp",
         "InferNumericNarrowing.cpp",
         "InitializeEmptyTensors.cpp",
         "InjectDispatchTracing.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     "FormDispatchWorkgroups.cpp"
     "FormScalarDispatches.cpp"
     "FusionOfTensorOps.cpp"
+    "GeneralizeLinalgNamedOps.cpp"
     "InferNumericNarrowing.cpp"
     "InitializeEmptyTensors.cpp"
     "InjectDispatchTracing.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/GeneralizeLinalgNamedOps.cpp
@@ -1,0 +1,73 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- GeneralizeLinalgOps.cpp - Pass to generalize named LinalgOps -------==//
+//
+// The pass is to generalize Linalg named operations that are better off being
+// represented as `linalg.generic` operations in IREE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+struct GeneralizeLinalgNamedOpsPass
+    : public GeneralizeLinalgNamedOpsBase<GeneralizeLinalgNamedOpsPass> {
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void GeneralizeLinalgNamedOpsPass::runOnOperation() {
+  auto funcOp = getOperation();
+  SmallVector<linalg::LinalgOp> namedOpCandidates;
+  funcOp.walk([&](linalg::LinalgOp linalgOp) {
+    if (!isNonNullAndOutsideDispatch(linalgOp)) {
+      return;
+    }
+    if (isa_and_nonnull<linalg::AbsOp, linalg::AddOp, linalg::BroadcastOp,
+                        linalg::CeilOp, linalg::CopyOp, linalg::DivOp,
+                        linalg::DivUOp, linalg::ElemwiseBinaryOp,
+                        linalg::ElemwiseUnaryOp, linalg::ExpOp, linalg::FloorOp,
+                        linalg::LogOp, linalg::MapOp, linalg::MaxOp,
+                        linalg::MulOp, linalg::NegFOp, linalg::ReduceOp,
+                        linalg::SubOp, linalg::TransposeOp>(
+            linalgOp.getOperation())) {
+      namedOpCandidates.push_back(linalgOp);
+    }
+  });
+
+  IRRewriter rewriter(&getContext());
+  for (auto linalgOp : namedOpCandidates) {
+    rewriter.setInsertionPoint(linalgOp);
+    FailureOr<linalg::GenericOp> generalizedOp =
+        linalg::generalizeNamedOp(rewriter, linalgOp);
+    if (failed(generalizedOp)) {
+      linalgOp->emitOpError("failed to generalize operation");
+      return signalPassFailure();
+    }
+  }
+}
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createGeneralizeLinalgNamedOpsPass() {
+  return std::make_unique<GeneralizeLinalgNamedOpsPass>();
+}
+
+} // namespace Flow
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -242,6 +242,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       // - Convert all elementwise ops to Linalg
       // - Remove unit-extent dimensions.
       .addPass(mlir::createConvertElementwiseToLinalgPass)
+      .addPass(createGeneralizeLinalgNamedOpsPass)
       .addPass(mlir::createLinalgFoldUnitExtentDimsPass)
       .addPass(createRaiseSpecialOps)
       .addPass(createInterchangeGenericOpsPass)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -95,6 +95,11 @@ std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createFusionOfTensorOpsPass(bool fuseMultiUse = false,
                             unsigned multiUseFusionIteration = 2);
 
+// Create a pass that generalizes some named Linalg ops into `linalg.generic`
+// operations since the IREE compiler can handle that better.
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createGeneralizeLinalgNamedOpsPass();
+
 // Infers and inserts util.numeric.optional_narrow ops at points that may be
 // beneficial.
 std::unique_ptr<Pass> createInferNumericNarrowingPass();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -174,6 +174,12 @@ def FusionOfTensorOps :
   ];
 }
 
+def GeneralizeLinalgNamedOps :
+    InterfacePass<"iree-flow-generalize-linalg-named-ops", "mlir::FunctionOpInterface"> {
+  let summary = "Convert some Linalg named ops into linalg.generics";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createGeneralizeLinalgNamedOpsPass()";
+}
+
 def InferNumericNarrowing :
     Pass<"iree-flow-infer-numeric-narrowing", ""> {
   let summary = "Infers and inserts util.numeric.optional_narrow ops at points that may be beneficial";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "form_dispatch_workgroups.mlir",
             "form_scalar_dispatches.mlir",
             "fusion_of_tensor_ops.mlir",
+            "generalize_named_ops.mlir",
             "infer_numeric_narrowing.mlir",
             "initialize_empty_tensors.mlir",
             "inject_dispatch_tracing.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_lit_test_suite(
     "form_dispatch_workgroups.mlir"
     "form_scalar_dispatches.mlir"
     "fusion_of_tensor_ops.mlir"
+    "generalize_named_ops.mlir"
     "infer_numeric_narrowing.mlir"
     "initialize_empty_tensors.mlir"
     "inject_dispatch_tracing.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/generalize_named_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/generalize_named_ops.mlir
@@ -1,0 +1,37 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-flow-generalize-linalg-named-ops))" --split-input-file %s | FileCheck %s
+
+func.func @generalize_op(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %empty = tensor.empty(%d0, %d1): tensor<?x?xf32>
+  %add = linalg.add ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%empty : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %add : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @generalize_op
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//       CHECK:   return %[[GENERIC]]
+
+// -----
+
+func.func @no_generalize_op_within_dispatch(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %dispatch = flow.dispatch.region[] -> (tensor<?x?xf32>{%d0, %d1}) {
+    %empty = tensor.empty(%d0, %d1): tensor<?x?xf32>
+    %add = linalg.add ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+        outs(%empty : tensor<?x?xf32>) -> tensor<?x?xf32>
+    flow.return %add : tensor<?x?xf32>
+  }
+  return %dispatch : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @no_generalize_op_within_dispatch
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     %[[ADD:.+]] = linalg.add
+//       CHECK:     flow.return %[[ADD]]
+//       CHECK:   return %[[DISPATCH]]
+


### PR DESCRIPTION
Linalg dialect have a number of named ops (like `linalg.add`, `linalg.sub`, etc.) that are better handled by IREE as `linalg.generic`s. Add a pass to convert such named ops into `linalg.generic`.