### PR TITLE
Updated ExpandTensorShapes to work on SCF operations

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExpandTensorShapes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExpandTensorShapes.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
@@ -247,6 +248,33 @@ static void expandRegion(Region &region, ExpandedGlobalMap &globalMap,
   }
 }
 
+static void retieResults(Operation *op, Operation *newOp,
+                         TensorDimMap &tensorDimMap) {
+  OpBuilder builder(newOp);
+
+  builder.setInsertionPointAfter(newOp);
+  unsigned newIdx = 0;
+  for (unsigned oldIdx = 0; oldIdx < op->getNumResults(); ++oldIdx) {
+    auto oldResult = op->getResult(oldIdx);
+    auto tensorType = llvm::dyn_cast<RankedTensorType>(oldResult.getType());
+    if (!tensorType || tensorType.hasStaticShape()) {
+      auto newResult = newOp->getResult(newIdx++);
+      oldResult.replaceAllUsesWith(newResult);
+      continue;
+    }
+    ExpandedValue expandedValue;
+    expandedValue.tensor = newOp->getResult(newIdx++);
+    expandedValue.dynamicDims =
+        newOp->getResults().slice(newIdx, tensorType.getNumDynamicDims());
+    newIdx += expandedValue.dynamicDims.size();
+    tensorDimMap[expandedValue.tensor] = expandedValue;
+    auto tieShapeOp = builder.create<IREE::Flow::TensorTieShapeOp>(
+        op->getLoc(), expandedValue.tensor.getType(), expandedValue.tensor,
+        expandedValue.dynamicDims);
+    oldResult.replaceAllUsesExcept(tieShapeOp.getResult(), tieShapeOp);
+  }
+}
+
 // Moves tensor dims from global stores to loads.
 // Requires that the ExpandGlobalStoreOp pattern performs the stores.
 //
@@ -364,28 +392,7 @@ static void expandCallOp(mlir::func::CallOp op, IndexSet &indexSet,
   // Insert shape ties on results that we are sinking across the call edge.
   // The hope is that by moving the ties here we can fold with queries inside of
   // this function.
-  builder.setInsertionPointAfter(newOp);
-  unsigned newIdx = 0;
-  for (unsigned oldIdx = 0; oldIdx < op.getNumResults(); ++oldIdx) {
-    auto oldResult = op.getResult(oldIdx);
-    auto tensorType = llvm::dyn_cast<RankedTensorType>(oldResult.getType());
-    if (!tensorType || tensorType.hasStaticShape()) {
-      auto newResult = newOp.getResult(newIdx++);
-      oldResult.replaceAllUsesWith(newResult);
-      continue;
-    }
-    ExpandedValue expandedValue;
-    expandedValue.tensor = newOp.getResult(newIdx++);
-    expandedValue.dynamicDims =
-        newOp.getResults().slice(newIdx, tensorType.getNumDynamicDims());
-    newIdx += expandedValue.dynamicDims.size();
-    tensorDimMap[expandedValue.tensor] = expandedValue;
-    auto tieShapeOp = builder.create<IREE::Flow::TensorTieShapeOp>(
-        op.getLoc(), expandedValue.tensor.getType(), expandedValue.tensor,
-        expandedValue.dynamicDims);
-    oldResult.replaceAllUsesExcept(tieShapeOp.getResult(), tieShapeOp);
-  }
-
+  retieResults(op, newOp, tensorDimMap);
   op.erase();
 }
 
@@ -484,6 +491,67 @@ static void expandSelectOp(mlir::arith::SelectOp op, IndexSet &indexSet,
   op.erase();
 }
 
+static void expandWhileOp(mlir::scf::WhileOp op, ExpandedGlobalMap &globalMap,
+                          IndexSet &indexSet, TensorDimMap &tensorDimMap) {
+  OpBuilder builder(op);
+  auto operands = expandOperands(op.getLoc(), op.getOperands(), tensorDimMap,
+                                 indexSet, builder);
+  auto resultTypes = expandTypes(op.getResultTypes());
+
+  auto newOp = builder.create<scf::WhileOp>(op.getLoc(), resultTypes, operands,
+                                            /*beforeBody*/ nullptr,
+                                            /*afterBody*/ nullptr);
+
+  IRMapping mapping;
+  newOp.getBefore().takeBody(op.getBefore());
+  newOp.getAfter().takeBody(op.getAfter());
+
+  expandRegion(newOp.getBefore(), globalMap, indexSet, tensorDimMap);
+  expandRegion(newOp.getAfter(), globalMap, indexSet, tensorDimMap);
+  retieResults(op, newOp, tensorDimMap);
+  op.erase();
+}
+
+static void expandIfOp(mlir::scf::IfOp op, ExpandedGlobalMap &globalMap,
+                       IndexSet &indexSet, TensorDimMap &tensorDimMap) {
+  OpBuilder builder(op);
+  auto resultTypes = expandTypes(op.getResultTypes());
+
+  auto newOp = builder.create<scf::IfOp>(
+      op.getLoc(), resultTypes, op.getOperand(), op.elseBlock() != nullptr);
+
+  IRMapping mapping;
+  newOp.getBodyRegion().takeBody(op.getBodyRegion());
+  expandRegion(newOp.getBodyRegion(), globalMap, indexSet, tensorDimMap);
+
+  if (newOp.elseBlock()) {
+    newOp.getElseRegion().takeBody(op.getElseRegion());
+    expandRegion(newOp.getElseRegion(), globalMap, indexSet, tensorDimMap);
+  }
+
+  retieResults(op, newOp, tensorDimMap);
+  op.erase();
+}
+
+static void expandScfYieldOp(mlir::scf::YieldOp op, IndexSet &indexSet,
+                             TensorDimMap &tensorDimMap) {
+  OpBuilder builder(op);
+  auto operands = expandOperands(op.getLoc(), op.getOperands(), tensorDimMap,
+                                 indexSet, builder);
+  builder.create<mlir::scf::YieldOp>(op.getLoc(), operands);
+  op.erase();
+}
+
+static void expandScfConditionOp(mlir::scf::ConditionOp op, IndexSet &indexSet,
+                                 TensorDimMap &tensorDimMap) {
+  OpBuilder builder(op);
+  auto operands = expandOperands(op.getLoc(), op.getArgs(), tensorDimMap,
+                                 indexSet, builder);
+  builder.create<mlir::scf::ConditionOp>(op.getLoc(), op.getCondition(),
+                                         operands);
+  op.erase();
+}
+
 // Recursively expands tensors into (tensor, dynamic dims...) in |op|.
 static void expandTensorDims(Operation *op, ExpandedGlobalMap &globalMap,
                              IndexSet &indexSet, TensorDimMap &tensorDimMap) {
@@ -505,6 +573,14 @@ static void expandTensorDims(Operation *op, ExpandedGlobalMap &globalMap,
     expandCondBranchOp(condBranchOp, indexSet, tensorDimMap);
   } else if (auto selectOp = dyn_cast<mlir::arith::SelectOp>(op)) {
     expandSelectOp(selectOp, indexSet, tensorDimMap);
+  } else if (auto whileOp = dyn_cast<mlir::scf::WhileOp>(op)) {
+    expandWhileOp(whileOp, globalMap, indexSet, tensorDimMap);
+  } else if (auto ifOp = dyn_cast<mlir::scf::IfOp>(op)) {
+    expandIfOp(ifOp, globalMap, indexSet, tensorDimMap);
+  } else if (auto yieldOp = dyn_cast<mlir::scf::YieldOp>(op)) {
+    expandScfYieldOp(yieldOp, indexSet, tensorDimMap);
+  } else if (auto conditionOp = dyn_cast<mlir::scf::ConditionOp>(op)) {
+    expandScfConditionOp(conditionOp, indexSet, tensorDimMap);
   }
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -170,6 +170,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       // compute op into the dispatch region, so that we can run additional
       // transformations afterwards with a simple region and without bothering
       // producers.
+      .addPass(IREE::Flow::createTopLevelSCFToCFGPass)
       .addPass([&]() {
         return createFormDispatchRegionsPass(FormDispatchRegionsOptions{
             clEnableFuseMultiUse, clDispatchGenerateWorkloadRegion,

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -54,9 +54,9 @@ void buildGlobalOptimizationPassPipeline(
   // Expand tensor shapes into SSA values and optimize the whole program.
   // The more we are able to equate shape dimensions at this level the
   // better our fusions will be.
+  mainPassManager.addPass(IREE::Flow::createExpandTensorShapesPass());
   FunctionLikeNest(mainPassManager)
       .addPass(IREE::Flow::createTopLevelSCFToCFGPass);
-  mainPassManager.addPass(IREE::Flow::createExpandTensorShapesPass());
 
   FunctionLikeNest(mainPassManager)
       // Preprocess the input to a form more amenable for fusion

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -55,8 +55,6 @@ void buildGlobalOptimizationPassPipeline(
   // The more we are able to equate shape dimensions at this level the
   // better our fusions will be.
   mainPassManager.addPass(IREE::Flow::createExpandTensorShapesPass());
-  FunctionLikeNest(mainPassManager)
-      .addPass(IREE::Flow::createTopLevelSCFToCFGPass);
 
   FunctionLikeNest(mainPassManager)
       // Preprocess the input to a form more amenable for fusion


### PR DESCRIPTION
Part of making Flow transforms support SCF requires that the expand tensor shapes pass can recurse in / expand the shape operations.