### PR TITLE
Small bugfix in EmplaceAllocations

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -90,6 +90,15 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp) {
         // TODO(#14566): continue if sparse emplacement on multiple results.
         break;
       }
+      if (!IREE::Util::isValueUsableForOp(updateOp.getTargetSize(), dispatchOp))
+        break;
+      if (!IREE::Util::isValueUsableForOp(updateOp.getTargetOffset(),
+                                          dispatchOp))
+        break;
+      if (!IREE::Util::isValueUsableForOp(updateOp.getTargetEnd(), dispatchOp))
+        break;
+      if (!IREE::Util::isValueUsableForOp(updateOp.getUpdateSize(), dispatchOp))
+        break;
       if (!IREE::Util::tryMoveProducerBefore(updateOp.getTarget(),
                                              dispatchOp)) {
         // Failed to move while keeping valid SSA dominance.


### PR DESCRIPTION
Added some checks to avoid insertion point errors. This is a bit of a quick fix, as ideally we would find a way to move entire trees up when possible, but I'll file an issue for that.


TODO add a test for this case