### PR TITLE
Implementing stack trace capture on iree_status_t for Win/Mac.

### DIFF
--- a/runtime/src/iree/base/config.h
+++ b/runtime/src/iree/base/config.h
@@ -120,6 +120,11 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 #endif  // NDEBUG
 #endif  // !IREE_STATUS_MODE
 
+#if !defined(IREE_STATUS_MAX_STACK_TRACE_FRAMES)
+// Maximum number of stack frames captured when enabled.
+#define IREE_STATUS_MAX_STACK_TRACE_FRAMES 16
+#endif  // IREE_STATUS_MAX_STACK_TRACE_FRAMES
+
 //===----------------------------------------------------------------------===//
 // Synchronization and threading
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -22,7 +22,6 @@
 #define IREE_HAVE_DYNAMIC_LIBRARY_PDB_SUPPORT 1
 #pragma warning(disable : 4091)
 #include <dbghelp.h>
-
 void IREEDbgHelpLock(void);
 void IREEDbgHelpUnlock(void);
 #endif  // TRACY_ENABLE

--- a/runtime/src/iree/base/internal/file_io.c
+++ b/runtime/src/iree/base/internal/file_io.c
@@ -290,7 +290,7 @@ static iree_status_t iree_file_map_contents_readonly_platform(
   HANDLE file =
       CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
                   FILE_ATTRIBUTE_READONLY | FILE_FLAG_RANDOM_ACCESS, NULL);
-  if (!file) {
+  if (file == INVALID_HANDLE_VALUE) {
     return iree_make_status(iree_status_code_from_win32_error(GetLastError()),
                             "failed to open file '%s'", path);
   }

--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -6,6 +6,24 @@
 
 #include "iree/base/status.h"
 
+#if defined(IREE_PLATFORM_APPLE)
+#include <dlfcn.h>
+#include <execinfo.h>
+#define IREE_HAVE_BACKTRACE 1
+#define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
+#elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
+// Currently disabled because we can't get meaningful stacks on Linux.
+// #define _GNU_SOURCE 1
+// #include <dlfcn.h>
+// #include <execinfo.h>
+// #define IREE_HAVE_BACKTRACE 1
+// #define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
+#elif defined(IREE_PLATFORM_WINDOWS)
+#pragma warning(disable : 4091)
+#include <dbghelp.h>
+#define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
+#endif  // IREE_PLATFORM_*
+
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
@@ -19,7 +37,6 @@
 #include "iree/base/alignment.h"
 #include "iree/base/allocator.h"
 #include "iree/base/assert.h"
-#include "iree/base/target_platform.h"
 #include "iree/base/tracing.h"
 
 //===----------------------------------------------------------------------===//
@@ -299,6 +316,8 @@ typedef enum iree_status_payload_type_e {
   IREE_STATUS_PAYLOAD_TYPE_OPAQUE = 0,
   // A string message annotation of type iree_status_payload_message_t.
   IREE_STATUS_PAYLOAD_TYPE_MESSAGE = 1,
+  // Platform-dependent stack trace in iree_status_payload_stack_trace_t.
+  IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE = 2,
   // Starting type ID for user payloads. IREE reserves all payloads with types
   // less than this.
   IREE_STATUS_PAYLOAD_TYPE_MIN_USER = 0x70000000u,
@@ -336,6 +355,14 @@ typedef struct iree_status_payload_message_t {
   // struct (if copied) or a constant string reference in rodata.
   iree_string_view_t message;
 } iree_status_payload_message_t;
+
+// A platform-dependent stack trace (IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE).
+typedef struct iree_status_payload_stack_trace_t {
+  iree_status_payload_t header;
+  uint16_t skip_frames;
+  uint16_t frame_count;
+  uintptr_t addresses[];
+} iree_status_payload_stack_trace_t;
 
 // Allocated storage for an iree_status_t.
 // Only statuses that have either source information or payloads will have
@@ -382,32 +409,361 @@ static iree_status_t iree_status_append_payload(
 // total number of characters in |buffer_capacity| required to contain the
 // entire message.
 static void iree_status_payload_message_formatter(
-    const iree_status_payload_t* payload, iree_host_size_t buffer_capacity,
+    const iree_status_payload_t* base_payload, iree_host_size_t buffer_capacity,
     char* buffer, iree_host_size_t* out_buffer_length) {
-  iree_status_payload_message_t* message_payload =
-      (iree_status_payload_message_t*)payload;
+  iree_status_payload_message_t* payload =
+      (iree_status_payload_message_t*)base_payload;
   if (!buffer) {
-    *out_buffer_length = message_payload->message.size;
+    *out_buffer_length = payload->message.size;
     return;
   }
-  iree_host_size_t n = buffer_capacity < message_payload->message.size
+  iree_host_size_t n = buffer_capacity < payload->message.size
                            ? buffer_capacity
-                           : message_payload->message.size;
-  memcpy(buffer, message_payload->message.data, n);
+                           : payload->message.size;
+  memcpy(buffer, payload->message.data, n);
   buffer[n] = '\0';
   *out_buffer_length = n;
+}
+
+#if defined(IREE_STATUS_HAVE_STACK_TRACE_SUPPORT) && \
+    ((IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_STACK_TRACE) != 0)
+
+// TODO(benvanik): make a string_view utility to share with console tracing.
+static iree_string_view_t iree_status_trim_file_path(const char* file_name) {
+  size_t file_name_length = strlen(file_name);
+  for (int i = (int)file_name_length - 1; i >= 0; --i) {
+    char c = file_name[i];
+    if (c == '/' || c == '\\') {
+      return iree_make_string_view(file_name + i + 1, file_name_length - i - 1);
+    }
+  }
+  return iree_make_string_view(file_name, file_name_length);
+}
+
+static iree_host_size_t iree_string_buffer_append_cstr(
+    iree_host_size_t buffer_capacity, char* buffer,
+    iree_host_size_t buffer_length, const char* str) {
+  iree_host_size_t n =
+      snprintf(buffer ? buffer + buffer_length : NULL,
+               buffer ? buffer_capacity - buffer_length : 0, "%s", str);
+  return IREE_UNLIKELY(n < 0) ? 0 : buffer_length + n;
+}
+
+static iree_host_size_t IREE_PRINTF_ATTRIBUTE(4, 5)
+    iree_string_buffer_append_format(iree_host_size_t buffer_capacity,
+                                     char* buffer,
+                                     iree_host_size_t buffer_length,
+                                     const char* format, ...) {
+  va_list varargs;
+  va_start(varargs, format);
+  iree_host_size_t n =
+      vsnprintf(buffer ? buffer + buffer_length : NULL,
+                buffer ? buffer_capacity - buffer_length : 0, format, varargs);
+  va_end(varargs);
+  return IREE_UNLIKELY(n < 0) ? 0 : buffer_length + n;
+}
+
+#if defined(IREE_PLATFORM_WINDOWS)
+
+typedef BOOL(WINAPI* PFN_SymInitialize)(HANDLE, PCSTR, BOOL);
+typedef BOOL(WINAPI* PFN_SymCleanup)(HANDLE);
+typedef BOOL(WINAPI* PFN_SymGetModuleInfo64)(HANDLE, DWORD64,
+                                             PIMAGEHLP_MODULE64);
+typedef BOOL(WINAPI* PFN_SymFromAddr)(HANDLE, DWORD64, PDWORD64, PSYMBOL_INFO);
+typedef BOOL(WINAPI* PFN_SymGetLineFromAddr64)(HANDLE, DWORD64, PDWORD,
+                                               PIMAGEHLP_LINE);
+typedef struct iree_symbol_resolver_t {
+  SRWLOCK mutex;
+  HMODULE library;
+  PFN_SymInitialize SymInitialize;
+  PFN_SymCleanup SymCleanup;
+  PFN_SymGetModuleInfo64 SymGetModuleInfo64;
+  PFN_SymFromAddr SymFromAddr;
+  PFN_SymGetLineFromAddr64 SymGetLineFromAddr64;
+} iree_symbol_resolver_t;
+
+// If tracy is enabled then it has its own dbghelp lock we need to use.
+// If not enabled then we
+#if defined(TRACY_ENABLE)
+void IREEDbgHelpInit(void);
+void IREEDbgHelpLock(void);
+void IREEDbgHelpUnlock(void);
+static void iree_symbol_resolver_initialize_mutex(
+    iree_symbol_resolver_t* resolver) {
+  IREEDbgHelpInit();
+}
+static void iree_symbol_resolver_lock(iree_symbol_resolver_t* resolver) {
+  IREEDbgHelpLock();
+}
+static void iree_symbol_resolver_unlock(iree_symbol_resolver_t* resolver) {
+  IREEDbgHelpUnlock();
+}
+#else
+static void iree_symbol_resolver_initialize_mutex(
+    iree_symbol_resolver_t* resolver) {
+  InitializeSRWLock(&resolver->mutex);
+}
+static void iree_symbol_resolver_lock(iree_symbol_resolver_t* resolver) {
+  AcquireSRWLockExclusive(&resolver->mutex);
+}
+static void iree_symbol_resolver_unlock(iree_symbol_resolver_t* resolver) {
+  ReleaseSRWLockExclusive(&resolver->mutex);
+}
+#endif  // TRACY_ENABLE
+
+static void iree_symbol_resolver_initialize(
+    iree_symbol_resolver_t* out_resolver) {
+  memset(out_resolver, 0, sizeof(*out_resolver));
+  iree_symbol_resolver_initialize_mutex(out_resolver);
+  out_resolver->library = LoadLibraryA("dbghelp.dll");
+  if (!out_resolver->library) return;
+  out_resolver->SymInitialize =
+      (PFN_SymInitialize)GetProcAddress(out_resolver->library, "SymInitialize");
+  out_resolver->SymCleanup =
+      (PFN_SymCleanup)GetProcAddress(out_resolver->library, "SymCleanup");
+  out_resolver->SymGetModuleInfo64 = (PFN_SymGetModuleInfo64)GetProcAddress(
+      out_resolver->library, "SymGetModuleInfo64");
+  out_resolver->SymFromAddr =
+      (PFN_SymFromAddr)GetProcAddress(out_resolver->library, "SymFromAddr");
+  out_resolver->SymGetLineFromAddr64 = (PFN_SymGetLineFromAddr64)GetProcAddress(
+      out_resolver->library, "SymGetLineFromAddr64");
+  if (!out_resolver->SymInitialize || !out_resolver->SymCleanup ||
+      !out_resolver->SymGetModuleInfo64 || !out_resolver->SymFromAddr ||
+      !out_resolver->SymGetLineFromAddr64) {
+    FreeLibrary(out_resolver->library);
+    memset(out_resolver, 0, sizeof(*out_resolver));
+    return;
+  }
+  out_resolver->SymInitialize(GetCurrentProcess(), /*UserSearchPath=*/NULL,
+                              /*fInvadeProcess=*/TRUE);
+}
+
+static void iree_symbol_resolver_deinitialize(
+    iree_symbol_resolver_t* resolver) {
+  if (resolver->SymCleanup) {
+    resolver->SymCleanup(GetCurrentProcess());
+  }
+  if (resolver->library) {
+    FreeLibrary(resolver->library);
+    resolver->library = NULL;
+  }
+  memset(resolver, 0, sizeof(*resolver));
+}
+
+static BOOL CALLBACK iree_symbol_resolver_setup(PINIT_ONCE InitOnce,
+                                                PVOID Parameter,
+                                                PVOID* Context) {
+  ((void)InitOnce);
+  ((void)Context);
+  iree_symbol_resolver_initialize((iree_symbol_resolver_t*)Parameter);
+  return TRUE;
+}
+
+static INIT_ONCE instance_flag = INIT_ONCE_STATIC_INIT;
+static iree_symbol_resolver_t instance;
+static iree_symbol_resolver_t* iree_symbol_resolver_get(void) {
+  InitOnceExecuteOnce(&instance_flag, iree_symbol_resolver_setup,
+                      (PVOID)&instance, NULL);
+  return &instance;
+}
+
+static bool iree_symbol_resolver_format_frame(iree_symbol_resolver_t* resolver,
+                                              void* address,
+                                              iree_host_size_t buffer_capacity,
+                                              char* buffer,
+                                              iree_host_size_t* buffer_length) {
+  if (IREE_UNLIKELY(!resolver->library)) return false;
+
+  HANDLE process = GetCurrentProcess();
+
+  // Query generic information like what module the address is located in and
+  // what the offset of the address is within its parent symbol.
+  char symbol_buffer[512];
+  SYMBOL_INFO* symbol_info = (SYMBOL_INFO*)symbol_buffer;
+  symbol_info->SizeOfStruct = sizeof(*symbol_info);
+  symbol_info->MaxNameLen = sizeof(symbol_buffer) - sizeof(*symbol_info);
+  DWORD64 displacement64 = 0;
+  iree_symbol_resolver_lock(resolver);
+  BOOL result = resolver->SymFromAddr(process, (DWORD64)address,
+                                      &displacement64, symbol_info);
+  iree_symbol_resolver_unlock(resolver);
+  if (!result) {
+    // Failed to get any information; bail.
+    return false;
+  }
+
+  IMAGEHLP_MODULE64 module;
+  module.SizeOfStruct = sizeof(module);
+  if (resolver->SymGetModuleInfo64(process, symbol_info->ModBase, &module)) {
+    *buffer_length = iree_string_buffer_append_cstr(
+        buffer_capacity, buffer, *buffer_length, module.ModuleName);
+  } else {
+    *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                    *buffer_length, "???");
+  }
+
+  *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                  *buffer_length, " <");
+  if (symbol_info->NameLen > 0) {
+    *buffer_length = iree_string_buffer_append_format(
+        buffer_capacity, buffer, *buffer_length, "%.*s",
+        (int)symbol_info->NameLen, symbol_info->Name);
+  } else {
+    *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                    *buffer_length, "???");
+  }
+  if (displacement64) {
+    *buffer_length = iree_string_buffer_append_format(
+        buffer_capacity, buffer, *buffer_length, "+0x%0" PRIx64,
+        displacement64);
+  }
+  *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                  *buffer_length, ">");
+
+  // Note that the returned name pointer is only valid while the lock is held.
+  IMAGEHLP_LINE64 line;
+  line.SizeOfStruct = sizeof(line);
+  DWORD displacement32 = 0;
+  iree_symbol_resolver_lock(resolver);
+  if (resolver->SymGetLineFromAddr64(process, (DWORD64)address, &displacement32,
+                                     &line)) {
+    *buffer_length = iree_string_buffer_append_format(
+        buffer_capacity, buffer, *buffer_length, " (%s:%u)", line.FileName,
+        line.LineNumber);
+  }
+  iree_symbol_resolver_unlock(resolver);
+
+  return true;
+}
+
+#endif  // IREE_PLATFORM_WINDOWS
+
+static iree_host_size_t iree_status_payload_stack_trace_format_frame(
+    void* address, iree_host_size_t buffer_capacity, char* buffer) {
+  iree_host_size_t buffer_length = iree_string_buffer_append_format(
+      buffer_capacity, buffer, 0, "  0x%016" PRIx64 " ",
+      (uint64_t)(uintptr_t)address);
+#if defined(IREE_HAVE_BACKTRACE)
+  Dl_info info;
+  if (dladdr(address, &info) != 0) {
+    if (info.dli_fname) {
+      iree_string_view_t fname = iree_status_trim_file_path(info.dli_fname);
+      buffer_length = iree_string_buffer_append_format(
+          buffer_capacity, buffer, buffer_length, "%.*s", (int)fname.size,
+          fname.data);
+    } else {
+      buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                     buffer_length, "???");
+    }
+    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                   buffer_length, " <");
+    if (info.dli_sname) {
+      iree_string_view_t sname = iree_make_cstring_view(info.dli_sname);
+      buffer_length = iree_string_buffer_append_format(
+          buffer_capacity, buffer, buffer_length, "%.*s", (int)sname.size,
+          sname.data);
+    } else {
+      buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                     buffer_length, "???");
+    }
+    void* saddr = info.dli_saddr ? info.dli_saddr : address;
+    ptrdiff_t diff = (ptrdiff_t)address - (ptrdiff_t)saddr;
+    if (diff) {
+      buffer_length = iree_string_buffer_append_format(
+          buffer_capacity, buffer, buffer_length, "+0x%0" PRIx32,
+          (int32_t)diff);
+    }
+    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                   buffer_length, ">");
+  } else {
+    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                   buffer_length, "???");
+  }
+#elif defined(IREE_PLATFORM_WINDOWS)
+  if (!iree_symbol_resolver_format_frame(iree_symbol_resolver_get(), address,
+                                         buffer_capacity, buffer,
+                                         &buffer_length)) {
+    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                   buffer_length, "???");
+  }
+#else
+  // Symbol resolution not implemented on the platform.
+  buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                 buffer_length, "???");
+#endif
+  return iree_string_buffer_append_cstr(buffer_capacity, buffer, buffer_length,
+                                        "\n");
+}
+
+static void iree_status_payload_stack_trace_formatter(
+    const iree_status_payload_t* base_payload, iree_host_size_t buffer_capacity,
+    char* buffer, iree_host_size_t* out_buffer_length) {
+  iree_status_payload_stack_trace_t* payload =
+      (iree_status_payload_stack_trace_t*)base_payload;
+  if (payload->frame_count - payload->skip_frames == 0) return;
+  iree_host_size_t buffer_length =
+      iree_string_buffer_append_cstr(buffer_capacity, buffer, 0, "stack:\n");
+  for (iree_host_size_t i = payload->skip_frames + 1; i < payload->frame_count;
+       ++i) {
+    buffer_length += iree_status_payload_stack_trace_format_frame(
+        (void*)payload->addresses[i],
+        buffer ? buffer_capacity - buffer_length : 0,
+        buffer ? buffer + buffer_length : NULL);
+    if (buffer_length > buffer_capacity) buffer = NULL;
+  }
+  *out_buffer_length = buffer_length;
 }
 
 // Captures the current stack and attaches it to the status storage.
 // A count of |skip_frames| will be skipped from the top of the stack.
 // Setting |skip_frames|=0 will include the caller in the stack while
 // |skip_frames|=1 will exclude it.
-static void iree_status_attach_stack_trace(iree_status_storage_t* storage,
-                                           int skip_frames) {
-#if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_STACK_TRACE) != 0
-  // TODO(#55): backtrace or other magic.
-#endif  // has IREE_STATUS_FEATURE_STACK_TRACE
+static iree_status_t iree_status_attach_stack_trace(
+    iree_status_t status, iree_status_storage_t* storage, int skip_frames) {
+  // Reserve storage for the number of stack frames so we can capture directly
+  // into the storage even if we don't need them all. At the point we are
+  // mallocing the exact size doesn't really matter.
+  iree_status_payload_stack_trace_t* payload = NULL;
+  iree_host_size_t total_size =
+      sizeof(*payload) +
+      sizeof(payload->addresses[0]) * IREE_STATUS_MAX_STACK_TRACE_FRAMES;
+
+  iree_allocator_t allocator = iree_allocator_system();
+  iree_status_ignore(
+      iree_allocator_malloc(allocator, total_size, (void**)&payload));
+  if (IREE_UNLIKELY(!payload)) return status;
+  memset(payload, 0, sizeof(*payload));
+  payload->header.type = IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE;
+  payload->header.allocator = allocator;
+  payload->header.formatter = iree_status_payload_stack_trace_formatter;
+
+#if defined(IREE_HAVE_BACKTRACE)
+  // Capture up to the max frame count and skip some frames when formatting -
+  // this means that our actual backtrace() max frame count is smaller than the
+  // defined value. We could instead overallocate by skip_frames to waste a bit
+  // of memory but keep the processing simpler.
+  payload->skip_frames = skip_frames;
+  payload->frame_count = backtrace((void**)&payload->addresses,
+                                   IREE_STATUS_MAX_STACK_TRACE_FRAMES);
+#elif defined(IREE_PLATFORM_WINDOWS)
+  // NOTE: Win32 supports skip frames by default so we don't lose any storage.
+  payload->frame_count =
+      CaptureStackBackTrace(skip_frames, IREE_STATUS_MAX_STACK_TRACE_FRAMES,
+                            (void**)&payload->addresses, NULL);
+#endif
+
+  return iree_status_append_payload(status, storage,
+                                    (iree_status_payload_t*)payload);
 }
+
+#else
+
+static iree_status_t iree_status_attach_stack_trace(
+    iree_status_t status, iree_status_storage_t* storage, int skip_frames) {
+  return status;
+}
+
+#endif  // has IREE_STATUS_FEATURE_STACK_TRACE
 
 IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t
 iree_status_allocate(iree_status_code_t code, const char* file, uint32_t line,
@@ -448,26 +804,14 @@ iree_status_allocate(iree_status_code_t code, const char* file, uint32_t line,
   storage->message = message;
 #endif  // has IREE_STATUS_FEATURE_ANNOTATIONS
 
-  iree_status_attach_stack_trace(storage, /*skip_frames=*/1);
-  return (iree_status_t)((uintptr_t)storage | (code & IREE_STATUS_CODE_MASK));
+  return iree_status_attach_stack_trace(
+      (iree_status_t)((uintptr_t)storage | (code & IREE_STATUS_CODE_MASK)),
+      storage, /*skip_frames=*/1);
 #endif  // has any IREE_STATUS_FEATURES
 }
 
-IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t
-iree_status_allocate_f(iree_status_code_t code, const char* file, uint32_t line,
-                       const char* format, ...) {
-  va_list varargs_0, varargs_1;
-  va_start(varargs_0, format);
-  va_start(varargs_1, format);
-  iree_status_t ret =
-      iree_status_allocate_vf(code, file, line, format, varargs_0, varargs_1);
-  va_end(varargs_0);
-  va_end(varargs_1);
-  return ret;
-}
-
-IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t iree_status_allocate_vf(
-    iree_status_code_t code, const char* file, uint32_t line,
+static IREE_MUST_USE_RESULT iree_status_t iree_status_allocate_vf_impl(
+    iree_status_code_t code, const char* file, uint32_t line, int skip_frames,
     const char* format, va_list varargs_0, va_list varargs_1) {
 #if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) == 0
   // Annotations disabled; ignore the format string/args.
@@ -510,9 +854,30 @@ IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t iree_status_allocate_vf(
     return (iree_status_t)code;
   }
 
-  iree_status_attach_stack_trace(storage, /*skip_frames=*/1);
-  return (iree_status_t)((uintptr_t)storage | (code & IREE_STATUS_CODE_MASK));
+  return iree_status_attach_stack_trace(
+      (iree_status_t)((uintptr_t)storage | (code & IREE_STATUS_CODE_MASK)),
+      storage, skip_frames);
 #endif  // has IREE_STATUS_FEATURE_ANNOTATIONS
+}
+
+IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t
+iree_status_allocate_f(iree_status_code_t code, const char* file, uint32_t line,
+                       const char* format, ...) {
+  va_list varargs_0, varargs_1;
+  va_start(varargs_0, format);
+  va_start(varargs_1, format);
+  iree_status_t ret = iree_status_allocate_vf_impl(
+      code, file, line, /*skip_frames=*/2, format, varargs_0, varargs_1);
+  va_end(varargs_0);
+  va_end(varargs_1);
+  return ret;
+}
+
+IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t iree_status_allocate_vf(
+    iree_status_code_t code, const char* file, uint32_t line,
+    const char* format, va_list varargs_0, va_list varargs_1) {
+  return iree_status_allocate_vf_impl(code, file, line, /*skip_frames=*/1,
+                                      format, varargs_0, varargs_1);
 }
 
 IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t


### PR DESCRIPTION
Enabled only when `IREE_STATUS_MODE`>=3, which by default means off in release builds and on in debug builds. Capturing stacks isn't free so performance sensitive code should keep them off, though we do split the symbol resolution/string formatting such that it's not the worst thing if they are always-on. It's important that we consistently use `iree_status_from_code` when using status returns for control flow.

Example from Windows:
```
D:\Dev\iree\runtime\src\iree\base\internal\file_io.c:295: NOT_FOUND; failed to open file 'oops.vmfb'; stack:
  0x00007ff6346eeff3 iree-run-module <iree_file_map_contents_readonly_platform+0xa3> (D:\Dev\iree\runtime\src\iree\base\internal\file_io.c:294)
  0x00007ff6346eece7 iree-run-module <iree_file_map_contents_readonly+0x117> (D:\Dev\iree\runtime\src\iree\base\internal\file_io.c:229)
  0x00007ff6346eea13 iree-run-module <iree_file_read_contents+0xa3> (D:\Dev\iree\runtime\src\iree\base\internal\file_io.c:132)
  0x00007ff634622c9d iree-run-module <iree_tooling_load_bytecode_module+0x27d> (D:\Dev\iree\runtime\src\iree\tooling\context_util.c:73)
  0x00007ff634621f97 iree-run-module <iree_tooling_load_modules_from_flags+0x347> (D:\Dev\iree\runtime\src\iree\tooling\context_util.c:155)
  0x00007ff6346259d4 iree-run-module <iree_tooling_create_run_context+0x74> (D:\Dev\iree\runtime\src\iree\tooling\run_module.c:96)
  0x00007ff634624e3e iree-run-module <iree_tooling_run_module_with_data+0x11e> (D:\Dev\iree\runtime\src\iree\tooling\run_module.c:341)
  0x00007ff634624d10 iree-run-module <iree_tooling_run_module_from_flags+0x90> (D:\Dev\iree\runtime\src\iree\tooling\run_module.c:327)
  0x00007ff63461a32e iree-run-module <main+0x10e> (D:\Dev\iree\tools\iree-run-module-main.c:43)
  0x00007ff6347d92e9 iree-run-module <invoke_main+0x39> (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:79)
  0x00007ff6347d918e iree-run-module <__scrt_common_main_seh+0x12e> (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
  0x00007ff6347d904e iree-run-module <__scrt_common_main+0xe> (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:331)
  0x00007ff6347d937e iree-run-module <mainCRTStartup+0xe> (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:17)
  0x00007ffc27b97344 ??? <BaseThreadInitThunk+0x14>
  0x00007ffc29a026b1 ??? <RtlUserThreadStart+0x21>
; loading bytecode module at 'oops.vmfb'; loading modules and dependencies; creating run context
```

Example from MacOS:
```
iree/runtime/src/iree/base/internal/file_io.c:253: NOT_FOUND; failed to open file '/Users/ben/Dev/iree/../iree-tmp/foo.vmfb'; stack:
  0x0000000100093644 iree-run-module <iree_file_map_contents_readonly_platform+0x64>
  0x0000000100093318 iree-run-module <iree_file_map_contents_readonly+0x12c>
  0x0000000100092ff0 iree-run-module <iree_file_read_contents+0x80>
  0x0000000100028a04 iree-run-module <iree_tooling_load_bytecode_module+0x208>
  0x0000000100028518 iree-run-module <iree_tooling_load_modules_from_flags+0x28c>
  0x000000010002ab90 iree-run-module <iree_tooling_create_run_context+0x68>
  0x000000010002a9d8 iree-run-module <iree_tooling_run_module_with_data+0x98>
  0x000000010002a934 iree-run-module <iree_tooling_run_module_from_flags+0x64>
  0x0000000100006228 iree-run-module <main+0xcc>
  0x000000018dd61058 dyld <start+0x8b0>
; loading bytecode module at '/Users/ben/Dev/iree/../iree-tmp/foo.vmfb'; loading modules and dependencies; creating run context
```

Example from Linux:
```
iree/runtime/src/iree/base/internal/file_io.c:199: NOT_FOUND; failed to open file 'oops.vmfb'; stack:
  0x00000000004cdafc iree-run-module <???>
  0x0000000000725319 iree-run-module <???>
  0x0000000000724e7b iree-run-module <???>
  0x00000000004dddc2 iree-run-module <???>
  0x00000000004dc898 iree-run-module <???>
  0x00000000004e7123 iree-run-module <???>
  0x00000000004e6586 iree-run-module <???>
  0x00000000004e5f8a iree-run-module <???>
  0x00000000004c8623 iree-run-module <???>
  0x00007f84b58e1083 libc.so.6 <__libc_start_main+0xf3>
  0x000000000041d9ce iree-run-module <???>
; loading bytecode module at 'oops.vmfb'; loading modules and dependencies; creating run context
```
^ https://www.youtube.com/watch?v=lRAZk0Xb0xM

If we want stack traces with symbols on linux we'll need to have libdwarf-dev installed and use it to resolve things ala https://gist.github.com/tuxology/6144170 - I'm happy with having symbols on Windows and basic ones in debug mode on Mac for now. We've got everything in place for making linux resolution better if someone cares. I couldn't figure out how to make the builds happy with all the GNU_SOURCE shenannigans and just disabled the whole thing for now.

Fixes #55.