### PR TITLE
Add an API to disable nanobind's leak checker.

### DIFF
--- a/runtime/bindings/python/initialize_module.cc
+++ b/runtime/bindings/python/initialize_module.cc
@@ -48,6 +48,8 @@ NB_MODULE(_runtime, m) {
                                     &argc, &argv),
                    "Error parsing flags");
   });
+
+  m.def("disable_leak_checker", []() { py::set_leak_warnings(false); });
 }
 
 }  // namespace python


### PR DESCRIPTION
Some uses of Dynamo always leave garbage around in a way that triggers the leak checker and spews warnings. Having an API to disable it let's us do so when using in this way.