### PR TITLE
Fix bounds check for dispatch break/trace pass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
@@ -165,7 +165,7 @@ struct InsertDebugTargetAtOrdinalPass
       auto dispatchOps = llvm::to_vector<8>(bodyRegion.getOps<DispatchOp>());
 
       // Trace on a valid ordinal.
-      if (localTraceOrdinal > 0 && localTraceOrdinal < dispatchOps.size()) {
+      if (localTraceOrdinal >= 0 && localTraceOrdinal < dispatchOps.size()) {
         auto traceTarget = dispatchOps[localTraceOrdinal];
         std::string entryPointName =
             traceTarget.getEntryPoint().getRootReference().getValue().str();
@@ -181,7 +181,7 @@ struct InsertDebugTargetAtOrdinalPass
       // Break on a valid ordinal, updating the function signature in the
       // process. Currently only a single ordinal is supported so no need to
       // check for overlapping breaks.
-      if (localBreakOrdinal > 0 && localBreakOrdinal < dispatchOps.size()) {
+      if (localBreakOrdinal >= 0 && localBreakOrdinal < dispatchOps.size()) {
         auto breakTarget = dispatchOps[localBreakOrdinal];
         if (failed(replaceReturnWithOpResults(getOperation(), funcOp,
                                               breakTarget)))

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/insert_dispatch_debug_markers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/insert_dispatch_debug_markers.mlir
@@ -1,21 +1,27 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-flow-insert-debug-target-at-ordinal{break-debug-target=@target_func:1 trace-debug-target=@target_func:1})" %s | FileCheck %s --check-prefixes=CHECK,ORDINAL
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-flow-insert-debug-target-at-ordinal{break-debug-target=@target_func:0 trace-debug-target=@target_func:0})" %s | FileCheck %s --check-prefixes=ORDINAL_0
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-flow-insert-debug-target-at-symbol{break-debug-target=dispatch_1 trace-debug-target=dispatch_1[^0-9]})" %s | FileCheck %s --check-prefixes=CHECK,SYMBOL
 
 /// Multiple functions
 
 // CHECK-LABEL: func.func @target_func
+// ORDINAL_0-LABEL: func.func @target_func
 func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
   %c4 = arith.constant 4 : index
-  // CHECK: %0 = flow.dispatch @dispatch_0::@dispatch_0_entry
+  // CHECK: %[[D0:.+]] = flow.dispatch @dispatch_0::@dispatch_0_entry
+  //      ORDINAL_0: flow.tensor.trace {key = "dispatch_0::dispatch_0_entry::0 inputs"}
+  // ORDINAL_0-NEXT: %[[D0:.+]] = flow.dispatch @dispatch_0::@dispatch_0_entry
   %0 = flow.dispatch @dispatch_0::@dispatch_0_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
-  // CHECK: %1 = flow.dispatch @dispatch_1::@dispatch_1_entry
+  // ORDINAL_0-NEXT: flow.tensor.trace {key = "dispatch_0::dispatch_0_entry::0 outputs"}
+  // CHECK: %[[D1:.+]] = flow.dispatch @dispatch_1::@dispatch_1_entry
   %1 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
   %2 = flow.dispatch @dispatch_2::@dispatch_2_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
   %3 = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
-  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %1 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %[[D1]] : tensor<4xf32> -> !hal.buffer_view
   // CHECK: return %[[EXPORT]] : !hal.buffer_view
   return %3 : !hal.buffer_view
 }
+
 
 // CHECK-LABEL: func.func @other_func
 func.func @other_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {


### PR DESCRIPTION
The bound needs to include zero to allow breaking on the first (ordinal) dispatch in a function.