### PR TITLE
Add output verification to linux benchmark tool

### DIFF
--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -56,6 +56,7 @@ class BenchmarkConfig:
       times.
     continue_from_previous: skip the benchmarks if their results are found in
       the benchmark_results_dir.
+    verify: verify the output if model's expected output is available.
     """
 
     root_benchmark_dir: pathlib.Path
@@ -73,6 +74,7 @@ class BenchmarkConfig:
     keep_going: bool = False
     benchmark_min_time: float = 0
     continue_from_previous: bool = False
+    verify: bool = False
 
     @staticmethod
     def build_from_args(args: Namespace, git_commit_hash: str):

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -126,4 +126,5 @@ class BenchmarkConfig:
             keep_going=args.keep_going,
             benchmark_min_time=args.benchmark_min_time,
             continue_from_previous=args.continue_from_previous,
+            verify=args.verify,
         )

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -53,6 +53,7 @@ class BenchmarkConfigTest(unittest.TestCase):
                 f"--e2e_test_artifacts_dir={self.e2e_test_artifacts_dir}",
                 f"--execution_benchmark_config={self.execution_config}",
                 "--target_device=test",
+                "--verify",
             ]
         )
 
@@ -79,6 +80,7 @@ class BenchmarkConfigTest(unittest.TestCase):
             keep_going=True,
             benchmark_min_time=10,
             use_compatible_filter=True,
+            verify=True,
         )
         self.assertEqual(config, expected_config)
 

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -9,10 +9,10 @@ See docs/developers/developing_iree/benchmark_suites.md for how to build the
 benchmark suite.
 """
 
-import collections
 import pathlib
 import re
 
+import dataclasses
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple
 from common.benchmark_definition import IREE_DRIVERS_INFOS, DriverInfo
@@ -36,6 +36,8 @@ class BenchmarkCase:
     benchmark_tool_name: the benchmark tool, e.g., 'iree-benchmark-module'.
     benchmark_case_dir: the path to benchmark case directory.
     run_config: the run config from e2e test framework.
+    input_uri: URI to find the input npy.
+    expected_output_uri: URI to find the expected output npy.
     """
 
     model_name: str
@@ -46,6 +48,9 @@ class BenchmarkCase:
     benchmark_tool_name: str
     benchmark_case_dir: pathlib.Path
     run_config: iree_definitions.E2EModelRunConfig
+    input_uri: Optional[str] = None
+    expected_output_uri: Optional[str] = None
+    verify_params: List[str] = dataclasses.field(default_factory=list)
 
 
 # A map from execution config to driver info. This is temporary during migration

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -171,6 +171,11 @@ class Parser(argparse.ArgumentParser):
             "information",
         )
         self.add_argument(
+            "--verify",
+            action="store_true",
+            help="Verify the output when the expected output is available",
+        )
+        self.add_argument(
             "--execution_benchmark_config",
             type=_check_file_path,
             required=True,

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -61,7 +61,8 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
             )
         if benchmark_case.expected_output_uri:
             expected_output_dir = self.__fetch_and_unpack_npy(
-                uri=benchmark_case.expected_output_uri, dest_dir=case_dir / "inputs_npy"
+                uri=benchmark_case.expected_output_uri,
+                dest_dir=case_dir / "expected_outputs_npy",
             )
 
         if benchmark_results_filename:

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -101,7 +101,8 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         )
         cmds.append(tool_path)
 
-        cmds += [f"--module={iree_artifacts.MODULE_FILENAME}"]
+        module_dir_path = benchmark_case.benchmark_case_dir
+        cmds += [f"--module={module_dir_path / iree_artifacts.MODULE_FILENAME}"]
         cmds += run_config.materialize_run_flags(
             gpu_id=self.gpu_id,
             inputs_dir=inputs_dir,
@@ -152,9 +153,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         # Currently only support single output.
         cmd.append(f'--expected_output=@{expected_outputs_dir / "output_0.npy"}')
         cmd += benchmark_case.verify_params
-        execute_cmd_and_get_output(
-            cmd, verbose=self.verbose, cwd=benchmark_case.benchmark_case_dir
-        )
+        execute_cmd_and_get_output(cmd, verbose=self.verbose)
 
     def __run_benchmark(
         self,
@@ -176,7 +175,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
             )
 
         benchmark_stdout, benchmark_stderr = execute_cmd_and_get_output(
-            cmd, verbose=self.verbose, cwd=benchmark_case.benchmark_case_dir
+            cmd, verbose=self.verbose
         )
         benchmark_metrics = parse_iree_benchmark_metrics(
             benchmark_stdout, benchmark_stderr

--- a/build_tools/python/e2e_model_tests/cmake_generator.py
+++ b/build_tools/python/e2e_model_tests/cmake_generator.py
@@ -54,12 +54,14 @@ def generate_rules(
         runner_args = (
             iree_definitions.generate_run_flags(
                 imported_model=imported_model,
-                input_data=test_config.input_data,
                 module_execution_config=test_config.execution_config,
                 with_driver=False,
             )
             + test_config.extra_test_flags
         )
+        runner_args += [
+            f"--input={input_type}=0" for input_type in imported_model.model.input_types
+        ]
         cmake_rule = cmake_builder.rules.build_iree_benchmark_suite_module_test(
             target_name=test_config.name,
             driver=test_config.execution_config.driver.value,

--- a/build_tools/python/e2e_model_tests/test_definitions.py
+++ b/build_tools/python/e2e_model_tests/test_definitions.py
@@ -49,9 +49,6 @@ class ModelTestConfig(object):
 
     # Either a string literal or a file path.
     expected_output: str
-    input_data: common_definitions.ModelInputData = (
-        common_definitions.ZEROS_MODEL_INPUT_DATA
-    )
 
     # Platforms to ignore this test.
     unsupported_platforms: List[CMakePlatform] = dataclasses.field(default_factory=list)

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions_test.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions_test.py
@@ -150,14 +150,16 @@ class IreeDefinitionsTest(unittest.TestCase):
             tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE,
         )
 
-        flags = run_config.materialize_run_flags(
-            gpu_id="10", inputs_dir=pathlib.PurePath("inputs_dir")
-        )
+        inputs_dir = pathlib.PurePath("inputs_dir")
+        flags = run_config.materialize_run_flags(gpu_id="10", inputs_dir=inputs_dir)
 
         self.assertIn("--device=cuda://10", flags)
-        self.assertIn("--input=@inputs_dir/input_0.npy", flags)
-        first_input_idx = flags.index("--input=@inputs_dir/input_0.npy")
-        self.assertEqual(flags[first_input_idx + 1], "--input=@inputs_dir/input_1.npy")
+        first_input = f'--input=@{inputs_dir / "input_0.npy"}'
+        self.assertIn(first_input, flags)
+        first_input_idx = flags.index(first_input)
+        self.assertEqual(
+            flags[first_input_idx + 1], f'--input=@{inputs_dir/"input_1.npy"}'
+        )
 
 
 class ModuleGenerationConfigTest(unittest.TestCase):

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions_test.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions_test.py
@@ -143,7 +143,10 @@ class IreeDefinitionsTest(unittest.TestCase):
             gen_config,
             exec_config,
             device_spec,
-            common_definitions.ZEROS_MODEL_INPUT_DATA,
+            # TODO(#15282): ZEROS_MODEL_INPUT_DATA should be renamed to
+            # DEFAULT_INPUT_DATA, which means to use input npys if available;
+            # otherwise use all zeros data.
+            input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
             tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE,
         )
 

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -13,8 +13,8 @@ iree_benchmark_suite_module_test(
     "x86_64-Linux=iree_module_MobileNetV1_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   RUNNER_ARGS
     "--function=main"
-    "--input=1x224x224x3xf32=0"
     "--device_allocator=caching"
+    "--input=1x224x224x3xf32=0"
 )
 
 iree_benchmark_suite_module_test(
@@ -25,8 +25,8 @@ iree_benchmark_suite_module_test(
     "x86_64-Linux=iree_module_EfficientNet_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   RUNNER_ARGS
     "--function=main"
-    "--input=1x224x224x3xui8=0"
     "--device_allocator=caching"
+    "--input=1x224x224x3xui8=0"
 )
 
 iree_benchmark_suite_module_test(
@@ -38,9 +38,9 @@ iree_benchmark_suite_module_test(
     "x86_64-Linux=iree_module_DeepLabV3_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   RUNNER_ARGS
     "--function=main"
-    "--input=1x257x257x3xf32=0"
     "--device_allocator=caching"
     "--expected_f32_threshold=0.001"
+    "--input=1x257x257x3xf32=0"
 )
 
 iree_benchmark_suite_module_test(
@@ -53,7 +53,7 @@ iree_benchmark_suite_module_test(
     "x86_64-Linux=iree_module_PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_/module.vmfb"
   RUNNER_ARGS
     "--function=main"
-    "--input=1x96x96x1xi8=0"
     "--device_allocator=caching"
+    "--input=1x96x96x1xi8=0"
 )
 


### PR DESCRIPTION
Support output verification with `iree-run-module` in linux benchmark tool.

The follow-up changes will propagate the input data and expected output from benchmark definitions to the tool