### PR TITLE
Add 'all-cores' config for running Mobile benchmarks

### DIFF
--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -339,6 +339,8 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
             return "80" if single_thread else "f0"
         elif device_parameters.ARM_LITTLE_CORES in device_params:
             return "08" if single_thread else "0f"
+        elif device_parameters.ALL_CORES in device_params:
+            return "80" if single_thread else "ff"
 
         raise ValueError(f"Unsupported config to deduce taskset: '{run_config}'.")
 

--- a/build_tools/python/e2e_test_framework/device_specs/device_collections.py
+++ b/build_tools/python/e2e_test_framework/device_specs/device_collections.py
@@ -55,9 +55,11 @@ ALL_DEVICE_SPECS = [
     # Pixel 4
     pixel_4_specs.LITTLE_CORES,
     pixel_4_specs.BIG_CORES,
+    pixel_4_specs.ALL_CORES,
     # Pixel 6 Pro
     pixel_6_pro_specs.LITTLE_CORES,
     pixel_6_pro_specs.BIG_CORES,
+    pixel_6_pro_specs.ALL_CORES,
     pixel_6_pro_specs.GPU,
     # Moto Edge X30
     moto_edge_x30_specs.GPU,

--- a/build_tools/python/e2e_test_framework/device_specs/pixel_4_specs.py
+++ b/build_tools/python/e2e_test_framework/device_specs/pixel_4_specs.py
@@ -27,3 +27,11 @@ LITTLE_CORES = common_definitions.DeviceSpec.build(
     device_parameters=[device_parameters.ARM_LITTLE_CORES],
     tags=["little-core"],
 )
+ALL_CORES = common_definitions.DeviceSpec.build(
+    id=unique_ids.DEVICE_SPEC_MOBILE_PIXEL_4 + "-all-core",
+    device_name=DEVICE_NAME,
+    architecture=common_definitions.DeviceArchitecture.ARMV8_2_A_GENERIC,
+    host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A,
+    device_parameters=[device_parameters.ALL_CORES],
+    tags=["all-cores"],
+)

--- a/build_tools/python/e2e_test_framework/device_specs/pixel_6_pro_specs.py
+++ b/build_tools/python/e2e_test_framework/device_specs/pixel_6_pro_specs.py
@@ -27,6 +27,14 @@ LITTLE_CORES = common_definitions.DeviceSpec.build(
     device_parameters=[device_parameters.ARM_LITTLE_CORES],
     tags=["little-core"],
 )
+ALL_CORES = common_definitions.DeviceSpec.build(
+    id=unique_ids.DEVICE_SPEC_MOBILE_PIXEL_6_PRO + "-all-core",
+    device_name=DEVICE_NAME,
+    architecture=common_definitions.DeviceArchitecture.ARMV8_2_A_GENERIC,
+    host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A,
+    device_parameters=[device_parameters.ALL_CORES],
+    tags=["all-cores"],
+)
 GPU = common_definitions.DeviceSpec.build(
     id=unique_ids.DEVICE_SPEC_MOBILE_PIXEL_6_PRO + "-gpu",
     device_name=DEVICE_NAME,


### PR DESCRIPTION
Currently mobile benchmarks run on either big cores or little cores, and not both. This PR adds the option to use all cores (assuming there are 8). This will be used for larger LLM benchmarks where all cores are needed.