### PR TITLE
Set `iree-stream-resource-alias-mutable-bindings` default true.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -67,7 +67,7 @@ static llvm::cl::opt<bool> clResourceAliasMutableBindings(
     "iree-stream-resource-alias-mutable-bindings",
     llvm::cl::desc(
         "Fuses bindings that are mutable instead of leaving them split."),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 //===----------------------------------------------------------------------===//
 // #stream.resource_config<...>
@@ -83,7 +83,7 @@ Attribute ResourceConfigAttr::parse(AsmParser &p, Type type) {
   int64_t maxBufferRange = 0;
   int64_t minBufferRangeAlignment = 0;
   int64_t indexBits = 32;
-  bool aliasMutableBindings = false;
+  bool aliasMutableBindings = true;
   while (failed(p.parseOptionalRBrace())) {
     StringRef key;
     int64_t value = 0;

--- a/experimental/web/sample_webgpu/build_sample.sh
+++ b/experimental/web/sample_webgpu/build_sample.sh
@@ -53,7 +53,6 @@ compile_sample() {
     --iree-input-type=$2 \
     --iree-hal-target-backends=webgpu \
     --iree-codegen-gpu-native-math-precision=true \
-    --iree-stream-resource-alias-mutable-bindings=true \
     --o ${BINARY_DIR}/$1_webgpu.vmfb
 }
 

--- a/experimental/web/sample_webgpu/index.html
+++ b/experimental/web/sample_webgpu/index.html
@@ -181,8 +181,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <textarea type="text" readonly spellcheck="false"
     class="form-control" style="width:610px; height:90px; resize:none; font-family: monospace;">
 --iree-hal-target-backends=webgpu \
---iree-codegen-gpu-native-math-precision=true \
---iree-stream-resource-alias-mutable-bindings=true \</textarea>
+--iree-codegen-gpu-native-math-precision=true \</textarea>
 
   </div>
 


### PR DESCRIPTION
Retrying https://github.com/openxla/iree/pull/13323 (which had CUDA regressions at the time).