### PR TITLE
Add a StableHLO canonicalizer that rewrites transpose as reshape.

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -993,20 +993,11 @@ struct TransposeIsReshape final
     }
 
     auto inputTy = dyn_cast<RankedTensorType>(input.getType());
-    if (!inputTy) {
+    if (!inputTy || !inputTy.hasStaticShape() ||
+        !op.getType().hasStaticShape()) {
       return rewriter.notifyMatchFailure(
-          op, "requires input to be of a ranked tensor type");
-    }
-
-    int64_t numDynDims = 0;
-    for (int i = 0; i < inputTy.getRank(); ++i) {
-      if (inputTy.isDynamicDim(i)) {
-        numDynDims++;
-      }
-    }
-
-    if (numDynDims > 1) {
-      return rewriter.notifyMatchFailure(op, "has more than one dynamic dim.");
+          op, "requires input/output to be of a statically-shaped ranked "
+              "tensor type");
     }
 
     SmallVector<int64_t> permValues = llvm::to_vector<6>(

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Canonicalization.cpp
@@ -1000,9 +1000,7 @@ struct TransposeIsReshape final
               "tensor type");
     }
 
-    SmallVector<int64_t> permValues = llvm::to_vector<6>(
-        llvm::map_range(permutation.getValues<APInt>(),
-                        [](const APInt &val) { return val.getSExtValue(); }));
+    SmallVector<int64_t> permValues(permutation.getValues<int64_t>());
 
     SmallVector<int64_t> nonZeroPerms;
     nonZeroPerms.reserve(permValues.size());


### PR DESCRIPTION
The canonicalization also "swallows" the TransposeOpCanon out of convenience, since the check has to happen either way (and a NoOp should take priority over different-op lowering).