### PR TITLE
Add precompilation compile mode to iree-compile

### DIFF
--- a/compiler/bindings/c/iree/compiler/embedding_api.h
+++ b/compiler/bindings/c/iree/compiler/embedding_api.h
@@ -246,8 +246,16 @@ ireeCompilerInvocationSetVerifyIR(iree_compiler_invocation_t *inv, bool enable);
 // Runs a compilation pipeline.
 // Returns false and emits diagnostics on failure.
 enum iree_compiler_pipeline_t {
+  // IREE's full compilation pipeline.
   IREE_COMPILER_PIPELINE_STD = 0,
+  // Pipeline to translate a single hal.executable into a target-specific
+  // binary form (such as an ELF file or a flatbuffer containing a SPIR-V
+  // blob).
   IREE_COMPILER_PIPELINE_HAL_EXECUTABLE = 1,
+  // IREE's precompilation pipeline, which does input preprocessing and
+  // pre-fusion global optimization.
+  // This is experimental and this should be changed as we move to a more
+  // cohesive approach for managing compilation phases.
   IREE_COMPILER_PIPELINE_PRECOMPILE = 2,
 };
 IREE_EMBED_EXPORTED bool

--- a/compiler/bindings/c/iree/compiler/embedding_api.h
+++ b/compiler/bindings/c/iree/compiler/embedding_api.h
@@ -248,6 +248,7 @@ ireeCompilerInvocationSetVerifyIR(iree_compiler_invocation_t *inv, bool enable);
 enum iree_compiler_pipeline_t {
   IREE_COMPILER_PIPELINE_STD = 0,
   IREE_COMPILER_PIPELINE_HAL_EXECUTABLE = 1,
+  IREE_COMPILER_PIPELINE_PRECOMPILE = 2,
 };
 IREE_EMBED_EXPORTED bool
 ireeCompilerInvocationPipeline(iree_compiler_invocation_t *inv,

--- a/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
+++ b/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
@@ -326,6 +326,7 @@ class Source:
 class PipelineType(IntEnum):
     IREE_COMPILER_PIPELINE_STD = 0
     IREE_COMPILER_PIPELINE_HAL_EXECUTABLE = 1
+    IREE_COMPILER_PIPELINE_PRECOMPILE = 2
 
 
 class Invocation:

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -538,6 +538,8 @@ struct Invocation {
   Operation *exportModule();
   bool importModule(Operation *inputModule, bool steal);
   bool runPipeline(enum iree_compiler_pipeline_t pipeline);
+  bool getCompilationPhase(IREEVMPipelinePhase &compileFrom,
+      IREEVMPipelinePhase &compileTo);
   bool runTextualPassPipeline(const char *textPassPipeline);
   Error *outputIR(Output &output);
   Error *outputIRBytecode(Output &output, int bytecodeVersion);
@@ -715,39 +717,52 @@ Operation *Invocation::exportModule() {
   return parsedModule;
 }
 
+bool Invocation::getCompilationPhase(IREEVMPipelinePhase &compileFrom,
+    IREEVMPipelinePhase &compileTo) {
+  // Parse the compile to phase name.
+  std::optional<IREEVMPipelinePhase> compileFromPhase;
+  std::optional<IREEVMPipelinePhase> compileToPhase;
+  enumerateIREEVMPipelinePhases(
+      [&](IREEVMPipelinePhase phase, StringRef mnemonic, StringRef desc) {
+        if (mnemonic == compileFromPhaseName) {
+          compileFromPhase = phase;
+        }
+        if (mnemonic == compileToPhaseName) {
+          compileToPhase = phase;
+        }
+      });
+  if (!compileFromPhase) {
+    parsedModule->emitError()
+        << "unrecognized compile-from phase name: " << compileFromPhaseName;
+    return false;
+  }
+  if (!compileToPhase) {
+    parsedModule->emitError()
+        << "unrecognized compile-to phase name: " << compileToPhaseName;
+    return false;
+  }
+  if (compileFromPhase >= compileToPhase) {
+    parsedModule->emitError()
+        << "compile-from phase " << compileFromPhaseName
+        << " must precede compile-to phase " << compileToPhaseName;
+    return false;
+  }
+
+  compileFrom = *compileFromPhase;
+  compileTo = *compileToPhase;
+
+  return true;
+}
+
 bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
   auto passManager = createPassManager();
   switch (pipeline) {
   case IREE_COMPILER_PIPELINE_STD: {
-    // Parse the compile to phase name.
-    std::optional<IREEVMPipelinePhase> compileFromPhase;
-    std::optional<IREEVMPipelinePhase> compileToPhase;
-    enumerateIREEVMPipelinePhases(
-        [&](IREEVMPipelinePhase phase, StringRef mnemonic, StringRef desc) {
-          if (mnemonic == compileFromPhaseName) {
-            compileFromPhase = phase;
-          }
-          if (mnemonic == compileToPhaseName) {
-            compileToPhase = phase;
-          }
-        });
-    if (!compileFromPhase) {
-      parsedModule->emitError()
-          << "unrecognized compile-from phase name: " << compileFromPhaseName;
+    IREEVMPipelinePhase compileFrom;
+    IREEVMPipelinePhase compileTo;
+    if (!getCompilationPhase(compileFrom, compileTo)) {
       return false;
     }
-    if (!compileToPhase) {
-      parsedModule->emitError()
-          << "unrecognized compile-to phase name: " << compileToPhaseName;
-      return false;
-    }
-    if (compileFromPhase >= compileToPhase) {
-      parsedModule->emitError()
-          << "compile-from phase " << compileFromPhaseName
-          << " must precede compile-to phase " << compileToPhaseName;
-      return false;
-    }
-
     // InlineStatic (currently) only supports the `vmvx-inline` backend.
     if (session.schedulingOptions.executionModel ==
         SchedulingOptions::ExecutionModel::InlineStatic) {
@@ -765,8 +780,8 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
         session.targetRegistry, session.bindingOptions, session.inputOptions,
         session.preprocessingOptions, session.highLevelOptimizationOptions,
         session.schedulingOptions, session.halTargetOptions,
-        session.vmTargetOptions, pipelineHooks, *passManager, *compileFromPhase,
-        *compileToPhase);
+        session.vmTargetOptions, pipelineHooks, *passManager, compileFrom,
+        compileTo);
     break;
   }
   case IREE_COMPILER_PIPELINE_HAL_EXECUTABLE: {
@@ -785,6 +800,20 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
     }
     IREE::HAL::buildHALTransformPassPipeline(
         *passManager, session.targetRegistry, session.halTargetOptions);
+    break;
+  }
+  case IREE_COMPILER_PIPELINE_PRECOMPILE: {
+    IREEVMPipelinePhase compileFrom;
+    IREEVMPipelinePhase compileTo;
+    if (!getCompilationPhase(compileFrom, compileTo)) {
+      return false;
+    }
+
+    buildIREEGlobalOptTransformPassPipeline(session.targetRegistry,
+        session.bindingOptions, session.inputOptions,
+        session.preprocessingOptions, session.highLevelOptimizationOptions,
+        session.schedulingOptions, session.halTargetOptions, pipelineHooks,
+        *passManager, compileFrom, compileTo);
     break;
   }
   default:

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -539,7 +539,7 @@ struct Invocation {
   bool importModule(Operation *inputModule, bool steal);
   bool runPipeline(enum iree_compiler_pipeline_t pipeline);
   bool getCompilationPhase(IREEVMPipelinePhase &compileFrom,
-      IREEVMPipelinePhase &compileTo);
+                           IREEVMPipelinePhase &compileTo);
   bool runTextualPassPipeline(const char *textPassPipeline);
   Error *outputIR(Output &output);
   Error *outputIRBytecode(Output &output, int bytecodeVersion);
@@ -718,7 +718,7 @@ Operation *Invocation::exportModule() {
 }
 
 bool Invocation::getCompilationPhase(IREEVMPipelinePhase &compileFrom,
-    IREEVMPipelinePhase &compileTo) {
+                                     IREEVMPipelinePhase &compileTo) {
   // Parse the compile to phase name.
   std::optional<IREEVMPipelinePhase> compileFromPhase;
   std::optional<IREEVMPipelinePhase> compileToPhase;
@@ -809,8 +809,8 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
       return false;
     }
 
-    buildIREEPrecompileTransformPassPipeline(session.targetRegistry,
-        session.bindingOptions, session.inputOptions,
+    buildIREEPrecompileTransformPassPipeline(
+        session.targetRegistry, session.bindingOptions, session.inputOptions,
         session.preprocessingOptions, session.highLevelOptimizationOptions,
         session.schedulingOptions, session.halTargetOptions, pipelineHooks,
         *passManager, compileFrom, compileTo);

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -809,7 +809,7 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
       return false;
     }
 
-    buildIREEGlobalOptTransformPassPipeline(session.targetRegistry,
+    buildIREEPrecompileTransformPassPipeline(session.targetRegistry,
         session.bindingOptions, session.inputOptions,
         session.preprocessingOptions, session.highLevelOptimizationOptions,
         session.schedulingOptions, session.halTargetOptions, pipelineHooks,

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -205,6 +205,9 @@ void buildIREEVMTransformPassPipeline(
       globalOptimizationOptions, schedulingOptions, executableOptions, hooks,
       passManager, compileFrom, compileTo);
 
+  if (compileTo <= IREEVMPipelinePhase::GlobalOptimization)
+    return; // early-exit
+
   IREE::Stream::TransformOptions streamOptions;
   // TODO(benvanik): find a way to share the enums w/o circular deps.
   streamOptions.dumpStatisticsFormat =

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -39,10 +39,8 @@ void buildIREEPrecompileTransformPassPipeline(
     PreprocessingOptions preprocessingOptions,
     GlobalOptimizationOptions globalOptimizationOptions,
     SchedulingOptions schedulingOptions,
-    IREE::HAL::TargetOptions executableOptions,
-    IREEVMPipelineHooks &hooks,
-    OpPassManager &passManager,
-    IREEVMPipelinePhase compileFrom,
+    IREE::HAL::TargetOptions executableOptions, IREEVMPipelineHooks &hooks,
+    OpPassManager &passManager, IREEVMPipelinePhase compileFrom,
     IREEVMPipelinePhase compileTo) {
   // If the user specified a set of target devices we attach them to the module
   // IR so that they are available for all passes that may want to use this
@@ -202,10 +200,10 @@ void buildIREEVMTransformPassPipeline(
     OpPassManager &passManager, IREEVMPipelinePhase compileFrom,
     IREEVMPipelinePhase compileTo) {
 
-  buildIREEPrecompileTransformPassPipeline(targetRegistry, bindingOptions,
-      inputOptions, preprocessingOptions, globalOptimizationOptions,
-      schedulingOptions, executableOptions, hooks, passManager, compileFrom,
-      compileTo);
+  buildIREEPrecompileTransformPassPipeline(
+      targetRegistry, bindingOptions, inputOptions, preprocessingOptions,
+      globalOptimizationOptions, schedulingOptions, executableOptions, hooks,
+      passManager, compileFrom, compileTo);
 
   IREE::Stream::TransformOptions streamOptions;
   // TODO(benvanik): find a way to share the enums w/o circular deps.

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -33,7 +33,7 @@
 namespace mlir {
 namespace iree_compiler {
 
-void buildIREEGlobalOptTransformPassPipeline(
+void buildIREEPrecompileTransformPassPipeline(
     const IREE::HAL::TargetBackendRegistry &targetRegistry,
     BindingOptions bindingOptions, InputDialectOptions inputOptions,
     PreprocessingOptions preprocessingOptions,
@@ -202,7 +202,7 @@ void buildIREEVMTransformPassPipeline(
     OpPassManager &passManager, IREEVMPipelinePhase compileFrom,
     IREEVMPipelinePhase compileTo) {
 
-  buildIREEGlobalOptTransformPassPipeline(targetRegistry, bindingOptions,
+  buildIREEPrecompileTransformPassPipeline(targetRegistry, bindingOptions,
       inputOptions, preprocessingOptions, globalOptimizationOptions,
       schedulingOptions, executableOptions, hooks, passManager, compileFrom,
       compileTo);

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -85,9 +85,9 @@ void buildIREEPrecompileTransformPassPipeline(
     BindingOptions bindingOptions, InputDialectOptions inputOptions,
     PreprocessingOptions preprocessingOptions,
     GlobalOptimizationOptions highLevelOptimizationOptions,
-    SchedulingOptions schedulingOptions, 
-    IREE::HAL::TargetOptions executableOptions,
-    IREEVMPipelineHooks &hooks, OpPassManager &passManager,
+    SchedulingOptions schedulingOptions,
+    IREE::HAL::TargetOptions executableOptions, IREEVMPipelineHooks &hooks,
+    OpPassManager &passManager,
     IREEVMPipelinePhase compileFrom = IREEVMPipelinePhase::Start,
     IREEVMPipelinePhase compileTo = IREEVMPipelinePhase::GlobalOptimization);
 

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -80,7 +80,7 @@ inline static void enumerateIREEVMPipelinePhases(
 }
 
 // Builds a pass pipeline to perform pre-compilation global optimizations.
-void buildIREEGlobalOptTransformPassPipeline(
+void buildIREEPrecompileTransformPassPipeline(
     const IREE::HAL::TargetBackendRegistry &targetRegistry,
     BindingOptions bindingOptions, InputDialectOptions inputOptions,
     PreprocessingOptions preprocessingOptions,

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -79,6 +79,18 @@ inline static void enumerateIREEVMPipelinePhases(
            "Complete the full compilation pipeline.");
 }
 
+// Builds a pass pipeline to perform pre-compilation global optimizations.
+void buildIREEGlobalOptTransformPassPipeline(
+    const IREE::HAL::TargetBackendRegistry &targetRegistry,
+    BindingOptions bindingOptions, InputDialectOptions inputOptions,
+    PreprocessingOptions preprocessingOptions,
+    GlobalOptimizationOptions highLevelOptimizationOptions,
+    SchedulingOptions schedulingOptions, 
+    IREE::HAL::TargetOptions executableOptions,
+    IREEVMPipelineHooks &hooks, OpPassManager &passManager,
+    IREEVMPipelinePhase compileFrom = IREEVMPipelinePhase::Start,
+    IREEVMPipelinePhase compileTo = IREEVMPipelinePhase::GlobalOptimization);
+
 // Builds a pass pipeline to perform end-to-end compilation from a
 // supported MLIR-based input to the IREE vm dialect.
 //

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -101,7 +101,9 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
               "Compile an MLIR module containing a single hal.executable into "
               "a target-specific binary form (such as an ELF file or a "
               "flatbuffer containing a SPIR-V blob)"),
-          clEnumValN(CompileMode::precompile, "precompile", "Precompilation pipeline which does input conversion and global optimizations.")),
+          clEnumValN(CompileMode::precompile, "precompile",
+                     "Precompilation pipeline which does input conversion and "
+                     "global optimizations.")),
       llvm::cl::init(CompileMode::std), llvm::cl::cat(mainOptions));
 
   // Debugging/diagnostics.
@@ -259,8 +261,8 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
     }
     case CompileMode::precompile: {
       outputFormat = OutputFormat::precompile;
-      if (!ireeCompilerInvocationPipeline(
-              r.inv, IREE_COMPILER_PIPELINE_PRECOMPILE))
+      if (!ireeCompilerInvocationPipeline(r.inv,
+                                          IREE_COMPILER_PIPELINE_PRECOMPILE))
         return false;
       break;
     }

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -27,10 +27,9 @@ enum class OutputFormat {
   vm_asm,
   vm_bytecode,
   vm_c,
-  // Non-user exposed output format for use with --compile-mode=hal-executable.
+  // Non-user exposed output formats.
   hal_executable,
-  // Non-user exposed output format for use with --compile-mode=hal-executable.
-  precompile, 
+  precompile,
 };
 
 enum class CompileMode {
@@ -43,7 +42,8 @@ enum class CompileMode {
   // target-specific binary form (such as an ELF file or a flatbuffer containing
   // a SPIR-V blob).
   hal_executable,
-  // Applies the global optimization pipeline on the input.
+  // IREE's precompilation pipeline, which does input preprocessing and
+  // pre-fusion global optimizations.
   precompile,
 };
 
@@ -258,7 +258,6 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
       break;
     }
     case CompileMode::precompile: {
-      // Compiling a HAL executable, it is only valid to output in that form.
       outputFormat = OutputFormat::precompile;
       if (!ireeCompilerInvocationPipeline(
               r.inv, IREE_COMPILER_PIPELINE_PRECOMPILE))

--- a/tests/compiler_driver/BUILD.bazel
+++ b/tests/compiler_driver/BUILD.bazel
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "hal_executable.mlir",
             "inline_dynamic_hal_executable.mlir",
             "inline_static_hal_executable.mlir",
+            "precompile.mlir",
             "preprocessing_flags.mlir",
             "smoketest.mlir",
             "streams.mlir",

--- a/tests/compiler_driver/CMakeLists.txt
+++ b/tests/compiler_driver/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "hal_executable.mlir"
     "inline_dynamic_hal_executable.mlir"
     "inline_static_hal_executable.mlir"
+    "precompile.mlir"
     "preprocessing_flags.mlir"
     "smoketest.mlir"
     "streams.mlir"

--- a/tests/compiler_driver/precompile.mlir
+++ b/tests/compiler_driver/precompile.mlir
@@ -1,0 +1,8 @@
+// RUN: iree-compile --compile-mode=precompile --iree-hal-target-backends=vmvx %s | iree-compile --iree-hal-target-backends=vmvx --compile-from=global-optimization --compile-to=stream - > %t && \
+// RUN: iree-compile --iree-hal-target-backends=vmvx --compile-to=stream %s | diff - %t
+
+func.func @test(%arg0 : tensor<10x20xf32>, %arg1 : tensor<20x30xf32>, %arg2 : tensor<10x30xf32>) -> tensor<10x30xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<10x20xf32>, tensor<20x30xf32>)
+      outs(%arg2 : tensor<10x30xf32>) -> tensor<10x30xf32>
+  return %0 : tensor<10x30xf32>
+}

--- a/tests/compiler_driver/precompile.mlir
+++ b/tests/compiler_driver/precompile.mlir
@@ -1,8 +1,10 @@
-// RUN: iree-compile --compile-mode=precompile --iree-hal-target-backends=vmvx %s | iree-compile --iree-hal-target-backends=vmvx --compile-from=global-optimization --compile-to=stream - > %t && \
-// RUN: iree-compile --iree-hal-target-backends=vmvx --compile-to=stream %s | diff - %t
+// RUN: iree-compile --compile-mode=precompile --iree-hal-target-backends=vmvx %s | FileCheck %s
 
 func.func @test(%arg0 : tensor<10x20xf32>, %arg1 : tensor<20x30xf32>, %arg2 : tensor<10x30xf32>) -> tensor<10x30xf32> {
   %0 = linalg.matmul ins(%arg0, %arg1 : tensor<10x20xf32>, tensor<20x30xf32>)
       outs(%arg2 : tensor<10x30xf32>) -> tensor<10x30xf32>
   return %0 : tensor<10x30xf32>
 }
+
+// Just check that we have the right target and executable targets.
+// CHECK: module attributes {hal.device.targets = [#hal.device.target<"vmvx", {executable_targets = [#hal.executable.target<"vmvx"


### PR DESCRIPTION
This patch adds a pre-compilation compilation mode for iree-compile. Currently, this is not much different from setting `compileTo=global-optimization`, but this mode will later be used to split the file into two different modules, one containing the weights and the other module containing the compute, which can be compiled separately. 

This mode is meant to be run as:

```
iree-compile --compile-mode=precompile <file>
```