### PR TITLE
Enable runtime/bindings/python/test/benchmark_test.

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -191,13 +191,6 @@ iree_py_test(
 
 iree_py_test(
   NAME
-    benchmark_test
-  SRCS
-    "tests/benchmark_test.py"
-)
-
-iree_py_test(
-  NAME
     flags_test
   SRCS
     "tests/flags_test.py"
@@ -234,6 +227,13 @@ iree_py_test(
 # These tests perform linking via the Compiler API, which is only supported
 # in bundled-LLVM builds at the moment (#14086).
 if(IREE_BUILD_BUNDLED_LLVM)
+  iree_py_test(
+    NAME
+      benchmark_test
+    SRCS
+      "tests/benchmark_test.py"
+  )
+
   iree_py_test(
     NAME
       system_api_test

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -191,6 +191,13 @@ iree_py_test(
 
 iree_py_test(
   NAME
+    benchmark_test
+  SRCS
+    "tests/benchmark_test.py"
+)
+
+iree_py_test(
+  NAME
     flags_test
   SRCS
     "tests/flags_test.py"

--- a/runtime/bindings/python/iree/runtime/benchmark.py
+++ b/runtime/bindings/python/iree/runtime/benchmark.py
@@ -57,7 +57,9 @@ class BenchmarkTimeoutError(Exception):
 
 
 def benchmark_exe():
-    return os.path.join(os.path.dirname(__file__), "iree-benchmark-module")
+    return os.path.join(
+        os.path.dirname(__file__), "..", "_runtime_libs", "iree-benchmark-module"
+    )
 
 
 def benchmark_module(module, entry_functiong=None, inputs=[], timeout=None, **kwargs):
@@ -96,9 +98,6 @@ def benchmark_module(module, entry_functiong=None, inputs=[], timeout=None, **kw
 
         args.append(f"--input={shape}x{abitype}={values}")
     args.append(f"--module=-")
-
-    # DEBUG - DO NOT SUBMIT
-    print(f"running process with args: '{args}'")
 
     try:
         benchmark_process = subprocess.run(

--- a/runtime/bindings/python/iree/runtime/benchmark.py
+++ b/runtime/bindings/python/iree/runtime/benchmark.py
@@ -97,6 +97,9 @@ def benchmark_module(module, entry_functiong=None, inputs=[], timeout=None, **kw
         args.append(f"--input={shape}x{abitype}={values}")
     args.append(f"--module=-")
 
+    # DEBUG - DO NOT SUBMIT
+    print(f"running process with args: '{args}'")
+
     try:
         benchmark_process = subprocess.run(
             args=args,

--- a/runtime/bindings/python/tests/benchmark_test.py
+++ b/runtime/bindings/python/tests/benchmark_test.py
@@ -82,3 +82,6 @@ class BenchmarkTest(unittest.TestCase):
                 inputs=[arg0, arg1, arg2],
                 timeout=0.1,
             )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runtime/bindings/python/tests/benchmark_test.py
+++ b/runtime/bindings/python/tests/benchmark_test.py
@@ -83,5 +83,6 @@ class BenchmarkTest(unittest.TestCase):
                 timeout=0.1,
             )
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This script has several issues. First, let's get the test actually running...

https://github.com/openxla/iree/pull/14639 moved native dependencies under `iree._runtime_libs`, but this test was not running, so we missed that it broke. The test was used with pytest before, but it was not added to ctest.