### PR TITLE
[spirv] Cherry-pick MLIR commits to fix i4 emulation correctness 

### DIFF
--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -78,6 +78,7 @@ iree_check_single_backend_test_suite(
         "layernorm.mlir",
         "lowering_config.mlir",
         "pack_pad_transpose_1x9_into_2x4x8x4_issue_12546.mlir",
+        "ui4_to_f32.mlir",
     ] + BACKEND_TESTS,
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "local-task",
@@ -110,7 +111,9 @@ iree_check_single_backend_test_suite(
 iree_check_single_backend_test_suite(
     name = "check_regression_vulkan-spirv",
     # TODO(#10024): Fix layernorm.mlir on Pixel 6 and put in BACKEND_TESTS.
-    srcs = BACKEND_TESTS,
+    srcs = [
+      "ui4_to_f32.mlir",
+    ] + BACKEND_TESTS,
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "vulkan",
     target_backend = "vulkan-spirv",

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -112,7 +112,7 @@ iree_check_single_backend_test_suite(
     name = "check_regression_vulkan-spirv",
     # TODO(#10024): Fix layernorm.mlir on Pixel 6 and put in BACKEND_TESTS.
     srcs = [
-      "ui4_to_f32.mlir",
+        "ui4_to_f32.mlir",
     ] + BACKEND_TESTS,
     compiler_flags = ["--iree-input-type=stablehlo"],
     driver = "vulkan",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -68,6 +68,7 @@ iree_check_single_backend_test_suite(
     "softmax.mlir"
     "strided_slice.mlir"
     "transpose.mlir"
+    "ui4_to_f32.mlir"
   TARGET_BACKEND
     "llvm-cpu"
   DRIVER
@@ -136,6 +137,7 @@ iree_check_single_backend_test_suite(
     "softmax.mlir"
     "strided_slice.mlir"
     "transpose.mlir"
+    "ui4_to_f32.mlir"
   TARGET_BACKEND
     "vulkan-spirv"
   DRIVER

--- a/tests/e2e/regression/ui4_to_f32.mlir
+++ b/tests/e2e/regression/ui4_to_f32.mlir
@@ -1,0 +1,25 @@
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+func.func @forward() {
+  %cst = util.unfoldable_constant dense<[
+    [0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15],
+    [0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15],
+    [0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15],
+    [0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]
+  ]> : tensor<8x8xi4>
+  %expanded_4 = tensor.expand_shape %cst [[0], [1, 2]] : tensor<8x8xi4> into tensor<8x4x2xi4>
+  %0 = tensor.empty() : tensor<8x4x2xf32>
+  %5 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%expanded_4 : tensor<8x4x2xi4>) outs(%0 : tensor<8x4x2xf32>) {
+  ^bb0(%in: i4, %out: f32):
+    %6 = arith.extui %in : i4 to i32
+    %7 = arith.uitofp %6 : i32 to f32
+    linalg.yield %7 : f32
+  } -> tensor<8x4x2xf32>
+  check.expect_almost_eq_const(%5, dense<[
+    [[0., 1.], [2., 3.], [4., 5.], [6., 7.]], [[8., 9.], [10., 11.], [12., 13.], [14., 15.]],
+    [[0., 1.], [2., 3.], [4., 5.], [6., 7.]], [[8., 9.], [10., 11.], [12., 13.], [14., 15.]],
+    [[0., 1.], [2., 3.], [4., 5.], [6., 7.]], [[8., 9.], [10., 11.], [12., 13.], [14., 15.]],
+    [[0., 1.], [2., 3.], [4., 5.], [6., 7.]], [[8., 9.], [10., 11.], [12., 13.], [14., 15.]]
+  ]> : tensor<8x4x2xf32>) : tensor<8x4x2xf32>
+  return
+}


### PR DESCRIPTION
This commit cherry-picks the following MLIR commits:
* llvm/llvm-project@81c326ccdd9b8475b6b7180da36b24bb29ce4f42
* llvm/llvm-project@2b066501b1bcb21c408310e6cfca31ba02068736
* llvm/llvm-project@69a3c9cddf1919b7caaa625efa1829cd5628bf10
* llvm/llvm-project@1a38843f86df67e28b5aa2080195ab955cafb94e

The above commits fixes integer extension/truncation.
A regression test is added for both CPU and Vulkan.

Fixes https://github.com/openxla/iree/issues/14634