### PR TITLE
Only emplace dispatch results up to the first unemplacable one.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
@@ -155,6 +155,40 @@ func.func @emplaceMultiResultDispatchInto(
 
 // -----
 
+// TODO(#14566): multiple results with sparse ties don't work due to implicit
+// operand/result ordering on the dispatch ops. Flow and stream dispatch ops and
+// the executable entry points need to be reworked to remove the implicit
+// ordering. For now we only emplace results until the first we can't then bail
+// and leave them out-of-place. This test should place the first but not the
+// third as the second isn't placed.
+
+// CHECK-LABEL: @dontEmplaceSparseMultiResult
+func.func @dontEmplaceSparseMultiResult(
+    // CHECK-SAME: %[[INPUT:arg[0-9]+]]: !stream.resource<*>, %[[INPUT_SIZE:arg[0-9]+]]: index,
+    %input: !stream.resource<*>, %input_size: index,
+    // CHECK-SAME: %[[UPDATE_SIZE:arg[0-9]+]]: index, %[[TARGET_SIZE:arg[0-9]+]]: index
+    %update_size: index, %target_size: index) -> !stream.resource<*> {
+  %c0 = arith.constant 0 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  // CHECK: %[[TARGET:.+]] = stream.async.alloca
+  // CHECK: %[[DISPATCH:.+]]:3 = stream.async.dispatch @ex::@dispatch0
+  // CHECK-SAME: ({{.+}}, %[[TARGET]][%c0 to %c32 for %[[UPDATE_SIZE]]]) :
+  // CHECK-SAME: ({{.+}}) -> (%[[TARGET]]{%[[TARGET_SIZE]]}, !stream.resource<*>{%[[UPDATE_SIZE]]}, !stream.resource<*>{%[[UPDATE_SIZE]]})
+  %update:3 = stream.async.dispatch @ex::@dispatch0(%input[%c0 to %input_size for %input_size]) :
+      (!stream.resource<*>{%input_size}) -> (!stream.resource<*>{%update_size}, !stream.resource<*>{%update_size}, !stream.resource<*>{%update_size})
+  // CHECK-NOT: stream.async.alloca
+  %target = stream.async.alloca : !stream.resource<*>{%target_size}
+  // CHECK-NOT: stream.async.update
+  %target0 = stream.async.update %update#0, %target[%c0 to %c32] : !stream.resource<*>{%update_size} -> %target as !stream.resource<*>{%target_size}
+  // CHECK: %[[TARGET1:.+]] = stream.async.update %[[DISPATCH]]#2, %[[DISPATCH]]#0[%c32 to %c64]
+  %target1 = stream.async.update %update#2, %target0[%c32 to %c64] : !stream.resource<*>{%update_size} -> %target0 as !stream.resource<*>{%target_size}
+  // CHECK: return %[[TARGET1]]
+  return %target1 : !stream.resource<*>
+}
+
+// -----
+
 // Tests that sequences with data dependencies don't hoist beyond them.
 
 // CHECK-LABEL: @emplaceDependentDispatchSequence


### PR DESCRIPTION
This avoids issues with implicit dispatch binding ordering that need a larger reworking of the flow/stream SSA-based dispatch ops in order to properly fix.

Workaround for #14566.