### PR TITLE
[vulkan][spirv] Update submodules and deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,7 +895,7 @@ if(IREE_TARGET_BACKEND_WEBGPU)
   #   * https://chromium.googlesource.com/vulkan-deps/+/refs/heads/main/DEPS
   # or they can be updated independently
   set(IREE_TINT_TAG         "fdb8787e9c1b79770bd98a8faf37fbe48a3077a4")  # 2023-03-06
-  set(IREE_SPIRV_TOOLS_TAG  "95f93810bbae12e1a601a3a5a5d975e5558a2994")  # 2023-02-15
+  set(IREE_SPIRV_TOOLS_TAG  "43b8886490eb6af81fc61e0ff071c51a922af864")  # 2023-08-11
 
   iree_set_spirv_headers_cmake_options()
   add_subdirectory(third_party/spirv_headers EXCLUDE_FROM_ALL)

--- a/build_tools/third_party/spirv_cross/BUILD.overlay
+++ b/build_tools/third_party/spirv_cross/BUILD.overlay
@@ -49,6 +49,7 @@ cc_library(
 cc_library(
     name = "spirv_cross_lib",
     hdrs = SPIRV_HEADERS,
+    copts = ["-Wno-error=unqualified-std-cast-call"],
     deps = [":spirv_cross_lib_real"],
     include_prefix = "third_party/spirv_cross",
 )

--- a/build_tools/third_party/spirv_cross/BUILD.overlay
+++ b/build_tools/third_party/spirv_cross/BUILD.overlay
@@ -49,7 +49,6 @@ cc_library(
 cc_library(
     name = "spirv_cross_lib",
     hdrs = SPIRV_HEADERS,
-    copts = ["-Wno-error=unqualified-std-cast-call"],
     deps = [":spirv_cross_lib_real"],
     include_prefix = "third_party/spirv_cross",
 )

--- a/build_tools/third_party/vulkan_headers/BUILD.overlay
+++ b/build_tools/third_party/vulkan_headers/BUILD.overlay
@@ -11,15 +11,11 @@ package(default_visibility = ["//visibility:public"])
 # Not all headers are hermetic, so they are just included as textual
 # headers to disable additional validation.
 cc_library(
-    name = "vulkan_video_headers",
-    hdrs = glob(["include/vk_video/*.h"]),
+    name = "vulkan_headers",
+    hdrs = glob([
+        "include/vulkan/*.h",
+        "include/vk_video/*.h",
+    ]),
     include_prefix = "third_party/vulkan_headers",
     includes = ["include"],
-)
-
-cc_library(
-    name = "vulkan_headers",
-    hdrs = glob(["include/vulkan/*.h"]),
-    include_prefix = "third_party/vulkan_headers",
-    deps = [":vulkan_video_headers"],
 )

--- a/build_tools/third_party/vulkan_headers/BUILD.overlay
+++ b/build_tools/third_party/vulkan_headers/BUILD.overlay
@@ -12,7 +12,7 @@ package(default_visibility = ["//visibility:public"])
 # headers to disable additional validation.
 cc_library(
     name = "vulkan_video_headers",
-    hdrs = glob(["include/vulkan/vk_video/*.h"]),
+    hdrs = glob(["include/vk_video/*.h"]),
     include_prefix = "third_party/vulkan_headers",
     includes = ["include"],
 )

--- a/build_tools/third_party/vulkan_headers/BUILD.overlay
+++ b/build_tools/third_party/vulkan_headers/BUILD.overlay
@@ -12,6 +12,9 @@ package(default_visibility = ["//visibility:public"])
 # headers to disable additional validation.
 cc_library(
     name = "vulkan_headers",
-    hdrs = glob(["include/vulkan/*.h"]),
+    hdrs = glob([
+        "include/vulkan/*.h",
+        "include/vulkan/vk_video/*.h",
+    ]),
     include_prefix = "third_party/vulkan_headers",
 )

--- a/build_tools/third_party/vulkan_headers/BUILD.overlay
+++ b/build_tools/third_party/vulkan_headers/BUILD.overlay
@@ -13,8 +13,8 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "vulkan_headers",
     hdrs = glob([
-        "include/vulkan/*.h",
         "include/vk_video/*.h",
+        "include/vulkan/*.h",
     ]),
     include_prefix = "third_party/vulkan_headers",
     includes = ["include"],

--- a/build_tools/third_party/vulkan_headers/BUILD.overlay
+++ b/build_tools/third_party/vulkan_headers/BUILD.overlay
@@ -11,10 +11,15 @@ package(default_visibility = ["//visibility:public"])
 # Not all headers are hermetic, so they are just included as textual
 # headers to disable additional validation.
 cc_library(
-    name = "vulkan_headers",
-    hdrs = glob([
-        "include/vulkan/*.h",
-        "include/vulkan/vk_video/*.h",
-    ]),
+    name = "vulkan_video_headers",
+    hdrs = glob(["include/vulkan/vk_video/*.h"]),
     include_prefix = "third_party/vulkan_headers",
+    includes = ["include"],
+)
+
+cc_library(
+    name = "vulkan_headers",
+    hdrs = glob(["include/vulkan/*.h"]),
+    include_prefix = "third_party/vulkan_headers",
+    deps = [":vulkan_video_headers"],
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/BUILD.bazel
@@ -56,8 +56,6 @@ iree_compiler_cc_library(
         "SPIRVToMSL.cpp",
     ],
     hdrs = ["SPIRVToMSL.h"],
-    # Required because of spirv-cross headers.
-    copts = ["-Wno-error=unqualified-std-cast-call"],
     deps = [
         ":MetalTargetPlatform",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/BUILD.bazel
@@ -56,6 +56,8 @@ iree_compiler_cc_library(
         "SPIRVToMSL.cpp",
     ],
     hdrs = ["SPIRVToMSL.h"],
+    # Required because of spirv-cross headers.
+    copts = ["-Wno-error=unqualified-std-cast-call"],
     deps = [
         ":MetalTargetPlatform",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/CMakeLists.txt
@@ -55,6 +55,8 @@ iree_cc_library(
 iree_cc_library(
   NAME
     SPIRVToMSL
+  COPTS
+    "-Wno-error=unqualified-std-cast-call"
   HDRS
     "SPIRVToMSL.h"
   SRCS

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/CMakeLists.txt
@@ -55,8 +55,6 @@ iree_cc_library(
 iree_cc_library(
   NAME
     SPIRVToMSL
-  COPTS
-    "-Wno-error=unqualified-std-cast-call"
   HDRS
     "SPIRVToMSL.h"
   SRCS


### PR DESCRIPTION
This is to pick up defines related to Vulkan defines from newer SDKs (incl. coop matrix khr).

Updated submodules:
-  vulkan-headers: https://github.com/KhronosGroup/Vulkan-Headers/commit/df60f0316899460eeaaefa06d2dd7e4e300c1604 (2023-09-23)
-  spirv-headers: https://github.com/KhronosGroup/SPIRV-Headers/commit/b730938c033ede3572b660ab019b438509ba24d9 (2023-08-10)
-  spirv-tools: https://github.com/KhronosGroup/SPIRV-Tools/commit/43b8886490eb6af81fc61e0ff071c51a922af864 (2023-08-11)
- spirv-cross: https://github.com/KhronosGroup/SPIRV-Cross/commit/6e1fb9b09efadee38748e0fd0e6210d329087e89 (2023-09-25)