### PR TITLE
Support scalable tile sizes in #iree_codegen.lowering_config 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
@@ -163,8 +163,11 @@ def IREECodegen_LoweringConfigTilingLevelAttr :
     ArrayRefParameter<"int64_t",
         "The tile sizes to use for this level of tiling">:$sizes,
     OptionalArrayRefParameter<"int64_t",
-        "The tile interchange to use for this level of tiling">:$interchange);
+        "The tile interchange to use for this level of tiling">:$interchange,
+    OptionalArrayRefParameter<"bool",
+        "The scalable tile flags for this level of tiling">:$scalableFlags);
   let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
 }
 
 def IREECodegen_LoweringConfigTilingLevelsAttr :

--- a/compiler/src/iree/compiler/Codegen/Dialect/test/lowering_config_attr.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/test/lowering_config_attr.mlir
@@ -69,3 +69,25 @@ module {
   }
 }
 // CHECK: #iree_codegen.export_config<workgroup_size = [4, 1]
+
+// -----
+
+module {
+  /// Lowering config where the middle size of the second level is scalable.
+  func.func @scalable_tile_sizes() attributes {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [1, [32], 0], [0, 0, 1], [0, 0, 0]]>} {
+    return
+  }
+  // CHECK: #config = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [1, [32], 0], [0, 0, 1], [0, 0, 0]{{\]}}>
+}
+
+// -----
+
+module {
+  /// Lowering config where the middle size of the second level is scalable has a tile interchange.
+  func.func @scalable_tile_sizes() attributes {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], {sizes=[1, [32], 0], interchange=[2, 1, 0]}, [0, 0, 1], [0, 0, 0]]>} {
+    return
+  }
+  // CHECK: #config = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], {sizes = [1, [32], 0], interchange = [2, 1, 0]}, [0, 0, 1], [0, 0, 0]{{\]}}>
+}


### PR DESCRIPTION
This extends the lowering config so that at each level tiles can be marked as scalable using an optional array of bools. The parser/printer has been updated to display this in the canonical MLIR syntax (i.e. the size wrapped in square brackets).

So for example, this lowering config:

```
  #iree_codegen.lowering_config<tile_sizes
	= [[128, 128, 0], [1, [32], 0], [0, 0, 1], [0, 0, 0]]>
```

Means that the middle tile size (32) of the second tiling level is scalable.

These are not yet used, but will be in subsequent patches.

---

Depends on #15032