### PR TITLE
[rocm] Add target dependency to ROCM bc file copies.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/CMakeLists.txt
@@ -89,7 +89,11 @@ add_custom_command(
     ${_all_device_bc_copy_commands}
 )
 add_custom_target(iree_compiler_Dialect_HAL_Target_ROCM_GenDeviceLibs
-  DEPENDS ${_all_device_bc_files}
+  DEPENDS
+    # Must depend on both the targets and the bc files in order for the
+    # transitive dep to work.
+    ${AMD_DEVICE_LIBS}
+    ${_all_device_bc_files}
 )
 
 # Ensure that the device libs are built when the compiler dylib is built.


### PR DESCRIPTION
This was causing clean builds to fail for ROCM unless if `ninja llvm-external-projects/ROCm-Device-Libs/all` was done first.