### PR TITLE
Make byo-bitcode usable wrt multiple targets

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -291,8 +291,8 @@ static LogicalResult linkObjects(Location loc, llvm::Module &module,
   // Link user modules and libdevice (if required).
   // Note that linking order matters:
   llvm::Linker linker(module);
-  if (failed(linkCmdlineBitcodeFile(loc, linker, llvm::Linker::OverrideFromSrc,
-                                    targetMachine, module.getContext()))) {
+  if (failed(linkCmdlineBitcodeFiles(loc, linker, llvm::Linker::OverrideFromSrc,
+                                     targetMachine, module.getContext()))) {
     return failure();
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/BUILD.bazel
@@ -45,6 +45,7 @@ iree_compiler_cc_library(
         "LLVMLinkerUtils.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "@llvm-project//llvm:BitReader",
         "@llvm-project//llvm:Core",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
@@ -47,6 +47,7 @@ iree_cc_library(
     LLVMSupport
     LLVMTarget
     LLVMipo
+    iree::compiler::Codegen::Utils
     iree::compiler::Dialect::HAL::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -438,9 +438,9 @@ public:
     llvm::Linker moduleLinker(*llvmModule);
 
     // Link any bitcode files specified on the command line.
-    if (failed(linkCmdlineBitcodeFile(variantOp.getLoc(), moduleLinker,
-                                      llvm::Linker::OverrideFromSrc,
-                                      *targetMachine, context))) {
+    if (failed(linkCmdlineBitcodeFiles(variantOp.getLoc(), moduleLinker,
+                                       llvm::Linker::OverrideFromSrc,
+                                       *targetMachine, context))) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.h"
 
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -16,9 +17,12 @@ namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
-static llvm::cl::opt<std::string> clBitcodeFile(
+static llvm::cl::opt<std::string> clBitcodeFiles(
     "iree-link-bitcode",
-    llvm::cl::desc("Paths of additional bitcode file to load and link."),
+    llvm::cl::desc(
+        "Paths of additional bitcode files to load and link. Comma-separated. "
+        "Any list entry that contains a colon (:) is parsed as `arch:path` and "
+        "is only linked if `arch` matches the target triple."),
     llvm::cl::init(""));
 
 bool anyRequiredSymbols(const llvm::Module &module, StringRef prefix) {
@@ -119,31 +123,48 @@ linkBitcodeObjects(Location loc, llvm::Linker &linker, unsigned linkerFlags,
   return success();
 }
 
-LogicalResult linkCmdlineBitcodeFile(Location loc, llvm::Linker &linker,
-                                     unsigned linkerFlags,
-                                     llvm::TargetMachine &targetMachine,
-                                     llvm::LLVMContext &context) {
-  if (clBitcodeFile.empty()) {
+LogicalResult linkCmdlineBitcodeFiles(Location loc, llvm::Linker &linker,
+                                      unsigned linkerFlags,
+                                      llvm::TargetMachine &targetMachine,
+                                      llvm::LLVMContext &context) {
+  if (clBitcodeFiles.empty()) {
     return success();
   }
-  auto bitcodeBufferRef = llvm::MemoryBuffer::getFile(clBitcodeFile);
-  if (auto ec = bitcodeBufferRef.getError()) {
-    return mlir::emitError(loc) << "failed reading user bitcode file `"
-                                << clBitcodeFile << "`: " << ec.message();
-  }
-  auto setAlwaysInline = [&](llvm::Module &module) {
-    for (auto &func : module.getFunctionList()) {
-      func.addFnAttr(llvm::Attribute::AlwaysInline);
+  SmallVector<StringRef> entries;
+  StringRef(clBitcodeFiles.getValue()).split(entries, ',');
+  for (StringRef entry : entries) {
+    StringRef path = entry;
+    if (entry.contains(':')) {
+      std::pair<StringRef, StringRef> components = entry.split(':');
+      StringRef filterArch = components.first;
+      const char *archName =
+          getIreeArchNameForTargetTriple(targetMachine.getTargetTriple());
+      if (filterArch != archName) {
+        continue;
+      }
+      path = components.second;
     }
-  };
-  if (failed(linkBitcodeModule(
-          loc, linker, linkerFlags, targetMachine, clBitcodeFile,
-          llvm::parseBitcodeFile(*bitcodeBufferRef->get(), context),
-          setAlwaysInline))) {
-    return mlir::emitError(loc) << "failed linking in user bitcode file `"
-                                << clBitcodeFile << "` for target triple '"
-                                << targetMachine.getTargetTriple().str() << "'";
+    auto bitcodeBufferRef = llvm::MemoryBuffer::getFile(path);
+    if (auto ec = bitcodeBufferRef.getError()) {
+      return mlir::emitError(loc) << "failed reading user bitcode file `"
+                                  << path << "`: " << ec.message();
+    }
+    auto setAlwaysInline = [&](llvm::Module &module) {
+      for (auto &func : module.getFunctionList()) {
+        func.addFnAttr(llvm::Attribute::AlwaysInline);
+      }
+    };
+    if (failed(linkBitcodeModule(
+            loc, linker, linkerFlags, targetMachine, path,
+            llvm::parseBitcodeFile(*bitcodeBufferRef->get(), context),
+            setAlwaysInline))) {
+      return mlir::emitError(loc)
+             << "failed linking in user bitcode file `" << path
+             << "` for target triple '" << targetMachine.getTargetTriple().str()
+             << "'";
+    }
   }
+
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.cpp
@@ -21,8 +21,8 @@ static llvm::cl::opt<std::string> clBitcodeFiles(
     "iree-link-bitcode",
     llvm::cl::desc(
         "Paths of additional bitcode files to load and link. Comma-separated. "
-        "Any list entry that contains a colon (:) is parsed as `arch:path` and "
-        "is only linked if `arch` matches the target triple."),
+        "Any list entry that contains an equals (=) is parsed as `arch=path` "
+        "and is only linked if `arch` matches the target triple."),
     llvm::cl::init(""));
 
 bool anyRequiredSymbols(const llvm::Module &module, StringRef prefix) {
@@ -134,8 +134,8 @@ LogicalResult linkCmdlineBitcodeFiles(Location loc, llvm::Linker &linker,
   StringRef(clBitcodeFiles.getValue()).split(entries, ',');
   for (StringRef entry : entries) {
     StringRef path = entry;
-    if (entry.contains(':')) {
-      std::pair<StringRef, StringRef> components = entry.split(':');
+    if (entry.contains('=')) {
+      std::pair<StringRef, StringRef> components = entry.split('=');
       StringRef filterArch = components.first;
       const char *archName =
           getIreeArchNameForTargetTriple(targetMachine.getTargetTriple());

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.h
@@ -51,10 +51,10 @@ linkBitcodeObjects(Location loc, llvm::Linker &linker, unsigned linkerFlags,
                    llvm::LLVMContext &context,
                    ModuleSpecializationCallback specializationCallback = {});
 
-LogicalResult linkCmdlineBitcodeFile(Location loc, llvm::Linker &linker,
-                                     unsigned linkerFlags,
-                                     llvm::TargetMachine &targetMachine,
-                                     llvm::LLVMContext &context);
+LogicalResult linkCmdlineBitcodeFiles(Location loc, llvm::Linker &linker,
+                                      unsigned linkerFlags,
+                                      llvm::TargetMachine &targetMachine,
+                                      llvm::LLVMContext &context);
 
 } // namespace HAL
 } // namespace IREE


### PR DESCRIPTION
We've added a `--iree-link-bitcode` flag allowing to BYO bitcode. It currently allows specifying a single bitcode file that's unconditionally linked into every executable variant.

That's not usable for a key intended use case, providing architecture-specific ukernel implementations, as demo'd in https://github.com/openxla/iree/pull/14496. Concretely the trigger for this was that @lundong gave that a try and ran into multiply-defined symbol issues, with the symbol that they were trying to provide a definition for on RISCV-32.  The problem was that because of constant-evaluation, even though they were targeting RISCV-32, there was a host executable variant, x86-64, and the custom bitcode file was being linked there too, clashing with the built-in ukernel bitcode for x86-64.

Because ukernel entry points are actually targeting wasm64/wasm32, so multiple architectures go through the same wasm architecture for the entry point, we can't rely on that to skip bitcode modules not relevant to the current executable variant.

So I don't think there is a way around the need to allow the user to specify that a bitcode file only applies to a specific architecture. This PR does that, implementing an optional `arch:path` syntax. The downside is that the colon (`:`) becomes an illegal character in paths.

Along the way, this PR allows specifying multiple bitcode files, as a comma-separated list.