### PR TITLE
Removing initial_data from iree_hal_allocator_allocate_buffer.

### DIFF
--- a/build_tools/cmake/static_linker_test.c.in
+++ b/build_tools/cmake/static_linker_test.c.in
@@ -159,8 +159,8 @@ iree_status_t Run() {
       }
     }
     if (iree_status_is_ok(status)) {
-      status = iree_hal_buffer_view_allocate_buffer(
-          iree_hal_device_allocator(device), rank[i], shape[i],
+      status = iree_hal_buffer_view_allocate_buffer_copy(
+          device, iree_hal_device_allocator(device), rank[i], shape[i],
           IREE_HAL_TYPE, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
           (iree_hal_buffer_params_t){
               .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -177,9 +177,8 @@ FunctionCall::importSerializableAttr(
   params.type =
       IREE_HAL_MEMORY_TYPE_HOST_VISIBLE | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   if (failed(handleRuntimeError(
-          loc, iree_hal_allocator_allocate_buffer(
-                   binary.getAllocator(), params, storageSize,
-                   iree_const_byte_span_t{nullptr, 0}, &buffer))))
+          loc, iree_hal_allocator_allocate_buffer(binary.getAllocator(), params,
+                                                  storageSize, &buffer))))
     return failure();
 
   iree_hal_buffer_mapping_t mapping;

--- a/experimental/cuda2/cuda_allocator.h
+++ b/experimental/cuda2/cuda_allocator.h
@@ -22,7 +22,6 @@ extern "C" {
 // and the pointer must remain valid for the lifetime of the allocator. Pools
 // may not be supported on all devices and can be NULL.
 iree_status_t iree_hal_cuda2_allocator_create(
-    iree_hal_device_t* base_device,
     const iree_hal_cuda2_dynamic_symbols_t* cuda_symbols, CUdevice device,
     CUstream stream, iree_hal_cuda2_memory_pools_t* pools,
     iree_allocator_t host_allocator, iree_hal_allocator_t** out_allocator);

--- a/experimental/cuda2/cuda_device.c
+++ b/experimental/cuda2/cuda_device.c
@@ -195,7 +195,7 @@ static iree_status_t iree_hal_cuda2_device_create_internal(
 
   if (iree_status_is_ok(status)) {
     status = iree_hal_cuda2_allocator_create(
-        (iree_hal_device_t*)device, cuda_symbols, cu_device, dispatch_stream,
+        cuda_symbols, cu_device, dispatch_stream,
         device->supports_memory_pools ? &device->memory_pools : NULL,
         host_allocator, &device->device_allocator);
   }
@@ -624,7 +624,7 @@ static iree_status_t iree_hal_cuda2_device_queue_alloca(
   } else {
     status = iree_hal_allocator_allocate_buffer(
         iree_hal_device_allocator(base_device), params, allocation_size,
-        iree_const_byte_span_empty(), out_buffer);
+        out_buffer);
   }
 
   // Only signal if not returning a synchronous error - synchronous failure

--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -19,7 +19,7 @@ iree_hal_cts_test_suite(
     iree::experimental::rocm::registration
   EXCLUDED_TESTS
     # This test depends on iree_hal_rocm_direct_command_buffer_update_buffer
-    # via iree_hal_buffer_view_allocate_buffer, which is not implemented yet.
+    # via iree_hal_buffer_view_allocate_buffer_copy, which is not implemented yet.
     "command_buffer_dispatch"
     # Semaphores are not implemented in the ROCm backend yet.
     "semaphore_submission"

--- a/experimental/rocm/rocm_allocator.h
+++ b/experimental/rocm/rocm_allocator.h
@@ -18,7 +18,7 @@ extern "C" {
 
 // Create a ROCM allocator.
 iree_status_t iree_hal_rocm_allocator_create(
-    iree_hal_device_t* base_device, iree_hal_rocm_context_wrapper_t* context,
+    iree_hal_rocm_context_wrapper_t* context,
     iree_hal_allocator_t** out_allocator);
 
 #ifdef __cplusplus

--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -103,8 +103,7 @@ static iree_status_t iree_hal_rocm_device_create_internal(
   device->context_wrapper.host_allocator = host_allocator;
   device->context_wrapper.syms = syms;
   iree_status_t status = iree_hal_rocm_allocator_create(
-      (iree_hal_device_t*)device, &device->context_wrapper,
-      &device->device_allocator);
+      &device->context_wrapper, &device->device_allocator);
   if (iree_status_is_ok(status)) {
     *out_device = (iree_hal_device_t*)device;
   } else {
@@ -301,9 +300,9 @@ static iree_status_t iree_hal_rocm_device_queue_alloca(
   // TODO: queue-ordered allocations.
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
                                                     iree_infinite_timeout()));
-  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-      iree_hal_device_allocator(base_device), params, allocation_size,
-      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_allocator_allocate_buffer(iree_hal_device_allocator(base_device),
+                                         params, allocation_size, out_buffer));
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
   return iree_ok_status();
 }

--- a/experimental/web/sample_dynamic/main.c
+++ b/experimental/web/sample_dynamic/main.c
@@ -203,8 +203,8 @@ void unload_program(iree_program_state_t* program_state) {
 }
 
 static iree_status_t parse_input_into_call(
-    iree_runtime_call_t* call, iree_hal_allocator_t* device_allocator,
-    iree_string_view_t input) {
+    iree_runtime_call_t* call, iree_hal_device_t* device,
+    iree_hal_allocator_t* device_allocator, iree_string_view_t input) {
   bool has_equal =
       iree_string_view_find_char(input, '=', 0) != IREE_STRING_VIEW_NPOS;
   bool has_x =
@@ -214,9 +214,9 @@ static iree_status_t parse_input_into_call(
     bool is_storage_reference =
         iree_string_view_consume_prefix(&input, iree_make_cstring_view("&"));
     iree_hal_buffer_view_t* buffer_view = NULL;
-    IREE_RETURN_IF_ERROR(
-        iree_hal_buffer_view_parse(input, device_allocator, &buffer_view),
-        "parsing value '%.*s'", (int)input.size, input.data);
+    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_parse(
+                             input, device, device_allocator, &buffer_view),
+                         "parsing value '%.*s'", (int)input.size, input.data);
     if (is_storage_reference) {
       // Storage buffer reference; just take the storage for the buffer view -
       // it'll still have whatever contents were specified (or 0) but we'll
@@ -260,8 +260,8 @@ static iree_status_t parse_input_into_call(
 }
 
 static iree_status_t parse_inputs_into_call(
-    iree_runtime_call_t* call, iree_hal_allocator_t* device_allocator,
-    iree_string_view_t inputs) {
+    iree_runtime_call_t* call, iree_hal_device_t* device,
+    iree_hal_allocator_t* device_allocator, iree_string_view_t inputs) {
   if (inputs.size == 0) return iree_ok_status();
 
   // Inputs are provided in a semicolon-delimited list.
@@ -273,7 +273,7 @@ static iree_status_t parse_inputs_into_call(
     split_index = iree_string_view_split(remaining_inputs, ';', &next_input,
                                          &remaining_inputs);
     IREE_RETURN_IF_ERROR(
-        parse_input_into_call(call, device_allocator, next_input));
+        parse_input_into_call(call, device, device_allocator, next_input));
   } while (split_index != -1);
 
   return iree_ok_status();
@@ -393,7 +393,8 @@ const char* call_function(iree_program_state_t* program_state,
 
   if (iree_status_is_ok(status)) {
     status = parse_inputs_into_call(
-        &call, iree_runtime_session_device_allocator(program_state->session),
+        &call, iree_runtime_session_device(program_state->session),
+        iree_runtime_session_device_allocator(program_state->session),
         iree_make_cstring_view(inputs));
   }
 

--- a/experimental/web/sample_static/main.c
+++ b/experimental/web/sample_static/main.c
@@ -121,10 +121,10 @@ int run_sample(iree_sample_state_t* state, float* image_data) {
   iree_hal_buffer_view_t* arg_buffer_view = NULL;
   iree_hal_dim_t buffer_shape[] = {1, 28, 28, 1};
   if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
-        iree_hal_device_allocator(state->device), IREE_ARRAYSIZE(buffer_shape),
-        buffer_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
+    status = iree_hal_buffer_view_allocate_buffer_copy(
+        state->device, iree_hal_device_allocator(state->device),
+        IREE_ARRAYSIZE(buffer_shape), buffer_shape,
+        IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
             .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,

--- a/experimental/web/sample_webgpu/main.c
+++ b/experimental/web/sample_webgpu/main.c
@@ -331,8 +331,8 @@ void unload_program(iree_program_state_t* program_state) {
 //===----------------------------------------------------------------------===//
 
 static iree_status_t parse_input_into_call(
-    iree_runtime_call_t* call, iree_hal_allocator_t* device_allocator,
-    iree_string_view_t input) {
+    iree_runtime_call_t* call, iree_hal_device_t* device,
+    iree_hal_allocator_t* device_allocator, iree_string_view_t input) {
   bool has_equal =
       iree_string_view_find_char(input, '=', 0) != IREE_STRING_VIEW_NPOS;
   bool has_x =
@@ -342,9 +342,9 @@ static iree_status_t parse_input_into_call(
     bool is_storage_reference =
         iree_string_view_consume_prefix(&input, iree_make_cstring_view("&"));
     iree_hal_buffer_view_t* buffer_view = NULL;
-    IREE_RETURN_IF_ERROR(
-        iree_hal_buffer_view_parse(input, device_allocator, &buffer_view),
-        "parsing value '%.*s'", (int)input.size, input.data);
+    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_parse(
+                             input, device, device_allocator, &buffer_view),
+                         "parsing value '%.*s'", (int)input.size, input.data);
     if (is_storage_reference) {
       // Storage buffer reference; just take the storage for the buffer view -
       // it'll still have whatever contents were specified (or 0) but we'll
@@ -388,8 +388,8 @@ static iree_status_t parse_input_into_call(
 }
 
 static iree_status_t parse_inputs_into_call(
-    iree_runtime_call_t* call, iree_hal_allocator_t* device_allocator,
-    iree_string_view_t inputs) {
+    iree_runtime_call_t* call, iree_hal_device_t* device,
+    iree_hal_allocator_t* device_allocator, iree_string_view_t inputs) {
   if (inputs.size == 0) return iree_ok_status();
 
   // Inputs are provided in a semicolon-delimited list.
@@ -401,7 +401,7 @@ static iree_status_t parse_inputs_into_call(
     split_index = iree_string_view_split(remaining_inputs, ';', &next_input,
                                          &remaining_inputs);
     IREE_RETURN_IF_ERROR(
-        parse_input_into_call(call, device_allocator, next_input));
+        parse_input_into_call(call, device, device_allocator, next_input));
   } while (split_index != -1);
 
   return iree_ok_status();
@@ -911,7 +911,7 @@ const bool call_function(
 
   if (iree_status_is_ok(status)) {
     status = parse_inputs_into_call(
-        &call_state->call,
+        &call_state->call, iree_runtime_session_device(program_state->session),
         iree_runtime_session_device_allocator(program_state->session),
         iree_make_cstring_view(inputs));
   }

--- a/experimental/webgpu/staging_buffer.c
+++ b/experimental/webgpu/staging_buffer.c
@@ -46,9 +46,9 @@ iree_status_t iree_hal_webgpu_staging_buffer_initialize(
   };
   iree_hal_buffer_t* device_buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_allocator_allocate_buffer(
-              device_allocator, buffer_params, out_staging_buffer->capacity,
-              iree_const_byte_span_empty(), &device_buffer));
+      z0, iree_hal_allocator_allocate_buffer(device_allocator, buffer_params,
+                                             out_staging_buffer->capacity,
+                                             &device_buffer));
   out_staging_buffer->device_buffer = device_buffer;
   iree_hal_buffer_retain(device_buffer);
   out_staging_buffer->device_buffer_handle =

--- a/experimental/webgpu/webgpu_device.c
+++ b/experimental/webgpu/webgpu_device.c
@@ -325,9 +325,9 @@ static iree_status_t iree_hal_webgpu_device_queue_alloca(
   // TODO(benvanik): queue-ordered allocations.
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
                                                     iree_infinite_timeout()));
-  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-      iree_hal_device_allocator(base_device), params, allocation_size,
-      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_allocator_allocate_buffer(iree_hal_device_allocator(base_device),
+                                         params, allocation_size, out_buffer));
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
   return iree_ok_status();
 }

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -149,9 +149,9 @@ class HalAllocator : public ApiRefCounted<HalAllocator, iree_hal_allocator_t> {
   py::str FormattedStatistics();
 
   py::object AllocateBufferCopy(
-      int memory_type, int allowed_usage, py::object buffer,
+      int memory_type, int allowed_usage, HalDevice& device, py::object buffer,
       std::optional<iree_hal_element_types_t> element_type);
-  HalBuffer AllocateHostStagingBufferCopy(py::handle buffer);
+  HalBuffer AllocateHostStagingBufferCopy(HalDevice& device, py::handle buffer);
 };
 
 struct HalShape {

--- a/runtime/bindings/python/invoke.cc
+++ b/runtime/bindings/python/invoke.cc
@@ -200,7 +200,7 @@ class InvokeStatics {
             retained_bv = c.allocator().AllocateBufferCopy(
                 IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
                 IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING,
-                host_array, hal_element_type);
+                c.device(), host_array, hal_element_type);
             bv = py::cast<HalBufferView *>(retained_bv);
           }
 
@@ -308,7 +308,7 @@ class InvokeStatics {
         throw std::invalid_argument(message);
       }
     } else {
-      // Primtive type.
+      // Primitive type.
       py::str prim_type = py::cast<py::str>(desc);
       if (prim_type.equal(kF32)) {
         // f32
@@ -405,7 +405,7 @@ class InvokeStatics {
       py::object retained_bv = c.allocator().AllocateBufferCopy(
           IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
           IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING,
-          host_array, hal_element_type);
+          c.device(), host_array, hal_element_type);
       HalBufferView *bv = py::cast<HalBufferView *>(retained_bv);
 
       // TODO: If adding further manipulation here, please make this common

--- a/runtime/bindings/python/iree/runtime/array_interop.py
+++ b/runtime/bindings/python/iree/runtime/array_interop.py
@@ -224,6 +224,7 @@ def asdevicearray(
     buffer_view = device.allocator.allocate_buffer_copy(
         memory_type=memory_type,
         allowed_usage=allowed_usage,
+        device=device,
         buffer=a,
         element_type=element_type,
     )

--- a/runtime/bindings/python/tests/array_interop_test.py
+++ b/runtime/bindings/python/tests/array_interop_test.py
@@ -59,6 +59,7 @@ class DeviceHalTest(unittest.TestCase):
         buffer_view = self.allocator.allocate_buffer_copy(
             memory_type=iree.runtime.MemoryType.DEVICE_LOCAL,
             allowed_usage=iree.runtime.BufferUsage.DEFAULT,
+            device=self.device,
             buffer=init_ary,
             element_type=iree.runtime.HalElementType.SINT_32,
         )

--- a/runtime/bindings/python/tests/function_test.py
+++ b/runtime/bindings/python/tests/function_test.py
@@ -493,6 +493,7 @@ class FunctionTest(unittest.TestCase):
         arg_buffer_view = self.device.allocator.allocate_buffer_copy(
             memory_type=IMPLICIT_BUFFER_ARG_MEMORY_TYPE,
             allowed_usage=IMPLICIT_BUFFER_ARG_USAGE,
+            device=self.device,
             buffer=np.asarray([1, 0], dtype=np.int32),
             element_type=rt.HalElementType.SINT_32,
         )
@@ -565,6 +566,7 @@ class FunctionTest(unittest.TestCase):
         arg_buffer_view = self.device.allocator.allocate_buffer_copy(
             memory_type=IMPLICIT_BUFFER_ARG_MEMORY_TYPE,
             allowed_usage=IMPLICIT_BUFFER_ARG_USAGE,
+            device=self.device,
             buffer=np.asarray([1, 0], dtype=np.int32),
             element_type=rt.HalElementType.SINT_32,
         )
@@ -590,6 +592,7 @@ class FunctionTest(unittest.TestCase):
             buffer_view = self.device.allocator.allocate_buffer_copy(
                 memory_type=IMPLICIT_BUFFER_ARG_MEMORY_TYPE,
                 allowed_usage=IMPLICIT_BUFFER_ARG_USAGE,
+                device=self.device,
                 buffer=result_array,
                 element_type=rt.HalElementType.SINT_32,
             )
@@ -617,6 +620,7 @@ class FunctionTest(unittest.TestCase):
             buffer_view = self.device.allocator.allocate_buffer_copy(
                 memory_type=IMPLICIT_BUFFER_ARG_MEMORY_TYPE,
                 allowed_usage=IMPLICIT_BUFFER_ARG_USAGE,
+                device=self.device,
                 buffer=result_array,
                 element_type=rt.HalElementType.SINT_32,
             )
@@ -636,6 +640,7 @@ class FunctionTest(unittest.TestCase):
             buffer_view = self.device.allocator.allocate_buffer_copy(
                 memory_type=IMPLICIT_BUFFER_ARG_MEMORY_TYPE,
                 allowed_usage=IMPLICIT_BUFFER_ARG_USAGE,
+                device=self.device,
                 buffer=result_array,
                 element_type=rt.HalElementType.UINT_8,
             )

--- a/runtime/bindings/python/tests/hal_test.py
+++ b/runtime/bindings/python/tests/hal_test.py
@@ -157,6 +157,7 @@ class DeviceHalTest(unittest.TestCase):
         buffer = self.allocator.allocate_buffer_copy(
             memory_type=iree.runtime.MemoryType.DEVICE_LOCAL,
             allowed_usage=iree.runtime.BufferUsage.DEFAULT,
+            device=self.device,
             buffer=ary,
         )
         # NOTE: the exact bits set on type/usage/etc is implementation defined.
@@ -170,6 +171,7 @@ class DeviceHalTest(unittest.TestCase):
         buffer = self.allocator.allocate_buffer_copy(
             memory_type=iree.runtime.MemoryType.DEVICE_LOCAL,
             allowed_usage=iree.runtime.BufferUsage.DEFAULT,
+            device=self.device,
             buffer=ary,
             element_type=iree.runtime.HalElementType.SINT_32,
         )
@@ -180,7 +182,9 @@ class DeviceHalTest(unittest.TestCase):
         )
 
     def testAllocateHostStagingBufferCopy(self):
-        buffer = self.allocator.allocate_host_staging_buffer_copy(np.int32(0))
+        buffer = self.allocator.allocate_host_staging_buffer_copy(
+            self.device, np.int32(0)
+        )
         # NOTE: the exact bits set on type/usage/etc is implementation defined.
         self.assertEqual(
             repr(buffer),

--- a/runtime/bindings/python/tests/vm_types_test.py
+++ b/runtime/bindings/python/tests/vm_types_test.py
@@ -68,6 +68,7 @@ class VmTypesTest(unittest.TestCase):
             bv1 = device.allocator.allocate_buffer_copy(
                 memory_type=rt.MemoryType.DEVICE_LOCAL,
                 allowed_usage=(rt.BufferUsage.DEFAULT | rt.BufferUsage.MAPPING),
+                device=device,
                 buffer=ary1,
                 element_type=et,
             )
@@ -88,6 +89,7 @@ class VmTypesTest(unittest.TestCase):
         buffer_view = device.allocator.allocate_buffer_copy(
             memory_type=rt.MemoryType.DEVICE_LOCAL,
             allowed_usage=(rt.BufferUsage.DEFAULT | rt.BufferUsage.MAPPING),
+            device=device,
             buffer=array,
             element_type=rt.HalElementType.SINT_32,
         )

--- a/runtime/bindings/tflite/tensor.c
+++ b/runtime/bindings/tflite/tensor.c
@@ -144,7 +144,7 @@ iree_status_t _TfLiteTensorReallocateIfNeeded(
                            IREE_HAL_BUFFER_USAGE_TRANSFER |
                            IREE_HAL_BUFFER_USAGE_MAPPING,
               },
-              allocation_size, iree_const_byte_span_empty(), &tensor->buffer));
+              allocation_size, &tensor->buffer));
 
   // Map the buffer memory immediately. The tflite API doesn't let us know if
   // this is a buffer the user will actually touch or some state buffer that is

--- a/runtime/src/iree/hal/allocator.c
+++ b/runtime/src/iree/hal/allocator.c
@@ -176,7 +176,6 @@ iree_hal_allocator_query_buffer_compatibility(
 IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
     iree_hal_buffer_params_t params, iree_device_size_t allocation_size,
-    iree_const_byte_span_t initial_data,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(out_buffer);
@@ -185,7 +184,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)allocation_size);
   iree_hal_buffer_params_canonicalize(&params);
   iree_status_t status = _VTABLE_DISPATCH(allocator, allocate_buffer)(
-      allocator, &params, allocation_size, initial_data, out_buffer);
+      allocator, &params, allocation_size, out_buffer);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/allocator.h
+++ b/runtime/src/iree/hal/allocator.h
@@ -442,9 +442,6 @@ iree_hal_allocator_query_buffer_compatibility(
     iree_device_size_t* out_allocation_size);
 
 // Allocates a buffer from the allocator.
-// If |initial_data| is provided then the bytes will be copied into the device
-// buffer. To avoid the copy when device-accessible constant data is used prefer
-// iree_hal_allocator_import_buffer when available.
 //
 // The memory type of the buffer returned may differ from the requested value
 // if the device can provide more functionality; for example, if requesting
@@ -460,7 +457,7 @@ iree_hal_allocator_query_buffer_compatibility(
 IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
     iree_hal_buffer_params_t params, iree_device_size_t allocation_size,
-    iree_const_byte_span_t initial_data, iree_hal_buffer_t** out_buffer);
+    iree_hal_buffer_t** out_buffer);
 
 // TODO(benvanik): iree_hal_allocator_query_external_buffer_compatibility to
 // check for support without needing an external buffer already. There's a few
@@ -560,7 +557,7 @@ typedef struct iree_hal_allocator_vtable_t {
   iree_status_t(IREE_API_PTR* allocate_buffer)(
       iree_hal_allocator_t* IREE_RESTRICT allocator,
       const iree_hal_buffer_params_t* IREE_RESTRICT params,
-      iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
+      iree_device_size_t allocation_size,
       iree_hal_buffer_t** IREE_RESTRICT out_buffer);
 
   void(IREE_API_PTR* deallocate_buffer)(

--- a/runtime/src/iree/hal/allocator_heap.c
+++ b/runtime/src/iree/hal/allocator_heap.c
@@ -178,7 +178,7 @@ iree_hal_heap_allocator_query_buffer_compatibility(
 static iree_status_t iree_hal_heap_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
+    iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   iree_hal_heap_allocator_t* allocator =
       iree_hal_heap_allocator_cast(base_allocator);
@@ -198,7 +198,7 @@ static iree_status_t iree_hal_heap_allocator_allocate_buffer(
   IREE_STATISTICS(statistics = &allocator->statistics);
   iree_hal_buffer_t* buffer = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_heap_buffer_create(
-      base_allocator, statistics, &compat_params, allocation_size, initial_data,
+      base_allocator, statistics, &compat_params, allocation_size,
       allocator->data_allocator, allocator->host_allocator, &buffer));
 
   *out_buffer = buffer;

--- a/runtime/src/iree/hal/buffer_heap.c
+++ b/runtime/src/iree/hal/buffer_heap.c
@@ -114,8 +114,8 @@ iree_status_t iree_hal_heap_buffer_create(
     iree_hal_allocator_t* allocator,
     iree_hal_heap_allocator_statistics_t* statistics,
     const iree_hal_buffer_params_t* params, iree_device_size_t allocation_size,
-    iree_const_byte_span_t initial_data, iree_allocator_t data_allocator,
-    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer) {
+    iree_allocator_t data_allocator, iree_allocator_t host_allocator,
+    iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(params);
   IREE_ASSERT_ARGUMENT(out_buffer);
@@ -160,12 +160,6 @@ iree_status_t iree_hal_heap_buffer_create(
         iree_slim_mutex_unlock(&statistics->mutex);
       }
     });
-
-    if (!iree_const_byte_span_is_empty(initial_data)) {
-      const iree_device_size_t initial_length =
-          iree_min(initial_data.data_length, allocation_size);
-      memcpy(buffer->data.data, initial_data.data, initial_length);
-    }
 
     *out_buffer = &buffer->base;
   }

--- a/runtime/src/iree/hal/buffer_heap_impl.h
+++ b/runtime/src/iree/hal/buffer_heap_impl.h
@@ -34,8 +34,8 @@ iree_status_t iree_hal_heap_buffer_create(
     iree_hal_allocator_t* allocator,
     iree_hal_heap_allocator_statistics_t* statistics,
     const iree_hal_buffer_params_t* params, iree_device_size_t allocation_size,
-    iree_const_byte_span_t initial_data, iree_allocator_t data_allocator,
-    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
+    iree_allocator_t data_allocator, iree_allocator_t host_allocator,
+    iree_hal_buffer_t** out_buffer);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/cts/allocator_test.h
+++ b/runtime/src/iree/hal/cts/allocator_test.h
@@ -85,9 +85,8 @@ TEST_P(allocator_test, AllocateBuffer) {
   params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
   iree_hal_buffer_t* buffer = NULL;
-  IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
-      device_allocator_, params, kAllocationSize, iree_const_byte_span_empty(),
-      &buffer));
+  IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(device_allocator_, params,
+                                                    kAllocationSize, &buffer));
 
   // At a mimimum, the requested memory type should be respected.
   // Additional bits may be optionally set depending on the allocator.
@@ -109,8 +108,7 @@ TEST_P(allocator_test, AllocateEmptyBuffer) {
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
   iree_hal_buffer_t* buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
-      device_allocator_, params, /*allocation_size=*/0,
-      iree_const_byte_span_empty(), &buffer));
+      device_allocator_, params, /*allocation_size=*/0, &buffer));
 
   iree_hal_buffer_release(buffer);
 }

--- a/runtime/src/iree/hal/cts/buffer_mapping_test.h
+++ b/runtime/src/iree/hal/cts/buffer_mapping_test.h
@@ -54,7 +54,7 @@ class buffer_mapping_test : public CtsTestBase {
     iree_hal_buffer_t* device_buffer = NULL;
     IREE_CHECK_OK(iree_hal_allocator_allocate_buffer(
         iree_hal_device_allocator(device_), params, buffer_size,
-        iree_const_byte_span_empty(), &device_buffer));
+        &device_buffer));
     *out_buffer = device_buffer;
   }
 };

--- a/runtime/src/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_dispatch_test.h
@@ -96,8 +96,8 @@ TEST_P(command_buffer_dispatch_test, DispatchAbs) {
       IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE | IREE_HAL_BUFFER_USAGE_TRANSFER;
   iree_hal_buffer_view_t* input_buffer_view = NULL;
   float input_data[1] = {-2.5f};
-  IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-      device_allocator_,
+  IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer_copy(
+      device_, device_allocator_,
       /*shape_rank=*/0, /*shape=*/NULL, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, input_params,
       iree_make_const_byte_span((void*)input_data, sizeof(input_data)),
@@ -110,8 +110,7 @@ TEST_P(command_buffer_dispatch_test, DispatchAbs) {
                         IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_t* output_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
-      device_allocator_, output_params, sizeof(float),
-      iree_const_byte_span_empty(), &output_buffer));
+      device_allocator_, output_params, sizeof(float), &output_buffer));
 
   iree_hal_descriptor_set_binding_t descriptor_set_bindings[] = {
       {

--- a/runtime/src/iree/hal/cts/command_buffer_push_constants_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_push_constants_test.h
@@ -99,8 +99,7 @@ TEST_P(command_buffer_push_constants_test, DispatchWithPushConstants) {
                         IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_t* output_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
-      device_allocator_, output_params, 4 * sizeof(uint32_t),
-      iree_const_byte_span_empty(), &output_buffer));
+      device_allocator_, output_params, 4 * sizeof(uint32_t), &output_buffer));
 
   iree_hal_descriptor_set_binding_t descriptor_set_bindings[] = {
       {

--- a/runtime/src/iree/hal/cts/command_buffer_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_test.h
@@ -39,7 +39,7 @@ class command_buffer_test : public CtsTestBase {
     iree_hal_buffer_t* device_buffer = NULL;
     IREE_CHECK_OK(iree_hal_allocator_allocate_buffer(
         iree_hal_device_allocator(device_), params, buffer_size,
-        iree_const_byte_span_empty(), &device_buffer));
+        &device_buffer));
     IREE_ASSERT_OK(
         iree_hal_buffer_map_zero(device_buffer, 0, IREE_WHOLE_BUFFER));
     *out_buffer = device_buffer;
@@ -144,10 +144,10 @@ TEST_P(command_buffer_test, CopyWholeBuffer) {
                       IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_t* host_buffer = nullptr;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
-      device_allocator_, host_params, kDefaultAllocationSize,
-      iree_make_const_byte_span(reference_buffer.data(),
-                                reference_buffer.size()),
-      &host_buffer));
+      device_allocator_, host_params, kDefaultAllocationSize, &host_buffer));
+  IREE_ASSERT_OK(iree_hal_device_transfer_h2d(
+      device_, reference_buffer.data(), host_buffer, 0, reference_buffer.size(),
+      IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
 
   // Create a device buffer.
   iree_hal_buffer_params_t device_params = {0};
@@ -159,7 +159,7 @@ TEST_P(command_buffer_test, CopyWholeBuffer) {
   iree_hal_buffer_t* device_buffer = nullptr;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, device_params, kDefaultAllocationSize,
-      iree_const_byte_span_empty(), &device_buffer));
+      &device_buffer));
 
   // Copy the host buffer to the device buffer.
   IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
@@ -202,7 +202,7 @@ TEST_P(command_buffer_test, CopySubBuffer) {
   iree_hal_buffer_t* device_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, device_params, kDefaultAllocationSize,
-      iree_const_byte_span_empty(), &device_buffer));
+      &device_buffer));
 
   uint8_t i8_val = 0x88;
   std::vector<uint8_t> reference_buffer(kDefaultAllocationSize);
@@ -220,9 +220,11 @@ TEST_P(command_buffer_test, CopySubBuffer) {
   iree_hal_buffer_t* host_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, host_params, host_buffer_data.size() / 2,
-      iree_make_const_byte_span(host_buffer_data.data(),
-                                host_buffer_data.size() / 2),
       &host_buffer));
+  IREE_ASSERT_OK(iree_hal_device_transfer_h2d(
+      device_, host_buffer_data.data(), host_buffer, 0,
+      host_buffer_data.size() / 2, IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
+      iree_infinite_timeout()));
 
   // Copy the host buffer to the device buffer; zero fill the untouched bytes.
   uint8_t zero_val = 0x0;

--- a/runtime/src/iree/hal/cts/file_test.h
+++ b/runtime/src/iree/hal/cts/file_test.h
@@ -38,7 +38,7 @@ class file_test : public CtsTestBase {
     iree_hal_buffer_t* device_buffer = NULL;
     IREE_CHECK_OK(iree_hal_allocator_allocate_buffer(
         iree_hal_device_allocator(device_), params, buffer_size,
-        iree_const_byte_span_empty(), &device_buffer));
+        &device_buffer));
 
     iree_hal_transfer_command_t transfer_command;
     memset(&transfer_command, 0, sizeof(transfer_command));

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.h
@@ -23,9 +23,8 @@ extern "C" {
 // and the pointer must remain valid for the lifetime of the allocator. Pools
 // may not be supported on all devices and can be NULL.
 iree_status_t iree_hal_cuda_allocator_create(
-    iree_hal_device_t* base_device, iree_hal_cuda_context_wrapper_t* context,
-    CUdevice device, CUstream stream, iree_hal_cuda_memory_pools_t* pools,
-    iree_hal_allocator_t** out_allocator);
+    iree_hal_cuda_context_wrapper_t* context, CUdevice device, CUstream stream,
+    iree_hal_cuda_memory_pools_t* pools, iree_hal_allocator_t** out_allocator);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -160,7 +160,7 @@ static iree_status_t iree_hal_cuda_device_create_internal(
 
   if (iree_status_is_ok(status)) {
     status = iree_hal_cuda_allocator_create(
-        (iree_hal_device_t*)device, &device->context_wrapper, cu_device, stream,
+        &device->context_wrapper, cu_device, stream,
         device->supports_memory_pools ? &device->memory_pools : NULL,
         &device->device_allocator);
   }
@@ -569,7 +569,7 @@ static iree_status_t iree_hal_cuda_device_queue_alloca(
   } else {
     status = iree_hal_allocator_allocate_buffer(
         iree_hal_device_allocator(base_device), params, allocation_size,
-        iree_const_byte_span_empty(), out_buffer);
+        out_buffer);
   }
 
   // Only signal if not returning a synchronous error - synchronous failure

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -316,9 +316,9 @@ static iree_status_t iree_hal_sync_device_queue_alloca(
   // TODO(benvanik): queue-ordered allocations.
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
                                                     iree_infinite_timeout()));
-  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-      iree_hal_device_allocator(base_device), params, allocation_size,
-      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_allocator_allocate_buffer(iree_hal_device_allocator(base_device),
+                                         params, allocation_size, out_buffer));
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -388,9 +388,9 @@ static iree_status_t iree_hal_task_device_queue_alloca(
   // TODO(benvanik): queue-ordered allocations.
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
                                                     iree_infinite_timeout()));
-  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-      iree_hal_device_allocator(base_device), params, allocation_size,
-      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_allocator_allocate_buffer(iree_hal_device_allocator(base_device),
+                                         params, allocation_size, out_buffer));
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -328,9 +328,8 @@ static iree_status_t iree_hal_metal_device_queue_alloca(
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   // TODO(benvanik): queue-ordered allocations.
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list, iree_infinite_timeout()));
-  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-      iree_hal_device_allocator(base_device), params, allocation_size, iree_const_byte_span_empty(),
-      out_buffer));
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(iree_hal_device_allocator(base_device),
+                                                          params, allocation_size, out_buffer));
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/vulkan/native_allocator.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_allocator.cc
@@ -22,7 +22,6 @@ static const char* IREE_HAL_VULKAN_NATIVE_ALLOCATOR_ID = "Vulkan/Native";
 typedef struct iree_hal_vulkan_native_allocator_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
-  iree_hal_device_t* device;  // unretained to avoid cycles
   iree_allocator_t host_allocator;
 
   // Cached from the API to avoid additional queries in hot paths.
@@ -52,11 +51,10 @@ static void iree_hal_vulkan_native_allocator_destroy(
 extern "C" iree_status_t iree_hal_vulkan_native_allocator_create(
     const iree_hal_vulkan_device_options_t* options, VkInstance instance,
     VkPhysicalDevice physical_device, VkDeviceHandle* logical_device,
-    iree_hal_device_t* device, iree_hal_allocator_t** out_allocator) {
+    iree_hal_allocator_t** out_allocator) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(physical_device);
   IREE_ASSERT_ARGUMENT(logical_device);
-  IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_allocator);
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -68,7 +66,6 @@ extern "C" iree_status_t iree_hal_vulkan_native_allocator_create(
   iree_hal_resource_initialize(&iree_hal_vulkan_native_allocator_vtable,
                                &allocator->resource);
   allocator->logical_device = logical_device;
-  allocator->device = device;
   allocator->host_allocator = host_allocator;
 
   const auto& syms = logical_device->syms();
@@ -187,7 +184,7 @@ static void iree_hal_vulkan_native_allocator_native_buffer_release(
 static iree_status_t iree_hal_vulkan_native_allocator_allocate_internal(
     iree_hal_vulkan_native_allocator_t* IREE_RESTRICT allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
+    iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   VkDeviceHandle* logical_device = allocator->logical_device;
 
@@ -273,18 +270,6 @@ static iree_status_t iree_hal_vulkan_native_allocator_allocate_internal(
         "vkBindBufferMemory");
   }
 
-  // Copy the initial contents into the buffer. This may require staging.
-  if (iree_status_is_ok(status) &&
-      !iree_const_byte_span_is_empty(initial_data)) {
-    status = iree_hal_device_transfer_range(
-        allocator->device,
-        iree_hal_make_host_transfer_buffer_span((void*)initial_data.data,
-                                                initial_data.data_length),
-        0, iree_hal_make_device_transfer_buffer(buffer), 0,
-        initial_data.data_length, IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
-        iree_infinite_timeout());
-  }
-
   if (iree_status_is_ok(status)) {
     iree_hal_allocator_statistics_record_alloc(
         &allocator->statistics, params->type, buffer->allocation_size);
@@ -298,7 +283,7 @@ static iree_status_t iree_hal_vulkan_native_allocator_allocate_internal(
 static iree_status_t iree_hal_vulkan_native_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
+    iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   iree_hal_vulkan_native_allocator_t* allocator =
       iree_hal_vulkan_native_allocator_cast(base_allocator);
@@ -315,7 +300,7 @@ static iree_status_t iree_hal_vulkan_native_allocator_allocate_buffer(
   }
 
   return iree_hal_vulkan_native_allocator_allocate_internal(
-      allocator, &compat_params, allocation_size, initial_data, out_buffer);
+      allocator, &compat_params, allocation_size, out_buffer);
 }
 
 static void iree_hal_vulkan_native_allocator_deallocate_buffer(

--- a/runtime/src/iree/hal/drivers/vulkan/native_allocator.h
+++ b/runtime/src/iree/hal/drivers/vulkan/native_allocator.h
@@ -21,7 +21,7 @@ iree_status_t iree_hal_vulkan_native_allocator_create(
     const iree_hal_vulkan_device_options_t* options, VkInstance instance,
     VkPhysicalDevice physical_device,
     iree::hal::vulkan::VkDeviceHandle* logical_device,
-    iree_hal_device_t* device, iree_hal_allocator_t** out_allocator);
+    iree_hal_allocator_t** out_allocator);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/vulkan/vma_allocator.h
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_allocator.h
@@ -36,7 +36,7 @@ iree_status_t iree_hal_vulkan_vma_allocator_create(
     const iree_hal_vulkan_device_options_t* options, VkInstance instance,
     VkPhysicalDevice physical_device,
     iree::hal::vulkan::VkDeviceHandle* logical_device,
-    iree_hal_device_t* device, iree_hal_allocator_t** out_allocator);
+    iree_hal_allocator_t** out_allocator);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -719,11 +719,11 @@ static iree_status_t iree_hal_vulkan_device_create_internal(
                         IREE_HAL_VULKAN_DEVICE_FLAG_VMA_ALLOCATOR)) {
     status = iree_hal_vulkan_vma_allocator_create(
         options, instance, physical_device, logical_device,
-        (iree_hal_device_t*)device, &device->device_allocator);
+        &device->device_allocator);
   } else {
     status = iree_hal_vulkan_native_allocator_create(
         options, instance, physical_device, logical_device,
-        (iree_hal_device_t*)device, &device->device_allocator);
+        &device->device_allocator);
   }
 
   // Create command pools for each queue family. If we don't have a transfer
@@ -1268,9 +1268,9 @@ static iree_status_t iree_hal_vulkan_device_queue_alloca(
   // TODO(benvanik): queue-ordered allocations.
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
                                                     iree_infinite_timeout()));
-  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-      iree_hal_device_allocator(base_device), params, allocation_size,
-      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_allocator_allocate_buffer(iree_hal_device_allocator(base_device),
+                                         params, allocation_size, out_buffer));
   IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/local/executable_library_benchmark.c
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.c
@@ -205,8 +205,9 @@ static iree_status_t iree_hal_executable_library_run(
   void* binding_ptrs[IREE_HAL_LOCAL_MAX_TOTAL_BINDING_COUNT];
   size_t binding_lengths[IREE_HAL_LOCAL_MAX_TOTAL_BINDING_COUNT];
   for (iree_host_size_t i = 0; i < dispatch_params.binding_count; ++i) {
-    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_parse(
-        dispatch_params.bindings[i], heap_allocator, &buffer_views[i]));
+    IREE_RETURN_IF_ERROR(
+        iree_hal_buffer_view_parse(dispatch_params.bindings[i], /*device=*/NULL,
+                                   heap_allocator, &buffer_views[i]));
     iree_hal_buffer_t* buffer = iree_hal_buffer_view_buffer(buffer_views[i]);
     iree_device_size_t buffer_length =
         iree_hal_buffer_view_byte_length(buffer_views[i]);

--- a/runtime/src/iree/hal/string_util_test.cc
+++ b/runtime/src/iree/hal/string_util_test.cc
@@ -519,7 +519,7 @@ struct BufferView final
     BufferView buffer_view;
     iree_status_t status = iree_hal_buffer_view_parse(
         iree_string_view_t{value.data(), (iree_host_size_t)value.size()},
-        allocator, &buffer_view);
+        /*device=*/NULL, allocator, &buffer_view);
     IREE_RETURN_IF_ERROR(std::move(status));
     return std::move(buffer_view);
   }

--- a/runtime/src/iree/hal/utils/buffer_transfer.c
+++ b/runtime/src/iree/hal/utils/buffer_transfer.c
@@ -163,15 +163,19 @@ IREE_API_EXPORT iree_status_t iree_hal_device_submit_transfer_range_and_wait(
     };
     status = iree_hal_allocator_allocate_buffer(
         iree_hal_device_allocator(device), source_params, data_length,
-        iree_make_const_byte_span(source.host_buffer.data + source_offset,
-                                  data_length),
         &source_buffer);
     source_offset = 0;
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_device_transfer_h2d(
+          device, source.host_buffer.data + source_offset, source_buffer, 0,
+          data_length, IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
+          iree_infinite_timeout());
+    }
   }
 
   // Allocate the staging buffer for download from the device.
   iree_hal_buffer_t* target_buffer = target.device_buffer;
-  if (!target_buffer) {
+  if (iree_status_is_ok(status) && !target_buffer) {
     // Allocate uninitialized staging memory for the transfer target.
     // We only allocate enough for the portion we are transfering.
     // TODO(benvanik): use import if supported to avoid the allocation/copy.
@@ -182,7 +186,7 @@ IREE_API_EXPORT iree_status_t iree_hal_device_submit_transfer_range_and_wait(
     };
     status = iree_hal_allocator_allocate_buffer(
         iree_hal_device_allocator(device), target_params, data_length,
-        iree_const_byte_span_empty(), &target_buffer);
+        &target_buffer);
     target_offset = 0;
   }
 
@@ -355,8 +359,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_emulated_map_range(
           .usage =
               IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING,
       },
-      local_byte_length, iree_const_byte_span_empty(),
-      &emulation_state->host_local_buffer);
+      local_byte_length, &emulation_state->host_local_buffer);
 
   // We need to capture a copy of the device buffer to work with; unless the
   // user was nice and said they don't care about the contents with the DISCARD

--- a/runtime/src/iree/hal/utils/debug_allocator.c
+++ b/runtime/src/iree/hal/utils/debug_allocator.c
@@ -187,7 +187,7 @@ static iree_status_t iree_hal_debug_allocator_fill_on_device(
 static iree_status_t iree_hal_debug_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
+    iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   iree_hal_debug_allocator_t* allocator =
       iree_hal_debug_allocator_cast(base_allocator);
@@ -196,17 +196,9 @@ static iree_status_t iree_hal_debug_allocator_allocate_buffer(
   // undefined contents (including those from prior allocations which may appear
   // correct).
   IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-      allocator->device_allocator, *params, allocation_size, initial_data,
-      out_buffer));
+      allocator->device_allocator, *params, allocation_size, out_buffer));
 
-  // If the buffer is read-only we can't fill it even if we wanted to. This
-  // usually happens with initial data.
   iree_hal_buffer_t* base_buffer = *out_buffer;
-  if (initial_data.data_length > 0 ||
-      !iree_all_bits_set(iree_hal_buffer_allowed_access(base_buffer),
-                         IREE_HAL_MEMORY_ACCESS_WRITE)) {
-    return iree_ok_status();
-  }
 
   // We could rotate this here if we wanted to have it vary over time (per
   // allocation, per trim, etc).

--- a/runtime/src/iree/modules/check/check_test.cc
+++ b/runtime/src/iree/modules/check/check_test.cc
@@ -91,9 +91,10 @@ class CheckTest : public ::testing::Test {
     params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING;
-    IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-        allocator_, shape.size(), shape.data(), IREE_HAL_ELEMENT_TYPE_INT_32,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
+    IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer_copy(
+        device_, allocator_, shape.size(), shape.data(),
+        IREE_HAL_ELEMENT_TYPE_INT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
+        params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(int32_t)),
         &*out_buffer_view));
@@ -113,9 +114,10 @@ class CheckTest : public ::testing::Test {
     params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING;
-    IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-        allocator_, shape.size(), shape.data(), IREE_HAL_ELEMENT_TYPE_FLOAT_16,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
+    IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer_copy(
+        device_, allocator_, shape.size(), shape.data(),
+        IREE_HAL_ELEMENT_TYPE_FLOAT_16, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
+        params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(uint16_t)),
         &*out_buffer_view));
@@ -135,9 +137,10 @@ class CheckTest : public ::testing::Test {
     params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING;
-    IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-        allocator_, shape.size(), shape.data(), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
+    IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer_copy(
+        device_, allocator_, shape.size(), shape.data(),
+        IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
+        params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(float)),
         &*out_buffer_view));
@@ -157,9 +160,10 @@ class CheckTest : public ::testing::Test {
     params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING;
-    IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-        allocator_, shape.size(), shape.data(), IREE_HAL_ELEMENT_TYPE_FLOAT_64,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
+    IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer_copy(
+        device_, allocator_, shape.size(), shape.data(),
+        IREE_HAL_ELEMENT_TYPE_FLOAT_64, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
+        params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(double)),
         &*out_buffer_view));

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -244,10 +244,10 @@ IREE_VM_ABI_EXPORT(iree_hal_module_allocator_allocate,  //
       .queue_affinity = queue_affinity,
   };
   iree_hal_buffer_t* buffer = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_allocator_allocate_buffer(allocator, params, allocation_size,
-                                         iree_const_byte_span_empty(), &buffer),
-      "failed to allocate buffer of length %" PRIdsz, allocation_size);
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+                           allocator, params, allocation_size, &buffer),
+                       "failed to allocate buffer of length %" PRIdsz,
+                       allocation_size);
 
   rets->r0 = iree_hal_buffer_move_ref(buffer);
   return iree_ok_status();

--- a/runtime/src/iree/runtime/demo/hello_world_explained.c
+++ b/runtime/src/iree/runtime/demo/hello_world_explained.c
@@ -181,6 +181,7 @@ static iree_status_t iree_runtime_demo_perform_mul(
   // Append the function inputs with the HAL device allocator in use by the
   // session. The buffers will be usable within the session and _may_ be usable
   // in other sessions depending on whether they share a compatible device.
+  iree_hal_device_t* device = iree_runtime_session_device(session);
   iree_hal_allocator_t* device_allocator =
       iree_runtime_session_device_allocator(session);
   iree_allocator_t host_allocator =
@@ -192,8 +193,8 @@ static iree_status_t iree_runtime_demo_perform_mul(
     if (iree_status_is_ok(status)) {
       static const iree_hal_dim_t arg0_shape[1] = {4};
       static const float arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
-      status = iree_hal_buffer_view_allocate_buffer(
-          device_allocator,
+      status = iree_hal_buffer_view_allocate_buffer_copy(
+          device, device_allocator,
           // Shape rank and dimensions:
           IREE_ARRAYSIZE(arg0_shape), arg0_shape,
           // Element type:
@@ -203,8 +204,8 @@ static iree_status_t iree_runtime_demo_perform_mul(
           (iree_hal_buffer_params_t){
               // Where to allocate (host or device):
               .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-              // Access to allow to this memory (this is .rodata so READ only):
-              .access = IREE_HAL_MEMORY_ACCESS_READ,
+              // Access to allow to this memory:
+              .access = IREE_HAL_MEMORY_ACCESS_ALL,
               // Intended usage of the buffer (transfers, dispatches, etc):
               .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
           },
@@ -229,13 +230,13 @@ static iree_status_t iree_runtime_demo_perform_mul(
     if (iree_status_is_ok(status)) {
       static const iree_hal_dim_t arg1_shape[1] = {4};
       static const float arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
-      status = iree_hal_buffer_view_allocate_buffer(
-          device_allocator, IREE_ARRAYSIZE(arg1_shape), arg1_shape,
+      status = iree_hal_buffer_view_allocate_buffer_copy(
+          device, device_allocator, IREE_ARRAYSIZE(arg1_shape), arg1_shape,
           IREE_HAL_ELEMENT_TYPE_FLOAT_32,
           IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
           (iree_hal_buffer_params_t){
               .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-              .access = IREE_HAL_MEMORY_ACCESS_READ,
+              .access = IREE_HAL_MEMORY_ACCESS_ALL,
               .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
           },
           iree_make_const_byte_span(arg1_data, sizeof(arg1_data)), &arg1);

--- a/runtime/src/iree/runtime/demo/hello_world_terse.c
+++ b/runtime/src/iree/runtime/demo/hello_world_terse.c
@@ -79,13 +79,14 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
   iree_hal_buffer_view_t* arg0 = NULL;
   static const iree_hal_dim_t arg0_shape[1] = {4};
   static const float arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
-  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer(
+  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer_copy(
+      iree_runtime_session_device(session),
       iree_runtime_session_device_allocator(session),
       IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-          .access = IREE_HAL_MEMORY_ACCESS_READ,
+          .access = IREE_HAL_MEMORY_ACCESS_ALL,
           .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
       },
       iree_make_const_byte_span(arg0_data, sizeof(arg0_data)), &arg0));
@@ -101,13 +102,14 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
   iree_hal_buffer_view_t* arg1 = NULL;
   static const iree_hal_dim_t arg1_shape[1] = {4};
   static const float arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
-  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer(
+  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer_copy(
+      iree_runtime_session_device(session),
       iree_runtime_session_device_allocator(session),
       IREE_ARRAYSIZE(arg1_shape), arg1_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-          .access = IREE_HAL_MEMORY_ACCESS_READ,
+          .access = IREE_HAL_MEMORY_ACCESS_ALL,
           .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
       },
       iree_make_const_byte_span(arg1_data, sizeof(arg1_data)), &arg1));

--- a/runtime/src/iree/tooling/comparison_test.cc
+++ b/runtime/src/iree/tooling/comparison_test.cc
@@ -20,7 +20,8 @@ namespace {
 
 using ::testing::HasSubstr;
 
-static void ParseToVariantList(iree_hal_allocator_t* device_allocator,
+static void ParseToVariantList(iree_hal_device_t* device,
+                               iree_hal_allocator_t* device_allocator,
                                iree::span<const std::string> input_strings,
                                iree_allocator_t host_allocator,
                                iree_vm_list_t** out_list) {
@@ -30,8 +31,8 @@ static void ParseToVariantList(iree_hal_allocator_t* device_allocator,
     input_string_views[i].size = input_strings[i].size();
   }
   IREE_CHECK_OK(iree_tooling_parse_to_variant_list(
-      device_allocator, input_string_views.data(), input_string_views.size(),
-      host_allocator, out_list));
+      device, device_allocator, input_string_views.data(),
+      input_string_views.size(), host_allocator, out_list));
 }
 
 class ComparisonTest : public ::testing::Test {
@@ -53,12 +54,12 @@ class ComparisonTest : public ::testing::Test {
       iree::span<const std::string> expected_strings,
       iree::span<const std::string> actual_strings, std::string* out_string) {
     vm::ref<iree_vm_list_t> expected_list;
-    ParseToVariantList(device_allocator_, expected_strings, host_allocator_,
-                       &expected_list);
+    ParseToVariantList(/*device=*/NULL, device_allocator_, expected_strings,
+                       host_allocator_, &expected_list);
 
     vm::ref<iree_vm_list_t> actual_list;
-    ParseToVariantList(device_allocator_, actual_strings, host_allocator_,
-                       &actual_list);
+    ParseToVariantList(/*device=*/NULL, device_allocator_, actual_strings,
+                       host_allocator_, &actual_list);
 
     iree_string_builder_t builder;
     iree_string_builder_initialize(host_allocator_, &builder);

--- a/runtime/src/iree/tooling/numpy_io.c
+++ b/runtime/src/iree/tooling/numpy_io.c
@@ -292,11 +292,11 @@ static iree_status_t iree_numpy_parse_shape_dims(iree_string_view_t shape,
   return iree_ok_status();
 }
 
-IREE_API_EXPORT iree_status_t
-iree_numpy_npy_load_ndarray(FILE* stream, iree_numpy_npy_load_options_t options,
-                            iree_hal_buffer_params_t buffer_params,
-                            iree_hal_allocator_t* device_allocator,
-                            iree_hal_buffer_view_t** out_buffer_view) {
+IREE_API_EXPORT iree_status_t iree_numpy_npy_load_ndarray(
+    FILE* stream, iree_numpy_npy_load_options_t options,
+    iree_hal_buffer_params_t buffer_params, iree_hal_device_t* device,
+    iree_hal_allocator_t* device_allocator,
+    iree_hal_buffer_view_t** out_buffer_view) {
   IREE_ASSERT_ARGUMENT(stream);
   IREE_ASSERT_ARGUMENT(device_allocator);
   IREE_ASSERT_ARGUMENT(out_buffer_view);
@@ -376,9 +376,9 @@ iree_numpy_npy_load_ndarray(FILE* stream, iree_numpy_npy_load_options_t options,
     };
     buffer_params.access |= IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE;
     status = iree_hal_buffer_view_generate_buffer(
-        device_allocator, shape_rank, shape, element_type, encoding_type,
-        buffer_params, iree_numpy_npy_read_into_mapping, &read_params,
-        out_buffer_view);
+        device, device_allocator, shape_rank, shape, element_type,
+        encoding_type, buffer_params, iree_numpy_npy_read_into_mapping,
+        &read_params, out_buffer_view);
   }
 
   iree_allocator_free(host_allocator, header_buffer);

--- a/runtime/src/iree/tooling/numpy_io.h
+++ b/runtime/src/iree/tooling/numpy_io.h
@@ -83,11 +83,11 @@ typedef uint32_t iree_numpy_npy_save_options_t;
 //
 // See `numpy.load`:
 // https://numpy.org/doc/stable/reference/generated/numpy.load.html
-IREE_API_EXPORT iree_status_t
-iree_numpy_npy_load_ndarray(FILE* stream, iree_numpy_npy_load_options_t options,
-                            iree_hal_buffer_params_t buffer_params,
-                            iree_hal_allocator_t* device_allocator,
-                            iree_hal_buffer_view_t** out_buffer_view);
+IREE_API_EXPORT iree_status_t iree_numpy_npy_load_ndarray(
+    FILE* stream, iree_numpy_npy_load_options_t options,
+    iree_hal_buffer_params_t buffer_params, iree_hal_device_t* device,
+    iree_hal_allocator_t* device_allocator,
+    iree_hal_buffer_view_t** out_buffer_view);
 
 // Saves |buffer_view| to a .npy |stream|.
 // The ndarray will be appended to the stream to produce a concatenated file.

--- a/runtime/src/iree/tooling/run_module.c
+++ b/runtime/src/iree/tooling/run_module.c
@@ -81,8 +81,8 @@ IREE_FLAG(bool, print_statistics, false,
           "Prints runtime statistics to stderr on exit.");
 
 static iree_status_t iree_tooling_process_outputs(
-    iree_vm_list_t* outputs, iree_allocator_t host_allocator,
-    int* out_exit_code);
+    iree_hal_device_t* device, iree_vm_list_t* outputs,
+    iree_allocator_t host_allocator, int* out_exit_code);
 
 static iree_status_t iree_tooling_create_run_context(
     iree_vm_instance_t* instance, iree_string_view_t default_device_uri,
@@ -183,8 +183,8 @@ static iree_status_t iree_tooling_run_function(
   iree_vm_list_t* inputs = NULL;
   iree_status_t status = iree_status_annotate_f(
       iree_tooling_parse_to_variant_list(
-          device_allocator, FLAG_input_list().values, FLAG_input_list().count,
-          host_allocator, &inputs),
+          device, device_allocator, FLAG_input_list().values,
+          FLAG_input_list().count, host_allocator, &inputs),
       "parsing function inputs");
 
   // If the function is async add fences so we can invoke it synchronously.
@@ -249,7 +249,8 @@ static iree_status_t iree_tooling_run_function(
   // expected values (basic pass/fail testing).
   if (iree_status_is_ok(status)) {
     status = iree_status_annotate_f(
-        iree_tooling_process_outputs(outputs, host_allocator, out_exit_code),
+        iree_tooling_process_outputs(device, outputs, host_allocator,
+                                     out_exit_code),
         "processing function outputs");
   }
   iree_vm_list_release(outputs);
@@ -260,8 +261,8 @@ static iree_status_t iree_tooling_run_function(
 }
 
 static iree_status_t iree_tooling_process_outputs(
-    iree_vm_list_t* outputs, iree_allocator_t host_allocator,
-    int* out_exit_code) {
+    iree_hal_device_t* device, iree_vm_list_t* outputs,
+    iree_allocator_t host_allocator, int* out_exit_code) {
   *out_exit_code = EXIT_SUCCESS;
 
   // Basic output handling to route to the console or files.
@@ -293,7 +294,7 @@ static iree_status_t iree_tooling_process_outputs(
   iree_vm_list_t* expected_list = NULL;
   iree_status_t status = iree_status_annotate_f(
       iree_tooling_parse_to_variant_list(
-          heap_allocator, FLAG_expected_output_list().values,
+          device, heap_allocator, FLAG_expected_output_list().values,
           FLAG_expected_output_list().count, host_allocator, &expected_list),
       "parsing expected function outputs");
 

--- a/runtime/src/iree/tooling/vm_util.h
+++ b/runtime/src/iree/tooling/vm_util.h
@@ -27,7 +27,7 @@ extern "C" {
 // Uses |device_allocator| to allocate the buffers.
 // The returned variant list must be freed by the caller.
 iree_status_t iree_tooling_parse_to_variant_list(
-    iree_hal_allocator_t* device_allocator,
+    iree_hal_device_t* device, iree_hal_allocator_t* device_allocator,
     const iree_string_view_t* input_strings,
     iree_host_size_t input_strings_count, iree_allocator_t host_allocator,
     iree_vm_list_t** out_list);
@@ -40,7 +40,7 @@ iree_status_t iree_tooling_parse_to_variant_list(
 // described in iree/hal/api.h
 // Uses |device_allocator| to allocate the buffers.
 iree_status_t iree_tooling_parse_into_variant_list(
-    iree_hal_allocator_t* device_allocator,
+    iree_hal_device_t* device, iree_hal_allocator_t* device_allocator,
     const iree_string_view_t* input_strings,
     iree_host_size_t input_strings_count, iree_allocator_t host_allocator,
     iree_vm_list_t* list);

--- a/runtime/src/iree/tooling/vm_util_test.cc
+++ b/runtime/src/iree/tooling/vm_util_test.cc
@@ -18,7 +18,8 @@
 namespace iree {
 namespace {
 
-static Status ParseToVariantList(iree_hal_allocator_t* device_allocator,
+static Status ParseToVariantList(iree_hal_device_t* device,
+                                 iree_hal_allocator_t* device_allocator,
                                  iree::span<const std::string> input_strings,
                                  iree_allocator_t host_allocator,
                                  iree_vm_list_t** out_list) {
@@ -28,8 +29,8 @@ static Status ParseToVariantList(iree_hal_allocator_t* device_allocator,
     input_string_views[i].size = input_strings[i].size();
   }
   return iree_tooling_parse_to_variant_list(
-      device_allocator, input_string_views.data(), input_string_views.size(),
-      host_allocator, out_list);
+      device, device_allocator, input_string_views.data(),
+      input_string_views.size(), host_allocator, out_list);
 }
 
 static Status PrintVariantList(iree_vm_list_t* variant_list,
@@ -75,9 +76,9 @@ class VmUtilTest : public ::testing::Test {
 TEST_F(VmUtilTest, ParsePrintBuffer) {
   std::string buf_string = "&2x2xi32=[42 43][44 45]";
   vm::ref<iree_vm_list_t> variant_list;
-  IREE_ASSERT_OK(
-      ParseToVariantList(allocator_, std::vector<std::string>{buf_string},
-                         iree_vm_instance_allocator(instance_), &variant_list));
+  IREE_ASSERT_OK(ParseToVariantList(
+      device_, allocator_, std::vector<std::string>{buf_string},
+      iree_vm_instance_allocator(instance_), &variant_list));
   std::string result;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &result));
   EXPECT_EQ(result,
@@ -87,9 +88,9 @@ TEST_F(VmUtilTest, ParsePrintBuffer) {
 TEST_F(VmUtilTest, ParsePrintBufferView) {
   std::string buf_string = "2x2xi32=[42 43][44 45]";
   vm::ref<iree_vm_list_t> variant_list;
-  IREE_ASSERT_OK(
-      ParseToVariantList(allocator_, std::vector<std::string>{buf_string},
-                         iree_vm_instance_allocator(instance_), &variant_list));
+  IREE_ASSERT_OK(ParseToVariantList(
+      device_, allocator_, std::vector<std::string>{buf_string},
+      iree_vm_instance_allocator(instance_), &variant_list));
   std::string result;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &result));
   EXPECT_EQ(result,
@@ -99,9 +100,9 @@ TEST_F(VmUtilTest, ParsePrintBufferView) {
 TEST_F(VmUtilTest, ParsePrintScalar) {
   std::string input_string = "42";
   vm::ref<iree_vm_list_t> variant_list;
-  IREE_ASSERT_OK(
-      ParseToVariantList(allocator_, std::vector<std::string>{input_string},
-                         iree_vm_instance_allocator(instance_), &variant_list));
+  IREE_ASSERT_OK(ParseToVariantList(
+      device_, allocator_, std::vector<std::string>{input_string},
+      iree_vm_instance_allocator(instance_), &variant_list));
   std::string result;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &result));
   EXPECT_EQ(result, std::string("result[0]: i32=") + input_string + "\n");
@@ -110,9 +111,9 @@ TEST_F(VmUtilTest, ParsePrintScalar) {
 TEST_F(VmUtilTest, ParsePrintRank0BufferView) {
   std::string buf_string = "i32=42";
   vm::ref<iree_vm_list_t> variant_list;
-  IREE_ASSERT_OK(
-      ParseToVariantList(allocator_, std::vector<std::string>{buf_string},
-                         iree_vm_instance_allocator(instance_), &variant_list));
+  IREE_ASSERT_OK(ParseToVariantList(
+      device_, allocator_, std::vector<std::string>{buf_string},
+      iree_vm_instance_allocator(instance_), &variant_list));
   std::string result;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &result));
   EXPECT_EQ(result,
@@ -124,7 +125,7 @@ TEST_F(VmUtilTest, ParsePrintMultipleBufferViews) {
   std::string buf_string2 = "2x3xf64=[1 2 3][4 5 6]";
   vm::ref<iree_vm_list_t> variant_list;
   IREE_ASSERT_OK(ParseToVariantList(
-      allocator_, std::vector<std::string>{buf_string1, buf_string2},
+      device_, allocator_, std::vector<std::string>{buf_string1, buf_string2},
       iree_vm_instance_allocator(instance_), &variant_list));
   std::string result;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &result));

--- a/samples/custom_module/async/main.c
+++ b/samples/custom_module/async/main.c
@@ -87,13 +87,14 @@ int main(int argc, char** argv) {
   const int32_t input_data[5] = {1, 2, 3, 4, 5};
   const iree_hal_dim_t shape[1] = {IREE_ARRAYSIZE(input_data)};
   iree_hal_buffer_view_t* input_view = NULL;
-  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer(
+  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer_copy(
+      iree_runtime_session_device(session),
       iree_runtime_session_device_allocator(session), IREE_ARRAYSIZE(shape),
       shape, IREE_HAL_ELEMENT_TYPE_INT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-          .access = IREE_HAL_MEMORY_ACCESS_READ,
+          .access = IREE_HAL_MEMORY_ACCESS_ALL,
           .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
       },
       iree_make_const_byte_span(input_data, sizeof(input_data)), &input_view));

--- a/samples/custom_module/sync/main.c
+++ b/samples/custom_module/sync/main.c
@@ -90,13 +90,14 @@ int main(int argc, char** argv) {
   const int32_t input_data[5] = {1, 2, 3, 4, 5};
   const iree_hal_dim_t shape[1] = {IREE_ARRAYSIZE(input_data)};
   iree_hal_buffer_view_t* input_view = NULL;
-  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer(
+  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer_copy(
+      iree_runtime_session_device(session),
       iree_runtime_session_device_allocator(session), IREE_ARRAYSIZE(shape),
       shape, IREE_HAL_ELEMENT_TYPE_INT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-          .access = IREE_HAL_MEMORY_ACCESS_READ,
+          .access = IREE_HAL_MEMORY_ACCESS_ALL,
           .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
       },
       iree_make_const_byte_span(input_data, sizeof(input_data)), &input_view));

--- a/samples/custom_module/sync/module.cc
+++ b/samples/custom_module/sync/module.cc
@@ -118,8 +118,7 @@ class CustomModuleState final {
     vm::ref<iree_hal_buffer_t> result_buffer;
     IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
         device_allocator, buffer_params,
-        iree_hal_buffer_view_byte_length(arg_view.get()),
-        iree_const_byte_span_empty(), &result_buffer));
+        iree_hal_buffer_view_byte_length(arg_view.get()), &result_buffer));
 
     // Hacky example accessing the source contents and producing the result
     // contents. This emulates what an external library the user is calling that

--- a/samples/dynamic_shapes/main.c
+++ b/samples/dynamic_shapes/main.c
@@ -19,7 +19,8 @@ iree_status_t reduce_sum_1d(iree_runtime_session_t* session, const int* values,
 
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
+    status = iree_hal_buffer_view_allocate_buffer_copy(
+        iree_runtime_session_device(session),
         iree_runtime_session_device_allocator(session),
         IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
@@ -68,7 +69,8 @@ iree_status_t reduce_sum_2d(iree_runtime_session_t* session, const int* values,
 
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
+    status = iree_hal_buffer_view_allocate_buffer_copy(
+        iree_runtime_session_device(session),
         iree_runtime_session_device_allocator(session),
         IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
@@ -108,7 +110,8 @@ iree_status_t add_one(iree_runtime_session_t* session, const int* values,
 
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
+    status = iree_hal_buffer_view_allocate_buffer_copy(
+        iree_runtime_session_device(session),
         iree_runtime_session_device_allocator(session),
         IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,

--- a/samples/simple_embedding/simple_embedding.c
+++ b/samples/simple_embedding/simple_embedding.c
@@ -78,16 +78,16 @@ iree_status_t Run() {
   iree_hal_dim_t shape[1] = {IREE_ARRAYSIZE(kFloat4)};
   iree_hal_buffer_view_t* arg0_buffer_view = NULL;
   iree_hal_buffer_view_t* arg1_buffer_view = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
-      iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer_copy(
+      device, iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
           .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
       },
       iree_make_const_byte_span(kFloat4, sizeof(kFloat4)), &arg0_buffer_view));
-  IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
-      iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer_copy(
+      device, iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/samples/static_library/static_library_demo.c
+++ b/samples/static_library/static_library_demo.c
@@ -121,8 +121,8 @@ iree_status_t Run() {
   float kFloat2[] = {2.0f, 2.0f, 2.0f, 2.0f};
 
   if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
-        iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
+    status = iree_hal_buffer_view_allocate_buffer_copy(
+        device, iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
         IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
@@ -133,8 +133,8 @@ iree_status_t Run() {
         &arg0_buffer_view);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
-        iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
+    status = iree_hal_buffer_view_allocate_buffer_copy(
+        device, iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
         IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/samples/variables_and_state/main.c
+++ b/samples/variables_and_state/main.c
@@ -47,7 +47,8 @@ iree_status_t counter_set_value(iree_runtime_session_t* session,
 
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
+    status = iree_hal_buffer_view_allocate_buffer_copy(
+        iree_runtime_session_device(session),
         iree_runtime_session_device_allocator(session),
         /*shape_rank=*/0, /*shape=*/NULL, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
@@ -79,7 +80,8 @@ iree_status_t counter_add_to_value(iree_runtime_session_t* session, int x) {
 
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
+    status = iree_hal_buffer_view_allocate_buffer_copy(
+        iree_runtime_session_device(session),
         iree_runtime_session_device_allocator(session), /*shape_rank=*/0,
         /*shape=*/NULL, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,

--- a/tools/android/run_module_app/src/main.cc
+++ b/tools/android/run_module_app/src/main.cc
@@ -142,8 +142,8 @@ Status RunModule(const IreeModuleInvocation& invocation) {
   }
   vm::ref<iree_vm_list_t> inputs;
   IREE_RETURN_IF_ERROR(iree_tooling_parse_to_variant_list(
-      iree_hal_device_allocator(device), input_views.data(), input_views.size(),
-      iree_allocator_system(), &inputs));
+      device, iree_hal_device_allocator(device), input_views.data(),
+      input_views.size(), iree_allocator_system(), &inputs));
 
   vm::ref<iree_vm_list_t> outputs;
   IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -490,7 +490,7 @@ class IREEBenchmark {
         &function));
 
     IREE_CHECK_OK(iree_tooling_parse_to_variant_list(
-        device_allocator_.get(), FLAG_input_list().values,
+        device_.get(), device_allocator_.get(), FLAG_input_list().values,
         FLAG_input_list().count, iree_vm_instance_allocator(instance_.get()),
         &inputs_));
 

--- a/tools/iree-benchmark-trace-main.c
+++ b/tools/iree-benchmark-trace-main.c
@@ -140,8 +140,9 @@ static iree_status_t iree_replay_benchmark_run_documents(
     // loading we can do that now before processing subsequent events.
     if (iree_status_is_ok(status) && !have_parsed_inputs && replay->device) {
       status = iree_tooling_parse_into_variant_list(
-          iree_hal_device_allocator(replay->device), FLAG_input_list().values,
-          FLAG_input_list().count, replay->host_allocator, replay->inputs);
+          replay->device, iree_hal_device_allocator(replay->device),
+          FLAG_input_list().values, FLAG_input_list().count,
+          replay->host_allocator, replay->inputs);
       have_parsed_inputs = true;
     }
 

--- a/tools/iree-run-trace-main.c
+++ b/tools/iree-run-trace-main.c
@@ -187,8 +187,9 @@ static iree_status_t iree_run_trace_file(iree_string_view_t root_path,
     // loading we can do that now before processing subsequent events.
     if (!have_parsed_inputs && replay.device) {
       status = iree_tooling_parse_into_variant_list(
-          iree_hal_device_allocator(replay.device), FLAG_input_list().values,
-          FLAG_input_list().count, replay.host_allocator, replay.inputs);
+          replay.device, iree_hal_device_allocator(replay.device),
+          FLAG_input_list().values, FLAG_input_list().count,
+          replay.host_allocator, replay.inputs);
       have_parsed_inputs = true;
     }
     if (!iree_status_is_ok(status)) break;


### PR DESCRIPTION
I didn't really like this when I added it and this reverts it back to
the original behavior of requiring users to allocate and then transfer
whatever they want in their buffers. All implementations besides local
CPU and WebGPU were staging via the extremely inefficient and blocking
synchronous transfer path and we don't want to encourage that - users
must make the decision as to whether they want to synchronously
transfer (in which case it's just an iree_hal_device_transfer_* call)
or asynchronously transfer from files or queue copies.

This likely breaks WebGPU but we can fix that with better solutions -
the existing approach worked a bit but ran down code paths that were
dangerously close to blocking and it didn't account for a lot of buffer
types.

Progress on https://github.com/openxla/iree/issues/14607.
Fixes https://github.com/openxla/iree/issues/14605.