### PR TITLE
Set custom configuration for dequantized matmul op to avoid bad vector lowering path.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/emulate_narrow_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/emulate_narrow_type.mlir
@@ -1,18 +1,21 @@
 // RUN: iree-opt --split-input-file --iree-codegen-emulate-narrow-type %s | FileCheck %s
 
-func.func @memref_i4_to_i8() {
+func.func @memref_i4_to_i8() -> i4 {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<3x15xi4>
-  return
+  %1 = memref.load %0[%c0, %c0] : memref<3x15xi4>
+  return %1 : i4
 }
 // CHECK-LABEL: func.func @memref_i4_to_i8
 //       CHECK:    hal.interface.binding.subspan {{.+}} memref<23xi8>
 
 // -----
 
-func.func @memref_i4_to_i8_dynamic(%arg0 : index, %arg1 : index, %arg2 : index) {
+func.func @memref_i4_to_i8_dynamic(%arg0 : index, %arg1 : index, %arg2 : index) -> i4 {
+  %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%arg0) flags(ReadOnly) : memref<?x?xi4, strided<[?, 1], offset: ?>>{%arg1, %arg2}
-  return
+  %1 = memref.load %0[%c0, %c0] : memref<?x?xi4, strided<[?, 1], offset: ?>>
+  return %1 : i4
 }
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> ((s0 * s1) floordiv 2)>
 //      CHECK: func.func @memref_i4_to_i8_dynamic
@@ -23,3 +26,17 @@ func.func @memref_i4_to_i8_dynamic(%arg0 : index, %arg1 : index, %arg2 : index) 
 //      CHECK:   hal.interface.binding.subspan
 // CHECK-SAME:       offset(%[[ARG0]])
 // CHECK-SAME:       memref<?xi8, strided<[1], offset: ?>>{%[[SIZE]]}
+
+// -----
+
+func.func @broadcast_extui() -> vector<1x1x64xi32> {
+  %c0 = arith.constant 0 : index
+  %0 = memref.alloc() : memref<64xi4>
+  %1 = vector.load %0[%c0] : memref<64xi4>, vector<64xi4>
+  %2 = vector.broadcast %1 : vector<64xi4> to vector<1x1x64xi4>
+  %3 = arith.extui %2 : vector<1x1x64xi4> to vector<1x1x64xi32>
+  return %3 : vector<1x1x64xi32>
+}
+// CHECK-LABEL: func @broadcast_extui()
+//   CHECK-NOT:   vector.bitcast
+//       CHECK:   vector.shuffle

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1683,6 +1683,173 @@ static LogicalResult setElementwiseGenericOpRootConfig(
                                                tileSizes, passPipeline);
 }
 
+// Checks if the passed op is a dequantization on grouped input
+// This function checks that the genericOp:
+// 1. Has a body like:
+//      arith.extui
+//      arith.uitofp
+//      arith.subf
+//      arith.mulf
+//      arith.mulf
+//      arith.addf
+// 2. Increases the bit width of the input
+// 3. Has 3 parallel dims
+// 4. Has 4 (rhs, weights, scales, zero points)
+//    inputs and 1 output
+static bool isGroupedDequantizationMatvecOp(linalg::GenericOp genericOp) {
+  // Check for 1 result, and 2 (input, scales) or 3 (input, scales, zero points)
+  // inputs
+  if (genericOp.getNumDpsInits() != 1) {
+    LLVM_DEBUG(KD_DBGS() << "Wrong number of outputs: "
+                         << genericOp.getNumDpsInits() << "\n");
+    return false;
+  }
+  if (genericOp.getNumDpsInputs() != 4) {
+    LLVM_DEBUG(KD_DBGS() << "Wrong number of inputs: "
+                         << genericOp.getNumDpsInputs() << "\n");
+    return false;
+  }
+
+  // Check that the rank is at least 3 and all loops are parallel
+  unsigned numLoops = genericOp.getNumLoops();
+  unsigned numReductionLoops = genericOp.getNumReductionLoops();
+  if (numLoops != 4) {
+    LLVM_DEBUG(KD_DBGS() << "Wrong number of loops: " << numLoops << "\n");
+    return false;
+  }
+  if (numReductionLoops != 2) {
+    LLVM_DEBUG(KD_DBGS() << "Wrong number of reduction loops: "
+                         << numReductionLoops << "\n");
+    return false;
+  }
+  // Work back from linalg.yield and check body of genericOp.
+  // The genericOp should yield the result of an arith.mulf,
+  // preceded by an arith.subf, arith.uitofp, and arith.extui
+  auto yieldOp = cast<linalg::YieldOp>(genericOp.getBody()->getTerminator());
+  Value producerOutput;
+  Operation *producer;
+
+  // Producer of linalg.yield op is arith.addf
+  {
+    producerOutput = yieldOp->getOperand(0);
+    producer = producerOutput.getDefiningOp();
+    if (!producer || producer->getNumOperands() == 0)
+      return false;
+    if (!matchPattern(producer, m_Op<arith::AddFOp>()))
+      return false;
+  }
+
+  // Producer of arith.addf op is arith.mulf
+  {
+    producerOutput = producer->getOperand(0);
+    producer = producerOutput.getDefiningOp();
+    if (!producer || producer->getNumOperands() == 0)
+      return false;
+    if (!matchPattern(producer, m_Op<arith::MulFOp>()))
+      return false;
+  }
+
+  // Producer of arith.mulf op is arith.mulf
+  {
+    producerOutput = producer->getOperand(1);
+    producer = producerOutput.getDefiningOp();
+    if (!producer || producer->getNumOperands() == 0)
+      return false;
+    if (!matchPattern(producer, m_Op<arith::MulFOp>()))
+      return false;
+  }
+
+  // Producer of arith.mulf op is arith.subf
+  {
+    producerOutput = producer->getOperand(0);
+    producer = producerOutput.getDefiningOp();
+    if (!producer || producer->getNumOperands() == 0)
+      return false;
+    if (!matchPattern(producer, m_Op<arith::SubFOp>()))
+      return false;
+  }
+
+  // Producer of arith.subf op is arith.uitofp
+  {
+    producerOutput = producer->getOperand(0);
+    producer = producerOutput.getDefiningOp();
+    if (!producer || producer->getNumOperands() == 0)
+      return false;
+    if (!matchPattern(producer, m_Op<arith::UIToFPOp>()))
+      return false;
+  }
+
+  // Producer of arith.uitofp op is arith.extui
+  {
+    producerOutput = producer->getOperand(0);
+    producer = producerOutput.getDefiningOp();
+    if (!producer)
+      return false;
+    if (!matchPattern(producer, m_Op<arith::ExtUIOp>()))
+      return false;
+  }
+
+  // Ensure that the dequantization increases the
+  // bitwidth from the input to the output
+  auto elementTypeOut =
+      llvm::cast<ShapedType>(genericOp.getOutputs()[0].getType())
+          .getElementType();
+  if (!elementTypeOut.isIntOrFloat())
+    return false;
+  unsigned bitWidthOut = elementTypeOut.getIntOrFloatBitWidth();
+  auto elementTypeIn =
+      llvm::cast<ShapedType>(genericOp.getInputs()[1].getType())
+          .getElementType();
+  if (!elementTypeIn.isIntOrFloat())
+    return false;
+  unsigned bitWidthIn = elementTypeIn.getIntOrFloatBitWidth();
+  if (bitWidthIn >= bitWidthOut)
+    return false;
+
+  return true;
+}
+
+/// Sets linalg.generic ops that represent rematerialized dequantized matvec
+/// ContractionOpInterface RootConfig
+static LogicalResult setDequantizationMatvecOpRootConfig(
+    func::FuncOp entryPointFn, linalg::GenericOp genericOp,
+    const LinalgOpInfo &linalgOpInfo,
+    const TargetMLTransformInfo &targetMLTransInfo) {
+  assert(!getLoweringConfig(genericOp) &&
+         "expected lowering_config is not set");
+  unsigned numLoops = genericOp.getNumLoops();
+  if (!isGroupedDequantizationMatvecOp(genericOp)) {
+    LLVM_DEBUG(KD_DBGS() << "Failed matching for dequantized matvec\n");
+    return failure();
+  }
+
+  SmallVector<int64_t> distTileSizes = {32, 32, 0, 0};
+  SmallVector<int64_t> parallelTileSizes = {1, 1, 0, 0};
+  SmallVector<int64_t> reductionTileSizes = {0, 0, 1, 64};
+
+  SmallVector<unsigned> reductionDims;
+  genericOp.getReductionDims(reductionDims);
+  SmallVector<int64_t, 4> bounds = genericOp.getStaticLoopRanges();
+
+  TileSizesListType tileSizes;
+  tileSizes.push_back(distTileSizes);
+  tileSizes.push_back(parallelTileSizes);
+  tileSizes.push_back(reductionTileSizes);
+  tileSizes.emplace_back(numLoops, 0);
+
+  LLVM_DEBUG(KD_DBGS() << "Setting dequantized matmul config\n");
+  LLVM_DEBUG(KD_DBGS() << "Distribution tile sizes: " << distTileSizes << "\n");
+  LLVM_DEBUG(KD_DBGS() << "Parallel tile sizes: " << parallelTileSizes << "\n");
+  LLVM_DEBUG(KD_DBGS() << "Reduction tile size: " << reductionTileSizes
+                       << "\n");
+
+  DispatchLoweringPassPipeline passPipeline =
+      DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
+
+  return setOpConfigAndEntryPointFnTranslation(entryPointFn, genericOp,
+                                               tileSizes, passPipeline);
+}
+
 /// Sets the lowering configuration for a generic op to use
 /// CPUDoubleTilingExpert pipeline.
 static LogicalResult
@@ -1702,6 +1869,10 @@ setRootConfig(func::FuncOp entryPointFn, linalg::GenericOp genericOp,
     return success();
   }
   if (succeeded(setElementwiseGenericOpRootConfig(
+          entryPointFn, genericOp, linalgOpInfo, targetMLTransInfo))) {
+    return success();
+  }
+  if (succeeded(setDequantizationMatvecOpRootConfig(
           entryPointFn, genericOp, linalgOpInfo, targetMLTransInfo))) {
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -412,7 +412,10 @@ void ConvertToSPIRVPass::runOnOperation() {
   /// rely on this rewrite for the cases seen today.
   /// TODO: Support general emulation of compute on sub-byte types. This is
   /// not mutually exclusive with this pattern, but does mean it is no longer
-  /// load bearing.
+  /// load bearing.  Also these patterns are already run during
+  /// `EmulateNarrotType` pass but dont trigger there due to missing support for
+  /// emulation of `vector.transfer_read` in the emulation path. Remove the
+  /// patterns from here after that is done.
   for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
     RewritePatternSet narrowingPatterns(context);
     vector::populateVectorNarrowTypeRewritePatterns(narrowingPatterns);


### PR DESCRIPTION
Without this config, the codegeneration goes down a vector lowering path that is very inefficient. See https://github.com/openxla/iree/issues/15091#issuecomment-1744201873