### PR TITLE
[rocm] Bundle HIP headers into a submodule and use that by default.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "third_party/ROCm-Device-Libs"]
 	path = third_party/ROCm-Device-Libs
 	url = https://github.com/shark-infra/ROCm-Device-Libs
+[submodule "third_party/hip-build-deps"]
+	path = third_party/hip-build-deps
+	url = https://github.com/shark-infra/hip-build-deps.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,7 @@ endif()
 
 #-------------------------------------------------------------------------------
 # Experimental next-generation CUDA HAL driver
+# Enable with: -DIREE_EXTERNAL_HAL_DRIVERS=cuda2
 #-------------------------------------------------------------------------------
 
 set(IREE_EXTERNAL_CUDA2_HAL_DRIVER_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/experimental/cuda2")
@@ -344,6 +345,7 @@ set(IREE_EXTERNAL_CUDA2_HAL_DRIVER_REGISTER "iree_hal_cuda2_driver_module_regist
 
 #-------------------------------------------------------------------------------
 # Experimental ROCM HAL driver
+# Enable with: -DIREE_EXTERNAL_HAL_DRIVERS=rocm
 #-------------------------------------------------------------------------------
 
 set(IREE_EXTERNAL_ROCM_HAL_DRIVER_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/experimental/rocm")
@@ -353,6 +355,7 @@ set(IREE_EXTERNAL_ROCM_HAL_DRIVER_REGISTER "iree_hal_rocm_driver_module_register
 
 #-------------------------------------------------------------------------------
 # Experimental WebGPU HAL driver
+# Enable with: -DIREE_EXTERNAL_HAL_DRIVERS=webgpu
 #-------------------------------------------------------------------------------
 
 set(IREE_EXTERNAL_WEBGPU_HAL_DRIVER_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/experimental/webgpu")

--- a/experimental/rocm/CMakeLists.txt
+++ b/experimental/rocm/CMakeLists.txt
@@ -24,14 +24,12 @@ set(IREE_ROCM_BC_DIR "${IREE_ROCM_BC_DIR_DEFAULT}" CACHE STRING
 
 iree_add_all_subdirs()
 
-if(NOT ROCM_HEADERS_API_ROOT)
-  set(ROCM_HEADERS_API_ROOT "/opt/rocm/include")
+if(NOT DEFINED ROCM_HEADERS_API_ROOT)
+  set(ROCM_HEADERS_API_ROOT "${IREE_SOURCE_DIR}/third_party/hip-build-deps/include")
 endif()
 
-if(EXISTS ${ROCM_HEADERS_API_ROOT})
-  message(STATUS "ROCm Header Path: ${ROCM_HEADERS_API_ROOT}")
-else()
-  message(SEND_ERROR "Could not locate ROCm: ${ROCM_HEADERS_API_ROOT}")
+if(NOT EXISTS "${ROCM_HEADERS_API_ROOT}/hip/hip_version.h")
+  message(SEND_ERROR "Could not find HIP headers at: ${ROCM_HEADERS_API_ROOT}")
 endif()
 
 iree_cc_library(


### PR DESCRIPTION
This required some surgery to extract headers from the upstream packages. All notes have been made in the submodule.

Tested on Windows with `iree-run-module --dump_devices` and verified that my AMD card shows up.