### PR TITLE
Fix bug with stablehlo canonicalizer which reordered operations that had more than one use.

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1075,8 +1075,8 @@ struct ReorderElementwiseAndShapeOp final
     auto intermediateResult = definingOp->getResult(0);
     if (std::distance(intermediateResult.getUses().begin(),
                       intermediateResult.getUses().end()) != 1) {
-      return rewriter.notifyMatchFailure(
-          op, "operation has more than one use.");
+      return rewriter.notifyMatchFailure(op,
+                                         "operation has more than one use.");
     }
 
     Value input = definingOp->getOperand(0);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1071,11 +1071,12 @@ struct ReorderElementwiseAndShapeOp final
           op, "defining operation of unexpected type.");
     }
 
-    // Only reorder if the defining op has no other uses
+    // Only reorder if the defining op has no other uses.
     auto intermediateResult = definingOp->getResult(0);
     if (std::distance(intermediateResult.getUses().begin(),
                       intermediateResult.getUses().end()) != 1) {
-      return failure();
+      return rewriter.notifyMatchFailure(
+          op, "operation has more than one use.");
     }
 
     Value input = definingOp->getOperand(0);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1071,6 +1071,13 @@ struct ReorderElementwiseAndShapeOp final
           op, "defining operation of unexpected type.");
     }
 
+    // Only reorder if the defining op has no other uses
+    auto intermediateResult = definingOp->getResult(0);
+    if (std::distance(intermediateResult.getUses().begin(),
+                      intermediateResult.getUses().end()) != 1) {
+      return failure();
+    }
+
     Value input = definingOp->getOperand(0);
     Value result = op->getResult(0);
     auto intermediateType = cast<ShapedType>(input.getType())

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1055,28 +1055,25 @@ struct ReorderElementwiseAndShapeOp final
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
     if (op->getOperands().size() != 1) {
-      return rewriter.notifyMatchFailure(op, "expected to be unary.");
+      return rewriter.notifyMatchFailure(op, "expected to be unary");
     }
 
     auto definingOp = op->getOperand(0).getDefiningOp();
     if (!definingOp) {
       return rewriter.notifyMatchFailure(
-          op, "expected to have an op before elementise op.");
+          op, "expected to have an op before elementise op");
     }
 
     if (!isa<mlir::stablehlo::ReshapeOp>(definingOp) &&
         !isa<mlir::stablehlo::TransposeOp>(definingOp) &&
         !isa<mlir::stablehlo::BroadcastOp>(definingOp)) {
       return rewriter.notifyMatchFailure(
-          op, "defining operation of unexpected type.");
+          op, "defining operation of unexpected type");
     }
 
     // Only reorder if the defining op has no other uses.
-    auto intermediateResult = definingOp->getResult(0);
-    if (std::distance(intermediateResult.getUses().begin(),
-                      intermediateResult.getUses().end()) != 1) {
-      return rewriter.notifyMatchFailure(op,
-                                         "operation has more than one use.");
+    if (!llvm::hasSingleElement(definingOp->getResult(0).getUses())) {
+      return rewriter.notifyMatchFailure(op, "operation has more than one use");
     }
 
     Value input = definingOp->getOperand(0);


### PR DESCRIPTION
The previously-added canonicalizer would reorder unary elementwise operations even when the first operation in the swap had other uses. The swap should only be applied when the elementwise op is the only user of the shape operation (since it may change the value/type of the result).