### PR TITLE
Un-unroll ukernel C+intrinsics code.

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -14,84 +14,46 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float* IREE_UK_RESTRICT out_ptr = out_tile;
-  float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
-      acc11, acc12, acc13, acc14, acc15;
+  float32x4_t acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = vld1q_f32(out_ptr + 4 * 0);
-    acc1 = vld1q_f32(out_ptr + 4 * 1);
-    acc2 = vld1q_f32(out_ptr + 4 * 2);
-    acc3 = vld1q_f32(out_ptr + 4 * 3);
-    acc4 = vld1q_f32(out_ptr + 4 * 4);
-    acc5 = vld1q_f32(out_ptr + 4 * 5);
-    acc6 = vld1q_f32(out_ptr + 4 * 6);
-    acc7 = vld1q_f32(out_ptr + 4 * 7);
-    acc8 = vld1q_f32(out_ptr + 4 * 8);
-    acc9 = vld1q_f32(out_ptr + 4 * 9);
-    acc10 = vld1q_f32(out_ptr + 4 * 10);
-    acc11 = vld1q_f32(out_ptr + 4 * 11);
-    acc12 = vld1q_f32(out_ptr + 4 * 12);
-    acc13 = vld1q_f32(out_ptr + 4 * 13);
-    acc14 = vld1q_f32(out_ptr + 4 * 14);
-    acc15 = vld1q_f32(out_ptr + 4 * 15);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vld1q_f32(out_ptr + 4 * i);
+    }
   } else {
-    acc0 = vdupq_n_f32(0);
-    acc1 = vdupq_n_f32(0);
-    acc2 = vdupq_n_f32(0);
-    acc3 = vdupq_n_f32(0);
-    acc4 = vdupq_n_f32(0);
-    acc5 = vdupq_n_f32(0);
-    acc6 = vdupq_n_f32(0);
-    acc7 = vdupq_n_f32(0);
-    acc8 = vdupq_n_f32(0);
-    acc9 = vdupq_n_f32(0);
-    acc10 = vdupq_n_f32(0);
-    acc11 = vdupq_n_f32(0);
-    acc12 = vdupq_n_f32(0);
-    acc13 = vdupq_n_f32(0);
-    acc14 = vdupq_n_f32(0);
-    acc15 = vdupq_n_f32(0);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vdupq_n_f32(0);
+    }
   }
   IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
-    float32x4_t lhs0 = vld1q_f32(lhs_ptr + 0);
-    float32x4_t lhs1 = vld1q_f32(lhs_ptr + 4);
+    float32x4_t lhs[2];
+    float32x4_t rhs[2];
+    for (int i = 0; i < 2; ++i) {
+      lhs[i] = vld1q_f32(lhs_ptr + 4 * i);
+      rhs[i] = vld1q_f32(rhs_ptr + 4 * i);
+    }
     lhs_ptr += 8;
-    float32x4_t rhs0 = vld1q_f32(rhs_ptr + 0);
-    float32x4_t rhs1 = vld1q_f32(rhs_ptr + 4);
     rhs_ptr += 8;
-    acc0 = vfmaq_lane_f32(acc0, rhs0, vget_low_f32(lhs0), 0);
-    acc1 = vfmaq_lane_f32(acc1, rhs1, vget_low_f32(lhs0), 0);
-    acc2 = vfmaq_lane_f32(acc2, rhs0, vget_low_f32(lhs0), 1);
-    acc3 = vfmaq_lane_f32(acc3, rhs1, vget_low_f32(lhs0), 1);
-    acc4 = vfmaq_lane_f32(acc4, rhs0, vget_high_f32(lhs0), 0);
-    acc5 = vfmaq_lane_f32(acc5, rhs1, vget_high_f32(lhs0), 0);
-    acc6 = vfmaq_lane_f32(acc6, rhs0, vget_high_f32(lhs0), 1);
-    acc7 = vfmaq_lane_f32(acc7, rhs1, vget_high_f32(lhs0), 1);
-    acc8 = vfmaq_lane_f32(acc8, rhs0, vget_low_f32(lhs1), 0);
-    acc9 = vfmaq_lane_f32(acc9, rhs1, vget_low_f32(lhs1), 0);
-    acc10 = vfmaq_lane_f32(acc10, rhs0, vget_low_f32(lhs1), 1);
-    acc11 = vfmaq_lane_f32(acc11, rhs1, vget_low_f32(lhs1), 1);
-    acc12 = vfmaq_lane_f32(acc12, rhs0, vget_high_f32(lhs1), 0);
-    acc13 = vfmaq_lane_f32(acc13, rhs1, vget_high_f32(lhs1), 0);
-    acc14 = vfmaq_lane_f32(acc14, rhs0, vget_high_f32(lhs1), 1);
-    acc15 = vfmaq_lane_f32(acc15, rhs1, vget_high_f32(lhs1), 1);
+    acc[0] = vfmaq_lane_f32(acc[0], rhs[0], vget_low_f32(lhs[0]), 0);
+    acc[1] = vfmaq_lane_f32(acc[1], rhs[1], vget_low_f32(lhs[0]), 0);
+    acc[2] = vfmaq_lane_f32(acc[2], rhs[0], vget_low_f32(lhs[0]), 1);
+    acc[3] = vfmaq_lane_f32(acc[3], rhs[1], vget_low_f32(lhs[0]), 1);
+    acc[4] = vfmaq_lane_f32(acc[4], rhs[0], vget_high_f32(lhs[0]), 0);
+    acc[5] = vfmaq_lane_f32(acc[5], rhs[1], vget_high_f32(lhs[0]), 0);
+    acc[6] = vfmaq_lane_f32(acc[6], rhs[0], vget_high_f32(lhs[0]), 1);
+    acc[7] = vfmaq_lane_f32(acc[7], rhs[1], vget_high_f32(lhs[0]), 1);
+    acc[8] = vfmaq_lane_f32(acc[8], rhs[0], vget_low_f32(lhs[1]), 0);
+    acc[9] = vfmaq_lane_f32(acc[9], rhs[1], vget_low_f32(lhs[1]), 0);
+    acc[10] = vfmaq_lane_f32(acc[10], rhs[0], vget_low_f32(lhs[1]), 1);
+    acc[11] = vfmaq_lane_f32(acc[11], rhs[1], vget_low_f32(lhs[1]), 1);
+    acc[12] = vfmaq_lane_f32(acc[12], rhs[0], vget_high_f32(lhs[1]), 0);
+    acc[13] = vfmaq_lane_f32(acc[13], rhs[1], vget_high_f32(lhs[1]), 0);
+    acc[14] = vfmaq_lane_f32(acc[14], rhs[0], vget_high_f32(lhs[1]), 1);
+    acc[15] = vfmaq_lane_f32(acc[15], rhs[1], vget_high_f32(lhs[1]), 1);
   }
-  vst1q_f32(out_ptr + 4 * 0, acc0);
-  vst1q_f32(out_ptr + 4 * 1, acc1);
-  vst1q_f32(out_ptr + 4 * 2, acc2);
-  vst1q_f32(out_ptr + 4 * 3, acc3);
-  vst1q_f32(out_ptr + 4 * 4, acc4);
-  vst1q_f32(out_ptr + 4 * 5, acc5);
-  vst1q_f32(out_ptr + 4 * 6, acc6);
-  vst1q_f32(out_ptr + 4 * 7, acc7);
-  vst1q_f32(out_ptr + 4 * 8, acc8);
-  vst1q_f32(out_ptr + 4 * 9, acc9);
-  vst1q_f32(out_ptr + 4 * 10, acc10);
-  vst1q_f32(out_ptr + 4 * 11, acc11);
-  vst1q_f32(out_ptr + 4 * 12, acc12);
-  vst1q_f32(out_ptr + 4 * 13, acc13);
-  vst1q_f32(out_ptr + 4 * 14, acc14);
-  vst1q_f32(out_ptr + 4 * 15, acc15);
+  for (int i = 0; i < 16; ++i) {
+    vst1q_f32(out_ptr + 4 * i, acc[i]);
+  }
 }
 
 // Shared implementation for f16f16f16 and f16f16f32.
@@ -103,125 +65,61 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
     const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type) {
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
-      acc11, acc12, acc13, acc14, acc15;
+  float32x4_t acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
-      acc0 = vld1q_f32(out_ptr + 4 * 0);
-      acc1 = vld1q_f32(out_ptr + 4 * 1);
-      acc2 = vld1q_f32(out_ptr + 4 * 2);
-      acc3 = vld1q_f32(out_ptr + 4 * 3);
-      acc4 = vld1q_f32(out_ptr + 4 * 4);
-      acc5 = vld1q_f32(out_ptr + 4 * 5);
-      acc6 = vld1q_f32(out_ptr + 4 * 6);
-      acc7 = vld1q_f32(out_ptr + 4 * 7);
-      acc8 = vld1q_f32(out_ptr + 4 * 8);
-      acc9 = vld1q_f32(out_ptr + 4 * 9);
-      acc10 = vld1q_f32(out_ptr + 4 * 10);
-      acc11 = vld1q_f32(out_ptr + 4 * 11);
-      acc12 = vld1q_f32(out_ptr + 4 * 12);
-      acc13 = vld1q_f32(out_ptr + 4 * 13);
-      acc14 = vld1q_f32(out_ptr + 4 * 14);
-      acc15 = vld1q_f32(out_ptr + 4 * 15);
+      for (int i = 0; i < 16; ++i) {
+        acc[i] = vld1q_f32(out_ptr + 4 * i);
+      }
     } else {
       float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-      acc0 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 0));
-      acc1 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 1));
-      acc2 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 2));
-      acc3 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 3));
-      acc4 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 4));
-      acc5 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 5));
-      acc6 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 6));
-      acc7 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 7));
-      acc8 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 8));
-      acc9 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 9));
-      acc10 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 10));
-      acc11 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 11));
-      acc12 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 12));
-      acc13 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 13));
-      acc14 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 14));
-      acc15 = vcvt_f32_f16(vld1_f16(out_ptr + 4 * 15));
+      for (int i = 0; i < 16; ++i) {
+        acc[i] = vcvt_f32_f16(vld1_f16(out_ptr + 4 * i));
+      }
     }
   } else {
-    acc0 = vdupq_n_f32(0);
-    acc1 = vdupq_n_f32(0);
-    acc2 = vdupq_n_f32(0);
-    acc3 = vdupq_n_f32(0);
-    acc4 = vdupq_n_f32(0);
-    acc5 = vdupq_n_f32(0);
-    acc6 = vdupq_n_f32(0);
-    acc7 = vdupq_n_f32(0);
-    acc8 = vdupq_n_f32(0);
-    acc9 = vdupq_n_f32(0);
-    acc10 = vdupq_n_f32(0);
-    acc11 = vdupq_n_f32(0);
-    acc12 = vdupq_n_f32(0);
-    acc13 = vdupq_n_f32(0);
-    acc14 = vdupq_n_f32(0);
-    acc15 = vdupq_n_f32(0);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vdupq_n_f32(0);
+    }
   }
   IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
-    float32x4_t lhs0 = vcvt_f32_f16(vld1_f16(lhs_ptr + 0));
-    float32x4_t lhs1 = vcvt_f32_f16(vld1_f16(lhs_ptr + 4));
+    float32x4_t lhs[2];
+    float32x4_t rhs[2];
+    for (int i = 0; i < 2; ++i) {
+      lhs[i] = vcvt_f32_f16(vld1_f16(lhs_ptr + 4 * i));
+      rhs[i] = vcvt_f32_f16(vld1_f16(rhs_ptr + 4 * i));
+    }
     lhs_ptr += 8;
-    float32x4_t rhs0 = vcvt_f32_f16(vld1_f16(rhs_ptr + 0));
-    float32x4_t rhs1 = vcvt_f32_f16(vld1_f16(rhs_ptr + 4));
     rhs_ptr += 8;
-    acc0 = vfmaq_lane_f32(acc0, rhs0, vget_low_f32(lhs0), 0);
-    acc1 = vfmaq_lane_f32(acc1, rhs1, vget_low_f32(lhs0), 0);
-    acc2 = vfmaq_lane_f32(acc2, rhs0, vget_low_f32(lhs0), 1);
-    acc3 = vfmaq_lane_f32(acc3, rhs1, vget_low_f32(lhs0), 1);
-    acc4 = vfmaq_lane_f32(acc4, rhs0, vget_high_f32(lhs0), 0);
-    acc5 = vfmaq_lane_f32(acc5, rhs1, vget_high_f32(lhs0), 0);
-    acc6 = vfmaq_lane_f32(acc6, rhs0, vget_high_f32(lhs0), 1);
-    acc7 = vfmaq_lane_f32(acc7, rhs1, vget_high_f32(lhs0), 1);
-    acc8 = vfmaq_lane_f32(acc8, rhs0, vget_low_f32(lhs1), 0);
-    acc9 = vfmaq_lane_f32(acc9, rhs1, vget_low_f32(lhs1), 0);
-    acc10 = vfmaq_lane_f32(acc10, rhs0, vget_low_f32(lhs1), 1);
-    acc11 = vfmaq_lane_f32(acc11, rhs1, vget_low_f32(lhs1), 1);
-    acc12 = vfmaq_lane_f32(acc12, rhs0, vget_high_f32(lhs1), 0);
-    acc13 = vfmaq_lane_f32(acc13, rhs1, vget_high_f32(lhs1), 0);
-    acc14 = vfmaq_lane_f32(acc14, rhs0, vget_high_f32(lhs1), 1);
-    acc15 = vfmaq_lane_f32(acc15, rhs1, vget_high_f32(lhs1), 1);
+    acc[0] = vfmaq_lane_f32(acc[0], rhs[0], vget_low_f32(lhs[0]), 0);
+    acc[1] = vfmaq_lane_f32(acc[1], rhs[1], vget_low_f32(lhs[0]), 0);
+    acc[2] = vfmaq_lane_f32(acc[2], rhs[0], vget_low_f32(lhs[0]), 1);
+    acc[3] = vfmaq_lane_f32(acc[3], rhs[1], vget_low_f32(lhs[0]), 1);
+    acc[4] = vfmaq_lane_f32(acc[4], rhs[0], vget_high_f32(lhs[0]), 0);
+    acc[5] = vfmaq_lane_f32(acc[5], rhs[1], vget_high_f32(lhs[0]), 0);
+    acc[6] = vfmaq_lane_f32(acc[6], rhs[0], vget_high_f32(lhs[0]), 1);
+    acc[7] = vfmaq_lane_f32(acc[7], rhs[1], vget_high_f32(lhs[0]), 1);
+    acc[8] = vfmaq_lane_f32(acc[8], rhs[0], vget_low_f32(lhs[1]), 0);
+    acc[9] = vfmaq_lane_f32(acc[9], rhs[1], vget_low_f32(lhs[1]), 0);
+    acc[10] = vfmaq_lane_f32(acc[10], rhs[0], vget_low_f32(lhs[1]), 1);
+    acc[11] = vfmaq_lane_f32(acc[11], rhs[1], vget_low_f32(lhs[1]), 1);
+    acc[12] = vfmaq_lane_f32(acc[12], rhs[0], vget_high_f32(lhs[1]), 0);
+    acc[13] = vfmaq_lane_f32(acc[13], rhs[1], vget_high_f32(lhs[1]), 0);
+    acc[14] = vfmaq_lane_f32(acc[14], rhs[0], vget_high_f32(lhs[1]), 1);
+    acc[15] = vfmaq_lane_f32(acc[15], rhs[1], vget_high_f32(lhs[1]), 1);
   }
   if (acc_type == IREE_UK_TYPE_FLOAT_32) {
     float* IREE_UK_RESTRICT out_ptr = out_tile;
-    vst1q_f32(out_ptr + 4 * 0, acc0);
-    vst1q_f32(out_ptr + 4 * 1, acc1);
-    vst1q_f32(out_ptr + 4 * 2, acc2);
-    vst1q_f32(out_ptr + 4 * 3, acc3);
-    vst1q_f32(out_ptr + 4 * 4, acc4);
-    vst1q_f32(out_ptr + 4 * 5, acc5);
-    vst1q_f32(out_ptr + 4 * 6, acc6);
-    vst1q_f32(out_ptr + 4 * 7, acc7);
-    vst1q_f32(out_ptr + 4 * 8, acc8);
-    vst1q_f32(out_ptr + 4 * 9, acc9);
-    vst1q_f32(out_ptr + 4 * 10, acc10);
-    vst1q_f32(out_ptr + 4 * 11, acc11);
-    vst1q_f32(out_ptr + 4 * 12, acc12);
-    vst1q_f32(out_ptr + 4 * 13, acc13);
-    vst1q_f32(out_ptr + 4 * 14, acc14);
-    vst1q_f32(out_ptr + 4 * 15, acc15);
+    for (int i = 0; i < 16; ++i) {
+      vst1q_f32(out_ptr + 4 * i, acc[i]);
+    }
   } else {
     float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-    vst1_f16(out_ptr + 4 * 0, vcvt_f16_f32(acc0));
-    vst1_f16(out_ptr + 4 * 1, vcvt_f16_f32(acc1));
-    vst1_f16(out_ptr + 4 * 2, vcvt_f16_f32(acc2));
-    vst1_f16(out_ptr + 4 * 3, vcvt_f16_f32(acc3));
-    vst1_f16(out_ptr + 4 * 4, vcvt_f16_f32(acc4));
-    vst1_f16(out_ptr + 4 * 5, vcvt_f16_f32(acc5));
-    vst1_f16(out_ptr + 4 * 6, vcvt_f16_f32(acc6));
-    vst1_f16(out_ptr + 4 * 7, vcvt_f16_f32(acc7));
-    vst1_f16(out_ptr + 4 * 8, vcvt_f16_f32(acc8));
-    vst1_f16(out_ptr + 4 * 9, vcvt_f16_f32(acc9));
-    vst1_f16(out_ptr + 4 * 10, vcvt_f16_f32(acc10));
-    vst1_f16(out_ptr + 4 * 11, vcvt_f16_f32(acc11));
-    vst1_f16(out_ptr + 4 * 12, vcvt_f16_f32(acc12));
-    vst1_f16(out_ptr + 4 * 13, vcvt_f16_f32(acc13));
-    vst1_f16(out_ptr + 4 * 14, vcvt_f16_f32(acc14));
-    vst1_f16(out_ptr + 4 * 15, vcvt_f16_f32(acc15));
+    for (int i = 0; i < 16; ++i) {
+      vst1_f16(out_ptr + 4 * i, vcvt_f16_f32(acc[i]));
+    }
   }
 }
 
@@ -248,42 +146,15 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x1_arm_64(
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
-  int32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
-      acc11, acc12, acc13, acc14, acc15;
+  int32x4_t acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = vld1q_s32(out_ptr + 4 * 0);
-    acc1 = vld1q_s32(out_ptr + 4 * 1);
-    acc2 = vld1q_s32(out_ptr + 4 * 2);
-    acc3 = vld1q_s32(out_ptr + 4 * 3);
-    acc4 = vld1q_s32(out_ptr + 4 * 4);
-    acc5 = vld1q_s32(out_ptr + 4 * 5);
-    acc6 = vld1q_s32(out_ptr + 4 * 6);
-    acc7 = vld1q_s32(out_ptr + 4 * 7);
-    acc8 = vld1q_s32(out_ptr + 4 * 8);
-    acc9 = vld1q_s32(out_ptr + 4 * 9);
-    acc10 = vld1q_s32(out_ptr + 4 * 10);
-    acc11 = vld1q_s32(out_ptr + 4 * 11);
-    acc12 = vld1q_s32(out_ptr + 4 * 12);
-    acc13 = vld1q_s32(out_ptr + 4 * 13);
-    acc14 = vld1q_s32(out_ptr + 4 * 14);
-    acc15 = vld1q_s32(out_ptr + 4 * 15);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vld1q_s32(out_ptr + 4 * i);
+    }
   } else {
-    acc0 = vdupq_n_s32(0);
-    acc1 = vdupq_n_s32(0);
-    acc2 = vdupq_n_s32(0);
-    acc3 = vdupq_n_s32(0);
-    acc4 = vdupq_n_s32(0);
-    acc5 = vdupq_n_s32(0);
-    acc6 = vdupq_n_s32(0);
-    acc7 = vdupq_n_s32(0);
-    acc8 = vdupq_n_s32(0);
-    acc9 = vdupq_n_s32(0);
-    acc10 = vdupq_n_s32(0);
-    acc11 = vdupq_n_s32(0);
-    acc12 = vdupq_n_s32(0);
-    acc13 = vdupq_n_s32(0);
-    acc14 = vdupq_n_s32(0);
-    acc15 = vdupq_n_s32(0);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vdupq_n_s32(0);
+    }
   }
   IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
@@ -291,37 +162,27 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x1_arm_64(
     lhs_ptr += 8;
     int16x8_t rhs = vmovl_s8(vld1_s8(rhs_ptr));
     rhs_ptr += 8;
-    acc0 = vmlal_lane_s16(acc0, vget_low_s16(rhs), vget_low_s16(lhs), 0);
-    acc1 = vmlal_lane_s16(acc1, vget_high_s16(rhs), vget_low_s16(lhs), 0);
-    acc2 = vmlal_lane_s16(acc2, vget_low_s16(rhs), vget_low_s16(lhs), 1);
-    acc3 = vmlal_lane_s16(acc3, vget_high_s16(rhs), vget_low_s16(lhs), 1);
-    acc4 = vmlal_lane_s16(acc4, vget_low_s16(rhs), vget_low_s16(lhs), 2);
-    acc5 = vmlal_lane_s16(acc5, vget_high_s16(rhs), vget_low_s16(lhs), 2);
-    acc6 = vmlal_lane_s16(acc6, vget_low_s16(rhs), vget_low_s16(lhs), 3);
-    acc7 = vmlal_lane_s16(acc7, vget_high_s16(rhs), vget_low_s16(lhs), 3);
-    acc8 = vmlal_lane_s16(acc8, vget_low_s16(rhs), vget_high_s16(lhs), 0);
-    acc9 = vmlal_lane_s16(acc9, vget_high_s16(rhs), vget_high_s16(lhs), 0);
-    acc10 = vmlal_lane_s16(acc10, vget_low_s16(rhs), vget_high_s16(lhs), 1);
-    acc11 = vmlal_lane_s16(acc11, vget_high_s16(rhs), vget_high_s16(lhs), 1);
-    acc12 = vmlal_lane_s16(acc12, vget_low_s16(rhs), vget_high_s16(lhs), 2);
-    acc13 = vmlal_lane_s16(acc13, vget_high_s16(rhs), vget_high_s16(lhs), 2);
-    acc14 = vmlal_lane_s16(acc14, vget_low_s16(rhs), vget_high_s16(lhs), 3);
-    acc15 = vmlal_lane_s16(acc15, vget_high_s16(rhs), vget_high_s16(lhs), 3);
+    acc[0] = vmlal_lane_s16(acc[0], vget_low_s16(rhs), vget_low_s16(lhs), 0);
+    acc[1] = vmlal_lane_s16(acc[1], vget_high_s16(rhs), vget_low_s16(lhs), 0);
+    acc[2] = vmlal_lane_s16(acc[2], vget_low_s16(rhs), vget_low_s16(lhs), 1);
+    acc[3] = vmlal_lane_s16(acc[3], vget_high_s16(rhs), vget_low_s16(lhs), 1);
+    acc[4] = vmlal_lane_s16(acc[4], vget_low_s16(rhs), vget_low_s16(lhs), 2);
+    acc[5] = vmlal_lane_s16(acc[5], vget_high_s16(rhs), vget_low_s16(lhs), 2);
+    acc[6] = vmlal_lane_s16(acc[6], vget_low_s16(rhs), vget_low_s16(lhs), 3);
+    acc[7] = vmlal_lane_s16(acc[7], vget_high_s16(rhs), vget_low_s16(lhs), 3);
+    acc[8] = vmlal_lane_s16(acc[8], vget_low_s16(rhs), vget_high_s16(lhs), 0);
+    acc[9] = vmlal_lane_s16(acc[9], vget_high_s16(rhs), vget_high_s16(lhs), 0);
+    acc[10] = vmlal_lane_s16(acc[10], vget_low_s16(rhs), vget_high_s16(lhs), 1);
+    acc[11] =
+        vmlal_lane_s16(acc[11], vget_high_s16(rhs), vget_high_s16(lhs), 1);
+    acc[12] = vmlal_lane_s16(acc[12], vget_low_s16(rhs), vget_high_s16(lhs), 2);
+    acc[13] =
+        vmlal_lane_s16(acc[13], vget_high_s16(rhs), vget_high_s16(lhs), 2);
+    acc[14] = vmlal_lane_s16(acc[14], vget_low_s16(rhs), vget_high_s16(lhs), 3);
+    acc[15] =
+        vmlal_lane_s16(acc[15], vget_high_s16(rhs), vget_high_s16(lhs), 3);
   }
-  vst1q_s32(out_ptr + 4 * 0, acc0);
-  vst1q_s32(out_ptr + 4 * 1, acc1);
-  vst1q_s32(out_ptr + 4 * 2, acc2);
-  vst1q_s32(out_ptr + 4 * 3, acc3);
-  vst1q_s32(out_ptr + 4 * 4, acc4);
-  vst1q_s32(out_ptr + 4 * 5, acc5);
-  vst1q_s32(out_ptr + 4 * 6, acc6);
-  vst1q_s32(out_ptr + 4 * 7, acc7);
-  vst1q_s32(out_ptr + 4 * 8, acc8);
-  vst1q_s32(out_ptr + 4 * 9, acc9);
-  vst1q_s32(out_ptr + 4 * 10, acc10);
-  vst1q_s32(out_ptr + 4 * 11, acc11);
-  vst1q_s32(out_ptr + 4 * 12, acc12);
-  vst1q_s32(out_ptr + 4 * 13, acc13);
-  vst1q_s32(out_ptr + 4 * 14, acc14);
-  vst1q_s32(out_ptr + 4 * 15, acc15);
+  for (int i = 0; i < 16; ++i) {
+    vst1q_s32(out_ptr + 4 * i, acc[i]);
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
@@ -38,122 +38,52 @@ void iree_uk_mmt4d_tile_bf16bf16f32_8x8x4_arm_64_bf16(
   const bfloat16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const bfloat16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float* IREE_UK_RESTRICT out_ptr = out_tile;
-  float32x4_t acc_01_01, acc_01_23, acc_01_45, acc_01_67;
-  float32x4_t acc_23_01, acc_23_23, acc_23_45, acc_23_67;
-  float32x4_t acc_45_01, acc_45_23, acc_45_45, acc_45_67;
-  float32x4_t acc_67_01, acc_67_23, acc_67_45, acc_67_67;
+  // Accumulator 2x2 register tiles.
+  float32x4_t acc[4][4];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    float32x4_t acc_0_0123 = vld1q_f32(out_ptr + 8 * 0 + 0);
-    float32x4_t acc_0_4567 = vld1q_f32(out_ptr + 8 * 0 + 4);
-    float32x4_t acc_1_0123 = vld1q_f32(out_ptr + 8 * 1 + 0);
-    float32x4_t acc_1_4567 = vld1q_f32(out_ptr + 8 * 1 + 4);
-    float32x4_t acc_2_0123 = vld1q_f32(out_ptr + 8 * 2 + 0);
-    float32x4_t acc_2_4567 = vld1q_f32(out_ptr + 8 * 2 + 4);
-    float32x4_t acc_3_0123 = vld1q_f32(out_ptr + 8 * 3 + 0);
-    float32x4_t acc_3_4567 = vld1q_f32(out_ptr + 8 * 3 + 4);
-    float32x4_t acc_4_0123 = vld1q_f32(out_ptr + 8 * 4 + 0);
-    float32x4_t acc_4_4567 = vld1q_f32(out_ptr + 8 * 4 + 4);
-    float32x4_t acc_5_0123 = vld1q_f32(out_ptr + 8 * 5 + 0);
-    float32x4_t acc_5_4567 = vld1q_f32(out_ptr + 8 * 5 + 4);
-    float32x4_t acc_6_0123 = vld1q_f32(out_ptr + 8 * 6 + 0);
-    float32x4_t acc_6_4567 = vld1q_f32(out_ptr + 8 * 6 + 4);
-    float32x4_t acc_7_0123 = vld1q_f32(out_ptr + 8 * 7 + 0);
-    float32x4_t acc_7_4567 = vld1q_f32(out_ptr + 8 * 7 + 4);
-    acc_01_01 = iree_uk_neon_zip1_f32_as_s64(acc_0_0123, acc_1_0123);
-    acc_01_23 = iree_uk_neon_zip2_f32_as_s64(acc_0_0123, acc_1_0123);
-    acc_01_45 = iree_uk_neon_zip1_f32_as_s64(acc_0_4567, acc_1_4567);
-    acc_01_67 = iree_uk_neon_zip2_f32_as_s64(acc_0_4567, acc_1_4567);
-    acc_23_01 = iree_uk_neon_zip1_f32_as_s64(acc_2_0123, acc_3_0123);
-    acc_23_23 = iree_uk_neon_zip2_f32_as_s64(acc_2_0123, acc_3_0123);
-    acc_23_45 = iree_uk_neon_zip1_f32_as_s64(acc_2_4567, acc_3_4567);
-    acc_23_67 = iree_uk_neon_zip2_f32_as_s64(acc_2_4567, acc_3_4567);
-    acc_45_01 = iree_uk_neon_zip1_f32_as_s64(acc_4_0123, acc_5_0123);
-    acc_45_23 = iree_uk_neon_zip2_f32_as_s64(acc_4_0123, acc_5_0123);
-    acc_45_45 = iree_uk_neon_zip1_f32_as_s64(acc_4_4567, acc_5_4567);
-    acc_45_67 = iree_uk_neon_zip2_f32_as_s64(acc_4_4567, acc_5_4567);
-    acc_67_01 = iree_uk_neon_zip1_f32_as_s64(acc_6_0123, acc_7_0123);
-    acc_67_23 = iree_uk_neon_zip2_f32_as_s64(acc_6_0123, acc_7_0123);
-    acc_67_45 = iree_uk_neon_zip1_f32_as_s64(acc_6_4567, acc_7_4567);
-    acc_67_67 = iree_uk_neon_zip2_f32_as_s64(acc_6_4567, acc_7_4567);
+    // Load row-major accumulator and swizzle into 2x2 register tiles.
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 2; ++j) {
+        float32x4_t acc_1x4_0 = vld1q_f32(out_ptr + 8 * (2 * i + 0) + 4 * j);
+        float32x4_t acc_1x4_1 = vld1q_f32(out_ptr + 8 * (2 * i + 1) + 4 * j);
+        acc[i][2 * j + 0] = iree_uk_neon_zip1_f32_as_s64(acc_1x4_0, acc_1x4_1);
+        acc[i][2 * j + 1] = iree_uk_neon_zip2_f32_as_s64(acc_1x4_0, acc_1x4_1);
+      }
+    }
   } else {
-    acc_01_01 = vdupq_n_f32(0);
-    acc_01_23 = vdupq_n_f32(0);
-    acc_01_45 = vdupq_n_f32(0);
-    acc_01_67 = vdupq_n_f32(0);
-    acc_23_01 = vdupq_n_f32(0);
-    acc_23_23 = vdupq_n_f32(0);
-    acc_23_45 = vdupq_n_f32(0);
-    acc_23_67 = vdupq_n_f32(0);
-    acc_45_01 = vdupq_n_f32(0);
-    acc_45_23 = vdupq_n_f32(0);
-    acc_45_45 = vdupq_n_f32(0);
-    acc_45_67 = vdupq_n_f32(0);
-    acc_67_01 = vdupq_n_f32(0);
-    acc_67_23 = vdupq_n_f32(0);
-    acc_67_45 = vdupq_n_f32(0);
-    acc_67_67 = vdupq_n_f32(0);
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = vdupq_n_f32(0);
+      }
+    }
   }
 
   IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
-    bfloat16x8_t lhs01 = vld1q_bf16(lhs_ptr + 0);
-    bfloat16x8_t lhs23 = vld1q_bf16(lhs_ptr + 8);
-    bfloat16x8_t lhs45 = vld1q_bf16(lhs_ptr + 16);
-    bfloat16x8_t lhs67 = vld1q_bf16(lhs_ptr + 24);
+    bfloat16x8_t lhs[4];
+    bfloat16x8_t rhs[4];
+    for (int i = 0; i < 4; ++i) {
+      lhs[i] = vld1q_bf16(lhs_ptr + 8 * i);
+      rhs[i] = vld1q_bf16(rhs_ptr + 8 * i);
+    }
     lhs_ptr += 32;
-    bfloat16x8_t rhs01 = vld1q_bf16(rhs_ptr + 0);
-    bfloat16x8_t rhs23 = vld1q_bf16(rhs_ptr + 8);
-    bfloat16x8_t rhs45 = vld1q_bf16(rhs_ptr + 16);
-    bfloat16x8_t rhs67 = vld1q_bf16(rhs_ptr + 24);
     rhs_ptr += 32;
-    acc_01_01 = vbfmmlaq_f32(acc_01_01, lhs01, rhs01);
-    acc_01_23 = vbfmmlaq_f32(acc_01_23, lhs01, rhs23);
-    acc_01_45 = vbfmmlaq_f32(acc_01_45, lhs01, rhs45);
-    acc_01_67 = vbfmmlaq_f32(acc_01_67, lhs01, rhs67);
-    acc_23_01 = vbfmmlaq_f32(acc_23_01, lhs23, rhs01);
-    acc_23_23 = vbfmmlaq_f32(acc_23_23, lhs23, rhs23);
-    acc_23_45 = vbfmmlaq_f32(acc_23_45, lhs23, rhs45);
-    acc_23_67 = vbfmmlaq_f32(acc_23_67, lhs23, rhs67);
-    acc_45_01 = vbfmmlaq_f32(acc_45_01, lhs45, rhs01);
-    acc_45_23 = vbfmmlaq_f32(acc_45_23, lhs45, rhs23);
-    acc_45_45 = vbfmmlaq_f32(acc_45_45, lhs45, rhs45);
-    acc_45_67 = vbfmmlaq_f32(acc_45_67, lhs45, rhs67);
-    acc_67_01 = vbfmmlaq_f32(acc_67_01, lhs67, rhs01);
-    acc_67_23 = vbfmmlaq_f32(acc_67_23, lhs67, rhs23);
-    acc_67_45 = vbfmmlaq_f32(acc_67_45, lhs67, rhs45);
-    acc_67_67 = vbfmmlaq_f32(acc_67_67, lhs67, rhs67);
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = vbfmmlaq_f32(acc[i][j], lhs[i], rhs[j]);
+      }
+    }
   }
 
-  float32x4_t acc_0_0123 = iree_uk_neon_uzp1_f32_as_s64(acc_01_01, acc_01_23);
-  float32x4_t acc_0_4567 = iree_uk_neon_uzp1_f32_as_s64(acc_01_45, acc_01_67);
-  float32x4_t acc_1_0123 = iree_uk_neon_uzp2_f32_as_s64(acc_01_01, acc_01_23);
-  float32x4_t acc_1_4567 = iree_uk_neon_uzp2_f32_as_s64(acc_01_45, acc_01_67);
-  float32x4_t acc_2_0123 = iree_uk_neon_uzp1_f32_as_s64(acc_23_01, acc_23_23);
-  float32x4_t acc_2_4567 = iree_uk_neon_uzp1_f32_as_s64(acc_23_45, acc_23_67);
-  float32x4_t acc_3_0123 = iree_uk_neon_uzp2_f32_as_s64(acc_23_01, acc_23_23);
-  float32x4_t acc_3_4567 = iree_uk_neon_uzp2_f32_as_s64(acc_23_45, acc_23_67);
-  float32x4_t acc_4_0123 = iree_uk_neon_uzp1_f32_as_s64(acc_45_01, acc_45_23);
-  float32x4_t acc_4_4567 = iree_uk_neon_uzp1_f32_as_s64(acc_45_45, acc_45_67);
-  float32x4_t acc_5_0123 = iree_uk_neon_uzp2_f32_as_s64(acc_45_01, acc_45_23);
-  float32x4_t acc_5_4567 = iree_uk_neon_uzp2_f32_as_s64(acc_45_45, acc_45_67);
-  float32x4_t acc_6_0123 = iree_uk_neon_uzp1_f32_as_s64(acc_67_01, acc_67_23);
-  float32x4_t acc_6_4567 = iree_uk_neon_uzp1_f32_as_s64(acc_67_45, acc_67_67);
-  float32x4_t acc_7_0123 = iree_uk_neon_uzp2_f32_as_s64(acc_67_01, acc_67_23);
-  float32x4_t acc_7_4567 = iree_uk_neon_uzp2_f32_as_s64(acc_67_45, acc_67_67);
-  vst1q_f32(out_ptr + 8 * 0 + 0, acc_0_0123);
-  vst1q_f32(out_ptr + 8 * 0 + 4, acc_0_4567);
-  vst1q_f32(out_ptr + 8 * 1 + 0, acc_1_0123);
-  vst1q_f32(out_ptr + 8 * 1 + 4, acc_1_4567);
-  vst1q_f32(out_ptr + 8 * 2 + 0, acc_2_0123);
-  vst1q_f32(out_ptr + 8 * 2 + 4, acc_2_4567);
-  vst1q_f32(out_ptr + 8 * 3 + 0, acc_3_0123);
-  vst1q_f32(out_ptr + 8 * 3 + 4, acc_3_4567);
-  vst1q_f32(out_ptr + 8 * 4 + 0, acc_4_0123);
-  vst1q_f32(out_ptr + 8 * 4 + 4, acc_4_4567);
-  vst1q_f32(out_ptr + 8 * 5 + 0, acc_5_0123);
-  vst1q_f32(out_ptr + 8 * 5 + 4, acc_5_4567);
-  vst1q_f32(out_ptr + 8 * 6 + 0, acc_6_0123);
-  vst1q_f32(out_ptr + 8 * 6 + 4, acc_6_4567);
-  vst1q_f32(out_ptr + 8 * 7 + 0, acc_7_0123);
-  vst1q_f32(out_ptr + 8 * 7 + 4, acc_7_4567);
+  // Swizzle accumulator 2x2 register tiles back to row-major and store.
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      float32x4_t acc_1x4_0 =
+          iree_uk_neon_uzp1_f32_as_s64(acc[i][2 * j + 0], acc[i][2 * j + 1]);
+      float32x4_t acc_1x4_1 =
+          iree_uk_neon_uzp2_f32_as_s64(acc[i][2 * j + 0], acc[i][2 * j + 1]);
+      vst1q_f32(out_ptr + 8 * (2 * i + 0) + 4 * j, acc_1x4_0);
+      vst1q_f32(out_ptr + 8 * (2 * i + 1) + 4 * j, acc_1x4_1);
+    }
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
@@ -14,82 +14,45 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x4_arm_64_dotprod(
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
-  int32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
-      acc11, acc12, acc13, acc14, acc15;
+  int32x4_t acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = vld1q_s32(out_ptr + 4 * 0);
-    acc1 = vld1q_s32(out_ptr + 4 * 1);
-    acc2 = vld1q_s32(out_ptr + 4 * 2);
-    acc3 = vld1q_s32(out_ptr + 4 * 3);
-    acc4 = vld1q_s32(out_ptr + 4 * 4);
-    acc5 = vld1q_s32(out_ptr + 4 * 5);
-    acc6 = vld1q_s32(out_ptr + 4 * 6);
-    acc7 = vld1q_s32(out_ptr + 4 * 7);
-    acc8 = vld1q_s32(out_ptr + 4 * 8);
-    acc9 = vld1q_s32(out_ptr + 4 * 9);
-    acc10 = vld1q_s32(out_ptr + 4 * 10);
-    acc11 = vld1q_s32(out_ptr + 4 * 11);
-    acc12 = vld1q_s32(out_ptr + 4 * 12);
-    acc13 = vld1q_s32(out_ptr + 4 * 13);
-    acc14 = vld1q_s32(out_ptr + 4 * 14);
-    acc15 = vld1q_s32(out_ptr + 4 * 15);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vld1q_s32(out_ptr + 4 * i);
+    }
   } else {
-    acc0 = vdupq_n_s32(0);
-    acc1 = vdupq_n_s32(0);
-    acc2 = vdupq_n_s32(0);
-    acc3 = vdupq_n_s32(0);
-    acc4 = vdupq_n_s32(0);
-    acc5 = vdupq_n_s32(0);
-    acc6 = vdupq_n_s32(0);
-    acc7 = vdupq_n_s32(0);
-    acc8 = vdupq_n_s32(0);
-    acc9 = vdupq_n_s32(0);
-    acc10 = vdupq_n_s32(0);
-    acc11 = vdupq_n_s32(0);
-    acc12 = vdupq_n_s32(0);
-    acc13 = vdupq_n_s32(0);
-    acc14 = vdupq_n_s32(0);
-    acc15 = vdupq_n_s32(0);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vdupq_n_s32(0);
+    }
   }
   IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
-    int8x16_t lhs0 = vld1q_s8(lhs_ptr + 0);
-    int8x16_t lhs1 = vld1q_s8(lhs_ptr + 16);
+    int8x16_t lhs[2];
+    int8x16_t rhs[2];
+    for (int i = 0; i < 2; ++i) {
+      lhs[i] = vld1q_s8(lhs_ptr + 16 * i);
+      rhs[i] = vld1q_s8(rhs_ptr + 16 * i);
+    }
     lhs_ptr += 32;
-    int8x16_t rhs0 = vld1q_s8(rhs_ptr + 0);
-    int8x16_t rhs1 = vld1q_s8(rhs_ptr + 16);
     rhs_ptr += 32;
-    acc0 = vdotq_lane_s32(acc0, rhs0, vget_low_s8(lhs0), 0);
-    acc1 = vdotq_lane_s32(acc1, rhs1, vget_low_s8(lhs0), 0);
-    acc2 = vdotq_lane_s32(acc2, rhs0, vget_low_s8(lhs0), 1);
-    acc3 = vdotq_lane_s32(acc3, rhs1, vget_low_s8(lhs0), 1);
-    acc4 = vdotq_lane_s32(acc4, rhs0, vget_high_s8(lhs0), 0);
-    acc5 = vdotq_lane_s32(acc5, rhs1, vget_high_s8(lhs0), 0);
-    acc6 = vdotq_lane_s32(acc6, rhs0, vget_high_s8(lhs0), 1);
-    acc7 = vdotq_lane_s32(acc7, rhs1, vget_high_s8(lhs0), 1);
-    acc8 = vdotq_lane_s32(acc8, rhs0, vget_low_s8(lhs1), 0);
-    acc9 = vdotq_lane_s32(acc9, rhs1, vget_low_s8(lhs1), 0);
-    acc10 = vdotq_lane_s32(acc10, rhs0, vget_low_s8(lhs1), 1);
-    acc11 = vdotq_lane_s32(acc11, rhs1, vget_low_s8(lhs1), 1);
-    acc12 = vdotq_lane_s32(acc12, rhs0, vget_high_s8(lhs1), 0);
-    acc13 = vdotq_lane_s32(acc13, rhs1, vget_high_s8(lhs1), 0);
-    acc14 = vdotq_lane_s32(acc14, rhs0, vget_high_s8(lhs1), 1);
-    acc15 = vdotq_lane_s32(acc15, rhs1, vget_high_s8(lhs1), 1);
+    acc[0] = vdotq_lane_s32(acc[0], rhs[0], vget_low_s8(lhs[0]), 0);
+    acc[1] = vdotq_lane_s32(acc[1], rhs[1], vget_low_s8(lhs[0]), 0);
+    acc[2] = vdotq_lane_s32(acc[2], rhs[0], vget_low_s8(lhs[0]), 1);
+    acc[3] = vdotq_lane_s32(acc[3], rhs[1], vget_low_s8(lhs[0]), 1);
+    acc[4] = vdotq_lane_s32(acc[4], rhs[0], vget_high_s8(lhs[0]), 0);
+    acc[5] = vdotq_lane_s32(acc[5], rhs[1], vget_high_s8(lhs[0]), 0);
+    acc[6] = vdotq_lane_s32(acc[6], rhs[0], vget_high_s8(lhs[0]), 1);
+    acc[7] = vdotq_lane_s32(acc[7], rhs[1], vget_high_s8(lhs[0]), 1);
+    acc[8] = vdotq_lane_s32(acc[8], rhs[0], vget_low_s8(lhs[1]), 0);
+    acc[9] = vdotq_lane_s32(acc[9], rhs[1], vget_low_s8(lhs[1]), 0);
+    acc[10] = vdotq_lane_s32(acc[10], rhs[0], vget_low_s8(lhs[1]), 1);
+    acc[11] = vdotq_lane_s32(acc[11], rhs[1], vget_low_s8(lhs[1]), 1);
+    acc[12] = vdotq_lane_s32(acc[12], rhs[0], vget_high_s8(lhs[1]), 0);
+    acc[13] = vdotq_lane_s32(acc[13], rhs[1], vget_high_s8(lhs[1]), 0);
+    acc[14] = vdotq_lane_s32(acc[14], rhs[0], vget_high_s8(lhs[1]), 1);
+    acc[15] = vdotq_lane_s32(acc[15], rhs[1], vget_high_s8(lhs[1]), 1);
   }
-  vst1q_s32(out_ptr + 4 * 0, acc0);
-  vst1q_s32(out_ptr + 4 * 1, acc1);
-  vst1q_s32(out_ptr + 4 * 2, acc2);
-  vst1q_s32(out_ptr + 4 * 3, acc3);
-  vst1q_s32(out_ptr + 4 * 4, acc4);
-  vst1q_s32(out_ptr + 4 * 5, acc5);
-  vst1q_s32(out_ptr + 4 * 6, acc6);
-  vst1q_s32(out_ptr + 4 * 7, acc7);
-  vst1q_s32(out_ptr + 4 * 8, acc8);
-  vst1q_s32(out_ptr + 4 * 9, acc9);
-  vst1q_s32(out_ptr + 4 * 10, acc10);
-  vst1q_s32(out_ptr + 4 * 11, acc11);
-  vst1q_s32(out_ptr + 4 * 12, acc12);
-  vst1q_s32(out_ptr + 4 * 13, acc13);
-  vst1q_s32(out_ptr + 4 * 14, acc14);
-  vst1q_s32(out_ptr + 4 * 15, acc15);
+
+  for (int i = 0; i < 16; ++i) {
+    vst1q_s32(out_ptr + 4 * i, acc[i]);
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16.c
@@ -14,25 +14,15 @@ void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64_fp16(
   float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  float16x8_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
+  float16x8_t acc[8];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = vld1q_f16(out_ptr + 8 * 0);
-    acc1 = vld1q_f16(out_ptr + 8 * 1);
-    acc2 = vld1q_f16(out_ptr + 8 * 2);
-    acc3 = vld1q_f16(out_ptr + 8 * 3);
-    acc4 = vld1q_f16(out_ptr + 8 * 4);
-    acc5 = vld1q_f16(out_ptr + 8 * 5);
-    acc6 = vld1q_f16(out_ptr + 8 * 6);
-    acc7 = vld1q_f16(out_ptr + 8 * 7);
+    for (int i = 0; i < 8; ++i) {
+      acc[i] = vld1q_f16(out_ptr + 8 * i);
+    }
   } else {
-    acc0 = vdupq_n_f16(0);
-    acc1 = vdupq_n_f16(0);
-    acc2 = vdupq_n_f16(0);
-    acc3 = vdupq_n_f16(0);
-    acc4 = vdupq_n_f16(0);
-    acc5 = vdupq_n_f16(0);
-    acc6 = vdupq_n_f16(0);
-    acc7 = vdupq_n_f16(0);
+    for (int i = 0; i < 8; ++i) {
+      acc[i] = vdupq_n_f16(0);
+    }
   }
   IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
@@ -40,21 +30,16 @@ void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64_fp16(
     lhs_ptr += 8;
     float16x8_t rhs = vld1q_f16(rhs_ptr);
     rhs_ptr += 8;
-    acc0 = vfmaq_lane_f16(acc0, rhs, vget_low_f16(lhs), 0);
-    acc1 = vfmaq_lane_f16(acc1, rhs, vget_low_f16(lhs), 1);
-    acc2 = vfmaq_lane_f16(acc2, rhs, vget_low_f16(lhs), 2);
-    acc3 = vfmaq_lane_f16(acc3, rhs, vget_low_f16(lhs), 3);
-    acc4 = vfmaq_lane_f16(acc4, rhs, vget_high_f16(lhs), 0);
-    acc5 = vfmaq_lane_f16(acc5, rhs, vget_high_f16(lhs), 1);
-    acc6 = vfmaq_lane_f16(acc6, rhs, vget_high_f16(lhs), 2);
-    acc7 = vfmaq_lane_f16(acc7, rhs, vget_high_f16(lhs), 3);
+    acc[0] = vfmaq_lane_f16(acc[0], rhs, vget_low_f16(lhs), 0);
+    acc[1] = vfmaq_lane_f16(acc[1], rhs, vget_low_f16(lhs), 1);
+    acc[2] = vfmaq_lane_f16(acc[2], rhs, vget_low_f16(lhs), 2);
+    acc[3] = vfmaq_lane_f16(acc[3], rhs, vget_low_f16(lhs), 3);
+    acc[4] = vfmaq_lane_f16(acc[4], rhs, vget_high_f16(lhs), 0);
+    acc[5] = vfmaq_lane_f16(acc[5], rhs, vget_high_f16(lhs), 1);
+    acc[6] = vfmaq_lane_f16(acc[6], rhs, vget_high_f16(lhs), 2);
+    acc[7] = vfmaq_lane_f16(acc[7], rhs, vget_high_f16(lhs), 3);
   }
-  vst1q_f16(out_ptr + 8 * 0, acc0);
-  vst1q_f16(out_ptr + 8 * 1, acc1);
-  vst1q_f16(out_ptr + 8 * 2, acc2);
-  vst1q_f16(out_ptr + 8 * 3, acc3);
-  vst1q_f16(out_ptr + 8 * 4, acc4);
-  vst1q_f16(out_ptr + 8 * 5, acc5);
-  vst1q_f16(out_ptr + 8 * 6, acc6);
-  vst1q_f16(out_ptr + 8 * 7, acc7);
+  for (int i = 0; i < 8; ++i) {
+    vst1q_f16(out_ptr + 8 * i, acc[i]);
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
@@ -42,42 +42,15 @@ void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64_fp16fml(
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
-      acc11, acc12, acc13, acc14, acc15;
+  float32x4_t acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = vld1q_f32(out_ptr + 4 * 0);
-    acc1 = vld1q_f32(out_ptr + 4 * 1);
-    acc2 = vld1q_f32(out_ptr + 4 * 2);
-    acc3 = vld1q_f32(out_ptr + 4 * 3);
-    acc4 = vld1q_f32(out_ptr + 4 * 4);
-    acc5 = vld1q_f32(out_ptr + 4 * 5);
-    acc6 = vld1q_f32(out_ptr + 4 * 6);
-    acc7 = vld1q_f32(out_ptr + 4 * 7);
-    acc8 = vld1q_f32(out_ptr + 4 * 8);
-    acc9 = vld1q_f32(out_ptr + 4 * 9);
-    acc10 = vld1q_f32(out_ptr + 4 * 10);
-    acc11 = vld1q_f32(out_ptr + 4 * 11);
-    acc12 = vld1q_f32(out_ptr + 4 * 12);
-    acc13 = vld1q_f32(out_ptr + 4 * 13);
-    acc14 = vld1q_f32(out_ptr + 4 * 14);
-    acc15 = vld1q_f32(out_ptr + 4 * 15);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vld1q_f32(out_ptr + 4 * i);
+    }
   } else {
-    acc0 = vdupq_n_f32(0);
-    acc1 = vdupq_n_f32(0);
-    acc2 = vdupq_n_f32(0);
-    acc3 = vdupq_n_f32(0);
-    acc4 = vdupq_n_f32(0);
-    acc5 = vdupq_n_f32(0);
-    acc6 = vdupq_n_f32(0);
-    acc7 = vdupq_n_f32(0);
-    acc8 = vdupq_n_f32(0);
-    acc9 = vdupq_n_f32(0);
-    acc10 = vdupq_n_f32(0);
-    acc11 = vdupq_n_f32(0);
-    acc12 = vdupq_n_f32(0);
-    acc13 = vdupq_n_f32(0);
-    acc14 = vdupq_n_f32(0);
-    acc15 = vdupq_n_f32(0);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = vdupq_n_f32(0);
+    }
   }
   IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
@@ -85,37 +58,24 @@ void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64_fp16fml(
     lhs_ptr += 8;
     float16x8_t rhs = vld1q_f16(rhs_ptr);
     rhs_ptr += 8;
-    acc0 = iree_workaround_vfmlalq_laneq_low_f16(acc0, rhs, lhs, 0);
-    acc1 = iree_workaround_vfmlalq_laneq_high_f16(acc1, rhs, lhs, 0);
-    acc2 = iree_workaround_vfmlalq_laneq_low_f16(acc2, rhs, lhs, 1);
-    acc3 = iree_workaround_vfmlalq_laneq_high_f16(acc3, rhs, lhs, 1);
-    acc4 = iree_workaround_vfmlalq_laneq_low_f16(acc4, rhs, lhs, 2);
-    acc5 = iree_workaround_vfmlalq_laneq_high_f16(acc5, rhs, lhs, 2);
-    acc6 = iree_workaround_vfmlalq_laneq_low_f16(acc6, rhs, lhs, 3);
-    acc7 = iree_workaround_vfmlalq_laneq_high_f16(acc7, rhs, lhs, 3);
-    acc8 = iree_workaround_vfmlalq_laneq_low_f16(acc8, rhs, lhs, 4);
-    acc9 = iree_workaround_vfmlalq_laneq_high_f16(acc9, rhs, lhs, 4);
-    acc10 = iree_workaround_vfmlalq_laneq_low_f16(acc10, rhs, lhs, 5);
-    acc11 = iree_workaround_vfmlalq_laneq_high_f16(acc11, rhs, lhs, 5);
-    acc12 = iree_workaround_vfmlalq_laneq_low_f16(acc12, rhs, lhs, 6);
-    acc13 = iree_workaround_vfmlalq_laneq_high_f16(acc13, rhs, lhs, 6);
-    acc14 = iree_workaround_vfmlalq_laneq_low_f16(acc14, rhs, lhs, 7);
-    acc15 = iree_workaround_vfmlalq_laneq_high_f16(acc15, rhs, lhs, 7);
+    acc[0] = iree_workaround_vfmlalq_laneq_low_f16(acc[0], rhs, lhs, 0);
+    acc[1] = iree_workaround_vfmlalq_laneq_high_f16(acc[1], rhs, lhs, 0);
+    acc[2] = iree_workaround_vfmlalq_laneq_low_f16(acc[2], rhs, lhs, 1);
+    acc[3] = iree_workaround_vfmlalq_laneq_high_f16(acc[3], rhs, lhs, 1);
+    acc[4] = iree_workaround_vfmlalq_laneq_low_f16(acc[4], rhs, lhs, 2);
+    acc[5] = iree_workaround_vfmlalq_laneq_high_f16(acc[5], rhs, lhs, 2);
+    acc[6] = iree_workaround_vfmlalq_laneq_low_f16(acc[6], rhs, lhs, 3);
+    acc[7] = iree_workaround_vfmlalq_laneq_high_f16(acc[7], rhs, lhs, 3);
+    acc[8] = iree_workaround_vfmlalq_laneq_low_f16(acc[8], rhs, lhs, 4);
+    acc[9] = iree_workaround_vfmlalq_laneq_high_f16(acc[9], rhs, lhs, 4);
+    acc[10] = iree_workaround_vfmlalq_laneq_low_f16(acc[10], rhs, lhs, 5);
+    acc[11] = iree_workaround_vfmlalq_laneq_high_f16(acc[11], rhs, lhs, 5);
+    acc[12] = iree_workaround_vfmlalq_laneq_low_f16(acc[12], rhs, lhs, 6);
+    acc[13] = iree_workaround_vfmlalq_laneq_high_f16(acc[13], rhs, lhs, 6);
+    acc[14] = iree_workaround_vfmlalq_laneq_low_f16(acc[14], rhs, lhs, 7);
+    acc[15] = iree_workaround_vfmlalq_laneq_high_f16(acc[15], rhs, lhs, 7);
   }
-  vst1q_f32(out_ptr + 4 * 0, acc0);
-  vst1q_f32(out_ptr + 4 * 1, acc1);
-  vst1q_f32(out_ptr + 4 * 2, acc2);
-  vst1q_f32(out_ptr + 4 * 3, acc3);
-  vst1q_f32(out_ptr + 4 * 4, acc4);
-  vst1q_f32(out_ptr + 4 * 5, acc5);
-  vst1q_f32(out_ptr + 4 * 6, acc6);
-  vst1q_f32(out_ptr + 4 * 7, acc7);
-  vst1q_f32(out_ptr + 4 * 8, acc8);
-  vst1q_f32(out_ptr + 4 * 9, acc9);
-  vst1q_f32(out_ptr + 4 * 10, acc10);
-  vst1q_f32(out_ptr + 4 * 11, acc11);
-  vst1q_f32(out_ptr + 4 * 12, acc12);
-  vst1q_f32(out_ptr + 4 * 13, acc13);
-  vst1q_f32(out_ptr + 4 * 14, acc14);
-  vst1q_f32(out_ptr + 4 * 15, acc15);
+  for (int i = 0; i < 16; ++i) {
+    vst1q_f32(out_ptr + 4 * i, acc[i]);
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c
@@ -34,121 +34,52 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm(
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
-  int32x4_t acc_01_01, acc_01_23, acc_01_45, acc_01_67;
-  int32x4_t acc_23_01, acc_23_23, acc_23_45, acc_23_67;
-  int32x4_t acc_45_01, acc_45_23, acc_45_45, acc_45_67;
-  int32x4_t acc_67_01, acc_67_23, acc_67_45, acc_67_67;
+  // Accumulator 2x2 register tiles.
+  int32x4_t acc[4][4];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    int32x4_t acc_0_0123 = vld1q_s32(out_ptr + 8 * 0 + 0);
-    int32x4_t acc_0_4567 = vld1q_s32(out_ptr + 8 * 0 + 4);
-    int32x4_t acc_1_0123 = vld1q_s32(out_ptr + 8 * 1 + 0);
-    int32x4_t acc_1_4567 = vld1q_s32(out_ptr + 8 * 1 + 4);
-    int32x4_t acc_2_0123 = vld1q_s32(out_ptr + 8 * 2 + 0);
-    int32x4_t acc_2_4567 = vld1q_s32(out_ptr + 8 * 2 + 4);
-    int32x4_t acc_3_0123 = vld1q_s32(out_ptr + 8 * 3 + 0);
-    int32x4_t acc_3_4567 = vld1q_s32(out_ptr + 8 * 3 + 4);
-    int32x4_t acc_4_0123 = vld1q_s32(out_ptr + 8 * 4 + 0);
-    int32x4_t acc_4_4567 = vld1q_s32(out_ptr + 8 * 4 + 4);
-    int32x4_t acc_5_0123 = vld1q_s32(out_ptr + 8 * 5 + 0);
-    int32x4_t acc_5_4567 = vld1q_s32(out_ptr + 8 * 5 + 4);
-    int32x4_t acc_6_0123 = vld1q_s32(out_ptr + 8 * 6 + 0);
-    int32x4_t acc_6_4567 = vld1q_s32(out_ptr + 8 * 6 + 4);
-    int32x4_t acc_7_0123 = vld1q_s32(out_ptr + 8 * 7 + 0);
-    int32x4_t acc_7_4567 = vld1q_s32(out_ptr + 8 * 7 + 4);
-    acc_01_01 = iree_uk_neon_zip1_s32_as_s64(acc_0_0123, acc_1_0123);
-    acc_01_23 = iree_uk_neon_zip2_s32_as_s64(acc_0_0123, acc_1_0123);
-    acc_01_45 = iree_uk_neon_zip1_s32_as_s64(acc_0_4567, acc_1_4567);
-    acc_01_67 = iree_uk_neon_zip2_s32_as_s64(acc_0_4567, acc_1_4567);
-    acc_23_01 = iree_uk_neon_zip1_s32_as_s64(acc_2_0123, acc_3_0123);
-    acc_23_23 = iree_uk_neon_zip2_s32_as_s64(acc_2_0123, acc_3_0123);
-    acc_23_45 = iree_uk_neon_zip1_s32_as_s64(acc_2_4567, acc_3_4567);
-    acc_23_67 = iree_uk_neon_zip2_s32_as_s64(acc_2_4567, acc_3_4567);
-    acc_45_01 = iree_uk_neon_zip1_s32_as_s64(acc_4_0123, acc_5_0123);
-    acc_45_23 = iree_uk_neon_zip2_s32_as_s64(acc_4_0123, acc_5_0123);
-    acc_45_45 = iree_uk_neon_zip1_s32_as_s64(acc_4_4567, acc_5_4567);
-    acc_45_67 = iree_uk_neon_zip2_s32_as_s64(acc_4_4567, acc_5_4567);
-    acc_67_01 = iree_uk_neon_zip1_s32_as_s64(acc_6_0123, acc_7_0123);
-    acc_67_23 = iree_uk_neon_zip2_s32_as_s64(acc_6_0123, acc_7_0123);
-    acc_67_45 = iree_uk_neon_zip1_s32_as_s64(acc_6_4567, acc_7_4567);
-    acc_67_67 = iree_uk_neon_zip2_s32_as_s64(acc_6_4567, acc_7_4567);
+    // Load row-major accumulator and swizzle into 2x2 register tiles.
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 2; ++j) {
+        int32x4_t acc_1x4_0 = vld1q_s32(out_ptr + 8 * (2 * i + 0) + 4 * j);
+        int32x4_t acc_1x4_1 = vld1q_s32(out_ptr + 8 * (2 * i + 1) + 4 * j);
+        acc[i][2 * j + 0] = iree_uk_neon_zip1_s32_as_s64(acc_1x4_0, acc_1x4_1);
+        acc[i][2 * j + 1] = iree_uk_neon_zip2_s32_as_s64(acc_1x4_0, acc_1x4_1);
+      }
+    }
   } else {
-    acc_01_01 = vdupq_n_s32(0);
-    acc_01_23 = vdupq_n_s32(0);
-    acc_01_45 = vdupq_n_s32(0);
-    acc_01_67 = vdupq_n_s32(0);
-    acc_23_01 = vdupq_n_s32(0);
-    acc_23_23 = vdupq_n_s32(0);
-    acc_23_45 = vdupq_n_s32(0);
-    acc_23_67 = vdupq_n_s32(0);
-    acc_45_01 = vdupq_n_s32(0);
-    acc_45_23 = vdupq_n_s32(0);
-    acc_45_45 = vdupq_n_s32(0);
-    acc_45_67 = vdupq_n_s32(0);
-    acc_67_01 = vdupq_n_s32(0);
-    acc_67_23 = vdupq_n_s32(0);
-    acc_67_45 = vdupq_n_s32(0);
-    acc_67_67 = vdupq_n_s32(0);
-  }
-  IREE_UK_ASSUME(params->K >= 1);
-  for (int k = 0; k < params->K; ++k) {
-    int8x16_t lhs01 = vld1q_s8(lhs_ptr + 0);
-    int8x16_t lhs23 = vld1q_s8(lhs_ptr + 16);
-    int8x16_t lhs45 = vld1q_s8(lhs_ptr + 32);
-    int8x16_t lhs67 = vld1q_s8(lhs_ptr + 48);
-    lhs_ptr += 64;
-    int8x16_t rhs01 = vld1q_s8(rhs_ptr + 0);
-    int8x16_t rhs23 = vld1q_s8(rhs_ptr + 16);
-    int8x16_t rhs45 = vld1q_s8(rhs_ptr + 32);
-    int8x16_t rhs67 = vld1q_s8(rhs_ptr + 48);
-    rhs_ptr += 64;
-    acc_01_01 = vmmlaq_s32(acc_01_01, lhs01, rhs01);
-    acc_01_23 = vmmlaq_s32(acc_01_23, lhs01, rhs23);
-    acc_01_45 = vmmlaq_s32(acc_01_45, lhs01, rhs45);
-    acc_01_67 = vmmlaq_s32(acc_01_67, lhs01, rhs67);
-    acc_23_01 = vmmlaq_s32(acc_23_01, lhs23, rhs01);
-    acc_23_23 = vmmlaq_s32(acc_23_23, lhs23, rhs23);
-    acc_23_45 = vmmlaq_s32(acc_23_45, lhs23, rhs45);
-    acc_23_67 = vmmlaq_s32(acc_23_67, lhs23, rhs67);
-    acc_45_01 = vmmlaq_s32(acc_45_01, lhs45, rhs01);
-    acc_45_23 = vmmlaq_s32(acc_45_23, lhs45, rhs23);
-    acc_45_45 = vmmlaq_s32(acc_45_45, lhs45, rhs45);
-    acc_45_67 = vmmlaq_s32(acc_45_67, lhs45, rhs67);
-    acc_67_01 = vmmlaq_s32(acc_67_01, lhs67, rhs01);
-    acc_67_23 = vmmlaq_s32(acc_67_23, lhs67, rhs23);
-    acc_67_45 = vmmlaq_s32(acc_67_45, lhs67, rhs45);
-    acc_67_67 = vmmlaq_s32(acc_67_67, lhs67, rhs67);
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = vdupq_n_s32(0);
+      }
+    }
   }
 
-  int32x4_t acc_0_0123 = iree_uk_neon_uzp1_s32_as_s64(acc_01_01, acc_01_23);
-  int32x4_t acc_0_4567 = iree_uk_neon_uzp1_s32_as_s64(acc_01_45, acc_01_67);
-  int32x4_t acc_1_0123 = iree_uk_neon_uzp2_s32_as_s64(acc_01_01, acc_01_23);
-  int32x4_t acc_1_4567 = iree_uk_neon_uzp2_s32_as_s64(acc_01_45, acc_01_67);
-  int32x4_t acc_2_0123 = iree_uk_neon_uzp1_s32_as_s64(acc_23_01, acc_23_23);
-  int32x4_t acc_2_4567 = iree_uk_neon_uzp1_s32_as_s64(acc_23_45, acc_23_67);
-  int32x4_t acc_3_0123 = iree_uk_neon_uzp2_s32_as_s64(acc_23_01, acc_23_23);
-  int32x4_t acc_3_4567 = iree_uk_neon_uzp2_s32_as_s64(acc_23_45, acc_23_67);
-  int32x4_t acc_4_0123 = iree_uk_neon_uzp1_s32_as_s64(acc_45_01, acc_45_23);
-  int32x4_t acc_4_4567 = iree_uk_neon_uzp1_s32_as_s64(acc_45_45, acc_45_67);
-  int32x4_t acc_5_0123 = iree_uk_neon_uzp2_s32_as_s64(acc_45_01, acc_45_23);
-  int32x4_t acc_5_4567 = iree_uk_neon_uzp2_s32_as_s64(acc_45_45, acc_45_67);
-  int32x4_t acc_6_0123 = iree_uk_neon_uzp1_s32_as_s64(acc_67_01, acc_67_23);
-  int32x4_t acc_6_4567 = iree_uk_neon_uzp1_s32_as_s64(acc_67_45, acc_67_67);
-  int32x4_t acc_7_0123 = iree_uk_neon_uzp2_s32_as_s64(acc_67_01, acc_67_23);
-  int32x4_t acc_7_4567 = iree_uk_neon_uzp2_s32_as_s64(acc_67_45, acc_67_67);
-  vst1q_s32(out_ptr + 8 * 0 + 0, acc_0_0123);
-  vst1q_s32(out_ptr + 8 * 0 + 4, acc_0_4567);
-  vst1q_s32(out_ptr + 8 * 1 + 0, acc_1_0123);
-  vst1q_s32(out_ptr + 8 * 1 + 4, acc_1_4567);
-  vst1q_s32(out_ptr + 8 * 2 + 0, acc_2_0123);
-  vst1q_s32(out_ptr + 8 * 2 + 4, acc_2_4567);
-  vst1q_s32(out_ptr + 8 * 3 + 0, acc_3_0123);
-  vst1q_s32(out_ptr + 8 * 3 + 4, acc_3_4567);
-  vst1q_s32(out_ptr + 8 * 4 + 0, acc_4_0123);
-  vst1q_s32(out_ptr + 8 * 4 + 4, acc_4_4567);
-  vst1q_s32(out_ptr + 8 * 5 + 0, acc_5_0123);
-  vst1q_s32(out_ptr + 8 * 5 + 4, acc_5_4567);
-  vst1q_s32(out_ptr + 8 * 6 + 0, acc_6_0123);
-  vst1q_s32(out_ptr + 8 * 6 + 4, acc_6_4567);
-  vst1q_s32(out_ptr + 8 * 7 + 0, acc_7_0123);
-  vst1q_s32(out_ptr + 8 * 7 + 4, acc_7_4567);
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
+    int8x16_t lhs[4];
+    int8x16_t rhs[4];
+    for (int i = 0; i < 4; ++i) {
+      lhs[i] = vld1q_s8(lhs_ptr + 16 * i);
+      rhs[i] = vld1q_s8(rhs_ptr + 16 * i);
+    }
+    lhs_ptr += 64;
+    rhs_ptr += 64;
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = vmmlaq_s32(acc[i][j], lhs[i], rhs[j]);
+      }
+    }
+  }
+
+  // Swizzle accumulator 2x2 register tiles back to row-major and store.
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      int32x4_t acc_1x4_0 =
+          iree_uk_neon_uzp1_s32_as_s64(acc[i][2 * j + 0], acc[i][2 * j + 1]);
+      int32x4_t acc_1x4_1 =
+          iree_uk_neon_uzp2_s32_as_s64(acc[i][2 * j + 0], acc[i][2 * j + 1]);
+      vst1q_s32(out_ptr + 8 * (2 * i + 0) + 4 * j, acc_1x4_0);
+      vst1q_s32(out_ptr + 8 * (2 * i + 1) + 4 * j, acc_1x4_1);
+    }
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
@@ -14,47 +14,27 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  __m256 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
+  __m256 acc[8];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
-    acc1 = _mm256_loadu_ps(out_ptr + 1 * 8);
-    acc2 = _mm256_loadu_ps(out_ptr + 2 * 8);
-    acc3 = _mm256_loadu_ps(out_ptr + 3 * 8);
-    acc4 = _mm256_loadu_ps(out_ptr + 4 * 8);
-    acc5 = _mm256_loadu_ps(out_ptr + 5 * 8);
-    acc6 = _mm256_loadu_ps(out_ptr + 6 * 8);
-    acc7 = _mm256_loadu_ps(out_ptr + 7 * 8);
+    for (int i = 0; i < 8; ++i) {
+      acc[i] = _mm256_loadu_ps(out_ptr + i * 8);
+    }
   } else {
-    acc0 = _mm256_setzero_ps();
-    acc1 = _mm256_setzero_ps();
-    acc2 = _mm256_setzero_ps();
-    acc3 = _mm256_setzero_ps();
-    acc4 = _mm256_setzero_ps();
-    acc5 = _mm256_setzero_ps();
-    acc6 = _mm256_setzero_ps();
-    acc7 = _mm256_setzero_ps();
+    for (int i = 0; i < 8; ++i) {
+      acc[i] = _mm256_setzero_ps();
+    }
   }
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m256 rhs = _mm256_loadu_ps(rhs_ptr);
     rhs_ptr += 8;
-    acc0 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 0), rhs, acc0);
-    acc1 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 1), rhs, acc1);
-    acc2 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 2), rhs, acc2);
-    acc3 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 3), rhs, acc3);
-    acc4 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 4), rhs, acc4);
-    acc5 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 5), rhs, acc5);
-    acc6 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 6), rhs, acc6);
-    acc7 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 7), rhs, acc7);
+    for (int i = 0; i < 8; ++i) {
+      acc[i] = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + i), rhs, acc[i]);
+    }
     lhs_ptr += 8;
   }
-  _mm256_storeu_ps(out_ptr + 0 * 8, acc0);
-  _mm256_storeu_ps(out_ptr + 1 * 8, acc1);
-  _mm256_storeu_ps(out_ptr + 2 * 8, acc2);
-  _mm256_storeu_ps(out_ptr + 3 * 8, acc3);
-  _mm256_storeu_ps(out_ptr + 4 * 8, acc4);
-  _mm256_storeu_ps(out_ptr + 5 * 8, acc5);
-  _mm256_storeu_ps(out_ptr + 6 * 8, acc6);
-  _mm256_storeu_ps(out_ptr + 7 * 8, acc7);
+  for (int i = 0; i < 8; ++i) {
+    _mm256_storeu_ps(out_ptr + i * 8, acc[i]);
+  }
 }
 
 // Shared implementation for f16f16f16 and f16f16f32.
@@ -66,96 +46,45 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
     const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type) {
   const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  __m256 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
+  __m256 acc[8];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
-      acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
-      acc1 = _mm256_loadu_ps(out_ptr + 1 * 8);
-      acc2 = _mm256_loadu_ps(out_ptr + 2 * 8);
-      acc3 = _mm256_loadu_ps(out_ptr + 3 * 8);
-      acc4 = _mm256_loadu_ps(out_ptr + 4 * 8);
-      acc5 = _mm256_loadu_ps(out_ptr + 5 * 8);
-      acc6 = _mm256_loadu_ps(out_ptr + 6 * 8);
-      acc7 = _mm256_loadu_ps(out_ptr + 7 * 8);
+      for (int i = 0; i < 8; ++i) {
+        acc[i] = _mm256_loadu_ps(out_ptr + i * 8);
+      }
     } else {
       iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-      acc0 =
-          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 0 * 8)));
-      acc1 =
-          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 1 * 8)));
-      acc2 =
-          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 2 * 8)));
-      acc3 =
-          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 3 * 8)));
-      acc4 =
-          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 4 * 8)));
-      acc5 =
-          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 5 * 8)));
-      acc6 =
-          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 6 * 8)));
-      acc7 =
-          _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + 7 * 8)));
+      for (int i = 0; i < 8; ++i) {
+        acc[i] =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(out_ptr + i * 8)));
+      }
     }
   } else {
-    acc0 = _mm256_setzero_ps();
-    acc1 = _mm256_setzero_ps();
-    acc2 = _mm256_setzero_ps();
-    acc3 = _mm256_setzero_ps();
-    acc4 = _mm256_setzero_ps();
-    acc5 = _mm256_setzero_ps();
-    acc6 = _mm256_setzero_ps();
-    acc7 = _mm256_setzero_ps();
+    for (int i = 0; i < 8; ++i) {
+      acc[i] = _mm256_setzero_ps();
+    }
   }
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m256 rhs = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)rhs_ptr));
     rhs_ptr += 8;
-    acc0 =
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[0])), rhs, acc0);
-    acc1 =
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[1])), rhs, acc1);
-    acc2 =
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[2])), rhs, acc2);
-    acc3 =
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[3])), rhs, acc3);
-    acc4 =
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[4])), rhs, acc4);
-    acc5 =
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[5])), rhs, acc5);
-    acc6 =
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[6])), rhs, acc6);
-    acc7 =
-        _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[7])), rhs, acc7);
+    for (int i = 0; i < 8; ++i) {
+      acc[i] = _mm256_fmadd_ps(_mm256_cvtph_ps(_mm_set1_epi16(lhs_ptr[i])), rhs,
+                               acc[i]);
+    }
     lhs_ptr += 8;
   }
   if (acc_type == IREE_UK_TYPE_FLOAT_32) {
     float* IREE_UK_RESTRICT out_ptr = out_tile;
-    _mm256_storeu_ps(out_ptr + 0 * 8, acc0);
-    _mm256_storeu_ps(out_ptr + 1 * 8, acc1);
-    _mm256_storeu_ps(out_ptr + 2 * 8, acc2);
-    _mm256_storeu_ps(out_ptr + 3 * 8, acc3);
-    _mm256_storeu_ps(out_ptr + 4 * 8, acc4);
-    _mm256_storeu_ps(out_ptr + 5 * 8, acc5);
-    _mm256_storeu_ps(out_ptr + 6 * 8, acc6);
-    _mm256_storeu_ps(out_ptr + 7 * 8, acc7);
+    for (int i = 0; i < 8; ++i) {
+      _mm256_storeu_ps(out_ptr + i * 8, acc[i]);
+    }
   } else {
     iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-    _mm_storeu_si128((__m128i*)(out_ptr + 0 * 8),
-                     _mm256_cvtps_ph(acc0, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128((__m128i*)(out_ptr + 1 * 8),
-                     _mm256_cvtps_ph(acc1, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128((__m128i*)(out_ptr + 2 * 8),
-                     _mm256_cvtps_ph(acc2, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128((__m128i*)(out_ptr + 3 * 8),
-                     _mm256_cvtps_ph(acc3, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128((__m128i*)(out_ptr + 4 * 8),
-                     _mm256_cvtps_ph(acc4, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128((__m128i*)(out_ptr + 5 * 8),
-                     _mm256_cvtps_ph(acc5, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128((__m128i*)(out_ptr + 6 * 8),
-                     _mm256_cvtps_ph(acc6, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128((__m128i*)(out_ptr + 7 * 8),
-                     _mm256_cvtps_ph(acc7, _MM_FROUND_TO_NEAREST_INT));
+    for (int i = 0; i < 8; ++i) {
+      _mm_storeu_si128((__m128i*)(out_ptr + i * 8),
+                       _mm256_cvtps_ph(acc[i], _MM_FROUND_TO_NEAREST_INT));
+    }
   }
 }
 
@@ -182,95 +111,60 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  __m256i acc_0_0123_4_4567;
-  __m256i acc_0_4567_4_0123;
-  __m256i acc_1_0123_5_4567;
-  __m256i acc_1_4567_5_0123;
-  __m256i acc_2_0123_6_4567;
-  __m256i acc_2_4567_6_0123;
-  __m256i acc_3_0123_7_4567;
-  __m256i acc_3_4567_7_0123;
-
+  // acc[i][0] contains the 1st half of row i and the 2nd half of row (i+4).
+  // acc[i][1] contains the 2nd half of row i and the 1st half of row (i+4).
+  // This unusual layout is chosen so that the inner arithmetic loop only needs
+  // to perform cheap shuffles within 128bit groups of lanes.
+  __m256i acc[4][2];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc_0_0123_4_4567 = iree_uk_avx_loadu_2x128(
-        (__m128i*)(out_ptr + 0 * 8 + 0), (__m128i*)(out_ptr + 4 * 8 + 4));
-    acc_0_4567_4_0123 = iree_uk_avx_loadu_2x128(
-        (__m128i*)(out_ptr + 0 * 8 + 4), (__m128i*)(out_ptr + 4 * 8 + 0));
-    acc_1_0123_5_4567 = iree_uk_avx_loadu_2x128(
-        (__m128i*)(out_ptr + 1 * 8 + 0), (__m128i*)(out_ptr + 5 * 8 + 4));
-    acc_1_4567_5_0123 = iree_uk_avx_loadu_2x128(
-        (__m128i*)(out_ptr + 1 * 8 + 4), (__m128i*)(out_ptr + 5 * 8 + 0));
-    acc_2_0123_6_4567 = iree_uk_avx_loadu_2x128(
-        (__m128i*)(out_ptr + 2 * 8 + 0), (__m128i*)(out_ptr + 6 * 8 + 4));
-    acc_2_4567_6_0123 = iree_uk_avx_loadu_2x128(
-        (__m128i*)(out_ptr + 2 * 8 + 4), (__m128i*)(out_ptr + 6 * 8 + 0));
-    acc_3_0123_7_4567 = iree_uk_avx_loadu_2x128(
-        (__m128i*)(out_ptr + 3 * 8 + 0), (__m128i*)(out_ptr + 7 * 8 + 4));
-    acc_3_4567_7_0123 = iree_uk_avx_loadu_2x128(
-        (__m128i*)(out_ptr + 3 * 8 + 4), (__m128i*)(out_ptr + 7 * 8 + 0));
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 2; ++j) {
+        acc[i][j] = iree_uk_avx_loadu_2x128(
+            (__m128i*)(out_ptr + i * 8 + j * 4),
+            (__m128i*)(out_ptr + (i + 4) * 8 + (1 - j) * 4));
+      }
+    }
   } else {
-    acc_0_0123_4_4567 = _mm256_setzero_si256();
-    acc_0_4567_4_0123 = _mm256_setzero_si256();
-    acc_1_0123_5_4567 = _mm256_setzero_si256();
-    acc_1_4567_5_0123 = _mm256_setzero_si256();
-    acc_2_0123_6_4567 = _mm256_setzero_si256();
-    acc_2_4567_6_0123 = _mm256_setzero_si256();
-    acc_3_0123_7_4567 = _mm256_setzero_si256();
-    acc_3_4567_7_0123 = _mm256_setzero_si256();
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 2; ++j) {
+        acc[i][j] = _mm256_setzero_si256();
+      }
+    }
   }
+
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
-    __m256i rhs_i16_01234567 =
+    __m256i rhs_i16_perm[2];
+    // rhs_i16_perm[0] is the rhs row, sign-extended to i16.
+    rhs_i16_perm[0] =
         _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)rhs_ptr));
     rhs_ptr += 16;
-    __m256i lhs_i16_01234567 =
+    // rhs_i16_perm[1] is that with the halves swapped.
+    rhs_i16_perm[1] =
+        _mm256_permute2x128_si256(rhs_i16_perm[0], rhs_i16_perm[0], 0x01);
+    // lhs_i16 is the lhs column, sign-extended to i16.
+    __m256i lhs_i16 =
         _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)lhs_ptr));
     lhs_ptr += 16;
-    __m256i rhs_i16_45670123 =
-        _mm256_permute2x128_si256(rhs_i16_01234567, rhs_i16_01234567, 0x01);
-    __m256i lhs_i16_00004444 = _mm256_shuffle_epi32(lhs_i16_01234567, 0 * 0x55);
-    __m256i lhs_i16_11115555 = _mm256_shuffle_epi32(lhs_i16_01234567, 1 * 0x55);
-    __m256i lhs_i16_22226666 = _mm256_shuffle_epi32(lhs_i16_01234567, 2 * 0x55);
-    __m256i lhs_i16_33337777 = _mm256_shuffle_epi32(lhs_i16_01234567, 3 * 0x55);
-
-    acc_0_0123_4_4567 =
-        _mm256_add_epi32(acc_0_0123_4_4567,
-                         _mm256_madd_epi16(lhs_i16_00004444, rhs_i16_01234567));
-    acc_0_4567_4_0123 =
-        _mm256_add_epi32(acc_0_4567_4_0123,
-                         _mm256_madd_epi16(lhs_i16_00004444, rhs_i16_45670123));
-    acc_1_0123_5_4567 =
-        _mm256_add_epi32(acc_1_0123_5_4567,
-                         _mm256_madd_epi16(lhs_i16_11115555, rhs_i16_01234567));
-    acc_1_4567_5_0123 =
-        _mm256_add_epi32(acc_1_4567_5_0123,
-                         _mm256_madd_epi16(lhs_i16_11115555, rhs_i16_45670123));
-    acc_2_0123_6_4567 =
-        _mm256_add_epi32(acc_2_0123_6_4567,
-                         _mm256_madd_epi16(lhs_i16_22226666, rhs_i16_01234567));
-    acc_2_4567_6_0123 =
-        _mm256_add_epi32(acc_2_4567_6_0123,
-                         _mm256_madd_epi16(lhs_i16_22226666, rhs_i16_45670123));
-    acc_3_0123_7_4567 =
-        _mm256_add_epi32(acc_3_0123_7_4567,
-                         _mm256_madd_epi16(lhs_i16_33337777, rhs_i16_01234567));
-    acc_3_4567_7_0123 =
-        _mm256_add_epi32(acc_3_4567_7_0123,
-                         _mm256_madd_epi16(lhs_i16_33337777, rhs_i16_45670123));
+    // lhs_i16_dup4[i] is lanes of lhs_i16 shuffled as:
+    // (i, i, i, i, i+4, i+4, i+4, i+4).
+    __m256i lhs_i16_dup4[4];
+    lhs_i16_dup4[0] = _mm256_shuffle_epi32(lhs_i16, 0 * 0x55);
+    lhs_i16_dup4[1] = _mm256_shuffle_epi32(lhs_i16, 1 * 0x55);
+    lhs_i16_dup4[2] = _mm256_shuffle_epi32(lhs_i16, 2 * 0x55);
+    lhs_i16_dup4[3] = _mm256_shuffle_epi32(lhs_i16, 3 * 0x55);
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 2; ++j) {
+        acc[i][j] = _mm256_add_epi32(
+            acc[i][j], _mm256_madd_epi16(lhs_i16_dup4[i], rhs_i16_perm[j]));
+      }
+    }
   }
-  iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + 0 * 8 + 0),
-                           (__m128i*)(out_ptr + 4 * 8 + 4), acc_0_0123_4_4567);
-  iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + 0 * 8 + 4),
-                           (__m128i*)(out_ptr + 4 * 8 + 0), acc_0_4567_4_0123);
-  iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + 1 * 8 + 0),
-                           (__m128i*)(out_ptr + 5 * 8 + 4), acc_1_0123_5_4567);
-  iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + 1 * 8 + 4),
-                           (__m128i*)(out_ptr + 5 * 8 + 0), acc_1_4567_5_0123);
-  iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + 2 * 8 + 0),
-                           (__m128i*)(out_ptr + 6 * 8 + 4), acc_2_0123_6_4567);
-  iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + 2 * 8 + 4),
-                           (__m128i*)(out_ptr + 6 * 8 + 0), acc_2_4567_6_0123);
-  iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + 3 * 8 + 0),
-                           (__m128i*)(out_ptr + 7 * 8 + 4), acc_3_0123_7_4567);
-  iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + 3 * 8 + 4),
-                           (__m128i*)(out_ptr + 7 * 8 + 0), acc_3_4567_7_0123);
+
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      iree_uk_avx_storeu_2x128((__m128i*)(out_ptr + i * 8 + j * 4),
+                               (__m128i*)(out_ptr + (i + 4) * 8 + (1 - j) * 4),
+                               acc[i][j]);
+    }
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -85,10 +85,27 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
     __m512 rhs = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
-    for (int i = 0; i < 16; ++i) {
-      acc[i] = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[i])),
-                               rhs, acc[i]);
-    }
+#define IREE_UK_F16F16F32_FMA_STEP(i)                                      \
+  acc[i] = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[i])), \
+                           rhs, acc[i]);
+    IREE_UK_F16F16F32_FMA_STEP(0);
+    IREE_UK_F16F16F32_FMA_STEP(1);
+    IREE_UK_F16F16F32_FMA_STEP(2);
+    IREE_UK_F16F16F32_FMA_STEP(3);
+    IREE_UK_F16F16F32_FMA_STEP(4);
+    IREE_UK_F16F16F32_FMA_STEP(5);
+    IREE_UK_F16F16F32_FMA_STEP(6);
+    IREE_UK_F16F16F32_FMA_STEP(7);
+    IREE_UK_F16F16F32_FMA_STEP(8);
+    IREE_UK_F16F16F32_FMA_STEP(9);
+    IREE_UK_F16F16F32_FMA_STEP(10);
+    IREE_UK_F16F16F32_FMA_STEP(11);
+    IREE_UK_F16F16F32_FMA_STEP(12);
+    IREE_UK_F16F16F32_FMA_STEP(13);
+    IREE_UK_F16F16F32_FMA_STEP(14);
+    IREE_UK_F16F16F32_FMA_STEP(15);
+#undef IREE_UK_F16F16F32_FMA_STEP
+
     _mm_prefetch((const char*)(lhs_ptr + 128), _MM_HINT_T0);
     lhs_ptr += 16;
   }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -85,6 +85,7 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
     __m512 rhs = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
+    // Unrolling needed to avoid 20% perf regression on Clang 15 on AMD Zen4.
 #define IREE_UK_F16F16F32_FMA_STEP(i)                                      \
   acc[i] = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[i])), \
                            rhs, acc[i]);

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -21,82 +21,31 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
   // kernels, even though they are very similar to this one.
   _mm_prefetch((const char*)lhs_ptr, _MM_HINT_T0);
   _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
-  __m512 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  __m512 acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
+  __m512 acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
-    acc1 = _mm512_loadu_ps(out_ptr + 1 * 16);
-    acc2 = _mm512_loadu_ps(out_ptr + 2 * 16);
-    acc3 = _mm512_loadu_ps(out_ptr + 3 * 16);
-    acc4 = _mm512_loadu_ps(out_ptr + 4 * 16);
-    acc5 = _mm512_loadu_ps(out_ptr + 5 * 16);
-    acc6 = _mm512_loadu_ps(out_ptr + 6 * 16);
-    acc7 = _mm512_loadu_ps(out_ptr + 7 * 16);
-    acc8 = _mm512_loadu_ps(out_ptr + 8 * 16);
-    acc9 = _mm512_loadu_ps(out_ptr + 9 * 16);
-    acc10 = _mm512_loadu_ps(out_ptr + 10 * 16);
-    acc11 = _mm512_loadu_ps(out_ptr + 11 * 16);
-    acc12 = _mm512_loadu_ps(out_ptr + 12 * 16);
-    acc13 = _mm512_loadu_ps(out_ptr + 13 * 16);
-    acc14 = _mm512_loadu_ps(out_ptr + 14 * 16);
-    acc15 = _mm512_loadu_ps(out_ptr + 15 * 16);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = _mm512_loadu_ps(out_ptr + i * 16);
+    }
   } else {
-    acc0 = _mm512_setzero_ps();
-    acc1 = _mm512_setzero_ps();
-    acc2 = _mm512_setzero_ps();
-    acc3 = _mm512_setzero_ps();
-    acc4 = _mm512_setzero_ps();
-    acc5 = _mm512_setzero_ps();
-    acc6 = _mm512_setzero_ps();
-    acc7 = _mm512_setzero_ps();
-    acc8 = _mm512_setzero_ps();
-    acc9 = _mm512_setzero_ps();
-    acc10 = _mm512_setzero_ps();
-    acc11 = _mm512_setzero_ps();
-    acc12 = _mm512_setzero_ps();
-    acc13 = _mm512_setzero_ps();
-    acc14 = _mm512_setzero_ps();
-    acc15 = _mm512_setzero_ps();
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = _mm512_setzero_ps();
+    }
   }
+
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_loadu_ps(rhs_ptr);
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
-    acc0 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[0]), rhs, acc0);
-    acc1 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[1]), rhs, acc1);
-    acc2 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[2]), rhs, acc2);
-    acc3 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[3]), rhs, acc3);
-    acc4 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[4]), rhs, acc4);
-    acc5 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[5]), rhs, acc5);
-    acc6 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[6]), rhs, acc6);
-    acc7 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[7]), rhs, acc7);
-    acc8 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[8]), rhs, acc8);
-    acc9 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[9]), rhs, acc9);
-    acc10 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[10]), rhs, acc10);
-    acc11 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[11]), rhs, acc11);
-    acc12 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[12]), rhs, acc12);
-    acc13 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[13]), rhs, acc13);
-    acc14 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[14]), rhs, acc14);
-    acc15 = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[15]), rhs, acc15);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[i]), rhs, acc[i]);
+    }
     _mm_prefetch((const char*)(lhs_ptr + 128), _MM_HINT_T0);
     lhs_ptr += 16;
   }
-  _mm512_storeu_ps(out_ptr + 0 * 16, acc0);
-  _mm512_storeu_ps(out_ptr + 1 * 16, acc1);
-  _mm512_storeu_ps(out_ptr + 2 * 16, acc2);
-  _mm512_storeu_ps(out_ptr + 3 * 16, acc3);
-  _mm512_storeu_ps(out_ptr + 4 * 16, acc4);
-  _mm512_storeu_ps(out_ptr + 5 * 16, acc5);
-  _mm512_storeu_ps(out_ptr + 6 * 16, acc6);
-  _mm512_storeu_ps(out_ptr + 7 * 16, acc7);
-  _mm512_storeu_ps(out_ptr + 8 * 16, acc8);
-  _mm512_storeu_ps(out_ptr + 9 * 16, acc9);
-  _mm512_storeu_ps(out_ptr + 10 * 16, acc10);
-  _mm512_storeu_ps(out_ptr + 11 * 16, acc11);
-  _mm512_storeu_ps(out_ptr + 12 * 16, acc12);
-  _mm512_storeu_ps(out_ptr + 13 * 16, acc13);
-  _mm512_storeu_ps(out_ptr + 14 * 16, acc14);
-  _mm512_storeu_ps(out_ptr + 15 * 16, acc15);
+
+  for (int i = 0; i < 16; ++i) {
+    _mm512_storeu_ps(out_ptr + i * 16, acc[i]);
+  }
 }
 
 // Shared implementation for f16f16f16 and f16f16f32.
@@ -112,171 +61,48 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
   // iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base.
   _mm_prefetch((const char*)lhs_ptr, _MM_HINT_T0);
   _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
-  __m512 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  __m512 acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
+  __m512 acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
-      acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
-      acc1 = _mm512_loadu_ps(out_ptr + 1 * 16);
-      acc2 = _mm512_loadu_ps(out_ptr + 2 * 16);
-      acc3 = _mm512_loadu_ps(out_ptr + 3 * 16);
-      acc4 = _mm512_loadu_ps(out_ptr + 4 * 16);
-      acc5 = _mm512_loadu_ps(out_ptr + 5 * 16);
-      acc6 = _mm512_loadu_ps(out_ptr + 6 * 16);
-      acc7 = _mm512_loadu_ps(out_ptr + 7 * 16);
-      acc8 = _mm512_loadu_ps(out_ptr + 8 * 16);
-      acc9 = _mm512_loadu_ps(out_ptr + 9 * 16);
-      acc10 = _mm512_loadu_ps(out_ptr + 10 * 16);
-      acc11 = _mm512_loadu_ps(out_ptr + 11 * 16);
-      acc12 = _mm512_loadu_ps(out_ptr + 12 * 16);
-      acc13 = _mm512_loadu_ps(out_ptr + 13 * 16);
-      acc14 = _mm512_loadu_ps(out_ptr + 14 * 16);
-      acc15 = _mm512_loadu_ps(out_ptr + 15 * 16);
+      for (int i = 0; i < 16; ++i) {
+        acc[i] = _mm512_loadu_ps(out_ptr + i * 16);
+      }
     } else {
       iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-      acc0 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 0 * 16)));
-      acc1 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 1 * 16)));
-      acc2 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 2 * 16)));
-      acc3 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 3 * 16)));
-      acc4 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 4 * 16)));
-      acc5 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 5 * 16)));
-      acc6 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 6 * 16)));
-      acc7 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 7 * 16)));
-      acc8 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 8 * 16)));
-      acc9 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 9 * 16)));
-      acc10 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 10 * 16)));
-      acc11 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 11 * 16)));
-      acc12 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 12 * 16)));
-      acc13 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 13 * 16)));
-      acc14 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 14 * 16)));
-      acc15 = _mm512_cvtph_ps(
-          _mm256_loadu_si256((const __m256i*)(out_ptr + 15 * 16)));
+      for (int i = 0; i < 16; ++i) {
+        acc[i] = _mm512_cvtph_ps(
+            _mm256_loadu_si256((const __m256i*)(out_ptr + i * 16)));
+      }
     }
   } else {
-    acc0 = _mm512_setzero_ps();
-    acc1 = _mm512_setzero_ps();
-    acc2 = _mm512_setzero_ps();
-    acc3 = _mm512_setzero_ps();
-    acc4 = _mm512_setzero_ps();
-    acc5 = _mm512_setzero_ps();
-    acc6 = _mm512_setzero_ps();
-    acc7 = _mm512_setzero_ps();
-    acc8 = _mm512_setzero_ps();
-    acc9 = _mm512_setzero_ps();
-    acc10 = _mm512_setzero_ps();
-    acc11 = _mm512_setzero_ps();
-    acc12 = _mm512_setzero_ps();
-    acc13 = _mm512_setzero_ps();
-    acc14 = _mm512_setzero_ps();
-    acc15 = _mm512_setzero_ps();
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = _mm512_setzero_ps();
+    }
   }
+
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
-    acc0 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[0])), rhs,
-                           acc0);
-    acc1 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[1])), rhs,
-                           acc1);
-    acc2 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[2])), rhs,
-                           acc2);
-    acc3 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[3])), rhs,
-                           acc3);
-    acc4 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[4])), rhs,
-                           acc4);
-    acc5 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[5])), rhs,
-                           acc5);
-    acc6 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[6])), rhs,
-                           acc6);
-    acc7 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[7])), rhs,
-                           acc7);
-    acc8 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[8])), rhs,
-                           acc8);
-    acc9 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[9])), rhs,
-                           acc9);
-    acc10 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[10])),
-                            rhs, acc10);
-    acc11 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[11])),
-                            rhs, acc11);
-    acc12 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[12])),
-                            rhs, acc12);
-    acc13 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[13])),
-                            rhs, acc13);
-    acc14 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[14])),
-                            rhs, acc14);
-    acc15 = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[15])),
-                            rhs, acc15);
+    for (int i = 0; i < 16; ++i) {
+      acc[i] = _mm512_fmadd_ps(_mm512_cvtph_ps(_mm256_set1_epi16(lhs_ptr[i])),
+                               rhs, acc[i]);
+    }
     _mm_prefetch((const char*)(lhs_ptr + 128), _MM_HINT_T0);
     lhs_ptr += 16;
   }
   if (acc_type == IREE_UK_TYPE_FLOAT_32) {
     float* IREE_UK_RESTRICT out_ptr = out_tile;
-    _mm512_storeu_ps(out_ptr + 0 * 16, acc0);
-    _mm512_storeu_ps(out_ptr + 1 * 16, acc1);
-    _mm512_storeu_ps(out_ptr + 2 * 16, acc2);
-    _mm512_storeu_ps(out_ptr + 3 * 16, acc3);
-    _mm512_storeu_ps(out_ptr + 4 * 16, acc4);
-    _mm512_storeu_ps(out_ptr + 5 * 16, acc5);
-    _mm512_storeu_ps(out_ptr + 6 * 16, acc6);
-    _mm512_storeu_ps(out_ptr + 7 * 16, acc7);
-    _mm512_storeu_ps(out_ptr + 8 * 16, acc8);
-    _mm512_storeu_ps(out_ptr + 9 * 16, acc9);
-    _mm512_storeu_ps(out_ptr + 10 * 16, acc10);
-    _mm512_storeu_ps(out_ptr + 11 * 16, acc11);
-    _mm512_storeu_ps(out_ptr + 12 * 16, acc12);
-    _mm512_storeu_ps(out_ptr + 13 * 16, acc13);
-    _mm512_storeu_ps(out_ptr + 14 * 16, acc14);
-    _mm512_storeu_ps(out_ptr + 15 * 16, acc15);
+    for (int i = 0; i < 16; ++i) {
+      _mm512_storeu_ps(out_ptr + i * 16, acc[i]);
+    }
   } else {
     iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-    _mm256_storeu_si256((__m256i*)(out_ptr + 0 * 16),
-                        _mm512_cvtps_ph(acc0, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 1 * 16),
-                        _mm512_cvtps_ph(acc1, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 2 * 16),
-                        _mm512_cvtps_ph(acc2, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 3 * 16),
-                        _mm512_cvtps_ph(acc3, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 4 * 16),
-                        _mm512_cvtps_ph(acc4, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 5 * 16),
-                        _mm512_cvtps_ph(acc5, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 6 * 16),
-                        _mm512_cvtps_ph(acc6, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 7 * 16),
-                        _mm512_cvtps_ph(acc7, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 8 * 16),
-                        _mm512_cvtps_ph(acc8, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 9 * 16),
-                        _mm512_cvtps_ph(acc9, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 10 * 16),
-                        _mm512_cvtps_ph(acc10, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 11 * 16),
-                        _mm512_cvtps_ph(acc11, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 12 * 16),
-                        _mm512_cvtps_ph(acc12, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 13 * 16),
-                        _mm512_cvtps_ph(acc13, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 14 * 16),
-                        _mm512_cvtps_ph(acc14, _MM_FROUND_TO_NEAREST_INT));
-    _mm256_storeu_si256((__m256i*)(out_ptr + 15 * 16),
-                        _mm512_cvtps_ph(acc15, _MM_FROUND_TO_NEAREST_INT));
+    for (int i = 0; i < 16; ++i) {
+      _mm256_storeu_si256((__m256i*)(out_ptr + i * 16),
+                          _mm512_cvtps_ph(acc[i], _MM_FROUND_TO_NEAREST_INT));
+    }
   }
 }
 
@@ -303,74 +129,26 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-
-  __m512i acc_0_0123_4_4567_8_89AB_C_CDEF;
-  __m512i acc_0_4567_4_0123_8_CDEF_C_89AB;
-  __m512i acc_0_89AB_4_CDEF_8_0123_C_4567;
-  __m512i acc_0_CDEF_4_89AB_8_4567_C_0123;
-  __m512i acc_1_0123_5_4567_9_89AB_D_CDEF;
-  __m512i acc_1_4567_5_0123_9_CDEF_D_89AB;
-  __m512i acc_1_89AB_5_CDEF_9_0123_D_4567;
-  __m512i acc_1_CDEF_5_89AB_9_4567_D_0123;
-  __m512i acc_2_0123_6_4567_A_89AB_E_CDEF;
-  __m512i acc_2_4567_6_0123_A_CDEF_E_89AB;
-  __m512i acc_2_89AB_6_CDEF_A_0123_E_4567;
-  __m512i acc_2_CDEF_6_89AB_A_4567_E_0123;
-  __m512i acc_3_0123_7_4567_B_89AB_F_CDEF;
-  __m512i acc_3_4567_7_0123_B_CDEF_F_89AB;
-  __m512i acc_3_89AB_7_CDEF_B_0123_F_4567;
-  __m512i acc_3_CDEF_7_89AB_B_4567_F_0123;
-
+  // acc[i][0] contains the 1st 128bits of row i, the 2nd 128bits of row (i+4),
+  //           the 3rd 128bits of row (i+8), the 4th 128bits of row (i+C).
+  // The other acc[i][j] are permutations of these 128bits groups.
+  // This unusual layout is chosen so that the inner arithmetic loop only needs
+  // to perform cheap shuffles within 128bit groups of lanes.
+  __m512i acc[4][4];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc_0_0123_4_4567_8_89AB_C_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 0, 0, 4, 4, 8, 8, 12, 12);
-    acc_0_4567_4_0123_8_CDEF_C_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 0, 4, 4, 0, 8, 12, 12, 8);
-    acc_0_89AB_4_CDEF_8_0123_C_4567 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 0, 8, 4, 12, 8, 0, 12, 4);
-    acc_0_CDEF_4_89AB_8_4567_C_0123 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 0, 12, 4, 8, 8, 4, 12, 0);
-    acc_1_0123_5_4567_9_89AB_D_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 1, 0, 5, 4, 9, 8, 13, 12);
-    acc_1_4567_5_0123_9_CDEF_D_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 1, 4, 5, 0, 9, 12, 13, 8);
-    acc_1_89AB_5_CDEF_9_0123_D_4567 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 1, 8, 5, 12, 9, 0, 13, 4);
-    acc_1_CDEF_5_89AB_9_4567_D_0123 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 1, 12, 5, 8, 9, 4, 13, 0);
-    acc_2_0123_6_4567_A_89AB_E_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 2, 0, 6, 4, 10, 8, 14, 12);
-    acc_2_4567_6_0123_A_CDEF_E_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 2, 4, 6, 0, 10, 12, 14, 8);
-    acc_2_89AB_6_CDEF_A_0123_E_4567 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 2, 8, 6, 12, 10, 0, 14, 4);
-    acc_2_CDEF_6_89AB_A_4567_E_0123 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 2, 12, 6, 8, 10, 4, 14, 0);
-    acc_3_0123_7_4567_B_89AB_F_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 3, 0, 7, 4, 11, 8, 15, 12);
-    acc_3_4567_7_0123_B_CDEF_F_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 3, 4, 7, 0, 11, 12, 15, 8);
-    acc_3_89AB_7_CDEF_B_0123_F_4567 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 3, 8, 7, 12, 11, 0, 15, 4);
-    acc_3_CDEF_7_89AB_B_4567_F_0123 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 3, 12, 7, 8, 11, 4, 15, 0);
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = iree_uk_avx512_loadu_4x128_from_16x16xi32(
+            out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
+            4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4));
+      }
+    }
   } else {
-    acc_0_0123_4_4567_8_89AB_C_CDEF = _mm512_setzero_si512();
-    acc_0_4567_4_0123_8_CDEF_C_89AB = _mm512_setzero_si512();
-    acc_0_89AB_4_CDEF_8_0123_C_4567 = _mm512_setzero_si512();
-    acc_0_CDEF_4_89AB_8_4567_C_0123 = _mm512_setzero_si512();
-    acc_1_0123_5_4567_9_89AB_D_CDEF = _mm512_setzero_si512();
-    acc_1_4567_5_0123_9_CDEF_D_89AB = _mm512_setzero_si512();
-    acc_1_89AB_5_CDEF_9_0123_D_4567 = _mm512_setzero_si512();
-    acc_1_CDEF_5_89AB_9_4567_D_0123 = _mm512_setzero_si512();
-    acc_2_0123_6_4567_A_89AB_E_CDEF = _mm512_setzero_si512();
-    acc_2_4567_6_0123_A_CDEF_E_89AB = _mm512_setzero_si512();
-    acc_2_89AB_6_CDEF_A_0123_E_4567 = _mm512_setzero_si512();
-    acc_2_CDEF_6_89AB_A_4567_E_0123 = _mm512_setzero_si512();
-    acc_3_0123_7_4567_B_89AB_F_CDEF = _mm512_setzero_si512();
-    acc_3_4567_7_0123_B_CDEF_F_89AB = _mm512_setzero_si512();
-    acc_3_89AB_7_CDEF_B_0123_F_4567 = _mm512_setzero_si512();
-    acc_3_CDEF_7_89AB_B_4567_F_0123 = _mm512_setzero_si512();
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = _mm512_setzero_si512();
+      }
+    }
   }
 
   __m512i idx_45670123CDEF89AB =
@@ -381,108 +159,43 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
-    __m512i rhs_i16_0123456789ABCDEF =
+    __m512i rhs_i16_perm[4];
+    // rhs_i16_perm[0] is the rhs row, sign-extended to i16.
+    rhs_i16_perm[0] =
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     rhs_ptr += 32;
-    __m512i lhs_i16_0123456789ABCDEF =
+    // The other 3 rhs_i16_perm[i] are permutations of 128-bit groups of that.
+    rhs_i16_perm[1] =
+        _mm512_permutexvar_epi32(idx_45670123CDEF89AB, rhs_i16_perm[0]);
+    rhs_i16_perm[2] =
+        _mm512_permutexvar_epi32(idx_89ABCDEF01234567, rhs_i16_perm[0]);
+    rhs_i16_perm[3] =
+        _mm512_permutexvar_epi32(idx_CDEF89AB45670123, rhs_i16_perm[0]);
+    // lhs_i16 is the lhs column, sign-extended to i16.
+    __m512i lhs_i16 =
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)lhs_ptr));
     lhs_ptr += 32;
-    __m512i rhs_i16_45670123CDEF89AB = _mm512_permutexvar_epi32(
-        idx_45670123CDEF89AB, rhs_i16_0123456789ABCDEF);
-    __m512i rhs_i16_89ABCDEF01234567 = _mm512_permutexvar_epi32(
-        idx_89ABCDEF01234567, rhs_i16_0123456789ABCDEF);
-    __m512i rhs_i16_CDEF89AB45670123 = _mm512_permutexvar_epi32(
-        idx_CDEF89AB45670123, rhs_i16_0123456789ABCDEF);
-    __m512i lhs_i16_000044448888CCCC =
-        _mm512_shuffle_epi32(lhs_i16_0123456789ABCDEF, 0 * 0x55);
-    __m512i lhs_i16_111155559999DDDD =
-        _mm512_shuffle_epi32(lhs_i16_0123456789ABCDEF, 1 * 0x55);
-    __m512i lhs_i16_22226666AAAAEEEE =
-        _mm512_shuffle_epi32(lhs_i16_0123456789ABCDEF, 2 * 0x55);
-    __m512i lhs_i16_33337777BBBBFFFF =
-        _mm512_shuffle_epi32(lhs_i16_0123456789ABCDEF, 3 * 0x55);
-    acc_0_0123_4_4567_8_89AB_C_CDEF = _mm512_add_epi32(
-        acc_0_0123_4_4567_8_89AB_C_CDEF,
-        _mm512_madd_epi16(lhs_i16_000044448888CCCC, rhs_i16_0123456789ABCDEF));
-    acc_0_4567_4_0123_8_CDEF_C_89AB = _mm512_add_epi32(
-        acc_0_4567_4_0123_8_CDEF_C_89AB,
-        _mm512_madd_epi16(lhs_i16_000044448888CCCC, rhs_i16_45670123CDEF89AB));
-    acc_0_89AB_4_CDEF_8_0123_C_4567 = _mm512_add_epi32(
-        acc_0_89AB_4_CDEF_8_0123_C_4567,
-        _mm512_madd_epi16(lhs_i16_000044448888CCCC, rhs_i16_89ABCDEF01234567));
-    acc_0_CDEF_4_89AB_8_4567_C_0123 = _mm512_add_epi32(
-        acc_0_CDEF_4_89AB_8_4567_C_0123,
-        _mm512_madd_epi16(lhs_i16_000044448888CCCC, rhs_i16_CDEF89AB45670123));
+    // lhs_i16_dup4[i] is lanes of lhs_i16 shuffled as:
+    // (i, i, i, i, i+4, i+4, i+4, i+4, i+8, i+8, i+8, i+C, i+C, i+C, i+C).
+    __m512i lhs_i16_dup4[4];
+    lhs_i16_dup4[0] = _mm512_shuffle_epi32(lhs_i16, 0 * 0x55);
+    lhs_i16_dup4[1] = _mm512_shuffle_epi32(lhs_i16, 1 * 0x55);
+    lhs_i16_dup4[2] = _mm512_shuffle_epi32(lhs_i16, 2 * 0x55);
+    lhs_i16_dup4[3] = _mm512_shuffle_epi32(lhs_i16, 3 * 0x55);
 
-    acc_1_0123_5_4567_9_89AB_D_CDEF = _mm512_add_epi32(
-        acc_1_0123_5_4567_9_89AB_D_CDEF,
-        _mm512_madd_epi16(lhs_i16_111155559999DDDD, rhs_i16_0123456789ABCDEF));
-    acc_1_4567_5_0123_9_CDEF_D_89AB = _mm512_add_epi32(
-        acc_1_4567_5_0123_9_CDEF_D_89AB,
-        _mm512_madd_epi16(lhs_i16_111155559999DDDD, rhs_i16_45670123CDEF89AB));
-    acc_1_89AB_5_CDEF_9_0123_D_4567 = _mm512_add_epi32(
-        acc_1_89AB_5_CDEF_9_0123_D_4567,
-        _mm512_madd_epi16(lhs_i16_111155559999DDDD, rhs_i16_89ABCDEF01234567));
-    acc_1_CDEF_5_89AB_9_4567_D_0123 = _mm512_add_epi32(
-        acc_1_CDEF_5_89AB_9_4567_D_0123,
-        _mm512_madd_epi16(lhs_i16_111155559999DDDD, rhs_i16_CDEF89AB45670123));
-
-    acc_2_0123_6_4567_A_89AB_E_CDEF = _mm512_add_epi32(
-        acc_2_0123_6_4567_A_89AB_E_CDEF,
-        _mm512_madd_epi16(lhs_i16_22226666AAAAEEEE, rhs_i16_0123456789ABCDEF));
-    acc_2_4567_6_0123_A_CDEF_E_89AB = _mm512_add_epi32(
-        acc_2_4567_6_0123_A_CDEF_E_89AB,
-        _mm512_madd_epi16(lhs_i16_22226666AAAAEEEE, rhs_i16_45670123CDEF89AB));
-    acc_2_89AB_6_CDEF_A_0123_E_4567 = _mm512_add_epi32(
-        acc_2_89AB_6_CDEF_A_0123_E_4567,
-        _mm512_madd_epi16(lhs_i16_22226666AAAAEEEE, rhs_i16_89ABCDEF01234567));
-    acc_2_CDEF_6_89AB_A_4567_E_0123 = _mm512_add_epi32(
-        acc_2_CDEF_6_89AB_A_4567_E_0123,
-        _mm512_madd_epi16(lhs_i16_22226666AAAAEEEE, rhs_i16_CDEF89AB45670123));
-
-    acc_3_0123_7_4567_B_89AB_F_CDEF = _mm512_add_epi32(
-        acc_3_0123_7_4567_B_89AB_F_CDEF,
-        _mm512_madd_epi16(lhs_i16_33337777BBBBFFFF, rhs_i16_0123456789ABCDEF));
-    acc_3_4567_7_0123_B_CDEF_F_89AB = _mm512_add_epi32(
-        acc_3_4567_7_0123_B_CDEF_F_89AB,
-        _mm512_madd_epi16(lhs_i16_33337777BBBBFFFF, rhs_i16_45670123CDEF89AB));
-    acc_3_89AB_7_CDEF_B_0123_F_4567 = _mm512_add_epi32(
-        acc_3_89AB_7_CDEF_B_0123_F_4567,
-        _mm512_madd_epi16(lhs_i16_33337777BBBBFFFF, rhs_i16_89ABCDEF01234567));
-    acc_3_CDEF_7_89AB_B_4567_F_0123 = _mm512_add_epi32(
-        acc_3_CDEF_7_89AB_B_4567_F_0123,
-        _mm512_madd_epi16(lhs_i16_33337777BBBBFFFF, rhs_i16_CDEF89AB45670123));
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = _mm512_add_epi32(
+            acc[i][j], _mm512_madd_epi16(lhs_i16_dup4[i], rhs_i16_perm[j]));
+      }
+    }
   }
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 0, 0, 4, 4, 8, 8, 12, 12,
-                                           acc_0_0123_4_4567_8_89AB_C_CDEF);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 0, 4, 4, 0, 8, 12, 12, 8,
-                                           acc_0_4567_4_0123_8_CDEF_C_89AB);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 0, 8, 4, 12, 8, 0, 12, 4,
-                                           acc_0_89AB_4_CDEF_8_0123_C_4567);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 0, 12, 4, 8, 8, 4, 12, 0,
-                                           acc_0_CDEF_4_89AB_8_4567_C_0123);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 1, 0, 5, 4, 9, 8, 13, 12,
-                                           acc_1_0123_5_4567_9_89AB_D_CDEF);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 1, 4, 5, 0, 9, 12, 13, 8,
-                                           acc_1_4567_5_0123_9_CDEF_D_89AB);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 1, 8, 5, 12, 9, 0, 13, 4,
-                                           acc_1_89AB_5_CDEF_9_0123_D_4567);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 1, 12, 5, 8, 9, 4, 13, 0,
-                                           acc_1_CDEF_5_89AB_9_4567_D_0123);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 2, 0, 6, 4, 10, 8, 14, 12,
-                                           acc_2_0123_6_4567_A_89AB_E_CDEF);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 2, 4, 6, 0, 10, 12, 14, 8,
-                                           acc_2_4567_6_0123_A_CDEF_E_89AB);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 2, 8, 6, 12, 10, 0, 14, 4,
-                                           acc_2_89AB_6_CDEF_A_0123_E_4567);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 2, 12, 6, 8, 10, 4, 14, 0,
-                                           acc_2_CDEF_6_89AB_A_4567_E_0123);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 3, 0, 7, 4, 11, 8, 15, 12,
-                                           acc_3_0123_7_4567_B_89AB_F_CDEF);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 3, 4, 7, 0, 11, 12, 15, 8,
-                                           acc_3_4567_7_0123_B_CDEF_F_89AB);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 3, 8, 7, 12, 11, 0, 15, 4,
-                                           acc_3_89AB_7_CDEF_B_0123_F_4567);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 3, 12, 7, 8, 11, 4, 15, 0,
-                                           acc_3_CDEF_7_89AB_B_4567_F_0123);
+
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      iree_uk_avx512_storeu_4x128_to_16x16xi32(
+          out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8, 4 * ((j + 2) % 4),
+          i + 12, 4 * ((7 - j) % 4), acc[i][j]);
+    }
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
@@ -14,74 +14,26 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-
-  __m512i acc_0_0123_4_4567_8_89AB_C_CDEF;
-  __m512i acc_0_4567_4_0123_8_CDEF_C_89AB;
-  __m512i acc_0_89AB_4_CDEF_8_0123_C_4567;
-  __m512i acc_0_CDEF_4_89AB_8_4567_C_0123;
-  __m512i acc_1_0123_5_4567_9_89AB_D_CDEF;
-  __m512i acc_1_4567_5_0123_9_CDEF_D_89AB;
-  __m512i acc_1_89AB_5_CDEF_9_0123_D_4567;
-  __m512i acc_1_CDEF_5_89AB_9_4567_D_0123;
-  __m512i acc_2_0123_6_4567_A_89AB_E_CDEF;
-  __m512i acc_2_4567_6_0123_A_CDEF_E_89AB;
-  __m512i acc_2_89AB_6_CDEF_A_0123_E_4567;
-  __m512i acc_2_CDEF_6_89AB_A_4567_E_0123;
-  __m512i acc_3_0123_7_4567_B_89AB_F_CDEF;
-  __m512i acc_3_4567_7_0123_B_CDEF_F_89AB;
-  __m512i acc_3_89AB_7_CDEF_B_0123_F_4567;
-  __m512i acc_3_CDEF_7_89AB_B_4567_F_0123;
-
+  // acc[i][0] contains the 1st 128bits of row i, the 2nd 128bits of row (i+4),
+  //           the 3rd 128bits of row (i+8), the 4th 128bits of row (i+C).
+  // The other acc[i][j] are permutations of these 128bits groups.
+  // This unusual layout is chosen so that the inner arithmetic loop only needs
+  // to perform cheap shuffles within 128bit groups of lanes.
+  __m512i acc[4][4];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    acc_0_0123_4_4567_8_89AB_C_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 0, 0, 4, 4, 8, 8, 12, 12);
-    acc_0_4567_4_0123_8_CDEF_C_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 0, 4, 4, 0, 8, 12, 12, 8);
-    acc_0_89AB_4_CDEF_8_0123_C_4567 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 0, 8, 4, 12, 8, 0, 12, 4);
-    acc_0_CDEF_4_89AB_8_4567_C_0123 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 0, 12, 4, 8, 8, 4, 12, 0);
-    acc_1_0123_5_4567_9_89AB_D_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 1, 0, 5, 4, 9, 8, 13, 12);
-    acc_1_4567_5_0123_9_CDEF_D_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 1, 4, 5, 0, 9, 12, 13, 8);
-    acc_1_89AB_5_CDEF_9_0123_D_4567 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 1, 8, 5, 12, 9, 0, 13, 4);
-    acc_1_CDEF_5_89AB_9_4567_D_0123 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 1, 12, 5, 8, 9, 4, 13, 0);
-    acc_2_0123_6_4567_A_89AB_E_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 2, 0, 6, 4, 10, 8, 14, 12);
-    acc_2_4567_6_0123_A_CDEF_E_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 2, 4, 6, 0, 10, 12, 14, 8);
-    acc_2_89AB_6_CDEF_A_0123_E_4567 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 2, 8, 6, 12, 10, 0, 14, 4);
-    acc_2_CDEF_6_89AB_A_4567_E_0123 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 2, 12, 6, 8, 10, 4, 14, 0);
-    acc_3_0123_7_4567_B_89AB_F_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 3, 0, 7, 4, 11, 8, 15, 12);
-    acc_3_4567_7_0123_B_CDEF_F_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 3, 4, 7, 0, 11, 12, 15, 8);
-    acc_3_89AB_7_CDEF_B_0123_F_4567 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 3, 8, 7, 12, 11, 0, 15, 4);
-    acc_3_CDEF_7_89AB_B_4567_F_0123 = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-        out_ptr, 3, 12, 7, 8, 11, 4, 15, 0);
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = iree_uk_avx512_loadu_4x128_from_16x16xi32(
+            out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
+            4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4));
+      }
+    }
   } else {
-    acc_0_0123_4_4567_8_89AB_C_CDEF = _mm512_setzero_si512();
-    acc_0_4567_4_0123_8_CDEF_C_89AB = _mm512_setzero_si512();
-    acc_0_89AB_4_CDEF_8_0123_C_4567 = _mm512_setzero_si512();
-    acc_0_CDEF_4_89AB_8_4567_C_0123 = _mm512_setzero_si512();
-    acc_1_0123_5_4567_9_89AB_D_CDEF = _mm512_setzero_si512();
-    acc_1_4567_5_0123_9_CDEF_D_89AB = _mm512_setzero_si512();
-    acc_1_89AB_5_CDEF_9_0123_D_4567 = _mm512_setzero_si512();
-    acc_1_CDEF_5_89AB_9_4567_D_0123 = _mm512_setzero_si512();
-    acc_2_0123_6_4567_A_89AB_E_CDEF = _mm512_setzero_si512();
-    acc_2_4567_6_0123_A_CDEF_E_89AB = _mm512_setzero_si512();
-    acc_2_89AB_6_CDEF_A_0123_E_4567 = _mm512_setzero_si512();
-    acc_2_CDEF_6_89AB_A_4567_E_0123 = _mm512_setzero_si512();
-    acc_3_0123_7_4567_B_89AB_F_CDEF = _mm512_setzero_si512();
-    acc_3_4567_7_0123_B_CDEF_F_89AB = _mm512_setzero_si512();
-    acc_3_89AB_7_CDEF_B_0123_F_4567 = _mm512_setzero_si512();
-    acc_3_CDEF_7_89AB_B_4567_F_0123 = _mm512_setzero_si512();
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] = _mm512_setzero_si512();
+      }
+    }
   }
 
   __m512i idx_45670123CDEF89AB =
@@ -92,108 +44,43 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
-    __m512i rhs_i16_0123456789ABCDEF =
+    __m512i rhs_i16_perm[4];
+    // rhs_i16_perm[0] is the rhs row, sign-extended to i16.
+    rhs_i16_perm[0] =
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     rhs_ptr += 32;
-    __m512i lhs_i16_0123456789ABCDEF =
+    // The other 3 rhs_i16_perm[i] are permutations of 128-bit groups of that.
+    rhs_i16_perm[1] =
+        _mm512_permutexvar_epi32(idx_45670123CDEF89AB, rhs_i16_perm[0]);
+    rhs_i16_perm[2] =
+        _mm512_permutexvar_epi32(idx_89ABCDEF01234567, rhs_i16_perm[0]);
+    rhs_i16_perm[3] =
+        _mm512_permutexvar_epi32(idx_CDEF89AB45670123, rhs_i16_perm[0]);
+    // lhs_i16 is the lhs column, sign-extended to i16.
+    __m512i lhs_i16 =
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)lhs_ptr));
     lhs_ptr += 32;
-    __m512i rhs_i16_45670123CDEF89AB = _mm512_permutexvar_epi32(
-        idx_45670123CDEF89AB, rhs_i16_0123456789ABCDEF);
-    __m512i rhs_i16_89ABCDEF01234567 = _mm512_permutexvar_epi32(
-        idx_89ABCDEF01234567, rhs_i16_0123456789ABCDEF);
-    __m512i rhs_i16_CDEF89AB45670123 = _mm512_permutexvar_epi32(
-        idx_CDEF89AB45670123, rhs_i16_0123456789ABCDEF);
-    __m512i lhs_i16_000044448888CCCC =
-        _mm512_shuffle_epi32(lhs_i16_0123456789ABCDEF, 0 * 0x55);
-    __m512i lhs_i16_111155559999DDDD =
-        _mm512_shuffle_epi32(lhs_i16_0123456789ABCDEF, 1 * 0x55);
-    __m512i lhs_i16_22226666AAAAEEEE =
-        _mm512_shuffle_epi32(lhs_i16_0123456789ABCDEF, 2 * 0x55);
-    __m512i lhs_i16_33337777BBBBFFFF =
-        _mm512_shuffle_epi32(lhs_i16_0123456789ABCDEF, 3 * 0x55);
-    acc_0_0123_4_4567_8_89AB_C_CDEF =
-        _mm512_dpwssd_epi32(acc_0_0123_4_4567_8_89AB_C_CDEF,
-                            lhs_i16_000044448888CCCC, rhs_i16_0123456789ABCDEF);
-    acc_0_4567_4_0123_8_CDEF_C_89AB =
-        _mm512_dpwssd_epi32(acc_0_4567_4_0123_8_CDEF_C_89AB,
-                            lhs_i16_000044448888CCCC, rhs_i16_45670123CDEF89AB);
-    acc_0_89AB_4_CDEF_8_0123_C_4567 =
-        _mm512_dpwssd_epi32(acc_0_89AB_4_CDEF_8_0123_C_4567,
-                            lhs_i16_000044448888CCCC, rhs_i16_89ABCDEF01234567);
-    acc_0_CDEF_4_89AB_8_4567_C_0123 =
-        _mm512_dpwssd_epi32(acc_0_CDEF_4_89AB_8_4567_C_0123,
-                            lhs_i16_000044448888CCCC, rhs_i16_CDEF89AB45670123);
+    // lhs_i16_dup4[i] is lanes of lhs_i16 shuffled as:
+    // (i, i, i, i, i+4, i+4, i+4, i+4, i+8, i+8, i+8, i+C, i+C, i+C, i+C).
+    __m512i lhs_i16_dup4[4];
+    lhs_i16_dup4[0] = _mm512_shuffle_epi32(lhs_i16, 0 * 0x55);
+    lhs_i16_dup4[1] = _mm512_shuffle_epi32(lhs_i16, 1 * 0x55);
+    lhs_i16_dup4[2] = _mm512_shuffle_epi32(lhs_i16, 2 * 0x55);
+    lhs_i16_dup4[3] = _mm512_shuffle_epi32(lhs_i16, 3 * 0x55);
 
-    acc_1_0123_5_4567_9_89AB_D_CDEF =
-        _mm512_dpwssd_epi32(acc_1_0123_5_4567_9_89AB_D_CDEF,
-                            lhs_i16_111155559999DDDD, rhs_i16_0123456789ABCDEF);
-    acc_1_4567_5_0123_9_CDEF_D_89AB =
-        _mm512_dpwssd_epi32(acc_1_4567_5_0123_9_CDEF_D_89AB,
-                            lhs_i16_111155559999DDDD, rhs_i16_45670123CDEF89AB);
-    acc_1_89AB_5_CDEF_9_0123_D_4567 =
-        _mm512_dpwssd_epi32(acc_1_89AB_5_CDEF_9_0123_D_4567,
-                            lhs_i16_111155559999DDDD, rhs_i16_89ABCDEF01234567);
-    acc_1_CDEF_5_89AB_9_4567_D_0123 =
-        _mm512_dpwssd_epi32(acc_1_CDEF_5_89AB_9_4567_D_0123,
-                            lhs_i16_111155559999DDDD, rhs_i16_CDEF89AB45670123);
-
-    acc_2_0123_6_4567_A_89AB_E_CDEF =
-        _mm512_dpwssd_epi32(acc_2_0123_6_4567_A_89AB_E_CDEF,
-                            lhs_i16_22226666AAAAEEEE, rhs_i16_0123456789ABCDEF);
-    acc_2_4567_6_0123_A_CDEF_E_89AB =
-        _mm512_dpwssd_epi32(acc_2_4567_6_0123_A_CDEF_E_89AB,
-                            lhs_i16_22226666AAAAEEEE, rhs_i16_45670123CDEF89AB);
-    acc_2_89AB_6_CDEF_A_0123_E_4567 =
-        _mm512_dpwssd_epi32(acc_2_89AB_6_CDEF_A_0123_E_4567,
-                            lhs_i16_22226666AAAAEEEE, rhs_i16_89ABCDEF01234567);
-    acc_2_CDEF_6_89AB_A_4567_E_0123 =
-        _mm512_dpwssd_epi32(acc_2_CDEF_6_89AB_A_4567_E_0123,
-                            lhs_i16_22226666AAAAEEEE, rhs_i16_CDEF89AB45670123);
-
-    acc_3_0123_7_4567_B_89AB_F_CDEF =
-        _mm512_dpwssd_epi32(acc_3_0123_7_4567_B_89AB_F_CDEF,
-                            lhs_i16_33337777BBBBFFFF, rhs_i16_0123456789ABCDEF);
-    acc_3_4567_7_0123_B_CDEF_F_89AB =
-        _mm512_dpwssd_epi32(acc_3_4567_7_0123_B_CDEF_F_89AB,
-                            lhs_i16_33337777BBBBFFFF, rhs_i16_45670123CDEF89AB);
-    acc_3_89AB_7_CDEF_B_0123_F_4567 =
-        _mm512_dpwssd_epi32(acc_3_89AB_7_CDEF_B_0123_F_4567,
-                            lhs_i16_33337777BBBBFFFF, rhs_i16_89ABCDEF01234567);
-    acc_3_CDEF_7_89AB_B_4567_F_0123 =
-        _mm512_dpwssd_epi32(acc_3_CDEF_7_89AB_B_4567_F_0123,
-                            lhs_i16_33337777BBBBFFFF, rhs_i16_CDEF89AB45670123);
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        acc[i][j] =
+            _mm512_dpwssd_epi32(acc[i][j], lhs_i16_dup4[i], rhs_i16_perm[j]);
+      }
+    }
   }
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 0, 0, 4, 4, 8, 8, 12, 12,
-                                           acc_0_0123_4_4567_8_89AB_C_CDEF);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 0, 4, 4, 0, 8, 12, 12, 8,
-                                           acc_0_4567_4_0123_8_CDEF_C_89AB);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 0, 8, 4, 12, 8, 0, 12, 4,
-                                           acc_0_89AB_4_CDEF_8_0123_C_4567);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 0, 12, 4, 8, 8, 4, 12, 0,
-                                           acc_0_CDEF_4_89AB_8_4567_C_0123);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 1, 0, 5, 4, 9, 8, 13, 12,
-                                           acc_1_0123_5_4567_9_89AB_D_CDEF);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 1, 4, 5, 0, 9, 12, 13, 8,
-                                           acc_1_4567_5_0123_9_CDEF_D_89AB);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 1, 8, 5, 12, 9, 0, 13, 4,
-                                           acc_1_89AB_5_CDEF_9_0123_D_4567);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 1, 12, 5, 8, 9, 4, 13, 0,
-                                           acc_1_CDEF_5_89AB_9_4567_D_0123);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 2, 0, 6, 4, 10, 8, 14, 12,
-                                           acc_2_0123_6_4567_A_89AB_E_CDEF);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 2, 4, 6, 0, 10, 12, 14, 8,
-                                           acc_2_4567_6_0123_A_CDEF_E_89AB);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 2, 8, 6, 12, 10, 0, 14, 4,
-                                           acc_2_89AB_6_CDEF_A_0123_E_4567);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 2, 12, 6, 8, 10, 4, 14, 0,
-                                           acc_2_CDEF_6_89AB_A_4567_E_0123);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 3, 0, 7, 4, 11, 8, 15, 12,
-                                           acc_3_0123_7_4567_B_89AB_F_CDEF);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 3, 4, 7, 0, 11, 12, 15, 8,
-                                           acc_3_4567_7_0123_B_CDEF_F_89AB);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 3, 8, 7, 12, 11, 0, 15, 4,
-                                           acc_3_89AB_7_CDEF_B_0123_F_4567);
-  iree_uk_avx512_storeu_4x128_to_16x16xi32(out_ptr, 3, 12, 7, 8, 11, 4, 15, 0,
-                                           acc_3_CDEF_7_89AB_B_4567_F_0123);
+
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      iree_uk_avx512_storeu_4x128_to_16x16xi32(
+          out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8, 4 * ((j + 2) % 4),
+          i + 12, 4 * ((7 - j) % 4), acc[i][j]);
+    }
+  }
 }


### PR DESCRIPTION
Fully unrolling C+intrinsics code is a common defensive practice vs. the tendency of compilers to miss good codegen of SIMD code. It's not just about the loops, it's about using arrays of vector-variables, which is necessary to be able to write loop. A sufficiently naive compiler will literally take that to mean that the vectors are memory objects. Several years ago I had filed https://bugs.llvm.org/show_bug.cgi?id=34945 and never heard back about it. To this day, XNNPACK sticks to this practice, e.g. https://github.com/google/XNNPACK/blob/master/src/f32-gemm/gen/f32-gemm-8x8s4-minmax-neon.c#L238-L269 .

This prompts the question of how to manage the resulting verbose code, how to scale to supporting many variants of ukernels. The immediate motivation for us here is as we are about to introduce narrow variants of matmul kernels. XNNPACK deals with that with a Python-based generator of unrolled C code. In our case, as our primary deployment path for ukernels is to compile them to LLVM bitcode that IREE can then inline at each call site and "LTO", where it should be able to perform loop unrolling and dead code optimization, it would be neat to simply take advantage of that, instead of inventing a new way to unroll loops and skip over dead code, or carry verbose source code.

The danger is regressing performance in the native-toolchain, non-bitcode builds of ukernels. That's only used in VMVX, and in ukernel's own micro benchmarks (and unit tests).  Performance of that isn't really critical. We want to make sure that we build correctly there, but it's OK to have suboptimal performance. To be clear, to preserve performance in the native build, we will still instantiate functions with the loop size known at compile time (calling into the shared loop impl, inlined into each case). The only question is whether the native toolchain will handle that inlining as well as Clang does. Concretely, I tried one case, and found that GCC generates ~ 2x slower code, while Clang and MSVC did fine. https://godbolt.org/z/WsbW487ze

Just look at the code shrink here. And this is only a first step.  As a next PR will introduce variants for narrow M0 dimensions, they will be able to all share the same loop implementation, both in source code and in embedded bitcode in the bitcode build.