### PR TITLE
Update to mkdocs-material 9.2.

### DIFF
--- a/docs/website/docs/building-from-source/android.md
+++ b/docs/website/docs/building-from-source/android.md
@@ -3,6 +3,7 @@ hide:
   - tags
 tags:
   - Android
+icon: simple/android
 ---
 
 # Android cross-compilation

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/bookmark-16
+---
+
 # Getting started
 
 ## :octicons-download-16: Prerequisites

--- a/docs/website/docs/building-from-source/ios.md
+++ b/docs/website/docs/building-from-source/ios.md
@@ -3,6 +3,7 @@ hide:
   - tags
 tags:
   - iOS
+icon: simple/apple
 ---
 
 # iOS cross-compilation

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -3,6 +3,7 @@ hide:
   - tags
 tags:
   - CPU
+icon: octicons/cpu-16
 ---
 
 # RISC-V cross-compilation

--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -3,6 +3,7 @@ hide:
   - tags
 tags:
   - CPU
+icon: octicons/cpu-16
 ---
 
 # Running on a Bare-Metal Platform

--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -3,6 +3,7 @@ hide:
   - tags
 tags:
   - CPU
+icon: octicons/cpu-16
 ---
 
 # CPU Deployment

--- a/docs/website/docs/guides/deployment-configurations/gpu-cuda-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-cuda-rocm.md
@@ -4,6 +4,7 @@ hide:
 tags:
   - GPU
   - CUDA
+icon: octicons/server-16
 ---
 
 # GPU Deployment using CUDA and ROCm

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -4,6 +4,7 @@ hide:
 tags:
   - GPU
   - Vulkan
+icon: octicons/server-16
 ---
 
 # GPU Deployment using Vulkan

--- a/docs/website/docs/guides/developer-tips.md
+++ b/docs/website/docs/guides/developer-tips.md
@@ -67,11 +67,11 @@ then be loaded and executed using IREE's runtime.
     C source modules provide low level connection points for constrained
     environments like bare metal platforms.
 
-By default, `.vmfb` files can be opened as zip files:
+By default, `.vmfb` files can be opened as zip files: (1)
+{ .annotate }
 
-<!-- TODO(scotttodd): add annotation (insiders only), qualifying "default" with
-                      `--iree-vm-emit-polyglot-zip=true`
--->
+1. Setting `--iree-vm-emit-polyglot-zip=false` will disable this feature and
+   decrease file size slightly
 
 ```console
 $ unzip -d simple_abs_cpu ./simple_abs_cpu.vmfb

--- a/docs/website/docs/guides/developer-tips.md
+++ b/docs/website/docs/guides/developer-tips.md
@@ -1,3 +1,8 @@
+---
+status: new
+icon: material/lightbulb-on
+---
+
 # IREE developer tips and tricks
 
 The IREE compiler is built using [MLIR](https://mlir.llvm.org/), so it naturally

--- a/docs/website/docs/guides/ml-frameworks/jax.md
+++ b/docs/website/docs/guides/ml-frameworks/jax.md
@@ -4,6 +4,7 @@ hide:
 tags:
   - Python
   - JAX
+icon: simple/python
 ---
 
 # JAX Integration

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -4,6 +4,7 @@ hide:
 tags:
   - Python
   - PyTorch
+icon: simple/pytorch
 ---
 
 # PyTorch Integration

--- a/docs/website/docs/guides/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/guides/ml-frameworks/tensorflow.md
@@ -4,6 +4,7 @@ hide:
 tags:
   - Python
   - TensorFlow
+icon: simple/tensorflow
 ---
 
 # TensorFlow Integration

--- a/docs/website/docs/guides/ml-frameworks/tflite.md
+++ b/docs/website/docs/guides/ml-frameworks/tflite.md
@@ -4,6 +4,7 @@ hide:
 tags:
   - Python
   - TensorFlow
+icon: simple/tensorflow
 ---
 
 # TFLite Integration

--- a/docs/website/docs/reference/bindings/c-api.md
+++ b/docs/website/docs/reference/bindings/c-api.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/code-16
+---
+
 # C API bindings
 
 ## Overview

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -3,6 +3,7 @@ hide:
   - tags
 tags:
   - Python
+icon: simple/python
 ---
 
 # Python bindings

--- a/docs/website/docs/reference/extensions.md
+++ b/docs/website/docs/reference/extensions.md
@@ -1,3 +1,13 @@
+---
+hide:
+  - tags
+tags:
+  - JAX
+  - PyTorch
+  - TensorFlow
+icon: octicons/gear-16
+---
+
 # Extension mechanisms
 
 !!! Note

--- a/docs/website/docs/reference/glossary.md
+++ b/docs/website/docs/reference/glossary.md
@@ -5,6 +5,7 @@ tags:
   - JAX
   - PyTorch
   - TensorFlow
+icon: octicons/book-16
 ---
 
 # Glossary

--- a/docs/website/docs/reference/mlir-dialects/index.md
+++ b/docs/website/docs/reference/mlir-dialects/index.md
@@ -1,3 +1,7 @@
+---
+icon: simple/llvm
+---
+
 # MLIR dialects
 
 These pages contain automatically generated documentation for the MLIR dialects

--- a/docs/website/docs/reference/optimization-options.md
+++ b/docs/website/docs/reference/optimization-options.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/rocket-16
+---
+
 # Optimization options
 
 This page documents various supported flags for optimizing IREE programs. Each

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -71,6 +71,9 @@ extra:
       link: https://groups.google.com/forum/#!forum/iree-discuss
       name: IREE Discuss Google Group
 
+  status:
+    new: Recently added
+
 extra_css:
   - assets/stylesheets/extra.css
   - assets/stylesheets/openxla.css

--- a/docs/website/requirements.txt
+++ b/docs/website/requirements.txt
@@ -1,4 +1,2 @@
-# TODO(scotttodd): pin versions to control how often we pull in updates?
-
-mkdocs-material
-mkdocs-redirects
+mkdocs-material==9.2.0b1
+mkdocs-redirects==1.2.1

--- a/third_party/mkdocs-material/overrides/partials/header.html
+++ b/third_party/mkdocs-material/overrides/partials/header.html
@@ -20,10 +20,12 @@
   IN THE SOFTWARE.
 -->
 
-<!-- Determine base classes -->
+<!-- Determine classes -->
 {% set class = "md-header" %}
 {% if "navigation.tabs.sticky" in features %}
-  {% set class = class ~ " md-header--lifted" %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
 {% endif %}
 
 <!-- Header -->
@@ -52,14 +54,15 @@
       aria-label="{{ config.site_name }}"
       data-md-component="logo"
     >
-      <div class="md-header__title">
-        {{ config.site_name }}
-      </div>
+    <div class="md-header__title">
+      {{ config.site_name }}
+    </div>
     </a>
 
     <!-- Button to open drawer -->
     <label class="md-header__button md-icon" for="__drawer">
-      {% include ".icons/material/menu" ~ ".svg" %}
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
     </label>
 
     <!-- Header title -->
@@ -78,37 +81,41 @@
     </div>
 
     <!-- Color palette -->
-    {% if not config.theme.palette is mapping %}
-      <form class="md-header__option" data-md-component="palette">
-        {% for option in config.theme.palette %}
-          {% set scheme = option.scheme | d("default", true) %}
-          <input
-            class="md-option"
-            data-md-color-media="{{ option.media }}"
-            data-md-color-scheme="{{ scheme | replace(' ', '-') }}"
-            data-md-color-primary="{{ option.primary | replace(' ', '-') }}"
-            data-md-color-accent="{{ option.accent | replace(' ', '-') }}"
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        <form class="md-header__option" data-md-component="palette">
+          {% for option in config.theme.palette %}
+            {% set scheme  = option.scheme  | d("default", true) %}
+            {% set primary = option.primary | d("indigo", true) %}
+            {% set accent  = option.accent  | d("indigo", true) %}
+            <input
+              class="md-option"
+              data-md-color-media="{{ option.media }}"
+              data-md-color-scheme="{{ scheme | replace(' ', '-') }}"
+              data-md-color-primary="{{ primary | replace(' ', '-') }}"
+              data-md-color-accent="{{ accent | replace(' ', '-') }}"
+              {% if option.toggle %}
+                aria-label="{{ option.toggle.name }}"
+              {% else  %}
+                aria-hidden="true"
+              {% endif %}
+              type="radio"
+              name="__palette"
+              id="__palette_{{ loop.index }}"
+            />
             {% if option.toggle %}
-              aria-label="{{ option.toggle.name }}"
-            {% else  %}
-              aria-hidden="true"
+              <label
+                class="md-header__button md-icon"
+                title="{{ option.toggle.name }}"
+                for="__palette_{{ loop.index0 or loop.length }}"
+                hidden
+              >
+                {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
+              </label>
             {% endif %}
-            type="radio"
-            name="__palette"
-            id="__palette_{{ loop.index }}"
-          />
-          {% if option.toggle %}
-            <label
-              class="md-header__button md-icon"
-              title="{{ option.toggle.name }}"
-              for="__palette_{{ loop.index0 or loop.length }}"
-              hidden
-            >
-              {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
-            </label>
-          {% endif %}
-        {% endfor %}
-      </form>
+          {% endfor %}
+        </form>
+      {% endif %}
     {% endif %}
 
     <!-- Site language selector -->
@@ -144,7 +151,8 @@
     <!-- Button to open search modal -->
     {% if "material/search" in config.plugins %}
       <label class="md-header__button md-icon" for="__search">
-        {% include ".icons/material/magnify.svg" %}
+        {% set icon = config.theme.icon.search or "material/magnify" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
       </label>
 
       <!-- Search interface -->

--- a/third_party/mkdocs-material/overrides/partials/nav.html
+++ b/third_party/mkdocs-material/overrides/partials/nav.html
@@ -20,7 +20,9 @@
   IN THE SOFTWARE.
 -->
 
-<!-- Determine class according to configuration -->
+{% import "partials/nav-item.html" as item with context %}
+
+<!-- Determine classes -->
 {% set class = "md-nav md-nav--primary" %}
 {% if "navigation.tabs" in features %}
   {% set class = class ~ " md-nav--lifted" %}
@@ -29,7 +31,7 @@
   {% set class = class ~ " md-nav--integrated" %}
 {% endif %}
 
-<!-- Main navigation -->
+<!-- Navigation -->
 <nav
   class="{{ class }}"
   aria-label="{{ lang.t('nav') }}"
@@ -58,12 +60,11 @@
     </div>
   {% endif %}
 
-  <!-- Render item list -->
+  <!-- Navigation list -->
   <ul class="md-nav__list" data-md-scrollfix>
     {% for nav_item in nav %}
       {% set path = "__nav_" ~ loop.index %}
-      {% set level = 1 %}
-      {% include "partials/nav-item.html" %}
+      {{ item.render(nav_item, path, 1) }}
     {% endfor %}
   </ul>
 </nav>


### PR DESCRIPTION
Note: 9.2 is in beta. We might want to wait until it is official released to merge this. Maybe we should pin our version first though... the changes to the partial files will break us with our currently unpinned / auto-updating publish CI.

### Changes

- [x] Pin downloaded mkdocs-material version
- [x] Merge upstream changes to partial files
- [x] Add 'new' [status](https://squidfunk.github.io/mkdocs-material/reference/#setting-the-page-status) to developer tips and tricks page
- [x] Add [icons](https://squidfunk.github.io/mkdocs-material/reference/#setting-the-page-icon) to most pages
- [x] Add an [annotation](https://squidfunk.github.io/mkdocs-material/reference/annotations/)
- [ ] (Not done) Switch blog pages to use [built-in blog plugin](https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/)

### Preview

![image](https://github.com/openxla/iree/assets/4010439/48f27bbd-20ac-4e6d-b106-f3b195104bd5) ![image](https://github.com/openxla/iree/assets/4010439/7b22aef3-9674-41d7-b3b7-4e33fb420572) ![image](https://github.com/openxla/iree/assets/4010439/7b59dcfb-db1d-4cf7-813a-b337a13ab2bf)