### PR TITLE
[CPU] Share SCF tile size computation logic with `-iree-llvmcpu-tile`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Codegen/LLVMCPU/Utils.h"
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -24,11 +25,6 @@
 
 namespace mlir {
 namespace iree_compiler {
-
-// Note: This is shared with iree-llvmcpu-tile.
-void setSCFTileSizes(scf::SCFTilingOptions &options, TilingInterface consumerOp,
-                     SmallVector<int64_t> tileSizes,
-                     SmallVector<bool> tileScalableFlags);
 
 namespace {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
@@ -8,7 +8,9 @@
 
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 #define DEBUG_TYPE "iree-llvmcpu-utils"
 
@@ -104,6 +106,37 @@ bool hasByteAlignedElementTypes(linalg::LinalgOp linalgOp) {
         getElementTypeOrSelf(operand.getType()).getIntOrFloatBitWidth();
     return bitwidth % 8 == 0;
   });
+}
+
+void setSCFTileSizes(scf::SCFTilingOptions &options, TilingInterface consumerOp,
+                     SmallVector<int64_t> tileSizes,
+                     SmallVector<bool> tileScalableFlags) {
+  // scf::tileUsingSCFForOp expects the num of tile sizes = num of loops.
+  int numLoops = consumerOp.getLoopIteratorTypes().size();
+  tileSizes.resize(numLoops, /*default=*/0);
+  tileScalableFlags.resize(numLoops, /*default=*/false);
+  if (!llvm::is_contained(tileSizes, true)) {
+    // Non-scalable case: All constant tile sizes.
+    options.setTileSizes(
+        getAsIndexOpFoldResult(consumerOp.getContext(), tileSizes));
+  } else {
+    // Scalable case: Multiply scalable tile sizes by vscale.
+    options.setTileSizeComputationFunction(
+        [=](OpBuilder &b, Operation *op) -> SmallVector<OpFoldResult> {
+          auto loc = op->getLoc();
+          return llvm::map_to_vector(
+              llvm::zip(tileSizes, tileScalableFlags),
+              [&](auto pair) -> OpFoldResult {
+                auto [t, isScalable] = pair;
+                Value size = b.create<arith::ConstantIndexOp>(loc, t);
+                if (isScalable) {
+                  Value vscale = b.create<vector::VectorScaleOp>(loc);
+                  size = b.create<arith::MulIOp>(loc, size, vscale);
+                }
+                return size;
+              });
+        });
+  }
 }
 
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
@@ -120,7 +120,7 @@ void setSCFTileSizes(scf::SCFTilingOptions &options, TilingInterface consumerOp,
     options.setTileSizes(
         getAsIndexOpFoldResult(consumerOp.getContext(), tileSizes));
   } else {
-    // Scalable case: Multiply scalable tile sizes by vscale.
+    // Scalable case: Multiply scalable tile sizes by a vector.vscale op.
     options.setTileSizeComputationFunction(
         [=](OpBuilder &b, Operation *op) -> SmallVector<OpFoldResult> {
           auto loc = op->getLoc();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
@@ -58,7 +58,8 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
 bool hasByteAlignedElementTypes(linalg::LinalgOp linalgOp);
 
 /// Sets the tile sizes of the SCFTilingOptions. If `tileScalableFlags` are
-/// provided the corresponding tile size will be multiplied by `vector.vscale`.
+/// provided the corresponding tile size will be multiplied by a vector.vscale
+/// op.
 void setSCFTileSizes(scf::SCFTilingOptions &options, TilingInterface consumerOp,
                      SmallVector<int64_t> tileSizes,
                      SmallVector<bool> tileScalableFlags);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
@@ -11,6 +11,11 @@
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 
 namespace mlir {
+
+namespace scf {
+struct SCFTilingOptions;
+}
+
 namespace iree_compiler {
 
 bool preferIntrinsicsOverAsm(IREE::HAL::ExecutableTargetAttr targetAttr);
@@ -51,6 +56,12 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
 /// Returns true if all of the element types involved in the linalg op are byte
 /// aligned.
 bool hasByteAlignedElementTypes(linalg::LinalgOp linalgOp);
+
+/// Sets the tile sizes of the SCFTilingOptions. If `tileScalableFlags` are
+/// provided the corresponding tile size will be multiplied by `vector.vscale`.
+void setSCFTileSizes(scf::SCFTilingOptions &options, TilingInterface consumerOp,
+                     SmallVector<int64_t> tileSizes,
+                     SmallVector<bool> tileScalableFlags);
 
 } // namespace iree_compiler
 } // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile.mlir
@@ -39,3 +39,23 @@ func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %ar
 // CHECK:         scf.for {{.*}} step %[[C1]]
 // CHECK:           scf.for {{.*}} step %[[C16]]
 // CHECK:             linalg.generic
+
+// -----
+
+func.func @scalable_matmul(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>) -> tensor<?x?xf32>{
+  // Matrix multiplication (ijk) with scalable tiling in the j-th dimension.
+  %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, [32], 1]]>} ins(%A, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+            outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func.func @scalable_matmul(
+//   CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+//   CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
+//       CHECK: %[[VSCALE:.*]] = vector.vscale
+//  CHECK-NEXT: %[[SCALABLE_TILE_SIZE:.*]] = arith.muli %[[VSCALE]], %[[C32]] : index
+//       CHECK: scf.for
+//  CHECK-SAME:     step %[[C1]]
+//       CHECK:   scf.for
+//  CHECK-SAME:       step %[[SCALABLE_TILE_SIZE]]
+//       CHECK:     scf.for
+//  CHECK-SAME:         step %[[C1]]


### PR DESCRIPTION
This makes `-iree-llvmcpu-tile-and-fuse` and `-iree-llvmcpu-tile` share the same logic for computing tile sizes. This enables scalable tiles in `-iree-llvmcpu-tile`.