### PR TITLE
[LLVMGPU] Allow reductions with dynamic parallel dimensions through WarpReduce

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -110,28 +110,6 @@ static bool fusedOpMayUseExtraSharedMemory(linalg::LinalgOp matmul) {
   return fusedWithOp;
 }
 
-// Check if there is a fused linalg op present in the backward slice of either
-// input.
-static bool hasFusedLeadingOp(linalg::LinalgOp matmul) {
-  assert(matmul.getNumDpsInputs() == 2 && "matmul expected to have two inputs");
-
-  BackwardSliceOptions options;
-  options.inclusive = true;
-
-  // Get the backward slice of the lhs.
-  SetVector<Operation *> backwardSlice;
-  getBackwardSlice(matmul->getOperand(0), &backwardSlice, options);
-
-  // Get the backward slice of the rhs and take the union.
-  SetVector<Operation *> rhsBackwardSlice;
-  getBackwardSlice(matmul->getOperand(1), &rhsBackwardSlice, options);
-  backwardSlice.set_union(rhsBackwardSlice);
-
-  return llvm::any_of(backwardSlice, [](Operation *op) {
-    return llvm::isa<linalg::LinalgOp>(op);
-  });
-}
-
 //===----------------------------------------------------------------------===//
 // Convolution Default Configuration
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -41,6 +41,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:TargetParser",
         "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_cc_library(
     LLVMSupport
     LLVMTargetParser
     MLIRAffineDialect
+    MLIRAnalysis
     MLIRArithDialect
     MLIRArithUtils
     MLIRFuncDialect

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -206,6 +206,10 @@ void sinkOpsInCFG(const SmallVector<Operation *> &allocs,
 // it means both the allocations and associated stores can be removed.
 void eraseDeadAllocAndStores(Operation *parentOp);
 
+// Check if there is a fused linalg op present in the backward slice of any of
+// the inputs.
+bool hasFusedLeadingOp(linalg::LinalgOp rootOp);
+
 } // namespace iree_compiler
 } // namespace mlir
 


### PR DESCRIPTION
This mirrors what is currently done on the SPIR-V side where we naively fully distribute dynamic parallel dimensions to workgroups and use the subgroup reduce path. In the future we will want to use some mix of padding/specialization for cases like contractions where data is reused.

Additionally, the pipeline matching logic between SPIR-V and LLVMGPU has nearly converged for subgroup reduction; unifying the two is left as TODO.

This also disables fused leading elementwise for the contraction pipelines as this will currently fail to rematerialize the elementwise and overuse shared memory.