### PR TITLE
[GlobalOptimization] Fold unit extent dims before fusing dequant with matmul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -301,6 +301,14 @@ getMinTilingSizesForEachDim(func::FuncOp entryPointFn, linalg::LinalgOp op,
   unsigned numLoops = op.getNumLoops();
   SmallVector<int64_t> minTileSizes(numLoops, 1);
   auto inputOutputOpOperands = op->getOpOperands();
+  int64_t fastestVaryingReductionDim = -1;
+  auto itTypes = op.getIteratorTypesArray();
+  for (int64_t idx = itTypes.size() - 1, e = 0; idx >= e; --idx) {
+    if (itTypes[idx] == utils::IteratorType::reduction) {
+      fastestVaryingReductionDim = idx;
+      break;
+    }
+  }
 
   for (auto [index, map] : llvm::enumerate(op.getIndexingMapsArray())) {
     // Check the fastest varying dimension of the operand. Set the vector size
@@ -312,6 +320,16 @@ getMinTilingSizesForEachDim(func::FuncOp entryPointFn, linalg::LinalgOp op,
     if (!fastestVaryingDimExpr)
       continue;
     unsigned fastestVaryingDim = fastestVaryingDimExpr.getPosition();
+
+    // If the fastest varying dimension for the operand is broadcasted along a
+    // faster varying reduction dimension, we should prefer a vector size of 1
+    // as the values will splat along the faster varying dim.
+    if (itTypes[fastestVaryingDim] == utils::IteratorType::reduction &&
+        fastestVaryingDim < fastestVaryingReductionDim &&
+        !map.isFunctionOfDim(fastestVaryingReductionDim)) {
+      minTileSizes[fastestVaryingDim] = 1;
+      continue;
+    }
 
     // If the indexing map has result it has to be a shaped type.
     auto operandType =

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -301,7 +301,7 @@ getMinTilingSizesForEachDim(func::FuncOp entryPointFn, linalg::LinalgOp op,
   unsigned numLoops = op.getNumLoops();
   SmallVector<int64_t> minTileSizes(numLoops, 1);
   auto inputOutputOpOperands = op->getOpOperands();
-  int64_t fastestVaryingReductionDim = -1;
+  std::optional<unsigned> fastestVaryingReductionDim = std::nullopt;
   auto itTypes = op.getIteratorTypesArray();
   for (int64_t idx = itTypes.size() - 1, e = 0; idx >= e; --idx) {
     if (itTypes[idx] == utils::IteratorType::reduction) {
@@ -325,8 +325,8 @@ getMinTilingSizesForEachDim(func::FuncOp entryPointFn, linalg::LinalgOp op,
     // faster varying reduction dimension, we should prefer a vector size of 1
     // as the values will splat along the faster varying dim.
     if (itTypes[fastestVaryingDim] == utils::IteratorType::reduction &&
-        fastestVaryingDim < fastestVaryingReductionDim &&
-        !map.isFunctionOfDim(fastestVaryingReductionDim)) {
+        fastestVaryingDim < *fastestVaryingReductionDim &&
+        !map.isFunctionOfDim(*fastestVaryingReductionDim)) {
       minTileSizes[fastestVaryingDim] = 1;
       continue;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -324,7 +324,8 @@ getMinTilingSizesForEachDim(func::FuncOp entryPointFn, linalg::LinalgOp op,
     // If the fastest varying dimension for the operand is broadcasted along a
     // faster varying reduction dimension, we should prefer a vector size of 1
     // as the values will splat along the faster varying dim.
-    if (itTypes[fastestVaryingDim] == utils::IteratorType::reduction &&
+    if (fastestVaryingReductionDim &&
+        itTypes[fastestVaryingDim] == utils::IteratorType::reduction &&
         fastestVaryingDim < *fastestVaryingReductionDim &&
         !map.isFunctionOfDim(*fastestVaryingReductionDim)) {
       minTileSizes[fastestVaryingDim] = 1;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
@@ -1954,3 +1954,71 @@ hal.executable private @non_trivial_program {
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>,
+    #hal.descriptor_set.binding<4, storage_buffer>
+  ]>
+]>
+
+hal.executable @i4_dequant_matvec {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    native_vector_size = 16 : index,
+    target_triple = "x86_64-unknown-linux-gnu"
+  }> {
+    hal.executable.export @i4_dequant_matvec_f32 layout(#pipeline_layout)
+    builtin.module {
+      func.func @i4_dequant_matvec_f32() {
+        %cst = arith.constant 0.000000e+00 : f32
+        %10 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<4096x86x128xi4>>
+        %11 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<4096x86xf32>>
+        %12 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<4096x86xf32>>
+        %13 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<86x128xf32>>
+        %14 = hal.interface.binding.subspan set(0) binding(4) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<4096xf32>>
+        %15 = flow.dispatch.tensor.load %10, offsets = [0, 0, 0], sizes = [4096, 86, 128], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<4096x86x128xi4>> -> tensor<4096x86x128xi4>
+        %16 = flow.dispatch.tensor.load %11, offsets = [0, 0], sizes = [4096, 86], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<4096x86xf32>> -> tensor<4096x86xf32>
+        %17 = flow.dispatch.tensor.load %12, offsets = [0, 0], sizes = [4096, 86], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<4096x86xf32>> -> tensor<4096x86xf32>
+        %18 = flow.dispatch.tensor.load %13, offsets = [0, 0], sizes = [86, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<86x128xf32>> -> tensor<86x128xf32>
+        %19 = tensor.empty() : tensor<4096xf32>
+        %20 = tensor.empty() : tensor<4096x86x128xf32>
+        %21 = linalg.fill ins(%cst : f32) outs(%19 : tensor<4096xf32>) -> tensor<4096xf32>
+        %22 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%15, %16, %17 : tensor<4096x86x128xi4>, tensor<4096x86xf32>, tensor<4096x86xf32>) outs(%20 : tensor<4096x86x128xf32>) {
+        ^bb0(%in: i4, %in_0: f32, %in_1: f32, %out: f32):
+          %24 = arith.extui %in : i4 to i32
+          %25 = arith.uitofp %24 : i32 to f32
+          %26 = arith.subf %25, %in_1 : f32
+          %27 = arith.mulf %26, %in_0 : f32
+          linalg.yield %27 : f32
+        } -> tensor<4096x86x128xf32>
+        %23 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%18, %22 : tensor<86x128xf32>, tensor<4096x86x128xf32>) outs(%21 : tensor<4096xf32>) {
+        ^bb0(%in: f32, %in_0: f32, %out: f32):
+          %24 = arith.mulf %in, %in_0 : f32
+          %25 = arith.addf %24, %out : f32
+          linalg.yield %25 : f32
+        } -> tensor<4096xf32>
+        flow.dispatch.tensor.store %23, %14, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf32> -> !flow.dispatch.tensor<writeonly:tensor<4096xf32>>
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32], [4], [0], [0]]>
+//   CHECK-DAG: #[[CONFIG1:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 0, 0], [4, 0, 0], [0, 0, 0], [0, 4, 4]]>
+//   CHECK-DAG: #[[CONFIG2:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 0, 0], [4, 0, 0], [0, 1, 4], [0, 0, 0]]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//       CHECK: hal.executable.export public @i4_dequant_matvec_f32
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.fill
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+//       CHECK: linalg.generic {{.*}} iterator_types = ["parallel", "parallel", "parallel"]
+//  CHECK-SAME:     lowering_config = #[[CONFIG1]]
+//       CHECK: linalg.generic {{.*}} iterator_types = ["parallel", "reduction", "reduction"]
+//  CHECK-SAME:     lowering_config = #[[CONFIG2]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fuse_dequantization_matmul.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fuse_dequantization_matmul.mlir
@@ -59,6 +59,64 @@ module {
 // -----
 
 module {
+  func.func @grouped_quantized_matvec(%arg0: tensor<4096x32x128xi8>, %arg1: tensor<32x128xf32>, %arg2: tensor<4096x32xf32>, %arg3: tensor<4096x32xf32>) -> tensor<4096xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<4096xf32>
+    %1 = tensor.empty() : tensor<4096x32x128xf32>
+    %2 = linalg.fill ins(%cst : f32) outs(%0 : tensor<4096xf32>) -> tensor<4096xf32>
+    %3 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, 
+                         affine_map<(d0, d1, d2) -> (d0, d1)>, 
+                         affine_map<(d0, d1, d2) -> (d0, d1)>, 
+                         affine_map<(d0, d1, d2) -> (d0, d1, d2)>], 
+        iterator_types = ["parallel", "parallel", "parallel"]} 
+        ins(%arg0, %arg2, %arg3 : tensor<4096x32x128xi8>, tensor<4096x32xf32>, tensor<4096x32xf32>) outs(%1 : tensor<4096x32x128xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %5 = arith.extui %in : i8 to i32
+      %6 = arith.uitofp %5 : i32 to f32
+      %7 = arith.subf %6, %in_1 : f32
+      %8 = arith.mulf %7, %in_0 : f32
+      linalg.yield %8 : f32
+    } -> tensor<4096x32x128xf32>
+    %4 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2)>, 
+                         affine_map<(d0, d1, d2) -> (d0, d1, d2)>, 
+                         affine_map<(d0, d1, d2) -> (d0)>], 
+        iterator_types = ["parallel", "reduction", "reduction"]} 
+        ins(%arg1, %3 : tensor<32x128xf32>, tensor<4096x32x128xf32>) outs(%2 : tensor<4096xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %5 = arith.mulf %in, %in_0 : f32
+      %6 = arith.addf %5, %out : f32
+      linalg.yield %6 : f32
+    } -> tensor<4096xf32>
+    return %4 : tensor<4096xf32>
+  }
+}
+//       CHECK: func.func @grouped_quantized_matvec
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<4096x32x128xi8>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<32x128xf32>
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<4096x32xf32>
+//  CHECK-SAME:   %[[ARG3:[a-zA-Z0-9_]+]]: tensor<4096x32xf32>
+//       CHECK:   %[[C0:.+]] = arith.constant 0.000000e+00 : f32
+//       CHECK:   %[[INIT1:.+]] = tensor.empty() : tensor<4096xf32>
+//       CHECK:   %[[INIT0:.+]] = tensor.empty() : tensor<4096x32x128xf32>
+//       CHECK:   %[[FILL:.+]] = linalg.fill ins(%[[C0]]
+//  CHECK-SAME:       outs(%[[INIT1]] :
+//       CHECK:   %[[DISP:.+]] = flow.dispatch.region -> (tensor<4096xf32>)
+//       CHECK:   %[[GEN0:.+]] = linalg.generic
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel"]
+//  CHECK-SAME:       ins(%[[ARG0]], %[[ARG2]], %[[ARG3]] :
+//  CHECK-SAME:       outs(%[[INIT0]] :
+//       CHECK:   %[[GEN1:.+]] = linalg.generic
+//  CHECK-SAME:       iterator_types = ["parallel", "reduction", "reduction"]
+//  CHECK-SAME:       ins(%[[ARG1]], %[[GEN0]] :
+//  CHECK-SAME:       outs(%[[FILL]] :
+//       CHECK:   flow.return %[[GEN1]] :
+//       CHECK:   return %[[DISP]]
+
+// -----
+
+module {
   func.func @ungrouped_quantized_matmul(%arg0: tensor<4096x32xi8>, %arg1: tensor<1x1x32xf32>, %arg2: tensor<4096x32xf32>, %arg3: tensor<4096x32xf32>) -> tensor<1x1x4096xf32> {
     %cst = arith.constant 0.000000e+00 : f32
     %0 = tensor.empty() : tensor<1x1x4096xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pipeline_tests.mlir
@@ -95,7 +95,7 @@ module {
 //       CHECK:   arith.subf
 //       CHECK:   arith.mulf
 //       CHECK:   %[[GEN1:.+]] = linalg.generic
-//  CHECK-SAME:       ["parallel", "parallel", "parallel", "reduction", "reduction"]
+//  CHECK-SAME:       ["parallel", "reduction", "reduction"]
 //  CHECK-SAME:       ins(
 //  CHECK-SAME:       %[[GEN0]]
 //  CHECK-SAME:       outs(
@@ -104,4 +104,5 @@ module {
 //       CHECK:   flow.dispatch.tensor.store %[[GEN1]]
 //       CHECK:   func.func @grouped_quantized_matmul(
 //       CHECK:     %[[T0:.+]] = flow.dispatch @[[EXECUTABLE0]]::@[[FUNC0]]
-//       CHECK:     return %[[T0]]
+//       CHECK:     %[[RS:.+]] = flow.tensor.reshape %[[T0]] : tensor<4096xf32> -> tensor<1x1x4096xf32>
+//       CHECK:     return %[[RS]]

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -62,8 +62,8 @@ void buildGlobalOptimizationPassPipeline(
       // - Remove unit-extent dimensions.
       .addPass(mlir::createConvertElementwiseToLinalgPass)
       .addPass(IREE::Flow::createGeneralizeLinalgNamedOpsPass)
-      .addPass(IREE::Flow::createFuseDequantizationMatmulPass)
       .addPass(IREE::Flow::createFoldUnitExtentDimsPass)
+      .addPass(IREE::Flow::createFuseDequantizationMatmulPass)
       // Enable data tiling after they are in a canonical form.
       .addPredicatedPass(transformOptions.options.dataTiling,
                          IREE::Flow::createSetEncodingPass)


### PR DESCRIPTION
Folding the unit dimensions away for matvec cases in advance eases codegen lowerings.

Additionally this improves tile size selection for multi-reduce ops with inputs broadcasted along a faster varying reduction dimension. In such cases, because we're expecting the broadcasted value to be splatted to the faster varying reduction dimension we should prefer a vector size of 1.