### PR TITLE
Disable running Benchmark-Large regularly

### DIFF
--- a/.github/workflows/benchmark_large.yml
+++ b/.github/workflows/benchmark_large.yml
@@ -9,9 +9,6 @@
 name: Benchmark Large
 
 on:
-  schedule:
-    # Scheduled to run at 09:00 UTC and 21:00 UTC.
-    - cron: '0 09,21 * * *'
   workflow_dispatch:
     inputs:
       shard-count:


### PR DESCRIPTION
Since we have disabled the XLA comparative benchmarks in `openxla-benchmark`, stop running this regularly. The workflow is still able to run on-demand.