### PR TITLE
[LLVMGPU] Lower descriptor type to global address space

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EraseHALDescriptorTypeFromMemRef.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EraseHALDescriptorTypeFromMemRef.cpp
@@ -17,6 +17,7 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -44,6 +45,7 @@ struct MemRefTypeConverter final : public TypeConverter {
       if (!dtAttr)
         return std::nullopt;
 
+
       // Erase the #hal.descriptor_type memory space.
       if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
         return MemRefType::get(memRefType.getShape(),
@@ -52,6 +54,35 @@ struct MemRefTypeConverter final : public TypeConverter {
       }
       return UnrankedMemRefType::get(memRefType.getElementType(),
                                      /*memorySpace=*/0);
+    });
+  }
+};
+
+struct GPUMemRefTypeConverter final : public TypeConverter {
+  GPUMemRefTypeConverter() {
+    // Pass through for all other types.
+    addConversion([](Type type) { return type; });
+
+    addConversion([](BaseMemRefType memRefType) -> std::optional<Type> {
+      // Expect #hal.descriptor_type memory spaces.
+      Attribute spaceAttr = memRefType.getMemorySpace();
+      if (!spaceAttr)
+        return std::nullopt;
+      auto dtAttr = llvm::dyn_cast<IREE::HAL::DescriptorTypeAttr>(spaceAttr);
+      if (!dtAttr)
+        return std::nullopt;
+
+      Attribute globalSpace = gpu::AddressSpaceAttr::get(
+          memRefType.getContext(), gpu::AddressSpace::Global);
+
+      // Erase the #hal.descriptor_type memory space.
+      if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
+        return MemRefType::get(memRefType.getShape(),
+                               memRefType.getElementType(),
+                               rankedType.getLayout(), globalSpace);
+      }
+      return UnrankedMemRefType::get(memRefType.getElementType(),
+                                     /*memorySpace=*/globalSpace);
     });
   }
 };
@@ -126,7 +157,35 @@ LogicalResult EraseMemorySpacePattern::matchAndRewrite(
 }
 
 //===----------------------------------------------------------------------===//
-// Conversion Pass
+// Rewrite Patterns
+//===----------------------------------------------------------------------===//
+
+static LogicalResult eraseHALDescriptorTypeFromMemRef(Operation *op) {
+  MLIRContext *context = op->getContext();
+  ConversionTarget target(*context);
+  target.markUnknownOpDynamicallyLegal(isLegalOp);
+
+  MemRefTypeConverter typeConverter;
+  RewritePatternSet patterns(context);
+  patterns.add<EraseMemorySpacePattern>(context, typeConverter);
+
+  return applyFullConversion(op, target, std::move(patterns));
+}
+
+static LogicalResult convertHALDescriptorTypeToGPUAddressSpace(Operation *op) {
+  MLIRContext *context = op->getContext();
+  ConversionTarget target(*context);
+  target.markUnknownOpDynamicallyLegal(isLegalOp);
+
+  GPUMemRefTypeConverter typeConverter;
+  RewritePatternSet patterns(context);
+  patterns.add<EraseMemorySpacePattern>(context, typeConverter);
+
+  return applyFullConversion(op, target, std::move(patterns));
+}
+
+//===----------------------------------------------------------------------===//
+// Conversion Passes
 //===----------------------------------------------------------------------===//
 
 struct EraseHALDescriptorTypeFromMemRefPass final
@@ -139,22 +198,24 @@ struct EraseHALDescriptorTypeFromMemRefPass final
   }
 };
 
+struct ConvertHALDescriptorTypeToGPUAddressSpacePass final
+    : public ConvertHALDescriptorTypeToGPUAddressSpaceBase<
+          ConvertHALDescriptorTypeToGPUAddressSpacePass> {
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    if (failed(convertHALDescriptorTypeToGPUAddressSpace(op)))
+      return signalPassFailure();
+  }
+};
+
 } // namespace
-
-LogicalResult eraseHALDescriptorTypeFromMemRef(Operation *op) {
-  MLIRContext *context = op->getContext();
-  ConversionTarget target(*context);
-  target.markUnknownOpDynamicallyLegal(isLegalOp);
-
-  MemRefTypeConverter typeConverter;
-  RewritePatternSet patterns(context);
-  patterns.add<EraseMemorySpacePattern>(context, typeConverter);
-
-  return applyFullConversion(op, target, std::move(patterns));
-}
 
 std::unique_ptr<Pass> createEraseHALDescriptorTypeFromMemRefPass() {
   return std::make_unique<EraseHALDescriptorTypeFromMemRefPass>();
+}
+
+std::unique_ptr<Pass> createConvertHALDescriptorTypeToGPUAddressSpacePass() {
+  return std::make_unique<ConvertHALDescriptorTypeToGPUAddressSpacePass>();
 }
 
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -108,6 +108,8 @@ createEraseDeadAllocAndStoresPass();
 
 std::unique_ptr<Pass> createEraseHALDescriptorTypeFromMemRefPass();
 
+std::unique_ptr<Pass> createConvertHALDescriptorTypeToGPUAddressSpacePass();
+
 // Extract address computations into their own separate instructions.
 std::unique_ptr<Pass> createExtractAddressComputationPass();
 
@@ -243,9 +245,6 @@ std::unique_ptr<OperationPass<func::FuncOp>> createTypePropagationPass();
 /// Creates a pass to vectorize a very specific form of tensor.pad ops with
 /// control flows.
 std::unique_ptr<OperationPass<func::FuncOp>> createVectorizePadPass();
-
-/// Erases #hal.descriptor_type as MemRef memory space.
-LogicalResult eraseHALDescriptorTypeFromMemRef(Operation *op);
 
 /// Populates patterns with patterns to concretize tensor.pad op's result
 /// shape. `numWorkgroups`, if not empty, will be used as bounds for simplifying

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -192,6 +192,13 @@ def EraseHALDescriptorTypeFromMemRef
       "mlir::iree_compiler::createEraseHALDescriptorTypeFromMemRefPass()";
 }
 
+def ConvertHALDescriptorTypeToGPUAddressSpace
+    : Pass<"iree-codegen-convert-hal-descriptor-type-to-gpu-address-space"> {
+  let summary = "Convert #hal.descriptor_type to #gpu.address_space<global>";
+  let constructor =
+      "mlir::iree_compiler::createConvertHALDescriptorTypeToGPUAddressSpacePass()";
+}
+
 def ExtractAddressComputation: Pass<"extract-address-computation"> {
   let summary = "Extract address computations from memory accesses";
   let description = [{

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -254,7 +254,14 @@ public:
     SmallVector<Type, 8> llvmInputTypes(
         argMapping.size(), LLVM::LLVMPointerType::get(rewriter.getContext()));
     funcOp.walk([&](IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
-      auto llvmType = LLVM::LLVMPointerType::get(rewriter.getContext());
+      LLVM::LLVMPointerType llvmType;
+      if (auto memrefType = dyn_cast<BaseMemRefType>(subspanOp.getType())) {
+        unsigned addrSpace =
+            *getTypeConverter()->getMemRefAddressSpace(memrefType);
+        llvmType = LLVM::LLVMPointerType::get(rewriter.getContext(), addrSpace);
+      } else {
+        llvmType = LLVM::LLVMPointerType::get(rewriter.getContext());
+      }
       llvmInputTypes[argMapping[SetBinding(subspanOp.getSet(),
                                            subspanOp.getBinding())]] = llvmType;
     });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -481,9 +481,7 @@ static void addLowerAndOptimzeAddressComputation(OpPassManager &pm) {
 }
 
 static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
-  // TODO: Remove the following pass the plumb support for #hal.descriptor_type
-  // memory space through the stack.
-  pm.addPass(createEraseHALDescriptorTypeFromMemRefPass());
+  pm.addPass(createConvertHALDescriptorTypeToGPUAddressSpacePass());
 
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -89,17 +89,17 @@ hal.executable @dot_dispatch_0 {
 //     CHECK-LABEL: hal.executable public @dot_dispatch_0
 //           CHECK:   hal.executable.variant public @cuda
 //       CHECK-NOT:   llvm.store
-//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr -> vector<4xf32>
+//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr<1> -> vector<4xf32>
 //           CHECK:   llvm.br
 //   CHECK-COUNT-3:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<3>
 //  CHECK-COUNT-32:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
 // CHECK-COUNT-128:   llvm.intr.fmuladd({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
-//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr -> vector<4xf32>
+//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr<1> -> vector<4xf32>
 //           CHECK:   llvm.br
 //   CHECK-COUNT-3:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<3>
 //  CHECK-COUNT-32:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
 // CHECK-COUNT-128:   llvm.intr.fmuladd({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
-//   CHECK-COUNT-4:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+//   CHECK-COUNT-4:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>
 
 // -----
 
@@ -167,7 +167,7 @@ hal.executable @dot_dispatch_0 {
 //         CHECK:   llvm.br
 // CHECK-COUNT-8:   llvm.intr.fmuladd({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 //         CHECK:   llvm.br
-// CHECK-COUNT-2:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+// CHECK-COUNT-2:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>
 
 // -----
 
@@ -213,10 +213,10 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 
 //   CHECK-LABEL: hal.executable public @conv2d_dispatch_0
 //         CHECK:   hal.executable.variant public @cuda
-// CHECK-COUNT-3:   llvm.load %{{.*}} : !llvm.ptr -> f32
+// CHECK-COUNT-3:   llvm.load %{{.*}} : !llvm.ptr<1> -> f32
 //         CHECK:   lvm.fmul %{{.*}}, %{{.*}}  : f32
 //         CHECK:   llvm.fadd %{{.*}}, %{{.*}}  : f32
-//         CHECK:   llvm.store {{.*}} : f32, !llvm.ptr
+//         CHECK:   llvm.store {{.*}} : f32, !llvm.ptr<1>
 
 // -----
 
@@ -351,7 +351,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //   CHECK-LABEL: hal.executable public @vector_add_dispatch
 //         CHECK:   hal.executable.variant public @cuda
 //         CHECK:   llvm.fadd %{{.*}}, %{{.*}}  : vector<4xf32
-//         CHECK:   llvm.store %{{.*}} : vector<4xf32>, !llvm.ptr
+//         CHECK:   llvm.store %{{.*}} : vector<4xf32>, !llvm.ptr<1>
 
 // -----
 
@@ -479,10 +479,10 @@ hal.executable @mma_fused {
 //           CHECK:   vvm.barrier0
 //           CHECK:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
 //           CHECK:   llvm.fadd {{.*}} : vector<4xf32>
-//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>
 //           CHECK:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
 //           CHECK:   llvm.fadd {{.*}} : vector<4xf32>
-//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>
 
 
 
@@ -562,7 +562,7 @@ hal.executable @mma_fused_fp16 {
 //           CHECK:   vvm.barrier0
 //           CHECK:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<8xf16>
 //           CHECK:   llvm.fadd {{.*}} : vector<8xf16>
-//           CHECK:   llvm.store {{.*}} : vector<8xf16>, !llvm.ptr
+//           CHECK:   llvm.store {{.*}} : vector<8xf16>, !llvm.ptr<1>
 //           CHECK:   vvm.barrier0
 
 // -----
@@ -641,9 +641,9 @@ hal.executable @mma_fused_fp16 {
 //   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<3>, f32, f32, f32, f32, f32, f32, f32, f32
 //           CHECK:   vvm.barrier0
 //           CHECK:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
-//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>
 //           CHECK:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
-//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>
 
 // -----
 
@@ -711,9 +711,9 @@ hal.executable @mma_fused_fp16 {
 //   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<3>, f32, f32, f32, f32, f32, f32, f32, f32
 //           CHECK:   vvm.barrier0
 //           CHECK:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
-//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>
 //           CHECK:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
-//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+//           CHECK:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>
 
 // -----
 
@@ -874,7 +874,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //         CHECK:     llvm.load {{.*}} : !llvm.ptr<3> -> f32
 // CHECK-COUNT-3:     nvvm.shfl.sync  bfly
 //         CHECK:     llvm.fdiv %{{.*}}, %{{.*}} 
-//         CHECK:     llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr
+//         CHECK:     llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<1>
 
 // -----
 
@@ -965,6 +965,6 @@ hal.executable private @shared_mem_transpose  {
 //   CHECK-LABEL: hal.executable private @shared_mem_transpose
 //         CHECK:   hal.executable.variant public @cuda
 //         CHECK:     nvvm.barrier0
-//         CHECK:     llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr -> vector<4xf32>
+//         CHECK:     llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<1> -> vector<4xf32>
 //         CHECK:     llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<3>
 //         CHECK:     nvvm.barrier0

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -89,14 +89,14 @@ hal.executable @dot_dispatch_0 {
 //   CHECK-LABEL: hal.executable public @dot_dispatch_0
 //         CHECK:   hal.executable.variant public @rocm
 //       CHECK-NOT:   llvm.store
-//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr -> vector<4xf32>
+//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr<1> -> vector<4xf32>
 //           CHECK:   llvm.br
 //   CHECK-COUNT-3:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<3>
 //  CHECK-COUNT-32:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
 // CHECK-COUNT-128:   llvm.intr.fmuladd({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
-//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr -> vector<4xf32>
+//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr<1> -> vector<4xf32>
 //           CHECK:   llvm.br
 //   CHECK-COUNT-3:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<3>
 //  CHECK-COUNT-32:   llvm.load {{.*}} : !llvm.ptr<3> -> vector<4xf32>
 // CHECK-COUNT-128:   llvm.intr.fmuladd({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
-//   CHECK-COUNT-4:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr
+//   CHECK-COUNT-4:   llvm.store {{.*}} : vector<4xf32>, !llvm.ptr<1>


### PR DESCRIPTION
The hal.descriptor_type memory space indicates a global memory space but
is currently dropped. Instead convert it to global to improve the load
instructions selected by LLVM.