### PR TITLE
Add a preprocessing pass to move entire function into a single dispatch.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -344,6 +344,11 @@ LogicalResult DispatchRegionOp::verify() {
     }
   }
 
+  Region &workgroupCount = getWorkgroupCount();
+  if (workgroupCount.empty()) {
+    return success();
+  }
+
   // If workgroup count region exists, check it has a single block.
   return verifyWorkgroupCountRegion(getOperation(), getWorkload(),
                                     getWorkgroupCount());

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -280,31 +280,73 @@ static void printDispatchWorkgroupsCountRegion(OpAsmPrinter &p, Operation *op,
 // flow.dispatch.region
 //===----------------------------------------------------------------------===//
 
-LogicalResult DispatchRegionOp::verify() {
-  // No block arguments.
-  if (!getBody().getArguments().empty())
-    return emitOpError() << "expected no block arguments";
+// Verifies the workgroup count
 
-  // Only one block.
-  if (!getBody().hasOneBlock())
-    return emitOpError() << "expected exactly 1 block";
+static LogicalResult
+verifyWorkgroupCountRegion(Operation *op, ValueRange workload, Region &region) {
+  // Verify the workload operands match the expected capture args.
+  if (workload.size() != region.getNumArguments()) {
+    return op->emitOpError()
+           << "workload operands and workgroup count args mismatch ("
+           << workload.size() << " vs " << region.getNumArguments() << ")";
+  }
+  for (auto [index, values] :
+       llvm::enumerate(llvm::zip_equal(workload, region.getArguments()))) {
+    auto [workloadValue, capturedArg] = values;
+    if (workloadValue.getType() != capturedArg.getType()) {
+      return op->emitOpError()
+             << "workload value " << index << " type mismatch; operand is "
+             << workloadValue.getType() << " but region captures "
+             << capturedArg.getType();
+    }
+  }
 
-  // Verify terminator.
-  auto returnOp = dyn_cast<Flow::ReturnOp>(getBody().front().getTerminator());
-  if (!returnOp)
-    return emitOpError() << "expected 'flow.return' terminator";
-  for (const auto [resultType, returnType] :
-       llvm::zip_equal(getResultTypes(), returnOp->getOperandTypes()))
-    if (resultType != returnType)
-      return returnOp->emitOpError()
-             << "operand types do not match with parent results";
-
-  // Make sure that all returned values are ranked tensors.
-  for (Type t : getResultTypes())
-    if (!llvm::isa<RankedTensorType>(t))
-      return emitOpError() << "only ranked tensor results are allowed";
+  // Verify the return ops all provide XYZ values.
+  for (auto returnOp : region.getOps<IREE::Flow::ReturnOp>()) {
+    if (returnOp.getNumOperands() != 3 ||
+        !llvm::all_of(returnOp.getOperandTypes(),
+                      [](Type type) { return type.isIndex(); })) {
+      return returnOp.emitOpError() << "workgroup count region must return "
+                                       "the XYZ dimension counts";
+    }
+  }
 
   return success();
+}
+
+LogicalResult DispatchRegionOp::verify() {
+  // No block arguments.
+  if (!getBody().getArguments().empty()) {
+    return emitOpError() << "expected no block arguments";
+  }
+
+  // Verify terminator.
+  SmallVector<Flow::ReturnOp> returnOps;
+  for (Block &block : getBody()) {
+    if (auto returnOp =
+            dyn_cast_or_null<Flow::ReturnOp>(block.getTerminator())) {
+      returnOps.push_back(returnOp);
+    }
+  }
+  for (auto returnOp : returnOps) {
+    for (const auto [resultType, returnType] :
+         llvm::zip_equal(getResultTypes(), returnOp->getOperandTypes()))
+      if (resultType != returnType) {
+        return returnOp->emitOpError()
+               << "operand types do not match with parent results";
+      }
+  }
+
+  // Make sure that all returned values are ranked tensors.
+  for (Type t : getResultTypes()) {
+    if (!llvm::isa<RankedTensorType>(t)) {
+      return emitOpError() << "only ranked tensor results are allowed";
+    }
+  }
+
+  // If workgroup count region exists, check it has a single block.
+  return verifyWorkgroupCountRegion(getOperation(), getWorkload(),
+                                    getWorkgroupCount());
 }
 
 ParseResult DispatchRegionOp::parse(OpAsmParser &parser,
@@ -348,7 +390,6 @@ ParseResult DispatchRegionOp::parse(OpAsmParser &parser,
     return failure();
   if (parser.parseRegion(*bodyRegion))
     return failure();
-  ensureTerminator(*bodyRegion, parser.getBuilder(), result.location);
 
   if (parseDispatchWorkgroupsCountRegion(parser, *workloadCountRegion)) {
     return failure();
@@ -868,38 +909,6 @@ static void printDispatchWorkgroupBody(OpAsmPrinter &p, Operation *op,
                 /*printBlockTerminators=*/true);
 }
 
-LogicalResult verifyWorkgroupCountRegion(Operation *op, ValueRange workload,
-                                         Region &region) {
-  // Verify the workload operands match the expected capture args.
-  if (workload.size() != region.getNumArguments()) {
-    return op->emitOpError()
-           << "workload operands and workgroup count args mismatch ("
-           << workload.size() << " vs " << region.getNumArguments() << ")";
-  }
-  for (auto [index, values] :
-       llvm::enumerate(llvm::zip_equal(workload, region.getArguments()))) {
-    auto [workloadValue, capturedArg] = values;
-    if (workloadValue.getType() != capturedArg.getType()) {
-      return op->emitOpError()
-             << "workload value " << index << " type mismatch; operand is "
-             << workloadValue.getType() << " but region captures "
-             << capturedArg.getType();
-    }
-  }
-
-  // Verify the return ops all provide XYZ values.
-  for (auto returnOp : region.getOps<IREE::Flow::ReturnOp>()) {
-    if (returnOp.getNumOperands() != 3 ||
-        !llvm::all_of(returnOp.getOperandTypes(),
-                      [](Type type) { return type.isIndex(); })) {
-      return returnOp.emitOpError() << "workgroup count region must return "
-                                       "the XYZ dimension counts";
-    }
-  }
-
-  return success();
-}
-
 LogicalResult DispatchWorkgroupsOp::verify() {
   Operation *op = getOperation();
 
@@ -1043,7 +1052,7 @@ DispatchWorkgroupsOp::getOperandAccess(unsigned operandIndex) {
 
 IREE::Util::ValueAccess
 DispatchWorkgroupsOp::getResultAccess(unsigned resultIndex) {
-  unsigned startIndex = getBody()->getNumArguments() - getNumResults();
+  unsigned startIndex = getWorkgroupBody().getNumArguments() - getNumResults();
   BlockArgument arg =
       getWorkgroupBody().front().getArgument(startIndex + resultIndex);
   if (auto tensorType = llvm::dyn_cast<DispatchTensorType>(arg.getType())) {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -35,8 +35,7 @@ let opDocGroup = OpGroupPartitionedRegionOps in {
 
 def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
     Util_ShapeAwareOp,
-    AttrSizedOperandSegments,
-    SingleBlockImplicitTerminator<"IREE::Flow::ReturnOp">]> {
+    AttrSizedOperandSegments]> {
   let summary = [{a group of ops}];
   let description = [{
     This op is a container/grouping of ops. It represents a fusion group before
@@ -76,7 +75,6 @@ def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
 def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
   IsolatedFromAbove,
   AttrSizedOperandSegments,
-  SingleBlockImplicitTerminator<"IREE::Flow::ReturnOp">,
   DeclareOpInterfaceMethods<Util_ClosureOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
     "getTiedOperandsIndexAndLength",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CaptureDispatchDynamicDims.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CaptureDispatchDynamicDims.cpp
@@ -30,7 +30,11 @@ namespace {
 // leave the cleanup of redundant work to further optimization passes to keep
 // this simple.
 static void captureDims(IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
-  auto *entryBlock = dispatchOp.getBody();
+  Region &body = dispatchOp.getWorkgroupBody();
+  if (body.empty()) {
+    return;
+  }
+  auto *entryBlock = &body.front();
 
   // Map of SSA values on the outside of the op to arguments on the inside.
   // This lets us avoid capturing duplicate values - they'd be cleaned up

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchWorkgroups.cpp
@@ -236,7 +236,11 @@ createDefaultWorkgroupCountRegion(RewriterBase &rewriter,
 
     // Annotate the values captures as workload with their position in the
     // workload list.
-    rewriter.setInsertionPointToStart(workgroupsOp.getBody());
+    Region &body = workgroupsOp.getWorkgroupBody();
+    if (body.empty()) {
+      return;
+    }
+    rewriter.setInsertionPointToStart(&body.front());
     int ordinalNumber = 0;
     for (auto [index, operand] : llvm::enumerate(workgroupsOp.getArguments())) {
       if (!llvm::isa<IndexType>(operand.getType()))

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
@@ -61,8 +61,7 @@ static bool isComputeOperation(Operation *op) {
     return true;
   }
   if (op->getDialect() == context->getLoadedDialect<tensor::TensorDialect>()) {
-    return !isa<tensor::CastOp, tensor::CollapseShapeOp, tensor::EmptyOp,
-                tensor::ExpandShapeOp>(op);
+    return !isa<tensor::CastOp, tensor::EmptyOp>(op);
   }
   return false;
 }
@@ -162,7 +161,7 @@ void FormScalarDispatchesPass::runOnOperation() {
   mlir::FunctionOpInterface funcOp = getOperation();
   MLIRContext *context = &getContext();
 
-  int scalarWorkloadLimit = 1;
+  int scalarWorkloadLimit = 2;
   // Convenient struct to hold all operations that need to be moved into a
   // descriptor.
   struct DispatchRegionDescriptor {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
@@ -61,7 +61,8 @@ static bool isComputeOperation(Operation *op) {
     return true;
   }
   if (op->getDialect() == context->getLoadedDialect<tensor::TensorDialect>()) {
-    return !isa<tensor::CastOp, tensor::EmptyOp>(op);
+    return !isa<tensor::CastOp, tensor::CollapseShapeOp, tensor::EmptyOp,
+                tensor::ExpandShapeOp>(op);
   }
   return false;
 }
@@ -161,7 +162,7 @@ void FormScalarDispatchesPass::runOnOperation() {
   mlir::FunctionOpInterface funcOp = getOperation();
   MLIRContext *context = &getContext();
 
-  int scalarWorkloadLimit = 2;
+  int scalarWorkloadLimit = 1;
   // Convenient struct to hold all operations that need to be moved into a
   // descriptor.
   struct DispatchRegionDescriptor {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -201,7 +201,7 @@ summarizeDispatchWorkgroupsOp(DispatchWorkgroupsOp regionOp) {
   Operation *bestOp = NULL;
   const int64_t kMinEstimatedCost = -1;
   int64_t bestEstimatedCost = kMinEstimatedCost;
-  regionOp.getBodyRegion().walk([&](Operation *op) {
+  regionOp.getWorkgroupBody().walk([&](Operation *op) {
     TypeSwitch<Operation *>(op)
         .Case<linalg::LinalgOp>([&](auto op) {
           int64_t estimatedCost = estimateLinalgOpCost(op);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_dispatch_workgroups.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_dispatch_workgroups.mlir
@@ -14,3 +14,32 @@ func.func @existing_count_region(%arg0 : index, %arg1 : index) -> tensor<?x?xf32
 //       CHECK:   count(%[[ARG2:[a-zA-Z0-9]+]]: index, %[[ARG3:[a-zA-Z0-9]+]]: index)
 //       CHECK:     %[[C1:.+]] = arith.constant 1 : index
 //       CHECK:     flow.return %[[ARG2]], %[[ARG3]], %[[C1]]
+
+// -----
+
+func.func @simple_test_with_cfg(%arg0: i1) -> (tensor<10x20xf32>) {
+  %cst = arith.constant dense<1.000000e+00> : tensor<10x20xf32>
+  %0 = flow.dispatch.region -> (tensor<10x20xf32>) {
+    %cst_0 = arith.constant dense<1.000000e+00> : tensor<10x20xf32>
+    cf.cond_br %arg0, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0                                                                                                                                                                                                                                                                                             
+    %2 = tensor.empty() : tensor<10x20xf32>
+    flow.return %2 : tensor<10x20xf32>
+  ^bb2:  // pred: ^bb0                                                                                                                                                                                                                                                                                             
+    flow.return %cst_0 : tensor<10x20xf32>
+  }
+  return %0 : tensor<10x20xf32>
+}
+// CHECK-LABEL: func @simple_test_with_cfg
+//  CHECK-SAME:     %[[ARG0:.+]]: i1
+//       CHECK:   %[[RESULT:.+]] = flow.dispatch.workgroups(%[[ARG0]])
+//  CHECK-SAME:       %[[ARG1:.+]]: i1, %[[ARG2:.+]]: !flow.dispatch.tensor
+//       CHECK:     %[[CST:.+]] = arith.constant
+//       CHECK:     ^[[BB1:.+]]:
+//       CHECK:       %[[EMPTY:.+]] = tensor.empty()
+//       CHECK:       flow.dispatch.tensor.store %[[EMPTY]], %[[ARG2]]
+//       CHECK:       flow.return
+//       CHECK:     ^[[BB2:.+]]:
+//       CHECK:       flow.dispatch.tensor.store %[[CST]], %[[ARG2]]
+//       CHECK:       flow.return
+//       CHECK:   return %[[RESULT]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_dispatch_workgroups.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_dispatch_workgroups.mlir
@@ -33,7 +33,7 @@ func.func @simple_test_with_cfg(%arg0: i1) -> (tensor<10x20xf32>) {
 // CHECK-LABEL: func @simple_test_with_cfg
 //  CHECK-SAME:     %[[ARG0:.+]]: i1
 //       CHECK:   %[[RESULT:.+]] = flow.dispatch.workgroups(%[[ARG0]])
-//  CHECK-SAME:       %[[ARG1:.+]]: i1, %[[ARG2:.+]]: !flow.dispatch.tensor
+//  CHECK-NEXT:       %[[ARG1:.+]]: i1, %[[ARG2:.+]]: !flow.dispatch.tensor
 //       CHECK:     %[[CST:.+]] = arith.constant
 //       CHECK:     ^[[BB1:.+]]:
 //       CHECK:       %[[EMPTY:.+]] = tensor.empty()

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -31,6 +31,7 @@ iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
         "ConvertConv2DToImg2Col.cpp",
+        "MakeSingleDispatchForFunction.cpp",
         "PadLinalgOps.cpp",
         "PassDetail.h",
         "Passes.cpp",

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -43,6 +43,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":PassesIncGen",
+        "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTensorUtils
     MLIRTransforms
+    iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::Transforms
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "Passes.h.inc"
   SRCS
     "ConvertConv2DToImg2Col.cpp"
+    "MakeSingleDispatchForFunction.cpp"
     "PadLinalgOps.cpp"
     "PassDetail.h"
     "Passes.cpp"

--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -60,7 +60,7 @@ void MakeSingleDispatchForFunctionPass::runOnOperation() {
   // Move the body of the function into the region.
   Region &region = dispatchRegionOp.getBody();
   region.getBlocks().splice(region.begin(), funcBody.getBlocks(),
-                            Region::iterator(funcBodyStart));
+                            Region::iterator(funcBodyStart), funcBody.end());
 
   // Replace all `func.return` with `flow.return`.
   SmallVector<func::ReturnOp> returnOps =

--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 The IREE Authors
+// Copyright 2023 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -1,0 +1,87 @@
+// Copyright 2020 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Preprocessing/Common/PassDetail.h"
+#include "iree/compiler/Preprocessing/Common/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+
+namespace {
+
+struct MakeSingleDispatchForFunctionPass
+    : public MakeSingleDispatchForFunctionBase<
+          MakeSingleDispatchForFunctionPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Flow::FlowDialect>();
+  }
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void MakeSingleDispatchForFunctionPass::runOnOperation() {
+  auto funcOp = getOperation();
+
+  // Currently this can only be done for static shapes cause
+  // there is no way of getting the tied dynamic shapes for
+  // a function.
+  auto resultTypes = funcOp.getFunctionType().getResults();
+  if (llvm::any_of(resultTypes, [&](Type t) {
+        auto shapedType = t.dyn_cast<ShapedType>();
+        return shapedType && !shapedType.hasStaticShape();
+      })) {
+    return;
+  }
+
+  IRRewriter rewriter(&getContext());
+  Location loc = funcOp.getLoc();
+  Region &funcBody = funcOp.getBody();
+
+  // Split the function entry block to create a new entry block into which the
+  // new operations will be added.
+  Block &entryBlock = funcBody.front();
+  Block *funcBodyStart = rewriter.splitBlock(&entryBlock, entryBlock.begin());
+
+  // Create an empty `flow.dispatch.region` operation with same result type as
+  // the function.
+  rewriter.setInsertionPointToEnd(&entryBlock);
+  auto dispatchRegionOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
+      loc, resultTypes, /*result_dims=*/ValueRange{},
+      /*workload=*/ValueRange{});
+
+  // Move the body of the function into the region.
+  Region &region = dispatchRegionOp.getBody();
+  region.getBlocks().splice(region.begin(), funcBody.getBlocks(),
+                            Region::iterator(funcBodyStart));
+
+  // Replace all `func.return` with `flow.return`.
+  SmallVector<func::ReturnOp> returnOps =
+      llvm::to_vector(region.getOps<func::ReturnOp>());
+  for (auto returnOp : returnOps) {
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(returnOp);
+    rewriter.replaceOpWithNewOp<IREE::Flow::ReturnOp>(returnOp,
+                                                      returnOp.getOperands());
+  }
+
+  // Return the results of the `flow.dispatch.region`.
+  rewriter.setInsertionPointAfter(dispatchRegionOp);
+  rewriter.create<func::ReturnOp>(loc, dispatchRegionOp.getResults());
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createMakeSingleDispatchForFunctionPass() {
+  return std::make_unique<MakeSingleDispatchForFunctionPass>();
+}
+
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
@@ -17,11 +17,15 @@ namespace mlir {
 namespace iree_compiler {
 namespace IREE {
 
-// Creates a pass to convert linalg convolution ops into linalg.matmul ops
-// using im2col tranformation.
+/// Creates a pass to convert linalg convolution ops into linalg.matmul ops
+/// using im2col tranformation.
 std::unique_ptr<Pass> createConvertConv2DToImg2ColPass();
 
-// A pass to pad linalg ops to the next integer multiple of `paddingSize`.
+// Moves the body of the entire function into a single dispatch.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createMakeSingleDispatchForFunctionPass();
+
+/// A pass to pad linalg ops to the next integer multiple of `paddingSize`.
 std::unique_ptr<Pass> createPadLinalgOpsToIntegerMultiplePass();
 
 /// Pass to merge parallel linalg operations.

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
@@ -21,7 +21,7 @@ namespace IREE {
 /// using im2col tranformation.
 std::unique_ptr<Pass> createConvertConv2DToImg2ColPass();
 
-// Moves the body of the entire function into a single dispatch.
+/// Moves the body of the entire function into a single dispatch.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createMakeSingleDispatchForFunctionPass();
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -15,6 +15,12 @@ def ConvertConv2DToImg2Col :
   let constructor = "mlir::iree_compiler::IREE::createConvertConv2DToImg2ColPass()";
 }
 
+def MakeSingleDispatchForFunction :
+    Pass<"iree-preprocessing-make-single-dispatch-for-function", "func::FuncOp"> {
+  let summary = "Convert entire function into a single dispatch";
+  let constructor = "mlir::iree_compiler::IREE::createMakeSingleDispatchForFunctionPass()";
+}
+
 def PadLinalgOps :
     Pass<"iree-preprocessing-pad-linalg-ops", ""> {
   let summary = "Pad linalg ops to the next integer multiple of paddingSize.";

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "conv2d_to_img2col.mlir",
+            "make_single_dispatch_for_function.mlir",
             "pad_linalg_ops.mlir",
             "rematerialize_parallel_ops.mlir",
         ],

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "conv2d_to_img2col.mlir"
+    "make_single_dispatch_for_function.mlir"
     "pad_linalg_ops.mlir"
     "rematerialize_parallel_ops.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/make_single_dispatch_for_function.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/make_single_dispatch_for_function.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-preprocessing--make-single-dispatch-for-function --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-preprocessing-make-single-dispatch-for-function --split-input-file %s | FileCheck %s
 
 func.func @simple_test() -> tensor<10x20xf32> {
   %0 = tensor.empty() : tensor<10x20xf32>

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/make_single_dispatch_for_function.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/make_single_dispatch_for_function.mlir
@@ -9,3 +9,27 @@ func.func @simple_test() -> tensor<10x20xf32> {
 //       CHECK:     %[[EMPTY:.+]] = tensor.empty
 //       CHECK:     flow.return %[[EMPTY]]
 //       CHECK:   return %[[DISPATCH]]
+
+// -----
+
+func.func @simple_test_with_cfg(%arg0 : i1) -> tensor<10x20xf32> {
+    cf.cond_br %arg0, ^bb1, ^bb2
+  ^bb1:
+    %0 = tensor.empty() : tensor<10x20xf32>
+    return %0 : tensor<10x20xf32>
+  ^bb2:
+    %1 = arith.constant dense<1.0> : tensor<10x20xf32>
+    return %1 : tensor<10x20xf32>
+}
+// CHECK-LABEL: func @simple_test_with_cfg
+//  CHECK-SAME:     %[[ARG0:.+]]: i1
+//  CHECK-NEXT:   %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<10x20xf32>) {
+//       CHECK:       cf.cond_br %[[ARG0]], ^[[BB1:[a-zA-Z0-9]+]], ^[[BB2:[a-zA-Z0-9]+]]
+//       CHECK:     ^[[BB1]]:
+//       CHECK:       %[[EMPTY:.+]] = tensor.empty
+//       CHECK:       flow.return %[[EMPTY]]
+//       CHECK:     ^[[BB2]]:
+//       CHECK:       %[[CST:.+]] = arith.constant
+//       CHECK:       flow.return %[[CST]]
+//       CHECK:   }
+//       CHECK:   return %[[DISPATCH]]

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/make_single_dispatch_for_function.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/make_single_dispatch_for_function.mlir
@@ -1,0 +1,11 @@
+// RUN: iree-opt --iree-preprocessing--make-single-dispatch-for-function --split-input-file %s | FileCheck %s
+
+func.func @simple_test() -> tensor<10x20xf32> {
+  %0 = tensor.empty() : tensor<10x20xf32>
+  return %0 : tensor<10x20xf32>
+}
+// CHECK-LABEL: func @simple_test() -> tensor<10x20xf32>
+//  CHECK-NEXT:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     %[[EMPTY:.+]] = tensor.empty
+//       CHECK:     flow.return %[[EMPTY]]
+//       CHECK:   return %[[DISPATCH]]

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -38,6 +38,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = [
         "fill_i64.mlir",
+        "force_single_dispatch.mlir",
         "globals.mlir",
         "libm_linking.mlir",
         "scalar.mlir",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "fill_i64.mlir"
+    "force_single_dispatch.mlir"
     "globals.mlir"
     "libm_linking.mlir"
     "scalar.mlir"

--- a/tests/e2e/regression/force_single_dispatch.mlir
+++ b/tests/e2e/regression/force_single_dispatch.mlir
@@ -1,0 +1,14 @@
+// RUN: iree-opt --iree-preprocessing-make-single-dispatch-for-function %s | iree-run-mlir --Xcompiler,iree-hal-target-backends=llvm-cpu --input="1"
+func.func @simple_test_with_cfg(%arg0 : i8) -> tensor<2x4xf32> {
+    %c0_i8 = arith.constant 0 : i8
+    %cond = arith.cmpi eq, %arg0, %c0_i8 : i8
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    %0 = tensor.empty() : tensor<2x4xf32>
+    return %0 : tensor<2x4xf32>
+  ^bb2:
+    %1 = arith.constant dense<1.0> : tensor<2x4xf32>
+    return %1 : tensor<2x4xf32>
+}
+// CHECK-LABEL: EXEC @simple_test_with_cfg
+//       CHECK: 2x4xf32=[1 1 1 1][1 1 1 1]

--- a/tests/e2e/regression/force_single_dispatch.mlir
+++ b/tests/e2e/regression/force_single_dispatch.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-preprocessing-make-single-dispatch-for-function %s | iree-run-mlir --Xcompiler,iree-hal-target-backends=llvm-cpu --input="1"
+// RUN: iree-opt --iree-preprocessing-make-single-dispatch-for-function %s | iree-run-mlir --Xcompiler,iree-hal-target-backends=llvm-cpu --input="1" -
 func.func @simple_test_with_cfg(%arg0 : i8) -> tensor<2x4xf32> {
     %c0_i8 = arith.constant 0 : i8
     %cond = arith.cmpi eq, %arg0, %c0_i8 : i8


### PR DESCRIPTION
For cases where the model is very small and does not have much concurrency, it is better to move the entire function body into a single dispatch. Eventually the default heuristics can probably figure out when a model is "too small", but for now this PR adds a pass to move the entire function body into a single dispatch to use as a way to find codegen issues such an approach throws up, and also to experiment with different heuristics needed to find such dispatches automatically.