### PR TITLE
[LLVMCPU] WIP: Add softmax ukernel for riscv64

### DIFF
--- a/build_tools/cmake/riscv.toolchain.cmake
+++ b/build_tools/cmake/riscv.toolchain.cmake
@@ -72,7 +72,7 @@ if(RISCV_CPU STREQUAL "linux-riscv_64")
   # Specify ISP spec for march=rv64gc. This is to resolve the mismatch between
   # llvm and binutil ISA version.
   set(RISCV_COMPILER_FLAGS "${RISCV_COMPILER_FLAGS} \
-      -march=rv64i2p1ma2p1f2p2d2p2c2p0 -mabi=lp64d")
+      -march=rv64i2p1ma2p1f2p2d2p2c2p0v1p0 -mabi=lp64d")
   set(RISCV_LINKER_FLAGS "${RISCV_LINKER_FLAGS} -lstdc++ -lpthread -lm -ldl")
   set(RISCV64_TEST_DEFAULT_LLVM_FLAGS
     "--iree-llvmcpu-target-triple=riscv64"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
@@ -15,8 +15,6 @@ void addCommonTargetExecutablePreprocessingPasses(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(createTypePropagationPass());
   passManager.addPass(createBubbleUpOrdinalOpsPass());
   passManager.addPass(createBufferizeCopyOnlyDispatchesPass());
-  passManager.addNestedPass<func::FuncOp>(
-      IREE::LinalgExt::createDecomposeSoftmaxPass());
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -246,7 +246,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
         switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
         case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
         case IREE::Codegen::DispatchLoweringPassPipeline::None:
-          addCPUDefaultPassPipeline(executableLoweringPipeline);
+          addCPUDefaultPassPipeline(executableLoweringPipeline, enableMicrokernels);
           break;
         case IREE::Codegen::DispatchLoweringPassPipeline::
             CPUBufferOpsTileAndVectorize: {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -246,7 +246,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
         switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
         case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
         case IREE::Codegen::DispatchLoweringPassPipeline::None:
-          addCPUDefaultPassPipeline(executableLoweringPipeline, enableMicrokernels);
+          addCPUDefaultPassPipeline(executableLoweringPipeline,
+                                    enableMicrokernels);
           break;
         case IREE::Codegen::DispatchLoweringPassPipeline::
             CPUBufferOpsTileAndVectorize: {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -569,8 +569,7 @@ void LLVMCPULowerToUKernelsPass::runOnOperation() {
   patterns.insert<LowerToUKernelPattern<IREE::Codegen::QueryTileSizesOp>>(
       context, isVMVXBackend);
   // These patterns are used on LLVMCPU and VMVX. Only for riscv target.
-  patterns.insert<LowerToUKernelPattern<linalg::SoftmaxOp>>(context,
-                                                                     isRISCV);
+  patterns.insert<LowerToUKernelPattern<linalg::SoftmaxOp>>(context, isRISCV);
   if (failed(
           applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -456,11 +456,11 @@ matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op,
 }
 
 static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
-    RewriterBase &rewriter, IREE::LinalgExt::SoftmaxOp op,
+    RewriterBase &rewriter, linalg::SoftmaxOp op,
     bool /*skipIntermediateRoundings*/) {
   Location loc = op.getLoc();
-  auto input = op.input();
-  auto output = op.output();
+  auto input = op.getInput();
+  auto output = op.getOutput();
   auto outputType = op.getInputOperandType();
   auto outputElemType = outputType.getElementType();
   uint64_t dim = op.getDimension();
@@ -569,7 +569,7 @@ void LLVMCPULowerToUKernelsPass::runOnOperation() {
   patterns.insert<LowerToUKernelPattern<IREE::Codegen::QueryTileSizesOp>>(
       context, isVMVXBackend);
   // These patterns are used on LLVMCPU and VMVX. Only for riscv target.
-  patterns.insert<LowerToUKernelPattern<IREE::LinalgExt::SoftmaxOp>>(context,
+  patterns.insert<LowerToUKernelPattern<linalg::SoftmaxOp>>(context,
                                                                      isRISCV);
   if (failed(
           applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -661,9 +661,14 @@ void addCPUDataTilingPipeline(OpPassManager &passManager,
   }
 }
 
-void addCPUDefaultPassPipeline(OpPassManager &passManager) {
+void addCPUDefaultPassPipeline(OpPassManager &passManager, bool enableMicrokernels) {
   addTileAndDistributePasses(passManager);
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+  if (enableMicrokernels) {
+    nestedModulePM.addPass(
+          createLLVMCPULowerToUKernelsPass(clSkipIntermediateRoundings));
+  }
+  nestedModulePM.addNestedPass<func::FuncOp>(IREE::LinalgExt::createDecomposeSoftmaxPass());
   addBufferizePasses(nestedModulePM);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -661,14 +661,16 @@ void addCPUDataTilingPipeline(OpPassManager &passManager,
   }
 }
 
-void addCPUDefaultPassPipeline(OpPassManager &passManager, bool enableMicrokernels) {
+void addCPUDefaultPassPipeline(OpPassManager &passManager,
+                               bool enableMicrokernels) {
   addTileAndDistributePasses(passManager);
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   if (enableMicrokernels) {
     nestedModulePM.addPass(
-          createLLVMCPULowerToUKernelsPass(clSkipIntermediateRoundings));
+        createLLVMCPULowerToUKernelsPass(clSkipIntermediateRoundings));
   }
-  nestedModulePM.addNestedPass<func::FuncOp>(IREE::LinalgExt::createDecomposeSoftmaxPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createDecomposeSoftmaxPass());
   addBufferizePasses(nestedModulePM);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -128,7 +128,8 @@ void addCPUDataTilingPipeline(OpPassManager &passManager,
 /// Populates the passes to lower to scalars operations for linalg based
 /// code-generation. This pipeline does not vectorize, but instead just
 /// converts to memrefs
-void addCPUDefaultPassPipeline(OpPassManager &passManager, bool enableMicrokernels);
+void addCPUDefaultPassPipeline(OpPassManager &passManager,
+                               bool enableMicrokernels);
 
 void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager,
                                                TilingConfig &tilingConfig,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -128,7 +128,7 @@ void addCPUDataTilingPipeline(OpPassManager &passManager,
 /// Populates the passes to lower to scalars operations for linalg based
 /// code-generation. This pipeline does not vectorize, but instead just
 /// converts to memrefs
-void addCPUDefaultPassPipeline(OpPassManager &passManager);
+void addCPUDefaultPassPipeline(OpPassManager &passManager, bool enableMicrokernels);
 
 void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager,
                                                TilingConfig &tilingConfig,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -598,6 +598,10 @@ void addGPUTransformDialectPasses(OpPassManager &passManager) {
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
   addCommonTargetExecutablePreprocessingPasses(pm.nest<ModuleOp>());
+  pm.nest<ModuleOp>().addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createDecomposeSoftmaxPass());
+  pm.nest<ModuleOp>().addNestedPass<func::FuncOp>(
+      createRematerializeParallelOpsPass());
   pm.addPass(createLLVMGPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = pm.nest<ModuleOp>();
   //===--------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -659,6 +659,7 @@ void addSPIRVTransformDialectPassPipeline(OpPassManager &pm) {
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
   addCommonTargetExecutablePreprocessingPasses(pm.nest<ModuleOp>());
   auto &nestedModulePM = pm.nest<ModuleOp>();
+  nestedModulePM.addNestedPass<func::FuncOp>(IREE::LinalgExt::createDecomposeSoftmaxPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createSPIRVGeneralizeNamedOpsPass());
   pm.addPass(createSPIRVLowerExecutableTargetPass());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -659,7 +659,8 @@ void addSPIRVTransformDialectPassPipeline(OpPassManager &pm) {
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
   addCommonTargetExecutablePreprocessingPasses(pm.nest<ModuleOp>());
   auto &nestedModulePM = pm.nest<ModuleOp>();
-  nestedModulePM.addNestedPass<func::FuncOp>(IREE::LinalgExt::createDecomposeSoftmaxPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createDecomposeSoftmaxPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createSPIRVGeneralizeNamedOpsPass());
   pm.addPass(createSPIRVLowerExecutableTargetPass());

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -36,6 +36,8 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
   // ---------------------------------------------------------------------------
   addCommonTargetExecutablePreprocessingPasses(passManager.nest<ModuleOp>());
   passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createDecomposeSoftmaxPass());
+  passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
       createCPUMaterializeEncodingPass());
   // TODO: Remove the following pass the plumb support for #hal.descriptor_type
   // memory space through the stack.

--- a/experimental/cpu_ukernel/plugin.c
+++ b/experimental/cpu_ukernel/plugin.c
@@ -41,6 +41,12 @@ static int iree_uk_plugin_unpack(void* params_ptr, void* context,
   return 0;
 }
 
+static int iree_uk_plugin_softmax(void* params_ptr, void* context,
+                                 void* reserved) {
+  iree_uk_softmax((const iree_uk_softmax_params_t*)params_ptr);
+  return 0;
+}
+
 static iree_hal_executable_plugin_status_t iree_uk_plugin_load(
     const iree_hal_executable_plugin_environment_v0_t* environment,
     size_t param_count, const iree_hal_executable_plugin_string_pair_t* params,
@@ -68,6 +74,7 @@ static iree_hal_executable_plugin_status_t iree_uk_plugin_resolve(
       {"iree_uk_mmt4d", iree_uk_plugin_mmt4d},
       {"iree_uk_pack", iree_uk_plugin_pack},
       {"iree_uk_unpack", iree_uk_plugin_unpack},
+      {"iree_uk_softmax", iree_uk_plugin_softmax},
   };
   *out_resolution = 0;
   bool any_required_not_found = false;

--- a/experimental/cpu_ukernel/plugin.c
+++ b/experimental/cpu_ukernel/plugin.c
@@ -42,7 +42,7 @@ static int iree_uk_plugin_unpack(void* params_ptr, void* context,
 }
 
 static int iree_uk_plugin_softmax(void* params_ptr, void* context,
-                                 void* reserved) {
+                                  void* reserved) {
   iree_uk_softmax((const iree_uk_softmax_params_t*)params_ptr);
   return 0;
 }

--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -316,10 +316,10 @@ static void iree_cpu_initialize_from_platform_x86_64(uint64_t* out_fields) {
 #define IREE_RISCV_64_ISA_SEARCH_START 4
 
 static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
-  char *line;
+  char* line;
   char isa[1024];
-  char *cpuinfo_path = "/proc/cpuinfo";
-  FILE *fp;
+  char* cpuinfo_path = "/proc/cpuinfo";
+  FILE* fp;
   size_t len = 0;
   ssize_t nread;
 
@@ -331,30 +331,29 @@ static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
   while ((nread = getline(&line, &len, fp)) != -1) {
     if (sscanf(line, "isa : %s\n", &isa[0])) {
       // First 4 characters are "rv32" or "rv64"
-      // We search th character 'v' from the 4th character to '_' occur or string end.
-      char *first = strchr(&isa[0], '_');
+      // We search th character 'v' from the 4th character to '_' occur or
+      // string end.
+      char* first = strchr(&isa[0], '_');
 
       // Can't find '_', search 'v' in the whole isa string.
       if (!first) {
         if (strchr(&isa[IREE_RISCV_64_ISA_SEARCH_START], 'v')) {
-          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1,
-                 1 << 0);
+          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1, 1 << 0);
         }
         break;
       } else {
         // search 'v' to the first '_' occur.
         int search_len = first - &isa[IREE_RISCV_64_ISA_SEARCH_START];
         if (memchr(&isa[IREE_RISCV_64_ISA_SEARCH_START], 'v', search_len)) {
-          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1,
-                 1 << 0);
+          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1, 1 << 0);
           break;
         }
       }
 
       // No 'v' before the first '_', search for "zve".
-      char *start = first;
-      char *end = &isa[0] + len;
-      char *next;
+      char* start = first;
+      char* end = &isa[0] + len;
+      char* next;
 
       while (start < end) {
         next = strchr(start, '_');
@@ -363,8 +362,7 @@ static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
         }
 
         if (strncmp("zve", start, 3) == 0) {
-          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1,
-               1 << 0);
+          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1, 1 << 0);
           break;
         }
         // Next search start from the char after '_'
@@ -378,8 +376,8 @@ static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
   fclose(fp);
 }
 
-#endif // IREE_PLATFORM_*
-#endif // defined(IREE_ARCH_ARM_64)
+#endif  // IREE_PLATFORM_*
+#endif  // defined(IREE_ARCH_ARM_64)
 
 static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
                                               uint64_t* out_fields) {

--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -310,7 +310,54 @@ static void iree_cpu_initialize_from_platform_x86_64(uint64_t* out_fields) {
   out_fields[0] = out0;
 }
 
-#endif  // defined(IREE_ARCH_ARM_64)
+#elif defined(IREE_ARCH_RISCV_64)
+#if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
+
+#define IREE_RISCV_64_ISA_SEARCH_START 4
+
+static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
+  char *line;
+  char isa[1024];
+  char *cpuinfo_path = "/proc/cpuinfo";
+  FILE *fp;
+  size_t len = 0;
+  ssize_t nread;
+
+  fp = fopen(cpuinfo_path, "r");
+  if (!fp) {
+    return;
+  }
+
+  while ((nread = getline(&line, &len, fp)) != -1) {
+    if (sscanf(line, "isa : %s\n", &isa[0])) {
+      // First 4 characters are "rv32" or "rv64"
+      // We search th character 'v' from the 4 character to '_' occur or string end.
+      char *end = strchr(&isa[0], '_');
+
+      // Can't find '_', search 'v' in whole isa string.
+      if (!end) {
+        if (strchr(&isa[IREE_RISCV_64_ISA_SEARCH_START], 'v')) {
+          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1,
+                 1 << 0);
+          break;
+        }
+      } else {
+        int search_len = end - &isa[IREE_RISCV_64_ISA_SEARCH_START];
+        if (memchr(&isa[IREE_RISCV_64_ISA_SEARCH_START], 'v', search_len)) {
+          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1,
+                 1 << 0);
+          break;
+        }
+      }
+    }
+  }
+
+  free(line);
+  fclose(fp);
+}
+
+#endif // IREE_PLATFORM_*
+#endif // defined(IREE_ARCH_ARM_64)
 
 static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
                                               uint64_t* out_fields) {
@@ -318,6 +365,8 @@ static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
   iree_cpu_initialize_from_platform_arm_64(out_fields);
 #elif defined(IREE_ARCH_X86_64)
   iree_cpu_initialize_from_platform_x86_64(out_fields);
+#elif defined(IREE_ARCH_RISCV_64)
+  iree_cpu_initialize_from_platform_riscv_64(out_fields);
 #else
   // No implementation available. CPU data will be all zeros.
 #endif  // defined(IREE_ARCH_ARM_64)

--- a/runtime/src/iree/builtins/ukernel/BUILD.bazel
+++ b/runtime/src/iree/builtins/ukernel/BUILD.bazel
@@ -37,6 +37,8 @@ internal_headers = [
     "static_assert.h",
     "unpack.h",
     "unpack_internal.h",
+    "softmax.h",
+    "softmax_internal.h"
 ]
 
 # Filegroup used in Bazel only (only Bazel enforces header dependencies).
@@ -65,6 +67,8 @@ iree_runtime_cc_library(
         "query_tile_sizes.c",
         "unpack.c",
         "unpack_tile.c",
+        "softmax.c",
+        "softmax_tile.c"
     ] + internal_headers,
     hdrs = ["api.h"],
     visibility = ["//visibility:private"],
@@ -121,6 +125,7 @@ if(IREE_BUILD_COMPILER AND IREE_TARGET_BACKEND_LLVM_CPU)
         "query_tile_sizes.c",
         "unpack_tile.c",
         "weak.c",
+        "softmax.c"
     ],
     # wasm_X here is a proxy for "some reasonable X-bit architecture". The
     # exact architecture should not matter (other than bitness) as the code here
@@ -145,6 +150,8 @@ c_embed_data(
         "//runtime/src/iree/builtins/ukernel/arch/arm_64:ukernel_bitcode_arm_64_entry_points.bc",
         "//runtime/src/iree/builtins/ukernel/arch/x86_64:ukernel_bitcode_x86_64.bc",
         "//runtime/src/iree/builtins/ukernel/arch/x86_64:ukernel_bitcode_x86_64_entry_points.bc",
+        "//runtime/src/iree/builtins/ukernel/arch/riscv_64:ukernel_bitcode_riscv_64.bc",
+        "//runtime/src/iree/builtins/ukernel/arch/riscv_64:ukernel_bitcode_riscv_64_entry_points.bc",
     ],
     c_file_output = "ukernel_bitcode.c",
     flatten = True,

--- a/runtime/src/iree/builtins/ukernel/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_cc_library(
     "static_assert.h"
     "unpack.h"
     "unpack_internal.h"
+    "softmax.h"
   DEPS
     iree::base::core_headers
   PUBLIC
@@ -74,6 +75,8 @@ iree_cc_library(
     "unpack.h"
     "unpack_internal.h"
     "unpack_tile.c"
+    "softmax.c"
+    "softmax.h"
   DEPS
     ::exported_bits
     ::static_assert
@@ -118,6 +121,7 @@ iree_bitcode_library(
     "query_tile_sizes.c"
     "unpack_tile.c"
     "weak.c"
+    "softmax.c"
 )
 
 iree_bitcode_library(
@@ -133,6 +137,7 @@ iree_bitcode_library(
     "query_tile_sizes.c"
     "unpack_tile.c"
     "weak.c"
+    "softmax.c"
 )
 
 iree_c_embed_data(

--- a/runtime/src/iree/builtins/ukernel/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/CMakeLists.txt
@@ -76,7 +76,9 @@ iree_cc_library(
     "unpack_internal.h"
     "unpack_tile.c"
     "softmax.c"
+    "softmax_tile.c"
     "softmax.h"
+    "softmax_internal.h"
   DEPS
     ::exported_bits
     ::static_assert
@@ -122,6 +124,7 @@ iree_bitcode_library(
     "unpack_tile.c"
     "weak.c"
     "softmax.c"
+    "softmax_tile.c"
 )
 
 iree_bitcode_library(
@@ -138,6 +141,7 @@ iree_bitcode_library(
     "unpack_tile.c"
     "weak.c"
     "softmax.c"
+    "softmax_tile.c"
 )
 
 iree_c_embed_data(
@@ -148,6 +152,8 @@ iree_c_embed_data(
     "runtime/src/iree/builtins/ukernel/arch/arm_64/ukernel_bitcode_arm_64_entry_points.bc"
     "runtime/src/iree/builtins/ukernel/arch/x86_64/ukernel_bitcode_x86_64.bc"
     "runtime/src/iree/builtins/ukernel/arch/x86_64/ukernel_bitcode_x86_64_entry_points.bc"
+    "runtime/src/iree/builtins/ukernel/arch/riscv_64/ukernel_bitcode_riscv_64.bc"
+    "runtime/src/iree/builtins/ukernel/arch/riscv_64/ukernel_bitcode_riscv_64_entry_points.bc"
     "ukernel_bitcode_32bit_base.bc"
     "ukernel_bitcode_64bit_base.bc"
   DEPS

--- a/runtime/src/iree/builtins/ukernel/api.h
+++ b/runtime/src/iree/builtins/ukernel/api.h
@@ -11,5 +11,6 @@
 #include "iree/builtins/ukernel/pack.h"
 #include "iree/builtins/ukernel/query_tile_sizes.h"
 #include "iree/builtins/ukernel/unpack.h"
+#include "iree/builtins/ukernel/softmax.h"
 
 #endif  // IREE_BUILTINS_UKERNEL_API_H_

--- a/runtime/src/iree/builtins/ukernel/api.h
+++ b/runtime/src/iree/builtins/ukernel/api.h
@@ -10,7 +10,7 @@
 #include "iree/builtins/ukernel/mmt4d.h"
 #include "iree/builtins/ukernel/pack.h"
 #include "iree/builtins/ukernel/query_tile_sizes.h"
-#include "iree/builtins/ukernel/unpack.h"
 #include "iree/builtins/ukernel/softmax.h"
+#include "iree/builtins/ukernel/unpack.h"
 
 #endif  // IREE_BUILTINS_UKERNEL_API_H_

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/CMakeLists.txt
@@ -1,0 +1,72 @@
+
+iree_add_all_subdirs()
+
+iree_compiler_targeting_iree_arch(_IREE_UKERNEL_BITCODE_BUILD_RISCV_64 "riscv_64")
+if(_IREE_UKERNEL_BITCODE_BUILD_RISCV_64)
+
+iree_bitcode_library(
+  NAME
+    ukernel_bitcode_riscv_64_entry_points
+  ARCH
+    wasm_64
+  SRCS
+    "softmax_riscv_64_entry_point.c"
+)
+
+iree_bitcode_library(
+  NAME
+    ukernel_bitcode_riscv_64_rvv
+  ARCH
+    riscv_64
+  SRCS
+    "softmax_riscv_64_rvv.c"
+  COPTS
+    "-march=rv64gcv_zvl512b"
+)
+
+iree_link_bitcode(
+  NAME
+    ukernel_bitcode_riscv_64
+  SRCS
+    "ukernel_bitcode_riscv_64_rvv.bc"
+)
+elseif(IREE_BUILD_COMPILER AND IREE_TARGET_BACKEND_LLVM_CPU)
+iree_make_empty_file("${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_riscv_64.bc")
+iree_make_empty_file("${CMAKE_CURRENT_BINARY_DIR}/ukernel_bitcode_riscv_64_entry_points.bc")
+endif() # _IREE_UKERNEL_BITCODE_BUILD_RISCV_64
+
+if (NOT (IREE_ARCH STREQUAL "riscv_64"))
+  return()
+endif()
+
+configure_file("config_riscv_64.h.in" "config_riscv_64.h")
+
+iree_cc_library(
+  NAME
+    common_riscv_64
+  HDRS
+    "common_riscv_64.h"
+  DEPS
+    iree::builtins::ukernel::internal_headers
+    iree::schemas::cpu_data
+)
+
+set(IREE_UK_RISCV_64_DEPS "")
+
+set(IREE_UK_RISCV_64_RVV)
+iree_cc_library(
+  NAME
+    riscv_64
+  SRCS
+    "softmax_riscv_64_rvv.c"
+    "softmax_riscv_64_entry_point.c"
+  DEPS
+    ::common_riscv_64
+    iree::base::core_headers
+    iree::schemas::cpu_data
+    iree::builtins::ukernel::internal_headers
+    ${IREE_UK_RISCV_64_DEPS}
+  PUBLIC
+)
+
+set(IREE_UK_ARCH_DEPS "iree::builtins::ukernel::arch::riscv_64" PARENT_SCOPE)

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/common_riscv_64.h
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/common_riscv_64.h
@@ -1,0 +1,12 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_COMMON_RISCV_64_H_
+#define IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_COMMON_RISCV_64_H_
+
+#include "iree/builtins/ukernel/common.h"
+
+#endif  // IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_COMMON_RISCV_64_H_

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/common_riscv_64_entry_point.h
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/common_riscv_64_entry_point.h
@@ -1,0 +1,21 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_COMMON_RISCV_64_ENTRY_POINT_H_
+#define IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_COMMON_RISCV_64_ENTRY_POINT_H_
+
+#include "iree/builtins/ukernel/common.h"
+#include "iree/schemas/cpu_data.h"
+
+#if defined(IREE_DEVICE_STANDALONE)
+// Standalone builds (e.g. bitcode) use our own Clang, supporting everything.
+#define IREE_UK_BUILD_RISCV_64_RVV
+#else
+// Compiling with the system toolchain. Include the configured header.
+#include "iree/builtins/ukernel/arch/riscv_64/config_riscv_64.h"
+#endif
+
+#endif // IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_COMMON_RISCV_64_ENTRY_POINT_H_

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/common_riscv_64_entry_point.h
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/common_riscv_64_entry_point.h
@@ -18,4 +18,4 @@
 #include "iree/builtins/ukernel/arch/riscv_64/config_riscv_64.h"
 #endif
 
-#endif // IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_COMMON_RISCV_64_ENTRY_POINT_H_
+#endif  // IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_COMMON_RISCV_64_ENTRY_POINT_H_

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/config_riscv_64.h.in
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/config_riscv_64.h.in
@@ -1,0 +1,16 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Source for configured header. Processed by CMake configure_file.
+// Only used in the system-toolchain build, not in standalone builds such as
+// bitcode where we use our own Clang.
+
+#ifndef IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_CONFIG_RISCV_64_H_
+#define IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_CONFIG_RISCV_64_H_
+
+#cmakedefine IREE_UK_BUILD_RISCV_64_RVV
+
+#endif  // IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_CONFIG_RISCV_64_H_

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_entry_point.c
@@ -1,0 +1,13 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/riscv_64/common_riscv_64_entry_point.h"
+#include "iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_internal.h"
+
+iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func_arch(
+    const iree_uk_softmax_params_t* params) {
+  return iree_uk_softmax_tile_riscv_64_f32_rvv;
+}

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_entry_point.c
@@ -9,5 +9,9 @@
 
 iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func_arch(
     const iree_uk_softmax_params_t* params) {
-  return iree_uk_softmax_tile_riscv_64_f32_rvv;
+  iree_uk_softmax_type_t softmax_type = iree_uk_softmax_type(params->flags);
+  if (softmax_type == iree_uk_softmax_type_f32) {
+    return iree_uk_softmax_tile_riscv_64_f32_rvv;
+  }
+  return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_internal.h
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_internal.h
@@ -1,0 +1,14 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_SOFTMAX_RISCV_64_INTERNAL_H_
+#define IREE_BUILTINS_UKERNEL_ARCH_RISCV_64_SOFTMAX_RISCV_64_INTERNAL_H_
+
+#include "iree/builtins/ukernel/softmax_internal.h"
+
+IREE_UK_SOFTMAX_TILE_FUNC_DECL(iree_uk_softmax_tile_riscv_64_f32_rvv)
+
+#endif  // foIREE_BUILTINS_UKERNEL_ARCH_RISCV_64_SOFTMAX_RISCV_64_INTERNAL_H_

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_rvv.c
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_rvv.c
@@ -1,0 +1,180 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/riscv_64/common_riscv_64.h"
+#include "iree/builtins/ukernel/softmax_internal.h"
+#include "iree/schemas/cpu_data.h"
+
+#include <riscv_vector.h>
+#include <float.h>
+
+static inline float fredmax_max(const float *input_data, size_t N) {
+    size_t avl;
+    size_t vl = __riscv_vsetvl_e32m8(N);
+    vfloat32m8_t t = __riscv_vle32_v_f32m8(input_data, vl);
+    input_data += vl;
+
+    for (avl = N - vl; avl; avl -= vl, input_data += vl) {
+        vl = __riscv_vsetvl_e32m8(N);
+        vfloat32m8_t vec = __riscv_vle32_v_f32m8(input_data, vl);
+        t = __riscv_vfmax_vv_f32m8_tu(t, t, vec, vl);
+    }
+
+    vfloat32m1_t f = __riscv_vfmv_s_f_f32m1(-FLT_MAX, 1);
+    f = __riscv_vfredmax_vs_f32m8_f32m1(t, f, N);
+
+    return __riscv_vfmv_f_s_f32m1_f32(f);
+}
+
+static inline vfloat32m4_t eval_poly_horner(vfloat32m4_t x,
+                                            float c6, float c5, float c4,
+                                            float c3, float c2, float c1,
+                                            float c0, size_t vl) {
+  vfloat32m4_t z;
+  vfloat32m4_t y = __riscv_vfmv_v_f_f32m4(c5, vl);
+  y = __riscv_vfmacc_vf_f32m4(y, c6, x, vl);
+
+  z = __riscv_vfmv_v_f_f32m4(c4, vl);
+  y = __riscv_vfmadd_vv_f32m4(y, x, z, vl);
+
+  z = __riscv_vfmv_v_f_f32m4(c3, vl);
+  y = __riscv_vfmadd_vv_f32m4(y, x, z, vl);
+
+  z = __riscv_vfmv_v_f_f32m4(c2, vl);
+  y = __riscv_vfmadd_vv_f32m4(y, x, z, vl);
+
+  z = __riscv_vfmv_v_f_f32m4(c1, vl);
+  y = __riscv_vfmadd_vv_f32m4(y, x, z, vl);
+
+  z = __riscv_vfmv_v_f_f32m4(c0, vl);
+  y = __riscv_vfmadd_vv_f32m4(y, x, z, vl);
+  return y;
+}
+
+/// @brief Computes the exponential function on vector of float32 values with a
+/// 1-ULP error bound in the range [-87, 0]. Smaller inputs are flushed to
+/// exp(-0x1.5d589ep6f) ~= 0x1.6a0a64p-127f while the result is undefined for
+/// inputs greater than zero as well as NaNs.
+///
+/// This function is intended for use in computing softmax, whose inputs are
+/// pre-normalized by subtracting the maximum, resulting in inputs in (-inf, 0).
+/// One of these inputs will contribute exp(0) = 1 to the final sum, so any
+/// inputs flushed upwards to -0x1.5d589ep6f and thus contributing at most
+/// 0x1.6a0a64p-127f to the total, will not result of softmax unless at least
+/// ~2^100 of them are summed in ascending order.
+///
+/// Exploitation of these properties results in a faster exponential by avoiding
+/// the need to handle edge cases that arise from very large or small exponents.
+///
+/// @param[in] x Input vector of float32 values
+/// @param[in] vl Length of vector x
+/// @return Result of applying softexp() to elements of x
+static inline vfloat32m4_t softexp_f32m4(vfloat32m4_t x, size_t vl) {
+  // Ensure that q = RN(x/log(2)) >= e_min, so that 2^q can be computed safely
+  // with a simple shift into the exponent field.
+  // xmin = round(-126.5 * log(2), single, RU) ~ -87.68311309814453125
+  const float xmin = -0x1.5ebb82p6;
+  x = __riscv_vfmax_vf_f32m4(x, xmin, vl);
+
+  // 0. Reduction
+  const float r_ln2f = 0x1.715476p0f; // single(1/log(2));
+  const float l2uf = 0x1.62e4p-1f;    // round(log(2), 24-8, RN);
+  const float l2lf = 0x1.7f7d1cp-20f; // round(log(2) - l2uf, single, RN);
+  vfloat32m4_t v = __riscv_vfmul_vf_f32m4(x, r_ln2f, vl);
+
+  vint16m2_t q = __riscv_vfncvt_x_f_w_i16m2(v, vl);
+  vfloat32m4_t z = __riscv_vfwcvt_f_x_v_f32m4(q, vl);
+
+  vfloat32m4_t s = __riscv_vfnmsac_vf_f32m4(x, l2uf, z, vl);
+  s = __riscv_vfnmsac_vf_f32m4(s, l2lf, z, vl);
+
+  // 1. Approximate e^s
+  //
+  // sollya> l = log(2)/2; d = [-l;l];
+  // sollya> p = fpminimax(exp(x), 6, [|SG...|], d, relative, floating);
+  // sollya> supnorm(p, exp(x), d, relative, 1b-24);
+  // [0x1.fbad01f097cp-29;0x1.fbad03dc6759e11302p-29]
+  // sollya> display=decimal!; -log2(0x1.fbad03dc6759e11302p-29);
+  // 28.0122362050833425660857275511423589911147971511534
+  vfloat32m4_t u = eval_poly_horner(s, 0x1.6850e4p-10f, 0x1.123bccp-7, 0x1.555b98p-5f,
+                                    0x1.55548ep-3f, 0x1.fffff8p-2f, 1.0f, 1.0f, vl);
+
+  // 2. Reconstruction: compute u = u*2^q
+  const int16_t p = FLT_MANT_DIG;
+  const int16_t bias = FLT_MAX_EXP - 1;
+  vint32m4_t qw = __riscv_vwadd_vx_i32m4(q, bias, vl);
+  vint32m4_t qq = __riscv_vsll_vx_i32m4(qw, p - 1, vl);
+  vfloat32m4_t qf = __riscv_vreinterpret_v_i32m4_f32m4(qq);
+  u = __riscv_vfmul_vv_f32m4(u, qf, vl);
+  return u;
+}
+
+void iree_uk_softmax_tile_riscv_64_f32_1d(
+    const float* input_data,
+    float* output_data,
+    iree_uk_int32_t N) {
+    size_t avl, vl;
+    size_t current;
+    float beta = 1.0f;
+    // Find max element value which we'll use to ensure numerical stability
+    // taking advantage of the following equality:
+    // exp(x[i])/sum(exp(x[i])) == exp(x[i]+C)/sum(exp(x[i]+C))
+    const float max = fredmax_max(input_data, N);
+
+    // Compute sum
+    vfloat32m4_t v_add_data = __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvl_e32m4(N));
+    for (current = 0, avl = N; avl; avl -= vl, current += vl) {
+        vl = __riscv_vsetvl_e32m4(avl);
+        // Compute x = (input - max) * beta => x <= 0, exp(x) <= 1
+        vfloat32m4_t v_input_data = __riscv_vle32_v_f32m4(input_data + current, vl);
+        vfloat32m4_t v_exp_c = __riscv_vfsub_vf_f32m4(v_input_data, max, vl);
+        v_exp_c = __riscv_vfmul_vf_f32m4(v_exp_c, beta, vl);
+
+        v_exp_c = softexp_f32m4(v_exp_c, vl);
+
+        // store back exp(x) to output location and divide it by sum later
+        __riscv_vse32_v_f32m4(output_data + current, v_exp_c, vl);
+
+        // Transform the reduce sum sequences into multiple elementwise additions
+        // along with last reduce sum operation
+
+        // Use elemtwise add with tail-undisturbed (to handle the case where
+        // two inputs of differnet effective length do elementwise add)
+        v_add_data = __riscv_vfadd_vv_f32m4_tu(v_add_data, v_add_data, v_exp_c, vl);
+    }
+
+    // Unordered sum change the numerics, but it won't necessarily hurt accuracy
+    // (the inputs are in fact randomly distributed)
+    vfloat32m1_t v_sum_data = __riscv_vfmv_v_f_f32m1(0.0f, N);
+    v_sum_data = __riscv_vfredusum_vs_f32m4_f32m1(v_add_data, v_sum_data, __riscv_vsetvl_e32m4(N));
+
+    // The reduce sum is stored in v_sum_data[0]
+    const float sum = __riscv_vfmv_f_s_f32m1_f32(v_sum_data);
+    const float reciprocal_sum = 1.0 / sum;
+
+    // Compute result.
+    for (current = 0, avl = N; avl; avl -= vl, current += vl) {
+      vl = __riscv_vsetvl_e32m4(avl);
+      vfloat32m4_t v_exp_c = __riscv_vle32_v_f32m4(output_data + current, vl);
+      v_exp_c = __riscv_vfmul_vf_f32m4(v_exp_c, reciprocal_sum, vl);
+      __riscv_vse32_v_f32m4(output_data + current, v_exp_c, vl);
+    }
+}
+
+void iree_uk_softmax_tile_riscv_64_f32_rvv(
+    const void* IREE_UK_RESTRICT src_buffer,
+    void* IREE_UK_RESTRICT dst_buffer,
+    iree_uk_int32_t M,
+    iree_uk_int32_t N) {
+    int i;
+    int offset;
+    const float *input_data = (const float *)src_buffer;
+    float *output_data = (float *)dst_buffer;
+
+    for (i = 0, offset = 0; i < M; i++, offset += N) {
+        iree_uk_softmax_tile_riscv_64_f32_1d(input_data + offset, output_data + offset, N);
+    }
+}

--- a/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_rvv.c
+++ b/runtime/src/iree/builtins/ukernel/arch/riscv_64/softmax_riscv_64_rvv.c
@@ -4,35 +4,34 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <float.h>
+#include <riscv_vector.h>
+
 #include "iree/builtins/ukernel/arch/riscv_64/common_riscv_64.h"
 #include "iree/builtins/ukernel/softmax_internal.h"
 #include "iree/schemas/cpu_data.h"
 
-#include <riscv_vector.h>
-#include <float.h>
-
 static inline float fredmax_max(const float *input_data, size_t N) {
-    size_t avl;
-    size_t vl = __riscv_vsetvl_e32m8(N);
-    vfloat32m8_t t = __riscv_vle32_v_f32m8(input_data, vl);
-    input_data += vl;
+  size_t avl;
+  size_t vl = __riscv_vsetvl_e32m8(N);
+  vfloat32m8_t t = __riscv_vle32_v_f32m8(input_data, vl);
+  input_data += vl;
 
-    for (avl = N - vl; avl; avl -= vl, input_data += vl) {
-        vl = __riscv_vsetvl_e32m8(N);
-        vfloat32m8_t vec = __riscv_vle32_v_f32m8(input_data, vl);
-        t = __riscv_vfmax_vv_f32m8_tu(t, t, vec, vl);
-    }
+  for (avl = N - vl; avl; avl -= vl, input_data += vl) {
+    vl = __riscv_vsetvl_e32m8(N);
+    vfloat32m8_t vec = __riscv_vle32_v_f32m8(input_data, vl);
+    t = __riscv_vfmax_vv_f32m8_tu(t, t, vec, vl);
+  }
 
-    vfloat32m1_t f = __riscv_vfmv_s_f_f32m1(-FLT_MAX, 1);
-    f = __riscv_vfredmax_vs_f32m8_f32m1(t, f, N);
+  vfloat32m1_t f = __riscv_vfmv_s_f_f32m1(-FLT_MAX, 1);
+  f = __riscv_vfredmax_vs_f32m8_f32m1(t, f, N);
 
-    return __riscv_vfmv_f_s_f32m1_f32(f);
+  return __riscv_vfmv_f_s_f32m1_f32(f);
 }
 
-static inline vfloat32m4_t eval_poly_horner(vfloat32m4_t x,
-                                            float c6, float c5, float c4,
-                                            float c3, float c2, float c1,
-                                            float c0, size_t vl) {
+static inline vfloat32m4_t eval_poly_horner(vfloat32m4_t x, float c6, float c5,
+                                            float c4, float c3, float c2,
+                                            float c1, float c0, size_t vl) {
   vfloat32m4_t z;
   vfloat32m4_t y = __riscv_vfmv_v_f_f32m4(c5, vl);
   y = __riscv_vfmacc_vf_f32m4(y, c6, x, vl);
@@ -80,9 +79,9 @@ static inline vfloat32m4_t softexp_f32m4(vfloat32m4_t x, size_t vl) {
   x = __riscv_vfmax_vf_f32m4(x, xmin, vl);
 
   // 0. Reduction
-  const float r_ln2f = 0x1.715476p0f; // single(1/log(2));
-  const float l2uf = 0x1.62e4p-1f;    // round(log(2), 24-8, RN);
-  const float l2lf = 0x1.7f7d1cp-20f; // round(log(2) - l2uf, single, RN);
+  const float r_ln2f = 0x1.715476p0f;  // single(1/log(2));
+  const float l2uf = 0x1.62e4p-1f;     // round(log(2), 24-8, RN);
+  const float l2lf = 0x1.7f7d1cp-20f;  // round(log(2) - l2uf, single, RN);
   vfloat32m4_t v = __riscv_vfmul_vf_f32m4(x, r_ln2f, vl);
 
   vint16m2_t q = __riscv_vfncvt_x_f_w_i16m2(v, vl);
@@ -99,8 +98,9 @@ static inline vfloat32m4_t softexp_f32m4(vfloat32m4_t x, size_t vl) {
   // [0x1.fbad01f097cp-29;0x1.fbad03dc6759e11302p-29]
   // sollya> display=decimal!; -log2(0x1.fbad03dc6759e11302p-29);
   // 28.0122362050833425660857275511423589911147971511534
-  vfloat32m4_t u = eval_poly_horner(s, 0x1.6850e4p-10f, 0x1.123bccp-7, 0x1.555b98p-5f,
-                                    0x1.55548ep-3f, 0x1.fffff8p-2f, 1.0f, 1.0f, vl);
+  vfloat32m4_t u =
+      eval_poly_horner(s, 0x1.6850e4p-10f, 0x1.123bccp-7, 0x1.555b98p-5f,
+                       0x1.55548ep-3f, 0x1.fffff8p-2f, 1.0f, 1.0f, vl);
 
   // 2. Reconstruction: compute u = u*2^q
   const int16_t p = FLT_MANT_DIG;
@@ -112,69 +112,69 @@ static inline vfloat32m4_t softexp_f32m4(vfloat32m4_t x, size_t vl) {
   return u;
 }
 
-void iree_uk_softmax_tile_riscv_64_f32_1d(
-    const float* input_data,
-    float* output_data,
-    iree_uk_int32_t N) {
-    size_t avl, vl;
-    size_t current;
-    float beta = 1.0f;
-    // Find max element value which we'll use to ensure numerical stability
-    // taking advantage of the following equality:
-    // exp(x[i])/sum(exp(x[i])) == exp(x[i]+C)/sum(exp(x[i]+C))
-    const float max = fredmax_max(input_data, N);
+void iree_uk_softmax_tile_riscv_64_f32_1d(const float *input_data,
+                                          float *output_data,
+                                          iree_uk_int32_t N) {
+  size_t avl, vl;
+  size_t current;
+  float beta = 1.0f;
+  // Find max element value which we'll use to ensure numerical stability
+  // taking advantage of the following equality:
+  // exp(x[i])/sum(exp(x[i])) == exp(x[i]+C)/sum(exp(x[i]+C))
+  const float max = fredmax_max(input_data, N);
 
-    // Compute sum
-    vfloat32m4_t v_add_data = __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvl_e32m4(N));
-    for (current = 0, avl = N; avl; avl -= vl, current += vl) {
-        vl = __riscv_vsetvl_e32m4(avl);
-        // Compute x = (input - max) * beta => x <= 0, exp(x) <= 1
-        vfloat32m4_t v_input_data = __riscv_vle32_v_f32m4(input_data + current, vl);
-        vfloat32m4_t v_exp_c = __riscv_vfsub_vf_f32m4(v_input_data, max, vl);
-        v_exp_c = __riscv_vfmul_vf_f32m4(v_exp_c, beta, vl);
+  // Compute sum
+  vfloat32m4_t v_add_data =
+      __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvl_e32m4(N));
+  for (current = 0, avl = N; avl; avl -= vl, current += vl) {
+    vl = __riscv_vsetvl_e32m4(avl);
+    // Compute x = (input - max) * beta => x <= 0, exp(x) <= 1
+    vfloat32m4_t v_input_data = __riscv_vle32_v_f32m4(input_data + current, vl);
+    vfloat32m4_t v_exp_c = __riscv_vfsub_vf_f32m4(v_input_data, max, vl);
+    v_exp_c = __riscv_vfmul_vf_f32m4(v_exp_c, beta, vl);
 
-        v_exp_c = softexp_f32m4(v_exp_c, vl);
+    v_exp_c = softexp_f32m4(v_exp_c, vl);
 
-        // store back exp(x) to output location and divide it by sum later
-        __riscv_vse32_v_f32m4(output_data + current, v_exp_c, vl);
+    // store back exp(x) to output location and divide it by sum later
+    __riscv_vse32_v_f32m4(output_data + current, v_exp_c, vl);
 
-        // Transform the reduce sum sequences into multiple elementwise additions
-        // along with last reduce sum operation
+    // Transform the reduce sum sequences into multiple elementwise additions
+    // along with last reduce sum operation
 
-        // Use elemtwise add with tail-undisturbed (to handle the case where
-        // two inputs of differnet effective length do elementwise add)
-        v_add_data = __riscv_vfadd_vv_f32m4_tu(v_add_data, v_add_data, v_exp_c, vl);
-    }
+    // Use elemtwise add with tail-undisturbed (to handle the case where
+    // two inputs of differnet effective length do elementwise add)
+    v_add_data = __riscv_vfadd_vv_f32m4_tu(v_add_data, v_add_data, v_exp_c, vl);
+  }
 
-    // Unordered sum change the numerics, but it won't necessarily hurt accuracy
-    // (the inputs are in fact randomly distributed)
-    vfloat32m1_t v_sum_data = __riscv_vfmv_v_f_f32m1(0.0f, N);
-    v_sum_data = __riscv_vfredusum_vs_f32m4_f32m1(v_add_data, v_sum_data, __riscv_vsetvl_e32m4(N));
+  // Unordered sum change the numerics, but it won't necessarily hurt accuracy
+  // (the inputs are in fact randomly distributed)
+  vfloat32m1_t v_sum_data = __riscv_vfmv_v_f_f32m1(0.0f, N);
+  v_sum_data = __riscv_vfredusum_vs_f32m4_f32m1(v_add_data, v_sum_data,
+                                                __riscv_vsetvl_e32m4(N));
 
-    // The reduce sum is stored in v_sum_data[0]
-    const float sum = __riscv_vfmv_f_s_f32m1_f32(v_sum_data);
-    const float reciprocal_sum = 1.0 / sum;
+  // The reduce sum is stored in v_sum_data[0]
+  const float sum = __riscv_vfmv_f_s_f32m1_f32(v_sum_data);
+  const float reciprocal_sum = 1.0 / sum;
 
-    // Compute result.
-    for (current = 0, avl = N; avl; avl -= vl, current += vl) {
-      vl = __riscv_vsetvl_e32m4(avl);
-      vfloat32m4_t v_exp_c = __riscv_vle32_v_f32m4(output_data + current, vl);
-      v_exp_c = __riscv_vfmul_vf_f32m4(v_exp_c, reciprocal_sum, vl);
-      __riscv_vse32_v_f32m4(output_data + current, v_exp_c, vl);
-    }
+  // Compute result.
+  for (current = 0, avl = N; avl; avl -= vl, current += vl) {
+    vl = __riscv_vsetvl_e32m4(avl);
+    vfloat32m4_t v_exp_c = __riscv_vle32_v_f32m4(output_data + current, vl);
+    v_exp_c = __riscv_vfmul_vf_f32m4(v_exp_c, reciprocal_sum, vl);
+    __riscv_vse32_v_f32m4(output_data + current, v_exp_c, vl);
+  }
 }
 
 void iree_uk_softmax_tile_riscv_64_f32_rvv(
-    const void* IREE_UK_RESTRICT src_buffer,
-    void* IREE_UK_RESTRICT dst_buffer,
-    iree_uk_int32_t M,
-    iree_uk_int32_t N) {
-    int i;
-    int offset;
-    const float *input_data = (const float *)src_buffer;
-    float *output_data = (float *)dst_buffer;
+    const void *IREE_UK_RESTRICT src_buffer, void *IREE_UK_RESTRICT dst_buffer,
+    iree_uk_int32_t M, iree_uk_int32_t N) {
+  int i;
+  int offset;
+  const float *input_data = (const float *)src_buffer;
+  float *output_data = (float *)dst_buffer;
 
-    for (i = 0, offset = 0; i < M; i++, offset += N) {
-        iree_uk_softmax_tile_riscv_64_f32_1d(input_data + offset, output_data + offset, N);
-    }
+  for (i = 0, offset = 0; i < M; i++, offset += N) {
+    iree_uk_softmax_tile_riscv_64_f32_1d(input_data + offset,
+                                         output_data + offset, N);
+  }
 }

--- a/runtime/src/iree/builtins/ukernel/exported_bits.h
+++ b/runtime/src/iree/builtins/ukernel/exported_bits.h
@@ -113,4 +113,11 @@ IREE_UK_ENSURE_CONSISTENT_FLAG(IREE_UK_FLAG_MMT4D_ACCUMULATE);
 #define IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MATMUL_BF16BF16F32 0x0500
 #define IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MATMUL_BF16BF16BF16 0x0600
 
+//===----------------------------------------------------------------------===//
+// softmax
+//===----------------------------------------------------------------------===//
+#define IREE_UK_FLAG_SOFTMAX_TYPE_MASK 0xFF
+#define IREE_UK_FLAG_SOFTMAX_TYPE_NONE 0x00
+#define IREE_UK_FLAG_SOFTMAX_TYPE_F32 0x01
+
 #endif  // IREE_BUILTINS_UKERNEL_EXPORTED_BITS_H_

--- a/runtime/src/iree/builtins/ukernel/softmax.c
+++ b/runtime/src/iree/builtins/ukernel/softmax.c
@@ -4,8 +4,43 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <stddef.h>
 #include "iree/builtins/ukernel/softmax.h"
+#include "iree/builtins/ukernel/softmax_internal.h"
+
+static void iree_uk_softmax_validate(const iree_uk_softmax_params_t* params) {
+#ifdef IREE_UK_ENABLE_ASSERTS
+  const iree_uk_int32_t allflags = IREE_UK_FLAG_SOFTMAX_TYPE_MASK;
+  IREE_UK_ASSERT(!(params->flags & ~allflags));
+  iree_uk_uint32_t flags_type = params->flags & IREE_UK_FLAG_SOFTMAX_TYPE_MASK;
+  IREE_UK_ASSERT((flags_type == IREE_UK_FLAG_SOFTMAX_TYPE_F32));
+#endif
+}
+
+static bool iree_uk_softmax_early(const iree_uk_softmax_params_t* params) {
+  if (params->M == 0) {
+    return true;
+  }
+  return false;
+}
+
+static void iree_uk_softmax_using_tile_func(const iree_uk_softmax_params_t *params,
+                                            iree_uk_softmax_tile_func_t tile_func) {
+  const float *src_buffer = params->src_buffer;
+  float *dst_buffer = params->dst_buffer;
+  iree_uk_int32_t M = params->M;
+  iree_uk_int32_t N = params->N;
+
+  tile_func(src_buffer, dst_buffer, M, N);
+}
 
 IREE_UK_EXPORT int iree_uk_softmax(const iree_uk_softmax_params_t* params) {
+  iree_uk_softmax_validate(params);
+
+  if (iree_uk_softmax_early(params)) return 0;
+
+  iree_uk_softmax_tile_func_t tile_func = iree_uk_softmax_select_tile_func(params);
+  iree_uk_softmax_using_tile_func(params, tile_func);
+
   return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/softmax.c
+++ b/runtime/src/iree/builtins/ukernel/softmax.c
@@ -4,8 +4,10 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <stddef.h>
 #include "iree/builtins/ukernel/softmax.h"
+
+#include <stddef.h>
+
 #include "iree/builtins/ukernel/softmax_internal.h"
 
 static void iree_uk_softmax_validate(const iree_uk_softmax_params_t* params) {
@@ -24,10 +26,11 @@ static bool iree_uk_softmax_early(const iree_uk_softmax_params_t* params) {
   return false;
 }
 
-static void iree_uk_softmax_using_tile_func(const iree_uk_softmax_params_t *params,
-                                            iree_uk_softmax_tile_func_t tile_func) {
-  const float *src_buffer = params->src_buffer;
-  float *dst_buffer = params->dst_buffer;
+static void iree_uk_softmax_using_tile_func(
+    const iree_uk_softmax_params_t* params,
+    iree_uk_softmax_tile_func_t tile_func) {
+  const float* src_buffer = params->src_buffer;
+  float* dst_buffer = params->dst_buffer;
   iree_uk_int32_t M = params->M;
   iree_uk_int32_t N = params->N;
 
@@ -39,7 +42,8 @@ IREE_UK_EXPORT int iree_uk_softmax(const iree_uk_softmax_params_t* params) {
 
   if (iree_uk_softmax_early(params)) return 0;
 
-  iree_uk_softmax_tile_func_t tile_func = iree_uk_softmax_select_tile_func(params);
+  iree_uk_softmax_tile_func_t tile_func =
+      iree_uk_softmax_select_tile_func(params);
   iree_uk_softmax_using_tile_func(params, tile_func);
 
   return 0;

--- a/runtime/src/iree/builtins/ukernel/softmax.c
+++ b/runtime/src/iree/builtins/ukernel/softmax.c
@@ -1,0 +1,11 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/softmax.h"
+
+IREE_UK_EXPORT int iree_uk_softmax(const iree_uk_softmax_params_t* params) {
+  return 0;
+}

--- a/runtime/src/iree/builtins/ukernel/softmax.h
+++ b/runtime/src/iree/builtins/ukernel/softmax.h
@@ -12,15 +12,18 @@
 #ifdef __cplusplus
 extern "c" {
 #endif  // __cplusplus
-        //
-typedef struct iree_uk_softmax_params_t {
-        const void* src_buffer;
-        iree_uk_index_t in_M;
-        iree_uk_index_t in_N;
-        void* out_buffer;
-        iree_uk_index_t out_M;
-        iree_uk_index_t out_N;
 
+typedef struct iree_uk_softmax_params_t {
+  const void* src_buffer;
+  iree_uk_index_t src_offset;
+  iree_uk_index_t src_stride0;
+  void* dst_buffer;
+  iree_uk_index_t dst_offset;
+  iree_uk_index_t dst_stride0;
+  iree_uk_int32_t M;
+  iree_uk_int32_t N;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
 } iree_uk_softmax_params_t;
 
 IREE_UK_EXPORT int iree_uk_softmax(const iree_uk_softmax_params_t* params);

--- a/runtime/src/iree/builtins/ukernel/softmax.h
+++ b/runtime/src/iree/builtins/ukernel/softmax.h
@@ -1,0 +1,32 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_SOFTMAX_H_
+#define IREE_BUILTINS_UKERNEL_SOFTMAX_H_
+
+#include "iree/builtins/ukernel/common.h"
+
+#ifdef __cplusplus
+extern "c" {
+#endif  // __cplusplus
+        //
+typedef struct iree_uk_softmax_params_t {
+        const void* src_buffer;
+        iree_uk_index_t in_M;
+        iree_uk_index_t in_N;
+        void* out_buffer;
+        iree_uk_index_t out_M;
+        iree_uk_index_t out_N;
+
+} iree_uk_softmax_params_t;
+
+IREE_UK_EXPORT int iree_uk_softmax(const iree_uk_softmax_params_t* params);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BUILTINS_UKERNEL_SOFTMAX_H_

--- a/runtime/src/iree/builtins/ukernel/softmax_internal.h
+++ b/runtime/src/iree/builtins/ukernel/softmax_internal.h
@@ -10,33 +10,33 @@
 #include "iree/builtins/ukernel/softmax.h"
 
 typedef enum iree_uk_softmax_type_t {
-    iree_uk_softmax_type_f32 = IREE_UK_TYPE_FLOAT_32,
+  iree_uk_softmax_type_f32 = IREE_UK_TYPE_FLOAT_32,
 } iree_uk_softmax_type_t;
 
 static inline iree_uk_softmax_type_t iree_uk_softmax_type(
-        iree_uk_int32_t flags) {
-    switch (flags & IREE_UK_FLAG_SOFTMAX_TYPE_MASK) {
-        case IREE_UK_FLAG_SOFTMAX_TYPE_F32:
-            return iree_uk_softmax_type_f32;
-        default:
-            IREE_UK_ASSUME_UNREACHABLE;
-    }
+    iree_uk_int32_t flags) {
+  switch (flags & IREE_UK_FLAG_SOFTMAX_TYPE_MASK) {
+    case IREE_UK_FLAG_SOFTMAX_TYPE_F32:
+      return iree_uk_softmax_type_f32;
+    default:
+      IREE_UK_ASSUME_UNREACHABLE;
+  }
 }
 
 typedef void (*iree_uk_softmax_tile_func_t)(
-    const void* IREE_UK_RESTRICT src_buffer,
-    void* IREE_UK_RESTRICT out_buffer,
-    iree_uk_int32_t M,
-    iree_uk_int32_t N);
+    const void* IREE_UK_RESTRICT src_buffer, void* IREE_UK_RESTRICT out_buffer,
+    iree_uk_int32_t M, iree_uk_int32_t N);
 
-iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func(const iree_uk_softmax_params_t *params);
+iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func(
+    const iree_uk_softmax_params_t* params);
 
-iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func_arch(const iree_uk_softmax_params_t *params);
+iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func_arch(
+    const iree_uk_softmax_params_t* params);
 
 // Tile kernel declarations. Prototype matches iree_uk_softmax_tile_func_t.
-#define IREE_UK_SOFTMAX_TILE_FUNC_DECL(NAME)                             \
-  void NAME(const void* IREE_UK_RESTRICT src_buffer,                      \
-            void* IREE_UK_RESTRICT out_buffer,                 \
-            iree_uk_int32_t M, iree_uk_int32_t N);
+#define IREE_UK_SOFTMAX_TILE_FUNC_DECL(NAME)                      \
+  void NAME(const void* IREE_UK_RESTRICT src_buffer,              \
+            void* IREE_UK_RESTRICT out_buffer, iree_uk_int32_t M, \
+            iree_uk_int32_t N);
 
-#endif // IREE_BUILTINS_UKERNEL_SOFTMAX_INTERNAL_H_
+#endif  // IREE_BUILTINS_UKERNEL_SOFTMAX_INTERNAL_H_

--- a/runtime/src/iree/builtins/ukernel/softmax_internal.h
+++ b/runtime/src/iree/builtins/ukernel/softmax_internal.h
@@ -1,0 +1,28 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_SOFTMAX_INTERNAL_H_
+#define IREE_BUILTINS_UKERNEL_SOFTMAX_INTERNAL_H_
+
+#include "iree/builtins/ukernel/softmax.h"
+
+typedef void (*iree_uk_softmax_tile_func_t)(
+    const void* IREE_UK_RESTRICT src_buffer,
+    void* IREE_UK_RESTRICT out_buffer,
+    iree_uk_int32_t M,
+    iree_uk_int32_t N);
+
+iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func(const iree_uk_softmax_params_t *params);
+
+iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func_arch(const iree_uk_softmax_params_t *params);
+
+// Tile kernel declarations. Prototype matches iree_uk_softmax_tile_func_t.
+#define IREE_UK_SOFTMAX_TILE_FUNC_DECL(NAME)                             \
+  void NAME(const void* IREE_UK_RESTRICT src_buffer,                      \
+            void* IREE_UK_RESTRICT out_buffer,                 \
+            iree_uk_int32_t M, iree_uk_int32_t N);
+
+#endif // IREE_BUILTINS_UKERNEL_SOFTMAX_INTERNAL_H_

--- a/runtime/src/iree/builtins/ukernel/softmax_internal.h
+++ b/runtime/src/iree/builtins/ukernel/softmax_internal.h
@@ -9,6 +9,20 @@
 
 #include "iree/builtins/ukernel/softmax.h"
 
+typedef enum iree_uk_softmax_type_t {
+    iree_uk_softmax_type_f32 = IREE_UK_TYPE_FLOAT_32,
+} iree_uk_softmax_type_t;
+
+static inline iree_uk_softmax_type_t iree_uk_softmax_type(
+        iree_uk_int32_t flags) {
+    switch (flags & IREE_UK_FLAG_SOFTMAX_TYPE_MASK) {
+        case IREE_UK_FLAG_SOFTMAX_TYPE_F32:
+            return iree_uk_softmax_type_f32;
+        default:
+            IREE_UK_ASSUME_UNREACHABLE;
+    }
+}
+
 typedef void (*iree_uk_softmax_tile_func_t)(
     const void* IREE_UK_RESTRICT src_buffer,
     void* IREE_UK_RESTRICT out_buffer,

--- a/runtime/src/iree/builtins/ukernel/softmax_tile.c
+++ b/runtime/src/iree/builtins/ukernel/softmax_tile.c
@@ -1,0 +1,87 @@
+#include "iree/builtins/ukernel/softmax_internal.h"
+#include <stddef.h>
+#include <limits.h>
+#include <float.h>
+
+static double fabs1(double x) {
+    if(x >= 0){
+        return x;
+    } else {
+        return x*(-1);
+    }
+}
+
+static double powerex(double x) {
+    double a = 1.0, e = 0;
+    int invert = x<0;
+    x = fabs1(x);
+    for (int n = 1; e != e + a ; ++n) {
+        e += a;
+        a = a * x / n;
+    }
+    return invert ? 1/e : e;
+}
+
+// The softmax inner function for last dimension
+static void iree_uk_softmax_tile_float_1d(
+    const float* IREE_UK_RESTRICT src_buffer,
+    float* IREE_UK_RESTRICT dst_buffer,
+    iree_uk_int32_t N) {
+  float beta = 1.0;
+  size_t length = N;
+  const float *src = src_buffer;
+  float *dst = dst_buffer;
+  int c;
+
+  // Find max element value which we'll use to ensure numerical stability
+  // taking advantage of the following equality:
+  // exp(x[i])/sum(exp(x[i])) == exp(x[i]+C)/sum(exp(x[i]+C))
+  float max = -FLT_MAX;
+  for (c = 0; c < length; ++c) {
+    max = max > src[c] ? max : src[c];
+  }
+
+  // Compute sum.
+  float sum = 0.f;
+  for (c = 0; c < length; ++c) {
+    const float exp_c = powerex((double)((src[c] - max) * beta));
+    dst[c] = exp_c;
+    sum += exp_c;
+  }
+
+  const float reciprocal_sum = 1.0f / sum;
+
+  // Compute result.
+  for (c = 0; c < length; ++c) {
+    dst[c] = dst[c] * reciprocal_sum;
+  }
+
+}
+
+static void iree_uk_softmax_tile_generic(
+    const void* IREE_UK_RESTRICT src_buffer,
+    void* IREE_UK_RESTRICT dst_buffer,
+    iree_uk_int32_t M,
+    iree_uk_int32_t N) {
+  int i;
+  const float *src = src_buffer;
+  float *dst = dst_buffer;
+  iree_uk_int32_t offset;
+
+  for (i = 0, offset = 0; i < M; i++, offset += N) {
+    iree_uk_softmax_tile_float_1d(src + offset, dst + offset, N);
+  }
+}
+
+static iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func_generic(
+    const iree_uk_softmax_params_t* params) {
+  return iree_uk_softmax_tile_generic;
+}
+
+iree_uk_softmax_tile_func_t iree_uk_softmax_select_tile_func(
+    const iree_uk_softmax_params_t* params) {
+  iree_uk_softmax_tile_func_t arch_tile_func =
+      iree_uk_softmax_select_tile_func_arch(params);
+  if (arch_tile_func) return arch_tile_func;
+  return iree_uk_softmax_select_tile_func_generic(params);
+}

--- a/runtime/src/iree/builtins/ukernel/softmax_tile.c
+++ b/runtime/src/iree/builtins/ukernel/softmax_tile.c
@@ -1,36 +1,36 @@
-#include "iree/builtins/ukernel/softmax_internal.h"
-#include <stddef.h>
-#include <limits.h>
 #include <float.h>
+#include <limits.h>
+#include <stddef.h>
+
+#include "iree/builtins/ukernel/softmax_internal.h"
 
 static double fabs1(double x) {
-    if(x >= 0){
-        return x;
-    } else {
-        return x*(-1);
-    }
+  if (x >= 0) {
+    return x;
+  } else {
+    return x * (-1);
+  }
 }
 
 static double powerex(double x) {
-    double a = 1.0, e = 0;
-    int invert = x<0;
-    x = fabs1(x);
-    for (int n = 1; e != e + a ; ++n) {
-        e += a;
-        a = a * x / n;
-    }
-    return invert ? 1/e : e;
+  double a = 1.0, e = 0;
+  int invert = x < 0;
+  x = fabs1(x);
+  for (int n = 1; e != e + a; ++n) {
+    e += a;
+    a = a * x / n;
+  }
+  return invert ? 1 / e : e;
 }
 
 // The softmax inner function for last dimension
 static void iree_uk_softmax_tile_float_1d(
     const float* IREE_UK_RESTRICT src_buffer,
-    float* IREE_UK_RESTRICT dst_buffer,
-    iree_uk_int32_t N) {
+    float* IREE_UK_RESTRICT dst_buffer, iree_uk_int32_t N) {
   float beta = 1.0;
   size_t length = N;
-  const float *src = src_buffer;
-  float *dst = dst_buffer;
+  const float* src = src_buffer;
+  float* dst = dst_buffer;
   int c;
 
   // Find max element value which we'll use to ensure numerical stability
@@ -55,17 +55,14 @@ static void iree_uk_softmax_tile_float_1d(
   for (c = 0; c < length; ++c) {
     dst[c] = dst[c] * reciprocal_sum;
   }
-
 }
 
 static void iree_uk_softmax_tile_generic(
-    const void* IREE_UK_RESTRICT src_buffer,
-    void* IREE_UK_RESTRICT dst_buffer,
-    iree_uk_int32_t M,
-    iree_uk_int32_t N) {
+    const void* IREE_UK_RESTRICT src_buffer, void* IREE_UK_RESTRICT dst_buffer,
+    iree_uk_int32_t M, iree_uk_int32_t N) {
   int i;
-  const float *src = src_buffer;
-  float *dst = dst_buffer;
+  const float* src = src_buffer;
+  float* dst = dst_buffer;
   iree_uk_int32_t offset;
 
   for (i = 0, offset = 0; i < M; i++, offset += N) {

--- a/runtime/src/iree/builtins/ukernel/tools/BUILD.bazel
+++ b/runtime/src/iree/builtins/ukernel/tools/BUILD.bazel
@@ -174,3 +174,31 @@ cc_binary_benchmark(
         "//runtime/src/iree/testing:benchmark",
     ],
 )
+
+cc_binary_benchmark(
+    name = "softmax_benchmark",
+    srcs = ["softmax_benchmark.c"],
+    deps = [
+        ":benchmark",
+        ":util",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:flags",
+        "//runtime/src/iree/builtins/ukernel",
+        "//runtime/src/iree/builtins/ukernel:internal_headers",
+        "//runtime/src/iree/testing:benchmark",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "softmax_test",
+    srcs = ["softmax_test.c"],
+    deps = [
+        ":test",
+        ":util",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/internal:flags",
+        "//runtime/src/iree/builtins/ukernel",
+        "//runtime/src/iree/builtins/ukernel:internal_headers",
+    ],
+)

--- a/runtime/src/iree/builtins/ukernel/tools/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/tools/CMakeLists.txt
@@ -196,4 +196,35 @@ iree_cc_binary_benchmark(
   TESTONLY
 )
 
+iree_cc_binary_benchmark(
+  NAME
+    softmax_benchmark
+  SRCS
+    "softmax_benchmark.c"
+  DEPS
+    ::benchmark
+    ::util
+    iree::base
+    iree::base::internal::flags
+    iree::builtins::ukernel
+    iree::builtins::ukernel::internal_headers
+    iree::testing::benchmark
+  TESTONLY
+)
+
+iree_cc_test(
+  NAME
+    softmax_test
+  SRCS
+    "softmax_test.c"
+  DEPS
+    ::test
+    ::util
+    iree::base
+    iree::base::internal
+    iree::base::internal::flags
+    iree::builtins::ukernel
+    iree::builtins::ukernel::internal_headers
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/builtins/ukernel/tools/softmax_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/softmax_benchmark.c
@@ -1,0 +1,177 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdio.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/flags.h"
+#include "iree/builtins/ukernel/api.h"
+#include "iree/builtins/ukernel/pack_internal.h"
+#include "iree/builtins/ukernel/tools/benchmark.h"
+#include "iree/builtins/ukernel/tools/memcpy_benchmark.h"
+#include "iree/builtins/ukernel/tools/util.h"
+
+IREE_FLAG(
+    int64_t, working_set_size, 10000,
+    "Number of bytes to be traversed by the benchmark workload (input and "
+    "output buffers together). Matrix shapes are computed accordingly.");
+IREE_FLAG(
+    int32_t, padding_size, 0,
+    "Padding size (same value used for both dimensions, 0 means no padding)");
+
+static iree_status_t iree_uk_benchmark_pack(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  const iree_uk_benchmark_user_data_t* user_data = benchmark_def->user_data;
+  const iree_uk_pack_params_t* src_params = iree_uk_benchmark_params(user_data);
+  iree_uk_pack_params_t params;
+  memcpy(&params, src_params, sizeof params);
+  params.cpu_data = iree_uk_benchmark_cpu_data(user_data);
+  iree_uk_pack_type_t pack_type = iree_uk_pack_type(params.flags);
+  iree_uk_type_t in_type = iree_uk_pack_in_type(pack_type);
+  iree_uk_type_t out_type = iree_uk_pack_out_type(pack_type);
+  iree_uk_index_t in_type_size = iree_uk_type_size(in_type);
+  iree_uk_index_t out_type_size = iree_uk_type_size(out_type);
+
+  // The inner dims 2, 3 are given to us as part of the benchmark user_data.
+  // The outer dims 0, 1 are to be determined based on FLAG_working_set_size.
+  iree_uk_index_t out_size0 = 1;
+  iree_uk_index_t out_size1 = 1;
+  iree_uk_index_t out_size2 = params.out_size2;
+  iree_uk_index_t out_size3 = params.out_size3;
+  int target_matrix_size_in_elems =
+      FLAG_working_set_size / (in_type_size + out_type_size);
+  int target_product_of_outer_sizes_0_1 =
+      target_matrix_size_in_elems / (out_size2 * out_size3);
+  while (target_product_of_outer_sizes_0_1 >= 4) {
+    target_product_of_outer_sizes_0_1 /= 4;
+    out_size0 *= 2;
+    out_size1 *= 2;
+  }
+  out_size1 *= target_product_of_outer_sizes_0_1;
+  params.out_size0 = out_size0;
+  params.out_size1 = out_size1;
+  if (params.flags & IREE_UK_FLAG_PACK_TRANSPOSE_OUTER) {
+    iree_uk_index_swap(&out_size0, &out_size1);
+  }
+  if (params.flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER) {
+    iree_uk_index_swap(&out_size2, &out_size3);
+  }
+  params.in_size0 = iree_max(0, out_size0 * out_size2 - FLAG_padding_size);
+  params.in_size1 = iree_max(0, out_size1 * out_size3 - FLAG_padding_size);
+  params.in_stride0 = params.in_size1;
+  params.out_stride0 = params.out_size1 * params.out_size2 * params.out_size3;
+  iree_uk_index_t in_buffer_size =
+      iree_uk_2d_buffer_length(in_type, params.in_size0, params.in_stride0);
+  iree_uk_index_t out_buffer_size =
+      iree_uk_2d_buffer_length(out_type, params.out_size0, params.out_stride0);
+  void* in_buffer = malloc(in_buffer_size);
+  void* out_buffer = malloc(out_buffer_size);
+  iree_uk_random_engine_t* engine = iree_uk_benchmark_random_engine(user_data);
+  // It's just about plausible that on some platform, for some number type,
+  // performance might be different on zero buffers vs random buffers. But it
+  // shouldn't matter that we recreate the random engine every time, getting
+  // the same random values again.
+  iree_uk_write_random_buffer(in_buffer, in_buffer_size, in_type, engine);
+  iree_uk_write_random_buffer(out_buffer, out_buffer_size, out_type, engine);
+  // Test single-byte padding pattern, most common use case as 0.0f is 0 bytes.
+  params.in_buffer = in_buffer;
+  params.out_buffer = out_buffer;
+  params.padding_value = 0;
+  int64_t total_iterations = 0;
+  int64_t batch_count = 1;
+  while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
+    for (int i = 0; i < batch_count; ++i) {
+      iree_uk_pack(&params);
+    }
+    total_iterations += batch_count;
+    batch_count *= 2;
+  }
+  // Report bytes per second, so that can be easily compared to known memory
+  // system performance metrics (e.g. RAM bandwidth, to tell whether this is
+  // memory-bound).
+  iree_benchmark_set_bytes_processed(benchmark_state,
+                                     total_iterations * out_buffer_size);
+  free(in_buffer);
+  free(out_buffer);
+  return iree_ok_status();
+}
+
+static void iree_uk_benchmark_register_pack(iree_uk_uint32_t flags,
+                                            int tile_size0, int tile_size1,
+                                            const char* cpu_features) {
+  iree_uk_pack_type_t type = iree_uk_pack_type(flags);
+  char type_str[32];
+  iree_uk_type_pair_str(type_str, sizeof type_str, type);
+  iree_uk_pack_params_t params = {.out_size2 = tile_size0,
+                                  .out_size3 = tile_size1};
+  typedef struct pack_variant_t {
+    const char* label;
+    iree_uk_uint32_t flags;
+  } pack_variant_t;
+  const pack_variant_t variants[] = {
+      {"trnone", 0},
+      {"trinner", IREE_UK_FLAG_PACK_TRANSPOSE_INNER},
+      {"trouter", IREE_UK_FLAG_PACK_TRANSPOSE_OUTER},
+      {"trboth",
+       IREE_UK_FLAG_PACK_TRANSPOSE_INNER | IREE_UK_FLAG_PACK_TRANSPOSE_OUTER},
+  };
+  for (int i = 0; i < IREE_ARRAYSIZE(variants); ++i) {
+    pack_variant_t variant = variants[i];
+    char name[128];
+    snprintf(name, sizeof name, "pack_%s_tile_%dx%d_%s_wss_%" PRIi64, type_str,
+             tile_size0, tile_size1, variant.label, FLAG_working_set_size);
+    params.flags = flags | variant.flags;
+    iree_uk_benchmark_register(name, iree_uk_benchmark_pack, &params,
+                               sizeof params, cpu_features);
+  }
+}
+
+int main(int argc, char** argv) {
+  /*
+  iree_flags_set_usage("pack_benchmark", "");
+
+  iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_UNDEFINED_OK, &argc, &argv);
+  iree_uk_benchmark_initialize(&argc, argv);
+
+  // The memcpy benchmark provides a useful comparison point, as pack is fairly
+  // close to memory-bound.
+  iree_uk_benchmark_register_memcpy(FLAG_working_set_size);
+
+#if defined(IREE_ARCH_ARM_64)
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, "");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, "");
+  // Tile size selected with cpu feature "dotprod".
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 4, "");
+  // Tile size selected with cpu feature "i8mm".
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 8, "");
+#elif defined(IREE_ARCH_X86_64)
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1,
+                                  "avx2_fma");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 16, 1,
+                                  "avx512_base");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 8,
+                                  "avx2_fma");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 16, 16,
+                                  "avx512_base");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 2,
+                                  "avx2_fma");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 16, 2,
+                                  "avx512_base");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 8, 8,
+                                  "avx2_fma");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 16, 16,
+                                  "avx512_base");
+#else   // defined(IREE_ARCH_ARM_64)
+  // Architectures on which we do not have any optimized ukernel code.
+  // Benchmark some arbitrary tile shape.
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, "");
+  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, "");
+#endif  // defined(IREE_ARCH_ARM_64)
+
+  iree_uk_benchmark_run_and_cleanup();
+  */
+}

--- a/runtime/src/iree/builtins/ukernel/tools/softmax_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/softmax_benchmark.c
@@ -17,7 +17,8 @@ static iree_status_t iree_uk_benchmark_softmax(
     const iree_benchmark_def_t* benchmark_def,
     iree_benchmark_state_t* benchmark_state) {
   const iree_uk_benchmark_user_data_t* user_data = benchmark_def->user_data;
-  const iree_uk_softmax_params_t* src_params = iree_uk_benchmark_params(user_data);
+  const iree_uk_softmax_params_t* src_params =
+      iree_uk_benchmark_params(user_data);
   iree_uk_softmax_params_t params;
   memcpy(&params, src_params, sizeof params);
   params.cpu_data = iree_uk_benchmark_cpu_data(user_data);
@@ -26,8 +27,8 @@ static iree_status_t iree_uk_benchmark_softmax(
   iree_uk_int32_t N = params.N;
   iree_uk_softmax_type_t softmax_type = iree_uk_softmax_type(params.flags);
   iree_uk_index_t buffer_size = iree_uk_2d_buffer_length(softmax_type, M, N);
-  void *src_buffer = malloc(buffer_size);
-  void *dst_buffer = malloc(buffer_size);
+  void* src_buffer = malloc(buffer_size);
+  void* dst_buffer = malloc(buffer_size);
   iree_uk_random_engine_t* engine = iree_uk_benchmark_random_engine(user_data);
   // It's just about plausible that on some platform, for some number type,
   // performance might be different on zero buffers vs random buffers. But it
@@ -48,25 +49,23 @@ static iree_status_t iree_uk_benchmark_softmax(
   }
 
   iree_benchmark_set_bytes_processed(benchmark_state,
-                                    total_iterations * buffer_size);
+                                     total_iterations * buffer_size);
 
   free(src_buffer);
   free(dst_buffer);
   return iree_ok_status();
 }
 
-static void iree_uk_benchmark_register_softmax(iree_uk_uint32_t flags,
-                                            int M, int N,
-                                            const char* cpu_features) {
+static void iree_uk_benchmark_register_softmax(iree_uk_uint32_t flags, int M,
+                                               int N,
+                                               const char* cpu_features) {
   iree_uk_softmax_type_t type = iree_uk_softmax_type(flags);
   char type_str[32];
   iree_uk_type_str(type_str, sizeof type_str, type);
-  iree_uk_softmax_params_t params = {.M = M,
-                                  .N = N};
+  iree_uk_softmax_params_t params = {.M = M, .N = N};
 
   char name[128];
-  snprintf(name, sizeof name, "softmax_%s_tile_%dx%d", type_str,
-           M, N);
+  snprintf(name, sizeof name, "softmax_%s_tile_%dx%d", type_str, M, N);
   params.flags = flags;
   iree_uk_benchmark_register(name, iree_uk_benchmark_softmax, &params,
                              sizeof params, cpu_features);

--- a/runtime/src/iree/builtins/ukernel/tools/softmax_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/softmax_benchmark.c
@@ -1,4 +1,4 @@
-// Copyright 2022 The IREE Authors
+// Copyright 2023 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,169 +9,82 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/flags.h"
 #include "iree/builtins/ukernel/api.h"
-#include "iree/builtins/ukernel/pack_internal.h"
+#include "iree/builtins/ukernel/softmax_internal.h"
 #include "iree/builtins/ukernel/tools/benchmark.h"
-#include "iree/builtins/ukernel/tools/memcpy_benchmark.h"
 #include "iree/builtins/ukernel/tools/util.h"
 
-IREE_FLAG(
-    int64_t, working_set_size, 10000,
-    "Number of bytes to be traversed by the benchmark workload (input and "
-    "output buffers together). Matrix shapes are computed accordingly.");
-IREE_FLAG(
-    int32_t, padding_size, 0,
-    "Padding size (same value used for both dimensions, 0 means no padding)");
-
-static iree_status_t iree_uk_benchmark_pack(
+static iree_status_t iree_uk_benchmark_softmax(
     const iree_benchmark_def_t* benchmark_def,
     iree_benchmark_state_t* benchmark_state) {
   const iree_uk_benchmark_user_data_t* user_data = benchmark_def->user_data;
-  const iree_uk_pack_params_t* src_params = iree_uk_benchmark_params(user_data);
-  iree_uk_pack_params_t params;
+  const iree_uk_softmax_params_t* src_params = iree_uk_benchmark_params(user_data);
+  iree_uk_softmax_params_t params;
   memcpy(&params, src_params, sizeof params);
   params.cpu_data = iree_uk_benchmark_cpu_data(user_data);
-  iree_uk_pack_type_t pack_type = iree_uk_pack_type(params.flags);
-  iree_uk_type_t in_type = iree_uk_pack_in_type(pack_type);
-  iree_uk_type_t out_type = iree_uk_pack_out_type(pack_type);
-  iree_uk_index_t in_type_size = iree_uk_type_size(in_type);
-  iree_uk_index_t out_type_size = iree_uk_type_size(out_type);
 
-  // The inner dims 2, 3 are given to us as part of the benchmark user_data.
-  // The outer dims 0, 1 are to be determined based on FLAG_working_set_size.
-  iree_uk_index_t out_size0 = 1;
-  iree_uk_index_t out_size1 = 1;
-  iree_uk_index_t out_size2 = params.out_size2;
-  iree_uk_index_t out_size3 = params.out_size3;
-  int target_matrix_size_in_elems =
-      FLAG_working_set_size / (in_type_size + out_type_size);
-  int target_product_of_outer_sizes_0_1 =
-      target_matrix_size_in_elems / (out_size2 * out_size3);
-  while (target_product_of_outer_sizes_0_1 >= 4) {
-    target_product_of_outer_sizes_0_1 /= 4;
-    out_size0 *= 2;
-    out_size1 *= 2;
-  }
-  out_size1 *= target_product_of_outer_sizes_0_1;
-  params.out_size0 = out_size0;
-  params.out_size1 = out_size1;
-  if (params.flags & IREE_UK_FLAG_PACK_TRANSPOSE_OUTER) {
-    iree_uk_index_swap(&out_size0, &out_size1);
-  }
-  if (params.flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER) {
-    iree_uk_index_swap(&out_size2, &out_size3);
-  }
-  params.in_size0 = iree_max(0, out_size0 * out_size2 - FLAG_padding_size);
-  params.in_size1 = iree_max(0, out_size1 * out_size3 - FLAG_padding_size);
-  params.in_stride0 = params.in_size1;
-  params.out_stride0 = params.out_size1 * params.out_size2 * params.out_size3;
-  iree_uk_index_t in_buffer_size =
-      iree_uk_2d_buffer_length(in_type, params.in_size0, params.in_stride0);
-  iree_uk_index_t out_buffer_size =
-      iree_uk_2d_buffer_length(out_type, params.out_size0, params.out_stride0);
-  void* in_buffer = malloc(in_buffer_size);
-  void* out_buffer = malloc(out_buffer_size);
+  iree_uk_int32_t M = params.M;
+  iree_uk_int32_t N = params.N;
+  iree_uk_softmax_type_t softmax_type = iree_uk_softmax_type(params.flags);
+  iree_uk_index_t buffer_size = iree_uk_2d_buffer_length(softmax_type, M, N);
+  void *src_buffer = malloc(buffer_size);
+  void *dst_buffer = malloc(buffer_size);
   iree_uk_random_engine_t* engine = iree_uk_benchmark_random_engine(user_data);
   // It's just about plausible that on some platform, for some number type,
   // performance might be different on zero buffers vs random buffers. But it
   // shouldn't matter that we recreate the random engine every time, getting
   // the same random values again.
-  iree_uk_write_random_buffer(in_buffer, in_buffer_size, in_type, engine);
-  iree_uk_write_random_buffer(out_buffer, out_buffer_size, out_type, engine);
-  // Test single-byte padding pattern, most common use case as 0.0f is 0 bytes.
-  params.in_buffer = in_buffer;
-  params.out_buffer = out_buffer;
-  params.padding_value = 0;
+  iree_uk_write_random_buffer(src_buffer, buffer_size, softmax_type, engine);
+
+  params.src_buffer = src_buffer;
+  params.dst_buffer = dst_buffer;
   int64_t total_iterations = 0;
   int64_t batch_count = 1;
   while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
     for (int i = 0; i < batch_count; ++i) {
-      iree_uk_pack(&params);
+      iree_uk_softmax(&params);
     }
     total_iterations += batch_count;
     batch_count *= 2;
   }
-  // Report bytes per second, so that can be easily compared to known memory
-  // system performance metrics (e.g. RAM bandwidth, to tell whether this is
-  // memory-bound).
+
   iree_benchmark_set_bytes_processed(benchmark_state,
-                                     total_iterations * out_buffer_size);
-  free(in_buffer);
-  free(out_buffer);
+                                    total_iterations * buffer_size);
+
+  free(src_buffer);
+  free(dst_buffer);
   return iree_ok_status();
 }
 
-static void iree_uk_benchmark_register_pack(iree_uk_uint32_t flags,
-                                            int tile_size0, int tile_size1,
+static void iree_uk_benchmark_register_softmax(iree_uk_uint32_t flags,
+                                            int M, int N,
                                             const char* cpu_features) {
-  iree_uk_pack_type_t type = iree_uk_pack_type(flags);
+  iree_uk_softmax_type_t type = iree_uk_softmax_type(flags);
   char type_str[32];
-  iree_uk_type_pair_str(type_str, sizeof type_str, type);
-  iree_uk_pack_params_t params = {.out_size2 = tile_size0,
-                                  .out_size3 = tile_size1};
-  typedef struct pack_variant_t {
-    const char* label;
-    iree_uk_uint32_t flags;
-  } pack_variant_t;
-  const pack_variant_t variants[] = {
-      {"trnone", 0},
-      {"trinner", IREE_UK_FLAG_PACK_TRANSPOSE_INNER},
-      {"trouter", IREE_UK_FLAG_PACK_TRANSPOSE_OUTER},
-      {"trboth",
-       IREE_UK_FLAG_PACK_TRANSPOSE_INNER | IREE_UK_FLAG_PACK_TRANSPOSE_OUTER},
-  };
-  for (int i = 0; i < IREE_ARRAYSIZE(variants); ++i) {
-    pack_variant_t variant = variants[i];
-    char name[128];
-    snprintf(name, sizeof name, "pack_%s_tile_%dx%d_%s_wss_%" PRIi64, type_str,
-             tile_size0, tile_size1, variant.label, FLAG_working_set_size);
-    params.flags = flags | variant.flags;
-    iree_uk_benchmark_register(name, iree_uk_benchmark_pack, &params,
-                               sizeof params, cpu_features);
-  }
+  iree_uk_type_str(type_str, sizeof type_str, type);
+  iree_uk_softmax_params_t params = {.M = M,
+                                  .N = N};
+
+  char name[128];
+  snprintf(name, sizeof name, "softmax_%s_tile_%dx%d", type_str,
+           M, N);
+  params.flags = flags;
+  iree_uk_benchmark_register(name, iree_uk_benchmark_softmax, &params,
+                             sizeof params, cpu_features);
 }
 
 int main(int argc, char** argv) {
-  /*
-  iree_flags_set_usage("pack_benchmark", "");
+  iree_flags_set_usage("softmax_benchmark", "");
 
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_UNDEFINED_OK, &argc, &argv);
   iree_uk_benchmark_initialize(&argc, argv);
 
-  // The memcpy benchmark provides a useful comparison point, as pack is fairly
-  // close to memory-bound.
-  iree_uk_benchmark_register_memcpy(FLAG_working_set_size);
-
-#if defined(IREE_ARCH_ARM_64)
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, "");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, "");
-  // Tile size selected with cpu feature "dotprod".
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 4, "");
-  // Tile size selected with cpu feature "i8mm".
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 8, "");
-#elif defined(IREE_ARCH_X86_64)
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1,
-                                  "avx2_fma");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 16, 1,
-                                  "avx512_base");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 8,
-                                  "avx2_fma");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 16, 16,
-                                  "avx512_base");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 2,
-                                  "avx2_fma");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 16, 2,
-                                  "avx512_base");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 8, 8,
-                                  "avx2_fma");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I32I32, 16, 16,
-                                  "avx512_base");
-#else   // defined(IREE_ARCH_ARM_64)
+#if defined(IREE_ARCH_RISCV_64)
+  iree_uk_benchmark_register_softmax(IREE_UK_FLAG_SOFTMAX_TYPE_F32, 8, 128, "");
+#else
   // Architectures on which we do not have any optimized ukernel code.
   // Benchmark some arbitrary tile shape.
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_F32F32, 8, 1, "");
-  iree_uk_benchmark_register_pack(IREE_UK_FLAG_PACK_TYPE_I8I8, 8, 1, "");
-#endif  // defined(IREE_ARCH_ARM_64)
+  iree_uk_benchmark_register_softmax(IREE_UK_FLAG_SOFTMAX_TYPE_F32, 8, 128, "");
+#endif  // defined(IREE_ARCH_RISCV_64)
 
   iree_uk_benchmark_run_and_cleanup();
-  */
 }

--- a/runtime/src/iree/builtins/ukernel/tools/softmax_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/softmax_test.c
@@ -8,15 +8,15 @@
 
 #include "iree/base/api.h"
 #include "iree/builtins/ukernel/api.h"
+#include "iree/builtins/ukernel/softmax_internal.h"
 #include "iree/builtins/ukernel/tools/test.h"
 #include "iree/builtins/ukernel/tools/util.h"
-#include "iree/builtins/ukernel/softmax_internal.h"
 
 #define IREE_UK_SOFTMAX_RELATIVE_ERROR 0x1p-14
 
 static void iree_softmax_reference(const iree_uk_softmax_params_t* params) {
-  const float *src_buffer = params->src_buffer;
-  float *dst_buffer = params->dst_buffer;
+  const float* src_buffer = params->src_buffer;
+  float* dst_buffer = params->dst_buffer;
   int M = params->M, N = params->N;
   int i, j;
   double sum;
@@ -35,7 +35,7 @@ static void iree_softmax_reference(const iree_uk_softmax_params_t* params) {
 }
 
 static void iree_uk_test_softmax_for_params(iree_uk_test_t* test,
-                                                const void* src_params) {
+                                            const void* src_params) {
   iree_uk_softmax_params_t params;
   memcpy(&params, src_params, sizeof(params));
   iree_uk_softmax_params_t reference_params;
@@ -49,7 +49,8 @@ static void iree_uk_test_softmax_for_params(iree_uk_test_t* test,
   float* reference_dst_buffer = malloc(buffer_size * sizeof(float));
   int i, j;
 
-  // Set all elements in last dimension to 1, the output of each element will be 1/N
+  // Set all elements in last dimension to 1, the output of each element will be
+  // 1/N
   iree_uk_random_engine_t* engine = iree_uk_test_random_engine(test);
   for (i = 0; i < M; i++) {
     for (j = 0; j < N; j++) {
@@ -65,8 +66,8 @@ static void iree_uk_test_softmax_for_params(iree_uk_test_t* test,
   iree_uk_softmax(&params);
   iree_softmax_reference(&reference_params);
 
-  if (!iree_uk_buffers_equal_f32(dst_buffer, reference_dst_buffer,
-        buffer_size, IREE_UK_SOFTMAX_RELATIVE_ERROR)) {
+  if (!iree_uk_buffers_equal_f32(dst_buffer, reference_dst_buffer, buffer_size,
+                                 IREE_UK_SOFTMAX_RELATIVE_ERROR)) {
     IREE_UK_TEST_FAIL(test);
   }
 
@@ -75,20 +76,19 @@ static void iree_uk_test_softmax_for_params(iree_uk_test_t* test,
   free(reference_dst_buffer);
 }
 
-static void iree_uk_test_softmax(iree_uk_uint32_t flags, int M,
-                                int N, const char* cpu_features) {
-  iree_uk_softmax_params_t params = {
-      .flags = flags, .M = M, .N = N};
+static void iree_uk_test_softmax(iree_uk_uint32_t flags, int M, int N,
+                                 const char* cpu_features) {
+  iree_uk_softmax_params_t params = {.flags = flags, .M = M, .N = N};
 
   char types_str[32];
   iree_uk_softmax_type_t softmax_type = iree_uk_softmax_type(flags);
   iree_uk_type_str(types_str, sizeof types_str, softmax_type);
   char test_label_str[256];
   snprintf(test_label_str, sizeof test_label_str, "types:%s tile:%dx%d",
-      types_str, M, N);
-  iree_uk_test(test_label_str, iree_uk_test_softmax_for_params, &params, cpu_features);
+           types_str, M, N);
+  iree_uk_test(test_label_str, iree_uk_test_softmax_for_params, &params,
+               cpu_features);
 }
-
 
 int main(int argc, char** argv) {
   // Generic tests, not matching any particular CPU feature. This is the place

--- a/runtime/src/iree/builtins/ukernel/tools/softmax_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/softmax_test.c
@@ -1,0 +1,103 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <math.h>
+
+#include "iree/base/api.h"
+#include "iree/builtins/ukernel/api.h"
+#include "iree/builtins/ukernel/tools/test.h"
+#include "iree/builtins/ukernel/tools/util.h"
+#include "iree/builtins/ukernel/softmax_internal.h"
+
+#define IREE_UK_SOFTMAX_RELATIVE_ERROR 0x1p-14
+
+static void iree_softmax_reference(const iree_uk_softmax_params_t* params) {
+  const float *src_buffer = params->src_buffer;
+  float *dst_buffer = params->dst_buffer;
+  int M = params->M, N = params->N;
+  int i, j;
+  double sum;
+
+  for (i = 0; i < M; i++) {
+    sum = 0;
+    for (j = 0; j < N; j++) {
+      double e = exp(src_buffer[i * N + j]);
+      sum += e;
+      dst_buffer[i * N + j] = e;
+    }
+    for (j = 0; j < N; j++) {
+      dst_buffer[i * N + j] = dst_buffer[i * N + j] / sum;
+    }
+  }
+}
+
+static void iree_uk_test_softmax_for_params(iree_uk_test_t* test,
+                                                const void* src_params) {
+  iree_uk_softmax_params_t params;
+  memcpy(&params, src_params, sizeof(params));
+  iree_uk_softmax_params_t reference_params;
+  memcpy(&reference_params, src_params, sizeof(params));
+
+  iree_uk_int32_t M = params.M;
+  iree_uk_int32_t N = params.N;
+  iree_uk_int32_t buffer_size = M * N;
+  float* src_buffer = malloc(buffer_size * sizeof(float));
+  float* dst_buffer = malloc(buffer_size * sizeof(float));
+  float* reference_dst_buffer = malloc(buffer_size * sizeof(float));
+  int i, j;
+
+  // Set all elements in last dimension to 1, the output of each element will be 1/N
+  iree_uk_random_engine_t* engine = iree_uk_test_random_engine(test);
+  for (i = 0; i < M; i++) {
+    for (j = 0; j < N; j++) {
+      src_buffer[i * M + j] = iree_uk_random_engine_get_minus16_plus15(engine);
+    }
+  }
+
+  params.src_buffer = src_buffer;
+  params.dst_buffer = dst_buffer;
+  reference_params.src_buffer = src_buffer;
+  reference_params.dst_buffer = reference_dst_buffer;
+
+  iree_uk_softmax(&params);
+  iree_softmax_reference(&reference_params);
+
+  if (!iree_uk_buffers_equal_f32(dst_buffer, reference_dst_buffer,
+        buffer_size, IREE_UK_SOFTMAX_RELATIVE_ERROR)) {
+    IREE_UK_TEST_FAIL(test);
+  }
+
+  free(src_buffer);
+  free(dst_buffer);
+  free(reference_dst_buffer);
+}
+
+static void iree_uk_test_softmax(iree_uk_uint32_t flags, int M,
+                                int N, const char* cpu_features) {
+  iree_uk_softmax_params_t params = {
+      .flags = flags, .M = M, .N = N};
+
+  char types_str[32];
+  iree_uk_softmax_type_t softmax_type = iree_uk_softmax_type(flags);
+  iree_uk_type_str(types_str, sizeof types_str, softmax_type);
+  char test_label_str[256];
+  snprintf(test_label_str, sizeof test_label_str, "types:%s tile:%dx%d",
+      types_str, M, N);
+  iree_uk_test(test_label_str, iree_uk_test_softmax_for_params, &params, cpu_features);
+}
+
+
+int main(int argc, char** argv) {
+  // Generic tests, not matching any particular CPU feature. This is the place
+  // to test weird tile shapes to ensure e.g. that we haven't unwittingly baked
+  // in a power-of-two assumption
+  iree_uk_test_softmax(IREE_UK_FLAG_SOFTMAX_TYPE_F32, 3, 5, "");
+
+#if defined(IREE_ARCH_RISCV_64)
+  iree_uk_test_softmax(IREE_UK_FLAG_SOFTMAX_TYPE_F32, 3, 5, "rvv");
+#endif  // defined(IREE_ARCH_RISCV_64)
+  return iree_uk_test_exit_status();
+}

--- a/runtime/src/iree/builtins/ukernel/tools/util.c
+++ b/runtime/src/iree/builtins/ukernel/tools/util.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #include "iree/base/api.h"
 #include "iree/base/internal/call_once.h"
@@ -47,6 +48,18 @@ bool iree_uk_2d_buffers_equal(const void* buf1, const void* buf2,
     if (memcmp(buf1_ptr, buf2_ptr, elem_size * size1)) return false;
     buf1_ptr += elem_size * stride0;
     buf2_ptr += elem_size * stride0;
+  }
+  return true;
+}
+
+bool iree_uk_buffers_equal_f32(const float* buf1, const float* buf2,
+                              iree_uk_index_t size, float relative_error) {
+  int i;
+
+  for (i = 0; i < size; i++) {
+    if (fabs(buf1[i] - buf2[i]) > relative_error) {
+      return false;
+    }
   }
   return true;
 }

--- a/runtime/src/iree/builtins/ukernel/tools/util.c
+++ b/runtime/src/iree/builtins/ukernel/tools/util.c
@@ -6,11 +6,11 @@
 
 #include "iree/builtins/ukernel/tools/util.h"
 
+#include <math.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 
 #include "iree/base/api.h"
 #include "iree/base/internal/call_once.h"
@@ -53,7 +53,7 @@ bool iree_uk_2d_buffers_equal(const void* buf1, const void* buf2,
 }
 
 bool iree_uk_buffers_equal_f32(const float* buf1, const float* buf2,
-                              iree_uk_index_t size, float relative_error) {
+                               iree_uk_index_t size, float relative_error) {
   int i;
 
   for (i = 0; i < size; i++) {

--- a/runtime/src/iree/builtins/ukernel/tools/util.h
+++ b/runtime/src/iree/builtins/ukernel/tools/util.h
@@ -18,6 +18,9 @@ bool iree_uk_2d_buffers_equal(const void* buf1, const void* buf2,
                               iree_uk_type_t type, iree_uk_index_t size0,
                               iree_uk_index_t size1, iree_uk_index_t stride0);
 
+bool iree_uk_buffers_equal_f32(const float* buf1, const float* buf2,
+                               iree_uk_index_t size, float relative_error);
+
 // Simple deterministic pseudorandom generator. Same as C++'s std::minstd_rand.
 typedef struct iree_uk_random_engine_t {
   iree_uk_uint32_t state;

--- a/runtime/src/iree/builtins/ukernel/weak.c
+++ b/runtime/src/iree/builtins/ukernel/weak.c
@@ -7,8 +7,8 @@
 #include "iree/builtins/ukernel/mmt4d_internal.h"
 #include "iree/builtins/ukernel/pack_internal.h"
 #include "iree/builtins/ukernel/query_tile_sizes_internal.h"
-#include "iree/builtins/ukernel/unpack_internal.h"
 #include "iree/builtins/ukernel/softmax_internal.h"
+#include "iree/builtins/ukernel/unpack_internal.h"
 
 #if defined(IREE_UK_HAVE_WEAK)
 

--- a/runtime/src/iree/builtins/ukernel/weak.c
+++ b/runtime/src/iree/builtins/ukernel/weak.c
@@ -8,6 +8,7 @@
 #include "iree/builtins/ukernel/pack_internal.h"
 #include "iree/builtins/ukernel/query_tile_sizes_internal.h"
 #include "iree/builtins/ukernel/unpack_internal.h"
+#include "iree/builtins/ukernel/softmax_internal.h"
 
 #if defined(IREE_UK_HAVE_WEAK)
 
@@ -32,4 +33,8 @@ IREE_UK_WEAK bool iree_uk_query_matmul_tile_sizes_arch(
   return false;
 }
 
+IREE_UK_WEAK iree_uk_softmax_tile_func_t
+iree_uk_softmax_select_tile_func_arch(const iree_uk_softmax_params_t* params) {
+  return 0;
+}
 #endif  // defined(IREE_UK_HAVE_WEAK)

--- a/runtime/src/iree/schemas/cpu_feature_bits.inl
+++ b/runtime/src/iree/schemas/cpu_feature_bits.inl
@@ -114,3 +114,11 @@ IREE_CPU_FEATURE_BIT(X86_64, 0, 32, AVX512FP16, "avx512fp16")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 50, AMXTILE, "amx-tile")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 51, AMXINT8, "amx-int8")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 52, AMXBF16, "amx-bf16")
+
+//===----------------------------------------------------------------------===//
+// IREE_ARCH_RISCV_64 / riscv64
+//===----------------------------------------------------------------------===//
+
+// General features and high-level switches.
+// RVV: riscv vector.
+IREE_CPU_FEATURE_BIT(RISCV_64, 0, 0, RVV, "rvv")


### PR DESCRIPTION
# Description
This patch adds softmax f32 ukernel for riscv64.
The softmax ukernel is lowering from linalg.softmax.

On 12x128x40960xf32 test case, the ukernel can improve the performance about 50% with single thread and about 70% with multithread. For the mobilebert f32 model, it can improve the performance about 30%.

The DecomposeSoftmaxPass is moved out from addCommonTargetExecutablePreprocessPass so the linalg.softmax op will not be decomposed.

# Discussion
1. Seems can't easily use `check_cxx_compiler_flag` to check riscv v extension, I enable v extension in `riscv.toolchain.cmake` currently.

2. Currently, we can't use the hwprobe in linux so I parse `/proc/cpuinfo` to check whether the CPU supports the v extension.
(Ps. the riscv hwprobe is available after 6.5)

3. The `LLVMCPULowerToUKernelsPass` is added to `addCPUDefaultPassPipeline`, is it better to put in another place?
