### PR TITLE
Ukernels: Fix inline assembly constraint for clang-9

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
@@ -18,9 +18,9 @@
 //      https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html
 #define iree_workaround_vfmlalq_laneq_x_f16(INSTR, A, B, C, L) \
   ({                                                           \
-    asm(INSTR " %[a].4s, %[b].4h, %[c].h[%[l]]"                \
+    asm(INSTR " %[a].4s, %[b].4h, %[c].h[" #L "]"              \
         : [a] "+w"(A)                                          \
-        : [b] "w"(B), [c] "x"(C), [l] "i"(L)                   \
+        : [b] "w"(B), [c] "x"(C)                               \
         :);                                                    \
     A;                                                         \
   })


### PR DESCRIPTION
When using clang-9 the immediate constraint produces a hash before the literal which throws an error.

Change-Id: I572c7aec83ee0e77c7a34e6b958ec6040a41c368