### PR TITLE
Workaround Vulkan driver bug triggered by native allocator code.

### DIFF
--- a/tests/e2e/models/fragment_000.mlir
+++ b/tests/e2e/models/fragment_000.mlir
@@ -1,7 +1,6 @@
 // RUN: iree-run-mlir --Xcompiler,iree-input-type=stablehlo --Xcompiler,iree-hal-target-backends=vmvx %s | FileCheck %s
 // RUN: iree-run-mlir --Xcompiler,iree-input-type=stablehlo --Xcompiler,iree-hal-target-backends=llvm-cpu %s | FileCheck %s
-// TODO(#14776): enable Vulkan when it passes on the bots - currently fails with an unexpected out-of-memory.
-// NO_R_U_N: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --Xcompiler,iree-input-type=stablehlo --Xcompiler,iree-hal-target-backends=vulkan-spirv %s | FileCheck %s)
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --Xcompiler,iree-input-type=stablehlo --Xcompiler,iree-hal-target-backends=vulkan-spirv %s | FileCheck %s)
 // RUN: [[ $IREE_METAL_DISABLE == 1 ]] || (iree-run-mlir --Xcompiler,iree-input-type=stablehlo --Xcompiler,iree-hal-target-backends=metal-spirv %s | FileCheck %s)
 
 // CHECK-LABEL: EXEC @entry

--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -39,18 +39,16 @@ if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
   )
 endif()
 
-# TODO(#14776): enable Vulkan when it passes on the bots - currently fails with
-# an unexpected out-of-memory.
-# if(IREE_TARGET_BACKEND_VULKAN_SPIRV AND IREE_HAL_DRIVER_VULKAN)
-#   iree_py_test(
-#     NAME
-#       mnist_train_test_vulkan
-#     SRCS
-#       "mnist_train_test.py"
-#     ARGS
-#       "--target_backend=vulkan-spirv"
-#       "--driver=vulkan"
-#     LABELS
-#       "driver=vulkan"
-#   )
-# endif()
+if(IREE_TARGET_BACKEND_VULKAN_SPIRV AND IREE_HAL_DRIVER_VULKAN)
+  iree_py_test(
+    NAME
+      mnist_train_test_vulkan
+    SRCS
+      "mnist_train_test.py"
+    ARGS
+      "--target_backend=vulkan-spirv"
+      "--driver=vulkan"
+    LABELS
+      "driver=vulkan"
+  )
+endif()

--- a/tests/e2e/tensor_ops/tensor_cast.mlir
+++ b/tests/e2e/tensor_ops/tensor_cast.mlir
@@ -1,7 +1,6 @@
 // RUN: iree-run-mlir --Xcompiler,iree-hal-target-backends=llvm-cpu %s | FileCheck %s
 // RUN: [[ $IREE_VMVX_DISABLE == 1 ]] || (iree-run-mlir --Xcompiler,iree-hal-target-backends=vmvx %s | FileCheck %s)
-// TODO(#14776): enable Vulkan when it passes on the bots - currently fails with an unexpected out-of-memory.
-// NO_R_U_N: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --Xcompiler,iree-hal-target-backends=vulkan-spirv %s | FileCheck %s)
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --Xcompiler,iree-hal-target-backends=vulkan-spirv %s | FileCheck %s)
 
 func.func @tensor_cast() -> tensor<2x?xf32> {
   %input = util.unfoldable_constant dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf32>


### PR DESCRIPTION
Workaround for https://github.com/openxla/iree/issues/14776

I haven't quite reached the root cause here, but I think we're hitting https://gitlab.freedesktop.org/mesa/mesa/-/issues/9251 and a particularly bad failure mode from the driver. When we try importing from memory that is already mapped, allocations fail - both the current allocation and future allocations.

More debugging notes are [here on Discord](https://discord.com/channels/689900678990135345/689959648501039106/1143574510847676436).