### PR TITLE
Add missing include for renderdoc dlopen usage.

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -47,7 +47,9 @@ using namespace iree::hal::vulkan;
 // avoid introducing a backdoor.
 #if defined(IREE_HAL_VULKAN_HAVE_RENDERDOC)
 
+#if !defined(IREE_PLATFORM_WINDOWS)
 #include <dlfcn.h>
+#endif  // IREE_PLATFORM_WINDOWS
 
 // NOTE: C API, see https://renderdoc.org/docs/in_application_api.html.
 // When compiled in the API will no-op itself if not running under a RenderDoc

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -47,6 +47,8 @@ using namespace iree::hal::vulkan;
 // avoid introducing a backdoor.
 #if defined(IREE_HAL_VULKAN_HAVE_RENDERDOC)
 
+#include <dlfcn.h>
+
 // NOTE: C API, see https://renderdoc.org/docs/in_application_api.html.
 // When compiled in the API will no-op itself if not running under a RenderDoc
 // capture context (renderdoc.dll/so already loaded).


### PR DESCRIPTION
This fixes compilation with `-DIREE_ENABLE_RENDERDOC_PROFILING=ON`. The header was probably included indirectly before.

skip-ci: trivial + not covered by any CI jobs