### PR TITLE
[GlobalOptimization] Add RaiseSpecialOps earlier in the pipeline

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -62,6 +62,10 @@ void buildGlobalOptimizationPassPipeline(
       // - Remove unit-extent dimensions.
       .addPass(mlir::createConvertElementwiseToLinalgPass)
       .addPass(IREE::Flow::createGeneralizeLinalgNamedOpsPass)
+      // RaiseSpecialOps, by virtue of implementing various peephole
+      // optimizations, is sensitive to surrounding IR structure. Thus we run
+      // this pass both before unit dim folding + consteval, as well as after.
+      .addPass(IREE::Flow::createRaiseSpecialOps)
       .addPass(IREE::Flow::createFoldUnitExtentDimsPass)
       .addPass(IREE::Flow::createFuseDequantizationMatmulPass)
       // Enable data tiling after they are in a canonical form.


### PR DESCRIPTION
Some of the raisings/optimizations in RaiseSpecialOps is sensitive to surrounding IR structure. This adds the pass before both constexpr hoisting and unit dim folding, allowing the patterns to kick in closer to the source. This does not replace the existing usage within flow, as certain patterns like slice raising benefit from unit dim folding happening first.