### PR TITLE
Switching --iree-stream-resource-index-bits= to 64 by default.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -62,7 +62,7 @@ static llvm::cl::opt<uint64_t> clResourceMaxRange(
 static llvm::cl::opt<unsigned> clResourceIndexBits(
     "iree-stream-resource-index-bits",
     llvm::cl::desc("Bit width of indices used to reference resource offsets."),
-    llvm::cl::init(32));
+    llvm::cl::init(64));
 static llvm::cl::opt<bool> clResourceAliasMutableBindings(
     "iree-stream-resource-alias-mutable-bindings",
     llvm::cl::desc(


### PR DESCRIPTION
PR #10510 switched the --iree-vm-target-index-bits= flag to 64 and this updates the stream side as well. This has implications around push constant utilization as what could have been 4 bytes will now be 8 when we can't guarantee that the high bits are 0. It does make running big models require no additional flags around index width, though.