### PR TITLE
[CPU] Collapse dimensions of elementwise ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -149,6 +149,7 @@ iree_compiler_cc_library(
         "BufferizationAnalysis.cpp",
         "BufferizeCopyOnlyDispatchesPass.cpp",
         "CleanupBufferAllocViewPass.cpp",
+        "CollapseElementwiseOpDims.cpp",
         "ConcretizePadResultShape.cpp",
         "ConvertBf16ArithToF32.cpp",
         "ConvertBf16ToUInt16Buffers.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -124,6 +124,7 @@ iree_cc_library(
     "BufferizationAnalysis.cpp"
     "BufferizeCopyOnlyDispatchesPass.cpp"
     "CleanupBufferAllocViewPass.cpp"
+    "CollapseElementwiseOpDims.cpp"
     "ConcretizePadResultShape.cpp"
     "ConvertBf16ArithToF32.cpp"
     "ConvertBf16ToUInt16Buffers.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/CollapseElementwiseOpDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CollapseElementwiseOpDims.cpp
@@ -114,7 +114,8 @@ struct CollapseElementwiseOpDimsPass
 
 } // namespace
 
-std::unique_ptr<OperationPass<func::FuncOp>> createCollapseElementwiseOpDimsPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createCollapseElementwiseOpDimsPass() {
   return std::make_unique<CollapseElementwiseOpDimsPass>();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/CollapseElementwiseOpDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CollapseElementwiseOpDims.cpp
@@ -1,0 +1,122 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/PassDetail.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace {
+
+/// Check whether the given dimensions are contiguous in the result map.
+/// If none of the dimension are present in the map return true as well.
+static bool areContiguousDims(int64_t dim, ArrayRef<int64_t> dims,
+                              AffineMap map) {
+  if (!map.isProjectedPermutation())
+    return false;
+
+  if (dims.empty())
+    return true;
+
+  // Checking for identity mapped dims for now.
+  // TODO: Add constraints based on dim/dims.
+  return map.getNumResults() == 0 || map.isMinorIdentityWithBroadcasting();
+}
+
+static SmallVector<ReassociationIndices>
+getCollapsableDims(linalg::GenericOp genericOp) {
+  if (genericOp.getNumParallelLoops() == 0) {
+    return {};
+  }
+
+  // TODO(dcaballe): Implement a more sophisticated union-find?
+  auto isContiguousParallelDim = [&](int64_t dim, utils::IteratorType iter,
+                                     ArrayRef<int64_t> parallelDimSet,
+                                     ArrayRef<AffineMap> indexingMaps) -> bool {
+    if (!linalg::isParallelIterator(iter)) {
+      return false;
+    }
+
+    for (AffineMap map : genericOp.getIndexingMapsArray()) {
+      if (!areContiguousDims(dim, parallelDimSet, map))
+        return false;
+    }
+    return true;
+  };
+
+  SmallVector<ReassociationIndices> collapsableDims;
+  ReassociationIndices parallelDimSet;
+  for (auto [dim, iter] : llvm::enumerate(genericOp.getIteratorTypesArray())) {
+    if (isContiguousParallelDim(dim, iter, parallelDimSet,
+                                genericOp.getIndexingMapsArray())) {
+      parallelDimSet.push_back(dim);
+    }
+
+    if (!linalg::isParallelIterator(iter) ||
+        dim == (genericOp.getNumParallelLoops() - 1)) {
+      if (parallelDimSet.size() > 1) {
+        collapsableDims.push_back(parallelDimSet);
+        parallelDimSet.clear();
+      }
+    }
+  }
+
+  return collapsableDims;
+}
+
+struct CollapseElementwiseOpDimsPass
+    : public CollapseElementwiseOpDimsBase<CollapseElementwiseOpDimsPass> {
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+
+    // Traverse the ops in the function to make sure we don't collapse
+    // operations that would prevent fusion. For now, we only collapse
+    // operations in functions with only generic ops, fill ops and tensor
+    // empty ops.
+    auto walkResult = funcOp.walk([](Operation *op) {
+      // Linalg ops.
+      if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
+        if (isa<linalg::FillOp>(op)) {
+          return WalkResult::advance();
+        }
+        if (isa<linalg::GenericOp>(op)) {
+          // TODO(dcaballe): Add extra checks on generic ops, if needed.
+          return WalkResult::advance();
+        }
+        return WalkResult::interrupt();
+      }
+
+      // Tensor ops.
+      if (isa<tensor::PackOp>(op)) {
+        return WalkResult::interrupt();
+      }
+
+      return WalkResult::advance();
+    });
+
+    if (walkResult.wasInterrupted()) {
+      return;
+    }
+
+    RewritePatternSet patterns(&getContext());
+    linalg::populateCollapseDimensions(patterns, getCollapsableDims);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>> createCollapseElementwiseOpDimsPass() {
+  return std::make_unique<CollapseElementwiseOpDimsPass>();
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -59,6 +59,10 @@ createBufferizeCopyOnlyDispatchesPass();
 /// allocations and view operations.
 std::unique_ptr<OperationPass<func::FuncOp>> createCleanupBufferAllocViewPass();
 
+/// TODO.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createCollapseElementwiseOpDimsPass();
+
 /// Concretizes tensor.pad op's result shape if its source op implements
 /// OffsetSizeAndStrideOpInterface. For example, pad(extract_slice).
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -39,6 +39,13 @@ def CleanupBufferAllocView :
   let constructor = "mlir::iree_compiler::createCleanupBufferAllocViewPass()";
 }
 
+def CollapseElementwiseOpDims :
+    Pass<"iree-codegen-collapse-elementwise-op-dims", "func::FuncOp"> {
+  let summary =
+      "TODO";
+  let constructor = "mlir::iree_compiler::createCollapseElementwiseOpDimsPass()";
+}
+
 def ConcretizePadResultShape :
     Pass<"iree-codegen-concretize-pad-result-shape", "func::FuncOp"> {
   let summary =


### PR DESCRIPTION
This PR adds a pass to collapse the dimensions of elementwise operations. Its applicability is currently limited to simple elementwise operations that do not perform transposes and are not expected to be fused with other operations that won't be collapsed.