### PR TITLE
[SPIRV] Handle sub-byte loads with EmulateNarrowTypes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -405,8 +405,14 @@ void ConvertToSPIRVPass::runOnOperation() {
     }
   }
 
-  /// Rewrite exti(bitcast) as a mix of vector.shuffle + bitwise arithmetic to
-  /// help manage sub-byte types.
+  /// Rewrite extui/si(bitcast) as a mix of vector.shuffle + bitwise arithmetic.
+  /// This handles cases like `vector.bitcast i8 to vector<2xi4>` that come from
+  /// narrow load emulation by never materializing the sub-byte values. SPIR-V
+  /// does not have support for arithmetic on sub-byte types so we currently
+  /// rely on this rewrite for the cases seen today.
+  /// TODO: Support general emulation of compute on sub-byte types. This is
+  /// not mutually exclusive with this pattern, but does mean it is no longer
+  /// load bearing.
   for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
     RewritePatternSet narrowingPatterns(context);
     vector::populateVectorNarrowTypeRewritePatterns(narrowingPatterns);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -195,6 +195,7 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
   // In SPIR-V we don't use memref descriptor so it's not possible to handle
   // subview ops.
   pm.addPass(memref::createFoldMemRefAliasOpsPass());
+  pm.addPass(createEmulateNarrowTypePass());
   pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -9,7 +9,7 @@
     #hal.descriptor_set.binding<4, storage_buffer>
   ]>
 ]>
-hal.executable @i4_dequant_matvec_f16 {
+hal.executable @i4_dequant_unit_matmul_f16 {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader, Float16, StorageBuffer16BitAccess, GroupNonUniform, GroupNonUniformShuffle], [SPV_KHR_16bit_storage]>, Unknown:IntegratedGPU, #spirv.resource_limits<
         max_compute_shared_memory_size = 32768,
@@ -17,13 +17,13 @@ hal.executable @i4_dequant_matvec_f16 {
         max_compute_workgroup_size = [1024, 1024, 64],
         subgroup_size = 32>>
     }> {
-    hal.executable.export @i4_dequant_matvec_f16 layout(#pipeline_layout) {
+    hal.executable.export @i4_dequant_unit_matmul_f16 layout(#pipeline_layout) {
     ^bb0(%arg0: !hal.device):
       %x, %y, %z = flow.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @i4_dequant_matvec_f16() {
+      func.func @i4_dequant_unit_matmul_f16() {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.000000e+00 : f16
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<4096x86x128xi4>>
@@ -72,15 +72,23 @@ hal.executable @i4_dequant_matvec_f16 {
   }
 }
 
-//   CHECK-LABEL: spirv.func @i4_dequant_matvec_f16()
+//   CHECK-LABEL: spirv.func @i4_dequant_unit_matmul_f16()
 
-//         CHECK: %[[C15:.+]] = spirv.Constant 15 : i32
+//     CHECK-DAG: %[[CSTVEC4XI32:.+]] = spirv.Constant dense<255> : vector<4xi32>
+//     CHECK-DAG: %[[CSTVEC4XI320:.+]] = spirv.Constant dense<[15, -16, 15, -16]> : vector<4xi32>
+//     CHECK-DAG: %[[CSTVEC4XI321:.+]] = spirv.Constant dense<[0, 4, 0, 4]> : vector<4xi32>
 
 //         CHECK: spirv.mlir.loop
 
 // Load the quantized weight and get 8xi4 out of it.
-//         CHECK:   spirv.Load "StorageBuffer" %{{.+}} : i32
-// CHECK-COUNT-8:   spirv.BitwiseAnd %{{.+}}, %[[C15]] : i32
+//         CHECK:   spirv.Load "StorageBuffer" %{{.+}} : vector<4xi32>
+//         CHECK:   spirv.VectorShuffle [0 : i32, 1 : i32] %{{.*}} : vector<4xi32>, %{{.*}} : vector<4xi32> -> vector<2xi32>
+//         CHECK:   spirv.VectorShuffle [0 : i32, 0 : i32, 1 : i32, 1 : i32] %{{.*}} : vector<2xi32>, %75 : vector<2xi32> -> vector<4xi32>
+//         CHECK:   spirv.BitwiseAnd %{{.*}}, %[[CSTVEC4XI320]] : vector<4xi32>
+//         CHECK:   spirv.ShiftRightLogical %{{.*}}, %[[CSTVEC4XI321]] : vector<4xi32>, vector<4xi32>
+//         CHECK:   spirv.BitwiseAnd %{{.*}}, %[[CSTVEC4XI32]] : vector<4xi32>
+
+//         CHECK:   spirv.VectorShuffle [2 : i32, 3 : i32] %{{.*}} : vector<4xi32>, %{{.*}} : vector<4xi32> -> vector<2xi32>
 
 // CHECK-COUNT-2:   spirv.ConvertUToF %{{.+}} : vector<4xi32> to vector<4xf16>
 // CHECK-COUNT-2:   spirv.FSub %{{.+}}, %{{.+}} : vector<4xf16>
@@ -98,5 +106,123 @@ hal.executable @i4_dequant_matvec_f16 {
 //         CHECK: spirv.Bitcast %[[VS1]] : vector<2xf32> to vector<4xf16>
 
 // CHECK-COUNT-5: spirv.GroupNonUniformShuffleXor <Subgroup>
+
+//         CHECK: spirv.mlir.selection
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 5, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>,
+    #hal.descriptor_set.binding<4, storage_buffer>
+  ]>
+]>
+hal.executable @i4_dequant_matvec_f16_subgroup_64 {
+  hal.executable.variant @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader, Float16, StorageBuffer16BitAccess, GroupNonUniform, GroupNonUniformShuffle], [SPV_KHR_16bit_storage]>, Unknown:IntegratedGPU, #spirv.resource_limits<
+        max_compute_shared_memory_size = 32768,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [1024, 1024, 64],
+        subgroup_size = 64>>
+    }> {
+    hal.executable.export @i4_dequant_matvec_f16_subgroup_64 layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @i4_dequant_matvec_f16_subgroup_64() {
+        %cst = arith.constant 0.000000e+00 : f16 
+        %0 = hal.interface.constant.load[0] : i32 
+        %1 = hal.interface.constant.load[1] : i32 
+        %2 = hal.interface.constant.load[2] : i32 
+        %3 = hal.interface.constant.load[3] : i32 
+        %4 = hal.interface.constant.load[4] : i32 
+        %5 = arith.index_castui %0 : i32 to index 
+        %6 = arith.index_castui %1 : i32 to index 
+        %7 = arith.index_castui %2 : i32 to index 
+        %8 = arith.index_castui %3 : i32 to index 
+        %9 = arith.index_castui %4 : i32 to index 
+        %10 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%5) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<4096x86x128xi4>>
+        %11 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%6) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<4096x86xf16>>
+        %12 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%7) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<4096x86xf16>>
+        %13 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%8) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<86x128xf16>>
+        %14 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%9) : !flow.dispatch.tensor<writeonly:tensor<4096xf16>>
+        %15 = flow.dispatch.tensor.load %10, offsets = [0, 0, 0], sizes = [4096, 86, 128], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<4096x86x128xi4>> -> tensor<4096x86x128xi4>
+        %16 = flow.dispatch.tensor.load %11, offsets = [0, 0], sizes = [4096, 86], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<4096x86xf16>> -> tensor<4096x86xf16>
+        %17 = flow.dispatch.tensor.load %12, offsets = [0, 0], sizes = [4096, 86], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<4096x86xf16>> -> tensor<4096x86xf16>
+        %18 = flow.dispatch.tensor.load %13, offsets = [0, 0], sizes = [86, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<86x128xf16>> -> tensor<86x128xf16>
+        %19 = tensor.empty() : tensor<4096xf16>
+        %20 = tensor.empty() : tensor<4096x86x128xf16>
+        %21 = linalg.fill ins(%cst : f16) outs(%19 : tensor<4096xf16>) -> tensor<4096xf16>
+        %22 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%15, %16, %17 : tensor<4096x86x128xi4>, tensor<4096x86xf16>, tensor<4096x86xf16>) outs(%20 : tensor<4096x86x128xf16>) {
+        ^bb0(%in: i4, %in_0: f16, %in_1: f16, %out: f16): 
+          %24 = arith.extui %in : i4 to i32
+          %25 = arith.uitofp %24 : i32 to f16
+          %26 = arith.subf %25, %in_1 : f16 
+          %27 = arith.mulf %26, %in_0 : f16 
+          linalg.yield %27 : f16 
+        } -> tensor<4096x86x128xf16>
+        %23 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%18, %22 : tensor<86x128xf16>, tensor<4096x86x128xf16>) outs(%21 : tensor<4096xf16>) {
+        ^bb0(%in: f16, %in_0: f16, %out: f16): 
+          %24 = arith.mulf %in, %in_0 : f16 
+          %25 = arith.addf %24, %out : f16 
+          linalg.yield %25 : f16 
+        } -> tensor<4096xf16>
+        flow.dispatch.tensor.store %23, %14, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf16> -> !flow.dispatch.tensor<writeonly:tensor<4096xf16>>
+        return
+
+      }
+    }
+  }
+}
+
+//   CHECK-LABEL: spirv.func @i4_dequant_matvec_f16_subgroup_64()
+
+//     CHECK-DAG: %[[C5504:.+]] = spirv.Constant 5504 : i32
+//     CHECK-DAG: %[[C64:.+]] = spirv.Constant 64 : i32
+//     CHECK-DAG: %[[C4:.+]] = spirv.Constant 4 : i32
+//     CHECK-DAG: %[[C2:.+]] = spirv.Constant 2 : i32
+//     CHECK-DAG: %[[C0:.+]] = spirv.Constant 0 : i32
+//     CHECK-DAG: %[[CSTVEC4XI32:.+]] = spirv.Constant dense<255> : vector<4xi32>
+//     CHECK-DAG: %[[CSTVEC4XI320:.+]] = spirv.Constant dense<[15, -16, 15, -16]> : vector<4xi32>
+//     CHECK-DAG: %[[CSTVEC4XI321:.+]] = spirv.Constant dense<[0, 4, 0, 4]> : vector<4xi32>
+
+//         CHECK: %[[WIDX:.+]] = spirv.CompositeExtract %{{.*}}[0 : i32] : vector<3xi32>
+//         CHECK: %[[PCPTR:.+]] = spirv.AccessChain %{{.*}}[{{.*}}, %[[C0]]] : !spirv.ptr<!spirv.struct<(!spirv.array<5 x i32, stride=4> [0])>, PushConstant>, i32, i32
+//         CHECK: %[[STREAMBINDING:.+]] = spirv.Load "PushConstant" %[[PCPTR]] : i32
+
+//         CHECK: %[[RADDR:.+]] = spirv.mlir.addressof @{{.*}} : !spirv.ptr<!spirv.struct<(!spirv.rtarray<i32, stride=4> [0])>, StorageBuffer>
+
+//         CHECK: spirv.mlir.loop
+
+// Load the quantized weight and get 4xi4 out of it. Ensure that the offset
+// calculation avoids excessive scaling down in computing the element offset.
+//         CHECK:   spirv.IMul %{{.*}}, %[[C64]] : i32
+//         CHECK:   spirv.IAdd %{{.*}}, %[[STREAMBINDING]] : i32
+//         CHECK:   spirv.IMul %{{.*}}, %[[C5504]] : i32
+//         CHECK:   spirv.IAdd %{{.*}}, %{{.*}} : i32
+//         CHECK:   spirv.IMul %[[WIDX]], %[[C2]] : i32
+//         CHECK:   spirv.IAdd %{{.*}}, %{{.*}} : i32
+//         CHECK:   %[[OFFSET:.+]] = spirv.SDiv %{{.*}}, %[[C4]] : i32
+//         CHECK:   %[[ACCESS:.+]] = spirv.AccessChain %[[RADDR]][{{.*}}, %[[OFFSET]]] : !spirv.ptr<!spirv.struct<(!spirv.rtarray<i32, stride=4> [0])>, StorageBuffer>, i32, i32
+//         CHECK:   spirv.Load "StorageBuffer" %[[ACCESS]] : i32
+
+//         CHECK:   spirv.VectorShuffle [0 : i32, 0 : i32, 1 : i32, 1 : i32] %{{.*}} : vector<2xi32>, %106 : vector<2xi32> -> vector<4xi32>
+//         CHECK:   spirv.BitwiseAnd %{{.*}}, %[[CSTVEC4XI320]] : vector<4xi32>
+//         CHECK:   spirv.ShiftRightLogical %{{.*}}, %[[CSTVEC4XI321]] : vector<4xi32>, vector<4xi32>
+//         CHECK:   spirv.BitwiseAnd %{{.*}}, %[[CSTVEC4XI32]] : vector<4xi32>
+
+//         CHECK:   spirv.ConvertUToF %{{.+}} : vector<4xi32> to vector<4xf16>
+//         CHECK:   spirv.FSub %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:   spirv.FMul %{{.+}}, %{{.+}} : vector<4xf16>
+//         CHECK:   spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+
+//         CHECK:   spirv.mlir.merge
+
+// CHECK-COUNT-6: spirv.GroupNonUniformShuffleXor <Subgroup>
 
 //         CHECK: spirv.mlir.selection

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
@@ -52,14 +52,13 @@ hal.executable @i4_dequant {
 
 //   CHECK-LABEL: spirv.func @i4_dequant()
 
-// CHECK-COUNT-4: spirv.BitwiseAnd
-//         CHECK: spirv.CompositeConstruct {{.+}} : (i32, i32, i32, i32) -> vector<4xi32>
-// CHECK-COUNT-4: spirv.BitwiseAnd
-//         CHECK: spirv.CompositeConstruct {{.+}} : (i32, i32, i32, i32) -> vector<4xi32>
-// CHECK-COUNT-4: spirv.BitwiseAnd
-//         CHECK: spirv.CompositeConstruct {{.+}} : (i32, i32, i32, i32) -> vector<4xi32>
-// CHECK-COUNT-4: spirv.BitwiseAnd
-//         CHECK: spirv.CompositeConstruct {{.+}} : (i32, i32, i32, i32) -> vector<4xi32>
+//         CHECK: spirv.VectorShuffle [0 : i32, 1 : i32] {{.*}} : vector<4xi32> -> vector<2xi32>
+//         CHECK: spirv.VectorShuffle [0 : i32, 0 : i32, 1 : i32, 1 : i32]
+//         CHECK: spirv.BitwiseAnd
+//         CHECK: spirv.ShiftRightLogical
+//         CHECK: spirv.BitwiseAnd
+//         CHECK: spirv.VectorShuffle [2 : i32, 3 : i32] {{.*}} : vector<4xi32> -> vector<2xi32>
+// CHECK-COUNT-3: spirv.VectorShuffle [0 : i32, 0 : i32, 1 : i32, 1 : i32]
 
 // CHECK-COUNT-4: spirv.ConvertUToF {{.+}} : vector<4xi32> to vector<4xf32>
 // CHECK-COUNT-4: spirv.FSub


### PR DESCRIPTION
Fixes #14972 by preventing offset calculation from temporarily exceeding the maximum i32 value (for 32 bit indexing) even if the byte offset does not exceed it. Additionally this bring handling of sub-byte loads more in line with other backends.