### PR TITLE
[Codegen][LLVMGPU] Use IREE strided memeta data expansion for LLVMGPU Pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -471,7 +471,7 @@ void addGPUDefaultPassPipeline(OpPassManager &pm) {
 static void addLowerAndOptimzeAddressComputation(OpPassManager &pm) {
   pm.addPass(createExtractAddressComputationGPUPass());
   pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
-  pm.addPass(memref::createExpandStridedMetadataPass());
+  pm.addPass(createIREEExpandStridedMetadataPass());
   // Hoist loop invariant variables to give decompose affine pass the right loop
   // dependencies.
   pm.addPass(createLoopInvariantCodeMotionPass());
@@ -546,7 +546,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addNestedPass<func::FuncOp>(createPolynomialApproximationPass());
 
   pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
-  pm.addPass(memref::createExpandStridedMetadataPass());
+  pm.addPass(createIREEExpandStridedMetadataPass());
   pm.addPass(memref::createFoldMemRefAliasOpsPass());
   pm.addPass(createEmulateNarrowTypePass());
   pm.addPass(createLowerAffinePass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
@@ -53,8 +53,7 @@
 // CHECK: %[[GRP_IDX3:.*]] = llvm.shl %[[GRP_IDX2]], %[[C2]]  : i64
 // CHECK: %{{.*}} = llvm.xor %[[SRC:.*]], %[[GRP_IDX3]]  : i64
 // CHECK: %[[ADJ_SRC:.*]] = llvm.add %[[SRC]], %[[C16]]  : i64
-// CHECK: %[[ADJ_SRC1:.*]] = llvm.xor %[[ADJ_SRC]], %[[GRP_IDX3]]  : i64
-// CHECK: %[[INV:.*]] = llvm.add %{{.*}}, %[[ADJ_SRC1]]  : i64
+// CHECK: %[[INV:.*]] = llvm.xor %[[ADJ_SRC]], %[[GRP_IDX3]]  : i64
 //
 // Find the basic block boundary.
 // CHECK: llvm.br ^[[LOOP_BODY:bb[0-9]+]](
@@ -66,7 +65,7 @@
 // CHECK: %[[VAR:.*]] = llvm.mul %[[IV]], %[[C4096]]
 //
 // Add the loop invariant part.
-// CHECK: %[[OFF:.*]] = llvm.add %[[INV]], %[[VAR]]
+// CHECK: %[[OFF:.*]] = llvm.add %{{.*}}, %[[INV]]
 //
 // Store the resulting offset in the memref descriptor.
 // llvm.insert %[[OFF]], %{{.*}}[2]


### PR DESCRIPTION
This patch uses IREE's ExpandStridedMetadata pass, which adds a pattern for hal.subspan. Without this, ExpandStridedMetadata leaves expand_strided_metadata ops, which are marked as illegal for EmulateNarrowTypePass, causing crashes.