### PR TITLE
[Codegen] Make IREEExpandStridedMetadata expand ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -132,7 +132,7 @@ struct EmulateNarrowTypePass
     RewritePatternSet patterns(ctx);
     arith::populateArithNarrowTypeEmulationPatterns(typeConverter, patterns);
     memref::populateMemRefNarrowTypeEmulationPatterns(typeConverter, patterns);
-    populateIREEResolveExtractStridedMetadataPatterns(ctx, patterns);
+    populateIREEResolveExtractStridedMetadataPatterns(patterns);
     vector::populateVectorNarrowTypeEmulationPatterns(typeConverter, patterns);
     populateIreeNarrowTypeEmulationPatterns(typeConverter, patterns);
 

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -239,14 +239,14 @@ struct IREEExpandStridedMetadataPass
 void populateIREEExpandExtractStridedMetadataPatterns(
     RewritePatternSet &patterns) {
   memref::populateExpandStridedMetadataPatterns(patterns);
-  patterns.insert<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
+  patterns.add<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
       patterns.getContext());
 }
 
 void populateIREEResolveExtractStridedMetadataPatterns(
     RewritePatternSet &patterns) {
   memref::populateResolveExtractStridedMetadataPatterns(patterns);
-  patterns.insert<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
+  patterns.add<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
       patterns.getContext());
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -244,10 +244,10 @@ void populateIREEExpandExtractStridedMetadataPatterns(
 }
 
 void populateIREEResolveExtractStridedMetadataPatterns(
-    MLIRContext *context, RewritePatternSet &patterns) {
+    RewritePatternSet &patterns) {
   memref::populateResolveExtractStridedMetadataPatterns(patterns);
   patterns.insert<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
-      context);
+      patterns.getContext());
 }
 
 void IREEExpandStridedMetadataPass::runOnOperation() {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -236,6 +236,13 @@ struct IREEExpandStridedMetadataPass
 };
 } // namespace
 
+void populateIREEExpandExtractStridedMetadataPatterns(
+    RewritePatternSet &patterns) {
+  memref::populateExpandStridedMetadataPatterns(patterns);
+  patterns.insert<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
+      patterns.getContext());
+}
+
 void populateIREEResolveExtractStridedMetadataPatterns(
     MLIRContext *context, RewritePatternSet &patterns) {
   memref::populateResolveExtractStridedMetadataPatterns(patterns);
@@ -246,7 +253,7 @@ void populateIREEResolveExtractStridedMetadataPatterns(
 void IREEExpandStridedMetadataPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
-  populateIREEResolveExtractStridedMetadataPatterns(context, patterns);
+  populateIREEExpandExtractStridedMetadataPatterns(patterns);
   populateRemoveDeadMemAllocPatterns(patterns);
   if (failed(
           applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -260,16 +260,6 @@ void populateConcretizePadResultShapePatterns(
 void populateFoldAffineMinInDistributedLoopsPatterns(
     RewritePatternSet &patterns, ArrayRef<int64_t> staticNumWorkgroup = {});
 
-/// Populates patterns for expanding memref operations that modify the metadata
-/// (sizes, offset, strides) of a memref into easier to analyze constructs.
-void populateIREEExpandExtractStridedMetadataPatterns(
-    RewritePatternSet &patterns);
-
-/// Populates patterns for resolving `memref.extract_strided_metadata` into
-/// `memref.extract_strided_metadata` of its source.
-void populateIREEResolveExtractStridedMetadataPatterns(
-    RewritePatternSet &patterns);
-
 /// Populates `patterns` with a very specific pattern that vectorizes a
 /// linalg.conv op for a single thread. The linalg.conv should compute on
 /// static-sized subviews. To match, output shape must be 1x1xWoxCo, where Co

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -178,7 +178,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createIREEComprehensiveBufferizePass(
         std::nullopt,
     std::optional<BufferizationOptions::MemCpyFn> memCpyFn = std::nullopt);
 
-/// Pass to resolve `memref.expand_strided_metadata` operations.
+/// Pass to expand memref operations that modify the metadata (sizes, offset,
+/// strides) of a memref into easier to analyze constructs.
 std::unique_ptr<Pass> createIREEExpandStridedMetadataPass();
 
 /// Instruments memory reads and writes for address tracking.
@@ -258,6 +259,16 @@ void populateConcretizePadResultShapePatterns(
 /// distributed loops.
 void populateFoldAffineMinInDistributedLoopsPatterns(
     RewritePatternSet &patterns, ArrayRef<int64_t> staticNumWorkgroup = {});
+
+/// Populates patterns for expanding memref operations that modify the metadata
+/// (sizes, offset, strides) of a memref into easier to analyze constructs.
+void populateIREEExpandExtractStridedMetadataPatterns(
+    RewritePatternSet &patterns);
+
+/// Populates patterns for resolving `memref.extract_strided_metadata` into
+/// `memref.extract_strided_metadata` of its source.
+void populateIREEResolveExtractStridedMetadataPatterns(
+    RewritePatternSet &patterns);
 
 /// Populates `patterns` with a very specific pattern that vectorizes a
 /// linalg.conv op for a single thread. The linalg.conv should compute on

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -290,7 +290,8 @@ def IREEComprehensiveBufferize :
 
 def IREEExpandStridedMetadata :
     Pass<"iree-codegen-expand-strided-metadata", ""> {
-  let summary = "Resolve memref.extract_strided_metadata operations";
+  let summary = "Expand memref operations that modify metadata (sizes, offset,"
+                "strides) of a memref into easier to analyze constructs.";
   let constructor = "mlir::iree_compiler::createIREEExpandStridedMetadataPass()";
   let options = [
     Option<"allowUnresolved", "allow-unresolved", "bool", /*default=*/"false",

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -48,10 +48,15 @@ tileAndFuseDispatchUsingSCFForOp(RewriterBase &rewriter, TilingInterface op,
 void populateTileAndDistributeToWorkgroupsCleanupPatterns(
     RewritePatternSet &patterns, linalg::LinalgTilingOptions options);
 
-/// Populate IREE patterns related to resolving
-/// `memref.extract_strided_metadata`.
+/// Populates patterns for expanding memref operations that modify the metadata
+/// (sizes, offset, strides) of a memref into easier to analyze constructs.
+void populateIREEExpandExtractStridedMetadataPatterns(
+    RewritePatternSet &patterns);
+
+/// Populates patterns for resolving `memref.extract_strided_metadata` into
+/// `memref.extract_strided_metadata` of its source.
 void populateIREEResolveExtractStridedMetadataPatterns(
-    MLIRContext *context, RewritePatternSet &patterns);
+    RewritePatternSet &patterns);
 
 } // namespace iree_compiler
 } // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -724,6 +724,7 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
 
   // Resolve get_buffer_descriptor ops. All structural buffer manipulations
   // must conclude before this point.
+  passManager.addPass(memref::createFoldMemRefAliasOpsPass());
   passManager.addNestedPass<func::FuncOp>(
       createIREEExpandStridedMetadataPass());
   passManager.addNestedPass<func::FuncOp>(createCleanupBufferAllocViewPass());

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -73,6 +73,8 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
   // Resolve get_buffer_descriptor ops. All structural buffer manipulations
   // must conclude before this point.
   nestedModulePM.addNestedPass<func::FuncOp>(
+      memref::createFoldMemRefAliasOpsPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createIREEExpandStridedMetadataPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createResolveBufferDescriptorsPass());


### PR DESCRIPTION
Make IREEExpandStridedMetadata pass expand memref operations also instead of just resolving them.  This makes the pass consistent with what the mlir pass does. 

Needed for #14817