### PR TITLE
Move demotion passes to GlobalOptimization.

### DIFF
--- a/build_tools/benchmarks/comparisons/setup_desktop.sh
+++ b/build_tools/benchmarks/comparisons/setup_desktop.sh
@@ -96,7 +96,7 @@ for i in $(ls ${ROOT_DIR}/models/tflite/); do
     --iree-input-type=tosa \
     --iree-hal-target-backends=cuda \
     --iree-hal-cuda-llvm-target-arch=sm_80 \
-    --iree-flow-demote-f32-to-f16 \
+    --iree-opt-demote-f32-to-f16 \
     --iree-llvmcpu-debug-symbols=false \
     --iree-vm-bytecode-module-strip-source-map=true \
     --iree-vm-emit-polyglot-zip=false \

--- a/build_tools/benchmarks/comparisons/setup_mobile.sh
+++ b/build_tools/benchmarks/comparisons/setup_mobile.sh
@@ -176,7 +176,7 @@ for i in $(ls ${ROOT_DIR}/models/tflite/); do
       --iree-input-type=tosa \
       --iree-hal-target-backends=vulkan-spirv \
       --iree-vulkan-target-triple=valhall-unknown-android31 \
-      --iree-flow-demote-f32-to-f16 \
+      --iree-opt-demote-f32-to-f16 \
       --iree-llvmcpu-debug-symbols=false \
       --iree-vm-bytecode-module-strip-source-map=true \
       --iree-vm-emit-polyglot-zip=false \

--- a/build_tools/python/benchmark_suites/iree/mali_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/mali_benchmarks.py
@@ -127,7 +127,7 @@ class Android_Mali_Benchmarks(object):
             id=compile_config.id + "-demote-f32-to-16",
             tags=compile_config.tags + ["demote-f32-to-f16"],
             compile_targets=compile_config.compile_targets,
-            extra_flags=compile_config.extra_flags + ["--iree-flow-demote-f32-to-f16"],
+            extra_flags=compile_config.extra_flags + ["--iree-opt-demote-f32-to-f16"],
         )
         return (
             [

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -123,7 +123,7 @@ struct GlobalInit {
   BindingOptions *clBindingOptions = nullptr;
   InputDialectOptions *clInputOptions = nullptr;
   PreprocessingOptions *clPreprocessingOptions = nullptr;
-  HighLevelOptimizationOptions *clHighLevelOptimizationOptions = nullptr;
+  GlobalOptimizationOptions *clGlobalOptimizationOptions = nullptr;
   SchedulingOptions *clSchedulingOptions = nullptr;
   IREE::HAL::TargetOptions *clHalTargetOptions = nullptr;
   IREE::VM::TargetOptions *clVmTargetOptions = nullptr;
@@ -167,8 +167,8 @@ void GlobalInit::registerCommandLineOptions() {
   clBindingOptions = &BindingOptions::FromFlags::get();
   clInputOptions = &InputDialectOptions::FromFlags::get();
   clPreprocessingOptions = &PreprocessingOptions::FromFlags::get();
-  clHighLevelOptimizationOptions =
-      &HighLevelOptimizationOptions::FromFlags::get();
+  clGlobalOptimizationOptions =
+      &GlobalOptimizationOptions::FromFlags::get();
   clSchedulingOptions = &SchedulingOptions::FromFlags::get();
   clHalTargetOptions = &IREE::HAL::TargetOptions::FromFlags::get();
   clVmTargetOptions = &IREE::VM::TargetOptions::FromFlags::get();
@@ -252,7 +252,7 @@ struct Session {
   BindingOptions bindingOptions;
   InputDialectOptions inputOptions;
   PreprocessingOptions preprocessingOptions;
-  HighLevelOptimizationOptions highLevelOptimizationOptions;
+  GlobalOptimizationOptions highLevelOptimizationOptions;
   SchedulingOptions schedulingOptions;
   IREE::HAL::TargetOptions halTargetOptions;
   IREE::VM::TargetOptions vmTargetOptions;
@@ -275,7 +275,7 @@ Session::Session(GlobalInit &globalInit)
     bindingOptions = *globalInit.clBindingOptions;
     inputOptions = *globalInit.clInputOptions;
     preprocessingOptions = *globalInit.clPreprocessingOptions;
-    highLevelOptimizationOptions = *globalInit.clHighLevelOptimizationOptions;
+    highLevelOptimizationOptions = *globalInit.clGlobalOptimizationOptions;
     schedulingOptions = *globalInit.clSchedulingOptions;
     halTargetOptions = *globalInit.clHalTargetOptions;
     vmTargetOptions = *globalInit.clVmTargetOptions;

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -167,8 +167,7 @@ void GlobalInit::registerCommandLineOptions() {
   clBindingOptions = &BindingOptions::FromFlags::get();
   clInputOptions = &InputDialectOptions::FromFlags::get();
   clPreprocessingOptions = &PreprocessingOptions::FromFlags::get();
-  clGlobalOptimizationOptions =
-      &GlobalOptimizationOptions::FromFlags::get();
+  clGlobalOptimizationOptions = &GlobalOptimizationOptions::FromFlags::get();
   clSchedulingOptions = &SchedulingOptions::FromFlags::get();
   clHalTargetOptions = &IREE::HAL::TargetOptions::FromFlags::get();
   clVmTargetOptions = &IREE::VM::TargetOptions::FromFlags::get();

--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -60,7 +60,7 @@ struct CompileOptions {
   BindingOptions bindingOptions;
   InputDialectOptions inputOptions;
   PreprocessingOptions preprocessingOptions;
-  HighLevelOptimizationOptions highLevelOptimizationOptions;
+  GlobalOptimizationOptions globalOptimizationOptions;
   SchedulingOptions schedulingOptions;
   IREE::HAL::TargetOptions executableOptions;
   IREE::VM::TargetOptions targetOptions;
@@ -336,12 +336,12 @@ struct JitGlobalsPass : public JitGlobalsBase<JitGlobalsPass> {
     // Disable constant evaluation for our Jit compilation pipeline.
     // It would make no sense to recursively do constant evaluation, and since
     // we omit the necessary hooks, it is unsupported anyway.
-    options->highLevelOptimizationOptions.constExprHoisting = false;
-    options->highLevelOptimizationOptions.constEval = false;
+    options->globalOptimizationOptions.constExprHoisting = false;
+    options->globalOptimizationOptions.constEval = false;
 
     buildIREEVMTransformPassPipeline(
         targetRegistry, options->bindingOptions, options->inputOptions,
-        options->preprocessingOptions, options->highLevelOptimizationOptions,
+        options->preprocessingOptions, options->globalOptimizationOptions,
         options->schedulingOptions, options->executableOptions,
         options->targetOptions, options->hooks, compilePipeline);
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -49,32 +49,6 @@ static llvm::cl::opt<std::string> clTraceDispatch(
                    "occurrences of the dispatch symbol."),
     llvm::cl::init(""));
 
-static llvm::cl::opt<bool> clDemoteI64ToI32(
-    "iree-flow-demote-i64-to-i32",
-    llvm::cl::desc("Converts all i64 ops and values into i32 counterparts "
-                   "unconditionally before main flow conversions."),
-    llvm::cl::init(false));
-static llvm::cl::opt<bool> clDemoteF32ToF16(
-    "iree-flow-demote-f32-to-f16",
-    llvm::cl::desc("Converts all f32 ops and values into f16 counterparts "
-                   "unconditionally before main flow conversions."),
-    llvm::cl::init(false));
-static llvm::cl::opt<bool> clPromoteBF16ToF32(
-    "iree-flow-promote-bf16-to-f32",
-    llvm::cl::desc("Converts all bf16 ops and values into f32 counterparts "
-                   "unconditionally before main flow conversions."),
-    llvm::cl::init(false));
-static llvm::cl::opt<bool> clPromoteF16ToF32(
-    "iree-flow-promote-f16-to-f32",
-    llvm::cl::desc("Converts all f16 ops and values into f32 counterparts "
-                   "unconditionally before main flow conversions."),
-    llvm::cl::init(false));
-static llvm::cl::opt<bool> clDemoteF64ToF32(
-    "iree-flow-demote-f64-to-f32",
-    llvm::cl::desc("Converts all f64 ops and values into f32 counterparts "
-                   "unconditionally before main flow conversions."),
-    llvm::cl::init(true));
-
 static llvm::cl::opt<bool> clDetensoring(
     "iree-flow-enable-detensoring",
     llvm::cl::desc(
@@ -148,28 +122,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
                                     const TransformOptions &transformOptions) {
   // Start of Flow pipeline, verify input legality.
   passManager.addPass(IREE::Flow::createVerifyInputLegalityPass());
-
-  // ML frontends have very uneven support for user-controlled types _and_ users
-  // tend to use types not well suited for the work they are doing. These
-  // demotions/promotions allow users to change the types after lowering out of
-  // the frontends. It'll always be better to do this higher up in the stack
-  // as these kind of blanket conversions have corner cases and potential
-  // accuracy/precision losses beyond what the user may expect.
-  if (clDemoteF64ToF32) {
-    passManager.addPass(IREE::Util::createDemoteF64ToF32Pass());
-  }
-  if (clDemoteF32ToF16) {
-    passManager.addPass(IREE::Util::createDemoteF32ToF16Pass());
-  }
-  if (clPromoteF16ToF32) {
-    passManager.addPass(IREE::Util::createPromoteF16ToF32Pass());
-  }
-  if (clDemoteI64ToI32) {
-    passManager.addPass(IREE::Util::createDemoteI64ToI32Pass());
-  }
-  if (clPromoteBF16ToF32) {
-    passManager.addPass(IREE::Util::createPromoteBF16ToF32Pass());
-  }
 
   // Transform pad operations into linalg.fill + tensor.insert_slice.
   // This is a WAR for not having native pad handling.

--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -23,6 +23,7 @@ iree_compiler_cc_library(
     deps = [
         "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
+        "//compiler/src/iree/compiler/Pipelines:Options",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     MLIRTransforms
     iree::compiler::Dialect::Flow::Transforms
     iree::compiler::Dialect::Util::Transforms
+    iree::compiler::Pipelines::Options
     iree::compiler::Utils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 
+#include "iree/compiler/Pipelines/Options.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 
@@ -16,13 +17,11 @@ namespace mlir {
 namespace iree_compiler {
 namespace GlobalOptimization {
 
+// We have a layer of indirection around the GlobalOptimizationOptions because
+// we also need a reference to the const-eval builder, which is injected
+// in by callers.
 struct TransformOptions : public PassPipelineOptions<TransformOptions> {
-  // Enables the iree-util-hoist-into-globals pass. This should eventually
-  // become the default.
-  bool constExprHoisting = false;
-
-  // Enables passes to perform numeric precision reduction.
-  bool numericPrecisionReduction = false;
+  GlobalOptimizationOptions options;
 
   // Hook to populate a constant evaluation pass pipeline. If nullptr, then
   // no passes are added for constant evaluation. This must be injected in

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -9,7 +9,7 @@
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::BindingOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::InputDialectOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(
-    mlir::iree_compiler::HighLevelOptimizationOptions);
+    mlir::iree_compiler::GlobalOptimizationOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::SchedulingOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::PreprocessingOptions);
 
@@ -98,9 +98,35 @@ InputDialectOptions::Type InputDialectOptions::parseInputTypeMnemonic() {
   }
 }
 
-void HighLevelOptimizationOptions::bindOptions(OptionsBinder &binder) {
+void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
   static llvm::cl::OptionCategory category(
-      "IREE options for controlling high level optimizations.");
+      "IREE options for controlling global optimizations.");
+  // Type promotion/demotion options.
+  binder.opt<bool>(
+      "iree-opt-demote-f64-to-f32", demoteF64ToF32,
+      llvm::cl::desc("Converts all f64 ops and values into f32 counterparts "
+                     "unconditionally before main global optimizations."),
+      llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-opt-demote-f32-to-f16", demoteF32ToF16,
+      llvm::cl::desc("Converts all f32 ops and values into f16 counterparts "
+                     "unconditionally before main global optimizations."),
+      llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-opt-promote-f16-to-f32", promoteF16ToF32,
+      llvm::cl::desc("Converts all f16 ops and values into f32 counterparts "
+                     "unconditionally before main global optimizations."),
+      llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-opt-promote-bf16-to-f32", promoteBF16ToF32,
+      llvm::cl::desc("Converts all bf16 ops and values into f32 counterparts "
+                     "unconditionally before main global optimizations."),
+      llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-opt-demote-i64-to-i32", demoteI64ToI32,
+      llvm::cl::desc("Converts all i64 ops and values into i32 counterparts "
+                     "unconditionally before main global optimizations."),
+      llvm::cl::cat(category));
 
   binder.opt<bool>(
       "iree-opt-const-eval", constEval,

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -75,7 +75,14 @@ struct InputDialectOptions {
 };
 
 // Options controlling high level optimizations.
-struct HighLevelOptimizationOptions {
+struct GlobalOptimizationOptions {
+  // Gate various type based demotion passes that run before anything else.
+  bool demoteF64ToF32 = true;
+  bool demoteF32ToF16 = false;
+  bool promoteF16ToF32 = false;
+  bool promoteBF16ToF32 = false;
+  bool demoteI64ToI32 = false;
+
   // Enables const-expr hoisting into globals.
   bool constExprHoisting = true;
 
@@ -90,7 +97,7 @@ struct HighLevelOptimizationOptions {
   bool stripAssertions = false;
 
   void bindOptions(OptionsBinder &binder);
-  using FromFlags = OptionsFromFlags<HighLevelOptimizationOptions>;
+  using FromFlags = OptionsFromFlags<GlobalOptimizationOptions>;
 };
 
 // Options controlling scheduling across host/device.

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -21,7 +21,7 @@ class PipelineExtensions;
 // Hooks for injecting behavior into the IREEVM pipeline. Since these are not
 // derived from CLI options, we maintain them as a separate struct.
 struct IREEVMPipelineHooks {
-  // If the HighLevelOptimizationOptions::constEval option is true, then
+  // If the GlobalOptimizationOptions::constEval option is true, then
   // this callback must be set to populate a pass manager to perform
   // constant eval. It typically just adds a ConstEval::createJitGlobalsPass()
   // pass. It must be injected like this to avoid circular dependencies from
@@ -88,7 +88,7 @@ void buildIREEVMTransformPassPipeline(
     const IREE::HAL::TargetBackendRegistry &targetRegistry,
     BindingOptions bindingOptions, InputDialectOptions inputOptions,
     PreprocessingOptions preprocessingOptions,
-    HighLevelOptimizationOptions highLevelOptimizationOptions,
+    GlobalOptimizationOptions highLevelOptimizationOptions,
     SchedulingOptions schedulingOptions,
     IREE::HAL::TargetOptions executableOptions,
     IREE::VM::TargetOptions targetOptions, IREEVMPipelineHooks &hooks,

--- a/experimental/regression_suite/tests/pregenerated/test_llama2.py
+++ b/experimental/regression_suite/tests/pregenerated/test_llama2.py
@@ -15,7 +15,7 @@ COMMON_FLAGS = [
     "--iree-input-type=none",
     "--iree-stream-resource-index-bits=64",
     "--iree-vm-target-index-bits=64",
-    "--iree-opt-const-expr-hoisting=false",
+    #"--iree-opt-const-expr-hoisting=false",
     "--iree-stream-resource-max-allocation-size=3221225472",
 ]
 

--- a/experimental/regression_suite/tests/pregenerated/test_llama2.py
+++ b/experimental/regression_suite/tests/pregenerated/test_llama2.py
@@ -15,7 +15,6 @@ COMMON_FLAGS = [
     "--iree-input-type=none",
     "--iree-stream-resource-index-bits=64",
     "--iree-vm-target-index-bits=64",
-    #"--iree-opt-const-expr-hoisting=false",
     "--iree-stream-resource-max-allocation-size=3221225472",
 ]
 

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -161,7 +161,7 @@ iree_check_single_backend_test_suite(
     srcs = [
         "disable_demote_f64_to_f32.mlir",
     ],
-    compiler_flags = ["-iree-flow-demote-f64-to-f32=false"],
+    compiler_flags = ["-iree-opt-demote-f64-to-f32=false"],
     driver = "local-task",
     target_backend = "llvm-cpu",
 )

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -209,7 +209,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "local-task"
   COMPILER_FLAGS
-    "-iree-flow-demote-f64-to-f32=false"
+    "-iree-opt-demote-f64-to-f32=false"
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -2104,7 +2104,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-demote-f32-to-f16"
+    "--iree-opt-demote-f32-to-f16"
   FRIENDLY_NAME "MobileBertSquad_fp16(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][default-flags,demote-f32-to-f16]"
   PUBLIC
 )
@@ -2239,7 +2239,7 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=valhall-unknown-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-stream-partitioning-favor=max-concurrency"
-    "--iree-flow-demote-f32-to-f16"
+    "--iree-opt-demote-f32-to-f16"
   FRIENDLY_NAME "MobileBertSquad_fp16(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,demote-f32-to-f16]"
   PUBLIC
 )
@@ -2387,7 +2387,7 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-stream-partitioning-favor=max-concurrency"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
+    "--iree-opt-demote-f32-to-f16"
   FRIENDLY_NAME "MobileBertSquad_fp16(tflite) [arm-valhall-vulkan_android31-vulkan_spirv][experimental-flags,fuse-padding,max-concurrency,repeated-kernel,demote-f32-to-f16]"
   PUBLIC
 )
@@ -5173,7 +5173,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-demote-f32-to-f16"
+    "--iree-opt-demote-f32-to-f16"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
@@ -5348,7 +5348,7 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=valhall-unknown-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-stream-partitioning-favor=max-concurrency"
-    "--iree-flow-demote-f32-to-f16"
+    "--iree-opt-demote-f32-to-f16"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"
@@ -5536,7 +5536,7 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-stream-partitioning-favor=max-concurrency"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
+    "--iree-opt-demote-f32-to-f16"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvmcpu-debug-symbols=false"
     "--iree-scheduling-dump-statistics-format=json"


### PR DESCRIPTION
The global optimizations really depend on the flow level demotion passes. Moves them to the right place. Also restores the ordering of the strip assertions pass so that it can guide optimizations.
    
Renames old `-iree-flow-(demote|promote)-*` flags to `-iree-opt-(demote|promote)-*` flags now that they are just part of the rest of the global optimizations.
    
Internally, renames "HighLevelOptimizations" to "GlobalOptimizations" for coherence.

This lets us enable consteval on llam2 7b qi4/f16 models and drops latency from 14.3ms -> 11.9ms. Mostly it is small scalar-level evaluations but it is also eliminating a 250MiB f16 transpose in both first/second that I expect is a main culprit.

Fixes #14835.