### PR TITLE
Fixing hal_inline file IO for variable initialization.

### DIFF
--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/cmd_ops.mlir
@@ -162,14 +162,14 @@ func.func @cmdCall(%arg0: !stream.resource<external>, %arg1: i32, %arg2: !stream
 // CHECK-LABEL: @trace_tensor
 // CHECK-SAME: %[[ARG0:.+]]: !hal.buffer
 func.func @trace_tensor(%arg0: !stream.resource<external>) -> () {
-  // CHECK: %[[C180:.+]] = arith.constant 180 : index
+  // CHECK-DAG: %[[C180:.+]] = arith.constant 180 : index
   %c180 = arith.constant 180 : index
 
-  // CHECK: %[[C1:.+]] = arith.constant 1 : index
-  // CHECK: %[[C45:.+]] = arith.constant 45 : index
-  // CHECK: %[[C0:.+]] = arith.constant 0 : index
-  // CHECK: %[[C268435488:.+]] = arith.constant 268435488 : i32
-  // CHECK: %[[C1_i32:.+]] = arith.constant 1 : i32
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C45:.+]] = arith.constant 45 : index
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C268435488:.+]] = arith.constant 268435488 : i32
+  // CHECK-DAG: %[[C1_i32:.+]] = arith.constant 1 : i32
   // CHECK: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%[[ARG0]] : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
   %tensor = stream.tensor.export %arg0 : tensor<1x45xi32> in !stream.resource<external>{%c180} -> tensor<1x45xi32>
 

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/file_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/file_ops.mlir
@@ -6,19 +6,22 @@
 // we'd need to support them and expose them through the runtime HAL module.
 
 // CHECK-LABEL: @file_constant
-//  CHECK-SAME: (%[[BUFFER:.+]]: !util.buffer)
-func.func @file_constant(%buffer: !util.buffer) {
+//  CHECK-SAME: (%[[BUFFER:.+]]: !util.buffer) -> !util.buffer
+func.func @file_constant(%buffer: !util.buffer) -> !stream.file {
   %c0 = arith.constant 0 : index
-  %c1088 = arith.constant 1088 : index
-  // CHECK: = arith.constant 0 : i32
-  %file = stream.file.constant %buffer[%c0 for %c1088] : !util.buffer{%c1088} -> !stream.file
-  return
+  %c100 = arith.constant 100 : index
+  %c200 = arith.constant 200 : index
+  %c300 = arith.constant 300 : index
+  // CHECK: %[[SPAN:.+]] = util.buffer.subspan %[[BUFFER]][%c100] : !util.buffer{%c300} -> !util.buffer{%c200}
+  %file = stream.file.constant %buffer[%c100 for %c200] : !util.buffer{%c300} -> !stream.file
+  // CHECK: return %[[SPAN]]
+  return %file : !stream.file
 }
 
 // -----
 
 // CHECK-LABEL: @file_read
-//  CHECK-SAME: (%[[WAIT:.+]]: i64, %[[FILE:.+]]: i32, %[[RESOURCE:.+]]: !util.buffer)
+//  CHECK-SAME: (%[[WAIT:.+]]: i64, %[[FILE:.+]]: !util.buffer, %[[RESOURCE:.+]]: !util.buffer)
 func.func @file_read(%wait: !stream.timepoint, %file: !stream.file, %resource: !stream.resource<variable>) -> !stream.timepoint {
   %c0 = arith.constant 0 : index
   %offset = arith.constant 100 : i64
@@ -32,13 +35,39 @@ func.func @file_read(%wait: !stream.timepoint, %file: !stream.file, %resource: !
 // -----
 
 // CHECK-LABEL: @file_write
-//  CHECK-SAME: (%[[WAIT:.+]]: i64, %[[FILE:.+]]: i32, %[[RESOURCE:.+]]: !util.buffer)
+//  CHECK-SAME: (%[[WAIT:.+]]: i64, %[[FILE:.+]]: !util.buffer, %[[RESOURCE:.+]]: !util.buffer)
 func.func @file_write(%wait: !stream.timepoint, %file: !stream.file, %resource: !stream.resource<variable>) -> !stream.timepoint {
   %c0 = arith.constant 0 : index
   %offset = arith.constant 100 : i64
   %c1088 = arith.constant 1088 : index
+  // CHECK: %[[FILE_SIZE:.+]] = util.buffer.size %[[FILE]]
+  // CHECK: util.buffer.copy %[[RESOURCE]][%c0], %[[FILE]][%c100], %c1088 : !util.buffer{%c1088} -> !util.buffer{%[[FILE_SIZE]]}
   // CHECK: %[[SIGNAL:.+]] = arith.constant 0 : i64
   %signal = stream.file.write await(%wait) => %resource[%c0], %file[%offset], %c1088 : !stream.resource<variable>{%c1088} -> !stream.file => !stream.timepoint
   // CHECK: return %[[SIGNAL]]
   return %signal : !stream.timepoint
+}
+
+// -----
+
+// CHECK-LABEL: @variable_read
+//  CHECK-SAME: (%[[WAIT:.+]]: i64) -> (!util.buffer, i64)
+func.func @variable_read(%wait: !stream.timepoint) -> (!stream.resource<variable>, !stream.timepoint) {
+  %c0 = arith.constant 0 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c100 = arith.constant 100 : i64
+  // CHECK: %[[CONSTANT:.+]] = util.buffer.constant
+  %constant = util.buffer.constant {alignment = 64 : index} : !util.buffer = dense<1> : tensor<64xi8>
+  // CHECK: %[[BUFFER:.+]], %[[STORAGE:.+]] = hal_inline.buffer.allocate
+  %resource = stream.resource.alloc uninitialized : !stream.resource<variable>{%c64}
+  // CHECK: %[[SPAN:.+]] = util.buffer.subspan %[[CONSTANT]][%c16] : !util.buffer{%c64} -> !util.buffer{%c32}
+  %file = stream.file.constant %constant[%c16 for %c32] : !util.buffer{%c64} -> !stream.file
+  // CHECK: %[[SPAN_SIZE:.+]] = util.buffer.size %[[SPAN]]
+  // CHECK: util.buffer.copy %[[SPAN]][%c100], %[[STORAGE]][%c32], %c32 : !util.buffer{%[[SPAN_SIZE]]} -> !util.buffer{%c64}
+  // CHECK: %[[SIGNAL:.+]] = arith.constant 0 : i64
+  %signal = stream.file.read await(%wait) => %file[%c100], %resource[%c32], %c32 : !stream.file -> !stream.resource<variable>{%c64} => !stream.timepoint
+  // CHECK: return %[[STORAGE]], %[[SIGNAL]]
+  return %resource, %signal : !stream.resource<variable>, !stream.timepoint
 }


### PR DESCRIPTION
This corrects the assumption in #14880 that all I/O would be loading into constants. Now we support the file I/O from constant buffers only by making copies. If we support file I/O on program ABI boundaries in the future (passing in a `!hal.file` as an argument/etc) we may need to change things but the hal_inline target isn't really intended for general programs doing arbitrary I/O.