### PR TITLE
clean up bindist before each package is built

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -172,6 +172,7 @@ jobs:
           packages: "iree-runtime"
           output_dir: "${{ github.workspace }}/bindist"
         run: |
+          [ -e ./bindist/* ] && rm ./bindist/*
           ./c/build_tools/python_deploy/build_linux_packages.sh
 
       - name: Build runtime wheels (MacOS)
@@ -183,6 +184,7 @@ jobs:
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11"
         run: |
+          [ -e ./bindist/* ] && rm ./bindist/*
           ./c/build_tools/python_deploy/build_macos_packages.sh
 
       - name: Build runtime wheels (Windows)
@@ -193,7 +195,11 @@ jobs:
           packages: "iree-runtime"
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11"
-        run: ./c/build_tools/python_deploy/build_windows_packages.ps1
+        run: |
+          if (Test-Path -Path "${{ github.workspace }}/bindist") {
+            Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force
+          }
+          ./c/build_tools/python_deploy/build_windows_packages.ps1
 
       ##########################################################################
       # py-compiler-pkg
@@ -208,6 +214,7 @@ jobs:
           packages: "iree-compiler"
           output_dir: "${{ github.workspace }}/bindist"
         run: |
+          [ -e ./bindist/* ] && rm ./bindist/*
           ./c/build_tools/python_deploy/build_linux_packages.sh
 
       - name: Build compiler wheels (MacOS)
@@ -219,6 +226,7 @@ jobs:
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11"
         run: |
+          [ -e ./bindist/* ] && rm ./bindist/*
           ./c/build_tools/python_deploy/build_macos_packages.sh
 
       - name: Build compiler wheels (Windows)
@@ -229,7 +237,11 @@ jobs:
           packages: "iree-compiler"
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11"
-        run: ./c/build_tools/python_deploy/build_windows_packages.ps1
+        run: |
+          if (Test-Path -Path "${{ github.workspace }}/bindist") {
+            Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force
+          }
+          ./c/build_tools/python_deploy/build_windows_packages.ps1
 
       ##########################################################################
       # TF Compiler Tools


### PR DESCRIPTION
This avoids self hosted runners from trying to upload old artifacts. 

Tested here: 

https://github.com/nod-ai/SRT/actions/runs/5872178100