### PR TITLE
Add a dedicated 'torch' input pipeline.

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
@@ -41,6 +41,16 @@ struct TorchSession
 
   bool extendCustomInputConversionPassPipeline(
       OpPassManager &passManager, std::string_view typeMnemonic) override {
+    if (typeMnemonic == "torch") {
+      TorchInput::createTorchToIREEPipeline(passManager);
+      passManager.addNestedPass<func::FuncOp>(
+          TorchInput::createConvertTMTensorToLinalgExtPass());
+      return true;
+    }
+    // TODO: Retire the tm_tensor input pipeline once we are fully switched
+    // to the 'torch' pipeline, which handles everything from the 'torch'
+    // dialect down (vs just 'tm_tensor' which was converting a couple of
+    // ops to linalg).
     if (typeMnemonic == "tm_tensor") {
       passManager.addNestedPass<func::FuncOp>(
           TorchInput::createConvertTMTensorToLinalgExtPass());
@@ -51,6 +61,7 @@ struct TorchSession
 
   void populateCustomInputConversionTypes(StringSet<> &typeMnemonics) override {
     typeMnemonics.insert("tm_tensor");
+    typeMnemonics.insert("torch");
   }
 };
 

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -53,6 +53,7 @@ void InputDialectOptions::bindOptions(OptionsBinder &binder) {
 // options here, even though it is a layering violation.
 #ifdef IREE_COMPILER_PLUGIN_HAVE_STATIC_TORCH_IREE
           "  =tm_tensor     - Legalize a subset of Torch input ops.\n"
+          "  =torch         - Legalize from the 'torch' dialect.\n"
 #endif  // IREE_COMPILER_PLUGIN_HAVE_STATIC_TORCH_IREE
           "  =*             - An extensible input type defined in a plugin."
           // clang-format on
@@ -91,10 +92,6 @@ InputDialectOptions::Type InputDialectOptions::parseInputTypeMnemonic() {
 #ifdef IREE_HAVE_TOSA_INPUT
   } else if (inputTypeMnemonic == "tosa") {
     return Type::tosa;
-#endif
-#ifdef IREE_HAVE_TORCH_INPUT
-  } else if (inputTypeMnemonic == "tm_tensor") {
-    return Type::tm_tensor;
 #endif
   } else {
     return Type::plugin;


### PR DESCRIPTION
This has been in use downstream via the `torch-to-iree` pass and is now ready to be exposed as a real input type.

As of https://github.com/nod-ai/SHARK-Turbine/pull/72, Turbine can now generate pure 'torch' level programs that can be fed to IREE directly with this input pipeline. We expect that this will be more stable and supportable vs half-lowering to IREE internal dialects in the frontend.