### PR TITLE
[ConstEval] Make ConstExprMaxSizeIncreaseThreshold be controlled by API.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -219,7 +219,7 @@ public:
 
   const ConstExprAnalysis &getAnalysis() const { return analysis; }
 
-  ConstExprHoistingPolicy(const ConstExprAnalysis &analysis);
+  ConstExprHoistingPolicy(const ConstExprAnalysis &analysis, int64_t threshold);
   void initialize();
   Decision *getDecision(const ConstExprAnalysis::ConstValueInfo *info) {
     return &decisions[info];
@@ -243,6 +243,8 @@ private:
                     Decision *decision);
 
   const ConstExprAnalysis &analysis;
+
+  int64_t constExprMaxSizeIncreaseThreshold;
 
   // Map of ConstValueInfo * to decision structs. All are allocated at
   // initialization and then the structure is not changed.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -47,12 +47,16 @@ public:
     registerConstExprDependentDialects(registry);
   }
 
+  HoistIntoGlobalsPass(int64_t threshold) {
+    this->maxSizeIncreaseThreshold.setValue(threshold);
+  }
+
   void runOnOperation() override {
     SymbolTable moduleSymbols(getOperation());
     const auto &constExprs = getAnalysis<ConstExprAnalysis>();
     LLVM_DEBUG(dbgs() << constExprs);
     LLVM_DEBUG(dbgs() << "\n\n");
-    ConstExprHoistingPolicy policy(constExprs);
+    ConstExprHoistingPolicy policy(constExprs, this->maxSizeIncreaseThreshold);
     policy.initialize();
 
     // Print analysis dot graph if requested.
@@ -252,8 +256,9 @@ public:
 
 } // namespace
 
-std::unique_ptr<OperationPass<mlir::ModuleOp>> createHoistIntoGlobalsPass() {
-  return std::make_unique<HoistIntoGlobalsPass>();
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createHoistIntoGlobalsPass(int64_t maxSizeIncreaseThreshold) {
+  return std::make_unique<HoistIntoGlobalsPass>(maxSizeIncreaseThreshold);
 }
 
 } // namespace Util

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -23,7 +23,8 @@ std::unique_ptr<OperationPass<void>>
 createFixedPointIteratorPass(OpPassManager pipeline);
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createFoldGlobalsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createFuseGlobalsPass();
-std::unique_ptr<OperationPass<mlir::ModuleOp>> createHoistIntoGlobalsPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createHoistIntoGlobalsPass(int64_t maxSizeIncreaseThreshold = 2147483647);
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createIPOPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createOutlineConstantsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createPropagateSubrangesPass();

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -105,6 +105,11 @@ def HoistIntoGlobals : Pass<"iree-util-hoist-into-globals", "mlir::ModuleOp"> {
   let constructor = [{
     mlir::iree_compiler::IREE::Util::createHoistIntoGlobalsPass()
   }];
+  let options = [
+    Option<"maxSizeIncreaseThreshold", "max-size-increase-threshold", "int64_t",
+      /*default=*/"2147483647",
+      "Maximum byte size increase allowed for constant expr hoisting policy to allow hoisting.">
+  ];
 }
 
 def SimplifyGlobalAccesses :

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -107,8 +107,9 @@ def HoistIntoGlobals : Pass<"iree-util-hoist-into-globals", "mlir::ModuleOp"> {
   }];
   let options = [
     Option<"maxSizeIncreaseThreshold", "max-size-increase-threshold", "int64_t",
-      /*default=*/"2147483647",
-      "Maximum byte size increase allowed for constant expr hoisting policy to allow hoisting.">
+      /*default=*/"1048576",
+      "Maximum byte size increase allowed for constant expr hoisting policy to"
+      "allow hoisting. The threshold is 1MB by default.">
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-util-hoist-into-globals --allow-unregistered-dialect --iree-util-const-expr-max-size-increase-threshold=64 %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-util-hoist-into-globals="max-size-increase-threshold=64" --allow-unregistered-dialect %s | FileCheck %s
 
 // CHECK-LABEL: @hoist_simple_const_expr
 module @hoist_simple_const_expr {

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -88,7 +88,8 @@ void buildGlobalOptimizationPassPipeline(
   pipeline.addPass(IREE::Util::createIPOPass());
 
   if (transformOptions.options.constExprHoisting) {
-    pipeline.addPass(IREE::Util::createHoistIntoGlobalsPass());
+    pipeline.addPass(IREE::Util::createHoistIntoGlobalsPass(
+        transformOptions.options.constExprMaxSizeIncreaseThreshold));
   }
 
   if (transformOptions.buildConstEvalPassPipeline) {

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -96,8 +96,8 @@ struct GlobalOptimizationOptions {
   bool stripAssertions = false;
 
   // Maximum byte size increase allowed for constant expr hoisting policy to
-  // allow hoisting.
-  int64_t constExprMaxSizeIncreaseThreshold = 2147483647;
+  // allow hoisting. The threshold is 1MB by default.
+  int64_t constExprMaxSizeIncreaseThreshold = 1024 * 1024;
 
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<GlobalOptimizationOptions>;

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -95,6 +95,10 @@ struct GlobalOptimizationOptions {
   // Strips debug assertions after any useful information has been extracted.
   bool stripAssertions = false;
 
+  // Maximum byte size increase allowed for constant expr hoisting policy to
+  // allow hoisting.
+  int64_t constExprMaxSizeIncreaseThreshold = 2147483647;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<GlobalOptimizationOptions>;
 };


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/15073