### PR TITLE
[spirv] Generalize transposed batch matmul op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVGeneralizeNamedOps.cpp
@@ -32,8 +32,8 @@ void SPIRVGeneralizeNamedOpsPass::runOnOperation() {
   auto funcOp = getOperation();
   SmallVector<linalg::LinalgOp> namedOpCandidates;
   funcOp.walk([&](linalg::LinalgOp linalgOp) {
-    if (isa<linalg::MatmulTransposeBOp, linalg::VecmatOp, linalg::MatvecOp>(
-            linalgOp))
+    if (isa<linalg::BatchMatmulTransposeBOp, linalg::MatmulTransposeBOp,
+            linalg::VecmatOp, linalg::MatvecOp>(linalgOp))
       namedOpCandidates.push_back(linalgOp);
   });
 


### PR DESCRIPTION
This allows it to go down generic op kernel configuration deduction so that we can use subgroup reduction pipeline for batch matvec cases.