### PR TITLE
[Stream] When materializing copies check for multiple users and not uses

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
@@ -57,11 +57,11 @@ static bool isSafeToElideCOW(Value operand, IREE::Stream::ResourceType type) {
   // If there's more than one user we can't make a local decision. It's
   // expensive to query relative operation order within a block and within a
   // region the lifetime of values may vary - all things we can't tell here.
-  Operation *singleUser = nullptr;
+  Operation *firstUser = nullptr;
   for (Operation *user : operand.getUsers()) {
-    if (singleUser == nullptr)
-      singleUser = user;
-    else if (singleUser != user)
+    if (firstUser == nullptr)
+      firstUser = user;
+    else if (firstUser != user)
       return false;
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
@@ -57,8 +57,13 @@ static bool isSafeToElideCOW(Value operand, IREE::Stream::ResourceType type) {
   // If there's more than one user we can't make a local decision. It's
   // expensive to query relative operation order within a block and within a
   // region the lifetime of values may vary - all things we can't tell here.
-  if (!operand.hasOneUse())
-    return false;
+  Operation *singleUser = nullptr;
+  for (Operation *user : operand.getUsers()) {
+    if (singleUser == nullptr)
+      singleUser = user;
+    else if (singleUser != user)
+      return false;
+  }
 
   // We are the only user and the value is contained entirely within the
   // current region. We by construction know we do not need to worry.


### PR DESCRIPTION
If value used multiple times by the same user there is no need to introduce a copy.