### PR TITLE
Avoid complaints about missing bc file if compiling for CUDA

### DIFF
--- a/build_tools/bazel/workspace.bzl
+++ b/build_tools/bazel/workspace.bzl
@@ -50,7 +50,7 @@ def cuda_auto_configure_impl(repository_ctx):
         Label("%s//:build_tools/third_party/cuda/BUILD.template" % iree_repo_alias),
         {
             "%ENABLED%": "True" if cuda_toolkit_root else "False",
-            "%LIBDEVICE_REL_PATH%": libdevice_rel_path,
+            "%LIBDEVICE_REL_PATH%": libdevice_rel_path if cuda_toolkit_root else "BUILD",
             "%IREE_REPO_ALIAS%": iree_repo_alias,
         },
     )


### PR DESCRIPTION
Previously this would throw errors like

```
ERROR: external/iree_cuda/BUILD:45:13: Executing genrule @iree_cuda//:libdevice_embedded__generator failed: missing input file 'external/iree_cuda/iree_local/libdevice.bc', owner: '@iree_cuda//:iree_local/libdevice.bc'
```

even though the CUDA build was not enabled. Use BUILD file as bc file as ... well its there and seems to work/it isn't used in anyway with CUDA build disabled it just has to be something that exists.