### PR TITLE
Add `--iree-llvmcpu-skip-intermediate-roundings`, on by default.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeRange.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -26,12 +27,31 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
-struct LLVMCPULowerToUKernelsPass
-    : LLVMCPULowerToUKernelsBase<LLVMCPULowerToUKernelsPass> {
+class LLVMCPULowerToUKernelsPass
+    : public LLVMCPULowerToUKernelsBase<LLVMCPULowerToUKernelsPass> {
+public:
+  LLVMCPULowerToUKernelsPass(bool skipIntermediateRoundings)
+      : skipIntermediateRoundings(skipIntermediateRoundings) {}
+
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Codegen::IREECodegenDialect>();
   }
+
   void runOnOperation() override;
+
+  LogicalResult initializeOptions(StringRef options) override {
+    if (failed(Pass::initializeOptions(options))) {
+      return failure();
+    }
+    // `skipIntermediateRoundings` may have been set to `true` in the
+    // constructor already. The |= is so we preserve that rather than overwrite
+    // it with the default value `false` of `optionSkipIntermediateRoundings`.
+    skipIntermediateRoundings |= optionSkipIntermediateRoundings;
+    return success();
+  }
+
+private:
+  bool skipIntermediateRoundings;
 };
 } // namespace
 
@@ -86,7 +106,8 @@ getFnNameAndDefAttrs(const char *ukernelName, RewriterBase &rewriter,
 /// it into a iree_codegen.ukernel.mmt4d operation, that is later lowered
 /// into a call to the microkernel.
 static FailureOr<IREE::Codegen::UKernelOpInterface>
-matchDAGForUKernel(RewriterBase &rewriter, linalg::Mmt4DOp op) {
+matchDAGForUKernel(RewriterBase &rewriter, linalg::Mmt4DOp op,
+                   bool skipIntermediateRoundings) {
   Value lhs = op.getDpsInputOperand(0)->get();
   Value rhs = op.getDpsInputOperand(1)->get();
   Value out = op.getDpsInitOperand(0)->get();
@@ -131,6 +152,11 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::Mmt4DOp op) {
     // Tell the mmt4d op to read the existing accumulator.
     flags |= IREE_UK_FLAG_MMT4D_ACCUMULATE;
   }
+
+  if (skipIntermediateRoundings) {
+    flags |= IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS;
+  }
+
   Location loc = op.getLoc();
   Value m = rewriter.create<tensor::DimOp>(loc, lhs, 0);
   Value n = rewriter.create<tensor::DimOp>(loc, rhs, 0);
@@ -159,7 +185,8 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::Mmt4DOp op) {
 }
 
 static FailureOr<IREE::Codegen::UKernelOpInterface>
-matchDAGForUKernel(RewriterBase &rewriter, tensor::PackOp op) {
+matchDAGForUKernel(RewriterBase &rewriter, tensor::PackOp op,
+                   bool /*skipIntermediateRoundings*/) {
   Value in = op.getSource();
   Value out = op.getDest();
   auto inType = llvm::cast<ShapedType>(in.getType());
@@ -275,7 +302,8 @@ matchDAGForUKernel(RewriterBase &rewriter, tensor::PackOp op) {
 }
 
 static FailureOr<IREE::Codegen::UKernelOpInterface>
-matchDAGForUKernel(RewriterBase &rewriter, tensor::UnPackOp op) {
+matchDAGForUKernel(RewriterBase &rewriter, tensor::UnPackOp op,
+                   bool /*skipIntermediateRoundings*/) {
   Value in = op.getSource();
   Value out = op.getDest();
   auto inType = llvm::cast<ShapedType>(in.getType());
@@ -384,7 +412,8 @@ static uint32_t flagForRole(IREE::LinalgExt::EncodingRole role) {
 }
 
 static FailureOr<IREE::Codegen::UKernelOpInterface>
-matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op) {
+matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op,
+                   bool /*skipIntermediateRoundings*/) {
   auto tensorType = op.getTensorType().dyn_cast<RankedTensorType>();
   if (!tensorType) {
     return rewriter.notifyMatchFailure(op,
@@ -426,9 +455,10 @@ using TargetPredicate = std::function<bool(IREE::HAL::ExecutableTargetAttr)>;
 
 template <typename OpType>
 struct LowerToUKernelPattern : OpRewritePattern<OpType> {
-  LowerToUKernelPattern(MLIRContext *context,
-                        TargetPredicate targetPredicate = {})
-      : OpRewritePattern<OpType>(context), targetPredicate(targetPredicate) {}
+  LowerToUKernelPattern(MLIRContext *context, TargetPredicate targetPredicate,
+                        bool skipIntermediateRoundings = false)
+      : OpRewritePattern<OpType>(context), targetPredicate(targetPredicate),
+        skipIntermediateRoundings(skipIntermediateRoundings) {}
 
   LogicalResult matchAndRewrite(OpType op,
                                 PatternRewriter &rewriter) const override {
@@ -437,7 +467,7 @@ struct LowerToUKernelPattern : OpRewritePattern<OpType> {
       return failure();
     }
     FailureOr<IREE::Codegen::UKernelOpInterface> ukernelOp =
-        matchDAGForUKernel(rewriter, op);
+        matchDAGForUKernel(rewriter, op, skipIntermediateRoundings);
     if (failed(ukernelOp)) {
       return rewriter.notifyMatchFailure(
           op, "failed to find microkernel op to replace with");
@@ -447,6 +477,7 @@ struct LowerToUKernelPattern : OpRewritePattern<OpType> {
   }
 
   TargetPredicate targetPredicate;
+  bool skipIntermediateRoundings;
 };
 
 } // namespace
@@ -466,7 +497,9 @@ void LLVMCPULowerToUKernelsPass::runOnOperation() {
   // that it is difficult for codegen to consistently approach microkernels
   // performance, and that consideration overrides the benefit of fusions for
   // these ops.
-  patterns.insert<LowerToUKernelPattern<linalg::Mmt4DOp>>(context);
+  auto allTargets = [](auto target) { return true; };
+  patterns.insert<LowerToUKernelPattern<linalg::Mmt4DOp>>(
+      context, allTargets, skipIntermediateRoundings);
   // These patterns could in principle be used on LLVMCPU, not just VMVX, but
   // we choose not to, for two reasons:
   // 1. Codegen for these ops is thought to be good enough, that we do not
@@ -488,8 +521,10 @@ void LLVMCPULowerToUKernelsPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<>> createLLVMCPULowerToUKernelsPass() {
-  return std::make_unique<LLVMCPULowerToUKernelsPass>();
+std::unique_ptr<OperationPass<>>
+createLLVMCPULowerToUKernelsPass(bool skipIntermediateRoundings) {
+  return std::make_unique<LLVMCPULowerToUKernelsPass>(
+      skipIntermediateRoundings);
 }
 
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -43,10 +43,10 @@ public:
     if (failed(Pass::initializeOptions(options))) {
       return failure();
     }
-    // `skipIntermediateRoundings` may have been set to `true` in the
-    // constructor already. The |= is so we preserve that rather than overwrite
-    // it with the default value `false` of `optionSkipIntermediateRoundings`.
-    skipIntermediateRoundings |= optionSkipIntermediateRoundings;
+    // This option defaults to `true` both in Passes.td and in C++ code.
+    // If either side has `false`, that's a non-default choice, so we let that
+    // override a `true` on the other side.
+    skipIntermediateRoundings &= optionSkipIntermediateRoundings;
     return success();
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -45,7 +45,8 @@ std::unique_ptr<Pass> createExpandF16OpToF32Pass();
 
 /// Pass to lower a sequence of operations to a iree_codegen.ukernel.*
 /// operation.
-std::unique_ptr<OperationPass<>> createLLVMCPULowerToUKernelsPass();
+std::unique_ptr<OperationPass<>>
+createLLVMCPULowerToUKernelsPass(bool skipIntermediateRoundings = false);
 
 std::unique_ptr<OperationPass<func::FuncOp>>
 createLLVMCPUMmt4dVectorLoweringPass();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -46,7 +46,7 @@ std::unique_ptr<Pass> createExpandF16OpToF32Pass();
 /// Pass to lower a sequence of operations to a iree_codegen.ukernel.*
 /// operation.
 std::unique_ptr<OperationPass<>>
-createLLVMCPULowerToUKernelsPass(bool skipIntermediateRoundings = false);
+createLLVMCPULowerToUKernelsPass(bool skipIntermediateRoundings = true);
 
 std::unique_ptr<OperationPass<func::FuncOp>>
 createLLVMCPUMmt4dVectorLoweringPass();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -79,6 +79,11 @@ def LLVMCPULowerToUKernels :
       "Separate out parts of the IR that lower to a micro-kernel";
   let constructor =
       "mlir::iree_compiler::createLLVMCPULowerToUKernelsPass()";
+  let options = [
+    Option<"optionSkipIntermediateRoundings", "skip-intermediate-roundings",
+      "bool", /*default=*/"true",
+      "Allow skipping intermediate roundings, e.g. in f16 ukernels internally doing f32 arithmetic.">,
+  ];
 }
 
 def LLVMCPUMmt4dVectorLowering

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_ukernel_ops.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt --iree-llvmcpu-lower-to-ukernels %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmcpu-lower-to-ukernels{skip-intermediate-roundings=true},cse,canonicalize))" %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmcpu-lower-to-ukernels{skip-intermediate-roundings=false},cse,canonicalize))" %s | FileCheck %s --check-prefix=NOSKIPROUND
 
 func.func @mmt4d_f32f32f32(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>,
     %arg2 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
@@ -14,7 +15,7 @@ func.func @mmt4d_f32f32f32(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 257 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1281 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -43,7 +44,7 @@ func.func @mmt4d_fill(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>, 
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1025 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -75,7 +76,7 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 258 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1282 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -107,7 +108,7 @@ func.func @mmt4d_f16f16f32(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 259 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1283 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -139,7 +140,7 @@ func.func @mmt4d_f16f16f16(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 260 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1284 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -154,6 +155,30 @@ func.func @mmt4d_f16f16f16(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
 //      CHECK:   return %[[MICRO_KERNEL]]
+
+//      NOSKIPROUND: func @mmt4d_f16f16f16(
+// NOSKIPROUND-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
+// NOSKIPROUND-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
+// NOSKIPROUND-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
+//  NOSKIPROUND-DAG:   %[[C0:.+]] = arith.constant 0
+//  NOSKIPROUND-DAG:   %[[C1:.+]] = arith.constant 1
+//  NOSKIPROUND-DAG:   %[[C2:.+]] = arith.constant 2
+//  NOSKIPROUND-DAG:   %[[C3:.+]] = arith.constant 3
+//  NOSKIPROUND-DAG:   %[[FLAGS:.+]] = arith.constant 260 : i32
+//  NOSKIPROUND-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  NOSKIPROUND-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
+//  NOSKIPROUND-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//  NOSKIPROUND-DAG:   %[[M0_index:.+]] = tensor.dim %[[ARG0]], %[[C2]]
+//  NOSKIPROUND-DAG:   %[[M0:.+]] = arith.index_cast %[[M0_index]] : index to i32
+//  NOSKIPROUND-DAG:   %[[N0_index:.+]] = tensor.dim %[[ARG1]], %[[C2]]
+//  NOSKIPROUND-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
+//  NOSKIPROUND-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
+//  NOSKIPROUND-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
+//      NOSKIPROUND:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+// NOSKIPROUND-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// NOSKIPROUND-SAME:       outs(%[[ARG2]] :
+// NOSKIPROUND-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
+//      NOSKIPROUND:   return %[[MICRO_KERNEL]]
 
 // -----
 
@@ -171,7 +196,7 @@ func.func @mmt4d_bf16bf16f32(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?x
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 261 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1285 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -203,7 +228,7 @@ func.func @mmt4d_bf16bf16bf16(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 262 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1286 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -95,33 +95,57 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
   vst1q_f32(out_ptr + 4 * 15, acc15);
 }
 
-void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64(
+// Shared implementation for f16f16f16 and f16f16f32.
+// In the f16f16f16 case, intermediate roundings are skipped. This function
+// should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
+void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
+    iree_uk_type_t acc_type) {
   (void)params;
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  float* IREE_UK_RESTRICT out_ptr = out_tile;
   float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
   if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = vld1q_f32(out_ptr + 4 * 0);
-    acc1 = vld1q_f32(out_ptr + 4 * 1);
-    acc2 = vld1q_f32(out_ptr + 4 * 2);
-    acc3 = vld1q_f32(out_ptr + 4 * 3);
-    acc4 = vld1q_f32(out_ptr + 4 * 4);
-    acc5 = vld1q_f32(out_ptr + 4 * 5);
-    acc6 = vld1q_f32(out_ptr + 4 * 6);
-    acc7 = vld1q_f32(out_ptr + 4 * 7);
-    acc8 = vld1q_f32(out_ptr + 4 * 8);
-    acc9 = vld1q_f32(out_ptr + 4 * 9);
-    acc10 = vld1q_f32(out_ptr + 4 * 10);
-    acc11 = vld1q_f32(out_ptr + 4 * 11);
-    acc12 = vld1q_f32(out_ptr + 4 * 12);
-    acc13 = vld1q_f32(out_ptr + 4 * 13);
-    acc14 = vld1q_f32(out_ptr + 4 * 14);
-    acc15 = vld1q_f32(out_ptr + 4 * 15);
+    if (acc_type == IREE_UK_TYPE_FLOAT_32) {
+      float* IREE_UK_RESTRICT out_ptr = out_tile;
+      acc0 = vld1q_f32(out_ptr + 4 * 0);
+      acc1 = vld1q_f32(out_ptr + 4 * 1);
+      acc2 = vld1q_f32(out_ptr + 4 * 2);
+      acc3 = vld1q_f32(out_ptr + 4 * 3);
+      acc4 = vld1q_f32(out_ptr + 4 * 4);
+      acc5 = vld1q_f32(out_ptr + 4 * 5);
+      acc6 = vld1q_f32(out_ptr + 4 * 6);
+      acc7 = vld1q_f32(out_ptr + 4 * 7);
+      acc8 = vld1q_f32(out_ptr + 4 * 8);
+      acc9 = vld1q_f32(out_ptr + 4 * 9);
+      acc10 = vld1q_f32(out_ptr + 4 * 10);
+      acc11 = vld1q_f32(out_ptr + 4 * 11);
+      acc12 = vld1q_f32(out_ptr + 4 * 12);
+      acc13 = vld1q_f32(out_ptr + 4 * 13);
+      acc14 = vld1q_f32(out_ptr + 4 * 14);
+      acc15 = vld1q_f32(out_ptr + 4 * 15);
+    } else {
+      float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
+      acc0 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 0));
+      acc1 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 1));
+      acc2 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 2));
+      acc3 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 3));
+      acc4 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 4));
+      acc5 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 5));
+      acc6 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 6));
+      acc7 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 7));
+      acc8 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 8));
+      acc9 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 9));
+      acc10 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 10));
+      acc11 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 11));
+      acc12 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 12));
+      acc13 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 13));
+      acc14 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 14));
+      acc15 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 15));
+    }
   } else {
     acc0 = vdupq_n_f32(0);
     acc1 = vdupq_n_f32(0);
@@ -165,126 +189,59 @@ void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64(
     acc14 = vfmaq_lane_f32(acc14, rhs0, vget_high_f32(lhs1), 1);
     acc15 = vfmaq_lane_f32(acc15, rhs1, vget_high_f32(lhs1), 1);
   }
-  vst1q_f32(out_ptr + 4 * 0, acc0);
-  vst1q_f32(out_ptr + 4 * 1, acc1);
-  vst1q_f32(out_ptr + 4 * 2, acc2);
-  vst1q_f32(out_ptr + 4 * 3, acc3);
-  vst1q_f32(out_ptr + 4 * 4, acc4);
-  vst1q_f32(out_ptr + 4 * 5, acc5);
-  vst1q_f32(out_ptr + 4 * 6, acc6);
-  vst1q_f32(out_ptr + 4 * 7, acc7);
-  vst1q_f32(out_ptr + 4 * 8, acc8);
-  vst1q_f32(out_ptr + 4 * 9, acc9);
-  vst1q_f32(out_ptr + 4 * 10, acc10);
-  vst1q_f32(out_ptr + 4 * 11, acc11);
-  vst1q_f32(out_ptr + 4 * 12, acc12);
-  vst1q_f32(out_ptr + 4 * 13, acc13);
-  vst1q_f32(out_ptr + 4 * 14, acc14);
-  vst1q_f32(out_ptr + 4 * 15, acc15);
+  if (acc_type == IREE_UK_TYPE_FLOAT_32) {
+    float* IREE_UK_RESTRICT out_ptr = out_tile;
+    vst1q_f32(out_ptr + 4 * 0, acc0);
+    vst1q_f32(out_ptr + 4 * 1, acc1);
+    vst1q_f32(out_ptr + 4 * 2, acc2);
+    vst1q_f32(out_ptr + 4 * 3, acc3);
+    vst1q_f32(out_ptr + 4 * 4, acc4);
+    vst1q_f32(out_ptr + 4 * 5, acc5);
+    vst1q_f32(out_ptr + 4 * 6, acc6);
+    vst1q_f32(out_ptr + 4 * 7, acc7);
+    vst1q_f32(out_ptr + 4 * 8, acc8);
+    vst1q_f32(out_ptr + 4 * 9, acc9);
+    vst1q_f32(out_ptr + 4 * 10, acc10);
+    vst1q_f32(out_ptr + 4 * 11, acc11);
+    vst1q_f32(out_ptr + 4 * 12, acc12);
+    vst1q_f32(out_ptr + 4 * 13, acc13);
+    vst1q_f32(out_ptr + 4 * 14, acc14);
+    vst1q_f32(out_ptr + 4 * 15, acc15);
+  } else {
+    float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
+    vst1_f16(out_ptr + 4 * 0, vcvt_f16_f32(acc0));
+    vst1_f16(out_ptr + 4 * 1, vcvt_f16_f32(acc1));
+    vst1_f16(out_ptr + 4 * 2, vcvt_f16_f32(acc2));
+    vst1_f16(out_ptr + 4 * 3, vcvt_f16_f32(acc3));
+    vst1_f16(out_ptr + 4 * 4, vcvt_f16_f32(acc4));
+    vst1_f16(out_ptr + 4 * 5, vcvt_f16_f32(acc5));
+    vst1_f16(out_ptr + 4 * 6, vcvt_f16_f32(acc6));
+    vst1_f16(out_ptr + 4 * 7, vcvt_f16_f32(acc7));
+    vst1_f16(out_ptr + 4 * 8, vcvt_f16_f32(acc8));
+    vst1_f16(out_ptr + 4 * 9, vcvt_f16_f32(acc9));
+    vst1_f16(out_ptr + 4 * 10, vcvt_f16_f32(acc10));
+    vst1_f16(out_ptr + 4 * 11, vcvt_f16_f32(acc11));
+    vst1_f16(out_ptr + 4 * 12, vcvt_f16_f32(acc12));
+    vst1_f16(out_ptr + 4 * 13, vcvt_f16_f32(acc13));
+    vst1_f16(out_ptr + 4 * 14, vcvt_f16_f32(acc14));
+    vst1_f16(out_ptr + 4 * 15, vcvt_f16_f32(acc15));
+  }
 }
 
 void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
     iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
-  const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
-  const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-  float16x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
-      acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = vld1_f16(out_ptr + 4 * 0);
-    acc1 = vld1_f16(out_ptr + 4 * 1);
-    acc2 = vld1_f16(out_ptr + 4 * 2);
-    acc3 = vld1_f16(out_ptr + 4 * 3);
-    acc4 = vld1_f16(out_ptr + 4 * 4);
-    acc5 = vld1_f16(out_ptr + 4 * 5);
-    acc6 = vld1_f16(out_ptr + 4 * 6);
-    acc7 = vld1_f16(out_ptr + 4 * 7);
-    acc8 = vld1_f16(out_ptr + 4 * 8);
-    acc9 = vld1_f16(out_ptr + 4 * 9);
-    acc10 = vld1_f16(out_ptr + 4 * 10);
-    acc11 = vld1_f16(out_ptr + 4 * 11);
-    acc12 = vld1_f16(out_ptr + 4 * 12);
-    acc13 = vld1_f16(out_ptr + 4 * 13);
-    acc14 = vld1_f16(out_ptr + 4 * 14);
-    acc15 = vld1_f16(out_ptr + 4 * 15);
-  } else {
-    acc0 = vdup_n_f16(0);
-    acc1 = vdup_n_f16(0);
-    acc2 = vdup_n_f16(0);
-    acc3 = vdup_n_f16(0);
-    acc4 = vdup_n_f16(0);
-    acc5 = vdup_n_f16(0);
-    acc6 = vdup_n_f16(0);
-    acc7 = vdup_n_f16(0);
-    acc8 = vdup_n_f16(0);
-    acc9 = vdup_n_f16(0);
-    acc10 = vdup_n_f16(0);
-    acc11 = vdup_n_f16(0);
-    acc12 = vdup_n_f16(0);
-    acc13 = vdup_n_f16(0);
-    acc14 = vdup_n_f16(0);
-    acc15 = vdup_n_f16(0);
-  }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
-    float32x4_t lhs0 = vcvt_f32_f16(vld1_f16(lhs_ptr + 0));
-    float32x4_t lhs1 = vcvt_f32_f16(vld1_f16(lhs_ptr + 4));
-    lhs_ptr += 8;
-    float32x4_t rhs0 = vcvt_f32_f16(vld1_f16(rhs_ptr + 0));
-    float32x4_t rhs1 = vcvt_f32_f16(vld1_f16(rhs_ptr + 4));
-    rhs_ptr += 8;
-    acc0 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc0), rhs0, vget_low_f32(lhs0), 0));
-    acc1 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc1), rhs1, vget_low_f32(lhs0), 0));
-    acc2 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc2), rhs0, vget_low_f32(lhs0), 1));
-    acc3 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc3), rhs1, vget_low_f32(lhs0), 1));
-    acc4 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc4), rhs0, vget_high_f32(lhs0), 0));
-    acc5 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc5), rhs1, vget_high_f32(lhs0), 0));
-    acc6 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc6), rhs0, vget_high_f32(lhs0), 1));
-    acc7 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc7), rhs1, vget_high_f32(lhs0), 1));
-    acc8 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc8), rhs0, vget_low_f32(lhs1), 0));
-    acc9 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc9), rhs1, vget_low_f32(lhs1), 0));
-    acc10 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc10), rhs0, vget_low_f32(lhs1), 1));
-    acc11 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc11), rhs1, vget_low_f32(lhs1), 1));
-    acc12 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc12), rhs0, vget_high_f32(lhs1), 0));
-    acc13 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc13), rhs1, vget_high_f32(lhs1), 0));
-    acc14 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc14), rhs0, vget_high_f32(lhs1), 1));
-    acc15 = vcvt_f16_f32(
-        vfmaq_lane_f32(vcvt_f32_f16(acc15), rhs1, vget_high_f32(lhs1), 1));
-  }
-  vst1_f16(out_ptr + 4 * 0, acc0);
-  vst1_f16(out_ptr + 4 * 1, acc1);
-  vst1_f16(out_ptr + 4 * 2, acc2);
-  vst1_f16(out_ptr + 4 * 3, acc3);
-  vst1_f16(out_ptr + 4 * 4, acc4);
-  vst1_f16(out_ptr + 4 * 5, acc5);
-  vst1_f16(out_ptr + 4 * 6, acc6);
-  vst1_f16(out_ptr + 4 * 7, acc7);
-  vst1_f16(out_ptr + 4 * 8, acc8);
-  vst1_f16(out_ptr + 4 * 9, acc9);
-  vst1_f16(out_ptr + 4 * 10, acc10);
-  vst1_f16(out_ptr + 4 * 11, acc11);
-  vst1_f16(out_ptr + 4 * 12, acc12);
-  vst1_f16(out_ptr + 4 * 13, acc13);
-  vst1_f16(out_ptr + 4 * 14, acc14);
-  vst1_f16(out_ptr + 4 * 15, acc15);
+  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
+      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+}
+
+void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64(
+    void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
+    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
+    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
+      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x1_arm_64(

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -98,7 +98,7 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
 // Shared implementation for f16f16f16 and f16f16f32.
 // In the f16f16f16 case, intermediate roundings are skipped. This function
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
-void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
+static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
     iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_entry_point.c
@@ -57,7 +57,8 @@ iree_uk_mmt4d_select_tile_func_arm_64_f16f16f32(
 static iree_uk_mmt4d_tile_func_t
 iree_uk_mmt4d_select_tile_func_arm_64_f16f16f16(
     const iree_uk_mmt4d_params_t* params) {
-  if (params->M0 == 8 && params->N0 == 8 && params->K0 == 1) {
+  if ((params->flags & IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS) &&
+      params->M0 == 8 && params->N0 == 8 && params->K0 == 1) {
     return iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64;
   }
   return 0;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
@@ -57,23 +57,47 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
   _mm256_storeu_ps(out_ptr + 7 * 8, acc7);
 }
 
-void iree_uk_mmt4d_tile_f16f16f32_8x8x1_x86_64_avx2_fma(
+// Shared implementation for f16f16f16 and f16f16f32.
+// In the f16f16f16 case, intermediate roundings are skipped. This function
+// should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
+static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  float* IREE_UK_RESTRICT out_ptr = out_tile;
+    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
+    iree_uk_type_t acc_type) {
   const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   __m256 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
   if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
-    acc1 = _mm256_loadu_ps(out_ptr + 1 * 8);
-    acc2 = _mm256_loadu_ps(out_ptr + 2 * 8);
-    acc3 = _mm256_loadu_ps(out_ptr + 3 * 8);
-    acc4 = _mm256_loadu_ps(out_ptr + 4 * 8);
-    acc5 = _mm256_loadu_ps(out_ptr + 5 * 8);
-    acc6 = _mm256_loadu_ps(out_ptr + 6 * 8);
-    acc7 = _mm256_loadu_ps(out_ptr + 7 * 8);
+    if (acc_type == IREE_UK_TYPE_FLOAT_32) {
+      float* IREE_UK_RESTRICT out_ptr = out_tile;
+      acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
+      acc1 = _mm256_loadu_ps(out_ptr + 1 * 8);
+      acc2 = _mm256_loadu_ps(out_ptr + 2 * 8);
+      acc3 = _mm256_loadu_ps(out_ptr + 3 * 8);
+      acc4 = _mm256_loadu_ps(out_ptr + 4 * 8);
+      acc5 = _mm256_loadu_ps(out_ptr + 5 * 8);
+      acc6 = _mm256_loadu_ps(out_ptr + 6 * 8);
+      acc7 = _mm256_loadu_ps(out_ptr + 7 * 8);
+    } else {
+      iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
+      acc0 =
+          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 0 * 8)));
+      acc1 =
+          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 1 * 8)));
+      acc2 =
+          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 2 * 8)));
+      acc3 =
+          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 3 * 8)));
+      acc4 =
+          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 4 * 8)));
+      acc5 =
+          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 5 * 8)));
+      acc6 =
+          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 6 * 8)));
+      acc7 =
+          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 7 * 8)));
+    }
   } else {
     acc0 = _mm256_setzero_ps();
     acc1 = _mm256_setzero_ps();
@@ -105,88 +129,51 @@ void iree_uk_mmt4d_tile_f16f16f32_8x8x1_x86_64_avx2_fma(
         _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[7])), rhs, acc7);
     lhs_ptr += 8;
   }
-  _mm256_storeu_ps(out_ptr + 0 * 8, acc0);
-  _mm256_storeu_ps(out_ptr + 1 * 8, acc1);
-  _mm256_storeu_ps(out_ptr + 2 * 8, acc2);
-  _mm256_storeu_ps(out_ptr + 3 * 8, acc3);
-  _mm256_storeu_ps(out_ptr + 4 * 8, acc4);
-  _mm256_storeu_ps(out_ptr + 5 * 8, acc5);
-  _mm256_storeu_ps(out_ptr + 6 * 8, acc6);
-  _mm256_storeu_ps(out_ptr + 7 * 8, acc7);
+  if (acc_type == IREE_UK_TYPE_FLOAT_32) {
+    float* IREE_UK_RESTRICT out_ptr = out_tile;
+    _mm256_storeu_ps(out_ptr + 0 * 8, acc0);
+    _mm256_storeu_ps(out_ptr + 1 * 8, acc1);
+    _mm256_storeu_ps(out_ptr + 2 * 8, acc2);
+    _mm256_storeu_ps(out_ptr + 3 * 8, acc3);
+    _mm256_storeu_ps(out_ptr + 4 * 8, acc4);
+    _mm256_storeu_ps(out_ptr + 5 * 8, acc5);
+    _mm256_storeu_ps(out_ptr + 6 * 8, acc6);
+    _mm256_storeu_ps(out_ptr + 7 * 8, acc7);
+  } else {
+    iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
+    _mm_storeu_si128((__m128i*)(out_ptr + 0 * 8),
+                     _mm256_cvtps_ph(acc0, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i*)(out_ptr + 1 * 8),
+                     _mm256_cvtps_ph(acc1, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i*)(out_ptr + 2 * 8),
+                     _mm256_cvtps_ph(acc2, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i*)(out_ptr + 3 * 8),
+                     _mm256_cvtps_ph(acc3, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i*)(out_ptr + 4 * 8),
+                     _mm256_cvtps_ph(acc4, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i*)(out_ptr + 5 * 8),
+                     _mm256_cvtps_ph(acc5, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i*)(out_ptr + 6 * 8),
+                     _mm256_cvtps_ph(acc6, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i*)(out_ptr + 7 * 8),
+                     _mm256_cvtps_ph(acc7, _MM_FROUND_TO_NEAREST_INT));
+  }
 }
 
 void iree_uk_mmt4d_tile_f16f16f16_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
     iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-  const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
-  const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  __m128i acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = _mm_loadu_si128((const __m128i*)(out_ptr + 0 * 8));
-    acc1 = _mm_loadu_si128((const __m128i*)(out_ptr + 1 * 8));
-    acc2 = _mm_loadu_si128((const __m128i*)(out_ptr + 2 * 8));
-    acc3 = _mm_loadu_si128((const __m128i*)(out_ptr + 3 * 8));
-    acc4 = _mm_loadu_si128((const __m128i*)(out_ptr + 4 * 8));
-    acc5 = _mm_loadu_si128((const __m128i*)(out_ptr + 5 * 8));
-    acc6 = _mm_loadu_si128((const __m128i*)(out_ptr + 6 * 8));
-    acc7 = _mm_loadu_si128((const __m128i*)(out_ptr + 7 * 8));
-  } else {
-    acc0 = _mm_setzero_si128();
-    acc1 = _mm_setzero_si128();
-    acc2 = _mm_setzero_si128();
-    acc3 = _mm_setzero_si128();
-    acc4 = _mm_setzero_si128();
-    acc5 = _mm_setzero_si128();
-    acc6 = _mm_setzero_si128();
-    acc7 = _mm_setzero_si128();
-  }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
-    __m256 rhs = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)rhs_ptr));
-    rhs_ptr += 8;
-    acc0 = _mm256_cvtps_ph(
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[0])), rhs,
-                        _mm256_cvtph_ps(acc0)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc1 = _mm256_cvtps_ph(
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[1])), rhs,
-                        _mm256_cvtph_ps(acc1)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc2 = _mm256_cvtps_ph(
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[2])), rhs,
-                        _mm256_cvtph_ps(acc2)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc3 = _mm256_cvtps_ph(
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[3])), rhs,
-                        _mm256_cvtph_ps(acc3)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc4 = _mm256_cvtps_ph(
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[4])), rhs,
-                        _mm256_cvtph_ps(acc4)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc5 = _mm256_cvtps_ph(
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[5])), rhs,
-                        _mm256_cvtph_ps(acc5)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc6 = _mm256_cvtps_ph(
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[6])), rhs,
-                        _mm256_cvtph_ps(acc6)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc7 = _mm256_cvtps_ph(
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[7])), rhs,
-                        _mm256_cvtph_ps(acc7)),
-        _MM_FROUND_TO_NEAREST_INT);
-    lhs_ptr += 8;
-  }
-  _mm_storeu_si128((__m128i*)(out_ptr + 0 * 8), acc0);
-  _mm_storeu_si128((__m128i*)(out_ptr + 1 * 8), acc1);
-  _mm_storeu_si128((__m128i*)(out_ptr + 2 * 8), acc2);
-  _mm_storeu_si128((__m128i*)(out_ptr + 3 * 8), acc3);
-  _mm_storeu_si128((__m128i*)(out_ptr + 4 * 8), acc4);
-  _mm_storeu_si128((__m128i*)(out_ptr + 5 * 8), acc5);
-  _mm_storeu_si128((__m128i*)(out_ptr + 6 * 8), acc6);
-  _mm_storeu_si128((__m128i*)(out_ptr + 7 * 8), acc7);
+  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
+      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+}
+
+void iree_uk_mmt4d_tile_f16f16f32_8x8x1_x86_64_avx2_fma(
+    void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
+    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
+    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
+      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -99,11 +99,14 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
   _mm512_storeu_ps(out_ptr + 15 * 16, acc15);
 }
 
-void iree_uk_mmt4d_tile_f16f16f32_16x16x1_x86_64_avx512_base(
+// Shared implementation for f16f16f16 and f16f16f32.
+// In the f16f16f16 case, intermediate roundings are skipped. This function
+// should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
+static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  float* IREE_UK_RESTRICT out_ptr = out_tile;
+    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
+    iree_uk_type_t acc_type) {
   const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   // The prefetches in this function are carried over from
@@ -113,22 +116,59 @@ void iree_uk_mmt4d_tile_f16f16f32_16x16x1_x86_64_avx512_base(
   __m512 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
   __m512 acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
   if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
-    acc1 = _mm512_loadu_ps(out_ptr + 1 * 16);
-    acc2 = _mm512_loadu_ps(out_ptr + 2 * 16);
-    acc3 = _mm512_loadu_ps(out_ptr + 3 * 16);
-    acc4 = _mm512_loadu_ps(out_ptr + 4 * 16);
-    acc5 = _mm512_loadu_ps(out_ptr + 5 * 16);
-    acc6 = _mm512_loadu_ps(out_ptr + 6 * 16);
-    acc7 = _mm512_loadu_ps(out_ptr + 7 * 16);
-    acc8 = _mm512_loadu_ps(out_ptr + 8 * 16);
-    acc9 = _mm512_loadu_ps(out_ptr + 9 * 16);
-    acc10 = _mm512_loadu_ps(out_ptr + 10 * 16);
-    acc11 = _mm512_loadu_ps(out_ptr + 11 * 16);
-    acc12 = _mm512_loadu_ps(out_ptr + 12 * 16);
-    acc13 = _mm512_loadu_ps(out_ptr + 13 * 16);
-    acc14 = _mm512_loadu_ps(out_ptr + 14 * 16);
-    acc15 = _mm512_loadu_ps(out_ptr + 15 * 16);
+    if (acc_type == IREE_UK_TYPE_FLOAT_32) {
+      float* IREE_UK_RESTRICT out_ptr = out_tile;
+      acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
+      acc1 = _mm512_loadu_ps(out_ptr + 1 * 16);
+      acc2 = _mm512_loadu_ps(out_ptr + 2 * 16);
+      acc3 = _mm512_loadu_ps(out_ptr + 3 * 16);
+      acc4 = _mm512_loadu_ps(out_ptr + 4 * 16);
+      acc5 = _mm512_loadu_ps(out_ptr + 5 * 16);
+      acc6 = _mm512_loadu_ps(out_ptr + 6 * 16);
+      acc7 = _mm512_loadu_ps(out_ptr + 7 * 16);
+      acc8 = _mm512_loadu_ps(out_ptr + 8 * 16);
+      acc9 = _mm512_loadu_ps(out_ptr + 9 * 16);
+      acc10 = _mm512_loadu_ps(out_ptr + 10 * 16);
+      acc11 = _mm512_loadu_ps(out_ptr + 11 * 16);
+      acc12 = _mm512_loadu_ps(out_ptr + 12 * 16);
+      acc13 = _mm512_loadu_ps(out_ptr + 13 * 16);
+      acc14 = _mm512_loadu_ps(out_ptr + 14 * 16);
+      acc15 = _mm512_loadu_ps(out_ptr + 15 * 16);
+    } else {
+      iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
+      acc0 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 0 * 16)));
+      acc1 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 1 * 16)));
+      acc2 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 2 * 16)));
+      acc3 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 3 * 16)));
+      acc4 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 4 * 16)));
+      acc5 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 5 * 16)));
+      acc6 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 6 * 16)));
+      acc7 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 7 * 16)));
+      acc8 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 8 * 16)));
+      acc9 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 9 * 16)));
+      acc10 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 10 * 16)));
+      acc11 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 11 * 16)));
+      acc12 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 12 * 16)));
+      acc13 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 13 * 16)));
+      acc14 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 14 * 16)));
+      acc15 = _mm512_cvtph_ps(
+          _mm256_loadu_si256((const __m256i*)(out_ptr + 15 * 16)));
+    }
   } else {
     acc0 = _mm512_setzero_ps();
     acc1 = _mm512_setzero_ps();
@@ -186,159 +226,75 @@ void iree_uk_mmt4d_tile_f16f16f32_16x16x1_x86_64_avx512_base(
     _mm_prefetch((const char*)(lhs_ptr + 128), _MM_HINT_T0);
     lhs_ptr += 16;
   }
-  _mm512_storeu_ps(out_ptr + 0 * 16, acc0);
-  _mm512_storeu_ps(out_ptr + 1 * 16, acc1);
-  _mm512_storeu_ps(out_ptr + 2 * 16, acc2);
-  _mm512_storeu_ps(out_ptr + 3 * 16, acc3);
-  _mm512_storeu_ps(out_ptr + 4 * 16, acc4);
-  _mm512_storeu_ps(out_ptr + 5 * 16, acc5);
-  _mm512_storeu_ps(out_ptr + 6 * 16, acc6);
-  _mm512_storeu_ps(out_ptr + 7 * 16, acc7);
-  _mm512_storeu_ps(out_ptr + 8 * 16, acc8);
-  _mm512_storeu_ps(out_ptr + 9 * 16, acc9);
-  _mm512_storeu_ps(out_ptr + 10 * 16, acc10);
-  _mm512_storeu_ps(out_ptr + 11 * 16, acc11);
-  _mm512_storeu_ps(out_ptr + 12 * 16, acc12);
-  _mm512_storeu_ps(out_ptr + 13 * 16, acc13);
-  _mm512_storeu_ps(out_ptr + 14 * 16, acc14);
-  _mm512_storeu_ps(out_ptr + 15 * 16, acc15);
+  if (acc_type == IREE_UK_TYPE_FLOAT_32) {
+    float* IREE_UK_RESTRICT out_ptr = out_tile;
+    _mm512_storeu_ps(out_ptr + 0 * 16, acc0);
+    _mm512_storeu_ps(out_ptr + 1 * 16, acc1);
+    _mm512_storeu_ps(out_ptr + 2 * 16, acc2);
+    _mm512_storeu_ps(out_ptr + 3 * 16, acc3);
+    _mm512_storeu_ps(out_ptr + 4 * 16, acc4);
+    _mm512_storeu_ps(out_ptr + 5 * 16, acc5);
+    _mm512_storeu_ps(out_ptr + 6 * 16, acc6);
+    _mm512_storeu_ps(out_ptr + 7 * 16, acc7);
+    _mm512_storeu_ps(out_ptr + 8 * 16, acc8);
+    _mm512_storeu_ps(out_ptr + 9 * 16, acc9);
+    _mm512_storeu_ps(out_ptr + 10 * 16, acc10);
+    _mm512_storeu_ps(out_ptr + 11 * 16, acc11);
+    _mm512_storeu_ps(out_ptr + 12 * 16, acc12);
+    _mm512_storeu_ps(out_ptr + 13 * 16, acc13);
+    _mm512_storeu_ps(out_ptr + 14 * 16, acc14);
+    _mm512_storeu_ps(out_ptr + 15 * 16, acc15);
+  } else {
+    iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
+    _mm256_storeu_si256((__m256i*)(out_ptr + 0 * 16),
+                        _mm512_cvtps_ph(acc0, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 1 * 16),
+                        _mm512_cvtps_ph(acc1, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 2 * 16),
+                        _mm512_cvtps_ph(acc2, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 3 * 16),
+                        _mm512_cvtps_ph(acc3, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 4 * 16),
+                        _mm512_cvtps_ph(acc4, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 5 * 16),
+                        _mm512_cvtps_ph(acc5, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 6 * 16),
+                        _mm512_cvtps_ph(acc6, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 7 * 16),
+                        _mm512_cvtps_ph(acc7, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 8 * 16),
+                        _mm512_cvtps_ph(acc8, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 9 * 16),
+                        _mm512_cvtps_ph(acc9, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 10 * 16),
+                        _mm512_cvtps_ph(acc10, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 11 * 16),
+                        _mm512_cvtps_ph(acc11, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 12 * 16),
+                        _mm512_cvtps_ph(acc12, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 13 * 16),
+                        _mm512_cvtps_ph(acc13, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 14 * 16),
+                        _mm512_cvtps_ph(acc14, _MM_FROUND_TO_NEAREST_INT));
+    _mm256_storeu_si256((__m256i*)(out_ptr + 15 * 16),
+                        _mm512_cvtps_ph(acc15, _MM_FROUND_TO_NEAREST_INT));
+  }
 }
 
 void iree_uk_mmt4d_tile_f16f16f16_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
     iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-  const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
-  const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  // The prefetches in this function are carried over from
-  // iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base.
-  _mm_prefetch((const char*)lhs_ptr, _MM_HINT_T0);
-  _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
-  __m256i acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  __m256i acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = _mm256_loadu_si256((const __m256i*)(out_ptr + 0 * 16));
-    acc1 = _mm256_loadu_si256((const __m256i*)(out_ptr + 1 * 16));
-    acc2 = _mm256_loadu_si256((const __m256i*)(out_ptr + 2 * 16));
-    acc3 = _mm256_loadu_si256((const __m256i*)(out_ptr + 3 * 16));
-    acc4 = _mm256_loadu_si256((const __m256i*)(out_ptr + 4 * 16));
-    acc5 = _mm256_loadu_si256((const __m256i*)(out_ptr + 5 * 16));
-    acc6 = _mm256_loadu_si256((const __m256i*)(out_ptr + 6 * 16));
-    acc7 = _mm256_loadu_si256((const __m256i*)(out_ptr + 7 * 16));
-    acc8 = _mm256_loadu_si256((const __m256i*)(out_ptr + 8 * 16));
-    acc9 = _mm256_loadu_si256((const __m256i*)(out_ptr + 9 * 16));
-    acc10 = _mm256_loadu_si256((const __m256i*)(out_ptr + 10 * 16));
-    acc11 = _mm256_loadu_si256((const __m256i*)(out_ptr + 11 * 16));
-    acc12 = _mm256_loadu_si256((const __m256i*)(out_ptr + 12 * 16));
-    acc13 = _mm256_loadu_si256((const __m256i*)(out_ptr + 13 * 16));
-    acc14 = _mm256_loadu_si256((const __m256i*)(out_ptr + 14 * 16));
-    acc15 = _mm256_loadu_si256((const __m256i*)(out_ptr + 15 * 16));
-  } else {
-    acc0 = _mm256_setzero_si256();
-    acc1 = _mm256_setzero_si256();
-    acc2 = _mm256_setzero_si256();
-    acc3 = _mm256_setzero_si256();
-    acc4 = _mm256_setzero_si256();
-    acc5 = _mm256_setzero_si256();
-    acc6 = _mm256_setzero_si256();
-    acc7 = _mm256_setzero_si256();
-    acc8 = _mm256_setzero_si256();
-    acc9 = _mm256_setzero_si256();
-    acc10 = _mm256_setzero_si256();
-    acc11 = _mm256_setzero_si256();
-    acc12 = _mm256_setzero_si256();
-    acc13 = _mm256_setzero_si256();
-    acc14 = _mm256_setzero_si256();
-    acc15 = _mm256_setzero_si256();
-  }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
-    __m512 rhs = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)rhs_ptr));
-    _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
-    rhs_ptr += 16;
-    acc0 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[0])), rhs,
-                        _mm512_cvtph_ps(acc0)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc1 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[1])), rhs,
-                        _mm512_cvtph_ps(acc1)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc2 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[2])), rhs,
-                        _mm512_cvtph_ps(acc2)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc3 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[3])), rhs,
-                        _mm512_cvtph_ps(acc3)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc4 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[4])), rhs,
-                        _mm512_cvtph_ps(acc4)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc5 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[5])), rhs,
-                        _mm512_cvtph_ps(acc5)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc6 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[6])), rhs,
-                        _mm512_cvtph_ps(acc6)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc7 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[7])), rhs,
-                        _mm512_cvtph_ps(acc7)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc8 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[8])), rhs,
-                        _mm512_cvtph_ps(acc8)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc9 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[9])), rhs,
-                        _mm512_cvtph_ps(acc9)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc10 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[10])), rhs,
-                        _mm512_cvtph_ps(acc10)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc11 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[11])), rhs,
-                        _mm512_cvtph_ps(acc11)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc12 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[12])), rhs,
-                        _mm512_cvtph_ps(acc12)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc13 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[13])), rhs,
-                        _mm512_cvtph_ps(acc13)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc14 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[14])), rhs,
-                        _mm512_cvtph_ps(acc14)),
-        _MM_FROUND_TO_NEAREST_INT);
-    acc15 = _mm512_cvtps_ph(
-        _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[15])), rhs,
-                        _mm512_cvtph_ps(acc15)),
-        _MM_FROUND_TO_NEAREST_INT);
-    _mm_prefetch((const char*)(lhs_ptr + 128), _MM_HINT_T0);
-    lhs_ptr += 16;
-  }
-  _mm256_storeu_si256((__m256i*)(out_ptr + 0 * 16), acc0);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 1 * 16), acc1);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 2 * 16), acc2);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 3 * 16), acc3);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 4 * 16), acc4);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 5 * 16), acc5);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 6 * 16), acc6);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 7 * 16), acc7);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 8 * 16), acc8);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 9 * 16), acc9);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 10 * 16), acc10);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 11 * 16), acc11);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 12 * 16), acc12);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 13 * 16), acc13);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 14 * 16), acc14);
-  _mm256_storeu_si256((__m256i*)(out_ptr + 15 * 16), acc15);
+  iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
+      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+}
+
+void iree_uk_mmt4d_tile_f16f16f32_16x16x1_x86_64_avx512_base(
+    void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
+    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
+    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
+      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_entry_point.c
@@ -44,7 +44,7 @@ static iree_uk_mmt4d_tile_func_t
 iree_uk_mmt4d_select_tile_func_x86_64_f16f16f32_16x16x1(
     const iree_uk_mmt4d_params_t* params) {
 #if defined(IREE_UK_BUILD_X86_64_AVX512_BASE)
-  if (iree_uk_cpu_supports_avx2_fma(params->cpu_data)) {
+  if (iree_uk_cpu_supports_avx512_base(params->cpu_data)) {
     return iree_uk_mmt4d_tile_f16f16f32_16x16x1_x86_64_avx512_base;
   }
 #endif
@@ -55,7 +55,8 @@ static iree_uk_mmt4d_tile_func_t
 iree_uk_mmt4d_select_tile_func_x86_64_f16f16f16_8x8x1(
     const iree_uk_mmt4d_params_t* params) {
 #if defined(IREE_UK_BUILD_X86_64_AVX2_FMA)
-  if (iree_uk_cpu_supports_avx2_fma(params->cpu_data)) {
+  if ((params->flags & IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS) &&
+      iree_uk_cpu_supports_avx2_fma(params->cpu_data)) {
     return iree_uk_mmt4d_tile_f16f16f16_8x8x1_x86_64_avx2_fma;
   }
 #endif
@@ -66,7 +67,8 @@ static iree_uk_mmt4d_tile_func_t
 iree_uk_mmt4d_select_tile_func_x86_64_f16f16f16_16x16x1(
     const iree_uk_mmt4d_params_t* params) {
 #if defined(IREE_UK_BUILD_X86_64_AVX512_BASE)
-  if (iree_uk_cpu_supports_avx2_fma(params->cpu_data)) {
+  if ((params->flags & IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS) &&
+      iree_uk_cpu_supports_avx512_base(params->cpu_data)) {
     return iree_uk_mmt4d_tile_f16f16f16_16x16x1_x86_64_avx512_base;
   }
 #endif

--- a/runtime/src/iree/builtins/ukernel/exported_bits.h
+++ b/runtime/src/iree/builtins/ukernel/exported_bits.h
@@ -55,6 +55,7 @@
 #define IREE_UK_FLAG_MMT4D_ACCUMULATE_BIT_POS 8
 IREE_UK_ENSURE_CONSISTENT_FLAG(IREE_UK_FLAG_MMT4D_ACCUMULATE);
 #define IREE_UK_FLAG_MMT4D_PREFER_INTRINSICS 0x200
+#define IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS 0x400
 
 //===----------------------------------------------------------------------===//
 // pack

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -10,9 +10,10 @@
 
 static void iree_uk_mmt4d_validate(const iree_uk_mmt4d_params_t* params) {
 #ifdef IREE_UK_ENABLE_ASSERTS
-  const iree_uk_uint32_t allflags = IREE_UK_FLAG_MMT4D_TYPE_MASK |
-                                    IREE_UK_FLAG_MMT4D_ACCUMULATE |
-                                    IREE_UK_FLAG_MMT4D_PREFER_INTRINSICS;
+  const iree_uk_uint32_t allflags =
+      IREE_UK_FLAG_MMT4D_TYPE_MASK | IREE_UK_FLAG_MMT4D_ACCUMULATE |
+      IREE_UK_FLAG_MMT4D_PREFER_INTRINSICS |
+      IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS;
   IREE_UK_ASSERT(!(params->flags & ~allflags));
   iree_uk_uint32_t flags_type = params->flags & IREE_UK_FLAG_MMT4D_TYPE_MASK;
   IREE_UK_ASSERT(flags_type == IREE_UK_FLAG_MMT4D_TYPE_F32F32F32 ||

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -95,7 +95,10 @@ static void iree_uk_benchmark_register_mmt4d_impl(
   snprintf(name, sizeof name, "mmt4d_%s_tile_%dx%dx%d%s", type_str, M0, N0, K0,
            code_path_suffix);
   iree_uk_mmt4d_params_t params = {
-      .flags = flags, .M0 = M0, .N0 = N0, .K0 = K0};
+      .flags = flags | IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS,
+      .M0 = M0,
+      .N0 = N0,
+      .K0 = K0};
   iree_uk_benchmark_register(name, iree_uk_benchmark_mmt4d, &params,
                              sizeof params, cpu_features);
 }

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c.orig
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c.orig
@@ -4,8 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <iree/builtins/ukernel/common.h>
-
 #include "iree/base/api.h"
 #include "iree/base/internal/math.h"
 #include "iree/builtins/ukernel/api.h"
@@ -43,7 +41,7 @@ static void iree_mmt4d_reference_innerloop_f16f16f32(
   *out_ptr = acc;
 }
 
-static void iree_mmt4d_reference_innerloop_f16f16f16_noskipround(
+static void iree_mmt4d_reference_innerloop_f16f16f16(
     uint16_t* out_ptr, const uint16_t* lhs_ptr, const uint16_t* rhs_ptr,
     const iree_uk_mmt4d_params_t* params) {
   uint16_t acc = params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE ? *out_ptr : 0;
@@ -58,36 +56,6 @@ static void iree_mmt4d_reference_innerloop_f16f16f16_noskipround(
     }
   }
   *out_ptr = acc;
-}
-
-static void iree_mmt4d_reference_innerloop_f16f16f16_skipround(
-    uint16_t* out_ptr, const uint16_t* lhs_ptr, const uint16_t* rhs_ptr,
-    const iree_uk_mmt4d_params_t* params) {
-  float acc_f32 = params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE
-                      ? iree_math_f16_to_f32(*out_ptr)
-                      : 0.f;
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t k0 = 0; k0 < params->K0; ++k0) {
-      float lhs_f32 =
-          iree_math_f16_to_f32(lhs_ptr[k * params->M0 * params->K0 + k0]);
-      float rhs_f32 =
-          iree_math_f16_to_f32(rhs_ptr[k * params->N0 * params->K0 + k0]);
-      acc_f32 += lhs_f32 * rhs_f32;
-    }
-  }
-  *out_ptr = iree_math_f32_to_f16(acc_f32);
-}
-
-static void iree_mmt4d_reference_innerloop_f16f16f16(
-    uint16_t* out_ptr, const uint16_t* lhs_ptr, const uint16_t* rhs_ptr,
-    const iree_uk_mmt4d_params_t* params) {
-  if (params->flags & IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS) {
-    iree_mmt4d_reference_innerloop_f16f16f16_skipround(out_ptr, lhs_ptr,
-                                                       rhs_ptr, params);
-  } else {
-    iree_mmt4d_reference_innerloop_f16f16f16_noskipround(out_ptr, lhs_ptr,
-                                                         rhs_ptr, params);
-  }
 }
 
 static void iree_mmt4d_reference_innerloop_bf16bf16f32(
@@ -243,11 +211,9 @@ static void iree_uk_test_mmt4d_for_shape_params(
   memcpy(&reference_params, &params, sizeof params);
   iree_uk_index_t out_buffer_size =
       iree_uk_2d_buffer_length(out_type, params.M, params.out_stride0);
-  void* init_out_buffer = malloc(out_buffer_size);
-  iree_uk_write_random_buffer(init_out_buffer, out_buffer_size, out_type,
-                              engine);
   void* reference_out_buffer = malloc(out_buffer_size);
-  memcpy(reference_out_buffer, init_out_buffer, out_buffer_size);
+  iree_uk_write_random_buffer(reference_out_buffer, out_buffer_size, out_type,
+                              engine);
   reference_params.out_buffer =
       (char*)reference_out_buffer -
       (params.out_offset * iree_uk_type_size(out_type));
@@ -255,7 +221,7 @@ static void iree_uk_test_mmt4d_for_shape_params(
   iree_uk_mmt4d_params_t actual_params;
   memcpy(&actual_params, &params, sizeof params);
   void* actual_out_buffer = malloc(out_buffer_size);
-  memcpy(actual_out_buffer, init_out_buffer, out_buffer_size);
+  memcpy(actual_out_buffer, reference_out_buffer, out_buffer_size);
   actual_params.out_buffer = (char*)actual_out_buffer -
                              (params.out_offset * iree_uk_type_size(out_type));
 
@@ -265,29 +231,14 @@ static void iree_uk_test_mmt4d_for_shape_params(
   // For now we use exact comparisons, even for float, even though the reference
   // code accumulates in a different order compared to the actual code. This
   // relies on picking input test matrix elements so that all intermediate
-  // values are exactly representable - i.e. small integer numerators.
-  bool fail = memcmp(actual_out_buffer, reference_out_buffer, out_buffer_size);
-  if (fail) {
-    // The one thing that causes legitimate bit differences at the moment is
-    // when we enable skipping intermediate roundings but the actual kernel does
-    // not skip intermediate roundings, such as when falling back on a generic
-    // code path. In that case, we retry with reference code not skipping
-    // intermediate roundings. This currently only happens when the output type
-    // is f16.
-    if (out_type == IREE_UK_TYPE_FLOAT_16 &&
-        (params.flags & IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS)) {
-      reference_params.flags &= ~IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS;
-      memcpy(reference_out_buffer, init_out_buffer, out_buffer_size);
-      iree_mmt4d_reference(&reference_params);
-      fail = memcmp(actual_out_buffer, reference_out_buffer, out_buffer_size);
-    }
-  }
-
-  if (fail) {
+  // values are exactly representable - i.e. small integer numerators. This
+  // become problematic when we do float16. See the comment at the top of this
+  // file explaining how we refrain from letting this grow into a 1000-line-long
+  // fully-featured test.
+  if (memcmp(actual_out_buffer, reference_out_buffer, out_buffer_size)) {
     IREE_UK_TEST_FAIL(test);
   }
 
-  free(init_out_buffer);
   free(reference_out_buffer);
   free(actual_out_buffer);
   free(lhs_buffer);
@@ -364,14 +315,6 @@ static void iree_uk_test_mmt4d_default_and_intrinsics(
 #endif  // defined(IREE_UK_HAVE_BOTH_INLINE_ASM_AND_INTRINSICS)
 }
 
-static void iree_uk_test_mmt4d_default_and_skip_intermediate_roundings(
-    iree_uk_uint32_t flags, int M0, int N0, int K0, const char* cpu_features) {
-  iree_uk_test_mmt4d_impl(flags, M0, N0, K0, cpu_features, "");
-  iree_uk_test_mmt4d_impl(
-      flags | IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS, M0, N0, K0,
-      cpu_features, " skipround");
-}
-
 int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place
   // to test weird M0, N0, K0 to ensure e.g. that we haven't unwittingly baked
@@ -388,8 +331,7 @@ int main(int argc, char** argv) {
   // we use iree_uk_test_mmt4d_default_and_intrinsics to test both.
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F32F32F32, 8, 8, 1, "");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F16F16F32, 8, 8, 1, "");
-  iree_uk_test_mmt4d_default_and_skip_intermediate_roundings(
-      IREE_UK_FLAG_MMT4D_TYPE_F16F16F16, 8, 8, 1, "");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F16F16F16, 8, 8, 1, "");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 1, "");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 4, "dotprod");
   iree_uk_test_mmt4d_default_and_intrinsics(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8,
@@ -402,10 +344,9 @@ int main(int argc, char** argv) {
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F16F16F32, 8, 8, 1, "avx2_fma");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F16F16F32, 16, 16, 1,
                      "avx512_base");
-  iree_uk_test_mmt4d_default_and_skip_intermediate_roundings(
-      IREE_UK_FLAG_MMT4D_TYPE_F16F16F16, 8, 8, 1, "avx2_fma");
-  iree_uk_test_mmt4d_default_and_skip_intermediate_roundings(
-      IREE_UK_FLAG_MMT4D_TYPE_F16F16F16, 16, 16, 1, "avx512_base");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F16F16F16, 8, 8, 1, "avx2_fma");
+  iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_F16F16F16, 16, 16, 1,
+                     "avx512_base");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 4, 2, "");  // SSE2
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 8, 8, 2, "avx2_fma");
   iree_uk_test_mmt4d(IREE_UK_FLAG_MMT4D_TYPE_I8I8I32, 16, 16, 2, "avx512_base");


### PR DESCRIPTION
This allows skipping intermediate roundings in any part of LLVMCPU codegen, though currently only used in ukernel lowerings; currently used in `f16` ukernels that internally do `f32` arithmetic for lack of native `f16` arithmetic support on the target. In such kernels, having to round internal `f32` values to the nearest `f16` value every time is a 2x performance loss, and is only useful for the purpose of bit-exact matching native `f16` arithmetic.

This adds a corresponding ukernel flag. We don't want to carry two flavors of `f16` ukernel code if users are only going to be using the faster and default skip-rounding code path. So this switches the `f16` kernels to skip-rounding. When the flag is not set, we simply fall back to slow generic code (only happens when the user explicitly passed `--iree-llvmcpu-skip-intermediate-roundings=false`).

Performance impact on `f16f16f16` mmt4d_benchmark - numbers in GFlop/s, higher is better. Single thread.

Machine   | AMD Zen2, AVX2 | Skylake, AVX-512 | Arm Cortex-A510 | Arm Cortex-X2
--- | --- | --- | --- | ---
Before | 15.2 | 27.6 | 4.18 | 10.0
After | 32.5 | 53.1 | 9.5 | 46.6
