### PR TITLE
WIP: make the vulkan header paths consistent for bazel and cmake

### DIFF
--- a/build_tools/bazel/workspace.bzl
+++ b/build_tools/bazel/workspace.bzl
@@ -109,7 +109,7 @@ def configure_iree_submodule_deps(iree_repo_alias = "@", iree_path = "./"):
 
     maybe(
         native.new_local_repository,
-        name = "vulkan_headers",
+        name = "iree_vulkan_headers",
         build_file = iree_repo_alias + "//:build_tools/third_party/vulkan_headers/BUILD.overlay",
         path = paths.join(iree_path, "third_party/vulkan_headers"),
     )

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -89,7 +89,7 @@ class TargetConverter:
                 # Tracy.
                 "@tracy_client//:runtime": ["tracy_client::runtime"],
                 # Vulkan
-                "@vulkan_headers": ["Vulkan::Headers"],
+                "@iree_vulkan_headers": ["Vulkan::Headers"],
                 # Misc single targets
                 "@com_google_benchmark//:benchmark": ["benchmark"],
                 "@com_github_dvidelabs_flatcc//:flatcc": ["flatcc"],

--- a/build_tools/third_party/vulkan_headers/BUILD.overlay
+++ b/build_tools/third_party/vulkan_headers/BUILD.overlay
@@ -16,6 +16,6 @@ cc_library(
         "include/vk_video/*.h",
         "include/vulkan/*.h",
     ]),
-    include_prefix = "third_party/vulkan_headers",
+    #include_prefix = "third_party/vulkan_headers",
     includes = ["include"],
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
@@ -103,7 +103,7 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
 bool hasByteAlignedElementTypes(linalg::LinalgOp linalgOp) {
   return llvm::all_of(linalgOp->getOperands(), [](Value operand) {
     auto bitwidth =
-        getElementTypeOrSelf(operand.getType()).getIntOrFloatBitWidth();
+        IREE::Util::getTypeBitWidth(getElementTypeOrSelf(operand.getType()));
     return bitwidth % 8 == 0;
   });
 }

--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -84,7 +84,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/utils:resource_set",
         "//runtime/src/iree/hal/utils:semaphore_base",
         "//runtime/src/iree/schemas:spirv_executable_def_c_fbs",
-        "@vulkan_headers",
+        "@iree_vulkan_headers//:vulkan_headers",
     ],
 )
 
@@ -104,7 +104,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:dynamic_library",
         "//runtime/src/iree/hal/drivers/vulkan/util:ref_ptr",
-        "@vulkan_headers",
+        "@iree_vulkan_headers//:vulkan_headers",
     ],
 )
 

--- a/runtime/src/iree/hal/drivers/vulkan/registration/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/BUILD.bazel
@@ -24,5 +24,6 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/internal:flags",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/vulkan",
+        "@iree_vulkan_headers//:vulkan_headers",
     ],
 )

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_headers.h
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_headers.h
@@ -41,10 +41,10 @@
 #define VK_USE_PLATFORM_WIN32_KHR 1
 #endif  // IREE_PLATFORM_*
 
-#include "third_party/vulkan_headers/include/vulkan/vulkan.h"  // IWYU pragma: export
+#include "vulkan/vulkan.h"  // IWYU pragma: export
 
 #ifdef IREE_PLATFORM_APPLE
-#include "third_party/vulkan_headers/include/vulkan/vulkan_beta.h"  // IWYU pragma: export
+#include "vulkan/vulkan_beta.h"  // IWYU pragma: export
 #endif
 
 #endif  // IREE_HAL_DRIVERS_VULKAN_VULKAN_HEADERS_H_


### PR DESCRIPTION
The build overlay for the Bazel build uses the prefix that includes "third_party/vulkan_headers", so we don't need to specify the prefix and "include", and it is consistent with the cmake behavior too. 