### PR TITLE
Integrate llvm-project to 5cf714bb2f75552b10e1eb62fd07aec4b6033881.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -96,7 +96,7 @@ struct CanonicalizeForOpInductionVarShape final
     SmallVector<Operation *, 8> resultOps;
     auto terminator = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
     auto returnValues = llvm::to_vector<8>(terminator.getOperands());
-    auto initArgs = llvm::to_vector<8>(forOp.getIterOperands());
+    auto initArgs = llvm::to_vector<8>(forOp.getInitArgs());
     for (auto [index, iterArg] : llvm::enumerate(forOp.getRegionIterArgs())) {
       if (!iterArg.hasOneUse())
         continue;
@@ -167,7 +167,7 @@ struct PackForOpInductionVarVector final : public OpRewritePattern<scf::ForOp> {
       return failure();
 
     // Bit cast all init values from v8f16 to v4f32.
-    auto ivInitValues = llvm::to_vector<8>(forOp.getIterOperands());
+    auto ivInitValues = llvm::to_vector<8>(forOp.getInitArgs());
     for (unsigned index : ivIndices) {
       Value oldValue = ivInitValues[index];
       ivInitValues[index] = rewriter.create<vector::BitCastOp>(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPULayoutAnalysisAndDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPULayoutAnalysisAndDistribution.cpp
@@ -961,7 +961,7 @@ static void replaceForOpWithNewSignature(RewriterBase &rewriter,
   // We will be using dummy values instead of the old operands
   // only for those operands that are being distributed
   SmallVector<Value> newOperands;
-  auto operands = llvm::to_vector(loop.getIterOperands());
+  auto operands = llvm::to_vector(loop.getInitArgs());
   for (auto operand : operands) {
     if (!layoutMap.count(operand)) {
       newOperands.push_back(operand);
@@ -1018,7 +1018,7 @@ static void distributeFor(scf::ForOp forOp, DenseMap<Value, Layout> &layoutMap,
   rewriter.setInsertionPoint(forOp);
 
   SmallVector<Value> newOperands;
-  for (const auto &operand : llvm::enumerate(forOp.getIterOperands())) {
+  for (const auto &operand : llvm::enumerate(forOp.getInitArgs())) {
     if (!simdToSimtMap.count(operand.value())) {
       continue;
     }
@@ -1044,7 +1044,7 @@ static void distributeYield(scf::YieldOp yieldOp,
       continue;
     // Replace the yield of old value with the for op argument to make it easier
     // to remove the dead code.
-    yieldOperands[operand.index()] = loop.getIterOperands()[operand.index()];
+    yieldOperands[operand.index()] = loop.getInitArgs()[operand.index()];
     yieldOperands.push_back(simdToSimtMap.at(operand.value()));
   }
   rewriter.create<scf::YieldOp>(yieldOp.getLoc(), yieldOperands);

--- a/compiler/src/iree/compiler/Codegen/Transforms/RemoveSingleIterationLoop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/RemoveSingleIterationLoop.cpp
@@ -181,9 +181,9 @@ struct SimplifyTrivialLoops : public OpRewritePattern<scf::ForOp> {
     // The first iteration is always run and the second iteration is never run
     // so the loop always have 1 iteration. Inline its body and remove the loop.
     SmallVector<Value> blockArgs;
-    blockArgs.reserve(op.getNumIterOperands() + 1);
+    blockArgs.reserve(op.getInitArgs().size() + 1);
     blockArgs.push_back(op.getLowerBound());
-    llvm::append_range(blockArgs, op.getIterOperands());
+    llvm::append_range(blockArgs, op.getInitArgs());
     replaceOpWithRegion(rewriter, op, op.getLoopBody(), blockArgs);
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
@@ -247,7 +247,7 @@ static LogicalResult printOperation(CppEmitter &emitter, scf::ForOp forOp) {
 
   raw_indented_ostream &os = emitter.ostream();
 
-  OperandRange operands = forOp.getIterOperands();
+  OperandRange operands = forOp.getInitArgs();
   Block::BlockArgListType iterArgs = forOp.getRegionIterArgs();
   Operation::result_range results = forOp.getResults();
 


### PR DESCRIPTION
This the next breaking API change, breaking on this commit:

```
    [mlir][SCF] scf.for: Consistent API around `initArgs` (#66512)

    * Always use the auto-generated `getInitArgs` function. Remove the
    hand-written `getInitOperands` duplicate.
    * Remove `hasIterOperands` and `getNumIterOperands`. The names were
    inconsistent because the "arg" is called `initArgs` in TableGen. Use
    `getInitArgs().size()` instead.
    * Fix verification around ops with no results.
```

Should be a mechanical fix.