### PR TITLE
Switch to the real amdgpu runner label now that it is setup.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   linux_x86_64:
     name: Linux (x86_64)
-    runs-on: nodai-amdgpu-x86_64
+    runs-on: nodai-amdgpu-w7900-x86-64
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts


### PR DESCRIPTION
The prior was just my workstation.