### PR TITLE
Push SCF support into Stream Dialect after RefineUsagePass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -704,13 +704,12 @@ static void fuseRootsWithProducers(MLIRContext *context, Operation *root,
 /// very simple heuristic is used below, but the mechanism should be general
 /// enough to capture any heuristic.
 static unsigned
-decideFusableLinalgOps(FunctionOpInterface funcOp,
-                       DominanceInfo const &dominanceInfo,
-                       FormDispatchRegionsOptions const &options) {
-  unsigned numRootOps = 0;
-  MLIRContext *context = funcOp->getContext();
+decideFusableLinalgOps(Region &region, DominanceInfo const &dominanceInfo,
+                       FormDispatchRegionsOptions const &options,
+                       unsigned numRootOps = 0) {
+  MLIRContext *context = region.getContext();
   OpBuilder builder(context);
-  for (Block &block : funcOp.getFunctionBody()) {
+  for (Block &block : region) {
     // Dispatch region formation works by first cloning the root into
     // the dispatch region and then pulling operations in.
     // So procedure here is to
@@ -718,6 +717,14 @@ decideFusableLinalgOps(FunctionOpInterface funcOp,
     // - To fuse with consumers make the consumer the root.
     SmallVector<Operation *> roots;
     for (Operation &op : llvm::reverse(block)) {
+      if (isa<scf::SCFDialect>(op.getDialect())) {
+        for (auto &region : op.getRegions()) {
+          numRootOps = decideFusableLinalgOps(region, dominanceInfo, options,
+                                              numRootOps);
+        }
+        continue;
+      }
+
       // Start with a root operation and fuse its producers.
       if (hasFusionGroupsAttribute(&op) || !isRootOp(&op))
         continue;
@@ -733,7 +740,7 @@ decideFusableLinalgOps(FunctionOpInterface funcOp,
 
   // Once all root linalg ops have been tagged, put all remaining generic ops
   // into their own dispatches.
-  for (Block &block : funcOp.getFunctionBody()) {
+  for (Block &block : region) {
     SmallVector<Operation *> roots;
     for (Operation &op : llvm::reverse(block)) {
       // If it is part of a fusion group or root op, ignore it.
@@ -773,7 +780,8 @@ createFusionGroups(TensorDimTrackingRewriter &rewriter,
                    FormDispatchRegionsOptions const &options) {
   // Step 1: Decide fusion groups (heuristic). This marks rootOps with an
   // attribute
-  unsigned numRoots = decideFusableLinalgOps(funcOp, dominanceInfo, options);
+  unsigned numRoots =
+      decideFusableLinalgOps(funcOp.getFunctionBody(), dominanceInfo, options);
   SmallVector<Operation *> roots(numRoots, nullptr);
   DenseMap<unsigned, SmallVector<Operation *>> producers;
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -432,10 +432,11 @@ public:
             std::string("_function_like_") + std::to_string(it.index());
       }
 
-      auto &bodyRegion = op.getFunctionBody();
+      llvm::SmallVector<DispatchWorkgroupsOp> dispatchWorkgroupsOps;
       // Outline all of the dispatch regions ops in this function.
-      auto dispatchWorkgroupsOps =
-          llvm::to_vector<8>(bodyRegion.getOps<DispatchWorkgroupsOp>());
+      op.walk([&](DispatchWorkgroupsOp op) {
+        dispatchWorkgroupsOps.push_back(op);
+      });
       for (int i = 0; i < dispatchWorkgroupsOps.size(); ++i) {
         std::string executableOpName =
             (namePrefix + "_dispatch_" + llvm::Twine(i)).str();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -163,7 +163,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       // compute op into the dispatch region, so that we can run additional
       // transformations afterwards with a simple region and without bothering
       // producers.
-      .addPass(IREE::Flow::createTopLevelSCFToCFGPass)
       .addPass([&]() {
         return createFormDispatchRegionsPass(FormDispatchRegionsOptions{
             clEnableFuseMultiUse, clDispatchGenerateWorkloadRegion,

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
     MLIRFuncDialect
     MLIRIR
     MLIRPass
+    MLIRSCFDialect
     MLIRSupport
     iree::compiler::Dialect::Stream::IR
     iree::compiler::Dialect::Util::Analysis

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -544,7 +544,7 @@ private:
                   dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
             auto value =
                 Position::forValue(whileOp.getBefore().getArgument(operandIdx));
-            auto& valueUsage = solver.getElementFor<ValueResourceUsage>(
+            auto &valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();
           }

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -493,12 +493,12 @@ private:
               });
         })
         .Case([&](mlir::scf::WhileOp op) {
-          auto operandUsage = solver.getElementFor<ValueResourceUsage>(
+          auto &operandUsage = solver.getElementFor<ValueResourceUsage>(
               *this, Position::forValue(op->getOperand(operandIdx)),
               DFX::Resolution::REQUIRED);
           getState() ^= operandUsage.getState();
 
-          auto beforeUsage = solver.getElementFor<ValueResourceUsage>(
+          auto &beforeUsage = solver.getElementFor<ValueResourceUsage>(
               *this,
               Position::forValue(op.getBeforeBody()->getArgument(operandIdx)),
               DFX::Resolution::REQUIRED);
@@ -506,12 +506,12 @@ private:
           getState() ^= beforeUsage.getState();
         })
         .Case([&](mlir::scf::ConditionOp op) {
-          auto operandUsage = solver.getElementFor<ValueResourceUsage>(
+          auto &operandUsage = solver.getElementFor<ValueResourceUsage>(
               *this, Position::forValue(op->getOperand(operandIdx)),
               DFX::Resolution::REQUIRED);
           getState() ^= operandUsage.getState();
 
-          auto parentUsage = solver.getElementFor<ValueResourceUsage>(
+          auto &parentUsage = solver.getElementFor<ValueResourceUsage>(
               *this,
               Position::forValue(op->getParentOp()->getResult(operandIdx - 1)),
               DFX::Resolution::REQUIRED);
@@ -521,19 +521,19 @@ private:
                   dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
             auto value = Position::forValue(
                 whileOp.getAfter().getArgument(operandIdx - 1));
-            auto valueUsage = solver.getElementFor<ValueResourceUsage>(
+            auto &valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();
           }
         })
         .Case([&](mlir::scf::YieldOp op) {
           if (isa<scf::IfOp>(op->getParentOp())) {
-            auto operandUsage = solver.getElementFor<ValueResourceUsage>(
+            auto &operandUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, Position::forValue(op->getOperand(operandIdx)),
                 DFX::Resolution::REQUIRED);
             getState() ^= operandUsage.getState();
 
-            auto parentUsage = solver.getElementFor<ValueResourceUsage>(
+            auto &parentUsage = solver.getElementFor<ValueResourceUsage>(
                 *this,
                 Position::forValue(op->getParentOp()->getResult(operandIdx)),
                 DFX::Resolution::REQUIRED);

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -544,7 +544,7 @@ private:
                   dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
             auto value =
                 Position::forValue(whileOp.getBefore().getArgument(operandIdx));
-            auto valueUsage = solver.getElementFor<ValueResourceUsage>(
+            auto& valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();
           }

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -492,6 +492,18 @@ private:
                 return WalkResult::advance();
               });
         })
+        .Case([&](mlir::scf::WhileOp op) {
+          auto operandUsage = solver.getElementFor<ValueResourceUsage>(
+              *this, Position::forValue(op->getOperand(operandIdx)),
+              DFX::Resolution::REQUIRED);
+          getState() ^= operandUsage.getState();
+
+          auto beforeUsage = solver.getElementFor<ValueResourceUsage>(
+              *this, Position::forValue(op.getBeforeBody()->getArgument(operandIdx)),
+              DFX::Resolution::REQUIRED);
+
+          getState() ^= beforeUsage.getState();
+        })
         .Case([&](mlir::scf::ConditionOp op) {
           auto operandUsage = solver.getElementFor<ValueResourceUsage>(
               *this, Position::forValue(op->getOperand(operandIdx)),
@@ -503,18 +515,35 @@ private:
               Position::forValue(op->getParentOp()->getResult(operandIdx - 1)),
               DFX::Resolution::REQUIRED);
           getState() ^= parentUsage.getState();
+
+          if (auto whileOp = dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
+            auto value = Position::forValue(whileOp.getAfter().getArgument(operandIdx - 1));
+            auto valueUsage = solver.getElementFor<ValueResourceUsage>(
+                *this, value, DFX::Resolution::REQUIRED);
+            getState() ^= valueUsage.getState();
+          }
+
         })
         .Case([&](mlir::scf::YieldOp op) {
-          auto operandUsage = solver.getElementFor<ValueResourceUsage>(
-              *this, Position::forValue(op->getOperand(operandIdx)),
-              DFX::Resolution::REQUIRED);
-          getState() ^= operandUsage.getState();
+          if(isa<scf::IfOp>(op->getParentOp()))  {
+            auto operandUsage = solver.getElementFor<ValueResourceUsage>(
+                *this, Position::forValue(op->getOperand(operandIdx)),
+                DFX::Resolution::REQUIRED);
+            getState() ^= operandUsage.getState();
 
-          auto parentUsage = solver.getElementFor<ValueResourceUsage>(
-              *this,
-              Position::forValue(op->getParentOp()->getResult(operandIdx)),
-              DFX::Resolution::REQUIRED);
-          getState() ^= parentUsage.getState();
+            auto parentUsage = solver.getElementFor<ValueResourceUsage>(
+                *this,
+                Position::forValue(op->getParentOp()->getResult(operandIdx)),
+                DFX::Resolution::REQUIRED);
+            getState() ^= parentUsage.getState();
+          }
+
+          if (auto whileOp = dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
+            auto value = Position::forValue(whileOp.getBefore().getArgument(operandIdx));
+            auto valueUsage = solver.getElementFor<ValueResourceUsage>(
+                *this, value, DFX::Resolution::REQUIRED);
+            getState() ^= valueUsage.getState();
+          }
         })
         .Case([&](mlir::func::ReturnOp op) {
           auto &operandUsage = solver.getElementFor<ValueResourceUsage>(
@@ -733,6 +762,7 @@ ResourceUsageAnalysis::ResourceUsageAnalysis(Operation *rootOp)
   explorer.setOpAction<IREE::Util::InitializerOp>(TraversalAction::RECURSE);
   explorer.setOpAction<mlir::func::FuncOp>(TraversalAction::RECURSE);
   explorer.setOpAction<mlir::scf::IfOp>(TraversalAction::RECURSE);
+  explorer.setOpAction<mlir::scf::WhileOp>(TraversalAction::RECURSE);
   explorer.setDialectAction<IREE::Stream::StreamDialect>(
       TraversalAction::RECURSE);
   // Ignore the contents of executables (linalg goo, etc).

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -499,7 +499,8 @@ private:
           getState() ^= operandUsage.getState();
 
           auto beforeUsage = solver.getElementFor<ValueResourceUsage>(
-              *this, Position::forValue(op.getBeforeBody()->getArgument(operandIdx)),
+              *this,
+              Position::forValue(op.getBeforeBody()->getArgument(operandIdx)),
               DFX::Resolution::REQUIRED);
 
           getState() ^= beforeUsage.getState();
@@ -516,16 +517,17 @@ private:
               DFX::Resolution::REQUIRED);
           getState() ^= parentUsage.getState();
 
-          if (auto whileOp = dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
-            auto value = Position::forValue(whileOp.getAfter().getArgument(operandIdx - 1));
+          if (auto whileOp =
+                  dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
+            auto value = Position::forValue(
+                whileOp.getAfter().getArgument(operandIdx - 1));
             auto valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();
           }
-
         })
         .Case([&](mlir::scf::YieldOp op) {
-          if(isa<scf::IfOp>(op->getParentOp()))  {
+          if (isa<scf::IfOp>(op->getParentOp())) {
             auto operandUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, Position::forValue(op->getOperand(operandIdx)),
                 DFX::Resolution::REQUIRED);
@@ -538,8 +540,10 @@ private:
             getState() ^= parentUsage.getState();
           }
 
-          if (auto whileOp = dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
-            auto value = Position::forValue(whileOp.getBefore().getArgument(operandIdx));
+          if (auto whileOp =
+                  dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
+            auto value =
+                Position::forValue(whileOp.getBefore().getArgument(operandIdx));
             auto valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/BUILD.bazel
@@ -32,6 +32,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:ShapeDialect",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     MLIRIR
     MLIRMemRefDialect
     MLIRPass
+    MLIRSCFDialect
     MLIRShapeDialect
     MLIRTensorDialect
     MLIRTransforms

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
@@ -466,28 +466,24 @@ void populateStandardStructuralToStreamPatterns(
           return typeConverter.isLegal(type);
         });
       });
-
   conversionTarget.addDynamicallyLegalOp<mlir::scf::IfOp>(
       [&](mlir::scf::IfOp op) {
         return llvm::all_of(op.getResultTypes(), [&](Type type) {
           return typeConverter.isLegal(type);
         });
       });
-
   conversionTarget.addDynamicallyLegalOp<mlir::scf::WhileOp>(
       [&](mlir::scf::WhileOp op) {
         return llvm::all_of(op.getResultTypes(), [&](Type type) {
           return typeConverter.isLegal(type);
         });
       });
-
   conversionTarget.addDynamicallyLegalOp<mlir::scf::ConditionOp>(
       [&](mlir::scf::ConditionOp op) {
         return llvm::all_of(op.getOperandTypes(), [&](Type type) {
           return typeConverter.isLegal(type);
         });
       });
-
   conversionTarget.addDynamicallyLegalOp<mlir::scf::YieldOp>(
       [&](mlir::scf::YieldOp op) {
         return llvm::all_of(op.getOperandTypes(), [&](Type type) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -238,6 +239,183 @@ struct SelectOpConversion : public OpConversionPattern<mlir::arith::SelectOp> {
   }
 };
 
+struct ScfIfOpConversion : public OpConversionPattern<mlir::scf::IfOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(mlir::scf::IfOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Expand any resource operands to resource + size.
+    auto expandedOperands =
+        expandResourceOperands(op.getLoc(), adaptor.getOperands(), rewriter);
+
+    // Expand any resource results to resource + size.
+    SmallVector<Type> expandedTypes;
+    struct Result {
+      size_t originalIndex;
+      size_t newIndex;
+      Type newType;
+    };
+    SmallVector<Result> resultMap;
+    for (auto originalType : llvm::enumerate(op.getResultTypes())) {
+      SmallVector<Type> newTypes;
+      if (failed(getTypeConverter()->convertType(originalType.value(),
+                                                 newTypes))) {
+        return rewriter.notifyMatchFailure(op,
+                                           "unable to convert result types");
+      }
+      resultMap.push_back(
+          Result{originalType.index(), expandedTypes.size(), newTypes.front()});
+      expandedTypes.append(newTypes);
+    }
+
+    // Create a new call that takes the expanded input operands and returns the
+    // expanded output results. We can't directly replace the original call as
+    // the result counts differ.
+    auto ifOp = rewriter.create<mlir::scf::IfOp>(op.getLoc(), expandedTypes,
+                                                 op.getCondition());
+
+    ifOp.getThenRegion().getBlocks().clear();
+    rewriter.inlineRegionBefore(op.getThenRegion(), ifOp.getThenRegion(),
+                                ifOp.getThenRegion().end());
+
+    ifOp.getElseRegion().getBlocks().clear();
+    rewriter.inlineRegionBefore(op.getElseRegion(), ifOp.getElseRegion(),
+                                ifOp.getElseRegion().end());
+
+    // Tie all resource results together so we end up with 1:1 results with the
+    // original op.
+    SmallVector<Value> results;
+    for (auto result : resultMap) {
+      if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
+        auto oldType = op.getResult(result.originalIndex).getType();
+        auto resource = ifOp.getResult(result.newIndex + 0);
+        auto resourceSize = ifOp.getResult(result.newIndex + 1);
+        results.push_back(rewriter
+                              .create<mlir::UnrealizedConversionCastOp>(
+                                  op.getLoc(), TypeRange{oldType},
+                                  ValueRange{resource, resourceSize})
+                              .getResult(0));
+      } else {
+        results.push_back(ifOp.getResult(result.newIndex));
+      }
+    }
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
+
+struct ScfWhileOpConversion : public OpConversionPattern<mlir::scf::WhileOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(mlir::scf::WhileOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto &typeConverter = *getTypeConverter();
+    // Expand any resource operands to resource + size.
+    auto expandedOperands =
+        expandResourceOperands(op.getLoc(), adaptor.getOperands(), rewriter);
+
+    // Expand any resource results to resource + size.
+    SmallVector<Type> expandedTypes;
+    struct Result {
+      size_t originalIndex;
+      size_t newIndex;
+      Type newType;
+    };
+    SmallVector<Result> resultMap;
+    for (auto originalType : llvm::enumerate(op.getResultTypes())) {
+      SmallVector<Type> newTypes;
+      if (failed(getTypeConverter()->convertType(originalType.value(),
+                                                 newTypes))) {
+        return rewriter.notifyMatchFailure(op,
+                                           "unable to convert result types");
+      }
+      resultMap.push_back(
+          Result{originalType.index(), expandedTypes.size(), newTypes.front()});
+      expandedTypes.append(newTypes);
+    }
+
+    TypeConverter::SignatureConversion newSignature(op.getNumOperands());
+    for (auto argType : llvm::enumerate(op.getOperandTypes())) {
+      if (failed(typeConverter.convertSignatureArg(
+              argType.index(), argType.value(), newSignature))) {
+        return failure();
+      }
+    }
+
+    // Create a new call that takes the expanded input operands and returns the
+    // expanded output results. We can't directly replace the original call as
+    // the result counts differ.
+    auto whileOp = rewriter.create<mlir::scf::WhileOp>(
+        op.getLoc(), expandedTypes, expandedOperands);
+
+    // Inline the `before` block and update the block arguments.
+    whileOp.getBefore().getBlocks().clear();
+    rewriter.inlineRegionBefore(op.getBefore(), whileOp.getBefore(),
+                                whileOp.getBefore().end());
+    if (failed(rewriter.convertRegionTypes(&whileOp.getBefore(), typeConverter,
+                                           &newSignature))) {
+      return failure();
+    }
+
+    // Inline the `after` block and update the block arguments.
+    whileOp.getAfter().getBlocks().clear();
+    rewriter.inlineRegionBefore(op.getAfter(), whileOp.getAfter(),
+                                whileOp.getAfter().end());
+    if (failed(rewriter.convertRegionTypes(&whileOp.getAfter(), typeConverter,
+                                           &newSignature))) {
+      return failure();
+    }
+
+    // Tie all resource results together so we end up with 1:1 results with the
+    // original op.
+    SmallVector<Value> results;
+    for (auto result : resultMap) {
+      if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
+        auto oldType = op.getResult(result.originalIndex).getType();
+        auto resource = whileOp.getResult(result.newIndex + 0);
+        auto resourceSize = whileOp.getResult(result.newIndex + 1);
+        results.push_back(rewriter
+                              .create<mlir::UnrealizedConversionCastOp>(
+                                  op.getLoc(), TypeRange{oldType},
+                                  ValueRange{resource, resourceSize})
+                              .getResult(0));
+      } else {
+        results.push_back(whileOp.getResult(result.newIndex));
+      }
+    }
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
+
+struct ScfConditionOpConversion
+    : public OpConversionPattern<mlir::scf::ConditionOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(mlir::scf::ConditionOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Expand any resource operands to resource + size.
+    auto expandedOperands =
+        expandResourceOperands(op.getLoc(), adaptor.getArgs(), rewriter);
+    rewriter.replaceOpWithNewOp<mlir::scf::ConditionOp>(
+        op, adaptor.getCondition(), expandedOperands);
+    return success();
+  }
+};
+
+struct ScfYieldOpConversion : public OpConversionPattern<mlir::scf::YieldOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(mlir::scf::YieldOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Expand any resource operands to resource + size.
+    auto expandedOperands =
+        expandResourceOperands(op.getLoc(), adaptor.getOperands(), rewriter);
+    rewriter.replaceOpWithNewOp<mlir::scf::YieldOp>(op, expandedOperands);
+    return success();
+  }
+};
+
 } // namespace
 
 void populateStandardStructuralToStreamPatterns(
@@ -289,10 +467,40 @@ void populateStandardStructuralToStreamPatterns(
         });
       });
 
+  conversionTarget.addDynamicallyLegalOp<mlir::scf::IfOp>(
+      [&](mlir::scf::IfOp op) {
+        return llvm::all_of(op.getResultTypes(), [&](Type type) {
+          return typeConverter.isLegal(type);
+        });
+      });
+
+  conversionTarget.addDynamicallyLegalOp<mlir::scf::WhileOp>(
+      [&](mlir::scf::WhileOp op) {
+        return llvm::all_of(op.getResultTypes(), [&](Type type) {
+          return typeConverter.isLegal(type);
+        });
+      });
+
+  conversionTarget.addDynamicallyLegalOp<mlir::scf::ConditionOp>(
+      [&](mlir::scf::ConditionOp op) {
+        return llvm::all_of(op.getOperandTypes(), [&](Type type) {
+          return typeConverter.isLegal(type);
+        });
+      });
+
+  conversionTarget.addDynamicallyLegalOp<mlir::scf::YieldOp>(
+      [&](mlir::scf::YieldOp op) {
+        return llvm::all_of(op.getOperandTypes(), [&](Type type) {
+          return typeConverter.isLegal(type);
+        });
+      });
+
   patterns
       .insert<FuncOpSignatureConversion, CallOpConversion, ReturnOpConversion,
               BranchOpConversion, CondBranchOpConversion, SwitchOpConversion,
-              SelectOpConversion>(typeConverter, context);
+              SelectOpConversion, ScfConditionOpConversion, ScfIfOpConversion,
+              ScfWhileOpConversion, ScfYieldOpConversion>(typeConverter,
+                                                          context);
 }
 
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/test/structural_ops.mlir
@@ -85,3 +85,36 @@ func.func @selectExpansion(%arg0: tensor<1xf32>, %cond: i1, %arg1: tensor<1xf32>
   // CHECK: return %[[RET]], %[[RET_SIZE]] : !stream.resource<*>, index
   return %0 : tensor<1xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @scfIfExpansion
+// CHECK-SAME: %[[COND:.+]]: i1, %[[ARG0:.+]]: !stream.resource<*>, %[[IDX0:.+]]: index, %[[ARG1:.+]]: !stream.resource<*>, %[[IDX1:.+]]: index
+func.func @scfIfExpansion(%cond: i1, %arg0: tensor<1xf32>, %arg1: tensor<1xf32>) -> tensor<1xf32> {
+  // CHECK: %[[IF:.+]]:2 = scf.if %arg0 -> (!stream.resource<*>, index)
+  %0 = scf.if %cond -> tensor<1xf32> {
+    // CHECK: scf.yield %[[ARG0]], %[[IDX0]]
+    scf.yield %arg0 : tensor<1xf32>
+  } else {
+    // CHECK: scf.yield %[[ARG1]], %[[IDX1]]
+    scf.yield %arg1 : tensor<1xf32>
+  }
+  // CHECK: return %[[IF]]#0, %[[IF]]#1
+  return %0 : tensor<1xf32>
+}
+
+// -----
+
+func.func @scfWhileExpansion(%arg0 : i32, %arg1 : tensor<1xf32>) {
+  %c1 = arith.constant 1 : i32
+  %c10 = arith.constant 10 : i32
+  %0:2 = scf.while (%arg2 = %arg0, %arg3 = %arg1) : (i32, tensor<1xf32>) -> (i32, tensor<1xf32>) {
+    %1 = arith.cmpi slt, %arg2, %c10 : i32
+    scf.condition(%1) %arg2, %arg1 : i32, tensor<1xf32>
+  } do {
+  ^bb0(%arg2: i32, %arg3 : tensor<1xf32>):
+    %1 = arith.addi %arg2, %c1 : i32
+    scf.yield %1, %arg1 : i32, tensor<1xf32>
+  }
+  return
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/test/structural_ops.mlir
@@ -105,15 +105,23 @@ func.func @scfIfExpansion(%cond: i1, %arg0: tensor<1xf32>, %arg1: tensor<1xf32>)
 
 // -----
 
+// CHECK-LABEL: @scfWhileExpansion
+// CHECK-SAME: %[[ARG0:.+]]: i32, %[[ARG1:.+]]: !stream.resource<*>, %[[ARG2:.+]]: index
 func.func @scfWhileExpansion(%arg0 : i32, %arg1 : tensor<1xf32>) {
   %c1 = arith.constant 1 : i32
   %c10 = arith.constant 10 : i32
+  // CHECK: scf.while
+  // CHECK-SAME: (%[[ARG3:.+]] = %[[ARG0]], %[[ARG4:.+]] = %[[ARG1]], %[[ARG5:.+]] = %[[ARG2]])
+  // CHECK-SAME: (i32, !stream.resource<*>, index) -> (i32, !stream.resource<*>, index)
   %0:2 = scf.while (%arg2 = %arg0, %arg3 = %arg1) : (i32, tensor<1xf32>) -> (i32, tensor<1xf32>) {
     %1 = arith.cmpi slt, %arg2, %c10 : i32
+    // CHECK: scf.condition(%[[V:.+]]) %[[ARG3]], %[[ARG1]], %[[ARG2]] : i32, !stream.resource<*>, index
     scf.condition(%1) %arg2, %arg1 : i32, tensor<1xf32>
   } do {
+  // CHECK: ^bb0(%[[ARG3:.+]]: i32, %[[ARG4:.+]]: !stream.resource<*>, %[[ARG5:.+]]: index):
   ^bb0(%arg2: i32, %arg3 : tensor<1xf32>):
     %1 = arith.addi %arg2, %c1 : i32
+  // CHECK: scf.yield %[[V:.+]], %[[ARG1]], %[[ARG2]] : i32, !stream.resource<*>, index
     scf.yield %1, %arg1 : i32, tensor<1xf32>
   }
   return

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -48,6 +48,7 @@ iree_compiler_cc_library(
     deps = [
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
+        "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/Stream/Analysis",
         "//compiler/src/iree/compiler/Dialect/Stream/Builtins",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -64,6 +64,7 @@ iree_cc_library(
     MLIRTransforms
     MLIRVectorDialect
     iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::Flow::Transforms
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::Stream::Analysis
     iree::compiler::Dialect::Stream::Builtins

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "iree/compiler/Utils/PassUtils.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
@@ -144,6 +145,11 @@ void buildStreamAsyncPassPipeline(OpPassManager &passManager,
   // move across devices. We do it before scheduling waves as lifetime doesn't
   // change and it makes the IR cleaner.
   passManager.addPass(IREE::Stream::createRefineUsagePass());
+
+  // Cleanup patterns currently fail on SCF operations.
+  passManager.addNestedPass<func::FuncOp>(
+      IREE::Flow::createTopLevelSCFToCFGPass());
+
   addCleanupPatterns(passManager);
 
   // Verify all stream.async.* op access ranges that we can by taking advantage

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
@@ -210,3 +210,75 @@ func.func @escapingAlloca() -> !hal.buffer_view {
   %2 = stream.tensor.export %1 : tensor<f32> in !stream.resource<external>{%c123} -> !hal.buffer_view
   return %2 : !hal.buffer_view
 }
+
+// -----
+
+// CHECK-LABEL: @testIf
+func.func @testIf(%arg0: i1, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub} {
+  %c4 = arith.constant 4 : index
+  %c0 = arith.constant 0 : index
+  %c268435488_i32 = arith.constant 268435488 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c1 = arith.constant 1 : index
+  hal.buffer_view.assert<%arg1 : !hal.buffer_view> message("input 1") shape([%c1]) type(%c268435488_i32) encoding(%c1_i32)
+  %0 = stream.tensor.import %arg1 : !hal.buffer_view -> tensor<1xi32> in !stream.resource<external>{%c4}
+  %1 = stream.async.transfer %0 : !stream.resource<external>{%c4} -> !stream.resource<*>{%c4}
+  hal.buffer_view.assert<%arg2 : !hal.buffer_view> message("input 2") shape([%c1]) type(%c268435488_i32) encoding(%c1_i32)
+  %2 = stream.tensor.import %arg2 : !hal.buffer_view -> tensor<1xi32> in !stream.resource<external>{%c4}
+  %3 = stream.async.transfer %2 : !stream.resource<external>{%c4} -> !stream.resource<*>{%c4}
+  // CHECK: %[[IF:.+]] = scf.if
+  // CHECK-SAME: !stream.resource<external>
+  %4 = scf.if %arg0 -> (!stream.resource<*>) {
+    // CHECK: %[[DISPATCH:.+]] = stream.async.dispatch
+    // CHECK-SAME: !stream.resource<external>
+    // CHECK-SAME: !stream.resource<external>
+    // CHECK-SAME: -> !stream.resource<external>
+    %7 = stream.async.dispatch @testIf_dispatch_0::@testIf_dispatch_0_generic(%1[%c0 to %c4 for %c4], %3[%c0 to %c4 for %c4]) : (!stream.resource<*>{%c4}, !stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
+    // CHECK: scf.yield
+    // CHECK-SAME: !stream.resource<external>
+    scf.yield %7 : !stream.resource<*>
+  } else {
+    // CHECK: scf.yield
+    // CHECK-SAME: !stream.resource<external>
+    scf.yield %1 : !stream.resource<*>
+  }
+  %5 = stream.async.transfer %4 : !stream.resource<*>{%c4} -> !stream.resource<external>{%c4}
+  %6 = stream.tensor.export %5 : tensor<1xi32> in !stream.resource<external>{%c4} -> !hal.buffer_view
+  return %6 : !hal.buffer_view
+}
+
+// -----
+
+// CHECK: @testWhile
+func.func @testWhile(%arg0: i32, %arg1: !hal.buffer_view) -> (i32, !hal.buffer_view) attributes {iree.abi.stub} {
+  %c4 = arith.constant 4 : index
+  %c0 = arith.constant 0 : index
+  %c10_i32 = arith.constant 10 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c268435488_i32 = arith.constant 268435488 : i32
+  %c1 = arith.constant 1 : index
+  hal.buffer_view.assert<%arg1 : !hal.buffer_view> message("input 1") shape([%c1]) type(%c268435488_i32) encoding(%c1_i32)
+  %0 = stream.tensor.import %arg1 : !hal.buffer_view -> tensor<1xi32> in !stream.resource<external>{%c4}
+  %1 = stream.async.transfer %0 : !stream.resource<external>{%c4} -> !stream.resource<*>{%c4}
+  // CHECK: scf.while
+  // CHECK-SAME: (i32, !stream.resource<external>)
+  // CHECK-SAME: (i32, !stream.resource<external>)
+  %2:2 = scf.while (%arg2 = %arg0, %arg3 = %1) : (i32, !stream.resource<*>) -> (i32, !stream.resource<*>) {
+    %5 = arith.cmpi slt, %arg2, %c10_i32 : i32
+    // CHECK: scf.condition
+    // CHECK-SAME: !stream.resource<external>
+    scf.condition(%5) %arg2, %arg3 : i32, !stream.resource<*>
+  } do {
+  ^bb0(%arg2: i32, %arg3: !stream.resource<*>):
+    %5 = arith.addi %arg2, %c1_i32 : i32
+    %6 = stream.async.dispatch @testWhile_dispatch_0::@testWhile_dispatch_0_generic(%arg3[%c0 to %c4 for %c4], %1[%c0 to %c4 for %c4]) : (!stream.resource<*>{%c4}, !stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
+    // CHECK: scf.yield
+    // CHECK-SAME: !stream.resource<external>
+    scf.yield %5, %6 : i32, !stream.resource<*>
+  }
+  %3 = stream.async.transfer %2#1 : !stream.resource<*>{%c4} -> !stream.resource<external>{%c4}
+  // CHECK: stream.tensor.export
+  // CHECK-SAME: !stream.resource<external>
+  %4 = stream.tensor.export %3 : tensor<1xi32> in !stream.resource<external>{%c4} -> !hal.buffer_view
+  return %2#0, %4 : i32, !hal.buffer_view
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
@@ -263,3 +263,47 @@ func.func @testWhile(%arg0: i32, %arg1: !stream.resource<*>) -> (i32, !stream.re
   // CHECK: return %[[IF]]#0, %[[IF]]#1 : i32, !stream.resource<external>
   return %while#0, %while#1 : i32, !stream.resource<*>
 }
+
+// -----
+
+// CHECK-LABEL: @testWhileRecurse
+// CHECK-SAME: %[[ARG0:.+]]: !stream.resource<external>
+// CHECK-SAME: -> !stream.resource<external>
+func.func @testWhileRecurse(%arg0 : !stream.resource<*>) -> !stream.resource<external> {
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1
+  // CHECK-DAG: %[[C4:.+]] = arith.constant 4
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+
+  // CHECK: %[[SIZE:.+]] = stream.resource.size %[[ARG0]] : !stream.resource<external>
+  %size = stream.resource.size %arg0 : !stream.resource<*>
+
+  // CHECK: %[[WHILE:.+]]:2 = scf.while (%[[ARG1:.+]] = %[[ARG0]], %[[ARG2:.+]] = %[[SIZE]]) : (!stream.resource<external>, index) -> (!stream.resource<external>, index)
+  %while:2 = scf.while (%arg1 = %arg0, %arg2 = %size) : (!stream.resource<*>, index) -> (!stream.resource<*>, index) {
+    // CHECK: %[[DISPATCH:.+]] = stream.async.dispatch @dispatch(%[[ARG1]][%[[C0]] to %[[ARG2]] for %[[ARG2]]]) : (!stream.resource<external>{%[[ARG2]]}) -> !stream.resource<transient>{%[[C1]]}
+    %dispatch = stream.async.dispatch @dispatch(%arg1[%c0 to %arg2 for %arg2]) : (!stream.resource<*>{%arg2}) -> !stream.resource<*>{%c1}
+
+    // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[DISPATCH]] : !stream.resource<transient>{%[[C1]]} -> !stream.resource<staging>{%[[C1]]}
+    %transfer = stream.async.transfer %dispatch : !stream.resource<*>{%c1} -> !stream.resource<staging>{%c1}
+
+    // CHECK: %[[LOAD:.+]] = stream.async.load %[[TRANSFER]][%[[C0]]] : !stream.resource<staging>{%[[C1]]} -> i1
+    %load = stream.async.load %transfer[%c0] : !stream.resource<staging>{%c1} -> i1
+
+    // CHECK: scf.condition(%[[LOAD]]) %[[ARG1]], %[[ARG2]] : !stream.resource<external>, index
+    scf.condition(%load) %arg1, %arg2 : !stream.resource<*>, index
+  } do {
+  // CHECK: ^bb0(%[[ARG1:.+]]: !stream.resource<external>, %[[ARG2:.+]]: index):
+  ^bb0(%arg1: !stream.resource<*>, %arg2: index):
+    // CHECK: %[[DISPATCH:.+]] = stream.async.dispatch @dispatch(%[[ARG1]][%[[C0]] to %[[ARG2]] for %[[ARG2]]]) : (!stream.resource<external>{%[[ARG2]]}) -> !stream.resource<external>{%[[C4]]}
+    %dispatch = stream.async.dispatch @dispatch(%arg1[%c0 to %arg2 for %arg2]) : (!stream.resource<*>{%arg2}) -> !stream.resource<*>{%c4}
+
+    // CHECK: scf.yield %[[DISPATCH]], %[[C4]] : !stream.resource<external>, index
+    scf.yield %dispatch, %c4 : !stream.resource<*>, index
+  }
+  %transfer = stream.async.transfer %while#0 : !stream.resource<*>{%while#1} -> !stream.resource<external>{%while#1}
+
+  // CHECK: return %[[WHILE]]#0
+  return %transfer : !stream.resource<external>
+}

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/BUILD.bazel
@@ -29,6 +29,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     MLIRControlFlowInterfaces
     MLIRIR
     MLIRPass
+    MLIRSCFDialect
     MLIRSupport
     iree::compiler::Dialect::Util::IR
   PUBLIC

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
@@ -1044,8 +1044,16 @@ TraversalResult Explorer::walkTransitiveUses(Value value, UseWalkFn fn) {
       }
 
       // If op is a return then we need to walk into the caller results.
-      if (ownerOp->hasTrait<OpTrait::ReturnLike>()) {
+      if (ownerOp->hasTrait<OpTrait::ReturnLike>() &&
+          llvm::isa<CallableOpInterface>(ownerOp->getParentOp())) {
         result |= traverseReturnOp(ownerOp, use.getOperandNumber());
+      }
+
+      if (ownerOp->hasTrait<OpTrait::ReturnLike>() &&
+          !llvm::isa<CallableOpInterface>(ownerOp->getParentOp())) {
+        auto parent = ownerOp->getParentOp();
+        auto result = parent->getResult(use.getOperandNumber());
+        worklist.insert(result);
       }
 
       // Step across global stores and into all of the loads across the program.

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
@@ -872,8 +872,8 @@ TraversalResult Explorer::walkTransitiveUses(Value value, UseWalkFn fn) {
                  << operandIdx << "\n");
       return TraversalResult::COMPLETE;
     }
-    auto result =
-        branchOp.getSuccessorOperands(RegionBranchPoint::parent())[operandIdx - beginIdx];
+    auto result = branchOp.getSuccessorOperands(
+        RegionBranchPoint::parent())[operandIdx - beginIdx];
     LLVM_DEBUG({
       llvm::dbgs() << "   + queuing region result ";
       result.printAsOperand(llvm::dbgs(), asmState);


### PR DESCRIPTION
We can support the `scf` operations into the stream dialect by including nested processing of:
- form dispathc regions
- structural op conversaion
- refine usage