### PR TITLE
[docs] Add instructions for printing iree SHA from venv

### DIFF
--- a/docs/developers/debugging/releases.md
+++ b/docs/developers/debugging/releases.md
@@ -10,6 +10,26 @@
   locally, just symlink your source dir as `c` in an empty
   directory (versus checking out).
 
+## Mapping releases back to git commits
+
+The source IREE commit SHA is embeded into pip releases in a few places.
+Starting in a python venv, you can find the IREE commit from both the shell:
+
+```shell
+"$(find . -name 'iree-compile' -executable)" --version
+IREE (https://openxla.github.io/iree):
+  IREE compiler version 20231016.553 @ f1cb2692a086738d7f16274b9b3af6d2c15ef133
+  LLVM version 18.0.0git
+  Optimized build
+```
+
+and the Python API:
+
+```shell
+python -c "import iree.compiler.version as v; print(v.REVISIONS['IREE'])"
+f1cb2692a086738d7f16274b9b3af6d2c15ef133
+``` 
+
 ## Manylinux releases
 
 The Linux releases are done in a manylinux2014 docker container. At the time of


### PR DESCRIPTION
This is for debugging IREE pip releases.