### PR TITLE
Fix TypePropagation pass to handle functions with control flow.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -607,6 +607,12 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
   func::FuncOp funcOp = getOperation();
   MLIRContext *context = &getContext();
 
+  // Dont do anything for functions that have multiple blocks for now.
+  // TODO: This needs to be fixed, but need to proceed incrementally.
+  if (!llvm::hasSingleElement(funcOp.getBody())) {
+    return;
+  }
+
   OpBuilder b(context);
   SmallVector<tensor::EmptyOp> emptyOps;
   funcOp.walk([&](tensor::EmptyOp emptyOp) { emptyOps.push_back(emptyOp); });

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2270,6 +2270,12 @@ LogicalResult initCPULaunchConfig(ModuleOp moduleOp) {
       continue;
     }
 
+    // For now pick the default for functions with control flow, cause
+    // the currently built pipelines dont work so well with control flow.
+    if (funcOp.getBody().empty() || !llvm::hasSingleElement(funcOp.getBody())) {
+      return lowerUsingDefaultPipeline(funcOp);
+    }
+
     SmallVector<Operation *> computeOps = getComputeOps(funcOp);
     if (failed(setTranslationInfoAndRootConfig(funcOp, computeOps))) {
       return failure();


### PR DESCRIPTION
In presence of control flow, the type-propagation pass should handle
branch instructions as well as basic blocks arguments.