### PR TITLE
Add descriptions for root compiler and runtime Python modules.

### DIFF
--- a/compiler/bindings/python/iree/compiler/__init__.py
+++ b/compiler/bindings/python/iree/compiler/__init__.py
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+"""IREE compiler Python bindings."""
+
 # Re-export some legacy APIs from the tools package to this top-level.
 # TODO: Deprecate and remove these names once clients are migrated.
 from .tools import *

--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -1,4 +1,4 @@
-"""Module init for the python bindings."""
+"""IREE runtime Python bindings."""
 
 # Copyright 2019 The IREE Authors
 #


### PR DESCRIPTION
Before:
```
λ python -c "import iree.compiler as ireec; help(ireec)"
Help on package iree.compiler in iree:

NAME
    iree.compiler

DESCRIPTION
    # Copyright 2021 The IREE Authors
    #
    # Licensed under the Apache License v2.0 with LLVM Exceptions.
    # See https://llvm.org/LICENSE.txt for license information.
    # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

PACKAGE CONTENTS
    _mlir_libs (package)
```

After:
```
λ python -c "import iree.compiler as ireec; help(ireec)"
Help on package iree.compiler in iree:

NAME
    iree.compiler - IREE compiler Python bindings.

PACKAGE CONTENTS
    _mlir_libs (package)
```

skip-ci: comment-only change