### PR TITLE
Assign variables with initial/default values

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -397,7 +397,8 @@ static uint32_t flagForUser(IREE::LinalgExt::EncodingUser user) {
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MATMUL_BF16BF16F32;
   case IREE::LinalgExt::EncodingUser::MATMUL_BF16BF16BF16:
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MATMUL_BF16BF16BF16;
-  default:
+  default: // Unreachable.
+    assert(false);
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_NONE;
   }
 }
@@ -410,6 +411,9 @@ static uint32_t flagForRole(IREE::LinalgExt::EncodingRole role) {
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERAND_ROLE_RHS;
   case IREE::LinalgExt::EncodingRole::RESULT:
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERAND_ROLE_RESULT;
+  default: // Unreachable.
+    assert(false);
+    return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERAND_ROLE_LHS;
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -397,6 +397,8 @@ static uint32_t flagForUser(IREE::LinalgExt::EncodingUser user) {
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MATMUL_BF16BF16F32;
   case IREE::LinalgExt::EncodingUser::MATMUL_BF16BF16BF16:
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MATMUL_BF16BF16BF16;
+  default:
+    return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_NONE;
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTensorPad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTensorPad.cpp
@@ -38,7 +38,7 @@ void LLVMCPUTensorPadPass::runOnOperation() {
   auto funcOp = getOperation();
   // Preserve the innermost tensor.pad ops (i.e., pad for reduction dims), so we
   // can kick canonicalization patterns to fold outer tensor.pad ops away.
-  bool nofold;
+  bool nofold = false;
   utils::IteratorType targetIterType;
   switch (option) {
   case LLVMCPUTensorPadOption::ParallelDims:

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTensorPad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTensorPad.cpp
@@ -39,7 +39,7 @@ void LLVMCPUTensorPadPass::runOnOperation() {
   // Preserve the innermost tensor.pad ops (i.e., pad for reduction dims), so we
   // can kick canonicalization patterns to fold outer tensor.pad ops away.
   bool nofold = false;
-  utils::IteratorType targetIterType;
+  utils::IteratorType targetIterType = utils::IteratorType::parallel;
   switch (option) {
   case LLVMCPUTensorPadOption::ParallelDims:
     LLVM_DEBUG(llvm::dbgs() << "padding parallel dims\n");
@@ -50,6 +50,9 @@ void LLVMCPUTensorPadPass::runOnOperation() {
     LLVM_DEBUG(llvm::dbgs() << "padding reduction dims\n");
     targetIterType = utils::IteratorType::reduction;
     nofold = true;
+    break;
+  default: // Unreachable.
+    assert(false);
     break;
   };
   SmallVector<linalg::LinalgOp> candidates;

--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -219,7 +219,7 @@ LogicalResult FunctionCall::addArgument(Location loc, Attribute attr) {
     for (size_t i = 0; i < rank; ++i) {
       shape[i] = stShape[i];
     }
-    iree_hal_element_type_t elementType;
+    iree_hal_element_type_t elementType = IREE_HAL_ELEMENT_TYPE_NONE;
     if (failed(convertToElementType(loc, st.getElementType(), &elementType)))
       return failure();
 


### PR DESCRIPTION
To avoid maybe-uninitialized GCC warning