### PR TITLE
Move SCFToCFG earlier in pipeline

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -182,6 +182,9 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
         return createFormDispatchWorkgroupsPass(
             clDispatchGenerateWorkloadRegion);
       })
+      // TODO(#15003): SCF support appears to be insufficient for stream work.
+      // Need to debug the cause.
+      .addPass(IREE::Flow::createTopLevelSCFToCFGPass)
       ////////////////////////////////////////////////////////////////////////
       .addPass(createCaptureDispatchDynamicDimsPass)
       .addPass(mlir::createCanonicalizerPass)


### PR DESCRIPTION
There appears to be a bug in the Stream pipeline's SCF support. Moving the SCFToCFG back to an earlier spot to avoid.

This is a workaround for https://github.com/openxla/iree/issues/15003 but should not be considered a fix.