### PR TITLE
Add COPTS flag in iree_c_module rule

### DIFF
--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -12,6 +12,7 @@ def iree_c_module(
         name,
         src,
         h_file_output,
+        copts,
         flags,
         deps = [
             "//runtime/src/iree/vm",
@@ -31,6 +32,7 @@ def iree_c_module(
         h_file_output: The H header file to output.
         flags: additional flags to pass to the compile tool.
             `--output-format=vm-c` is included automatically.
+        copts: Additional c flags.
         deps: Optional. Dependencies to add to the generated library.
         compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
@@ -80,7 +82,7 @@ def iree_c_module(
         srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
         copts = [
             "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
-        ],
+        ] + copts,
         deps = deps_list,
         **kwargs
     )

--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -12,7 +12,6 @@ def iree_c_module(
         name,
         src,
         h_file_output,
-        copts,
         flags,
         deps = [
             "//runtime/src/iree/vm",
@@ -21,6 +20,7 @@ def iree_c_module(
             "//runtime/src/iree/vm:shims_emitc",
         ],
         compile_tool = "//tools:iree-compile",
+        copts = None,
         no_runtime = None,
         static_lib_path = "",
         **kwargs):
@@ -32,7 +32,7 @@ def iree_c_module(
         h_file_output: The H header file to output.
         flags: additional flags to pass to the compile tool.
             `--output-format=vm-c` is included automatically.
-        copts: Additional c flags.
+        copts: Optional additional c flags.
         deps: Optional. Dependencies to add to the generated library.
         compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
@@ -76,13 +76,15 @@ def iree_c_module(
     if not no_runtime:
         deps_list = deps
 
+    copts_list = ["-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output]
+    if copts:
+        copts_list += copts
+
     iree_runtime_cc_library(
         name = name,
         hdrs = [h_file_output],
         srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
-        copts = [
-            "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
-        ] + copts,
+        copts = copts_list,
         deps = deps_list,
         **kwargs
     )

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -22,6 +22,7 @@ include(CMakeParseArguments)
 #     -DIREE_BUILD_TESTS=ON to CMake.
 # NO_RUNTIME: When added, this target will be built without the runtime library
 #     support.
+# COPTS: Extra c flags.
 #
 # Note:
 # By default, iree_c_module will create a library named ${NAME},
@@ -32,7 +33,7 @@ function(iree_c_module)
     _RULE
     "TESTONLY;NO_RUNTIME"
     "NAME;SRC;H_FILE_OUTPUT;COMPILE_TOOL;STATIC_LIB_PATH"
-    "FLAGS"
+    "FLAGS;COPTS"
     ${ARGN}
   )
 
@@ -99,6 +100,7 @@ function(iree_c_module)
     COPTS
       "-DEMITC_IMPLEMENTATION=\"${_RULE_H_FILE_OUTPUT}\""
       "${_TESTONLY_ARG}"
+      ${_RULE_COPTS}
     DEPS
       # Include paths and options for the runtime sources.
       iree::defs

--- a/runtime/src/iree/vm/test/emitc/BUILD.bazel
+++ b/runtime/src/iree/vm/test/emitc/BUILD.bazel
@@ -103,9 +103,13 @@ iree_c_module(
     h_file_output = "assignment_ops_i64.h",
 )
 
+# TODO(#14507): Investigate the maybe-uninitialized warning.
 iree_c_module(
     name = "buffer_ops",
     src = "//runtime/src/iree/vm/test:buffer_ops.mlir",
+    copts = [
+        "-Wno-uninitialized",
+    ],
     flags = [
         "--compile-mode=vm",
     ],

--- a/runtime/src/iree/vm/test/emitc/BUILD.bazel
+++ b/runtime/src/iree/vm/test/emitc/BUILD.bazel
@@ -103,10 +103,10 @@ iree_c_module(
     h_file_output = "assignment_ops_i64.h",
 )
 
-# TODO(#14507): Investigate the maybe-uninitialized warning.
 iree_c_module(
     name = "buffer_ops",
     src = "//runtime/src/iree/vm/test:buffer_ops.mlir",
+    # TODO(#14540): Investigate the maybe-uninitialized warning.
     copts = [
         "-Wno-uninitialized",
     ],

--- a/runtime/src/iree/vm/test/emitc/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/emitc/CMakeLists.txt
@@ -121,7 +121,6 @@ iree_c_module(
     iree-compile
 )
 
-# TODO(#14507): Investigate the maybe-uninitialized warning.
 iree_c_module(
   NAME
     buffer_ops
@@ -131,6 +130,7 @@ iree_c_module(
     "buffer_ops.h"
   FLAGS
     "--compile-mode=vm"
+  # TODO(#14540): Investigate the maybe-uninitialized warning.
   COPTS
     "-Wno-uninitialized"
   COMPILE_TOOL

--- a/runtime/src/iree/vm/test/emitc/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/emitc/CMakeLists.txt
@@ -121,6 +121,7 @@ iree_c_module(
     iree-compile
 )
 
+# TODO(#14507): Investigate the maybe-uninitialized warning.
 iree_c_module(
   NAME
     buffer_ops
@@ -130,6 +131,8 @@ iree_c_module(
     "buffer_ops.h"
   FLAGS
     "--compile-mode=vm"
+  COPTS
+    "-Wno-uninitialized"
   COMPILE_TOOL
     iree-compile
 )


### PR DESCRIPTION
To add extra c flags for emitc modules and optionally silence the warning flags.