### PR TITLE
[CPU] Add mask cleanup patterns to vectorizer pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -298,7 +298,10 @@ void GenericVectorizationPass::runOnOperation() {
                                                         funcOp.getContext());
     vector::MaskOp::getCanonicalizationPatterns(maskCanonPatterns,
                                                 funcOp.getContext());
-    (void)applyPatternsAndFoldGreedily(funcOp, std::move(maskCanonPatterns));
+    if (failed(applyPatternsAndFoldGreedily(funcOp,
+                                            std::move(maskCanonPatterns)))) {
+      return signalPassFailure();
+    }
   }
 
   // TODO: Move this down the pipeline once we have the ODM-based masking

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -289,6 +289,18 @@ void GenericVectorizationPass::runOnOperation() {
                             vectorizeGatherAccesses);
   };
 
+  {
+    // Canonicalize mask related ops before we lower them.
+    RewritePatternSet maskCanonPatterns(funcOp.getContext());
+    vector::CreateMaskOp::getCanonicalizationPatterns(maskCanonPatterns,
+                                                      funcOp.getContext());
+    vector::ConstantMaskOp::getCanonicalizationPatterns(maskCanonPatterns,
+                                                        funcOp.getContext());
+    vector::MaskOp::getCanonicalizationPatterns(maskCanonPatterns,
+                                                funcOp.getContext());
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(maskCanonPatterns));
+  }
+
   // TODO: Move this down the pipeline once we have the ODM-based masking
   // representation.
   RewritePatternSet vectorizationPatterns(funcOp.getContext());


### PR DESCRIPTION
This PR adds cleanup patterns to remove redundant mask ops that won't be removed otherwise if the mask ops are lowered.