### PR TITLE
[IREEInput] Add !iree_input.byte_buffer and byte buffer constants

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -408,6 +408,9 @@ IREETypeConverter::IREETypeConverter() {
   addConversion([=](IREE::Input::BufferViewType t) {
     return IREE::HAL::BufferViewType::get(t.getContext());
   });
+  addConversion([=](IREE::Input::BytesType t) {
+    return IREE::Util::BufferType::get(t.getContext());
+  });
   addConversion([=](IREE::Input::ListType t) -> IREE::Util::ListType {
     auto subType = convertType(t.getElementType());
     if (!subType)
@@ -488,6 +491,7 @@ void IREEImportPublicPass::runOnOperation() {
   ONE_TO_ONE(IREE::Input::BufferViewCreateOp, IREE::HAL::BufferViewCreateOp);
   ONE_TO_ONE(IREE::Input::BufferViewRankOp, IREE::HAL::BufferViewRankOp);
   ONE_TO_ONE(IREE::Input::BufferViewDimOp, IREE::HAL::BufferViewDimOp);
+  ONE_TO_ONE(IREE::Input::BytesConstantOp, IREE::Util::BufferConstantOp);
   ONE_TO_ONE(IREE::Input::ListCreateOp, IREE::Util::ListCreateOp);
   ONE_TO_ONE(IREE::Input::ListSizeOp, IREE::Util::ListSizeOp);
   ONE_TO_ONE(IREE::Input::ListResizeOp, IREE::Util::ListResizeOp);

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -408,7 +408,7 @@ IREETypeConverter::IREETypeConverter() {
   addConversion([=](IREE::Input::BufferViewType t) {
     return IREE::HAL::BufferViewType::get(t.getContext());
   });
-  addConversion([=](IREE::Input::BytesType t) {
+  addConversion([=](IREE::Input::ByteBufferType t) {
     return IREE::Util::BufferType::get(t.getContext());
   });
   addConversion([=](IREE::Input::ListType t) -> IREE::Util::ListType {
@@ -491,7 +491,7 @@ void IREEImportPublicPass::runOnOperation() {
   ONE_TO_ONE(IREE::Input::BufferViewCreateOp, IREE::HAL::BufferViewCreateOp);
   ONE_TO_ONE(IREE::Input::BufferViewRankOp, IREE::HAL::BufferViewRankOp);
   ONE_TO_ONE(IREE::Input::BufferViewDimOp, IREE::HAL::BufferViewDimOp);
-  ONE_TO_ONE(IREE::Input::BytesConstantOp, IREE::Util::BufferConstantOp);
+  ONE_TO_ONE(IREE::Input::ByteBufferConstantOp, IREE::Util::BufferConstantOp);
   ONE_TO_ONE(IREE::Input::ListCreateOp, IREE::Util::ListCreateOp);
   ONE_TO_ONE(IREE::Input::ListSizeOp, IREE::Util::ListSizeOp);
   ONE_TO_ONE(IREE::Input::ListResizeOp, IREE::Util::ListResizeOp);

--- a/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
@@ -146,12 +146,12 @@ func.func @buffer_view_rank(%arg0 : !iree_input.buffer_view) -> index {
 }
 
 // -----
-// CHECK-LABEL: func.func @bytes_constant
+// CHECK-LABEL: func.func @byte_buffer_constant
 // CHECK: %[[B:.*]] = util.buffer.constant "name" {alignment = 64 : index, mime_type = "text/plain"} : !util.buffer = "foo"
 // CHECK: return %[[B]] : !util.buffer
-func.func @bytes_constant() -> !iree_input.bytes {
-  %0 = iree_input.bytes.constant "name" {alignment = 64 : index, mime_type = "text/plain"} : !iree_input.bytes = "foo"
-  return %0 : !iree_input.bytes
+func.func @byte_buffer_constant() -> !iree_input.byte_buffer {
+  %0 = iree_input.byte_buffer.constant "name" {alignment = 64 : index, mime_type = "text/plain"} : !iree_input.byte_buffer = "foo"
+  return %0 : !iree_input.byte_buffer
 }
 
 // -----

--- a/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
@@ -146,6 +146,15 @@ func.func @buffer_view_rank(%arg0 : !iree_input.buffer_view) -> index {
 }
 
 // -----
+// CHECK-LABEL: func.func @bytes_constant
+// CHECK: %[[B:.*]] = util.buffer.constant "name" {alignment = 64 : index, mime_type = "text/plain"} : !util.buffer = "foo"
+// CHECK: return %[[B]] : !util.buffer
+func.func @bytes_constant() -> !iree_input.bytes {
+  %0 = iree_input.bytes.constant "name" {alignment = 64 : index, mime_type = "text/plain"} : !iree_input.bytes = "foo"
+  return %0 : !iree_input.bytes
+}
+
+// -----
 // CHECK-LABEL: func.func @buffer_view_dim
 // CHECK: hal.buffer_view.dim<%arg0 : !hal.buffer_view>[0] : index
 func.func @buffer_view_dim(%arg0 : !iree_input.buffer_view) -> index {

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.td
@@ -58,8 +58,8 @@ def IREEInput_VariantType : IREEInput_Type<"Variant"> {
   }];
 }
 
-def IREEInput_BytesType : IREEInput_Type<"Bytes"> {
-  let mnemonic = "bytes";
+def IREEInput_ByteBufferType : IREEInput_Type<"ByteBuffer"> {
+  let mnemonic = "byte_buffer";
 
   let summary = [{a reference counted byte buffer}];
   let description = [{

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.td
@@ -58,6 +58,21 @@ def IREEInput_VariantType : IREEInput_Type<"Variant"> {
   }];
 }
 
+def IREEInput_BytesType : IREEInput_Type<"Bytes"> {
+  let mnemonic = "bytes";
+
+  let summary = [{a reference counted byte buffer}];
+  let description = [{
+    A reference counted byte buffer that models a pointer, offset, and length.
+  }];
+
+  let builders = [
+    TypeBuilder<(ins), [{
+      return $_get($_ctxt);
+    }]>
+  ];
+}
+
 def IREEInput_ListType : IREEInput_Type<"List"> {
   let mnemonic = "list";
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -10,6 +10,7 @@
 include "iree-dialects/Dialect/Input/InputDialect.td"
 include "iree-dialects/Dialect/Input/InputInterfaces.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -307,6 +308,46 @@ def IREEInput_BufferViewDimOp : IREEInput_PureOp<"buffer_view.dim"> {
 }
 
 } // OpGroupBufferAndBufferViewOps
+
+//===----------------------------------------------------------------------===//
+// Byte buffers
+//===----------------------------------------------------------------------===//
+
+def OpGroupBytesOps : OpDocGroup {
+  let summary = "Bytes ops";
+  let description = "";
+}
+
+let opDocGroup = OpGroupBytesOps in {
+
+def IREEInput_BytesConstantOp : IREEInput_PureOp<"bytes.constant", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
+  let summary = [{constant host-side byte buffer}];
+  let description = [{
+    Defines a compile-time byte buffer based on the given attribute value.
+    The attribute will be serialized into the canonical IREE format for the
+    chosen host target.
+  }];
+
+  let arguments = (ins
+    OptionalAttr<StrAttr>:$name,
+    StrAttr:$value,
+    OptionalAttr<IndexAttr>:$alignment,
+    OptionalAttr<StrAttr>:$mime_type
+  );
+  let results = (outs
+    IREEInput_BytesType:$result
+  );
+
+  let assemblyFormat = [{
+    ($name^)? attr-dict `:` type($result) `=` $value
+  }];
+
+  let hasVerifier = 1;
+}
+
+} // OpGroupBytesOps
 
 //===----------------------------------------------------------------------===//
 // Mutable Lists

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -313,14 +313,14 @@ def IREEInput_BufferViewDimOp : IREEInput_PureOp<"buffer_view.dim"> {
 // Byte buffers
 //===----------------------------------------------------------------------===//
 
-def OpGroupBytesOps : OpDocGroup {
-  let summary = "Bytes ops";
+def OpGroupByteBufferOps : OpDocGroup {
+  let summary = "Byte buffer ops";
   let description = "";
 }
 
-let opDocGroup = OpGroupBytesOps in {
+let opDocGroup = OpGroupByteBufferOps in {
 
-def IREEInput_BytesConstantOp : IREEInput_PureOp<"bytes.constant", [
+def IREEInput_ByteBufferConstantOp : IREEInput_PureOp<"byte_buffer.constant", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
   let summary = [{constant host-side byte buffer}];
@@ -337,7 +337,7 @@ def IREEInput_BytesConstantOp : IREEInput_PureOp<"bytes.constant", [
     OptionalAttr<StrAttr>:$mime_type
   );
   let results = (outs
-    IREEInput_BytesType:$result
+    IREEInput_ByteBufferType:$result
   );
 
   let assemblyFormat = [{
@@ -347,7 +347,7 @@ def IREEInput_BytesConstantOp : IREEInput_PureOp<"bytes.constant", [
   let hasVerifier = 1;
 }
 
-} // OpGroupBytesOps
+} // OpGroupByteBufferOps
 
 //===----------------------------------------------------------------------===//
 // Mutable Lists

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -621,6 +621,25 @@ LogicalResult GlobalStoreIndirectOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// !iree_input.bytes
+//===----------------------------------------------------------------------===//
+
+void BytesConstantOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(getResult(), getName().value_or("bytes_cst"));
+}
+
+LogicalResult BytesConstantOp::verify() {
+  if (auto minAlignmentAttr = getAlignmentAttr()) {
+    int64_t minAlignment = minAlignmentAttr.getInt();
+    if (minAlignment > 0 && !llvm::isPowerOf2_64(minAlignment)) {
+      return emitOpError("invalid alignment; must be a power of two");
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // iree_input.buffer_view.create
 //===----------------------------------------------------------------------===//
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -621,15 +621,15 @@ LogicalResult GlobalStoreIndirectOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// !iree_input.bytes
+// !iree_input.byte_vuffer
 //===----------------------------------------------------------------------===//
 
-void BytesConstantOp::getAsmResultNames(
+void ByteBufferConstantOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   setNameFn(getResult(), getName().value_or("bytes_cst"));
 }
 
-LogicalResult BytesConstantOp::verify() {
+LogicalResult ByteBufferConstantOp::verify() {
   if (auto minAlignmentAttr = getAlignmentAttr()) {
     int64_t minAlignment = minAlignmentAttr.getInt();
     if (minAlignment > 0 && !llvm::isPowerOf2_64(minAlignment)) {


### PR DESCRIPTION
`!iree_input.byte_buffer` is a host side byte buffer that is lowered to `!util.buffer` type