### PR TITLE
Update Mac build docs regarding thin archives

### DIFF
--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -118,11 +118,14 @@ settings can improve compile and link times substantially.
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DIREE_ENABLE_ASSERTIONS=ON \
         -DIREE_ENABLE_SPLIT_DWARF=ON \
-        -DIREE_ENABLE_THIN_ARCHIVES=ON \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
         -DIREE_ENABLE_LLD=ON
     ```
+
+    It is also possible to add `-DIREE_ENABLE_THIN_ARCHIVES=ON` if the
+    `CMAKE_AR` variable is defined and points to the path of either the GNU
+    binutils or LLVM `ar` program, overriding the default Apple `ar`.
 
 === "Windows"
 


### PR DESCRIPTION
Apple `ar` does not support thin archives, so passing `-DIREE_ENABLE_THIN_ARCHIVES=ON` on Mac results in CMake spew (raw output of `ar` + explicit Warning). Fix that default behavior and document how to properly switch to thin archives on Mac.