### PR TITLE
[CPU][SVE] Update how matmul tile sizes are calculated

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -98,7 +98,7 @@ hal.executable private @matmul_tensors_sve  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [20, 4, 0], [0, 0, 64], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [8, 32, 0], [0, 0, 16], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
This simply brings linalg.matmul tile calculation for AArch64 SVE in line with X86 and RISC-V. This change is not driven by any performance considerations just yet. However, it helps with development for SVE (i.e. SVE and scalable vectorisation bring-up).

More specifically, the matmul tile sizes resulting from current set-up, `[20, 4, 64]`, mixed with vectorisation via `vector.contract` lead to very expansive unrolling during `LVMCPUVectorLowering`. The new set-up effectively prevents that.

This changes should not affect current AArch64 testing/performance as that's targeting NEON and these changes will only affect compilations with SVE enabled.