### PR TITLE
[gpu] Consider operand element type in shared memory distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_fusion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_fusion.mlir
@@ -99,38 +99,33 @@ hal.executable @matmul_i4_quant_weight {
 //           CHECK:   %[[SCALE_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
 //           CHECK:   %[[ZP_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(2)
 //           CHECK:   scf.for %arg0 = %c0 to %c86 step %c1 iter_args({{.+}}) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>)
-//           CHECK:     %[[SCALE:.+]] = vector.transfer_read %[[SCALE_BINDING]]
+//           CHECK:     %[[SCALE0:.+]] = vector.transfer_read %[[SCALE_BINDING]]
+//           CHECK:     %[[SCALE1:.+]] = vector.transfer_read %[[SCALE_BINDING]]
 //           CHECK:     %[[ZP:.+]] = vector.transfer_read %[[ZP_BINDING]]
-//           CHECK:     %[[ZP_EXT:.+]] = arith.extsi %[[ZP]] : vector<4xi4> to vector<4xi32>
+//           CHECK:     %[[SLICE0:.+]] = vector.extract_strided_slice %[[ZP]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xi4> to vector<4xi4>
+//           CHECK:     %[[ZP_EXT0:.+]] = arith.extsi %[[SLICE0]] : vector<4xi4> to vector<4xi32>
+//           CHECK:     %[[SLICE1:.+]] = vector.extract_strided_slice %[[ZP]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xi4> to vector<4xi4>
+//           CHECK:     %[[ZP_EXT1:.+]] = arith.extsi %[[SLICE1]] : vector<4xi4> to vector<4xi32>
+
 //           CHECK:     scf.for %arg5 = %c0 to %c96 step %c32 iter_args({{.+}}) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>)
 
 //           CHECK:       vector.transfer_read %[[WEIGHT_BINDING]]
-//           CHECK:       arith.extsi %{{.+}} : vector<4xi4> to vector<4xi32>
-//           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT]] : vector<4xi32>
-//           CHECK:       arith.sitofp %{{.+}} : vector<4xi32> to vector<4xf32>
-//           CHECK:       arith.mulf %{{.+}}, %[[SCALE]] : vector<4xf32>
-//           CHECK:       vector.transfer_write %{{.+}}, %[[B_ALLOC]]
+//   CHECK-COUNT-2:       arith.extsi %{{.+}} : vector<4xi4> to vector<4xi32>
+//           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT0]] : vector<4xi32>
+//           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT1]] : vector<4xi32>
+//   CHECK-COUNT-2:       arith.sitofp %{{.+}} : vector<4xi32> to vector<4xf32>
+//           CHECK:       arith.mulf %{{.+}}, %[[SCALE0]] : vector<4xf32>
+//           CHECK:       arith.mulf %{{.+}}, %[[SCALE1]] : vector<4xf32>
+//     CHECK-COUNT:       vector.transfer_write %{{.+}}, %[[B_ALLOC]]
 
 //           CHECK:       vector.transfer_read %[[WEIGHT_BINDING]]
-//           CHECK:       arith.extsi %{{.+}} : vector<4xi4> to vector<4xi32>
-//           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT]] : vector<4xi32>
-//           CHECK:       arith.sitofp %{{.+}} : vector<4xi32> to vector<4xf32>
-//           CHECK:       arith.mulf %{{.+}}, %[[SCALE]] : vector<4xf32>
-//           CHECK:       vector.transfer_write %{{.+}}, %[[B_ALLOC]]
-
-//           CHECK:       vector.transfer_read %[[WEIGHT_BINDING]]
-//           CHECK:       arith.extsi %{{.+}} : vector<4xi4> to vector<4xi32>
-//           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT]] : vector<4xi32>
-//           CHECK:       arith.sitofp %{{.+}} : vector<4xi32> to vector<4xf32>
-//           CHECK:       arith.mulf %{{.+}}, %[[SCALE]] : vector<4xf32>
-//           CHECK:       vector.transfer_write %{{.+}}, %[[B_ALLOC]]
-
-//           CHECK:       vector.transfer_read %[[WEIGHT_BINDING]]
-//           CHECK:       arith.extsi %{{.+}} : vector<4xi4> to vector<4xi32>
-//           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT]] : vector<4xi32>
-//           CHECK:       arith.sitofp %{{.+}} : vector<4xi32> to vector<4xf32>
-//           CHECK:       arith.mulf %{{.+}}, %[[SCALE]] : vector<4xf32>
-//           CHECK:       vector.transfer_write %{{.+}}, %[[B_ALLOC]]
+//   CHECK-COUNT-2:       arith.extsi %{{.+}} : vector<4xi4> to vector<4xi32>
+//           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT0]] : vector<4xi32>
+//           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT1]] : vector<4xi32>
+//   CHECK-COUNT-2:       arith.sitofp %{{.+}} : vector<4xi32> to vector<4xf32>
+//           CHECK:       arith.mulf %{{.+}}, %[[SCALE0]] : vector<4xf32>
+//           CHECK:       arith.mulf %{{.+}}, %[[SCALE1]] : vector<4xf32>
+//     CHECK-COUNT:       vector.transfer_write %{{.+}}, %[[B_ALLOC]]
 
 //           CHECK:       vector.transfer_write %{{.+}}, %[[A_ALLOC]]
 //           CHECK:       gpu.barrier


### PR DESCRIPTION
When distributing an elementwise generic op, consider the operand element types. If we have some sub-byte types there, make sure we at least read a full byte for the sub-byte-element operands. This makes converting to SPIR-V easier.

Fixes https://github.com/openxla/iree/issues/13601