### PR TITLE
Adding `--module_mode=mmap` tooling flag.

### DIFF
--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -137,7 +137,12 @@ foreach(_object_lib ${_EXPORT_OBJECT_LIBS})
   # another level of fix upstream if you like pain.
   list(APPEND _EXPORT_OBJECT_DEPS "$<GENEX_EVAL:$<GENEX_EVAL:$<GENEX_EVAL:$<GENEX_EVAL:$<TARGET_PROPERTY:${_object_lib},LINK_LIBRARIES>>>>>")
 endforeach()
-file(GENERATE OUTPUT export_objects_debug.txt CONTENT "OBJECTS:${_EXPORT_OBJECT_SRCS}\n\nDEPS:${_EXPORT_OBJECT_DEPS}")
+if(NOT GENERATOR_IS_MULTI_CONFIG)
+  # NOTE: multi-config generators (xcode, visual studio, ninja in multi-config
+  # mode, etc) don't support writing files with fixed names with contents that
+  # differ based on the available variants.
+  file(GENERATE OUTPUT export_objects_debug.txt CONTENT "OBJECTS:${_EXPORT_OBJECT_SRCS}\n\nDEPS:${_EXPORT_OBJECT_DEPS}")
+endif()
 iree_cc_library(
   SHARED
   NAME

--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -129,6 +129,48 @@ static inline bool iree_device_size_has_alignment(
 //  IREE_CHECK_OK(iree_allocator_malloc(allocator, total_size, (void**)&p));
 #define iree_sizeof_struct(t) iree_host_align(sizeof(t), iree_max_align_t)
 
+// Returns the ceil-divide of |lhs| by non-zero |rhs|.
+static inline iree_device_size_t iree_device_size_ceil_div(
+    iree_device_size_t lhs, iree_device_size_t rhs) {
+  return ((lhs != 0) && (lhs > 0) == (rhs > 0))
+             ? ((lhs + ((rhs > 0) ? -1 : 1)) / rhs) + 1
+             : -(-lhs / rhs);
+}
+
+// Returns the floor-divide of |lhs| by non-zero |rhs|.
+static inline iree_device_size_t iree_device_size_floor_div(
+    iree_device_size_t lhs, iree_device_size_t rhs) {
+  return ((lhs != 0) && ((lhs < 0) != (rhs < 0)))
+             ? -((-lhs + ((rhs < 0) ? 1 : -1)) / rhs) - 1
+             : lhs / rhs;
+}
+
+// Returns the greatest common divisor between two values.
+//
+// See: https://en.wikipedia.org/wiki/Greatest_common_divisor
+//
+// Examples:
+//  gcd(8, 16) = 8
+//  gcd(3, 5) = 1
+static inline iree_device_size_t iree_device_size_gcd(iree_device_size_t a,
+                                                      iree_device_size_t b) {
+  if (b == 0) return a;
+  return iree_device_size_gcd(b, a % b);
+}
+
+// Returns the least common multiple between two values, often used for
+// finding a common alignment.
+//
+// See: https://en.wikipedia.org/wiki/Least_common_multiple
+//
+// Examples:
+//  lcm(8, 16) = 16
+//  lcm(3, 5) = 15 (15 % 3 == 0, 15 % 5 == 0)
+static inline iree_device_size_t iree_device_size_lcm(iree_device_size_t a,
+                                                      iree_device_size_t b) {
+  return a * (b / iree_device_size_gcd(a, b));
+}
+
 //===----------------------------------------------------------------------===//
 // Alignment intrinsics
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/base/internal/file_io.h
+++ b/runtime/src/iree/base/internal/file_io.h
@@ -36,6 +36,7 @@ typedef struct iree_file_contents_t {
     iree_byte_span_t buffer;
     iree_const_byte_span_t const_buffer;
   };
+  void* mapping;
 } iree_file_contents_t;
 
 // Returns an allocator that deallocates the |contents|.
@@ -45,14 +46,47 @@ iree_allocator_t iree_file_contents_deallocator(iree_file_contents_t* contents);
 // Frees memory associated with |contents|.
 void iree_file_contents_free(iree_file_contents_t* contents);
 
-// Synchronously reads a file's contents into memory.
+typedef enum iree_file_read_flag_bits_t {
+  IREE_FILE_READ_FLAG_PRELOAD = (1u << 0),
+  IREE_FILE_READ_FLAG_MMAP = (1u << 1),
+  IREE_FILE_READ_FLAG_DEFAULT = IREE_FILE_READ_FLAG_PRELOAD,
+} iree_file_read_flags_t;
+
+// Reads a file's contents into memory.
 //
 // Returns the contents of the file in |out_contents|.
 // |allocator| is used to allocate the memory and the caller must use
 // iree_file_contents_free to release the memory.
 iree_status_t iree_file_read_contents(const char* path,
+                                      iree_file_read_flags_t flags,
                                       iree_allocator_t allocator,
                                       iree_file_contents_t** out_contents);
+
+// Synchronously allocates and reads a file's contents into memory.
+// This will block the calling thread until the entire file is loaded into
+// memory and all pages are wired. After returning the file will not be accessed
+// and can be deleted or overwritten.
+//
+// Returns the contents of the file in |out_contents|.
+// |allocator| is used to allocate the memory and the caller must use
+// iree_file_contents_free to release the memory.
+iree_status_t iree_file_preload_contents(const char* path,
+                                         iree_allocator_t allocator,
+                                         iree_file_contents_t** out_contents);
+
+// Maps a file's contents into memory for read-only access.
+// The file must remain valid and be treated as immutable as calls may return
+// before the file has been fully read into memory and the pages read may be
+// discarded and reloaded at any time. As pages may be loaded on demand care
+// should be used when profiling/benchmarking as warm-up costs will be higher
+// and variance during execution will go up.
+//
+// Returns the contents of the file in |out_contents|.
+// |allocator| is used to allocate the memory and the caller must use
+// iree_file_contents_free to release the memory.
+iree_status_t iree_file_map_contents_readonly(
+    const char* path, iree_allocator_t allocator,
+    iree_file_contents_t** out_contents);
 
 // Synchronously writes a byte buffer into a file.
 // Existing contents are overwritten.

--- a/runtime/src/iree/base/internal/flags.c
+++ b/runtime/src/iree/base/internal/flags.c
@@ -505,7 +505,8 @@ static iree_status_t iree_flags_parse_file(iree_string_view_t file_path) {
   iree_allocator_t allocator = iree_flags_leaky_allocator();
   iree_file_contents_t* file_contents = NULL;
   IREE_RETURN_IF_ERROR(
-      iree_file_read_contents(file_path.data, allocator, &file_contents),
+      iree_file_read_contents(file_path.data, IREE_FILE_READ_FLAG_DEFAULT,
+                              allocator, &file_contents),
       "while trying to parse flagfile");
 
   // Run through the file line-by-line.

--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -224,6 +224,7 @@ iree_status_code_from_win32_error(uint32_t error) {
     case ERROR_ACCESS_DENIED:
       return IREE_STATUS_PERMISSION_DENIED;
     case ERROR_INVALID_HANDLE:
+    case ERROR_INVALID_PARAMETER:
       return IREE_STATUS_INVALID_ARGUMENT;
     case ERROR_NOT_READY:
     case ERROR_READ_FAULT:

--- a/runtime/src/iree/hal/local/executable_library_benchmark.c
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.c
@@ -161,6 +161,7 @@ static iree_status_t iree_hal_executable_library_run(
   // Load the executable data.
   iree_file_contents_t* file_contents = NULL;
   IREE_RETURN_IF_ERROR(iree_file_read_contents(FLAG_executable_file,
+                                               IREE_FILE_READ_FLAG_DEFAULT,
                                                host_allocator, &file_contents));
   executable_params.executable_data = file_contents->const_buffer;
 

--- a/runtime/src/iree/hal/local/plugins/embedded_elf_plugin.c
+++ b/runtime/src/iree/hal/local/plugins/embedded_elf_plugin.c
@@ -121,7 +121,8 @@ iree_status_t iree_hal_embedded_elf_executable_plugin_load_from_file(
   // Try to load the file first, which is the most likely thing to fail.
   iree_file_contents_t* file_contents = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_file_read_contents(path, host_allocator, &file_contents));
+      z0, iree_file_read_contents(path, IREE_FILE_READ_FLAG_DEFAULT,
+                                  host_allocator, &file_contents));
 
   iree_hal_file_embedded_elf_executable_plugin_t* plugin = NULL;
   iree_status_t status =

--- a/runtime/src/iree/runtime/session.c
+++ b/runtime/src/iree/runtime/session.c
@@ -237,7 +237,7 @@ iree_runtime_session_append_bytecode_module_from_file(
   // contents.
   iree_file_contents_t* flatbuffer_contents = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_file_read_contents(file_path,
+      z0, iree_file_read_contents(file_path, IREE_FILE_READ_FLAG_DEFAULT,
                                   iree_runtime_session_host_allocator(session),
                                   &flatbuffer_contents));
 

--- a/runtime/src/iree/tooling/trace_replay.c
+++ b/runtime/src/iree/tooling/trace_replay.c
@@ -197,6 +197,9 @@ static iree_status_t iree_trace_replay_load_bytecode_module(
   yaml_node_t* path_node = NULL;
   IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(document, module_node,
                                               IREE_SV("path"), &path_node));
+  yaml_node_t* mmap_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(document, module_node,
+                                                  IREE_SV("mmap"), &mmap_node));
 
   // Special case sourcing from stdin, which is useful for fast iteration and
   // tests where iree-compile output is piped directly into the replay tool.
@@ -222,8 +225,10 @@ static iree_status_t iree_trace_replay_load_bytecode_module(
     IREE_RETURN_IF_ERROR(iree_file_path_join(
         replay->root_path, iree_yaml_node_as_string(path_node),
         replay->host_allocator, &full_path));
-    status = iree_file_read_contents(full_path, replay->host_allocator,
-                                     &flatbuffer_contents);
+    status = iree_file_read_contents(
+        full_path,
+        mmap_node ? IREE_FILE_READ_FLAG_MMAP : IREE_FILE_READ_FLAG_PRELOAD,
+        replay->host_allocator, &flatbuffer_contents);
     iree_allocator_free(replay->host_allocator, full_path);
   }
 

--- a/samples/custom_module/basic/main.c
+++ b/samples/custom_module/basic/main.c
@@ -64,8 +64,8 @@ int main(int argc, char** argv) {
   if (strcmp(module_path, "-") == 0) {
     IREE_CHECK_OK(iree_stdin_read_contents(allocator, &module_contents));
   } else {
-    IREE_CHECK_OK(
-        iree_file_read_contents(module_path, allocator, &module_contents));
+    IREE_CHECK_OK(iree_file_read_contents(
+        module_path, IREE_FILE_READ_FLAG_DEFAULT, allocator, &module_contents));
   }
 
   // Load the bytecode module from the vmfb.

--- a/tools/iree-dump-instruments-main.c
+++ b/tools/iree-dump-instruments-main.c
@@ -279,7 +279,8 @@ int main(int argc, char** argv) {
 
   iree_file_contents_t* file_contents = NULL;
   iree_status_t status =
-      iree_file_read_contents(argv[1], iree_allocator_system(), &file_contents);
+      iree_file_read_contents(argv[1], IREE_FILE_READ_FLAG_DEFAULT,
+                              iree_allocator_system(), &file_contents);
   if (iree_status_is_ok(status)) {
     status =
         iree_tooling_dump_instrument_file(file_contents->const_buffer, stdout);

--- a/tools/iree-dump-module-main.c
+++ b/tools/iree-dump-module-main.c
@@ -559,8 +559,8 @@ int main(int argc, char** argv) {
   }
 
   iree_file_contents_t* file_contents = NULL;
-  iree_status_t status =
-      iree_file_read_contents(argv[1], host_allocator, &file_contents);
+  iree_status_t status = iree_file_read_contents(
+      argv[1], IREE_FILE_READ_FLAG_DEFAULT, host_allocator, &file_contents);
 
   iree_const_byte_span_t flatbuffer_contents = iree_const_byte_span_empty();
   iree_const_byte_span_t rodata_contents = iree_const_byte_span_empty();

--- a/tools/iree-fatelf.c
+++ b/tools/iree-fatelf.c
@@ -194,8 +194,9 @@ static iree_status_t fatelf_join(int argc, char** argv) {
       (fatelf_entry_t*)iree_alloca(entry_count * sizeof(fatelf_entry_t));
   memset(entries, 0, entry_count * sizeof(*entries));
   for (iree_elf64_byte_t i = 0; i < entry_count; ++i) {
-    IREE_RETURN_IF_ERROR(iree_file_read_contents(
-        argv[i], iree_allocator_system(), &entries[i].contents));
+    IREE_RETURN_IF_ERROR(
+        iree_file_read_contents(argv[i], IREE_FILE_READ_FLAG_DEFAULT,
+                                iree_allocator_system(), &entries[i].contents));
     entries[i].elf_data = entries[i].contents->const_buffer;
   }
 
@@ -327,8 +328,9 @@ static const char* fatelf_byte_order_id_str(iree_elf64_byte_t value) {
 // Splits a FatELF into multiple files, writing each beside the input file.
 static iree_status_t fatelf_split(int argc, char** argv) {
   iree_file_contents_t* fatelf_contents = NULL;
-  IREE_RETURN_IF_ERROR(iree_file_read_contents(argv[0], iree_allocator_system(),
-                                               &fatelf_contents));
+  IREE_RETURN_IF_ERROR(
+      iree_file_read_contents(argv[0], IREE_FILE_READ_FLAG_DEFAULT,
+                              iree_allocator_system(), &fatelf_contents));
   iree_fatelf_header_t* header = NULL;
   IREE_RETURN_IF_ERROR(fatelf_parse(fatelf_contents->const_buffer, &header));
 
@@ -374,8 +376,9 @@ static iree_status_t fatelf_split(int argc, char** argv) {
 static iree_status_t fatelf_select(int argc, char** argv) {
   IREE_SET_BINARY_MODE(stdout);  // ensure binary output mode
   iree_file_contents_t* fatelf_contents = NULL;
-  IREE_RETURN_IF_ERROR(iree_file_read_contents(argv[0], iree_allocator_system(),
-                                               &fatelf_contents));
+  IREE_RETURN_IF_ERROR(
+      iree_file_read_contents(argv[0], IREE_FILE_READ_FLAG_DEFAULT,
+                              iree_allocator_system(), &fatelf_contents));
   iree_const_byte_span_t elf_data = iree_const_byte_span_empty();
   IREE_RETURN_IF_ERROR(
       iree_fatelf_select(fatelf_contents->const_buffer, &elf_data));
@@ -409,8 +412,9 @@ static const char* fatelf_byte_order_enum_str(iree_elf64_byte_t value) {
 // Dumps the FatELF file records.
 static iree_status_t fatelf_dump(int argc, char** argv) {
   iree_file_contents_t* fatelf_contents = NULL;
-  IREE_RETURN_IF_ERROR(iree_file_read_contents(argv[0], iree_allocator_system(),
-                                               &fatelf_contents));
+  IREE_RETURN_IF_ERROR(
+      iree_file_read_contents(argv[0], IREE_FILE_READ_FLAG_DEFAULT,
+                              iree_allocator_system(), &fatelf_contents));
   iree_fatelf_header_t* header = NULL;
   IREE_RETURN_IF_ERROR(fatelf_parse(fatelf_contents->const_buffer, &header));
 

--- a/tools/iree-run-trace-main.c
+++ b/tools/iree-run-trace-main.c
@@ -260,6 +260,7 @@ int main(int argc, char** argv) {
       "module:\n"
       "  type: bytecode\n"
       "  path: ../build/some_module.vmfb\n"
+      "  mmap: true\n"
       "---\n"
       "type: call\n"
       "function: module.mul\n"


### PR DESCRIPTION
This uses the platform memory mapping support - if available - to map VMFB file contents into memory on-demand. This can skew profiling results as it introduces both high warm-up costs and high per-iteration variance as the OS is free to discard/reload pages at any time. It can be useful for very large models though that otherwise exceed available physical memory. On certain HAL targets this can avoid additional wired memory but most (GPUs) will still require fully loading the contents into memory and mapping will be less efficient but be friendlier to host resource usage.

This isn't a great API but is good enough for our tools for now. I still plan on exposing proper memory objects but that'll likely happen as part of sparse residency/file queue operations in the HAL.