### PR TITLE
Allow runtime build without tracy tools but with instrumented.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -155,7 +155,6 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-runtime"
           output_dir: "${{ github.workspace }}/bindist"
-          IREE_RUNTIME_BUILD_TRACY: ON
         run: |
           ./c/build_tools/python_deploy/build_linux_packages.sh
 
@@ -167,7 +166,6 @@ jobs:
           packages: "iree-runtime"
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11"
-          IREE_RUNTIME_BUILD_TRACY: ON
         run: |
           ./c/build_tools/python_deploy/build_macos_packages.sh
 
@@ -179,7 +177,6 @@ jobs:
           packages: "iree-runtime"
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11"
-          IREE_RUNTIME_BUILD_TRACY: ON
         run: |
           ./c/build_tools/python_deploy/build_windows_packages.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,7 +518,6 @@ jobs:
           # Note when upgrading: Build just one Python version synced to our
           # minimum.
           override_python_versions: cp38-cp38
-          IREE_RUNTIME_BUILD_TRACY: ON
         run: |
           ./build_tools/python_deploy/build_linux_packages.sh
       # Note that it is just a trade-off decision to have this serialized

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -144,6 +144,9 @@ function build_wheel() {
 }
 
 function build_iree_runtime() {
+  export IREE_RUNTIME_BUILD_TRACY=ON
+  # We install the needed build deps below for the tools.
+  export IREE_RUNTIME_BUILD_TRACY_TOOLS=ON
   build_wheel runtime/
 }
 

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -76,6 +76,7 @@ function run() {
 
 function build_iree_runtime() {
   # TODO(antiagainst): remove Vulkan once IREE_HAL_DRIVER_METAL is stable
+  export IREE_RUNTIME_BUILD_TRACY=ON
   IREE_HAL_DRIVER_VULKAN=ON \
   python3 -m pip wheel -v -w $output_dir $repo_root/runtime/
 }

--- a/build_tools/python_deploy/build_windows_packages.sh
+++ b/build_tools/python_deploy/build_windows_packages.sh
@@ -64,6 +64,7 @@ function run() {
 
 function build_iree_runtime() {
   local python_version="$1"
+  export IREE_RUNTIME_BUILD_TRACY=ON
   IREE_HAL_DRIVER_VULKAN=ON \
   py -${python_version} -m pip wheel -v -w $output_dir $repo_root/runtime/
 }


### PR DESCRIPTION
Only enables tracy tools on Linux (disable on MacOS/Windows where we don't have deps).