### PR TITLE
Avoid constant folding of operations not in the same scope as the constant.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -91,6 +91,10 @@ ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp) {
     Operation *constOp = it.second;
     for (auto &use : constOp->getUses()) {
       Operation *useOp = use.getOwner();
+      // For now ignore operations that are not in the same scope.
+      if (constOp->getParentOp() != useOp->getParentOp()) {
+        continue;
+      }
       expandToOp(useOp);
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -215,3 +215,22 @@ module @do_not_hoist_non_value_type_results {
     return %2 : !iree_unregistered.unknown_type
   }
 }
+
+// -----
+
+module @do_not_hoist_uses_within_dispatches {
+  func.func @main() -> (tensor<i32>) {
+    %cst = arith.constant dense<[2, 3]>: tensor<2xi32>
+    %result = flow.dispatch.region -> (tensor<i32>) {
+      %slice = tensor.extract_slice %cst[0] [1] [1] : tensor<2xi32> to tensor<i32>
+      flow.return %slice : tensor<i32>
+    }
+    return %result : tensor<i32>
+  }
+}
+// CHECK-LABEL: @do_not_hoist_uses_within_dispatches
+//       CHECK:   %[[CST:.+]] = arith.constant
+//       CHECK:   %[[RESULT:.+]] = flow.dispatch.region
+//       CHECK:     %[[SLICE:.+]] = tensor.extract_slice %[[CST]]
+//       CHECK:     flow.return %[[SLICE]]
+//       CHECK:   return %[[RESULT]]


### PR DESCRIPTION
This avoid unintentionally hoisting operations from within pre-formed
dispatches.