### PR TITLE
Revert "Turn off GCC warnings from third_party libraries"

### DIFF
--- a/build_tools/third_party/libyaml/BUILD.overlay
+++ b/build_tools/third_party/libyaml/BUILD.overlay
@@ -30,8 +30,6 @@ cc_library(
         "-DYAML_VERSION_MINOR=2",
         "-DYAML_VERSION_PATCH=5",
         "-Iexternal/com_github_yaml_libyaml/include/",
-        # GCC warning
-        "-Wno-unused-value",
     ],
     includes = [
       "include/",

--- a/build_tools/third_party/libyaml/CMakeLists.txt
+++ b/build_tools/third_party/libyaml/CMakeLists.txt
@@ -41,7 +41,4 @@ external_cc_library(
 
 if(MSVC)
   target_compile_options(yaml_yaml PRIVATE /wd4996)
-else()
-  # GCC warning.
-  target_compile_options(yaml_yaml PRIVATE "-Wno-unused-value")
 endif()

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -7,13 +7,7 @@
 #include <algorithm>
 #include <numeric>
 
-// The underlying llvm-project/llvm/include/llvm/ADT/DenseMap.h has incorrect
-// GCC warning.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
-#pragma GCC diagnostic pop
-
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -14,13 +14,7 @@
 //
 //===---------------------------------------------------------------------===//
 
-// The underlying llvm-project/llvm/include/llvm/ADT/DenseMap.h has incorrect
-// GCC warning.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
-#pragma GCC diagnostic pop
-
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree-dialects/Dialect/LinalgExt/Passes/Transforms.h"
 #include "iree/compiler/Codegen/Common/EncodingInfo.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -4,13 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// The underlying llvm-project/llvm/include/llvm/ADT/DenseMap.h has incorrect
-// GCC warning.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
-#pragma GCC diagnostic pop
-
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
 #include "iree/compiler/Codegen/Common/CPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMTypes.cpp
@@ -10,13 +10,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
-
-// TODO(llvm-project#64312): Fix this upstream
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "mlir/IR/DialectImplementation.h"
-#pragma GCC diagnostic pop
-
 #include "mlir/IR/TypeSupport.h"
 
 // clang-format off: must be included after all LLVM/MLIR headers.


### PR DESCRIPTION
Reverts openxla/iree#14538

Adding compiler-specific pragmas should be avoided unless very carefully crafted. This PR caused just as many warnings as GCC had in MSVC:
```
[build] D:\Dev\iree\compiler\src\iree\compiler\Codegen\Common\TileAndDistributeToWorkgroupsPass.cpp(19): warning C4068: unknown pragma 'GCC'
[build] D:\Dev\iree\compiler\src\iree\compiler\Codegen\Common\TileAndDistributeToWorkgroupsPass.cpp(20): warning C4068: unknown pragma 'GCC'
[build] D:\Dev\iree\compiler\src\iree\compiler\Codegen\Common\TileAndDistributeToWorkgroupsPass.cpp(22): warning C4068: unknown pragma 'GCC'
...
```

Future fixes for warning issues should focus on fixing what is causing the warning - including making upstream fixes where required.