### PR TITLE
[macos] Properly filter known failing tests

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -122,7 +122,7 @@ elif [[ "${OSTYPE}" =~ ^darwin ]]; then
     #TODO(#12496): Remove after fixing the test on macOS
     "iree/compiler/bindings/python/test/transforms/ireec/compile_sample_module"
     #TODO(#13501): Fix failing sample on macOS
-    "iree/samples/custom_module/async/test/example.mlir"
+    "iree/samples/custom_module/async/test/example.mlir.test"
   )
 fi
 


### PR DESCRIPTION
We already have an issue tracking the failing tests. This just properly filters it out in `ctest_all.sh`.

See recent errors: https://github.com/openxla/iree/actions/runs/5814806910/job/15765184289