### PR TITLE
Add runtime tracing build to gcc CI job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,16 +624,15 @@ jobs:
       - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
-    env:
-      BUILD_DIR: build-gcc
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
-      - name: "Building IREE with gcc"
+      - name: "Building IREE with gcc (all)"
         env:
           IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+          BUILD_DIR: build-gcc
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env CC=/usr/bin/gcc-9 \
@@ -645,6 +644,18 @@ jobs:
             --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:d6c426d1fe55947a4afe7669abae6c7e6aa44fa94e84804bc5d7e7304dd183c9" \
             gcr.io/iree-oss/base@sha256:d6c426d1fe55947a4afe7669abae6c7e6aa44fa94e84804bc5d7e7304dd183c9 \
             ./build_tools/cmake/build_all.sh \
+            "${BUILD_DIR}"
+      - name: "Building IREE with gcc (runtime with tracing)"
+        env:
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+          BUILD_DIR: build-gcc-tracing
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:d6c426d1fe55947a4afe7669abae6c7e6aa44fa94e84804bc5d7e7304dd183c9" \
+            gcr.io/iree-oss/base@sha256:d6c426d1fe55947a4afe7669abae6c7e6aa44fa94e84804bc5d7e7304dd183c9 \
+            ./build_tools/cmake/build_tracing.sh \
             "${BUILD_DIR}"
 
   tracing:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,6 +651,8 @@ jobs:
           BUILD_DIR: build-gcc-tracing
         run: |
           ./build_tools/github_actions/docker_run.sh \
+            --env CC=/usr/bin/gcc-9 \
+            --env CXX=/usr/bin/g++-9 \
             --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
             --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
             --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:d6c426d1fe55947a4afe7669abae6c7e6aa44fa94e84804bc5d7e7304dd183c9" \


### PR DESCRIPTION
Seeing if this catches issues like https://github.com/openxla/iree/pull/14704#issuecomment-1682508763 (logs here: https://github.com/nod-ai/SRT/actions/runs/5889584884/job/15973053794)

ci-exactly: gcc