### PR TITLE
Populate __init__.py files for top level runtime packages.

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -122,6 +122,7 @@ iree_py_library(
     "iree/runtime/system_setup.py"
     "iree/runtime/tracing.py"
     "iree/runtime/version.py"
+    "iree/_runtime/__init__.py"
     "iree/_runtime/libs.py"
     "iree/_runtime/scripts/iree_benchmark_trace/__main__.py"
     "iree/_runtime/scripts/iree_benchmark_module/__main__.py"

--- a/runtime/bindings/python/iree/_runtime/README.md
+++ b/runtime/bindings/python/iree/_runtime/README.md
@@ -1,7 +1,7 @@
 # Non user-API runtime support.
 
 This package contains elements of the runtime which are not user
-visible parts of the API. It is a pure namespace package that does
+visible parts of the API. It is a pure source package that does
 no native initialization by default (unlike the `runtime` package
 which initializes the native library as part of exporting its API).
 


### PR DESCRIPTION
These packages were never meant to be namespace packages. Adding an __init__.py turns them into regular packages, which are a bit better supported by tooling (still).