### PR TITLE
Adding iree_allocator_inline_arena and using it from VM tracing.

### DIFF
--- a/runtime/src/iree/base/allocator.h
+++ b/runtime/src/iree/base/allocator.h
@@ -217,6 +217,10 @@ iree_allocator_clone(iree_allocator_t allocator,
 // Frees a previously-allocated block of memory to the given allocator.
 IREE_API_EXPORT void iree_allocator_free(iree_allocator_t allocator, void* ptr);
 
+//===----------------------------------------------------------------------===//
+// Built-in iree_allocator_t implementations
+//===----------------------------------------------------------------------===//
+
 // Default C allocator controller using malloc/free.
 IREE_API_EXPORT iree_status_t
 iree_allocator_system_ctl(void* self, iree_allocator_command_t command,
@@ -239,6 +243,46 @@ static inline iree_allocator_t iree_allocator_null(void) {
 // Returns true if the allocator is `iree_allocator_null()`.
 static inline bool iree_allocator_is_null(iree_allocator_t allocator) {
   return allocator.ctl == NULL;
+}
+
+typedef struct {
+  iree_host_size_t capacity;
+  iree_host_size_t length;
+  iree_host_size_t head_size;
+  uint8_t* buffer;
+} iree_allocator_inline_storage_t;
+
+// Stack storage for an inline arena-style allocator.
+//
+// Usage:
+//  IREE_ALLOCATOR_INLINE_STORAGE(inline_storage, 2048);
+//  something_allocating(iree_allocator_inline_arena(&inline_storage.header));
+#define IREE_ALLOCATOR_INLINE_STORAGE(var, storage_capacity) \
+  struct {                                                   \
+    iree_allocator_inline_storage_t header;                  \
+    uint8_t data[storage_capacity];                          \
+  } var = {                                                  \
+      .header =                                              \
+          {                                                  \
+              .capacity = sizeof((var).data),                \
+              .length = 0,                                   \
+              .buffer = &(var).data[0],                      \
+          },                                                 \
+  };
+
+// Inline arena allocator controller used by iree_allocator_inline_arena.
+IREE_API_EXPORT iree_status_t
+iree_allocator_inline_arena_ctl(void* self, iree_allocator_command_t command,
+                                const void* params, void** inout_ptr);
+
+// Allocates with arena semantics within the given fixed-size |storage|.
+// Frees are ignored and all allocations will fail once the allocated length
+// exceeds the capacity. A special case for reallocations of the entire
+// outstanding memory is supported to allow the arena to be implicitly reset.
+static inline iree_allocator_t iree_allocator_inline_arena(
+    iree_allocator_inline_storage_t* storage) {
+  iree_allocator_t v = {storage, iree_allocator_inline_arena_ctl};
+  return v;
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -2177,8 +2177,10 @@ iree_status_t iree_vm_bytecode_disassemble_op(
 iree_status_t iree_vm_bytecode_trace_disassembly(
     iree_vm_stack_frame_t* frame, iree_vm_source_offset_t pc,
     const iree_vm_registers_t* regs, FILE* file) {
+  IREE_ALLOCATOR_INLINE_STORAGE(inline_storage, 2048);
   iree_string_builder_t b;
-  iree_string_builder_initialize(iree_allocator_system(), &b);
+  iree_string_builder_initialize(
+      iree_allocator_inline_arena(&inline_storage.header), &b);
 
   // TODO(benvanik): ensure frame is in-sync before call or restore original.
   // It's shady to manipulate the frame here but I know we expect the pc to be


### PR DESCRIPTION
Simple stack storage that is optimized for buffers/arrays/builders. Removes all the tracing noise when --trace_execution is enabled.