### PR TITLE
[spirv] Fix transfer op crash when vectorizing memref 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -37,12 +37,17 @@ constexpr int kMaxVectorNumElements = 4;
 
 namespace mlir {
 namespace iree_compiler {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Utility Functions
+//===----------------------------------------------------------------------===//
 
 /// Scans all uses of the given memref `value` to make sure they are ops that we
 /// can vectorize, including vector transfer ops and GPU subgroup MMA ops, or
 /// other ops that doesn't care. If so, places all vector transfer or GPU
 /// subgroup MMA ops in `uses` and returns true.
-static bool getUsesIfAllTransferOp(Value value,
+bool getUsesIfAllTransferOp(Value value,
                                    SmallVectorImpl<Operation *> &uses) {
   assert(uses.empty() && "expected uses to be empty");
   for (Operation *userOp : value.getUsers()) {
@@ -72,12 +77,12 @@ static bool getUsesIfAllTransferOp(Value value,
 }
 
 /// Returns the bitwidth of a scalar or vector type.
-static std::optional<unsigned> getBitWidth(Type type) {
+std::optional<unsigned> getBitWidth(Type type) {
   if (type.isIntOrFloat()) {
     return type.getIntOrFloatBitWidth();
   }
   if (llvm::isa<VectorType>(type)) {
-    auto vecType = llvm::cast<VectorType>(type);
+    auto vecType = cast<VectorType>(type);
     auto elementType = vecType.getElementType();
     return elementType.getIntOrFloatBitWidth() * vecType.getNumElements();
   }
@@ -85,7 +90,7 @@ static std::optional<unsigned> getBitWidth(Type type) {
 }
 
 // Calculates the vector bit count we want to use based on the memref uses.
-static unsigned
+unsigned
 calculateMemRefVectorNumBits(SmallVectorImpl<Operation *> &uses) {
   unsigned minBits = kMaxVectorNumBits;
   for (Operation *op : uses) {
@@ -120,7 +125,7 @@ calculateMemRefVectorNumBits(SmallVectorImpl<Operation *> &uses) {
     // still need to make sure we can load/store with good strides.
     // The `leadingDimension` attributes specifies the stride (numer of
     // *elements*) over the memref for the leading dimension.
-    auto memrefType = llvm::cast<MemRefType>(memrefVal.getType());
+    auto memrefType = cast<MemRefType>(memrefVal.getType());
     std::optional<unsigned> elementBits =
         getBitWidth(memrefType.getElementType());
     if (!elementBits)
@@ -137,9 +142,9 @@ calculateMemRefVectorNumBits(SmallVectorImpl<Operation *> &uses) {
 /// If the memref is vectorizable return the vector bit count we want to use,
 /// otherwise return 0. If it returns a value greater than 0 it also returns the
 /// memref uses.
-static unsigned isMemRefVectorizable(Value value,
+unsigned isMemRefVectorizable(Value value,
                                      SmallVectorImpl<Operation *> &uses) {
-  auto memrefType = llvm::dyn_cast<MemRefType>(value.getType());
+  auto memrefType = dyn_cast<MemRefType>(value.getType());
 
   // Require scalar element type
   if (!memrefType || (!llvm::isa<IntegerType>(memrefType.getElementType()) &&
@@ -205,7 +210,10 @@ static unsigned isMemRefVectorizable(Value value,
   return 0;
 }
 
-namespace {
+//===----------------------------------------------------------------------===//
+// MemRef Usage Analysis
+//===----------------------------------------------------------------------===//
+
 /// Analyze memref usages to decide if it should be vectorized. Right now the
 /// logic is to vectorize memref only if it is used by vector transfer
 /// read/write ops.
@@ -262,6 +270,10 @@ void MemRefUsageAnalysis::analyzeMemRefValue(Value value) {
   }
 }
 
+//===----------------------------------------------------------------------===//
+// MemRef Conversion Patterns
+//===----------------------------------------------------------------------===//
+
 template <typename OpTy>
 class MemRefConversionPattern : public OpConversionPattern<OpTy> {
 public:
@@ -292,7 +304,29 @@ public:
 
   LogicalResult
   matchAndRewrite(func::FuncOp funcOp, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override;
+                  ConversionPatternRewriter &rewriter) const override {
+    TypeConverter::SignatureConversion signatureConverter(
+        funcOp.getFunctionType().getNumInputs());
+    for (const auto &[index, arg] : llvm::enumerate(funcOp.getArguments())) {
+      if (memrefUsageAnalysis.shouldVectorizeMemRef(arg)) {
+        if (auto memrefType = getVectorizedMemRefType(rewriter, arg)) {
+          signatureConverter.addInputs(index, *memrefType);
+          continue;
+        }
+      }
+      signatureConverter.addInputs(index, arg.getType());
+    }
+    // Creates a new function with the update signature.
+    rewriter.applySignatureConversion(&funcOp.getFunctionBody(),
+                                      signatureConverter);
+
+    // Creates a new function with the update signature.
+    rewriter.updateRootInPlace(funcOp, [&] {
+      funcOp.setType(rewriter.getFunctionType(
+          signatureConverter.getConvertedTypes(), std::nullopt));
+    });
+    return success();
+  }
 };
 
 class ProcessTransferRead final
@@ -312,40 +346,88 @@ public:
 
     Location loc = read.getLoc();
 
-    auto scalarMemrefType =
-        llvm::dyn_cast<MemRefType>(read.getSource().getType());
-    auto vectorMemrefType =
-        llvm::dyn_cast<MemRefType>(adaptor.getSource().getType());
+    auto scalarMemrefType = dyn_cast<MemRefType>(read.getSource().getType());
+    auto vectorMemrefType = dyn_cast<MemRefType>(adaptor.getSource().getType());
+    auto memrefVectorType = cast<VectorType>(vectorMemrefType.getElementType());
     auto readVectorType = read.getVectorType();
-    if (!scalarMemrefType || !vectorMemrefType)
-      return failure();
+    if (!scalarMemrefType || !vectorMemrefType) {
+      return rewriter.notifyMatchFailure(
+          read, "failed to get scalar/vector memref type");
+    }
 
     std::optional<unsigned> vectorMemrefElemSize =
         getBitWidth(vectorMemrefType.getElementType());
     std::optional<unsigned> readVecSize = getBitWidth(readVectorType);
 
-    auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
-                                 adaptor.getIndices(), rewriter, loc);
+    FailureOr<SmallVector<Value>> indices =
+        adjustIndices(scalarMemrefType, vectorMemrefType, adaptor.getIndices(),
+                      rewriter, loc);
     if (failed(indices))
-      return failure();
+      return rewriter.notifyMatchFailure(read, "failed to adjust indices");
 
     // If the transfer_read can be replaced by a load after vectorization use
     // LoadOp and cast back to the original type.
     if (*vectorMemrefElemSize == *readVecSize) {
-      Type elemType = vectorMemrefType.getElementType();
       Value newLoad = rewriter.create<memref::LoadOp>(
-          loc, elemType, adaptor.getSource(), indices.value());
-      Type serializedVecType =
-          VectorType::get(read.getVectorType().getNumElements(),
-                          read.getVectorType().getElementType());
-      newLoad =
-          rewriter.create<vector::BitCastOp>(loc, serializedVecType, newLoad);
-      rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(
-          read, read.getVectorType(), newLoad);
-    } else {
-      rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
-          read, read.getVectorType(), adaptor.getSource(), indices.value());
+          loc, memrefVectorType, adaptor.getSource(), indices.value());
+      rewriter.replaceOpWithNewOp<vector::BitCastOp>(read, readVectorType,
+                                                     newLoad);
+      return success();
     }
+
+    // We use the minimal vector seen in all transfer uses as the vectorized
+    // memref element type, so it's guaranteed that the read vector size is
+    // some multiple of that.
+    assert(*readVecSize % *vectorMemrefElemSize == 0);
+
+    MLIRContext *context = rewriter.getContext();
+    AffineExpr sym0, sym1;
+    bindSymbols(context, sym0, sym1);
+    auto addMap = AffineMap::get(0, 2, {sym0 + sym1}, context);
+
+    // We have checked that this transfer op has identity map, so we increase
+    // the innermost index to perform continuous reads.
+    Value oldIndex = indices->back();
+
+    int vectorCount = *readVecSize / *vectorMemrefElemSize;
+    SmallVector<Value, 4> vectors;
+
+    VectorType combinedType =
+        VectorType::get(memrefVectorType.getNumElements() * vectorCount,
+                        memrefVectorType.getElementType());
+
+    for (int i = 0; i < vectorCount; ++i) {
+      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
+      indices->back() = rewriter.create<affine::AffineApplyOp>(
+          loc, addMap, ValueRange{oldIndex, iVal});
+      vectors.push_back(
+          rewriter.create<memref::LoadOp>(loc, adaptor.getSource(), *indices));
+    }
+
+    // If there is only two component vectors, we can use ShuffleOp, which is a
+    // bit simpler.
+    if (vectorCount == 2) {
+      SmallVector<int64_t> seqIndices =
+          llvm::to_vector(llvm::seq<int64_t>(readVectorType.getNumElements()));
+      auto ShuffleOp = rewriter.create<vector::ShuffleOp>(
+          loc, vectors[0], vectors[1], seqIndices);
+      rewriter.replaceOpWithNewOp<vector::BitCastOp>(read, readVectorType,
+                                                     ShuffleOp);
+      return success();
+    }
+
+    SmallVector<int64_t> offsets(combinedType.getRank(), 0);
+    SmallVector<int64_t> strides(combinedType.getRank(), 1);
+
+    Value newVector = rewriter.create<arith::ConstantOp>(
+        loc, combinedType, rewriter.getZeroAttr(combinedType));
+    for (int i = 0; i < vectorCount; ++i) {
+      offsets.back() = i * memrefVectorType.getNumElements();
+      newVector = rewriter.create<vector::InsertStridedSliceOp>(
+          loc, vectors[i], newVector, offsets, strides);
+    }
+
+    rewriter.replaceOp(read, newVector);
     return success();
   }
 };
@@ -367,38 +449,70 @@ public:
 
     Location loc = write.getLoc();
 
-    auto scalarMemrefType =
-        llvm::dyn_cast<MemRefType>(write.getSource().getType());
-    auto vectorMemrefType =
-        llvm::dyn_cast<MemRefType>(adaptor.getSource().getType());
+    auto scalarMemrefType = dyn_cast<MemRefType>(write.getSource().getType());
+    auto vectorMemrefType = dyn_cast<MemRefType>(adaptor.getSource().getType());
+    auto memrefVectorType = cast<VectorType>(vectorMemrefType.getElementType());
     auto writeVectorType = write.getVectorType();
-    if (!scalarMemrefType || !vectorMemrefType)
-      return failure();
+    if (!scalarMemrefType || !vectorMemrefType) {
+      return rewriter.notifyMatchFailure(
+          write, "failed to get scalar/vector memref type");
+    }
 
     std::optional<unsigned> vectorMemrefElemSize =
-        getBitWidth(vectorMemrefType.getElementType());
+        getBitWidth(memrefVectorType);
     std::optional<unsigned> writeVecSize = getBitWidth(writeVectorType);
 
-    auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
-                                 adaptor.getIndices(), rewriter, loc);
+    FailureOr<SmallVector<Value>> indices =
+        adjustIndices(scalarMemrefType, vectorMemrefType, adaptor.getIndices(),
+                      rewriter, loc);
     if (failed(indices))
-      return failure();
+      return rewriter.notifyMatchFailure(write, "failed to adjust indices");
 
     // If the transfer_write can be replaced by a store after vectorization cast
     // the original value and use StoreOp.
     if (*vectorMemrefElemSize == *writeVecSize) {
-      Type serializedVecType = VectorType::get(
-          writeVectorType.getNumElements(), writeVectorType.getElementType());
-      Value data = rewriter.create<vector::ShapeCastOp>(loc, serializedVecType,
-                                                        adaptor.getVector());
-      data = rewriter.create<vector::BitCastOp>(
-          loc, vectorMemrefType.getElementType(), data);
+      Value data = rewriter.create<vector::BitCastOp>(loc, memrefVectorType,
+                                                      adaptor.getVector());
       rewriter.replaceOpWithNewOp<memref::StoreOp>(
           write, data, adaptor.getSource(), indices.value());
-    } else {
-      rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
-          write, adaptor.getVector(), adaptor.getSource(), indices.value());
+      return success();
     }
+
+    // We use the minimal vector seen in all transfer uses as the vectorized
+    // memref element type, so it's guaranteed that the read vector size is
+    // some multiple of that.
+    assert(*writeVecSize % *vectorMemrefElemSize == 0);
+
+    MLIRContext *context = rewriter.getContext();
+    AffineExpr sym0, sym1;
+    bindSymbols(context, sym0, sym1);
+    auto addMap = AffineMap::get(0, 2, {sym0 + sym1}, context);
+
+    // We have checked that this transfer op has identity map, so we increase
+    // the innermost index to perform continuous reads.
+    Value oldIndex = indices->back();
+
+    int vectorCount = *writeVecSize / *vectorMemrefElemSize;
+
+    SmallVector<int64_t> offsets(writeVectorType.getRank(), 0);
+    SmallVector<int64_t> sizes(writeVectorType.getRank(), 1);
+    SmallVector<int64_t> strides(writeVectorType.getRank(), 1);
+    sizes.back() = memrefVectorType.getNumElements();
+
+    for (int i = 0; i < vectorCount; ++i) {
+      offsets.back() = i * memrefVectorType.getNumElements();
+      auto slice = rewriter.create<vector::ExtractStridedSliceOp>(
+          loc, adaptor.getVector(), offsets, sizes, strides);
+      auto component =
+          rewriter.create<vector::BitCastOp>(loc, memrefVectorType, slice);
+      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
+      indices->back() = rewriter.create<affine::AffineApplyOp>(
+          loc, addMap, ValueRange{oldIndex, iVal});
+      rewriter.create<memref::StoreOp>(loc, component, adaptor.getSource(),
+                                       *indices);
+    }
+
+    rewriter.eraseOp(write);
     return success();
   }
 };
@@ -415,7 +529,7 @@ template <typename OpTy>
 std::optional<MemRefType>
 MemRefConversionPattern<OpTy>::getVectorizedMemRefType(
     ConversionPatternRewriter &rewriter, Value memRefValue) const {
-  MemRefType type = llvm::cast<MemRefType>(memRefValue.getType());
+  MemRefType type = cast<MemRefType>(memRefValue.getType());
   unsigned vectorNumBits =
       memrefUsageAnalysis.getMemRefVectorSizeInBits(memRefValue);
 
@@ -426,8 +540,8 @@ MemRefConversionPattern<OpTy>::getVectorizedMemRefType(
   // allowed for loads use a larger element type.
   if (vectorNumElements > kMaxVectorNumElements) {
     scalarType = llvm::isa<IntegerType>(scalarType)
-                     ? llvm::cast<Type>(rewriter.getI32Type())
-                     : llvm::cast<Type>(rewriter.getF32Type());
+                     ? cast<Type>(rewriter.getI32Type())
+                     : cast<Type>(rewriter.getF32Type());
     scalarNumBits = scalarType.getIntOrFloatBitWidth();
     vectorNumElements = vectorNumBits / scalarNumBits;
   }
@@ -435,7 +549,7 @@ MemRefConversionPattern<OpTy>::getVectorizedMemRefType(
   if (scalarNumBits < 8) {
     assert(isa<IntegerType>(scalarType));
     assert(8 % scalarNumBits == 0);
-    scalarType = llvm::cast<Type>(rewriter.getI8Type());
+    scalarType = cast<Type>(rewriter.getI8Type());
     scalarNumBits = scalarType.getIntOrFloatBitWidth();
     vectorNumElements = vectorNumBits / scalarNumBits;
   }
@@ -449,7 +563,7 @@ MemRefConversionPattern<OpTy>::getVectorizedMemRefType(
 
   MemRefLayoutAttrInterface layout = {};
   if (auto stridedLayout =
-          llvm::dyn_cast<StridedLayoutAttr>(type.getLayout())) {
+          dyn_cast<StridedLayoutAttr>(type.getLayout())) {
     auto offset = stridedLayout.getOffset();
     if (offset != ShapedType::kDynamic) {
       offset = offset / ratio;
@@ -518,7 +632,7 @@ public:
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp subspanOp,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto memrefType = llvm::dyn_cast<MemRefType>(subspanOp.getType());
+    auto memrefType = dyn_cast<MemRefType>(subspanOp.getType());
     if (!memrefType)
       return failure();
 
@@ -548,9 +662,9 @@ struct ProcessSubgroupMMALoad final
   matchAndRewrite(gpu::SubgroupMmaLoadMatrixOp loadOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto scalarMemrefType =
-        llvm::dyn_cast<MemRefType>(loadOp.getSrcMemref().getType());
+        dyn_cast<MemRefType>(loadOp.getSrcMemref().getType());
     auto vectorMemrefType =
-        llvm::dyn_cast<MemRefType>(adaptor.getSrcMemref().getType());
+        dyn_cast<MemRefType>(adaptor.getSrcMemref().getType());
 
     Location loc = loadOp.getLoc();
     auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
@@ -582,9 +696,9 @@ struct ProcessSubgroupMMAStore final
   matchAndRewrite(gpu::SubgroupMmaStoreMatrixOp storeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto scalarMemrefType =
-        llvm::dyn_cast<MemRefType>(storeOp.getDstMemref().getType());
+        dyn_cast<MemRefType>(storeOp.getDstMemref().getType());
     auto vectorMemrefType =
-        llvm::dyn_cast<MemRefType>(adaptor.getDstMemref().getType());
+        dyn_cast<MemRefType>(adaptor.getDstMemref().getType());
 
     Location loc = storeOp.getLoc();
     auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
@@ -607,6 +721,10 @@ struct ProcessSubgroupMMAStore final
     return success();
   }
 };
+
+//===----------------------------------------------------------------------===//
+// Auxiliary Conversion Patterns
+//===----------------------------------------------------------------------===//
 
 template <typename OpT>
 class PassThroughConversion : public OpConversionPattern<OpT> {
@@ -760,6 +878,10 @@ struct ScalarizeVectorTransferWrite final
   }
 };
 
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
 class SPIRVVectorizeLoadStorePass final
     : public SPIRVVectorizeLoadStoreBase<SPIRVVectorizeLoadStorePass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -773,37 +895,26 @@ private:
 };
 } // namespace
 
-LogicalResult ProcessFunctionArgument::matchAndRewrite(
-    func::FuncOp funcOp, OpAdaptor adaptor,
-    ConversionPatternRewriter &rewriter) const {
-  TypeConverter::SignatureConversion signatureConverter(
-      funcOp.getFunctionType().getNumInputs());
-  for (const auto &[index, arg] : llvm::enumerate(funcOp.getArguments())) {
-    if (memrefUsageAnalysis.shouldVectorizeMemRef(arg)) {
-      if (auto memrefType = getVectorizedMemRefType(rewriter, arg)) {
-        signatureConverter.addInputs(index, *memrefType);
-        continue;
-      }
-    }
-    signatureConverter.addInputs(index, arg.getType());
-  }
-  // Creates a new function with the update signature.
-  rewriter.applySignatureConversion(&funcOp.getFunctionBody(),
-                                    signatureConverter);
-
-  // Creates a new function with the update signature.
-  rewriter.updateRootInPlace(funcOp, [&] {
-    funcOp.setType(rewriter.getFunctionType(
-        signatureConverter.getConvertedTypes(), std::nullopt));
-  });
-  return success();
-}
-
 void SPIRVVectorizeLoadStorePass::runOnOperation() {
   // Uses the signature conversion methodology of the dialect conversion
   // framework to implement the conversion.
   ModuleOp module = getOperation();
   MLIRContext *context = &getContext();
+
+  // Prior pass should have unrolled and broken down vectors with rank > 1.
+  for (func::FuncOp func : module.getOps<func::FuncOp>()) {
+    auto result = func.walk([](VectorTransferOpInterface transferOp) {
+      if (cast<VectorType>(transferOp.vector().getType()).getRank() > 1) {
+        transferOp.emitOpError(
+            "with rank > 1 should be broken down by prior passes");
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted()) {
+      signalPassFailure();
+    }
+  }
 
   memrefUsageAnalysis = &getAnalysis<MemRefUsageAnalysis>();
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -47,8 +47,7 @@ namespace {
 /// can vectorize, including vector transfer ops and GPU subgroup MMA ops, or
 /// other ops that doesn't care. If so, places all vector transfer or GPU
 /// subgroup MMA ops in `uses` and returns true.
-bool getUsesIfAllTransferOp(Value value,
-                                   SmallVectorImpl<Operation *> &uses) {
+bool getUsesIfAllTransferOp(Value value, SmallVectorImpl<Operation *> &uses) {
   assert(uses.empty() && "expected uses to be empty");
   for (Operation *userOp : value.getUsers()) {
     if (isa<memref::DeallocOp, memref::AssumeAlignmentOp>(userOp))
@@ -90,8 +89,7 @@ std::optional<unsigned> getBitWidth(Type type) {
 }
 
 // Calculates the vector bit count we want to use based on the memref uses.
-unsigned
-calculateMemRefVectorNumBits(SmallVectorImpl<Operation *> &uses) {
+unsigned calculateMemRefVectorNumBits(SmallVectorImpl<Operation *> &uses) {
   unsigned minBits = kMaxVectorNumBits;
   for (Operation *op : uses) {
     if (isa<gpu::SubgroupMmaLoadMatrixOp, gpu::SubgroupMmaStoreMatrixOp>(op)) {
@@ -142,8 +140,7 @@ calculateMemRefVectorNumBits(SmallVectorImpl<Operation *> &uses) {
 /// If the memref is vectorizable return the vector bit count we want to use,
 /// otherwise return 0. If it returns a value greater than 0 it also returns the
 /// memref uses.
-unsigned isMemRefVectorizable(Value value,
-                                     SmallVectorImpl<Operation *> &uses) {
+unsigned isMemRefVectorizable(Value value, SmallVectorImpl<Operation *> &uses) {
   auto memrefType = dyn_cast<MemRefType>(value.getType());
 
   // Require scalar element type
@@ -562,8 +559,7 @@ MemRefConversionPattern<OpTy>::getVectorizedMemRefType(
   newShape.back() = newShape.back() / ratio;
 
   MemRefLayoutAttrInterface layout = {};
-  if (auto stridedLayout =
-          dyn_cast<StridedLayoutAttr>(type.getLayout())) {
+  if (auto stridedLayout = dyn_cast<StridedLayoutAttr>(type.getLayout())) {
     auto offset = stridedLayout.getOffset();
     if (offset != ShapedType::kDynamic) {
       offset = offset / ratio;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
@@ -521,17 +521,19 @@ func.func @transfer_write_vector2_vector8(%x: index, %val0: vector<2xi32>, %val1
 
 // CHECK-LABEL: func @transfer_write_vector2_vector8
 //  CHECK-SAME: (%[[INDEX:.+]]: index, %[[VAL0:.+]]: vector<2xi32>, %[[VAL1:.+]]: vector<8xi32>)
-// CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<1024xvector<2xi32>>
-// CHECK:   %[[OFFSET0:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2)>()[%[[INDEX]]]
-// CHECK:   memref.store %[[VAL0]], %[[SUBSPAN]][%[[OFFSET0]]]
-// CHECK:   %[[SLICE0:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [0], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
-// CHECK:   memref.store %[[SLICE0]], %[[SUBSPAN]][%[[OFFSET0]]]
-// CHECK:   %[[SLICE1:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [2], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
-// CHECK:   %[[OFFSET1:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 1)>()[%[[INDEX]]]
-// CHECK:   memref.store %[[SLICE1]], %[[SUBSPAN]][%[[OFFSET1]]]
-// CHECK:   %[[SLICE2:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [4], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
-// CHECK:   %[[OFFSET2:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 2)>()[%[[INDEX]]]
-// CHECK:   memref.store %[[SLICE2]], %[[SUBSPAN]][%[[OFFSET2]]]
-// CHECK:   %[[SLICE3:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [6], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
-// CHECK:   %[[OFFSET3:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 3)>()[%[[INDEX]]]
-// CHECK:   memref.store %[[SLICE3]], %[[SUBSPAN]][%[[OFFSET3]]]
+//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<1024xvector<2xi32>>
+
+//       CHECK:   %[[OFFSET0:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2)>()[%[[INDEX]]]
+//       CHECK:   memref.store %[[VAL0]], %[[SUBSPAN]][%[[OFFSET0]]]
+
+//       CHECK:   %[[SLICE0:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [0], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
+//       CHECK:   memref.store %[[SLICE0]], %[[SUBSPAN]][%[[OFFSET0]]]
+//       CHECK:   %[[SLICE1:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [2], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
+//       CHECK:   %[[OFFSET1:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 1)>()[%[[INDEX]]]
+//       CHECK:   memref.store %[[SLICE1]], %[[SUBSPAN]][%[[OFFSET1]]]
+//       CHECK:   %[[SLICE2:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [4], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
+//       CHECK:   %[[OFFSET2:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 2)>()[%[[INDEX]]]
+//       CHECK:   memref.store %[[SLICE2]], %[[SUBSPAN]][%[[OFFSET2]]]
+//       CHECK:   %[[SLICE3:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [6], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
+//       CHECK:   %[[OFFSET3:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 3)>()[%[[INDEX]]]
+//       CHECK:   memref.store %[[SLICE3]], %[[SUBSPAN]][%[[OFFSET3]]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
@@ -1,38 +1,50 @@
 // RUN: iree-opt --split-input-file --iree-spirv-vectorize-load-store --canonicalize -cse --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-spirv-vectorize-load-store --cse --mlir-print-local-scope %s | FileCheck %s --check-prefix=BASE
 
-// CHECK-LABEL: func.func @alloc_copy
-//  CHECK-SAME: (%[[ARG0:.+]]: memref<4096x1024xvector<4xf32>>, %[[X:.+]]: index, %[[Y:.+]]: index)
-//       CHECK: %[[ALLOC:.+]] = memref.alloc() : memref<128x8xvector<4xf32>, 3>
-//       CHECK: %[[IDX:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 4)>()[%[[Y]]]
-//       CHECK: %[[V:.+]] = memref.load %[[ARG0]][%[[X]], %[[IDX]]] : memref<4096x1024xvector<4xf32>>
-//       CHECK: memref.store %[[V]], %[[ALLOC]][%[[X]], %[[IDX]]] : memref<128x8xvector<4xf32>, 3>
-//       CHECK: %[[MAT:.+]] = vector.transfer_read %[[ARG0]][%[[X]], %[[IDX]]], %{{.*}} : memref<4096x1024xvector<4xf32>>, vector<32x8xf32>
-//       CHECK: vector.transfer_write %[[MAT]], %[[ALLOC]][%[[X]], %[[IDX]]] : vector<32x8xf32>, memref<128x8xvector<4xf32>, 3>
-//       CHECK: memref.dealloc %[[ALLOC]] : memref<128x8xvector<4xf32>, 3>
-func.func @alloc_copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) {
+func.func @alloc_transfer_read_write_vector4_vector8(%arg0: memref<4096x4096xf32>, %x: index, %y: index) {
   %cst = arith.constant 0.000000e+00 : f32
   %0 = memref.alloc() : memref<128x32xf32, 3>
-  %v = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<1x4xf32>
-  vector.transfer_write %v, %0[%x, %y] : vector<1x4xf32>, memref<128x32xf32, 3>
-  %mat = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<32x8xf32>
-  vector.transfer_write %mat, %0[%x, %y] : vector<32x8xf32>, memref<128x32xf32, 3>
+  %v = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<4xf32>
+  vector.transfer_write %v, %0[%x, %y] : vector<4xf32>, memref<128x32xf32, 3>
+  %mat = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<8xf32>
+  vector.transfer_write %mat, %0[%x, %y] : vector<8xf32>, memref<128x32xf32, 3>
   memref.dealloc %0 : memref<128x32xf32, 3>
   return
 }
+
+// BASE-LABEL: func @alloc_transfer_read_write_vector4_vector8
+//  BASE-SAME: (%[[ARG:.+]]: memref<4096x1024xvector<4xf32>>, %[[IDX0:.+]]: index, %[[IDX1:.+]]: index)
+
+//   BASE-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   BASE-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   BASE-DAG:   %[[C4:.+]] = arith.constant 4 : index
+
+//       BASE:   %[[ALLOC:.+]] = memref.alloc() : memref<128x8xvector<4xf32>, 3>
+
+//       BASE:   %[[OFFSET0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 floordiv s1)>()[%[[IDX1]], %[[C4]]]
+//       BASE:   %[[LOAD:.+]] = memref.load %[[ARG]][%[[IDX0]], %[[OFFSET0]]]
+//       BASE:   memref.store %[[LOAD]], %[[ALLOC]][%[[IDX0]], %[[OFFSET0]]]
+
+//       BASE:   %[[OFFSET1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%0, %[[C0]]]
+//       BASE:   %[[LOAD1:.+]] = memref.load %[[ARG]][%[[IDX0]], %[[OFFSET1]]]
+//       BASE:   %[[OFFSET2:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%0, %[[C1]]]
+//       BASE:   %[[LOAD2:.+]] = memref.load %[[ARG]][%[[IDX0]], %[[OFFSET2]]]
+//       BASE:   %[[VEC:.+]] = vector.shuffle %[[LOAD1]], %[[LOAD2]] [0, 1, 2, 3, 4, 5, 6, 7] : vector<4xf32>, vector<4xf32>
+
+//       BASE:   %[[VEC0:.+]] = vector.extract_strided_slice %[[VEC]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+//       BASE:   memref.store %[[VEC0]], %[[ALLOC]][%[[IDX0]], %[[OFFSET1]]]
+//       BASE:   %[[VEC1:.+]] = vector.extract_strided_slice %[[VEC]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+//       BASE:   memref.store %[[VEC1]], %[[ALLOC]][%[[IDX0]], %4]
 
 // -----
 
 // Test that the memref is not vectorized if used by scalar load or store.
 
-// CHECK-LABEL: func.func @alloc_copy
+// CHECK-LABEL: func.func @dont_vectorize_scalar_load
 //  CHECK-SAME: %[[ARG0:.+]]: memref<4096x4096xf32>
-func.func @alloc_copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) {
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = memref.alloc() : memref<128x32xf32, 3>
+func.func @dont_vectorize_scalar_load(%arg0: memref<4096x4096xf32>, %x: index, %y: index) -> f32 {
   %s = memref.load %arg0[%x, %y] : memref<4096x4096xf32>
-  memref.store %s, %0[%x, %y] : memref<128x32xf32, 3>
-  memref.dealloc %0 : memref<128x32xf32, 3>
-  return
+  return %s : f32
 }
 
 // -----
@@ -42,17 +54,13 @@ func.func @alloc_copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) {
 //     CHECK: %[[B:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x1024xvector<4xf32>>
 //     CHECK: %[[V:.+]] = memref.load %[[A]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
 //     CHECK: memref.store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
-//     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf32>>, vector<32x8xf32>
-//     CHECK: vector.transfer_write %[[MAT]], %[[B]][%{{.*}}, %{{.*}}] {{.*}} : vector<32x8xf32>, memref<4096x1024xvector<4xf32>>
 func.func @resource_copy() {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4096x4096xf32>
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x4096xf32>
-  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<1x4xf32>
-  vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf32>, memref<4096x4096xf32>
-  %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<32x8xf32>
-  vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf32>, memref<4096x4096xf32>
+  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<4xf32>
+  vector.transfer_write %v, %1[%c0, %c0] : vector<4xf32>, memref<4096x4096xf32>
   return
 }
 
@@ -63,18 +71,14 @@ func.func @resource_copy() {
 //     CHECK: %[[B:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x1024xvector<4xf32>>
 //     CHECK: %[[V:.+]] = memref.load %[[A]][%{{.*}}, %{{.*}}, %{{.*}}] : memref<2048x4096x1024xvector<4xf32>, strided<[4194304, 1024, 1], offset: ?>>
 //     CHECK: memref.store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
-//     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}, %{{.*}}], %{{.*}} : memref<2048x4096x1024xvector<4xf32>, strided<[4194304, 1024, 1], offset: ?>>, vector<32x8xf32>
-//     CHECK: vector.transfer_write %[[MAT]], %[[B]][%{{.*}}, %{{.*}}] {{.*}} : vector<32x8xf32>, memref<4096x1024xvector<4xf32>>
 func.func @resource_copy_with_offset() {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
   %offset = hal.interface.constant.load[0] : index
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%offset) : memref<2048x4096x4096xf32, strided<[16777216, 4096, 1], offset: ?>>
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x4096xf32>
-  %v = vector.transfer_read %0[%c0, %c0, %c0], %cst : memref<2048x4096x4096xf32, strided<[16777216, 4096, 1], offset: ?>>, vector<1x4xf32>
-  vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf32>, memref<4096x4096xf32>
-  %mat = vector.transfer_read %0[%c0, %c0, %c0], %cst : memref<2048x4096x4096xf32, strided<[16777216, 4096, 1], offset: ?>>, vector<32x8xf32>
-  vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf32>, memref<4096x4096xf32>
+  %v = vector.transfer_read %0[%c0, %c0, %c0], %cst : memref<2048x4096x4096xf32, strided<[16777216, 4096, 1], offset: ?>>, vector<4xf32>
+  vector.transfer_write %v, %1[%c0, %c0] : vector<4xf32>, memref<4096x4096xf32>
   return
 }
 
@@ -85,17 +89,13 @@ func.func @resource_copy_with_offset() {
 //     CHECK: %[[B:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x1024xvector<4xf16>>
 //     CHECK: %[[V:.+]] = memref.load %[[A]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf16>>
 //     CHECK: memref.store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf16>>
-//     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf16>>, vector<32x8xf16>
-//     CHECK: vector.transfer_write %[[MAT]], %[[B]][%{{.*}}, %{{.*}}] {{.*}} : vector<32x8xf16>, memref<4096x1024xvector<4xf16>>
 func.func @resource_copy_f16() {
   %cst = arith.constant 0.000000e+00 : f16
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4096x4096xf16>
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x4096xf16>
-  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<1x4xf16>
-  vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf16>, memref<4096x4096xf16>
-  %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<32x8xf16>
-  vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf16>, memref<4096x4096xf16>
+  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<4xf16>
+  vector.transfer_write %v, %1[%c0, %c0] : vector<4xf16>, memref<4096x4096xf16>
   return
 }
 
@@ -106,17 +106,13 @@ func.func @resource_copy_f16() {
 //     CHECK: %[[B:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x512xvector<4xf32>>
 //     CHECK: %[[V:.+]] = memref.load %[[A]][%{{.*}}, %{{.*}}] : memref<4096x512xvector<4xf32>>
 //     CHECK: memref.store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x512xvector<4xf32>>
-//     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x512xvector<4xf32>>, vector<32x8xf16>
-//     CHECK: vector.transfer_write %[[MAT]], %[[B]][%{{.*}}, %{{.*}}] {{.*}} : vector<32x8xf16>, memref<4096x512xvector<4xf32>>
 func.func @resource_copy_8xf16() {
   %cst = arith.constant 0.000000e+00 : f16
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4096x4096xf16>
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x4096xf16>
-  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<1x8xf16>
-  vector.transfer_write %v, %1[%c0, %c0] : vector<1x8xf16>, memref<4096x4096xf16>
-  %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<32x8xf16>
-  vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf16>, memref<4096x4096xf16>
+  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<8xf16>
+  vector.transfer_write %v, %1[%c0, %c0] : vector<8xf16>, memref<4096x4096xf16>
   return
 }
 
@@ -136,15 +132,11 @@ func.func @resource_copy_dynamic_shape() {
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x8x?x128xf32>{%dim0, %dim1}
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x8x?x128xf32>{%dim0, %dim1}
 
-  // CHECK: %[[VAL1:.+]] = memref.load %[[INPUT]]
-  // CHECK: memref.store %[[VAL1]], %[[OUTPUT]]
-  %v = vector.transfer_read %0[%c0, %c0, %c0, %c0], %cst : memref<?x8x?x128xf32>, vector<1x4xf32>
-  vector.transfer_write %v, %1[%c0, %c0, %c0, %c0] : vector<1x4xf32>, memref<?x8x?x128xf32>
+  // CHECK: %[[VAL:.+]] = memref.load %[[INPUT]]
+  // CHECK: memref.store %[[VAL]], %[[OUTPUT]]
+  %v = vector.transfer_read %0[%c0, %c0, %c0, %c0], %cst : memref<?x8x?x128xf32>, vector<4xf32>
+  vector.transfer_write %v, %1[%c0, %c0, %c0, %c0] : vector<4xf32>, memref<?x8x?x128xf32>
 
-  // CHECK: %[[VAL2:.+]] = vector.transfer_read %[[INPUT]]
-  // CHECK: vector.transfer_write %[[VAL2]], %[[OUTPUT]]
-  %mat = vector.transfer_read %0[%c0, %c0, %c0, %c0], %cst : memref<?x8x?x128xf32>, vector<32x8xf32>
-  vector.transfer_write %mat, %1[%c0, %c0, %c0, %c0] : vector<32x8xf32>, memref<?x8x?x128xf32>
   return
 }
 
@@ -159,15 +151,15 @@ func.func @resource_copy_dynamic_last_dim() {
   // CHECK: hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x?xf32>
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4096x?xf32>{%dim}
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x?xf32>{%dim}
-  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x?xf32>, vector<1x4xf32>
-  vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf32>, memref<4096x?xf32>
+  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x?xf32>, vector<4xf32>
+  vector.transfer_write %v, %1[%c0, %c0] : vector<4xf32>, memref<4096x?xf32>
   return
 }
 
 // -----
 
-// CHECK-LABEL: func.func @do_not_vectorize_odd_vector_size
-func.func @do_not_vectorize_odd_vector_size() {
+// CHECK-LABEL: func.func @dont_vectorize_odd_vector_size
+func.func @dont_vectorize_odd_vector_size() {
   %cst = arith.constant 0.0 : f32
   %c0 = arith.constant 0 : index
   // CHECK: hal.interface.binding.subspan
@@ -180,21 +172,6 @@ func.func @do_not_vectorize_odd_vector_size() {
   vector.transfer_write %v, %1[%c0, %c0] : vector<3xf32>, memref<4x3xf32>
   return
 }
-
-// -----
-
-func.func @vectorize_binding_subspan() {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  // CHECK: hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4096x1024xvector<4xf32>>
-  // CHECK: hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x1024xvector<4xf32>>
-  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4096x4096xf32>
-  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<4096x4096xf32>
-  %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<32x8xf32>
-  vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf32>, memref<4096x4096xf32>
-  return
-}
-
 
 // -----
 
@@ -503,3 +480,58 @@ func.func @transfer_read_i3_memref_vector8(%x: index) -> vector<8xi3> {
 //   CHECK-LABEL: func.func @transfer_read_i3_memref_vector8
 //         CHECK:   hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<2048xi3>
 // CHECK-COUNT-8:   memref.load {{.+}} : memref<2048xi3>
+
+// -----
+
+func.func @transfer_read_vector2_vector8(%x: index) -> (vector<2xi32>, vector<8xi32>) {
+  %c0 = arith.constant 0 : i32
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<2048xi32>
+  %1 = vector.transfer_read %0[%x], %c0 {in_bounds = [true]} : memref<2048xi32>, vector<2xi32>
+  %2 = vector.transfer_read %0[%x], %c0 {in_bounds = [true]} : memref<2048xi32>, vector<8xi32>
+  return %1, %2: vector<2xi32>, vector<8xi32>
+}
+
+// CHECK-LABEL: func @transfer_read_vector2_vector8
+//  CHECK-SAME: (%[[INDEX:.+]]: index) -> (vector<2xi32>, vector<8xi32>)
+//       CHECK:   %[[INIT:.+]] = arith.constant dense<0> : vector<8xi32>
+//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan {{.+}} : memref<1024xvector<2xi32>>
+//       CHECK:   %[[OFFSET0:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2)>()[%[[INDEX]]]
+//       CHECK:   %[[LOAD0:.+]] = memref.load %[[SUBSPAN]][%[[OFFSET0]]]
+//       CHECK:   %[[OFFSE1:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 1)>()[%[[INDEX]]]
+//       CHECK:   %[[LOAD1:.+]] = memref.load %[[SUBSPAN]][%[[OFFSE1]]]
+//       CHECK:   %[[OFFSET2:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 2)>()[%[[INDEX]]]
+//       CHECK:   %[[LOAD2:.+]] = memref.load %[[SUBSPAN]][%[[OFFSET2]]]
+//       CHECK:   %[[OFFSET3:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 3)>()[%[[INDEX]]]
+//       CHECK:   %[[LOAD3:.+]] = memref.load %[[SUBSPAN]][%[[OFFSET3]]]
+//       CHECK:   %[[INSERT0:.+]] = vector.insert_strided_slice %[[LOAD0]], %[[INIT]] {offsets = [0], strides = [1]} : vector<2xi32> into vector<8xi32>
+//       CHECK:   %[[INSERT1:.+]] = vector.insert_strided_slice %[[LOAD1]], %[[INSERT0]] {offsets = [2], strides = [1]} : vector<2xi32> into vector<8xi32>
+//       CHECK:   %[[INSERT2:.+]] = vector.insert_strided_slice %[[LOAD2]], %[[INSERT1]] {offsets = [4], strides = [1]} : vector<2xi32> into vector<8xi32>
+//       CHECK:   %[[INSERT3:.+]] = vector.insert_strided_slice %[[LOAD3]], %[[INSERT2]] {offsets = [6], strides = [1]} : vector<2xi32> into vector<8xi32>
+//       CHECK:   return %[[LOAD0]], %[[INSERT3]]
+
+// -----
+
+func.func @transfer_write_vector2_vector8(%x: index, %val0: vector<2xi32>, %val1: vector<8xi32>) {
+  %c0 = arith.constant 0 : i32
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<2048xi32>
+  vector.transfer_write %val0, %0[%x] : vector<2xi32>, memref<2048xi32>
+  vector.transfer_write %val1, %0[%x] : vector<8xi32>, memref<2048xi32>
+  return
+}
+
+// CHECK-LABEL: func @transfer_write_vector2_vector8
+//  CHECK-SAME: (%[[INDEX:.+]]: index, %[[VAL0:.+]]: vector<2xi32>, %[[VAL1:.+]]: vector<8xi32>)
+// CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<1024xvector<2xi32>>
+// CHECK:   %[[OFFSET0:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2)>()[%[[INDEX]]]
+// CHECK:   memref.store %[[VAL0]], %[[SUBSPAN]][%[[OFFSET0]]]
+// CHECK:   %[[SLICE0:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [0], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
+// CHECK:   memref.store %[[SLICE0]], %[[SUBSPAN]][%[[OFFSET0]]]
+// CHECK:   %[[SLICE1:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [2], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
+// CHECK:   %[[OFFSET1:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 1)>()[%[[INDEX]]]
+// CHECK:   memref.store %[[SLICE1]], %[[SUBSPAN]][%[[OFFSET1]]]
+// CHECK:   %[[SLICE2:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [4], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
+// CHECK:   %[[OFFSET2:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 2)>()[%[[INDEX]]]
+// CHECK:   memref.store %[[SLICE2]], %[[SUBSPAN]][%[[OFFSET2]]]
+// CHECK:   %[[SLICE3:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [6], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
+// CHECK:   %[[OFFSET3:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 3)>()[%[[INDEX]]]
+// CHECK:   memref.store %[[SLICE3]], %[[SUBSPAN]][%[[OFFSET3]]]


### PR DESCRIPTION
In the `SPIRVVectorizeLoadStore` pass, we try to use the smallest
vector as the new element type for vectorizing scalar memref types.
This means afterwards we can see transfer ops where we are reading
or writing a larger vector size, e.g., vector<4xf32> -> memref of
vector<2xf32>. Such cases would require us to unroll the vector
and perform read/write for its subparts.

Fixes https://github.com/openxla/iree/issues/14973