### PR TITLE
[vulkan] Enable coop matrix features when available

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
@@ -222,6 +222,9 @@ iree_hal_vulkan_populate_enabled_device_extensions(
     } else if (strcmp(extension_name,
                       VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME) == 0) {
       extensions.shader_float16_int8 = true;
+    } else if (strcmp(extension_name,
+                      VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME) == 0) {
+      extensions.cooperative_matrix = true;
     }
   }
   return extensions;

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
@@ -90,6 +90,8 @@ typedef struct iree_hal_vulkan_device_extensions_t {
   bool shader_8bit_storage : 1;
   // VK_KHR_shader_float16_int8 is enabled.
   bool shader_float16_int8 : 1;
+  // VK_KHR_cooperative_matrix is enabled.
+  bool cooperative_matrix : 1;
 } iree_hal_vulkan_device_extensions_t;
 
 // Returns a bitfield with all of the provided extension names.

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -254,6 +254,12 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
   ADD_EXT(IREE_HAL_VULKAN_EXTENSIBILITY_DEVICE_EXTENSIONS_OPTIONAL,
           VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
 
+  // VK_KHR_cooperative_matrix:
+  // This extension exposes SIMD matrix-matrix multiply accumulate operations.
+  // It's available in Vulkan 1.3.
+  ADD_EXT(IREE_HAL_VULKAN_EXTENSIBILITY_DEVICE_EXTENSIONS_OPTIONAL,
+          VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
+
   //===--------------------------------------------------------------------===//
   // Optional debugging features
   //===--------------------------------------------------------------------===//
@@ -961,6 +967,15 @@ iree_status_t iree_hal_vulkan_device_create(
   available_shader_float16_int8_features.pNext = available_features2.pNext;
   available_features2.pNext = &available_shader_float16_int8_features;
 
+  // + Cooperative matrix features.
+  VkPhysicalDeviceCooperativeMatrixFeaturesKHR available_coop_matrix_features;
+  memset(&available_coop_matrix_features, 0,
+         sizeof(available_coop_matrix_features));
+  available_coop_matrix_features.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR;
+  available_coop_matrix_features.pNext = available_features2.pNext;
+  available_features2.pNext = &available_coop_matrix_features;
+
   instance_syms->vkGetPhysicalDeviceFeatures2(physical_device,
                                               &available_features2);
   const VkPhysicalDeviceFeatures* available_features =
@@ -1078,6 +1093,12 @@ iree_status_t iree_hal_vulkan_device_create(
   if (enabled_device_extensions.shader_float16_int8) {
     available_shader_float16_int8_features.pNext = enabled_features2.pNext;
     enabled_features2.pNext = &available_shader_float16_int8_features;
+  }
+
+  // Enable all available coop matrix features.
+  if (enabled_device_extensions.cooperative_matrix) {
+    available_coop_matrix_features.pNext = enabled_features2.pNext;
+    enabled_features2.pNext = &available_coop_matrix_features;
   }
 
   auto logical_device = new VkDeviceHandle(


### PR DESCRIPTION
We already emit shaders with coop matrix khr, so this is mostly to satisfy the Vulkan validation requirements.