### PR TITLE
NFC: Move RematerializeParallelOps to CodeGen/Common

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -180,6 +180,7 @@ iree_compiler_cc_library(
         "PadDynamicAlloc.cpp",
         "Passes.cpp",
         "PolynomialApproximationPass.cpp",
+        "RematerializeParallelOps.cpp",
         "RemoveTrivialLoops.cpp",
         "SplitFullPartialTransferPass.cpp",
         "TestExecutablePreprocessing.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -155,6 +155,7 @@ iree_cc_library(
     "PadDynamicAlloc.cpp"
     "Passes.cpp"
     "PolynomialApproximationPass.cpp"
+    "RematerializeParallelOps.cpp"
     "RemoveTrivialLoops.cpp"
     "SplitFullPartialTransferPass.cpp"
     "TestExecutablePreprocessing.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -194,6 +194,10 @@ std::unique_ptr<OperationPass<func::FuncOp>> createPadDynamicAlloc();
 /// Pass to convert math operations to their polynomial approximation.
 std::unique_ptr<OperationPass<>> createPolynomialApproximationPass();
 
+/// Pass to fuse parallel linalg operations.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createRematerializeParallelOpsPass();
+
 /// Creates a pass to remove single iteration distributed loops.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createRemoveSingleIterationLoopPass();

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -340,7 +340,7 @@ def PolynomialApproximationPass :
 
 def RematerializeParallelOps :
     Pass<"iree-codegen-rematerialize-parallel-ops", "func::FuncOp"> {
-  let summary = "Pass to rematerialize and merge parallel ops on pre-formed dispatches.";
+  let summary = "Pass to rematerialize and merge parallel ops into consumers.";
   let constructor = "mlir::iree_compiler::createRematerializeParallelOpsPass()";
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -338,6 +338,12 @@ def PolynomialApproximationPass :
       "mlir::iree_compiler::createPolynomialApproximationPass()";
 }
 
+def RematerializeParallelOps :
+    Pass<"iree-codegen-rematerialize-parallel-ops", "func::FuncOp"> {
+  let summary = "Pass to rematerialize and merge parallel ops on pre-formed dispatches.";
+  let constructor = "mlir::iree_compiler::createRematerializeParallelOpsPass()";
+}
+
 def RemoveSingleIterationLoop :
     Pass<"iree-codegen-remove-single-iteration-loop", "func::FuncOp"> {
   let summary = "Remove distributed loop with single iteration.";

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -4,19 +4,17 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/PassDetail.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
-#include "iree/compiler/Preprocessing/Common/PassDetail.h"
-#include "iree/compiler/Preprocessing/Common/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#define DEBUG_TYPE "iree-preprocessing-rematerialize-parallel-ops"
+#define DEBUG_TYPE "iree-codegen-rematerialize-parallel-ops"
 
 namespace mlir {
 namespace iree_compiler {
-namespace IREE {
 
 namespace {
 
@@ -35,11 +33,6 @@ struct RematerializeParallelOpsPattern
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
-    // Restrict to operations within pre-formed dispatches to avoid blanket
-    // rematerialization over the whole model.
-    if (Flow::isNonNullAndOutsideDispatch(genericOp))
-      return failure();
-
     // Avoid doing this for scalar operations.
     auto isScalarValue = [](Value v) {
       return isScalarOrTensorOfSizeOne(v.getType());
@@ -88,6 +81,5 @@ createRematerializeParallelOpsPass() {
   return std::make_unique<RematerializeParallelOpsPass>();
 }
 
-} // namespace IREE
 } // namespace iree_compiler
 } // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -6,7 +6,6 @@
 
 #include "iree/compiler/Codegen/Common/PassDetail.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
-#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -49,6 +49,7 @@ iree_lit_test_suite(
             "pad_dynamic_alloc.mlir",
             "polynomial_approximation.mlir",
             "reductions.mlir",
+            "rematerialize_parallel_ops.mlir",
             "remove_dead_allocs.mlir",
             "remove_trivial_loops.mlir",
             "repeated_matcher_use.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_lit_test_suite(
     "pad_dynamic_alloc.mlir"
     "polynomial_approximation.mlir"
     "reductions.mlir"
+    "rematerialize_parallel_ops.mlir"
     "remove_dead_allocs.mlir"
     "remove_trivial_loops.mlir"
     "repeated_matcher_use.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/rematerialize_parallel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/rematerialize_parallel_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -iree-preprocessing-rematerialize-parallel-ops %s | FileCheck %s
+// RUN: iree-opt -iree-codegen-rematerialize-parallel-ops %s | FileCheck %s
 
 func.func @merged_reduction_parallel(%0: tensor<1x40960xf32>, %1: tensor<1xf32>, %7: tensor<1xf32>)
   -> tensor<1x40960xf32> {
@@ -137,43 +137,3 @@ func.func @no_rematerialize_scalar_ops(%arg0 : tensor<f32>) -> tensor<f32> {
 //       CHECK:   linalg.generic
 //       CHECK:   linalg.generic
 //       CHECK:   linalg.generic
-
-// -----
-
-func.func @no_rematerialize_non_dispatch(%0: tensor<1x40960xf32>, %1: tensor<1xf32>, %7: tensor<1xf32>)
-  -> tensor<1x40960xf32> {
-   %2 = tensor.empty() : tensor<1x40960xf32>
-   %cst = arith.constant -3.40282347E+38 : f32
-   %8 = linalg.generic
-   {indexing_maps = [
-       affine_map<(d0, d1) -> (d0, d1)>,
-       affine_map<(d0, d1) -> (d0)>,
-       affine_map<(d0, d1) -> (d0, d1)>],
-       iterator_types = ["parallel", "parallel"]}
-       ins(%0, %1 : tensor<1x40960xf32>, tensor<1xf32>)
-       outs(%2 : tensor<1x40960xf32>) {
-     ^bb0(%in: f32, %in_2: f32, %out: f32):
-       %10 = arith.subf %in, %in_2 : f32
-       %11 = math.exp %10 : f32
-       linalg.yield %11 : f32
-     } -> (tensor<1x40960xf32>)
-   %9 = linalg.generic {
-       indexing_maps = [
-           affine_map<(d0, d1) -> (d0, d1)>,
-           affine_map<(d0, d1) -> (d0)>,
-           affine_map<(d0, d1) -> (d0, d1)>],
-           iterator_types = ["parallel", "parallel"]}
-           ins(%8, %7 : tensor<1x40960xf32>, tensor<1xf32>)
-           outs(%2 : tensor<1x40960xf32>) {
-     ^bb0(%in: f32, %in_2: f32, %out: f32):
-       %10 = arith.divf %cst, %in_2 : f32
-       %11 = arith.mulf %in, %10 : f32
-       linalg.yield %11 : f32
-     } -> tensor<1x40960xf32>
-   return %9 : tensor<1x40960xf32>
-}
-
-
-//   CHECK-LABEL: func.func @no_rematerialize_non_dispatch
-//         CHECK:   linalg.generic
-//         CHECK:   linalg.generic

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -35,7 +35,6 @@ iree_compiler_cc_library(
         "PadLinalgOps.cpp",
         "PassDetail.h",
         "Passes.cpp",
-        "RematerializeParallelOps.cpp",
     ],
     hdrs = [
         "Passes.h",

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -31,7 +31,6 @@ iree_cc_library(
     "PadLinalgOps.cpp"
     "PassDetail.h"
     "Passes.cpp"
-    "RematerializeParallelOps.cpp"
   DEPS
     ::PassesIncGen
     LLVMSupport

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
@@ -28,10 +28,6 @@ createMakeSingleDispatchForFunctionPass();
 /// A pass to pad linalg ops to the next integer multiple of `paddingSize`.
 std::unique_ptr<Pass> createPadLinalgOpsToIntegerMultiplePass();
 
-/// Pass to merge parallel linalg operations.
-std::unique_ptr<OperationPass<func::FuncOp>>
-createRematerializeParallelOpsPass();
-
 //===----------------------------------------------------------------------===//
 // Register all Passes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -32,10 +32,4 @@ def PadLinalgOps :
   ];
 }
 
-def RematerializeParallelOps :
-    Pass<"iree-preprocessing-rematerialize-parallel-ops", "func::FuncOp"> {
-  let summary = "Pass to rematerialize and merge parallel ops on pre-formed dispatches.";
-  let constructor = "mlir::iree_compiler::IREE::createRematerializeParallelOpsPass()";
-}
-
 #endif  // IREE_PREPROCESSING_COMMON_PASSES

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
@@ -19,7 +19,6 @@ iree_lit_test_suite(
             "conv2d_to_img2col.mlir",
             "make_single_dispatch_for_function.mlir",
             "pad_linalg_ops.mlir",
-            "rematerialize_parallel_ops.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
@@ -17,7 +17,6 @@ iree_lit_test_suite(
     "conv2d_to_img2col.mlir"
     "make_single_dispatch_for_function.mlir"
     "pad_linalg_ops.mlir"
-    "rematerialize_parallel_ops.mlir"
   TOOLS
     FileCheck
     iree-opt


### PR DESCRIPTION
This is in preparation for usage in SPIR-V subgroup reduction pipeline later. It will not be enabled for all pipelines.