### PR TITLE
[scf] Fix Resource processing for `scf.for`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -182,9 +182,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
         return createFormDispatchWorkgroupsPass(
             clDispatchGenerateWorkloadRegion);
       })
-      // TODO(#15003): SCF support appears to be insufficient for stream work.
-      // Need to debug the cause.
-      .addPass(IREE::Flow::createTopLevelSCFToCFGPass)
       ////////////////////////////////////////////////////////////////////////
       .addPass(createCaptureDispatchDynamicDimsPass)
       .addPass(mlir::createCanonicalizerPass)

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -586,7 +586,7 @@ private:
                 DFX::Resolution::REQUIRED);
             getState() ^= parentUsage.getState();
           } else {
-            assert("Unsupported test case");
+            assert(false && "Unsupported test case");
           }
         })
         .Case([&](mlir::func::ReturnOp op) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -567,19 +567,16 @@ private:
                 Position::forValue(op->getParentOp()->getResult(operandIdx)),
                 DFX::Resolution::REQUIRED);
             getState() ^= parentUsage.getState();
-          }
-          if (auto whileOp =
+          } else if (auto whileOp =
                   dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
             auto value =
                 Position::forValue(whileOp.getBefore().getArgument(operandIdx));
             auto &valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();
-          }
-
-          if (auto forOp = dyn_cast_or_null<scf::ForOp>(op->getParentOp())) {
+          } else if (auto forOp = dyn_cast_or_null<scf::ForOp>(op->getParentOp())) {
             auto value = Position::forValue(forOp.getRegionIterArg(
-                operandIdx + forOp.getNumInductionVars()));
+                operandIdx));
             auto &valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();
@@ -588,6 +585,8 @@ private:
                 *this, Position::forValue(forOp->getResult(operandIdx)),
                 DFX::Resolution::REQUIRED);
             getState() ^= parentUsage.getState();
+          } else {
+            assert("Unsupported test case");
           }
         })
         .Case([&](mlir::func::ReturnOp op) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -517,10 +517,10 @@ private:
               *this, Position::forValue(op.getOperand(operandIdx)),
               DFX::Resolution::REQUIRED);
           getState() ^= operandUsage.getState();
-          int64_t blockIdx = operandIdx > 0 ? operandIdx - 2 : operandIdx;
-          if (blockIdx >= 0) {
+          if (operandIdx >= op.getNumControlOperands()) {
+            int64_t blockIdx = operandIdx - op.getNumControlOperands();
             auto &beforeUsage = solver.getElementFor<ValueResourceUsage>(
-                *this, Position::forValue(op.getBody()->getArgument(blockIdx)),
+                *this, Position::forValue(op.getRegionIterArg(blockIdx)),
                 DFX::Resolution::REQUIRED);
             getState() ^= beforeUsage.getState();
           }
@@ -578,8 +578,8 @@ private:
           }
 
           if (auto forOp = dyn_cast_or_null<scf::ForOp>(op->getParentOp())) {
-            auto value = Position::forValue(
-                forOp.getRegion().front().getArgument(operandIdx + 1));
+            auto value = Position::forValue(forOp.getRegionIterArg(
+                operandIdx + forOp.getNumInductionVars()));
             auto &valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -568,15 +568,15 @@ private:
                 DFX::Resolution::REQUIRED);
             getState() ^= parentUsage.getState();
           } else if (auto whileOp =
-                  dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
+                         dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
             auto value =
                 Position::forValue(whileOp.getBefore().getArgument(operandIdx));
             auto &valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();
-          } else if (auto forOp = dyn_cast_or_null<scf::ForOp>(op->getParentOp())) {
-            auto value = Position::forValue(forOp.getRegionIterArg(
-                operandIdx));
+          } else if (auto forOp =
+                         dyn_cast_or_null<scf::ForOp>(op->getParentOp())) {
+            auto value = Position::forValue(forOp.getRegionIterArg(operandIdx));
             auto &valueUsage = solver.getElementFor<ValueResourceUsage>(
                 *this, value, DFX::Resolution::REQUIRED);
             getState() ^= valueUsage.getState();

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
@@ -343,7 +343,7 @@ struct ScfForOpConversion : public OpConversionPattern<mlir::scf::ForOp> {
       }
     }
 
-    // Create a new call that takes the expanded input operands and returns the
+    // Create a new loop that takes the expanded input operands and returns the
     // expanded output results. We can't directly replace the original loop as
     // the result counts differ.
     auto forOp = rewriter.create<mlir::scf::ForOp>(

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
@@ -304,6 +304,83 @@ struct ScfIfOpConversion : public OpConversionPattern<mlir::scf::IfOp> {
   }
 };
 
+struct ScfForOpConversion : public OpConversionPattern<mlir::scf::ForOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(mlir::scf::ForOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto &typeConverter = *getTypeConverter();
+    // Expand any resource operands to resource + size.
+    auto expandedOperands =
+        expandResourceOperands(op.getLoc(), adaptor.getInitArgs(), rewriter);
+
+    // Expand any resource results to resource + size.
+    SmallVector<Type> expandedTypes;
+    struct Result {
+      size_t originalIndex;
+      size_t newIndex;
+      Type newType;
+    };
+    SmallVector<Result> resultMap;
+    for (auto originalType : llvm::enumerate(op.getResultTypes())) {
+      SmallVector<Type> newTypes;
+      if (failed(getTypeConverter()->convertType(originalType.value(),
+                                                 newTypes))) {
+        return rewriter.notifyMatchFailure(op,
+                                           "unable to convert result types");
+      }
+      resultMap.push_back(
+          Result{originalType.index(), expandedTypes.size(), newTypes.front()});
+      expandedTypes.append(newTypes);
+    }
+
+    auto &block = op.getRegion().front();
+    TypeConverter::SignatureConversion newSignature(block.getNumArguments());
+    for (auto arg : llvm::enumerate(block.getArgumentTypes())) {
+      if (failed(typeConverter.convertSignatureArg(arg.index(), arg.value(),
+                                                   newSignature))) {
+        return failure();
+      }
+    }
+
+    // Create a new call that takes the expanded input operands and returns the
+    // expanded output results. We can't directly replace the original call as
+    // the result counts differ.
+    auto forOp = rewriter.create<mlir::scf::ForOp>(
+        op.getLoc(), adaptor.getLowerBound(), adaptor.getUpperBound(),
+        adaptor.getStep(), expandedOperands);
+
+    // Inline the block and update the block arguments.
+    forOp.getRegion().getBlocks().clear();
+    rewriter.inlineRegionBefore(op.getRegion(), forOp.getRegion(),
+                                forOp.getRegion().end());
+    if (failed(rewriter.convertRegionTypes(&forOp.getRegion(), typeConverter,
+                                           &newSignature))) {
+      return failure();
+    }
+
+    // Tie all resource results together so we end up with 1:1 results with the
+    // original op.
+    SmallVector<Value> results;
+    for (auto result : resultMap) {
+      if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
+        auto oldType = op.getResult(result.originalIndex).getType();
+        auto resource = forOp.getResult(result.newIndex + 0);
+        auto resourceSize = forOp.getResult(result.newIndex + 1);
+        results.push_back(rewriter
+                              .create<mlir::UnrealizedConversionCastOp>(
+                                  op.getLoc(), TypeRange{oldType},
+                                  ValueRange{resource, resourceSize})
+                              .getResult(0));
+      } else {
+        results.push_back(forOp.getResult(result.newIndex));
+      }
+    }
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
+
 struct ScfWhileOpConversion : public OpConversionPattern<mlir::scf::WhileOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -472,6 +549,12 @@ void populateStandardStructuralToStreamPatterns(
           return typeConverter.isLegal(type);
         });
       });
+  conversionTarget.addDynamicallyLegalOp<mlir::scf::ForOp>(
+      [&](mlir::scf::ForOp op) {
+        return llvm::all_of(op.getResultTypes(), [&](Type type) {
+          return typeConverter.isLegal(type);
+        });
+      });
   conversionTarget.addDynamicallyLegalOp<mlir::scf::WhileOp>(
       [&](mlir::scf::WhileOp op) {
         return llvm::all_of(op.getResultTypes(), [&](Type type) {
@@ -495,8 +578,8 @@ void populateStandardStructuralToStreamPatterns(
       .insert<FuncOpSignatureConversion, CallOpConversion, ReturnOpConversion,
               BranchOpConversion, CondBranchOpConversion, SwitchOpConversion,
               SelectOpConversion, ScfConditionOpConversion, ScfIfOpConversion,
-              ScfWhileOpConversion, ScfYieldOpConversion>(typeConverter,
-                                                          context);
+              ScfForOpConversion, ScfWhileOpConversion, ScfYieldOpConversion>(
+          typeConverter, context);
 }
 
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStructuralOps.cpp
@@ -344,7 +344,7 @@ struct ScfForOpConversion : public OpConversionPattern<mlir::scf::ForOp> {
     }
 
     // Create a new call that takes the expanded input operands and returns the
-    // expanded output results. We can't directly replace the original call as
+    // expanded output results. We can't directly replace the original loop as
     // the result counts differ.
     auto forOp = rewriter.create<mlir::scf::ForOp>(
         op.getLoc(), adaptor.getLowerBound(), adaptor.getUpperBound(),

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/test/structural_ops.mlir
@@ -126,3 +126,22 @@ func.func @scfWhileExpansion(%arg0 : i32, %arg1 : tensor<1xf32>) {
   }
   return
 }
+
+// -----
+
+// CHECK-LABEL: @scfWhileExpansion
+// CHECK-SAME: %[[ARG0:.+]]: index,
+// CHECK-SAME: %[[ARG1:.+]]: !stream.resource<*>,
+// CHECK-SAME: %[[ARG2:.+]]: index
+func.func @scfWhileExpansion(%arg0 : index, %arg1 : tensor<1xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK: [[FOR:.+]]:2 = scf.for %[[ARG3:.+]] = %[[C0]] to %[[ARG0]] step %c1 iter_args(%[[ARG4:.+]] = %[[ARG1]], %[[ARG5:.+]] = %[[ARG2]]) -> (!stream.resource<*>, index)
+  scf.for %i = %c0 to %arg0 step %c1 iter_args(%arg2 = %arg1) -> (tensor<1xf32>) {
+    scf.yield %arg2 : tensor<1xf32>
+  }
+  return
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
@@ -261,10 +261,11 @@ private:
       // Branch argument.
       traversalResult |= solver.getExplorer().walkIncomingBranchOperands(
           arg.getParentBlock(),
-          [&](Block *sourceBlock, OperandRange operands) -> WalkResult {
+          [&](Block *sourceBlock, OperandRange operands,
+              size_t offset) -> WalkResult {
             unsigned baseIdx = operands.getBeginOperandIndex();
             auto &sourceOperand = sourceBlock->getTerminator()->getOpOperand(
-                baseIdx + arg.getArgNumber());
+                baseIdx + arg.getArgNumber() + offset);
             updateFromPredecessorUse(sourceOperand, solver);
             return WalkResult::advance();
           });

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -315,7 +315,6 @@ struct ApplyScfForOp : public UsageRefinementPattern<mlir::scf::ForOp> {
           didChange |= true;
       }
     }
-
     return success(didChange);
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
@@ -318,7 +318,6 @@ func.func @testForOp(%arg0 : index, %arg1 : !stream.resource<*>) -> !stream.reso
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
 
-
 // CHECK: %[[C0:.+]] = arith.constant 0 : index
 // CHECK: %[[C1:.+]] = arith.constant 1 : index
 // CHECK: %[[C4:.+]] = arith.constant 4 : index

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
@@ -307,3 +307,39 @@ func.func @testWhileRecurse(%arg0 : !stream.resource<*>) -> !stream.resource<ext
   // CHECK: return %[[WHILE]]#0
   return %transfer : !stream.resource<external>
 }
+
+// -----
+
+// CHECK-LABEL: @testForOp
+// CHECK-SAME: %[[ARG0:.+]]: index
+// CHECK-SAME: %[[ARG1:.+]]: !stream.resource<external>
+func.func @testForOp(%arg0 : index, %arg1 : !stream.resource<*>) -> !stream.resource<external> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+
+
+// CHECK: %[[C0:.+]] = arith.constant 0 : index
+// CHECK: %[[C1:.+]] = arith.constant 1 : index
+// CHECK: %[[C4:.+]] = arith.constant 4 : index
+// CHECK: %[[DISP0:.+]] = stream.async.dispatch @dispatch0(%arg1[%[[C0]] to %[[ARG0]] for %[[ARG0]]]) : (!stream.resource<external>{%[[C4]]}) -> !stream.resource<transient>{%[[C4]]}
+  %dispatch6 = stream.async.dispatch @dispatch0(%arg1[%c0 to %arg0 for %arg0]) : (!stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
+  // CHECK: %[[FOR:.+]] = scf.for %[[ARG2:.+]] = %[[C0]] to %[[ARG0]] step %[[C1]] iter_args(%[[ARG3:.+]] = %[[DISP0]]) -> (!stream.resource<transient>) {
+  %for = scf.for %i = %c0 to %arg0 step %c1 iter_args(%arg3 = %dispatch6) -> (!stream.resource<*>) {
+
+    // CHECK:   %[[DISP1:.+]] = stream.async.dispatch @dispatch1(%[[ARG3]][%[[C0]] to %[[ARG0]] for %[[ARG0]]]) : (!stream.resource<transient>{%[[C4]]}) -> !stream.resource<transient>{%[[C4]]}
+    // CHECK:   %[[DISP2:.+]] = stream.async.dispatch @dispatch2(%[[DISP1]][%[[C0]] to %[[ARG0]] for %[[ARG0]]]) : (!stream.resource<transient>{%[[C4]]}) -> !stream.resource<transient>{%[[C4]]}
+    // CHECK:   %[[DISP3:.+]] = stream.async.dispatch @dispatch3(%[[DISP2]][%[[C0]] to %[[ARG0]] for %[[ARG0]]]) : (!stream.resource<transient>{%[[C4]]}) -> !stream.resource<transient>{%[[C4]]}
+    %dispatch1 = stream.async.dispatch @dispatch1(%arg3[%c0 to %arg0 for %arg0]) : (!stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
+    %dispatch2 = stream.async.dispatch @dispatch2(%dispatch1[%c0 to %arg0 for %arg0]) : (!stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
+    %dispatch3 = stream.async.dispatch @dispatch3(%dispatch2[%c0 to %arg0 for %arg0]) : (!stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
+    // CHECK:   scf.yield %[[DISP3]] : !stream.resource<transient>
+    scf.yield %dispatch3 : !stream.resource<*>
+  }
+  // CHECK: %[[DISP4:.+]] = stream.async.dispatch @dispatch4(%[[FOR]][%[[C0]] to %[[ARG0]] for %[[ARG0]]]) : (!stream.resource<transient>{%[[C4]]}) -> !stream.resource<external>{%[[C4]]}
+  %dispatch5 = stream.async.dispatch @dispatch4(%for[%c0 to %arg0 for %arg0]) : (!stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
+  %transfer = stream.async.transfer %dispatch5 : !stream.resource<*>{%arg0} -> !stream.resource<external>{%arg0}
+
+  // CHECK: return %[[DISP4]] : !stream.resource<external>
+  return %transfer : !stream.resource<external>
+}

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.h
@@ -231,7 +231,7 @@ public:
 
   // Walks all predecessor blocks of |targetBlock| and provides the operands
   // passed to them along the incoming edge. Note that |targetBlock| may be
-  // enumerated if there is recursion. Includes an offset for mapping the 
+  // enumerated if there is recursion. Includes an offset for mapping the
   // block arguments.
   TraversalResult walkIncomingBranchOperands(
       Block *targetBlock,

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.h
@@ -234,7 +234,9 @@ public:
   // enumerated if there is recursion.
   TraversalResult walkIncomingBranchOperands(
       Block *targetBlock,
-      std::function<WalkResult(Block *sourceBlock, OperandRange operands)> fn);
+      std::function<WalkResult(Block *sourceBlock, OperandRange operands,
+                               size_t offset)>
+          fn);
 
   // Walks all predecessor blocks providing values for |blockArg|.
   TraversalResult walkIncomingBlockArgument(

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.h
@@ -231,7 +231,8 @@ public:
 
   // Walks all predecessor blocks of |targetBlock| and provides the operands
   // passed to them along the incoming edge. Note that |targetBlock| may be
-  // enumerated if there is recursion.
+  // enumerated if there is recursion. Includes an offset for mapping the 
+  // block arguments.
   TraversalResult walkIncomingBranchOperands(
       Block *targetBlock,
       std::function<WalkResult(Block *sourceBlock, OperandRange operands,


### PR DESCRIPTION
Resource refinement did not include support for `scf.for`. Expanded to include
this support. This included some minor fixes for `scf.while`.