### PR TITLE
[Flow] Add TensorBitCastOp

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/BitCastQuantTensor.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/BitCastQuantTensor.cpp
@@ -1,0 +1,151 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace TorchInput {
+
+namespace {
+class BitCastQuantizedMatmulWeights
+    : public OpRewritePattern<torch::Torch::ValueTensorLiteralOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(torch::Torch::ValueTensorLiteralOp constOp,
+                                PatternRewriter &rewriter) const override {
+    if (!constOp->hasOneUse())
+      return failure();
+
+    OpOperand *use = constOp.getResult().use_begin().getOperand();
+    auto op = dyn_cast<torch::Torch::OperatorOp>(use->getOwner());
+
+    // Verify that the user of the constant is the right hand side of a group
+    // quantized matrix multiplication.
+    if (!op) {
+      return failure();
+    }
+    if (op.getName().str() != "quant.matmul_rhs_group_quant") {
+      return failure();
+    }
+    if (use->getOperandNumber() != 1) {
+      return failure();
+    }
+
+    Value rhs = op.getOperand(1);
+    Value bitWidth = op.getOperand(4);
+
+    // Extract the target bitwidth from the constant on the matmul.
+    auto getConstantIntegerFromDefiningOp = [](Value operand,
+                                               int &extractedInt) {
+      auto constOp =
+          dyn_cast<torch::Torch::ConstantIntOp>(operand.getDefiningOp());
+      if (!constOp) {
+        return failure();
+      }
+      extractedInt = constOp.getValue();
+      return success();
+    };
+    int unpackedBitWidth;
+    if (failed(getConstantIntegerFromDefiningOp(bitWidth, unpackedBitWidth)))
+      return failure();
+
+    auto rhsType = rhs.getType().dyn_cast<torch::Torch::ValueTensorType>();
+    if (!rhsType)
+      return failure();
+
+    if (!rhsType.hasDtype())
+      return failure();
+
+    Type dType = rhsType.getDtype();
+    int dTypeWidth = dType.getIntOrFloatBitWidth();
+    // If the dtype width already matches the target width, nothing to do.
+    if (dTypeWidth == unpackedBitWidth)
+      return failure();
+
+    if (!rhsType.hasSizes())
+      return failure();
+
+    SmallVector<int64_t> tensorShape(rhsType.getSizes());
+    // Constants should have constant shape.
+    if (llvm::any_of(tensorShape,
+                     [](int64_t s) { return s == torch::Torch::kUnknownSize; }))
+      return failure();
+    int packRatio = dTypeWidth / unpackedBitWidth;
+
+    tensorShape[tensorShape.size() - 1] *= packRatio;
+
+    Location loc = constOp.getLoc();
+    auto bitCastTargetType = RankedTensorType::get(
+        tensorShape, rewriter.getIntegerType(unpackedBitWidth));
+    // Cast to the builtin tensor type.
+    auto builtinCast =
+        rewriter.create<torch::TorchConversion::ToBuiltinTensorOp>(loc,
+                                                                   constOp);
+
+    // No dynamic dims because we are bitcasting a constant.
+    auto flowBitcast = rewriter.create<IREE::Flow::TensorBitCastOp>(
+        loc, bitCastTargetType, builtinCast, ValueRange(), ValueRange());
+
+    // Cast back to the (un)signed torch tensor type to inform later lowerings.
+    Type unpackedElementType;
+    if (dType.isSignedInteger())
+      unpackedElementType = rewriter.getIntegerType(unpackedBitWidth, true);
+    else
+      unpackedElementType = rewriter.getIntegerType(unpackedBitWidth, false);
+    torch::Torch::ValueTensorType newRhsType =
+        torch::Torch::ValueTensorType::get(rewriter.getContext(), tensorShape,
+                                           unpackedElementType);
+    auto torchCast =
+        rewriter.create<torch::TorchConversion::FromBuiltinTensorOp>(
+            loc, newRhsType, flowBitcast);
+    rewriter.replaceAllUsesExcept(constOp.getResult(), torchCast.getResult(),
+                                  builtinCast);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class BitCastQuantTensorPass
+    : public BitCastQuantTensorPassBase<BitCastQuantTensorPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Flow::FlowDialect>();
+    registry.insert<torch::Torch::TorchDialect>();
+    registry.insert<torch::TorchConversion::TorchConversionDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<BitCastQuantizedMatmulWeights>(context);
+
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>> createBitCastQuantTensorPass() {
+  return std::make_unique<BitCastQuantTensorPass>();
+}
+
+} // namespace TorchInput
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_library(
   HDRS
     "Passes.h"
   SRCS
+    "BitCastQuantTensor.cpp"
     "ConvertTMTensorToLinalgExt.cpp"
     "SetStrictSymbolicShapes.cpp"
     "Passes.cpp"
@@ -52,5 +53,6 @@ iree_cc_library(
     torch-mlir::TorchConversionDialectIR
     torch-mlir::TorchDialectPasses
     torch-mlir-dialects::TMTensorDialectIR
+    iree::compiler::Dialect::Flow::IR
   PUBLIC
 )

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
@@ -42,8 +42,7 @@ void createTorchToIREEPipeline(
     // now be simplified.
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   }
-  pm.addNestedPass<func::FuncOp>(
-      torch::TorchConversion::createUnpackQuantTensorPass());
+  pm.addNestedPass<func::FuncOp>(createBitCastQuantTensorPass());
   pm.addNestedPass<func::FuncOp>(
       mlir::torch::TorchConversion::createConvertCustomQuantOpPass());
   pm.addNestedPass<func::FuncOp>(

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.h
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.h
@@ -21,6 +21,8 @@ struct TorchToIREELoweringPipelineOptions
       llvm::cl::desc("Use strict symbolic shapes."), llvm::cl::init(true)};
 };
 
+std::unique_ptr<OperationPass<func::FuncOp>> createBitCastQuantTensorPass();
+
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertTMTensorToLinalgExtPass();
 

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.td
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.td
@@ -9,6 +9,12 @@
 
 include "mlir/Pass/PassBase.td"
 
+def BitCastQuantTensorPass :
+    Pass<"torch-iree-bitcast-quant-tensor", "func::FuncOp"> {
+  let summary = "Bitcasts i8 packed tensors of sub-byte types to the actual bit width";
+  let constructor = "mlir::iree_compiler::TorchInput::createBitCastQuantTensorPass()";
+}
+
 def ConvertTMTensorToLinalgExt :
     Pass<"torch-iree-tm-tensor-to-linalg-ext", "func::FuncOp"> {
   let summary = "Convert from TMTensor ops to LinalgExt ops on tensors";

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/CMakeLists.txt
@@ -4,6 +4,7 @@ iree_lit_test_suite(
   SRCS
     "assume_strict_symbols.mlir"
     "attention.mlir"
+    "bitcast_quant_tensor.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/bitcast_quant_tensor.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/bitcast_quant_tensor.mlir
@@ -1,0 +1,16 @@
+// RUN: iree-opt %s -torch-iree-bitcast-quant-tensor -split-input-file -verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: func @forward
+func.func @forward(%arg0: !torch.vtensor<[1,1,8],f16>) -> !torch.vtensor<[1,1,8],f16> {
+  %q_rhs = torch.vtensor.literal(dense<[[57, 128, 249, 244], [7, 243, 27, 15], [1, 2, 159, 71], [159, 253, 160, 231], [248, 224, 191, 228], [96, 15, 158, 220], [240, 250, 47, 208], [127, 192, 239, 176]]> : tensor<8x4xui8>) : !torch.vtensor<[8,4],ui8>
+  // CHECK: %[[C0:.*]] = torch.vtensor.literal(dense<{{\[\[}}57, 128, 249, 244], [7, 243, 27, 15], [1, 2, 159, 71], [159, 253, 160, 231], [248, 224, 191, 228], [96, 15, 158, 220], [240, 250, 47, 208], [127, 192, 239, 176]]> : tensor<8x4xui8>) : !torch.vtensor<[8,4],ui8>
+  %scales = torch.vtensor.literal(dense<1.0> : tensor<8x4x1xf16>) : !torch.vtensor<[8,4,1],f16>
+  %zps = torch.vtensor.literal(dense<0.0> : tensor<8x4x1xf16>) : !torch.vtensor<[8,4,1],f16>
+  %bit_width = torch.constant.int 4
+  %group_size = torch.constant.int 2
+  // CHECK: %[[TOBUILTIN:.*]] = torch_c.to_builtin_tensor %[[C0]] : !torch.vtensor<[8,4],ui8> -> tensor<8x4xi8>
+  // CHECK: %[[BITCAST:.*]] = flow.tensor.bitcast %[[TOBUILTIN]] : tensor<8x4xi8> -> tensor<8x8xi4>
+  // CHECK: %[[TOTORCH:.*]] = torch_c.from_builtin_tensor %[[BITCAST]] : tensor<8x8xi4> -> !torch.vtensor<[8,8],ui4>
+  %output = torch.operator "quant.matmul_rhs_group_quant"(%arg0, %q_rhs, %scales, %zps, %bit_width, %group_size) : (!torch.vtensor<[1,1,8],f16>, !torch.vtensor<[8,4],ui8>, !torch.vtensor<[8,4,1],f16>, !torch.vtensor<[8,4,1],f16>, !torch.int, !torch.int) -> !torch.vtensor<[1,1,8],f16>
+  return %output : !torch.vtensor<[1,1,8],f16>
+}

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -84,7 +84,7 @@ struct ConvertTensorBitcastPattern
     }
     auto dynamicDims = IREE::Util::buildDynamicDimsForValue(
         op.getLoc(), op.getOperand(), rewriter);
-    rewriter.replaceOpWithNewOp<IREE::Flow::TensorReshapeOp>(
+    rewriter.replaceOpWithNewOp<IREE::Flow::TensorBitCastOp>(
         op, op.getResult().getType(), op.getOperand(), dynamicDims,
         dynamicDims);
     return success();

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/bitcast.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/bitcast.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
 
 func.func @static_tensor_bitcast(%arg0: tensor<4x4xf32>) -> tensor<4x4xi32> {
-  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<4x4xf32> -> tensor<4x4xi32>
+  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.bitcast %arg0 : tensor<4x4xf32> -> tensor<4x4xi32>
   // CHECK: return %[[RESULT]]
   %0 = tensor.bitcast %arg0 : tensor<4x4xf32> to tensor<4x4xi32>
   return %0 : tensor<4x4xi32>
@@ -12,7 +12,7 @@ func.func @static_tensor_bitcast(%arg0: tensor<4x4xf32>) -> tensor<4x4xi32> {
 func.func @dynamic_tensor_bitcast(%arg0: tensor<?x?xf32>) -> tensor<?x?xi32> {
   // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   // CHECK: %[[DIM1:.+]] = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-  // CHECK: %[[RESULT:.+]] = flow.tensor.reshape %arg0 : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xi32>{%[[DIM0]], %[[DIM1]]}
+  // CHECK: %[[RESULT:.+]] = flow.tensor.bitcast %arg0 : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xi32>{%[[DIM0]], %[[DIM1]]}
   // CHECK: return %[[RESULT]]
   %0 = tensor.bitcast %arg0 : tensor<?x?xf32> to tensor<?x?xi32>
   return %0 : tensor<?x?xi32>

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -916,10 +916,9 @@ struct FlattenTensorCastLikeChain : public OpRewritePattern<CastOpTy> {
     auto sourceType = llvm::cast<ShapedType>(source.getType());
     auto resultType = llvm::cast<ShapedType>(reshapeOp.getResult().getType());
 
-    // If the bitwidths don't match, this is a bitcast, else we can use
+    // If the element types don't match, this is a bitcast, else we can use
     // reshape.
-    if (IREE::Util::getTypeBitWidth(sourceType.getElementType()) !=
-        IREE::Util::getTypeBitWidth(resultType.getElementType())) {
+    if (sourceType.getElementType() != resultType.getElementType()) {
       rewriter.replaceOpWithNewOp<TensorBitCastOp>(
           reshapeOp, reshapeOp.getResult().getType(), source, sourceDims,
           reshapeOp.getResultDims());

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -863,27 +863,71 @@ OpFoldResult TensorReshapeOp::fold(FoldAdaptor operands) {
   return {};
 }
 
+//===----------------------------------------------------------------------===//
+// flow.tensor.bitcast
+//===----------------------------------------------------------------------===//
+
+OpFoldResult TensorBitCastOp::fold(FoldAdaptor operands) {
+  auto sourceType = llvm::cast<ShapedType>(getSource().getType());
+  auto resultType = llvm::cast<ShapedType>(getResult().getType());
+  if (sourceType.getElementType() != resultType.getElementType()) {
+    // Element type mismatch, this is a bitcast.
+    return {};
+  }
+  if (compareShapesEqual(sourceType, getSourceDims(), resultType,
+                         getResultDims())) {
+    // Shapes match and this is a no-op so just fold to the source.
+    return getSource();
+  }
+  return {};
+}
+
 namespace {
 
-// Flatten a chain of reshapes (reshape feeding into reshape) such that a
-// reshape only ever pulls from a non-reshape source. This prevents big useless
-// chains and makes it easier to track the original storage for the tensor.
-struct FlattenTensorReshapeChain : public OpRewritePattern<TensorReshapeOp> {
-  using OpRewritePattern<TensorReshapeOp>::OpRewritePattern;
+// Flatten a chain of reshapes or bitcasts (reshape/bitcast feeding into
+// reshape or bitcast) such that a reshape only ever pulls from a non-reshape
+// source. This prevents big useless chains and makes it easier to track the
+// original storage for the tensor.
+template <typename CastOpTy>
+struct FlattenTensorCastLikeChain : public OpRewritePattern<CastOpTy> {
+  using OpRewritePattern<CastOpTy>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(TensorReshapeOp reshapeOp,
+  LogicalResult matchAndRewrite(CastOpTy reshapeOp,
                                 PatternRewriter &rewriter) const override {
-    auto sourceOp = dyn_cast_or_null<TensorReshapeOp>(
-        reshapeOp.getSource().getDefiningOp());
-    if (!sourceOp)
-      return failure();
-
     // We want the same result value/shape but to source from the ancestor. We
     // need to pull any dynamic dims from that as we don't care about the
     // intermediate reshapes.
-    rewriter.replaceOpWithNewOp<TensorReshapeOp>(
-        reshapeOp, reshapeOp.getResult().getType(), sourceOp.getSource(),
-        sourceOp.getSourceDims(), reshapeOp.getResultDims());
+    Value source;
+    ValueRange sourceDims;
+    if (auto sourceOp = dyn_cast_or_null<TensorReshapeOp>(
+            reshapeOp.getSource().getDefiningOp())) {
+      source = sourceOp.getSource();
+      sourceDims = sourceOp.getSourceDims();
+    } else if (auto sourceOp = dyn_cast_or_null<TensorBitCastOp>(
+                   reshapeOp.getSource().getDefiningOp())) {
+      source = sourceOp.getSource();
+      sourceDims = sourceOp.getSourceDims();
+    }
+
+    if (!source) {
+      return failure();
+    }
+
+    auto sourceType = llvm::cast<ShapedType>(source.getType());
+    auto resultType = llvm::cast<ShapedType>(reshapeOp.getResult().getType());
+
+    // If the bitwidths don't match, this is a bitcast, else we can use
+    // reshape.
+    if (IREE::Util::getTypeBitWidth(sourceType.getElementType()) !=
+        IREE::Util::getTypeBitWidth(resultType.getElementType())) {
+      rewriter.replaceOpWithNewOp<TensorBitCastOp>(
+          reshapeOp, reshapeOp.getResult().getType(), source, sourceDims,
+          reshapeOp.getResultDims());
+    } else {
+      rewriter.replaceOpWithNewOp<TensorReshapeOp>(
+          reshapeOp, reshapeOp.getResult().getType(), source, sourceDims,
+          reshapeOp.getResultDims());
+    }
     return success();
   }
 };
@@ -981,7 +1025,19 @@ void TensorReshapeOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<ReplaceOpIfTensorResultZeroElements<TensorReshapeOp, 0>>(
       context);
   results.insert<ReplaceOpIfTensorOperandEmpty<TensorReshapeOp, 0, 0>>(context);
-  results.insert<FlattenTensorReshapeChain>(context);
+  results.insert<FlattenTensorCastLikeChain<TensorReshapeOp>>(context);
+  results.insert<ResolveShapedRank>(context);
+  results.insert<ResolveShapedDim>(context);
+}
+
+void TensorBitCastOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                                  MLIRContext *context) {
+  results.insert<ReplaceOpIfTensorOperandZeroElements<TensorBitCastOp, 0>>(
+      context);
+  results.insert<ReplaceOpIfTensorResultZeroElements<TensorBitCastOp, 0>>(
+      context);
+  results.insert<ReplaceOpIfTensorOperandEmpty<TensorBitCastOp, 0, 0>>(context);
+  results.insert<FlattenTensorCastLikeChain<TensorBitCastOp>>(context);
   results.insert<ResolveShapedRank>(context);
   results.insert<ResolveShapedDim>(context);
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1627,6 +1627,36 @@ SmallVector<int64_t> TensorReshapeOp::getTiedResultOperandIndices() {
 }
 
 //===----------------------------------------------------------------------===//
+// flow.tensor.bitcast
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorBitCastOp::verify() {
+  // The element types don't need to match, we can just check the requisite
+  // number of dynamic dims.
+  if (failed(verifyOpDynamicDims(getOperation(), {getSource()},
+                                 getSourceDims())) ||
+      failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 {getResultDims()}))) {
+    return failure();
+  }
+
+  return success();
+}
+
+Value TensorBitCastOp::getTiedResult(unsigned resultIndex) {
+  return IREE::Util::TiedOpInterface::findTiedBaseValue(getSource());
+}
+
+::std::optional<unsigned>
+TensorBitCastOp::getTiedResultOperandIndex(unsigned resultIndex) {
+  return {0}; // source
+}
+
+SmallVector<int64_t> TensorBitCastOp::getTiedResultOperandIndices() {
+  return {0}; // source
+}
+
+//===----------------------------------------------------------------------===//
 // flow.tensor.load
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1109,6 +1109,7 @@ def FLOW_TensorTieShapeOp : FLOW_PureOp<"tensor.tie_shape", [
 
 def FLOW_TensorReshapeOp : FLOW_PureOp<"tensor.reshape", [
   FLOW_StreamableOp,
+  AllElementTypesMatch<["source", "result"]>,
   AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
       "getTiedResult",

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1163,6 +1163,62 @@ def FLOW_TensorReshapeOp : FLOW_PureOp<"tensor.reshape", [
   let hasCanonicalizer = 1;
 }
 
+def FLOW_TensorBitCastOp : FLOW_PureOp<"tensor.bitcast", [
+  FLOW_StreamableOp,
+  AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<Util_TiedOpInterface, [
+      "getTiedResult",
+      "getTiedResultOperandIndex",
+      "getTiedResultOperandIndices",
+  ]>,
+  Util_ShapeAwareOp,
+]> {
+  let summary = [{bitcasts a tensor}];
+  let description = [{
+    Bitcasts a tensor to a new type without modifying the contents.
+  }];
+
+  let arguments = (ins
+    FLOW_Tensor:$source,
+    FLOW_ShapeDynamicDims:$source_dims,
+    FLOW_ShapeDynamicDims:$result_dims
+  );
+  let results = (outs
+    FLOW_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $source `:`
+    type($source) (`{` $source_dims^ `}`)? `->`
+    type($result) (`{` $result_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+
+  let builders = [
+    OpBuilder<(ins
+      "Type":$result_type, "Value":$source, "ValueRange":$target_dims),
+    [{
+      build($_builder, $_state,
+          result_type,
+          source,
+          IREE::Util::buildDynamicDimsForValue($_state.location, source, $_builder),
+          target_dims);
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    // StreamableOpInterface:
+    bool isTransfer() { return true; }
+
+    ValueRange getOperandDynamicDims(unsigned idx) { return getSourceDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
+  }];
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
+}
+
 def FLOW_TensorLoadOp : FLOW_PureOp<"tensor.load", [
   TypesMatchWith<"value type matches element type of target operand",
                   "source", "result",

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -75,10 +75,10 @@ func.func @reshapeNoOpStatic(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-// CHECK-LABEL: @reshapeElementTypeDifferent
-func.func @reshapeElementTypeDifferent(%arg0: tensor<f32>) -> tensor<i32> {
-  // CHECK-NEXT: flow.tensor.reshape %arg0
-  %0 = flow.tensor.reshape %arg0 : tensor<f32> -> tensor<i32>
+// CHECK-LABEL: @bitcastSameBitWidth
+func.func @bitcastSameBitWidth(%arg0: tensor<f32>) -> tensor<i32> {
+  // CHECK-NEXT: flow.tensor.bitcast %arg0
+  %0 = flow.tensor.bitcast %arg0 : tensor<f32> -> tensor<i32>
   return %0 : tensor<i32>
 }
 
@@ -137,9 +137,9 @@ func.func @flattenReshapeChain(%arg0: tensor<4x?xf32>, %dim0: index, %dim1: inde
 // CHECK-SAME: %[[ARG:.+]]: tensor<4x?xi16>,
 // CHECK-SAME: %[[DIM0:.+]]: index, %[[DIM1:.+]]: index, %[[DIM2:.+]]: index
 func.func @flattenReshapeBitcastChain(%arg0: tensor<4x?xi16>, %dim0: index, %dim1: index, %dim2: index) -> tensor<4x?xbf16> {
-  // CHECK-NEXT: %[[RET:.+]] = flow.tensor.reshape %[[ARG]] : tensor<4x?xi16>{%[[DIM0]]} -> tensor<4x?xbf16>{%[[DIM2]]}
-  %0 = flow.tensor.reshape %arg0 : tensor<4x?xi16>{%dim0} -> tensor<4x?xf16>{%dim1}
-  %1 = flow.tensor.reshape %0 : tensor<4x?xf16>{%dim1} -> tensor<4x?xbf16>{%dim2}
+  // CHECK-NEXT: %[[RET:.+]] = flow.tensor.bitcast %[[ARG]] : tensor<4x?xi16>{%[[DIM0]]} -> tensor<4x?xbf16>{%[[DIM2]]}
+  %0 = flow.tensor.bitcast %arg0 : tensor<4x?xi16>{%dim0} -> tensor<4x?xf16>{%dim1}
+  %1 = flow.tensor.bitcast %0 : tensor<4x?xf16>{%dim1} -> tensor<4x?xbf16>{%dim2}
   // CHECK-NEXT: return %[[RET]]
   return %1 : tensor<4x?xbf16>
 }
@@ -165,8 +165,8 @@ func.func @flattenBitCastChain(%arg0: tensor<?x4xi16>, %dim0: index, %dim1: inde
 func.func @flattenBitCastReshapeBitCast(%arg0: tensor<?x16xi16>, %dim0: index, %dim1: index, %dim2: index, %dim3: index) -> tensor<?x4x4xi16> {
   // CHECK-NEXT: %[[RET:.+]] = flow.tensor.reshape %[[ARG]] : tensor<?x16xi16>{%[[DIM0]]} -> tensor<?x4x4xi16>{%[[DIM3]]}
   %0 = flow.tensor.bitcast %arg0 : tensor<?x16xi16>{%dim0} -> tensor<?x8xi32>{%dim1}
-  %1 = flow.tensor.reshape %0 : tensor<?x8xi32>{%dim1} -> tensor<?x4x2xf32>{%dim2}
-  %2 = flow.tensor.bitcast %1 : tensor<?x4x2xf32>{%dim2} -> tensor<?x4x4xi16>{%dim3}
+  %1 = flow.tensor.reshape %0 : tensor<?x8xi32>{%dim1} -> tensor<?x4x2xi32>{%dim2}
+  %2 = flow.tensor.bitcast %1 : tensor<?x4x2xi32>{%dim2} -> tensor<?x4x4xi16>{%dim3}
   // CHECK-NEXT: return %[[RET]]
   return %2 : tensor<?x4x4xi16>
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -146,6 +146,34 @@ func.func @flattenReshapeBitcastChain(%arg0: tensor<4x?xi16>, %dim0: index, %dim
 
 // -----
 
+// CHECK-LABEL: @flattenBitCastChain
+// CHECK-SAME: %[[ARG:.+]]: tensor<?x4xi16>,
+// CHECK-SAME: %[[DIM0:.+]]: index, %[[DIM1:.+]]: index, %[[DIM2:.+]]: index
+func.func @flattenBitCastChain(%arg0: tensor<?x4xi16>, %dim0: index, %dim1: index, %dim2: index) -> tensor<?x8xi8> {
+  // CHECK-NEXT: %[[RET:.+]] = flow.tensor.bitcast %[[ARG]] : tensor<?x4xi16>{%[[DIM0]]} -> tensor<?x8xi8>{%[[DIM2]]}
+  %0 = flow.tensor.bitcast %arg0 : tensor<?x4xi16>{%dim0} -> tensor<?x2xi32>{%dim1}
+  %1 = flow.tensor.bitcast %0 : tensor<?x2xi32>{%dim1} -> tensor<?x8xi8>{%dim2}
+  // CHECK-NEXT: return %[[RET]]
+  return %1 : tensor<?x8xi8>
+}
+
+// -----
+
+// CHECK-LABEL: @flattenBitCastReshapeBitCast
+// CHECK-SAME: %[[ARG:.+]]: tensor<?x16xi16>,
+// CHECK-SAME: %[[DIM0:.+]]: index, %[[DIM1:.+]]: index, %[[DIM2:.+]]: index, %[[DIM3:.+]]: index
+func.func @flattenBitCastReshapeBitCast(%arg0: tensor<?x16xi16>, %dim0: index, %dim1: index, %dim2: index, %dim3: index) -> tensor<?x4x4xi16> {
+  // CHECK-NEXT: %[[RET:.+]] = flow.tensor.reshape %[[ARG]] : tensor<?x16xi16>{%[[DIM0]]} -> tensor<?x4x4xi16>{%[[DIM3]]}
+  %0 = flow.tensor.bitcast %arg0 : tensor<?x16xi16>{%dim0} -> tensor<?x8xi32>{%dim1}
+  %1 = flow.tensor.reshape %0 : tensor<?x8xi32>{%dim1} -> tensor<?x4x2xf32>{%dim2}
+  %2 = flow.tensor.bitcast %1 : tensor<?x4x2xf32>{%dim2} -> tensor<?x4x4xi16>{%dim3}
+  // CHECK-NEXT: return %[[RET]]
+  return %2 : tensor<?x4x4xi16>
+}
+
+
+// -----
+
 // CHECK-LABEL: @reshapeFromStaticZeroElements
 // CHECK-SAME: (%[[OPERAND:.+]]: tensor<4x0xf32>, %[[DIM:.+]]: index)
 func.func @reshapeFromStaticZeroElements(%arg0: tensor<4x0xf32>, %dim: index) -> tensor<4x?xf32> {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -32,6 +32,15 @@ func.func @tensorReshapeComplex(%arg0 : tensor<4x4xcomplex<f32>>) -> tensor<16xc
 
 // -----
 
+// CHECK-LABEL: @tensorBitCast
+func.func @tensorBitCast(%arg0 : tensor<16xi32>) -> tensor<4x8xi16> {
+  // CHECK-NEXT: %0 = flow.tensor.bitcast %arg0 : tensor<16xi32> -> tensor<4x8xi16>
+  %0 = flow.tensor.bitcast %arg0 : tensor<16xi32> -> tensor<4x8xi16>
+  return %0 : tensor<4x8xi16>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorLoad
 func.func @tensorLoad(%arg0 : tensor<4x4xf32>, %arg1 : index, %arg2 : index) -> f32 {
   // CHECK-NEXT: %0 = flow.tensor.load %arg0[%arg1, %arg2] : tensor<4x4xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchWorkgroups.cpp
@@ -318,6 +318,8 @@ void FormDispatchWorkgroupsPass::runOnOperation() {
         convertToFlowPatterns);
     IREE::Flow::TensorReshapeOp::getCanonicalizationPatterns(
         convertToFlowPatterns, context);
+    IREE::Flow::TensorBitCastOp::getCanonicalizationPatterns(
+        convertToFlowPatterns, context);
     if (failed(applyPatternsAndFoldGreedily(
             funcOp, std::move(convertToFlowPatterns)))) {
       funcOp->emitOpError("failed conversion to flow.tensor ops");

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -46,14 +46,14 @@ static Value buildResultSizeOf(Location loc, Value tensorValue,
       dynamicDims, getAffinityFor(tensorValue.getDefiningOp()));
 }
 
-// Reshapes become clones here to preserve shape information (which may become
-// actual transfers depending on source/target shape) - they'll be elided if not
-// needed.
-struct ConvertTensorReshapeOp
-    : public OpConversionPattern<IREE::Flow::TensorReshapeOp> {
-  using OpConversionPattern::OpConversionPattern;
+// Reshapes and bitcasts become clones here to preserve shape/element type
+// information (which may become actual transfers depending on source/target
+// shape) - they'll be elided if not needed.
+template <typename CastOpTy>
+struct ConvertTensorCastLikeOp : public OpConversionPattern<CastOpTy> {
+  using OpConversionPattern<CastOpTy>::OpConversionPattern;
   LogicalResult
-  matchAndRewrite(IREE::Flow::TensorReshapeOp op, OpAdaptor adaptor,
+  matchAndRewrite(CastOpTy op, typename CastOpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
     auto source =
@@ -853,11 +853,12 @@ void populateFlowToStreamConversionPatterns(MLIRContext *context,
                                             TypeConverter &typeConverter,
                                             RewritePatternSet &patterns) {
   patterns
-      .insert<ConvertTensorReshapeOp, ConvertTensorAllocaOp,
-              ConvertTensorEmptyOp, ConvertTensorSplatOp, ConvertTensorCloneOp,
-              ConvertTensorSliceOp, ConvertTensorUpdateOp, ConvertTensorLoadOp,
-              ConvertTensorStoreOp, ConvertTensorTraceOp>(typeConverter,
-                                                          context);
+      .insert<ConvertTensorCastLikeOp<IREE::Flow::TensorReshapeOp>,
+              ConvertTensorCastLikeOp<IREE::Flow::TensorBitCastOp>,
+              ConvertTensorAllocaOp, ConvertTensorEmptyOp, ConvertTensorSplatOp,
+              ConvertTensorCloneOp, ConvertTensorSliceOp, ConvertTensorUpdateOp,
+              ConvertTensorLoadOp, ConvertTensorStoreOp, ConvertTensorTraceOp>(
+          typeConverter, context);
   patterns.insert<ConvertChannelDefaultOp, ConvertChannelSplitOp,
                   ConvertChannelRankOp, ConvertChannelCountOp>(typeConverter,
                                                                context);

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -46,6 +46,20 @@ func.func @tensorReshapeWithMultipleUses(%input: tensor<5x24x48xf32>)
 
 // -----
 
+// CHECK-LABEL: @tensorBitCastWithSingleUse
+//  CHECK-SAME: (%[[INPUT:.+]]: !stream.resource<*>, %[[INPUT_SIZE:.+]]: index)
+func.func @tensorBitCastWithSingleUse(%input: tensor<5x24x48xi8>) -> tensor<30x2x192xi4> {
+  // CHECK: %[[RESULT_SIZE:.+]] = stream.tensor.sizeof tensor<30x2x192xi4> : index
+  // CHECK: %[[BITCAST:.+]] = stream.tensor.clone %[[INPUT]] : tensor<5x24x48xi8> in !stream.resource<*>{%[[INPUT_SIZE]]} -> tensor<30x2x192xi4> in !stream.resource<*>{%[[RESULT_SIZE]]}
+  %0 = flow.tensor.bitcast %input : tensor<5x24x48xi8> -> tensor<30x2x192xi4>
+  // CHECK: %[[RESULT:.+]] = stream.tensor.clone %[[BITCAST]] : tensor<30x2x192xi4> in !stream.resource<*>{%[[RESULT_SIZE]]} -> tensor<30x2x192xi4> in !stream.resource<*>{%[[RESULT_SIZE]]}
+  %1 = flow.tensor.clone %0 : tensor<30x2x192xi4>
+  // CHECK: return %[[RESULT]], %[[RESULT_SIZE]] : !stream.resource<*>, index
+  return %1 : tensor<30x2x192xi4>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorAlloca
 //  CHECK-SAME: (%[[DIM0:.+]]: index)
 func.func @tensorAlloca(%dim0: index) -> tensor<?x0xf32> {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1180,7 +1180,8 @@ bool TensorSplatOp::preferCloneToConsumers() { return true; }
 
 LogicalResult TensorCloneOp::verify() {
   TensorCloneOp op = *this;
-  // Clones can't change encodings but they can change shape information.
+  // Clones can't change encodings but they can change shape and element type
+  // information.
   auto sourceEncoding = llvm::cast<RankedTensorType>(op.getSourceEncoding());
   auto resultEncoding = llvm::cast<RankedTensorType>(op.getResultEncoding());
   if (sourceEncoding.getEncoding() != resultEncoding.getEncoding()) {

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -517,6 +517,7 @@ void IREEImportPublicPass::runOnOperation() {
   ONE_TO_ONE(IREE::Input::TensorCloneOp, IREE::Flow::TensorCloneOp);
   ONE_TO_ONE(IREE::Input::TensorLoadOp, IREE::Flow::TensorLoadOp);
   ONE_TO_ONE(IREE::Input::TensorReshapeOp, IREE::Flow::TensorReshapeOp);
+  ONE_TO_ONE(IREE::Input::TensorBitCastOp, IREE::Flow::TensorBitCastOp);
   ONE_TO_ONE(IREE::Input::TensorSliceOp, IREE::Flow::TensorSliceOp);
   ONE_TO_ONE(IREE::Input::TensorSplatOp, IREE::Flow::TensorSplatOp);
   ONE_TO_ONE(IREE::Input::TensorStoreOp, IREE::Flow::TensorStoreOp);

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -506,6 +506,32 @@ def IREEInput_TensorReshapeOp : IREEInput_PureOp<"tensor.reshape", [
   }];
 }
 
+def IREEInput_TensorBitCastOp : IREEInput_PureOp<"tensor.bitcast", [
+    AllElementTypesMatch<["source", "result"]>,
+    AttrSizedOperandSegments,
+  ]> {
+  let summary = [{bitcasts a tensor}];
+  let description = [{
+    Bitcasts a tensor to a new shape without modifying the contents.
+  }];
+
+  let arguments = (ins
+    IREEInput_Tensor:$source,
+    IREEInput_ShapeDynamicDims:$source_dims,
+    IREEInput_ShapeDynamicDims:$result_dims
+  );
+  let results = (outs
+    IREEInput_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $source `:`
+    type($source) (`{` $source_dims^ `}`)? `->`
+    type($result) (`{` $result_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+}
+
 def IREEInput_TensorLoadOp : IREEInput_PureOp<"tensor.load", [
     TypesMatchWith<"value type matches element type of target operand",
                    "source", "result",


### PR DESCRIPTION
This is a pseudo-rfc about how to handle bitcasting of tensors within IREE. This patch adds `flow.tensor.bitcast` as a near mirror of `flow.tensor.reshape`, however allowing changing element type bit widths as well. This allows earlier lowerings to skip materializing a constant tensor of some difficult to represent type and instead bitcast from a nicer byte-aligned and/or integer type. Similarly, this can help bridge the gap between frameworks, which might have limited support even for integers of varying bit widths, and IREE.

In terms of direct applications today, this removes the need to materialize the sub-byte constant tensors for quantized LLMs like LLaMa that have seen recent burn-downs. As a result, we can store the constants as i8 instead of converting the elements one-by-one to APInt to allow MLIR to represent the constant tensor, and instead just keep the values as is from the frontend (the frontend is giving it to us packed!). This should improve memory usage at compile time by at least, say, a factor of 2 for `i4` (or more, not sure how APInt is storing those values), as well as give significant compile time gains both at load and serialization time.

If this op is too much of a clone of reshape, it's easy to just simplify the verifier for reshape, but I figured letting the reshape also bitcast (with changing bit width) might be doing too much, and I see this bitcast op as introducing potential footguns/points of ambiguity. Essentially with this op, we would have a situation where the storage of a non-power-of-two sub-byte resource could be ambiguous from codegen's perspective.

Currently let's say we have a constant of `tensor<64xi3>`. Currently this would be serialized such that 2 `i3`s are packed per byte with 2 wasted bits. If we instead had a constant of `tensor<24xi8>` and bitcasted to `tensor<64xi3>`, semantically a bitcast is a no-op and thus the resulting `i3` tensor will be stored with 24 bytes as opposed to 32. Codegen would only see the interface binding + offset for a `tensor<64xi3>` and thus can't know how to generate code.

(see compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir)

I haven't thought through the right way to handle this yet, but I also figured that codegen can't really handle non-power-of-two types right now anyway so I ignored the problem for now :/

Edit: I'm realizing now that because tensors don't specify a storage format, this is kind of undefined unless the element bit width stays the same.