### PR TITLE
suppress warnings on XCode 15

### DIFF
--- a/build_tools/cmake/iree_setup_toolchain.cmake
+++ b/build_tools/cmake/iree_setup_toolchain.cmake
@@ -189,6 +189,17 @@ macro(iree_setup_toolchain)
       message(WARNING "Thin archives requested but not supported by ar")
     endif()
   endif()
+
+  # As of XCode 15, the default linker warns on duplicate libraries.
+  if(APPLE AND NOT IREE_USE_LINKER)
+    SET(_FLAG_NO_WARN_DUP_LIB "-Wl,-no_warn_duplicate_libraries")
+    check_linker_flag(CXX "${_FLAG_NO_WARN_DUP_LIB}"
+      IREE_LINKER_HAVE_NO_WARN_DUPLICATE_LIBRARIES)
+    if (IREE_LINKER_HAVE_NO_WARN_DUPLICATE_LIBRARIES)
+      string(APPEND CMAKE_EXE_LINKER_FLAGS " ${_FLAG_NO_WARN_DUP_LIB}")
+      string(APPEND CMAKE_SHARED_LINKER_FLAGS " ${_FLAG_NO_WARN_DUP_LIB}")
+    endif()
+  endif()
 endmacro()
 
 iree_setup_toolchain()

--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -177,10 +177,12 @@ target_link_libraries(iree_compiler_API_SharedImpl PRIVATE
 
 # If not using sanitizers, ask linkers to error on undefined symbols.
 # For shared libraries, using sanitizers implies undefined symbols on Unix-like.
+# Also disabled on Apple (unsupported in XCode 15 default linker).
 if(NOT IREE_ENABLE_ASAN
     AND NOT IREE_ENABLE_MSAN
     AND NOT IREE_ENABLE_TSAN
-    AND NOT IREE_ENABLE_UBSAN)
+    AND NOT IREE_ENABLE_UBSAN
+    AND NOT APPLE)
   target_link_options(iree_compiler_API_SharedImpl PRIVATE
     $<$<PLATFORM_ID:Linux>:-Wl,--no-undefined>
     $<$<PLATFORM_ID:Darwin>:-Wl,-undefined,error>


### PR DESCRIPTION
XCode 15 changed the default linker to warn on multiply specified libraries in linker command lines, so we get warnings on about everything we link. Everyone seems to be having that problem at the moment, from some Googling, e.g. https://github.com/firebase/firebase-ios-sdk/issues/11818 .

Another issue with XCode 15's new linker is it doesn't support `-Wl,-undefined,error` anymore.