### PR TITLE
[LLVMGPU] Fold alias memrefs before expanding strided metadata in LLVMGPU

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -471,6 +471,7 @@ void addGPUDefaultPassPipeline(OpPassManager &pm) {
 static void addLowerAndOptimzeAddressComputation(OpPassManager &pm) {
   pm.addPass(createExtractAddressComputationGPUPass());
   pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
+  pm.addPass(memref::createFoldMemRefAliasOpsPass());
   pm.addPass(memref::createExpandStridedMetadataPass());
   // Hoist loop invariant variables to give decompose affine pass the right loop
   // dependencies.
@@ -546,8 +547,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addNestedPass<func::FuncOp>(createPolynomialApproximationPass());
 
   pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
-  pm.addPass(memref::createExpandStridedMetadataPass());
   pm.addPass(memref::createFoldMemRefAliasOpsPass());
+  pm.addPass(memref::createExpandStridedMetadataPass());
   pm.addPass(createEmulateNarrowTypePass());
   pm.addPass(createLowerAffinePass());
   pm.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
@@ -53,8 +53,7 @@
 // CHECK: %[[GRP_IDX3:.*]] = llvm.shl %[[GRP_IDX2]], %[[C2]]  : i64
 // CHECK: %{{.*}} = llvm.xor %[[SRC:.*]], %[[GRP_IDX3]]  : i64
 // CHECK: %[[ADJ_SRC:.*]] = llvm.add %[[SRC]], %[[C16]]  : i64
-// CHECK: %[[ADJ_SRC1:.*]] = llvm.xor %[[ADJ_SRC]], %[[GRP_IDX3]]  : i64
-// CHECK: %[[INV:.*]] = llvm.add %{{.*}}, %[[ADJ_SRC1]]  : i64
+// CHECK: %[[INV:.*]] = llvm.xor %[[ADJ_SRC]], %[[GRP_IDX3]]  : i64
 //
 // Find the basic block boundary.
 // CHECK: llvm.br ^[[LOOP_BODY:bb[0-9]+]](
@@ -66,7 +65,7 @@
 // CHECK: %[[VAR:.*]] = llvm.mul %[[IV]], %[[C4096]]
 //
 // Add the loop invariant part.
-// CHECK: %[[OFF:.*]] = llvm.add %[[INV]], %[[VAR]]
+// CHECK: %[[OFF:.*]] = llvm.add %{{.*}}, %[[INV]]
 //
 // Store the resulting offset in the memref descriptor.
 // llvm.insert %[[OFF]], %{{.*}}[2]


### PR DESCRIPTION
This patch makes sure that `memref.subview` ops are folded before expanding strided metadata for them, which causes lowering issues.