### PR TITLE
[metal] Disable crashing reduce_window tests for now

### DIFF
--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -576,7 +576,7 @@ iree_check_single_backend_test_suite(
     "philox.mlir"
     "pow.mlir"
     "reduce.mlir"
-    "reduce_window.mlir"
+    # "reduce_window.mlir"  # TODO(15012): fix test crash
     "remainder.mlir"
     "reshape.mlir"
     "reverse.mlir"


### PR DESCRIPTION
Filed https://github.com/openxla/iree/issues/15012 to track the issue. Disbling for now to avoid marking all subsequent commits as failing CI.