### PR TITLE
Add riscv vector extension in cpu feature

### DIFF
--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -310,6 +310,74 @@ static void iree_cpu_initialize_from_platform_x86_64(uint64_t* out_fields) {
   out_fields[0] = out0;
 }
 
+#elif defined(IREE_ARCH_RISCV_64)
+#if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
+
+// First 4 characters are "rv32" or "rv64"
+#define IREE_RISCV_64_ISA_SEARCH_START 4
+
+static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
+  char* line;
+  char isa[1024];
+  char* cpuinfo_path = "/proc/cpuinfo";
+  FILE* fp;
+  size_t len = 0;
+  ssize_t nread;
+
+  fp = fopen(cpuinfo_path, "r");
+  if (!fp) {
+    return;
+  }
+
+  while ((nread = getline(&line, &len, fp)) != -1) {
+    if (sscanf(line, "isa : %s\n", &isa[0])) {
+      // First 4 characters are "rv32" or "rv64"
+      // We search the character 'v' from the 4th character to '_' occur or
+      // string end.
+      char* first = strchr(&isa[0], '_');
+
+      // Can't find '_', search 'v' in the whole isa string.
+      if (!first) {
+        if (strchr(&isa[IREE_RISCV_64_ISA_SEARCH_START], 'v')) {
+          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1, 1 << 0);
+        }
+        break;
+      } else {
+        // search 'v' to the first '_' occur.
+        int search_len = first - &isa[IREE_RISCV_64_ISA_SEARCH_START];
+        if (memchr(&isa[IREE_RISCV_64_ISA_SEARCH_START], 'v', search_len)) {
+          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1, 1 << 0);
+          break;
+        }
+      }
+
+      // No 'v' before the first '_', search for "zve".
+      char* start = first;
+      char* end = &isa[0] + len;
+      char* next;
+
+      while (start < end) {
+        next = strchr(start, '_');
+        if (!next) {
+          next = end;
+        }
+
+        if (strncmp("zve", start, 3) == 0) {
+          IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_RVV, 1, 1 << 0);
+          break;
+        }
+        // Next search start from the char after '_'
+        start = next + 1;
+      }
+      break;
+    }
+  }
+
+  free(line);
+  fclose(fp);
+}
+
+#endif  // IREE_PLATFORM_*
 #endif  // defined(IREE_ARCH_ARM_64)
 
 static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
@@ -318,6 +386,8 @@ static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
   iree_cpu_initialize_from_platform_arm_64(out_fields);
 #elif defined(IREE_ARCH_X86_64)
   iree_cpu_initialize_from_platform_x86_64(out_fields);
+#elif defined(IREE_ARCH_RISCV_64)
+  iree_cpu_initialize_from_platform_riscv_64(out_fields);
 #else
   // No implementation available. CPU data will be all zeros.
 #endif  // defined(IREE_ARCH_ARM_64)

--- a/runtime/src/iree/schemas/cpu_feature_bits.inl
+++ b/runtime/src/iree/schemas/cpu_feature_bits.inl
@@ -114,3 +114,11 @@ IREE_CPU_FEATURE_BIT(X86_64, 0, 32, AVX512FP16, "avx512fp16")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 50, AMXTILE, "amx-tile")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 51, AMXINT8, "amx-int8")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 52, AMXBF16, "amx-bf16")
+
+//===----------------------------------------------------------------------===//
+// IREE_ARCH_RISCV_64 / riscv64
+//===----------------------------------------------------------------------===//
+
+// General features and high-level switches.
+// RISCV vector extension.
+IREE_CPU_FEATURE_BIT(RISCV_64, 0, 0, RVV, "rvv")


### PR DESCRIPTION
This patch parse `/proc/cpuinfo` isa string in linux/android platform to check the support of riscv vector extension.