### PR TITLE
[Reducer] Fix ReduceOptimizationBarrierDelta

### DIFF
--- a/compiler/src/iree/compiler/Reducer/Strategies/ReduceOptimizationBarriersDelta.cpp
+++ b/compiler/src/iree/compiler/Reducer/Strategies/ReduceOptimizationBarriersDelta.cpp
@@ -33,6 +33,7 @@ void mlir::iree_compiler::Reducer::reduceOptimizationBarriersDelta(
 
   // Replace all dispatch ops with the chosen operand.
   for (auto optBarrier : optBarriers) {
+    optBarrier.replaceAllUsesWith(optBarrier.getOperands());
     optBarrier.erase();
   }
 


### PR DESCRIPTION
This patch fixes a bug in ReduceOptimizationBarrierDelta where the outputs of optimization_barrier were not being replaced before deleting it.