### PR TITLE
[SPIRV] Add VecmatOp and MatvecOp to generalized named ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVGeneralizeNamedOps.cpp
@@ -30,9 +30,11 @@ struct SPIRVGeneralizeNamedOpsPass
 
 void SPIRVGeneralizeNamedOpsPass::runOnOperation() {
   auto funcOp = getOperation();
-  SmallVector<linalg::MatmulTransposeBOp> namedOpCandidates;
-  funcOp.walk([&](linalg::MatmulTransposeBOp linalgOp) {
-    namedOpCandidates.push_back(linalgOp);
+  SmallVector<linalg::LinalgOp> namedOpCandidates;
+  funcOp.walk([&](linalg::LinalgOp linalgOp) {
+    if (isa<linalg::MatmulTransposeBOp, linalg::VecmatOp, linalg::MatvecOp>(
+            linalgOp))
+      namedOpCandidates.push_back(linalgOp);
   });
 
   IRRewriter rewriter(&getContext());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/generalize_named_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/generalize_named_ops.mlir
@@ -26,3 +26,52 @@ module {
 // CHECK:      %[[A1:.+]] = arith.addf %[[OUT]], %[[A0]] : f32
 // CHECK:      linalg.yield %[[A1]] : f32
 // CHECK:      return %[[GEN]] : tensor<1x32000xf32>
+
+// -----
+
+module {
+  func.func @matvec(%arg0: tensor<32000x4096xf32>, %arg1: tensor<4096xf32>) -> tensor<32000xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<32000xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<32000xf32>) -> tensor<32000xf32>
+    %2 = linalg.matvec ins(%arg0, %arg1 : tensor<32000x4096xf32>, tensor<4096xf32>) outs(%1 : tensor<32000xf32>) -> tensor<32000xf32>
+    return %2 : tensor<32000xf32>
+  }
+}
+
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK:      func.func @matvec
+// CHECK:        linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "reduction"]
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[IN0:.+]]: f32, %[[OUT:.+]]: f32)
+// CHECK:          %[[A0:.+]] = arith.mulf %[[IN]], %[[IN0]] : f32
+// CHECK:          %[[A1:.+]] = arith.addf %[[OUT]], %[[A0]] : f32
+// CHECK:          linalg.yield %[[A1]] : f32
+
+
+// -----
+
+module {
+  func.func @vecmat(%arg0: tensor<4096xf32>, %arg1: tensor<4096x32000xf32>) -> tensor<32000xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<32000xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<32000xf32>) -> tensor<32000xf32>
+    %2 = linalg.vecmat ins(%arg0, %arg1 : tensor<4096xf32>, tensor<4096x32000xf32>) outs(%1 : tensor<32000xf32>) -> tensor<32000xf32>
+    return %2 : tensor<32000xf32>
+  }
+}
+
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d1, d0)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK:      func.func @vecmat
+// CHECK:        linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "reduction"]
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[IN0:.+]]: f32, %[[OUT:.+]]: f32)
+// CHECK:          %[[A0:.+]] = arith.mulf %[[IN]], %[[IN0]] : f32
+// CHECK:          %[[A1:.+]] = arith.addf %[[OUT]], %[[A0]] : f32
+// CHECK:          linalg.yield %[[A1]] : f32


### PR DESCRIPTION
Following suit with `linalg.matmul_transpose_b`, generalizing such contraction-like named ops before simplifies the matching logic during KernelConfig given that such operations currently are treated like reductions at the moment anyway. Once a proper matvec pipeline is in place we can consider reverting this change.

Fixes #14961