### PR TITLE
[cuda] Avoid serializing all nodes in graph command buffer

### DIFF
--- a/experimental/cuda2/graph_command_buffer.c
+++ b/experimental/cuda2/graph_command_buffer.c
@@ -434,7 +434,7 @@ static iree_status_t iree_hal_cuda2_command_segment_record_barrier(
   // barrier segment.
   for (iree_hal_cuda2_command_segment_t* segment = base_segment->prev; segment;
        segment = segment->prev) {
-    if (segment->action == IREE_HAL_cuda2_COMMAND_SEGMENT_ACTION_BARRIER) break;
+    if (segment->action == IREE_HAL_CUDA_COMMAND_SEGMENT_ACTION_BARRIER) break;
     nodes[--command_buffer->current_batch_count] = segment->cu_graph_node;
   }
   IREE_ASSERT(command_buffer->current_batch_count == 0);


### PR DESCRIPTION
This commit improves the graph node dependency management by avoid serializing all nodes in the graph command buffer to a linear chain. Instead we categorize nodes into batches, using barriers as boundaries. Nodes inside two consecutive barrier commands can now run in parallel. This works for the current compiler. In the future we can further improve the logic to take into consideration of access scopes.

Progress towards https://github.com/openxla/iree/issues/13245