### PR TITLE
Remove unnecessary pragma

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_bf16.c
@@ -65,7 +65,6 @@ iree_uk_mmt4d_tile_bf16bf16f32_1x16x2_to_16x16x2_x86_64_avx512_bf16(
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_loadu_ps(rhs_ptr);
     rhs_ptr += 32;
-#pragma clang loop unroll(full)
     for (int i = 0; i < M0; ++i) {
       acc[i] = iree_mm512_dpbf16_ps_broadcast_rhs(acc[i], rhs, lhs_ptr + 2 * i);
     }


### PR DESCRIPTION
This pragma is needed with `clang -O2` as it otherwise doesn't unroll this loop at size M0==16.

But it is causing GCC warnings-as-errors: https://github.com/openxla/iree/pull/15089#discussion_r1363115336

Clang does unroll this at -O3, which is what we use in Release builds. -O2 is only used in RelWithDebInfo builds, which is my go-to configuration during development, but it's fair to require me to change build types for benchmarking.