### PR TITLE
Switch release python packages to use clang/lld.

### DIFF
--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -237,6 +237,7 @@ function install_native_deps() {
     yum update -y
     # Required for Tracy
     yum install -y capstone-devel tbb-devel libzstd-devel
+    yum install -y clang lld
   elif [[ "$uname_m" == "x86_64" ]]; then
     # Check if the output is x86_64
     echo "Running on an architecture which has deps in docker image."


### PR DESCRIPTION
Should speed things up and makes consistent with pkgci and others. Also enables some more options for making debug binaries, which we may enable soon for the runtime.

Was doing this for consistency, but it also happens to speed the package built up by ~3 minutes.

(Possible now that we are on the new manylinux)