### PR TITLE
Adding hal.dispatch.extern op.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -367,6 +367,9 @@ void ConvertToSPIRVPass::runOnOperation() {
   MLIRContext *context = &getContext();
   ModuleOp moduleOp = getOperation();
 
+  if (moduleOp.getBody()->empty())
+    return;
+
   llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
       getAllEntryPoints(moduleOp);
   for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -63,14 +63,19 @@ verifyDispatchWorkload(Operation *op, IREE::Flow::ExecutableExportOp exportOp,
   // the workload here matches what is expected.
   if (!exportOp.getWorkgroupCount().empty()) {
     auto &workgroupCount = exportOp.getWorkgroupCount();
-    if (workgroupCount.getNumArguments() != workload.size()) {
+    auto explicitArgs = llvm::make_filter_range(
+        workgroupCount.getArgumentTypes(), [](Type type) {
+          return !type.hasTrait<
+              mlir::OpTrait::IREE::Util::ImplicitlyCaptured>();
+        });
+    if (llvm::range_size(explicitArgs) != workload.size()) {
       return op->emitOpError()
              << "workload mismatch; entry point expects "
-             << workgroupCount.getNumArguments()
+             << llvm::range_size(explicitArgs)
              << " arguments but dispatch provides " << workload.size();
     }
-    for (auto [index, expectedType, actualType] : llvm::enumerate(
-             workgroupCount.getArgumentTypes(), workload.getTypes())) {
+    for (auto [index, expectedType, actualType] :
+         llvm::enumerate(explicitArgs, workload.getTypes())) {
       if (expectedType != actualType) {
         return op->emitOpError()
                << "workload operand " << index << " type mismatch; expected "

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -660,7 +660,7 @@ def FLOW_ExecutableOp : FLOW_Op<"executable", [
     // TODO(benvanik): add compatibility and versioning attributes.
   );
 
-  let regions = (region SizedRegion<1>:$body);
+  let regions = (region AnyRegion:$body);
 
   let assemblyFormat = [{
     custom<SymbolVisibility>($sym_visibility)
@@ -676,9 +676,10 @@ def FLOW_ExecutableOp : FLOW_Op<"executable", [
 
   let extraClassDeclaration = [{
     Block& getBlock() { return getBody().front(); }
-
     ::mlir::ModuleOp getInnerModule() {
-      return *getBlock().getOps<::mlir::ModuleOp>().begin();
+      auto it = getBlock().getOps<::mlir::ModuleOp>();
+      if (it.empty()) return {};
+      return *it.begin();
     }
   }];
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
@@ -385,6 +385,8 @@ private:
 
     auto calleeNameAttr = entryPoint.getLeafReference();
     auto innerModule = executableOp.getInnerModule();
+    if (!innerModule)
+      return;
     auto funcOps = innerModule.getOps<func::FuncOp>();
     auto funcIt = llvm::find_if(funcOps, [&](func::FuncOp op) {
       return op.getNameAttr() == calleeNameAttr;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -195,8 +195,8 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
         return createInitializeEmptyTensorsPass(clZeroFillEmptyTensors);
       });
 
-  // Module pass to outline the dispatch regions into their own functions
-  // wrapped in executables.
+  // Module pass to outline dispatch regions (and similar ops) into their own
+  // functions wrapped in executables.
   passManager.addPass(IREE::Flow::createOutlineDispatchRegionsPass());
 
   // Annotate executables based on their contents.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
@@ -164,3 +164,12 @@ flow.executable private @ex {
     }
   }
 }
+
+// -----
+
+// Executables with no contents are ignored.
+
+flow.executable private @ex {
+  // CHECK: flow.executable.export public @dispatch
+  flow.executable.export public @dispatch
+}

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -669,6 +669,10 @@ def HAL_InterfaceBindingAttr :
   }];
 }
 
+def HAL_InterfaceBindingArrayAttr :
+    TypedArrayAttrBase<HAL_InterfaceBindingAttr,
+                       "HAL binding array attribute">;
+
 //===----------------------------------------------------------------------===//
 // Device and executable target specification
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -289,6 +289,151 @@ def HAL_TensorBarrierOp : HAL_Op<"tensor.barrier", [
   let hasCanonicalizer = 1;
 }
 
+def HAL_DispatchExternOp : HAL_PureOp<"dispatch.extern", [
+  IsolatedFromAbove,
+  AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<Util_TiedOpInterface, [
+    "getTiedOperandsIndexAndLength",
+  ]>,
+  Util_ShapeAwareOp,
+]> {
+  let summary = [{a dispatch of workgroups across a 3-dimensional grid}];
+  let description = [{
+    Dispatches some number of workgroups across a 3-dimensional grid using a
+    function defined externally in one or more referenced objects. Objects are
+    declared per executable target and selected automatically during linking
+    based on where the dispatch is used. Semantically this is equivalent to
+    a `flow.dispatch.workgroups` but with the workgroup region invisible to the
+    compiler. See `hal.executable` for more information about object linkage.
+
+    Note that since this happens at tensor level the dispatch operation has
+    value semantics: some tensors (and optionally other primitive types) are
+    consumed and one or more new result tensors are produced. Inside each
+    workgroup, however, the input and output tensors are available for arbitrary
+    loads and stores. In many cases each workgroup will load some particular
+    tile(s) from the input tensors and store some particular tile(s) to the
+    output tensors unique to that workgroup. Though it's possible for multiple
+    workgroups to load the same regions of the input tensors behavior is
+    undefined if multiple workgroups store to the same regions of the output
+    tensors. Codegen guarantees this behavior but when sourcing externally
+    authored dispatch functions it's critical that this behavior is observed.
+
+    Though the representation is similar to the GPU-style grid dispatch model
+    here we still have not yet allocated buffers, determined the target device
+    for execution, or even completed fully resolving shapes/types/etc. Because
+    of this it's important that the workgroup body use the platform-dependent
+    primitives for accessing workgroup ID, size, and count intrinsics instead
+    of hardcoding them to a particular set of values. Assume that any workgroup
+    dispatch may end up being specialized for several different target devices
+    and even several different variants for a particular target device
+    (differing workgroup sizes, etc). To aid deduplication code producing these
+    external dispatches should try not to specialize early for particular shapes
+    and instead emit the most generic code possible as having 500 slightly
+    different `hal.dispatch.extern` ops pointing at the same object file is
+    likely to require 500 copies of the object instead of 500 calls to the same
+    object.
+
+    Because at this point in the layering devices have not yet been selected the
+    workgroup count cannot be fully evaluated. Instead workload parameters are
+    captured that are then passed to a function that when later evaluated
+    computes the actual workgroup count based on target information. The
+    workload is not limited to the 3D XYZ grid dispatch of the workgroup count
+    and can contain any number of parameters used to compute it. If workgroup
+    size or distribution varies based on the target device a `!hal.device`
+    argument can be used by the workgroup count calculation region to factor in
+    device parameters. See `hal.device.query` for more information on how to
+    query information.
+
+    ```mlir
+    %r = hal.dispatch.extern "some_function"[%c5, %c5](%0, %1)
+        : (tensor<5x5xf32>, tensor<5xf32>) -> tensor<5x5xf32>
+      ...
+    ```
+
+    The number of results of the operation is equal to the number of results
+    in the type signature (`(tensor<5x5xf32>, tensor<5xf32>) -> tensor<5x5xf32>`).
+    Each tensor argument and result in the type signature has a corresponding
+    pipeline layout slot and must be declared. If multiple arguments or results
+    share the same layout slot they can be aliased using the `bindings`
+    attribute and otherwise each is assumed unique.
+
+    There are no `arguments` operands for results, but a result can be tied an
+    argument by writing the argument operand's SSA value instead of its type:
+    E.g., in the above example, `-> %0` would tie the first argument to the
+    result. In that case, there would be no separate block argument for the
+    result.
+  }];
+
+  let arguments = (ins
+    StrAttr:$export,
+    Variadic<Index>:$workload,
+    Variadic<AnyType>:$arguments,
+    HAL_ShapeDynamicDims:$argument_dims,
+    HAL_ShapeDynamicDims:$result_dims,
+    HAL_PipelineLayoutAttr:$layout,
+    HAL_ExecutableObjectsAttr:$objects,
+    OptionalAttr<HAL_WorkgroupSizeAttr>:$workgroup_size,
+    OptionalAttr<HAL_SubgroupSizeAttr>:$subgroup_size,
+    OptionalAttr<IndexAttr>:$workgroup_local_memory,
+    OptionalAttr<HAL_InterfaceBindingArrayAttr>:$bindings,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands
+  );
+  let results = (outs
+    Variadic<AnyType>:$results
+  );
+
+  let regions = (region
+    AnyRegion:$workgroup_count
+  );
+
+  let assemblyFormat = [{
+    $export
+    (`[` $workload^ `]`)? ``
+    `(` $arguments `)` `:`
+    custom<ShapedFunctionType>(ref($arguments),
+                               type($arguments), $argument_dims,
+                               type($results), $result_dims,
+                               $tied_operands)
+    `layout` `(` $layout `)`
+    (`bindings` `(` $bindings^ `)`)?
+    `objects` `(` $objects `)`
+    `count` `` custom<WorkgroupCountRegion>($workgroup_count)
+    attr-dict-with-keyword
+  }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      "ValueRange":$workload,
+      "TypeRange":$resultTypes, "ValueRange":$resultDims,
+      "ValueRange":$arguments, "ValueRange":$argumentDims,
+      "ArrayRef<int64_t>":$tiedOperands,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
+  ];
+
+  let extraClassDeclaration = [{
+    FunctionType getDispatchType() {
+      return FunctionType::get(
+          getContext(), llvm::map_to_vector(getArguments(), [](Value value) {
+            return value.getType();
+          }),
+          getResultTypes());
+    }
+
+    /// Returns the index of the args() operand in the Operation operands list.
+    unsigned mapArgOperandToOpOperand(unsigned i) { return i + getWorkload().size(); };
+
+    ValueRange getOperandDynamicDims(unsigned idx) {
+      return IREE::Util::findVariadicDynamicDims(idx - getWorkload().size(), getArguments(), getArgumentDims());
+    }
+    ValueRange getResultDynamicDims(unsigned idx) {
+      return IREE::Util::findVariadicDynamicDims(idx, getResults(), getResultDims());
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
 } // OpGroupPseudoOps
 
 //===----------------------------------------------------------------------===//
@@ -1827,9 +1972,9 @@ def HAL_ExecutableSourceOp : HAL_Op<"executable.source", [
     }
 
     ::mlir::ModuleOp getInnerModule() {
-      auto moduleOps = getBlock().getOps<::mlir::ModuleOp>();
-      assert(!moduleOps.empty() && "source ops need inner modules");
-      return *moduleOps.begin();
+      auto it = getBlock().getOps<::mlir::ModuleOp>();
+      if (it.empty()) return {};
+      return *it.begin();
     }
   }];
 }
@@ -1902,11 +2047,10 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
     An entry point exported by the executable with statically-available
     information describing the IO interface it uses and other dispatch metadata.
 
-    The `calculate_workgroup_count` region represents the computation that
+    The `workgroup_count` region represents the computation that
     returns the number of workgroups to use in the 3D grid dispatch.
     The arguments to the region represents the workload as captured by each
-    dispatch.
-    It returns the number of workgroups along x, y, and z.
+    dispatch. It returns the number of workgroups along x, y, and z.
   }];
 
   let arguments = (ins
@@ -2002,9 +2146,9 @@ def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
     }
 
     ::mlir::ModuleOp getInnerModule() {
-      auto moduleOps = getBlock().getOps<::mlir::ModuleOp>();
-      assert(!moduleOps.empty() && "source ops need inner modules");
-      return *moduleOps.begin();
+      auto it = getBlock().getOps<::mlir::ModuleOp>();
+      if (it.empty()) return {};
+      return *it.begin();
     }
 
     // Returns a map of constant key attributes to ordinals across all constant

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
@@ -11,6 +11,7 @@
 #include <optional>
 
 #include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTraits.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
@@ -109,7 +110,9 @@ struct DescriptorSetLayoutType
   using Base::Base;
 };
 
-struct DeviceType : public Type::TypeBase<DeviceType, Type, TypeStorage> {
+struct DeviceType
+    : public Type::TypeBase<DeviceType, Type, TypeStorage,
+                            mlir::OpTrait::IREE::Util::ImplicitlyCaptured> {
   using Base::Base;
 };
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
@@ -51,3 +51,44 @@ func.func @tensorBarrier(%arg0: tensor<3xf32>, %arg1: tensor<4xf32>, %arg2: !hal
   %0:2 = hal.tensor.barrier join(%arg0, %arg1 : tensor<3xf32>, tensor<4xf32>) => %arg2 : !hal.fence
   return %0#0, %0#1 : tensor<3xf32>, tensor<4xf32>
 }
+
+// -----
+
+// Demonstrates the full functionality of an extern dispatch op.
+// Note that some fields are optional.
+
+// CHECK-LABEL: func.func @dispatchExtern
+func.func @dispatchExtern(%arg0: tensor<4xi32>, %arg1: tensor<8xi32>, %arg2: i32) -> tensor<8xi32> {
+  %x = arith.constant 100 : index
+  %y = arith.constant 50 : index
+  // Dispatch workgroups to the externally defined function "main" in the
+  // referenced object files.
+  %0 = hal.dispatch.extern "main"[%x, %y](%arg0, %arg1, %arg2) : (tensor<4xi32>, tensor<8xi32>, i32) -> %arg1
+    // Must match the external definition.
+    layout(#hal.pipeline.layout<push_constants = 1, sets = [
+      <0, bindings = [
+          <0, storage_buffer, ReadOnly>,
+          <1, storage_buffer>
+      ]>
+    ]>)
+    // Optional, automatically inferred if omitted.
+    bindings([
+      #hal.interface.binding<0, 0>,
+      #hal.interface.binding<0, 1>
+    ])
+    // Can have object references for multiple targets or configurations.
+    objects(#hal.executable.objects<{
+      #hal.executable.target<"llvm-cpu", "a"> = [#hal.executable.object<{path = "a.o"}>],
+      #hal.executable.target<"llvm-cpu", "b"> = [#hal.executable.object<{path = "b.o"}>]
+    }>)
+    // Translates the workload (%x and %y captured above) into an XYZ workgroup
+    // count, optionally using device information.
+    count(%device: !hal.device, %x_capture: index, %y_capture: index) -> (index, index, index) {
+      // Shows how device queries can be used when computing the workgroup count.
+      // The device is the one used at runtime.
+      %ok, %z_i32 = hal.device.query<%device : !hal.device> key("some" :: "value") : i1, i32
+      %z = arith.index_cast %z_i32 : i32 to index
+      hal.return %x_capture, %y_capture, %z : index, index, index
+    }
+  return %0 : tensor<8xi32>
+}

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -350,6 +350,8 @@ public:
     for (auto exportOp : variantOp.getBlock().getOps<ExecutableExportOp>()) {
       // Find the matching function in the LLVM module.
       auto *llvmFunc = llvmModule->getFunction(exportOp.getName());
+      if (!llvmFunc)
+        continue;
       llvmFunc->setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
       llvmFunc->setDSOLocal(true);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -234,7 +234,7 @@ convertBindingUsage(mlir::func::FuncOp sourceFuncOp, BlockArgument arg,
 // and use the HAL interface access primitives.
 static mlir::func::FuncOp
 cloneFuncWithInterface(mlir::func::FuncOp sourceFuncOp,
-                       const PipelineLayout &pipelineLayout,
+                       const PipelineResourceMap &resourceMap,
                        IREE::HAL::PipelineLayoutAttr layoutAttr) {
   // Clone so that we can do a bunch of unsafe in-place updates.
   auto clonedFuncOp = sourceFuncOp.clone();
@@ -258,7 +258,7 @@ cloneFuncWithInterface(mlir::func::FuncOp sourceFuncOp,
   for (auto arg : entryBlock->getArguments()) {
     if (!llvm::isa<IREE::Stream::BindingType>(arg.getType()))
       continue;
-    auto setBinding = pipelineLayout.resourceMap[resourceIdx++];
+    auto setBinding = resourceMap[resourceIdx++];
     auto setLayoutAttr = layoutAttr.getSetLayouts()[setBinding.first];
     auto bindingAttr = setLayoutAttr.getBindings()[setBinding.second];
     convertBindingUsage(sourceFuncOp, arg, setLayoutAttr, bindingAttr);
@@ -294,6 +294,9 @@ updateDispatchTargets(IREE::Stream::CmdDispatchOp dispatchOp,
 // TODO(benvanik): have a HAL op with structured information instead.
 static void annotateDispatchSite(IREE::Stream::CmdDispatchOp dispatchOp,
                                  const PipelineResourceMap &resourceMap) {
+  // Ignore if bindings already defined.
+  if (dispatchOp->hasAttr("hal.interface.bindings"))
+    return;
   SmallVector<Attribute> bindingAttrs;
   for (auto setBinding : resourceMap) {
     bindingAttrs.push_back(IREE::HAL::InterfaceBindingAttr::get(
@@ -311,7 +314,6 @@ declareEntryPointOps(IREE::Stream::ExecutableOp sourceExecutableOp,
                      IREE::HAL::ExecutableOp targetExecutableOp,
                      const BindingLayoutAnalysis &layoutAnalysis,
                      EntryPointExpansions &entryPointExpansions) {
-  auto sourceModuleOp = sourceExecutableOp.getInnerModule();
   auto variantOps =
       targetExecutableOp.getBlock().getOps<IREE::HAL::ExecutableVariantOp>();
   OpBuilder executableBuilder(&targetExecutableOp.getBlock().front());
@@ -323,27 +325,37 @@ declareEntryPointOps(IREE::Stream::ExecutableOp sourceExecutableOp,
   int nextOrdinal = 0;
   for (auto exportOp : sourceExecutableOp.getBody()
                            .getOps<IREE::Stream::ExecutableExportOp>()) {
-    auto sourceFuncOp = sourceModuleOp.lookupSymbol<mlir::func::FuncOp>(
-        exportOp.getFunctionRef());
-    if (failed(verifyEntryPointTypes(sourceFuncOp)))
-      return failure();
+    func::FuncOp sourceFuncOp; // optional, may be extern
+    if (auto sourceModuleOp = sourceExecutableOp.getInnerModule()) {
+      sourceFuncOp = sourceModuleOp.lookupSymbol<mlir::func::FuncOp>(
+          exportOp.getFunctionRef());
+      if (failed(verifyEntryPointTypes(sourceFuncOp)))
+        return failure();
+    }
 
-    // Create the interface for this entry point based on the analysis of its
-    // usage within the program.
+    // Lookup to see if a layout was specified already. If not we'll perform
+    // some basic analysis to come up with our own layout.
+    auto forcedLayoutAttr =
+        exportOp->getAttrOfType<IREE::HAL::PipelineLayoutAttr>(
+            "hal.interface.layout");
     const auto &pipelineLayout = layoutAnalysis.getPipelineLayout(exportOp);
+    const PipelineResourceMap &resourceMap = pipelineLayout.resourceMap;
 
     // Update all dispatch sites with the binding information required for
     // conversion into the HAL dialect. By doing this here we ensure that the
     // dialect conversion needs only local information on the ops and that it's
     // not possible for the dispatches and their targets to get out of sync.
     for (auto dispatchOp : layoutAnalysis.getExportDispatches(exportOp)) {
-      annotateDispatchSite(dispatchOp, pipelineLayout.resourceMap);
+      annotateDispatchSite(dispatchOp, resourceMap);
     }
 
     // Clone the updated function declaration into each variant.
     int ordinal = nextOrdinal++;
     for (auto variantOp : variantOps) {
-      OpBuilder targetBuilder(variantOp.getInnerModule());
+      auto targetBuilder = OpBuilder::atBlockBegin(&variantOp.getBlock());
+
+      // TODO(ravishankarm): use hal.interface.workgroup_size instead of codegen
+      // attributes.
       // Check if workgroup size is set externally.
       ArrayAttr workgroupSize;
       for (auto attr : exportOp->getAttrs()) {
@@ -362,12 +374,15 @@ declareEntryPointOps(IREE::Stream::ExecutableOp sourceExecutableOp,
       }
 
       // Declare the entry point on the target.
-      auto layoutAttr = makePipelineLayoutAttr(
-          pipelineLayout, variantOp.getTargetAttr(), targetBuilder);
+      auto variantLayoutAttr =
+          forcedLayoutAttr ? forcedLayoutAttr
+                           : makePipelineLayoutAttr(pipelineLayout,
+                                                    variantOp.getTargetAttr(),
+                                                    targetBuilder);
       auto newExportOp = targetBuilder.create<IREE::HAL::ExecutableExportOp>(
           exportOp.getLoc(),
           targetBuilder.getStringAttr(exportOp.getFunctionRef()),
-          targetBuilder.getIndexAttr(ordinal), layoutAttr, workgroupSize,
+          targetBuilder.getIndexAttr(ordinal), variantLayoutAttr, workgroupSize,
           /*subgroup_size=*/IntegerAttr{},
           /*workgroup_local_memory=*/IntegerAttr{});
 
@@ -383,16 +398,21 @@ declareEntryPointOps(IREE::Stream::ExecutableOp sourceExecutableOp,
         mlir::IRMapping mapper;
         exportOp.getWorkgroupCount().cloneInto(&newExportOp.getWorkgroupCount(),
                                                mapper);
-        // Insert the !hal.device argument.
+        // Insert the !hal.device argument if it doesn't already exist.
         Type deviceType = targetBuilder.getType<IREE::HAL::DeviceType>();
-        newExportOp.getWorkgroupCount().insertArgument(0u, deviceType,
-                                                       newExportOp.getLoc());
+        if (!llvm::is_contained(exportOp.getWorkgroupCount().getArgumentTypes(),
+                                deviceType)) {
+          newExportOp.getWorkgroupCount().insertArgument(0u, deviceType,
+                                                         newExportOp.getLoc());
+        }
       }
 
       // Clone the source function and update it to use the new interface.
-      auto variantFuncOp =
-          cloneFuncWithInterface(sourceFuncOp, pipelineLayout, layoutAttr);
-      targetFuncOps[sourceFuncOp][variantOp] = variantFuncOp;
+      if (sourceFuncOp) {
+        auto variantFuncOp = cloneFuncWithInterface(sourceFuncOp, resourceMap,
+                                                    variantLayoutAttr);
+        targetFuncOps[sourceFuncOp][variantOp] = variantFuncOp;
+      }
     }
   }
 
@@ -403,18 +423,20 @@ declareEntryPointOps(IREE::Stream::ExecutableOp sourceExecutableOp,
   // functions and multiple exports (with an N:M mapping) and in this way we
   // perform the variant construction in a single pass with deterministic
   // ordering that preserves the unmodified ops.
-  for (auto variantOp : variantOps) {
-    auto targetBuilder = OpBuilder::atBlockBegin(
-        &variantOp.getInnerModule().getBodyRegion().front());
-    for (auto &op : sourceModuleOp.getOps()) {
-      auto targetVariantFuncOps = targetFuncOps.find(&op);
-      if (targetVariantFuncOps != targetFuncOps.end()) {
-        // Move the updated function into place.
-        auto variantFuncOp = targetVariantFuncOps->second[variantOp];
-        targetBuilder.insert(variantFuncOp);
-      } else {
-        // Regular op (globals, external function declarations, etc).
-        targetBuilder.clone(op);
+  if (auto sourceModuleOp = sourceExecutableOp.getInnerModule()) {
+    for (auto variantOp : variantOps) {
+      auto targetBuilder = OpBuilder::atBlockBegin(
+          &variantOp.getInnerModule().getBodyRegion().front());
+      for (auto &op : sourceModuleOp.getOps()) {
+        auto targetVariantFuncOps = targetFuncOps.find(&op);
+        if (targetVariantFuncOps != targetFuncOps.end()) {
+          // Move the updated function into place.
+          auto variantFuncOp = targetVariantFuncOps->second[variantOp];
+          targetBuilder.insert(variantFuncOp);
+        } else {
+          // Regular op (globals, external function declarations, etc).
+          targetBuilder.clone(op);
+        }
       }
     }
   }
@@ -565,8 +587,10 @@ public:
                 targetAttr);
         setApplicableObjects(sourceOp, targetContainerOp);
         targetSymbolTable.insert(targetContainerOp);
-        OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
-        containerBuilder.create<mlir::ModuleOp>(sourceOp->getLoc());
+        if (sourceOp.getInnerModule()) {
+          OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
+          containerBuilder.create<mlir::ModuleOp>(sourceOp->getLoc());
+        }
       }
 
       // Define interfaces for each exported function based on analysis.
@@ -596,10 +620,6 @@ public:
       // Annotate the dispatch site with binding information if required.
       // TODO(benvanik): remove this path; shouldn't be needed in real usage.
       // Because this is a hack we just look for the first target entry point.
-      if (dispatchOp->hasAttr("hal.interface.bindings")) {
-        // Already have bindings defined.
-        return WalkResult::advance();
-      }
       PipelineResourceMap resourceMap;
       auto anyEntryPointAttr = *dispatchOp.getEntryPointRefs().begin();
       auto anyExportOp =

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/executable_ops.mlir
@@ -1,5 +1,14 @@
 // RUN: iree-opt --split-input-file --iree-stream-conversion --canonicalize %s | FileCheck %s
 
+// CHECK-LABEL: @extern_executable
+flow.executable private @extern_executable {
+  // CHECK: stream.executable.export public @dispatch
+  flow.executable.export public @dispatch
+  // CHECK-NOT: builtin.module
+}
+
+// -----
+
 // CHECK-LABEL: @workgroup_count_region
 flow.executable private @workgroup_count_region {
   // CHECK-NEXT: stream.executable.export public @dispatch

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -3591,7 +3591,7 @@ def Stream_ExecutableOp : Stream_Op<"executable", [
     SymbolNameAttr:$sym_name
   );
 
-  let regions = (region SizedRegion<1>:$body);
+  let regions = (region AnyRegion:$body);
 
   let assemblyFormat = [{
     custom<SymbolVisibility>($sym_visibility)
@@ -3608,7 +3608,9 @@ def Stream_ExecutableOp : Stream_Op<"executable", [
   let extraClassDeclaration = [{
     Block& getBlock() { return getBody().front(); }
     ::mlir::ModuleOp getInnerModule() {
-      return *getBlock().getOps<::mlir::ModuleOp>().begin();
+      auto it = getBlock().getOps<::mlir::ModuleOp>();
+      if (it.empty()) return {};
+      return *it.begin();
     }
   }];
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchArguments.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchArguments.cpp
@@ -481,6 +481,8 @@ static void annotateExport(IREE::Stream::ExecutableOp executableOp,
   // Operands/resources on the func are in an arbitrary order; get maps that
   // lets us go from dispatch site operand/resource to function argument.
   auto funcOp = exportOp.lookupFunctionRef();
+  if (!funcOp)
+    return;
   auto operandToArgMap =
       IREE::Stream::CmdDispatchOp::makeOperandToArgMap(funcOp);
   auto resourceToArgMap =

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FoldUniformOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FoldUniformOperands.cpp
@@ -284,6 +284,8 @@ public:
     // Optimize each dispatch op.
     for (auto executableOp :
          getOperation().getBodyRegion().getOps<IREE::Stream::ExecutableOp>()) {
+      if (!executableOp.getInnerModule())
+        continue;
       for (auto exportOp :
            executableOp.getOps<IREE::Stream::ExecutableExportOp>()) {
         auto &dispatchOps = entryDispatchMap[exportOp];

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -450,6 +450,8 @@ public:
     MemoizedCmdZeros memoizedZeros;
     for (auto executableOp :
          getOperation().getBodyRegion().getOps<IREE::Stream::ExecutableOp>()) {
+      if (!executableOp.getInnerModule())
+        continue;
       for (auto exportOp :
            executableOp.getOps<IREE::Stream::ExecutableExportOp>()) {
         fuseDispatchBindings(executableOp, exportOp, entryDispatchMap[exportOp],

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -298,8 +298,10 @@ public:
     // Convert all public function signatures and manipulate the arguments.
     for (auto executableOp :
          getOperation().getOps<IREE::Stream::ExecutableOp>()) {
-      for (auto funcOp :
-           executableOp.getInnerModule().getOps<mlir::func::FuncOp>()) {
+      auto innerModuleOp = executableOp.getInnerModule();
+      if (!innerModuleOp)
+        continue;
+      for (auto funcOp : innerModuleOp.getOps<mlir::func::FuncOp>()) {
         if (funcOp.isPublic()) {
           updateExportFuncOp(funcOp);
         }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTraits.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTraits.h
@@ -37,6 +37,12 @@ struct DebugOnly : public OpTrait::TraitBase<ConcreteType, DebugOnly> {
   static LogicalResult verifyTrait(Operation *op) { return success(); }
 };
 
+template <typename ConcreteType>
+struct ImplicitlyCaptured
+    : public OpTrait::TraitBase<ConcreteType, ImplicitlyCaptured> {
+  static LogicalResult verifyTrait(Operation *op) { return success(); }
+};
+
 } // namespace Util
 } // namespace IREE
 } // namespace OpTrait

--- a/samples/custom_dispatch/vulkan/shaders/CMakeLists.txt
+++ b/samples/custom_dispatch/vulkan/shaders/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 # custom shaders in .spv format and not supporting infrastructure for compiling
 # shaders from various textual input languages (HLSL/etc). Users are expected to
 # bring their own infrastructure if they want to bring their own source code.
-find_program(GLSLC glslc)
+find_program(GLSLC glslc HINTS "D:\\Tools\\VulkanSDK\\1.3.261.1\\Bin\\glslc.exe")
 if(NOT GLSLC)
   message(STATUS "IREE custom_dispatch/vulkan/shaders ignored -- glslc not found")
   return()
@@ -49,6 +49,7 @@ iree_lit_test_suite(
     example
   SRCS
     "example.mlir"
+    "example_inline.mlir"
   DATA
     ${_SPV_TARGET}
   TOOLS

--- a/samples/custom_dispatch/vulkan/shaders/example_inline.mlir
+++ b/samples/custom_dispatch/vulkan/shaders/example_inline.mlir
@@ -1,0 +1,116 @@
+// RUN: iree-compile %s \
+// RUN:     --iree-hal-executable-object-search-path=$IREE_BINARY_DIR | \
+// RUN: iree-run-module \
+// RUN:     --device=vulkan \
+// RUN:     --module=- \
+// RUN:     --function=mixed_invocation \
+// RUN:     --input=8xf32=2 \
+// RUN:     --input=8xf32=4 | \
+// RUN: FileCheck %s
+
+// The configuration used for executable compilation.
+// This lets the compiler and runtime know the format and requirements of the
+// executable binaries produced and multiple variants with differing formats
+// and compilation options (architectures, etc) can be embedded for runtime
+// selection.
+#spirv_target = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.3, [Shader, GroupNonUniform], [SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>,
+    #spirv.resource_limits<max_compute_workgroup_size = [128, 128, 64], subgroup_size = 64>
+  >
+}>
+
+// The target devices that the program will run on.
+// These can come from compiler flags and multiple targets can be supported
+// It's possible, for example, to support targeting multiple devices in the same
+// compiled binary.
+#vulkan_target = #hal.device.target<"vulkan", {
+  executable_targets = [#spirv_target],
+  // HACK: Vulkan target currently uses the legacy synchronous execution model.
+  legacy_sync
+}>
+
+module @example attributes {hal.device.targets = [#vulkan_target]} {
+
+  // Function demonstrating a few hand-authored dispatches mixed with codegen.
+  // Invoke with:
+  //  --device=vulkan
+  //  --function=mixed_invocation
+  //  --input=8xf32=2
+  //  --input=8xf32=4
+  // CHECK-LABEL: EXEC @mixed_invocation
+  func.func @mixed_invocation(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+    // HACK: for hand-authored shaders all primitive values passed in need to
+    // be i32 or a bit-castable type. This is because ABI packing of other types
+    // happens inside of the PackDispatchOperandsPass that is currently not
+    // usable with external functions as it changes the ABI. In the future we
+    // can better define the ABI such that it's possible to match the compiler
+    // expectations around padding/alignment. For now users must do the packing
+    // themselves (splitting i64 into i32+i32, etc).
+    %c0 = arith.constant 0 : index
+    %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+    %dim_i32 = arith.index_cast %dim : index to i32
+
+    // Dispatch a basic `ret = lhs * rhs` shader.
+    %0 = hal.dispatch.extern "main"[%dim](%dim_i32, %arg0, %arg1) : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
+      // The layout defines the required bindings and push constants and can be
+      // thought of as the function signature.
+      layout(#hal.pipeline.layout<push_constants = 1, sets = [
+        <0, bindings = [
+            <0, storage_buffer, ReadOnly>,
+            <1, storage_buffer, ReadOnly>,
+            <2, storage_buffer>
+        ]>
+      ]>)
+      // Bindings are automatically inferred when possible as part of the ABI
+      // but can be overridden if the user wants to use features such as sparse
+      // bindings or multiple descriptor sets. To do so the
+      // `hal.interface.bindings` attribute can be added to a dispatch op as
+      // follows mapping tensor operands/results to the pipeline layout
+      // sets/bindings:
+      bindings([
+        #hal.interface.binding<0, 0>,
+        #hal.interface.binding<0, 1>,
+        #hal.interface.binding<0, 2>
+      ])
+      // Object files linked into the executable.
+      // Certain backends (today) support either wholesale definition or linking
+      // of partial objects for imports used by generated code. Each compilation
+      // target can have its own unique set of objects to link in and the target
+      // keys can be generic. This allows for an object file to be linked in based
+      // only on the target triple while allowing for more specialized ones
+      // requiring certain CPU features to be only included when building those.
+      objects(#hal.executable.objects<{
+        #spirv_target = [
+          #hal.executable.object<{
+            // Referencing a file path on disk but could also have the data
+            // embedded in order to make the MLIR file hermetic/portable across
+            // compilation pipelines. In the future we'll likely use MLIR's
+            // external resource functionality for this. By allowing for the
+            // objects to be embedded we can support JIT scenarios where some
+            // layer higher or lower may be emitting the objects to link in as
+            // part of the overall compilation.
+            path = "samples/custom_dispatch/vulkan/shaders/simple_mul.spv"
+          }>
+        ]
+      }>)
+      count(%device: !hal.device, %workload: index) -> (index, index, index) {
+        // This host function is used to compute the XYZ workgroup count
+        // dispatched at runtime. It can query the %device for capabilities
+        // and limits (shared memory size, etc). The other arguments are the
+        // values passed in the dispatch operation (usually things like root
+        // output op tensor dimensions and other abstract values).
+        %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+        %c1 = arith.constant 1 : index
+        hal.return %x, %c1, %c1 : index, index, index
+      }
+
+    // Code gen some other ops - these will interleave with the hand-authored
+    // ones but naturally won't be able to fuse with them.
+    %1 = arith.addf %0, %arg1 : tensor<?xf32>
+
+    // CHECK: 8xf32=12 12 12 12 12 12 12 12
+    return %1 : tensor<?xf32>
+  }
+
+}  // module


### PR DESCRIPTION
This is an inline dispatch op on tensors that can be inserted in source programs to fully specify an externally derived dispatch region. Improvements were made for external executables in flow/stream/hal.

There's a decent amount of cruft on these paths that'll need to be cleaned up; particularly MaterializeInterfaces has long been in need of a reworking (likely decomposing with the assistance of a new op or two) and it's not great that flow now has handling of a HAL pseudo-op. The stream convert HAL->stream which handles hal.tensor.import/export would be a better place but executable deduplication happens in flow today and we need inlined dispatches like this to deduplicate. I toyed with also having a DeduplicateExecutables in stream but decided against it for today.