### PR TITLE
Restrict the constexpr constant types to the subset we currently support

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
@@ -55,7 +55,16 @@ ConstExprOpInfo getInfoForDefaultConstExprOp(Operation *op) {
 // it is best to be conservative here, and we limit to known value
 // types.
 bool isLegalConstExprType(Type t) {
-  if (llvm::isa<IntegerType, FloatType, IndexType>(t)) {
+  if (llvm::isa<IntegerType, FloatType>(t)) {
+    // TODO: We shouldn't need to be this conservative about the bit widths we
+    // support, but for now the consteval JIT has interop limitations. Lift
+    // this restriction when the JIT interops for all types.
+    auto bitWidth = t.getIntOrFloatBitWidth();
+    return bitWidth == 1 || bitWidth == 8 || bitWidth == 16 || bitWidth == 32 ||
+           bitWidth == 64;
+  }
+
+  if (llvm::isa<IndexType>(t)) {
     return true;
   }
 
@@ -72,6 +81,8 @@ void registerConstExprDependentDialects(DialectRegistry &registry) {
   registry.insert<IREE::Util::UtilDialect>();
   registry.insert<linalg::LinalgDialect>();
 }
+
+bool isLegalConstExprRootType(Type t) { return isLegalConstExprType(t); }
 
 ConstExprOpInfo ConstExprOpInfo::getForOp(Operation *op) {
   // We have a specific allow-list for Linalg ops because we want to consider

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h
@@ -42,6 +42,11 @@ struct ConstExprOpInfo {
   static ConstExprOpInfo getForOp(Operation *op);
 };
 
+// Whether the type is considered legal for a constexpr root. For example,
+// this would be called with the i32 type below:
+//   %cst = arith.constant 4 : i32
+bool isLegalConstExprRootType(Type t);
+
 // Whether a const-expr op is eligible to be hoistable. This enforces
 // policies for excluding certain, otherwise eligible, const-expr ops from
 // being hoisted to a global.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -15,7 +15,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/SymbolTable.h"
 
-#define DEBUG_TYPE "iree-util-hoist-into-globals"
+#define DEBUG_TYPE "iree-constexpr"
 
 using llvm::dbgs;
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -91,11 +91,25 @@ module @hoist_sub_byte_aligned_scalar_transitive {
 }
 
 // -----
-// CHECK-LABEL: @hoist_sub_byte_aligned_tensor_transitive
-// CHECK: util.global private {{.*}} : i32
+// CHECK-LABEL: @do_not_hoist_sub_byte_tensor_transitive
+// CHECK-NOT: util.global
+// We do not yet support constexpr of sub-byte types that are 
 // Can hoist a const-expr tree that transitively includes sub-byte aligned
 // values.
-module @hoist_sub_byte_aligned_tensor_transitive {
+module @do_not_hoist_sub_byte_tensor_transitive {
+  func.func @main() -> (i32) {
+    %0 = arith.constant dense<3> : tensor<i4>
+    %2 = "iree_unregistered.const_expr"(%0) : (tensor<i4>) -> i32
+    return %2 : i32
+  }
+}
+
+// -----
+// CHECK-LABEL: @hoist_i1_tensor_transitive
+// CHECK: util.global private {{.*}} : i32
+// We presently expand i1 -> i8 for legacy reasons. As such, we support
+// it, even though we don't generally support sub-byte constexprs.
+module @hoist_i1_tensor_transitive {
   func.func @main() -> (i32) {
     %0 = arith.constant dense<true> : tensor<i1>
     %2 = "iree_unregistered.const_expr"(%0) : (tensor<i1>) -> i32


### PR DESCRIPTION
Notably, this eliminates constexpr identification for non-byte aligned types (except for i1, which is presently stored in i8) that are not supported by the JIT. Note that the analysis for these seemed wrong anyway, since it was possible to hoist an expansion. As all of these types need work, we just opt them all out for the moment.

This also fixed a bug where the type of the root constant node was not being checked for legality.