### PR TITLE
Fixing a bug in --iree-util-fold-globals when globals are uninitialized.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -352,6 +352,10 @@ static bool deduplicateConstantGlobals(GlobalTable &globalTable) {
       // Stores - not eligible for deduplication.
       continue;
     }
+    if (!global.op.getGlobalInitialValue()) {
+      // No initial value, not constant.
+      continue;
+    }
     auto it = leaderMap.insert(
         {global.op.getGlobalInitialValue(), global.op.getGlobalName()});
     if (it.second) {


### PR DESCRIPTION
Most models need to initialize them but it's valid not to so we should accept that input.