### PR TITLE
Lint fix trailing space in debugging/releases.md.

### DIFF
--- a/docs/developers/debugging/releases.md
+++ b/docs/developers/debugging/releases.md
@@ -28,7 +28,7 @@ and the Python API:
 ```shell
 python -c "import iree.compiler.version as v; print(v.REVISIONS['IREE'])"
 f1cb2692a086738d7f16274b9b3af6d2c15ef133
-``` 
+```
 
 ## Manylinux releases
 


### PR DESCRIPTION
Should have synced https://github.com/openxla/iree/pull/15168 before I merged. Oops.