### PR TITLE
[rocm] Print GPU information when dumping device info

### DIFF
--- a/experimental/rocm/dynamic_symbol_tables.h
+++ b/experimental/rocm/dynamic_symbol_tables.h
@@ -8,6 +8,7 @@ RC_PFN_DECL(hipCtxCreate, hipCtx_t *, unsigned int, hipDevice_t)
 RC_PFN_DECL(hipCtxDestroy, hipCtx_t)
 RC_PFN_DECL(hipDeviceGet, hipDevice_t *, int)  // No direct, need to modify
 RC_PFN_DECL(hipGetDeviceCount, int *)
+RC_PFN_DECL(hipGetDeviceProperties, hipDeviceProp_t *, int)
 RC_PFN_DECL(hipDeviceGetName, char *, int,
             hipDevice_t)  // No direct, need to modify
 RC_PFN_STR_DECL(


### PR DESCRIPTION
Example on 7900 XTX:

```
- gpu-compute-capability: 11.0
- gpu-arch-name: gfx1100

- launch-max-block-dims: (1024, 1024, 1024)

- block-max-thread-count: 1024
- block-max-32-bit-register-count: 65536
- block-max-shared-memory: 64 KB

- memory-is-integrated-memory: 0
- memory-supports-managed-memory: 1
- memory-total-const-memory-size: 2047 MB
- memory-total-global-memory-size: 24560 MB
- memory-l2-cache-size: 6291456 bytes

- gpu-compute-unit-count: 48
- gpu-compute-max-clock-rate: 2304 mHz
- gpu-memory-max-clock-rate: 1249 mHz
- gpu-warp-size: 32
```