### PR TITLE
Run `build_test_all_windows` on presubmit for relevant changes.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -132,6 +132,7 @@ DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
 # The file paths should be specified using Unix shell-style wildcards.
 PRESUBMIT_TOUCH_ONLY_JOBS = [
     ("build_test_all_macos_arm64", ["runtime/src/iree/hal/drivers/metal/*"]),
+    ("build_test_all_windows", ["*win32*", "*windows*", "*msvc*"])
 ]
 
 DEFAULT_BENCHMARK_PRESET_GROUP = [

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -132,7 +132,7 @@ DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
 # The file paths should be specified using Unix shell-style wildcards.
 PRESUBMIT_TOUCH_ONLY_JOBS = [
     ("build_test_all_macos_arm64", ["runtime/src/iree/hal/drivers/metal/*"]),
-    ("build_test_all_windows", ["*win32*", "*windows*", "*msvc*"])
+    ("build_test_all_windows", ["*win32*", "*windows*", "*msvc*"]),
 ]
 
 DEFAULT_BENCHMARK_PRESET_GROUP = [

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -275,6 +275,35 @@ class ConfigureCITest(unittest.TestCase):
         expected_jobs = {"job1", "build_test_all_macos_arm64"}
         self.assertCountEqual(jobs, expected_jobs)
 
+    def test_get_enabled_jobs_windows(self):
+        trailers = {}
+        all_jobs = {"job1"}
+        is_pr = True
+        modified_paths = ["runtime/src/iree/base/internal/threading_win32.c"]
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modified_paths=modified_paths,
+            is_pr=is_pr,
+        )
+        expected_jobs = {"job1", "build_test_all_windows"}
+        self.assertCountEqual(jobs, expected_jobs)
+
+    def test_get_enabled_jobs_windows_docs(self):
+        # docs/ directory is excluded from CI, superceding "windows" inclusion
+        trailers = {}
+        all_jobs = {"job1"}
+        is_pr = True
+        modified_paths = ["docs/windows.md"]
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modified_paths=modified_paths,
+            is_pr=is_pr,
+        )
+        expected_jobs = {}
+        self.assertCountEqual(jobs, expected_jobs)
+
     def test_parse_path_from_workflow_ref(self):
         path = configure_ci.parse_path_from_workflow_ref(
             "octocat/example", "octocat/example/.github/test.yml@1234"


### PR DESCRIPTION
This CI job is somewhat expensive (cloud $$, time to check out the repo before even building), but I think it makes sense to run on changes that directly modify Windows/MSVC files, similar to how the macos_arm64 build should run on changes to the Metal HAL driver.

Note that we already run the `build_test_runtime_windows` job on presubmit for all changes, but that does not exercise the compiler code or e2e tests. That being said, most of our Windows-specific files are runtime code, so we should have relatively good coverage even without this.

These are the currently affected files:
```
iree/build_tools/python_deploy/build_windows_packages.ps1
iree/build_tools/python_deploy/install_windows_deps.ps1
iree/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/WindowsLinkerTool.cpp
iree/runtime/src/iree/base/internal/atomics_msvc.h
iree/runtime/src/iree/base/internal/dynamic_library_win32.c
iree/runtime/src/iree/base/internal/threading_win32.c
iree/runtime/src/iree/base/internal/wait_handle_win32.c
iree/runtime/src/iree/hal/local/elf/arch/x86_64_msvc.asm
iree/runtime/src/iree/hal/local/elf/platform/windows.c
iree/runtime/src/iree/task/topology_win32.c
```