### PR TITLE
Make rematerialization trigger before tile and distribute only for CPU and CUDA backends.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
@@ -17,7 +17,6 @@ void addCommonTargetExecutablePreprocessingPasses(OpPassManager &passManager) {
   passManager.addPass(createBufferizeCopyOnlyDispatchesPass());
   passManager.addNestedPass<func::FuncOp>(
       IREE::LinalgExt::createDecomposeSoftmaxPass());
-  passManager.addNestedPass<func::FuncOp>(createRematerializeParallelOpsPass());
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -761,17 +761,22 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
 }
 
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
-  addCommonTargetExecutablePreprocessingPasses(passManager.nest<ModuleOp>());
-  // TODO(#13888): This(createExpandF16OpToF32Pass()) pass is being added way to
-  // late and should insted be be done during lowering to LLVM.
-  passManager.addPass(createExpandF16OpToF32Pass());
+  {
+    OpPassManager &modulePassManager = passManager.nest<ModuleOp>();
+    addCommonTargetExecutablePreprocessingPasses(modulePassManager);
+    modulePassManager.addNestedPass<func::FuncOp>(
+        createRematerializeParallelOpsPass());
+    // TODO(#13888): This(createExpandF16OpToF32Pass()) pass is being added way
+    // to late and should insted be be done during lowering to LLVM.
+    modulePassManager.addPass(createExpandF16OpToF32Pass());
 
-  passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
-      createCPUMaterializeEncodingPass());
-  // TODO: Remove the following pass the plumb support for #hal.descriptor_type
-  // memory space through the stack.
-  passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
-      createEraseHALDescriptorTypeFromMemRefPass());
+    modulePassManager.addNestedPass<func::FuncOp>(
+        createCPUMaterializeEncodingPass());
+    // TODO: Remove the following pass the plumb support for
+    // #hal.descriptor_type memory space through the stack.
+    modulePassManager.addNestedPass<func::FuncOp>(
+        createEraseHALDescriptorTypeFromMemRefPass());
+  }
 
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -584,6 +584,8 @@ void addGPUTransformDialectPasses(OpPassManager &passManager) {
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
   addCommonTargetExecutablePreprocessingPasses(pm.nest<ModuleOp>());
+  pm.nest<ModuleOp>().addNestedPass<func::FuncOp>(
+      createRematerializeParallelOpsPass());
   pm.addPass(createLLVMGPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = pm.nest<ModuleOp>();
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
The rematerialization pass should be triggered after tile and fuse. For now this is triggered before tile and distribute on CPU and CUDA backends. For SPIR-V backends, the rematerialization is inserted where it should be already.