### PR TITLE
[vulkan] Request 8-/16-bit integer/floating-point features

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
@@ -216,6 +216,12 @@ iree_hal_vulkan_populate_enabled_device_extensions(
     } else if (strcmp(extension_name,
                       VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME) == 0) {
       extensions.buffer_device_address = true;
+    } else if (strcmp(extension_name, VK_KHR_8BIT_STORAGE_EXTENSION_NAME) ==
+               0) {
+      extensions.shader_8bit_storage = true;
+    } else if (strcmp(extension_name,
+                      VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME) == 0) {
+      extensions.shader_float16_int8 = true;
     }
   }
   return extensions;

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
@@ -86,6 +86,10 @@ typedef struct iree_hal_vulkan_device_extensions_t {
   bool external_memory_host : 1;
   // VK_KHR_buffer_device_address is enabled.
   bool buffer_device_address : 1;
+  // VK_KHR_8bit_storage is enabled.
+  bool shader_8bit_storage : 1;
+  // VK_KHR_shader_float16_int8 is enabled.
+  bool shader_float16_int8 : 1;
 } iree_hal_vulkan_device_extensions_t;
 
 // Returns a bitfield with all of the provided extension names.


### PR DESCRIPTION
When the Vulkan implementation supports 8-/16-bit integer or floating-point features, we can just request them. This helps to address validation errors regarding them.