### PR TITLE
[Flow] Re-enable dynamic shaped dequant fusion

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FuseDequantizationMatmul.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FuseDequantizationMatmul.cpp
@@ -64,15 +64,6 @@ static LogicalResult isGroupedContractionOp(linalg::GenericOp genericOp) {
     return failure();
   if (genericOp.getNumReductionLoops() != 2)
     return failure();
-  if (!llvm::cast<ShapedType>(genericOp.getInputs()[0].getType())
-           .hasStaticShape() ||
-      !llvm::cast<ShapedType>(genericOp.getInputs()[0].getType())
-           .hasStaticShape() ||
-      !llvm::cast<ShapedType>(genericOp.getInputs()[0].getType())
-           .hasStaticShape()) {
-    // Codegen can't handle the dynamic case yet.
-    return failure();
-  }
   return success();
 }
 


### PR DESCRIPTION
Support was added for the SPIR-V backend in #14751