### PR TITLE
[Reducer] Add delta pass to reduce optimization barriers

### DIFF
--- a/compiler/src/iree/compiler/Reducer/Strategies/BUILD.bazel
+++ b/compiler/src/iree/compiler/Reducer/Strategies/BUILD.bazel
@@ -18,6 +18,7 @@ iree_compiler_cc_library(
         "ReduceFlowDispatchOperandToResult.cpp",
         "ReduceFlowDispatchResultBySplat.cpp",
         "ReduceLinalgOnTensorsDelta.cpp",
+        "ReduceOptimizationBarriersDelta.cpp"
     ],
     hdrs = [
         "DeltaStrategies.h",

--- a/compiler/src/iree/compiler/Reducer/Strategies/BUILD.bazel
+++ b/compiler/src/iree/compiler/Reducer/Strategies/BUILD.bazel
@@ -18,7 +18,7 @@ iree_compiler_cc_library(
         "ReduceFlowDispatchOperandToResult.cpp",
         "ReduceFlowDispatchResultBySplat.cpp",
         "ReduceLinalgOnTensorsDelta.cpp",
-        "ReduceOptimizationBarriersDelta.cpp"
+        "ReduceOptimizationBarriersDelta.cpp",
     ],
     hdrs = [
         "DeltaStrategies.h",

--- a/compiler/src/iree/compiler/Reducer/Strategies/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Reducer/Strategies/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     "ReduceFlowDispatchOperandToResult.cpp"
     "ReduceFlowDispatchResultBySplat.cpp"
     "ReduceLinalgOnTensorsDelta.cpp"
+    "ReduceOptimizationBarriersDelta.cpp"
   DEPS
     LLVMSupport
     MLIRArithDialect

--- a/compiler/src/iree/compiler/Reducer/Strategies/DeltaStrategies.h
+++ b/compiler/src/iree/compiler/Reducer/Strategies/DeltaStrategies.h
@@ -16,6 +16,7 @@ void reduceFlowDispatchOperandToResultDelta(ChunkManager &chunker,
                                             WorkItem &workItem);
 void reduceFlowDispatchResultBySplatDelta(ChunkManager &chunker,
                                           WorkItem &workItem);
+void reduceOptimizationBarriersDelta(ChunkManager &chunker, WorkItem &workItem);
 
 } // namespace mlir::iree_compiler::Reducer
 

--- a/compiler/src/iree/compiler/Reducer/Strategies/ReduceOptimizationBarriersDelta.cpp
+++ b/compiler/src/iree/compiler/Reducer/Strategies/ReduceOptimizationBarriersDelta.cpp
@@ -1,0 +1,49 @@
+
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Reducer/Strategies/DeltaStrategies.h"
+
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+using namespace mlir::iree_compiler::Reducer;
+
+void mlir::iree_compiler::Reducer::reduceOptimizationBarriersDelta(
+    ChunkManager &chunker, WorkItem &workItem) {
+  ModuleOp module = workItem.getModule();
+
+  SmallVector<IREE::Util::OptimizationBarrierOp> optBarriers;
+  module.walk([&](IREE::Util::OptimizationBarrierOp optBarrier) {
+    if (!chunker.shouldFeatureBeKept()) {
+      optBarriers.push_back(optBarrier);
+    }
+  });
+
+  if (optBarriers.empty()) {
+    return;
+  }
+
+  // Replace all dispatch ops with the chosen operand.
+  for (auto optBarrier : optBarriers) {
+    optBarrier.erase();
+  }
+
+  PassManager pm(module.getContext());
+  // Dead code eliminate the dispatch ops.
+  pm.addPass(createCSEPass());
+  // Dead code eliminate the weights.
+  pm.addPass(createSymbolDCEPass());
+  // Canonicalize the module.
+  pm.addPass(createCanonicalizerPass());
+  if (failed(pm.run(module))) {
+    return;
+  }
+}

--- a/compiler/src/iree/compiler/Reducer/iree_reduce_lib.cc
+++ b/compiler/src/iree/compiler/Reducer/iree_reduce_lib.cc
@@ -24,7 +24,11 @@ Operation *mlir::iree_compiler::Reducer::ireeRunReducingStrategies(
                      "Dispatch operand to result delta");
   delta.runDeltaPass(reduceFlowDispatchResultBySplatDelta,
                      "Dispatch result to splat delta");
+  delta.runDeltaPass(reduceOptimizationBarriersDelta,
+                     "Optimization barriers delta");
   delta.runDeltaPass(reduceLinalgOnTensorsDelta, "Linalg on tensors delta");
+  delta.runDeltaPass(reduceOptimizationBarriersDelta,
+                     "Optimization barriers delta");
 
   return workItem.getModule();
 }


### PR DESCRIPTION
util.optimization_barrier is used in some delta passes (ReduceLinalgOnTensorsDelta and ReduceFlowDispatchResultBySplat) to prevent DCE of interesting use cases. Sometimes, the util.optimization_barrier can be entirely removed after these delta passes. This delta pass removes these optimization barriers.