### PR TITLE
Revert "Add COPTS flag in iree_c_module rule (#14537)"

### DIFF
--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -20,7 +20,6 @@ def iree_c_module(
             "//runtime/src/iree/vm:shims_emitc",
         ],
         compile_tool = "//tools:iree-compile",
-        copts = None,
         no_runtime = None,
         static_lib_path = "",
         **kwargs):
@@ -32,7 +31,6 @@ def iree_c_module(
         h_file_output: The H header file to output.
         flags: additional flags to pass to the compile tool.
             `--output-format=vm-c` is included automatically.
-        copts: Optional additional c flags.
         deps: Optional. Dependencies to add to the generated library.
         compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
@@ -76,15 +74,13 @@ def iree_c_module(
     if not no_runtime:
         deps_list = deps
 
-    copts_list = ["-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output]
-    if copts:
-        copts_list += copts
-
     iree_runtime_cc_library(
         name = name,
         hdrs = [h_file_output],
         srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
-        copts = copts_list,
+        copts = [
+            "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
+        ],
         deps = deps_list,
         **kwargs
     )

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -22,7 +22,6 @@ include(CMakeParseArguments)
 #     -DIREE_BUILD_TESTS=ON to CMake.
 # NO_RUNTIME: When added, this target will be built without the runtime library
 #     support.
-# COPTS: Extra c flags.
 #
 # Note:
 # By default, iree_c_module will create a library named ${NAME},
@@ -33,7 +32,7 @@ function(iree_c_module)
     _RULE
     "TESTONLY;NO_RUNTIME"
     "NAME;SRC;H_FILE_OUTPUT;COMPILE_TOOL;STATIC_LIB_PATH"
-    "FLAGS;COPTS"
+    "FLAGS"
     ${ARGN}
   )
 
@@ -100,7 +99,6 @@ function(iree_c_module)
     COPTS
       "-DEMITC_IMPLEMENTATION=\"${_RULE_H_FILE_OUTPUT}\""
       "${_TESTONLY_ARG}"
-      ${_RULE_COPTS}
     DEPS
       # Include paths and options for the runtime sources.
       iree::defs

--- a/runtime/src/iree/vm/test/emitc/BUILD.bazel
+++ b/runtime/src/iree/vm/test/emitc/BUILD.bazel
@@ -106,10 +106,6 @@ iree_c_module(
 iree_c_module(
     name = "buffer_ops",
     src = "//runtime/src/iree/vm/test:buffer_ops.mlir",
-    # TODO(#14540): Investigate the maybe-uninitialized warning.
-    copts = [
-        "-Wno-uninitialized",
-    ],
     flags = [
         "--compile-mode=vm",
     ],

--- a/runtime/src/iree/vm/test/emitc/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/emitc/CMakeLists.txt
@@ -130,9 +130,6 @@ iree_c_module(
     "buffer_ops.h"
   FLAGS
     "--compile-mode=vm"
-  # TODO(#14540): Investigate the maybe-uninitialized warning.
-  COPTS
-    "-Wno-uninitialized"
   COMPILE_TOOL
     iree-compile
 )


### PR DESCRIPTION
This reverts commit 3d4dc72cb07fba47a804205032ac3c65bc6f9e35.

Reason to revert: Breaks Windows build