### PR TITLE
Extend VerifyInputLegalityPass to error out on ops with f64

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -90,6 +90,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/DFX",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
+        "//compiler/src/iree/compiler/Pipelines:Options",
         "//compiler/src/iree/compiler/Utils",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/VerifyInputLegality.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/VerifyInputLegality.cpp
@@ -6,9 +6,11 @@
 
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Pipelines/Options.h"
 #include "iree/compiler/Utils/ConversionUtils.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -17,12 +19,40 @@ namespace iree_compiler {
 namespace IREE {
 namespace Flow {
 
+static llvm::cl::opt<bool>
+    clVerifyNoF64("iree-flow-verify-no-f64",
+                  llvm::cl::desc("Verify that there are no ops that use f64."),
+                  llvm::cl::init(true));
+
 namespace {
+
 class VerifyInputLegalityPass
     : public VerifyInputLegalityBase<VerifyInputLegalityPass> {
   void runOnOperation() override {
     ConversionTarget target(getContext());
-    target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+    target.markUnknownOpDynamicallyLegal([seenF64 =
+                                              false](Operation *op) mutable {
+      // Diagnose only the first encountered F64
+      if (seenF64)
+        return true;
+      bool shouldVerifyNoF64 =
+          clVerifyNoF64.getNumOccurrences()
+              ? clVerifyNoF64
+              : !GlobalOptimizationOptions::FromFlags::get().demoteF64ToF32;
+      if (!shouldVerifyNoF64)
+        return true;
+      // TODO: Query the targets this will execute on to check if F64 is
+      // supported.
+      auto isF64 = [](Type type) {
+        return llvm::isa<Float64Type>(getElementTypeOrSelf(type));
+      };
+      seenF64 |= llvm::any_of(op->getOperandTypes(), isF64);
+      seenF64 |= llvm::any_of(op->getResultTypes(), isF64);
+      if (seenF64)
+        op->emitError() << "uses partially supported type f64; pass "
+                           "--iree-flow-verify-no-f64=false to allow anyway";
+      return !seenF64;
+    });
     target.addLegalOp<tosa::ApplyScaleOp>();
     // We're already depending on the Tosa Dialect
     target.addIllegalDialect<tosa::TosaDialect>();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/verify_input_ir.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/verify_input_ir.mlir
@@ -47,3 +47,15 @@ func.func @check_linalg_ok(%conv : tensor<1x112x112x16xf32>, %bias : tensor<16xf
       } -> tensor<1x112x112x16xf32>
   return %result : tensor<1x112x112x16xf32>
 }
+
+// -----
+
+// expected-error@below {{illegal operations still remain}}
+func.func @check_f64_not_ok() -> tensor<3xf64> {
+    // expected-error@+2 {{illegal op still exists}}
+    // expected-error@+1 {{uses partially supported type f64}}
+    %cst = arith.constant dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf64>
+    // expected-error@+2 {{illegal op still exists}}
+    // expected-error@+1 {{uses partially supported type f64}}
+    return %cst : tensor<3xf64>
+}

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -73,7 +73,7 @@ struct InputDialectOptions {
 // Options controlling high level optimizations.
 struct GlobalOptimizationOptions {
   // Gate various type based demotion passes that run before anything else.
-  bool demoteF64ToF32 = true;
+  bool demoteF64ToF32 = false;
   bool demoteF32ToF16 = false;
   bool promoteF16ToF32 = false;
   bool promoteBF16ToF32 = false;

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -161,7 +161,10 @@ iree_check_single_backend_test_suite(
     srcs = [
         "disable_demote_f64_to_f32.mlir",
     ],
-    compiler_flags = ["-iree-opt-demote-f64-to-f32=false"],
+    compiler_flags = [
+        "-iree-opt-demote-f64-to-f32=false",
+        "-iree-flow-verify-no-f64=false",
+    ],
     driver = "local-task",
     target_backend = "llvm-cpu",
 )

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -210,6 +210,7 @@ iree_check_single_backend_test_suite(
     "local-task"
   COMPILER_FLAGS
     "-iree-opt-demote-f64-to-f32=false"
+    "-iree-flow-verify-no-f64=false"
 )
 
 iree_check_single_backend_test_suite(


### PR DESCRIPTION
Extend VerifyInputLegalityPass to error out on ops with f64.

Associated GitHub issue:  https://github.com/openxla/iree/issues/8826 

Test plan:  build_tools/cmake/ctest_all.sh build_output