### PR TITLE
Enabling Vulkan buffer device addresses support in the runtime.

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/api.h
+++ b/runtime/src/iree/hal/drivers/vulkan/api.h
@@ -90,6 +90,10 @@ enum iree_hal_vulkan_feature_bits_t {
   // to allow for queue-ordered virtual memory management.
   IREE_HAL_VULKAN_FEATURE_ENABLE_SPARSE_RESIDENCY_ALIASED =
       IREE_HAL_VULKAN_FEATURE_ENABLE_SPARSE_BINDING | (1u << 5),
+
+  // Enables buffer device addresses when supported and uses them when
+  // appropriately compiled SPIR-V executables require them.
+  IREE_HAL_VULKAN_FEATURE_ENABLE_BUFFER_DEVICE_ADDRESSES = 1u << 6,
 };
 typedef uint32_t iree_hal_vulkan_features_t;
 

--- a/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
@@ -14,7 +14,7 @@ iree_hal_cts_test_suite(
   COMPILER_TARGET_BACKEND
     "vulkan-spirv"
   EXECUTABLE_FORMAT
-    "\"SPVE\""
+    "\"vulkan-spirv-fb\""
   DEPS
     iree::hal::drivers::vulkan::registration
   EXCLUDED_TESTS

--- a/runtime/src/iree/hal/drivers/vulkan/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/vulkan/dynamic_symbol_tables.h
@@ -293,6 +293,9 @@ namespace vulkan {
   DEV_PFN(OPTIONAL, vkSignalSemaphore)                                  \
   DEV_PFN(OPTIONAL, vkSignalSemaphoreKHR)                               \
                                                                         \
+  DEV_PFN(OPTIONAL, vkGetBufferDeviceAddress)                           \
+  DEV_PFN(OPTIONAL, vkGetBufferDeviceAddressKHR)                        \
+                                                                        \
   INS_PFN(EXCLUDED, vkCreateDebugReportCallbackEXT)                     \
   INS_PFN(OPTIONAL, vkCreateDebugUtilsMessengerEXT)                     \
   INS_PFN(EXCLUDED, vkCreateDisplayPlaneSurfaceKHR)                     \
@@ -329,7 +332,7 @@ namespace vulkan {
   INS_PFN(EXCLUDED, vkGetPhysicalDeviceExternalSemaphoreProperties)     \
   INS_PFN(EXCLUDED, vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)  \
   INS_PFN(REQUIRED, vkGetPhysicalDeviceFeatures)                        \
-  INS_PFN(EXCLUDED, vkGetPhysicalDeviceFeatures2)                       \
+  INS_PFN(REQUIRED, vkGetPhysicalDeviceFeatures2)                       \
   INS_PFN(EXCLUDED, vkGetPhysicalDeviceFeatures2KHR)                    \
   INS_PFN(REQUIRED, vkGetPhysicalDeviceFormatProperties)                \
   INS_PFN(EXCLUDED, vkGetPhysicalDeviceFormatProperties2)               \

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
@@ -213,6 +213,9 @@ iree_hal_vulkan_populate_enabled_device_extensions(
     } else if (strcmp(extension_name,
                       VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME) == 0) {
       extensions.external_memory_host = true;
+    } else if (strcmp(extension_name,
+                      VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME) == 0) {
+      extensions.buffer_device_address = true;
     }
   }
   return extensions;
@@ -234,6 +237,13 @@ iree_hal_vulkan_infer_enabled_device_extensions(
   }
   if (device_syms->vkGetCalibratedTimestampsEXT) {
     extensions.calibrated_timestamps = true;
+  }
+  if (device_syms->vkGetMemoryHostPointerPropertiesEXT) {
+    extensions.external_memory_host = true;
+  }
+  if (device_syms->vkGetBufferDeviceAddress ||
+      device_syms->vkGetBufferDeviceAddressKHR) {
+    extensions.buffer_device_address = true;
   }
   return extensions;
 }

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
@@ -84,6 +84,8 @@ typedef struct iree_hal_vulkan_device_extensions_t {
   bool subgroup_size_control : 1;
   // VK_EXT_external_memory_host is enabled.
   bool external_memory_host : 1;
+  // VK_KHR_buffer_device_address is enabled.
+  bool buffer_device_address : 1;
 } iree_hal_vulkan_device_extensions_t;
 
 // Returns a bitfield with all of the provided extension names.

--- a/runtime/src/iree/hal/drivers/vulkan/native_allocator.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_allocator.cc
@@ -293,6 +293,17 @@ static iree_status_t iree_hal_vulkan_native_allocator_commit_and_wrap(
   allocate_info.pNext = NULL;
   allocate_info.allocationSize = requirements.size;
   allocate_info.memoryTypeIndex = memory_type_index;
+  VkMemoryAllocateFlagsInfo allocate_flags_info = {};
+  allocate_flags_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+  allocate_flags_info.pNext = NULL;
+  allocate_flags_info.flags = 0;
+  if (iree_all_bits_set(
+          logical_device->enabled_features(),
+          IREE_HAL_VULKAN_FEATURE_ENABLE_BUFFER_DEVICE_ADDRESSES)) {
+    allocate_flags_info.flags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+  }
+  allocate_flags_info.deviceMask = 0;
+  allocate_info.pNext = &allocate_flags_info;
   VkDeviceMemory device_memory = VK_NULL_HANDLE;
   VK_RETURN_IF_ERROR(logical_device->syms()->vkAllocateMemory(
                          *logical_device, &allocate_info,

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -38,6 +38,9 @@ IREE_FLAG(
 IREE_FLAG(bool, vulkan_sparse_residency, true,
           "Enables the Vulkan 'sparseResidencyBuffer' feature (and others) "
           "when available.");
+IREE_FLAG(bool, vulkan_buffer_device_addresses, true,
+          "Enables the Vulkan 'bufferDeviceAddress` feature and support for "
+          "SPIR-V executables compiled to use it.");
 
 IREE_FLAG(
     bool, vulkan_dedicated_compute_queue, false,
@@ -93,6 +96,10 @@ static iree_status_t iree_hal_vulkan_create_driver_with_flags(
   if (FLAG_vulkan_sparse_residency) {
     driver_options.requested_features |=
         IREE_HAL_VULKAN_FEATURE_ENABLE_SPARSE_RESIDENCY_ALIASED;
+  }
+  if (FLAG_vulkan_buffer_device_addresses) {
+    driver_options.requested_features |=
+        IREE_HAL_VULKAN_FEATURE_ENABLE_BUFFER_DEVICE_ADDRESSES;
   }
 
   if (FLAG_vulkan_dedicated_compute_queue) {


### PR DESCRIPTION
We'll need command buffer and compiler support to use it but this will let us see if there are any issues enabling the features on our targets. There's support for mixed SPIR-V programs using buffer device addresses and those not and VMFBs can contain both to allow for graceful fallback when not supported. SPIR-V executables with the `vulkan-spirv-fb-ptr` will get the support and future changes will add descriptor set layout flags (`IREE_HAL_DESCRIPTOR_SET_LAYOUT_FLAG_INDIRECT` or something) that allows for routing certain descriptors into the indirect parameter buffer.

Progress on #13945.