### PR TITLE
Adding `--iree-vulkan-experimental-indirect-bindings=true` flag.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -177,11 +177,11 @@ def HAL_DescriptorFlagsAttr :
 }
 
 def HAL_DescriptorSetLayoutFlags_None : I32BitEnumAttrCase<"None", 0x0000>;
-def HAL_DescriptorSetLayoutFlags_Reserved : I32BitEnumAttrCase<"Reserved", 0x0001>;
+def HAL_DescriptorSetLayoutFlags_Indirect : I32BitEnumAttrCase<"Indirect", 0x0001>;
 def HAL_DescriptorSetLayoutFlagsAttr :
     I32BitEnumAttr<"DescriptorSetLayoutFlags", "valid DescriptorSetLayout flags", [
       HAL_DescriptorSetLayoutFlags_None,
-      HAL_DescriptorSetLayoutFlags_Reserved,  // to make tblgen happy
+      HAL_DescriptorSetLayoutFlags_Indirect,
     ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
 }
@@ -614,12 +614,14 @@ def HAL_DescriptorSetLayoutAttr :
   }];
   let parameters = (ins
     AttrParameter<"int64_t", "">:$ordinal,
-    ArrayRefParameter<"DescriptorSetBindingAttr", "">:$bindings
+    ArrayRefParameter<"DescriptorSetBindingAttr", "">:$bindings,
+    OptionalParameter<"std::optional<DescriptorSetLayoutFlags>">:$flags
   );
   let assemblyFormat = [{
     `<`
     $ordinal `,`
     `bindings` `=` `[` $bindings `]`
+    (`,` `flags` `=` $flags^)?
     `>`
   }];
 }
@@ -714,7 +716,7 @@ def HAL_DeviceTargetAttr :
     bool hasConfigurationAttr(StringRef name);
 
     // Returns zero or more executable targets that this device supports.
-    SmallVector<ExecutableTargetAttr, 4> getExecutableTargets();
+    SmallVector<IREE::HAL::ExecutableTargetAttr, 4> getExecutableTargets();
 
     // Returns a list of target devices that may be active for the given
     // operation. This will recursively walk parent operations until one with
@@ -752,7 +754,7 @@ def HAL_DeviceTargetAttr :
 
     // Returns a list of all target executable configurations that may be
     // required for the given operation.
-    static SmallVector<ExecutableTargetAttr, 4>
+    static SmallVector<IREE::HAL::ExecutableTargetAttr, 4>
     lookupExecutableTargets(Operation *op);
   }];
   let hasCustomAssemblyFormat = 1;
@@ -807,6 +809,10 @@ def HAL_ExecutableTargetAttr :
     // device that can load an executable of this target.
     Attribute getMatchExpression();
 
+    // Returns true if there's an attribute with the given name in the
+    // configuration dictionary.
+    bool hasConfigurationAttr(StringRef name);
+
     // Returns true if this attribute is a generic version of |specificAttr|.
     // A more generic version will match with many specific versions.
     bool isGenericOf(IREE::HAL::ExecutableTargetAttr specificAttr);
@@ -815,7 +821,7 @@ def HAL_ExecutableTargetAttr :
     // This will recursively walk parent operations until one with the
     // `hal.executable.target` attribute is found or a `hal.executable.variant`
     // specifies a value. Returns nullptr if no target specification can be found.
-    static ExecutableTargetAttr lookup(Operation *op);
+    static IREE::HAL::ExecutableTargetAttr lookup(Operation *op);
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -516,6 +516,11 @@ Attribute ExecutableTargetAttr::getMatchExpression() {
   return DeviceMatchExecutableFormatAttr::get(getContext(), getFormat());
 }
 
+bool ExecutableTargetAttr::hasConfigurationAttr(StringRef name) {
+  auto configAttr = getConfiguration();
+  return configAttr && configAttr.get(name);
+}
+
 // For now this is very simple: if there are any specified fields that are
 // present in this attribute they must match. We could allow target backends
 // to customize this via attribute interfaces in the future if we needed.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
@@ -196,6 +196,31 @@ operator<<(AsmPrinter &printer,
 
 template <>
 struct FieldParser<
+    std::optional<mlir::iree_compiler::IREE::HAL::DescriptorSetLayoutFlags>> {
+  static FailureOr<mlir::iree_compiler::IREE::HAL::DescriptorSetLayoutFlags>
+  parse(AsmParser &parser) {
+    std::string value;
+    if (parser.parseKeywordOrString(&value))
+      return failure();
+    auto result = mlir::iree_compiler::IREE::HAL::symbolizeEnum<
+        mlir::iree_compiler::IREE::HAL::DescriptorSetLayoutFlags>(value);
+    if (!result.has_value())
+      return failure();
+    return result.value();
+  }
+};
+static inline AsmPrinter &operator<<(
+    AsmPrinter &printer,
+    std::optional<mlir::iree_compiler::IREE::HAL::DescriptorSetLayoutFlags>
+        param) {
+  printer << (param.has_value()
+                  ? mlir::iree_compiler::IREE::HAL::stringifyEnum(param.value())
+                  : StringRef{""});
+  return printer;
+}
+
+template <>
+struct FieldParser<
     std::optional<mlir::iree_compiler::IREE::HAL::DescriptorFlags>> {
   static FailureOr<mlir::iree_compiler::IREE::HAL::DescriptorFlags>
   parse(AsmParser &parser) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
@@ -18,9 +18,11 @@ namespace HAL {
 // Options controlling the SPIR-V translation.
 struct VulkanSPIRVTargetOptions {
   // Vulkan target environment as #vk.target_env attribute assembly.
-  std::string vulkanTargetEnv;
+  std::string targetEnv;
   // Vulkan target triple.
-  std::string vulkanTargetTriple;
+  std::string targetTriple;
+  // Whether to use indirect bindings for all generated dispatches.
+  bool indirectBindings = false;
 };
 
 // Returns a VulkanSPIRVTargetOptions struct initialized with Vulkan/SPIR-V

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -91,7 +91,6 @@ static std::optional<IREE::HAL::DescriptorFlags>
 convertDescriptorFlags(std::optional<IREE::Input::DescriptorFlags> src) {
   if (!src.has_value())
     return std::nullopt;
-
   switch (*src) {
   case IREE::Input::DescriptorFlags::None:
     return IREE::HAL::DescriptorFlags::None;
@@ -109,12 +108,28 @@ convertDescriptorSetBinding(IREE::Input::DescriptorSetBindingAttr src) {
       convertDescriptorFlags(src.getFlags()));
 }
 
+static std::optional<IREE::HAL::DescriptorSetLayoutFlags>
+convertDescriptorSetLayoutFlags(
+    std::optional<IREE::Input::DescriptorSetLayoutFlags> src) {
+  if (!src.has_value())
+    return std::nullopt;
+  switch (*src) {
+  case IREE::Input::DescriptorSetLayoutFlags::None:
+    return IREE::HAL::DescriptorSetLayoutFlags::None;
+  case IREE::Input::DescriptorSetLayoutFlags::Indirect:
+    return IREE::HAL::DescriptorSetLayoutFlags::Indirect;
+  default:
+    return std::nullopt;
+  }
+}
+
 static IREE::HAL::DescriptorSetLayoutAttr
 convertDescriptorSetLayout(IREE::Input::DescriptorSetLayoutAttr src) {
   return IREE::HAL::DescriptorSetLayoutAttr::get(
       src.getContext(), src.getOrdinal(),
       convertAttributes<IREE::HAL::DescriptorSetBindingAttr>(
-          src.getBindings(), convertDescriptorSetBinding));
+          src.getBindings(), convertDescriptorSetBinding),
+      convertDescriptorSetLayoutFlags(src.getFlags()));
 }
 
 static IREE::HAL::PipelineLayoutAttr

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
@@ -281,6 +281,18 @@ def IREEInput_DescriptorSetBindingAttr :
   }];
 }
 
+def IREEInput_DescriptorSetLayoutFlags_None :
+    I32BitEnumAttrCase<"None", 0x0000>;
+def IREEInput_DescriptorSetLayoutFlags_Indirect :
+    I32BitEnumAttrCase<"Indirect", 0x0001>;
+def IREEInput_DescriptorSetLayoutFlagsAttr :
+    I32BitEnumAttr<"DescriptorSetLayoutFlags", "valid DescriptorSetLayout flags", [
+      IREEInput_DescriptorSetLayoutFlags_None,
+      IREEInput_DescriptorSetLayoutFlags_Indirect,
+    ]> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Input";
+}
+
 def IREEInput_DescriptorSetLayoutAttr :
     AttrDef<IREEInput_Dialect, "DescriptorSetLayout", []> {
   let mnemonic = "descriptor_set.layout";
@@ -288,13 +300,15 @@ def IREEInput_DescriptorSetLayoutAttr :
 
   let parameters = (ins
     AttrParameter<"int64_t", "">:$ordinal,
-    ArrayRefParameter<"DescriptorSetBindingAttr", "">:$bindings
+    ArrayRefParameter<"DescriptorSetBindingAttr", "">:$bindings,
+    OptionalParameter<"std::optional<DescriptorSetLayoutFlags>">:$flags
   );
 
   let assemblyFormat = [{
     `<`
     $ordinal `,`
     `bindings` `=` `[` $bindings `]`
+    (`,` `flags` `=` $flags^)?
     `>`
   }];
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputDialect.h
@@ -48,6 +48,33 @@ namespace mlir {
 
 template <>
 struct FieldParser<
+    std::optional<mlir::iree_compiler::IREE::Input::DescriptorSetLayoutFlags>> {
+  static FailureOr<mlir::iree_compiler::IREE::Input::DescriptorSetLayoutFlags>
+  parse(AsmParser &parser) {
+    std::string value;
+    if (parser.parseKeywordOrString(&value))
+      return failure();
+    auto result = mlir::iree_compiler::IREE::Input::symbolizeEnum<
+        mlir::iree_compiler::IREE::Input::DescriptorSetLayoutFlags>(value);
+    if (!result.has_value())
+      return failure();
+    return result.value();
+  }
+};
+
+static inline AsmPrinter &operator<<(
+    AsmPrinter &printer,
+    std::optional<mlir::iree_compiler::IREE::Input::DescriptorSetLayoutFlags>
+        param) {
+  printer << (param.has_value()
+                  ? mlir::iree_compiler::IREE::Input::stringifyEnum(
+                        param.value())
+                  : StringRef{""});
+  return printer;
+}
+
+template <>
+struct FieldParser<
     std::optional<mlir::iree_compiler::IREE::Input::DescriptorFlags>> {
   static FailureOr<mlir::iree_compiler::IREE::Input::DescriptorFlags>
   parse(AsmParser &parser) {

--- a/runtime/src/iree/hal/pipeline_layout.h
+++ b/runtime/src/iree/hal/pipeline_layout.h
@@ -26,7 +26,11 @@ typedef struct iree_hal_device_t iree_hal_device_t;
 // A bitmask of flags controlling the behavior of a descriptor set.
 enum iree_hal_descriptor_set_layout_flag_bits_t {
   IREE_HAL_DESCRIPTOR_SET_LAYOUT_FLAG_NONE = 0u,
-  // TODO(benvanik): add flag bits for binding table usage modes.
+
+  // Indicates the descriptor sets are 'bindless' and passed via implementation-
+  // specific parameter buffers stored in memory instead of API-level calls.
+  // Ignored by implementations that don't have a concept of indirect bindings.
+  IREE_HAL_DESCRIPTOR_SET_LAYOUT_FLAG_INDIRECT = 1u << 0,
 };
 typedef uint32_t iree_hal_descriptor_set_layout_flags_t;
 


### PR DESCRIPTION
This makes all descriptor set layouts have the new `Indirect` bit set and plumbs it all the way through to the runtime
`IREE_HAL_DESCRIPTOR_SET_LAYOUT_FLAG_INDIRECT` bit. SPIR-V codegen can inspect the pipeline layout attr of exports to discover which descriptor sets are indirect and lower via `VK_KHR_buffer_device_address` and for the runtime to specially handle the indirect descriptor sets by producing device address buffers. The flag is currently experimental as interop with non-indirect dispatches (custom/produced by other higher layers like IREE input dialects/plugins) and multi-versioning (producing both direct and indirect) are TBD. It should be sufficient for users targeting specific Vulkan devices where they know the support is present, though.

Note that while this is just the plumbing for the flag and the IR/runtime bits nothing is either lowering differently or setting up the appropriate runtime structures but it should allow codegen to start experimenting with alternative lowerings.

Progress on #13945.