### PR TITLE
A few fixes for compiling experimental/cuda2.

### DIFF
--- a/experimental/cuda2/cuda_dynamic_symbol_table.h
+++ b/experimental/cuda2/cuda_dynamic_symbol_table.h
@@ -84,4 +84,4 @@ IREE_CU_PFN_DECL(cuFuncSetAttribute, CUfunction, CUfunction_attribute, int)
 IREE_CU_PFN_DECL(cuLaunchKernel, CUfunction, unsigned int, unsigned int,
                  unsigned int, unsigned int, unsigned int, unsigned int,
                  unsigned int, CUstream, void**, void**)
-IREE_CU_PFN_DECL(cuLaunchHostFunc, CUstream, CUhostFn, void*);
+IREE_CU_PFN_DECL(cuLaunchHostFunc, CUstream, CUhostFn, void*)

--- a/experimental/cuda2/registration/driver_module.c
+++ b/experimental/cuda2/registration/driver_module.c
@@ -14,11 +14,11 @@
 #include "iree/base/internal/flags.h"
 
 IREE_FLAG(
-    bool, cuda_async_allocations, true,
+    bool, cuda2_async_allocations, true,
     "Enables CUDA asynchronous stream-ordered allocations when supported.");
 
 IREE_FLAG(
-    bool, cuda_tracing, true,
+    bool, cuda2_tracing, true,
     "Enables tracing of stream events when Tracy instrumentation is enabled.\n"
     "Severely impacts benchmark timings and should only be used when\n"
     "analyzing dispatch timings.");
@@ -90,8 +90,8 @@ static iree_status_t iree_hal_cuda2_driver_factory_try_create(
 
   iree_hal_cuda2_device_params_t device_params;
   iree_hal_cuda2_device_params_initialize(&device_params);
-  device_params.stream_tracing = FLAG_cuda_tracing;
-  device_params.async_allocations = FLAG_cuda_async_allocations;
+  device_params.stream_tracing = FLAG_cuda2_tracing;
+  device_params.async_allocations = FLAG_cuda2_async_allocations;
 
   driver_options.default_device_index = FLAG_cuda2_default_index;
   if (FLAG_cuda2_default_index_from_mpi) {


### PR DESCRIPTION
* Remove trailing semicolon in cuda2/cuda_dynamic_symbol_table.h to fix
  ```
  [build] D:\dev\projects\iree\experimental/cuda2/cuda_dynamic_symbol_table.h(87): error C2059: syntax error: ';'
  [build] D:\dev\projects\iree\experimental/cuda2/cuda_dynamic_symbols.h(33): error C2059: syntax error: '}'
  [build] D:\dev\projects\iree\experimental/cuda2/cuda_dynamic_symbols.h(40): error C2143: syntax error: missing ')' before '*'
  ```

* Make cuda2 flags use unique names to fix
  ```
  [build] iree_experimental_cuda2_registration_registration.lib(driver_module.c.obj) : error LNK2005: iree_flag_register_cuda_async_allocations_ already defined in iree_hal_drivers_cuda_registration_registration.lib(driver_module.c.obj)
  [build] iree_experimental_cuda2_registration_registration.lib(driver_module.c.obj) : error LNK2005: iree_flag_register_cuda_tracing_ already defined in iree_hal_drivers_cuda_registration_registration.lib(driver_module.c.obj)
  [build] tools\iree-run-module.exe : fatal error LNK1169: one or more multiply defined symbols found
  ```

---

I see some runtime errors on my Windows machine (2080 TI, CUDA 12.2, Driver version 536.25, using `--iree-hal-cuda-llvm-target-arch=sm_60`):

```
λ ..\iree-build\tools\iree-run-module.exe --module=..\iree-tmp\2023_08_14\model_EfficientNetB7PT_alias.vmfb --device=cuda2 --function=forward --input=1x3x600x600xf32
EXEC @forward
D:\dev\projects\iree\experimental\cuda2\graph_command_buffer.c:421: INVALID_ARGUMENT; CUDA error 'CUDA_ERROR_INVALID_VALUE' (1): invalid argument; cuGraphAddMemsetNode; while invoking native function hal.command_buffer.fill_buffer; while calling import;
[ 1]   native hal.command_buffer.fill_buffer:0 -
[ 0] bytecode module.forward:9022 [
    <eval_with_key>.29:2509:12,
```

