### PR TITLE
Fix test assuming deterministic constant ordering.

### DIFF
--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
@@ -95,15 +95,15 @@ func.func @cmdDispatch(%buffer0: !stream.resource<transient>, %buffer0_size: ind
 // CHECK-LABEL: @trace_tensor
 // CHECK-SAME: %[[ARG0:.+]]: !hal.buffer
 func.func @trace_tensor(%arg0: !stream.resource<external>) -> () {
-  // CHECK: %[[C180:.+]] = arith.constant 180 : index
+  // CHECK-DAG: %[[C180:.+]] = arith.constant 180 : index
   %c180 = arith.constant 180 : index
 
-  // CHECK: %[[C1:.+]] = arith.constant 1 : index
-  // CHECK: %[[C45:.+]] = arith.constant 45 : index
-  // CHECK: %[[C0:.+]] = arith.constant 0 : index
-  // CHECK: %[[C268435488:.+]] = arith.constant 268435488 : i32
-  // CHECK: %[[C1_i32:.+]] = arith.constant 1 : i32
-  // CHECK: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%[[ARG0]] : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C45:.+]] = arith.constant 45 : index
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C268435488:.+]] = arith.constant 268435488 : i32
+  // CHECK-DAG: %[[C1_i32:.+]] = arith.constant 1 : i32
+  // CHECK-DAG: %[[VIEW:.+]] = hal_inline.buffer_view.create buffer(%[[ARG0]] : !hal.buffer)[%[[C0]], %[[C180]]] shape([%[[C1]], %[[C45]]]) type(%[[C268435488]]) encoding(%[[C1_i32]]) : !hal.buffer_view
   %tensor = stream.tensor.export %arg0 : tensor<1x45xi32> in !stream.resource<external>{%c180} -> tensor<1x45xi32>
 
   // CHECK: hal_inline.buffer_view.trace %[[VIEW]] : !hal.buffer_view attributes {key = "whatevs"}


### PR DESCRIPTION
This fixes a test failure on Windows/MSVC: https://github.com/openxla/iree/actions/runs/6268693140/job/17024038388#step:9:2202

```
 iree-opt --split-input-file --iree-hal-loader-conversion --canonicalize C:/a/iree/iree/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+ FileCheck C:/a/iree/iree/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
C:/a/iree/iree/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir:105:12: error: CHECK: expected string not found in input
 // CHECK: %[[C1_i32:.+]] = arith.constant 1 : i32
           ^
<stdin>:48:50: note: scanning from here
 %c268435488_i32 = arith.constant 268435488 : i32
                                                 ^
```

(Why isn't canonicalize deterministic??)