### PR TITLE
[Python] Add Fence VMRef Binding to enable async-exec on py.

### DIFF
--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -1109,7 +1109,11 @@ void SetupHalBindings(nanobind::module_ m) {
                        "signaling semaphore");
       });
 
-  py::class_<HalFence>(m, "HalFence")
+  auto hal_fence = py::class_<HalFence>(m, "HalFence");
+  VmRef::BindRefProtocol(hal_fence, iree_hal_fence_type,
+                         iree_hal_fence_retain_ref, iree_hal_fence_deref,
+                         iree_hal_fence_isa);
+  hal_fence
       .def(
           "__init__",
           [](HalFence* new_fence, iree_host_size_t capacity) {

--- a/runtime/bindings/python/tests/vm_types_test.py
+++ b/runtime/bindings/python/tests/vm_types_test.py
@@ -96,6 +96,12 @@ class VmTypesTest(unittest.TestCase):
         lst.push_ref(buffer_view)
         self.assertEqual(str(lst), "<VmVariantList(1): [HalBufferView(:0x20000011)]>")
 
+    def test_variant_list_fence_to_str(self):
+        lst = rt.VmVariantList(1)
+        fence = rt.HalFence(2)
+        lst.push_ref(fence)
+        self.assertEqual(str(lst), "<VmVariantList(1): [fence(0)]>")
+
     def test_variant_list_list(self):
         lst1 = rt.VmVariantList(5)
         lst2 = rt.VmVariantList(5)

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -742,6 +742,12 @@ void AppendListContents(std::string& out, iree_vm_list_t* list,
           out.append("...circular...");
         }
         out.append("]");
+      } else if (iree_hal_fence_isa(variant.ref)) {
+        out.append("fence(");
+        auto* hal_fence = iree_hal_fence_deref(variant.ref);
+        iree_host_size_t timepoint_count =
+            iree_hal_fence_timepoint_count(hal_fence);
+        out.append(std::to_string(timepoint_count) + ")");
       } else {
         out += "Unknown(" +
                std::to_string(iree_vm_type_def_as_ref(variant.type)) + ")";


### PR DESCRIPTION
To use `iree-execution-model=async-*`, we'd need to feed in `HalFence` as inputs to `Vm.Invoke`. Which means we'd need to be able to push_ref `HalFence` into `VmVariantList`, this PR enables that support.