### PR TITLE
[Codegen] Only bufferize dispatches if not already bufferized

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
@@ -58,14 +58,17 @@ void BufferizeCopyOnlyDispatchesPass::runOnOperation() {
     /// Check if the dispatch has all sources for `flow.dispatch.tensor.store`
     /// operations coming from `flow.dispatch.tensor.load` operations. If so,
     /// this dispatch is just a copy dispatch.
+    bool hasFlowDispatchStore = false;
     auto walkResult = funcOp.walk(
         [&](IREE::Flow::DispatchTensorStoreOp storeOp) -> WalkResult {
+          hasFlowDispatchStore = true;
           return success(isReadOnly(storeOp.getValue()));
         });
     if (walkResult.wasInterrupted())
       continue;
-    // The function is just a copy.
-    copyOnlyFunctions.push_back(funcOp);
+    // The function is just a copy and is not yet bufferized.
+    if (hasFlowDispatchStore)
+      copyOnlyFunctions.push_back(funcOp);
   }
 
   // There are no copy-only functions. So nothing to do.

--- a/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
@@ -90,35 +90,21 @@ builtin.module {
 // -----
 
 #map = affine_map<(d0) -> (d0)>
-#map1 = affine_map<(d0) -> ()>
-#map2 = affine_map<(d0, d1) -> (d0, d1)>
-#map3 = affine_map<(d0, d1) -> ()>
 module {
   func.func @already_bufferized() {
     %c5120 = arith.constant 5120 : index
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : f32
     %cst_0 = arith.constant 1.000000e+00 : f32
-    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c5120) : memref<1001xf32, strided<[1], offset: 1280>, #hal.descriptor_type<storage_buffer>>
-    memref.assume_alignment %0, 64 : memref<1001xf32, strided<[1], offset: 1280>, #hal.descriptor_type<storage_buffer>>
-    %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c5120) : memref<1x1001xf32, strided<[1001, 1], offset: 1280>, #hal.descriptor_type<storage_buffer>>
-    memref.assume_alignment %1, 64 : memref<1x1001xf32, strided<[1001, 1], offset: 1280>, #hal.descriptor_type<storage_buffer>>
-    %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : memref<1x1001xf32, #hal.descriptor_type<storage_buffer>>
-    memref.assume_alignment %2, 64 : memref<1x1001xf32, #hal.descriptor_type<storage_buffer>>
-    %alloc = memref.alloc() : memref<f32>
-    linalg.fill ins(%cst : f32) outs(%alloc : memref<f32>)
-    linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["reduction"]} ins(%0 : memref<1001xf32, strided<[1], offset: 1280>, #hal.descriptor_type<storage_buffer>>) outs(%alloc : memref<f32>) {
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : memref<1001xf32, #hal.descriptor_type<storage_buffer>>
+    memref.assume_alignment %0, 64 : memref<1001xf32, #hal.descriptor_type<storage_buffer>>
+    %alloc = memref.alloc() : memref<1001xf32>
+    linalg.fill ins(%cst : f32) outs(%alloc : memref<1001xf32>)
+    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["reduction"]} ins(%alloc : memref<1001xf32>) outs(%0 : memref<1001xf32, #hal.descriptor_type<storage_buffer>>) {
     ^bb0(%in: f32, %out: f32):
-      %3 = arith.addf %in, %out : f32
-      linalg.yield %3 : f32
+      linalg.yield %in : f32
     }
-    linalg.generic {indexing_maps = [#map2, #map3, #map2], iterator_types = ["parallel", "parallel"]} ins(%1, %alloc : memref<1x1001xf32, strided<[1001, 1], offset: 1280>, #hal.descriptor_type<storage_buffer>>, memref<f32>) outs(%2 : memref<1x1001xf32, #hal.descriptor_type<storage_buffer>>) {
-    ^bb0(%in: f32, %in_1: f32, %out: f32):
-      %3 = arith.divf %cst_0, %in_1 : f32
-      %4 = arith.mulf %in, %3 : f32
-      linalg.yield %4 : f32
-    }
-    memref.dealloc %alloc : memref<f32>
+    memref.dealloc %alloc : memref<1001xf32>
     return
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
@@ -92,10 +92,8 @@ builtin.module {
 #map = affine_map<(d0) -> (d0)>
 module {
   func.func @already_bufferized() {
-    %c5120 = arith.constant 5120 : index
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : f32
-    %cst_0 = arith.constant 1.000000e+00 : f32
     %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : memref<1001xf32, #hal.descriptor_type<storage_buffer>>
     memref.assume_alignment %0, 64 : memref<1001xf32, #hal.descriptor_type<storage_buffer>>
     %alloc = memref.alloc() : memref<1001xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
@@ -86,3 +86,42 @@ builtin.module {
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       ins(%[[ZERO]] :
 //  CHECK-SAME:       outs(%[[SUBVIEW]] :
+
+// -----
+
+#map = affine_map<(d0) -> (d0)>
+#map1 = affine_map<(d0) -> ()>
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+#map3 = affine_map<(d0, d1) -> ()>
+module {
+  func.func @already_bufferized() {
+    %c5120 = arith.constant 5120 : index
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %cst_0 = arith.constant 1.000000e+00 : f32
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c5120) : memref<1001xf32, strided<[1], offset: 1280>, #hal.descriptor_type<storage_buffer>>
+    memref.assume_alignment %0, 64 : memref<1001xf32, strided<[1], offset: 1280>, #hal.descriptor_type<storage_buffer>>
+    %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c5120) : memref<1x1001xf32, strided<[1001, 1], offset: 1280>, #hal.descriptor_type<storage_buffer>>
+    memref.assume_alignment %1, 64 : memref<1x1001xf32, strided<[1001, 1], offset: 1280>, #hal.descriptor_type<storage_buffer>>
+    %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : memref<1x1001xf32, #hal.descriptor_type<storage_buffer>>
+    memref.assume_alignment %2, 64 : memref<1x1001xf32, #hal.descriptor_type<storage_buffer>>
+    %alloc = memref.alloc() : memref<f32>
+    linalg.fill ins(%cst : f32) outs(%alloc : memref<f32>)
+    linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["reduction"]} ins(%0 : memref<1001xf32, strided<[1], offset: 1280>, #hal.descriptor_type<storage_buffer>>) outs(%alloc : memref<f32>) {
+    ^bb0(%in: f32, %out: f32):
+      %3 = arith.addf %in, %out : f32
+      linalg.yield %3 : f32
+    }
+    linalg.generic {indexing_maps = [#map2, #map3, #map2], iterator_types = ["parallel", "parallel"]} ins(%1, %alloc : memref<1x1001xf32, strided<[1001, 1], offset: 1280>, #hal.descriptor_type<storage_buffer>>, memref<f32>) outs(%2 : memref<1x1001xf32, #hal.descriptor_type<storage_buffer>>) {
+    ^bb0(%in: f32, %in_1: f32, %out: f32):
+      %3 = arith.divf %cst_0, %in_1 : f32
+      %4 = arith.mulf %in, %3 : f32
+      linalg.yield %4 : f32
+    }
+    memref.dealloc %alloc : memref<f32>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @already_bufferized
+//       CHECK: memref.alloc

--- a/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
@@ -89,7 +89,6 @@ builtin.module {
 
 // -----
 
-#map = affine_map<(d0) -> (d0)>
 module {
   func.func @already_bufferized() {
     %c0 = arith.constant 0 : index
@@ -98,7 +97,7 @@ module {
     memref.assume_alignment %0, 64 : memref<1001xf32, #hal.descriptor_type<storage_buffer>>
     %alloc = memref.alloc() : memref<1001xf32>
     linalg.fill ins(%cst : f32) outs(%alloc : memref<1001xf32>)
-    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["reduction"]} ins(%alloc : memref<1001xf32>) outs(%0 : memref<1001xf32, #hal.descriptor_type<storage_buffer>>) {
+    linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["reduction"]} ins(%alloc : memref<1001xf32>) outs(%0 : memref<1001xf32, #hal.descriptor_type<storage_buffer>>) {
     ^bb0(%in: f32, %out: f32):
       linalg.yield %in : f32
     }


### PR DESCRIPTION
This essentially skips the check for new allocations in "copy-only" dispatches when the incoming dispatch is already bufferized. If the incoming dispatch is already bufferized we assume the user knows what they are doing.