### PR TITLE
Set benchmark repetition in capture mode

### DIFF
--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -151,7 +151,7 @@ def get_iree_benchmark_module_arguments(
     elif capture_mode:
         # Capture mode is slower and we just need enough repetition to collect
         # trace after the warmup phase.
-        repetitions = 3
+        repetitions = 4
     else:
         repetitions = 10
 

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -137,8 +137,8 @@ def get_git_commit_hash(commit: str) -> str:
 
 
 def get_iree_benchmark_module_arguments(
-    results_filename: str,
     driver_info: DriverInfo,
+    results_filename: Optional[str] = None,
     benchmark_min_time: Optional[float] = None,
 ):
     """Returns the common arguments to run iree-benchmark-module."""
@@ -150,13 +150,16 @@ def get_iree_benchmark_module_arguments(
     else:
         repetitions = 10
 
-    cmd = [
-        "--time_unit=ns",
-        "--benchmark_format=json",
-        "--benchmark_out_format=json",
-        f"--benchmark_out={results_filename}",
-        "--print_statistics=true",
-    ]
+    cmd = []
+    if results_filename is not None:
+        cmd += [
+            "--time_unit=ns",
+            "--benchmark_format=json",
+            "--benchmark_out_format=json",
+            "--print_statistics=true",
+            f"--benchmark_out={results_filename}",
+        ]
+
     if benchmark_min_time:
         cmd.extend(
             [

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -140,12 +140,17 @@ def get_iree_benchmark_module_arguments(
     driver_info: DriverInfo,
     results_filename: Optional[str] = None,
     benchmark_min_time: Optional[float] = None,
+    capture_mode = False,
 ):
     """Returns the common arguments to run iree-benchmark-module."""
 
     if driver_info.loader_name == "vmvx-module":
         # VMVX is very unoptimized for now and can take a long time to run.
         # Decrease the repetition for it until it's reasonably fast.
+        repetitions = 3
+    elif capture_mode:
+        # Capture mode is slower and we just need enough repetition to collect
+        # trace after the warmup phase.
         repetitions = 3
     else:
         repetitions = 10

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -140,7 +140,7 @@ def get_iree_benchmark_module_arguments(
     driver_info: DriverInfo,
     results_filename: Optional[str] = None,
     benchmark_min_time: Optional[float] = None,
-    capture_mode = False,
+    capture_mode=False,
 ):
     """Returns the common arguments to run iree-benchmark-module."""
 

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -124,6 +124,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
                 get_iree_benchmark_module_arguments(
                     driver_info=benchmark_case.driver_info,
                     benchmark_min_time=self.config.benchmark_min_time,
+                    capture_mode=True,
                 )
             )
 

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -112,11 +112,20 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         if capture_config is None:
             raise ValueError("capture_config can't be None.")
 
+        tool_name = benchmark_case.benchmark_tool_name
         tool_path = (
             capture_config.traced_benchmark_tool_dir
             / benchmark_case.benchmark_tool_name
         )
         cmd = self.__build_tool_cmds(benchmark_case=benchmark_case, tool_path=tool_path)
+
+        if tool_name == "iree-benchmark-module":
+            cmd.extend(
+                get_iree_benchmark_module_arguments(
+                    driver_info=benchmark_case.driver_info,
+                    benchmark_min_time=self.config.benchmark_min_time,
+                )
+            )
 
         process = subprocess.Popen(
             cmd, env={"TRACY_NO_EXIT": "1"}, stdout=subprocess.PIPE, text=True


### PR DESCRIPTION
Historically we don't run benchmarks with multiple repetitions (`--benchmark_repetitions`) when capturing traces but only in the normal runs (10 repetitions by default). I suspect it was to save the total run time.

However in some benchmarks the first warm-up iteration is significantly slower than the follow-up runs. This creates issues when we want to investigate the regressions on normal runs with the captured traces.

Ideally we should use the same repetitions in both normal and capture runs, however that will increase the total run time too much (>1hr on Pixel 6 benchmarks). This change is trying to find a balance between them and only runs 4 repetitions in capture mode, which at least captures the iterations after the warmup.

![image](https://github.com/openxla/iree/assets/2104162/f5024808-e02e-4443-8425-f3e643e26207)

Testing all benchmarks on https://github.com/openxla/iree/actions/runs/5871720156

Before:

![image](https://github.com/openxla/iree/assets/2104162/e068528a-80e8-417e-861f-d1e8ca8d5424)

After:

![image](https://github.com/openxla/iree/assets/2104162/5210d1e8-e1db-4132-ae28-e837f4560c04)

