### PR TITLE
Handling useless initial task barriers in command buffers.

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
@@ -314,8 +314,12 @@ static iree_status_t iree_hal_task_command_buffer_emit_global_barrier(
   // Reset the tail of the command buffer to the barrier. This leaves us in a
   // consistent state if the recording ends immediate after this (the barrier
   // will be the last task).
-  iree_task_list_initialize(&command_buffer->leaf_tasks);
-  iree_task_list_push_back(&command_buffer->leaf_tasks, &barrier->header);
+  iree_task_list_t* target_task_list =
+      iree_task_list_is_empty(&command_buffer->root_tasks)
+          ? &command_buffer->root_tasks
+          : &command_buffer->leaf_tasks;
+  iree_task_list_initialize(target_task_list);
+  iree_task_list_push_back(target_task_list, &barrier->header);
 
   // NOTE: all new tasks emitted will be executed after this barrier.
   command_buffer->state.open_barrier = barrier;

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -137,7 +137,11 @@ static iree_status_t iree_hal_task_queue_wait_cmd(
 static void iree_hal_task_queue_wait_cmd_cleanup(
     iree_task_t* task, iree_status_code_t status_code) {
   iree_hal_task_queue_wait_cmd_t* cmd = (iree_hal_task_queue_wait_cmd_t*)task;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
   iree_hal_semaphore_list_release(&cmd->wait_semaphores);
+
+  IREE_TRACE_ZONE_END(z0);
 }
 
 // Allocates and initializes a iree_hal_task_queue_wait_cmd_t task.
@@ -224,6 +228,7 @@ static iree_status_t iree_hal_task_queue_issue_cmd(
 static void iree_hal_task_queue_issue_cmd_cleanup(
     iree_task_t* task, iree_status_code_t status_code) {
   iree_hal_task_queue_issue_cmd_t* cmd = (iree_hal_task_queue_issue_cmd_t*)task;
+  IREE_TRACE_ZONE_BEGIN(z0);
 
   // Release command buffers; some may have been released after issuing but this
   // handles leftovers that may appear due to failures.
@@ -231,6 +236,8 @@ static void iree_hal_task_queue_issue_cmd_cleanup(
     iree_hal_command_buffer_release(cmd->command_buffers[i]);
     cmd->command_buffers[i] = NULL;
   }
+
+  IREE_TRACE_ZONE_END(z0);
 }
 
 // Allocates and initializes a iree_hal_task_queue_issue_cmd_t task.
@@ -329,6 +336,7 @@ static void iree_hal_task_queue_retire_cmd_cleanup(
     iree_task_t* task, iree_status_code_t status_code) {
   iree_hal_task_queue_retire_cmd_t* cmd =
       (iree_hal_task_queue_retire_cmd_t*)task;
+  IREE_TRACE_ZONE_BEGIN(z0);
 
   // Release resources now that all are known to have retired.
   // In success cases we try to do this eagerly to allow for more potential
@@ -354,6 +362,8 @@ static void iree_hal_task_queue_retire_cmd_cleanup(
   iree_arena_allocator_t arena = cmd->arena;
   cmd = NULL;
   iree_arena_deinitialize(&arena);
+
+  IREE_TRACE_ZONE_END(z0);
 }
 
 // Allocates and initializes a iree_hal_task_queue_retire_cmd_t task.


### PR DESCRIPTION
These can arise from poorly optimized IR and ideally the compiler would not emit them but it's valid to do so and the implementation needs to check for them.

Fixes an assert hit in #14798.