### PR TITLE
Fix workflow name in schedule_candidate_release.

### DIFF
--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -45,10 +45,10 @@ jobs:
           draft: true
           prerelease: true
 
-      - name: "Invoke workflow :: Build Native Release Packages"
+      - name: "Invoke workflow :: Build Release Packages"
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
         with:
-          workflow: Build Native Release Packages
+          workflow: Build Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
           inputs: '{"package_suffix": "", "package_version": "${{ env.package_version }}", "release_id": "${{ steps.create_release.outputs.id }}"}'

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -54,10 +54,10 @@ jobs:
           draft: true
           prerelease: true
 
-      - name: "Invoke workflow :: Build Native Release Packages"
+      - name: "Invoke workflow :: Build Release Packages"
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
         with:
-          workflow: Build Native Release Packages
+          workflow: Build Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
           inputs: |

--- a/docs/developers/debugging/releases.md
+++ b/docs/developers/debugging/releases.md
@@ -113,9 +113,9 @@ build takes ~5, while the others can take several hours.
 From your development branch, you can manually run the
 [Schedule Snapshot Release](https://github.com/openxla/iree/actions/workflows/schedule_snapshot_release.yml)
 action, which invokes the
-[Build Native Release Packages](https://github.com/openxla/iree/actions/workflows/build_package.yml)
+[Build Release Packages](https://github.com/openxla/iree/actions/workflows/build_package.yml)
 action, which finally invokes the
 [Validate and Publish Release](https://github.com/openxla/iree/actions/workflows/validate_and_publish_release.yml)
 action.  If you already have a draft release and know the release id, package
-version, and run ID from a previous Build Native Release Packages run, you can
+version, and run ID from a previous Build Release Packages run, you can
 also manually run just the Validate and Publish Release action.


### PR DESCRIPTION
This should fix "Unable to find workflow 'Build Native Release Packages' in openxla/iree" (https://github.com/openxla/iree/actions/runs/5795511355)

skip-ci: not tested on presubmit