### PR TITLE
[Reducer] Verify module before running the interesting script

### DIFF
--- a/compiler/src/iree/compiler/Reducer/Framework/Delta.cpp
+++ b/compiler/src/iree/compiler/Reducer/Framework/Delta.cpp
@@ -83,8 +83,6 @@ void Delta::runDeltaPass(DeltaFunc deltaFunc, StringRef message) {
   deltaFunc(chunkManager, root);
   int numTargets = chunkManager.getCurrentFeatureCount();
 
-  assert(root.verify().succeeded() &&
-         "Output module does not verify after counting chunks.");
   assert(oracle.isInteresting(root) &&
          "Output module not interesting after counting chunks.");
 

--- a/compiler/src/iree/compiler/Reducer/Framework/Oracle.cpp
+++ b/compiler/src/iree/compiler/Reducer/Framework/Oracle.cpp
@@ -18,6 +18,14 @@ using namespace mlir::iree_compiler::Reducer;
 #define DEBUG_TYPE "iree-reduce-framework"
 
 bool Oracle::isInteresting(WorkItem &workItem) {
+  // Check if the module verifies before running the interestingness script.
+  // iree-reduce expects a verifiable program at start, so if the program does
+  // not verify anymore, it is not interesting.
+  if (failed(workItem.verify())) {
+    LLVM_DEBUG(llvm::dbgs() << "Module does not verify\n");
+    return false;
+  }
+
   // Print module to a temporary file.
   SmallString<128> filepath;
   int fd;


### PR DESCRIPTION
The Delta passes are allowed to produce a non-verifiable module. This patch marks these non-verifiable modules as not interesting.