### PR TITLE
[HAL] Add a pass to materialize homogeneous encodings.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.h
@@ -12,6 +12,7 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_CPU_PASSES_H_
 #define IREE_COMPILER_CODEGEN_COMMON_CPU_PASSES_H_
 
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
@@ -23,6 +24,8 @@ namespace iree_compiler {
 ///   linalg_ext.unset_encoding -> tensor.unpack
 ///   linalg.matmul             -> linalg.mmt4d
 std::unique_ptr<OperationPass<func::FuncOp>> createCPUMaterializeEncodingPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createCPUMaterializeEncodingPass(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Like createLLVMCPUMaterializeEncodingPass, but specifically for
 /// linalg_ext.upper_bound_tile_size, converting it to constants.
@@ -41,6 +44,9 @@ std::unique_ptr<OperationPass<func::FuncOp>> createCPUMaterializeEncodingPass();
 // as needed.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createCPUMaterializeUpperBoundTileSizePass();
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createCPUMaterializeUpperBoundTileSizePass(
+    IREE::HAL::ExecutableTargetAttr targetAttr);
 
 void registerCodegenCommonCPUPasses();
 

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.h
@@ -46,7 +46,7 @@ std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createCPUMaterializeUpperBoundTileSizePass();
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createCPUMaterializeUpperBoundTileSizePass(
-    IREE::HAL::ExecutableTargetAttr targetAttr);
+    ArrayRef<IREE::HAL::ExecutableTargetAttr> targetAttrs);
 
 void registerCodegenCommonCPUPasses();
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
         ":LinkerTool",
         ":StaticLibraryGenerator",
         "//compiler/src/iree/compiler/Codegen/Common",
+        "//compiler/src/iree/compiler/Codegen/Common/CPU:CommonCPUPasses",
         "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/LLVMCPU",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     MLIRTargetLLVMIRExport
     MLIRTransformDialect
     iree::compiler::Codegen::Common
+    iree::compiler::Codegen::Common::CPU::CommonCPUPasses
     iree::compiler::Codegen::Dialect::IREECodegenDialect
     iree::compiler::Codegen::LLVMCPU
     iree::compiler::Codegen::Utils

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -225,7 +225,7 @@ public:
     passManager.addNestedPass<func::FuncOp>(
         createCPUMaterializeUpperBoundTileSizePass(executableTarget));
     passManager.addNestedPass<func::FuncOp>(
-        createCPUMaterializeEncodingPass(executableTarget));
+        createCPUMaterializeEncodingPass({executableTarget}));
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) override {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -11,6 +11,7 @@
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
+#include "iree/compiler/Codegen/Common/CPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -216,6 +217,15 @@ public:
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpPassManager &passManager) override {
     buildLLVMCPUCodegenPassPipeline(passManager);
+  }
+
+  void buildMaterializeEncodingsPassPipeline(
+      IREE::HAL::ExecutableTargetAttr executableTarget,
+      OpPassManager &passManager) override {
+    passManager.addNestedPass<func::FuncOp>(
+        createCPUMaterializeUpperBoundTileSizePass(executableTarget));
+    passManager.addNestedPass<func::FuncOp>(
+        createCPUMaterializeEncodingPass(executableTarget));
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) override {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -185,6 +185,10 @@ public:
   buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                OpPassManager &passManager) = 0;
 
+  virtual void buildMaterializeEncodingsPassPipeline(
+      IREE::HAL::ExecutableTargetAttr executableTarget,
+      OpPassManager &passManager) {}
+
   // Inserts passes used to link `hal.executable.variant` ops together.
   // The pass manager will be nested on the parent module of `hal.executable`
   // ops and the pipeline will need to find relevant variant ops itself.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -25,6 +25,7 @@ iree_compiler_cc_library(
         "InlineDeviceSwitches.cpp",
         "LinkExecutables.cpp",
         "MaterializeDispatchInstrumentation.cpp",
+        "MaterializeHomogeneousEncodings.cpp",
         "MaterializeInterfaces.cpp",
         "MaterializeResourceCaches.cpp",
         "MemoizeDeviceQueries.cpp",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     "InlineDeviceSwitches.cpp"
     "LinkExecutables.cpp"
     "MaterializeDispatchInstrumentation.cpp"
+    "MaterializeHomogeneousEncodings.cpp"
     "MaterializeInterfaces.cpp"
     "MaterializeResourceCaches.cpp"
     "MemoizeDeviceQueries.cpp"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeHomogeneousEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeHomogeneousEncodings.cpp
@@ -1,0 +1,86 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/CPU/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetBackend.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+class MaterializeHomogeneousEncodingsPass
+    : public PassWrapper<MaterializeHomogeneousEncodingsPass,
+                         OperationPass<ModuleOp>> {
+public:
+  MaterializeHomogeneousEncodingsPass()
+      : targetRegistry(TargetBackendRegistry::getGlobal()) {}
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::HAL::HALDialect>();
+  }
+
+  StringRef getArgument() const override {
+    return "iree-hal-materialize-homogeneous-encodings";
+  }
+
+  StringRef getDescription() const override {
+    return "Mateiralizes logical encodings to physical encodings if there is "
+           "a single device target.";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    auto targetsAttr = moduleOp->getAttrOfType<ArrayAttr>("hal.device.targets");
+    if (!targetsAttr || targetsAttr.size() != 1) {
+      return;
+    }
+    auto deviceTarget = cast<IREE::HAL::DeviceTargetAttr>(targetsAttr[0]);
+    SmallVector<ExecutableTargetAttr, 4> executableTargets =
+        deviceTarget.getExecutableTargets();
+    if (executableTargets.size() != 1) {
+      return;
+    }
+    auto executableTarget = executableTargets[0];
+    OpPassManager passManager(moduleOp.getOperationName());
+    auto targetBackend =
+        targetRegistry.getTargetBackend(executableTarget.getBackend());
+    targetBackend->buildMaterializeEncodingsPassPipeline(executableTarget,
+                                                         passManager);
+    if (failed(runPipeline(passManager, moduleOp))) {
+      return signalPassFailure();
+    }
+  }
+
+private:
+  const TargetBackendRegistry &targetRegistry;
+};
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createMaterializeHomogeneousEncodingsPass() {
+  return std::make_unique<MaterializeHomogeneousEncodingsPass>();
+}
+
+static PassRegistration<MaterializeHomogeneousEncodingsPass> pass([] {
+  return std::make_unique<MaterializeHomogeneousEncodingsPass>();
+});
+
+} // namespace HAL
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeHomogeneousEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeHomogeneousEncodings.cpp
@@ -61,7 +61,8 @@ public:
     auto targetBackend =
         targetRegistry.getTargetBackend(executableTarget.getBackend());
     if (!targetBackend) {
-      moduleOp.emitError() << "unregistered target backend '" << target << "'";
+      moduleOp.emitError() << "unregistered target backend '"
+                           << executableTarget.getBackend() << "'";
       return;
     }
     targetBackend->buildMaterializeEncodingsPassPipeline(executableTarget,

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeHomogeneousEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeHomogeneousEncodings.cpp
@@ -60,6 +60,10 @@ public:
     OpPassManager passManager(moduleOp.getOperationName());
     auto targetBackend =
         targetRegistry.getTargetBackend(executableTarget.getBackend());
+    if (!targetBackend) {
+      moduleOp.emitError() << "unregistered target backend '" << target << "'";
+      return;
+    }
     targetBackend->buildMaterializeEncodingsPassPipeline(executableTarget,
                                                          passManager);
     if (failed(runPipeline(passManager, moduleOp))) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeHomogeneousEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeHomogeneousEncodings.cpp
@@ -4,7 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/Common/CPU/Passes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/Target/TargetBackend.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -227,8 +227,9 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
     // Executable translation
     //----------------------------------------------------------------------------
 
-    FunctionLikeNest(passManager)
-        .addPass(createCPUMaterializeUpperBoundTileSizePass);
+    FunctionLikeNest(passManager).addPass([]() {
+      return createCPUMaterializeUpperBoundTileSizePass();
+    });
 
     // Preprocess executables using an external tool. The tool may mutate one or
     // more variants and even insert or remove variants.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -106,6 +106,9 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createMemoizeDeviceQueriesPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createMaterializeInterfacesPass();
 
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createMaterializeHomogeneousEncodingsPass();
+
 // Dumps individual hal.executable source listings to |path|.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createDumpExecutableSourcesPass(StringRef path);
@@ -213,6 +216,7 @@ inline void registerHALPasses() {
   createLinkExecutablesPass(TargetBackendRegistry::getGlobal());
   createLinkTargetExecutablesPass(TargetBackendRegistry::getGlobal(), "");
   createMaterializeDispatchInstrumentationPass(0);
+  createMaterializeHomogeneousEncodingsPass();
   createMaterializeInterfacesPass();
   createMaterializeResourceCachesPass(targetOptions);
   createMemoizeDeviceQueriesPass();

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "fixup_legacy_sync.mlir",
             "inline_device_switches.mlir",
             "materialize_dispatch_instrumentation.mlir",
+            "materialize_homogeneous_encodings.mlir",
             "materialize_interfaces.mlir",
             "materialize_resource_caches.mlir",
             "memoize_device_queries.mlir",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     "fixup_legacy_sync.mlir"
     "inline_device_switches.mlir"
     "materialize_dispatch_instrumentation.mlir"
+    "materialize_homogeneous_encodings.mlir"
     "materialize_interfaces.mlir"
     "materialize_resource_caches.mlir"
     "memoize_device_queries.mlir"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_homogeneous_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_homogeneous_encodings.mlir
@@ -1,0 +1,97 @@
+// RUN: iree-opt --split-input-file --iree-hal-materialize-homogeneous-encodings %s | FileCheck %s
+
+#map = affine_map<()[s0] -> ((1025 ceildiv s0) * s0 - 1025)>
+#map1 = affine_map<()[s0] -> ((257 ceildiv s0) * s0 - 257)>
+#map2 = affine_map<()[s0] -> ((513 ceildiv s0) * s0 - 513)>
+#map3 = affine_map<()[s0] -> ((1025 ceildiv s0) * s0)>
+#map4 = affine_map<()[s0] -> ((513 ceildiv s0) * s0)>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "cascadelake", cpu_features = "+cmov,+mmx,+popcnt,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+fma,+avx512f,+bmi,+bmi2,+aes,+pclmul,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vnni,+adx,+clflushopt,+clwb,+cx16,+cx8,+crc32,+f16c,+fsgsbase,+fxsr,+invpcid,+lzcnt,+movbe,+pku,+prfchw,+rdrnd,+rdseed,+sahf,+x87,+xsave,+xsavec,+xsaveopt,+xsaves", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-unknown-unknown-eabi-elf", ukernels = true}>
+#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#executable_target_embedded_elf_x86_64_]}>
+module attributes {hal.device.targets = [#device_target_llvm_cpu]} {
+  func.func @matmul_1025x513x257(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub} {
+    %cst = arith.constant 0.000000e+00 : f32
+    %cst_0 = arith.constant dense<2.000000e+00> : tensor<257x513xf32>
+    %0 = hal.tensor.import %arg0 "input 0" : !hal.buffer_view -> tensor<1025x257xf32>
+    %1:2 = iree_linalg_ext.upper_bound_tile_size tensor<1025x257xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS>> -> index, index
+    %2 = affine.apply #map()[%1#0]
+    %3 = affine.apply #map1()[%1#1]
+    %padded = tensor.pad %0 low[0, 0] high[%2, %3] {
+    ^bb0(%arg1: index, %arg2: index):
+      tensor.yield %cst : f32
+    } : tensor<1025x257xf32> to tensor<?x?xf32>
+    %4 = iree_linalg_ext.set_encoding %padded : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<1025x257xf32>>>
+    %5:2 = iree_linalg_ext.upper_bound_tile_size tensor<257x513xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RHS>> -> index, index
+    %6 = affine.apply #map1()[%5#0]
+    %7 = affine.apply #map2()[%5#1]
+    %padded_1 = tensor.pad %cst_0 low[0, 0] high[%6, %7] {
+    ^bb0(%arg1: index, %arg2: index):
+      tensor.yield %cst : f32
+    } : tensor<257x513xf32> to tensor<?x?xf32>
+    %8 = iree_linalg_ext.set_encoding %padded_1 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RHS, original_type = tensor<257x513xf32>>>
+    %9:2 = iree_linalg_ext.upper_bound_tile_size tensor<1025x513xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT>> -> index, index
+    %10 = affine.apply #map3()[%9#0]
+    %11 = affine.apply #map4()[%9#1]
+    %12 = tensor.empty(%10, %11) : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>
+    %13 = linalg.fill ins(%cst : f32) outs(%12 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>) -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>
+    %14 = linalg.matmul ins(%4, %8 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<1025x257xf32>>>, tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RHS, original_type = tensor<257x513xf32>>>) outs(%13 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>) -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>
+    %15 = iree_linalg_ext.unset_encoding %14 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>> -> tensor<?x?xf32>
+    %extracted_slice = tensor.extract_slice %15[0, 0] [1025, 513] [1, 1] : tensor<?x?xf32> to tensor<1025x513xf32>
+    %16 = hal.tensor.export %extracted_slice "output 0" : tensor<1025x513xf32> -> !hal.buffer_view
+    return %16 : !hal.buffer_view
+  }
+}
+// CHECK-LABEL: func.func @matmul_1025x513x257
+// CHECK:         tensor.pack
+// CHECK:         tensor.pack
+// CHECK:         linalg.mmt4d
+// CHECK:         tensor.unpack
+
+// -----
+
+#map = affine_map<()[s0] -> ((1025 ceildiv s0) * s0 - 1025)>
+#map1 = affine_map<()[s0] -> ((257 ceildiv s0) * s0 - 257)>
+#map2 = affine_map<()[s0] -> ((513 ceildiv s0) * s0 - 513)>
+#map3 = affine_map<()[s0] -> ((1025 ceildiv s0) * s0)>
+#map4 = affine_map<()[s0] -> ((513 ceildiv s0) * s0)>
+#executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader, GroupNonUniform], [SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>, api=Vulkan, #spirv.resource_limits<max_compute_workgroup_size = [128, 128, 64], subgroup_size = 64, cooperative_matrix_properties_nv = []>>}>
+#device_target_vulkan = #hal.device.target<"vulkan", {executable_targets = [#executable_target_vulkan_spirv_fb], legacy_sync}>
+module attributes {hal.device.targets = [#device_target_vulkan]} {
+  func.func @matmul_1025x513x257(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub} {
+    %cst = arith.constant 0.000000e+00 : f32
+    %cst_0 = arith.constant dense<2.000000e+00> : tensor<257x513xf32>
+    %0 = hal.tensor.import %arg0 "input 0" : !hal.buffer_view -> tensor<1025x257xf32>
+    %1:2 = iree_linalg_ext.upper_bound_tile_size tensor<1025x257xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS>> -> index, index
+    %2 = affine.apply #map()[%1#0]
+    %3 = affine.apply #map1()[%1#1]
+    %padded = tensor.pad %0 low[0, 0] high[%2, %3] {
+    ^bb0(%arg1: index, %arg2: index):
+      tensor.yield %cst : f32
+    } : tensor<1025x257xf32> to tensor<?x?xf32>
+    %4 = iree_linalg_ext.set_encoding %padded : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<1025x257xf32>>>
+    %5:2 = iree_linalg_ext.upper_bound_tile_size tensor<257x513xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RHS>> -> index, index
+    %6 = affine.apply #map1()[%5#0]
+    %7 = affine.apply #map2()[%5#1]
+    %padded_1 = tensor.pad %cst_0 low[0, 0] high[%6, %7] {
+    ^bb0(%arg1: index, %arg2: index):
+      tensor.yield %cst : f32
+    } : tensor<257x513xf32> to tensor<?x?xf32>
+    %8 = iree_linalg_ext.set_encoding %padded_1 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RHS, original_type = tensor<257x513xf32>>>
+    %9:2 = iree_linalg_ext.upper_bound_tile_size tensor<1025x513xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT>> -> index, index
+    %10 = affine.apply #map3()[%9#0]
+    %11 = affine.apply #map4()[%9#1]
+    %12 = tensor.empty(%10, %11) : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>
+    %13 = linalg.fill ins(%cst : f32) outs(%12 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>) -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>
+    %14 = linalg.matmul ins(%4, %8 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS, original_type = tensor<1025x257xf32>>>, tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RHS, original_type = tensor<257x513xf32>>>) outs(%13 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>) -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>>
+    %15 = iree_linalg_ext.unset_encoding %14 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = RESULT, original_type = tensor<1025x513xf32>>> -> tensor<?x?xf32>
+    %extracted_slice = tensor.extract_slice %15[0, 0] [1025, 513] [1, 1] : tensor<?x?xf32> to tensor<1025x513xf32>
+    %16 = hal.tensor.export %extracted_slice "output 0" : tensor<1025x513xf32> -> !hal.buffer_view
+    return %16 : !hal.buffer_view
+  }
+}
+// vulkan does not implement buildMaterializeEncodingsPassPipeline method.
+// CHECK-LABEL: func.func @matmul_1025x513x257
+// CHECK:         iree_linalg_ext.upper_bound_tile_size
+// CHECK:         iree_linalg_ext.set_encoding
+// CHECK:         iree_linalg_ext.upper_bound_tile_size
+// CHECK:         iree_linalg_ext.set_encoding
+// CHECK:         iree_linalg_ext.unset_encoding


### PR DESCRIPTION
- Adds buildMaterializeEncodingsPassPipeline method to TargetBackend. In this revision, only llvm-cpu backend implements the method.