### PR TITLE
[Transform] Add transform.iree.gpu_distribute_shared_memory_copy

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -350,6 +350,104 @@ UnrollSharedMemoryLoops(func::FuncOp funcOp,
   }
 }
 
+LogicalResult gpuDistributeSharedMemoryCopy(func::FuncOp funcOp) {
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
+  if (failed(exportOp))
+    return success();
+  auto workgroupSize = getWorkgroupSize(exportOp.value());
+  workgroupSize.resize(3, 1);
+  MLIRContext *context = funcOp.getContext();
+  SmallVector<linalg::GenericOp> copiesToWorkgroupMem;
+  funcOp.walk([&](linalg::GenericOp copyOp) {
+    if (hasMarker(copyOp, getCopyToWorkgroupMemoryMarker()))
+      copiesToWorkgroupMem.push_back(copyOp);
+  });
+  if (copiesToWorkgroupMem.empty())
+    return success();
+
+  // Step 0. First clean up the IR.
+  hoistAlloc(funcOp);
+  removeRedundantBarriers(funcOp);
+
+  int64_t flatWorkgroupSize =
+      workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
+  bool isAligned = llvm::all_of(
+      copiesToWorkgroupMem, [flatWorkgroupSize](linalg::GenericOp copyOp) {
+        MemRefType dstMemRefType = llvm::cast<MemRefType>(
+            copyOp.getDpsInitOperand(0)->get().getType());
+        auto shape = dstMemRefType.getShape();
+        int targetVectorSize =
+            copyVectorNumBits / dstMemRefType.getElementTypeBitWidth();
+        return canPerformVectorAccessUsingAllThreads(shape, flatWorkgroupSize,
+                                                     targetVectorSize);
+      });
+  debugPrint(funcOp, "After initial IR cleanup");
+
+  if (isAligned) {
+    // Ignore all the exisiting loop
+    llvm::SmallDenseSet<scf::ForOp> loopsToIgnore;
+    funcOp.walk([&](scf::ForOp loop) { loopsToIgnore.insert(loop); });
+
+    // Step 1. tile copies to get to a shape that can be distributed to
+    // 128bits per lane copies.
+    RewritePatternSet serialTilingPatterns(context);
+    populateTileToUnroll(serialTilingPatterns, flatWorkgroupSize);
+    if (failed(applyPatternsAndFoldGreedily(funcOp,
+                                            std::move(serialTilingPatterns)))) {
+      return failure();
+    }
+    debugPrint(funcOp, "After step 1: tiling");
+
+    // Calculate a flat id that will then be broken down during distribution.
+    Value flatId = createFlatId(funcOp, workgroupSize);
+    // Step 2. Distribute the linalg op onto threads.
+    RewritePatternSet tileAndDistributePatterns(context);
+    populateTilingAndDistribute(tileAndDistributePatterns, flatId);
+    if (failed(applyPatternsAndFoldGreedily(
+            funcOp, std::move(tileAndDistributePatterns)))) {
+      return failure();
+    }
+    debugPrint(funcOp, "After step 2: thread distribution");
+
+    // Step 3. Vectorize the distributed copies.
+    RewritePatternSet vectorizationPatterns(context);
+    populateVectorizationPatterns(vectorizationPatterns);
+    if (failed(applyPatternsAndFoldGreedily(
+            funcOp, std::move(vectorizationPatterns)))) {
+      return failure();
+    }
+    debugPrint(funcOp, "After step 3: vectorization");
+
+    // Step4. Finally unroll all the loop created
+    UnrollSharedMemoryLoops(funcOp, loopsToIgnore);
+    debugPrint(funcOp, "After step 4: unrolling");
+  } else {
+    // Fall back to basic tiling for cases where workgroup memory size is not
+    // well aligned on the number of threads.
+    // TODO(thomasraoux): Handle this case with padding instead so that we get
+    // good performance for more complex shapes.
+    RewritePatternSet threadLevelTilingPatterns(context);
+    populateTilingCopyToWorkgroupMemPatterns(threadLevelTilingPatterns,
+                                             workgroupSize);
+    if (failed(applyPatternsAndFoldGreedily(
+            funcOp, std::move(threadLevelTilingPatterns)))) {
+      return failure();
+    }
+    debugPrint(funcOp, "After tiling for unaligned case");
+
+    // Apply canonicalization patterns.
+    RewritePatternSet threadTilingCanonicalizationPatterns =
+        linalg::getLinalgTilingCanonicalizationPatterns(context);
+    populateAffineMinSCFCanonicalizationPattern(
+        threadTilingCanonicalizationPatterns);
+    if (failed(applyPatternsAndFoldGreedily(
+            funcOp, std::move(threadTilingCanonicalizationPatterns)))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
 namespace {
 
 class GPUDistributeSharedMemoryCopyPass
@@ -359,101 +457,8 @@ class GPUDistributeSharedMemoryCopyPass
     registry.insert<gpu::GPUDialect, vector::VectorDialect, scf::SCFDialect>();
   }
   void runOnOperation() override {
-    func::FuncOp funcOp = getOperation();
-    FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
-    if (failed(exportOp))
-      return;
-    auto workgroupSize = getWorkgroupSize(exportOp.value());
-    workgroupSize.resize(3, 1);
-    MLIRContext *context = &getContext();
-    SmallVector<linalg::GenericOp> copiesToWorkgroupMem;
-    funcOp.walk([&](linalg::GenericOp copyOp) {
-      if (hasMarker(copyOp, getCopyToWorkgroupMemoryMarker()))
-        copiesToWorkgroupMem.push_back(copyOp);
-    });
-    if (copiesToWorkgroupMem.empty())
-      return;
-
-    // Step 0. First clean up the IR.
-    hoistAlloc(funcOp);
-    removeRedundantBarriers(funcOp);
-
-    int64_t flatWorkgroupSize =
-        workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
-    bool isAligned = llvm::all_of(
-        copiesToWorkgroupMem, [flatWorkgroupSize](linalg::GenericOp copyOp) {
-          MemRefType dstMemRefType = llvm::cast<MemRefType>(
-              copyOp.getDpsInitOperand(0)->get().getType());
-          auto shape = dstMemRefType.getShape();
-          int targetVectorSize =
-              copyVectorNumBits / dstMemRefType.getElementTypeBitWidth();
-          return canPerformVectorAccessUsingAllThreads(shape, flatWorkgroupSize,
-                                                       targetVectorSize);
-        });
-    debugPrint(funcOp, "After initial IR cleanup");
-
-    if (isAligned) {
-      // Ignore all the exisiting loop
-      llvm::SmallDenseSet<scf::ForOp> loopsToIgnore;
-      funcOp.walk([&](scf::ForOp loop) { loopsToIgnore.insert(loop); });
-
-      // Step 1. tile copies to get to a shape that can be distributed to
-      // 128bits per lane copies.
-      RewritePatternSet serialTilingPatterns(context);
-      populateTileToUnroll(serialTilingPatterns, flatWorkgroupSize);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(serialTilingPatterns)))) {
-        return signalPassFailure();
-      }
-      debugPrint(funcOp, "After step 1: tiling");
-
-      // Calculate a flat id that will then be broken down during distribution.
-      Value flatId = createFlatId(funcOp, workgroupSize);
-      // Step 2. Distribute the linalg op onto threads.
-      RewritePatternSet tileAndDistributePatterns(context);
-      populateTilingAndDistribute(tileAndDistributePatterns, flatId);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(tileAndDistributePatterns)))) {
-        return signalPassFailure();
-      }
-      debugPrint(funcOp, "After step 2: thread distribution");
-
-      // Step 3. Vectorize the distributed copies.
-      RewritePatternSet vectorizationPatterns(context);
-      populateVectorizationPatterns(vectorizationPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(vectorizationPatterns)))) {
-        return signalPassFailure();
-      }
-      debugPrint(funcOp, "After step 3: vectorization");
-
-      // Step4. Finally unroll all the loop created
-      UnrollSharedMemoryLoops(funcOp, loopsToIgnore);
-      debugPrint(funcOp, "After step 4: unrolling");
-    } else {
-      // Fall back to basic tiling for cases where workgroup memory size is not
-      // well aligned on the number of threads.
-      // TODO(thomasraoux): Handle this case with padding instead so that we get
-      // good performance for more complex shapes.
-      RewritePatternSet threadLevelTilingPatterns(context);
-      populateTilingCopyToWorkgroupMemPatterns(threadLevelTilingPatterns,
-                                               workgroupSize);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(threadLevelTilingPatterns)))) {
-        return signalPassFailure();
-      }
-      debugPrint(funcOp, "After tiling for unaligned case");
-
-      // Apply canonicalization patterns.
-      RewritePatternSet threadTilingCanonicalizationPatterns =
-          linalg::getLinalgTilingCanonicalizationPatterns(context);
-      populateAffineMinSCFCanonicalizationPattern(
-          threadTilingCanonicalizationPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(threadTilingCanonicalizationPatterns)))) {
-        return signalPassFailure();
-      }
-    }
+    if (failed(gpuDistributeSharedMemoryCopy(getOperation())))
+      signalPassFailure();
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -55,6 +55,11 @@ LogicalResult tileReductionToSerialLoops(func::FuncOp funcOp,
 LogicalResult swizzleWorkgroupsInFunc(func::FuncOp funcOp,
                                       unsigned swizzleLogTile);
 
+// Lowers workgroup memory copies to distributed transfer_read/transfer_write
+// ops. Expects the memory copy to be marked with copy_to_workgroup_memory
+// marker.
+LogicalResult gpuDistributeSharedMemoryCopy(func::FuncOp funcOp);
+
 //===----------------------------------------------------------------------===//
 // Passes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -28,7 +28,7 @@ iree_lit_test_suite(
             "gpu_workgroup_swizzle.mlir",
             "gpu_tile_reduction.mlir",
             "reduce_bank_conflicts.mlir",
-            "transform_gpu_distribute_shared_memory.mlir",
+            "transform_dialect_gpu_distribute_shared_memory.mlir",
             "transform_gpu_workgroup_swizzle.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "gpu_workgroup_swizzle.mlir",
             "gpu_tile_reduction.mlir",
             "reduce_bank_conflicts.mlir",
+            "transform_gpu_distribute_shared_memory.mlir",
             "transform_gpu_workgroup_swizzle.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_lit_test_suite(
     "gpu_vectorization.mlir"
     "gpu_workgroup_swizzle.mlir"
     "reduce_bank_conflicts.mlir"
+    "transform_gpu_distribute_shared_memory.mlir"
     "transform_gpu_workgroup_swizzle.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -24,7 +24,7 @@ iree_lit_test_suite(
     "gpu_vectorization.mlir"
     "gpu_workgroup_swizzle.mlir"
     "reduce_bank_conflicts.mlir"
-    "transform_gpu_distribute_shared_memory.mlir"
+    "transform_dialect_gpu_distribute_shared_memory.mlir"
     "transform_gpu_workgroup_swizzle.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/transform_gpu_distribute_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/transform_gpu_distribute_shared_memory.mlir
@@ -1,0 +1,76 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule | FileCheck %s
+
+// CHECK-DAG: #[[$MAP0:.*]] = affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 32 + s0 floordiv 4)>
+// CHECK-DAG: #[[$MAP1:.*]] = affine_map<()[s0] -> (s0 * 4 - (s0 floordiv 4) * 16)>
+// CHECK-DAG: #[[$MAP2:.*]] = affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 32 + s0 floordiv 4 + 32)>
+// CHECK-DAG: #[[$MAP3:.*]] = affine_map<(d0, d1) -> (d0, d1)>
+
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>
+  ]>
+]>
+hal.executable private @shared_mem_cpy  {
+  hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
+    hal.executable.export @shared_mem_cpy layout(#pipeline_layout) attributes {
+      workgroup_size = [32: index, 4: index, 1:index]
+    } {
+    ^bb0(%arg0: !hal.device, %arg1 : index, %arg2 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      memref.global "private" @__shared_memory__ : memref<64x16xf32, #gpu.address_space<workgroup>>
+    // CHECK-LABEL: @shared_mem_cpy(
+      func.func @shared_mem_cpy(%m0 : memref<64x16xf32>) {
+        %c0 = arith.constant 0 : index
+
+        %0 = "affine.apply"(%c0) {map = affine_map<(d0) -> (d0)>} : (index) -> (index)
+        %sm0 = memref.get_global @__shared_memory__ : memref<64x16xf32, #gpu.address_space<workgroup>>
+        gpu.barrier
+    // CHECK-DAG: %[[TX:.*]] = gpu.thread_id x
+    // CHECK-DAG: %[[TY:.*]] = gpu.thread_id y
+    // CHECK-DAG: %[[TZ:.*]] = gpu.thread_id z
+
+    // CHECK-DAG: %[[Y0:.*]] = affine.apply #[[$MAP0]]()[%[[TX]], %[[TY]], %[[TZ]]]
+    // CHECK-DAG: %[[X0:.*]] = affine.apply #[[$MAP1]]()[%[[TX]]]
+    //     CHECK: %[[R0:.*]] = vector.transfer_read %{{.*}}[%[[Y0]], %[[X0]]], %{{.*}} {in_bounds = [true, true]} : memref<64x16xf32>, vector<1x4xf32>
+    //     CHECK: vector.transfer_write %[[R0]], %{{.*}}[%[[Y0]], %[[X0]]] {in_bounds = [true, true]} : vector<1x4xf32>, memref<64x16xf32, #gpu.address_space<workgroup>>
+    // CHECK-DAG: %[[Y1:.*]] = affine.apply #[[$MAP2]]()[%[[TX]], %[[TY]], %[[TZ]]]
+    //     CHECK: %[[R1:.*]] = vector.transfer_read %{{.*}}[%[[Y1]], %[[X0]]], %{{.*}} {in_bounds = [true, true]} : memref<64x16xf32>, vector<1x4xf32>
+    //     CHECK: vector.transfer_write %[[R1]], %{{.*}}[%[[Y1]], %[[X0]]] {in_bounds = [true, true]} : vector<1x4xf32>, memref<64x16xf32, #gpu.address_space<workgroup>>
+
+        linalg.generic {indexing_maps = [#map1, #map1],
+        iterator_types = ["parallel", "parallel"]}
+          ins(%m0 : memref<64x16xf32>)
+          outs(%sm0 : memref<64x16xf32, #gpu.address_space<workgroup>>) {
+          ^bb0(%arg3: f32, %s: f32):
+            linalg.yield %arg3 : f32
+        }
+    // CHECK: gpu.barrier
+
+    // CHECK: linalg.generic
+        linalg.generic {indexing_maps = [#map1, #map1],
+        iterator_types = ["parallel", "parallel"]}
+          ins(%sm0 : memref<64x16xf32, #gpu.address_space<workgroup>>)
+          outs(%sm0 : memref<64x16xf32, #gpu.address_space<workgroup>>) {
+          ^bb0(%arg4: f32, %s: f32):
+            %add = arith.addf %arg4, %arg4 : f32
+            linalg.yield %add : f32
+        }
+
+        return
+      }
+    }
+  }
+
+  transform.sequence failures(propagate) {
+  ^bb1(%variant_op: !pdl.operation):
+    %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
+    transform.iree.gpu_distribute_shared_memory_copy %func : (!pdl.operation) -> ()
+    transform.iree.apply_patterns %func 
+      { fold_memref_aliases, canonicalization, tiling_canonicalization, cse } : (!pdl.operation) -> ()
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -17,6 +17,7 @@
 #include "iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -953,6 +954,69 @@ DiagnosedSilenceableFailure transform_dialect::WorkgroupSwizzleOp::applyToOne(
 }
 
 void transform_dialect::WorkgroupSwizzleOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
+}
+
+//===----------------------------------------------------------------------===//
+// GpuDistributeSharedMemoryCopyOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+transform_dialect::GpuDistributeSharedMemoryCopyOp::applyToOne(
+    transform::TransformRewriter &rewriter, func::FuncOp target,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+
+  // Look for ops that move to/from workgroup memory and mark as copies for
+  // distribution.
+  target.walk([&](linalg::GenericOp copyOp) {
+    if (copyOp.getDpsInputOperands().size() != 1 ||
+        copyOp.getDpsInitOperands().size() != 1)
+      return;
+    auto sourceType =
+        copyOp.getDpsInputOperand(0)->get().getType().dyn_cast<MemRefType>();
+    auto destType =
+        copyOp.getDpsInitOperand(0)->get().getType().dyn_cast<MemRefType>();
+    if (!sourceType || !destType)
+      return;
+
+    Block &body = copyOp.getRegion().front();
+    if (!std::begin(body)->hasTrait<OpTrait::IsTerminator>())
+      return;
+
+    auto sourceSpace = sourceType.getMemorySpace();
+    auto destSpace = destType.getMemorySpace();
+    if ((!sourceSpace && !destSpace) || sourceSpace == destSpace)
+      return;
+
+    auto sourceGpuSpace = sourceSpace.dyn_cast_or_null<gpu::AddressSpaceAttr>();
+    auto destGpuSpace = destSpace.dyn_cast_or_null<gpu::AddressSpaceAttr>();
+    if ((!sourceGpuSpace || sourceGpuSpace.getValue() !=
+                                gpu::GPUDialect::getWorkgroupAddressSpace()) &&
+        (!destGpuSpace || destGpuSpace.getValue() !=
+                              gpu::GPUDialect::getWorkgroupAddressSpace()))
+      return;
+
+    setMarker(copyOp, getCopyToWorkgroupMemoryMarker());
+    // Insert barriers immediately after copies to workgroup memory.
+    if (destGpuSpace && destGpuSpace.getValue() ==
+                            gpu::GPUDialect::getWorkgroupAddressSpace()) {
+      OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPointAfter(copyOp);
+      rewriter.create<gpu::BarrierOp>(copyOp.getLoc());
+    }
+  });
+
+  if (failed(mlir::iree_compiler::gpuDistributeSharedMemoryCopy(target))) {
+    return mlir::emitDefiniteFailure(state.getTopLevel(),
+                                     "Pattern failed to apply");
+  }
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::GpuDistributeSharedMemoryCopyOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   transform::onlyReadsHandle(getTarget(), effects);
   transform::modifiesPayload(effects);

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -562,4 +562,37 @@ def WorkgroupSwizzleOp :  Op<Transform_Dialect, "iree.workgroup_swizzle",
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// GpuDistributeSharedMemoryCopyOp
+//===----------------------------------------------------------------------===//
+
+def GpuDistributeSharedMemoryCopyOp :
+  Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformOpInterface, TransformEachOpTrait]> {
+  let summary = "Distribute shared memory copies";
+  let description = [{
+    Find shared memory copies, hoist them, and distribute the copy loops based
+    on the workgroup size.
+
+    #### Return modes
+    This operation applies to the entire function and does not consume the
+    target handle. It always return success.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs);
+
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::func::FuncOp funcOp,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS


### PR DESCRIPTION
This patch adds `GPUDistributeSharedMemoryCopy` pass as a transform op. The transform op matches for potential copies in the form of linalg.generic, by looking at the memory space of memrefs in input/output of the op, and adds markers for shared memory copies. Additionally, inserts barriers after copies to shared memory.