### PR TITLE
[API][Flow] Add option for custom dispatch formation pipelines

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -10,6 +10,7 @@
 #include <functional>
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/PluginAPI/Client.h"
 #include "llvm/ADT/StringMap.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
@@ -33,6 +34,10 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
   // Enables passes to perform numeric precision reduction.
   bool numericPrecisionReduction = false;
 
+  // Textual representation of a custom pass pipeline to run before dispatch
+  // formation.
+  std::string customFusionPassPipeline = "";
+
   // Hook to populate a constant evaluation pass pipeline. If nullptr, then
   // no passes are added for constant evaluation. This must be injected in
   // because constant-evaluators can depend on the whole compiler, of which
@@ -51,8 +56,9 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
 //     - Directly passing supported flow plus core ops
 //   buildFlowTransformPassPipeline
 //   <run conversion from flow to sequencer/hal/vm/etc>
-void buildFlowTransformPassPipeline(OpPassManager &passManager,
-                                    const TransformOptions &transformOptions);
+void buildFlowTransformPassPipeline(
+    OpPassManager &passManager, const TransformOptions &transformOptions,
+    PipelineExtensions *pipelineExtensions = nullptr);
 
 void registerFlowTransformPassPipeline();
 

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -122,6 +122,11 @@ void HighLevelOptimizationOptions::bindOptions(OptionsBinder &binder) {
                    llvm::cl::desc("Strips debug assertions after any useful "
                                   "information has been extracted."),
                    llvm::cl::cat(category));
+  binder.opt<std::string>(
+      "iree-flow-custom-fusion-pass-pipeline", customFusionPassPipeline,
+      llvm::cl::desc("Textual description of the pass pipeline to run before "
+                     "running normal IREE dispatch formation"),
+      llvm::cl::cat(category));
 }
 
 void SchedulingOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -89,6 +89,10 @@ struct HighLevelOptimizationOptions {
   // Strips debug assertions after any useful information has been extracted.
   bool stripAssertions = false;
 
+  // Specifies a set of passes to run immediately before dispatch formation
+  // intended for forming custom fusions.
+  std::string customFusionPassPipeline;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<HighLevelOptimizationOptions>;
 };

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -151,6 +151,8 @@ void buildIREEVMTransformPassPipeline(
       highLevelOptimizationOptions.constExprHoisting;
   flowOptions.numericPrecisionReduction =
       highLevelOptimizationOptions.numericPrecisionReduction;
+  flowOptions.customFusionPassPipeline =
+      highLevelOptimizationOptions.customFusionPassPipeline;
 
   // Enable const-eval via hook. For debug builds, we assert if enabled
   // without a hook. For release, we just silently skip enabling const-eval.
@@ -193,7 +195,8 @@ void buildIREEVMTransformPassPipeline(
 
     if (compileFrom < IREEVMPipelinePhase::Flow) { // late-entry
       IREE_TRACE_ADD_BEGIN_FRAME_PASS(passManager, "Flow");
-      IREE::Flow::buildFlowTransformPassPipeline(passManager, flowOptions);
+      IREE::Flow::buildFlowTransformPassPipeline(passManager, flowOptions,
+                                                 hooks.pipelineExtensions);
       IREE_TRACE_ADD_END_FRAME_PASS(passManager, "Flow");
     }
     if (compileTo == IREEVMPipelinePhase::Flow)

--- a/compiler/src/iree/compiler/PluginAPI/Client.h
+++ b/compiler/src/iree/compiler/PluginAPI/Client.h
@@ -69,6 +69,9 @@ public:
 
   // Adds passes to the |buildPreprocessingPassPipeline| pipeline at the end.
   virtual void extendPreprocessingPassPipeline(OpPassManager &passManager) {}
+
+  // Adds passes to the |buildCustomFusionPassPipeline| pipeline at the end.
+  virtual void extendCustomFusionPassPipeline(OpPassManager &passManager) {}
 };
 
 // Policy for how to activate the plugin.

--- a/compiler/src/iree/compiler/PluginAPI/PluginManager.h
+++ b/compiler/src/iree/compiler/PluginAPI/PluginManager.h
@@ -126,6 +126,12 @@ public:
     }
   }
 
+  void extendCustomFusionPassPipeline(OpPassManager &passManager) override {
+    for (auto *s : initializedSessions) {
+      s->extendCustomFusionPassPipeline(passManager);
+    }
+  }
+
   // Populates the given list of HAL target backends for all initialized
   // plugins.
   void populateHALTargetBackends(IREE::HAL::TargetBackendList &list);

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -6,55 +6,11 @@
 #include "iree/compiler/Preprocessing/Passes.h"
 
 #include "iree/compiler/Preprocessing/Common/Passes.h"
-#include "llvm/Support/Debug.h"
-#include "mlir/Pass/PassRegistry.h"
-
-#define DEBUG_TYPE "iree-preprocessing-pass-pipeline"
+#include "iree/compiler/Utils/PassUtils.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
-
-namespace {
-
-void extendWithTextPipeline(OpPassManager &passManager,
-                            StringRef textPipeline) {
-  StringRef orig = textPipeline;
-  // Strip the `builtin.module(...)` that surrounds the pass pipeline
-  // description. On failure an assertion is triggered, but in release builds
-  // it just will silently return and not raise an error. There is no
-  // way to handle the error in caller currently.
-  size_t pos = textPipeline.find_first_of("(");
-  if (pos == StringRef::npos) {
-    llvm::errs() << "ERROR: expected preprocessing pass pipeline string to be "
-                    "nested within `builtin.module(..)`; got `"
-                 << orig << "`\n";
-    return;
-  }
-  if (textPipeline.substr(0, pos) != "builtin.module") {
-    llvm::errs() << "ERROR: expected preprocessing pass pipeline string to be "
-                    "nested within `builtin.module(..)`; got `"
-                 << orig << "`\n";
-    return;
-  }
-  if (textPipeline.back() != ')') {
-    llvm::errs() << "ERROR: mismatched parenthesis in pass pipeline `" << orig
-                 << "`\n";
-    return;
-  }
-  textPipeline = textPipeline.substr(pos + 1);
-  if (failed(parsePassPipeline(textPipeline.drop_back(), passManager))) {
-    llvm::errs() << "ERROR: mismatched parenthesis in pass pipeline `" << orig
-                 << "`\n";
-    return;
-  }
-  LLVM_DEBUG({
-    llvm::dbgs() << "Preprocessing pass pipeline : ";
-    passManager.printAsTextualPipeline(llvm::dbgs());
-  });
-}
-
-} // namespace
 
 void buildPreprocessingPassPipeline(
     OpPassManager &passManager,
@@ -63,7 +19,8 @@ void buildPreprocessingPassPipeline(
   auto pipelineStr = preprocessingOptions.preprocessingPassPipeline;
   if (!preprocessingOptions.preprocessingPassPipeline.empty()) {
     extendWithTextPipeline(passManager,
-                           preprocessingOptions.preprocessingPassPipeline);
+                           preprocessingOptions.preprocessingPassPipeline,
+                           "preprocessing");
   }
 
   if (pipelineExtensions) {

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Utils/PassUtils.h"
 
 #include "llvm/Support/Debug.h"
+#include "mlir/Pass/PassRegistry.h"
 
 #define DEBUG_TYPE "iree-utils"
 
@@ -23,6 +24,47 @@ void signalFixedPointModified(Operation *rootOp) {
 
   LLVM_DEBUG(llvm::dbgs() << "Signalling fixed-point iterator modification");
   rootOp->setAttr("iree.fixedpoint.modified", UnitAttr::get(context));
+}
+
+// Extends the pass manager with the given textual pipeline, following standard
+// MLIR `--pass-pipeline` syntax.
+void extendWithTextPipeline(OpPassManager &passManager, StringRef textPipeline,
+                            StringRef pipelineDebugType) {
+  StringRef orig = textPipeline;
+  // Strip the `builtin.module(...)` that surrounds the pass pipeline
+  // description. On failure an assertion is triggered, but in release builds
+  // it just will silently return and not raise an error. There is no
+  // way to handle the error in caller currently.
+  size_t pos = textPipeline.find_first_of("(");
+  if (pos == StringRef::npos) {
+    llvm::errs() << "ERROR: expected " << pipelineDebugType
+                 << " pass pipeline string to be "
+                    "nested within `builtin.module(..)`; got `"
+                 << orig << "`\n";
+    return;
+  }
+  if (textPipeline.substr(0, pos) != "builtin.module") {
+    llvm::errs() << "ERROR: expected " << pipelineDebugType
+                 << " pass pipeline string to be "
+                    "nested within `builtin.module(..)`; got `"
+                 << orig << "`\n";
+    return;
+  }
+  if (textPipeline.back() != ')') {
+    llvm::errs() << "ERROR: mismatched parenthesis in pass pipeline `" << orig
+                 << "`\n";
+    return;
+  }
+  textPipeline = textPipeline.substr(pos + 1);
+  if (failed(parsePassPipeline(textPipeline.drop_back(), passManager))) {
+    llvm::errs() << "ERROR: mismatched parenthesis in pass pipeline `" << orig
+                 << "`\n";
+    return;
+  }
+  LLVM_DEBUG({
+    llvm::dbgs() << pipelineDebugType << " pass pipeline : ";
+    passManager.printAsTextualPipeline(llvm::dbgs());
+  });
 }
 
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -83,6 +83,11 @@ private:
 // has been made which requires another iteration. No-op otherwise.
 void signalFixedPointModified(Operation *rootOp);
 
+// Extends the pass manager with the given textual pipeline, following standard
+// MLIR `--pass-pipeline` syntax.
+void extendWithTextPipeline(OpPassManager &passManager, StringRef textPipeline,
+                            StringRef pipelineDebugType);
+
 } // namespace iree_compiler
 } // namespace mlir
 

--- a/samples/compiler_plugins/simple_io_sample/src/PluginRegistration.cpp
+++ b/samples/compiler_plugins/simple_io_sample/src/PluginRegistration.cpp
@@ -42,6 +42,10 @@ struct MySession : public PluginSession<MySession, MyOptions> {
   void extendPreprocessingPassPipeline(OpPassManager &pm) override {
     pm.addPass(IREE::SimpleIO::createLegalizeSimpleIOPass());
   }
+
+  void extendCustomFusionPassPipeline(OpPassManager &pm) override {
+    pm.addPass(IREE::SimpleIO::createLegalizeSimpleIOPass());
+  }
 };
 
 }  // namespace

--- a/tests/compiler_driver/BUILD.bazel
+++ b/tests/compiler_driver/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "custom_fusion_flags.mlir",
             "executable_benchmarks.mlir",
             "hal_executable.mlir",
             "inline_dynamic_hal_executable.mlir",

--- a/tests/compiler_driver/CMakeLists.txt
+++ b/tests/compiler_driver/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "custom_fusion_flags.mlir"
     "executable_benchmarks.mlir"
     "hal_executable.mlir"
     "inline_dynamic_hal_executable.mlir"

--- a/tests/compiler_driver/custom_fusion_flags.mlir
+++ b/tests/compiler_driver/custom_fusion_flags.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-to=flow \
+// RUN:   --iree-flow-custom-fusion-pass-pipeline="builtin.module(func.func(linalg-generalize-named-ops))" \
+// RUN:   --mlir-print-ir-after=linalg-generalize-named-ops %s 2>&1 \
+// RUN:   | FileCheck %s
+
+func.func @test(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>, %arg2 : tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<10x10xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<10x10xf32>) -> tensor<10x10xf32>
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<10x10xf32>, tensor<10x10xf32>)
+      outs(%fill : tensor<10x10xf32>) -> tensor<10x10xf32>
+  %empty_2 = tensor.empty() : tensor<10x10xf32>
+  %fill_2 = linalg.fill ins(%cst : f32) outs(%empty_2 : tensor<10x10xf32>) -> tensor<10x10xf32>
+  %1 = linalg.matmul ins(%0, %arg2 : tensor<10x10xf32>, tensor<10x10xf32>)
+      outs(%fill_2 : tensor<10x10xf32>) -> tensor<10x10xf32>
+  return %1 : tensor<10x10xf32>
+}
+// Just check that the pass runs, and that the compilation finishes
+//       CHECK: LinalgGeneralization (linalg-generalize-named-ops)
+// CHECK-LABEL: module
+// CHECK-NOT:   linalg.matmul
+// CHECK:       linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>]
+// CHECK-NOT:   linalg.matmul


### PR DESCRIPTION
Similar to `--iree-preprocessing-pass-pipeline`, this adds `--iree-flow-custom-fusion-pass-pipeline` that runs at the beginning of dispatch formation to allow plugging in custom fusion logic.

This also adds a hook to plugin a custom pass pipeline in the same location, matching preprocessing.