### PR TITLE
[vulkan] Add e2e coop matrix f16 matmul test

### DIFF
--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -38,6 +38,9 @@ fi
 if ! [[ -v IREE_NVIDIA_GPU_TESTS_DISABLE ]]; then
   IREE_NVIDIA_GPU_TESTS_DISABLE=1
 fi
+if ! [[ -v IREE_AMD_RDNA3_GPU_TESTS_DISABLE ]]; then
+  IREE_AMD_RDNA3_GPU_TESTS_DISABLE=1
+fi
 
 declare -a test_env_args=(
   --test_env="LD_PRELOAD=libvulkan.so.1"
@@ -68,6 +71,9 @@ if (( IREE_VULKAN_DISABLE == 1 )); then
 fi
 if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
   default_test_tag_filters+=("-requires-gpu-nvidia" "-requires-gpu-sm80")
+fi
+if (( IREE_AMD_RDNA3_GPU_TESTS_DISABLE == 1 )); then
+  default_test_tag_filters+=("-requires-gpu-rdna3")
 fi
 
 # Use user-environment variables if set, otherwise use CI-friendly defaults.

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -39,6 +39,8 @@ export IREE_VULKAN_F16_DISABLE="${IREE_VULKAN_F16_DISABLE:-1}"
 export IREE_NVIDIA_GPU_TESTS_DISABLE="${IREE_NVIDIA_GPU_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require SM80 Nvidia GPU.
 export IREE_NVIDIA_SM80_TESTS_DISABLE="${IREE_NVIDIA_SM80_TESTS_DISABLE:-1}"
+# Respect the user setting, but default to skipping tests that require RDNA3 AMD GPU.
+export IREE_AMD_RDNA3_TESTS_DISABLE="${IREE_AMD_RDNA3_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require more than one device(GPU).
 export IREE_MULTI_DEVICE_TESTS_DISABLE="${IREE_MULTI_DEVICE_TESTS_DISABLE:-1}"
 # Respect the user setting, default to no --repeat-until-fail.
@@ -85,6 +87,9 @@ if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
 fi
 if (( IREE_NVIDIA_SM80_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-sm80$")
+fi
+if (( IREE_AMD_RDNA3_TESTS_DISABLE == 1 )); then
+  label_exclude_args+=("^requires-gpu-rdna3$")
 fi
 if (( IREE_MULTI_DEVICE_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-multiple-devices$")

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -491,25 +491,25 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_f16_gpu_large_rdna3",
+    compiler_flags = [
+        "--iree-vulkan-target-triple=rdna3-unknown-linux",
+    ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=f16",
         "--shapes=gpu_large_aligned",
         "--compilation_info=SPIRVCooperativeMatrixVectorize",
     ],
-    target_backends_and_drivers = [
-        ("vulkan-spirv", "vulkan"),
-    ],
-    compiler_flags = [
-        "--iree-vulkan-target-triple=rdna3-unknown-linux"
+    runner_args = [
+        "--require_exact_results=false",
     ],
     tags = [
         "requires-gpu",
         "requires-gpu-rdna3",
         "vulkan_uses_vk_khr_shader_float16_int8",
     ],
-    trace_runner = "//tools:iree-e2e-matmul-test",
-    runner_args = [
-        "--require_exact_results=false"
+    target_backends_and_drivers = [
+        ("vulkan-spirv", "vulkan"),
     ],
+    trace_runner = "//tools:iree-e2e-matmul-test",
 )

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -488,3 +488,24 @@ iree_generated_trace_runner_test(
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
 )
+
+iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f16_gpu_large_rdna3",
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f16",
+        "--shapes=gpu_large_aligned",
+        "--compilation_info=SPIRVCooperativeMatrixVectorize",
+    ],
+    target_backends_and_drivers = [
+        ("vulkan-spirv", "vulkan"),
+    ],
+    compiler_flags = [
+        "--iree-vulkan-target-triple=rdna3-unknown-linux"
+    ],
+    tags = [
+        "requires-gpu-rdna3",
+        "vulkan_uses_vk_khr_shader_float16_int8",
+    ],
+    trace_runner = "//tools:iree-e2e-matmul-test",
+)

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -504,8 +504,12 @@ iree_generated_trace_runner_test(
         "--iree-vulkan-target-triple=rdna3-unknown-linux"
     ],
     tags = [
+        "requires-gpu",
         "requires-gpu-rdna3",
         "vulkan_uses_vk_khr_shader_float16_int8",
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
+    runner_args = [
+        "--require_exact_results=false"
+    ],
 )

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -710,4 +710,26 @@ iree_generated_trace_runner_test(
     "--iree-codegen-enable-vector-padding=false"
 )
 
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f16_gpu_large_rdna3
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--shapes=gpu_large_aligned"
+    "--compilation_info=SPIRVCooperativeMatrixVectorize"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "vulkan-spirv"
+  DRIVERS
+    "vulkan"
+  COMPILER_FLAGS
+    "--iree-vulkan-target-triple=rdna3-unknown-linux"
+  LABELS
+    "requires-gpu-rdna3"
+    "vulkan_uses_vk_khr_shader_float16_int8"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -727,7 +727,10 @@ iree_generated_trace_runner_test(
     "vulkan"
   COMPILER_FLAGS
     "--iree-vulkan-target-triple=rdna3-unknown-linux"
+  RUNNER_ARGS
+    "--require_exact_results=false"
   LABELS
+    "requires-gpu"
     "requires-gpu-rdna3"
     "vulkan_uses_vk_khr_shader_float16_int8"
 )

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -46,6 +46,7 @@ class CompilationInfoId(enum.Enum):
     LLVMGPUMatmulSimt = "LLVMGPUMatmulSimt"
     LLVMGPUMatmulTensorCore = "LLVMGPUMatmulTensorCore"
     LLVMGPUMatmulTensorCoreMmaSync = "LLVMGPUMatmulTensorCoreMmaSync"
+    SPIRVCooperativeMatrixVectorize = "SPIRVCooperativeMatrixVectorize"
     SPIRVVectorizeMali = "SPIRVVectorizeMali"
     SPIRVVectorizeNVIDIA = "SPIRVVectorizeNVIDIA"
 
@@ -239,6 +240,12 @@ def get_test_compilation_infos(
             TileWorkgroupSizePair([[16, 64, 4]], [16, 2, 1]),
             TileWorkgroupSizePair([[1, 128, 8]], [32, 1, 1]),
         ]
+    elif compilation_info_id == CompilationInfoId.SPIRVCooperativeMatrixVectorize:
+        tile_workgroup_size_pairs = [
+            TileWorkgroupSizePair(
+                [[64, 64], [16, 64], [0, 0, 16], [16, 16, 16]], [64, 4, 1]
+            )
+        ]
     elif compilation_info_id == CompilationInfoId.SPIRVVectorizeNVIDIA:
         tile_workgroup_size_pairs = get_all_spirv_tile_workgroup_size_pairs(32)
     elif compilation_info_id == CompilationInfoId.SPIRVVectorizeMali:
@@ -426,6 +433,11 @@ def generate_function(
             == "SPIRVVectorizeMali"
         ):
             dispatch_lowering_pass_pipeline = "SPIRVBaseVectorize"
+        elif (
+            compilation_info.dispatch_lowering_pass_pipeline
+            == "SPIRVCooperativeMatrixVectorize"
+        ):
+            dispatch_lowering_pass_pipeline = "SPIRVCooperativeMatrixVectorize"
         elif compilation_info.dispatch_lowering_pass_pipeline == "SPIRVVectorizeNVIDIA":
             # TODO: change to test SPIRVMatmulPromoteVectorize too
             dispatch_lowering_pass_pipeline = "SPIRVBaseVectorize"

--- a/tools/iree-e2e-matmul-test.c
+++ b/tools/iree-e2e-matmul-test.c
@@ -666,22 +666,14 @@ static bool matmul_result_elements_agree(iree_e2e_test_value_t expected,
     // expected values. Inexact results are only permitted when the
     // `require_exact_results` flag is set to `false`.
     case IREE_E2E_TEST_VALUE_TYPE_F16:
-      if (actual.f16_u16 == expected.f16_u16) {
-        return true;
-      }
-      if (FLAG_require_exact_results) {
-        return false;
-      }
+      if (actual.f16_u16 == expected.f16_u16) return true;
+      if (FLAG_require_exact_results) return false;
       return fabsf(iree_math_f16_to_f32(actual.f16_u16) -
                    iree_math_f16_to_f32(expected.f16_u16)) <
              FLAG_acceptable_fp_delta;
     case IREE_E2E_TEST_VALUE_TYPE_F32:
-      if (actual.f32 == expected.f32) {
-        return true;
-      }
-      if (FLAG_require_exact_results) {
-        return false;
-      }
+      if (actual.f32 == expected.f32) return true;
+      if (FLAG_require_exact_results) return false;
       return fabsf(actual.f32 - expected.f32) < FLAG_acceptable_fp_delta;
     default:
       iree_status_abort(iree_make_status(IREE_STATUS_INVALID_ARGUMENT,

--- a/tools/iree-e2e-matmul-test.c
+++ b/tools/iree-e2e-matmul-test.c
@@ -22,6 +22,12 @@
 #include "iree/tooling/yaml_util.h"
 #include "iree/vm/api.h"
 
+IREE_FLAG(bool, require_exact_results, true,
+          "Requires floating point result elements to match exactly.");
+IREE_FLAG(
+    double, acceptable_fp_delta, 1e-5,
+    "Maximum absolute difference allowed with inexact floating point results.");
+
 IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");
 
 static const char* emoji(bool good) { return good ? "🦄" : "🐞"; }
@@ -656,12 +662,27 @@ static bool matmul_result_elements_agree(iree_e2e_test_value_t expected,
     case IREE_E2E_TEST_VALUE_TYPE_I32:
       return actual.i32 == expected.i32;
     // Since we fill buffers with small integers for floating point GEMMs
-    // functional testing, we test for bit-exactness on the actual and
-    // expected values.
+    // functional testing, we can test for bit-exactness on the actual and
+    // expected values. Inexact results are only permitted when the
+    // `require_exact_results` flag is set to `false`.
     case IREE_E2E_TEST_VALUE_TYPE_F16:
-      return actual.f16_u16 == expected.f16_u16;
+      if (actual.f16_u16 == expected.f16_u16) {
+        return true;
+      }
+      if (FLAG_require_exact_results) {
+        return false;
+      }
+      return fabsf(iree_math_f16_to_f32(actual.f16_u16) -
+                   iree_math_f16_to_f32(expected.f16_u16)) <
+             FLAG_acceptable_fp_delta;
     case IREE_E2E_TEST_VALUE_TYPE_F32:
-      return actual.f32 == expected.f32;
+      if (actual.f32 == expected.f32) {
+        return true;
+      }
+      if (FLAG_require_exact_results) {
+        return false;
+      }
+      return fabsf(actual.f32 - expected.f32) < FLAG_acceptable_fp_delta;
     default:
       iree_status_abort(iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                          "unhandled value type"));

--- a/tools/iree-e2e-matmul-test.c
+++ b/tools/iree-e2e-matmul-test.c
@@ -25,7 +25,7 @@
 IREE_FLAG(bool, require_exact_results, true,
           "Requires floating point result elements to match exactly.");
 IREE_FLAG(
-    double, acceptable_fp_delta, 1e-5,
+    float, acceptable_fp_delta, 1e-5,
     "Maximum absolute difference allowed with inexact floating point results.");
 
 IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");


### PR DESCRIPTION
-   Add a new test label for rdna3 tests. Make it disabled by default in CI/test scripts.
-   Add spirv coop matrix vectorization pipeline to the matmul test generator.
-  Teach the iree-e2e-matmul-test tool to allow inexact fp results. This is to accept small numerical imprecision with fp16 coop matrix on rdna3 (zero elements are not always exactly zero).