### PR TITLE
[Flow] Improve slice raising to handle dynamic and unit dims

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -130,6 +130,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TransformDialectTransforms",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:ValueBoundsOpInterface",
     ],
 )
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -111,6 +111,7 @@ iree_cc_library(
     MLIRTransformDialectTransforms
     MLIRTransformUtils
     MLIRTransforms
+    MLIRValueBoundsOpInterface
     iree::compiler::Dialect::Flow::Conversion::TensorToFlow
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
@@ -288,12 +288,11 @@ tryRaiseToExtractSlice(AffineMap inputIndexingMap, AffineMap outputIndexingMap,
     // Constant accesses can either be rank reducing or an access into a unit
     // dim. This is tracked by counting the number of unit output dimensions
     // between non-unit ones.
-    if (expr.isa<AffineConstantExpr>()) {
-      IntegerAttr constIdx = rewriter.getI64IntegerAttr(
-          expr.cast<AffineConstantExpr>().getValue());
+    if (auto constExpr = expr.dyn_cast<AffineConstantExpr>()) {
+      IntegerAttr constIdx = rewriter.getI64IntegerAttr(constExpr.getValue());
       offsets.push_back(constIdx);
       sizes.push_back(one);
-      if (outShape[leadOutDim] == 1) {
+      if (leadOutDim < outShape.size() && outShape[leadOutDim] == 1) {
         ++leadOutDim;
       }
       continue;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/raise_special_ops.mlir
@@ -240,9 +240,8 @@ func.func @generic_fill(%arg0: tensor<?x?xf32>) -> tensor<1x1x?x?xf32> {
 // -----
 
 #map = affine_map<(d0) -> (d0)>
-func.func @test(%A : tensor<1x1x5120xf32>, %B : tensor<5120xf32>) -> tensor<5120xf32> {
+func.func @test_rank_reduce(%A : tensor<1x1x5120xf32>, %B : tensor<5120xf32>) -> tensor<5120xf32> {
   %c0 = arith.constant 0 : index
-  // CHECK: tensor.extract_slice
   %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs(%B : tensor<5120xf32>) {
   ^bb0(%out: f32):
     %12 = linalg.index 0 : index
@@ -252,12 +251,77 @@ func.func @test(%A : tensor<1x1x5120xf32>, %B : tensor<5120xf32>) -> tensor<5120
   return %0 : tensor<5120xf32>
 }
 
+// CHECK-LABEL: func @test_rank_reduce
+//       CHECK:   tensor.extract_slice %{{.*}}[0, 0, 0] [1, 1, 5120] [1, 1, 1]
+//  CHECK-SAME:     tensor<1x1x5120xf32> to tensor<5120xf32>
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @test_slice_middle(%A : tensor<64x64x64xf32>, %B : tensor<64x64xf32>) -> tensor<64x64xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%B : tensor<64x64xf32>) {
+  ^bb0(%out: f32):
+    %i1 = linalg.index 0 : index
+    %i2 = linalg.index 1 : index
+    %extracted = tensor.extract %A[%i1, %c0, %i2] : tensor<64x64x64xf32>
+    linalg.yield %extracted : f32
+  } -> tensor<64x64xf32>
+  return %0 : tensor<64x64xf32>
+}
+
+// CHECK-LABEL: func @test_slice_middle
+//       CHECK:   tensor.extract_slice %{{.*}}[0, 0, 0] [64, 1, 64] [1, 1, 1]
+//  CHECK-SAME:     tensor<64x64x64xf32> to tensor<64x64xf32>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+func.func @test_unit_identity_slice(%A : tensor<1x1x64xf32>, %B : tensor<1x1x64xf32>) -> tensor<1x1x64xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel", "parallel"]} outs(%B : tensor<1x1x64xf32>) {
+  ^bb0(%out: f32):
+    %i2 = linalg.index 2 : index
+    %extracted = tensor.extract %A[%c0, %c0, %i2] : tensor<1x1x64xf32>
+    linalg.yield %extracted : f32
+  } -> tensor<1x1x64xf32>
+  return %0 : tensor<1x1x64xf32>
+}
+
+// CHECK-LABEL: func @test_unit_identity_slice
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x1x64xf32>,
+//       CHECK:   return %[[ARG0]]
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @test_dynamic_slice(%A : tensor<1x128x?xf32>) -> tensor<128x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %dim = tensor.dim %A, %c2 : tensor<1x128x?xf32>
+  %empty = tensor.empty(%dim) : tensor<128x?xf32>
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%empty : tensor<128x?xf32>) {
+  ^bb0(%out: f32):
+    %i0 = linalg.index 0 : index
+    %i1 = linalg.index 1 : index
+    %extracted = tensor.extract %A[%c0, %i0, %i1] : tensor<1x128x?xf32>
+    linalg.yield %extracted : f32
+  } -> tensor<128x?xf32>
+  return %0 : tensor<128x?xf32>
+}
+
+// CHECK-LABEL: func @test_dynamic_slice
+//       CHECK:   %[[DIM:.+]] = tensor.dim {{.*}} : tensor<1x128x?xf32>
+//       CHECK:   tensor.extract_slice %{{.*}}[0, 0, 0] [1, 128, %[[DIM]]] [1, 1, 1]
+//  CHECK-SAME:     tensor<1x128x?xf32> to tensor<128x?xf32>
+
 // -----
 
 // This currently should not be raised as the operation does not remain
 // elementwise after raising the tensor.extract to input.
 #map = affine_map<(d0, d1) -> (d0, d1)>
-func.func @test(%A : tensor<128x128x128xf32>, %B : tensor<64x64xf32>) -> tensor<64x64xf32> {
+// CHECK-LABEL: func @test_non_slice
+func.func @test_non_slice(%A : tensor<128x128x128xf32>, %B : tensor<64x64xf32>) -> tensor<64x64xf32> {
   %c0 = arith.constant 0 : index
   // CHECK: linalg.generic
   %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%B : tensor<64x64xf32>) {
@@ -265,22 +329,6 @@ func.func @test(%A : tensor<128x128x128xf32>, %B : tensor<64x64xf32>) -> tensor<
     %i1 = linalg.index 0 : index
     %i2 = linalg.index 1 : index
     %extracted = tensor.extract %A[%i1, %c0, %i2] : tensor<128x128x128xf32>
-    linalg.yield %extracted : f32
-  } -> tensor<64x64xf32>
-  return %0 : tensor<64x64xf32>
-}
-
-// -----
-
-#map = affine_map<(d0, d1) -> (d0, d1)>
-func.func @test(%A : tensor<64x64x64xf32>, %B : tensor<64x64xf32>) -> tensor<64x64xf32> {
-  %c0 = arith.constant 0 : index
-  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%B : tensor<64x64xf32>) {
-  ^bb0(%out: f32):
-    %i1 = linalg.index 0 : index
-    %i2 = linalg.index 1 : index
-    // CHECK: tensor.extract_slice
-    %extracted = tensor.extract %A[%i1, %c0, %i2] : tensor<64x64x64xf32>
     linalg.yield %extracted : f32
   } -> tensor<64x64xf32>
   return %0 : tensor<64x64xf32>


### PR DESCRIPTION
This enables the following raising cases:
  1. Dynamic dimensions able to be statically analyzed as matching the associated dimension in the output.
  2. Unit dimensions indexed by 0.

Dynamic dimensions are compared using the ValueBounds interface, however this currently has no pattern for analyzing tensor.expand/collapse shape ops, making this pattern interact poorly with FoldUnitExtentDims.

Also cleans up some of the test cases for slice raising.