### PR TITLE
Land a short-term fix for 128-bit stablehlo RNG

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgRandom.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgRandom.cpp
@@ -196,8 +196,7 @@ std::pair<Value, Value> extractKey32(OpBuilder &builder, Location loc,
     return std::pair<Value, Value>(pair.first, pair.second);
   }
 
-  // TODO(suderman): This gets the 128-bit counter to work however
-  // may not match XLA.
+  // TODO(#14859): Properly handle 128-bit storage keys.
   if (storeTy.getDimSize(0) == 3 && storeETy.isInteger(64)) {
     Value idx1 = builder.create<arith::ConstantIndexOp>(loc, 0);
     Value state = builder.create<tensor::ExtractOp>(loc, store, idx1);
@@ -225,8 +224,7 @@ Value extractState64(OpBuilder &builder, Location loc, Value store) {
     return cast;
   }
 
-  // TODO(suderman): This gets the 128-bit counter to work however
-  // may not match XLA.
+  // TODO(#14859): Properly handle 128-bit storage keys.
   if (storeTy.getDimSize(0) == 3 && storeETy.isInteger(64)) {
     Value idx1 = builder.create<arith::ConstantIndexOp>(loc, 1);
     Value state = builder.create<tensor::ExtractOp>(loc, store, idx1);
@@ -263,8 +261,7 @@ Value setState64(OpBuilder &b, Location loc, Value store, Value state) {
                                       ValueRange{idx1});
   }
 
-  // TODO(suderman): This gets the 128-bit counter to work however
-  // may not match XLA.
+  // TODO(#14859): Properly handle 128-bit storage keys.
   if (storeTy.getDimSize(0) == 3 && storeETy.isInteger(64)) {
     state = b.create<arith::BitcastOp>(loc, storeETy, state);
     Value idx1 = b.create<arith::ConstantIndexOp>(loc, 1);

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg_random.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_linalg_random.mlir
@@ -527,6 +527,15 @@ func.func @philox_i32(%arg0: tensor<2xi64>) -> (tensor<2xi64>, tensor<8xi32>) {
 
 // -----
 
+// CHECK-LABEL: func.func @philox_128_i32
+// CHECK-SAME:  %[[ARG0:.*]]: tensor<3xi64>
+func.func @philox_128_i32(%arg0: tensor<3xi64>) -> (tensor<3xi64>, tensor<8xi32>) {
+  %output_state, %output = "stablehlo.rng_bit_generator"(%arg0) {rng_algorithm = #stablehlo<rng_algorithm PHILOX>} : (tensor<3xi64>) -> (tensor<3xi64>, tensor<8xi32>)
+  return %output_state, %output : tensor<3xi64>, tensor<8xi32>
+}
+
+// -----
+
 func.func @philox_i32_odd(%arg0: tensor<2xi64>) -> (tensor<2xi64>, tensor<7x11xi32>) {
   %output_state, %output = "stablehlo.rng_bit_generator"(%arg0) {rng_algorithm = #stablehlo<rng_algorithm PHILOX>} : (tensor<2xi64>) -> (tensor<2xi64>, tensor<7x11xi32>)
   return %output_state, %output : tensor<2xi64>, tensor<7x11xi32>


### PR DESCRIPTION
We can use a 128-bit counter for philox number generation. In these cases only load 64-bits of the key. This should work in the short term, and would only impact cases where we generate more than 2^64 random numbers.