### PR TITLE
Fix use-after-free error in allocator

### DIFF
--- a/runtime/src/iree/base/allocator.c
+++ b/runtime/src/iree/base/allocator.c
@@ -4,7 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -95,15 +94,14 @@ static iree_status_t iree_allocator_system_alloc(
     }
   });
 
-  // This variable is necessary to avoid use-after-free errors.
-  // According to the standard after realloc using existing_ptr
-  // is undefined behavior even when not dereferencing it.
-  uintptr_t existing_ptr_for_trace = (uintptr_t)existing_ptr;
   void* new_ptr = NULL;
   if (existing_ptr && command == IREE_ALLOCATOR_COMMAND_REALLOC) {
+    // This will erroneusly trace the free if the realloc fails.
+    // It can't be after it because it may trigger use-after-free error on
+    // GCC 12.
+    IREE_TRACE_FREE(existing_ptr);
     new_ptr = realloc(existing_ptr, byte_length);
   } else {
-    existing_ptr_for_trace = (uintptr_t)NULL;
     if (command == IREE_ALLOCATOR_COMMAND_CALLOC) {
       new_ptr = calloc(1, byte_length);
     } else {
@@ -115,9 +113,6 @@ static iree_status_t iree_allocator_system_alloc(
                             "system allocator failed the request");
   }
 
-  if (existing_ptr_for_trace) {
-    IREE_TRACE_FREE((void*)existing_ptr_for_trace);
-  }
   IREE_TRACE_ALLOC(new_ptr, byte_length);
 
   *inout_ptr = new_ptr;


### PR DESCRIPTION
GCC 12 flags this as an error due to realloc followed by IREE_TRACE_FREE. Using the pointer even without dereferencing it after the realloc is undefined behavior.