### PR TITLE
Remove redundant parameters from ukernel tile funcs

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -9,15 +9,14 @@
 
 void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_f32(out_ptr + 4 * 0);
     acc1 = vld1q_f32(out_ptr + 4 * 1);
     acc2 = vld1q_f32(out_ptr + 4 * 2);
@@ -52,8 +51,8 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
     acc14 = vdupq_n_f32(0);
     acc15 = vdupq_n_f32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     float32x4_t lhs0 = vld1q_f32(lhs_ptr + 0);
     float32x4_t lhs1 = vld1q_f32(lhs_ptr + 4);
     lhs_ptr += 8;
@@ -100,15 +99,13 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
 static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
-    iree_uk_type_t acc_type) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type) {
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
       acc0 = vld1q_f32(out_ptr + 4 * 0);
@@ -164,8 +161,8 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
     acc14 = vdupq_n_f32(0);
     acc15 = vdupq_n_f32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     float32x4_t lhs0 = vcvt_f32_f16(vld1_f16(lhs_ptr + 0));
     float32x4_t lhs1 = vcvt_f32_f16(vld1_f16(lhs_ptr + 4));
     lhs_ptr += 8;
@@ -230,31 +227,30 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
 
 void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(out_tile, lhs_panel, rhs_panel,
+                                            params, IREE_UK_TYPE_FLOAT_16);
 }
 
 void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(out_tile, lhs_panel, rhs_panel,
+                                            params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   int32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_s32(out_ptr + 4 * 0);
     acc1 = vld1q_s32(out_ptr + 4 * 1);
     acc2 = vld1q_s32(out_ptr + 4 * 2);
@@ -289,8 +285,8 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x1_arm_64(
     acc14 = vdupq_n_s32(0);
     acc15 = vdupq_n_s32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     int16x8_t lhs = vmovl_s8(vld1_s8(lhs_ptr));
     lhs_ptr += 8;
     int16x8_t rhs = vmovl_s8(vld1_s8(rhs_ptr));

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
@@ -33,9 +33,8 @@ static inline float32x4_t iree_uk_neon_uzp2_f32_as_s64(float32x4_t a,
 
 void iree_uk_mmt4d_tile_bf16bf16f32_8x8x4_arm_64_bf16(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const bfloat16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const bfloat16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float* IREE_UK_RESTRICT out_ptr = out_tile;
@@ -43,7 +42,7 @@ void iree_uk_mmt4d_tile_bf16bf16f32_8x8x4_arm_64_bf16(
   float32x4_t acc_23_01, acc_23_23, acc_23_45, acc_23_67;
   float32x4_t acc_45_01, acc_45_23, acc_45_45, acc_45_67;
   float32x4_t acc_67_01, acc_67_23, acc_67_45, acc_67_67;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     float32x4_t acc_0_0123 = vld1q_f32(out_ptr + 8 * 0 + 0);
     float32x4_t acc_0_4567 = vld1q_f32(out_ptr + 8 * 0 + 4);
     float32x4_t acc_1_0123 = vld1q_f32(out_ptr + 8 * 1 + 0);
@@ -95,8 +94,8 @@ void iree_uk_mmt4d_tile_bf16bf16f32_8x8x4_arm_64_bf16(
     acc_67_67 = vdupq_n_f32(0);
   }
 
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     bfloat16x8_t lhs01 = vld1q_bf16(lhs_ptr + 0);
     bfloat16x8_t lhs23 = vld1q_bf16(lhs_ptr + 8);
     bfloat16x8_t lhs45 = vld1q_bf16(lhs_ptr + 16);

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
@@ -9,15 +9,14 @@
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x4_arm_64_dotprod(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   int32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_s32(out_ptr + 4 * 0);
     acc1 = vld1q_s32(out_ptr + 4 * 1);
     acc2 = vld1q_s32(out_ptr + 4 * 2);
@@ -52,8 +51,8 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x4_arm_64_dotprod(
     acc14 = vdupq_n_s32(0);
     acc15 = vdupq_n_s32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     int8x16_t lhs0 = vld1q_s8(lhs_ptr + 0);
     int8x16_t lhs1 = vld1q_s8(lhs_ptr + 16);
     lhs_ptr += 32;

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16.c
@@ -9,14 +9,13 @@
 
 void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64_fp16(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float16x8_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_f16(out_ptr + 8 * 0);
     acc1 = vld1q_f16(out_ptr + 8 * 1);
     acc2 = vld1q_f16(out_ptr + 8 * 2);
@@ -35,8 +34,8 @@ void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64_fp16(
     acc6 = vdupq_n_f16(0);
     acc7 = vdupq_n_f16(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     float16x8_t lhs = vld1q_f16(lhs_ptr);
     lhs_ptr += 8;
     float16x8_t rhs = vld1q_f16(rhs_ptr);

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
@@ -37,15 +37,14 @@
 
 void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64_fp16fml(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_f32(out_ptr + 4 * 0);
     acc1 = vld1q_f32(out_ptr + 4 * 1);
     acc2 = vld1q_f32(out_ptr + 4 * 2);
@@ -80,8 +79,8 @@ void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64_fp16fml(
     acc14 = vdupq_n_f32(0);
     acc15 = vdupq_n_f32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     float16x8_t lhs = vld1q_f16(lhs_ptr);
     lhs_ptr += 8;
     float16x8_t rhs = vld1q_f16(rhs_ptr);

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c
@@ -29,9 +29,8 @@ static inline int32x4_t iree_uk_neon_uzp2_s32_as_s64(int32x4_t a, int32x4_t b) {
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
@@ -39,7 +38,7 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm(
   int32x4_t acc_23_01, acc_23_23, acc_23_45, acc_23_67;
   int32x4_t acc_45_01, acc_45_23, acc_45_45, acc_45_67;
   int32x4_t acc_67_01, acc_67_23, acc_67_45, acc_67_67;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     int32x4_t acc_0_0123 = vld1q_s32(out_ptr + 8 * 0 + 0);
     int32x4_t acc_0_4567 = vld1q_s32(out_ptr + 8 * 0 + 4);
     int32x4_t acc_1_0123 = vld1q_s32(out_ptr + 8 * 1 + 0);
@@ -90,8 +89,8 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm(
     acc_67_45 = vdupq_n_s32(0);
     acc_67_67 = vdupq_n_s32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     int8x16_t lhs01 = vld1q_s8(lhs_ptr + 0);
     int8x16_t lhs23 = vld1q_s8(lhs_ptr + 16);
     int8x16_t lhs45 = vld1q_s8(lhs_ptr + 32);

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
@@ -9,13 +9,13 @@
 
 void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   __m256 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
     acc1 = _mm256_loadu_ps(out_ptr + 1 * 8);
     acc2 = _mm256_loadu_ps(out_ptr + 2 * 8);
@@ -34,7 +34,7 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
     acc6 = _mm256_setzero_ps();
     acc7 = _mm256_setzero_ps();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m256 rhs = _mm256_loadu_ps(rhs_ptr);
     rhs_ptr += 8;
     acc0 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 0), rhs, acc0);
@@ -62,13 +62,12 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
 static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
-    iree_uk_type_t acc_type) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type) {
   const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   __m256 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
       acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
@@ -108,7 +107,7 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
     acc6 = _mm256_setzero_ps();
     acc7 = _mm256_setzero_ps();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m256 rhs = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)rhs_ptr));
     rhs_ptr += 8;
     acc0 =
@@ -162,24 +161,24 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
 
 void iree_uk_mmt4d_tile_f16f16f16_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+      out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_16);
 }
 
 void iree_uk_mmt4d_tile_f16f16f32_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
+      out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -192,7 +191,7 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(
   __m256i acc_3_0123_7_4567;
   __m256i acc_3_4567_7_0123;
 
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567 = iree_uk_avx_loadu_2x128(
         (__m128i*)(out_ptr + 0 * 8 + 0), (__m128i*)(out_ptr + 4 * 8 + 4));
     acc_0_4567_4_0123 = iree_uk_avx_loadu_2x128(
@@ -219,7 +218,7 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(
     acc_3_0123_7_4567 = _mm256_setzero_si256();
     acc_3_4567_7_0123 = _mm256_setzero_si256();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m256i rhs_i16_01234567 =
         _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)rhs_ptr));
     rhs_ptr += 16;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -9,8 +9,8 @@
 
 void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -23,7 +23,7 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
   _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
   __m512 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
   __m512 acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
     acc1 = _mm512_loadu_ps(out_ptr + 1 * 16);
     acc2 = _mm512_loadu_ps(out_ptr + 2 * 16);
@@ -58,7 +58,7 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
     acc14 = _mm512_setzero_ps();
     acc15 = _mm512_setzero_ps();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_loadu_ps(rhs_ptr);
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
@@ -104,9 +104,8 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
 static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
-    iree_uk_type_t acc_type) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type) {
   const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   // The prefetches in this function are carried over from
@@ -115,7 +114,7 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
   _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
   __m512 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
   __m512 acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
       acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
@@ -187,7 +186,7 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
     acc14 = _mm512_setzero_ps();
     acc15 = _mm512_setzero_ps();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
@@ -283,24 +282,24 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
 
 void iree_uk_mmt4d_tile_f16f16f16_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+      out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_16);
 }
 
 void iree_uk_mmt4d_tile_f16f16f32_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
+      out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -322,7 +321,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
   __m512i acc_3_89AB_7_CDEF_B_0123_F_4567;
   __m512i acc_3_CDEF_7_89AB_B_4567_F_0123;
 
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567_8_89AB_C_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
         out_ptr, 0, 0, 4, 4, 8, 8, 12, 12);
     acc_0_4567_4_0123_8_CDEF_C_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
@@ -381,7 +380,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
   __m512i idx_CDEF89AB45670123 =
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512i rhs_i16_0123456789ABCDEF =
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     rhs_ptr += 32;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
@@ -9,8 +9,8 @@
 
 void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -32,7 +32,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
   __m512i acc_3_89AB_7_CDEF_B_0123_F_4567;
   __m512i acc_3_CDEF_7_89AB_B_4567_F_0123;
 
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567_8_89AB_C_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
         out_ptr, 0, 0, 4, 4, 8, 8, 12, 12);
     acc_0_4567_4_0123_8_CDEF_C_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
@@ -91,7 +91,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
   __m512i idx_CDEF89AB45670123 =
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512i rhs_i16_0123456789ABCDEF =
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     rhs_ptr += 32;

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -50,7 +50,6 @@ static void iree_uk_mmt4d_using_tile_func(const iree_uk_mmt4d_params_t* params,
                                           iree_uk_mmt4d_tile_func_t tile_func) {
   const iree_uk_int32_t M = params->M;
   const iree_uk_int32_t N = params->N;
-  const iree_uk_int32_t K = params->K;
   const iree_uk_int16_t M0 = params->M0;
   const iree_uk_int16_t N0 = params->N0;
   iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(params->flags);
@@ -78,7 +77,7 @@ static void iree_uk_mmt4d_using_tile_func(const iree_uk_mmt4d_params_t* params,
     IREE_UK_PREFETCH_RO(lhs_panel, IREE_UK_PREFETCH_LOCALITY_L1);
     IREE_UK_PREFETCH_RO(rhs_panel, IREE_UK_PREFETCH_LOCALITY_L1);
     for (iree_uk_int32_t j = 0; j < N; ++j) {
-      tile_func(out_tile, lhs_panel, rhs_panel, K, params->flags, params);
+      tile_func(out_tile, lhs_panel, rhs_panel, params);
       out_tile += out_tile_size;
       rhs_panel += rhs_panel_stride;
     }

--- a/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
@@ -69,24 +69,17 @@ static inline iree_uk_type_t iree_uk_mmt4d_out_type(iree_uk_mmt4d_type_t type) {
 // the inner-most loop of the matmul, i.e. the thing that we should actually
 // be calling "micro kernel" except that the name is already taken by the
 // higher-level builtin name.
-//
-// The 'params' argument is only used by generic kernels. Actual optimized
-// kernels are already specialized for a given tile shape (M0xN0xK0), so the
-// five first arguments here are the only information that they need. Not having
-// to address 'params' struct fields in the middle of assembly kernels is
-// good, because it's hard to get the struct field offsets right in assembly
-// and keep that in sync with future struct changes.
 typedef void (*iree_uk_mmt4d_tile_func_t)(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params);
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params);
 
 // Tile kernel declarations. Prototype matches iree_uk_mmt4d_tile_func_t.
-#define IREE_UK_MMT4D_TILE_FUNC_DECL(NAME)                             \
-  void NAME(void* IREE_UK_RESTRICT out_tile,                           \
-            const void* IREE_UK_RESTRICT lhs_panel,                    \
-            const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K, \
-            iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params);
+#define IREE_UK_MMT4D_TILE_FUNC_DECL(NAME)          \
+  void NAME(void* IREE_UK_RESTRICT out_tile,        \
+            const void* IREE_UK_RESTRICT lhs_panel, \
+            const void* IREE_UK_RESTRICT rhs_panel, \
+            const iree_uk_mmt4d_params_t* params);
 
 // In order to be helpful as a reference for future architecture-specific
 // kernels, the generic kernels are structured like an actual optimized kernel,

--- a/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
@@ -9,8 +9,7 @@
 // Generic implementation of matmul tile, i8*i8->i32 case.
 static void iree_uk_mmt4d_tile_i8i8i32_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* out_tile = out_tile_untyped;
   const iree_uk_int8_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_int8_t* rhs_panel = rhs_panel_untyped;
@@ -19,13 +18,13 @@ static void iree_uk_mmt4d_tile_i8i8i32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   iree_uk_int32_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -45,8 +44,7 @@ static void iree_uk_mmt4d_tile_i8i8i32_generic(
 // Generic implementation of matmul tile, f32*f32->f32 case.
 static void iree_uk_mmt4d_tile_f32f32f32_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   float* out_tile = out_tile_untyped;
   const float* lhs_panel = lhs_panel_untyped;
   const float* rhs_panel = rhs_panel_untyped;
@@ -55,13 +53,13 @@ static void iree_uk_mmt4d_tile_f32f32f32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -81,8 +79,7 @@ static void iree_uk_mmt4d_tile_f32f32f32_generic(
 // Generic implementation of matmul tile, f16*f16->f32 case.
 static void iree_uk_mmt4d_tile_f16f16f32_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   float* out_tile = out_tile_untyped;
   const iree_uk_uint16_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_uint16_t* rhs_panel = rhs_panel_untyped;
@@ -91,13 +88,13 @@ static void iree_uk_mmt4d_tile_f16f16f32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -117,8 +114,7 @@ static void iree_uk_mmt4d_tile_f16f16f32_generic(
 // Generic implementation of matmul tile, f16*f16->f16 case.
 static void iree_uk_mmt4d_tile_f16f16f16_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   iree_uk_int16_t* out_tile = out_tile_untyped;
   const iree_uk_uint16_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_uint16_t* rhs_panel = rhs_panel_untyped;
@@ -127,13 +123,13 @@ static void iree_uk_mmt4d_tile_f16f16f16_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   iree_uk_int16_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -155,8 +151,7 @@ static void iree_uk_mmt4d_tile_f16f16f16_generic(
 // Generic implementation of matmul tile, bf16*bf16->f32 case.
 static void iree_uk_mmt4d_tile_bf16bf16f32_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   float* out_tile = out_tile_untyped;
   const iree_uk_uint16_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_uint16_t* rhs_panel = rhs_panel_untyped;
@@ -165,13 +160,13 @@ static void iree_uk_mmt4d_tile_bf16bf16f32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -191,8 +186,7 @@ static void iree_uk_mmt4d_tile_bf16bf16f32_generic(
 // Generic implementation of matmul tile, bf16*bf16->bf16 case.
 static void iree_uk_mmt4d_tile_bf16bf16bf16_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   iree_uk_int16_t* out_tile = out_tile_untyped;
   const iree_uk_uint16_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_uint16_t* rhs_panel = rhs_panel_untyped;
@@ -201,13 +195,13 @@ static void iree_uk_mmt4d_tile_bf16bf16bf16_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   iree_uk_int16_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {


### PR DESCRIPTION
ukernel tile funcs used to take by value some params fields, even though they also took the params pointer from which they could be obtained.

This trait dates back to when tile funcs were implemented in out-of-line assembly. Passing by value the two fields that they needed avoided having to worry about using the right field offsets in assembly. We don't have any out-of-line assembly anymore as that was incompatible with compilation to bitcode, so we don't need that anymore.