### PR TITLE
Move test_a100 to postsubmit-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,25 +279,11 @@ jobs:
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    strategy:
-      matrix:
-        target:
-          - runner-type: gpu
-            iree-ctest-label-regex: ^requires-gpu|^driver=vulkan$|^driver=cuda$
-            iree-nvidia-sm80-tests-disable: 1
-            iree-multi-device-tests-disable: 1
-          - runner-type: a100
-            iree-ctest-label-regex: ^requires-gpu-sm80$
-            iree-nvidia-sm80-tests-disable: 0
-            iree-multi-device-tests-disable: 1
-      # Run other jobs even if one fails.
-      fail-fast: false
-    name: test_${{ matrix.target.runner-type }}
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=${{ needs.setup.outputs.runner-env }}
-      - ${{ matrix.target.runner-type }}
+      - gpu
       - os-family=Linux
     steps:
       - name: "Checking out repository"
@@ -314,9 +300,57 @@ jobs:
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Testing all"
         env:
-          IREE_NVIDIA_SM80_TESTS_DISABLE: ${{ matrix.target.iree-nvidia-sm80-tests-disable }}
-          IREE_MULTI_DEVICE_TESTS_DISABLE: ${{ matrix.target.iree-multi-device-tests-disable }}
-          IREE_CTEST_LABEL_REGEX: ${{ matrix.target.iree-ctest-label-regex }}
+          IREE_NVIDIA_SM80_TESTS_DISABLE: "1"
+          IREE_MULTI_DEVICE_TESTS_DISABLE: "1"
+          IREE_CTEST_LABEL_REGEX: "^requires-gpu|^driver=vulkan$|^driver=cuda$"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+              --env IREE_NVIDIA_SM80_TESTS_DISABLE \
+              --env IREE_MULTI_DEVICE_TESTS_DISABLE \
+              --env IREE_CTEST_LABEL_REGEX \
+              --env IREE_VULKAN_F16_DISABLE=0 \
+              --env IREE_CUDA_DISABLE=0 \
+              --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+              --env CTEST_PARALLEL_LEVEL=2 \
+              --env NVIDIA_DRIVER_CAPABILITIES=all \
+              --gpus all \
+              gcr.io/iree-oss/nvidia@sha256:1717431fd46b8b1e96d95fa72508e3e3eacb5c95f1245b9b7dbeec23ae823d02 \
+              bash -euo pipefail -c \
+                "./build_tools/scripts/check_cuda.sh
+                ./build_tools/scripts/check_vulkan.sh
+                ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+
+  test_a100:
+    needs: [setup, build_all]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_a100')
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - a100
+      - os-family=Linux
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          submodules: true
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+      - name: "Downloading build dir archive"
+        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Testing all"
+        env:
+          IREE_NVIDIA_SM80_TESTS_DISABLE: "0"
+          IREE_MULTI_DEVICE_TESTS_DISABLE: "1"
+          IREE_CTEST_LABEL_REGEX: "^requires-gpu-sm80$"
         run: |
           ./build_tools/github_actions/docker_run.sh \
               --env IREE_NVIDIA_SM80_TESTS_DISABLE \
@@ -1035,6 +1069,7 @@ jobs:
 
       # Accelerators
       - test_gpu
+      - test_a100
 
       # Subsets
       - build_test_runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,9 +300,9 @@ jobs:
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Testing all"
         env:
-          IREE_NVIDIA_SM80_TESTS_DISABLE: "1"
-          IREE_MULTI_DEVICE_TESTS_DISABLE: "1"
-          IREE_CTEST_LABEL_REGEX: "^requires-gpu|^driver=vulkan$|^driver=cuda$"
+          IREE_NVIDIA_SM80_TESTS_DISABLE: 1
+          IREE_MULTI_DEVICE_TESTS_DISABLE: 1
+          IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=vulkan$|^driver=cuda$
         run: |
           ./build_tools/github_actions/docker_run.sh \
               --env IREE_NVIDIA_SM80_TESTS_DISABLE \
@@ -348,9 +348,9 @@ jobs:
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Testing all"
         env:
-          IREE_NVIDIA_SM80_TESTS_DISABLE: "0"
-          IREE_MULTI_DEVICE_TESTS_DISABLE: "1"
-          IREE_CTEST_LABEL_REGEX: "^requires-gpu-sm80$"
+          IREE_NVIDIA_SM80_TESTS_DISABLE: 0
+          IREE_MULTI_DEVICE_TESTS_DISABLE: 1
+          IREE_CTEST_LABEL_REGEX: ^requires-gpu-sm80$
         run: |
           ./build_tools/github_actions/docker_run.sh \
               --env IREE_NVIDIA_SM80_TESTS_DISABLE \

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -120,6 +120,7 @@ POSTSUBMIT_ONLY_JOBS = frozenset(
         "build_test_all_windows",
         "build_test_all_macos_arm64",
         "build_test_all_macos_x86_64",
+        "test_a100",
     ]
 )
 

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -120,6 +120,7 @@ POSTSUBMIT_ONLY_JOBS = frozenset(
         "build_test_all_windows",
         "build_test_all_macos_arm64",
         "build_test_all_macos_x86_64",
+        # Due to the outstock of A100, only run this test in postsubmit.
         "test_a100",
     ]
 )


### PR DESCRIPTION
Due to the outstock of A100, split and move `test_a100` into postsubmit only.

Tested to trigger `test_a100` job and it was scheduled to run (but no a100 runner available at that moment): https://github.com/openxla/iree/actions/runs/5732222135

Fix #14545