### PR TITLE
Turn on `-Werror` in GCC

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -205,9 +205,9 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     # intrinsics (#14168).
     "-fno-lax-vector-conversions"
 
-  # TODO(#6959): Enable -Werror once we have a presubmit CI.
   GCC
     "-Wall"
+    "-Werror"
     "-Wno-address-of-packed-member"
     "-Wno-comment"
     "-Wno-format-zero-length"


### PR DESCRIPTION
Cleaned up all the existing GCC warnings via #14507 Turn on `-Werror` to catch future build problem in CI.