### PR TITLE
[cuda] Initialize resource immediately after allocation

### DIFF
--- a/experimental/cuda2/native_executable.c
+++ b/experimental/cuda2/native_executable.c
@@ -164,6 +164,9 @@ iree_status_t iree_hal_cuda2_native_executable_create(
           (char*)((char*)executable + sizeof(*executable) +
                   entry_point_count * sizeof(executable->entry_points[0])));
 
+  iree_hal_resource_initialize(&iree_hal_cuda2_native_executable_vtable,
+                               &executable->resource);
+
   // Load the PTX image - this will fail if the device cannot handle the
   // contents. We could check this prior to creating
   CUmodule module = NULL;
@@ -185,8 +188,6 @@ iree_status_t iree_hal_cuda2_native_executable_create(
   }
 
   if (iree_status_is_ok(status)) {
-    iree_hal_resource_initialize(&iree_hal_cuda2_native_executable_vtable,
-                                 &executable->resource);
     executable->host_allocator = host_allocator;
     executable->symbols = symbols;
     executable->cu_module = module;


### PR DESCRIPTION
This prevents a crash during error cases, where we would call `iree_hal_executable_destroy` on the allocated data structure. That requires it to be Initialized.