### PR TITLE
[FlashAttention] Adapt attention for tiling + implement tiling/decompose

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/ConvertTMTensorToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/ConvertTMTensorToLinalgExt.cpp
@@ -152,10 +152,10 @@ struct AttentionOpConversion
         collapsedResult);
 
     if (sizes.size() > 3)
-      rewriter.replaceOp(op, expandBatches(rewriter, loc, batchSizes,
-                                           attention.getResult()[0]));
+      rewriter.replaceOp(
+          op, expandBatches(rewriter, loc, batchSizes, attention.getResult(0)));
     else
-      rewriter.replaceOp(op, attention.getResult()[0]);
+      rewriter.replaceOp(op, attention.getResult(0));
     return success();
   }
 };

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -37,19 +37,6 @@ class IREELinalgExt_Op<string mnemonic, list<Trait> traits = []> :
 }
 
 //===----------------------------------------------------------------------===//
-// Helpers.
-//===----------------------------------------------------------------------===//
-
-class CheckNumOperands<int i> : CPred<"$_op.getNumOperands() == " # i>;
-
-// This class checks that the operand has a shaped type and has rank 3
-class CheckShapedOperandOfRank3<int i> : And<[
-         CPred<"$_op.getNumOperands() > " # i>,
-         SubstLeaves<"$_self", "$_op.getOperand(" # i # ").getType()",
-           IsShapedTypePred>,
-         CPred<"$_op.getOperand(" # i # ").getType().cast<::mlir::ShapedType>().getRank() == 3">]>;
-
-//===----------------------------------------------------------------------===//
 // Utility ops
 //===----------------------------------------------------------------------===//
 
@@ -543,13 +530,7 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 //===----------------------------------------------------------------------===//
 
 def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
-    [PredOpTrait<"only 3 inputs and 1 output",  CheckNumOperands<4>>,
-     PredOpTrait<"all operands have same element type", TCopVTEtAreSameAt<[0, 1, 2, 3]>>,
-     PredOpTrait<"query has shaped type of rank 3", CheckShapedOperandOfRank3<0>>,
-     PredOpTrait<"key has shaped type of rank 3", CheckShapedOperandOfRank3<1>>,
-     PredOpTrait<"value has shaped type of rank 3", CheckShapedOperandOfRank3<2>>,
-     PredOpTrait<"output has shaped type of rank 3", CheckShapedOperandOfRank3<3>>,
-     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["getIterationDomain",
        "getLoopIteratorTypes",
@@ -566,6 +547,8 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     that out of the current implementation. For cross-attention, the query and output
     have the same shape (BxNxd), while the key and value differ in sequence length
     (they have shape BxLxd, where L != N).
+    This operator after tiling results in a tiled result as per flash attention and results
+    in the current `max` and `sum` statistics while processing the current tile.
   }];
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,
@@ -576,13 +559,13 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs)>
   ];
 
-  let results = (outs Variadic<AnyRankedTensor>:$result);
+  let results = (outs Variadic<AnyRankedTensor>:$results);
   let hasFolder = 1;
   let assemblyFormat = [{
     attr-dict
     `ins` `(` $inputs `:` type($inputs) `)`
     `outs` `(` $outputs `:` type($outputs) `)`
-    (`->` type($result)^)?
+    (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
@@ -598,6 +581,16 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     Value getOutput() {
       return getDpsInitOperand(0)->get();
     }
+    std::optional<Value> getMax() {
+      if (getNumResults() == 1)
+        return std::nullopt;
+      return getDpsInitOperand(1)->get();
+    }
+    std::optional<Value> getSum() {
+      if (getNumResults() == 1)
+        return std::nullopt;
+      return getDpsInitOperand(2)->get();
+    }
     ShapedType getQueryType() {
       return getQuery().getType().cast<ShapedType>();
     }
@@ -610,6 +603,16 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     ShapedType getOutputType() {
       return getOutput().getType().cast<ShapedType>();
     }
+    std::optional<ShapedType> getMaxType() {
+      if (!getMax().has_value())
+        return std::nullopt;
+      return (*getMax()).getType().cast<ShapedType>();
+    }
+    std::optional<ShapedType> getSumType() {
+      if (!getSum().has_value())
+        return std::nullopt;
+      return (*getSum()).getType().cast<ShapedType>();      
+    }
     int64_t getQueryRank() {
       return getQueryType().getRank();
     }
@@ -621,6 +624,16 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     }
     int64_t getOutputRank() {
       return getOutputType().getRank();
+    }
+    std::optional<int64_t> getMaxRank() {
+      if (!getMax())
+        return std::nullopt;
+      return (*getMaxType()).getRank();
+    }
+    std::optional<int64_t> getSumRank() {
+      if (!getSum().has_value())
+        return std::nullopt;
+      return (*getSumType()).getRank();
     }
     int64_t getIterationDomainRank() {
       return 2;

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -171,10 +171,10 @@ std::unique_ptr<Pass> createConvertConv2DToWinogradPass();
 // linalg generic ops.
 std::unique_ptr<Pass> createDecomposeSoftmaxPass();
 
-// Transform dialect version of tile and decompose attention
+// Transform dialect version of tile and decompose attention wrapper.
 SmallVector<Operation *>
 tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
-                          RewriterBase &rewriter);
+                          RewriterBase &rewriter, bool onlyTile = false);
 
 // Creates a pass to convert the attention op into a sequence of
 // linalg ops.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -93,6 +93,10 @@ def TileAndDecomposeAttention :
       "Tiles and decomposes attention op into a sequence of linalg ops";
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::"
                     "createTileAndDecomposeAttentionPass()";
+  let options = [
+    Option<"onlyTile", "onlyTile", "bool", /*default=*/"false",
+           "Choose whether to only tile or go through till decomposition">,
+  ];
 }
 
 #endif  // IREE_DIALECT_LINALGEXT_PASSES

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeAttention.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeAttention.cpp
@@ -321,9 +321,10 @@ static Value insertOutputSlice(Value src, Value dst,
 
 } // namespace
 
-SmallVector<Operation *>
-tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
-                          RewriterBase &rewriter) {
+/// Tile iree_linalg_ext.attention.
+/// TODO: Adopt getTiledImplementation with this.
+static SmallVector<Operation *>
+tileAttention(IREE::LinalgExt::AttentionOp attnOp, RewriterBase &rewriter) {
   SmallVector<Operation *> ops;
   Location loc = attnOp.getLoc();
   OpBuilder::InsertionGuard guard(rewriter);
@@ -396,17 +397,22 @@ tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
       extractSlices(key, value, query, queryShape, ivs, sequenceTileLength,
                     headDimension, elementType, loc, rewriter);
 
-  // Create body of innermost loop
-  auto [result, newMax, newSum] = createAttentionBody(
-      keySlice, valueSlice, querySlice, iterArgResult, iterArgMax, iterArgSum,
-      sequenceTileLength, headDimension, elementType, ops, loc, rewriter);
+  auto tiledAttentionOp = rewriter.create<IREE::LinalgExt::AttentionOp>(
+      attnOp.getLoc(),
+      SmallVector<Type>{accumulatorF32.getType(), sum.getType(), max.getType()},
+      SmallVector<Value>{querySlice, keySlice, valueSlice},
+      SmallVector<Value>{iterArgResult, iterArgMax, iterArgSum});
+
+  Value tiledResult = tiledAttentionOp.getResult(0);
+  Value newMax = tiledAttentionOp.getResult(1);
+  Value newSum = tiledAttentionOp.getResult(2);
 
   if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
           loopNest.loops.back().getBody()->getTerminator())) {
     OpBuilder::InsertionGuard yieldGuard(rewriter);
     rewriter.setInsertionPoint(yieldOp);
     rewriter.replaceOpWithNewOp<scf::YieldOp>(
-        yieldOp, ValueRange{result, newMax, newSum});
+        yieldOp, ValueRange{tiledResult, newMax, newSum});
   }
 
   OpBuilder::InsertionGuard yieldGuard(rewriter);
@@ -420,6 +426,65 @@ tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
                         headDimension, loc, rewriter);
 
   attnOp.getResults()[0].replaceAllUsesWith(loopNest.results[0]);
+  ops.push_back(tiledAttentionOp);
+  return ops;
+}
+
+/// Decompose tiled iree_linalg_ext.attention op.
+/// TODO: Adopt decomposeOperation with this.
+static void decomposeTiledAttention(IREE::LinalgExt::AttentionOp tiledAttnOp,
+                                    SmallVector<Operation *> &ops,
+                                    RewriterBase &rewriter) {
+  Location loc = tiledAttnOp.getLoc();
+  Value keySlice = tiledAttnOp.getKey();
+  Value valueSlice = tiledAttnOp.getValue();
+  Value querySlice = tiledAttnOp.getQuery();
+  Value tiledResult = tiledAttnOp.getOutput();
+  Value max = *tiledAttnOp.getMax();
+  Value sum = *tiledAttnOp.getSum();
+
+  assert(max && "expected max statistic operand to be present");
+  assert(sum && "expected sum statistic operand to be present");
+
+  OpBuilder::InsertionGuard withinScfLoop(rewriter);
+  rewriter.setInsertionPointAfter(tiledAttnOp);
+  SmallVector<OpFoldResult> queryDimValues =
+      tensor::getMixedSizes(rewriter, loc, querySlice);
+  OpFoldResult headDimension = queryDimValues[1];
+  OpFoldResult sequenceTileLength = queryDimValues[0];
+
+  Type elementType = tiledAttnOp.getQueryType().getElementType();
+  auto [result, newMax, newSum] = createAttentionBody(
+      keySlice, valueSlice, querySlice, tiledResult, max, sum,
+      sequenceTileLength, headDimension, elementType, ops, loc, rewriter);
+
+  tiledAttnOp.getResults()[0].replaceAllUsesWith(result);
+  tiledAttnOp.getResults()[1].replaceAllUsesWith(newMax);
+  tiledAttnOp.getResults()[2].replaceAllUsesWith(newSum);
+
+  OpBuilder::InsertionGuard afterScfLoop(rewriter);
+  rewriter.setInsertionPointAfter(tiledAttnOp->getParentOp());
+}
+
+/// Utility function which tiles and then decomposes attention op via
+/// FlashAttention algorithm.
+SmallVector<Operation *>
+tileAndDecomposeAttention(IREE::LinalgExt::AttentionOp attnOp,
+                          RewriterBase &rewriter, bool onlyTile) {
+  SmallVector<Operation *> ops = tileAttention(attnOp, rewriter);
+  if (onlyTile)
+    return ops;
+  auto tiledAttnOp = cast<IREE::LinalgExt::AttentionOp>(ops[ops.size() - 1]);
+  ops.pop_back();
+  Operation *truncateToF16 = NULL;
+  Type elementType = attnOp.getQueryType().getElementType();
+  if (elementType.isF16()) {
+    truncateToF16 = ops[ops.size() - 1];
+    ops.pop_back();
+  }
+  decomposeTiledAttention(tiledAttnOp, ops, rewriter);
+  if (truncateToF16)
+    ops.push_back(truncateToF16);
   return ops;
 }
 
@@ -452,10 +517,10 @@ namespace {
 ///    j. Compute matmul(s, v) and add new_accumulator
 ///
 ///
-LogicalResult reifyAttentionTransform(func::FuncOp funcOp) {
+LogicalResult reifyAttentionTransform(func::FuncOp funcOp, bool onlyTile) {
   IRRewriter rewriter(funcOp.getContext());
   funcOp.walk([&](IREE::LinalgExt::AttentionOp attnOp) {
-    tileAndDecomposeAttention(attnOp, rewriter);
+    tileAndDecomposeAttention(attnOp, rewriter, onlyTile);
     return WalkResult::advance();
   });
   return success();
@@ -471,7 +536,11 @@ struct TileAndDecomposeAttentionPass
         affine::AffineDialect, IREE::LinalgExt::IREELinalgExtDialect,
         linalg::LinalgDialect, scf::SCFDialect, tensor::TensorDialect>();
   }
-
+  TileAndDecomposeAttentionPass() = default;
+  TileAndDecomposeAttentionPass(bool onlyTile) { this->onlyTile = onlyTile; }
+  TileAndDecomposeAttentionPass(const TileAndDecomposeAttentionPass &pass) {
+    onlyTile = pass.onlyTile;
+  }
   void runOnOperation() override;
 };
 } // namespace
@@ -479,7 +548,7 @@ struct TileAndDecomposeAttentionPass
 void TileAndDecomposeAttentionPass::runOnOperation() {
   MLIRContext *context = &getContext();
   IRRewriter rewriter(context);
-  if (failed(reifyAttentionTransform(getOperation())))
+  if (failed(reifyAttentionTransform(getOperation(), onlyTile)))
     return signalPassFailure();
 }
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -734,9 +734,20 @@ func.func @illegal_softmax_output_shape(%arg0: tensor<2x16x32xf32>) -> tensor<2x
 
 func.func @illegal_attention_inputs(%query: tensor<6x12x20x8xf32>, %key: tensor<6x12x20x8xf32>, %value: tensor<6x12x20x8xf32>) {
   %0 = tensor.empty() : tensor<6x12x20x8xf32>
-  // expected-error @+1 {{failed to verify that query has shaped type of rank 3}}
+  // expected-error @+1 {{'iree_linalg_ext.attention' op expected query to have rank 3 but found 4}}
   %1 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<6x12x20x8xf32>, tensor<6x12x20x8xf32>, tensor<6x12x20x8xf32>) outs(%0 : tensor<6x12x20x8xf32>) -> tensor<6x12x20x8xf32>
   return %1 : tensor<6x12x20x8xf32>
+}
+
+// -----
+
+func.func @illegal_flash_attention_inputs(%query: tensor<20xf32>, %key: tensor<20x8xf32>, %value: tensor<20x8xf32>) -> (tensor<20x8xf32>, tensor<8xf32>, tensor<8xf32>) {
+  %result = tensor.empty() : tensor<20x8xf32>
+  %max = tensor.empty() : tensor<8xf32>
+  %sum = tensor.empty() : tensor<8xf32>
+  // expected-error @+1 {{'iree_linalg_ext.attention' op expected query to have rank 2 but found 1}}
+  %1:3 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<20xf32>, tensor<20x8xf32>, tensor<20x8xf32>) outs(%result, %max, %sum : tensor<20x8xf32>, tensor<8xf32>, tensor<8xf32>) -> tensor<20x8xf32>, tensor<8xf32>, tensor<8xf32>
+  return %1#0, %1#1, %1#2 : tensor<20x8xf32>, tensor<8xf32>, tensor<8xf32>
 }
 
 // -----

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_attention.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_attention.mlir
@@ -1,10 +1,43 @@
 // RUN: iree-dialects-opt --split-input-file -iree-linalg-ext-tile-and-decompose-attention -cse %s | FileCheck %s
+// RUN: iree-dialects-opt --split-input-file -iree-linalg-ext-tile-and-decompose-attention=onlyTile -cse %s | FileCheck %s --check-prefix=TILING
 
 func.func @attention(%query: tensor<1x1024x64xf32>, %key: tensor<1x1024x64xf32>, %value: tensor<1x1024x64xf32>) -> tensor<1x1024x64xf32> {
   %0 = tensor.empty() : tensor<1x1024x64xf32>
   %1 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<1x1024x64xf32>, tensor<1x1024x64xf32>, tensor<1x1024x64xf32>) outs(%0 : tensor<1x1024x64xf32>) -> tensor<1x1024x64xf32>
   return %1 : tensor<1x1024x64xf32>
 }
+
+// TILING-LABEL: @attention
+// TILING-SAME: (%[[QUERY:.+]]: tensor<1x1024x64xf32>, %[[KEY:.+]]: tensor<1x1024x64xf32>, %[[VALUE:.+]]: tensor<1x1024x64xf32>)
+// TILING:        %[[D0:.+]] = tensor.empty() : tensor<1x1024x64xf32>
+// TILING:        %[[D1:.+]] = tensor.empty() : tensor<1024x64xf32>
+// TILING-DAG:    %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// TILING:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<1024x64xf32>) ->
+// TILING-SAME:     tensor<1024x64xf32>
+// TILING-DAG:    %[[CST_0:.+]] = arith.constant -1.000000e+30 : f32
+// TILING:        %[[D3:.+]] = tensor.empty() : tensor<1024xf32>
+// TILING:        %[[D4:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D3]] : tensor<1024xf32>) -> tensor<1024xf32>
+// TILING:        %[[D5:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D3]] : tensor<1024xf32>) -> tensor<1024xf32>
+// TILING-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// TILING-DAG:    %[[C1024:.+]] = arith.constant 1024 : index
+// TILING:        %[[D6:.+]]:3 = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C1024]]
+// TILING-SAME:     iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[D2]], %[[ARG5:[a-zA-Z0-9_]+]] = %[[D4]],
+// TILING-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] = %[[D5]]) -> (tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>) {
+// TILING:          %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[KEY]][0, %[[ARG3]], 0] [1, 1024, 64] [1, 1, 1] :
+// TILING-SAME:       tensor<1x1024x64xf32> to tensor<1024x64xf32>
+// TILING:          %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[VALUE]][0, %[[ARG3]], 0] [1, 1024, 64] [1, 1, 1] :
+// TILING-SAME:       tensor<1x1024x64xf32> to tensor<1024x64xf32>
+// TILING:          %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[QUERY]][0, 0, 0] [1, 1024, 64] [1, 1, 1] :
+// TILING-SAME:       tensor<1x1024x64xf32> to tensor<1024x64xf32>
+// TILING:          %[[TILED_ATTENTION:.+]]:3 = iree_linalg_ext.attention ins(%[[EXTRACTED_SLICE_2]], %[[EXTRACTED_SLICE]], %[[EXTRACTED_SLICE_1]] :
+// TILING-SAME:                                           outs(%[[ARG4]], %[[ARG5]], %[[ARG6]] :
+// TILING-SAME:                                           -> tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>
+// TILING:          scf.yield %[[TILED_ATTENTION]]#0, %[[TILED_ATTENTION]]#1, %[[TILED_ATTENTION]]#2 : tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>
+// TILING:        }
+// TILING:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]]#[[D0:.+]] into %[[D0]][0, 0, 0] [1, 1024, 64] [1,
+// TILING-SAME:     1, 1] : tensor<1024x64xf32> into tensor<1x1024x64xf32>
+// TILING:        return %[[INSERTED_SLICE]] : tensor<1x1024x64xf32>
+// TILING:      }
 
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0)>
@@ -103,6 +136,42 @@ func.func @attention(%query: tensor<?x?x?xf32>, %key: tensor<?x?x?xf32>, %value:
   return %1 : tensor<?x?x?xf32>
 }
 
+// TILING:      @attention(
+// TILING-SAME:  %[[QUERY:.+]]: tensor<?x?x?xf32>, %[[KEY:.+]]: tensor<?x?x?xf32>, %[[VALUE:.+]]: tensor<?x?x?xf32>,
+// TILING-SAME:  %[[ARG3:[a-zA-Z0-9_]+]]: index, %[[ARG4:[a-zA-Z0-9_]+]]: index, %[[ARG5:[a-zA-Z0-9_]+]]: index)
+// TILING:        %[[D0:.+]] = tensor.empty(%[[ARG3]], %[[ARG4]], %[[ARG5]]) : tensor<?x?x?xf32>
+// TILING-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// TILING-DAG:    %[[C1:.+]] = arith.constant 1 : index
+// TILING:        %[[DIM:.+]] = tensor.dim %[[QUERY]], %[[C1]] : tensor<?x?x?xf32>
+// TILING-DAG:    %[[C2:.+]] = arith.constant 2 : index
+// TILING:        %[[DIM_0:.+]] = tensor.dim %[[QUERY]], %[[C2]] : tensor<?x?x?xf32>
+// TILING:        %[[DIM_1:.+]] = tensor.dim %[[KEY]], %[[C1]] : tensor<?x?x?xf32>
+// TILING:        %[[D1:.+]] = tensor.empty(%[[DIM]], %[[DIM_0]]) : tensor<?x?xf32>
+// TILING-DAG:    %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// TILING:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+// TILING-DAG:    %[[CST_2:.+]] = arith.constant -1.000000e+30 : f32
+// TILING:        %[[D3:.+]] = tensor.empty(%[[DIM]]) : tensor<?xf32>
+// TILING:        %[[D4:.+]] = linalg.fill ins(%[[CST_2]] : f32) outs(%[[D3]] : tensor<?xf32>) -> tensor<?xf32>
+// TILING:        %[[D5:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D3]] : tensor<?xf32>) -> tensor<?xf32>
+// TILING:        %[[D6:.+]]:3 = scf.for %[[ARG6:[a-zA-Z0-9_]+]] = %[[C0]] to %[[DIM_1]] step %[[DIM]]
+// TILING-SAME:     iter_args(%[[ARG7:[a-zA-Z0-9_]+]] = %[[D2]], %[[ARG8:[a-zA-Z0-9_]+]] = %[[D4]],
+// TILING-SAME:     %[[ARG9:[a-zA-Z0-9_]+]] = %[[D5]]) -> (tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>) {
+// TILING:          %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[KEY]][0, %[[ARG6]], 0] [1, %[[DIM]], %[[DIM_0]]]
+// TILING-SAME:       [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
+// TILING:          %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[VALUE]][0, %[[ARG6]], 0] [1, %[[DIM]], %[[DIM_0]]]
+// TILING-SAME:       [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
+// TILING:          %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[QUERY]][0, 0, 0] [1, %[[DIM]], %[[DIM_0]]] [1, 1,
+// TILING-SAME:       1] : tensor<?x?x?xf32> to tensor<?x?xf32>
+// TILING:          %[[TILED_ATTENTION]]:3 = iree_linalg_ext.attention ins(%[[EXTRACTED_SLICE_4]], %[[EXTRACTED_SLICE]], %[[EXTRACTED_SLICE_3]] : 
+// TILING-SAME:                      outs(%[[ARG7]], %[[ARG8]], %[[ARG9]] : 
+// TILING-SAME:                      -> tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>
+// TILING:          scf.yield %[[TILED_ATTENTION]]#0, %[[TILED_ATTENTION]]#1, %[[TILED_ATTENTION]]#2 : tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>
+// TILING:        }
+// TILING:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]]#[[D0:.+]] into %[[D0]][0, 0, 0] [1, %[[DIM]],
+// TILING-SAME:     %[[DIM_0]]] [1, 1, 1] : tensor<?x?xf32> into tensor<?x?x?xf32>
+// TILING:        return %[[INSERTED_SLICE]] : tensor<?x?x?xf32>
+// TILING:      }
+
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0)>
 // CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0)>
@@ -132,7 +201,8 @@ func.func @attention(%query: tensor<?x?x?xf32>, %key: tensor<?x?x?xf32>, %value:
 // CHECK-SAME:       [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?xf32>
 // CHECK:          %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[ARG0]][0, 0, 0] [1, %[[DIM]], %[[DIM_0]]] [1, 1,
 // CHECK-SAME:       1] : tensor<?x?x?xf32> to tensor<?x?xf32>
-// CHECK:          %[[D7:.+]] = tensor.empty(%[[DIM]], %[[DIM]]) : tensor<?x?xf32>
+// CHECK:          %[[QUERY_SLICE_DIM_0:.+]] = tensor.dim %[[EXTRACTED_SLICE_4]], %[[C0]] : tensor<?x?xf32>
+// CHECK:          %[[D7:.+]] = tensor.empty(%[[QUERY_SLICE_DIM_0]], %[[QUERY_SLICE_DIM_0]]) : tensor<?x?xf32>
 // CHECK:          %[[D8:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D7]] : tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK:          %[[D9:.+]] = linalg.matmul_transpose_b ins(%[[EXTRACTED_SLICE_4]], %[[EXTRACTED_SLICE]] :
 // CHECK-SAME:       tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[D8]] : tensor<?x?xf32>) -> tensor<?x?xf32>
@@ -201,6 +271,48 @@ func.func @attention(%query: tensor<1x1024x64xf16>, %key: tensor<1x1024x64xf16>,
   %1 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<1x1024x64xf16>, tensor<1x1024x64xf16>, tensor<1x1024x64xf16>) outs(%0 : tensor<1x1024x64xf16>) -> tensor<1x1024x64xf16>
   return %1 : tensor<1x1024x64xf16>
 }
+
+// TILING-DAG:  #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// TILING:      @attention(
+// TILING-SAME:  %[[QUERY:.+]]: tensor<1x1024x64xf16>, %[[KEY:.+]]: tensor<1x1024x64xf16>, %[[VALUE:.+]]: tensor<1x1024x64xf16>)
+// TILING:        %[[D0:.+]] = tensor.empty() : tensor<1x1024x64xf16>
+// TILING:        %[[D1:.+]] = tensor.empty() : tensor<1024x64xf32>
+// TILING:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[D0]][0, 0, 0] [1, 1024, 64] [1, 1, 1] :
+// TILING-SAME:     tensor<1x1024x64xf16> to tensor<1024x64xf16>
+// TILING-DAG:    %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// TILING:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<1024x64xf32>) ->
+// TILING-SAME:     tensor<1024x64xf32>
+// TILING-DAG:    %[[CST_0:.+]] = arith.constant -1.000000e+30 : f32
+// TILING:        %[[D3:.+]] = tensor.empty() : tensor<1024xf32>
+// TILING:        %[[D4:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D3]] : tensor<1024xf32>) -> tensor<1024xf32>
+// TILING:        %[[D5:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D3]] : tensor<1024xf32>) -> tensor<1024xf32>
+// TILING-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// TILING-DAG:    %[[C1024:.+]] = arith.constant 1024 : index
+// TILING:        %[[D6:.+]]:3 = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C1024]]
+// TILING-SAME:     iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[D2]], %[[ARG5:[a-zA-Z0-9_]+]] = %[[D4]],
+// TILING-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] = %[[D5]]) -> (tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>) {
+// TILING:          %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[KEY]][0, %[[ARG3]], 0] [1, 1024, 64] [1, 1, 1] :
+// TILING-SAME:       tensor<1x1024x64xf16> to tensor<1024x64xf16>
+// TILING:          %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[VALUE]][0, %[[ARG3]], 0] [1, 1024, 64] [1, 1, 1] :
+// TILING-SAME:       tensor<1x1024x64xf16> to tensor<1024x64xf16>
+// TILING:          %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[QUERY]][0, 0, 0] [1, 1024, 64] [1, 1, 1] :
+// TILING-SAME:       tensor<1x1024x64xf16> to tensor<1024x64xf16>
+// TILING:          %[[TILED_ATTENTION:.+]]:3 = iree_linalg_ext.attention ins(%[[EXTRACTED_SLICE_3]], %[[EXTRACTED_SLICE_1]], %[[EXTRACTED_SLICE_2]] :
+// TILING-SAME:                                           outs(%[[ARG4]], %[[ARG5]], %[[ARG6]] :
+// TILING-SAME:                                           -> tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>
+// TILING:          scf.yield %[[TILED_ATTENTION]]#0, %[[TILED_ATTENTION]]#1, %[[TILED_ATTENTION]]#2 : tensor<1024x64xf32>, tensor<1024xf32>, tensor<1024xf32>
+// TILING:        }
+// TILING:        %[[D7:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel",
+// TILING-SAME:     "parallel"]} ins(%[[D6]]#[[D0:.+]] : tensor<1024x64xf32>) outs(%[[EXTRACTED_SLICE]] :
+// TILING-SAME:     tensor<1024x64xf16>) {
+// TILING:        ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f16):
+// TILING:          %[[D8:.+]] = arith.truncf %[[IN]] : f32 to f16
+// TILING:          linalg.yield %[[D8]] : f16
+// TILING:        } -> tensor<1024x64xf16>
+// TILING:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D7]] into %[[D0]][0, 0, 0] [1, 1024, 64] [1, 1, 1] :
+// TILING-SAME:     tensor<1024x64xf16> into tensor<1x1024x64xf16>
+// TILING:        return %[[INSERTED_SLICE]] : tensor<1x1024x64xf16>
+// TILING:      }
 
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0)>


### PR DESCRIPTION
-- This commit adapts attention op to have optional tiling statistic
   constructs.
-- It also implements the flash attention's tiling and decomposition
   around the same.
-- It also adds an option in `iree-linalg-ext-tile-and-decompose-attention`
   to perform only tiling.
   
 Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>