### PR TITLE
Switch SPIR-V to use generic vectorizer instead of GPUVectorization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -12,6 +12,8 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_PASSES_H_
 #define IREE_COMPILER_CODEGEN_COMMON_PASSES_H_
 
+#include <type_traits>
+
 #include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -143,6 +145,13 @@ struct GenericVectorizationPassOptions {
   bool enableVectorMasking = false;
   bool vectorizePadding = false;
   bool vectorizeGatherAccesses = false;
+  // The flag controls whether it touches the structure generated from tiling,
+  // which affects later steps like bufferization and vector hoisting.
+  bool enableCleanup = true;
+  // Enable conversion for reduction ops to contraction ops.
+  bool generateContract = true;
+  // Max vector size allowed to avoid creating large vectors.
+  int64_t maxVectorSize = std::numeric_limits<int64_t>::max();
 };
 /// Creates a pass to perform vectorization on LinAlg and tensor ops.
 std::unique_ptr<OperationPass<func::FuncOp>> createGenericVectorizationPass();

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -12,7 +12,7 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_PASSES_H_
 #define IREE_COMPILER_CODEGEN_COMMON_PASSES_H_
 
-#include <type_traits>
+#include <limits>
 
 #include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -249,6 +249,14 @@ def GenericVectorization :
       "Rewrite all tensor.pad ops in the function to vector form.">,
     Option<"vectorizeGatherAccesses", "vectorize-gather-accesses", "bool", /*default=*/"false",
       "Enable vectorizaiton of operations that may generate vector.gather operations.">,
+    Option<"enableCleanup", "enable-cleanup", "bool",/*default=*/"true",
+      "Enable cleanups after vectorization. The patterns touch the structure"
+      "generated from tiling so it affects later steps like bufferization and vector hoisting.">,
+    Option<"generateContract", "generate-contract", "bool",/*default=*/"true",
+      "Enable conversion for reduction ops to contraction ops.">,
+    Option<"maxVectorSize", "max-vector-size", "int64_t",
+            /*default=*/"2147483647",
+           "Max vector size allowed to avoid creating large vectors.">
   ];
   let constructor =
       "mlir::iree_compiler::createGenericVectorizationPass()";


### PR DESCRIPTION
SPIR-V backend tests rely on the structure generated by tiling, so we have to disable some "cleanup". Otherwise, it fails to remove redundant buffers. To make the transition smooth, this revision introduces a few options that are provided by GPUVectorization as well.