### PR TITLE
Update to macOS SDK 13.0 for Metal3

### DIFF
--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -28,7 +28,7 @@ packages="${packages:-iree-runtime iree-runtime-instrumented iree-compiler}"
 
 # Note that this typically is selected to match the version that the official
 # Python distributed is built at.
-export MACOSX_DEPLOYMENT_TARGET=11.0
+export MACOSX_DEPLOYMENT_TARGET=13.0
 
 # cpuinfo is incompatible with universal builds.
 export IREE_ENABLE_CPUINFO=OFF


### PR DESCRIPTION
Metal3 requires SDK 13.0.  You run into failures like: 
https://github.com/nod-ai/SHARK-Runtime/actions/runs/5800760561/job/15723536281 with 11.0