### PR TITLE
Adding the `#util.byte_pattern` attribute.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -120,8 +120,7 @@ struct GlobalOpExpansion
       auto *entryBlock = rewriter.createBlock(&initializerOp.getBody());
       rewriter.setInsertionPointToStart(entryBlock);
       auto constantOp = rewriter.create<IREE::Stream::TensorConstantOp>(
-          globalOp.getLoc(), resourceOp.getType(),
-          llvm::cast<ElementsAttr>(initialValue),
+          globalOp.getLoc(), resourceOp.getType(), initialValue,
           TypeAttr::get(globalOp.getType()),
           /*result_encoding_dims=*/ValueRange{}, /*affinity=*/nullptr);
       auto constantSizeOp = rewriter.create<IREE::Stream::ResourceSizeOp>(

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -1350,8 +1350,8 @@ struct ConvertSplatConstantsIntoSplats
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(AsyncConstantOp constantOp,
                                 PatternRewriter &rewriter) const override {
-    auto value = constantOp.getValue();
-    if (!value.isSplat())
+    auto value = dyn_cast<ElementsAttr>(constantOp.getValue());
+    if (!value || !value.isSplat())
       return failure();
 
     auto splatElementAttr =

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -522,7 +522,7 @@ def Stream_ResourceConstantsOp : Stream_PureOp<"resource.constants", [
   }];
 
   let arguments = (ins
-    TypedArrayAttrBase<ElementsAttr, "constant value array attribute">:$values,
+    TypedArrayAttrBase<AnyAttr, "constant value array attribute">:$values,
     Variadic<Stream_Size>:$result_sizes,
     OptionalAttr<Stream_AffinityAttr>:$affinity
   );
@@ -834,7 +834,7 @@ def Stream_TensorConstantOp : Stream_PureOp<"tensor.constant", [
   }];
 
   let arguments = (ins
-    ElementsAttr:$value,
+    AnyAttr:$value,
     TypeAttr:$result_encoding,
     Stream_ShapeDynamicDims:$result_encoding_dims,
     OptionalAttr<Stream_AffinityAttr>:$affinity
@@ -1334,7 +1334,7 @@ def Stream_AsyncConstantOp : Stream_PureOp<"async.constant", [
   }];
 
   let arguments = (ins
-    ElementsAttr:$value,
+    AnyAttr:$value,
     Stream_Size:$result_size,
     OptionalAttr<Stream_AffinityAttr>:$affinity
   );

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
@@ -318,7 +318,7 @@ struct EncodeTensorConstantOp
     // expanded to a power of 2 byte-aligned width. This is unfortunate: it's
     // wasted bits in the final binary that we could otherwise use productively.
     RankedTensorType alignedType = alignTensorType(resultType);
-    ElementsAttr encodedAttr = op.getValue();
+    Attribute encodedAttr = op.getValue();
     if (alignedType != resultType) {
       if (auto sourceAttr = llvm::dyn_cast<DenseIntElementsAttr>(encodedAttr)) {
         auto alignedBitWidth = alignedType.getElementTypeBitWidth();

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -397,7 +397,42 @@ serializeGenericElementData(DenseElementsAttr elementsAttr,
 }
 
 //===----------------------------------------------------------------------===//
-// Buffer attributes
+// #util.byte_pattern
+//===----------------------------------------------------------------------===//
+
+int64_t BytePatternAttr::getStorageSize() const {
+  if (auto shapedType = getType().dyn_cast<ShapedType>()) {
+    return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
+  } else {
+    return IREE::Util::getTypePhysicalStorageBitWidth(getType());
+  }
+}
+
+LogicalResult
+BytePatternAttr::serializeToBuffer(llvm::support::endianness endian,
+                                   ArrayRef<char> buffer) const {
+  const uint8_t byte = static_cast<uint8_t>(getPattern() % 256);
+  std::memset(const_cast<char *>(buffer.data()), byte, buffer.size());
+  return success();
+}
+
+LogicalResult
+BytePatternAttr::serializeToStream(llvm::support::endianness endian,
+                                   llvm::raw_ostream &os) const {
+  const uint8_t byte = static_cast<uint8_t>(getPattern() % 256);
+  const char bytes[256] = {static_cast<char>(byte)};
+  int64_t remaining = getStorageSize();
+  while (remaining) {
+    int64_t write_length =
+        std::min(remaining, static_cast<int64_t>(sizeof(bytes)));
+    os.write(bytes, static_cast<size_t>(write_length));
+    remaining -= write_length;
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// #util.byte_range
 //===----------------------------------------------------------------------===//
 
 Attribute ByteRangeAttr::parse(AsmParser &p, Type type) {
@@ -460,6 +495,10 @@ void ByteRangeAttr::print(AsmPrinter &p) const {
   os << getLength();
   os << ">";
 }
+
+//===----------------------------------------------------------------------===//
+// #util.composite
+//===----------------------------------------------------------------------===//
 
 // static
 CompositeAttr CompositeAttr::get(MLIRContext *context,
@@ -580,6 +619,10 @@ LogicalResult CompositeAttr::serializeToStream(llvm::support::endianness endian,
   }
   return success();
 }
+
+//===----------------------------------------------------------------------===//
+// SerializableAttrInterface implementations
+//===----------------------------------------------------------------------===//
 
 // External interface applied to ElementsAttrs so that we can serialize them to
 // byte buffers.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
@@ -10,10 +10,38 @@
 include "iree/compiler/Dialect/Util/IR/UtilBase.td"
 include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/OpBase.td"
 
 //===----------------------------------------------------------------------===//
-// Buffer attributes
+// #util.byte_pattern
+//===----------------------------------------------------------------------===//
+
+def Util_BytePatternAttr : AttrDef<Util_Dialect, "BytePattern", [
+  TypedAttrInterface,
+  DeclareAttrInterfaceMethods<Util_SerializableAttrInterface, [
+    "serializeToBuffer",
+    "serializeToStream",
+  ]>,
+]> {
+  let mnemonic = "byte_pattern";
+  let summary = [{an attribute containing a filled byte pattern}];
+  let description = [{
+    A dense serializable attribute with the given byte pattern.
+  }];
+
+  let parameters = (ins
+    AttributeSelfTypeParameter<"">:$type,
+    AttrParameter<"int64_t", "">:$pattern
+  );
+
+  let assemblyFormat = [{
+    `<` $pattern `>`
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// #util.byte_range
 //===----------------------------------------------------------------------===//
 
 def Util_ByteRangeAttr : AttrDef<Util_Dialect, "ByteRange", []> {
@@ -30,6 +58,10 @@ def Util_ByteRangeAttr : AttrDef<Util_Dialect, "ByteRange", []> {
 
   let hasCustomAssemblyFormat = 1;
 }
+
+//===----------------------------------------------------------------------===//
+// #util.composite
+//===----------------------------------------------------------------------===//
 
 def Util_CompositeAttr : AttrDef<Util_Dialect, "Composite", [
   DeclareAttrInterfaceMethods<Util_SerializableAttrInterface, [

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/attributes.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/attributes.mlir
@@ -1,5 +1,17 @@
 // RUN: iree-opt --split-input-file --mlir-print-local-scope %s | iree-opt --split-input-file --mlir-print-local-scope | FileCheck %s
 
+// CHECK-LABEL: @byte_pattern
+builtin.module @byte_pattern attributes {
+  // CHECK: r0 = #util.byte_pattern<0> : i8
+  util.r0 = #util.byte_pattern<0> : i8,
+  // CHECK: r1 = #util.byte_pattern<0> : tensor<28xi8>
+  util.r1 = #util.byte_pattern<0> : tensor<28xi8>,
+  // CHECK: r2 = #util.byte_pattern<6> : tensor<33x4xi4>
+  util.r2 = #util.byte_pattern<6> : tensor<33x4xi4>
+} {}
+
+// -----
+
 // CHECK-LABEL: @byte_range
 builtin.module @byte_range attributes {
   // CHECK: br0 = #util.byte_range<123, 456>

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/VM/IR/VMDialect.h"
 
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
 #include "iree/compiler/Dialect/VM/IR/VMTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -146,6 +147,8 @@ struct VMFolderInterface : public DialectFoldInterface {
 VMDialect::VMDialect(MLIRContext *context)
     : Dialect(getDialectNamespace(), context, TypeID::get<VMDialect>()),
       fallbackOpAsmInterface(new VMOpAsmInterface) {
+  context->loadDialect<IREE::Util::UtilDialect>();
+
   registerAttributes();
   registerTypes();
   addInterfaces<VMInlinerInterface, VMFolderInterface>();

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir
@@ -150,4 +150,12 @@ vm.module @constants {
   // CHECK-NEXT:   0
   // CHECK-NEXT: ]
   vm.rodata private @elided_f32 dense_resource<__elided__> : tensor<3xf32>
+
+  // Tests #util.byte_pattern on sub-byte types.
+  //      CHECK: "embedded_data": [
+  // CHECK-NEXT:   1,
+  // CHECK-NEXT:   1,
+  // CHECK-NEXT:   1
+  // CHECK-NEXT: ]
+  vm.rodata private @byte_pattern_i2 #util.byte_pattern<1> : tensor<9xi2>
 }


### PR DESCRIPTION
This allows for non-splat attributes that are serialized out to files with predictable values but in the future this should be extented as documented in #6908 to be backed by a PRNG to approximate model compression ratios on vmfb files. We could also make the byte pattern variable width based on the element type but today it's bytes only ala memset.

Progress on #6908.