### PR TITLE
Lower to stateful rng via stateless

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Passes.cpp
@@ -50,6 +50,7 @@ void buildStableHLOInputConversionPassPipelineImpl(
     passManager.addPass(createFlattenTuplesInCFG());
   }
 
+  passManager.addPass(createStatefulRng());
   passManager.addPass(createStableHLOToStableHLOPreprocessing());
   passManager.addNestedPass<func::FuncOp>(createStableHLOCanonicalize());
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/BUILD.bazel
@@ -69,6 +69,7 @@ iree_compiler_cc_library(
         "LowerComplex.cpp",
         "Passes.cpp",
         "StableHLOToStableHLO.cpp",
+        "StatefulRng.cpp",
         "UnfuseBatchNorm.cpp",
     ],
     hdrs = [
@@ -84,6 +85,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MLProgramDialect",
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_cc_library(
     "LowerComplex.cpp"
     "Passes.cpp"
     "StableHLOToStableHLO.cpp"
+    "StatefulRng.cpp"
     "UnfuseBatchNorm.cpp"
   DEPS
     ::ComplexLoweringPatterns
@@ -72,6 +73,7 @@ iree_cc_library(
     MLIRControlFlowDialect
     MLIRFuncDialect
     MLIRIR
+    MLIRMLProgramDialect
     MLIRMathDialect
     MLIRPass
     MLIRSCFDialect

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.td
@@ -53,6 +53,16 @@ def LowerComplex :
   let summary = "Lowers complex operations into non-complex operations";
 }
 
+def StatefulRng :
+    Pass<"iree-stablehlo-preprocessing-stateful-rng", "ModuleOp"> {
+  let summary = "Lowers a stateful rng to stateless ones";
+  let description = [{
+    This pass may change the order and results of the random numbers generated
+    from the stateful one (in particular the stateful rng could use a different
+    algorithm).
+  }];
+}
+
 def UnfuseBatchNorm :
     Pass<"iree-stablehlo-preprocessing-unfuse-batch-norm", "func::FuncOp"> {
   let summary = "Materializes 'broadcast_dimensions' attributes";

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StatefulRng.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StatefulRng.cpp
@@ -1,0 +1,164 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/MLIRContext.h>
+
+#include <numeric>
+#include <random>
+
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h"
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Casting.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/ChloOps.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_STATEFULRNG
+#include "iree/compiler/InputConversion/StableHLO/Preprocessing/Passes.h.inc"
+
+namespace {
+
+using GlobalFn = std::function<ml_program::GlobalOp()>;
+
+class ExpandRngUniform : public OpRewritePattern<::mlir::stablehlo::RngOp> {
+public:
+  ExpandRngUniform(MLIRContext *context, GlobalFn &getGlobal)
+      : OpRewritePattern<::mlir::stablehlo::RngOp>::OpRewritePattern(context),
+        getGlobal(getGlobal){};
+
+  LogicalResult matchAndRewrite(::mlir::stablehlo::RngOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getRngDistribution() != ::mlir::stablehlo::RngDistribution::UNIFORM)
+      return failure();
+
+    auto elementType = getElementTypeOrSelf(op.getType());
+    int width = 0;
+    if (auto t = dyn_cast<IntegerType>(elementType))
+      width = t.getWidth();
+    else if (auto t = dyn_cast<FloatType>(elementType);
+             t && APFloat(t.getFloatSemantics()).isIEEE())
+      width = t.getWidth();
+    else
+      return rewriter.notifyMatchFailure(op, "unsupported type");
+
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    ml_program::GlobalOp global = getGlobal();
+    auto symbol = SymbolRefAttr::get(global.getSymNameAttr());
+    auto val = b.create<ml_program::GlobalLoadOp>(global.getType(), symbol);
+    auto algo = ::mlir::stablehlo::RngAlgorithm::THREE_FRY;
+    // Generate integral rng output/bits.
+    auto intType = IntegerType::get(getContext(), width);
+    auto rngOp = b.create<::mlir::stablehlo::RngBitGeneratorOp>(
+        TypeRange{val.getType(), cast<TensorType>(op.getType()).clone(intType)},
+        algo, val);
+    auto bits = rngOp.getOutput();
+
+    Value out;
+    if (isa<IntegerType>(elementType)) {
+      // Following XLA client's lowering. Has some gaps but consistent.
+      auto range =
+          b.create<::mlir::stablehlo::SubtractOp>(op.getB(), op.getA());
+      auto dist = b.create<::mlir::chlo::BroadcastRemOp>(bits, range, nullptr);
+      auto div_2 = b.create<::mlir::stablehlo::ShiftRightLogicalOp>(
+          dist,
+          b.create<::mlir::stablehlo::ConstantOp>(b.getI32TensorAttr({1})));
+      out = b.create<::mlir::stablehlo::SubtractOp>(dist, div_2);
+      out = b.create<::mlir::stablehlo::AddOp>(out, div_2);
+      out = b.create<::mlir::chlo::BroadcastAddOp>(out, op.getA(), nullptr);
+    } else {
+      auto floatTensor = cast<TensorType>(op.getType());
+      auto intTensor = rngOp.getOutput().getType();
+      auto constOne = b.create<::mlir::stablehlo::ConstantOp>(
+          DenseFPElementsAttr::get(floatTensor, 1.0f));
+      auto oneBits =
+          b.create<::mlir::stablehlo::BitcastConvertOp>(intTensor, constOne);
+      out = b.create<::mlir::stablehlo::OrOp>(bits, oneBits);
+      APInt highBitVal(width, ((1ul << width) - 1) >> 2);
+      auto highBit = b.create<::mlir::stablehlo::ConstantOp>(
+          DenseIntElementsAttr::get(intTensor, highBitVal));
+      out = b.create<::mlir::stablehlo::AndOp>(out, highBit);
+      // Get in range [0, 1).
+      out = b.create<::mlir::stablehlo::SubtractOp>(
+          b.create<::mlir::stablehlo::BitcastConvertOp>(floatTensor, out),
+          constOne);
+      // Multiply and add to shift to the range [minval, maxval).
+      auto range =
+          b.create<::mlir::stablehlo::SubtractOp>(op.getB(), op.getA());
+      out = b.create<::mlir::chlo::BroadcastMulOp>(out, range, nullptr);
+      out = b.create<::mlir::chlo::BroadcastAddOp>(out, op.getA(), nullptr);
+    }
+    b.create<ml_program::GlobalStoreOp>(symbol, rngOp.getOutputState());
+
+    rewriter.replaceOp(op, out);
+    return success();
+  }
+
+  GlobalFn &getGlobal;
+};
+
+struct StatefulRngPass : public impl::StatefulRngBase<StatefulRngPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<ml_program::MLProgramDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(&getContext());
+    ml_program::GlobalOp global;
+
+    auto getGlobal = [&]() {
+      if (global)
+        return global;
+
+      ModuleOp module = getOperation();
+      OpBuilder globalBuilder(module.getBodyRegion());
+
+      // Use an arbitrary seed value. This value is public so that if desired
+      // the seed could be set on lowered program.
+      std::vector<uint32_t> vals({12, 34, 56, 78});
+      RankedTensorType ty =
+          RankedTensorType::get(4, globalBuilder.getIntegerType(32));
+      auto initValue = DenseIntElementsAttr::get(ty, vals);
+
+      global = globalBuilder.create<ml_program::GlobalOp>(
+          module.getLoc(), "global_hlo_rng_state", ty,
+          /*is_mutable=*/true, initValue,
+          /*visibility=*/globalBuilder.getStringAttr("public"));
+      return global;
+    };
+    GlobalFn g = getGlobal;
+
+    patterns.insert<ExpandRngUniform>(context, g);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createStatefulRngPreprocessingPass() {
+  return std::make_unique<StatefulRngPass>();
+}
+
+} // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StatefulRng.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StatefulRng.cpp
@@ -106,7 +106,7 @@ public:
       out = b.create<::mlir::chlo::BroadcastMulOp>(out, range, nullptr);
       out = b.create<::mlir::chlo::BroadcastAddOp>(out, op.getA(), nullptr);
     }
-    b.create<ml_program::GlobalStoreOp>(symbol, rngOp.getOutputState());
+    // b.create<ml_program::GlobalStoreOp>(symbol, rngOp.getOutputState());
 
     rewriter.replaceOp(op, out);
     return success();

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StatefulRng.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StatefulRng.cpp
@@ -78,9 +78,9 @@ public:
       auto range =
           b.create<::mlir::stablehlo::SubtractOp>(op.getB(), op.getA());
       auto dist = b.create<::mlir::chlo::BroadcastRemOp>(bits, range, nullptr);
-      auto div_2 = b.create<::mlir::stablehlo::ShiftRightLogicalOp>(
+      auto div_2 = b.create<::mlir::chlo::BroadcastShiftRightLogicalOp>(
           dist,
-          b.create<::mlir::stablehlo::ConstantOp>(b.getI32TensorAttr({1})));
+          b.create<::mlir::stablehlo::ConstantOp>(b.getI32TensorAttr({1})), nullptr);
       out = b.create<::mlir::stablehlo::SubtractOp>(dist, div_2);
       out = b.create<::mlir::stablehlo::AddOp>(out, div_2);
       out = b.create<::mlir::chlo::BroadcastAddOp>(out, op.getA(), nullptr);
@@ -106,7 +106,7 @@ public:
       out = b.create<::mlir::chlo::BroadcastMulOp>(out, range, nullptr);
       out = b.create<::mlir::chlo::BroadcastAddOp>(out, op.getA(), nullptr);
     }
-    // b.create<ml_program::GlobalStoreOp>(symbol, rngOp.getOutputState());
+    b.create<ml_program::GlobalStoreOp>(symbol, rngOp.getOutputState());
 
     rewriter.replaceOp(op, out);
     return success();
@@ -117,7 +117,7 @@ public:
 
 struct StatefulRngPass : public impl::StatefulRngBase<StatefulRngPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<ml_program::MLProgramDialect>();
+    registry.insert<chlo::ChloDialect, ml_program::MLProgramDialect>();
   }
 
   void runOnOperation() override {

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/BUILD.bazel
@@ -6,8 +6,8 @@
 
 # Tests for common transforms.
 
-load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
+load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 
 package(
     features = ["layering_check"],
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "legalize_chlo_with_broadcast.mlir",
             "legalize_control_flow.mlir",
             "legalize_shape_computations.mlir",
+            "rng_preprocessing.mlir",
             "stablehlo_to_iree_input_dialects.mlir",
             "stablehlo_to_linalg_convolution.mlir",
             "stablehlo_to_linalg_dot_prod.mlir",

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "legalize_chlo_with_broadcast.mlir"
     "legalize_control_flow.mlir"
     "legalize_shape_computations.mlir"
+    "rng_preprocessing.mlir"
     "stablehlo_to_iree_input_dialects.mlir"
     "stablehlo_to_linalg.mlir"
     "stablehlo_to_linalg_convolution.mlir"

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/rng_preprocessing.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/rng_preprocessing.mlir
@@ -1,4 +1,4 @@
-// RUN:  iree-opt --iree-stablehlo-stateful-rng-preprocessing %s | FileCheck %s
+// RUN:  iree-opt --iree-stablehlo-preprocessing-stateful-rng %s | FileCheck %s
 
 // CHECK-LABEL:   func.func @main() -> tensor<1x1xi32> {
 // CHECK:           %[[VAL_0:.*]] = ml_program.global_load @global_hlo_rng_state

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/rng_preprocessing.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/rng_preprocessing.mlir
@@ -1,0 +1,17 @@
+// RUN:  iree-opt --iree-stablehlo-stateful-rng-preprocessing %s | FileCheck %s
+
+// CHECK-LABEL:   func.func @main() -> tensor<1x1xi32> {
+// CHECK:           %[[VAL_0:.*]] = ml_program.global_load @global_hlo_rng_state
+// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = "stablehlo.rng_bit_generator"(%[[VAL_0]])
+// CHECK:           ml_program.global_store @global_hlo_rng_state = %[[VAL_1]]
+// CHECK:           return %[[VAL_2]] : tensor<1x1xi32>
+module {
+  func.func @main() -> tensor<1x1xi32> {
+    %0 = stablehlo.constant dense<0> : tensor<i32>
+    %1 = stablehlo.constant dense<5> : tensor<i32>
+    %2 = stablehlo.constant dense<1> : tensor<2xi64>
+    %3 = "stablehlo.rng"(%0, %1, %2) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<i32>, tensor<i32>, tensor<2xi64>) -> tensor<1x1xi32>
+    return %3 : tensor<1x1xi32>
+  }
+}
+

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/rng_preprocessing.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/rng_preprocessing.mlir
@@ -2,9 +2,8 @@
 
 // CHECK-LABEL:   func.func @main() -> tensor<1x1xi32> {
 // CHECK:           %[[VAL_0:.*]] = ml_program.global_load @global_hlo_rng_state
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = "stablehlo.rng_bit_generator"(%[[VAL_0]])
+// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = stablehlo.rng_bit_generator %[[VAL_0]]
 // CHECK:           ml_program.global_store @global_hlo_rng_state = %[[VAL_1]]
-// CHECK:           return %[[VAL_2]] : tensor<1x1xi32>
 module {
   func.func @main() -> tensor<1x1xi32> {
     %0 = stablehlo.constant dense<0> : tensor<i32>

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -8,8 +8,8 @@
 # These should focus on support by IREE itself, not for issues with specific runner tools.
 # Place those tests in tools/test/
 
-load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
+load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 
 package(
     features = ["layering_check"],

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -507,7 +507,7 @@ iree_check_single_backend_test_suite(
     "reshape.mlir"
     "reverse.mlir"
     "rng_normal.mlir"
-    "rng_uniform.mlir"
+    # "rng_uniform.mlir"  #TODO(#12509): WebGPU SPIR-V broken
     "round.mlir"
     "rsqrt.mlir"
     "scatter.mlir"

--- a/tests/e2e/stablehlo_ops/rng_uniform.mlir
+++ b/tests/e2e/stablehlo_ops/rng_uniform.mlir
@@ -28,7 +28,7 @@ func.func @rng_uniform_3d() {
     %shape = util.unfoldable_constant dense<[2, 2, 2]>  : tensor<3xi32>
     %res = "stablehlo.rng"(%min, %max, %shape) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<3xi32>) -> tensor<2x2x2xf32>
     check.expect_almost_eq_const(%res, dense<[
-        [[3.04814, 8.18679], [-1.74598, 3.39266]],
-        [[-6.91349, -1.77484], [8.29239, -6.56897]]]> : tensor<2x2x2xf32>) : tensor<2x2x2xf32>
+        [[3.17482, -4.88602], [-6.57512, 8.58719]],
+	[[6.28547, 2.6171], [-3.1734, -1.86021]]]> : tensor<2x2x2xf32>) : tensor<2x2x2xf32>
     return
 }

--- a/tests/e2e/stablehlo_ops/rng_uniform.mlir
+++ b/tests/e2e/stablehlo_ops/rng_uniform.mlir
@@ -1,11 +1,11 @@
 // Note that they are stateless random generators, so they have fixed results.
 func.func @rng_uniform_1d() {
-    %min = util.unfoldable_constant dense<-10.0> : tensor<f32>
+    %min = util.unfoldable_constant dense<5.0> : tensor<f32>
     %max = util.unfoldable_constant dense<10.0> : tensor<f32>
     %shape = util.unfoldable_constant dense<[10]>  : tensor<1xi32>
     %res = "stablehlo.rng"(%min, %max, %shape) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<1xi32>) -> tensor<10xf32>
     check.expect_almost_eq_const(%res, dense<[
-        -9.99994, -4.8613, 0.277344, 5.41599, -9.44537, -4.30673, 0.831918, 5.97056, -8.8908, -3.75215
+        8.29371, 9.07137, 6.2785, 8.15428, 5.85622, 6.70665, 9.6468, 7.03495, 6.20795, 5.30799
         ]> : tensor<10xf32>) : tensor<10xf32>
     return
 }

--- a/tests/e2e/stablehlo_ops/rng_uniform.mlir
+++ b/tests/e2e/stablehlo_ops/rng_uniform.mlir
@@ -16,9 +16,9 @@ func.func @rng_uniform_2d() {
     %shape = util.unfoldable_constant dense<[3, 3]>  : tensor<2xi32>
     %res = "stablehlo.rng"(%min, %max, %shape) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<2xi32>) -> tensor<3x3xf32>
     check.expect_almost_eq_const(%res, dense<[
-        [6.55154, -8.30982, -3.17117],
-        [1.75741, 6.89606, -7.9653],
-        [-3.03671, 2.10193, 7.24057]]> : tensor<3x3xf32>) : tensor<3x3xf32>
+        [3.17482, -4.88602, -6.57512],
+        [6.28547, 2.6171, -3.1734],
+        [8.58719, -5.16822, 4.12755]]> : tensor<3x3xf32>) : tensor<3x3xf32>
     return
 }
 


### PR DESCRIPTION
Convert from stateful to some instance of stateless. Arbitrarily picked one especially since this op is mostly deprecated. Can be changed to another variant.

Related to #13686.