### PR TITLE
Fix bytecode module leak in iree-run-mlir.

### DIFF
--- a/runtime/src/iree/tooling/run_module.c
+++ b/runtime/src/iree/tooling/run_module.c
@@ -111,6 +111,7 @@ static iree_status_t iree_tooling_create_run_context(
     if (iree_status_is_ok(status)) {
       status = iree_tooling_module_list_push_back(&module_list, module);
     }
+    iree_vm_module_release(module);  // Now tracked in module_list.
   }
   if (!iree_status_is_ok(status)) {
     iree_tooling_module_list_reset(&module_list);


### PR DESCRIPTION
Caught by ASan:

```
370: =================================================================
370: ==3911909==ERROR: LeakSanitizer: detected memory leaks
370: 
370: Direct leak of 376 byte(s) in 1 object(s) allocated from:
370:     #0 0x6a9b022 in calloc (iree-build/tools/iree-run-mlir+0x6a9b022)
370:     #1 0x6ad5d47 in iree_allocator_system_alloc iree/runtime/src/iree/base/allocator.c:104:17
370:     #2 0x6ad5d47 in iree_allocator_system_ctl iree/runtime/src/iree/base/allocator.c:144:14
370:     #3 0x6ad56ad in iree_allocator_issue_alloc iree/runtime/src/iree/base/allocator.c:27:10
370:     #4 0x6ad56ad in iree_allocator_malloc iree/runtime/src/iree/base/allocator.c:32:10
370:     #5 0x1acf2486 in iree_vm_bytecode_module_create iree/runtime/src/iree/vm/bytecode/module.c:836:3
370:     #6 0x6afdf31 in iree_tooling_create_run_context iree/runtime/src/iree/tooling/run_module.c:107:9
370:     #7 0x6afdf31 in iree_tooling_run_module_with_data iree/runtime/src/iree/tooling/run_module.c:340:3
370:     #8 0x6ad2a24 in iree::(anonymous namespace)::CompileAndRunFile(iree_compiler_session_t*, char const*) iree/tools/iree-run-mlir-main.cc:359:3
370:     #9 0x6ad2a24 in main iree/tools/iree-run-mlir-main.cc:520:20
370:     #10 0x7fce3bc456c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
```