### PR TITLE
[cuda] Avoid sorting when composing kernel arguments

### DIFF
--- a/experimental/cuda2/graph_command_buffer.c
+++ b/experimental/cuda2/graph_command_buffer.c
@@ -724,7 +724,7 @@ static iree_status_t iree_hal_cuda2_graph_command_buffer_push_descriptor_set(
     return iree_make_status(
         IREE_STATUS_RESOURCE_EXHAUSTED,
         "exceeded available binding slots for push "
-        "descriptor set #%" PRIu32 "; requested %lu vs. maximal %d",
+        "descriptor set #%" PRIu32 "; requested %" PRIhsz " vs. maximal %d",
         set, binding_count, IREE_HAL_CUDA_MAX_DESCRIPTOR_SET_BINDING_COUNT);
   }
 

--- a/experimental/cuda2/native_executable.c
+++ b/experimental/cuda2/native_executable.c
@@ -33,7 +33,7 @@ typedef struct iree_hal_cuda2_native_executable_t {
   iree_host_size_t entry_point_count;
   // The list of entry point data pointers, pointing to trailing inline
   // allocation after the end of this struct.
-  iree_hal_cuda2_kernel_params_t entry_points[];
+  iree_hal_cuda2_kernel_info_t entry_points[];
 } iree_hal_cuda2_native_executable_t;
 // + Additional inline allocation for holding entry point information.
 
@@ -224,20 +224,20 @@ iree_status_t iree_hal_cuda2_native_executable_create(
       if (!iree_status_is_ok(status)) break;
 
       // Package required parameters for kernel launches for each entry point.
-      iree_hal_cuda2_kernel_params_t* params = &executable->entry_points[i];
-      params->layout = executable_params->pipeline_layouts[i];
-      iree_hal_pipeline_layout_retain(params->layout);
-      params->function = function;
-      params->block_size[0] = block_sizes_vec[i].x;
-      params->block_size[1] = block_sizes_vec[i].y;
-      params->block_size[2] = block_sizes_vec[i].z;
-      params->shared_memory_size = shared_memory_sizes[i];
+      iree_hal_cuda2_kernel_info_t* info = &executable->entry_points[i];
+      info->layout = executable_params->pipeline_layouts[i];
+      iree_hal_pipeline_layout_retain(info->layout);
+      info->function = function;
+      info->block_size[0] = block_sizes_vec[i].x;
+      info->block_size[1] = block_sizes_vec[i].y;
+      info->block_size[2] = block_sizes_vec[i].z;
+      info->shared_memory_size = shared_memory_sizes[i];
 
       // Stash the entry point name in the string table for use when tracing.
       IREE_TRACE({
         iree_host_size_t entry_name_length = flatbuffers_string_len(entry_name);
         memcpy(string_table_buffer, entry_name, entry_name_length);
-        params->function_name =
+        info->function_name =
             iree_make_string_view(string_table_buffer, entry_name_length);
         string_table_buffer += entry_name_length;
       });
@@ -252,9 +252,9 @@ iree_status_t iree_hal_cuda2_native_executable_create(
           flatbuffers_string_t filename =
               iree_hal_cuda_FileLineLocDef_filename_get(source_loc);
           uint32_t line = iree_hal_cuda_FileLineLocDef_line_get(source_loc);
-          params->source_filename =
+          info->source_filename =
               iree_make_string_view(filename, flatbuffers_string_len(filename));
-          params->source_line = line;
+          info->source_line = line;
         }
       });
     }
@@ -289,9 +289,9 @@ static void iree_hal_cuda2_native_executable_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
-iree_status_t iree_hal_cuda2_native_executable_entry_point_kernel_params(
+iree_status_t iree_hal_cuda2_native_executable_entry_point_kernel_info(
     iree_hal_executable_t* base_executable, int32_t entry_point,
-    iree_hal_cuda2_kernel_params_t* out_params) {
+    iree_hal_cuda2_kernel_info_t* out_info) {
   iree_hal_cuda2_native_executable_t* executable =
       iree_hal_cuda2_native_executable_cast(base_executable);
   if (entry_point >= executable->entry_point_count) {
@@ -300,8 +300,7 @@ iree_status_t iree_hal_cuda2_native_executable_entry_point_kernel_params(
                             "only contains %" PRIhsz " entry points",
                             entry_point, executable->entry_point_count);
   }
-  memcpy(out_params, &executable->entry_points[entry_point],
-         sizeof(*out_params));
+  memcpy(out_info, &executable->entry_points[entry_point], sizeof(*out_info));
   return iree_ok_status();
 }
 

--- a/experimental/cuda2/native_executable.h
+++ b/experimental/cuda2/native_executable.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_cuda2_kernel_params_t {
+typedef struct iree_hal_cuda2_kernel_info_t {
   iree_hal_pipeline_layout_t* layout;
   CUfunction function;
   uint32_t block_size[3];
@@ -28,7 +28,7 @@ typedef struct iree_hal_cuda2_kernel_params_t {
   IREE_TRACE(iree_string_view_t function_name;)
   IREE_TRACE(iree_string_view_t source_filename;)
   IREE_TRACE(uint32_t source_line;)
-} iree_hal_cuda2_kernel_params_t;
+} iree_hal_cuda2_kernel_info_t;
 
 // Creates an IREE executable from a CUDA PTX module. The module may contain
 // several kernels that can be extracted along with the associated block size.
@@ -37,11 +37,11 @@ iree_status_t iree_hal_cuda2_native_executable_create(
     const iree_hal_executable_params_t* executable_params,
     iree_allocator_t host_allocator, iree_hal_executable_t** out_executable);
 
-// Returns the kernel launch parameters for the given |entry_point| in the
+// Returns the kernel launch information for the given |entry_point| in the
 // |executable|.
-iree_status_t iree_hal_cuda2_native_executable_entry_point_kernel_params(
+iree_status_t iree_hal_cuda2_native_executable_entry_point_kernel_info(
     iree_hal_executable_t* executable, int32_t entry_point,
-    iree_hal_cuda2_kernel_params_t* out_params);
+    iree_hal_cuda2_kernel_info_t* out_info);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/experimental/cuda2/pipeline_layout.c
+++ b/experimental/cuda2/pipeline_layout.c
@@ -38,6 +38,14 @@ iree_hal_cuda2_descriptor_set_layout_cast(
   return (iree_hal_cuda2_descriptor_set_layout_t*)base_value;
 }
 
+static const iree_hal_cuda2_descriptor_set_layout_t*
+iree_hal_cuda2_descriptor_set_layout_const_cast(
+    const iree_hal_descriptor_set_layout_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value,
+                       &iree_hal_cuda2_descriptor_set_layout_vtable);
+  return (const iree_hal_cuda2_descriptor_set_layout_t*)base_value;
+}
+
 iree_status_t iree_hal_cuda2_descriptor_set_layout_create(
     iree_hal_descriptor_set_layout_flags_t flags,
     iree_host_size_t binding_count,
@@ -69,9 +77,10 @@ iree_status_t iree_hal_cuda2_descriptor_set_layout_create(
 }
 
 iree_host_size_t iree_hal_cuda2_descriptor_set_layout_binding_count(
-    iree_hal_descriptor_set_layout_t* base_descriptor_set_layout) {
-  iree_hal_cuda2_descriptor_set_layout_t* descriptor_set_layout =
-      iree_hal_cuda2_descriptor_set_layout_cast(base_descriptor_set_layout);
+    const iree_hal_descriptor_set_layout_t* base_descriptor_set_layout) {
+  const iree_hal_cuda2_descriptor_set_layout_t* descriptor_set_layout =
+      iree_hal_cuda2_descriptor_set_layout_const_cast(
+          base_descriptor_set_layout);
   return descriptor_set_layout->binding_count;
 }
 
@@ -128,6 +137,13 @@ static iree_hal_cuda2_pipeline_layout_t* iree_hal_cuda2_pipeline_layout_cast(
     iree_hal_pipeline_layout_t* base_value) {
   IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_cuda2_pipeline_layout_vtable);
   return (iree_hal_cuda2_pipeline_layout_t*)base_value;
+}
+
+static const iree_hal_cuda2_pipeline_layout_t*
+iree_hal_cuda2_pipeline_layout_const_cast(
+    const iree_hal_pipeline_layout_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_cuda2_pipeline_layout_vtable);
+  return (const iree_hal_cuda2_pipeline_layout_t*)base_value;
 }
 
 iree_status_t iree_hal_cuda2_pipeline_layout_create(
@@ -198,24 +214,48 @@ static void iree_hal_cuda2_pipeline_layout_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+iree_host_size_t iree_hal_cuda2_pipeline_layout_descriptor_set_count(
+    const iree_hal_pipeline_layout_t* base_pipeline_layout) {
+  const iree_hal_cuda2_pipeline_layout_t* pipeline_layout =
+      iree_hal_cuda2_pipeline_layout_const_cast(base_pipeline_layout);
+  return pipeline_layout->set_layout_count;
+}
+
+const iree_hal_descriptor_set_layout_t*
+iree_hal_cuda2_pipeline_layout_descriptor_set_layout(
+    const iree_hal_pipeline_layout_t* base_pipeline_layout, uint32_t set) {
+  const iree_hal_cuda2_pipeline_layout_t* pipeline_layout =
+      iree_hal_cuda2_pipeline_layout_const_cast(base_pipeline_layout);
+  if (set < pipeline_layout->set_layout_count) {
+    return pipeline_layout->set_layouts[set].set_layout;
+  }
+  return NULL;
+}
+
 iree_host_size_t iree_hal_cuda2_pipeline_layout_base_binding_index(
-    iree_hal_pipeline_layout_t* base_pipeline_layout, uint32_t set) {
-  iree_hal_cuda2_pipeline_layout_t* pipeline_layout =
-      iree_hal_cuda2_pipeline_layout_cast(base_pipeline_layout);
+    const iree_hal_pipeline_layout_t* base_pipeline_layout, uint32_t set) {
+  const iree_hal_cuda2_pipeline_layout_t* pipeline_layout =
+      iree_hal_cuda2_pipeline_layout_const_cast(base_pipeline_layout);
   return pipeline_layout->set_layouts[set].base_index;
 }
 
+iree_host_size_t iree_hal_cuda2_pipeline_layout_total_binding_count(
+    const iree_hal_pipeline_layout_t* base_pipeline_layout) {
+  return iree_hal_cuda2_pipeline_layout_push_constant_index(
+      base_pipeline_layout);
+}
+
 iree_host_size_t iree_hal_cuda2_pipeline_layout_push_constant_index(
-    iree_hal_pipeline_layout_t* base_pipeline_layout) {
-  iree_hal_cuda2_pipeline_layout_t* pipeline_layout =
-      iree_hal_cuda2_pipeline_layout_cast(base_pipeline_layout);
+    const iree_hal_pipeline_layout_t* base_pipeline_layout) {
+  const iree_hal_cuda2_pipeline_layout_t* pipeline_layout =
+      iree_hal_cuda2_pipeline_layout_const_cast(base_pipeline_layout);
   return pipeline_layout->push_constant_base_index;
 }
 
 iree_host_size_t iree_hal_cuda2_pipeline_layout_push_constant_count(
-    iree_hal_pipeline_layout_t* base_pipeline_layout) {
-  iree_hal_cuda2_pipeline_layout_t* pipeline_layout =
-      iree_hal_cuda2_pipeline_layout_cast(base_pipeline_layout);
+    const iree_hal_pipeline_layout_t* base_pipeline_layout) {
+  const iree_hal_cuda2_pipeline_layout_t* pipeline_layout =
+      iree_hal_cuda2_pipeline_layout_const_cast(base_pipeline_layout);
   return pipeline_layout->push_constant_count;
 }
 

--- a/experimental/cuda2/pipeline_layout.h
+++ b/experimental/cuda2/pipeline_layout.h
@@ -14,6 +14,17 @@
 extern "C" {
 #endif  // __cplusplus
 
+// The max number of bindings per descriptor set allowed in the CUDA HAL
+// implementation.
+#define IREE_HAL_CUDA_MAX_DESCRIPTOR_SET_BINDING_COUNT 16
+
+// The max number of descriptor sets allowed in the CUDA HAL implementation.
+//
+// This depends on the general descriptor set planning in IREE and should adjust
+// with it.
+#define IREE_HAL_CUDA_MAX_DESCRIPTOR_SET_COUNT 4
+
+// The max number of push constants supported by the CUDA HAL implementation.
 #define IREE_HAL_CUDA_MAX_PUSH_CONSTANT_COUNT 64
 
 // Note that IREE HAL uses a descriptor binding model for expressing resources
@@ -50,7 +61,7 @@ iree_status_t iree_hal_cuda2_descriptor_set_layout_create(
 
 // Returns the binding count for the given descriptor set layout.
 iree_host_size_t iree_hal_cuda2_descriptor_set_layout_binding_count(
-    iree_hal_descriptor_set_layout_t* descriptor_set_layout);
+    const iree_hal_descriptor_set_layout_t* descriptor_set_layout);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_cuda2_pipeline_layout_t
@@ -67,17 +78,30 @@ iree_status_t iree_hal_cuda2_pipeline_layout_create(
     iree_host_size_t push_constant_count, iree_allocator_t host_allocator,
     iree_hal_pipeline_layout_t** out_pipeline_layout);
 
+// Returns the total number of sets in the given |pipeline_layout|.
+iree_host_size_t iree_hal_cuda2_pipeline_layout_descriptor_set_count(
+    const iree_hal_pipeline_layout_t* pipeline_layout);
+
+// Returns the descriptor set layout of the given |set| in |pipeline_layout|.
+const iree_hal_descriptor_set_layout_t*
+iree_hal_cuda2_pipeline_layout_descriptor_set_layout(
+    const iree_hal_pipeline_layout_t* pipeline_layout, uint32_t set);
+
 // Returns the base kernel argument index for the given set.
 iree_host_size_t iree_hal_cuda2_pipeline_layout_base_binding_index(
-    iree_hal_pipeline_layout_t* pipeline_layout, uint32_t set);
+    const iree_hal_pipeline_layout_t* pipeline_layout, uint32_t set);
+
+// Returns the total number of descriptor bindings across all sets.
+iree_host_size_t iree_hal_cuda2_pipeline_layout_total_binding_count(
+    const iree_hal_pipeline_layout_t* pipeline_layout);
 
 // Returns the kernel argument index for push constant data.
 iree_host_size_t iree_hal_cuda2_pipeline_layout_push_constant_index(
-    iree_hal_pipeline_layout_t* pipeline_layout);
+    const iree_hal_pipeline_layout_t* pipeline_layout);
 
 // Returns the number of push constants in the pipeline layout.
 iree_host_size_t iree_hal_cuda2_pipeline_layout_push_constant_count(
-    iree_hal_pipeline_layout_t* pipeline_layout);
+    const iree_hal_pipeline_layout_t* pipeline_layout);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
This commit changes the graph command buffer to keep track of a fixed list of descriptor sets. This simplifies the logic of preparing stage; we only perform kernel parameter serialization at the dispatch segment composition time. This means we don't pay the overhead if multiple push descriptor set commands are issued before dispatching. Also we don't need to sort descriptors anymore.

Progress towards https://github.com/openxla/iree/issues/13245