### PR TITLE
Add torch-to-iree pipeline.

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/CMakeLists.txt
@@ -43,9 +43,13 @@ iree_cc_library(
     IREELinalgExtDialect
     MLIRFuncDialect
     MLIRIR
+    MLIRMemRefDialect
     MLIRPass
     MLIRTensorDialect
     MLIRTransforms
+    torch-mlir::ConversionPasses
+    torch-mlir::TorchConversionDialectIR
+    torch-mlir::TorchDialectPasses
     torch-mlir-dialects::TMTensorDialectIR
   PUBLIC
 )

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
@@ -6,6 +6,17 @@
 
 #include "torch-iree/InputConversion/Passes.h"
 
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+#include "torch-mlir/Conversion/TorchConversionToMLProgram/TorchConversionToMLProgram.h"
+#include "torch-mlir/Conversion/TorchToArith/TorchToArith.h"
+#include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
+#include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
+#include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
+
 namespace mlir {
 namespace iree_compiler {
 namespace TorchInput {
@@ -15,9 +26,48 @@ namespace {
 #include "torch-iree/InputConversion/Passes.h.inc" // IWYU pragma: export
 } // namespace
 
+void createTorchToIREEPipeline(OpPassManager &pm) {
+  // This pipeline adapted from
+  // createTorchBackendToLinalgOnTensorsBackendPipeline. Keep in sync with
+  // additions there. Lower to linalg + guards which is the input to codegen
+  // backends. We do this first as it tends to involve pattern-matching against
+  // constants, (e.g. dimensions which must be constant in a ranked programming
+  // model) and those constants get somewhat obscured by TorchToArith.
+  pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTMTensorPass());
+  pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToLinalgPass());
+  pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToSCFPass());
+  pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToArithPass());
+  pm.addPass(torch::createConvertTorchConversionToMLProgramPass());
+  pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
+
+  // Clean up any non-canonical code introduced above..
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  // Resolve `dim` ops on tensors (which currently live in the `memref`
+  // dialect for some reason -- we don't have memrefs at this level).
+  pm.addNestedPass<func::FuncOp>(
+      memref::createResolveShapedTypeResultDimsPass());
+  // The resolution of `dim` ops tends to create identical ops. CSE them.
+  pm.addNestedPass<func::FuncOp>(createCSEPass());
+
+  // Finish the type conversion from `torch` types to the types of the
+  // linalg-on-tensors backend contract.
+  pm.addPass(torch::TorchConversion::createFuncBackendTypeConversionPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(
+      torch::TorchConversion::createFinalizingBackendTypeConversionPass());
+
+  // TODO: Add validation pass.
+  pm.addPass(createSymbolDCEPass());
+}
+
 void registerTMTensorConversionPasses() {
   // Generated.
   registerPasses();
+
+  mlir::PassPipelineRegistration<>(
+      "torch-to-iree",
+      "Pipeline to lower from the Torch backend contract to legal IREE input.",
+      createTorchToIREEPipeline);
 }
 
 } // namespace TorchInput

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.h
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.h
@@ -17,6 +17,11 @@ namespace TorchInput {
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertTMTensorToLinalgExtPass();
 
+// Creates a pipeline that lowers from the torch backend contract to IREE.
+// This is based on the torch-backend-to-linalg-on-tensors-backend-pipeline
+// pipeline in torch-mlir but includes IREE specific lowerings.
+void createTorchToIREEPipeline(OpPassManager &pm);
+
 //===----------------------------------------------------------------------===//
 // Register all Passes
 //===----------------------------------------------------------------------===//

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/CMakeLists.txt
@@ -6,6 +6,7 @@ iree_lit_test_suite(
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"
+    "torch_to_iree.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/torch_to_iree.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/torch_to_iree.mlir
@@ -1,0 +1,29 @@
+// RUN: iree-opt --split-input-file --torch-to-iree %s | FileCheck %s
+// This is just a smoke test that the pipeline functions, and it also
+// validates any features different from upstream.
+
+// Verify that we can have IREE ops in the input and the types convert
+// properly.
+// CHECK: func @forward(%arg0: tensor<128x20xf32>) -> tensor<128x30xf32>
+// CHECK: linalg.matmul
+module {
+  func.func @forward(%arg0: !torch.vtensor<[128,20],f32>) -> !torch.vtensor<[128,30],f32> {
+    %_params.classifier.weight = util.global.load @_params.classifier.weight : tensor<30x20xf32>
+    %0 = torch_c.from_builtin_tensor %_params.classifier.weight : tensor<30x20xf32> -> !torch.vtensor<[30,20],f32>
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %1 = torch.aten.transpose.int %0, %int0, %int1 : !torch.vtensor<[30,20],f32>, !torch.int, !torch.int -> !torch.vtensor<[20,30],f32>
+    %2 = torch.aten.mm %arg0, %1 : !torch.vtensor<[128,20],f32>, !torch.vtensor<[20,30],f32> -> !torch.vtensor<[128,30],f32>
+    %int1_0 = torch.constant.int 1
+    %3 = torch.aten.mul.Scalar %2, %int1_0 : !torch.vtensor<[128,30],f32>, !torch.int -> !torch.vtensor<[128,30],f32>
+    %_params.classifier.bias = util.global.load @_params.classifier.bias : tensor<30xf32>
+    %4 = torch_c.from_builtin_tensor %_params.classifier.bias : tensor<30xf32> -> !torch.vtensor<[30],f32>
+    %int1_1 = torch.constant.int 1
+    %5 = torch.aten.mul.Scalar %4, %int1_1 : !torch.vtensor<[30],f32>, !torch.int -> !torch.vtensor<[30],f32>
+    %int1_2 = torch.constant.int 1
+    %6 = torch.aten.add.Tensor %3, %5, %int1_2 : !torch.vtensor<[128,30],f32>, !torch.vtensor<[30],f32>, !torch.int -> !torch.vtensor<[128,30],f32>
+    return %6 : !torch.vtensor<[128,30],f32>
+  }
+  util.global private @_params.classifier.weight {noinline} : tensor<30x20xf32>
+  util.global private @_params.classifier.bias {noinline} : tensor<30xf32>
+}


### PR DESCRIPTION
This is presently a very close cousin of the upstream MLIR pipeline, but it explicitly allows IREE specific IR that is not legal upstream.