### PR TITLE
Support default configs for BATCH_MATMUL_* in MaterializeEncoding pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/BUILD.bazel
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtEncodingUtils",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgExtUtils",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     ::PassHeaders
     ::PassesIncGen
     IREELinalgExtDialect
+    IREELinalgExtEncodingUtils
     IREELinalgExtTransforms
     IREELinalgExtUtils
     LLVMSupport

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
@@ -7,6 +7,7 @@
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
+#include "iree-dialects/Dialect/LinalgExt/Utils/EncodingUtils.h"
 #include "iree-dialects/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/Codegen/Common/CPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/CPU/Passes.h"
@@ -171,7 +172,8 @@ materializeEncodingForTarget(RankedTensorType tensorType,
   auto user = encoding.getUser().getValue();
   auto role = encoding.getRole().getValue();
   MatmulTileParams tileParams = chooseMatmulTileParams(user, targetAttr);
-  auto encodingInfo = chooseEncodingInfoForMatmul(user, role, tileParams);
+  auto encodingInfo =
+      IREE::LinalgExt::chooseEncodingInfoForMatmul(user, role, tileParams);
   auto originalTypeAttr = encoding.getOriginalType();
   auto originalType = originalTypeAttr
                           ? originalTypeAttr.getValue().cast<RankedTensorType>()

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingInfo.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingInfo.h
@@ -14,20 +14,9 @@
 namespace mlir {
 namespace iree_compiler {
 
-struct MatmulTileParams {
-  int64_t M = 1;
-  int64_t K = 1;
-  int64_t N = 1;
-};
-
 void adjustTileSizesToNarrowStaticShape(
     IREE::LinalgExt::MaterializeEncodingInfo &encodingInfo,
     ArrayRef<int64_t> shape);
-
-IREE::LinalgExt::MaterializeEncodingInfo
-chooseEncodingInfoForMatmul(IREE::LinalgExt::EncodingUser user,
-                            IREE::LinalgExt::EncodingRole role,
-                            MatmulTileParams tileParams);
 
 IREE::LinalgExt::MaterializeEncodingValueFn
 getMaterializeEncodingValueFn(IREE::HAL::ExecutableTargetAttr targetAttr);

--- a/llvm-external-projects/iree-dialects/BUILD.bazel
+++ b/llvm-external-projects/iree-dialects/BUILD.bazel
@@ -312,12 +312,13 @@ gentbl_cc_library(
 
 cc_library(
     name = "IREELinalgExtUtils",
-    srcs = glob([
-        "lib/Dialect/LinalgExt/Utils/*.cpp",
-    ]),
-    hdrs = glob([
-        "include/iree-dialects/Dialect/LinalgExt/Utils/*.h",
-    ]),
+    srcs = [
+        "lib/Dialect/LinalgExt/Utils/Utils.cpp",
+    ],
+    hdrs = [
+        "include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h",
+        "include/iree-dialects/Dialect/LinalgExt/Utils/WinogradConstants.h",
+    ],
     includes = ["include"],
     deps = [
         "@llvm-project//llvm:Support",
@@ -328,6 +329,21 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorUtils",
+    ],
+)
+
+cc_library(
+    name = "IREELinalgExtEncodingUtils",
+    srcs = [
+        "lib/Dialect/LinalgExt/Utils/EncodingUtils.cpp",
+    ],
+    hdrs = [
+        "include/iree-dialects/Dialect/LinalgExt/Utils/EncodingUtils.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IREELinalgExtDialect",
+        ":IREELinalgExtUtils",
     ],
 )
 
@@ -437,6 +453,7 @@ cc_library(
     deps = [
         ":IREEInputDialect",
         ":IREELinalgExtDialect",
+        ":IREELinalgExtEncodingUtils",
         ":IREELinalgExtPassIncGen",
         ":IREELinalgExtUtils",
         "@llvm-project//llvm:Support",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/EncodingUtils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/EncodingUtils.h
@@ -1,0 +1,33 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECTS_DIALECT_LINALGEXT_UTILS_ENCODING_UTILS_H_
+#define IREE_DIALECTS_DIALECT_LINALGEXT_UTILS_ENCODING_UTILS_H_
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Utils/Utils.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace LinalgExt {
+
+struct MatmulTileParams {
+  int64_t M = 1;
+  int64_t K = 1;
+  int64_t N = 1;
+};
+
+MaterializeEncodingInfo
+chooseEncodingInfoForMatmul(EncodingUser user, EncodingRole role,
+                            MatmulTileParams tileParams);
+
+} // namespace LinalgExt
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir
+
+#endif // IREE_DIALECTS_DIALECT_LINALGEXT_UTILS_ENCODING_UTILS_H_

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_library(IREELinalgExtPasses
   LINK_LIBS PUBLIC
   IREEInputDialect
   IREELinalgExtDialect
+  IREELinalgExtEncodingUtils
   IREELinalgExtUtils
   MLIRAffineDialect
   MLIRIR

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/CMakeLists.txt
@@ -11,3 +11,11 @@ add_mlir_library(IREELinalgExtUtils
   MLIRTensorDialect
   MLIRMemRefDialect
 )
+
+add_mlir_library(IREELinalgExtEncodingUtils
+  EncodingUtils.cpp
+
+  LINK_LIBS PUBLIC
+  IREELinalgExtDialect
+  IREELinalgExtUtils
+)

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/EncodingUtils.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/EncodingUtils.cpp
@@ -1,0 +1,63 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/Utils/EncodingUtils.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace LinalgExt {
+
+MaterializeEncodingInfo
+chooseEncodingInfoForMatmul(EncodingUser user, EncodingRole role,
+                            MatmulTileParams tileParams) {
+  // Start dim of the MxK (LHS), KxN (RHS), or MxN (RESULT) 2D matrix.
+  int64_t matmulDimBase = 0;
+  switch (user) {
+  case EncodingUser::BATCH_MATMUL_F32F32F32:
+  case EncodingUser::BATCH_MATMUL_F16F16F32:
+  case EncodingUser::BATCH_MATMUL_F16F16F16:
+  case EncodingUser::BATCH_MATMUL_BF16BF16F32:
+  case EncodingUser::BATCH_MATMUL_BF16BF16BF16:
+  case EncodingUser::BATCH_MATMUL_I8I8I32:
+    matmulDimBase = 1;
+    break;
+  default:
+    break;
+  }
+
+  MaterializeEncodingInfo encodingInfo;
+  encodingInfo.innerDimsPos = {matmulDimBase, matmulDimBase + 1};
+  switch (role) {
+  case (EncodingRole::LHS): {
+    encodingInfo.innerTileSizes = {tileParams.M, tileParams.K};
+    break;
+  }
+  case (EncodingRole::RHS): {
+    encodingInfo.innerTileSizes = {tileParams.N, tileParams.K};
+    encodingInfo.innerDimsPos = {matmulDimBase + 1, matmulDimBase};
+    encodingInfo.outerDimsPerm =
+        llvm::to_vector(llvm::seq<int64_t>(0, matmulDimBase));
+    encodingInfo.outerDimsPerm.push_back(matmulDimBase + 1);
+    encodingInfo.outerDimsPerm.push_back(matmulDimBase);
+    break;
+  }
+  case (EncodingRole::RESULT): {
+    encodingInfo.innerTileSizes = {tileParams.M, tileParams.N};
+    break;
+  }
+  default: {
+    assert(false);
+    return {};
+  }
+  }
+  return encodingInfo;
+}
+
+} // namespace LinalgExt
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir


### PR DESCRIPTION
In #14705 we added `BATCH_MATMUL_*` encoding users and handled the materialization in IREE codegen path by providing a custom `MaterializeEncodingFn`. However MaterializeEncoding pass also can be called standalone, this change updates the default `chooseEncodingInfo` function to support new encoding users.

This is done by moving `chooseEncodingInfoForMatmul` under LinalgExt to reuse the logic of deciding materialization based on matmul encoding.

The problem was found when adding tests for `MaterializeEncoding` with `BATCH_MATMUL_*` encoding users, since `MaterializeEncoding` pass is called standalone by `--iree-linalg-ext-materialize-encoding`

#14431