### PR TITLE
Add new benchmark machine template `c2s601t`

### DIFF
--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -172,6 +172,7 @@ function create_template() {
 }
 
 for group in presubmit postsubmit; do
+  # TODO(#14661): Remove c2s601t if we decide not to migrate benchmarks to it.
   for type in gpu a100 cpu c2s16 c2s601t; do
     create_template "${group}" "${type}"
   done

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -151,6 +151,13 @@ function create_template() {
       --maintenance-policy=MIGRATE
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${DISK_SIZE_GB},type=pd-ssd"
     )
+  elif [[ "${type}" == c2s601t ]]; then
+    cmd+=(
+      --machine-type=c2-standard-60
+      --threads-per-core=1
+      --maintenance-policy=MIGRATE
+      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${DISK_SIZE_GB},type=pd-ssd"
+    )
   else
     echo "Got unrecognized type '${type}'" >2
     exit 1
@@ -165,7 +172,7 @@ function create_template() {
 }
 
 for group in presubmit postsubmit; do
-  for type in gpu a100 cpu c2s16; do
+  for type in gpu a100 cpu c2s16 c2s601t; do
     create_template "${group}" "${type}"
   done
 done


### PR DESCRIPTION
Add a new template to create benchmark VM `c2s601t`: `c2-standard-60` with 1 thread per code (hyper-threading disabled).

This configuration provides 30 cores (15 cores per NUMA node) for CPU benchmarking and exclusive hardware access, which should gives us more stable benchmark results and enables benchmark configurations with more threads.

Regarding the cost, `c2-standard-60` is ~3.6x more expensive than `c2-standard-16`. However as they are benchmark VMs, we only need a few in presubmit and postsubmit (3 in each side). Currently it won't have a big impact on total costs comparing to much more expensive A100 and build machines (`n2-standard-96`, which is 1.5x more expensive than `c2-standard-60` and we have 10x number of VMs to handle the building workload at peak). If total cost becomes a problem, we should first optimize the utilization of build machines to cut back the cost.

The next step is to set up test runners and collect data in postsubmit to verify if it actually gives better results. See more details in #14661

skip-ci: Not running in CI