### PR TITLE
[Codegen] Add RematerializeParallelOps pass back to codegen pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
@@ -17,6 +17,7 @@ void addCommonTargetExecutablePreprocessingPasses(OpPassManager &passManager) {
   passManager.addPass(createBufferizeCopyOnlyDispatchesPass());
   passManager.addNestedPass<func::FuncOp>(
       IREE::LinalgExt::createDecomposeSoftmaxPass());
+  passManager.addNestedPass<func::FuncOp>(createRematerializeParallelOpsPass());
 }
 
 //===---------------------------------------------------------------------===//


### PR DESCRIPTION
Removing this pass breaks codegen (CPU/CUDA/SPIRV) for dequantization by adding a big alloc.

Fixes #14713 
Fixes #14741
Fixes #14740