### PR TITLE
Add error message for InlineExecutables with unsupported variants.

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/Embed.cpp
+++ b/compiler/src/iree/compiler/API/Internal/Embed.cpp
@@ -728,6 +728,19 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
       return false;
     }
 
+    // InlineStatic (currently) only supports the `vmvx-inline` backend.
+    if (session.schedulingOptions.executionModel ==
+        SchedulingOptions::ExecutionModel::InlineStatic) {
+      for (auto target : session.halTargetOptions.targets) {
+        if (target != "vmvx-inline") {
+          parsedModule->emitError() << "InlineStatic execution model is not "
+                                       "compatible with hal target '"
+                                    << target << "'";
+          return false;
+        }
+      }
+    }
+
     buildIREEVMTransformPassPipeline(
         session.targetRegistry, session.bindingOptions, session.inputOptions,
         session.preprocessingOptions, session.highLevelOptimizationOptions,

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
@@ -133,8 +133,7 @@ public:
       auto bodyFuncOp =
           innerSymbolTable.lookup<func::FuncOp>(exportOp.getName());
       if (!bodyFuncOp) {
-        return exportOp.emitOpError("in variant missing body function. Does "
-                                    "this variant support inline executables?");
+        return exportOp.emitOpError("missing body function");
       }
       if (bodyFuncOp.isPublic()) {
         if (failed(rewriteWorkgroupSignature(layoutAttr, totalBindingCount,

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
@@ -132,6 +132,10 @@ public:
       // Build the dispatch function by calling the target function in a loop.
       auto bodyFuncOp =
           innerSymbolTable.lookup<func::FuncOp>(exportOp.getName());
+      if (!bodyFuncOp) {
+        return exportOp.emitOpError("in variant missing body function. Does "
+                                    "this variant support inline executables?");
+      }
       if (bodyFuncOp.isPublic()) {
         if (failed(rewriteWorkgroupSignature(layoutAttr, totalBindingCount,
                                              bodyFuncOp))) {


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/14587 (cc @dcaballe ). `--iree-execution-model=inline-static` only works with `--iree-hal-target-backends=vmvx-inline`. It was crashing when other backends were used, so this adds a check and error log.

Sample logs:
```
D:\dev\projects\iree (inline-error-message)
λ ..\iree-build\tools\iree-compile.exe -iree-input-type=stablehlo --iree-hal-target-backends=llvm-cpu --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu --iree-execution-model=inline-static ./tests/e2e/stablehlo_ops/add.mlir -o ../iree-tmp/add.vmfb
./tests/e2e/stablehlo_ops/add.mlir:0:0: error: InlineStatic execution model is not compatible with hal target 'llvm-cpu'
./tests/e2e/stablehlo_ops/add.mlir:0:0: note: see current operation:
"builtin.module"() ({
...
```