### PR TITLE
Fix build after #15151

### DIFF
--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -810,7 +810,7 @@ iree_status_allocate(iree_status_code_t code, const char* file, uint32_t line,
 #endif  // has any IREE_STATUS_FEATURES
 }
 
-static IREE_MUST_USE_RESULT iree_status_t iree_status_allocate_vf_impl(
+IREE_MUST_USE_RESULT static iree_status_t iree_status_allocate_vf_impl(
     iree_status_code_t code, const char* file, uint32_t line, int skip_frames,
     const char* format, va_list varargs_0, va_list varargs_1) {
 #if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) == 0


### PR DESCRIPTION
Fixes the following build error (gcc-11.4):
```
/iree/runtime/src/iree/base/status.c:813:1: error: ‘nodiscard’ attribute ignored [-Werror=attributes]
  813 | static IREE_MUST_USE_RESULT iree_status_t iree_status_allocate_vf_impl(
      | ^~~~~~
```

Quick repro: https://godbolt.org/z/xYGddPxfd
