### PR TITLE
[CPU][SVE] Enable scalable vectorization and tiling for non-padded matmuls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -64,16 +64,18 @@ SizesAndScalableFlags TilingConfig::getVectorTileSizes() {
   auto [parallelInnerSizes, parallelInnerScalableFlags] =
       getVectorInnerParallelSizes();
   for (int i = 0; i < numDims; ++i) {
-    unsigned nonZeroCnt =
-        llvm::count(ArrayRef<bool>{!!parallelCommonSizes[i], !!reductionSizes[i],
-                                   !!parallelInnerSizes[i]},
-                    true);
+    unsigned nonZeroCnt = llvm::count(
+        ArrayRef<bool>{
+            !!parallelCommonSizes[i] || parallelCommonScalableFlags[i],
+            !!reductionSizes[i] || reductionScalableFlags[i],
+            !!parallelInnerSizes[i] || parallelInnerScalableFlags[i]},
+        true);
     assert(nonZeroCnt <= 1 && "expected one tile size at most to be non-zero");
     (void)nonZeroCnt;
     vectorSizes[i] =
         parallelCommonSizes[i] ^ reductionSizes[i] ^ parallelInnerSizes[i];
-    scalableFlags[i] = parallelCommonScalableFlags[i] |
-                       reductionScalableFlags[i] |
+    scalableFlags[i] = parallelCommonScalableFlags[i] ||
+                       reductionScalableFlags[i] ||
                        parallelInnerScalableFlags[i];
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -54,24 +54,30 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
 
 /// Returns the tile sizes of all the vector dimensions, including parallel
 /// and reduction dimensions.
-SmallVector<int64_t> TilingConfig::getVectorTileSizes() {
+SizesAndScalableFlags TilingConfig::getVectorTileSizes() {
   unsigned numDims = getNumDimensions();
   SmallVector<int64_t> vectorSizes(numDims, 0);
-  SmallVector<int64_t> parallelCommonSizes = getVectorCommonParallelSizes();
-  SmallVector<int64_t> reductionSizes = getVectorReductionSizes();
-  SmallVector<int64_t> parallelInnerSizes = getVectorInnerParallelSizes();
+  SmallVector<bool> scalableFlags(numDims, false);
+  auto [parallelCommonSizes, parallelCommonScalableFlags] =
+      getVectorCommonParallelSizes();
+  auto [reductionSizes, reductionScalableFlags] = getVectorReductionSizes();
+  auto [parallelInnerSizes, parallelInnerScalableFlags] =
+      getVectorInnerParallelSizes();
   for (int i = 0; i < numDims; ++i) {
-    unsigned nonZeroCnt = llvm::count_if(
-        ArrayRef<int64_t>{parallelCommonSizes[i], reductionSizes[i],
-                          parallelInnerSizes[i]},
-        [](auto v) { return v != 0; });
+    unsigned nonZeroCnt =
+        llvm::count(ArrayRef<bool>{!!parallelCommonSizes[i], !!reductionSizes[i],
+                                   !!parallelInnerSizes[i]},
+                    true);
     assert(nonZeroCnt <= 1 && "expected one tile size at most to be non-zero");
     (void)nonZeroCnt;
     vectorSizes[i] =
         parallelCommonSizes[i] ^ reductionSizes[i] ^ parallelInnerSizes[i];
+    scalableFlags[i] = parallelCommonScalableFlags[i] |
+                       reductionScalableFlags[i] |
+                       parallelInnerScalableFlags[i];
   }
 
-  return vectorSizes;
+  return std::make_pair(vectorSizes, scalableFlags);
 }
 
 /// Returns a list with the tiling levels that can be fused for this

--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.h
@@ -22,6 +22,9 @@ namespace iree_compiler {
 /// Typedef for tile sizes to use at different levels of tiling.
 using TileSizesListType = SmallVector<SmallVector<int64_t>>;
 using TileSizesListTypeRef = ArrayRef<SmallVector<int64_t>>;
+/// Typedef for scalable tile flags at different levels of tiling.
+using ScalableTileFlagsListType = SmallVector<SmallVector<bool>>;
+using ScalableTileFlagsListTypeRef = ArrayRef<SmallVector<bool>>;
 } // namespace iree_compiler
 } // namespace mlir
 
@@ -121,13 +124,15 @@ void setLoweringConfig(Operation *op, IREE::Codegen::LoweringConfigAttr config);
 /// translation.
 inline LogicalResult setOpConfigAndEntryPointFnTranslation(
     func::FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
+    ScalableTileFlagsListTypeRef scalableTileFlags,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
     ArrayRef<int64_t> workgroupSize = {},
     std::optional<int64_t> subgroupSize = {},
     unsigned softwarePipelineDepth = 0,
     unsigned softwarePipelineStoreStage = 1) {
   MLIRContext *context = entryPointFn.getContext();
-  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
+  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes,
+                                                       scalableTileFlags);
   setLoweringConfig(op, config);
   if (failed(setDispatchConfig(entryPointFn, workgroupSize, subgroupSize)))
     return failure();
@@ -135,6 +140,20 @@ inline LogicalResult setOpConfigAndEntryPointFnTranslation(
       entryPointFn.getContext(), passPipeline, softwarePipelineDepth,
       softwarePipelineStoreStage);
   return setTranslationInfo(entryPointFn, translationInfo);
+}
+
+/// Overload of setOpConfigAndEntryPointFnTranslation() for the "no scalable
+/// flags" case.
+inline LogicalResult setOpConfigAndEntryPointFnTranslation(
+    func::FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
+    IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
+    ArrayRef<int64_t> workgroupSize = {},
+    std::optional<int64_t> subgroupSize = {},
+    unsigned softwarePipelineDepth = 0,
+    unsigned softwarePipelineStoreStage = 1) {
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPointFn, op, tileSizes, {}, passPipeline, workgroupSize,
+      subgroupSize, softwarePipelineDepth, softwarePipelineStoreStage);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.td
@@ -208,6 +208,10 @@ def IREECodegen_LoweringConfigAttr :
   let builders = [
     AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
         CArg<"TileSizesListTypeRef", "{}">:$tileInterchange,
+        CArg<"ArrayRef<int64_t>", "{}">:$nativeVectorSize)>,
+    AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
+        "ScalableTileFlagsListTypeRef":$scalableTileFlags,
+        CArg<"TileSizesListTypeRef", "{}">:$tileInterchange,
         CArg<"ArrayRef<int64_t>", "{}">:$nativeVectorSize)>
   ];
   let extraClassDeclaration = [{
@@ -216,6 +220,12 @@ def IREECodegen_LoweringConfigAttr :
 
     // Returns the tile sizes for a level set for the op.
     SmallVector<int64_t> getTileSizeVals(unsigned level);
+
+    // Returns the scalable tile flags for all levels set for the op.
+    ScalableTileFlagsListType getScalableTileFlagVals();
+
+    // Returns the scalable tile flags for a level set for the op.
+    SmallVector<bool> getScalableTileFlagVals(unsigned level);
 
     // Returns the tile interchange for a level set for the op.
     SmallVector<int64_t> getTileInterchangeVals(unsigned level);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -196,7 +196,13 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
       continue;
     }
     TilingConfig tilingConfig(maybeLoweringConfig.value());
-    auto reductionSizes = tilingConfig.getVectorReductionSizes();
+    auto [reductionSizes, scalableDims] =
+        tilingConfig.getVectorReductionSizes();
+    if (scalableDims.back()) {
+      LLVM_DEBUG(llvm::dbgs() << "scalable reduction dimensions not yet "
+                                 "supported, skip SplitReduction");
+      continue;
+    }
     if (reductionSizes.empty()) {
       LLVM_DEBUG(llvm::dbgs() << "the list of reduction tiling sizes is empty, "
                                  "skip SplitReduction");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -203,7 +203,8 @@ LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
       }
     }
 
-    SmallVector<int64_t> secondLevelTileSizes =
+    SmallVector<int64_t> secondLevelTileSizes;
+    std::tie(secondLevelTileSizes, std::ignore) =
         tilingConfig.getVectorCommonParallelSizes();
     for (auto [index, tileSize] : llvm::enumerate(secondLevelTileSizes)) {
       if (tileSize != 0 && !pLoopsSet.contains(index)) {
@@ -214,7 +215,8 @@ LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
       }
     }
 
-    SmallVector<int64_t> thirdLevelTileSizes =
+    SmallVector<int64_t> thirdLevelTileSizes;
+    std::tie(thirdLevelTileSizes, std::ignore) =
         tilingConfig.getVectorReductionSizes();
     for (auto [index, tileSize] : llvm::enumerate(thirdLevelTileSizes)) {
       if (tileSize != 0 && pLoopsSet.contains(index)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -47,6 +47,7 @@ iree_lit_test_suite(
             "peel.mlir",
             "peel_and_vectorize.mlir",
             "pipeline_tests.mlir",
+            "scalable_tile_and_vectorize_matmul.mlir",
             "split_reduction.mlir",
             "split_reduction_pipeline_tests.mlir",
             "synchronize_symbol_visibility.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_lit_test_suite(
     "peel.mlir"
     "peel_and_vectorize.mlir"
     "pipeline_tests.mlir"
+    "scalable_tile_and_vectorize_matmul.mlir"
     "split_reduction.mlir"
     "split_reduction_pipeline_tests.mlir"
     "synchronize_symbol_visibility.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -98,7 +98,7 @@ hal.executable private @matmul_tensors_sve  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [8, 32, 0], [0, 0, 16], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [8, [32], 0], [0, 0, 16], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/scalable_tile_and_vectorize_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/scalable_tile_and_vectorize_matmul.mlir
@@ -1,0 +1,33 @@
+// RUN: iree-opt --split-input-file \
+// RUN: --iree-llvmcpu-tile-and-fuse=tiling-level=1 \
+// RUN: --iree-llvmcpu-tile=tiling-level=2 \
+// RUN: --iree-codegen-generic-vectorization=enable-vector-masking %s | FileCheck %s
+
+// -----
+
+/// This test checks we successfully tile the matmul and invoke the linalg vectorizer,
+/// and produce scalable vector ops.
+
+/// Simple scalable lowering config, derived from the default for SVE on AArch64.
+#scalable_lowering_config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [1, [32], 0], [0, 0, 1], [0, 0, 0]]>
+
+func.func @scalable_matmul(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>) -> tensor<?x?xf32>{
+  %1 = linalg.matmul {lowering_config = #scalable_lowering_config} ins(%A, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+            outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func.func @scalable_matmul(
+// CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:   %[[C32:.*]] = arith.constant 32 : index
+// CHECK:       %[[VSCALE:.*]] = vector.vscale
+// CHECK-DAG:   %[[SCALABLE_TILE_SIZE:.*]] = arith.muli %[[VSCALE]], %[[C32]] : index
+// CHECK:       scf.for
+// CHECK-SAME:      step %[[C1]]
+// CHECK:         scf.for
+// CHECK-SAME:        step %[[SCALABLE_TILE_SIZE]]
+// CHECK:           scf.for
+// CHECK-SAME:          step %[[C1]]
+// CHECK:             vector.create_mask {{.*}} : vector<1x[32]xi1>
+// CHECK:             vector.mask
+// CHECK-SAME:          vector.contract
+// CHECK-SAME:          vector<1x1xf32>, vector<1x[32]xf32> into vector<1x[32]xf32>


### PR DESCRIPTION
This patch implements a "vertical slice" that allows for the scalable vectorization of matmuls on AArch64 targets with SVE. This only updates lowerings along that path, so more is needed to enable scalable vectorization everywhere.

This required a few changes:

- The default vector sizes of matmuls on AArch64+SVE are now (8, [32], 16)
   * That is a middle scalable dimension (i.e. 32 x vscale)
- `iree-llvmcpu-tile-and-fuse` now generates vscale bounded loops for scalable tiles
- `TilingConfig` now returns a pair of tile sizes and scalable flags (`SizesAndScalableFlags`) for vector sizes
   * This allows connecting the scalable sizes to the generic vectorizer (which passes them down to the linalg vectorizer)

A few unit tests have been added for this, but a complete e2e test is not possible without SVE testing infrastructure.