### PR TITLE
Disable tensor.from_elements from being a scalar outline

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
@@ -62,7 +62,7 @@ static bool isComputeOperation(Operation *op) {
   }
   if (op->getDialect() == context->getLoadedDialect<tensor::TensorDialect>()) {
     return !isa<tensor::CastOp, tensor::CollapseShapeOp, tensor::EmptyOp,
-                tensor::ExpandShapeOp>(op);
+                tensor::ExpandShapeOp, tensor::FromElementsOp>(op);
   }
   return false;
 }


### PR DESCRIPTION
`tensor.from_elements` should remain as a `flow` operation and should not be outlined when forming scalar dispatches.