### PR TITLE
Exclude executable files in root .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ build-*/
 # Bazel artifacts
 **/bazel-*
 
+# Executables
+*.exe
+*.out
+
 # Local-only config options
 configured.bazelrc
 user.bazelrc


### PR DESCRIPTION
Seeing `a.out` files sneak in from somewhere... (https://github.com/openxla/iree/commit/d87a97ec3248b298c2828441b3ebbaaf6c30ad6a)

GitHub recommends these: https://github.com/github/gitignore/blob/main/C%2B%2B.gitignore