### PR TITLE
Integrate changes to vectorization transform ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/Common/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/Common/Common.cpp
@@ -42,7 +42,7 @@ using transform::SequenceOp;
 using transform::SplitHandleOp;
 using transform::SplitReductionOp;
 using transform::TileToForallOp;
-using transform::VectorizeOp;
+using transform::VectorizeChildrenAndApplyPatternsOp;
 using transform_ext::RegisterMatchCallbacksOp;
 using transform_ext::TakeFirstOp;
 
@@ -291,7 +291,7 @@ Value mlir::iree_compiler::buildVectorize(ImplicitLocOpBuilder &b, Value funcH,
                                           bool applyCleanups,
                                           bool vectorizePadding,
                                           bool vectorizeNdExtract) {
-  funcH = b.create<VectorizeOp>(funcH, vectorizePadding, vectorizeNdExtract);
+  funcH = b.create<VectorizeChildrenAndApplyPatternsOp>(funcH, vectorizePadding, vectorizeNdExtract);
   if (applyCleanups) {
     iree_compiler::buildCanonicalizationAndEnablingTransforms(b, funcH);
   }

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.cpp
@@ -491,21 +491,21 @@ void mlir::iree_compiler::gpu::buildMatmulVectorization(
   if (!strategy.alignedLhs()) {
     MappingInfo lhsCopyMapping = strategy.lhsCopyMapping();
     SmallVector<bool> scalableSizes(lhsCopyMapping.tileSizes.size(), false);
-    b.create<transform::MaskedVectorizeOp>(lhsCopyOpH, ValueRange(), nullptr,
+    b.create<transform::VectorizeOp>(lhsCopyOpH, ValueRange(), nullptr,
                                            scalableSizes,
                                            lhsCopyMapping.tileSizes);
   }
   if (!strategy.alignedRhs()) {
     MappingInfo rhsCopyMapping = strategy.rhsCopyMapping();
     SmallVector<bool> scalableSizes(rhsCopyMapping.tileSizes.size(), false);
-    b.create<transform::MaskedVectorizeOp>(rhsCopyOpH, ValueRange(), nullptr,
+    b.create<transform::VectorizeOp>(rhsCopyOpH, ValueRange(), nullptr,
                                            scalableSizes,
                                            rhsCopyMapping.tileSizes);
   }
   if (!strategy.alignedRes()) {
     MappingInfo resCopyMapping = strategy.resCopyMapping();
     SmallVector<bool> scalableSizes(resCopyMapping.tileSizes.size(), false);
-    b.create<transform::MaskedVectorizeOp>(copyBackOpH, ValueRange(), nullptr,
+    b.create<transform::VectorizeOp>(copyBackOpH, ValueRange(), nullptr,
                                            scalableSizes,
                                            resCopyMapping.tileSizes);
   }

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.cpp
@@ -114,8 +114,8 @@ void iree_compiler::gpu::buildPadStrategy(ImplicitLocOpBuilder &b,
 
   // Step 3. Masked vectorization.
   SmallVector<bool> scalableSizes(strategy.vectorSize.size(), false);
-  b.create<transform::MaskedVectorizeOp>(padThreadH, ValueRange(), nullptr,
-                                         scalableSizes, strategy.vectorSize);
+  b.create<transform::VectorizeOp>(padThreadH, ValueRange(), nullptr,
+                        	   scalableSizes, strategy.vectorSize);
 
   // Step 4. Lower all masked vector transfers at this point, as they make
   // canonicalization generate incorrect IR.


### PR DESCRIPTION
Integrates op naming changes introduced by llvm-project commit [69bc1cbbff40ad6ff6feb552816b98a7ad6d4130](https://github.com/shark-infra/llvm-project/commit/69bc1cbbff40ad6ff6feb552816b98a7ad6d4130)