### PR TITLE
Cleanup references to Buildkite.

### DIFF
--- a/build_tools/benchmarks/post_benchmark_comment.py
+++ b/build_tools/benchmarks/post_benchmark_comment.py
@@ -180,8 +180,6 @@ def _parse_arguments():
     parser.add_argument("--verbose", action="store_true")
     verification_parser = parser.add_mutually_exclusive_group(required=True)
     verification_parser.add_argument("--github_event_json", type=pathlib.Path)
-    # Temporary option for buildkite pipeline.
-    verification_parser.add_argument("--no_verify_pr", action="store_true")
     return parser.parse_args()
 
 

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Upload benchmark results to IREE Benchmark Dashboards.
 
-This script is meant to be used by Buildkite for automation.
+This script is meant to be used by GitHub Actions workflows for automation.
 
 Example usage:
   # Export necessary environment variables:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -91,7 +91,6 @@ SKIP_PATH_PATTERNS = [
     "docs/*",
     "third_party/mkdocs-material/*",
     "experimental/*",
-    "build_tools/buildkite/*",
     # These configure the runners themselves and don't affect presubmit.
     "build_tools/github_actions/runner/*",
     ".github/ISSUE_TEMPLATE/*",

--- a/experimental/web/generate_web_metrics.sh
+++ b/experimental/web/generate_web_metrics.sh
@@ -84,8 +84,8 @@ wget -nc https://storage.googleapis.com/iree-model-artifacts/MobileNetV3SmallSta
 # Import programs into MLIR                                                   #
 ###############################################################################
 
-# Note: you can also download imported programs from runs of the
-# https://buildkite.com/iree/iree-benchmark-android pipeline.
+# Note: you can also download imported programs from CI runs:
+# https://github.com/openxla/iree/blob/main/docs/developers/developing_iree/benchmark_suites.md#fetching-benchmark-artifacts-from-ci
 
 IREE_IMPORT_TFLITE_PATH=iree-import-tflite
 


### PR DESCRIPTION
We've used GitHub Actions exclusively for a while now.