### PR TITLE
Relax NCCL version constraints

### DIFF
--- a/experimental/cuda2/cuda_device.c
+++ b/experimental/cuda2/cuda_device.c
@@ -440,10 +440,10 @@ static iree_status_t iree_hal_cuda2_device_create_channel(
   if (!device->nccl_symbols || !device->nccl_symbols->dylib) {
     return iree_make_status(
         IREE_STATUS_UNAVAILABLE,
-        "NCCL runtime library (%d.%d.%d) not available; ensure installed and "
-        "the shared library is on your PATH/LD_LIBRARY_PATH "
-        "(nccl.dll/libnccl.so)",
-        NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
+        "NCCL runtime library version %d.%d and greater not available; "
+        "ensure installed and the shared library (nccl.dll/libnccl.so) "
+        "is on your PATH/LD_LIBRARY_PATH.",
+        NCCL_MAJOR, NCCL_MINOR);
   }
 
   // Today we only allow a single logical device per channel.

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -357,10 +357,10 @@ static iree_status_t iree_hal_cuda_device_create_channel(
   if (!device->context_wrapper.syms->nccl_library) {
     return iree_make_status(
         IREE_STATUS_UNAVAILABLE,
-        "NCCL runtime library (%d.%d.%d) not available; ensure installed and "
-        "the shared library is on your PATH/LD_LIBRARY_PATH "
-        "(nccl.dll/libnccl.so)",
-        NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
+        "NCCL runtime library version %d.%d and greater not available; "
+        "ensure installed and the shared library (nccl.dll/libnccl.so) "
+        "is on your PATH/LD_LIBRARY_PATH.",
+        NCCL_MAJOR, NCCL_MINOR);
   }
 
   // Today we only allow a single logical device per channel.

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
@@ -139,11 +139,12 @@ static iree_status_t iree_hal_cuda_nccl_check_version(
     minor = (nccl_version % 10000) / 100;
   }
   patch = nccl_version % 100;
-  if (major != NCCL_MAJOR || minor != NCCL_MINOR || patch != NCCL_PATCH) {
+  int required_minimum_version = NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, 0);
+  if (major != NCCL_MAJOR || nccl_version < required_minimum_version) {
     return iree_make_status(
         IREE_STATUS_UNAVAILABLE,
-        "NCCL version is %d.%d.%d, but %d.%d.%d is required", major, minor,
-        patch, NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
+        "NCCL version is %d.%d.%d, but >=%d.%d and <%d is required", major,
+        minor, patch, NCCL_MAJOR, NCCL_MINOR, NCCL_MAJOR + 1);
   }
 
   return iree_ok_status();
@@ -174,10 +175,10 @@ iree_status_t iree_hal_cuda_nccl_dynamic_symbols_initialize(
     iree_status_ignore(status);
     status = iree_make_status(
         IREE_STATUS_UNAVAILABLE,
-        "NCCL runtime library (%d.%d.%d) not available; ensure installed and "
-        "the shared library is on your PATH/LD_LIBRARY_PATH "
-        "(nccl.dll/libnccl.so)",
-        NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
+        "NCCL runtime library version %d.%d and greater not available; "
+        "ensure installed and the shared library (nccl.dll/libnccl.so) "
+        "is on your PATH/LD_LIBRARY_PATH.",
+        NCCL_MAJOR, NCCL_MINOR);
   }
 
   if (iree_status_is_ok(status)) {


### PR DESCRIPTION
Instead of requiring exact NCCL version, relax constraints to the standard ABI versioning rules, namely
found_version >= major.minor && found_version < major + 1,
where major and minor are from the NCCL headers we use.