### PR TITLE
[third_party/rocm] Add ROCM dependencies for .bc file as third_party dep

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "third_party/stablehlo"]
 	path = third_party/stablehlo
 	url = https://github.com/iree-org/stablehlo.git
+[submodule "third_party/rocm-device-libs"]
+	path = third_party/rocm-device-libs
+	url = https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,20 @@ else()
 endif()
 
 #-------------------------------------------------------------------------------
+# ROCM device-libs.
+#
+# Using the (optional) ROCUM support in the compiler and runtime requires the
+# ROCM device-libs. The toolkit can either be built ahead of time or
+# it can be automatically downloaded and built on certain host architectures.
+#-------------------------------------------------------------------------------
+
+set(IREE_ROCM_AVAILABLE OFF)
+find_package(ROCMDeviceLibs)
+if(ROCMDeviceLibs_FOUND)
+  set(IREE_ROCM_AVAILABLE ON)
+endif()
+
+#-------------------------------------------------------------------------------
 # Runtime HAL Driver Options
 # By default, all runtime drivers supported by the current platform which do
 # not require external deps are enabled by default. This can be changed with:
@@ -773,6 +787,11 @@ if(IREE_TARGET_BACKEND_CUDA OR IREE_HAL_DRIVER_CUDA)
   add_subdirectory(build_tools/third_party/cuda EXCLUDE_FROM_ALL)
 endif()
 
+# If any ROCM features are being built, try to locate ROCM device-libs.
+if(IREE_TARGET_BACKEND_ROCM)
+  add_subdirectory(build_tools/third_party/rocm EXCLUDE_FROM_ALL)
+endif()
+
 #-------------------------------------------------------------------------------
 # MLIR/LLVM Dependency
 #-------------------------------------------------------------------------------
@@ -812,6 +831,7 @@ else()
   # Add default external projects.
   iree_llvm_add_external_project(mlir-iree-dialects ${CMAKE_CURRENT_SOURCE_DIR}/llvm-external-projects/iree-dialects)
   iree_llvm_add_external_project(stablehlo ${CMAKE_CURRENT_SOURCE_DIR}/third_party/stablehlo)
+  iree_llvm_add_external_project(rocm-device-libs ${CMAKE_CURRENT_SOURCE_DIR}/third_party/rocm-device-libs)
   if(IREE_INPUT_TORCH)
     iree_llvm_add_external_project(torch-mlir-dialects ${CMAKE_CURRENT_SOURCE_DIR}/third_party/torch-mlir-dialects)
   endif()

--- a/build_tools/third_party/rocm/CMakeLists.txt
+++ b/build_tools/third_party/rocm/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(ROCM_SOURCE_DIR
+  "${IREE_SOURCE_DIR}/third_party/rocm-device-libs/"
+)
+set(ROCM_BINARY_DIR
+  "${IREE_BINARY_DIR}/third_party/rocm-device-libs"
+)


### PR DESCRIPTION
-- This commit adds ROCM dependencies for .bc file as third_party dep.

Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>

I've verified generation of .bc files when building ROCM as :-
1. A standalone repo with a separate build of llvm-project repo.
2. An external project in a clone of llvm-project repo.

In both case, I was trying to build it via command-line.
In case `1` I was using the command :
```
cmake -DCMAKE_PREFIX_PATH=$LLVM_BUILD ..
```
And in case `2` I used the command :
```
cmake ../llvm -DCMAKE_BUILD_TYPE=Release       -DLLVM_ENABLE_PROJECTS="clang;lld"       -DLLVM_EXTERNAL_PROJECTS="device-libs"       -DLLVM_EXTERNAL_DEVICE_LIBS_SOURCE_DIR=../amd/device-libs
```