### PR TITLE
[stablehlo] Convert stablehlo.return to mlir return.

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_iree_input_dialects.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/test/stablehlo_to_iree_input_dialects.mlir
@@ -98,3 +98,13 @@ func.func public @empty_zero_extent(%arg0: tensor<ui8>, %arg1: tensor<0x4xui32>)
   // CHECK: return %[[EMPTY]]
   return %0 : tensor<0x4xui32>
 }
+
+// -----
+
+// CHECK-LABEL: @convert_return
+func.func @convert_return() -> tensor<i32> {
+  // CHECK: %[[CST:.+]] = arith.constant dense<1>
+  %cst = arith.constant dense<1> : tensor<i32>
+  // CHECK: return %[[CST]]
+  stablehlo.return %cst : tensor<i32>
+}


### PR DESCRIPTION
Stablehlo.return is marked explicitly illegal and thus when it is occurring inside a function, it is converted to mlir::func::return.

Fix for #14837