### PR TITLE
[Winograd] Adapt winograd for tiling + implement tiling/decompose

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -71,6 +71,10 @@ def TileAndDecomposeWinogradTransform :
       "Tiles and decomposes winograd transform ops into linalg ops";
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::"
                     "createTileAndDecomposeWinogradTransformPass()";
+  let options = [
+    Option<"onlyTile", "onlyTile", "bool", /*default=*/"false",
+           "Choose whether to only tile or go through till decomposition">,
+  ];
 }
 
 def ConvertConv2DToWinograd :

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -57,7 +57,7 @@ SmallVector<int64_t> computeInterchangeFromDimPos(ArrayRef<int64_t> dimsPos,
 /// Converts a 2D float array to a constant value. The 2D array is stored as
 /// a 1D row-major array in `val` and has shape `rows` x `cols`.
 Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
-                                Location loc, PatternRewriter &rewriter);
+                                Location loc, RewriterBase &rewriter);
 
 // Converts OpFoldResults to int64_t shape entries, unconditionally mapping all
 // Value's to kDynamic, even if they are arith.constant values.

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
@@ -44,324 +44,457 @@ static void computeLoopParams(SmallVectorImpl<Value> &lbs,
   }
 }
 
-class ReifyWinogradInputTransform final
-    : public OpRewritePattern<WinogradInputTransformOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  /// The input to this op is either (N, H, W, C) or (N, C, H, W)
-  /// but the output to this op is always (T, T, N, H', W', C).
-  /// Since the first two dimensions are used for the inner matrix
-  /// multiplication, we create the loop nest over (N, H', W', C).
-  LogicalResult matchAndRewrite(WinogradInputTransformOp inputOp,
-                                PatternRewriter &rewriter) const override {
-    Location loc = inputOp.getLoc();
-    auto funcOp = inputOp->getParentOfType<func::FuncOp>();
-    if (!funcOp) {
-      return rewriter.notifyMatchFailure(
-          inputOp, "Could not find parent of type funcOp");
-    }
-
-    const float *BT{nullptr};
-    const float *B{nullptr};
-    const int64_t inputTileSize = inputOp.getInputTileSize();
-    const int64_t outputTileSize = inputOp.getOutputTileSize();
-    switch (outputTileSize) {
-    case 6:
-      B = IREE::LinalgExt::Winograd::B_6x6_3x3;
-      BT = IREE::LinalgExt::Winograd::BT_6x6_3x3;
-      break;
-    default:
-      return failure();
-    }
-    /// The two values below are the transpose(B) [BTV]
-    /// and B [BV] constant matrices that convert the input
-    /// tile to the Winograd domain.
-    Value BTV = IREE::LinalgExt::createValueFrom2DConstant(
-        BT, inputTileSize, inputTileSize, loc, rewriter);
-    Value BV = IREE::LinalgExt::createValueFrom2DConstant(
-        B, inputTileSize, inputTileSize, loc, rewriter);
-
-    Value input = inputOp.input();
-    Value output = inputOp.output();
-    auto outputType = output.getType().cast<ShapedType>();
-    auto inputType = input.getType().cast<ShapedType>();
-    SmallVector<int64_t> inputShape(inputType.getShape());
-    const bool isNchw = inputOp.isNchw();
-    if (isNchw) {
-      permute<Permutation::NCHW_TO_NHWC>(inputShape);
-    }
-    Type elementType = outputType.getElementType();
-    const std::array<int64_t, 2> imageDims = inputOp.nhwcImageDimensions();
-    const size_t numImageDims = imageDims.size();
-    llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
-                                                  imageDims.end());
-    SmallVector<int64_t> inputTileSquare(imageDims.size(), inputTileSize);
-
-    rewriter.setInsertionPointToStart(&funcOp.getBody().front());
-    Value zeroF32 = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
-    Value scratch =
-        rewriter.create<tensor::EmptyOp>(loc, inputTileSquare, elementType);
-
-    rewriter.setInsertionPoint(inputOp);
-    SmallVector<Value> lbs, ubs, steps;
-    computeLoopParams(lbs, ubs, steps, output, numImageDims, loc, rewriter);
-    // Construct loops
-    scf::LoopNest loopNest = scf::buildLoopNest(
-        rewriter, loc, lbs, ubs, steps, ValueRange({output}),
-        [&](OpBuilder &nestedBuilder, Location loc, ValueRange outputIvs,
-            ValueRange iterArgs) -> scf::ValueVector { return {iterArgs[0]}; });
-
-    // Extract input slice
-    auto one = rewriter.getIndexAttr(1);
-    auto zero = rewriter.getIndexAttr(0);
-    auto inputTileSizeAttr = rewriter.getIndexAttr(inputTileSize);
-    SmallVector<OpFoldResult> strides(inputOp.getInputOperandRank(), one);
-    SmallVector<OpFoldResult> sizes(inputOp.getInputOperandRank(), one);
-    SmallVector<OpFoldResult> offsets(inputOp.getInputOperandRank(), zero);
-    SmallVector<Value> ivs;
-    for (scf::ForOp loop : loopNest.loops) {
-      ivs.push_back(loop.getInductionVar());
-    }
-    for (int i = 0; i < inputShape.size(); i++) {
-      if (!imageDimsSet.contains(i)) {
-        offsets[i] = ivs[i];
-      } else {
-        rewriter.setInsertionPointToStart(loopNest.loops[i].getBody());
-        AffineExpr dim0;
-        auto it = rewriter.getAffineConstantExpr(inputTileSize);
-        auto ot = rewriter.getAffineConstantExpr(outputTileSize);
-        auto delta = rewriter.getAffineConstantExpr(inputShape[i]);
-        bindDims(rewriter.getContext(), dim0);
-        AffineMap scaleMap =
-            AffineMap::get(1, 0, {dim0 * ot}, rewriter.getContext());
-        offsets[i] = rewriter.createOrFold<affine::AffineApplyOp>(
-            loc, scaleMap, ValueRange{ivs[i]});
-        AffineMap minMap =
-            AffineMap::get(1, 0, {-dim0 + delta, it}, rewriter.getContext());
-        sizes[i] = rewriter.createOrFold<affine::AffineMinOp>(
-            loc, minMap,
-            ValueRange{
-                getValueOrCreateConstantIndexOp(rewriter, loc, offsets[i])});
-      }
-    }
-    rewriter.setInsertionPointToStart(loopNest.loops.back().getBody());
-    auto tensorType = RankedTensorType::get(
-        SmallVector<int64_t>(numImageDims, ShapedType::kDynamic), elementType);
-    if (isNchw) {
-      permute<Permutation::NHWC_TO_NCHW>(offsets);
-      permute<Permutation::NHWC_TO_NCHW>(sizes);
-    }
-    Value dynamicSlice = rewriter.create<tensor::ExtractSliceOp>(
-        loc, tensorType, input, offsets, sizes, strides);
-
-    // Copy input slice into zeroed padded scratch space
-    strides = SmallVector<OpFoldResult>(numImageDims, one);
-    offsets = SmallVector<OpFoldResult>(numImageDims, zero);
-    SmallVector<OpFoldResult> sliceSizes;
-    for (const int64_t dim : inputOp.imageDimensions())
-      sliceSizes.push_back(sizes[dim]);
-    linalg::FillOp fillOp = rewriter.create<linalg::FillOp>(
-        loc, ValueRange{zeroF32}, ValueRange{scratch});
-    Value inputSlice = rewriter.create<tensor::InsertSliceOp>(
-        loc, dynamicSlice, fillOp.result(), offsets, sliceSizes, strides);
-
-    // Extract output slice
-    strides = SmallVector<OpFoldResult>(inputOp.getOutputOperandRank(), one);
-    offsets = SmallVector<OpFoldResult>(numImageDims, zero);
-    offsets.append(ivs.begin(), ivs.end());
-    sizes = SmallVector<OpFoldResult>(inputOp.getOutputOperandRank(), one);
-    sizes[0] = sizes[1] = inputTileSizeAttr;
-    tensorType = RankedTensorType::get(inputTileSquare, elementType);
-    Value iterArg = loopNest.loops.back().getRegionIterArg(0);
-    Value outputSlice = rewriter.create<tensor::ExtractSliceOp>(
-        loc, tensorType, iterArg, offsets, sizes, strides);
-
-    // Create computation
-    Value result, AMatrix, BMatrix;
-    linalg::MatmulOp matmulOp;
-    for (int i = 0; i < 2; i++) {
-      fillOp = rewriter.create<linalg::FillOp>(loc, ValueRange{zeroF32},
-                                               ValueRange{outputSlice});
-      if (i == 0) {
-        AMatrix = inputSlice;
-        BMatrix = BV;
-      } else {
-        AMatrix = BTV;
-        BMatrix = result;
-      }
-      matmulOp = rewriter.create<linalg::MatmulOp>(
-          loc, tensorType, ValueRange{AMatrix, BMatrix}, fillOp.result());
-      result = matmulOp.getResult(0);
-    }
-
-    // Insert results into output slice
-    Value updatedOutput = rewriter.create<tensor::InsertSliceOp>(
-        loc, result, iterArg, offsets, sizes, strides);
-
-    // Replace returned value
-    if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
-            loopNest.loops.back().getBody()->getTerminator())) {
-      rewriter.replaceOpWithNewOp<scf::YieldOp>(yieldOp, updatedOutput);
-    }
-    inputOp.getResults()[0].replaceAllUsesWith(loopNest.results[0]);
-    return success();
+/// Tile iree_linalg_ext.winograd.input_transform op.
+/// TODO: Adopt getTiledImplementation with this.
+static LogicalResult tileWinogradInputTransformOp(
+    WinogradInputTransformOp inputOp, RewriterBase &rewriter,
+    WinogradInputTransformOp &tiledWinogradInputTransformOp) {
+  Location loc = inputOp.getLoc();
+  auto funcOp = inputOp->getParentOfType<func::FuncOp>();
+  if (!funcOp) {
+    return rewriter.notifyMatchFailure(inputOp,
+                                       "Could not find parent of type funcOp");
   }
-};
+
+  const int64_t inputTileSize = inputOp.getInputTileSize();
+  const int64_t outputTileSize = inputOp.getOutputTileSize();
+  switch (outputTileSize) {
+  case 6:
+    break;
+  default:
+    return failure();
+  }
+
+  Value input = inputOp.input();
+  Value output = inputOp.output();
+  auto outputType = output.getType().cast<ShapedType>();
+  auto inputType = input.getType().cast<ShapedType>();
+  SmallVector<int64_t> inputShape(inputType.getShape());
+  const bool isNchw = inputOp.isNchw();
+  if (isNchw) {
+    permute<Permutation::NCHW_TO_NHWC>(inputShape);
+  }
+  Type elementType = outputType.getElementType();
+  const std::array<int64_t, 2> imageDims = inputOp.nhwcImageDimensions();
+  const size_t numImageDims = imageDims.size();
+  llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
+                                                imageDims.end());
+  SmallVector<int64_t> inputTileSquare(imageDims.size(), inputTileSize);
+
+  rewriter.setInsertionPointToStart(&funcOp.getBody().front());
+
+  SmallVector<Value> lbs, ubs, steps;
+  computeLoopParams(lbs, ubs, steps, output, numImageDims, loc, rewriter);
+  // Construct loops
+  rewriter.setInsertionPoint(inputOp);
+  scf::LoopNest loopNest = scf::buildLoopNest(
+      rewriter, loc, lbs, ubs, steps, ValueRange({output}),
+      [&](OpBuilder &nestedBuilder, Location loc, ValueRange outputIvs,
+          ValueRange iterArgs) -> scf::ValueVector { return {iterArgs[0]}; });
+
+  // Extract input slice
+  auto one = rewriter.getIndexAttr(1);
+  auto zero = rewriter.getIndexAttr(0);
+  auto inputTileSizeAttr = rewriter.getIndexAttr(inputTileSize);
+  SmallVector<OpFoldResult> strides(inputOp.getInputOperandRank(), one);
+  SmallVector<OpFoldResult> sizes(inputOp.getInputOperandRank(), one);
+  SmallVector<OpFoldResult> offsets(inputOp.getInputOperandRank(), zero);
+  SmallVector<Value> ivs;
+  for (scf::ForOp loop : loopNest.loops) {
+    ivs.push_back(loop.getInductionVar());
+  }
+  for (int i = 0; i < inputShape.size(); i++) {
+    if (!imageDimsSet.contains(i)) {
+      offsets[i] = ivs[i];
+    } else {
+      rewriter.setInsertionPointToStart(loopNest.loops[i].getBody());
+      AffineExpr dim0;
+      auto it = rewriter.getAffineConstantExpr(inputTileSize);
+      auto ot = rewriter.getAffineConstantExpr(outputTileSize);
+      auto delta = rewriter.getAffineConstantExpr(inputShape[i]);
+      bindDims(rewriter.getContext(), dim0);
+      AffineMap scaleMap =
+          AffineMap::get(1, 0, {dim0 * ot}, rewriter.getContext());
+      offsets[i] = rewriter.createOrFold<affine::AffineApplyOp>(
+          loc, scaleMap, ValueRange{ivs[i]});
+      AffineMap minMap =
+          AffineMap::get(1, 0, {-dim0 + delta, it}, rewriter.getContext());
+      sizes[i] = rewriter.createOrFold<affine::AffineMinOp>(
+          loc, minMap,
+          ValueRange{
+              getValueOrCreateConstantIndexOp(rewriter, loc, offsets[i])});
+    }
+  }
+  rewriter.setInsertionPointToStart(loopNest.loops.back().getBody());
+  auto tensorType = RankedTensorType::get(
+      SmallVector<int64_t>(numImageDims, ShapedType::kDynamic), elementType);
+  if (isNchw) {
+    permute<Permutation::NHWC_TO_NCHW>(offsets);
+    permute<Permutation::NHWC_TO_NCHW>(sizes);
+  }
+  Value dynamicSlice = rewriter.create<tensor::ExtractSliceOp>(
+      loc, tensorType, input, offsets, sizes, strides);
+
+  // Extract output slice
+  auto stridesOutputSlice =
+      SmallVector<OpFoldResult>(inputOp.getOutputOperandRank(), one);
+  auto offsetsOutputSlice = SmallVector<OpFoldResult>(numImageDims, zero);
+  offsetsOutputSlice.append(ivs.begin(), ivs.end());
+  auto sizesOutputSlice =
+      SmallVector<OpFoldResult>(inputOp.getOutputOperandRank(), one);
+  sizesOutputSlice[0] = sizesOutputSlice[1] = inputTileSizeAttr;
+  tensorType = RankedTensorType::get(inputTileSquare, elementType);
+  Value iterArg = loopNest.loops.back().getRegionIterArg(0);
+  Value outputSlice = rewriter.create<tensor::ExtractSliceOp>(
+      loc, tensorType, iterArg, offsetsOutputSlice, sizesOutputSlice,
+      stridesOutputSlice);
+
+  IntegerAttr outputTileSizeI64Attr =
+      rewriter.getI64IntegerAttr(inputOp.getOutputTileSize());
+  IntegerAttr kernelSizeI64Attr =
+      rewriter.getI64IntegerAttr(inputOp.getKernelSize());
+  DenseI64ArrayAttr imageDimensionsDenseI64ArrayAttr =
+      rewriter.getDenseI64ArrayAttr(inputOp.imageDimensions());
+  tiledWinogradInputTransformOp = rewriter.create<WinogradInputTransformOp>(
+      loc, tensorType, dynamicSlice, outputSlice, outputTileSizeI64Attr,
+      kernelSizeI64Attr, imageDimensionsDenseI64ArrayAttr);
+
+  // Insert results into output slice
+  Value updatedOutput = rewriter.create<tensor::InsertSliceOp>(
+      loc, tiledWinogradInputTransformOp.getResult()[0], iterArg,
+      offsetsOutputSlice, sizesOutputSlice, stridesOutputSlice);
+
+  // Replace returned value
+  if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
+          loopNest.loops.back().getBody()->getTerminator())) {
+    OpBuilder::InsertionGuard yieldGuard(rewriter);
+    rewriter.setInsertionPoint(yieldOp);
+    rewriter.replaceOpWithNewOp<scf::YieldOp>(yieldOp, updatedOutput);
+  }
+  inputOp.getResults()[0].replaceAllUsesWith(loopNest.results[0]);
+
+  return success();
+}
+
+/// Decompose tiled iree_linalg_ext.winograd.input_transform op.
+/// TODO: Adopt decomposeOperation with this.
+static LogicalResult decomposeTiledWinogradInputTransformOp(
+    WinogradInputTransformOp tiledWinogradInputTransformOp,
+    RewriterBase &rewriter) {
+  Location loc = tiledWinogradInputTransformOp.getLoc();
+  auto funcOp = tiledWinogradInputTransformOp->getParentOfType<func::FuncOp>();
+  if (!funcOp) {
+    return rewriter.notifyMatchFailure(tiledWinogradInputTransformOp,
+                                       "Could not find parent of type funcOp");
+  }
+  rewriter.setInsertionPointToStart(&funcOp.getBody().front());
+
+  Value dynamicSlice = tiledWinogradInputTransformOp.input();
+  Value outputSlice = tiledWinogradInputTransformOp.output();
+  assert(tiledWinogradInputTransformOp.getInputOperandRank() == 2 &&
+         "input operand expected to have rank-2");
+  assert(tiledWinogradInputTransformOp.getOutputOperandRank() == 2 &&
+         "output operand expected to have rank-2");
+  auto one = rewriter.getIndexAttr(1);
+  auto zero = rewriter.getIndexAttr(0);
+  const int64_t inputTileSize =
+      tiledWinogradInputTransformOp.getInputTileSize();
+  const std::array<int64_t, 2> imageDims =
+      tiledWinogradInputTransformOp.nhwcImageDimensions();
+  llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
+                                                imageDims.end());
+  SmallVector<int64_t> inputTileSquare(imageDims.size(), inputTileSize);
+  Type elementType =
+      tiledWinogradInputTransformOp.getOutputOperandType().getElementType();
+  Value zeroF32 = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getZeroAttr(elementType));
+  Value scratch =
+      rewriter.create<tensor::EmptyOp>(loc, inputTileSquare, elementType);
+  const float *BT{nullptr};
+  const float *B{nullptr};
+  B = IREE::LinalgExt::Winograd::B_6x6_3x3;
+  BT = IREE::LinalgExt::Winograd::BT_6x6_3x3;
+  Value BTV = IREE::LinalgExt::createValueFrom2DConstant(
+      BT, inputTileSize, inputTileSize, loc, rewriter);
+  Value BV = IREE::LinalgExt::createValueFrom2DConstant(
+      B, inputTileSize, inputTileSize, loc, rewriter);
+
+  auto inputExtractSliceOp =
+      dynamicSlice.getDefiningOp<tensor::ExtractSliceOp>();
+  SmallVector<OpFoldResult> staticOffsets = inputExtractSliceOp.getOffsets();
+  SmallVector<OpFoldResult> staticSizes = inputExtractSliceOp.getSizes();
+  // Harcoding input rank as 4 here - since we'd be getting a tiled version with
+  // rank 2. We are always expected to either have a rank 4 version of this op,
+  // or rank 2 (tiled). And at this point in the flow, it is guaranteed to be a
+  // rank 2 version of the op as ensured by the assertion above. Copy input
+  // slice into zeroed padded scratch space
+  SmallVector<OpFoldResult> offsets(2, zero);
+  SmallVector<OpFoldResult> sizes(4, one);
+  SmallVector<OpFoldResult> strides(2, one);
+  unsigned staticSizeIndexCounter = 0;
+  for (int i = 0; i < 4; i++) {
+    if (!imageDimsSet.contains(i)) {
+      continue;
+    }
+    sizes[i] = staticSizes[staticSizeIndexCounter++];
+  }
+  SmallVector<OpFoldResult> sliceOffsets;
+  SmallVector<OpFoldResult> sliceSizes;
+  const bool isNchw = tiledWinogradInputTransformOp.isNchw();
+  if (isNchw) {
+    permute<Permutation::NHWC_TO_NCHW>(sizes);
+  }
+  for (const int64_t dim : tiledWinogradInputTransformOp.imageDimensions()) {
+    sliceSizes.push_back(sizes[dim]);
+  }
+  OpBuilder::InsertionGuard afterTiledWinogradInputTransformOp(rewriter);
+  rewriter.setInsertionPointAfter(tiledWinogradInputTransformOp);
+  linalg::FillOp fillOp = rewriter.create<linalg::FillOp>(
+      loc, ValueRange{zeroF32}, ValueRange{scratch});
+  Value inputSlice = rewriter.create<tensor::InsertSliceOp>(
+      loc, dynamicSlice, fillOp.result(), offsets, sliceSizes, strides);
+
+  // Create computation
+  Value result, AMatrix, BMatrix;
+  linalg::MatmulOp matmulOp;
+  Type tensorType = outputSlice.getType();
+  for (int i = 0; i < 2; i++) {
+    fillOp = rewriter.create<linalg::FillOp>(loc, ValueRange{zeroF32},
+                                             ValueRange{outputSlice});
+    if (i == 0) {
+      AMatrix = inputSlice;
+      BMatrix = BV;
+    } else {
+      AMatrix = BTV;
+      BMatrix = result;
+    }
+    matmulOp = rewriter.create<linalg::MatmulOp>(
+        loc, tensorType, ValueRange{AMatrix, BMatrix}, fillOp.result());
+    result = matmulOp.getResult(0);
+  }
+  tiledWinogradInputTransformOp.getResult()[0].replaceAllUsesWith(result);
+  return success();
+}
+
+/// The input to WinogradInputTransformOp op is either (N, H, W, C) or (N, C,
+/// H, W) but the output to this op is always (T, T, N, H', W', C). Since the
+/// first two dimensions are used for the inner matrix multiplication, we
+/// create the loop nest over (N, H', W', C).
+LogicalResult tileAndDecomposeWinogradInputTransformOp(
+    WinogradInputTransformOp inputOp, RewriterBase &rewriter, bool onlyTile) {
+  WinogradInputTransformOp tiledWinogradInputTransformOp;
+  if (failed(tileWinogradInputTransformOp(inputOp, rewriter,
+                                          tiledWinogradInputTransformOp))) {
+    return failure();
+  }
+  if (onlyTile)
+    return success();
+  return decomposeTiledWinogradInputTransformOp(tiledWinogradInputTransformOp,
+                                                rewriter);
+}
 
 } // namespace
 
 namespace {
 
-class ReifyWinogradOutputTransform final
-    : public OpRewritePattern<WinogradOutputTransformOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  /// The input to this op is always (T, T, N, H', W', C)
-  /// but the output is either (N, H, W, C) or (N, C, H, W).
-  LogicalResult matchAndRewrite(WinogradOutputTransformOp outputOp,
-                                PatternRewriter &rewriter) const override {
-    Location loc = outputOp.getLoc();
-    auto funcOp = outputOp->getParentOfType<func::FuncOp>();
-    if (!funcOp) {
-      return rewriter.notifyMatchFailure(
-          outputOp, "Could not find parent of type funcOp");
-    }
-
-    const float *AT{nullptr};
-    const float *A{nullptr};
-    const int64_t inputTileSize = outputOp.getInputTileSize();
-    const int64_t outputTileSize = outputOp.getOutputTileSize();
-    switch (outputTileSize) {
-    case 6:
-      A = IREE::LinalgExt::Winograd::A_6x6_3x3;
-      AT = IREE::LinalgExt::Winograd::AT_6x6_3x3;
-      break;
-    default:
-      return failure();
-    }
-    /// The two values below are the transpose(A) [ATV]
-    /// and A [AV] constant matrices that convert the output
-    /// tile from the Winograd domain to the original domain.
-    Value ATV = IREE::LinalgExt::createValueFrom2DConstant(
-        AT, outputTileSize, inputTileSize, loc, rewriter);
-    Value AV = IREE::LinalgExt::createValueFrom2DConstant(
-        A, inputTileSize, outputTileSize, loc, rewriter);
-
-    Value input = outputOp.input();
-    Value output = outputOp.output();
-    auto outputType = output.getType().cast<ShapedType>();
-    ArrayRef<int64_t> outputShape = outputType.getShape();
-    Type elementType = outputType.getElementType();
-    const std::array<int64_t, 2> imageDims = outputOp.nhwcImageDimensions();
-    const size_t numImageDims = imageDims.size();
-    llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
-                                                  imageDims.end());
-    SmallVector<int64_t> inputTileSquare(imageDims.size(), inputTileSize);
-
-    rewriter.setInsertionPointToStart(&funcOp.getBody().front());
-    Value zeroF32 = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
-    SmallVector<int64_t> scratchShape = {inputTileSize, outputTileSize};
-    Value scratch =
-        rewriter.create<tensor::EmptyOp>(loc, scratchShape, elementType);
-
-    rewriter.setInsertionPoint(outputOp);
-    SmallVector<Value> lbs, ubs, steps;
-    computeLoopParams(lbs, ubs, steps, input, numImageDims, loc, rewriter);
-    // Construct loops
-    scf::LoopNest loopNest = scf::buildLoopNest(
-        rewriter, loc, lbs, ubs, steps, ValueRange({output}),
-        [&](OpBuilder &nestedBuilder, Location loc, ValueRange outputIvs,
-            ValueRange iterArgs) -> scf::ValueVector { return {iterArgs[0]}; });
-
-    // Extract input slice
-    rewriter.setInsertionPointToStart(loopNest.loops.back().getBody());
-    auto one = rewriter.getIndexAttr(1);
-    auto zero = rewriter.getIndexAttr(0);
-    auto inputTileSizeAttr = rewriter.getIndexAttr(inputTileSize);
-    auto outputTileSizeAttr = rewriter.getIndexAttr(outputTileSize);
-    SmallVector<OpFoldResult> strides(outputOp.getInputOperandRank(), one);
-    SmallVector<OpFoldResult> sizes(outputOp.getInputOperandRank(), one);
-    SmallVector<OpFoldResult> offsets(numImageDims, zero);
-    sizes[0] = sizes[1] = inputTileSizeAttr;
-    SmallVector<Value> ivs;
-    for (scf::ForOp loop : loopNest.loops) {
-      ivs.push_back(loop.getInductionVar());
-    }
-    offsets.append(ivs.begin(), ivs.end());
-    auto tensorType = RankedTensorType::get(inputTileSquare, elementType);
-    tensor::ExtractSliceOp extractSliceOp =
-        rewriter.create<tensor::ExtractSliceOp>(loc, tensorType, input, offsets,
-                                                sizes, strides);
-    Value inputSlice = extractSliceOp.getResult();
-
-    // Extract output slice
-    strides = SmallVector<OpFoldResult>(outputOp.getOutputOperandRank(), one);
-    offsets = SmallVector<OpFoldResult>(outputOp.getOutputOperandRank(), zero);
-    sizes = SmallVector<OpFoldResult>(outputOp.getOutputOperandRank(), one);
-    for (int i = 0; i < outputShape.size(); i++) {
-      if (!imageDimsSet.contains(i)) {
-        offsets[i] = ivs[i];
-      } else {
-        rewriter.setInsertionPointToStart(loopNest.loops[i].getBody());
-        AffineExpr dim0;
-        auto ot = rewriter.getAffineConstantExpr(outputTileSize);
-        bindDims(rewriter.getContext(), dim0);
-        AffineMap scaleMap =
-            AffineMap::get(1, 0, {dim0 * ot}, rewriter.getContext());
-        offsets[i] = rewriter.createOrFold<affine::AffineApplyOp>(
-            loc, scaleMap, ValueRange{ivs[i]});
-        sizes[i] = outputTileSizeAttr;
-      }
-    }
-    rewriter.setInsertionPointAfter(extractSliceOp);
-    tensorType = RankedTensorType::get(
-        SmallVector<int64_t>(numImageDims, outputTileSize), elementType);
-    Value iterArg = loopNest.loops.back().getRegionIterArg(0);
-    if (outputOp.isNchw()) {
-      permute<Permutation::NHWC_TO_NCHW>(offsets);
-      permute<Permutation::NHWC_TO_NCHW>(sizes);
-    }
-    Value outputSlice = rewriter.create<tensor::ExtractSliceOp>(
-        loc, tensorType, iterArg, offsets, sizes, strides);
-
-    // Create computation
-    Value result, AMatrix, BMatrix;
-    linalg::MatmulOp matmulOp;
-    linalg::FillOp fillOp;
-    Value tmp;
-    for (int i = 0; i < 2; i++) {
-      tmp = i == 0 ? scratch : outputSlice;
-      fillOp = rewriter.create<linalg::FillOp>(loc, ValueRange{zeroF32},
-                                               ValueRange{tmp});
-      if (i == 0) {
-        AMatrix = inputSlice;
-        BMatrix = AV;
-      } else {
-        AMatrix = ATV;
-        BMatrix = result;
-      }
-      matmulOp = rewriter.create<linalg::MatmulOp>(
-          loc, tmp.getType(), ValueRange{AMatrix, BMatrix}, fillOp.result());
-      result = matmulOp.getResult(0);
-    }
-
-    // Insert results into output slice
-    Value updatedOutput = rewriter.create<tensor::InsertSliceOp>(
-        loc, result, iterArg, offsets, sizes, strides);
-
-    // Replace returned value
-    if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
-            loopNest.loops.back().getBody()->getTerminator())) {
-      rewriter.replaceOpWithNewOp<scf::YieldOp>(yieldOp, updatedOutput);
-    }
-    outputOp.getResults()[0].replaceAllUsesWith(loopNest.results[0]);
-    return success();
+/// Tile iree_linalg_ext.winograd.output_transform op.
+/// TODO: Adopt getTiledImplementation with this.
+static LogicalResult tileWinogradOutputTransformOp(
+    WinogradOutputTransformOp outputOp, RewriterBase &rewriter,
+    WinogradOutputTransformOp &tiledWinogradOutputTransformOp) {
+  Location loc = outputOp.getLoc();
+  auto funcOp = outputOp->getParentOfType<func::FuncOp>();
+  if (!funcOp) {
+    return rewriter.notifyMatchFailure(outputOp,
+                                       "Could not find parent of type funcOp");
   }
-};
+
+  const int64_t inputTileSize = outputOp.getInputTileSize();
+  const int64_t outputTileSize = outputOp.getOutputTileSize();
+  switch (outputTileSize) {
+  case 6:
+    break;
+  default:
+    return failure();
+  }
+
+  Value input = outputOp.input();
+  Value output = outputOp.output();
+  auto outputType = output.getType().cast<ShapedType>();
+  ArrayRef<int64_t> outputShape = outputType.getShape();
+  Type elementType = outputType.getElementType();
+  const std::array<int64_t, 2> imageDims = outputOp.nhwcImageDimensions();
+  const size_t numImageDims = imageDims.size();
+  llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
+                                                imageDims.end());
+  SmallVector<int64_t> inputTileSquare(imageDims.size(), inputTileSize);
+
+  rewriter.setInsertionPointToStart(&funcOp.getBody().front());
+
+  SmallVector<Value> lbs, ubs, steps;
+  computeLoopParams(lbs, ubs, steps, input, numImageDims, loc, rewriter);
+  // Construct loops
+  rewriter.setInsertionPoint(outputOp);
+  scf::LoopNest loopNest = scf::buildLoopNest(
+      rewriter, loc, lbs, ubs, steps, ValueRange({output}),
+      [&](OpBuilder &nestedBuilder, Location loc, ValueRange outputIvs,
+          ValueRange iterArgs) -> scf::ValueVector { return {iterArgs[0]}; });
+
+  // Extract input slice
+  rewriter.setInsertionPointToStart(loopNest.loops.back().getBody());
+  auto one = rewriter.getIndexAttr(1);
+  auto zero = rewriter.getIndexAttr(0);
+  auto inputTileSizeAttr = rewriter.getIndexAttr(inputTileSize);
+  auto outputTileSizeAttr = rewriter.getIndexAttr(outputTileSize);
+  SmallVector<OpFoldResult> strides(outputOp.getInputOperandRank(), one);
+  SmallVector<OpFoldResult> sizes(outputOp.getInputOperandRank(), one);
+  SmallVector<OpFoldResult> offsets(numImageDims, zero);
+  sizes[0] = sizes[1] = inputTileSizeAttr;
+  SmallVector<Value> ivs;
+  for (scf::ForOp loop : loopNest.loops) {
+    ivs.push_back(loop.getInductionVar());
+  }
+  offsets.append(ivs.begin(), ivs.end());
+  auto tensorType = RankedTensorType::get(inputTileSquare, elementType);
+  tensor::ExtractSliceOp extractSliceOp =
+      rewriter.create<tensor::ExtractSliceOp>(loc, tensorType, input, offsets,
+                                              sizes, strides);
+  Value inputSlice = extractSliceOp.getResult();
+
+  // Extract output slice
+  strides = SmallVector<OpFoldResult>(outputOp.getOutputOperandRank(), one);
+  offsets = SmallVector<OpFoldResult>(outputOp.getOutputOperandRank(), zero);
+  sizes = SmallVector<OpFoldResult>(outputOp.getOutputOperandRank(), one);
+  for (int i = 0; i < outputShape.size(); i++) {
+    if (!imageDimsSet.contains(i)) {
+      offsets[i] = ivs[i];
+    } else {
+      rewriter.setInsertionPointToStart(loopNest.loops[i].getBody());
+      AffineExpr dim0;
+      auto ot = rewriter.getAffineConstantExpr(outputTileSize);
+      bindDims(rewriter.getContext(), dim0);
+      AffineMap scaleMap =
+          AffineMap::get(1, 0, {dim0 * ot}, rewriter.getContext());
+      offsets[i] = rewriter.createOrFold<affine::AffineApplyOp>(
+          loc, scaleMap, ValueRange{ivs[i]});
+      sizes[i] = outputTileSizeAttr;
+    }
+  }
+  rewriter.setInsertionPointAfter(extractSliceOp);
+  tensorType = RankedTensorType::get(
+      SmallVector<int64_t>(numImageDims, outputTileSize), elementType);
+  Value iterArg = loopNest.loops.back().getRegionIterArg(0);
+  if (outputOp.isNchw()) {
+    permute<Permutation::NHWC_TO_NCHW>(offsets);
+    permute<Permutation::NHWC_TO_NCHW>(sizes);
+  }
+  Value outputSlice = rewriter.create<tensor::ExtractSliceOp>(
+      loc, tensorType, iterArg, offsets, sizes, strides);
+
+  IntegerAttr outputTileSizeI64Attr =
+      rewriter.getI64IntegerAttr(outputOp.getOutputTileSize());
+  IntegerAttr kernelSizeI64Attr =
+      rewriter.getI64IntegerAttr(outputOp.getKernelSize());
+  DenseI64ArrayAttr imageDimensionsDenseI64ArrayAttr =
+      rewriter.getDenseI64ArrayAttr(outputOp.imageDimensions());
+  tiledWinogradOutputTransformOp = rewriter.create<WinogradOutputTransformOp>(
+      loc, tensorType, inputSlice, outputSlice, outputTileSizeI64Attr,
+      kernelSizeI64Attr, imageDimensionsDenseI64ArrayAttr);
+
+  // Insert results into output slice
+  Value updatedOutput = rewriter.create<tensor::InsertSliceOp>(
+      loc, tiledWinogradOutputTransformOp.getResult()[0], iterArg, offsets,
+      sizes, strides);
+
+  // Replace returned value
+  if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
+          loopNest.loops.back().getBody()->getTerminator())) {
+    rewriter.replaceOpWithNewOp<scf::YieldOp>(yieldOp, updatedOutput);
+  }
+  outputOp.getResults()[0].replaceAllUsesWith(loopNest.results[0]);
+  return success();
+}
+
+/// Decompose tiled iree_linalg_ext.winograd.output_transform op.
+/// TODO: Adopt decomposeOperation with this.
+static LogicalResult decomposeTiledWinogradOutputTransformOp(
+    WinogradOutputTransformOp tiledWinogradOutputTransformOp,
+    RewriterBase &rewriter) {
+  Location loc = tiledWinogradOutputTransformOp.getLoc();
+  auto funcOp = tiledWinogradOutputTransformOp->getParentOfType<func::FuncOp>();
+  if (!funcOp) {
+    return rewriter.notifyMatchFailure(tiledWinogradOutputTransformOp,
+                                       "Could not find parent of type funcOp");
+  }
+  rewriter.setInsertionPointToStart(&funcOp.getBody().front());
+  Value inputSlice = tiledWinogradOutputTransformOp.input();
+  Value outputSlice = tiledWinogradOutputTransformOp.output();
+  assert(tiledWinogradOutputTransformOp.getInputOperandRank() == 2 &&
+         "input operand expected to have rank-2");
+  assert(tiledWinogradOutputTransformOp.getOutputOperandRank() == 2 &&
+         "output operand expected to have rank-2");
+  ShapedType outputType = tiledWinogradOutputTransformOp.getOutputOperandType();
+  Type elementType = outputType.getElementType();
+  const float *AT{nullptr};
+  const float *A{nullptr};
+  A = IREE::LinalgExt::Winograd::A_6x6_3x3;
+  AT = IREE::LinalgExt::Winograd::AT_6x6_3x3;
+  const int64_t inputTileSize =
+      tiledWinogradOutputTransformOp.getInputTileSize();
+  const int64_t outputTileSize =
+      tiledWinogradOutputTransformOp.getOutputTileSize();
+  /// The two values below are the transpose(A) [ATV]
+  /// and A [AV] constant matrices that convert the output
+  /// tile from the Winograd domain to the original domain.
+  Value ATV = IREE::LinalgExt::createValueFrom2DConstant(
+      AT, outputTileSize, inputTileSize, loc, rewriter);
+  Value AV = IREE::LinalgExt::createValueFrom2DConstant(
+      A, inputTileSize, outputTileSize, loc, rewriter);
+  Value zeroF32 = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getZeroAttr(elementType));
+  SmallVector<int64_t> scratchShape = {inputTileSize, outputTileSize};
+  Value scratch =
+      rewriter.create<tensor::EmptyOp>(loc, scratchShape, elementType);
+  // Create computation
+  OpBuilder::InsertionGuard afterTiledWinogradOutputTransformOp(rewriter);
+  rewriter.setInsertionPointAfter(tiledWinogradOutputTransformOp);
+  Value result, AMatrix, BMatrix;
+  linalg::MatmulOp matmulOp;
+  linalg::FillOp fillOp;
+  Value tmp;
+  for (int i = 0; i < 2; i++) {
+    tmp = i == 0 ? scratch : outputSlice;
+    fillOp = rewriter.create<linalg::FillOp>(loc, ValueRange{zeroF32},
+                                             ValueRange{tmp});
+    if (i == 0) {
+      AMatrix = inputSlice;
+      BMatrix = AV;
+    } else {
+      AMatrix = ATV;
+      BMatrix = result;
+    }
+    matmulOp = rewriter.create<linalg::MatmulOp>(
+        loc, tmp.getType(), ValueRange{AMatrix, BMatrix}, fillOp.result());
+    result = matmulOp.getResult(0);
+  }
+  tiledWinogradOutputTransformOp.getResult()[0].replaceAllUsesWith(result);
+  return success();
+}
+
+/// The input to WinogradOutputTransformOp is always (T, T, N, H', W', C)
+/// but the output is either (N, H, W, C) or (N, C, H, W).
+LogicalResult tileAndDecomposeWinogradOutputTransformOp(
+    WinogradOutputTransformOp outputOp, RewriterBase &rewriter, bool onlyTile) {
+  WinogradOutputTransformOp tiledWinogradOutputTransformOp;
+  if (failed(tileWinogradOutputTransformOp(outputOp, rewriter,
+                                           tiledWinogradOutputTransformOp))) {
+    return failure();
+  }
+  if (onlyTile)
+    return success();
+  return decomposeTiledWinogradOutputTransformOp(tiledWinogradOutputTransformOp,
+                                                 rewriter);
+}
 
 } // namespace
 
@@ -375,19 +508,40 @@ struct TileAndDecomposeWinogradTransformPass
         linalg::LinalgDialect, scf::SCFDialect, tensor::TensorDialect>();
   }
 
+  TileAndDecomposeWinogradTransformPass() = default;
+  TileAndDecomposeWinogradTransformPass(bool onlyTile) {
+    this->onlyTile = onlyTile;
+  }
+  TileAndDecomposeWinogradTransformPass(
+      const TileAndDecomposeWinogradTransformPass &pass) {
+    onlyTile = pass.onlyTile;
+  }
+
   void runOnOperation() override;
 };
 } // namespace
 
+LogicalResult reifyWinogradTransform(func::FuncOp funcOp, bool onlyTile) {
+  IRRewriter rewriter(funcOp.getContext());
+  LogicalResult resultOfTransformations = success();
+  funcOp.walk([&](WinogradInputTransformOp inputOp) {
+    if (failed(tileAndDecomposeWinogradInputTransformOp(inputOp, rewriter,
+                                                        onlyTile)))
+      resultOfTransformations = failure();
+    return WalkResult::advance();
+  });
+  funcOp.walk([&](WinogradOutputTransformOp outputOp) {
+    if (failed(tileAndDecomposeWinogradOutputTransformOp(outputOp, rewriter,
+                                                         onlyTile)))
+      resultOfTransformations = failure();
+    return WalkResult::advance();
+  });
+  return resultOfTransformations;
+}
+
 void TileAndDecomposeWinogradTransformPass::runOnOperation() {
-  MLIRContext *context = &getContext();
-  RewritePatternSet patterns(&getContext());
-  patterns.insert<ReifyWinogradInputTransform, ReifyWinogradOutputTransform>(
-      context);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(reifyWinogradTransform(getOperation(), onlyTile)))
     return signalPassFailure();
-  }
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
@@ -72,7 +72,7 @@ SmallVector<int64_t> computeInterchangeFromDimPos(ArrayRef<int64_t> dimsPos,
 }
 
 Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
-                                Location loc, PatternRewriter &rewriter) {
+                                Location loc, RewriterBase &rewriter) {
   ArrayRef<float> vector(val, rows * cols);
   SmallVector<int64_t> shape{rows, cols};
   return rewriter.create<arith::ConstantOp>(

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_winograd.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_winograd.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-dialects-opt --iree-linalg-ext-tile-and-decompose-winograd --split-input-file %s | FileCheck %s
+// RUN: iree-dialects-opt --iree-linalg-ext-tile-and-decompose-winograd --cse --split-input-file %s | FileCheck %s
+// RUN: iree-dialects-opt --iree-linalg-ext-tile-and-decompose-winograd=onlyTile --cse --split-input-file %s | FileCheck %s --check-prefix=TILING
 
 #map = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
 #map1 = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
@@ -30,15 +31,15 @@ module {
 // CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0) -> (-d0 + 10, 8)>
 // CHECK:      func.func @winograd_input_transform(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x10x10x1280xf32>) ->
 // CHECK-SAME:   tensor<8x8x1x2x2x1280xf32> {
-// CHECK:        %[[C32:.+]] = arith.constant 32 : index
-// CHECK:        %[[C1280:.+]] = arith.constant 1280 : index
-// CHECK:        %[[C1:.+]] = arith.constant 1 : index
-// CHECK:        %[[C0:.+]] = arith.constant 0 : index
+// CHECK:        %[[CST_1:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<8x8xf32>
 // CHECK:        %[[CST:.+]] = arith.constant dense<
 // CHECK:        %[[CST_0:.+]] = arith.constant dense<
-// CHECK:        %[[CST_1:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[C0:.+]] = arith.constant 0 : index
+// CHECK:        %[[C1:.+]] = arith.constant 1 : index
 // CHECK:        %[[C2:.+]] = arith.constant 2 : index
-// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<8x8xf32>
+// CHECK:        %[[C1280:.+]] = arith.constant 1280 : index
+// CHECK:        %[[C32:.+]] = arith.constant 32 : index
 // CHECK:        %[[D1:.+]] = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
 // CHECK:        %[[D2:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1]] step %[[C1]]
 // CHECK-SAME:     iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D1]]) -> (tensor<8x8x1x2x2x1280xf32>) {
@@ -66,21 +67,19 @@ module {
 // CHECK:                    %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][%[[ARG5]], %[[D8]],
 // CHECK-SAME:                 %[[D11]], %[[ARG11]]] [1, %[[D9]], %[[D12]], 1] [1, 1, 1, 1] : tensor<?x10x10x?xf32> to
 // CHECK-SAME:                 tensor<?x?xf32>
+// CHECK:                    %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[ARG12]][0, 0, %[[ARG5]], %[[ARG7]],
+// CHECK-SAME:                 %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> to
+// CHECK-SAME:                 tensor<8x8xf32>
 // CHECK:                    %[[D14:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[D0]] : tensor<8x8xf32>) ->
 // CHECK-SAME:                 tensor<8x8xf32>
 // CHECK:                    %[[INSERTED_SLICE_4:.+]] = tensor.insert_slice %[[EXTRACTED_SLICE_3]] into %[[D14]][0, 0]
 // CHECK-SAME:                 [%[[D9]], %[[D12]]] [1, 1] : tensor<?x?xf32> into tensor<8x8xf32>
-// CHECK:                    %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[ARG12]][0, 0, %[[ARG5]], %[[ARG7]],
-// CHECK-SAME:                 %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> to
-// CHECK-SAME:                 tensor<8x8xf32>
 // CHECK:                    %[[D15:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_5]] :
 // CHECK-SAME:                 tensor<8x8xf32>) -> tensor<8x8xf32>
 // CHECK:                    %[[D16:.+]] = linalg.matmul ins(%[[INSERTED_SLICE_4]], %[[CST_0]] : tensor<8x8xf32>,
 // CHECK-SAME:                 tensor<8x8xf32>) outs(%[[D15]] : tensor<8x8xf32>) -> tensor<8x8xf32>
-// CHECK:                    %[[D17:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_5]] :
-// CHECK-SAME:                 tensor<8x8xf32>) -> tensor<8x8xf32>
 // CHECK:                    %[[D18:.+]] = linalg.matmul ins(%[[CST]], %[[D16]] : tensor<8x8xf32>, tensor<8x8xf32>)
-// CHECK-SAME:                 outs(%[[D17]] : tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK-SAME:                 outs(%[[D15]] : tensor<8x8xf32>) -> tensor<8x8xf32>
 // CHECK:                    %[[INSERTED_SLICE_6:.+]] = tensor.insert_slice %[[D18]] into %[[ARG12]][0, 0, %[[ARG5]],
 // CHECK-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8xf32>
 // CHECK-SAME:                 into tensor<8x8x?x2x2x?xf32>
@@ -101,6 +100,71 @@ module {
 // CHECK:        }
 // CHECK:        return %[[D2]] : tensor<8x8x1x2x2x1280xf32>
 // CHECK:      }
+
+// TILING-DAG:  #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+// TILING-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+// TILING-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 * 6)>
+// TILING-DAG:  #[[MAP3:.+]] = affine_map<(d0) -> (-d0 + 10, 8)>
+// TILING:      func.func @winograd_input_transform(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x10x10x1280xf32>) ->
+// TILING-SAME:   tensor<8x8x1x2x2x1280xf32> {
+// TILING:        %[[C0:.+]] = arith.constant 0 : index
+// TILING:        %[[C1:.+]] = arith.constant 1 : index
+// TILING:        %[[C2:.+]] = arith.constant 2 : index
+// TILING:        %[[C1280:.+]] = arith.constant 1280 : index
+// TILING:        %[[C32:.+]] = arith.constant 32 : index
+// TILING:        %[[D1:.+]] = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
+// TILING:        %[[D2:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1]] step %[[C1]]
+// TILING-SAME:     iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D1]]) -> (tensor<8x8x1x2x2x1280xf32>) {
+// TILING-DAG:        %[[D3:.+]] = affine.min #[[MAP]](%[[ARG1]])[%[[C1]], %[[C1]]]
+// TILING:          %[[D4:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1280]] step %[[C32]]
+// TILING-SAME:       iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[ARG2]]) -> (tensor<8x8x1x2x2x1280xf32>) {
+// TILING-DAG:          %[[D5:.+]] = affine.min #[[MAP1]](%[[ARG3]])[%[[C32]], %[[C1280]]]
+// TILING:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG1]], 0, 0, %[[ARG3]]] [%[[D3]], 10,
+// TILING-SAME:         10, %[[D5]]] [1, 1, 1, 1] : tensor<1x10x10x1280xf32> to tensor<?x10x10x?xf32>
+// TILING:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D1]][0, 0, %[[ARG1]], 0, 0, %[[ARG3]]] [8, 8,
+// TILING-SAME:         %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x1280xf32> to
+// TILING-SAME:         tensor<8x8x?x2x2x?xf32>
+// TILING:            %[[D6:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D3]] step %[[C1]]
+// TILING-SAME:         iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[EXTRACTED_SLICE_2]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// TILING:              %[[D7:.+]] = scf.for %[[ARG7:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// TILING-SAME:           iter_args(%[[ARG8:[a-zA-Z0-9_]+]] = %[[ARG6]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// TILING-DAG:              %[[D8:.+]] = affine.apply #[[MAP2]](%[[ARG7]])
+// TILING-DAG:              %[[D9:.+]] = affine.min #[[MAP3]](%[[D8]])
+// TILING:                %[[D10:.+]] = scf.for %[[ARG9:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// TILING-SAME:             iter_args(%[[ARG10:[a-zA-Z0-9_]+]] = %[[ARG8]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// TILING-DAG:                %[[D11:.+]] = affine.apply #[[MAP2]](%[[ARG9]])
+// TILING-DAG:                %[[D12:.+]] = affine.min #[[MAP3]](%[[D11]])
+// TILING:                  %[[D13:.+]] = scf.for %[[ARG11:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D5]] step %[[C1]]
+// TILING-SAME:               iter_args(%[[ARG12:[a-zA-Z0-9_]+]] = %[[ARG10]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// TILING:                    %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][%[[ARG5]], %[[D8]],
+// TILING-SAME:                 %[[D11]], %[[ARG11]]] [1, %[[D9]], %[[D12]], 1] [1, 1, 1, 1] : tensor<?x10x10x?xf32> to
+// TILING-SAME:                 tensor<?x?xf32>
+// TILING:                    %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[ARG12]][0, 0, %[[ARG5]], %[[ARG7]],
+// TILING-SAME:                 %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> to
+// TILING-SAME:                 tensor<8x8xf32>
+// TILING:                    %[[TILED_WINOGRAD:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2])
+// TILING-SAME:                                                  ins(%[[EXTRACTED_SLICE_3]] : tensor<?x?xf32>)
+// TILING-SAME:                                                  outs(%[[EXTRACTED_SLICE_5]] : tensor<8x8xf32>) -> tensor<8x8xf32>
+// TILING:                    %[[INSERTED_SLICE_6:.+]] = tensor.insert_slice %[[TILED_WINOGRAD]] into %[[ARG12]][0, 0, %[[ARG5]],
+// TILING-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8xf32>
+// TILING-SAME:                 into tensor<8x8x?x2x2x?xf32>
+// TILING:                    scf.yield %[[INSERTED_SLICE_6]] : tensor<8x8x?x2x2x?xf32>
+// TILING:                  }
+// TILING:                  scf.yield %[[D13]] : tensor<8x8x?x2x2x?xf32>
+// TILING:                }
+// TILING:                scf.yield %[[D10]] : tensor<8x8x?x2x2x?xf32>
+// TILING:              }
+// TILING:              scf.yield %[[D7]] : tensor<8x8x?x2x2x?xf32>
+// TILING:            }
+// TILING:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]] into %[[ARG4]][0, 0, %[[ARG1]], 0, 0,
+// TILING-SAME:         %[[ARG3]]] [8, 8, %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> into
+// TILING-SAME:         tensor<8x8x1x2x2x1280xf32>
+// TILING:            scf.yield %[[INSERTED_SLICE]] : tensor<8x8x1x2x2x1280xf32>
+// TILING:          }
+// TILING:          scf.yield %[[D4]] : tensor<8x8x1x2x2x1280xf32>
+// TILING:        }
+// TILING:        return %[[D2]] : tensor<8x8x1x2x2x1280xf32>
+// TILING:      }
 
 // -----
 
@@ -132,14 +196,14 @@ module {
 // CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 * 6)>
 // CHECK:      func.func @winograd_output_transform(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<8x8x1x2x2x32xf32>) ->
 // CHECK-SAME:   tensor<1x12x12x32xf32> {
-// CHECK:        %[[C32:.+]] = arith.constant 32 : index
-// CHECK:        %[[C1:.+]] = arith.constant 1 : index
-// CHECK:        %[[C0:.+]] = arith.constant 0 : index
 // CHECK:        %[[CST:.+]] = arith.constant dense<
 // CHECK:        %[[CST_0:.+]] = arith.constant dense<
 // CHECK:        %[[CST_1:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK:        %[[C2:.+]] = arith.constant 2 : index
 // CHECK:        %[[D0:.+]] = tensor.empty() : tensor<8x6xf32>
+// CHECK:        %[[C0:.+]] = arith.constant 0 : index
+// CHECK:        %[[C1:.+]] = arith.constant 1 : index
+// CHECK:        %[[C2:.+]] = arith.constant 2 : index
+// CHECK:        %[[C32:.+]] = arith.constant 32 : index
 // CHECK:        %[[D1:.+]] = tensor.empty() : tensor<1x12x12x32xf32>
 // CHECK:        %[[D2:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1]] step %[[C1]]
 // CHECK-SAME:     iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D1]]) -> (tensor<1x12x12x32xf32>) {
@@ -194,6 +258,64 @@ module {
 // CHECK:        return %[[D2]] : tensor<1x12x12x32xf32>
 // CHECK:      }
 
+// TILING-DAG:  #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+// TILING-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+// TILING-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 * 6)>
+// TILING:      func.func @winograd_output_transform(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<8x8x1x2x2x32xf32>) ->
+// TILING-SAME:   tensor<1x12x12x32xf32> {
+// TILING:        %[[C0:.+]] = arith.constant 0 : index
+// TILING:        %[[C1:.+]] = arith.constant 1 : index
+// TILING:        %[[C2:.+]] = arith.constant 2 : index
+// TILING:        %[[C32:.+]] = arith.constant 32 : index
+// TILING:        %[[D1:.+]] = tensor.empty() : tensor<1x12x12x32xf32>
+// TILING:        %[[D2:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1]] step %[[C1]]
+// TILING-SAME:     iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D1]]) -> (tensor<1x12x12x32xf32>) {
+// TILING-DAG:        %[[D3:.+]] = affine.min #[[MAP]](%[[ARG1]])[%[[C1]], %[[C1]]]
+// TILING:          %[[D4:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C32]] step %[[C32]]
+// TILING-SAME:       iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[ARG2]]) -> (tensor<1x12x12x32xf32>) {
+// TILING-DAG:          %[[D5:.+]] = affine.min #[[MAP1]](%[[ARG3]])[%[[C32]], %[[C32]]]
+// TILING:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, 0, %[[ARG1]], 0, 0, %[[ARG3]]] [8, 8,
+// TILING-SAME:         %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x32xf32> to tensor<8x8x?x2x2x?xf32>
+// TILING:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D1]][%[[ARG1]], 0, 0, %[[ARG3]]] [%[[D3]], 12,
+// TILING-SAME:         12, %[[D5]]] [1, 1, 1, 1] : tensor<1x12x12x32xf32> to tensor<?x12x12x?xf32>
+// TILING:            %[[D6:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D3]] step %[[C1]]
+// TILING-SAME:         iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[EXTRACTED_SLICE_2]]) -> (tensor<?x12x12x?xf32>) {
+// TILING:              %[[D7:.+]] = scf.for %[[ARG7:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// TILING-SAME:           iter_args(%[[ARG8:[a-zA-Z0-9_]+]] = %[[ARG6]]) -> (tensor<?x12x12x?xf32>) {
+// TILING-DAG:              %[[D8:.+]] = affine.apply #[[MAP2]](%[[ARG7]])
+// TILING:                %[[D9:.+]] = scf.for %[[ARG9:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// TILING-SAME:             iter_args(%[[ARG10:[a-zA-Z0-9_]+]] = %[[ARG8]]) -> (tensor<?x12x12x?xf32>) {
+// TILING-DAG:                %[[D10:.+]] = affine.apply #[[MAP2]](%[[ARG9]])
+// TILING:                  %[[D11:.+]] = scf.for %[[ARG11:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D5]] step %[[C1]]
+// TILING-SAME:               iter_args(%[[ARG12:[a-zA-Z0-9_]+]] = %[[ARG10]]) -> (tensor<?x12x12x?xf32>) {
+// TILING:                    %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][0, 0, %[[ARG5]],
+// TILING-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] :
+// TILING-SAME:                 tensor<8x8x?x2x2x?xf32> to tensor<8x8xf32>
+// TILING:                    %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[ARG12]][%[[ARG5]], %[[D8]], %[[D10]],
+// TILING-SAME:                 %[[ARG11]]] [1, 6, 6, 1] [1, 1, 1, 1] : tensor<?x12x12x?xf32> to tensor<6x6xf32>
+// TILING:                    %[[TILED_WINOGRAD:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2])
+// TILING-SAME:                                                  ins(%[[EXTRACTED_SLICE_3]] : tensor<8x8xf32>)
+// TILING-SAME:                                                  outs(%[[EXTRACTED_SLICE_4]] : tensor<6x6xf32>) -> tensor<6x6xf32>
+// TILING:                    %[[INSERTED_SLICE_5:.+]] = tensor.insert_slice %[[TILED_WINOGRAD]] into %[[ARG12]][%[[ARG5]], %[[D8]],
+// TILING-SAME:                 %[[D10]], %[[ARG11]]] [1, 6, 6, 1] [1, 1, 1, 1] : tensor<6x6xf32> into
+// TILING-SAME:                 tensor<?x12x12x?xf32>
+// TILING:                    scf.yield %[[INSERTED_SLICE_5]] : tensor<?x12x12x?xf32>
+// TILING:                  }
+// TILING:                  scf.yield %[[D11]] : tensor<?x12x12x?xf32>
+// TILING:                }
+// TILING:                scf.yield %[[D9]] : tensor<?x12x12x?xf32>
+// TILING:              }
+// TILING:              scf.yield %[[D7]] : tensor<?x12x12x?xf32>
+// TILING:            }
+// TILING:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]] into %[[ARG4]][%[[ARG1]], 0, 0, %[[ARG3]]]
+// TILING-SAME:         [%[[D3]], 12, 12, %[[D5]]] [1, 1, 1, 1] : tensor<?x12x12x?xf32> into tensor<1x12x12x32xf32>
+// TILING:            scf.yield %[[INSERTED_SLICE]] : tensor<1x12x12x32xf32>
+// TILING:          }
+// TILING:          scf.yield %[[D4]] : tensor<1x12x12x32xf32>
+// TILING:        }
+// TILING:        return %[[D2]] : tensor<1x12x12x32xf32>
+// TILING:      }
+
 // -----
 
 #map = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
@@ -226,15 +348,15 @@ module {
 // CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0) -> (-d0 + 10, 8)>
 // CHECK:      func.func @winograd_input_transform_nchw(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x1280x10x10xf32>) ->
 // CHECK-SAME:   tensor<8x8x1x2x2x1280xf32> {
-// CHECK:        %[[C32:.+]] = arith.constant 32 : index
-// CHECK:        %[[C1280:.+]] = arith.constant 1280 : index
-// CHECK:        %[[C1:.+]] = arith.constant 1 : index
-// CHECK:        %[[C0:.+]] = arith.constant 0 : index
+// CHECK:        %[[CST_1:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<8x8xf32>
 // CHECK:        %[[CST:.+]] = arith.constant dense<
 // CHECK:        %[[CST_0:.+]] = arith.constant dense<
-// CHECK:        %[[CST_1:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[C0:.+]] = arith.constant 0 : index
+// CHECK:        %[[C1:.+]] = arith.constant 1 : index
 // CHECK:        %[[C2:.+]] = arith.constant 2 : index
-// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<8x8xf32>
+// CHECK:        %[[C1280:.+]] = arith.constant 1280 : index
+// CHECK:        %[[C32:.+]] = arith.constant 32 : index
 // CHECK:        %[[D1:.+]] = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
 // CHECK:        %[[D2:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1]] step %[[C1]]
 // CHECK-SAME:     iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D1]]) -> (tensor<8x8x1x2x2x1280xf32>) {
@@ -262,21 +384,19 @@ module {
 // CHECK:                    %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][%[[ARG5]],
 // CHECK-SAME:                 %[[ARG11]], %[[D8]], %[[D11]]] [1, 1, %[[D9]], %[[D12]]] [1, 1, 1, 1] :
 // CHECK-SAME:                 tensor<?x?x10x10xf32> to tensor<?x?xf32>
+// CHECK:                    %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[ARG12]][0, 0, %[[ARG5]], %[[ARG7]],
+// CHECK-SAME:                 %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> to
+// CHECK-SAME:                 tensor<8x8xf32>
 // CHECK:                    %[[D14:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[D0]] : tensor<8x8xf32>) ->
 // CHECK-SAME:                 tensor<8x8xf32>
 // CHECK:                    %[[INSERTED_SLICE_4:.+]] = tensor.insert_slice %[[EXTRACTED_SLICE_3]] into %[[D14]][0, 0]
 // CHECK-SAME:                 [%[[D9]], %[[D12]]] [1, 1] : tensor<?x?xf32> into tensor<8x8xf32>
-// CHECK:                    %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[ARG12]][0, 0, %[[ARG5]], %[[ARG7]],
-// CHECK-SAME:                 %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> to
-// CHECK-SAME:                 tensor<8x8xf32>
 // CHECK:                    %[[D15:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_5]] :
 // CHECK-SAME:                 tensor<8x8xf32>) -> tensor<8x8xf32>
 // CHECK:                    %[[D16:.+]] = linalg.matmul ins(%[[INSERTED_SLICE_4]], %[[CST_0]] : tensor<8x8xf32>,
 // CHECK-SAME:                 tensor<8x8xf32>) outs(%[[D15]] : tensor<8x8xf32>) -> tensor<8x8xf32>
-// CHECK:                    %[[D17:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_5]] :
-// CHECK-SAME:                 tensor<8x8xf32>) -> tensor<8x8xf32>
 // CHECK:                    %[[D18:.+]] = linalg.matmul ins(%[[CST]], %[[D16]] : tensor<8x8xf32>, tensor<8x8xf32>)
-// CHECK-SAME:                 outs(%[[D17]] : tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK-SAME:                 outs(%[[D15]] : tensor<8x8xf32>) -> tensor<8x8xf32>
 // CHECK:                    %[[INSERTED_SLICE_6:.+]] = tensor.insert_slice %[[D18]] into %[[ARG12]][0, 0, %[[ARG5]],
 // CHECK-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8xf32>
 // CHECK-SAME:                 into tensor<8x8x?x2x2x?xf32>
@@ -298,6 +418,72 @@ module {
 // CHECK:        return %[[D2]] : tensor<8x8x1x2x2x1280xf32>
 // CHECK:      }
 // CHECK:    }
+
+// TILING-DAG:  #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+// TILING-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+// TILING-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 * 6)>
+// TILING-DAG:  #[[MAP3:.+]] = affine_map<(d0) -> (-d0 + 10, 8)>
+// TILING:      func.func @winograd_input_transform_nchw(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x1280x10x10xf32>) ->
+// TILING-SAME:   tensor<8x8x1x2x2x1280xf32> {
+// TILING:        %[[C0:.+]] = arith.constant 0 : index
+// TILING:        %[[C1:.+]] = arith.constant 1 : index
+// TILING:        %[[C2:.+]] = arith.constant 2 : index
+// TILING:        %[[C1280:.+]] = arith.constant 1280 : index
+// TILING:        %[[C32:.+]] = arith.constant 32 : index
+// TILING:        %[[D1:.+]] = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
+// TILING:        %[[D2:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1]] step %[[C1]]
+// TILING-SAME:     iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D1]]) -> (tensor<8x8x1x2x2x1280xf32>) {
+// TILING-DAG:        %[[D3:.+]] = affine.min #[[MAP]](%[[ARG1]])[%[[C1]], %[[C1]]]
+// TILING:          %[[D4:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1280]] step %[[C32]]
+// TILING-SAME:       iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[ARG2]]) -> (tensor<8x8x1x2x2x1280xf32>) {
+// TILING-DAG:          %[[D5:.+]] = affine.min #[[MAP1]](%[[ARG3]])[%[[C32]], %[[C1280]]]
+// TILING:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG1]], %[[ARG3]], 0, 0] [%[[D3]],
+// TILING-SAME:         %[[D5]], 10, 10] [1, 1, 1, 1] : tensor<1x1280x10x10xf32> to tensor<?x?x10x10xf32>
+// TILING:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D1]][0, 0, %[[ARG1]], 0, 0, %[[ARG3]]] [8, 8,
+// TILING-SAME:         %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x1280xf32> to
+// TILING-SAME:         tensor<8x8x?x2x2x?xf32>
+// TILING:            %[[D6:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D3]] step %[[C1]]
+// TILING-SAME:         iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[EXTRACTED_SLICE_2]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// TILING:              %[[D7:.+]] = scf.for %[[ARG7:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// TILING-SAME:           iter_args(%[[ARG8:[a-zA-Z0-9_]+]] = %[[ARG6]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// TILING-DAG:              %[[D8:.+]] = affine.apply #[[MAP2]](%[[ARG7]])
+// TILING-DAG:              %[[D9:.+]] = affine.min #[[MAP3]](%[[D8]])
+// TILING:                %[[D10:.+]] = scf.for %[[ARG9:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// TILING-SAME:             iter_args(%[[ARG10:[a-zA-Z0-9_]+]] = %[[ARG8]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// TILING-DAG:                %[[D11:.+]] = affine.apply #[[MAP2]](%[[ARG9]])
+// TILING-DAG:                %[[D12:.+]] = affine.min #[[MAP3]](%[[D11]])
+// TILING:                  %[[D13:.+]] = scf.for %[[ARG11:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D5]] step %[[C1]]
+// TILING-SAME:               iter_args(%[[ARG12:[a-zA-Z0-9_]+]] = %[[ARG10]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// TILING:                    %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][%[[ARG5]],
+// TILING-SAME:                 %[[ARG11]], %[[D8]], %[[D11]]] [1, 1, %[[D9]], %[[D12]]] [1, 1, 1, 1] :
+// TILING-SAME:                 tensor<?x?x10x10xf32> to tensor<?x?xf32>
+// TILING:                    %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[ARG12]][0, 0, %[[ARG5]], %[[ARG7]],
+// TILING-SAME:                 %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> to
+// TILING-SAME:                 tensor<8x8xf32>
+// TILING:                    %[[TILED_WINOGRAD:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+// TILING-SAME:                                                  ins(%[[EXTRACTED_SLICE_3]] : tensor<?x?xf32>)
+// TILING-SAME:                                                  outs(%[[EXTRACTED_SLICE_5]] : tensor<8x8xf32>) -> tensor<8x8xf32>
+// TILING:                    %[[INSERTED_SLICE_6:.+]] = tensor.insert_slice %[[TILED_WINOGRAD]] into %[[ARG12]][0, 0, %[[ARG5]],
+// TILING-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8xf32>
+// TILING-SAME:                 into tensor<8x8x?x2x2x?xf32>
+// TILING:                    scf.yield %[[INSERTED_SLICE_6]] : tensor<8x8x?x2x2x?xf32>
+// TILING:                  }
+// TILING:                  scf.yield %[[D13]] : tensor<8x8x?x2x2x?xf32>
+// TILING:                }
+// TILING:                scf.yield %[[D10]] : tensor<8x8x?x2x2x?xf32>
+// TILING:              }
+// TILING:              scf.yield %[[D7]] : tensor<8x8x?x2x2x?xf32>
+// TILING:            }
+// TILING:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]] into %[[ARG4]][0, 0, %[[ARG1]], 0, 0,
+// TILING-SAME:         %[[ARG3]]] [8, 8, %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> into
+// TILING-SAME:         tensor<8x8x1x2x2x1280xf32>
+// TILING:            scf.yield %[[INSERTED_SLICE]] : tensor<8x8x1x2x2x1280xf32>
+// TILING:          }
+// TILING:          scf.yield %[[D4]] : tensor<8x8x1x2x2x1280xf32>
+// TILING:        }
+// TILING:        return %[[D2]] : tensor<8x8x1x2x2x1280xf32>
+// TILING:      }
+// TILING:    }
 
 // -----
 
@@ -324,52 +510,52 @@ module {
     return %1 : tensor<1x32x12x12xf32>
   }
 }
-// CHECK-DAG:  #[[MAP]] = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
-// CHECK-DAG:  #[[MAP1]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
-// CHECK-DAG:  #[[MAP2]] = affine_map<(d0) -> (d0 * 6)>
-// CHECK:      func.func @winograd_output_transform_nchw(%[[ARG0]]: tensor<8x8x1x2x2x32xf32>) -> tensor<1x32x12x12xf32>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 * 6)>
+// CHECK:      func.func @winograd_output_transform_nchw(%[[ARG0:.+]]: tensor<8x8x1x2x2x32xf32>) -> tensor<1x32x12x12xf32>
 // CHECK-SAME:   {
-// CHECK:        %[[C32]] = arith.constant 32 : index
-// CHECK:        %[[C1]] = arith.constant 1 : index
-// CHECK:        %[[C0]] = arith.constant 0 : index
-// CHECK:        %[[CST]] = arith.constant dense<
-// CHECK:        %[[CST_0]] = arith.constant dense<
-// CHECK:        %[[CST_1]] = arith.constant 0.000000e+00 : f32
-// CHECK:        %[[C2]] = arith.constant 2 : index
-// CHECK:        %[[D0]] = tensor.empty() : tensor<8x6xf32>
-// CHECK:        %[[D1]] = tensor.empty() : tensor<1x32x12x12xf32>
-// CHECK:        %[[D2]] = scf.for %[[ARG1]] = %[[C0]] to %[[C1]] step %[[C1]] iter_args(%[[ARG2]] = %[[D1]]) ->
+// CHECK:        %[[CST:.+]] = arith.constant dense<
+// CHECK:        %[[CST_0:.+]] = arith.constant dense<
+// CHECK:        %[[CST_1:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<8x6xf32>
+// CHECK:        %[[C0:.+]] = arith.constant 0 : index
+// CHECK:        %[[C1:.+]] = arith.constant 1 : index
+// CHECK:        %[[C2:.+]] = arith.constant 2 : index
+// CHECK:        %[[C32:.+]] = arith.constant 32 : index
+// CHECK:        %[[D1:.+]] = tensor.empty() : tensor<1x32x12x12xf32>
+// CHECK:        %[[D2:.+]] = scf.for %[[ARG1:.+]] = %[[C0]] to %[[C1]] step %[[C1]] iter_args(%[[ARG2:.+]] = %[[D1]]) ->
 // CHECK-SAME:     (tensor<1x32x12x12xf32>) {
-// CHECK-DAG:        %[[D3]] = affine.min #[[MAP]](%[[ARG1]])[%[[C1]], %[[C1]]]
-// CHECK:          %[[D4]] = scf.for %[[ARG3]] = %[[C0]] to %[[C32]] step %[[C32]] iter_args(%[[ARG4]] = %[[ARG2]]) ->
+// CHECK-DAG:        %[[D3:.+]] = affine.min #[[MAP]](%[[ARG1]])[%[[C1]], %[[C1]]]
+// CHECK:          %[[D4:.+]] = scf.for %[[ARG3:.+]] = %[[C0]] to %[[C32]] step %[[C32]] iter_args(%[[ARG4:.+]] = %[[ARG2]]) ->
 // CHECK-SAME:       (tensor<1x32x12x12xf32>) {
-// CHECK-DAG:          %[[D5]] = affine.min #[[MAP1]](%[[ARG3]])[%[[C32]], %[[C32]]]
-// CHECK:            %[[EXTRACTED_SLICE]] = tensor.extract_slice %[[ARG0]][0, 0, %[[ARG1]], 0, 0, %[[ARG3]]] [8, 8,
+// CHECK-DAG:          %[[D5:.+]] = affine.min #[[MAP1]](%[[ARG3]])[%[[C32]], %[[C32]]]
+// CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, 0, %[[ARG1]], 0, 0, %[[ARG3]]] [8, 8,
 // CHECK-SAME:         %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x32xf32> to tensor<8x8x?x2x2x?xf32>
-// CHECK:            %[[EXTRACTED_SLICE_2]] = tensor.extract_slice %[[D1]][%[[ARG1]], %[[ARG3]], 0, 0] [%[[D3]],
+// CHECK:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D1]][%[[ARG1]], %[[ARG3]], 0, 0] [%[[D3]],
 // CHECK-SAME:         %[[D5]], 12, 12] [1, 1, 1, 1] : tensor<1x32x12x12xf32> to tensor<?x?x12x12xf32>
-// CHECK:            %[[D6]] = scf.for %[[ARG5]] = %[[C0]] to %[[D3]] step %[[C1]] iter_args(%[[ARG6]] =
+// CHECK:            %[[D6:.+]] = scf.for %[[ARG5:.+]] = %[[C0]] to %[[D3]] step %[[C1]] iter_args(%[[ARG6:.+]] =
 // CHECK-SAME:         %[[EXTRACTED_SLICE_2]]) -> (tensor<?x?x12x12xf32>) {
-// CHECK:              %[[D7]] = scf.for %[[ARG7]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG8]] = %[[ARG6]]) ->
+// CHECK:              %[[D7:.+]] = scf.for %[[ARG7:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG8:.+]] = %[[ARG6]]) ->
 // CHECK-SAME:           (tensor<?x?x12x12xf32>) {
-// CHECK-DAG:              %[[D8]] = affine.apply #[[MAP2]](%[[ARG7]])
-// CHECK:                %[[D9]] = scf.for %[[ARG9]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG10]] = %[[ARG8]])
+// CHECK-DAG:              %[[D8:.+]] = affine.apply #[[MAP2]](%[[ARG7]])
+// CHECK:                %[[D9:.+]] = scf.for %[[ARG9:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG10:.+]] = %[[ARG8]])
 // CHECK-SAME:             -> (tensor<?x?x12x12xf32>) {
-// CHECK-DAG:                %[[D10]] = affine.apply #[[MAP2]](%[[ARG9]])
-// CHECK:                  %[[D11]] = scf.for %[[ARG11]] = %[[C0]] to %[[D5]] step %[[C1]] iter_args(%[[ARG12]] =
+// CHECK-DAG:                %[[D10:.+]] = affine.apply #[[MAP2]](%[[ARG9]])
+// CHECK:                  %[[D11:.+]] = scf.for %[[ARG11:.+]] = %[[C0]] to %[[D5]] step %[[C1]] iter_args(%[[ARG12:.+]] =
 // CHECK-SAME:               %[[ARG10]]) -> (tensor<?x?x12x12xf32>) {
-// CHECK:                    %[[EXTRACTED_SLICE_3]] = tensor.extract_slice %[[EXTRACTED_SLICE]][0, 0, %[[ARG5]],
+// CHECK:                    %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][0, 0, %[[ARG5]],
 // CHECK-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] :
 // CHECK-SAME:                 tensor<8x8x?x2x2x?xf32> to tensor<8x8xf32>
 // CHECK:                    %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[ARG12]][%[[ARG5]], %[[ARG11]], %[[D8]],
 // CHECK-SAME:                 %[[D10]]] [1, 1, 6, 6] [1, 1, 1, 1] : tensor<?x?x12x12xf32> to tensor<6x6xf32>
-// CHECK:                    %[[D12]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[D0]] : tensor<8x6xf32>) ->
+// CHECK:                    %[[D12:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[D0]] : tensor<8x6xf32>) ->
 // CHECK-SAME:                 tensor<8x6xf32>
-// CHECK:                    %[[D13]] = linalg.matmul ins(%[[EXTRACTED_SLICE_3]], %[[CST_0]] : tensor<8x8xf32>,
+// CHECK:                    %[[D13:.+]] = linalg.matmul ins(%[[EXTRACTED_SLICE_3]], %[[CST_0]] : tensor<8x8xf32>,
 // CHECK-SAME:                 tensor<8x6xf32>) outs(%[[D12]] : tensor<8x6xf32>) -> tensor<8x6xf32>
-// CHECK:                    %[[D14]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_4]] : tensor<6x6xf32>)
+// CHECK:                    %[[D14:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_4]] : tensor<6x6xf32>)
 // CHECK-SAME:                 -> tensor<6x6xf32>
-// CHECK:                    %[[D15]] = linalg.matmul ins(%[[CST]], %[[D13]] : tensor<6x8xf32>, tensor<8x6xf32>)
+// CHECK:                    %[[D15:.+]] = linalg.matmul ins(%[[CST]], %[[D13]] : tensor<6x8xf32>, tensor<8x6xf32>)
 // CHECK-SAME:                 outs(%[[D14]] : tensor<6x6xf32>) -> tensor<6x6xf32>
 // CHECK:                    %[[INSERTED_SLICE_5:.+]] = tensor.insert_slice %[[D15]] into %[[ARG12]][%[[ARG5]],
 // CHECK-SAME:                 %[[ARG11]], %[[D8]], %[[D10]]] [1, 1, 6, 6] [1, 1, 1, 1] : tensor<6x6xf32> into
@@ -382,7 +568,7 @@ module {
 // CHECK:              }
 // CHECK:              scf.yield %[[D7]] : tensor<?x?x12x12xf32>
 // CHECK:            }
-// CHECK:            %[[INSERTED_SLICE]] = tensor.insert_slice %[[D6]] into %[[ARG4]][%[[ARG1]], %[[ARG3]], 0, 0]
+// CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]] into %[[ARG4]][%[[ARG1]], %[[ARG3]], 0, 0]
 // CHECK-SAME:         [%[[D3]], %[[D5]], 12, 12] [1, 1, 1, 1] : tensor<?x?x12x12xf32> into tensor<1x32x12x12xf32>
 // CHECK:            scf.yield %[[INSERTED_SLICE]] : tensor<1x32x12x12xf32>
 // CHECK:          }
@@ -390,3 +576,62 @@ module {
 // CHECK:        }
 // CHECK:        return %[[D2]] : tensor<1x32x12x12xf32>
 // CHECK:      }
+
+// TILING-DAG:  #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+// TILING-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+// TILING-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 * 6)>
+// TILING:      func.func @winograd_output_transform_nchw(%[[ARG0:.+]]: tensor<8x8x1x2x2x32xf32>) -> tensor<1x32x12x12xf32>
+// TILING-SAME:   {
+// TILING:        %[[C0:.+]] = arith.constant 0 : index
+// TILING:        %[[C1:.+]] = arith.constant 1 : index
+// TILING:        %[[C2:.+]] = arith.constant 2 : index
+// TILING:        %[[C32:.+]] = arith.constant 32 : index
+// TILING:        %[[D1:.+]] = tensor.empty() : tensor<1x32x12x12xf32>
+// TILING:        %[[D2:.+]] = scf.for %[[ARG1:.+]] = %[[C0]] to %[[C1]] step %[[C1]] iter_args(%[[ARG2:.+]] = %[[D1]]) ->
+// TILING-SAME:     (tensor<1x32x12x12xf32>) {
+// TILING-DAG:        %[[D3:.+]] = affine.min #[[MAP]](%[[ARG1]])[%[[C1]], %[[C1]]]
+// TILING:          %[[D4:.+]] = scf.for %[[ARG3:.+]] = %[[C0]] to %[[C32]] step %[[C32]] iter_args(%[[ARG4:.+]] = %[[ARG2]]) ->
+// TILING-SAME:       (tensor<1x32x12x12xf32>) {
+// TILING-DAG:          %[[D5:.+]] = affine.min #[[MAP1]](%[[ARG3]])[%[[C32]], %[[C32]]]
+// TILING:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, 0, %[[ARG1]], 0, 0, %[[ARG3]]] [8, 8,
+// TILING-SAME:         %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x32xf32> to tensor<8x8x?x2x2x?xf32>
+// TILING:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D1]][%[[ARG1]], %[[ARG3]], 0, 0] [%[[D3]],
+// TILING-SAME:         %[[D5]], 12, 12] [1, 1, 1, 1] : tensor<1x32x12x12xf32> to tensor<?x?x12x12xf32>
+// TILING:            %[[D6:.+]] = scf.for %[[ARG5:.+]] = %[[C0]] to %[[D3]] step %[[C1]] iter_args(%[[ARG6:.+]] =
+// TILING-SAME:         %[[EXTRACTED_SLICE_2]]) -> (tensor<?x?x12x12xf32>) {
+// TILING:              %[[D7:.+]] = scf.for %[[ARG7:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG8:.+]] = %[[ARG6]]) ->
+// TILING-SAME:           (tensor<?x?x12x12xf32>) {
+// TILING-DAG:              %[[D8:.+]] = affine.apply #[[MAP2]](%[[ARG7]])
+// TILING:                %[[D9:.+]] = scf.for %[[ARG9:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG10:.+]] = %[[ARG8]])
+// TILING-SAME:             -> (tensor<?x?x12x12xf32>) {
+// TILING-DAG:                %[[D10:.+]] = affine.apply #[[MAP2]](%[[ARG9]])
+// TILING:                  %[[D11:.+]] = scf.for %[[ARG11:.+]] = %[[C0]] to %[[D5]] step %[[C1]] iter_args(%[[ARG12:.+]] =
+// TILING-SAME:               %[[ARG10]]) -> (tensor<?x?x12x12xf32>) {
+// TILING:                    %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][0, 0, %[[ARG5]],
+// TILING-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] :
+// TILING-SAME:                 tensor<8x8x?x2x2x?xf32> to tensor<8x8xf32>
+// TILING:                    %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[ARG12]][%[[ARG5]], %[[ARG11]], %[[D8]],
+// TILING-SAME:                 %[[D10]]] [1, 1, 6, 6] [1, 1, 1, 1] : tensor<?x?x12x12xf32> to tensor<6x6xf32>
+// TILING:                    %[[TILED_WINOGRAD:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+// TILING-SAME:                                                  ins(%[[EXTRACTED_SLICE_3]] : tensor<8x8xf32>)
+// TILING-SAME:                                                  outs(%[[EXTRACTED_SLICE_4]] : tensor<6x6xf32>) -> tensor<6x6xf32>
+// TILING:                    %[[INSERTED_SLICE_5:.+]] = tensor.insert_slice %[[TILED_WINOGRAD]] into %[[ARG12]][%[[ARG5]],
+// TILING-SAME:                 %[[ARG11]], %[[D8]], %[[D10]]] [1, 1, 6, 6] [1, 1, 1, 1] : tensor<6x6xf32> into
+// TILING-SAME:                 tensor<?x?x12x12xf32>
+// TILING:                    scf.yield %[[INSERTED_SLICE_5]] : tensor<?x?x12x12xf32>
+// TILING:                  }
+// TILING:                  scf.yield %[[D11]] : tensor<?x?x12x12xf32>
+// TILING:                }
+// TILING:                scf.yield %[[D9]] : tensor<?x?x12x12xf32>
+// TILING:              }
+// TILING:              scf.yield %[[D7]] : tensor<?x?x12x12xf32>
+// TILING:            }
+// TILING:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]] into %[[ARG4]][%[[ARG1]], %[[ARG3]], 0, 0]
+// TILING-SAME:         [%[[D3]], %[[D5]], 12, 12] [1, 1, 1, 1] : tensor<?x?x12x12xf32> into tensor<1x32x12x12xf32>
+// TILING:            scf.yield %[[INSERTED_SLICE]] : tensor<1x32x12x12xf32>
+// TILING:          }
+// TILING:          scf.yield %[[D4]] : tensor<1x32x12x12xf32>
+// TILING:        }
+// TILING:        return %[[D2]] : tensor<1x32x12x12xf32>
+// TILING:      }
+


### PR DESCRIPTION
-- This commit adapts winograd op to also have the tiling construct (main changes in `verify`).
-- It also implements winograd's tiling and decomposition around the same.
-- It also adds an option in `iree-linalg-ext-tile-and-decompose-winograd` to perform only tiling.

Signed-off-by: Abhishek Varma [abhishek@nod-labs.com](mailto:abhishek@nod-labs.com)