### PR TITLE
Correct input type typo in error message

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -654,7 +654,7 @@ bool Invocation::initializeInvocation() {
         inputTypeMnemonics);
     if (!inputTypeMnemonics.contains(session.inputOptions.inputTypeMnemonic)) {
       auto diag = emitError(UnknownLoc::get(&session.context))
-                  << "unknown custom value for --input-input-type='"
+                  << "unknown custom value for --iree-input-type='"
                   << session.inputOptions.inputTypeMnemonic << "'";
       if (inputTypeMnemonics.empty()) {
         diag << " (none registered)";


### PR DESCRIPTION
Confirmed that changing the value of the arg to `--iree-input-type=` with `iree-compile` was reflected in this particular error message. So, I'm pretty sure this message is referring to that argument. :)