### PR TITLE
Fix runtime pointer direct cast

### DIFF
--- a/runtime/src/iree/hal/allocator_heap.c
+++ b/runtime/src/iree/hal/allocator_heap.c
@@ -234,7 +234,7 @@ static iree_status_t iree_hal_heap_allocator_import_buffer(
       ptr = external_buffer->handle.host_allocation.ptr;
       break;
     case IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION:
-      ptr = (void*)external_buffer->handle.device_allocation.ptr;
+      ptr = (void*)((intptr_t)external_buffer->handle.device_allocation.ptr);
       break;
     default:
       return iree_make_status(IREE_STATUS_UNAVAILABLE,

--- a/runtime/src/iree/vm/bytecode/module.c
+++ b/runtime/src/iree/vm/bytecode/module.c
@@ -525,7 +525,7 @@ static iree_status_t iree_vm_bytecode_module_source_location_format(
   iree_vm_DebugDatabaseDef_table_t debug_database_def =
       (iree_vm_DebugDatabaseDef_table_t)self;
   iree_vm_FunctionSourceMapDef_table_t source_map_def =
-      (iree_vm_FunctionSourceMapDef_table_t)data[0];
+      (iree_vm_FunctionSourceMapDef_table_t)((intptr_t)data[0]);
   iree_vm_BytecodeLocationDef_vec_t locations =
       iree_vm_FunctionSourceMapDef_locations(source_map_def);
   iree_vm_source_offset_t source_offset = (iree_vm_source_offset_t)data[1];
@@ -587,7 +587,7 @@ static iree_status_t iree_vm_bytecode_module_resolve_source_location(
   // The source location stores the source map and PC and will perform the
   // actual lookup within the source map on demand.
   out_source_location->self = (void*)debug_database_def;
-  out_source_location->data[0] = (uint64_t)source_map_def;
+  out_source_location->data[0] = (uint64_t)((intptr_t)source_map_def);
   out_source_location->data[1] = (uint64_t)pc;
   out_source_location->format = iree_vm_bytecode_module_source_location_format;
   return iree_ok_status();


### PR DESCRIPTION
Add `intptr_t` cast in between `uint64_t` and the `void*` or flatbuffer pointer types.


To void the `int-to-pointer-cast` and `pointer-to int-cast` warnings when build with 32-bit system

```
iree/runtime/src/iree/hal/allocator_heap.c:237:13: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  237 |       ptr = (void*)external_buffer->handle.device_allocation.ptr;
      |             ^

```
```
iree/runtime/src/iree/vm/bytecode/module.c:528:7: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  528 |       (iree_vm_FunctionSourceMapDef_table_t)data[0];
      |       ^

iree/vm/bytecode/module.c:590:34: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  590 |   out_source_location->data[0] = (uint64_t)source_map_def;
      |                                  ^

```
