### PR TITLE
Add a way to hook custom TD strategy for specific ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -235,7 +235,8 @@ createTileAndDistributeToWorkgroupsPass(
 std::unique_ptr<Pass> createTransformDialectInterpreterPass(
     llvm::StringRef transformFileName = llvm::StringRef(),
     llvm::StringRef debugPayloadRootTag = llvm::StringRef(),
-    llvm::StringRef debugTransformRootTag = llvm::StringRef());
+    llvm::StringRef debugTransformRootTag = llvm::StringRef(),
+    llvm::StringRef transformLibraryFileName = llvm::StringRef());
 
 /// Pass to propagate type to avoid generating load/stores of illegal types.
 std::unique_ptr<OperationPass<func::FuncOp>> createTypePropagationPass();

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -234,9 +234,9 @@ createTileAndDistributeToWorkgroupsPass(
 /// registrations necessary for IREE.
 std::unique_ptr<Pass> createTransformDialectInterpreterPass(
     llvm::StringRef transformFileName = llvm::StringRef(),
+    llvm::StringRef transformLibraryFileName = llvm::StringRef(),
     llvm::StringRef debugPayloadRootTag = llvm::StringRef(),
-    llvm::StringRef debugTransformRootTag = llvm::StringRef(),
-    llvm::StringRef transformLibraryFileName = llvm::StringRef());
+    llvm::StringRef debugTransformRootTag = llvm::StringRef());
 
 /// Pass to propagate type to avoid generating load/stores of illegal types.
 std::unique_ptr<OperationPass<func::FuncOp>> createTypePropagationPass();

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -130,6 +130,9 @@ public:
                                          : clTransformLibraryFileName;
     this->debugPayloadRootTag = debugPayloadRootTag.str();
     this->debugTransformRootTag = debugTransformRootTag.str();
+    // Disable expensive checks until
+    // https://github.com/llvm/llvm-project/pull/67437 gets merged.
+    this->options.enableExpensiveChecks(false);
   }
   TransformDialectInterpreterPass(const TransformDialectInterpreterPass &pass) =
       default;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -48,6 +48,12 @@
 
 using namespace mlir;
 
+static llvm::cl::opt<std::string> clTransformLibraryFileName(
+    "iree-codegen-transform-library-file-name", llvm::cl::init(""),
+    llvm::cl::desc(
+        "Optional name of the file containing transform dialect symbol "
+        "definitions to be injected into the transform module."));
+
 namespace {
 
 /// Pass declaration.
@@ -115,9 +121,13 @@ public:
 
   TransformDialectInterpreterPass(
       StringRef transformFileName = StringRef(),
+      StringRef transformLibraryFileName = StringRef(),
       StringRef debugPayloadRootTag = StringRef(),
       StringRef debugTransformRootTag = StringRef()) {
     this->transformFileName = transformFileName.str();
+    this->transformLibraryFileName = clTransformLibraryFileName.empty()
+                                         ? transformLibraryFileName.str()
+                                         : clTransformLibraryFileName;
     this->debugPayloadRootTag = debugPayloadRootTag.str();
     this->debugTransformRootTag = debugTransformRootTag.str();
   }
@@ -131,10 +141,12 @@ namespace iree_compiler {
 /// Create a Transform dialect interpreter pass.
 std::unique_ptr<Pass>
 createTransformDialectInterpreterPass(llvm::StringRef transformFileName,
+                                      llvm::StringRef transformLibraryFileName,
                                       llvm::StringRef debugPayloadRootTag,
                                       llvm::StringRef debugTransformRootTag) {
   return std::make_unique<TransformDialectInterpreterPass>(
-      transformFileName, debugPayloadRootTag, debugTransformRootTag);
+      transformFileName, transformLibraryFileName, debugPayloadRootTag,
+      debugTransformRootTag);
 }
 } // namespace iree_compiler
 } // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Dialect/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/BUILD.bazel
@@ -84,6 +84,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformDialect",
     ],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     MLIRMemRefDialect
     MLIRParser
     MLIRSupport
+    MLIRTransformDialect
     iree::builtins::ukernel::exported_bits
     iree::compiler::Codegen::Interfaces::UKernelOpInterface
     iree::compiler::Codegen::Utils

--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
@@ -132,7 +132,9 @@ def IREECodegen_TranslationInfoAttr :
   let assemblyFormat = [{
     `<` `` $passPipeline
     (`pipeline_depth` `=` $softwarePipelineDepth^)?
-    (`store_stage` `=` $softwarePipelineStoreStage^)? `>`
+    (`store_stage` `=` $softwarePipelineStoreStage^)?
+    (`codegen_spec_file_name` `=` $codegenSpecFileName^)?
+    (`codegen_spec` `=` $codegenSpec^)? `>`
   }];
 
   let parameters = (ins
@@ -141,12 +143,18 @@ def IREECodegen_TranslationInfoAttr :
     OptionalParameter<"unsigned",
         "The software pipeline depth to be used">:$softwarePipelineDepth,
     DefaultValuedParameter<"unsigned", "1",
-        "The software pipeline stage to place stores">:$softwarePipelineStoreStage
+        "The software pipeline stage to place stores">:$softwarePipelineStoreStage,
+    OptionalParameter<"StringAttr",
+        "The path to the transform dialect codegen spec to be used">:$codegenSpecFileName,
+    OptionalParameter<"SymbolRefAttr",
+        "The symbol pointing to the transform dialect codegen spec to be used">:$codegenSpec
   );
   let builders = [
     AttrBuilder<(ins "DispatchLoweringPassPipeline":$passPipeline,
         CArg<"unsigned", "0">:$softwarePipelineDepth,
-        CArg<"unsigned", "1">:$softwarePipelineStoreStage)>
+        CArg<"unsigned", "1">:$softwarePipelineStoreStage,
+        CArg<"StringAttr", "{}">:$codegenSpecFileName,
+        CArg<"SymbolRefAttr", "{}">:$codegenSpec)>
   ];
   let extraClassDeclaration = [{
     // Returns the lowering pass pipeline set.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -309,7 +309,9 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
         // Transform-dialect pipelines.
         case IREE::Codegen::DispatchLoweringPassPipeline::
             TransformDialectCodegen:
-          addTransformDialectPasses(executableLoweringPipeline);
+          addTransformDialectPasses(
+              executableLoweringPipeline,
+              translationInfo.value().getCodegenSpecFileName());
           break;
         default:
           moduleOp.emitOpError("Unsupported pipeline on CPU target.");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -672,7 +672,8 @@ void addTransformDialectPasses(OpPassManager &passManager,
                            : codegenSpecFileName.getValue();
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
-          fileName, clCPUCodegenTransformDialectDebugPayloadTag,
+          fileName, /*transformLibraryFileName=*/StringRef(),
+          clCPUCodegenTransformDialectDebugPayloadTag,
           clCPUCodegenTransformDialectDebugTransformTag));
   // Dropping the schedule is needed:
   //   1. if we want to embed the transform in the module: we should drop the

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -664,12 +664,15 @@ void addCPUDefaultPassPipeline(OpPassManager &passManager) {
   addBufferizePasses(nestedModulePM);
 }
 
-void addTransformDialectPasses(OpPassManager &passManager) {
+void addTransformDialectPasses(OpPassManager &passManager,
+                               StringAttr codegenSpecFileName) {
   // Give control to the transform dialect.
+  StringRef fileName = codegenSpecFileName == StringAttr()
+                           ? clCPUCodegenTransformDialectFileName
+                           : codegenSpecFileName.getValue();
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
-          clCPUCodegenTransformDialectFileName,
-          clCPUCodegenTransformDialectDebugPayloadTag,
+          fileName, clCPUCodegenTransformDialectDebugPayloadTag,
           clCPUCodegenTransformDialectDebugTransformTag));
   // Dropping the schedule is needed:
   //   1. if we want to embed the transform in the module: we should drop the

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -153,7 +153,8 @@ void addTensorToVectorsPassPipeline(OpPassManager &passManager,
                                     bool lowerToVectors = true);
 
 /// Transform dialect-based common.
-void addTransformDialectPasses(OpPassManager &passManager);
+void addTransformDialectPasses(OpPassManager &passManager,
+                               StringAttr codegenSpecFileName);
 
 /// Populates the passes to lower to tiled/distributed/bufferized ops,
 /// suitable for library call dispatch and lowering to loops.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -47,6 +47,7 @@ iree_lit_test_suite(
             "peel.mlir",
             "peel_and_vectorize.mlir",
             "pipeline_tests.mlir",
+            "set_transform_strategy_from_file.mlir",
             "split_reduction.mlir",
             "split_reduction_pipeline_tests.mlir",
             "synchronize_symbol_visibility.mlir",
@@ -66,8 +67,14 @@ iree_lit_test_suite(
             "verify_linalg_transform_legality.mlir",
         ],
         include = ["*.mlir"],
+        exclude = [
+            "transform_dialect_dummy_spec.mlir",
+        ],
     ),
     cfg = "//compiler:lit.cfg.py",
+    data = [
+        "transform_dialect_dummy_spec.mlir",
+    ],
     tools = [
         "//tools:iree-compile",
         "//tools:iree-opt",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_lit_test_suite(
     "peel.mlir"
     "peel_and_vectorize.mlir"
     "pipeline_tests.mlir"
+    "set_transform_strategy_from_file.mlir"
     "split_reduction.mlir"
     "split_reduction_pipeline_tests.mlir"
     "synchronize_symbol_visibility.mlir"
@@ -63,6 +64,8 @@ iree_lit_test_suite(
     FileCheck
     iree-compile
     iree-opt
+  DATA
+    transform_dialect_dummy_spec.mlir
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/set_transform_strategy_from_file.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/set_transform_strategy_from_file.mlir
@@ -1,0 +1,53 @@
+// RUN: iree-opt --split-input-file %s --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))" --iree-codegen-llvmcpu-use-transform-dialect=%p/transform_dialect_dummy_spec.mlir | FileCheck %s
+// RUN: iree-opt --split-input-file %s --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))" --iree-codegen-transform-library-file-name=%p/transform_dialect_dummy_spec.mlir | FileCheck %s --check-prefix=CONFIG
+
+// If we set the config on the command line, it takes precedence.
+// CHECK: IR printer: from_flag
+
+// When we include the library, we should honor the config we set in the
+// attribute.
+// CONFIG: IR printer: from_config
+
+#blank_config = #iree_codegen.lowering_config<tile_sizes = []>
+#translation = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec=@print_config>
+#config = #iree_codegen.compilation_info<lowering_config = #blank_config, translation_info = #translation, workgroup_size = []>
+
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "broadwell", cpu_features = "+cmov,+mmx,+popcnt,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+fma,+bmi,+bmi2,+pclmul,+adx,+cx16,+cx8,+crc32,+f16c,+fsgsbase,+fxsr,+invpcid,+lzcnt,+movbe,+prfchw,+rdrnd,+rdseed,+sahf,+x87,+xsave,+xsaveopt", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 32 : index, target_triple = "x86_64-unknown-unknown-eabi-elf", ukernels = false}>
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>
+
+#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#executable_target_embedded_elf_x86_64_]}>
+module attributes {hal.device.targets = [#device_target_llvm_cpu]} {
+  hal.executable private @matmul_4x2304x768_f32_dispatch_0 {
+    hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ attributes {transform.target_tag = "payload_root"} {
+      hal.executable.export public @matmul_4x2304x768_f32_dispatch_0_generic_4x2304x768_f32 ordinal(0) layout(#pipeline_layout) {
+      ^bb0(%arg0: !hal.device):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+        hal.return %x, %y, %z : index, index, index
+      }
+
+      builtin.module {
+        func.func @matmul_4x2304x768_f32_dispatch_0_generic_4x2304x768_f32() {
+          %c0 = arith.constant 0 : index
+          %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<4x768xf32>>
+          %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<768x2304xf32>>
+          %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readwrite:tensor<4x2304xf32>>
+          %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<4x768xf32>> -> tensor<4x768xf32>
+          %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [768, 2304], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<768x2304xf32>> -> tensor<768x2304xf32>
+          %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [4, 2304], strides = [1, 1] : !flow.dispatch.tensor<readwrite:tensor<4x2304xf32>> -> tensor<4x2304xf32>
+          %6 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<4x768xf32>, tensor<768x2304xf32>) outs(%5 : tensor<4x2304xf32>)
+            attrs =  {compilation_info = #config} {
+          ^bb0(%in: f32, %in_0: f32, %out: f32):
+            %7 = arith.mulf %in, %in_0 fastmath<fast> : f32
+            %8 = arith.addf %out, %7 fastmath<fast> : f32
+            linalg.yield %8 : f32
+          } -> tensor<4x2304xf32>
+          flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [4, 2304], strides = [1, 1] : tensor<4x2304xf32> -> !flow.dispatch.tensor<readwrite:tensor<4x2304xf32>>
+          return
+        }
+      }
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_dummy_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_dummy_spec.mlir
@@ -1,0 +1,14 @@
+// RUN: iree-opt %s
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @print_config(%variant_op: !transform.any_op {transform.consumed}) {
+    transform.print %variant_op {name = "from_config"} : !transform.any_op
+    transform.yield
+  }
+
+  transform.sequence failures(propagate) {
+  ^bb0(%arg0: !transform.any_op):
+    print %arg0 {name = "from_flag"} : !transform.any_op
+    transform.yield
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -187,7 +187,9 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
       break;
     // Transform-dialect pipelines.
     case IREE::Codegen::DispatchLoweringPassPipeline::TransformDialectCodegen:
-      addGPUTransformDialectPasses(executableLoweringPipeline);
+      addGPUTransformDialectPasses(
+          executableLoweringPipeline,
+          translationInfo.value().getCodegenSpecFileName());
       break;
     default:
       variantOp.emitOpError("Unsupported pipeline on GPU target.");

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -564,12 +564,15 @@ extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectFileName;
 extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectDebugPayloadTag;
 extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectDebugTransformTag;
 
-void addGPUTransformDialectPasses(OpPassManager &passManager) {
+void addGPUTransformDialectPasses(OpPassManager &passManager,
+                                  StringAttr codegenSpecFileName) {
   // Give control to the transform dialect.
+  StringRef fileName = codegenSpecFileName == StringAttr()
+                           ? clGPUCodegenTransformDialectFileName
+                           : codegenSpecFileName.getValue();
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
-          clGPUCodegenTransformDialectFileName,
-          clGPUCodegenTransformDialectDebugPayloadTag,
+          fileName, clGPUCodegenTransformDialectDebugPayloadTag,
           clGPUCodegenTransformDialectDebugTransformTag));
 
   // Dropping the schedule is needed:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -572,7 +572,8 @@ void addGPUTransformDialectPasses(OpPassManager &passManager,
                            : codegenSpecFileName.getValue();
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
-          fileName, clGPUCodegenTransformDialectDebugPayloadTag,
+          fileName, /*transformLibraryFileName=*/StringRef(),
+          clGPUCodegenTransformDialectDebugPayloadTag,
           clGPUCodegenTransformDialectDebugTransformTag));
 
   // Dropping the schedule is needed:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -41,7 +41,8 @@ void addGPUPackUnPackPasses(OpPassManager &pm);
 void addGPUSimpleDistributePassPipeline(OpPassManager &pm);
 
 /// Transform dialect-based path.
-void addGPUTransformDialectPasses(OpPassManager &pm);
+void addGPUTransformDialectPasses(OpPassManager &pm,
+                                  StringAttr codegenSpecFileName);
 
 /// Lowering transpose using shared memory.
 void addGPUTransposePassPipeline(OpPassManager &pm);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -257,11 +257,14 @@ static void addSPIRVLoweringPasses(OpPassManager &pm, bool enableFastMath) {
 
 extern llvm::cl::opt<std::string> clSPIRVTransformDialectFileName;
 
-void addSPIRVTransformDialectPasses(OpPassManager &passManager) {
+void addSPIRVTransformDialectPasses(OpPassManager &passManager,
+                                    StringAttr codegenSpecFileName) {
   // Give control to the transform dialect.
+  StringRef fileName = codegenSpecFileName == StringAttr()
+                           ? clSPIRVTransformDialectFileName
+                           : codegenSpecFileName.getValue();
   passManager.addPass(
-      mlir::iree_compiler::createTransformDialectInterpreterPass(
-          clSPIRVTransformDialectFileName));
+      mlir::iree_compiler::createTransformDialectInterpreterPass(fileName));
 
   // Dropping the schedule is needed:
   //   1. if we want to embed the transform in the module: we should drop the
@@ -622,8 +625,9 @@ void addSPIRVWinogradVectorizePassPipeline(OpPassManager &pm) {
       /*flatten=*/false, /*dropUnitDims=*/false));
 }
 
-void addSPIRVTransformDialectPassPipeline(OpPassManager &pm) {
-  addSPIRVTransformDialectPasses(pm);
+void addSPIRVTransformDialectPassPipeline(OpPassManager &pm,
+                                          StringAttr codegenSpecFileName) {
+  addSPIRVTransformDialectPasses(pm, codegenSpecFileName);
 
   // Run SPIRVVectorize pass additionally to convert vectors into forms needed
   // for SPIR-V.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -41,7 +41,8 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm,
 void addSPIRVSubgroupReducePassPipeline(OpPassManager &pm);
 
 /// Pass pipeline to lower IREE HAL executables via transform dialect schedules.
-void addSPIRVTransformDialectPassPipeline(OpPassManager &pm);
+void addSPIRVTransformDialectPassPipeline(OpPassManager &pm,
+                                          StringAttr codegenSpecFileName);
 
 /// Pass pipeline to lower winograd ops. This pipeline follows the
 /// SPIRVBaseVectorize pipeline with the following exception:

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -192,7 +192,8 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
       addSPIRVWinogradVectorizePassPipeline(pipeline);
       break;
     case CodeGenPipeline::TransformDialectCodegen:
-      addSPIRVTransformDialectPassPipeline(pipeline);
+      addSPIRVTransformDialectPassPipeline(
+          pipeline, translationInfo.value().getCodegenSpecFileName());
       break;
     default:
       variantOp.emitOpError("Unsupported pipeline on GPU target.");

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/transform_dialect_dummy_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/transform_dialect_dummy_spec.mlir
@@ -1,6 +1,14 @@
 // RUN: iree-opt %s
 
-transform.sequence failures(propagate) {
-^bb0(%arg0: !transform.any_op):
-  print %arg0 : !transform.any_op
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @print_config(%variant_op: !transform.any_op {transform.consumed}) {
+    transform.print %variant_op {name = "from_config"} : !transform.any_op
+    transform.yield
+  }
+
+  transform.sequence failures(propagate) {
+  ^bb0(%arg0: !transform.any_op):
+    print %arg0 {name = "from_flag"} : !transform.any_op
+    transform.yield
+  }
 }

--- a/tests/transform_dialect/cpu/BUILD.bazel
+++ b/tests/transform_dialect/cpu/BUILD.bazel
@@ -23,7 +23,7 @@ iree_lit_test_suite(
         "fold_tensor_slice_into_transfer.mlir",
         "matmul.mlir",
         "select_strategy_matvec4.mlir",
-        "select_strategy_matvec6.mlir"
+        "select_strategy_matvec6.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,

--- a/tests/transform_dialect/cpu/BUILD.bazel
+++ b/tests/transform_dialect/cpu/BUILD.bazel
@@ -22,6 +22,8 @@ iree_lit_test_suite(
         "eltwise_reduction_eltwise.mlir",
         "fold_tensor_slice_into_transfer.mlir",
         "matmul.mlir",
+        "select_strategy_matvec4.mlir",
+        "select_strategy_matvec6.mlir"
     ],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,
@@ -30,6 +32,8 @@ iree_lit_test_suite(
         "attention_codegen_spec.mlir",
         "matmul_codegen_custom_dispatch_formation_spec.mlir",
         "matmul_codegen_default_spec.mlir",
+        "transform_dialect_dummy_select.mlir",
+        "transform_dialect_dummy_spec.mlir",
     ],
     tags = [
         "noasan",

--- a/tests/transform_dialect/cpu/CMakeLists.txt
+++ b/tests/transform_dialect/cpu/CMakeLists.txt
@@ -20,6 +20,8 @@ iree_lit_test_suite(
     "eltwise_reduction_eltwise.mlir"
     "fold_tensor_slice_into_transfer.mlir"
     "matmul.mlir"
+    "select_strategy_matvec4.mlir"
+    "select_strategy_matvec6.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck
@@ -31,6 +33,8 @@ iree_lit_test_suite(
     attention_codegen_spec.mlir
     matmul_codegen_custom_dispatch_formation_spec.mlir
     matmul_codegen_default_spec.mlir
+    transform_dialect_dummy_select.mlir
+    transform_dialect_dummy_spec.mlir
   LABELS
     "noasan"
     "nomsan"

--- a/tests/transform_dialect/cpu/select_strategy_matvec4.mlir
+++ b/tests/transform_dialect/cpu/select_strategy_matvec4.mlir
@@ -1,0 +1,50 @@
+// RUN: not iree-compile \
+// RUN:   --iree-codegen-transform-library-file-name=%p/transform_dialect_dummy_spec.mlir \
+// RUN:   --iree-hal-target-backends=llvm-cpu \
+// RUN:   %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=DEFAULT
+
+// RUN: not iree-compile \
+// RUN:   --iree-codegen-transform-library-file-name=%p/transform_dialect_dummy_spec.mlir \
+// RUN:   --iree-llvmcpu-transform-dialect-select-strategy=%p/transform_dialect_dummy_select.mlir \
+// RUN:   --iree-hal-target-backends=llvm-cpu \
+// RUN:   %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=MATCHER
+
+// Check that we can select the transform dialect strategy used for the lowering
+// by passing a "select file" to the compiler.
+// We know the compilation will fail here because we use a dummy strategy, i.e.,
+// the code is not actually lowered. Hence the `not` in the command line.
+
+// Default we don't select a strategy and just use what is set in the attribute:
+// print_config.
+// DEFAULT: IR printer: from_config
+
+// When using the matcher, check that we override what is already set in the
+// attribute. I.e., use print_matvec4 instead of print_config.
+// MATCHER: IR printer: from_selected4
+
+!tlhs = tensor<4x768xf32>
+!trhs = tensor<768x2304xf32>
+!tres = tensor<4x2304xf32>
+
+#blank_config = #iree_codegen.lowering_config<tile_sizes = []>
+#translation = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec=@print_config>
+#config = #iree_codegen.compilation_info<lowering_config = #blank_config, translation_info = #translation, workgroup_size = []>
+
+func.func @matmul_4x2304x768_f32(
+  %a: !tlhs,
+  %b: !trhs,
+  %c: !tres) -> !tres attributes { llvm.emit_c_interface } {
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                     affine_map<(d0, d1, d2) -> (d2, d1)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%a, %b: !tlhs, !trhs) outs(%c: !tres)
+    attrs = {compilation_info = #config} {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %0 = arith.mulf %arg0, %arg1 {fastmath = #arith.fastmath<fast>} : f32
+    %1 = arith.addf %arg2, %0  {fastmath = #arith.fastmath<fast>} : f32
+    linalg.yield %1 : f32
+  } -> !tres
+  return %result : !tres
+}

--- a/tests/transform_dialect/cpu/select_strategy_matvec6.mlir
+++ b/tests/transform_dialect/cpu/select_strategy_matvec6.mlir
@@ -1,0 +1,40 @@
+// RUN: not iree-compile \
+// RUN:   --iree-codegen-transform-library-file-name=%p/transform_dialect_dummy_spec.mlir \
+// RUN:   --iree-llvmcpu-transform-dialect-select-strategy=%p/transform_dialect_dummy_select.mlir \
+// RUN:   --iree-hal-target-backends=llvm-cpu \
+// RUN:   %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=MATCHER
+
+// Check that we can select the transform dialect strategy used for the lowering
+// by passing a "select file" to the compiler.
+// We know the compilation will fail here because we use a dummy strategy, i.e.,
+// the code is not actually lowered. Hence the `not` in the command line.
+
+// When using the matcher, check that we can run the right transform dialect
+// strategy, even if the matched instruction didn't have the
+// "TransformDialectCodegen codegen_spec" attribute before.
+// I.e., make sure the attribute gets added properly by observing that the
+// expected transform gets called. In this case we want a print of use
+// print_matvec6.
+// MATCHER: IR printer: from_selected6
+
+!tlhs = tensor<6x768xf32>
+!trhs = tensor<768x2304xf32>
+!tres = tensor<6x2304xf32>
+
+func.func @matmul_6x2304x768_f32(
+  %a: !tlhs,
+  %b: !trhs,
+  %c: !tres) -> !tres attributes { llvm.emit_c_interface } {
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                     affine_map<(d0, d1, d2) -> (d2, d1)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%a, %b: !tlhs, !trhs) outs(%c: !tres) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %0 = arith.mulf %arg0, %arg1 {fastmath = #arith.fastmath<fast>} : f32
+    %1 = arith.addf %arg2, %0  {fastmath = #arith.fastmath<fast>} : f32
+    linalg.yield %1 : f32
+  } -> !tres
+  return %result : !tres
+}

--- a/tests/transform_dialect/cpu/transform_dialect_dummy_select.mlir
+++ b/tests/transform_dialect/cpu/transform_dialect_dummy_select.mlir
@@ -1,0 +1,60 @@
+#transform = #iree_codegen.translation_info<TransformDialectCodegen>
+#blank_config = #iree_codegen.lowering_config<tile_sizes = []>
+#translation4 = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec=@print_selected4>
+#matvec4_config = #iree_codegen.compilation_info<lowering_config = #blank_config, translation_info = #translation4, workgroup_size = []>
+#translation6 = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec=@print_selected6>
+#matvec6_config = #iree_codegen.compilation_info<lowering_config = #blank_config, translation_info = #translation6, workgroup_size = []>
+
+module attributes { transform.with_named_sequence } {
+
+
+  //===------------------------------------------------------===
+  // Matvec
+  //===------------------------------------------------------===
+  transform.named_sequence @match_matvec4(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    %0 = transform.match.structured failures(propagate) %arg0 : (!transform.any_op) -> !transform.any_op {
+    ^bb1(%arg1: !transform.any_op):
+      %c4 = transform.param.constant 4 : i64 -> !transform.param<i64>
+
+      %dim = transform.match.structured.dim %arg1[0] : (!transform.any_op) -> !transform.param<i64>
+      transform.match.param.cmpi eq %c4, %dim : !transform.param<i64>
+      transform.match.structured.yield %arg1 : !transform.any_op
+    }
+
+    %config = transform.param.constant #matvec4_config -> !transform.any_param
+    transform.yield %0, %config : !transform.any_op, !transform.any_param
+  }
+
+  transform.named_sequence @match_matvec6(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    %0 = transform.match.structured failures(propagate) %arg0 : (!transform.any_op) -> !transform.any_op {
+    ^bb1(%arg1: !transform.any_op):
+      %c6 = transform.param.constant 6 : i64 -> !transform.param<i64>
+
+      %dim = transform.match.structured.dim %arg1[0] : (!transform.any_op) -> !transform.param<i64>
+      transform.match.param.cmpi eq %c6, %dim : !transform.param<i64>
+      transform.match.structured.yield %arg1 : !transform.any_op
+    }
+
+    %config = transform.param.constant #matvec6_config -> !transform.any_param
+    transform.yield %0, %config : !transform.any_op, !transform.any_param
+  }
+
+  //===------------------------------------------------------===
+  // Annotation and Application
+  //===------------------------------------------------------===
+
+  transform.named_sequence @annotate_op(%target: !transform.any_op {transform.readonly}, %config: !transform.any_param {transform.readonly}) {
+    transform.annotate %target "compilation_info" = %config : !transform.any_op, !transform.any_param
+    transform.yield
+  }
+
+
+  transform.sequence failures(propagate) {
+  ^bb0(%dispatch: !transform.any_op):
+    %dispatch_func = transform.structured.match ops{["func.func"]} in %dispatch : (!transform.any_op) -> !transform.any_op
+    transform.foreach_match in %dispatch_func
+        @match_matvec4 -> @annotate_op,
+        @match_matvec6 -> @annotate_op
+      : (!transform.any_op) -> (!transform.any_op)
+  }
+}

--- a/tests/transform_dialect/cpu/transform_dialect_dummy_spec.mlir
+++ b/tests/transform_dialect/cpu/transform_dialect_dummy_spec.mlir
@@ -1,0 +1,24 @@
+// RUN: iree-opt %s
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @print_config(%variant_op: !transform.any_op {transform.consumed}) {
+    transform.print %variant_op {name = "from_config"} : !transform.any_op
+    transform.yield
+  }
+
+  transform.named_sequence @print_selected4(%variant_op: !transform.any_op {transform.consumed}) {
+    transform.print %variant_op {name = "from_selected4"} : !transform.any_op
+    transform.yield
+  }
+
+  transform.named_sequence @print_selected6(%variant_op: !transform.any_op {transform.consumed}) {
+    transform.print %variant_op {name = "from_selected6"} : !transform.any_op
+    transform.yield
+  }
+
+  transform.sequence failures(propagate) {
+  ^bb0(%arg0: !transform.any_op):
+    print %arg0 {name = "from_flag"} : !transform.any_op
+    transform.yield
+  }
+}


### PR DESCRIPTION
Note: part of the changes here come straight from https://github.com/openxla/iree/pull/14788
Note2: The "select script" used in the test case has been inspired by @qedawkins in https://gist.github.com/qedawkins/fd1a837528fe363198e018ea55387aae

This patch adds a transform dialect interpreter pass that can be used to
annotate specific operations with specific strategies. This patch relies on
https://github.com/openxla/iree/pull/14788 to actually "link" the strategy
within the related module.

The intended use case, as demonstrated in the added test cases, is to:
1. specify the matcher in a dedicated file (in the transform dialect format)
   that is passed to the compiler through
   `--iree-llvmcpu-transform-dialect-select-strategy`.
2. provide the strategy as a named sequence through the library option
   `--iree-codegen-transform-library-file-name`.

If the matcher applies in #1, then the transform dialect pipeline will pick
up the proper strategy for #2 and apply it to the annotated operations.