### PR TITLE
Add support for i16->i64 signed extension and i16->i8 truncation in VM

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -849,6 +849,9 @@ class SignExtendIOpConversion : public OpConversionPattern<arith::ExtSIOp> {
     } else if (srcType.isInteger(16) && dstType.isInteger(32)) {
       rewriter.replaceOpWithNewOp<IREE::VM::ExtI16I32SOp>(srcOp, dstType,
                                                           adaptor.getIn());
+    } else if (srcType.isInteger(16) && dstType.isInteger(64)) {
+      rewriter.replaceOpWithNewOp<IREE::VM::ExtI16I64SOp>(srcOp, dstType,
+                                                          adaptor.getIn());
     } else if (srcType.isInteger(32) && dstType.isInteger(64)) {
       rewriter.replaceOpWithNewOp<IREE::VM::ExtI32I64SOp>(srcOp, dstType,
                                                           adaptor.getIn());
@@ -879,6 +882,9 @@ class TruncateIOpConversion : public OpConversionPattern<arith::TruncIOp> {
       rewriter.replaceOpWithNewOp<IREE::VM::AndI32Op>(
           srcOp, dstType, value,
           rewriter.createOrFold<IREE::VM::ConstI32Op>(srcOp.getLoc(), 1));
+    } else if (srcType.isInteger(16) && resultType.isInteger(8)) {
+      rewriter.replaceOpWithNewOp<IREE::VM::TruncI16I8Op>(srcOp, dstType,
+                                                          adaptor.getIn());
     } else if (srcType.isInteger(32) && resultType.isInteger(8)) {
       rewriter.replaceOpWithNewOp<IREE::VM::TruncI32I8Op>(srcOp, dstType,
                                                           adaptor.getIn());

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -4428,6 +4428,8 @@ void populateVMToEmitCPatterns(ConversionTarget &conversionTarget,
                                                          "vm_ctlz_i32");
 
   // Casting and type conversion/emulation ops
+  patterns.add<GenericOpConversion<IREE::VM::TruncI16I8Op>>(
+      typeConverter, context, "vm_trunc_i16i8");
   patterns.add<GenericOpConversion<IREE::VM::TruncI32I8Op>>(
       typeConverter, context, "vm_trunc_i32i8");
   patterns.add<GenericOpConversion<IREE::VM::TruncI32I16Op>>(

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -1625,7 +1625,7 @@ struct PseudoIntegerConversionToSplitConversionOp
 void TruncI16I8Op::getCanonicalizationPatterns(RewritePatternSet &results,
                                                MLIRContext *context) {
   results.insert<PseudoIntegerConversionToSplitConversionOp<
-      TruncI16I8Op, ExtI16I32SOp, 32, TruncI32I8Op>>(context);
+      TruncI16I8Op, ExtI16I32UOp, 32, TruncI32I8Op>>(context);
 }
 
 void TruncI64I8Op::getCanonicalizationPatterns(RewritePatternSet &results,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -1497,6 +1497,12 @@ static Attribute constFoldConversionOp(Type resultType, Attribute rawOperand,
   return {};
 }
 
+OpFoldResult TruncI16I8Op::fold(FoldAdaptor operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(getContext(), 32), operands.getOperand(),
+      [&](const APInt &a) { return a.trunc(8).zext(32); });
+}
+
 OpFoldResult TruncI32I8Op::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
       IntegerType::get(getContext(), 32), operands.getOperand(),
@@ -1615,6 +1621,12 @@ struct PseudoIntegerConversionToSplitConversionOp
 };
 
 } // namespace
+
+void TruncI16I8Op::getCanonicalizationPatterns(RewritePatternSet &results,
+                                               MLIRContext *context) {
+  results.insert<PseudoIntegerConversionToSplitConversionOp<
+      TruncI16I8Op, ExtI16I32SOp, 32, TruncI32I8Op>>(context);
+}
 
 void TruncI64I8Op::getCanonicalizationPatterns(RewritePatternSet &results,
                                                MLIRContext *context) {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -2951,6 +2951,12 @@ class VM_ConversionPseudoOp<Type src_type, Type dst_type, string mnemonic,
   let hasCanonicalizer = 1;
 }
 
+def VM_TruncI16I8Op :
+    VM_ConversionPseudoOp<I32, I32, "trunc.i16.i8"> {
+  let summary = [{integer truncate to 8 bits}];
+  let hasFolder = 1;
+}
+
 def VM_TruncI32I8Op :
     VM_ConversionOp<I32, I32, "trunc.i32.i8", VM_OPC_TruncI32I8> {
   let summary = [{integer truncate to 8 bits}];

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
@@ -7,7 +7,9 @@ vm.module @my_module {
     %0 = vm.trunc.i32.i8 %arg0 : i32 -> i32
     // CHECK-NEXT: %1 = vm.trunc.i32.i16 %0 : i32 -> i32
     %1 = vm.trunc.i32.i16 %0 : i32 -> i32
-    vm.return %1 : i32
+    // CHECK: %2 = vm.trunc.i16.i8 %1 : i32 -> i32
+    %2 = vm.trunc.i16.i8 %1 : i32 -> i32
+    vm.return %2 : i32
   }
 }
 


### PR DESCRIPTION
The i16->i8 truncation first extends the i16 to an i32. This seems a bit hacky but I'm not sure what would be a better way to approach this. Happy to rewrite this in a different way or in a different part of the stack.