### PR TITLE
`avx512bf16` ukernel: work around yet another Clang-16 crash

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_bf16.c
@@ -9,33 +9,36 @@
 #include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
 #include "iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_internal.h"
 
-static inline __m512bh bitcast_16xf32_to_32xbf16(__m512 a) {
-  return *(const __m512bh*)(&a);
-}
-
 #ifdef IREE_UK_COMPILER_CLANG
 // This inline-asm function is a work-around for:
 // 1. https://github.com/llvm/llvm-project/issues/68117
 //    Summary: LLVM crash affecting Clang 16-17. Fixed in Clang 18.
 // 2. https://github.com/llvm/llvm-project/issues/68810
 //    Summary: performance regression in the generated code.
+// 3. Passing lhs as `__m512` instead of the more proper `__m512bh`
+//    works around https://github.com/llvm/llvm-project/issues/68149,
+//    and passing it as-is as the asm operand instead of casting it in C
+//    works around a crash in clang-16 in Red Hat specifically, not
+//    reproducible in other clang-16.
 static inline __m512 iree_mm512_dpbf16_ps_broadcast_rhs(
-    __m512 acc, __m512bh lhs, const iree_uk_uint16_t* rhs) {
-  // lhs_as_m512 works around https://github.com/llvm/llvm-project/issues/68149
-  __m512 lhs_as_m512 = (__m512)lhs;
+    __m512 acc, __m512 lhs, const iree_uk_uint16_t* rhs) {
   // Sorry about the crazy AT&T syntax with reversed operand order.
   // Couldn't figure how to use Intel syntax with inline asm operands.
   asm("vdpbf16ps %[rhs]%{1to16%}, %[lhs], %[acc]"
       : [acc] "+v"(acc)
-      : [lhs] "v"(lhs_as_m512), [rhs] "m"(*rhs)
+      : [lhs] "v"(lhs), [rhs] "m"(*rhs)
       :);
   return acc;
 }
 #else
+static inline __m512bh bitcast_16xf32_to_32xbf16(__m512 a) {
+  return *(const __m512bh*)(&a);
+}
 static inline __m512 iree_mm512_dpbf16_ps_broadcast_rhs(
-    __m512 acc, __m512bh lhs, const iree_uk_uint16_t* rhs) {
+    __m512 acc, __m512 lhs, const iree_uk_uint16_t* rhs) {
   return _mm512_dpbf16_ps(
-      acc, lhs, bitcast_16xf32_to_32xbf16(_mm512_set1_ps(*(const float*)rhs)));
+      acc, bitcast_16xf32_to_32xbf16(lhs),
+      bitcast_16xf32_to_32xbf16(_mm512_set1_ps(*(const float*)rhs)));
 }
 #endif
 
@@ -60,7 +63,7 @@ iree_uk_mmt4d_tile_bf16bf16f32_1x16x2_to_16x16x2_x86_64_avx512_bf16(
   }
 
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
-    __m512bh rhs = bitcast_16xf32_to_32xbf16(_mm512_loadu_ps(rhs_ptr));
+    __m512 rhs = _mm512_loadu_ps(rhs_ptr);
     rhs_ptr += 32;
 #pragma clang loop unroll(full)
     for (int i = 0; i < M0; ++i) {


### PR DESCRIPTION
This one, reported by @Groverkss , seems to only reproduce in some Red Hat build of clang-16.

The bug seems to be yet again about buggy support for the relatively rare and new `__m512bh` type, and the work-around consists in not using it at all in the Clang-specific work-around path that we already have, instead just passing things down as `__m512` into the asm where it gets interpreted as if it were a `__m512bh` but the compiler doesn't notice.