### PR TITLE
Move expected output URL into the parameter of `iree_run_module_test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1058,12 +1058,6 @@ jobs:
         run: |
           mkdir -p ${E2E_TEST_ARTIFACTS_DIR}
           gcloud storage cp -r "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/*" "${E2E_TEST_ARTIFACTS_DIR}"
-      - name: "Download benchmark expected output"
-        env:
-          EXPECTED_OUTPUT_GSC_ARTIFACT: gs://iree-model-artifacts/deeplab_v3_fp32_input_0_expected_output.npy
-          EXPECTED_OUTPUT_FILE: deeplab_v3_fp32_input_0_expected_output.npy
-        run: |
-          gcloud storage cp "${EXPECTED_OUTPUT_GSC_ARTIFACT}" "${E2E_TEST_ARTIFACTS_DIR}/${EXPECTED_OUTPUT_FILE}"
       - name: "Build iree-run-module and test benchmark suite modules"
         run: |
           ./build_tools/github_actions/docker_run.sh \

--- a/build_tools/cmake/iree_run_module_test.cmake
+++ b/build_tools/cmake/iree_run_module_test.cmake
@@ -26,7 +26,7 @@ endfunction()
 #       and input file are passed automatically.
 #   EXPECTED_OUTPUT: A string representing the expected output from executing
 #       the module in the format accepted by `iree-run-module` or a file
-#       containing the same.
+#       containing the same. Can also be an HTTPS URL to download large npy.
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
 #   XFAIL_PLATFORMS: List of platforms (see iree_get_platform) for which the
@@ -118,7 +118,7 @@ function(iree_run_module_test)
       list(APPEND _RULE_RUNNER_ARGS ${_EXPECTED_OUTPUT_STR})
     elseif(_OUTPUT_FILE_TYPE STREQUAL ".npy")
       # Large npy files are not stored in the codebase. Need to download them
-      # from HTTPS link first and store them in the following possible paths.
+      # from the URL first and store them in the following possible paths.
       if(_RULE_EXPECTED_OUTPUT MATCHES "^https://.+/([^/]+)$")
         set(_EXPECTED_OUTPUT_URL "${_RULE_EXPECTED_OUTPUT}")
         set(_RULE_EXPECTED_OUTPUT "${CMAKE_MATCH_1}")

--- a/build_tools/python/e2e_model_tests/test_definitions.py
+++ b/build_tools/python/e2e_model_tests/test_definitions.py
@@ -96,7 +96,7 @@ TEST_CONFIGS = [
             tflite_models.DEEPLABV3_FP32
         ),
         execution_config=module_execution_configs.ELF_LOCAL_SYNC_CONFIG,
-        expected_output="deeplab_v3_fp32_input_0_expected_output.npy",
+        expected_output="https://storage.googleapis.com/iree-model-artifacts/deeplab_v3_fp32_input_0_expected_output.npy",
         extra_test_flags=["--expected_f32_threshold=0.001"],
         unsupported_platforms=[
             CMakePlatform.LINUX_RISCV32,

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -32,7 +32,7 @@ iree_benchmark_suite_module_test(
 iree_benchmark_suite_module_test(
   NAME "deeplab_v3_fp32_correctness_test"
   DRIVER "local-sync"
-  EXPECTED_OUTPUT "deeplab_v3_fp32_input_0_expected_output.npy"
+  EXPECTED_OUTPUT "https://storage.googleapis.com/iree-model-artifacts/deeplab_v3_fp32_input_0_expected_output.npy"
   MODULES
     "arm_64-Android=iree_module_DeepLabV3_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_/module.vmfb"
     "x86_64-Linux=iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"


### PR DESCRIPTION
Instead of hard-coding the artifact URL in the cmake rule `iree_run_module_test`, put the URL as `EXPECTED_OUTPUT` parameter of `iree_run_module_test` if the file needs to be downloaded.

This is a refactor missed out in #15238 after prototyping.