### PR TITLE
Tune compiler tracing usage of 'frame's.

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -896,6 +896,8 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
   if (failed(passManager->run(parsedModule))) {
     return false;
   }
+  // Done with the pipeline, mark the start of a new 'frame'.
+  IREE_TRACE_FRAME_MARK();
   return true;
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -566,6 +566,8 @@ translateModuleToBytecode(IREE::VM::ModuleOp moduleOp,
                           IREE::VM::TargetOptions vmOptions,
                           IREE::VM::BytecodeTargetOptions bytecodeOptions,
                           llvm::raw_ostream &output) {
+  IREE_TRACE_FRAME_MARK();
+  IREE_TRACE_FRAME_MARK_BEGIN_NAMED("TranslateToBytecode");
   moduleOp.getContext()->getOrLoadDialect<IREE::Util::UtilDialect>();
 
   if (failed(canonicalizeModule(bytecodeOptions, moduleOp))) {
@@ -686,6 +688,7 @@ translateModuleToBytecode(IREE::VM::ModuleOp moduleOp,
   }
   archiveWriter.reset();
 
+  IREE_TRACE_FRAME_MARK_END_NAMED("TranslateToBytecode");
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -566,8 +566,7 @@ translateModuleToBytecode(IREE::VM::ModuleOp moduleOp,
                           IREE::VM::TargetOptions vmOptions,
                           IREE::VM::BytecodeTargetOptions bytecodeOptions,
                           llvm::raw_ostream &output) {
-  IREE_TRACE_FRAME_MARK();
-  IREE_TRACE_FRAME_MARK_BEGIN_NAMED("TranslateToBytecode");
+  IREE_TRACE_SCOPE();
   moduleOp.getContext()->getOrLoadDialect<IREE::Util::UtilDialect>();
 
   if (failed(canonicalizeModule(bytecodeOptions, moduleOp))) {
@@ -688,7 +687,6 @@ translateModuleToBytecode(IREE::VM::ModuleOp moduleOp,
   }
   archiveWriter.reset();
 
-  IREE_TRACE_FRAME_MARK_END_NAMED("TranslateToBytecode");
   return success();
 }
 

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -159,10 +159,9 @@ void buildIREEPrecompileTransformPassPipeline(
     break;
   default:
     if (compileFrom < IREEVMPipelinePhase::Preprocessing) { // late-entry.
-      IREE_TRACE_ADD_BEGIN_FRAME_PASS(passManager, "Preprocessing");
+      // Not a large enough phase for IREE_TRACE_ADD_[BEGIN,END]_FRAME_PASS.
       IREE::buildPreprocessingPassPipeline(passManager, preprocessingOptions,
                                            hooks.pipelineExtensions);
-      IREE_TRACE_ADD_END_FRAME_PASS(passManager, "Preprocessing");
     }
     if (compileTo == IREEVMPipelinePhase::Preprocessing)
       return; // early-exit

--- a/compiler/src/iree/compiler/Utils/TracingUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/TracingUtils.cpp
@@ -70,10 +70,8 @@ public:
   TraceFrameMarkBeginPass(llvm::StringRef name) { this->name = name; }
 
   void runOnOperation() override {
-    // Always mark the top level (unnamed) frame.
-    IREE_TRACE_FRAME_MARK();
-
     if (!name.empty()) {
+      IREE_TRACE_FRAME_MARK(); // Top level (unnamed) frame.
       IREE_TRACE_FRAME_MARK_BEGIN_NAMED(name.data());
     }
   }


### PR DESCRIPTION
Compiler tracing was a bit confusing when profiling to find https://github.com/openxla/iree/issues/15209.

First, this fixes an issue where frame frames were unbalanced upon recursing into the compiler, leading to confusing rendering in the Tracy UI that could misattribute sections of the compiler running to the "GlobalOptimization" pass pipeline: 
![image](https://github.com/openxla/iree/assets/4010439/9407b54d-4e5f-4ed1-9232-4f870561ac48)

Second, this tweaks how frames are defined for unnamed pipelines and adds a scope for bytecode translation (which happens outside of a pass pipeline): 
![image](https://github.com/openxla/iree/assets/4010439/43cc02ba-e9e6-4a49-8ebe-972be2ca7106)