### PR TITLE
[spirv] Fix element extraction order when breaking down vectors

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/break_down_large_vector.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/break_down_large_vector.mlir
@@ -45,14 +45,12 @@ func.func @bitcast_extract_extend_0(%input: vector<1xi32>) -> vector<4xi32> {
 // CHECK-LABEL: func @bitcast_extract_extend_0
 //  CHECK-SAME:  (%[[INPUT:.+]]: vector<1xi32>)
 //       CHECK:   %[[ZERO:.+]] = arith.constant dense<0> : vector<4xi32>
-//       CHECK:   %[[MASK:.+]] = arith.constant 15 : i32
-//       CHECK:   %[[OFF0:.+]] = arith.constant 28 : i32
-//       CHECK:   %[[OFF1:.+]] = arith.constant 24 : i32
-//       CHECK:   %[[OFF2:.+]] = arith.constant 20 : i32
-//       CHECK:   %[[OFF3:.+]] = arith.constant 16 : i32
+//   CHECK-DAG:   %[[MASK:.+]] = arith.constant 15 : i32
+//   CHECK-DAG:   %[[OFF1:.+]] = arith.constant 4 : i32
+//   CHECK-DAG:   %[[OFF2:.+]] = arith.constant 8 : i32
+//   CHECK-DAG:   %[[OFF3:.+]] = arith.constant 12 : i32
 //       CHECK:   %[[BASE:.+]] = vector.extract %[[INPUT]][0] : vector<1xi32>
-//       CHECK:   %[[SHR0:.+]] = arith.shrui %[[BASE]], %[[OFF0]] : i32
-//       CHECK:   %[[AND0:.+]] = arith.andi %[[SHR0]], %[[MASK]] : i32
+//       CHECK:   %[[AND0:.+]] = arith.andi %[[BASE]], %[[MASK]] : i32
 //       CHECK:   %[[INS0:.+]] = vector.insert %[[AND0]], %[[ZERO]] [0]
 //       CHECK:   %[[SHR1:.+]] = arith.shrui %[[BASE]], %[[OFF1]] : i32
 //       CHECK:   %[[AND1:.+]] = arith.andi %[[SHR1]], %[[MASK]] : i32
@@ -78,10 +76,11 @@ func.func @bitcast_extract_extend_1(%input: vector<4xi32>) -> vector<4xi32> {
 // CHECK-LABEL: func.func @bitcast_extract_extend_1
 //  CHECK-SAME: (%[[INPUT:.+]]: vector<4xi32>)
 //       CHECK:   %[[ZERO:.+]] = arith.constant dense<0> : vector<4xi32>
-//       CHECK:   %[[MASK:.+]] = arith.constant 15 : i32
-//       CHECK:   %[[OFF0:.+]] = arith.constant 12 : i32
-//       CHECK:   %[[OFF1:.+]] = arith.constant 8 : i32
-//       CHECK:   %[[OFF2:.+]] = arith.constant 4 : i32
+//   CHECK-DAG:   %[[MASK:.+]] = arith.constant 15 : i32
+//   CHECK-DAG:   %[[OFF0:.+]] = arith.constant 16 : i32
+//   CHECK-DAG:   %[[OFF1:.+]] = arith.constant 20 : i32
+//   CHECK-DAG:   %[[OFF2:.+]] = arith.constant 24 : i32
+//   CHECK-DAG:   %[[OFF3:.+]] = arith.constant 28 : i32
 //       CHECK:   %[[BASE:.+]] = vector.extract %[[INPUT]][2] : vector<4xi32>
 //       CHECK:   %[[SHR0:.+]] = arith.shrui %[[BASE]], %[[OFF0]] : i32
 //       CHECK:   %[[AND0:.+]] = arith.andi %[[SHR0]], %[[MASK]] : i32
@@ -92,6 +91,7 @@ func.func @bitcast_extract_extend_1(%input: vector<4xi32>) -> vector<4xi32> {
 //       CHECK:   %[[SHR2:.+]] = arith.shrui %[[BASE]], %[[OFF2]] : i32
 //       CHECK:   %[[AND2:.+]] = arith.andi %[[SHR2]], %[[MASK]] : i32
 //       CHECK:   %[[INS2:.+]] = vector.insert %[[AND2]], %[[INS1]] [2]
-//       CHECK:   %[[AND3:.+]] = arith.andi %[[BASE]], %[[MASK]] : i32
+//       CHECK:   %[[SHR3:.+]] = arith.shrui %[[BASE]], %[[OFF3]] : i32
+//       CHECK:   %[[AND3:.+]] = arith.andi %[[SHR3]], %[[MASK]] : i32
 //       CHECK:   %[[INS3:.+]] = vector.insert %[[AND3]], %[[INS2]] [3]
 //       CHECK:   return %[[INS3]] : vector<4xi32>


### PR DESCRIPTION
Assuming little-endian style encoding of the sub-byte elements, for 8xi4 [A, B, C, D, E, F, G, H], they are stored in memory as [BA, DC, FE, HG], and read as an i32 HGFEDCBA. Therefore the first i4 element is the lest significant 4 bits, and such.

Fixes https://github.com/openxla/iree/issues/14739