### PR TITLE
Add `llvm-link` and `clang` to CMake install

### DIFF
--- a/build_tools/cmake/iree_bitcode_library.cmake
+++ b/build_tools/cmake/iree_bitcode_library.cmake
@@ -78,13 +78,13 @@ function(iree_bitcode_library)
       OUTPUT
         "${_BITCODE_FILE}"
       COMMAND
-        "${IREE_CLANG_BINARY}"
+        "clang"
         ${_COPTS}
         "${_BITCODE_SRC_PATH}"
         "-o"
         "${_BITCODE_FILE}"
       DEPENDS
-        "${IREE_CLANG_BINARY}"
+        "clang"
         "${_SRC}"
       COMMENT
         "Compiling ${_SRC} to ${_BITCODE_FILE}"
@@ -96,12 +96,12 @@ function(iree_bitcode_library)
     OUTPUT
       ${_OUT}
     COMMAND
-      ${IREE_LLVM_LINK_BINARY}
+      "llvm-link"
       ${_BITCODE_FILES}
       "-o"
       "${_OUT}"
     DEPENDS
-      ${IREE_LLVM_LINK_BINARY}
+      "llvm-link"
       ${_BITCODE_FILES}
     COMMENT
       "Linking bitcode to ${_OUT}"
@@ -167,13 +167,13 @@ function(iree_cuda_bitcode_library)
       OUTPUT
         "${_BITCODE_FILE}"
       COMMAND
-        "${IREE_CLANG_BINARY}"
+        "clang"
         ${_COPTS}
         "${_BITCODE_SRC_PATH}"
         "-o"
         "${_BITCODE_FILE}"
       DEPENDS
-        "${IREE_CLANG_BINARY}"
+        "clang"
         "${_SRC}"
       COMMENT
         "Compiling ${_SRC} to ${_BITCODE_FILE}"
@@ -185,12 +185,12 @@ function(iree_cuda_bitcode_library)
     OUTPUT
       ${_OUT}
     COMMAND
-      ${IREE_LLVM_LINK_BINARY}
+      "llvm-link"
       ${_BITCODE_FILES}
       "-o"
       "${_OUT}"
     DEPENDS
-      ${IREE_LLVM_LINK_BINARY}
+      "llvm-link"
       ${_BITCODE_FILES}
     COMMENT
       "Linking bitcode to ${_OUT}"
@@ -235,12 +235,12 @@ function(iree_link_bitcode)
     OUTPUT
       ${_OUT}
     COMMAND
-      ${IREE_LLVM_LINK_BINARY}
+      "llvm-link"
       ${_BITCODE_FILES}
       "-o"
       "${_OUT}"
     DEPENDS
-      ${IREE_LLVM_LINK_BINARY}
+      "llvm-link"
       ${_BITCODE_FILES}
     COMMENT
       "Linking bitcode to ${_OUT}"

--- a/build_tools/cmake/iree_bitcode_library.cmake
+++ b/build_tools/cmake/iree_bitcode_library.cmake
@@ -78,13 +78,13 @@ function(iree_bitcode_library)
       OUTPUT
         "${_BITCODE_FILE}"
       COMMAND
-        "clang"
+        "${IREE_CLANG_BINARY}"
         ${_COPTS}
         "${_BITCODE_SRC_PATH}"
         "-o"
         "${_BITCODE_FILE}"
       DEPENDS
-        "clang"
+        "${IREE_CLANG_BINARY}"
         "${_SRC}"
       COMMENT
         "Compiling ${_SRC} to ${_BITCODE_FILE}"
@@ -96,12 +96,12 @@ function(iree_bitcode_library)
     OUTPUT
       ${_OUT}
     COMMAND
-      "llvm-link"
+      ${IREE_LLVM_LINK_BINARY}
       ${_BITCODE_FILES}
       "-o"
       "${_OUT}"
     DEPENDS
-      "llvm-link"
+      ${IREE_LLVM_LINK_BINARY}
       ${_BITCODE_FILES}
     COMMENT
       "Linking bitcode to ${_OUT}"
@@ -167,13 +167,13 @@ function(iree_cuda_bitcode_library)
       OUTPUT
         "${_BITCODE_FILE}"
       COMMAND
-        "clang"
+        "${IREE_CLANG_BINARY}"
         ${_COPTS}
         "${_BITCODE_SRC_PATH}"
         "-o"
         "${_BITCODE_FILE}"
       DEPENDS
-        "clang"
+        "${IREE_CLANG_BINARY}"
         "${_SRC}"
       COMMENT
         "Compiling ${_SRC} to ${_BITCODE_FILE}"
@@ -185,12 +185,12 @@ function(iree_cuda_bitcode_library)
     OUTPUT
       ${_OUT}
     COMMAND
-      "llvm-link"
+      ${IREE_LLVM_LINK_BINARY}
       ${_BITCODE_FILES}
       "-o"
       "${_OUT}"
     DEPENDS
-      "llvm-link"
+      ${IREE_LLVM_LINK_BINARY}
       ${_BITCODE_FILES}
     COMMENT
       "Linking bitcode to ${_OUT}"
@@ -235,12 +235,12 @@ function(iree_link_bitcode)
     OUTPUT
       ${_OUT}
     COMMAND
-      "llvm-link"
+      ${IREE_LLVM_LINK_BINARY}
       ${_BITCODE_FILES}
       "-o"
       "${_OUT}"
     DEPENDS
-      "llvm-link"
+      ${IREE_LLVM_LINK_BINARY}
       ${_BITCODE_FILES}
     COMMENT
       "Linking bitcode to ${_OUT}"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -40,6 +40,8 @@ if(IREE_HOST_BIN_DIR AND NOT IREE_BUILD_COMPILER)
   iree_import_binary(NAME iree-compile)
   iree_import_binary(NAME iree-opt)
   iree_import_binary(NAME iree-run-mlir)
+  iree_import_binary(NAME clang)
+  iree_import_binary(NAME llvm-link)
 endif()
 
 # TODO(#6353): Tools has thread dependencies in gtest, benchmark, yaml, etc.
@@ -224,6 +226,22 @@ if(IREE_BUILD_COMPILER)
   if(IREE_LLD_TARGET)
     install(
       TARGETS lld
+      COMPONENT Compiler
+      RUNTIME DESTINATION bin
+    )
+  endif()
+
+  if(IREE_LLVM_LINK_TARGET)
+    install(
+      TARGETS llvm-link
+      COMPONENT Compiler
+      RUNTIME DESTINATION bin
+    )
+  endif()
+
+  if(IREE_CLANG_TARGET)
+    install(
+      TARGETS clang
       COMPONENT Compiler
       RUNTIME DESTINATION bin
     )


### PR DESCRIPTION
They are used to generate ukernel bitcode targets. Include the binaries in the host tool install to support cross-compilation

The binaries will be added as CMake `TARGET` via `iree_import_binary` for cross-compile flows.