### PR TITLE
Turn off strict aliasing in iree_h2f library

### DIFF
--- a/runtime/src/iree/builtins/device/BUILD.bazel
+++ b/runtime/src/iree/builtins/device/BUILD.bazel
@@ -34,6 +34,9 @@ iree_runtime_cc_library(
     name = "device",
     srcs = BITCODE_SRCS,
     hdrs = BITCODE_HDRS,
+    copts = [
+        "-fno-strict-aliasing",
+    ],
 )
 
 #===------------------------------------------------------------------------===#

--- a/runtime/src/iree/builtins/device/CMakeLists.txt
+++ b/runtime/src/iree/builtins/device/CMakeLists.txt
@@ -13,6 +13,8 @@ iree_add_all_subdirs()
 iree_cc_library(
   NAME
     device
+  COPTS
+    "-fno-strict-aliasing"
   HDRS
     "device.h"
   SRCS


### PR DESCRIPTION
The library use hex coding to represent f16 numbers. Turn off the strict aliasing to use the manipulation without GCC warnings.