### PR TITLE
[Codegen][LLVMCPU] Use output element type to decide if reduction is over integers.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -69,7 +69,7 @@ LogicalResult splitReductionPrecondition(Operation *op,
   }
 
   auto elemType =
-      getElementTypeOrSelf(linalgOp.getDpsInputOperand(0)->get().getType());
+      getElementTypeOrSelf(linalgOp.getDpsInitOperand(0)->get().getType());
   if (!(fpReductionReordering || elemType.isIntOrIndex())) {
     LLVM_DEBUG(
         llvm::dbgs()


### PR DESCRIPTION
Using the input type might lead to incorrect behavior of always enabling associative reordering (irrespective of whether the override flag `--iree-llvmcpu-reassociate-fp-reductions=false` is set or not). The output element type has to be used to make sure the flag is enforced correctly.

Towards #14934