### PR TITLE
Support multi-block functions in EraseHALDescriptorTypeFormMemRef

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -106,8 +106,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createEmulateNarrowTypePass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createEraseDeadAllocAndStoresPass();
 
-std::unique_ptr<OperationPass<func::FuncOp>>
-createEraseHALDescriptorTypeFromMemRefPass();
+std::unique_ptr<Pass> createEraseHALDescriptorTypeFromMemRefPass();
 
 // Extract address computations into their own separate instructions.
 std::unique_ptr<Pass> createExtractAddressComputationPass();
@@ -238,7 +237,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createTypePropagationPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createVectorizePadPass();
 
 /// Erases #hal.descriptor_type as MemRef memory space.
-LogicalResult eraseHALDescriptorTypeFromMemRef(func::FuncOp funcOp);
+LogicalResult eraseHALDescriptorTypeFromMemRef(Operation *op);
 
 /// Populates patterns with patterns to concretize tensor.pad op's result
 /// shape. `numWorkgroups`, if not empty, will be used as bounds for simplifying

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -177,8 +177,8 @@ def EraseDeadAllocAndStores :
       "mlir::iree_compiler::createEraseDeadAllocAndStoresPass()";
 }
 
-def EraseHALDescriptorTypeFromMemRef :
-    Pass<"iree-codegen-erase-hal-descriptor-type-from-memref", "func::FuncOp"> {
+def EraseHALDescriptorTypeFromMemRef
+    : Pass<"iree-codegen-erase-hal-descriptor-type-from-memref"> {
   let summary = "Erase #hal.descriptor_type from MemRef memory space";
   let constructor =
       "mlir::iree_compiler::createEraseHALDescriptorTypeFromMemRefPass()";

--- a/compiler/src/iree/compiler/Codegen/Common/test/erase_hal_descriptor_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/erase_hal_descriptor_type.mlir
@@ -41,3 +41,20 @@ func.func @shared_memory_address_space() {
   "dialect.memref_consumer"(%3) : (memref<?x8xf32, 3>) -> ()
   return
 }
+
+// -----
+
+// CHECK-LABEL: func.func @multi_block()
+func.func @multi_block() {
+  // CHECK:   %[[P:.+]] = "dialect.memref_producer"() : () -> memref<?x8xf32>
+  // CHECK:   cf.br ^[[B:bb.+]](%[[P]] : memref<?x8xf32>)
+  // CHECK: ^[[B]](%[[A:.+]]: memref<?x8xf32>):
+  // CHECK:   "dialect.memref_consumer"(%[[A]]) : (memref<?x8xf32>) -> ()
+  %0 = "dialect.memref_producer"() : () -> (memref<?x8xf32, #hal.descriptor_type<uniform_buffer>>)
+  cf.br ^bb2(%0: memref<?x8xf32, #hal.descriptor_type<uniform_buffer>>)
+^bb2(%1 : memref<?x8xf32, #hal.descriptor_type<uniform_buffer>>):
+  "dialect.memref_consumer"(%1) : (memref<?x8xf32, #hal.descriptor_type<uniform_buffer>>) -> ()
+  return
+}
+
+

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -686,8 +686,7 @@ void addTransformDialectPasses(OpPassManager &passManager) {
 static void addLowerToLLVMPasses(OpPassManager &passManager) {
   // TODO: Remove the following pass and plumb support for #hal.descriptor_type
   // memory space through the stack.
-  passManager.addNestedPass<func::FuncOp>(
-      createEraseHALDescriptorTypeFromMemRefPass());
+  passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
 
   // Lower `ukernel.*` ops to function calls
   passManager.addPass(createLowerUKernelOpsToCallsPass());
@@ -774,8 +773,7 @@ void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
         createCPUMaterializeEncodingPass());
     // TODO: Remove the following pass the plumb support for
     // #hal.descriptor_type memory space through the stack.
-    modulePassManager.addNestedPass<func::FuncOp>(
-        createEraseHALDescriptorTypeFromMemRefPass());
+    modulePassManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   }
 
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -487,7 +487,7 @@ static void addLowerAndOptimzeAddressComputation(OpPassManager &pm) {
 static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   // TODO: Remove the following pass the plumb support for #hal.descriptor_type
   // memory space through the stack.
-  pm.addNestedPass<func::FuncOp>(createEraseHALDescriptorTypeFromMemRefPass());
+  pm.addPass(createEraseHALDescriptorTypeFromMemRefPass());
 
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -39,8 +39,7 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
       createCPUMaterializeEncodingPass());
   // TODO: Remove the following pass the plumb support for #hal.descriptor_type
   // memory space through the stack.
-  passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
-      createEraseHALDescriptorTypeFromMemRefPass());
+  passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();


### PR DESCRIPTION
If we have functions with multiple basic blocks and the HAL descriptor is part of a block signature, we have to replace the function when getting rid of these descriptors. This PR adds the logic to remove these descriptors and makes sure the pass runs from the function's parent op (otherwise, we couldn't replace the function as part of the transformation).