### PR TITLE
Ensure lowering configs match tiled ops 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2328,8 +2328,8 @@ static void setLoweringConfigForComputeOps(func::FuncOp entryPointFn,
     maxLoopNums = std::max(maxLoopNums, iterTypes.size());
   }
 
-  // Adjust the distribution tile sizes and union parallel vector tile sizes
-  // from other ops. The results of parallel vector tile sizes might overlap
+  // Adjust the distribution tile sizes and join parallel vector tile sizes from
+  // other ops. The results of parallel vector tile sizes might overlap
   // reduction dimensions on some ops, so it will be splitted into common vector
   // tile sizes and inner vector tile sizes later.
   //
@@ -2337,8 +2337,8 @@ static void setLoweringConfigForComputeOps(func::FuncOp entryPointFn,
   // sizes.
   //
   // Here we use the assumption in FormDispatchRegions that all ops in a
-  // dispatch have identity maps between producer-consumer relations. So we
-  // don't need to handle the permutation of dimensions between ops except for
+  // dispatch have identity mapping between their parallel dimensions. So we
+  // don't need to handle the permutation on dimensions between ops except for
   // the pack op.
   llvm::SmallDenseMap<Operation *, SmallVector<int64_t>> reductionTileSizeMap;
   distTileSizes.resize(maxLoopNums);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2310,7 +2310,7 @@ static void setLoweringConfigForComputeOps(func::FuncOp entryPointFn,
     // Multi-lowering config works only if all the operations can share the same
     // distribution tile sizes.
     auto iterTypes = cast<TilingInterface>(op).getLoopIteratorTypes();
-    for (auto [size, iterType] : llvm::zip_equal(distTileSizes, iterTypes)) {
+    for (auto [size, iterType] : llvm::zip(distTileSizes, iterTypes)) {
       if (size && iterType != utils::IteratorType::parallel)
         return;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2361,6 +2361,9 @@ static void setLoweringConfigForComputeOps(func::FuncOp entryPointFn,
         });
   }
 
+  LLVM_DEBUG(KD_DBGS() << "Parallel vector tile sizes: " << parallelVecTileSizes
+                       << "\n");
+
   // Split parallel vector tile sizes into common parts and op-specific parts.
   SmallVector<int64_t> commonVecTileSizes = parallelVecTileSizes;
   SmallVector<int64_t> innerVecTileSizes(maxLoopNums, 0);
@@ -2368,7 +2371,7 @@ static void setLoweringConfigForComputeOps(func::FuncOp entryPointFn,
     auto iterTypes = cast<TilingInterface>(op).getLoopIteratorTypes();
     for (auto [idx, iterType] : llvm::enumerate(iterTypes)) {
       if (iterType == utils::IteratorType::reduction) {
-        innerVecTileSizes[idx] = commonVecTileSizes[idx];
+        innerVecTileSizes[idx] = parallelVecTileSizes[idx];
         commonVecTileSizes[idx] = 0;
       }
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
@@ -1616,8 +1616,8 @@ hal.executable private @unpack_generic_pack  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG1:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 64], [1, 16], [0, 0], [1, 4]]>
-//  CHECK-DAG: #[[CONFIG2:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [16, 16], [0, 0], [0, 0]]>
+//  CHECK-DAG: #[[CONFIG1:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 64], [1, 4], [0, 0], [0, 0]]>
+//  CHECK-DAG: #[[CONFIG2:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [16, 4], [0, 0], [0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @unpack_generic_pack
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1659,8 +1659,8 @@ hal.executable private @elem_pack {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG1:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [8, 4], [0, 0], [0, 0]]>
-//  CHECK-DAG: #[[CONFIG2:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 64], [1, 4], [0, 0], [1, 1]]>
+//  CHECK-DAG: #[[CONFIG1:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [8, 1], [0, 0], [0, 0]]>
+//  CHECK-DAG: #[[CONFIG2:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 64], [1, 1], [0, 0], [0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @elem_pack
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1702,8 +1702,8 @@ hal.executable private @transpose_pack  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG1:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 16], [8, 16], [0, 0], [0, 0]]>
-//  CHECK-DAG: #[[CONFIG2:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64], [1, 8], [0, 0], [1, 1]]>
+//  CHECK-DAG: #[[CONFIG1:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 16], [1, 16], [0, 0], [0, 0]]>
+//  CHECK-DAG: #[[CONFIG2:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64], [1, 1], [0, 0], [0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @transpose_pack
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1771,8 +1771,8 @@ hal.executable private @reduction_broadcast_pack  {
 }
 //  CHECK-DAG: #[[CONFIG1:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32], [16], [0], [0]]>
 //  CHECK-DAG: #[[CONFIG2:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 0], [16, 0], [0, 16], [0, 0]]>
-//  CHECK-DAG: #[[CONFIG3:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 0], [16, 0], [0, 0], [0, 16]]>
-//  CHECK-DAG: #[[CONFIG4:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[2, 0], [1, 0], [0, 0], [1, 1]]>
+//  CHECK-DAG: #[[CONFIG3:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 0], [16, 0], [0, 0], [0, 1]]>
+//  CHECK-DAG: #[[CONFIG4:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[2, 0], [1, 0], [0, 0], [0, 1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @reduction_broadcast_pack
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
This change attempts to ensure the consistency between the multiple lowering configs set in [setLoweringConfigForComputeOps](https://github.com/openxla/iree/blob/00b75cb00b59e9e52a0234b736681557517d1001/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp#L2259) and how their ops are actually tiled-and-fused in the pipeline.

The goal is to provide accurate lowering configs for vectorization, as we start using them to decide vector sizes (#14935, #15032)

### Background
Currently in `setLoweringConfigForComputeOps` each op calculates and sets `vecTileSizes` (4th-level tiling config) in its own lowering config. For example, generic ops set tile sizes on dims that haven't been tiled by the root op, pack ops set special tile sizes to improve transpose performance.

However, since the 4th level tiling config is [fusable](https://github.com/openxla/iree/blob/bb087a1dc6b03a2b663621c7c77c5b60df1f0a2e/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp#L94) in the multi-level tiling pipeline, we use the last lowering config in the dispatch to tile-and-fuse its consumer chain. The lowering configs on other ops are not used and they can be tiled in a different way than their own lowering configs, which results in inconsistency between the lowering configs and how those ops are tiled. We often observed such issues with pack ops, as it is the last op in the dispatch and has special tile sizes different from other generic ops.

For example, in #15132, we have `[[0, 64, 64], [0, 8, 16], [0, 0, 0], [0, 0, 0]] ` on a pure parallel generic op and `[[0, 4, 64], [0, 1, 8], [0, 0, 0], [1, 1, 1]]` (permuted and scaled with inner tile sizes) on its consumer pack op.

The `[1, 1, 1]` from the pack op tiles both the pack and generic op. Therefore the tile-and-fuse result of the generic op doesn't reflect on its lowering config:

Input IR:
```mlir
// -----// IR Dump After TileAndDistributeToWorkgroups (iree-codegen-tile-and-distribute-to-workgroups) //----- //
hal.executable.variant public @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64", {cpu = "cascadelake", cpu_features = "+cmov,+mmx,+popcnt,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+fma,+avx512f,+bmi,+bmi2,+aes,+pclmul,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vnni,+adx,+clflushopt,+clwb,+cx16,+cx8,+crc32,+f16c,+fsgsbase,+fxsr,+invpcid,+lzcnt,+movbe,+pku,+prfchw,+rdrnd,+rdseed,+sahf,+x87,+xsave,+xsavec,+xsaveopt,+xsaves,+evex512", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", link_embedded = false, native_vector_size = 64 : index, target_triple = "x86_64-unknown-linux-gnu", ukernels = true}> {
  hal.executable.export public @main_dispatch_178_generic_1x256x5120_f32 ordinal(0) layout(#hal.pipeline.layout<push_constants = 1, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<CPUDoubleTilingExpert>} {
  ^bb0(%arg0: !hal.device):
    %c4 = arith.constant 4 : index
    %c80 = arith.constant 80 : index
    %c1 = arith.constant 1 : index
    hal.return %c4, %c80, %c1 : index, index, index
  }
  builtin.module {
    func.func @main_dispatch_178_generic_1x256x5120_f32() {
      %c4 = arith.constant 4 : index
      %c64 = arith.constant 64 : index
      %c256 = arith.constant 256 : index
      %c320 = arith.constant 320 : index
      %cst = arith.constant 0.000000e+00 : f32
      %c9482304 = arith.constant 9482304 : index
      %0 = hal.interface.constant.load[0] : i32
      %1 = arith.index_castui %0 : i32 to index
      %2 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%1) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<5120x1x256xf32>>
      %3 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c9482304) : !flow.dispatch.tensor<writeonly:tensor<1x320x256x16x1xf32>>
      %workgroup_id_x = hal.interface.workgroup.id[0] : index
      %workgroup_count_x = hal.interface.workgroup.count[0] : index
      %workgroup_id_y = hal.interface.workgroup.id[1] : index
      %workgroup_count_y = hal.interface.workgroup.count[1] : index
      %4 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_id_y]
      %5 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_count_y]
      scf.for %arg0 = %4 to %c320 step %5 {
        %6 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
        %7 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_x]
        scf.for %arg1 = %6 to %c256 step %7 {
          %8 = affine.apply affine_map<(d0) -> (d0 * 16)>(%arg0)
          %9 = flow.dispatch.tensor.load %2, offsets = [%8, 0, %arg1], sizes = [%c64, 1, %c64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<5120x1x256xf32>> -> tensor<?x1x?xf32>
          %10 = tensor.empty() : tensor<1x64x64xf32>
          %cast = tensor.cast %9 : tensor<?x1x?xf32> to tensor<64x1x64xf32>
          %11 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cast : tensor<64x1x64xf32>) outs(%10 : tensor<1x64x64xf32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[0, 64, 64], [0, 8, 16], [0, 0, 0], [0, 0, 0]]>} {
          ^bb0(%in: f32, %out: f32):
            linalg.yield %in : f32
          } -> tensor<1x64x64xf32>
          %12 = tensor.empty() : tensor<1x4x64x16x1xf32>
          %pack = tensor.pack %11 padding_value(%cst : f32) outer_dims_perm = [0, 2, 1] inner_dims_pos = [2, 1] inner_tiles = [16, 1] into %12 {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[0, 4, 64], [0, 1, 8], [0, 0, 0], [1, 1, 1]]>} : tensor<1x64x64xf32> -> tensor<1x4x64x16x1xf32>
          %cast_0 = tensor.cast %pack : tensor<1x4x64x16x1xf32> to tensor<1x?x?x16x1xf32>
          flow.dispatch.tensor.store %cast_0, %3, offsets = [0, %arg0, %arg1, 0, 0], sizes = [1, %c4, %c64, 16, 1], strides = [1, 1, 1, 1, 1] : tensor<1x?x?x16x1xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x320x256x16x1xf32>>
        }
      }
      return
    }
  }
}
```

After tile-and-fuse:
```mlir
// -----// IR Dump After LLVMCPUTileAndFuse (iree-llvmcpu-tile-and-fuse) //----- //
func.func @main_dispatch_178_generic_1x256x5120_f32() {
  %c64 = arith.constant 64 : index
  %c4 = arith.constant 4 : index
  %c8 = arith.constant 8 : index
  %c1 = arith.constant 1 : index
  %c0 = arith.constant 0 : index
  %c256 = arith.constant 256 : index
  %c320 = arith.constant 320 : index
  %cst = arith.constant 0.000000e+00 : f32
  %c9482304 = arith.constant 9482304 : index
  %0 = hal.interface.constant.load[0] : i32
  %1 = arith.index_castui %0 : i32 to index
  %2 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%1) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<5120x1x256xf32>>
  %3 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c9482304) : !flow.dispatch.tensor<writeonly:tensor<1x320x256x16x1xf32>>
  %workgroup_id_x = hal.interface.workgroup.id[0] : index
  %workgroup_count_x = hal.interface.workgroup.count[0] : index
  %workgroup_id_y = hal.interface.workgroup.id[1] : index
  %workgroup_count_y = hal.interface.workgroup.count[1] : index
  %4 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_id_y]
  %5 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_count_y]
  scf.for %arg0 = %4 to %c320 step %5 {
    %6 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
    %7 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_x]
    scf.for %arg1 = %6 to %c256 step %7 {
      %8 = flow.dispatch.tensor.load %3, offsets = [0, %arg0, %arg1, 0, 0], sizes = [1, 4, 64, 16, 1], strides = [1, 1, 1, 1, 1] : !flow.dispatch.tensor<writeonly:tensor<1x320x256x16x1xf32>> -> tensor<1x4x64x16x1xf32>
      %9 = affine.apply affine_map<(d0) -> (d0 * 16)>(%arg0)
      %10 = flow.dispatch.tensor.load %2, offsets = [%9, 0, %arg1], sizes = [64, 1, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<5120x1x256xf32>> -> tensor<64x1x64xf32>
      %11 = scf.for %arg2 = %c0 to %c4 step %c1 iter_args(%arg3 = %8) -> (tensor<1x4x64x16x1xf32>) {
        %12 = scf.for %arg4 = %c0 to %c64 step %c8 iter_args(%arg5 = %arg3) -> (tensor<1x4x64x16x1xf32>) {
          %13 = affine.apply affine_map<(d0) -> (d0 * 16)>(%arg2)
          %extracted_slice = tensor.extract_slice %10[%13, 0, %arg4] [16, 1, 8] [1, 1, 1] : tensor<64x1x64xf32> to tensor<16x1x8xf32>
          %extracted_slice_0 = tensor.extract_slice %arg5[0, %arg2, %arg4, 0, 0] [1, 1, 8, 16, 1] [1, 1, 1, 1, 1] : tensor<1x4x64x16x1xf32> to tensor<1x1x8x16x1xf32>
          %14 = scf.for %arg6 = %c0 to %c8 step %c1 iter_args(%arg7 = %extracted_slice_0) -> (tensor<1x1x8x16x1xf32>) {
            %extracted_slice_1 = tensor.extract_slice %extracted_slice[0, 0, %arg6] [16, 1, 1] [1, 1, 1] : tensor<16x1x8xf32> to tensor<16x1x1xf32>
            %15 = tensor.empty() : tensor<1x1x16xf32>
            %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%extracted_slice_1 : tensor<16x1x1xf32>) outs(%15 : tensor<1x1x16xf32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[0, 64, 64], [0, 8, 16], [0, 0, 0], [0, 0, 0]]>} {
            ^bb0(%in: f32, %out: f32):
              linalg.yield %in : f32
            } -> tensor<1x1x16xf32>
            %extracted_slice_2 = tensor.extract_slice %arg7[0, 0, %arg6, 0, 0] [1, 1, 1, 16, 1] [1, 1, 1, 1, 1] : tensor<1x1x8x16x1xf32> to tensor<1x1x1x16x1xf32>
            %pack = tensor.pack %16 padding_value(%cst : f32) outer_dims_perm = [0, 2, 1] inner_dims_pos = [2, 1] inner_tiles = [16, 1] into %extracted_slice_2 {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[0, 4, 64], [0, 1, 8], [0, 0, 0], [1, 1, 1]]>} : tensor<1x1x16xf32> -> tensor<1x1x1x16x1xf32>
            %inserted_slice_3 = tensor.insert_slice %pack into %arg7[0, 0, %arg6, 0, 0] [1, 1, 1, 16, 1] [1, 1, 1, 1, 1] : tensor<1x1x1x16x1xf32> into tensor<1x1x8x16x1xf32>
            scf.yield %inserted_slice_3 : tensor<1x1x8x16x1xf32>
          }
          %inserted_slice = tensor.insert_slice %14 into %arg5[0, %arg2, %arg4, 0, 0] [1, 1, 8, 16, 1] [1, 1, 1, 1, 1] : tensor<1x1x8x16x1xf32> into tensor<1x4x64x16x1xf32>
          scf.yield %inserted_slice : tensor<1x4x64x16x1xf32>
        }
        scf.yield %12 : tensor<1x4x64x16x1xf32>
      }
      flow.dispatch.tensor.store %11, %3, offsets = [0, %arg0, %arg1, 0, 0], sizes = [1, 4, 64, 16, 1], strides = [1, 1, 1, 1, 1] : tensor<1x4x64x16x1xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x320x256x16x1xf32>>
    }
  }
  return
}
```

The generic op is actually tiled with a lowering config equivalent to `[[0, 64, 64], [0, 8 16], [0, 0, 0], [1, 1, 16]]`

### Proposed Solution
One way to handle this problem is instead of letting each op set their 4th-level tile sizes, we join all tile sizes and decide how to set a single set of 4th-level tile sizes across all ops.

This change tries to populate consistent lowering configs on all ops with the logic below:

1. Collect and join parallel tile sizes from all ops in the dispatch. The root op and pack op tile sizes have higher priority due to their performance impact. Other generic ops only fill in when a dimension has no tile size yet.
2. Split the joined parallel tile sizes into common tile sizes (2nd-level tiling config) and inner tile sizes (4th-level tiling config). Common tile sizes are for parallel dims across all ops. The inner tile sizes are used to tile each op on its rest of parallel dims.

As the lowering configs of all ops are derived from the same list of parallel tile sizes, they will be consistent with the tile-and-fuse results, as long as the mapping between their parallel dimensions are identity maps (the assumption from [hasCompatibleOuterParallelLoops](https://github.com/openxla/iree/blob/cda49ca393cfe2d9e151e273015971eaac6171a9/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp#L343) during dispatch formation).

Fix #15132