### PR TITLE
Isolate LLVMTarget in the llvm-cpu backend.

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-consteval-jit-use-vmvx=true --verify-diagnostics --iree-consteval-jit-debug --iree-consteval-jit-globals  %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-consteval-jit-target-backend=vmvx --verify-diagnostics --iree-consteval-jit-debug --iree-consteval-jit-globals  %s | FileCheck %s
 
 // TODO(laurenzo): Full type matrix for tests.
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/BUILD.bazel
@@ -111,6 +111,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Target",
         "@llvm-project//llvm:TargetParser",
+        "@llvm-project//mlir:IR",
     ],
 )
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/CMakeLists.txt
@@ -92,6 +92,7 @@ iree_cc_library(
     LLVMSupport
     LLVMTarget
     LLVMTargetParser
+    MLIRIR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMIRPasses.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMIRPasses.h
@@ -21,10 +21,10 @@ namespace HAL {
 
 // Creates target machine form target options.
 std::unique_ptr<llvm::TargetMachine>
-createTargetMachine(const LLVMTarget &target, const LLVMTargetOptions &options);
+createTargetMachine(const LLVMTarget &target);
 
 // Creates and runs LLVMIR optimization passes defined in LLVMTargetOptions.
-LogicalResult runLLVMIRPasses(const LLVMTargetOptions &options,
+LogicalResult runLLVMIRPasses(const LLVMTarget &target,
                               llvm::TargetMachine *machine,
                               llvm::Module *module);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.cpp
@@ -16,20 +16,26 @@
 #include "llvm/TargetParser/SubtargetFeature.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/TargetParser/X86TargetParser.h"
+#include "mlir/IR/Builders.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
-static LLVMTargetOptions getDefaultLLVMTargetOptions() {
-  static LLVMTargetOptions targetOptions;
-  static std::once_flag onceFlag;
-  std::call_once(onceFlag, [&]() {
-    // Get process target triple along with host CPU name and features.
-    targetOptions.target.triple = llvm::sys::getProcessTriple();
-    targetOptions.target.cpu = llvm::sys::getHostCPUName().str();
-    {
+namespace {
+
+// Defaults for key fields on the host that we use in various logic below.
+struct HostDefaults {
+  std::string triple;
+  std::string cpu;
+  std::string cpuFeatures;
+
+  static const HostDefaults &get() {
+    static HostDefaults hostDefaults = ([]() {
+      // Get process target triple along with host CPU name and features.
+      std::string triple = llvm::sys::getProcessTriple();
+      std::string cpu = llvm::sys::getHostCPUName().str();
       llvm::SubtargetFeatures features;
       llvm::StringMap<bool> hostFeatures;
       if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
@@ -37,52 +43,352 @@ static LLVMTargetOptions getDefaultLLVMTargetOptions() {
           features.AddFeature(feature.first(), feature.second);
         }
       }
-      targetOptions.target.cpuFeatures = features.getString();
-    }
+      return HostDefaults{triple, cpu, features.getString()};
+    })();
+    return hostDefaults;
+  }
+};
 
-    // LLVM loop optimization options.
-    targetOptions.pipelineTuningOptions.LoopInterleaving = true;
-    targetOptions.pipelineTuningOptions.LoopVectorization = false;
-    targetOptions.pipelineTuningOptions.LoopUnrolling = true;
+} // namespace
 
-    // LLVM SLP Auto vectorizer.
-    targetOptions.pipelineTuningOptions.SLPVectorization = false;
+LLVMTarget::LLVMTarget() {
+  // LLVM loop optimization options.
+  pipelineTuningOptions.LoopInterleaving = DEFAULT_LOOP_INTERLEAVING;
+  pipelineTuningOptions.LoopVectorization = DEFAULT_LOOP_VECTORIZATION;
+  pipelineTuningOptions.LoopUnrolling = DEFAULT_LOOP_UNROLLING;
 
-    // LLVM optimization levels.
-    // TODO(benvanik): add an option for this.
-    targetOptions.optimizerOptLevel = llvm::OptimizationLevel::O2;
-    targetOptions.codeGenOptLevel = llvm::CodeGenOpt::Aggressive;
-    targetOptions.options.FloatABIType = llvm::FloatABI::Hard;
+  // LLVM SLP Auto vectorizer.
+  pipelineTuningOptions.SLPVectorization = DEFAULT_SLP_VECTORIZATION;
 
-    // Force `-ffunction-sections` so we can strip unused code.
-    targetOptions.options.FunctionSections = true;
-    targetOptions.options.DataSections = true;
-    targetOptions.options.UniqueSectionNames = true;
-  });
-  return targetOptions;
+  // LLVM optimization levels.
+  // TODO(benvanik): add an option for this.
+  optimizerOptLevel = llvm::OptimizationLevel::O2;
+  codeGenOptLevel = llvm::CodeGenOpt::Aggressive;
+  llvmTargetOptions.FloatABIType = DEFAULT_FLOAT_ABI;
+
+  // Force `-ffunction-sections` so we can strip unused code.
+  llvmTargetOptions.FunctionSections = true;
+  llvmTargetOptions.DataSections = true;
+  llvmTargetOptions.UniqueSectionNames = true;
 }
 
-static void addTargetCPUFeaturesForCPU(LLVMTarget &target) {
-  if (!llvm::Triple(target.triple).isX86()) {
+LLVMTarget::LLVMTarget(std::string_view triple, std::string_view cpu,
+                       std::string_view cpuFeatures, bool requestLinkEmbedded)
+    : LLVMTarget() {
+  const HostDefaults &hostDefaults = HostDefaults::get();
+  this->linkEmbedded = requestLinkEmbedded;
+  this->triple = triple;
+  if (cpu == "host") {
+    this->cpu = hostDefaults.cpu;
+  } else {
+    this->cpu = cpu;
+  }
+  if (cpuFeatures == "host") {
+    this->cpuFeatures = hostDefaults.cpuFeatures;
+  } else {
+    this->cpuFeatures = cpuFeatures;
+  }
+  if (cpu != "host" && cpu != "generic") {
+    addTargetCPUFeaturesForCPU();
+  }
+
+  llvm::Triple targetTriple(this->triple);
+  // TODO(muralivi): Move this into `addTargetCPUFeaturesForCPU`, after fixing
+  // the predicate for when `addTargetCPUFeaturesForCPU` is called (i.e.
+  // removing the condition that clTargetCPU is neither host nor generic).
+  if (llvm::Triple(this->triple).isAArch64()) {
+    llvm::SubtargetFeatures targetCpuFeatures(this->cpuFeatures);
+    targetCpuFeatures.AddFeature("reserve-x18", true);
+    this->cpuFeatures = targetCpuFeatures.getString();
+  }
+
+  // Special casing if linkEmbedded.
+  if (targetTriple.isWasm()) {
+    // The embedded ELF loader is not supported on WebAssembly, so force it off.
+    this->linkEmbedded = false;
+  }
+  if (this->linkEmbedded) {
+    // Force the triple to something compatible with embedded linking.
+    targetTriple.setVendor(llvm::Triple::VendorType::UnknownVendor);
+    targetTriple.setEnvironment(llvm::Triple::EnvironmentType::EABI);
+    targetTriple.setOS(llvm::Triple::OSType::UnknownOS);
+    targetTriple.setObjectFormat(llvm::Triple::ObjectFormatType::ELF);
+    this->triple = targetTriple.str();
+  }
+}
+
+const LLVMTarget &LLVMTarget::getForHost() {
+  static LLVMTarget hostTarget = ([]() {
+    const HostDefaults &hostDefaults = HostDefaults::get();
+    return LLVMTarget(hostDefaults.triple, hostDefaults.cpu,
+                      hostDefaults.cpuFeatures,
+                      /*requestLinkEmbedded=*/true);
+  })();
+
+  return hostTarget;
+}
+
+void LLVMTarget::print(llvm::raw_ostream &os) const {
+  os << "LLVMTarget{\n"
+     << "  triple=" << triple << ", cpu=" << cpu
+     << ", cpuFeatures=" << cpuFeatures << "\n"
+     << "  linkEmbedded=" << linkEmbedded << "\n"
+     << "  debugSymbols=" << debugSymbols << "\n"
+     << "  sanitizer=" << static_cast<int>(sanitizerKind) << "\n"
+     << "  staticLibraryOutput=" << staticLibraryOutput << "\n"
+     << "  linkStatic=" << linkStatic << "\n"
+     << "  pipelineTuningOptions={\n"
+     << "    LoopInterleaving=" << pipelineTuningOptions.LoopInterleaving
+     << "\n"
+     << "    LoopVectorization=" << pipelineTuningOptions.LoopVectorization
+     << "\n"
+     << "    LoopUnrolling=" << pipelineTuningOptions.LoopUnrolling << "\n"
+     << "    SLPVectorization=" << pipelineTuningOptions.SLPVectorization
+     << "\n"
+     << "  }, llvmTargetOptions={\n"
+     << "    FloatABIType=" << static_cast<int>(llvmTargetOptions.FloatABIType)
+     << "\n"
+     << "  }\n"
+     << "}\n";
+}
+
+void LLVMTarget::storeToConfigAttrs(MLIRContext *context,
+                                    SmallVector<NamedAttribute> &config) const {
+  Builder b(context);
+  auto addString = [&](StringRef name, StringRef value) {
+    config.emplace_back(b.getStringAttr(name), b.getStringAttr(value));
+  };
+  auto addBool = [&](StringRef name, bool value) {
+    config.emplace_back(b.getStringAttr(name), b.getBoolAttr(value));
+  };
+
+  addString("target_triple", triple);
+  addString("cpu", cpu);
+  addString("cpu_features", cpuFeatures);
+  if (linkEmbedded != DEFAULT_LINK_EMBEDDED) {
+    addBool("link_embedded", linkEmbedded);
+  }
+  if (debugSymbols != DEFAULT_DEBUG_SYMBOLS) {
+    addBool("debug_symbols", debugSymbols);
+  }
+  if (linkStatic != DEFAULT_LINK_STATIC) {
+    addBool("link_static", linkStatic);
+  }
+  if (sanitizerKind != DEFAULT_SANITIZER_KIND) {
+    switch (sanitizerKind) {
+    case SanitizerKind::kNone:
+      addString("sanitizer", "none");
+      break;
+    case SanitizerKind::kAddress:
+      addString("sanitizer", "address");
+      break;
+    case SanitizerKind::kThread:
+      addString("sanitizer", "thread");
+      break;
+    }
+  }
+  if (!staticLibraryOutput.empty()) {
+    addString("static_library_output", staticLibraryOutput);
+  }
+  if (pipelineTuningOptions.LoopInterleaving != DEFAULT_LOOP_INTERLEAVING)
+    addBool("loop_interleaving", DEFAULT_LOOP_INTERLEAVING);
+  if (pipelineTuningOptions.LoopVectorization != DEFAULT_LOOP_VECTORIZATION)
+    addBool("loop_vectorization", DEFAULT_LOOP_VECTORIZATION);
+  if (pipelineTuningOptions.LoopUnrolling != DEFAULT_LOOP_UNROLLING)
+    addBool("loop_unrolling", DEFAULT_LOOP_UNROLLING);
+  if (pipelineTuningOptions.SLPVectorization != DEFAULT_SLP_VECTORIZATION)
+    addBool("slp_vectorization", DEFAULT_SLP_VECTORIZATION);
+  if (!llvmTargetOptions.MCOptions.ABIName.empty())
+    addString("target_abi", llvmTargetOptions.MCOptions.ABIName);
+  if (llvmTargetOptions.FloatABIType != DEFAULT_FLOAT_ABI) {
+    switch (llvmTargetOptions.FloatABIType) {
+    case llvm::FloatABI::Default:
+      addString("float_abi", "default");
+      break;
+    case llvm::FloatABI::Soft:
+      addString("float_abi", "soft");
+      break;
+    case llvm::FloatABI::Hard:
+      addString("float_abi", "hard");
+      break;
+    }
+  }
+}
+
+std::optional<LLVMTarget>
+LLVMTarget::loadFromConfigAttr(Location loc, DictionaryAttr config,
+                               const LLVMTarget &defaultTarget) {
+  bool hasFailures = false;
+  auto getString = [&](StringRef name, StringRef fallback,
+                       bool required) -> StringRef {
+    Attribute attr = config.get(name);
+    if (auto sattr = llvm::dyn_cast_if_present<StringAttr>(attr)) {
+      return sattr.strref();
+    } else {
+      if (required) {
+        hasFailures = true;
+        emitError(loc) << "executable config '" << name
+                       << "' required but not present on attribute";
+      }
+      return fallback;
+    }
+  };
+  auto getOptionalString = [&](StringRef name) -> std::optional<StringRef> {
+    Attribute attr = config.get(name);
+    if (auto sattr = llvm::dyn_cast_if_present<StringAttr>(attr)) {
+      return sattr.strref();
+    } else if (attr) {
+      hasFailures = true;
+      emitError(loc) << "executable config '" << name
+                     << "' requires string but got " << attr;
+    }
+    return {};
+  };
+  auto getBoolValue = [&](StringRef name, bool fallback) -> bool {
+    Attribute attr = config.get(name);
+    if (auto battr = llvm::dyn_cast_if_present<BoolAttr>(attr)) {
+      return battr.getValue();
+    } else if (attr) {
+      hasFailures = true;
+      emitError(loc) << "executable config '" << name
+                     << "' requires bool but got " << attr;
+    }
+    return fallback;
+  };
+
+  LLVMTarget target;
+
+  // Constructor arguments.
+  auto triple = getOptionalString("target_triple");
+  auto cpu = getOptionalString("cpu");
+  auto cpuFeatures = getOptionalString("cpu_features");
+  bool linkEmbedded = getBoolValue("link_embedded", DEFAULT_LINK_EMBEDDED);
+  if (triple || cpu || cpuFeatures) {
+    if (!triple) {
+      emitError(loc) << "executable config 'cpu' or 'cpu_features' must be "
+                        "accompanied by 'target_triple'";
+      return {};
+    }
+    target.triple = *triple;
+    target.cpu = cpu ? *cpu : "generic";
+    target.cpuFeatures = cpuFeatures ? *cpuFeatures : "";
+    target.linkEmbedded = linkEmbedded;
+  } else {
+    target.triple = defaultTarget.triple;
+    target.cpu = defaultTarget.cpu;
+    target.cpuFeatures = defaultTarget.cpuFeatures;
+    target.linkEmbedded = defaultTarget.linkEmbedded;
+  }
+
+  // Loose items.
+  target.debugSymbols = getBoolValue("debug_symbols", DEFAULT_DEBUG_SYMBOLS);
+  target.linkStatic = getBoolValue("link_static", DEFAULT_LINK_STATIC);
+  auto sanitizer = getOptionalString("sanitizer");
+  if (sanitizer) {
+    if (sanitizer == "none")
+      target.sanitizerKind = SanitizerKind::kNone;
+    else if (sanitizer == "address")
+      target.sanitizerKind = SanitizerKind::kAddress;
+    else if (sanitizer == "thread")
+      target.sanitizerKind = SanitizerKind::kThread;
+    else {
+      emitError(loc) << "executable config unexpected value for 'sanitizer': "
+                     << *sanitizer;
+      return {};
+    }
+  }
+  target.staticLibraryOutput = getString("static_library_output", "", false);
+  target.pipelineTuningOptions.LoopInterleaving = getBoolValue(
+      "loop_interleaving", target.pipelineTuningOptions.LoopInterleaving);
+  target.pipelineTuningOptions.LoopVectorization = getBoolValue(
+      "loop_vectorization", target.pipelineTuningOptions.LoopVectorization);
+  target.pipelineTuningOptions.LoopUnrolling = getBoolValue(
+      "loop_unrolling", target.pipelineTuningOptions.LoopUnrolling);
+  target.pipelineTuningOptions.SLPVectorization = getBoolValue(
+      "slp_vectorization", target.pipelineTuningOptions.SLPVectorization);
+  auto targetAbi = getOptionalString("target_abi");
+  if (targetAbi)
+    target.llvmTargetOptions.MCOptions.ABIName = *targetAbi;
+  auto floatAbi = getOptionalString("float_abi");
+  if (floatAbi) {
+    if (floatAbi == "default")
+      target.llvmTargetOptions.FloatABIType = llvm::FloatABI::Default;
+    else if (floatAbi == "soft")
+      target.llvmTargetOptions.FloatABIType = llvm::FloatABI::Default;
+    else if (floatAbi == "hard")
+      target.llvmTargetOptions.FloatABIType = llvm::FloatABI::Default;
+    else {
+      emitError(loc) << "executable config unexpected value for 'float_abi'";
+      return {};
+    }
+  }
+
+  if (hasFailures) {
+    return {};
+  }
+  return target;
+}
+
+void LLVMTarget::addTargetCPUFeaturesForCPU() {
+  if (!llvm::Triple(triple).isX86()) {
     // Currently only implemented on x86.
     return;
   }
-  llvm::SubtargetFeatures targetCpuFeatures(target.cpuFeatures);
-  llvm::SmallVector<llvm::StringRef> cpuFeatures;
-  llvm::X86::getFeaturesForCPU(target.cpu, cpuFeatures);
-  for (auto &feature : cpuFeatures) {
+  llvm::SubtargetFeatures targetCpuFeatures(cpuFeatures);
+  llvm::SmallVector<llvm::StringRef> cpuFeatureList;
+  llvm::X86::getFeaturesForCPU(cpu, cpuFeatureList);
+  for (auto &feature : cpuFeatureList) {
     targetCpuFeatures.AddFeature(feature);
   }
-  target.cpuFeatures = targetCpuFeatures.getString();
+  cpuFeatures = targetCpuFeatures.getString();
 }
 
-LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
-  auto targetOptions = getDefaultLLVMTargetOptions();
+void LLVMTargetOptions::initializeTargetInvariantFlags() {
+  static llvm::cl::opt<std::string> clSystemLinkerPath(
+      "iree-llvmcpu-system-linker-path",
+      llvm::cl::desc("Tool used to link system shared libraries produced by "
+                     "IREE (for --iree-llvmcpu-link-embedded=false)."),
+      llvm::cl::init(""));
+  systemLinkerPath = clSystemLinkerPath;
 
+  static llvm::cl::opt<std::string> clEmbeddedLinkerPath(
+      "iree-llvmcpu-embedded-linker-path",
+      llvm::cl::desc("Tool used to link embedded ELFs produced by IREE (for "
+                     "--iree-llvmcpu-link-embedded=true)."),
+      llvm::cl::init(""));
+  embeddedLinkerPath = clEmbeddedLinkerPath;
+
+  static llvm::cl::opt<std::string> clWasmLinkerPath(
+      "iree-llvmcpu-wasm-linker-path",
+      llvm::cl::desc("Tool used to link WebAssembly modules produced by "
+                     "IREE (for --iree-llvmcpu-target-triple=wasm32-*)."),
+      llvm::cl::init(""));
+  wasmLinkerPath = clWasmLinkerPath;
+
+  static llvm::cl::opt<bool> clKeepLinkerArtifacts(
+      "iree-llvmcpu-keep-linker-artifacts",
+      llvm::cl::desc("Keep LLVM linker target artifacts (.so/.dll/etc)"),
+      llvm::cl::init(keepLinkerArtifacts));
+  keepLinkerArtifacts = clKeepLinkerArtifacts;
+}
+
+LLVMTargetOptions LLVMTargetOptions::getHostOptions() {
+  LLVMTargetOptions targetOptions;
+  targetOptions.target = LLVMTarget::getForHost();
+  targetOptions.initializeTargetInvariantFlags();
+  return targetOptions;
+}
+
+LLVMTargetOptions LLVMTargetOptions::getFromFlags() {
+  LLVMTargetOptions targetOptions;
+  const HostDefaults &hostDefaults = HostDefaults::get();
+  targetOptions.initializeTargetInvariantFlags();
+
+  // Target parameters.
   static llvm::cl::opt<std::string> clTargetTriple(
       "iree-llvmcpu-target-triple",
       llvm::cl::desc("LLVM target machine triple"),
-      llvm::cl::init(targetOptions.target.triple));
+      llvm::cl::init(hostDefaults.triple));
   static llvm::cl::opt<std::string> clTargetCPU(
       "iree-llvmcpu-target-cpu",
       llvm::cl::desc(
@@ -93,45 +399,38 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
       llvm::cl::desc("LLVM target machine CPU features; use 'host' for your "
                      "host native CPU"),
       llvm::cl::init(""));
+  static llvm::cl::opt<bool> clLinkEmbedded(
+      "iree-llvmcpu-link-embedded",
+      llvm::cl::desc("Links binaries into a platform-agnostic ELF to be loaded "
+                     "by the embedded IREE ELF loader"),
+      llvm::cl::init(LLVMTarget::DEFAULT_LINK_EMBEDDED));
+  targetOptions.target =
+      LLVMTarget(clTargetTriple, clTargetCPU, clTargetCPUFeatures,
+                 /*requestLinkEmbedded=*/clLinkEmbedded);
+  LLVMTarget &target = targetOptions.target;
 
   static llvm::cl::opt<bool> llvmLoopInterleaving(
-      "iree-llvmcpu-loop-interleaving", llvm::cl::init(false),
+      "iree-llvmcpu-loop-interleaving",
+      llvm::cl::init(LLVMTarget::DEFAULT_LOOP_INTERLEAVING),
       llvm::cl::desc("Enable LLVM loop interleaving opt"));
   static llvm::cl::opt<bool> llvmLoopVectorization(
-      "iree-llvmcpu-loop-vectorization", llvm::cl::init(false),
+      "iree-llvmcpu-loop-vectorization",
+      llvm::cl::init(LLVMTarget::DEFAULT_LOOP_VECTORIZATION),
       llvm::cl::desc("Enable LLVM loop vectorization opt"));
   static llvm::cl::opt<bool> llvmLoopUnrolling(
-      "iree-llvmcpu-loop-unrolling", llvm::cl::init(true),
+      "iree-llvmcpu-loop-unrolling",
+      llvm::cl::init(LLVMTarget::DEFAULT_LOOP_UNROLLING),
       llvm::cl::desc("Enable LLVM loop unrolling opt"));
   static llvm::cl::opt<bool> llvmSLPVectorization(
-      "iree-llvmcpu-slp-vectorization", llvm::cl::init(false),
+      "iree-llvmcpu-slp-vectorization",
+      llvm::cl::init(LLVMTarget::DEFAULT_SLP_VECTORIZATION),
       llvm::cl::desc("Enable LLVM SLP Vectorization opt"));
 
-  targetOptions.target.triple = clTargetTriple;
-  llvm::Triple targetTriple(targetOptions.target.triple);
-  if (clTargetCPU != "host") {
-    targetOptions.target.cpu = clTargetCPU;
-  }
-  if (clTargetCPUFeatures != "host") {
-    targetOptions.target.cpuFeatures = clTargetCPUFeatures;
-  }
-  if (clTargetCPU != "host" && clTargetCPU != "generic") {
-    addTargetCPUFeaturesForCPU(targetOptions.target);
-  }
-  // TODO(muralivi): Move this into `addTargetCPUFeaturesForCPU`, after fixing
-  // the predicate for when `addTargetCPUFeaturesForCPU` is called (i.e.
-  // removing the condition that clTargetCPU is neither host nor generic).
-  if (llvm::Triple(targetOptions.target.triple).isAArch64()) {
-    llvm::SubtargetFeatures targetCpuFeatures(targetOptions.target.cpuFeatures);
-    targetCpuFeatures.AddFeature("reserve-x18", true);
-    targetOptions.target.cpuFeatures = targetCpuFeatures.getString();
-  }
-
   // LLVM opt options.
-  targetOptions.pipelineTuningOptions.LoopInterleaving = llvmLoopInterleaving;
-  targetOptions.pipelineTuningOptions.LoopVectorization = llvmLoopVectorization;
-  targetOptions.pipelineTuningOptions.LoopUnrolling = llvmLoopUnrolling;
-  targetOptions.pipelineTuningOptions.SLPVectorization = llvmSLPVectorization;
+  target.pipelineTuningOptions.LoopInterleaving = llvmLoopInterleaving;
+  target.pipelineTuningOptions.LoopVectorization = llvmLoopVectorization;
+  target.pipelineTuningOptions.LoopUnrolling = llvmLoopUnrolling;
+  target.pipelineTuningOptions.SLPVectorization = llvmSLPVectorization;
 
   static llvm::cl::opt<SanitizerKind> clSanitizerKind(
       "iree-llvmcpu-sanitize", llvm::cl::desc("Apply LLVM sanitize feature"),
@@ -140,86 +439,40 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
                                   "Address sanitizer support"),
                        clEnumValN(SanitizerKind::kThread, "thread",
                                   "Thread sanitizer support")));
-  targetOptions.sanitizerKind = clSanitizerKind;
+  target.sanitizerKind = clSanitizerKind;
 
   static llvm::cl::opt<std::string> clTargetABI(
       "iree-llvmcpu-target-abi",
       llvm::cl::desc("LLVM target machine ABI; specify for -mabi"),
       llvm::cl::init(""));
-  targetOptions.options.MCOptions.ABIName = clTargetABI;
+  target.llvmTargetOptions.MCOptions.ABIName = clTargetABI;
 
   static llvm::cl::opt<llvm::FloatABI::ABIType> clTargetFloatABI(
       "iree-llvmcpu-target-float-abi",
       llvm::cl::desc("LLVM target codegen enables soft float abi e.g "
                      "-mfloat-abi=softfp"),
-      llvm::cl::init(targetOptions.options.FloatABIType),
+      llvm::cl::init(target.llvmTargetOptions.FloatABIType),
       llvm::cl::values(
           clEnumValN(llvm::FloatABI::Default, "default", "Default (softfp)"),
           clEnumValN(llvm::FloatABI::Soft, "soft",
                      "Software floating-point emulation"),
           clEnumValN(llvm::FloatABI::Hard, "hard",
                      "Hardware floating-point instructions")));
-  targetOptions.options.FloatABIType = clTargetFloatABI;
+  target.llvmTargetOptions.FloatABIType = clTargetFloatABI;
 
   static llvm::cl::opt<bool> clDebugSymbols(
       "iree-llvmcpu-debug-symbols",
       llvm::cl::desc("Generate and embed debug information (DWARF, PDB, etc)"),
-      llvm::cl::init(targetOptions.debugSymbols));
-  targetOptions.debugSymbols = clDebugSymbols;
-
-  static llvm::cl::opt<std::string> clSystemLinkerPath(
-      "iree-llvmcpu-system-linker-path",
-      llvm::cl::desc("Tool used to link system shared libraries produced by "
-                     "IREE (for --iree-llvmcpu-link-embedded=false)."),
-      llvm::cl::init(""));
-  targetOptions.systemLinkerPath = clSystemLinkerPath;
-
-  static llvm::cl::opt<std::string> clEmbeddedLinkerPath(
-      "iree-llvmcpu-embedded-linker-path",
-      llvm::cl::desc("Tool used to link embedded ELFs produced by IREE (for "
-                     "--iree-llvmcpu-link-embedded=true)."),
-      llvm::cl::init(""));
-  targetOptions.embeddedLinkerPath = clEmbeddedLinkerPath;
-
-  static llvm::cl::opt<std::string> clWasmLinkerPath(
-      "iree-llvmcpu-wasm-linker-path",
-      llvm::cl::desc("Tool used to link WebAssembly modules produced by "
-                     "IREE (for --iree-llvmcpu-target-triple=wasm32-*)."),
-      llvm::cl::init(""));
-  targetOptions.wasmLinkerPath = clWasmLinkerPath;
-
-  static llvm::cl::opt<bool> clLinkEmbedded(
-      "iree-llvmcpu-link-embedded",
-      llvm::cl::desc("Links binaries into a platform-agnostic ELF to be loaded "
-                     "by the embedded IREE ELF loader"),
-      llvm::cl::init(targetOptions.linkEmbedded));
-  targetOptions.linkEmbedded = clLinkEmbedded;
-  if (targetTriple.isWasm()) {
-    // The embedded ELF loader is not supported on WebAssembly, so force it off.
-    targetOptions.linkEmbedded = false;
-  }
-  if (targetOptions.linkEmbedded) {
-    // Force the triple to something compatible with embedded linking.
-    targetTriple.setVendor(llvm::Triple::VendorType::UnknownVendor);
-    targetTriple.setEnvironment(llvm::Triple::EnvironmentType::EABI);
-    targetTriple.setOS(llvm::Triple::OSType::UnknownOS);
-    targetTriple.setObjectFormat(llvm::Triple::ObjectFormatType::ELF);
-    targetOptions.target.triple = targetTriple.str();
-  }
+      llvm::cl::init(target.debugSymbols));
+  target.debugSymbols = clDebugSymbols;
 
   static llvm::cl::opt<bool> clLinkStatic(
       "iree-llvmcpu-link-static",
       llvm::cl::desc(
           "Links system libraries into binaries statically to isolate them "
           "from platform dependencies needed at runtime"),
-      llvm::cl::init(targetOptions.linkStatic));
-  targetOptions.linkStatic = clLinkStatic;
-
-  static llvm::cl::opt<bool> clKeepLinkerArtifacts(
-      "iree-llvmcpu-keep-linker-artifacts",
-      llvm::cl::desc("Keep LLVM linker target artifacts (.so/.dll/etc)"),
-      llvm::cl::init(targetOptions.keepLinkerArtifacts));
-  targetOptions.keepLinkerArtifacts = clKeepLinkerArtifacts;
+      llvm::cl::init(target.linkStatic));
+  target.linkStatic = clLinkStatic;
 
   static llvm::cl::opt<std::string> clStaticLibraryOutputPath(
       "iree-llvmcpu-static-library-output-path",
@@ -227,8 +480,8 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
           "Path to output static object (EX: '/path/to/static-library.o'). "
           "This will produce the static library at the specified path along "
           "with a similarly named '.h' file for static linking."),
-      llvm::cl::init(targetOptions.staticLibraryOutput));
-  targetOptions.staticLibraryOutput = clStaticLibraryOutputPath;
+      llvm::cl::init(target.staticLibraryOutput));
+  target.staticLibraryOutput = clStaticLibraryOutputPath;
 
   static llvm::cl::opt<bool> clListTargets(
       "iree-llvmcpu-list-targets",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.h
@@ -7,8 +7,13 @@
 #ifndef IREE_COMPILER_DIALECT_HAL_TARGET_LLVMCPU_LLVMTARGETOPTIONS_H_
 #define IREE_COMPILER_DIALECT_HAL_TARGET_LLVMCPU_LLVMTARGETOPTIONS_H_
 
+#include <string_view>
+
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetOptions.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Location.h"
 
 namespace mlir {
 namespace iree_compiler {
@@ -23,32 +28,90 @@ enum class SanitizerKind {
   kThread,
 };
 
+// The LLVMTarget contains all of the information to perform code generation
+// and linking for an ExecutableVariant. It should not contain any
+// environmental configuration like linker paths, diagnostic aids, etc.
 struct LLVMTarget {
-  std::string triple;
-  std::string cpu;
-  std::string cpuFeatures;
-};
+  static constexpr bool DEFAULT_LINK_EMBEDDED = true;
+  static constexpr bool DEFAULT_DEBUG_SYMBOLS = true;
+  static constexpr SanitizerKind DEFAULT_SANITIZER_KIND = SanitizerKind::kNone;
+  static constexpr bool DEFAULT_LINK_STATIC = false;
+  static constexpr bool DEFAULT_LOOP_INTERLEAVING = false;
+  static constexpr bool DEFAULT_LOOP_VECTORIZATION = false;
+  static constexpr bool DEFAULT_LOOP_UNROLLING = true;
+  static constexpr bool DEFAULT_SLP_VECTORIZATION = false;
+  static constexpr llvm::FloatABI::ABIType DEFAULT_FLOAT_ABI =
+      llvm::FloatABI::ABIType::Hard;
 
-struct LLVMTargetOptions {
-  // Default target machine configuration.
-  LLVMTarget target;
+  // Default initialize all fields.
+  LLVMTarget();
+  // Initialize for specific triple, CPU and link features.
+  LLVMTarget(std::string_view triple, std::string_view cpu,
+             std::string_view cpuFeatures, bool requestLinkEmbedded);
+  static const LLVMTarget &getForHost();
+  void print(llvm::raw_ostream &os) const;
+
+  // Stores the target to the given DictionaryAttr in a way that can be
+  // later loaded from loadFromConfigAttr().
+  void storeToConfigAttrs(MLIRContext *context,
+                          SmallVector<NamedAttribute> &config) const;
+
+  // Loads from a DictionaryAttr. On failure returns none and emits.
+  static std::optional<LLVMTarget>
+  loadFromConfigAttr(Location loc, DictionaryAttr config,
+                     const LLVMTarget &defaultTarget);
+
+  // Key fields about the machine can only be set via constructor.
+  const std::string &getTriple() const { return triple; }
+  const std::string &getCpu() const { return cpu; }
+  const std::string &getCpuFeatures() const { return cpuFeatures; }
+  bool getLinkEmbedded() const { return linkEmbedded; }
 
   llvm::PipelineTuningOptions pipelineTuningOptions;
   // Optimization level to be used by the LLVM optimizer (middle-end).
   llvm::OptimizationLevel optimizerOptLevel;
   // Optimization level to be used by the LLVM code generator (back-end).
   llvm::CodeGenOpt::Level codeGenOptLevel;
-  llvm::TargetOptions options;
+  llvm::TargetOptions llvmTargetOptions;
 
   // Include debug information in output files (PDB, DWARF, etc).
   // Though this can be set independently from the optLevel (so -O3 with debug
   // information is valid) it may significantly change the output program
   // contents and benchmarking of binary sizes and to some extent execution
   // time should be avoided with symbols present.
-  bool debugSymbols = true;
+  bool debugSymbols = DEFAULT_DEBUG_SYMBOLS;
 
   // Sanitizer Kind for CPU Kernels
-  SanitizerKind sanitizerKind = SanitizerKind::kNone;
+  SanitizerKind sanitizerKind = DEFAULT_SANITIZER_KIND;
+
+  // Build for IREE static library loading using this output path for
+  // a "{staticLibraryOutput}.o" object file and "{staticLibraryOutput}.h"
+  // header file.
+  //
+  // This option is incompatible with the linkEmbedded option.
+  std::string staticLibraryOutput;
+
+  // Link any required runtime libraries into the produced binaries statically.
+  // This increases resulting binary size but enables the binaries to be used on
+  // any machine without requiring matching system libraries to be installed.
+  bool linkStatic = DEFAULT_LINK_STATIC;
+
+private:
+  void addTargetCPUFeaturesForCPU();
+
+  std::string triple;
+  std::string cpu;
+  std::string cpuFeatures;
+
+  // Build for the IREE embedded platform-agnostic ELF loader.
+  // Note: this is ignored for target machines that do not support the ELF
+  // loader, such as WebAssembly.
+  bool linkEmbedded = DEFAULT_LINK_EMBEDDED;
+};
+
+struct LLVMTargetOptions {
+  // Default target machine configuration.
+  LLVMTarget target;
 
   // Tool to use for native platform linking (like ld on Unix or link.exe on
   // Windows). Acts as a prefix to the command line and can contain additional
@@ -61,29 +124,20 @@ struct LLVMTargetOptions {
   // Tool to use for linking WebAssembly modules. Must be wasm-ld or lld.
   std::string wasmLinkerPath;
 
-  // Build for the IREE embedded platform-agnostic ELF loader.
-  // Note: this is ignored for target machines that do not support the ELF
-  // loader, such as WebAssembly.
-  bool linkEmbedded = true;
-
-  // Link any required runtime libraries into the produced binaries statically.
-  // This increases resulting binary size but enables the binaries to be used on
-  // any machine without requiring matching system libraries to be installed.
-  bool linkStatic = false;
-
   // True to keep linker artifacts for debugging.
   bool keepLinkerArtifacts = false;
 
-  // Build for IREE static library loading using this output path for
-  // a "{staticLibraryOutput}.o" object file and "{staticLibraryOutput}.h"
-  // header file.
-  //
-  // This option is incompatible with the linkEmbedded option.
-  std::string staticLibraryOutput;
-};
+  // Returns LLVMTargetOptions that are suitable for running on the host.
+  // This does not configure the options from global flags unless if they
+  // are target invariant.
+  static LLVMTargetOptions getHostOptions();
 
-// Returns LLVMTargetOptions struct intialized with the iree-llvmcpu-* flags.
-LLVMTargetOptions getLLVMTargetOptionsFromFlags();
+  // Returns LLVMTargetOptions struct intialized with the iree-llvmcpu-* flags.
+  static LLVMTargetOptions getFromFlags();
+
+private:
+  void initializeTargetInvariantFlags();
+};
 
 } // namespace HAL
 } // namespace IREE

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/AndroidLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/AndroidLinkerTool.cpp
@@ -208,7 +208,7 @@ public:
     };
 
     // Strip debug information (only, no relocations) when not requested.
-    if (!targetOptions.debugSymbols) {
+    if (!targetOptions.target.debugSymbols) {
       flagsToPrefixForLinker.push_back("--strip-debug");
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/EmbeddedLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/EmbeddedLinkerTool.cpp
@@ -90,7 +90,7 @@ public:
     // the downside of making some tooling (disassemblers/decompilers/binary
     // size analysis tools/etc) a bit harder to work with, though, so when
     // compiling in debug mode we export all the functions.
-    if (targetOptions.debugSymbols) {
+    if (targetOptions.target.debugSymbols) {
       for (auto llvmFunc : exportedFuncs) {
         llvmFunc->setVisibility(
             llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
@@ -186,7 +186,7 @@ public:
     flags.push_back("--hash-style=sysv");
 
     // Strip debug information (only, no relocations) when not requested.
-    if (!targetOptions.debugSymbols) {
+    if (!targetOptions.target.debugSymbols) {
       flags.push_back("--strip-debug");
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/LinkerTools.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/LinkerTools.cpp
@@ -34,7 +34,7 @@ createWindowsLinkerTool(const llvm::Triple &targetTriple,
 std::unique_ptr<LinkerTool>
 LinkerTool::getForTarget(const llvm::Triple &targetTriple,
                          LLVMTargetOptions &targetOptions) {
-  if (targetOptions.linkEmbedded) {
+  if (targetOptions.target.getLinkEmbedded()) {
     return createEmbeddedLinkerTool(targetTriple, targetOptions);
   } else if (targetTriple.isAndroid()) {
     return createAndroidLinkerTool(targetTriple, targetOptions);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/UnixLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/UnixLinkerTool.cpp
@@ -121,7 +121,7 @@ public:
     }
 
     // Strip debug information (only, no relocations) when not requested.
-    if (!targetOptions.debugSymbols) {
+    if (!targetOptions.target.debugSymbols) {
       flags.push_back("--strip-debug");
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WasmLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WasmLinkerTool.cpp
@@ -123,7 +123,7 @@ public:
     };
 
     // Strip debug information when not requested.
-    if (!targetOptions.debugSymbols) {
+    if (!targetOptions.target.debugSymbols) {
       flags.push_back("--strip-debug");
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WindowsLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WindowsLinkerTool.cpp
@@ -75,7 +75,7 @@ public:
     // the downside of making some tooling (disassemblers/decompilers/binary
     // size analysis tools/etc) a bit harder to work with, though, so when
     // compiling in debug mode we export all the functions.
-    if (targetOptions.debugSymbols) {
+    if (targetOptions.target.debugSymbols) {
       for (auto *llvmFunc : exportedFuncs) {
         llvmFunc->setVisibility(
             llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
@@ -180,8 +180,8 @@ public:
         "/out:" + artifacts.libraryFile.path,
     };
 
-    if (targetOptions.optimizerOptLevel.getSpeedupLevel() >= 2 ||
-        targetOptions.optimizerOptLevel.getSizeLevel() >= 2) {
+    if (targetOptions.target.optimizerOptLevel.getSpeedupLevel() >= 2 ||
+        targetOptions.target.optimizerOptLevel.getSizeLevel() >= 2) {
       // https://docs.microsoft.com/en-us/cpp/build/reference/opt-optimizations?view=vs-2019
       // Enable all the fancy optimizations.
       flags.push_back("/opt:ref,icf,lbr");
@@ -235,12 +235,12 @@ public:
     // We need to link against different libraries based on our configuration
     // matrix (dynamic/static and debug/release).
     int libIndex = 0;
-    if (targetOptions.optimizerOptLevel.getSpeedupLevel() == 0) {
+    if (targetOptions.target.optimizerOptLevel.getSpeedupLevel() == 0) {
       libIndex += 0; // debug
     } else {
       libIndex += 2; // release
     }
-    libIndex += targetOptions.linkStatic ? 1 : 0;
+    libIndex += targetOptions.target.linkStatic ? 1 : 0;
 
     // The required libraries for linking DLLs:
     // https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-library-features?view=msvc-160

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_DIALECT_HAL_TARGET_TARGETBACKEND_H_
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -134,9 +135,20 @@ public:
   // Types, Attributes).
   virtual void getDependentDialects(DialectRegistry &registry) const {}
 
-  // Returns the default device this backend targets.
+  // Returns the default device this backend targets. This may involve setting
+  // defaults from flags and other environmental sources, and it may be
+  // cross-targeting in a way that is not compatible with the host.
   virtual IREE::HAL::DeviceTargetAttr
   getDefaultDeviceTarget(MLIRContext *context) const = 0;
+
+  // Similar to getDefaultDeviceTarget, but always returns a DeviceTargetAttr
+  // that is configured for the host, regardless of if flags/environment were
+  // configured to cross-target in some way.
+  //
+  virtual std::optional<IREE::HAL::DeviceTargetAttr>
+  getHostDeviceTarget(MLIRContext *context) const {
+    return {};
+  }
 
   // Inserts passes used to translate the `hal.executable.variant` op contents.
   // The pass manager will be nested on `hal.executable` such that the pipeline

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
@@ -71,6 +71,11 @@ public:
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
+  std::optional<IREE::HAL::DeviceTargetAttr>
+  getHostDeviceTarget(MLIRContext *context) const override {
+    return getDefaultDeviceTarget(context);
+  }
+
   IREE::VM::TargetOptions
   getTargetOptions(IREE::HAL::ExecutableTargetAttr targetAttr) {
     // TODO(benvanik): derive these from a vm target triple.

--- a/compiler/src/iree/compiler/Tools/init_targets.cc
+++ b/compiler/src/iree/compiler/Tools/init_targets.cc
@@ -39,7 +39,7 @@ void registerHALTargetBackends() {
 
 #ifdef IREE_HAVE_LLVM_CPU_TARGET
     IREE::HAL::registerLLVMCPUTargetBackends(
-        []() { return IREE::HAL::getLLVMTargetOptionsFromFlags(); });
+        []() { return IREE::HAL::LLVMTargetOptions::getFromFlags(); });
 #endif // IREE_HAVE_LLVM_CPU_TARGET
 #ifdef IREE_HAVE_METALSPIRV_TARGET
     IREE::HAL::registerMetalSPIRVTargetBackends();


### PR DESCRIPTION
Isolate LLVMTarget in the llvm-cpu backend.

This carefully pry's apart the LLVMTargetOptions from the LLVMTarget, making sure that the latter is hermetic for anything affecting the generated code.

Further replumbs the target backend so that it doesn't reach into default state and works off of the configuration IR exclusively.

Also updates the consteval JIT to use this new capability for targeting the host, even if the overall compilation is cross-compiling.

Flags changed:

* Removes `iree-consteval-jit-use-vmvx`
* Adds `iree-consteval-jit-target-backend`: Currently still defaults to VMVX but with this change it should be possible to reliably flip it to llvm-cpu.

I tested this by adding a similar print function to the options in a base branch and exhaustively compared the results of of the target information before and after the change for full builds. There were some tricky things in the original since it was initializing flags off of defaults which would then be re-calculated and such. I've smoothed all of this out so that at least the paths are straight through once the initial configuration is set.