### PR TITLE
Adding iree_hal_device_profiling_flush.

### DIFF
--- a/experimental/cuda2/cuda_device.c
+++ b/experimental/cuda2/cuda_device.c
@@ -762,6 +762,12 @@ static iree_status_t iree_hal_cuda2_device_profiling_begin(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_cuda2_device_profiling_flush(
+    iree_hal_device_t* base_device) {
+  // Unimplemented (and that's ok).
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_cuda2_device_profiling_end(
     iree_hal_device_t* base_device) {
   // Unimplemented (and that's ok).
@@ -797,5 +803,6 @@ static const iree_hal_device_vtable_t iree_hal_cuda2_device_vtable = {
     .queue_flush = iree_hal_cuda2_device_queue_flush,
     .wait_semaphores = iree_hal_cuda2_device_wait_semaphores,
     .profiling_begin = iree_hal_cuda2_device_profiling_begin,
+    .profiling_flush = iree_hal_cuda2_device_profiling_flush,
     .profiling_end = iree_hal_cuda2_device_profiling_end,
 };

--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -397,6 +397,12 @@ static iree_status_t iree_hal_rocm_device_profiling_begin(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_rocm_device_profiling_flush(
+    iree_hal_device_t* base_device) {
+  // Unimplemented (and that's ok).
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_rocm_device_profiling_end(
     iree_hal_device_t* base_device) {
   // Unimplemented (and that's ok).
@@ -432,5 +438,6 @@ static const iree_hal_device_vtable_t iree_hal_rocm_device_vtable = {
     .queue_flush = iree_hal_rocm_device_queue_flush,
     .wait_semaphores = iree_hal_rocm_device_wait_semaphores,
     .profiling_begin = iree_hal_rocm_device_profiling_begin,
+    .profiling_flush = iree_hal_rocm_device_profiling_flush,
     .profiling_end = iree_hal_rocm_device_profiling_end,
 };

--- a/experimental/webgpu/webgpu_device.c
+++ b/experimental/webgpu/webgpu_device.c
@@ -430,14 +430,20 @@ static iree_status_t iree_hal_webgpu_device_wait_semaphores(
 }
 
 static iree_status_t iree_hal_webgpu_device_profiling_begin(
-    iree_hal_device_t* device,
+    iree_hal_device_t* base_device,
     const iree_hal_device_profiling_options_t* options) {
   // Unimplemented (and that's ok).
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_webgpu_device_profiling_flush(
+    iree_hal_device_t* base_device) {
+  // Unimplemented (and that's ok).
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_webgpu_device_profiling_end(
-    iree_hal_device_t* device) {
+    iree_hal_device_t* base_device) {
   // Unimplemented (and that's ok).
   return iree_ok_status();
 }
@@ -468,5 +474,6 @@ const iree_hal_device_vtable_t iree_hal_webgpu_device_vtable = {
     .queue_flush = iree_hal_webgpu_device_queue_flush,
     .wait_semaphores = iree_hal_webgpu_device_wait_semaphores,
     .profiling_begin = iree_hal_webgpu_device_profiling_begin,
+    .profiling_flush = iree_hal_webgpu_device_profiling_flush,
     .profiling_end = iree_hal_webgpu_device_profiling_end,
 };

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -398,6 +398,15 @@ IREE_API_EXPORT iree_status_t iree_hal_device_profiling_begin(
 }
 
 IREE_API_EXPORT iree_status_t
+iree_hal_device_profiling_flush(iree_hal_device_t* device) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(device, profiling_flush)(device);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t
 iree_hal_device_profiling_end(iree_hal_device_t* device) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -535,6 +535,10 @@ IREE_API_EXPORT iree_status_t iree_hal_device_profiling_begin(
     iree_hal_device_t* device,
     const iree_hal_device_profiling_options_t* options);
 
+// Flushes any pending profiling data. May be a no-op.
+IREE_API_EXPORT iree_status_t
+iree_hal_device_profiling_flush(iree_hal_device_t* device);
+
 // Ends a profile previous started with iree_hal_device_profiling_begin.
 // The device must be idle before calling this method.
 IREE_API_EXPORT iree_status_t
@@ -662,6 +666,7 @@ typedef struct iree_hal_device_vtable_t {
   iree_status_t(IREE_API_PTR* profiling_begin)(
       iree_hal_device_t* device,
       const iree_hal_device_profiling_options_t* options);
+  iree_status_t(IREE_API_PTR* profiling_flush)(iree_hal_device_t* device);
   iree_status_t(IREE_API_PTR* profiling_end)(iree_hal_device_t* device);
 } iree_hal_device_vtable_t;
 IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_device_vtable_t);

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -720,6 +720,12 @@ static iree_status_t iree_hal_cuda_device_profiling_begin(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_cuda_device_profiling_flush(
+    iree_hal_device_t* base_device) {
+  // Unimplemented (and that's ok).
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_cuda_device_profiling_end(
     iree_hal_device_t* base_device) {
   // Unimplemented (and that's ok).
@@ -755,5 +761,6 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .queue_flush = iree_hal_cuda_device_queue_flush,
     .wait_semaphores = iree_hal_cuda_device_wait_semaphores,
     .profiling_begin = iree_hal_cuda_device_profiling_begin,
+    .profiling_flush = iree_hal_cuda_device_profiling_flush,
     .profiling_end = iree_hal_cuda_device_profiling_end,
 };

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -464,7 +464,7 @@ static iree_status_t iree_hal_sync_device_wait_semaphores(
 }
 
 static iree_status_t iree_hal_sync_device_profiling_begin(
-    iree_hal_device_t* device,
+    iree_hal_device_t* base_device,
     const iree_hal_device_profiling_options_t* options) {
   // Unimplemented (and that's ok).
   // We could hook in to vendor APIs (Intel/ARM/etc) or generic perf infra:
@@ -477,8 +477,14 @@ static iree_status_t iree_hal_sync_device_profiling_begin(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_sync_device_profiling_flush(
+    iree_hal_device_t* base_device) {
+  // Unimplemented (and that's ok).
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_sync_device_profiling_end(
-    iree_hal_device_t* device) {
+    iree_hal_device_t* base_device) {
   // Unimplemented (and that's ok).
   return iree_ok_status();
 }
@@ -512,5 +518,6 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .queue_flush = iree_hal_sync_device_queue_flush,
     .wait_semaphores = iree_hal_sync_device_wait_semaphores,
     .profiling_begin = iree_hal_sync_device_profiling_begin,
+    .profiling_flush = iree_hal_sync_device_profiling_flush,
     .profiling_end = iree_hal_sync_device_profiling_end,
 };

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -484,7 +484,7 @@ static iree_status_t iree_hal_task_device_wait_semaphores(
 }
 
 static iree_status_t iree_hal_task_device_profiling_begin(
-    iree_hal_device_t* device,
+    iree_hal_device_t* base_device,
     const iree_hal_device_profiling_options_t* options) {
   // Unimplemented (and that's ok).
   // We could hook in to vendor APIs (Intel/ARM/etc) or generic perf infra:
@@ -497,8 +497,14 @@ static iree_status_t iree_hal_task_device_profiling_begin(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_task_device_profiling_flush(
+    iree_hal_device_t* base_device) {
+  // Unimplemented (and that's ok).
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_task_device_profiling_end(
-    iree_hal_device_t* device) {
+    iree_hal_device_t* base_device) {
   // Unimplemented (and that's ok).
   return iree_ok_status();
 }
@@ -532,5 +538,6 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .queue_flush = iree_hal_task_device_queue_flush,
     .wait_semaphores = iree_hal_task_device_wait_semaphores,
     .profiling_begin = iree_hal_task_device_profiling_begin,
+    .profiling_flush = iree_hal_task_device_profiling_flush,
     .profiling_end = iree_hal_task_device_profiling_end,
 };

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -523,6 +523,10 @@ static iree_status_t iree_hal_metal_device_profiling_begin(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_metal_device_profiling_flush(iree_hal_device_t* base_device) {
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_metal_device_profiling_end(iree_hal_device_t* base_device) {
   iree_hal_metal_device_t* device = iree_hal_metal_device_cast(base_device);
   if (device->capture_manager) {
@@ -559,5 +563,6 @@ static const iree_hal_device_vtable_t iree_hal_metal_device_vtable = {
     .queue_flush = iree_hal_metal_device_queue_flush,
     .wait_semaphores = iree_hal_metal_device_wait_semaphores,
     .profiling_begin = iree_hal_metal_device_profiling_begin,
+    .profiling_flush = iree_hal_metal_device_profiling_flush,
     .profiling_end = iree_hal_metal_device_profiling_end,
 };


### PR DESCRIPTION
This allows HAL devices to be poked to flush profiling data. The Vulkan HAL now uses this signal to flush tracing events and iree-benchmark-module has been updated to send the signal.

Fixes #14827.