### PR TITLE
Lay groundwork for documenting Metal (Apple) configuration.

### DIFF
--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -6,7 +6,7 @@ tags:
 icon: octicons/cpu-16
 ---
 
-# Running on a Bare-Metal Platform
+# Running on a bare-metal platform
 
 IREE supports model execution via CPU on bare-metal platforms. Bare metal
 platforms have no operating system support, and executables are built using

--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -6,7 +6,7 @@ tags:
 icon: octicons/cpu-16
 ---
 
-# CPU Deployment
+# CPU deployment
 
 IREE supports efficient program execution on CPU devices by using
 [LLVM](https://llvm.org/) to compile all dense computations in each program into

--- a/docs/website/docs/guides/deployment-configurations/gpu-cuda-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-cuda-rocm.md
@@ -7,7 +7,7 @@ tags:
 icon: octicons/server-16
 ---
 
-# GPU Deployment using CUDA and ROCm
+# GPU deployment using CUDA and ROCm
 
 IREE can accelerate model execution on Nvidia GPUs using CUDA and on AMD GPUs
 using ROCm. Due to the similarity of CUDA and ROCm APIs and infrastructure, the

--- a/docs/website/docs/guides/deployment-configurations/gpu-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-metal.md
@@ -1,0 +1,12 @@
+---
+hide:
+  - tags
+tags:
+  - GPU
+  - iOS
+icon: simple/apple
+---
+
+# GPU deployment using Metal
+
+!!! note "Documentation coming soon!"

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -7,7 +7,7 @@ tags:
 icon: octicons/server-16
 ---
 
-# GPU Deployment using Vulkan
+# GPU deployment using Vulkan
 
 IREE can accelerate model execution on GPUs via
 [Vulkan](https://www.khronos.org/vulkan/), a low-overhead graphics and compute

--- a/docs/website/docs/guides/deployment-configurations/index.md
+++ b/docs/website/docs/guides/deployment-configurations/index.md
@@ -14,7 +14,7 @@ runtime entirely or interface with custom accelerators.
 * [:octicons-server-16: GPU - Vulkan](./deployment-configurations/gpu-vulkan.md)
   for cross-platform usage and interop with graphics applications
 * [:octicons-server-16: GPU - CUDA/ROCm](./deployment-configurations/gpu-cuda-rocm.md)
-  for NVIDIA/AMD-specific optimizations
+  for NVIDIA/AMD-specific solutions
 * [:simple-apple: GPU - Metal](./deployment-configurations/gpu-metal.md)
   for running on Apple hardware
 

--- a/docs/website/docs/guides/deployment-configurations/index.md
+++ b/docs/website/docs/guides/deployment-configurations/index.md
@@ -7,10 +7,16 @@ runtime entirely or interface with custom accelerators.
 
 ## Stable configurations
 
-* [CPU](./cpu.md) for general purpose CPU deployment
-* [CPU - Bare-Metal](./bare-metal.md) with minimal platform dependencies
-* [GPU - Vulkan](./gpu-vulkan.md)
-* [GPU - CUDA/ROCm](./gpu-cuda-rocm.md)
+* [:octicons-cpu-16: CPU](./deployment-configurations/cpu.md) for general
+  purpose CPU deployment
+* [:octicons-cpu-16: CPU - Bare-Metal](./deployment-configurations/bare-metal.md)
+  with minimal platform dependencies
+* [:octicons-server-16: GPU - Vulkan](./deployment-configurations/gpu-vulkan.md)
+  for cross-platform usage and interop with graphics applications
+* [:octicons-server-16: GPU - CUDA/ROCm](./deployment-configurations/gpu-cuda-rocm.md)
+  for NVIDIA/AMD-specific optimizations
+* [:simple-apple: GPU - Metal](./deployment-configurations/gpu-metal.md)
+  for running on Apple hardware
 
 These are just the most stable configurations IREE supports. Feel free to reach
 out on any of IREE's
@@ -35,9 +41,9 @@ When compiling programs, a list of target backends must be specified via
 | `vmvx` | Portable interpreter powered by a microkernel library | `local-sync`, `local-task` |
 | `vulkan` or<br>`vulkan-spirv` | Portable GPU support via SPIR-V for Vulkan | `vulkan` |
 | `cuda` | NVIDIA GPU support via PTX for CUDA | `cuda` |
+| `metal` or<br>`metal-spirv` | GPU support on Apple platforms via MSL for Metal | `metal` |
 | `rocm` | **Experimental** <br> AMD GPU support via HSACO for ROCm | `rocm` |
 | `webgpu-wgsl` | **Experimental** <br> GPU support on the Web via WGSL for WebGPU | `webgpu` |
-| `metal` or<br>`metal-spirv` | **Experimental** <br> GPU support on Apple platforms via MSL for Metal | `metal` |
 
 !!! tip "Tip - listing available backends"
     The list of compiler target backends can be queried:
@@ -85,9 +91,9 @@ focus and the build configuration.
 | `local-task` | Multithreaded local CPU device using a 'task' executor |
 | `vulkan`     | Portable GPU execution using the Vulkan API |
 | `cuda`       | NVIDIA GPU execution using CUDA |
+| `metal`      | GPU execution on Apple platforms using Metal |
 | `rocm`       | **Experimental** <br> AMD GPU execution using ROCm |
 | `webgpu`     | **Experimental** <br> GPU execution on the web using WebGPU |
-| `metal`      | **Experimental** <br> GPU execution on Apple platforms using Metal |
 
 Additional HAL drivers can also be defined external to the core project via
 `IREE_EXTERNAL_HAL_DRIVERS`.

--- a/docs/website/docs/guides/index.md
+++ b/docs/website/docs/guides/index.md
@@ -8,10 +8,10 @@
 
 Guides for specific frameworks:
 
-* [TensorFlow](./ml-frameworks/tensorflow.md)
-* [TensorFlow Lite](./ml-frameworks/tflite.md)
-* [JAX](./ml-frameworks/jax.md)
-* [PyTorch](./ml-frameworks/pytorch.md)
+* [:simple-tensorflow: TensorFlow](./ml-frameworks/tensorflow.md) and
+  [:simple-tensorflow: TensorFlow Lite](./ml-frameworks/tflite.md)
+* [:simple-python: JAX](./ml-frameworks/jax.md)
+* [:simple-pytorch: PyTorch](./ml-frameworks/pytorch.md)
 
 ## Deployment configurations
 
@@ -21,11 +21,17 @@ Guides for specific frameworks:
 
 Guides for specific configurations:
 
-* [CPU](./deployment-configurations/cpu.md)
-* [CPU - Bare-Metal](./deployment-configurations/bare-metal.md)
-* [GPU - Vulkan](./deployment-configurations/gpu-vulkan.md)
-* [GPU - CUDA/ROCm](./deployment-configurations/gpu-cuda-rocm.md)
+* [:octicons-cpu-16: CPU](./deployment-configurations/cpu.md) for general
+  purpose CPU deployment
+* [:octicons-cpu-16: CPU - Bare-Metal](./deployment-configurations/bare-metal.md)
+  with minimal platform dependencies
+* [:octicons-server-16: GPU - Vulkan](./deployment-configurations/gpu-vulkan.md)
+  for cross-platform usage and interop with graphics applications
+* [:octicons-server-16: GPU - CUDA/ROCm](./deployment-configurations/gpu-cuda-rocm.md)
+  for NVIDIA/AMD-specific optimizations
+* [:simple-apple: GPU - Metal](./deployment-configurations/gpu-metal.md)
+  for running on Apple hardware
 
 ## Other topics
 
-* [Developer tips and tricks](./developer-tips.md)
+* [:material-lightbulb-on: Developer tips and tricks](./developer-tips.md)

--- a/docs/website/docs/guides/index.md
+++ b/docs/website/docs/guides/index.md
@@ -28,7 +28,7 @@ Guides for specific configurations:
 * [:octicons-server-16: GPU - Vulkan](./deployment-configurations/gpu-vulkan.md)
   for cross-platform usage and interop with graphics applications
 * [:octicons-server-16: GPU - CUDA/ROCm](./deployment-configurations/gpu-cuda-rocm.md)
-  for NVIDIA/AMD-specific optimizations
+  for NVIDIA/AMD-specific solutions
 * [:simple-apple: GPU - Metal](./deployment-configurations/gpu-metal.md)
   for running on Apple hardware
 

--- a/docs/website/docs/guides/ml-frameworks/index.md
+++ b/docs/website/docs/guides/ml-frameworks/index.md
@@ -27,9 +27,10 @@ graph LR
 
 See end-to-end examples of how to use each framework with IREE:
 
-* [TensorFlow](./tensorflow.md) and [TensorFlow Lite](./tflite.md)
-* [JAX](./jax.md)
-* [PyTorch](./pytorch.md)
+* [:simple-tensorflow: TensorFlow](./tensorflow.md) and
+  [:simple-tensorflow: TensorFlow Lite](./tflite.md)
+* [:simple-python: JAX](./jax.md)
+* [:simple-pytorch: PyTorch](./pytorch.md)
 
 Importing from other frameworks is planned - stay tuned!
 

--- a/docs/website/docs/guides/ml-frameworks/jax.md
+++ b/docs/website/docs/guides/ml-frameworks/jax.md
@@ -7,7 +7,7 @@ tags:
 icon: simple/python
 ---
 
-# JAX Integration
+# JAX integration
 
 !!! note
     IREE's JAX support is under active development. This page is still under

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -7,7 +7,7 @@ tags:
 icon: simple/pytorch
 ---
 
-# PyTorch Integration
+# PyTorch integration
 
 IREE supports compiling and running PyTorch programs represented as
 `nn.Module` [classes](https://pytorch.org/docs/stable/generated/torch.nn.Module.html)

--- a/docs/website/docs/guides/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/guides/ml-frameworks/tensorflow.md
@@ -7,7 +7,7 @@ tags:
 icon: simple/tensorflow
 ---
 
-# TensorFlow Integration
+# TensorFlow integration
 
 IREE supports compiling and running TensorFlow programs represented as
 `tf.Module` [classes](https://www.tensorflow.org/api_docs/python/tf/Module)

--- a/docs/website/docs/guides/ml-frameworks/tflite.md
+++ b/docs/website/docs/guides/ml-frameworks/tflite.md
@@ -7,10 +7,10 @@ tags:
 icon: simple/tensorflow
 ---
 
-# TFLite Integration
+# TensorFlow Lite integration
 
-IREE supports compiling and running TensorFlow Lite programs stored as [TFLite
-FlatBuffers](https://www.tensorflow.org/lite/guide). These files can be
+IREE supports compiling and running TensorFlow Lite (TFLite) programs stored as
+[TFLite FlatBuffers](https://www.tensorflow.org/lite/guide). These files can be
 imported into an IREE-compatible format then compiled to a series of backends.
 
 ``` mermaid

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
           - CPU - Bare-Metal: "guides/deployment-configurations/bare-metal.md"
           - GPU - Vulkan: "guides/deployment-configurations/gpu-vulkan.md"
           - GPU - CUDA/ROCm: "guides/deployment-configurations/gpu-cuda-rocm.md"
+          - GPU - Metal: "guides/deployment-configurations/gpu-metal.md"
       - "Other topics":
           - Developer tips and tricks: "guides/developer-tips.md"
   - "Reference":


### PR DESCRIPTION
We do already have a page on _building_ for iOS: https://openxla.github.io/iree/building-from-source/ios/, but that page is less polished than the other building from source pages. This moves us closer to having a complete set of documentation pages for iOS/macOS development and deployment, now that the Metal HAL is moved out of `experimental/`.

---

Add placeholder gpu-metal documentation page 
![image](https://github.com/openxla/iree/assets/4010439/018cf40a-eda6-4f55-a331-7c583dea41ef)

---

Drop "experimental" qualifier on Metal compiler target and runtime HAL driver 

| | |
| -- | -- |
| before | ![image](https://github.com/openxla/iree/assets/4010439/fee4e326-c1e6-4818-a0bb-6bbfdf8a4ae7) |
| after |  ![image](https://github.com/openxla/iree/assets/4010439/b964fa1a-ada2-4a95-a5cb-ceff2d40d73e) | 

---

Refresh language and icon usage for the other pages in this section 
![image](https://github.com/openxla/iree/assets/4010439/96578d03-3f96-44f5-8545-bf6f34c8a0da)
