### PR TITLE
Python API: Enforce C-Contiguous ndarray

### DIFF
--- a/runtime/bindings/python/iree/runtime/array_interop.py
+++ b/runtime/bindings/python/iree/runtime/array_interop.py
@@ -216,8 +216,8 @@ def asdevicearray(
         logging.warn(
             "Implicit dtype conversion of a DeviceArray forces a host transfer"
         )
-    # First get an ndarray.
-    a = np.asarray(a, dtype=dtype)
+    # First get an ndarray. Needs to be C-contiguous, enforcing it here.
+    a = np.asarray(a, dtype=dtype, order="C")
     element_type = map_dtype_to_element_type(a.dtype)
     if element_type is None:
         raise ValueError(f"Could not map dtype {a.dtype} to IREE element type")


### PR DESCRIPTION
Enforce ndarray to be C-Contiguous. Been tested on SHARK Tank models.