### PR TITLE
Drop references to an already-fixed test and some no-longer-existing files.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -122,10 +122,6 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
   )
 elif [[ "${OSTYPE}" =~ ^darwin ]]; then
   excluded_tests+=(
-    #TODO(#12496): Remove after fixing the test on macOS
-    "iree/compiler/bindings/c/loader_test"
-    #TODO(#12496): Remove after fixing the test on macOS
-    "iree/compiler/bindings/python/test/transforms/ireec/compile_sample_module"
     #TODO(#13501): Fix failing sample on macOS
     "iree/samples/custom_module/async/test/example.mlir.test"
   )

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -37,9 +37,3 @@ To directly install:
 ```
 python -m pip install compiler/
 ```
-
-In order to sanity check once the package is installed:
-
-```
-python compiler/src/iree/compiler/bindings/python/test/transforms/ireec/compile_sample_module.py
-```


### PR DESCRIPTION
Fixes #12496.

`loader_test` is fixed by #15201.

`compile_sample_module` no longer occurs as a substring according to `git grep`, and two levels of enclosing directories also no longer exist... so dropping that mention in the docs.