### PR TITLE
Add pass to expand all vectors in vecmat/matvec operations into matrices to enable tiling

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -47,6 +47,7 @@ iree_compiler_cc_library(
         "Convert1X1FilterConv2DToMatmul.cpp",
         "DetachElementwiseFromNamedOps.cpp",
         "EraseUnusedLinalgOperands.cpp",
+        "ExpandVectors.cpp",
         "MaterializeHomogeneousEncodings.cpp",
         "Passes.cpp",
         "RemoveZeroExtentTensors.cpp",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     "Convert1X1FilterConv2DToMatmul.cpp"
     "DetachElementwiseFromNamedOps.cpp"
     "EraseUnusedLinalgOperands.cpp"
+    "ExpandVectors.cpp"
     "MaterializeHomogeneousEncodings.cpp"
     "Passes.cpp"
     "RemoveZeroExtentTensors.cpp"

--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
@@ -1,0 +1,141 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===--------------- ExpandVectors.cpp -----------------------------------===//
+// Expands vectors in matrix/vector operations (vecmat, matvec, batch_matvec)
+// into matrices in order to enable tiling.
+//===---------------------------------------------------------------------===//
+
+#include "iree/compiler/GlobalOptimization/PassDetail.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace GlobalOptimization {
+
+namespace {
+
+struct ExpandVectors
+    : public OpInterfaceRewritePattern<linalg::ContractionOpInterface> {
+  using OpInterfaceRewritePattern<
+      linalg::ContractionOpInterface>::OpInterfaceRewritePattern;
+  LogicalResult matchAndRewrite(linalg::ContractionOpInterface op,
+                                PatternRewriter &rewriter) const override {
+    auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
+    if (!linalgOp || !linalgOp.hasTensorSemantics())
+      return failure();
+
+    if (op.isRowMajorMatmul() || op.isColumnMajorMatmul() ||
+        op.isRowMajorBatchMatmul()) {
+      return rewriter.notifyMatchFailure(linalgOp, "op is already a matmul");
+    }
+    Value lhs = linalgOp.getDpsInputs()[0];
+    Value rhs = linalgOp.getDpsInputs()[1];
+
+    Value vectorIn;
+    if (op.isVecmat()) {
+      vectorIn = lhs;
+    } else if (op.isMatvec() || op.isBatchMatvec()) {
+      vectorIn = rhs;
+    } else {
+      return rewriter.notifyMatchFailure(linalgOp,
+                                         "unsupported contraction op");
+    }
+
+    auto vectorOut = linalgOp.getDpsInits()[0];
+    auto vectorInTy = llvm::dyn_cast<RankedTensorType>(vectorIn.getType());
+    auto vectorOutTy = llvm::dyn_cast<RankedTensorType>(vectorOut.getType());
+
+    if (!vectorInTy || !vectorOutTy) {
+      return failure();
+    }
+
+    Type inEType = vectorInTy.getElementType();
+    Type outEType = vectorOutTy.getElementType();
+
+    SmallVector<int64_t> expandedInDims, expandedOutDims;
+    bool isBatched = false;
+    SmallVector<ReassociationIndices> ri = {{0, 1}};
+
+    // Expand (N * NxM = M) into (1xN * NxM = 1xM)
+    if (op.isVecmat()) {
+      expandedInDims = {1, vectorInTy.getDimSize(0)};
+      expandedOutDims = {1, vectorOutTy.getDimSize(0)};
+      // Expand (NxM * M = N) into (NxM * Mx1 = Mx1)
+    } else if (op.isMatvec()) {
+      expandedInDims = {vectorInTy.getDimSize(0), 1};
+      expandedOutDims = {vectorOutTy.getDimSize(0), 1};
+      // Expand (BxNxM * BxM = BxN) into (BxNxM * BxMx1 = BxMx1)
+    } else {
+      expandedInDims = {vectorInTy.getDimSize(0), vectorInTy.getDimSize(1), 1};
+      expandedOutDims = {vectorOutTy.getDimSize(0), vectorOutTy.getDimSize(1),
+                         1};
+      ri = {{0}, {1, 2}};
+      isBatched = true;
+    }
+
+    auto newVectorInTy = RankedTensorType::get(expandedInDims, inEType);
+    auto newVectorOutTy = RankedTensorType::get(expandedOutDims, outEType);
+    Location loc = linalgOp.getLoc();
+    Value expandedIn =
+        rewriter.create<tensor::ExpandShapeOp>(loc, newVectorInTy, vectorIn, ri)
+            .getResult();
+    Value expandedOut =
+        rewriter
+            .create<tensor::ExpandShapeOp>(loc, newVectorOutTy, vectorOut, ri)
+            .getResult();
+
+    Value matmul;
+    if (op.isVecmat()) {
+      lhs = expandedIn;
+    } else {
+      rhs = expandedIn;
+    }
+    if (isBatched) {
+      matmul = rewriter
+                   .create<linalg::BatchMatmulOp>(
+                       loc, newVectorOutTy, ValueRange{lhs, rhs}, expandedOut)
+                   .getResult(0);
+    } else {
+      matmul = rewriter
+                   .create<linalg::MatmulOp>(loc, newVectorOutTy,
+                                             ValueRange{lhs, rhs}, expandedOut)
+                   .getResult(0);
+    }
+    Value result =
+        rewriter.create<tensor::CollapseShapeOp>(loc, vectorOutTy, matmul, ri)
+            .getResult();
+    rewriter.replaceOp(linalgOp, result);
+    return success();
+  }
+};
+
+struct ExpandVectorsPass : public ExpandVectorsBase<ExpandVectorsPass> {
+  void runOnOperation() override;
+};
+
+} // namespace
+void ExpandVectorsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  {
+    RewritePatternSet patterns(context);
+    patterns.insert<ExpandVectors>(context);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+}
+
+std::unique_ptr<Pass> createExpandVectorsPass() {
+  return std::make_unique<ExpandVectorsPass>();
+}
+
+} // namespace GlobalOptimization
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -68,6 +68,8 @@ void buildGlobalOptimizationPassPipeline(
       .addPass(IREE::Flow::createRaiseSpecialOps)
       .addPass(IREE::Flow::createFoldUnitExtentDimsPass)
       .addPass(IREE::Flow::createFuseDequantizationMatmulPass)
+      // Expand all vectors in vecmat/matvec ops into matrices for tiling.
+      .addPass(createExpandVectorsPass)
       // Enable data tiling after they are in a canonical form.
       .addPredicatedPass(transformOptions.options.dataTiling,
                          createSetEncodingPass)

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -69,7 +69,8 @@ void buildGlobalOptimizationPassPipeline(
       .addPass(IREE::Flow::createFoldUnitExtentDimsPass)
       .addPass(IREE::Flow::createFuseDequantizationMatmulPass)
       // Expand all vectors in vecmat/matvec ops into matrices for tiling.
-      .addPass(createExpandVectorsPass)
+      .addPredicatedPass(transformOptions.options.dataTiling,
+                         createExpandVectorsPass)
       // Enable data tiling after they are in a canonical form.
       .addPredicatedPass(transformOptions.options.dataTiling,
                          createSetEncodingPass)

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -54,6 +54,10 @@ std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createEraseUnusedLinalgOperands();
 
+// Expands vectors in vector/matrix operations into matrices to allow for
+// tiling.
+std::unique_ptr<Pass> createExpandVectorsPass();
+
 // Materializes logical encodings to physical encodings if there is a single
 // device target.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -54,8 +54,8 @@ std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createEraseUnusedLinalgOperands();
 
-// Expands vectors in vector/matrix operations into matrices to allow for
-// tiling.
+// Expands vectors in vector/matrix operations into linalg.batch_matmul/matmul
+// forms.
 std::unique_ptr<Pass> createExpandVectorsPass();
 
 // Materializes logical encodings to physical encodings if there is a single

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -27,6 +27,11 @@ def EraseUnusedLinalgOperands :
   let constructor = "mlir::iree_compiler::GlobalOptimization::createEraseUnusedLinalgOperands()";
 }
 
+def ExpandVectors : Pass<"iree-global-opt-expand-vectors", ""> {
+  let summary = "Expand vector in vector/matrix operations";
+  let constructor = "mlir::iree_compiler::GlobalOptimization::createExpandVectorsPass()";
+}
+
 def MaterializeHomogeneousEncodings :
   Pass<"iree-global-opt-materialize-homogeneous-encodings", "mlir::ModuleOp"> {
   let summary = "Materializes logical encodings to physical encodings if there is a single device target.";

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         [
             "conv1x1_to_matmul.mlir",
             "detach_elementwise_from_named_ops.mlir",
+            "expand_vectors.mlir",
             "materialize_homogeneous_encodings.mlir",
             "remove_zero_extent_tensors.mlir",
             "set_encoding.mlir",

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "conv1x1_to_matmul.mlir"
     "detach_elementwise_from_named_ops.mlir"
+    "expand_vectors.mlir"
     "materialize_homogeneous_encodings.mlir"
     "remove_zero_extent_tensors.mlir"
     "set_encoding.mlir"

--- a/compiler/src/iree/compiler/GlobalOptimization/test/expand_vectors.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/expand_vectors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-global-opt-expand-vectors --cse --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-global-opt-expand-vectors --split-input-file %s | FileCheck %s
 
 func.func @vecmat_f32f32f32(%arg0 : tensor<250xf32>, %arg1 : tensor<250x100xf32>,
     %arg2 : tensor<100xf32>) -> tensor<100xf32> {

--- a/compiler/src/iree/compiler/GlobalOptimization/test/expand_vectors.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/expand_vectors.mlir
@@ -1,0 +1,95 @@
+// RUN: iree-opt --iree-global-opt-expand-vectors --cse --split-input-file %s | FileCheck %s
+
+func.func @vecmat_f32f32f32(%arg0 : tensor<250xf32>, %arg1 : tensor<250x100xf32>,
+    %arg2 : tensor<100xf32>) -> tensor<100xf32> {
+  %0 = linalg.vecmat ins(%arg0, %arg1 : tensor<250xf32>, tensor<250x100xf32>)
+      outs(%arg2 : tensor<100xf32>) -> tensor<100xf32>
+  return %0 : tensor<100xf32>
+}
+//      CHECK:  func @vecmat_f32f32f32(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<250xf32>, %[[ARG1:.+]]: tensor<250x100xf32>, %[[ARG2:.+]]: tensor<100xf32>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG0]] {{\[}}[0, 1]] : tensor<250xf32> into tensor<1x250xf32>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1]] : tensor<100xf32> into tensor<1x100xf32>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.matmul ins(%[[EXPANDED_IN]], %[[ARG1]] : tensor<1x250xf32>, tensor<250x100xf32>) outs(%[[EXPANDED_OUT]] : tensor<1x100xf32>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0, 1]] : tensor<1x100xf32> into tensor<100xf32>
+//      CHECK:  return %[[COLLAPSED]]
+
+// -----
+
+func.func @vecmat_bf16bf16f32_dynamic(%arg0 : tensor<?xbf16>, %arg1 : tensor<?x?xbf16>,
+    %arg2 : tensor<?xf32>) -> tensor<?xf32> {
+  %0 = linalg.vecmat ins(%arg0, %arg1 : tensor<?xbf16>, tensor<?x?xbf16>)
+      outs(%arg2 : tensor<?xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+//      CHECK:  func @vecmat_bf16bf16f32_dynamic(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<?xbf16>, %[[ARG1:.+]]: tensor<?x?xbf16>, %[[ARG2:.+]]: tensor<?xf32>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG0]] {{\[}}[0, 1]] : tensor<?xbf16> into tensor<1x?xbf16>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1]] : tensor<?xf32> into tensor<1x?xf32>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.matmul ins(%[[EXPANDED_IN]], %[[ARG1]] : tensor<1x?xbf16>, tensor<?x?xbf16>) outs(%[[EXPANDED_OUT]] : tensor<1x?xf32>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0, 1]] : tensor<1x?xf32> into tensor<?xf32>
+//      CHECK:  return %[[COLLAPSED]]
+
+// -----
+
+func.func @matvec_f32f32f32(%arg0 : tensor<100x250xf32>, %arg1 : tensor<250xf32>,
+    %arg2 : tensor<100xf32>) -> tensor<100xf32> {
+  %0 = linalg.matvec ins(%arg0, %arg1 : tensor<100x250xf32>, tensor<250xf32>)
+      outs(%arg2 : tensor<100xf32>) -> tensor<100xf32>
+  return %0 : tensor<100xf32>
+}
+//      CHECK:  func @matvec_f32f32f32(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<100x250xf32>, %[[ARG1:.+]]: tensor<250xf32>, %[[ARG2:.+]]: tensor<100xf32>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0, 1]] : tensor<250xf32> into tensor<250x1xf32>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1]] : tensor<100xf32> into tensor<100x1xf32>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.matmul ins(%[[ARG0]], %[[EXPANDED_IN]] : tensor<100x250xf32>, tensor<250x1xf32>) outs(%[[EXPANDED_OUT]] : tensor<100x1xf32>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0, 1]] : tensor<100x1xf32> into tensor<100xf32>
+//      CHECK:  return %[[COLLAPSED]]
+
+// -----
+
+func.func @matvec_i8i8i32_dynamic(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?xi8>,
+    %arg2 : tensor<?xi32>) -> tensor<?xi32> {
+  %0 = linalg.matvec ins(%arg0, %arg1 : tensor<?x?xi8>, tensor<?xi8>)
+      outs(%arg2 : tensor<?xi32>) -> tensor<?xi32>
+  return %0 : tensor<?xi32>
+}
+//      CHECK:  func @matvec_i8i8i32_dynamic(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<?x?xi8>, %[[ARG1:.+]]: tensor<?xi8>, %[[ARG2:.+]]: tensor<?xi32>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0, 1]] : tensor<?xi8> into tensor<?x1xi8>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1]] : tensor<?xi32> into tensor<?x1xi32>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.matmul ins(%[[ARG0]], %[[EXPANDED_IN]] : tensor<?x?xi8>, tensor<?x1xi8>) outs(%[[EXPANDED_OUT]] : tensor<?x1xi32>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0, 1]] : tensor<?x1xi32> into tensor<?xi32>
+//      CHECK:  return %[[COLLAPSED]]
+
+// -----
+
+func.func @batch_matvec_f32f32f32(%arg0 : tensor<3x100x250xf32>, %arg1 : tensor<3x250xf32>,
+    %arg2 : tensor<3x100xf32>) -> tensor<3x100xf32> {
+  %0 = linalg.batch_matvec ins(%arg0, %arg1 : tensor<3x100x250xf32>, tensor<3x250xf32>)
+      outs(%arg2 : tensor<3x100xf32>) -> tensor<3x100xf32>
+  return %0 : tensor<3x100xf32>
+}
+//      CHECK:  func @batch_matvec_f32f32f32(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<3x100x250xf32>, %[[ARG1:.+]]: tensor<3x250xf32>, %[[ARG2:.+]]: tensor<3x100xf32>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0], [1, 2]] : tensor<3x250xf32> into tensor<3x250x1xf32>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0], [1, 2]] : tensor<3x100xf32> into tensor<3x100x1xf32>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.batch_matmul ins(%[[ARG0]], %[[EXPANDED_IN]] : tensor<3x100x250xf32>, tensor<3x250x1xf32>) outs(%[[EXPANDED_OUT]] : tensor<3x100x1xf32>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0], [1, 2]] : tensor<3x100x1xf32> into tensor<3x100xf32>
+//      CHECK:  return %[[COLLAPSED]]
+
+// -----
+
+func.func @batch_matvec_f16f16f16_dynamic(%arg0 : tensor<?x?x?xf16>, %arg1 : tensor<?x?xf16>,
+    %arg2 : tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %0 = linalg.batch_matvec ins(%arg0, %arg1 : tensor<?x?x?xf16>, tensor<?x?xf16>)
+      outs(%arg2 : tensor<?x?xf16>) -> tensor<?x?xf16>
+  return %0 : tensor<?x?xf16>
+}
+//      CHECK:  func @batch_matvec_f16f16f16_dynamic(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<?x?x?xf16>, %[[ARG1:.+]]: tensor<?x?xf16>, %[[ARG2:.+]]: tensor<?x?xf16>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0], [1, 2]] : tensor<?x?xf16> into tensor<?x?x1xf16>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0], [1, 2]] : tensor<?x?xf16> into tensor<?x?x1xf16>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.batch_matmul ins(%[[ARG0]], %[[EXPANDED_IN]] : tensor<?x?x?xf16>, tensor<?x?x1xf16>) outs(%[[EXPANDED_OUT]] : tensor<?x?x1xf16>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0], [1, 2]] : tensor<?x?x1xf16> into tensor<?x?xf16>
+//      CHECK:  return %[[COLLAPSED]]


### PR DESCRIPTION
This PR fails until the newest llvm integration as it depends on [68945](https://github.com/llvm/llvm-project/pull/68945).

As discussed in [issue#15053](https://github.com/openxla/iree/issues/15053) and [PR#15257](https://github.com/openxla/iree/pull/15257), expanding the vectors in vecmat/matvec operations and avoiding them in the encoding step entirely seems like the best approach.