### PR TITLE
Fix build warning (-Wreturn-type) in MaterializeEncoding.cpp with GCC

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -108,6 +108,7 @@ chooseEncodingInfo(RankedTensorType tensorType) {
   case EncodingUser::BATCH_MATMUL_I8I8I32:
     return chooseEncodingInfoForMatmul(user, role, /*tileParams=*/{8, 4, 8});
   }
+  llvm_unreachable("unhandled EncodingUser case");
 }
 
 //===---------------------------------------------------------------------===//


### PR DESCRIPTION
/data/iree/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp: In function ‘mlir::FailureOr<mlir::iree_compiler::IREE::LinalgExt::MaterializeEncodingInfo> chooseEncodingInfo(mlir::RankedTensorType)’:
/data/iree/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp:111:1: warning: control reaches end of non-void function [-Wreturn-type]
  111 | }
      | ^