### PR TITLE
[StableHLO] Fix null deref in topk rewrite

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -1720,6 +1720,9 @@ struct IotaSortSliceIsTopK final : OpRewritePattern<mlir::stablehlo::SortOp> {
     int64_t k;
     // Check that the output of the sort op gets fed into a slice.
     for (auto [idx, result] : llvm::enumerate(opResults)) {
+      if (result.getUsers().empty())
+        return rewriter.notifyMatchFailure(
+            op, "Sort isn't calling into a slice op.");
       auto sliceOp =
           dyn_cast<mlir::stablehlo::SliceOp>(*result.getUsers().begin());
       if (!sliceOp) {


### PR DESCRIPTION
We were dereferencing the first user of a result with no users.