### PR TITLE
Avoid using ccache for 'runtime' builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,8 +383,6 @@ jobs:
       - name: "Checking out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: "Building runtime"
-        # Note ccache is read-only here since this job runs on a GitHub-hosted runner
-        # and GitHub runners don't have write access to GCS
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "BUILD_PRESET=test" \
@@ -637,8 +635,6 @@ jobs:
       - name: "Checking out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: "Building size-optimized runtime"
-        # Note ccache is read-only here since this job runs on a GitHub-hosted runner
-        # and GitHub runners don't have write access to GCS
         run: |
           ./build_tools/github_actions/docker_run.sh \
             gcr.io/iree-oss/base@sha256:796fb81a11ff7e7d057c93de468b74e48b6a9641aa19b7f7673c2772e8ea3b33 \

--- a/build_tools/cmake/build_runtime.sh
+++ b/build_tools/cmake/build_runtime.sh
@@ -19,7 +19,7 @@ BUILD_DIR="${1:-${IREE_TARGET_BUILD_DIR:-build-runtime}}"
 BUILD_PRESET="${BUILD_PRESET:-test}"
 
 source build_tools/cmake/setup_build.sh
-source build_tools/cmake/setup_ccache.sh
+# Note: not using ccache since the runtime build should be fast already.
 
 declare -a args
 args=(

--- a/build_tools/cmake/build_runtime.sh
+++ b/build_tools/cmake/build_runtime.sh
@@ -73,7 +73,3 @@ case "${BUILD_PRESET}" in
     exit 1
     ;;
 esac
-
-if (( IREE_USE_CCACHE == 1 )); then
-  ccache --show-stats
-fi

--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -49,7 +49,3 @@ echo "------------------------"
 echo "Building test deps"
 echo "------------------"
 "${CMAKE_BIN?}" --build . --target iree-test-deps -- -k 0
-
-if (( IREE_USE_CCACHE == 1 )); then
-  ccache --show-stats
-fi

--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -25,7 +25,7 @@ BUILD_DIR="build-emscripten"
 IREE_HOST_BIN_DIR="$(realpath ${IREE_HOST_BIN_DIR})"
 
 source build_tools/cmake/setup_build.sh
-source build_tools/cmake/setup_ccache.sh
+# Note: not using ccache since the runtime build should be fast already.
 
 cd "${BUILD_DIR}"
 

--- a/build_tools/cmake/build_runtime_small.sh
+++ b/build_tools/cmake/build_runtime_small.sh
@@ -24,7 +24,3 @@ source build_tools/cmake/setup_build.sh
   -DIREE_SIZE_OPTIMIZED=ON \
   -DIREE_BUILD_COMPILER=OFF
 "${CMAKE_BIN?}" --build "${BUILD_DIR}" -- -k 0
-
-if (( IREE_USE_CCACHE == 1 )); then
-  ccache --show-stats
-fi

--- a/build_tools/cmake/build_runtime_small.sh
+++ b/build_tools/cmake/build_runtime_small.sh
@@ -14,7 +14,7 @@ set -xeuo pipefail
 BUILD_DIR="${1:-${IREE_RUNTIME_SMALL_BUILD_DIR:-build-runtime-small}}"
 
 source build_tools/cmake/setup_build.sh
-source build_tools/cmake/setup_ccache.sh
+# Note: not using ccache since the runtime build should be fast already.
 
 "${CMAKE_BIN?}" -B "${BUILD_DIR}" \
   -G Ninja . \


### PR DESCRIPTION
These were seeing 0% cache hit rates and are fast enough without caching (< 2 minutes on all CI jobs).

The Windows runners also stopped coming with ccache preinstalled, and it's not worth spending ~45 seconds installing a dependency that is not useful.