### PR TITLE
Add an API to set global compiler CL options.

### DIFF
--- a/compiler/bindings/python/iree/compiler/api/__init__.py
+++ b/compiler/bindings/python/iree/compiler/api/__init__.py
@@ -24,6 +24,7 @@ the process of being compiled.
 """
 
 from .ctypes_dl import (
+    _initializeGlobalCL,
     Session,
     Invocation,
     Source,

--- a/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
+++ b/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
@@ -43,6 +43,12 @@ def _init_dylib():
         raise RuntimeError("Could not find libIREECompiler.so")
     _dylib = cdll.LoadLibrary(dylib_path)
 
+    _setsig(
+        _dylib.ireeCompilerSetupGlobalCL,
+        None,
+        [c_int, POINTER(c_char_p), c_char_p, c_bool],
+    )
+
     # Setup signatures.
     # Error
     _setsig(_dylib.ireeCompilerErrorDestroy, None, [c_void_p])
@@ -163,6 +169,12 @@ def _handle_error(err_p, exc_type=ValueError):
     message = _dylib.ireeCompilerErrorGetMessage(err_p).decode("UTF-8")
     _dylib.ireeCompilerErrorDestroy(err_p)
     raise exc_type(message)
+
+
+def _initializeGlobalCL(*cl_args: str):
+    arg_buffers = [create_string_buffer(s.encode()) for s in cl_args]
+    arg_pointers = (c_char_p * len(cl_args))(*map(addressof, arg_buffers))
+    _dylib.ireeCompilerSetupGlobalCL(len(cl_args), arg_pointers, b"ctypes", False)
 
 
 class Session:


### PR DESCRIPTION
This isn't recommended (and thus named as private): options we want to set should be done in an API compatible way. However, this helps unblock demos and special cases for compiler flags that are not properly exposed for API use.