### PR TITLE
Rebase PyTorch guide on SHARK-Turbine.

### DIFF
--- a/docs/.markdownlint.yml
+++ b/docs/.markdownlint.yml
@@ -53,6 +53,9 @@ no-inline-html: false
 no-duplicate-heading:
   siblings_only: true
 
+# Allow headers to end with punctuation for icons (e.g. `:icon-name:`)
+no-trailing-punctuation: false
+
 # Allow images w/o alt-text
 no-alt-text: false
 

--- a/docs/website/docs/guides/developer-tips.md
+++ b/docs/website/docs/guides/developer-tips.md
@@ -1,5 +1,4 @@
 ---
-status: new
 icon: material/lightbulb-on
 ---
 

--- a/docs/website/docs/guides/ml-frameworks/jax.md
+++ b/docs/website/docs/guides/ml-frameworks/jax.md
@@ -13,6 +13,8 @@ icon: simple/python
     IREE's JAX support is under active development. This page is still under
     construction.
 
+## :octicons-book-16: Overview
+
 IREE offers two ways to interface with [JAX](https://github.com/google/jax)
 programs:
 

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -8,11 +8,16 @@ icon: simple/pytorch
 status: new
 ---
 
-# PyTorch + IREE = ?
+# PyTorch + IREE = :octicons-heart-16:
 
-!!! note "Note - under development"
-    The PyTorch ecosystem is evolving rapidly. APIs and workflows are expected
-    to change.
+!!! caution "Caution - under development"
+    We are still validating and fixing specific models. Between bug fixes in
+    flight and releases running behind, we don't expect that you will be able
+    to do a lot of advanced things without using nightly releases or working
+    with us.
+
+    Stay tuned and join the discussion in our
+    [Discord server](https://discord.gg/26P4xW4)'s `#pytorch` channel.
 
 ## :octicons-book-16: Overview
 

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -5,197 +5,243 @@ tags:
   - Python
   - PyTorch
 icon: simple/pytorch
+status: new
 ---
 
-# PyTorch integration
+# PyTorch + IREE = ?
 
-IREE supports compiling and running PyTorch programs represented as
-`nn.Module` [classes](https://pytorch.org/docs/stable/generated/torch.nn.Module.html)
-as well as models defined using [`functorch`](https://pytorch.org/functorch/).
+!!! note "Note - under development"
+    The PyTorch ecosystem is evolving rapidly. APIs and workflows are expected
+    to change.
 
-``` mermaid
+## :octicons-book-16: Overview
+
+[SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine) offers a tight
+integration between compatible versions of IREE,
+[torch-mlir](https://github.com/llvm/torch-mlir), and
+[PyTorch](https://pytorch.org/).
+
+- [x] Seamless integration with standard PyTorch workflows
+- [x] Deployment support for running PyTorch models on cloud and edge devices
+- [x] General purpose model compilation and execution tools
+
+Both just-in-time (JIT) and ahead-of-time (AOT) workflows are supported:
+
+```mermaid
 graph LR
-  accTitle: PyTorch to runtime deployment workflow overview
+  accTitle: PyTorch integration overview
   accDescr {
-    Programs start as either PyTorch nn.Module or functorch programs.
-    Programs are imported into MLIR as either StableHLO, TOSA, or Linalg.
-    The IREE compiler uses the imported MLIR.
-    Compiled programs are used by the runtime.
+    PyTorch programs can be optimized within a Python session with
+    SHARK-Turbine's just-in-time tools.
+    PyTorch programs can be exported out of Python to native binaries using
+    SHARK-Turbine's ahead-of-time export toolkit.
   }
 
-  subgraph A[PyTorch]
-    direction TB
-    A1[nn.Module]
-    A2[functorch]
+  subgraph Python
+    pytorch(PyTorch)
+    subgraph turbine [SHARK-Turbine]
+      jit("Eager execution (JIT)")
+      aot("Export toolkit (AOT)")
+    end
 
-    A1 --- A2
+    pytorch --> jit
+    jit --> pytorch
+    pytorch --> aot
   end
 
-  subgraph B[MLIR]
-    direction TB
-    B1[StableHLO]
-    B2[TOSA]
-    B3[Linalg]
-
-    B1 --- B2
-    B2 --- B3
+  subgraph Native
+    binary(["binary (.vmfb)"])
   end
 
-  C[IREE compiler]
-  D[Runtime deployment]
-
-  A -- torch_mlir --> B
-  B --> C
-  C --> D
+  aot -.-> binary
 ```
 
 ## :octicons-download-16: Prerequisites
 
-1. Install IREE packages, either by
-    [building from source](../../building-from-source/getting-started.md#python-bindings)
-    or from pip:
+Install Turbine and its requirements:
 
-    === "Stable releases"
-
-        Stable release packages are
-        [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
-
-        ``` shell
-        python -m pip install \
-          iree-compiler \
-          iree-runtime
-        ```
-
-    === ":material-alert: Nightly releases"
-
-        Nightly releases are published on
-        [GitHub releases](https://github.com/openxla/iree/releases).
-
-        ``` shell
-        python -m pip install \
-          --find-links https://openxla.github.io/iree/pip-release-links.html \
-          --upgrade \
-          iree-compiler \
-          iree-runtime
-        ```
-
-2. Install [`torch-mlir`](https://github.com/llvm/torch-mlir), necessary for
-    compiling PyTorch models to a format IREE is able to execute:
-
-    ```shell
-    pip install --pre torch-mlir \
-      -f https://llvm.github.io/torch-mlir/package-index/
-      --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-    ```
-
-    The command will also install the right version of `torch` that has been tested
-    with the version of `torch-mlir` being installed.
-
-## Running a model
-
-Going from a loaded PyTorch model to one that's executing on IREE happens in
-four steps:
-
-1. Compile the model to [MLIR](https://mlir.llvm.org)
-2. Compile the MLIR to IREE VM flatbuffer
-3. Load the VM flatbuffer into IREE
-4. Execute the model via IREE
-
-!!! note
-    In the following steps, we'll be borrowing the model from
-    [this BERT colab](https://github.com/iree-org/iree-torch/blob/main/examples/bert.ipynb)
-    and assuming it is available as `model`.
-
-### Compile the model to MLIR
-
-First, we need to trace and compile our model to MLIR:
-
-```python
-model = # ... the model we're compiling
-example_input = # ... an input to the model with the expected shape and dtype
-mlir = torch_mlir.compile(
-    model,
-    example_input,
-    output_type="linalg-on-tensors",
-    use_tracing=True)
+``` shell
+python -m pip install shark-turbine
 ```
 
-The full list of available output types can be found
-[in the source code](https://github.com/llvm/torch-mlir/blob/main/python/torch_mlir/__init__.py),
-and includes `linalg-on-tensors`, `stablehlo`, and `tosa`.
+## :octicons-flame-16: Just-in-time (JIT) execution
 
-### Compile the MLIR to an IREE VM flatbuffer
+Just-in-time integration allows for Python code using TorchDynamo to optimize
+PyTorch models/functions using IREE, all within an interactive Python session.
 
-Next, we compile the resulting MLIR to IREE's deployable file format:
+<!-- TODO(scotttodd): mention targets like AMD GPUs when supported
+                      https://github.com/nod-ai/SHARK-Turbine/issues/94 -->
 
-```python
-iree_backend = "llvm-cpu"
-iree_input_type = "tm_tensor"
-bytecode_stream = io.BytesIO()
-mlir.operation.write_bytecode(bytecode_stream)
-iree_vmfb = ireec.compile_str(bytecode_stream.getvalue(),
-                              target_backends=[iree_backend],
-                              input_type=iree_input_type)
+``` mermaid
+graph TD
+  accTitle: PyTorch JIT workflow overview
+  accDescr {
+    Programs start as either PyTorch nn.Module objects or callable functions.
+    Programs are compiled into optimized modules using torch.compile.
+    Within torch.compile, Dynamo runs the program through Turbine and IREE.
+  }
+
+  subgraph Python
+    input([nn.Module / function])
+
+    subgraph compile ["torch.compile()"]
+      direction LR
+      dynamo{{TorchDynamo}}
+      turbine{{SHARK-Turbine}}
+      iree{{IREE}}
+      dynamo --> turbine --> iree
+    end
+
+    output([Optimized module])
+    input --> compile --> output
+  end
 ```
 
-Here we have a choice of backend we want to target. See the
-[deployment configuration guides](../deployment-configurations/index.md)
-for more details about specific targets and configurations.
+For deployment outside of Python, see the ahead-of-time section below.
 
-The generated flatbuffer can now be serialized and stored for another time or
-loaded and executed immediately.
+### :octicons-rocket-16: Quickstart
 
-!!! note
-    The input type `tm_tensor` corresponds to the `linalg-on-tensors`
-    output type of `torch-mlir`.
+Turbine integrates into PyTorch as a
+[custom backend](https://pytorch.org/docs/2.0/dynamo/custom-backends.html) for
+[`torch.compile`](https://pytorch.org/docs/stable/generated/torch.compile.html).
 
-!!! note
-    The conversion to bytecode before passing the module to IREE is needed
-    to cross the border from the Torch-MLIR MLIR C API to the IREE MLIR C API.
-
-### Load the VM flatbuffer into IREE
-
-Next, we load the flatbuffer into the IREE runtime:
+Behind the scenes, PyTorch captures the structure of the input model into a
+computation graph and feeds that graph through to the selected backend compiler.
 
 ```python
-config = ireert.Config(driver_name="local-sync")
-ctx = ireert.SystemContext(config=config)
-vm_module = ireert.VmModule.from_flatbuffer(ctx.instance, flatbuffer)
-ctx.add_vm_module(vm_module)
-invoker = ctx.modules.module
+import torch
+
+# Define the `nn.Module` or Python function to run.
+class LinearModule(torch.nn.Module):
+  def __init__(self, in_features, out_features):
+    super().__init__()
+    self.weight = torch.nn.Parameter(torch.randn(in_features, out_features))
+    self.bias = torch.nn.Parameter(torch.randn(out_features))
+
+  def forward(self, input):
+    return (input @ self.weight) + self.bias
+
+linear_module = LinearModule(4, 3)
+
+# Compile the program using the turbine backend.(1)
+opt_linear_module = torch.compile(linear_module, backend="turbine_cpu")
+
+# Use the compiled program as you would the original program.
+args = torch.randn(4)
+turbine_output = opt_linear_module(args)
 ```
 
-### Execute the model via IREE
+1. Initial integration only supports CPU, but support for many of IREE's other
+   targets is coming soon.
 
-Finally, we can execute the loaded model:
-
-```python
-result = invoker.forward(example_input.numpy())
-numpy_result = np.asarray(result)
-```
-
-## Training
-
-Training with PyTorch in IREE is supported via `functorch`. The steps for
-loading the model into IREE, once defined, are nearly identical to the above
-example.
-
-You can find a full end-to-end example of defining a basic regression model,
-training with it, and running inference on it
-[here](https://github.com/iree-org/iree-torch/blob/main/examples/regression.py).
-
-## Native / On-device Training
-
-A small (~100-250KB), self-contained binary can be built for deploying to
-resource-constrained environments. An example illustrating this can be found in
-[this example](https://github.com/iree-org/iree-torch/tree/main/examples/native_training).
-This binary runs a model without a Python interpreter.
-
-## :octicons-code-16: Samples
+### :octicons-code-16: Samples
 
 | Colab notebooks |  |
 | -- | -- |
-Inference on BERT | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/iree-org/iree-torch/blob/main/examples/bert.ipynb)
+Eager execution / JIT compilation | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/iree/blob/main/samples/colab/pytorch_jit.ipynb)
+
+## :octicons-package-dependents-16: Ahead-of-time (AOT) export
+
+The ahead-of-time toolkit allows developers to define a program's structure in
+Python and then export deployment-ready artifacts that can be used in IREE's
+[deployment configurations](../deployment-configurations/index.md) via the
+[API bindings](../../reference/bindings/index.md).
+
+=== ":octicons-plug-16: Simple API"
+
+    For simple models, a one-shot export API is available.
+
+    ```mermaid
+    graph LR
+      accTitle: PyTorch simple AOT workflow overview
+      accDescr {
+        Programs start as PyTorch nn.Module objects.
+        Modules are exported using the "aot" API.
+        Exported outputs are then compiled to .vmfb files with executable binaries.
+      }
+
+      subgraph Python
+        input([nn.Module])
+        export(["ExportOutput (MLIR)"])
+      end
+
+      subgraph Native
+        binary(["binary (.vmfb)"])
+      end
+
+      input -- "aot.export()" --> export
+      export -. "compile()" .-> binary
+    ```
+
+=== ":octicons-tools-16: Advanced API"
+
+    For more complex models, an underlying advanced API is available that gives
+    access to more features.
+
+    !!! note "Documentation coming soon!"
+
+### :octicons-rocket-16: Quickstart
+
+=== ":octicons-plug-16: Simple API"
+
+    ```python
+    import iree.runtime as ireert
+    import numpy as np
+    import shark_turbine.aot as aot
+    import torch
+
+    # Define the `nn.Module` to export.
+    class LinearModule(torch.nn.Module):
+      def __init__(self, in_features, out_features):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(in_features, out_features))
+        self.bias = torch.nn.Parameter(torch.randn(out_features))
+
+      def forward(self, input):
+        return (input @ self.weight) + self.bias
+
+    linear_module = LinearModule(4, 3)
+
+    # Export the program using the simple API.
+    example_arg = torch.randn(4)
+    export_output = aot.export(linear_module, example_arg)
+
+    # Compile to a deployable artifact.
+    binary = export_output.compile(save_to=None)
+
+    # Use the IREE runtime API to test the compiled program.
+    config = ireert.Config("local-task")
+    vm_module = ireert.load_vm_module(
+        ireert.VmModule.wrap_buffer(config.vm_instance, binary.map_memory()),
+        config,
+    )
+    input = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    result = vm_module.main(input)
+    print(result.to_host())
+    ```
+
+=== ":octicons-tools-16: Advanced API"
+
+    !!! note "Documentation coming soon!"
+
+### :octicons-code-16: Samples
+
+| Colab notebooks |  |
+| -- | -- |
+Simple AOT export | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/iree/blob/main/samples/colab/pytorch_aot_simple.ipynb)
+
+## Alternate workflows
+
+!!! caution "Caution - These are due for migration to SHARK-Turbine."
+
+| Colab notebooks |  |
+| -- | -- |
+(Deprecated) Inference on BERT | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/iree-org/iree-torch/blob/main/examples/bert.ipynb)
+
+### Native / on-device training
+
+A small (~100-250KB), self-contained binary can be built for deploying to
+resource-constrained environments without a Python interpreter.
 
 | Example scripts |
 | -- |

--- a/docs/website/docs/guides/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/guides/ml-frameworks/tensorflow.md
@@ -9,6 +9,8 @@ icon: simple/tensorflow
 
 # TensorFlow integration
 
+## :octicons-book-16: Overview
+
 IREE supports compiling and running TensorFlow programs represented as
 `tf.Module` [classes](https://www.tensorflow.org/api_docs/python/tf/Module)
 or stored in the `SavedModel`

--- a/docs/website/docs/guides/ml-frameworks/tflite.md
+++ b/docs/website/docs/guides/ml-frameworks/tflite.md
@@ -9,6 +9,8 @@ icon: simple/tensorflow
 
 # TensorFlow Lite integration
 
+## :octicons-book-16: Overview
+
 IREE supports compiling and running TensorFlow Lite (TFLite) programs stored as
 [TFLite FlatBuffers](https://www.tensorflow.org/lite/guide). These files can be
 imported into an IREE-compatible format then compiled to a series of backends.

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -70,7 +70,7 @@ extra:
       name: IREE Discuss Google Group
 
   status:
-    new: Recently added
+    new: Recently updated
 
 extra_css:
   - assets/stylesheets/extra.css


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/15114 (future work can be tracked elsewhere, this does the initial lift).

This refreshes the docs from pointing to a mix of [torch-mlir](https://github.com/llvm/torch-mlir) and [iree-torch](https://github.com/iree-org/iree-torch) to just pointing to [SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine). Turbine is built on top of torch-mlir and IREE and is under active development.
* Turbine supports both JIT and AOT workflows, and this PR documents both
* The "AOT toolkit" has a simple API and an advanced API, but I've only documented the simple API in this first PR

---

|  | |
|--------|--------|
| Current page | https://www.iree.dev/guides/ml-frameworks/pytorch/ |
| Preview of this PR | https://scotttodd.github.io/iree/guides/ml-frameworks/pytorch/ | 

---

Depends on https://github.com/openxla/iree/pull/15166 for one sample Colab notebook.