### PR TITLE
[Flow] Teach RaiseSpecialOps to raise tensor.extract and views

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
@@ -286,17 +286,16 @@ struct RaiseSpecialOpsPass : public RaiseSpecialOpsBase<RaiseSpecialOpsPass> {
     IRRewriter rewriter(&getContext());
 
     getOperation()->walk([&](linalg::GenericOp op) {
-      rewriter.setInsertionPoint(op);
-
       // Try raising to tensor.export.
+      rewriter.setInsertionPoint(op);
       FailureOr<linalg::GenericOp> maybeNewOp =
           raiseTensorExtractToInput(op, rewriter);
-      // Update op if we succeeded.
       if (succeeded(maybeNewOp)) {
-        op = maybeNewOp.value();
+        op = *maybeNewOp;
       }
 
       // Try raising to a view-like operation.
+      rewriter.setInsertionPoint(op);
       (void)tryRaiseToView(op, rewriter);
     });
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
@@ -251,7 +251,7 @@ static LogicalResult tryRaiseToView(linalg::GenericOp linalgOp,
   if (!blockArg)
     return failure();
   // Check if the block argument is an argument of the linalgOp.
-  if (blockArg.getOwner() == linalgOp.getBody())
+  if (blockArg.getOwner() != linalgOp.getBody())
     return failure();
   // Check that the block arguement corresponds to the input.
   if (blockArg.getArgNumber() != 0)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/raise_special_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-flow-raise-special-ops -canonicalize %s | FileCheck %s
+// RUN: iree-opt --iree-flow-raise-special-ops -canonicalize --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: @softmax
 //  CHECK-SAME: %[[ARG:.+]]: tensor<?x?x?xf32>
@@ -186,3 +186,35 @@ func.func @aTransposeBMatmul(%arg0 : tensor<10x20xf32>,
 //       CHECK:   %[[RESULT:.+]] = linalg.matmul_transpose_b
 //  CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 //       CHECK:   return %[[RESULT]]
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @test(%arg0: tensor<1x1x?x?xf32>, %arg1: tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xf32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: linalg.generic
+  // CHECK:  (%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+  // CHECK:  linalg.yield %[[IN]] : f32
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%arg1 : tensor<1x1x?x?xf32>) {
+  ^bb0(%out: f32):
+    %1 = linalg.index 2 : index
+    %2 = linalg.index 3 : index
+    %extracted = tensor.extract %arg0[%c0, %c0, %1, %2] : tensor<1x1x?x?xf32>
+    linalg.yield %extracted : f32
+  } -> tensor<1x1x?x?xf32>
+  return %0 : tensor<1x1x?x?xf32>
+}
+
+// -----
+
+#map = affine_map<(d0) -> (d0)>
+func.func @test(%A : tensor<1x1x5120xf32>, %B : tensor<5120xf32>) -> tensor<5120xf32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: tensor.extract_slice
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs(%B : tensor<5120xf32>) {
+  ^bb0(%out: f32):
+    %12 = linalg.index 0 : index
+    %extracted = tensor.extract %A[%c0, %c0, %12] : tensor<1x1x5120xf32>
+    linalg.yield %extracted : f32
+  } -> tensor<5120xf32>
+  return %0 : tensor<5120xf32>
+}


### PR DESCRIPTION
This patch teaches RaiseSpecialOps pass to raise tensor.extract to an input arguement to a linalg.generic. It also teaches it to raise linalg.generic to tensor.expand_shape.

Fixes #14742 