### PR TITLE
Avoid concurrently scheduling tied ops with hazards.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_concurrency.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_concurrency.mlir
@@ -103,6 +103,31 @@ func.func @partitioningForMaxConcurrency(%arg0: !stream.resource<external>, %arg
 
 // -----
 
+// Tests that tied operands properly trigger hazard detection.
+// Here @dispatch_1 has a read/write hazard on %capture0 with @dispatch_0 and
+// should not be placed into the same concurrency group.
+
+// CHECK-LABEL: @keepTiedOpsSeparate
+// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<external>)
+func.func @keepTiedOpsSeparate(%arg0: !stream.resource<external>) -> (!stream.resource<external>, !stream.resource<external>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  // CHECK: stream.async.execute
+  // CHECK-SAME: with(%[[ARG0]] as %[[CAPTURE0:.+]]: !stream.resource<external>{%c4}) ->
+  %results:2, %result_timepoint = stream.async.execute with(%arg0 as %capture0: !stream.resource<external>{%c4}) -> (!stream.resource<external>{%c4}, %arg0{%c4}) {
+    // CHECK-NOT: stream.async.concurrent
+    // CHECK-NEXT: stream.async.dispatch @ex::@dispatch_0
+    %1 = stream.async.dispatch @ex::@dispatch_0(%capture0[%c0 to %c4 for %c4]) : (!stream.resource<external>{%c4}) -> !stream.resource<external>{%c4}
+    // CHECK-NEXT: stream.async.dispatch @ex::@dispatch_1
+    %2 = stream.async.dispatch @ex::@dispatch_1(%capture0[%c0 to %c4 for %c4]) : (!stream.resource<external>{%c4}) -> %capture0{%c4}
+    // CHECK-NEXT: stream.yield
+    stream.yield %1, %2 : !stream.resource<external>{%c4}, !stream.resource<external>{%c4}
+  } => !stream.timepoint
+  return %results#0, %results#1 : !stream.resource<external>, !stream.resource<external>
+}
+
+// -----
+
 // TODO(#11249): add a test for in-place collectives (send == recv).
 
 // Tests that multiple collective ops will get grouped together in a concurrent


### PR DESCRIPTION
Fixes #14889.