### PR TITLE
Replace more uses of `cc_library` with `iree_runtime_cc_library`.

### DIFF
--- a/build_tools/BUILD.bazel
+++ b/build_tools/BUILD.bazel
@@ -4,16 +4,21 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
-# Helper for getting linkopts into libraries in a way we can easily spot and
-# rewrite from bazel-to-cmake and copybara.
-cc_library(
-    name = "default_linkopts",
+# The choice between iree_runtime_cc_library/iree_compiler_cc_library doesn't
+# really matter here, as these "libraries" only define linkopts. However, it is
+# still useful to go through one of the wrapper functions to avoid going
+# directly to the native/global cc_library.
+
+iree_runtime_cc_library(
+    name = "pthreads",
     linkopts = select({
         "//build_tools/bazel:iree_is_msvc": [],
         "//build_tools/bazel:iree_is_android": [
@@ -26,7 +31,7 @@ cc_library(
     }),
 )
 
-cc_library(
+iree_runtime_cc_library(
     name = "dl",
     linkopts = select({
         "//build_tools/bazel:iree_is_msvc": [],

--- a/build_tools/BUILD.bazel
+++ b/build_tools/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -12,12 +12,7 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-# The choice between iree_runtime_cc_library/iree_compiler_cc_library doesn't
-# really matter here, as these "libraries" only define linkopts. However, it is
-# still useful to go through one of the wrapper functions to avoid going
-# directly to the native/global cc_library.
-
-iree_runtime_cc_library(
+iree_cc_library(
     name = "pthreads",
     linkopts = select({
         "//build_tools/bazel:iree_is_msvc": [],
@@ -31,7 +26,7 @@ iree_runtime_cc_library(
     }),
 )
 
-iree_runtime_cc_library(
+iree_cc_library(
     name = "dl",
     linkopts = select({
         "//build_tools/bazel:iree_is_msvc": [],

--- a/build_tools/bazel/build_defs.oss.bzl
+++ b/build_tools/bazel/build_defs.oss.bzl
@@ -60,13 +60,24 @@ def iree_cmake_extra_content(content = "", inline = False):
     """
     pass
 
+def iree_cc_library(**kwargs):
+    """Base function for all cc_library targets.
+
+    This is a pass-through to the native cc_library, which integrators can
+    customize with additional flags as needed. Prefer to use the compiler
+    and runtime versions instead.
+    """
+    native.cc_library(
+        **kwargs
+    )
+
 def iree_compiler_cc_library(deps = [], **kwargs):
     """Used for cc_library targets within the //compiler tree.
 
     This is a pass-through to the native cc_library which adds specific
     compiler specific options and deps.
     """
-    native.cc_library(
+    iree_cc_library(
         deps = deps + [
             "//compiler/src:defs",
         ],
@@ -112,7 +123,7 @@ def iree_runtime_cc_library(deps = [], **kwargs):
     This is a pass-through to the native cc_library which adds specific
     runtime specific options and deps.
     """
-    native.cc_library(
+    iree_cc_library(
         deps = deps + [
             # TODO: Rename to //runtime/src:defs to match compiler.
             "//runtime/src:runtime_defines",

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -17,7 +17,7 @@ class TargetConverter:
         self._update_target_mappings(
             {
                 # Internal utilities to emulate various binary/library options.
-                f"{iree_core_repo}//build_tools:default_linkopts": [],
+                f"{iree_core_repo}//build_tools:pthreads": [],
                 f"{iree_core_repo}//build_tools:dl": ["${CMAKE_DL_LIBS}"],
                 f"{iree_core_repo}//compiler/src/iree/compiler/API:CAPI": [
                     "IREECompilerCAPILib"

--- a/runtime/src/BUILD.bazel
+++ b/runtime/src/BUILD.bazel
@@ -4,13 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
-cc_library(
+iree_runtime_cc_library(
     name = "runtime_defines",
     includes = [
         ".",

--- a/runtime/src/BUILD.bazel
+++ b/runtime/src/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -12,7 +12,7 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-iree_runtime_cc_library(
+iree_cc_library(
     name = "runtime_defines",
     includes = [
         ".",

--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -123,8 +123,8 @@ iree_runtime_cc_library(
         ":internal",
         ":path",
         ":synchronization",
-        "//build_tools:default_linkopts",
         "//build_tools:dl",
+        "//build_tools:pthreads",
         "//runtime/src/iree/base",
     ],
 )
@@ -273,7 +273,7 @@ iree_runtime_cc_library(
     ],
     deps = [
         ":internal",
-        "//build_tools:default_linkopts",
+        "//build_tools:pthreads",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:core_headers",
     ],
@@ -372,8 +372,8 @@ iree_runtime_cc_library(
     deps = [
         ":internal",
         ":synchronization",
-        "//build_tools:default_linkopts",
         "//build_tools:dl",
+        "//build_tools:pthreads",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:core_headers",
     ],

--- a/runtime/src/iree/base/tracing/BUILD.bazel
+++ b/runtime/src/iree/base/tracing/BUILD.bazel
@@ -41,7 +41,7 @@ config_setting(
     },
 )
 
-cc_library(
+iree_runtime_cc_library(
     name = "disabled",
 )
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -224,7 +224,6 @@ iree_compiler_cc_binary(
     ],
     tags = ["hostonly"],
     deps = [
-        "//build_tools:default_linkopts",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:TableGen",
         "@llvm-project//mlir:MlirTableGenMain",


### PR DESCRIPTION
For open source / Bazel usage, this should make it easier to address the `Function "cc_library" is not global anymore and needs to be loaded from "@rules_cc//cc:defs.bzl".` warning.

For downstream usage it makes it easier to pass extra arguments through via `iree_runtime_cc_library` (defined in a fork of [`build_defs.oss.bzl`](https://github.com/openxla/iree/blob/main/build_tools/bazel/build_defs.oss.bzl)) where useful. Specifically, we may want to add constraints via `compatible_with = [...]`, see https://bazel.build/reference/be/common-definitions#common-attributes.