### PR TITLE
Fix calculation of byte offset to element offset during bufferization.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -196,6 +196,10 @@ static inline unsigned getTypeBitWidth(Type type) {
   if (auto complexType = type.dyn_cast<ComplexType>()) {
     return 2 * complexType.getElementType().getIntOrFloatBitWidth();
   }
+  if (auto vectorType = type.dyn_cast<VectorType>()) {
+    return vectorType.getNumElements() *
+           getTypeBitWidth(vectorType.getElementType());
+  }
   return type.getIntOrFloatBitWidth();
 }
 


### PR DESCRIPTION
The logic was not adapted to handle sub-byte sizes. This handles powers of 2 sub-byte sizes only. To handle more general case requires upstream MLIR to have a good representation of the packing of such types. This should be revisited and adapted then.

Fixes #14642