### PR TITLE
Add copy (cp) command to ir_tool.

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/ir_tool/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/ir_tool/__main__.py
@@ -52,15 +52,13 @@ def parse_arguments(argv=None):
     # copy (cp) command.
     cp_parser = subparsers.add_parser(
         "copy",
-        aliases=['cp'],
+        aliases=["cp"],
         help="Read a file and then output it using the given options, without "
         "modification",
     )
     add_ouptut_options(cp_parser)
     cp_parser.add_argument("input_file", help="File to process")
-    cp_parser.add_argument(
-        "-o", required=True, dest="output_file", help="Output file"
-    )
+    cp_parser.add_argument("-o", required=True, dest="output_file", help="Output file")
 
     # strip-data command.
     strip_data_parser = subparsers.add_parser(

--- a/compiler/bindings/python/iree/compiler/tools/ir_tool/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/ir_tool/__main__.py
@@ -49,6 +49,19 @@ def parse_arguments(argv=None):
             help="Bytecode version to emit or -1 for latest",
         )
 
+    # copy (cp) command.
+    cp_parser = subparsers.add_parser(
+        "copy",
+        aliases=['cp'],
+        help="Read a file and then output it using the given options, without "
+        "modification",
+    )
+    add_ouptut_options(cp_parser)
+    cp_parser.add_argument("input_file", help="File to process")
+    cp_parser.add_argument(
+        "-o", required=True, dest="output_file", help="Output file"
+    )
+
     # strip-data command.
     strip_data_parser = subparsers.add_parser(
         "strip-data",
@@ -66,16 +79,29 @@ def parse_arguments(argv=None):
     strip_data_parser.add_argument(
         "-o", required=True, dest="output_file", help="Output file"
     )
+
     args = parser.parse_args(argv)
     return args
 
 
 def main(args) -> int:
+    if args.sub_command == "copy":
+        return do_copy(args)
     if args.sub_command == "strip-data":
         return do_strip_data(args)
     else:
         print("error: Unrecognized sub-command {args.sub_command}", file=sys.stderr)
         return 1
+    return 0
+
+
+def do_copy(args) -> int:
+    session = Session()
+    output = Output.open_file(args.output_file)
+    inv = session.invocation()
+    inv.enable_console_diagnostics()
+    load_source(inv, args.input_file)
+    write_output(inv, output, args)
     return 0
 
 

--- a/compiler/bindings/python/test/tools/ir_tool_test.py
+++ b/compiler/bindings/python/test/tools/ir_tool_test.py
@@ -41,6 +41,53 @@ class IrToolTest(unittest.TestCase):
         with open(self.outputPath, "rt" if text else "rb") as f:
             return f.read()
 
+    def testCpDefaultArgs(self):
+        self.saveInput(
+            r"""
+            builtin.module {
+            }
+            """
+        )
+        run_tool("copy", self.inputPath, "-o", self.outputPath)
+        output = self.loadOutput()
+        print("Output:", output)
+        self.assertIn("module", output)
+
+    def testCpEmitBytecode(self):
+        self.saveInput(
+            r"""
+            builtin.module {
+            }
+            """
+        )
+        run_tool(
+            "copy",
+            "--emit-bytecode",
+            self.inputPath,
+            "-o",
+            self.outputPath,
+        )
+        output = self.loadOutput(text=False)
+        self.assertIn(b"MLIR", output)
+
+    def testCpEmitBytecodeVersion(self):
+        self.saveInput(
+            r"""
+            builtin.module {
+            }
+            """
+        )
+        run_tool(
+            "copy",
+            "--emit-bytecode",
+            "--bytecode-version=0",
+            self.inputPath,
+            "-o",
+            self.outputPath,
+        )
+        output = self.loadOutput(text=False)
+        self.assertIn(b"MLIR", output)
+
     def testStripDataWithImport(self):
         self.saveInput(
             r"""


### PR DESCRIPTION
This allows for efficient, ergonomic copying of files between MLIR bytecode and text formats.

CLI usage from a build directory:

| | |
| -- | -- |
bytecode to text | `python -m iree.compiler.tools.ir_tool copy input.mlirbc -o output.mlir` 
text to bytecode | `python -m iree.compiler.tools.ir_tool copy --emit-bytecode input.mlir -o output.mlirbc`

From installed packages:

| | |
| -- | -- |
bytecode to text | `iree-ir-tool copy input.mlirbc -o output.mlir` 
text to bytecode | `iree-ir-tool copy --emit-bytecode input.mlir -o output.mlirbc`

More context: [this Discord discussion](https://discord.com/channels/689900678990135345/706175572920762449/1141464453003624629), https://github.com/openxla/iree/pull/14636