### PR TITLE
[stablehlo] Rewriter for stablehlo.dot to linalg vec operations

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
@@ -318,9 +318,7 @@ struct GeneralDotConvert final
   }
 };
 
-
-struct DotVectorOptimization final
-    : OpRewritePattern<mlir::stablehlo::DotOp> {
+struct DotVectorOptimization final : OpRewritePattern<mlir::stablehlo::DotOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(mlir::stablehlo::DotOp op,
                                 PatternRewriter &rewriter) const override {
@@ -334,13 +332,15 @@ struct DotVectorOptimization final
 
     llvm::SmallVector<int64_t> dotShape;
     if (lhsTy.getRank() == 2 && lhsTy.getDimSize(0) == 1) {
-      lhs = b.create<mlir::stablehlo::ReshapeOp>(lhsTy.clone({lhsTy.getDimSize(1)}), lhs);
+      lhs = b.create<mlir::stablehlo::ReshapeOp>(
+          lhsTy.clone({lhsTy.getDimSize(1)}), lhs);
     } else if (lhsTy.getRank() == 2) {
       dotShape.push_back(lhsTy.getDimSize(0));
     }
 
     if (rhsTy.getRank() == 2 && rhsTy.getDimSize(1) == 1) {
-      rhs = b.create<mlir::stablehlo::ReshapeOp>(rhsTy.clone({rhsTy.getDimSize(0)}), rhs);
+      rhs = b.create<mlir::stablehlo::ReshapeOp>(
+          rhsTy.clone({rhsTy.getDimSize(0)}), rhs);
     } else if (lhsTy.getRank() == 2) {
       dotShape.push_back(rhsTy.getDimSize(1));
     }
@@ -350,9 +350,8 @@ struct DotVectorOptimization final
     }
 
     auto newDot = b.create<mlir::stablehlo::DotOp>(
-      resultTy.clone(dotShape), lhs, rhs, op.getPrecisionConfigAttr());
-    auto resultReshape = b.create<mlir::stablehlo::ReshapeOp>(
-      resultTy, newDot);
+        resultTy.clone(dotShape), lhs, rhs, op.getPrecisionConfigAttr());
+    auto resultReshape = b.create<mlir::stablehlo::ReshapeOp>(resultTy, newDot);
 
     rewriter.replaceOp(op, resultReshape);
     return success();

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
@@ -10,7 +10,9 @@
 #include "iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "stablehlo/dialect/StablehloOps.h"
@@ -316,7 +318,53 @@ struct GeneralDotConvert final
   }
 };
 
+
+struct DotVectorOptimization final
+    : OpRewritePattern<mlir::stablehlo::DotOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(mlir::stablehlo::DotOp op,
+                                PatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    Value lhs = op.getLhs();
+    Value rhs = op.getRhs();
+
+    ShapedType lhsTy = lhs.getType().cast<ShapedType>();
+    ShapedType rhsTy = rhs.getType().cast<ShapedType>();
+    ShapedType resultTy = op.getType().cast<ShapedType>();
+
+    llvm::SmallVector<int64_t> dotShape;
+    if (lhsTy.getRank() == 2 && lhsTy.getDimSize(0) == 1) {
+      lhs = b.create<mlir::stablehlo::ReshapeOp>(lhsTy.clone({lhsTy.getDimSize(1)}), lhs);
+    } else if (lhsTy.getRank() == 2) {
+      dotShape.push_back(lhsTy.getDimSize(0));
+    }
+
+    if (rhsTy.getRank() == 2 && rhsTy.getDimSize(1) == 1) {
+      rhs = b.create<mlir::stablehlo::ReshapeOp>(rhsTy.clone({rhsTy.getDimSize(0)}), rhs);
+    } else if (lhsTy.getRank() == 2) {
+      dotShape.push_back(rhsTy.getDimSize(1));
+    }
+
+    if (lhs == op.getLhs() && rhs == op.getRhs()) {
+      return rewriter.notifyMatchFailure(op, "no vector reform available.");
+    }
+
+    auto newDot = b.create<mlir::stablehlo::DotOp>(
+      resultTy.clone(dotShape), lhs, rhs, op.getPrecisionConfigAttr());
+    auto resultReshape = b.create<mlir::stablehlo::ReshapeOp>(
+      resultTy, newDot);
+
+    rewriter.replaceOp(op, resultReshape);
+    return success();
+  }
+};
+
 struct DotGeneralToDot final : impl::DotGeneralToDotBase<DotGeneralToDot> {
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<mlir::stablehlo::StablehloDialect, tensor::TensorDialect>();
+  }
+
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     populatePreprocessingDotGeneralToDotPatterns(&getContext(), &patterns);
@@ -330,8 +378,9 @@ struct DotGeneralToDot final : impl::DotGeneralToDotBase<DotGeneralToDot> {
 } // namespace
 
 void populatePreprocessingDotGeneralToDotPatterns(mlir::MLIRContext *context,
-                                                  RewritePatternSet *patterns) {
-  patterns->add<GeneralDotConvert>(context);
+                                                  RewritePatternSet *patterns,
+                                                  PatternBenefit benefit) {
+  patterns->add<GeneralDotConvert, DotVectorOptimization>(context, benefit);
 }
 
 } // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
@@ -10,7 +10,6 @@
 #include "iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Value.h"
@@ -359,10 +358,6 @@ struct DotVectorOptimization final : OpRewritePattern<mlir::stablehlo::DotOp> {
 };
 
 struct DotGeneralToDot final : impl::DotGeneralToDotBase<DotGeneralToDot> {
-
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<mlir::stablehlo::StablehloDialect, tensor::TensorDialect>();
-  }
 
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
@@ -340,7 +340,7 @@ struct DotVectorOptimization final : OpRewritePattern<mlir::stablehlo::DotOp> {
     if (rhsTy.getRank() == 2 && rhsTy.getDimSize(1) == 1) {
       rhs = b.create<mlir::stablehlo::ReshapeOp>(
           rhsTy.clone({rhsTy.getDimSize(0)}), rhs);
-    } else if (lhsTy.getRank() == 2) {
+    } else if (rhsTy.getRank() == 2) {
       dotShape.push_back(rhsTy.getDimSize(1));
     }
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/Rewriters.h
@@ -24,7 +24,8 @@ void populateCanonicalizationPatterns(MLIRContext *context,
 /// Collection of rewrite patterns for lowering of StableHLO dot general
 /// operations.
 void populatePreprocessingDotGeneralToDotPatterns(MLIRContext *context,
-                                                  RewritePatternSet *patterns);
+                                                  RewritePatternSet *patterns,
+                                                  PatternBenefit benefit = 1);
 
 /// Collection of rewrite patterns for lowering of StableHLO einsum operations.
 void populatePreprocessingEinsumToDotGeneralPatterns(

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgDotProd.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgDotProd.cpp
@@ -284,8 +284,8 @@ void populateStableHloDotProdToLinalgConversionPatterns(
             DotOpConversion<DotOperationType::kVectorDot, linalg::DotOp>,
             DotGeneralBatchMatMulOpConversion>(typeConverter, context,
                                                PatternBenefit(2));
-  // patterns->add<DotGeneralOpConversion>(typeConverter, context,
-  //                                       PatternBenefit(1));
+  patterns->add<DotGeneralOpConversion>(typeConverter, context,
+                                        PatternBenefit(1));
 }
 } // namespace detail
 } // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgDotProd.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/StableHLOToLinalgDotProd.cpp
@@ -284,8 +284,8 @@ void populateStableHloDotProdToLinalgConversionPatterns(
             DotOpConversion<DotOperationType::kVectorDot, linalg::DotOp>,
             DotGeneralBatchMatMulOpConversion>(typeConverter, context,
                                                PatternBenefit(2));
-  patterns->add<DotGeneralOpConversion>(typeConverter, context,
-                                        PatternBenefit(1));
+  // patterns->add<DotGeneralOpConversion>(typeConverter, context,
+  //                                       PatternBenefit(1));
 }
 } // namespace detail
 } // namespace mlir::iree_compiler::stablehlo


### PR DESCRIPTION
We should ensure that `linalg.matvec`, `linalg.vecmat` and `linalg.dot` are replaced when possible. This means DotGeneralToDot should bias towards the more efficient `linalg` implementations.