### PR TITLE
Integrate llvm-project at 2acf00bd0ac2

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_pack_unpack_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_pack_unpack_ops.mlir
@@ -157,7 +157,9 @@ func.func @KCRSsr_to_KCRS(%arg0: tensor<13x12x4x8x8x32xf32>, %arg1: tensor<13x12
 // CHECK-SAME:      permutation = [0, 1, 2, 5, 3, 4]
 // CHECK:         %[[COLLAPSE:.+]] = tensor.collapse_shape %[[TRANSP]]
 // CHECK-SAME:      {{\[}}[0], [1], [2, 3], [4, 5]] : tensor<13x12x4x32x8x8xf32> into tensor<13x12x128x64xf32>
-// CHECK:         return %[[COLLAPSE]]
+// CHECK:         %[[COPY:.]] = linalg.copy ins(%[[COLLAPSE]]
+// CHECK-SAME:        outs(%[[OUT]]
+// CHECK:         return %[[COPY]]
 
 // -----
 
@@ -175,9 +177,11 @@ func.func @unpack_and_extract_slice(%arg0: tensor<2x8x8x2xf32>, %arg1: tensor<13
 // CHECK-SAME:       permutation = [0, 2, 1, 3]
 // CHECK:          %[[COLLAPSE:.+]] = tensor.collapse_shape %[[TRANSP]]
 // CHECK-SAME:       {{\[}}[0, 1], [2, 3]] : tensor<2x8x8x2xf32> into tensor<16x16xf32>
-// CHECK:          %[[RES:.+]] = tensor.extract_slice %[[COLLAPSE]]
+// CHECK:          %[[SLICE:.+]] = tensor.extract_slice %[[COLLAPSE]]
 // CHECK-SAME:       [0, 0] [13, 15] [1, 1] : tensor<16x16xf32> to tensor<13x15xf32>
-// CHECK:          return %[[RES]]
+// CHECK:          %[[COPY:.]] = linalg.copy ins(%[[SLICE]]
+// CHECK-SAME:         outs(%[[OUT]]
+// CHECK:          return %[[COPY]]
 // -----
 
 func.func @CKck_to_KC(%arg0: tensor<32x4x32x8xf32>, %arg1: tensor<128x256xf32>) -> tensor<128x256xf32> {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pad_pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pad_pipeline_tests.mlir
@@ -131,13 +131,12 @@ hal.executable private @pad_with_producer {
 //       CHECK:         scf.for
 //       CHECK:           scf.for
 //   CHECK-DAG:             %[[INPUT_SLICE:.+]] = memref.subview %[[INPUT_SUBVIEW]]
-//   CHECK-DAG:             %[[BIAS_ALLOC:.+]] = memref.alloca
+//   CHECK-DAG:             %[[ALLOC:.+]] = memref.alloca
+//       CHECK:             %[[CONV_OUTPUT:.+]] = memref.subview %[[ALLOC]]
 //       CHECK:               scf.for
 //       CHECK:               %[[FILTER_SLICE:.+]] = memref.subview %[[FILTER_SUBVIEW]]
-//       CHECK:               %[[FILL_ALLOC:.+]] = memref.alloca
 //       CHECK:               linalg.fill
-//  CHECK-SAME:                   outs(%[[FILL_ALLOC]]
-//       CHECK:               %[[CONV_OUTPUT:.+]] = memref.subview %[[FILL_ALLOC]]
+//  CHECK-SAME:                   outs(%[[ALLOC]]
 //       CHECK:               scf.for
 //       CHECK:                 %[[CONV_INPUT:.+]] = memref.subview %[[INPUT_SLICE]]
 //       CHECK:                 %[[CONV_FILTER:.+]] = memref.subview %[[FILTER_SLICE]]
@@ -146,13 +145,13 @@ hal.executable private @pad_with_producer {
 //  CHECK-SAME:                     outs(%[[CONV_OUTPUT]] :
 //       CHECK:               %[[BIAS_INPUT:.+]] = memref.subview %[[BIAS_SUBVIEW]]
 //       CHECK:               linalg.generic
-//  CHECK-SAME:                   ins(%[[FILL_ALLOC]], %[[BIAS_INPUT]] :
-//  CHECK-SAME:                   outs(%[[BIAS_ALLOC]]
+//  CHECK-SAME:                   ins(%[[ALLOC]], %[[BIAS_INPUT]] :
+//  CHECK-SAME:                   outs(%[[ALLOC]]
 //       CHECK:               %[[OUTPUT_SLICE:.+]] = memref.subview %[[OUTPUT_SUBVIEW]]
 //       CHECK:               linalg.fill ins(%{{.+}} :   f32) outs(%[[OUTPUT_SLICE]]
 //       CHECK:               %[[INTERIOR_SLICE:.+]] = memref.subview %[[OUTPUT_SLICE]]
 //       CHECK:               linalg.generic
-//  CHECK-SAME:                   ins(%[[BIAS_ALLOC]] :
+//  CHECK-SAME:                   ins(%[[ALLOC]] :
 //  CHECK-SAME:                   outs(%[[INTERIOR_SLICE]] :
 
 // -----


### PR DESCRIPTION
* Reset third_party/llvm-project: 2acf00bd0ac28bc7e95163d3c2d954164c6c245d (2023-08-25 02:22:23 -0500): Revert "Recommit "[InstCombine] Expand `foldSelectICmpAndOr` -> `foldSelectICmpAndBinOp` to work for more binops" (2nd Try)"

Cherry-pick commits:

*  https://reviews.llvm.org/D158606

Revert commits:

* llvm/llvm-project@dad9de0ae5360b18c890985d212bec266bf8c122