### PR TITLE
Add canonicalizer that reorders unary elementwise ops and shape manipulation ops.

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1073,15 +1073,15 @@ struct ReorderElementwiseAndShapeOp final
 
     Value input = definingOp->getOperand(0);
     Value result = op->getResult(0);
-    if (getElementTypeOrSelf(input) != getElementTypeOrSelf(result)) {
-      return rewriter.notifyMatchFailure(
-          op, "input and result element types must be the same.");
-    }
+    auto intermediateType =
+        cast<ShapedType>(input.getType())
+            .clone(cast<ShapedType>(result.getType()).getElementType());
 
     // Reorder the operation and rewire the inputs/outputs.
     op->moveBefore(definingOp);
+    definingOp->getResult(0).setType(result.getType());
     rewriter.replaceAllUsesWith(result, definingOp->getResult(0));
-    result.setType(input.getType());
+    result.setType(intermediateType);
     op->setOperands(input);
     definingOp->setOperands(result);
     return success();

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1066,7 +1066,8 @@ struct ReorderElementwiseAndShapeOp final : OpRewritePattern<ElementwiseOpT> {
     }
 
     Value input = definingOp->getOperand(0);
-    if (getElementTypeOrSelf(op.getOperand()) != getElementTypeOrSelf(op.getResult())) {
+    if (getElementTypeOrSelf(op.getOperand()) !=
+        getElementTypeOrSelf(op.getResult())) {
       return failure();
     }
 
@@ -1126,7 +1127,6 @@ void populateCanonicalizationPatterns(MLIRContext *context,
       ->add<ReorderElementwiseAndShapeOp<mlir::stablehlo::AbsOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::CeilOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::CbrtOp>,
-            ReorderElementwiseAndShapeOp<mlir::stablehlo::ConvertOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::ClzOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::CosineOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::ExpOp>,
@@ -1139,7 +1139,6 @@ void populateCanonicalizationPatterns(MLIRContext *context,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::LogisticOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::NotOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::NegOp>,
-            ReorderElementwiseAndShapeOp<mlir::stablehlo::PopulationCountOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::RealOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::RoundOp>,
             ReorderElementwiseAndShapeOp<mlir::stablehlo::RoundNearestEvenOp>,

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1066,6 +1066,10 @@ struct ReorderElementwiseAndShapeOp final : OpRewritePattern<ElementwiseOpT> {
     }
 
     Value input = definingOp->getOperand(0);
+    if (getElementTypeOrSelf(op.getOperand()) != getElementTypeOrSelf(op.getResult())) {
+      return failure();
+    }
+
     Value newEwiseVal =
         rewriter.create<ElementwiseOpT>(loc, input.getType(), input)
             .getResult();

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1056,19 +1056,22 @@ struct ReorderElementwiseAndShapeOp final : OpRewritePattern<ElementwiseOpT> {
     Location loc = op.getLoc();
     auto definingOp = op.getOperand().getDefiningOp();
     if (!definingOp) {
-      return failure();
+      return rewriter.notifyMatchFailure(
+          op, "expected to have an op before elementise op.");
     }
 
     if (!isa<mlir::stablehlo::ReshapeOp>(definingOp) &&
         !isa<mlir::stablehlo::TransposeOp>(definingOp) &&
         !isa<mlir::stablehlo::BroadcastOp>(definingOp)) {
-      return failure();
+      return rewriter.notifyMatchFailure(
+          op, "defining operation of unexpected type.");
     }
 
     Value input = definingOp->getOperand(0);
     if (getElementTypeOrSelf(op.getOperand()) !=
         getElementTypeOrSelf(op.getResult())) {
-      return failure();
+      return rewriter.notifyMatchFailure(
+          op, "input and result element types must be the same.");
     }
 
     Value newEwiseVal =

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1073,9 +1073,8 @@ struct ReorderElementwiseAndShapeOp final
 
     Value input = definingOp->getOperand(0);
     Value result = op->getResult(0);
-    auto intermediateType =
-        cast<ShapedType>(input.getType())
-            .clone(cast<ShapedType>(result.getType()).getElementType());
+    auto intermediateType = cast<ShapedType>(input.getType())
+                                .clone(getElementTypeOrSelf(result.getType()));
 
     // Reorder the operation and rewire the inputs/outputs.
     op->moveBefore(definingOp);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
@@ -703,3 +703,23 @@ func.func public @while_zero_extent(%arg0: tensor<i32>, %arg1: tensor<3xf32>, %a
   }
   return %3#0, %3#1 : tensor<i32>, tensor<75x0xf32>
 }
+
+// -----
+
+func.func @push_shape_ops_to_end(%arg0 : tensor<12xf32>) -> tensor<3x4x2x1xf32> {
+  %0 = stablehlo.reshape %arg0 : (tensor<12xf32>) -> tensor<3x4xf32>
+  %1 = stablehlo.broadcast %0, sizes = [1, 2] : (tensor<3x4xf32>) -> tensor<1x2x3x4xf32>
+  %2 = stablehlo.cosine %1 : (tensor<1x2x3x4xf32>) -> tensor<1x2x3x4xf32>
+  %3 = stablehlo.transpose %2, dims = [2, 3, 1, 0]  : (tensor<1x2x3x4xf32>) -> tensor<3x4x2x1xf32>
+  %4 = stablehlo.abs %3 : (tensor<3x4x2x1xf32>) -> tensor<3x4x2x1xf32>
+  return %4 : tensor<3x4x2x1xf32>
+}
+
+// CHECK-LABEL: @push_shape_ops_to_end
+// CHECK: %[[COS:.+]] = stablehlo.cosine %arg0 : tensor<12xf32>
+// CHECK: %[[ABS:.+]] = stablehlo.abs %[[COS]] : tensor<12xf32>
+// CHECK: %[[RESHAPE:.+]] = stablehlo.reshape %[[ABS]] : (tensor<12xf32>) -> tensor<3x4xf32>
+// CHECK: %[[BROADCAST:.+]] = stablehlo.broadcast %[[RESHAPE]], sizes = [1, 2] : (tensor<3x4xf32>) -> tensor<1x2x3x4xf32>
+// CHECK: %[[TRANSPOSE:.+]] = stablehlo.transpose %[[BROADCAST]], dims = [2, 3, 1, 0] : (tensor<1x2x3x4xf32>) -> tensor<3x4x2x1xf32>
+// CHECK: return %[[TRANSPOSE]]
+

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
@@ -725,14 +725,14 @@ func.func @push_shape_ops_to_end(%arg0 : tensor<12xf32>) -> tensor<3x4x2x1xf32> 
 
 // -----
 
-func.func @no_reorder_on_etype_change(%arg0 : tensor<12xi32>) -> tensor<12xi64> {
-  %0 = stablehlo.convert %arg0 : (tensor<12xi32>) -> tensor<12xi64>
-  %1 = stablehlo.abs %0 : (tensor<12xi64>) -> tensor<12xi64>
+func.func @reorder_with_type_change(%arg0 : tensor<3x4xi32>) -> tensor<12xi64> {
+  %0 = stablehlo.reshape %arg0 : (tensor<3x4xi32>) -> tensor<12xi32>
+  %1 = stablehlo.convert %0 : (tensor<12xi32>) -> tensor<12xi64>
   return %1 : tensor<12xi64>
 }
 
-// CHECK-LABEL: @no_reorder_on_etype_change
-// CHECK: %[[CONVERT:.+]] = stablehlo.convert %arg0 : (tensor<12xi32>) -> tensor<12xi64>
-// CHECK: %[[ABS:.+]] = stablehlo.abs %[[CONVERT]] : tensor<12xi64>
-// CHECK: return %[[ABS]]
+// CHECK-LABEL: @reorder_with_type_change
+// CHECK: %[[CONVERT:.+]] = stablehlo.convert %arg0 : (tensor<3x4xi32>) -> tensor<3x4xi64>
+// CHECK: %[[RESHAPE:.+]] = stablehlo.reshape %[[CONVERT]] : (tensor<3x4xi64>) -> tensor<12xi64>
+// CHECK: return %[[RESHAPE]]
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/canonicalization.mlir
@@ -723,3 +723,16 @@ func.func @push_shape_ops_to_end(%arg0 : tensor<12xf32>) -> tensor<3x4x2x1xf32> 
 // CHECK: %[[TRANSPOSE:.+]] = stablehlo.transpose %[[BROADCAST]], dims = [2, 3, 1, 0] : (tensor<1x2x3x4xf32>) -> tensor<3x4x2x1xf32>
 // CHECK: return %[[TRANSPOSE]]
 
+// -----
+
+func.func @no_reorder_on_etype_change(%arg0 : tensor<12xi32>) -> tensor<12xi64> {
+  %0 = stablehlo.convert %arg0 : (tensor<12xi32>) -> tensor<12xi64>
+  %1 = stablehlo.abs %0 : (tensor<12xi64>) -> tensor<12xi64>
+  return %1 : tensor<12xi64>
+}
+
+// CHECK-LABEL: @no_reorder_on_etype_change
+// CHECK: %[[CONVERT:.+]] = stablehlo.convert %arg0 : (tensor<12xi32>) -> tensor<12xi64>
+// CHECK: %[[ABS:.+]] = stablehlo.abs %[[CONVERT]] : tensor<12xi64>
+// CHECK: return %[[ABS]]
+


### PR DESCRIPTION
The pass identifies shape manipulation operations (`reshape`, `transpose`, `broadcast`) that feed into unary elementwise operations and swaps their order. Since elementwise ops do not manipulate the input shape (and there is no interaction between the elements), the reordering doesn't affect the result. 
This enables a future PR where some consecutive shape manipulation operations should be collapsed together into a single operation.
`Broadcast_in_dim` is not included in this PR as the same thing is done for it as part of an existing `StablehloToStablehlo` pass.
In the future, we might want to consider merging/more clearly defining the difference between `Canonicalizations.cpp` and `StablehloToStablehlo.cpp` files, as at the moment their function is almost indistinguishable in some cases. 