### PR TITLE
Refine release build CMake options.

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -151,19 +151,16 @@ function build_wheel() {
 }
 
 function build_iree_runtime() {
-  IREE_HAL_DRIVER_CUDA=$(uname -m | awk '{print ($1 == "x86_64") ? "ON" : "OFF"}') \
   build_wheel runtime/
 }
 
 function build_iree_runtime_instrumented() {
-  IREE_HAL_DRIVER_CUDA=$(uname -m | awk '{print ($1 == "x86_64") ? "ON" : "OFF"}') \
   IREE_BUILD_TRACY=ON IREE_ENABLE_RUNTIME_TRACING=ON \
   IREE_RUNTIME_CUSTOM_PACKAGE_SUFFIX="-instrumented" \
   build_wheel runtime/
 }
 
 function build_iree_compiler() {
-  IREE_TARGET_BACKEND_CUDA=$(uname -m | awk '{print ($1 == "x86_64") ? "ON" : "OFF"}') \
   build_wheel compiler/
 }
 

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -80,6 +80,7 @@ function run() {
 }
 
 function build_iree_runtime() {
+  # TODO(antiagainst): remove Vulkan once IREE_HAL_DRIVER_METAL is stable
   IREE_HAL_DRIVER_VULKAN=ON \
   python3 -m pip wheel -v -w $output_dir $repo_root/runtime/
 }

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -20,7 +20,6 @@
 # This can be set with the IREE_COMPILER_API_CMAKE_BUILD_DIR env var.
 #
 # Select CMake options are available from environment variables:
-#   IREE_TARGET_BACKEND_CUDA
 #   IREE_ENABLE_CPUINFO
 
 from gettext import install
@@ -257,7 +256,6 @@ def prepare_installation():
             "-DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON",
             "-DPython3_EXECUTABLE={}".format(sys.executable),
             "-DCMAKE_BUILD_TYPE={}".format(cfg),
-            get_env_cmake_option("IREE_TARGET_BACKEND_CUDA"),
             # TODO(scotttodd): include IREE_TARGET_BACKEND_WEBGPU here (and in env)
             get_env_cmake_option("IREE_ENABLE_CPUINFO", "ON"),
         ]

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Build/install the iree-compiler-backend python package.
+# Build/install the iree-compiler python package.
 # Note that this includes a relatively large build of LLVM (~2400 C++ files)
 # and can take a considerable amount of time, especially with defaults.
 # To install:
@@ -251,6 +251,8 @@ def prepare_installation():
             "-GNinja",
             "--log-level=VERBOSE",
             "-DIREE_BUILD_PYTHON_BINDINGS=ON",
+            "-DIREE_BUILD_SAMPLES=OFF",
+            "-DIREE_BUILD_TESTS=OFF",
             # Disable .so.0 style symlinking. Python wheels don't preserve links,
             # so this ~doubles the binary size if not disabled (yikes!).
             "-DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON",

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -216,13 +216,15 @@ def get_env_cmake_option(name: str, default_value: bool = False) -> str:
         svalue = "ON" if default_value else "OFF"
     return f"-D{name}={svalue}"
 
+
 def get_env_cmake_list(name: str, default_value: str = "") -> str:
     svalue = os.getenv(name)
     if not svalue:
-      if not default_value:
-        return f"-U{name}"
-      svalue = default_value
+        if not default_value:
+            return f"-U{name}"
+        svalue = default_value
     return f"-D{name}={svalue}"
+
 
 def add_env_cmake_setting(args, env_name: str, cmake_name=None) -> str:
     svalue = os.getenv(env_name)

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -216,6 +216,13 @@ def get_env_cmake_option(name: str, default_value: bool = False) -> str:
         svalue = "ON" if default_value else "OFF"
     return f"-D{name}={svalue}"
 
+def get_env_cmake_list(name: str, default_value: str = "") -> str:
+    svalue = os.getenv(name)
+    if not svalue:
+      if not default_value:
+        return f"-U{name}"
+      svalue = default_value
+    return f"-D{name}={svalue}"
 
 def add_env_cmake_setting(args, env_name: str, cmake_name=None) -> str:
     svalue = os.getenv(env_name)
@@ -252,6 +259,7 @@ def prepare_installation():
                 "IREE_HAL_DRIVER_VULKAN",
                 "OFF" if platform.system() == "Darwin" else "ON",
             ),
+            get_env_cmake_list("IREE_EXTERNAL_HAL_DRIVERS", ""),
             get_env_cmake_option("IREE_ENABLE_RUNTIME_TRACING"),
             get_env_cmake_option("IREE_BUILD_TRACY"),
             get_env_cmake_option("IREE_ENABLE_CPUINFO", "ON"),

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -21,7 +21,6 @@
 #   IREE_RUNTIME_CUSTOM_PACKAGE_SUFFIX
 #
 # Select CMake options are available from environment variables:
-#   IREE_HAL_DRIVER_CUDA
 #   IREE_HAL_DRIVER_VULKAN
 #   IREE_ENABLE_RUNTIME_TRACING
 #   IREE_BUILD_TRACY
@@ -249,7 +248,6 @@ def prepare_installation():
             "-DIREE_BUILD_TESTS=OFF",
             "-DPython3_EXECUTABLE={}".format(sys.executable),
             "-DCMAKE_BUILD_TYPE={}".format(cfg),
-            get_env_cmake_option("IREE_HAL_DRIVER_CUDA"),
             get_env_cmake_option(
                 "IREE_HAL_DRIVER_VULKAN",
                 "OFF" if platform.system() == "Darwin" else "ON",


### PR DESCRIPTION
* We now rely on build system logic rather than script overrides for enabling CUDA (so the CUDA compiler target is now enabled in the Windows releases).
  * Tested at https://github.com/openxla/iree/actions/runs/5813793199 and verified that the expected runtime HAL drivers and compiler target backends were enabled for each of the [Linux, macOS, Windows] x [compiler, runtime] builds.
* Added a section to specify external HAL drivers in runtime/setup.py. This project leaves the section empty and _unsets_ the variable with `-UIREE_EXTERNAL_HAL_DRIVERS`, but downstream projects can provide a list to _set_ the variable if they wish.
* Disabled samples and tests in compiler python package (to work around path length limits on Windows, see logs at https://github.com/nod-ai/SHARK-Runtime/actions/runs/5814626661/job/15764674157).