### PR TITLE
Adding `vm.br_table` op.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -520,15 +520,21 @@ struct FeedbackArcSet {
 
 SmallVector<std::pair<Register, Register>, 8>
 RegisterAllocation::remapSuccessorRegisters(Operation *op, int successorIndex) {
+  auto *targetBlock = op->getSuccessor(successorIndex);
+  auto targetOperands = cast<BranchOpInterface>(op)
+                            .getSuccessorOperands(successorIndex)
+                            .getForwardedOperands();
+  return remapSuccessorRegisters(op->getLoc(), targetBlock, targetOperands);
+}
+
+SmallVector<std::pair<Register, Register>, 8>
+RegisterAllocation::remapSuccessorRegisters(Location loc, Block *targetBlock,
+                                            OperandRange targetOperands) {
   // Compute the initial directed graph of register movements.
   // This may contain cycles ([reg 0->1], [reg 1->0], ...) that would not be
   // possible to evaluate as a direct remapping.
   SmallVector<std::pair<Register, Register>, 8> srcDstRegs;
-  auto *targetBlock = op->getSuccessor(successorIndex);
-  auto operands = cast<BranchOpInterface>(op)
-                      .getSuccessorOperands(successorIndex)
-                      .getForwardedOperands();
-  for (auto it : llvm::enumerate(operands)) {
+  for (auto it : llvm::enumerate(targetOperands)) {
     auto srcReg = mapToRegister(it.value());
     BlockArgument targetArg = targetBlock->getArgument(it.index());
     auto dstReg = mapToRegister(targetArg);
@@ -580,7 +586,7 @@ RegisterAllocation::remapSuccessorRegisters(Operation *op, int successorIndex) {
     assert(getMaxI32RegisterOrdinal() <= Register::kInt32RegisterCount &&
            "spilling i32 regs");
     if (getMaxI32RegisterOrdinal() > Register::kInt32RegisterCount) {
-      op->emitOpError() << "spilling entire i32 register address space";
+      mlir::emitError(loc) << "spilling entire i32 register address space";
     }
   }
   if (localScratchRefRegCount > 0) {
@@ -589,7 +595,7 @@ RegisterAllocation::remapSuccessorRegisters(Operation *op, int successorIndex) {
     assert(getMaxRefRegisterOrdinal() <= Register::kRefRegisterCount &&
            "spilling ref regs");
     if (getMaxRefRegisterOrdinal() > Register::kRefRegisterCount) {
-      op->emitOpError() << "spilling entire ref register address space";
+      mlir::emitError(loc) << "spilling entire ref register address space";
     }
   }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.h
@@ -200,6 +200,9 @@ public:
   // may have their move bit set.
   SmallVector<std::pair<Register, Register>, 8>
   remapSuccessorRegisters(Operation *op, int successorIndex);
+  SmallVector<std::pair<Register, Register>, 8>
+  remapSuccessorRegisters(Location loc, Block *targetBlock,
+                          OperandRange targetOperands);
 
 private:
   int maxI32RegisterOrdinal_ = -1;

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -1085,6 +1085,80 @@ class CondBranchOpConversion : public OpConversionPattern<cf::CondBranchOp> {
   }
 };
 
+class SwitchOpConversion : public OpConversionPattern<cf::SwitchOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(cf::SwitchOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Special handling for default only ops: just jump to default.
+    if (srcOp.getCaseDestinations().empty()) {
+      rewriter.replaceOpWithNewOp<IREE::VM::BranchOp>(
+          srcOp, srcOp.getDefaultDestination(), adaptor.getDefaultOperands());
+      return success();
+    }
+
+    // NOTE: cf.switch can have sparse indices but we cannot; instead we fill
+    // any gaps with branches to the default block. This is wasteful but keeps
+    // the runtime super simple - if we have offset or really sparse tables
+    // (default + case 10000 + case 400000) we can optimize those in the
+    // compiler by using multiple branch tables, inverse lookups via a lookup
+    // op, etc.
+    //
+    // To make this simple here we get all cases, sort them, and then walk in
+    // order while filling gaps as need.
+    SmallVector<std::pair<int, int64_t>> caseValues;
+    for (auto [i, value] : llvm::enumerate(srcOp.getCaseValues().value())) {
+      caseValues.push_back(std::make_pair(i, value.getSExtValue()));
+    }
+    llvm::stable_sort(caseValues,
+                      [](std::pair<int, int64_t> a, std::pair<int, int64_t> b) {
+                        return a.second < b.second;
+                      });
+
+    // Sanity check negative values, which are tricky.
+    int64_t minValue = caseValues.front().second;
+    if (minValue < 0) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "negative case indices are not supported by the VM (today); "
+                 "needs positive offsetting");
+    }
+
+    // If the first branch is offset from 0 then we can subtract that out to
+    // avoid holes at the start of the table.
+    Value index = adaptor.getFlag();
+    if (minValue > 0) {
+      index = rewriter.create<IREE::VM::SubI32Op>(
+          srcOp.getLoc(), rewriter.getI32Type(), index,
+          rewriter.create<IREE::VM::ConstI32Op>(
+              srcOp.getLoc(), static_cast<int32_t>(minValue)));
+      for (auto &[i, value] : caseValues) {
+        value -= minValue;
+      }
+    }
+
+    // Emit each dense case, filling interior holes as needed.
+    SmallVector<Block *> caseDestinations;
+    SmallVector<ValueRange> caseOperands;
+    int64_t lastValue = 0;
+    for (auto [i, value] : caseValues) {
+      while (value != lastValue && value - lastValue != 1) {
+        // Hole to fill.
+        caseDestinations.push_back(srcOp.getDefaultDestination());
+        caseOperands.push_back(adaptor.getDefaultOperands());
+        ++lastValue;
+      }
+      caseDestinations.push_back(srcOp.getCaseDestinations()[i]);
+      caseOperands.push_back(srcOp.getCaseOperands(i));
+      lastValue = value;
+    }
+
+    rewriter.replaceOpWithNewOp<IREE::VM::BranchTableOp>(
+        srcOp, index, adaptor.getDefaultOperands(), caseOperands,
+        srcOp.getDefaultDestination(), caseDestinations);
+    return success();
+  }
+};
+
 } // namespace
 
 void populateStandardToVMPatterns(MLIRContext *context,
@@ -1093,9 +1167,9 @@ void populateStandardToVMPatterns(MLIRContext *context,
   patterns
       .insert<AssertOpConversion, BranchOpConversion, CallOpConversion,
               CmpI32OpConversion, CmpI64OpConversion, CmpF32OpConversion,
-              CondBranchOpConversion, ModuleOpConversion, FuncOpConversion,
-              ExternalFuncOpConversion, ReturnOpConversion, SelectOpConversion>(
-          typeConverter, context);
+              CondBranchOpConversion, SwitchOpConversion, ModuleOpConversion,
+              FuncOpConversion, ExternalFuncOpConversion, ReturnOpConversion,
+              SelectOpConversion>(typeConverter, context);
 
   // TODO(#2878): figure out how to pass the type converter in a supported way.
   // Right now if we pass the type converter as the first argument - triggering

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/control_flow_ops.mlir
@@ -74,6 +74,43 @@ module {
 }
 
 // -----
+// CHECK-LABEL: @t005_br_table
+module @t005_br_table {
+
+module {
+  // CHECK: vm.func private @my_fn
+  // CHECK-SAME: %[[FLAG:[a-zA-Z0-9$._-]+]]
+  // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
+  // CHECK-SAME: %[[ARG2:[a-zA-Z0-9$._-]+]]
+  // CHECK-SAME: %[[ARG3:[a-zA-Z0-9$._-]+]]
+  func.func @my_fn(%flag: i32, %arg1: i32, %arg2: i32, %arg3: i32) -> i32 {
+    // CHECK: %[[INDEX:.+]] = vm.sub.i32 %[[FLAG]], %c100
+    //      CHECK: vm.br_table %[[INDEX]] {
+    // CHECK-NEXT:   default: ^bb1(%[[ARG1]] : i32),
+    // CHECK-NEXT:   0: ^bb1(%[[ARG2]] : i32),
+    // CHECK-NEXT:   1: ^bb1(%[[ARG1]] : i32),
+    // CHECK-NEXT:   2: ^bb1(%[[ARG1]] : i32),
+    // CHECK-NEXT:   3: ^bb1(%[[ARG1]] : i32),
+    // CHECK-NEXT:   4: ^bb1(%[[ARG3]] : i32),
+    // CHECK-NEXT:   5: ^bb1(%[[ARG1]] : i32),
+    // CHECK-NEXT:   6: ^bb2
+    // CHECK-NEXT: }
+    cf.switch %flag : i32, [
+      default: ^bb1(%arg1 : i32),
+      104: ^bb1(%arg3 : i32),
+      100: ^bb1(%arg2 : i32),
+      106: ^bb2
+    ]
+  ^bb1(%0 : i32):
+    return %0 : i32
+  ^bb2:
+    return %arg1 : i32
+  }
+}
+
+}
+
+// -----
 // CHECK-LABEL: @t006_assert
 module @t006_assert {
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
@@ -279,6 +279,56 @@ vm.module @my_module {
 
 // -----
 
+// CHECK-LABEL: @my_module_br_table_empty
+vm.module @my_module {
+  vm.func @br_table_empty(%arg0: i32, %arg1: i32) -> i32 {
+    //  CHECK-NOT: vm.br_table
+    //      CHECK:  cf.br ^bb1
+    // CHECK-NEXT: ^bb1:
+    // CHECK-NEXT:  cf.br ^bb2(%arg4 : i32)
+    // CHECK-NEXT: ^bb2(%0: i32):
+    //      CHECK:  return
+    vm.br_table %arg0 {
+      default: ^bb1(%arg1 : i32)
+    }
+  ^bb1(%0 : i32):
+    // CHECK: return
+    // CHECK-NOT: vm.return
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @my_module_br_table
+vm.module @my_module {
+  vm.func @br_table(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+    //  CHECK-NOT: vm.br_table
+    //      CHECK:  cf.br ^bb1
+    // CHECK-NEXT: ^bb1:
+    //      CHECK:  emitc.call "vm_cmp_eq_i32"
+    //      CHECK:  emitc.call "vm_cmp_nz_i32"
+    //      CHECK:  cf.cond_br %{{.+}}, ^bb5(%arg4 : i32), ^bb2
+    //      CHECK: ^bb2:
+    //      CHECK:  emitc.call "vm_cmp_eq_i32"
+    //      CHECK:  emitc.call "vm_cmp_nz_i32"
+    //      CHECK:  cf.cond_br %{{.+}}, ^bb5(%arg5 : i32), ^bb3
+    //      CHECK: ^bb3:
+    //      CHECK:  cf.br ^bb4(%arg3 : i32)
+    vm.br_table %arg0 {
+      default: ^bb1(%arg0 : i32),
+      0: ^bb2(%arg1 : i32),
+      1: ^bb2(%arg2 : i32)
+    }
+  ^bb1(%0 : i32):
+    vm.return %0 : i32
+  ^bb2(%1 : i32):
+    vm.return %1 : i32
+  }
+}
+
+// -----
+
 vm.module @my_module {
   // CHECK-LABEL: @my_module_fail
   vm.func @fail(%arg0 : i32) {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -126,6 +126,8 @@ class VM_EncStrAttr<string name> : VM_EncEncodeExpr<
     "e.encodeStrAttr(getOperation()->getAttrOfType<StringAttr>(\"" # name # "\"))">;
 class VM_EncBranch<string blockName, string operandsName, int successorIndex> : VM_EncEncodeExpr<
     "e.encodeBranch({0}(), " # operandsName # "(), " # successorIndex # ")", [blockName]>;
+class VM_EncBranchTable<string caseBlockNames, string caseOperandsName, int baseSuccessorIndex> : VM_EncEncodeExpr<
+    "e.encodeBranchTable(" # caseBlockNames # "(), " # caseOperandsName # "(), " # baseSuccessorIndex # ")">;
 class VM_EncOperand<string name, int ordinal> : VM_EncEncodeExpr<
     "e.encodeOperand({0}(), " # ordinal # ")", [name]>;
 class VM_EncVariadicOperands<string name> : VM_EncEncodeExpr<

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMFuncEncoder.h
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMFuncEncoder.h
@@ -61,6 +61,11 @@ public:
                                      Operation::operand_range operands,
                                      int successorIndex) = 0;
 
+  // Encodes a branch table.
+  virtual LogicalResult encodeBranchTable(SuccessorRange caseSuccessors,
+                                          OperandRangeRange caseOperands,
+                                          int baseSuccessorIndex) = 0;
+
   // Encodes an operand value (by reference).
   virtual LogicalResult encodeOperand(Value value, int ordinal) = 0;
 

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
@@ -47,7 +47,7 @@ class VM_OPC_EnumAttr<string name, string enumName, string enumTag,
   string opcodeEnumTag = enumTag;
 }
 
-// Next available opcode: 0x83
+// Next available opcode: 0x84
 
 // Globals:
 def VM_OPC_GlobalLoadI32         : VM_OPC<0x00, "GlobalLoadI32">;
@@ -184,6 +184,7 @@ def VM_OPC_CmpNZRef              : VM_OPC<0x55, "CmpNZRef">;
 def VM_OPC_Block                 : VM_OPC<0x79, "Block">;
 def VM_OPC_Branch                : VM_OPC<0x56, "Branch">;
 def VM_OPC_CondBranch            : VM_OPC<0x57, "CondBranch">;
+def VM_OPC_BranchTable           : VM_OPC<0x83, "BranchTable">;
 def VM_OPC_Call                  : VM_OPC<0x58, "Call">;
 def VM_OPC_CallVariadic          : VM_OPC<0x59, "CallVariadic">;
 def VM_OPC_Return                : VM_OPC<0x5A, "Return">;
@@ -347,6 +348,7 @@ def VM_CoreOpcodeAttr :
 
     VM_OPC_Branch,
     VM_OPC_CondBranch,
+    VM_OPC_BranchTable,
     VM_OPC_Call,
     VM_OPC_CallVariadic,
     VM_OPC_Return,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.h
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_DIALECT_VM_IR_VMOPS_H_
 
 #include <cstdint>
+#include <numeric>
 
 #include "iree/compiler/Dialect/Util/IR/UtilTraits.h"
 #include "iree/compiler/Dialect/VM/IR/VMDialect.h"

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -3941,9 +3941,9 @@ def VM_CondBranchOp : VM_Op<"cond_br", [
       build($_builder, $_state, condition, trueOperands, falseOperands, trueDest,
             falseDest);
     }]>,
-  OpBuilder<(ins "Value":$condition, "Block *":$trueDest,
-    "Block *":$falseDest, CArg<"ValueRange", "{}">:$falseOperands),
-  [{
+    OpBuilder<(ins "Value":$condition, "Block *":$trueDest,
+      "Block *":$falseDest, CArg<"ValueRange", "{}">:$falseOperands),
+    [{
       build($_builder, $_state, condition, trueDest, ValueRange(), falseDest,
             falseOperands);
     }]>
@@ -4003,6 +4003,69 @@ def VM_CondBranchOp : VM_Op<"cond_br", [
   }];
 
   let hasCanonicalizer = 1;
+}
+
+def VM_BranchTableOp : VM_PureOp<"br_table", [
+    AttrSizedOperandSegments,
+    DeclareOpInterfaceMethods<BranchOpInterface, ["getSuccessorForOperands"]>,
+    DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    Terminator,
+  ]> {
+  let summary = [{branch table operation}];
+  let description = [{
+    Represents a branch table instructing execution to branch to the block with
+    the specified index. If the index is out of bounds then execution will
+    branch to the default block.
+
+    ```
+    vm.br_table %index {
+      default: ^bb1(%a : i64),
+      0: ^bb2,
+      1: ^bb3(%c : i64)
+    }
+   ```
+  }];
+
+  let arguments = (ins
+    I32:$index,
+    Variadic<VM_AnyType>:$defaultOperands,
+    VariadicOfVariadic<VM_AnyType, "case_operand_segments">:$caseOperands,
+    DenseI32ArrayAttr:$case_operand_segments
+  );
+
+  let successors = (successor
+    AnySuccessor:$defaultDestination,
+    VariadicSuccessor<AnySuccessor>:$caseDestinations
+  );
+
+  let assemblyFormat = [{
+    $index ` ` `{` `\n`
+    custom<BranchTableCases>(
+        $defaultDestination, $defaultOperands, type($defaultOperands),
+        $caseDestinations, $caseOperands, type($caseOperands))
+    `}`
+    attr-dict
+  }];
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_BranchTable>,
+    VM_EncOperand<"index", 0>,
+    VM_EncBranch<"defaultDestination", "getDefaultOperands", 0>,
+    VM_EncBranchTable<"getCaseDestinations", "getCaseOperands", 0>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return the operands for the case destination block at the given index.
+    OperandRange getCaseOperands(unsigned index) {
+      return getCaseOperands()[index];
+    }
+
+    /// Return a mutable range of operands for the case destination block at the
+    /// given index.
+    MutableOperandRange getCaseOperandsMutable(unsigned index) {
+      return getCaseOperandsMutable()[index];
+    }
+  }];
 }
 
 class VM_CallBaseOp<string mnemonic, list<Trait> traits = []> :

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
@@ -52,6 +52,44 @@ vm.module @my_module {
 
 // -----
 
+// CHECK-LABEL: @br_table_empty
+vm.module @my_module {
+  vm.func @br_table_empty(%arg0: i32, %arg1: i32) -> i32 {
+    //      CHECK: vm.br_table %arg0 {
+    // CHECK-NEXT:   default: ^bb1(%arg1 : i32)
+    // CHECK-NEXT: }
+    vm.br_table %arg0 {
+      default: ^bb1(%arg1 : i32)
+    }
+  ^bb1(%0 : i32):
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @br_table
+vm.module @my_module {
+  vm.func @br_table(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+    //      CHECK: vm.br_table %arg0 {
+    // CHECK-NEXT:   default: ^bb1(%arg0 : i32),
+    // CHECK-NEXT:   0: ^bb2(%arg1 : i32),
+    // CHECK-NEXT:   1: ^bb2(%arg2 : i32)
+    // CHECK-NEXT: }
+    vm.br_table %arg0 {
+      default: ^bb1(%arg0 : i32),
+      0: ^bb2(%arg1 : i32),
+      1: ^bb2(%arg2 : i32)
+    }
+  ^bb1(%0 : i32):
+    vm.return %0 : i32
+  ^bb2(%1 : i32):
+    vm.return %1 : i32
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @call_fn
 vm.module @my_module {
   vm.import private @import_fn(%arg0 : i32) -> i32

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -216,6 +216,19 @@ public:
     return success();
   }
 
+  LogicalResult encodeBranchTable(SuccessorRange caseSuccessors,
+                                  OperandRangeRange caseOperands,
+                                  int baseSuccessorIndex) override {
+    if (failed(writeUint16(caseSuccessors.size())))
+      return failure();
+    for (auto [successor, operands] :
+         llvm::zip_equal(caseSuccessors, caseOperands)) {
+      if (failed(encodeBranch(successor, operands, ++baseSuccessorIndex)))
+        return failure();
+    }
+    return success();
+  }
+
   LogicalResult encodeOperand(Value value, int ordinal) override {
     uint16_t reg =
         registerAllocation_->mapUseToRegister(value, currentOp_, ordinal)

--- a/runtime/src/iree/vm/bytecode/dispatch_util.h
+++ b/runtime/src/iree/vm/bytecode/dispatch_util.h
@@ -135,6 +135,9 @@ static inline iree_vm_type_def_t iree_vm_map_type(
 #define VM_DecConstI8(name) \
   OP_I8(0);                 \
   ++pc;
+#define VM_DecConstI16(name) \
+  OP_I16(0);                 \
+  pc += 2;
 #define VM_DecConstI32(name) \
   OP_I32(0);                 \
   pc += 4;

--- a/runtime/src/iree/vm/bytecode/utils/generated/op_table.h
+++ b/runtime/src/iree/vm/bytecode/utils/generated/op_table.h
@@ -138,7 +138,7 @@ typedef enum {
   IREE_VM_OP_CORE_MaxI64S = 0x80,
   IREE_VM_OP_CORE_MaxI64U = 0x81,
   IREE_VM_OP_CORE_CastAnyRef = 0x82,
-  IREE_VM_OP_CORE_RSV_0x83,
+  IREE_VM_OP_CORE_BranchTable = 0x83,
   IREE_VM_OP_CORE_RSV_0x84,
   IREE_VM_OP_CORE_RSV_0x85,
   IREE_VM_OP_CORE_RSV_0x86,
@@ -397,7 +397,7 @@ typedef enum {
     OPC(0x80, MaxI64S) \
     OPC(0x81, MaxI64U) \
     OPC(0x82, CastAnyRef) \
-    RSV(0x83) \
+    OPC(0x83, BranchTable) \
     RSV(0x84) \
     RSV(0x85) \
     RSV(0x86) \

--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -516,6 +516,11 @@ iree_status_t iree_vm_bytecode_function_verify(
   uint8_t name = OP_I8(0);                 \
   (void)(name);                            \
   ++pc;
+#define VM_VerifyConstI16(name)            \
+  IREE_VM_VERIFY_PC_RANGE(pc + 2, max_pc); \
+  uint32_t name = OP_I16(0);               \
+  (void)(name);                            \
+  pc += 2;
 #define VM_VerifyConstI32(name)            \
   IREE_VM_VERIFY_PC_RANGE(pc + 4, max_pc); \
   uint32_t name = OP_I32(0);               \
@@ -1545,6 +1550,18 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
       VM_VerifyBranchOperands(true_operands);
       VM_VerifyBranchTarget(false_dest_pc);
       VM_VerifyBranchOperands(false_operands);
+      verify_state->in_block = 0;  // terminator
+    });
+
+    VERIFY_OP(CORE, BranchTable, {
+      VM_VerifyOperandRegI32(index);
+      VM_VerifyBranchTarget(default_dest_pc);
+      VM_VerifyBranchOperands(default_operands);
+      VM_VerifyConstI16(table_size);
+      for (uint16_t i = 0; i < table_size; ++i) {
+        VM_VerifyBranchTarget(case_dest_pc);
+        VM_VerifyBranchOperands(case_operands);
+      }
       verify_state->in_block = 0;  // terminator
     });
 

--- a/runtime/src/iree/vm/test/control_flow_ops.mlir
+++ b/runtime/src/iree/vm/test/control_flow_ops.mlir
@@ -124,6 +124,43 @@ vm.module @control_flow_ops {
     vm.return
   }
 
+  vm.export @test_br_table_inbounds
+  vm.func private @test_br_table_inbounds() {
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    %c1dno = util.optimization_barrier %c1 : i32
+    vm.br_table %c1dno {
+      default: ^bb1(%c2 : i32),
+      0: ^bb2(%c0 : i32),
+      1: ^bb2(%c1 : i32)
+    }
+  ^bb1(%arg0: i32):
+    vm.fail %arg0, "unreachable"
+  ^bb2(%arg1: i32):
+    vm.check.eq %arg1, %c1, "expected table[1] branch" : i32
+    vm.return
+  }
+
+  vm.export @test_br_table_outofbounds
+  vm.func private @test_br_table_outofbounds() {
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    %c-1 = vm.const.i32 -1
+    %c-1dno = util.optimization_barrier %c-1 : i32
+    vm.br_table %c-1dno {
+      default: ^bb1(%c0 : i32),
+      0: ^bb2(%c1 : i32),
+      1: ^bb2(%c2 : i32)
+    }
+  ^bb1(%arg0: i32):
+    vm.check.eq %arg0, %c0, "expected default branch" : i32
+    vm.return
+  ^bb2(%arg1: i32):
+    vm.fail %arg1, "unreachable"
+  }
+
   vm.rodata private @buffer_a dense<[1]> : tensor<1xi8>
   vm.rodata private @buffer_b dense<[2]> : tensor<1xi8>
   vm.rodata private @buffer_c dense<[3]> : tensor<1xi8>


### PR DESCRIPTION
This implements a 0-based dense branch table that can be lowered from `cf.switch` which is a weird op but what we have and what comes from `scf.index_switch`. The exact encoding may change in the future to make interpreting faster but as structured it should be good for basic JITs.

The initial usage of this will come from entirely dense (or mostly dense) `scf.index_switch` ops so only the most basic optimization for offseting the base of the table is implemented. There's no canonicalization/folding as `cf.switch` has most of that but we should probably add some of the same handlers in the future.