### PR TITLE
Fix `ireeCompilerLoadBinary` on Apple: pass unprefixed symbol name to `dlsym`

### DIFF
--- a/compiler/bindings/c/iree/compiler/loader/loader.cpp
+++ b/compiler/bindings/c/iree/compiler/loader/loader.cpp
@@ -63,13 +63,6 @@ void *lookupLibrarySymbol(DlHandle lib, const char *symbol) {
 } // namespace
 #endif
 
-// Some operating systems have a prefix for cdecl exported symbols.
-#if __APPLE__
-#define IREE_CDECL_SYMBOL_PREFIX "_"
-#else
-#define IREE_CDECL_SYMBOL_PREFIX ""
-#endif
-
 namespace {
 DlHandle libraryHandle = nullptr;
 
@@ -101,7 +94,7 @@ bool ireeCompilerLoadLibrary(const char *libraryPath) {
 
   // Resolve the api version separately.
   int (*apiVersionFn)() = (int (*)())lookupLibrarySymbol(
-      localLibraryHandle, IREE_CDECL_SYMBOL_PREFIX "ireeCompilerGetAPIVersion");
+      localLibraryHandle, "ireeCompilerGetAPIVersion");
   if (!apiVersionFn) {
     fprintf(stderr, "IREE COMPILER ERROR: Could not find symbol "
                     "'ireeCompilerGetAPIVersion'\n");
@@ -113,10 +106,10 @@ bool ireeCompilerLoadLibrary(const char *libraryPath) {
 
 #define HANDLE_SYMBOL(fn_name)                                                 \
   __##fn_name = (decltype(__##fn_name))lookupLibrarySymbol(                    \
-      localLibraryHandle, IREE_CDECL_SYMBOL_PREFIX #fn_name);                  \
+      localLibraryHandle, #fn_name);                  \
   if (!__##fn_name) {                                                          \
     fprintf(stderr, "IREE COMPILER ERROR: Could not find symbol '%s'\n",       \
-            IREE_CDECL_SYMBOL_PREFIX #fn_name);                                \
+            #fn_name);                                \
     return false;                                                              \
   }
 #define HANDLE_VERSIONED_SYMBOL(fn_name, availApiMajor, availApiMinor)         \

--- a/compiler/bindings/c/iree/compiler/loader/loader.cpp
+++ b/compiler/bindings/c/iree/compiler/loader/loader.cpp
@@ -105,11 +105,11 @@ bool ireeCompilerLoadLibrary(const char *libraryPath) {
   int apiMajor = packedApiVersion >> 16;
 
 #define HANDLE_SYMBOL(fn_name)                                                 \
-  __##fn_name = (decltype(__##fn_name))lookupLibrarySymbol(                    \
-      localLibraryHandle, #fn_name);                  \
+  __##fn_name = (decltype(__##fn_name))lookupLibrarySymbol(localLibraryHandle, \
+                                                           #fn_name);          \
   if (!__##fn_name) {                                                          \
     fprintf(stderr, "IREE COMPILER ERROR: Could not find symbol '%s'\n",       \
-            #fn_name);                                \
+            #fn_name);                                                         \
     return false;                                                              \
   }
 #define HANDLE_VERSIONED_SYMBOL(fn_name, availApiMajor, availApiMinor)         \


### PR DESCRIPTION
This PR fixes this test failure on macOS:

```
ctest -R iree/compiler/bindings/c/loader_test --output-on-failure
Test project /Users/benoitjacob/iree-build
    Start 449: iree/compiler/bindings/c/loader_test
1/1 Test #449: iree/compiler/bindings/c/loader_test ...***Failed    0.37 sec
IREE COMPILER ERROR: Could not find symbol 'ireeCompilerGetAPIVersion'
ERROR: Could not load library
```

The symbol names are indeed prefixed with leading `_` in the `.dylib` being loaded:

```
~/iree-build nm /Users/benoitjacob/iree-build/lib/libIREECompiler.dylib | grep ireeCompilerGetAPIVersion
0000000000018270 T _ireeCompilerGetAPIVersion
```

But `dlsym`, which is being used to perform the lookup, still wants us to pass the unprefixed symbol name, as apparently it is doing the prefixing on its own.  From [`man dlsym` (Apple)](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlsym.3.html):

```
NOTES
     Unlike other dyld API's, the symbol name passed to dlsym() must NOT be
     prepended with an underscore.
```

Also some echoes on that on mailing lists around:
https://luajit.freelists.narkive.com/QJrHoi0u/os-x-leading-underscores-and-symbol-name-redirection

Which refers to an earlier Apple `dlsym` man page (the link is now dead) that was more helpfully stating:

```
The symbol name passed to dlsym() is the name used in C source code.
For example to find the address of function foo(), you would pass "foo" as the symbol name.
```