### PR TITLE
[scf] Pushed SCF support through rest of the Flow/Stream/HAL

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -146,10 +146,6 @@ void buildStreamAsyncPassPipeline(OpPassManager &passManager,
   // change and it makes the IR cleaner.
   passManager.addPass(IREE::Stream::createRefineUsagePass());
 
-  // Cleanup patterns currently fail on SCF operations.
-  passManager.addNestedPass<func::FuncOp>(
-      IREE::Flow::createTopLevelSCFToCFGPass());
-
   addCleanupPatterns(passManager);
 
   // Verify all stream.async.* op access ranges that we can by taking advantage

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -1822,9 +1822,12 @@ public:
           callableOp.getCallableRegion()->empty()) {
         continue;
       }
-      for (auto &op : llvm::make_early_inc_range(
-               callableOp.getCallableRegion()->getOps())) {
-        if (failed(TypeSwitch<Operation *, LogicalResult>(&op)
+
+      llvm::SmallVector<Operation *> operations;
+      callableOp.walk([&](Operation *op) { operations.push_back(op); });
+
+      for (auto op : operations) {
+        if (failed(TypeSwitch<Operation *, LogicalResult>(op)
                        .Case([&](IREE::Stream::AsyncExecuteOp op) {
                          return allocateExecutionRegion(op);
                        })

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -302,7 +302,6 @@ LogicalResult processRegion(Location loc, MLIRContext *context, Region &region,
     for (auto &op : *block) {
       if (isa<scf::SCFDialect>(op.getDialect())) {
         for (auto &subregion : op.getRegions()) {
-          llvm::errs() << "Recursing into: " << op.getName() << "\n";
           if (failed(processRegion(loc, context, subregion, configAttr)))
             return failure();
         }


### PR DESCRIPTION
Final support required so that SCF is supported through the entire Flow/Stream/HAL pipeline. Just includes a few more cases of recursion into the `scf` operations.