### PR TITLE
Fix ROCm conformance tests

### DIFF
--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -23,6 +23,8 @@ include(CMakeParseArguments)
 #       `-iree-hal-target-backends` option of `iree-compile` to use for
 #       executable generation. If this is omitted, or the associated compiler
 #       target is not enabled, tests which use executables will be disabled.
+#   COMPILER_FLAGS: Additional compiler flags.
+#       Example: "--iree-llvmcpu-target-float-abi=hard --iree-llvmcpu-loop-unrolling"
 #   EXECUTABLE_FORMAT: Executable format identifier. Will be interpreted
 #       literally in C++ and may include macros like IREE_ARCH as needed.
 #       Examples:
@@ -46,7 +48,7 @@ function(iree_hal_cts_test_suite)
     _RULE
     ""
     "DRIVER_NAME;VARIANT_SUFFIX;DRIVER_REGISTRATION_HDR;DRIVER_REGISTRATION_FN;COMPILER_TARGET_BACKEND;EXECUTABLE_FORMAT"
-    "DEPS;ARGS;INCLUDED_TESTS;EXCLUDED_TESTS;LABELS"
+    "DEPS;ARGS;COMPILER_FLAGS;INCLUDED_TESTS;EXCLUDED_TESTS;LABELS;"
     ${ARGN}
   )
 
@@ -83,6 +85,7 @@ function(iree_hal_cts_test_suite)
     set(_TRANSLATE_FLAGS
       "--compile-mode=hal-executable"
       "--iree-hal-target-backends=${_RULE_COMPILER_TARGET_BACKEND}"
+      ${_RULE_COMPILER_FLAGS}
     )
 
     # Skip if already created (multiple suites using the same compiler setting).

--- a/experimental/rocm/CMakeLists.txt
+++ b/experimental/rocm/CMakeLists.txt
@@ -12,6 +12,16 @@ cmake_path(ABSOLUTE_PATH IREE_PACKAGE_ROOT_DIR
   OUTPUT_VARIABLE IREE_PACKAGE_ROOT_DIR)
 set(IREE_PACKAGE_ROOT_PREFIX iree)
 
+set(IREE_ROCM_TARGET_CHIP_DEFAULT "gfx908")
+set(IREE_ROCM_TARGET_CHIP "${IREE_ROCM_TARGET_CHIP_DEFAULT}" CACHE STRING
+  "Target chip for ROCm. This influences conformance tests that need to compile device code. Defaults to \"${IREE_ROCM_TARGET_CHIP_DEFAULT}\".")
+set(IREE_ROCM_LINK_BC_DEFAULT OFF)
+set(IREE_ROCM_LINK_BC ${IREE_ROCM_LINK_BC_DEFAULT} CACHE BOOL
+  "Whether to try Linking to AMD Bitcodes. This influences conformance tests that need to compile device code. Defaults to ${IREE_ROCM_LINK_BC}.")
+set(IREE_ROCM_BC_DIR_DEFAULT "/opt/rocm/amdgcn/bitcode")
+set(IREE_ROCM_BC_DIR "${IREE_ROCM_BC_DIR_DEFAULT}" CACHE STRING
+  "Directory of ROCM Bitcode. This influences conformance tests that need to compile device code. Defaults to \"${IREE_ROCM_TARGET_CHIP_DEFAULT}\".")
+
 iree_add_all_subdirs()
 
 if(NOT ROCM_HEADERS_API_ROOT)

--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 iree_hal_cts_test_suite(
   DRIVER_NAME
-    experimental_rocm
+    rocm
   DRIVER_REGISTRATION_HDR
     "experimental/rocm/registration/driver_module.h"
   DRIVER_REGISTRATION_FN

--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -4,6 +4,16 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+unset(COMPILER_FLAGS)
+if(IREE_ROCM_LINK_BC)
+  list(APPEND COMPILER_FLAGS "--iree-rocm-link-bc=true")
+else()
+  list(APPEND COMPILER_FLAGS "--iree-rocm-link-bc=false")
+endif()
+list(APPEND COMPILER_FLAGS
+  "--iree-rocm-target-chip=${IREE_ROCM_TARGET_CHIP}"
+  "--iree-rocm-bc-dir=${IREE_ROCM_BC_DIR}")
+
 iree_hal_cts_test_suite(
   DRIVER_NAME
     rocm
@@ -15,6 +25,8 @@ iree_hal_cts_test_suite(
     "rocm"
   EXECUTABLE_FORMAT
     "\"PTXE\""
+  COMPILER_FLAGS
+    ${COMPILER_FLAGS}
   DEPS
     iree::experimental::rocm::registration
   EXCLUDED_TESTS

--- a/runtime/src/iree/hal/cts/command_buffer_push_constants_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_push_constants_test.h
@@ -78,7 +78,7 @@ class command_buffer_push_constants_test : public CtsTestBase {
 };
 
 TEST_P(command_buffer_push_constants_test, DispatchWithPushConstants) {
-  PrepareExecutable();
+  ASSERT_NO_FATAL_FAILURE(PrepareExecutable());
 
   iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(


### PR DESCRIPTION
This PR requires to expose additional compiler arguments with HAL conformance test that require compilation of MLIR.
I added them here. I can put them in a separate PR. 