### PR TITLE
Initialize results of buffer.load.* ops to zero.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -3625,8 +3625,9 @@ private:
         results.push_back(ref.value());
         operands.push_back(ref.value());
       } else {
-        Value resultValue =
-            emitc_builders::allocateVariable(rewriter, loc, result.getType());
+        Type type = result.getType();
+        Value resultValue = emitc_builders::allocateVariable(
+            rewriter, loc, type, rewriter.getZeroAttr(type));
         Value resultPtr = emitc_builders::addressOf(rewriter, loc, resultValue);
 
         results.push_back(resultValue);

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -112,14 +112,21 @@ Value binaryOperator(OpBuilder builder, Location location, BinaryOperator op,
 }
 
 Value allocateVariable(OpBuilder builder, Location location, Type type,
-                       std::optional<StringRef> initializer) {
-  auto ctx = builder.getContext();
+                       Attribute initializer) {
   return builder
       .create<emitc::VariableOp>(
           /*location=*/location,
           /*resultType=*/type,
-          /*value=*/emitc::OpaqueAttr::get(ctx, initializer.value_or("")))
+          /*value=*/initializer)
       .getResult();
+}
+
+Value allocateVariable(OpBuilder builder, Location location, Type type,
+                       std::optional<StringRef> initializer) {
+  auto ctx = builder.getContext();
+  return allocateVariable(
+      builder, location, type,
+      emitc::OpaqueAttr::get(ctx, initializer.value_or("")));
 }
 
 Value addressOf(OpBuilder builder, Location location, Value operand) {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.h
@@ -66,6 +66,9 @@ Value binaryOperator(OpBuilder builder, Location location, BinaryOperator op,
                      Value lhs, Value rhs, Type resultType);
 
 Value allocateVariable(OpBuilder builder, Location location, Type type,
+                       Attribute initializer);
+
+Value allocateVariable(OpBuilder builder, Location location, Type type,
                        std::optional<StringRef> initializer = std::nullopt);
 
 Value addressOf(OpBuilder builder, Location location, Value operand);

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops.mlir
@@ -75,7 +75,7 @@ vm.module @my_module {
     // CHECK: %[[BUFFER_REF2:.+]] = emitc.apply "*"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
+    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i32}> : () -> i32
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (i32) -> !emitc.ptr<i32>
     // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_compare"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
@@ -158,7 +158,7 @@ vm.module @my_module {
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
+    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i32}> : () -> i32
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%6) : (i32) -> !emitc.ptr<i32>
     // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_load_i8s"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f32.mlir
@@ -29,7 +29,7 @@ vm.module @my_module {
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0.000000e+00 : f32}> : () -> f32
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%6) : (f32) -> !emitc.ptr<f32>
     // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_load_f32"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f32>) -> !emitc.opaque<"iree_status_t">
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f64.mlir
@@ -29,7 +29,7 @@ vm.module @my_module {
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f64
+    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0.000000e+00 : f64}> : () -> f64
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%6) : (f64) -> !emitc.ptr<f64>
     // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_load_f64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f64>) -> !emitc.opaque<"iree_status_t">
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_i64.mlir
@@ -29,7 +29,7 @@ vm.module @my_module {
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i64
+    // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i64}> : () -> i64
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%6) : (i64) -> !emitc.ptr<i64>
     // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_load_i64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i64>) -> !emitc.opaque<"iree_status_t">
 


### PR DESCRIPTION
This works around warnings about maybe uninitialized values generated by gcc by initializing result variables to zero before their addresses to .

Older versions of gcc seem to be unable to follow writes to uninitialized values across conditional control flow like

```C
A:
  int result;
  int *resultPtr;
  bool failure;

...

X:
  /* result = 0; */ // Zero initialization added in this PR
  resultPtr = &result;
  failure = tryWrite(resultPtr, ...);  // resultPtr is written iff this returns false  
  if (failure)
    goto Y;
  else
    goto Z;
Y:
  return;
Z:
  use(result);
```