### PR TITLE
[CPU] Fold unit dimensions introduced after tensor fusion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -8,8 +8,6 @@
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
 #include "iree/compiler/Codegen/Common/CPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
-#include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
-#include "iree/compiler/Codegen/LLVMCPU/KernelDispatch.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
@@ -372,6 +370,10 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager,
 void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager,
                                           TilingConfig &tilingConfig,
                                           bool enableVectorMasking) {
+  // Make sure we get rid of unit dimensions at tensor level before we add
+  // `lowering_config`.
+  passManager.addNestedPass<func::FuncOp>(createLinalgFoldUnitExtentDimsPass());
+
   addTileAndDistributePasses(passManager);
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
@@ -448,6 +450,10 @@ void addVMVXDefaultPassPipeline(OpPassManager &passManager,
 void addMultiTilingExpertPassPipeline(
     OpPassManager &passManager, TilingConfig &tilingConfig, bool enablePeeling,
     bool enableVectorMasking, bool lowerToAVX2, bool enableAArch64SSVE) {
+  // Make sure we get rid of unit dimensions at tensor level before we add
+  // `lowering_config`.
+  passManager.addNestedPass<func::FuncOp>(createLinalgFoldUnitExtentDimsPass());
+
   addTileAndDistributePasses(passManager);
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
@@ -531,6 +537,10 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager,
                                                TilingConfig &tilingConfig,
                                                bool enableVectorMasking,
                                                bool enableAArch64SSVE) {
+  // Make sure we get rid of unit dimensions at tensor level before we add
+  // `lowering_config`.
+  passManager.addNestedPass<func::FuncOp>(createLinalgFoldUnitExtentDimsPass());
+
   addTileAndDistributePasses(passManager);
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();


### PR DESCRIPTION
This PR adds the FoldUnitExtentDim pass after tensor fusion. We run this
pass before fusion and it removes some unit dimensions. However, some
unit dimensions are reintroduced back after tensor fusion, leading to
vectorizing single element dimensions (scalar code).