### PR TITLE
[GPU] Fix hoisting after upstream change disallowing view ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -239,7 +239,8 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
   // Linalg -> vector
   nestedModulePM.addNestedPass<func::FuncOp>(
       createLLVMGPUTensorCoreVectorizationPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      memref::createFoldMemRefAliasOpsPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass());
@@ -302,7 +303,8 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
   // Linalg -> vector
   nestedModulePM.addNestedPass<func::FuncOp>(
       createLLVMGPUTensorCoreVectorizationPass(GPUTensorCoreType::MMA_SYNC));
-  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      memref::createFoldMemRefAliasOpsPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test.mlir
@@ -82,17 +82,17 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 //   CHECK-LABEL:  func.func @conv_nchw
 // TODO: hoist the accumulator read and fold the transfer_write.
 //         CHECK:    vector.transfer_write
+// CHECK-COUNT-4:    vector.transfer_read
 //         CHECK:    scf.for
 //         CHECK:      scf.for
-// CHECK-COUNT-3:        vector.transfer_read
-//         CHECK:        vector.contract
-//         CHECK:        vector.transfer_write
 // CHECK-COUNT-2:        vector.transfer_read
 //         CHECK:        vector.contract
-//         CHECK:        vector.transfer_write
-// CHECK-COUNT-2:        vector.transfer_read
+//         CHECK:        vector.transfer_read
 //         CHECK:        vector.contract
-//         CHECK:        vector.transfer_write
-// CHECK-COUNT-2:        vector.transfer_read
+//         CHECK:        vector.transfer_read
 //         CHECK:        vector.contract
-//         CHECK:        vector.transfer_write
+//         CHECK:        vector.transfer_read
+//         CHECK:        vector.contract
+//         CHECK:      scf.yield
+//         CHECK:    scf.yield
+// CHECK-COUNT-4:    vector.transfer_write

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.cpp
@@ -570,6 +570,11 @@ Value mlir::iree_compiler::gpu::buildConvertToTensorCoreOp(
   // be replaced by a single transform.
   b.create<SynchronizeLoopOp>(forH);
 
+  b.create<transform::ApplyPatternsOp>(funcH, [](OpBuilder &b, Location loc) {
+    b.create<transform::ApplyFoldMemrefAliasOpsPatternsOp>(loc);
+  });
+  b.create<IREE::transform_dialect::ApplyCommonSubexpressionEliminationOp>(
+      funcH);
   // TODO: not a functional style transform and avoid returning funcH.
   funcH = b.create<transform::HoistRedundantVectorTransfersOp>(
       transform::AnyOpType::get(b.getContext()), funcH);


### PR DESCRIPTION
MLIR changed to disallow hoisting involving memref view-like ops, which is heavily relied on in LLVMGPU and SPIR-V CodeGen for better performance. Now we need to first fold aliased memrefs and then perform hoisting.

This drops the local revert for llvm/llvm-project@94c04772
It additionally cherry-picks the following commits:
* llvm/llvm-project@ebaf8d49
* llvm/llvm-project@3049ac44

Fixes https://github.com/openxla/iree/issues/15083