### PR TITLE
[spirv] NFC: Restructure TileAndVectorizeToCooperativeOps pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -78,7 +78,6 @@ static constexpr char coopMatShapeAttrName[] = "iree.spirv.coop_mat_shape";
 /// hal.executable.export op for the given `funcOp`.
 void setSPIRVCooperativeMatrixShape(func::FuncOp funcOp,
                                     ArrayRef<int64_t> shape) {
-  assert(shape.size() == 3);
   auto moduleOp = funcOp->getParentOfType<ModuleOp>();
   auto exportOp = getAllEntryPoints(moduleOp).lookup(funcOp.getName());
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -72,7 +72,7 @@ static SmallVector<int64_t> getTargetCooperativeOpSize(linalg::LinalgOp op) {
   return getTileSizes(op, 3); // For native vector sizes
 }
 
-static constexpr char coopMatShapeAttrName[] = "iree.spirv.coop_mat_shape";
+constexpr char coopMatShapeAttrName[] = "iree.spirv.coop_mat_shape";
 
 /// Sets the chosen cooperative matrix shape for CodeGen onto the
 /// hal.executable.export op for the given `funcOp`.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -4,11 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-//===- Utils.cpp - Utility functions used in Linalg to SPIR-V lowering ----===//
-//
-// Implementaiton of utility functions used while lowering from Linalg to SPIRV.
-//
-//===----------------------------------------------------------------------===//
+//===- Utils.cpp - Utility functions for SPIR-V CodeGen -------------------===//
 
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.h
@@ -21,6 +21,9 @@
 namespace mlir {
 namespace iree_compiler {
 
+/// Returns the attribute name carrying information about distribution.
+const char *getSPIRVDistributeAttrName();
+
 /// Given an operation, returns the `spirv.target_env` attribute.
 spirv::TargetEnvAttr getSPIRVTargetEnvAttr(Operation *op);
 
@@ -28,9 +31,6 @@ spirv::TargetEnvAttr getSPIRVTargetEnvAttr(Operation *op);
 /// querying the hal.executable.export op, and then the SPIR-V target
 /// environment. Returns std::nullopt on failures.
 std::optional<int> getSPIRVSubgroupSize(func::FuncOp funcOp);
-
-/// Returns the attribute name carrying information about distribution.
-const char *getSPIRVDistributeAttrName();
 
 /// Returns the tile sizes at the given `tilingLevel` for compute ops in
 /// `funcOp`.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file \
-// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-spirv-tile-to-cooperative-ops, iree-spirv-vectorize-to-cooperative-ops, canonicalize, cse)))))' \
+// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-spirv-tile-to-cooperative-ops, iree-codegen-generic-vectorization, iree-spirv-vectorize-to-cooperative-ops, iree-codegen-hoist-redundant-vector-transfers, canonicalize, cse)))))' \
 // RUN:   %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[32, 32], [16, 16], [0, 0, 32], [16, 16, 16]]>


### PR DESCRIPTION
This commit lifted the general vectorization and hoisting steps
out of the `TileAndVectorizeToCooperativeOps` pass, and changed
to use the `GenericVectorization` and `HoistRedundantVectorTransfers`
common passes for such functionalities.

Progress towards https://github.com/openxla/iree/issues/15083