### PR TITLE
Skip routinely-updated submodules in CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,8 @@
 # Except for routinely-updated submodules
 /third_party/llvm-project @ghost
 /third_party/llvm-project.branch-pin @ghost
-/third_party/mlir-hlo @ghost
+/third_party/stablehlo @ghost
+/third_party/torch-mlir @ghost
 
 # Bindings
 /runtime/bindings/python/ @stellaraccident


### PR DESCRIPTION
For dependencies that are updated several times a month, it's more useful to add CODEOWNERS that are invested in those specific projects/integrations. I mostly want to be notified for new third party dependencies, to audit for things like Bazel/CMake configuration, licenses, code complexity, etc.