### PR TITLE
[Codegen] Remove unused NVGPU includes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/PassDetail.h
+++ b/compiler/src/iree/compiler/Codegen/Common/PassDetail.h
@@ -12,7 +12,6 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/PassDetail.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/PassDetail.h
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -39,7 +39,6 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:MemRefDialect",
-        "@llvm-project//mlir:NVGPUDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Transforms",
     ],

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -30,7 +30,6 @@ iree_cc_library(
     ::PassesIncGen
     MLIRLinalgTransforms
     MLIRMemRefDialect
-    MLIRNVGPUDialect
     MLIRPass
     MLIRTransforms
     iree::compiler::Codegen::Dialect::IREECodegenDialect

--- a/compiler/src/iree/compiler/Codegen/SPIRV/PassDetail.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/PassDetail.h
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {


### PR DESCRIPTION
A few unused includes of NVGPU dialect made its way into LLVMCPU/others after the codegen pass split.