### PR TITLE
Fix dynamic offset handling of sub-byte element types in lowering to LLVM

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -244,6 +244,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MathTransforms",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:MemRefTransforms",
+        "@llvm-project//mlir:MemRefUtils",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFToControlFlow",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -195,6 +195,7 @@ iree_cc_library(
     MLIRMathTransforms
     MLIRMemRefDialect
     MLIRMemRefTransforms
+    MLIRMemRefUtils
     MLIRPass
     MLIRSCFDialect
     MLIRSCFToControlFlow

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "iree/compiler/Codegen/Common/PassDetail.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -15,6 +16,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Pass/Pass.h"
@@ -36,17 +38,49 @@ struct ConvertHalInterfaceBindingSubspan final
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Type newResultTy = getTypeConverter()->convertType(op.getType());
-    if (!newResultTy)
+    auto currentType = op.getType().dyn_cast<MemRefType>();
+    if (!currentType) {
+      return rewriter.notifyMatchFailure(op->getLoc(),
+                                         "unhandled non-memref types");
+    }
+    auto newResultType =
+        getTypeConverter()->convertType(currentType).dyn_cast<MemRefType>();
+    if (!newResultType) {
       return rewriter.notifyMatchFailure(
           op->getLoc(),
           llvm::formatv("failed to legalize memref type: {0}", op.getType()));
+    }
+    Location loc = op.getLoc();
+    OpFoldResult zero = rewriter.getIndexAttr(0);
+    SmallVector<OpFoldResult> indices(currentType.getRank(), zero);
+
+    // Get linearized type.
+    int srcBits = currentType.getElementType().getIntOrFloatBitWidth();
+    int dstBits = newResultType.getElementType().getIntOrFloatBitWidth();
+    OpFoldResult elementOffset;
+    Value byteOffset = adaptor.getByteOffset();
+    if (byteOffset && !matchPattern(byteOffset, m_Zero())) {
+      elementOffset = convertByteOffsetToElementOffset(
+          rewriter, loc, byteOffset, currentType.getElementType());
+    } else {
+      elementOffset = rewriter.getIndexAttr(0);
+    }
+    SmallVector<OpFoldResult> sizes = getMixedValues(
+        currentType.getShape(), adaptor.getDynamicDims(), rewriter);
+    memref::LinearizedMemRefInfo linearizedMemRefInfo =
+        memref::getLinearizedMemRefOffsetAndSize(rewriter, loc, srcBits,
+                                                 dstBits, elementOffset, sizes);
+
+    SmallVector<Value> dynamicLinearizedSize;
+    if (newResultType.getRank() > 0 && !newResultType.hasStaticShape()) {
+      dynamicLinearizedSize.push_back(getValueOrCreateConstantIndexOp(
+          rewriter, loc, linearizedMemRefInfo.linearizedSize));
+    }
 
     rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
-        op, newResultTy, adaptor.getSet(), adaptor.getBinding(),
-        adaptor.getDescriptorType(), adaptor.getByteOffset(),
-        adaptor.getDynamicDims(), adaptor.getAlignmentAttr(),
-        adaptor.getDescriptorFlagsAttr());
+        op, newResultType, adaptor.getSet(), adaptor.getBinding(),
+        adaptor.getDescriptorType(), byteOffset, dynamicLinearizedSize,
+        adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
     return success();
   }
 };
@@ -98,6 +132,7 @@ struct EmulateNarrowTypePass
     RewritePatternSet patterns(ctx);
     arith::populateArithNarrowTypeEmulationPatterns(typeConverter, patterns);
     memref::populateMemRefNarrowTypeEmulationPatterns(typeConverter, patterns);
+    populateIREEResolveExtractStridedMetadataPatterns(ctx, patterns);
     vector::populateVectorNarrowTypeEmulationPatterns(typeConverter, patterns);
     populateIreeNarrowTypeEmulationPatterns(typeConverter, patterns);
 

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -48,6 +48,11 @@ tileAndFuseDispatchUsingSCFForOp(RewriterBase &rewriter, TilingInterface op,
 void populateTileAndDistributeToWorkgroupsCleanupPatterns(
     RewritePatternSet &patterns, linalg::LinalgTilingOptions options);
 
+/// Populate IREE patterns related to resolving
+/// `memref.extract_strided_metadata`.
+void populateIREEResolveExtractStridedMetadataPatterns(
+    MLIRContext *context, RewritePatternSet &patterns);
+
 } // namespace iree_compiler
 } // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/emulate_narrow_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/emulate_narrow_type.mlir
@@ -2,10 +2,24 @@
 
 func.func @memref_i4_to_i8() {
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<8xi4>
-  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : memref<8xf32>
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<3x15xi4>
   return
 }
 // CHECK-LABEL: func.func @memref_i4_to_i8
-// CHECK:         hal.interface.binding.subspan {{.+}} memref<8xi8>
-// CHECK:         hal.interface.binding.subspan {{.+}} memref<8xf32>
+//       CHECK:    hal.interface.binding.subspan {{.+}} memref<23xi8>
+
+// -----
+
+func.func @memref_i4_to_i8_dynamic(%arg0 : index, %arg1 : index, %arg2 : index) {
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%arg0) flags(ReadOnly) : memref<?x?xi4, strided<[?, 1], offset: ?>>{%arg1, %arg2}
+  return
+}
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> ((s0 * s1) floordiv 2)>
+//      CHECK: func.func @memref_i4_to_i8_dynamic
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+//      CHECK:   %[[SIZE:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]], %[[ARG2]]]
+//      CHECK:   hal.interface.binding.subspan
+// CHECK-SAME:       offset(%[[ARG0]])
+// CHECK-SAME:       memref<?xi8, strided<[1], offset: ?>>{%[[SIZE]]}

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -785,12 +785,15 @@ MemRefDescriptor HALDispatchABI::loadBinding(Operation *forOp, int64_t ordinal,
       // The offset in the subspan is byteoffset. It is converted to element
       // offset here. It is assumed that the byte offset is a multiple of
       // the element type byte width.
-      int32_t elementWidth =
-          IREE::Util::getRoundedElementByteWidth(memRefType.getElementType());
+      int32_t elementBitWidth =
+          IREE::Util::getTypeBitWidth(memRefType.getElementType());
       Value elementWidthVal =
-          builder.create<LLVM::ConstantOp>(loc, llvmIndexType, elementWidth);
+          builder.create<LLVM::ConstantOp>(loc, llvmIndexType, elementBitWidth);
+      Value eight = builder.create<LLVM::ConstantOp>(loc, llvmIndexType, 8);
+      Value bitOffset =
+          builder.create<LLVM::MulOp>(loc, baseOffsetValue, eight);
       Value elementOffsetVal =
-          builder.create<LLVM::UDivOp>(loc, baseOffsetValue, elementWidthVal);
+          builder.create<LLVM::UDivOp>(loc, bitOffset, elementWidthVal);
       desc.setOffset(builder, loc, elementOffsetVal);
     } else {
       desc.setConstantOffset(builder, loc, offset);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -742,6 +742,8 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
   passManager.addPass(memref::createFoldMemRefAliasOpsPass());
   passManager.addPass(createEmulateNarrowTypePass());
+  passManager.addPass(createCanonicalizerPass());
+  passManager.addPass(createCSEPass());
   if (clInstrumentMemoryAccesses) {
     passManager.addNestedPass<func::FuncOp>(
         createInstrumentMemoryAccessesPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -389,12 +389,15 @@ public:
           typeConverter->convertType(IndexType::get(rewriter.getContext()));
       auto baseOffsetValue = adaptor.getByteOffset();
       if (ShapedType::isDynamic(offset)) {
-        int32_t elementWidth =
-            IREE::Util::getRoundedElementByteWidth(memrefType.getElementType());
-        Value elementWidthVal =
-            rewriter.create<LLVM::ConstantOp>(loc, llvmIndexType, elementWidth);
-        Value elementOffsetVal = rewriter.create<LLVM::UDivOp>(
-            loc, baseOffsetValue, elementWidthVal);
+        int32_t elementBitWidth =
+            IREE::Util::getTypeBitWidth(memrefType.getElementType());
+        Value elementBitWidthVal = rewriter.create<LLVM::ConstantOp>(
+            loc, llvmIndexType, elementBitWidth);
+        Value eight = rewriter.create<LLVM::ConstantOp>(loc, llvmIndexType, 8);
+        Value bitOffset =
+            rewriter.create<LLVM::MulOp>(loc, baseOffsetValue, eight);
+        Value elementOffsetVal =
+            rewriter.create<LLVM::UDivOp>(loc, bitOffset, elementBitWidthVal);
         desc.setOffset(rewriter, loc, elementOffsetVal);
       } else {
         desc.setConstantOffset(rewriter, loc, offset);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -94,7 +94,7 @@ hal.executable @abs_dynamic {
 //   CHECK: %[[GEP:.+]] = llvm.getelementptr %[[GEP1]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, f32
 //   CHECK: %[[LOAD:.+]] = llvm.load %[[GEP]] : !llvm.ptr -> f32
 //   CHECK: %[[GEP2:.+]] = llvm.getelementptr %[[ARG0]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-//   CHECK: %27 = llvm.load %[[GEP2]] : !llvm.ptr -> i32
+//   CHECK: llvm.load %[[GEP2]] : !llvm.ptr -> i32
 //   CHECK: %[[FADD:.+]] = llvm.fadd %[[LOAD]], %{{.*}}  : f32
 //   CHECK: %[[ADD:.+]] = llvm.add
 //   CHECK: %[[ADD2:.+]] = llvm.add


### PR DESCRIPTION
This uses the revamped implementation from
https://reviews.llvm.org/D158125 and updates the IREE passes to use
them. Also some minor changes to offset handling while lowering to
LLVM/NVVM.

Issue https://github.com/openxla/iree/issues/14662