### PR TITLE
Add Tensor Tracing to inline-dynamic lowerings

### DIFF
--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/cmd_ops.mlir
@@ -156,3 +156,24 @@ func.func @cmdCall(%arg0: !stream.resource<external>, %arg1: i32, %arg2: !stream
   } => !stream.timepoint
   return %timepoint : !stream.timepoint
 }
+
+// -----
+
+// CHECK-LABEL: @trace_tensor
+// CHECK-SAME: %[[ARG0:.+]]: !hal.buffer
+func.func @trace_tensor(%arg0: !stream.resource<external>) -> () {
+  // CHECK: %[[C180:.+]] = arith.constant 180 : index
+  %c180 = arith.constant 180 : index
+
+  // CHECK: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK: %[[C45:.+]] = arith.constant 45 : index
+  // CHECK: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK: %[[C268435488:.+]] = arith.constant 268435488 : i32
+  // CHECK: %[[C1_i32:.+]] = arith.constant 1 : i32
+  // CHECK: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%[[ARG0]] : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
+  %tensor = stream.tensor.export %arg0 : tensor<1x45xi32> in !stream.resource<external>{%c180} -> tensor<1x45xi32>
+
+  // CHECK: hal_inline.buffer_view.trace %[[VIEW]] : !hal.buffer_view attributes {key = "whatevs"}
+  stream.tensor.trace {key = "whatevs"} %tensor : tensor<1x45xi32>
+  return
+}

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/BUILD.bazel
@@ -22,6 +22,7 @@ iree_compiler_cc_library(
     hdrs = ["Passes.h"],
     deps = [
         ":PassHeaders",
+        "//compiler/src/iree/compiler/Dialect/HAL/Conversion",
         "//compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL",
         "//compiler/src/iree/compiler/Dialect/HAL/Conversion/UtilToHAL",
         "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_library(
     MLIRSCFToControlFlow
     MLIRSupport
     MLIRTransforms
+    iree::compiler::Dialect::HAL::Conversion
     iree::compiler::Dialect::HAL::Conversion::StandardToHAL
     iree::compiler::Dialect::HAL::Conversion::UtilToHAL
     iree::compiler::Dialect::HAL::IR::HALDialect

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
@@ -103,7 +103,7 @@ func.func @trace_tensor(%arg0: !stream.resource<external>) -> !hal.buffer_view {
   // CHECK: %[[C0:.+]] = arith.constant 0 : index
   // CHECK: %[[C268435488:.+]] = arith.constant 268435488 : i32
   // CHECK: %[[C1_i32:.+]] = arith.constant 1 : i32
-  // CHECK: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%arg0 : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
+  // CHECK: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%[[ARG0]] : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
   %tensor = stream.tensor.export %arg0 : tensor<1x45xi32> in !stream.resource<external>{%c180} -> tensor<1x45xi32>
 
   // CHECK: hal_inline.buffer_view.trace %[[VIEW]] : !hal.buffer_view attributes {key = "whatevs"}

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
@@ -94,7 +94,7 @@ func.func @cmdDispatch(%buffer0: !stream.resource<transient>, %buffer0_size: ind
 
 // CHECK-LABEL: @trace_tensor
 // CHECK-SAME: %[[ARG0:.+]]: !hal.buffer
-func.func @trace_tensor(%arg0: !stream.resource<external>) -> !hal.buffer_view {
+func.func @trace_tensor(%arg0: !stream.resource<external>) -> () {
   // CHECK: %[[C180:.+]] = arith.constant 180 : index
   %c180 = arith.constant 180 : index
 
@@ -108,5 +108,5 @@ func.func @trace_tensor(%arg0: !stream.resource<external>) -> !hal.buffer_view {
 
   // CHECK: hal_inline.buffer_view.trace %[[VIEW]] : !hal.buffer_view attributes {key = "whatevs"}
   stream.tensor.trace {key = "whatevs"} %tensor : tensor<1x45xi32>
-
+  return
 }

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
@@ -89,3 +89,29 @@ func.func @cmdDispatch(%buffer0: !stream.resource<transient>, %buffer0_size: ind
   // CHECK: return %c0
   return %fence : !stream.timepoint
 }
+
+// -----
+
+// CHECK-LABEL: @trace_tensor
+// CHECK-SAME: %[[ARG0:.+]]: !hal.buffer
+func.func @trace_tensor(%arg0: !stream.resource<external>) -> !hal.buffer_view {
+  // CHECK: %[[C180:.+]] = arith.constant 180 : index
+  %c180 = arith.constant 180 : index
+
+  // CHECK: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK: %[[C45:.+]] = arith.constant 45 : index
+  // CHECK: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK: %[[C268435488:.+]] = arith.constant 268435488 : i32
+  // CHECK: %[[C1_i32:.+]] = arith.constant 1 : i32
+  // CHECK: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%arg0 : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
+  %tensor = stream.tensor.export %arg0 : tensor<1x45xi32> in !stream.resource<external>{%c180} -> tensor<1x45xi32>
+
+  // CHECK: hal_inline.buffer_view.trace %[[VIEW]] : !hal.buffer_view attributes {key = "whatevs"}
+  stream.tensor.trace {key = "whatevs"} %tensor : tensor<1x45xi32>
+
+  // CHECK: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%[[ARG0]] : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
+  %buffer = stream.tensor.export %arg0 : tensor<1x45xi32> in !stream.resource<external>{%c180} -> !hal.buffer_view
+
+  // CHECK: return %[[VIEW]] : !hal.buffer_view
+  return %buffer : !hal.buffer_view
+}

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
@@ -109,9 +109,4 @@ func.func @trace_tensor(%arg0: !stream.resource<external>) -> !hal.buffer_view {
   // CHECK: hal_inline.buffer_view.trace %[[VIEW]] : !hal.buffer_view attributes {key = "whatevs"}
   stream.tensor.trace {key = "whatevs"} %tensor : tensor<1x45xi32>
 
-  // CHECK: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%[[ARG0]] : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
-  %buffer = stream.tensor.export %arg0 : tensor<1x45xi32> in !stream.resource<external>{%c180} -> !hal.buffer_view
-
-  // CHECK: return %[[VIEW]] : !hal.buffer_view
-  return %buffer : !hal.buffer_view
 }

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/BUILD.bazel
@@ -23,6 +23,7 @@ iree_compiler_cc_library(
     hdrs = ["Passes.h"],
     deps = [
         ":PassHeaders",
+        "//compiler/src/iree/compiler/Dialect/HAL/Conversion",
         "//compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL",
         "//compiler/src/iree/compiler/Dialect/HAL/Conversion/UtilToHAL",
         "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
     MLIRSCFToControlFlow
     MLIRSupport
     MLIRTransforms
+    iree::compiler::Dialect::HAL::Conversion
     iree::compiler::Dialect::HAL::Conversion::StandardToHAL
     iree::compiler::Dialect::HAL::Conversion::UtilToHAL
     iree::compiler::Dialect::HAL::IR::HALDialect

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Conversion.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/HAL/Conversion/StandardToHAL/Patterns.h"
+#include "iree/compiler/Dialect/HAL/Conversion/TypeConverter.h"
 #include "iree/compiler/Dialect/HAL/Conversion/UtilToHAL/Patterns.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/Util/Conversion/ConversionPatterns.h"
@@ -49,11 +50,19 @@ public:
         mlir::func::FuncDialect, mlir::scf::SCFDialect,
         mlir::arith::ArithDialect, mlir::affine::AffineDialect>();
 
-    TypeConverter typeConverter;
+    SmallVector<const HALConversionDialectInterface *> conversionInterfaces;
+    for (auto *dialect : context->getLoadedDialects()) {
+      if (auto *conversionInterface =
+              dialect
+                  ->getRegisteredInterface<HALConversionDialectInterface>()) {
+        conversionInterfaces.emplace_back(conversionInterface);
+      }
+    }
+
+    HALTypeConverter typeConverter(conversionInterfaces);
     RewritePatternSet patterns(context);
 
     // Pass-through.
-    typeConverter.addConversion([](Type type) { return type; });
     typeConverter.addConversion([](IndexType type) { return type; });
     typeConverter.addConversion([](IntegerType type) { return type; });
     typeConverter.addConversion([](FloatType type) { return type; });


### PR DESCRIPTION
The TypeConverter in StreamToHALLoader was missing the right type conversion causing failures when lowering to inlined HAL. Updated for the correct type conversion.