### PR TITLE
NFC: ResourceUsage: Remove accidental copies

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/Stream/Analysis/ResourceUsage.h"
-#include <iree/compiler/Dialect/Stream/IR/StreamTypes.h>
 
 #include <utility>
 


### PR DESCRIPTION
This makes pass ~2x faster by avoiding copies.