### PR TITLE
Document available phase names in tips and tricks guide.

### DIFF
--- a/docs/website/docs/guides/developer-tips.md
+++ b/docs/website/docs/guides/developer-tips.md
@@ -398,6 +398,31 @@ graph LR
   E --> F([VM])
 ```
 
+??? tip "Tip - available phases"
+
+    These are the phase names available for use with the `--compile-to` and
+    `--compile-from` flags described below:
+
+    | Phase name | Description |
+    | ---------- | ----------- |
+    `input` | Performs input processing and lowering into core IREE input dialects (linalg/etc)
+    `abi` | Adjusts the program ABI for the specified execution environment
+    `preprocessing` | Applies customizable `preprocessing` prior to FLow/Stream/HAL/VM
+    `flow` | Models execution data flow and partitioning using the `flow` dialect
+    `stream` | Models execution partitioning and scheduling using the `stream` dialect
+    `executable-sources` | Prepares `hal` dialect executables for translation, prior to codegen
+    `executable-targets` | Runs code generation for `hal` dialect executables
+    `hal` | Finishes `hal` dialect processing
+    `vm` | Lowers to IREE's abstract virtual machine using the `vm` dialect
+    `end` | Completes the full compilation pipeline
+
+    For an accurate list of phases, see the source code or check the help output
+    with a command such as:
+
+    ```shell
+    iree-compile --help | sed -n '/--compile-to/,/--/p' | head -n -1
+    ```
+
 You can output a program snapshot at intermediate phases with the
 `--compile-to=<phase name>` flag:
 


### PR DESCRIPTION
Making https://openxla.github.io/iree/guides/developer-tips/#compiling-phase-by-phase easier to follow

A new tip starts collapsed: 
![image](https://github.com/openxla/iree/assets/4010439/feab68fc-a7f6-40ac-92d3-28bd4d17259c)

It expands to this: 
![image](https://github.com/openxla/iree/assets/4010439/ab4ef5a0-1884-4bee-a49e-320758b600b9)

Text was referenced from [`Pipelines.h`](https://github.com/openxla/iree/blob/main/compiler/src/iree/compiler/Pipelines/Pipelines.h) (with substantial edits)