### PR TITLE
[spirv] Improve CodeGen flow for transposed matmul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -62,6 +62,7 @@ iree_compiler_cc_library(
         "SPIRVDistribute.cpp",
         "SPIRVEmulateI64.cpp",
         "SPIRVEraseStorageBufferStaticShape.cpp",
+        "SPIRVGeneralizeNamedOps.cpp",
         "SPIRVLowerExecutableTargetPass.cpp",
         "SPIRVMapMemRefStorageClass.cpp",
         "SPIRVTile.cpp",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_cc_library(
     "SPIRVDistribute.cpp"
     "SPIRVEmulateI64.cpp"
     "SPIRVEraseStorageBufferStaticShape.cpp"
+    "SPIRVGeneralizeNamedOps.cpp"
     "SPIRVLowerExecutableTargetPass.cpp"
     "SPIRVMapMemRefStorageClass.cpp"
     "SPIRVTile.cpp"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -600,6 +600,9 @@ void addSPIRVTransformDialectPassPipeline(OpPassManager &pm) {
 
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
   addCommonTargetExecutablePreprocessingPasses(pm.nest<ModuleOp>());
+  auto &nestedModulePM = pm.nest<ModuleOp>();
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createSPIRVGeneralizeNamedOpsPass());
   pm.addPass(createSPIRVLowerExecutableTargetPass());
 
   addMemRefLoweringPasses(pm.nest<ModuleOp>());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -95,6 +95,11 @@ createSPIRVEraseStorageBufferStaticShapePass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVFoldProcessorIDUsesPass();
 
+// This pass generalizes linalg.matmul_transpose_b ops that are equivalent
+// to a transposed matvec op (have a unit dimension in the output)
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVGeneralizeNamedOpsPass();
+
 /// Main pass to lower executables to scalar + vector code on SPIR-V path.
 /// Invokes one of the pass pipelines that translate the executable to
 /// scalar + vector code.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -95,8 +95,7 @@ createSPIRVEraseStorageBufferStaticShapePass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVFoldProcessorIDUsesPass();
 
-// This pass generalizes linalg.matmul_transpose_b ops that are equivalent
-// to a transposed matvec op (have a unit dimension in the output)
+// This pass generalizes named Linalg ops that are better off as generics.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVGeneralizeNamedOpsPass();
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
@@ -60,7 +60,7 @@ def SPIRVEraseStorageBufferStaticShape :
 
 def SPIRVGeneralizeNamedOps :
     Pass<"iree-spirv-generalize-named-ops", "func::FuncOp"> {
-  let summary = "Convert linalg.matmul_transpose_b ops into linalg.generics";
+  let summary = "Convert named Linalg ops to linalg.generic ops";
   let constructor = "mlir::iree_compiler::createSPIRVGeneralizeNamedOpsPass()";
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
@@ -58,6 +58,12 @@ def SPIRVEraseStorageBufferStaticShape :
   let constructor = "mlir::iree_compiler::createSPIRVEraseStorageBufferStaticShapePass()";
 }
 
+def SPIRVGeneralizeNamedOps :
+    Pass<"iree-spirv-generalize-named-ops", "func::FuncOp"> {
+  let summary = "Convert linalg.matmul_transpose_b ops into linalg.generics";
+  let constructor = "mlir::iree_compiler::createSPIRVGeneralizeNamedOpsPass()";
+}
+
 def SPIRVLowerExecutableTarget :
     Pass<"iree-spirv-lower-executable-target-pass",
          "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVGeneralizeNamedOps.cpp
@@ -1,0 +1,71 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- SPIRVGeneralizeNamedOps.cpp - Pass to generalize ---------===//
+//===- linalg.matmul_transpose_b LinalgOps with unit dimensions -----------===//
+//
+// The pass is to generalize linalg.matmul_transpose_b ops that are equivalent
+// to a transposed matvec op
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/SPIRV/PassDetail.h"
+#include "iree/compiler/Codegen/SPIRV/Passes.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+struct SPIRVGeneralizeNamedOpsPass
+    : public SPIRVGeneralizeNamedOpsBase<
+          SPIRVGeneralizeNamedOpsPass> {
+
+  void runOnOperation() override;
+};
+} // namespace
+
+// Check if any of the input dimensions are static 1
+static bool hasUnitDims(linalg::MatmulTransposeBOp linalgOp) {
+  auto initDims =
+      llvm::cast<ShapedType>(linalgOp.getDpsInitOperand(0)->get().getType())
+          .getShape();
+  return (llvm::any_of(initDims, [](auto dim) {
+    return !ShapedType::isDynamic(dim) && dim == 1;
+  }));
+}
+
+void SPIRVGeneralizeNamedOpsPass::runOnOperation() {
+  auto funcOp = getOperation();
+  SmallVector<linalg::MatmulTransposeBOp> namedOpCandidates;
+  funcOp.walk([&](linalg::MatmulTransposeBOp linalgOp) {
+    if (isa_and_nonnull<linalg::MatmulTransposeBOp>(linalgOp.getOperation())) {
+      if (hasUnitDims(linalgOp))
+        namedOpCandidates.push_back(linalgOp);
+    }
+  });
+
+  IRRewriter rewriter(&getContext());
+  for (auto linalgOp : namedOpCandidates) {
+    rewriter.setInsertionPoint(linalgOp);
+    FailureOr<linalg::GenericOp> generalizedOp =
+        linalg::generalizeNamedOp(rewriter, linalgOp);
+    if (failed(generalizedOp)) {
+      linalgOp->emitOpError("failed to generalize operation");
+      return signalPassFailure();
+    }
+  }
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVGeneralizeNamedOpsPass() {
+  return std::make_unique<SPIRVGeneralizeNamedOpsPass>();
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -41,6 +41,7 @@ iree_lit_test_suite(
             "distribute_to_invocations.mlir",
             "emulate_i64.mlir",
             "erase_storage_buffer_static_shape.mlir",
+            "generalize_named_ops.mlir",
             "illegal_configuration.mlir",
             "lowering_matmul_fusion.mlir",
             "lowering_matmul_promotion.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_lit_test_suite(
     "distribute_to_invocations.mlir"
     "emulate_i64.mlir"
     "erase_storage_buffer_static_shape.mlir"
+    "generalize_named_ops.mlir"
     "illegal_configuration.mlir"
     "lowering_matmul_fusion.mlir"
     "lowering_matmul_promotion.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/generalize_named_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/generalize_named_ops.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-opt --split-input-file --iree-spirv-generalize-named-ops %s | FileCheck %s
+
+module {
+  func.func @transpose_matmul(%arg0: tensor<1x4096xf32>, %arg1: tensor<32000x4096xf32>) -> tensor<1x32000xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x32000xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x32000xf32>) -> tensor<1x32000xf32>
+    %2 = linalg.matmul_transpose_b ins(%arg0, %arg1 : tensor<1x4096xf32>, tensor<32000x4096xf32>) outs(%1 : tensor<1x32000xf32>) -> tensor<1x32000xf32>
+    return %2 : tensor<1x32000xf32>
+  }
+}
+
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK:      func.func @transpose_matmul(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x4096xf32>, %[[ARG1:[a-zA-Z0-9_]+]]: tensor<32000x4096xf32>) -> tensor<1x32000xf32>
+// CHECK:      %[[FILL:.+]] = linalg.fill
+// CHECK-SAME: -> tensor<1x32000xf32>
+// CHECK:      %[[GEN:.+]] = linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[ARG0]], %[[ARG1]] : tensor<1x4096xf32>, tensor<32000x4096xf32>)
+// CHECK-SAME: outs(%[[FILL]] : tensor<1x32000xf32>)
+// CHECK:      ^bb0(%[[IN:.+]]: f32, %[[IN0:.+]]: f32, %[[OUT:.+]]: f32)
+// CHECK:      %[[A0:.+]] = arith.mulf %[[IN]], %[[IN0]] : f32
+// CHECK:      %[[A1:.+]] = arith.addf %[[OUT]], %[[A0]] : f32
+// CHECK:      linalg.yield %[[A1]] : f32
+// CHECK:      return %[[GEN]] : tensor<1x32000xf32>
+
+// -----
+
+module {
+  func.func @transpose_matmul_no_unit(%arg0: tensor<2x4096xf32>, %arg1: tensor<32000x4096xf32>) -> tensor<2x32000xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<2x32000xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<2x32000xf32>) -> tensor<2x32000xf32>
+    %2 = linalg.matmul_transpose_b ins(%arg0, %arg1 : tensor<2x4096xf32>, tensor<32000x4096xf32>) outs(%1 : tensor<2x32000xf32>) -> tensor<2x32000xf32>
+    return %2 : tensor<2x32000xf32>
+  }
+}
+
+// CHECK:      func.func @transpose_matmul_no_unit(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x4096xf32>, %[[ARG1:[a-zA-Z0-9_]+]]: tensor<32000x4096xf32>)
+// CHECK:      %[[MM:.+]] = linalg.matmul_transpose_b ins(%[[ARG0]], %[[ARG1]] : tensor<2x4096xf32>, tensor<32000x4096xf32>)
+// CHECK:      return %[[MM]] : tensor<2x32000xf32>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/generalize_named_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/generalize_named_ops.mlir
@@ -26,19 +26,3 @@ module {
 // CHECK:      %[[A1:.+]] = arith.addf %[[OUT]], %[[A0]] : f32
 // CHECK:      linalg.yield %[[A1]] : f32
 // CHECK:      return %[[GEN]] : tensor<1x32000xf32>
-
-// -----
-
-module {
-  func.func @transpose_matmul_no_unit(%arg0: tensor<2x4096xf32>, %arg1: tensor<32000x4096xf32>) -> tensor<2x32000xf32> {
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = tensor.empty() : tensor<2x32000xf32>
-    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<2x32000xf32>) -> tensor<2x32000xf32>
-    %2 = linalg.matmul_transpose_b ins(%arg0, %arg1 : tensor<2x4096xf32>, tensor<32000x4096xf32>) outs(%1 : tensor<2x32000xf32>) -> tensor<2x32000xf32>
-    return %2 : tensor<2x32000xf32>
-  }
-}
-
-// CHECK:      func.func @transpose_matmul_no_unit(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x4096xf32>, %[[ARG1:[a-zA-Z0-9_]+]]: tensor<32000x4096xf32>)
-// CHECK:      %[[MM:.+]] = linalg.matmul_transpose_b ins(%[[ARG0]], %[[ARG1]] : tensor<2x4096xf32>, tensor<32000x4096xf32>)
-// CHECK:      return %[[MM]] : tensor<2x32000xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -27,6 +28,54 @@ namespace Flow {
 
 namespace {
 
+// Method to match a transpose operation.
+static bool match2DTranspose(linalg::LinalgOp genericOp) {
+  if (genericOp.getNumDpsInputs() != 1 || genericOp.getNumDpsInits() != 1) {
+    return false;
+  }
+  // Check only for 2D ops.
+  if (genericOp.getNumLoops() != 2 ||
+      genericOp.getNumLoops() != genericOp.getNumParallelLoops()) {
+    return false;
+  }
+  // Check for transpose map.
+  AffineExpr d0, d1;
+  MLIRContext *context = genericOp.getContext();
+  bindDims(context, d0, d1);
+  SmallVector<AffineMap> expectedMaps = {
+      AffineMap::get(2, 0, {d0, d1}, context),
+      AffineMap::get(2, 0, {d1, d0}, context)};
+  if (genericOp.getIndexingMapsArray() != expectedMaps) {
+    return false;
+  }
+
+  Block *body = genericOp.getBlock();
+  if (!llvm::hasSingleElement(*body)) {
+    return false;
+  }
+  auto yieldOp = cast<linalg::YieldOp>(body->getTerminator());
+  auto blockArg = yieldOp.getOperand(0).dyn_cast<BlockArgument>();
+  if (!blockArg || blockArg.getOwner() != body ||
+      blockArg.getArgNumber() != 0) {
+    return false;
+  }
+  return true;
+}
+
+// Method to match a linalg.matmul(a, linalg.transpose(b)). Returns `b` on
+// success.
+std::optional<Value> matchATransposeBMatmul(linalg::LinalgOp matmulOp) {
+  if (!isa<linalg::MatmulOp>(matmulOp.getOperation())) {
+    return std::nullopt;
+  }
+  auto rhs = matmulOp.getDpsInputOperand(1);
+  auto genericOp = rhs->get().getDefiningOp<linalg::GenericOp>();
+  if (genericOp && match2DTranspose(genericOp)) {
+    return genericOp.getDpsInputOperand(0)->get();
+  }
+  return std::nullopt;
+}
+
 struct RaiseSpecialOpsPass : public RaiseSpecialOpsBase<RaiseSpecialOpsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::LinalgExt::IREELinalgExtDialect>();
@@ -34,6 +83,7 @@ struct RaiseSpecialOpsPass : public RaiseSpecialOpsBase<RaiseSpecialOpsPass> {
 
   void runOnOperation() override {
     SmallVector<std::pair<linalg::LinalgOp, Value>> softmaxRoots;
+    SmallVector<std::pair<linalg::MatmulOp, Value>> transposeMatmulRoots;
     getOperation()->walk([&](linalg::LinalgOp op) {
       {
         transform_ext::MatcherContext matcherContext;
@@ -44,15 +94,30 @@ struct RaiseSpecialOpsPass : public RaiseSpecialOpsBase<RaiseSpecialOpsPass> {
           Value src = maxReduction->getCaptured()->getOperand(0);
           softmaxRoots.push_back(std::make_pair(op, src));
         }
+        if (std::optional<Value> newRhs = matchATransposeBMatmul(op)) {
+          transposeMatmulRoots.push_back(std::make_pair(
+              cast<linalg::MatmulOp>(op.getOperation()), newRhs.value()));
+        }
       }
     });
+    IRRewriter rewriter(&getContext());
     for (std::pair<linalg::LinalgOp, Value> softmax : softmaxRoots) {
       linalg::LinalgOp op = softmax.first;
       Value src = softmax.second;
-      IRRewriter rewriter(op.getContext());
       rewriter.setInsertionPoint(softmax.first);
       rewriter.replaceOpWithNewOp<IREE::LinalgExt::SoftmaxOp>(
           op, src, op.getDpsInitOperand(0)->get(), op.getNumLoops() - 1);
+    }
+    for (std::pair<linalg::MatmulOp, Value> aTransposeBMatmul :
+         transposeMatmulRoots) {
+      auto matmulOp = aTransposeBMatmul.first;
+      Value lhs = matmulOp.getDpsInputOperand(0)->get();
+      auto newRhs = aTransposeBMatmul.second;
+      Value init = matmulOp.getDpsInitOperand(0)->get();
+      rewriter.setInsertionPoint(matmulOp);
+      SmallVector<NamedAttribute> attrs = getPrunedAttributeList(matmulOp);
+      rewriter.replaceOpWithNewOp<linalg::MatmulTransposeBOp>(
+          matmulOp, ValueRange{lhs, newRhs}, ValueRange{init}, attrs);
     }
   }
 };


### PR DESCRIPTION
To handle the lowering of this op on the SPIR-V side, the operation needs to be generalized to `linalg.generic`. Add a SPIRV specific generalization pass to handle the lowering of such ops.