### PR TITLE
Enable constexpr hoisting globally.

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
@@ -220,3 +220,20 @@ module @eval_i64_tensor {
     util.initializer.return
   }
 }
+
+// -----
+// Splat of an 8byte value ensures that large fills are possible.
+// CHECK-LABEL: @eval_i64_tensor_splat
+// CHECK: util.global private @{{.*}} = dense<2> : tensor<2xi64>
+module @eval_i64_tensor_splat {
+  util.global private @hoisted : tensor<2xi64>
+  func.func @main() -> tensor<2xi64> {
+    %hoisted = util.global.load @hoisted : tensor<2xi64>
+    return %hoisted : tensor<2xi64>
+  }
+  util.initializer attributes {iree.compiler.consteval} {
+    %cst = arith.constant dense<2> : tensor<2xi64>
+    util.global.store %cst, @hoisted : tensor<2xi64>
+    util.initializer.return
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -35,11 +35,12 @@ namespace iree_compiler {
 namespace IREE {
 namespace Flow {
 
-// TODO(#12033): solve for the slow linalg transpose folder and remove the flag.
+// TODO: Remove this and the backing code once consteval is beyond being
+// rolled back.
 static llvm::cl::opt<int64_t> clLinalgMaxConstantFoldElements(
     "iree-codegen-linalg-max-constant-fold-elements",
     llvm::cl::desc("Maximum number of elements to try to constant fold."),
-    llvm::cl::init(INT64_MAX));
+    llvm::cl::init(0));
 
 /// Check if any of the use dominates all other uses of the operation.
 static std::optional<OpOperand *> getFusableUse(Operation *op,

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -202,3 +202,16 @@ module @hoist_implicit_capture {
   // CHECK:       util.initializer.return
   // CHECK: }
 }
+
+// -----
+// CHECK-LABEL: @do_not_hoist_non_value_type_results
+// CHECK-NOT: util.global
+// CHECK-NOT: util.initializer
+module @do_not_hoist_non_value_type_results {
+  func.func @main() -> (!iree_unregistered.unknown_type) {
+    %0 = arith.constant 0 : i32
+    %1 = arith.constant 1 : i32
+    %2 = "iree_unregistered.const_expr"(%0, %1) : (i32, i32) -> !iree_unregistered.unknown_type
+    return %2 : !iree_unregistered.unknown_type
+  }
+}

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -77,7 +77,7 @@ struct InputDialectOptions {
 // Options controlling high level optimizations.
 struct HighLevelOptimizationOptions {
   // Enables const-expr hoisting into globals.
-  bool constExprHoisting = false;
+  bool constExprHoisting = true;
 
   // Enables recursive evaluation of immutable globals using the compiler
   // and runtime.


### PR DESCRIPTION
* Disables corresponding evaluation in FusionOfTensors.
* Fixes some hoisting issues encountered in the test suite.