### PR TITLE
[CPU][SVE] Refine tile size calculation for Matmul ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -98,7 +98,7 @@ hal.executable private @matmul_tensors_sve  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [8, 32, 0], [0, 0, 16], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [1, 32, 0], [0, 0, 1], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
This patch updates the `setVectorSizesForDynamicShapes` hook so that it is used when:
  * the pre-vectorization strategy is set to Masking (previously it was limited to Peeling)
  * the compilation is targeting SVE (so that no other targets are affected).
 
This change means that for the cases that I'm testing (`linalg.matmul`), the canonical vector shape is calculated as `vector<1x32x1xi32>` rather than ` vector<8x32x16xi32>`. ATM this is only enabled for `linalg.matmul` as that's the only Op that I am evaluating.

A few other small updates are made to `setVectorSizesForDynamicShapes` to clarify the logic and assumptions made.