### PR TITLE
[metal] Refcount block pool to outlive resource sets

### DIFF
--- a/runtime/src/iree/hal/drivers/metal/direct_command_buffer.h
+++ b/runtime/src/iree/hal/drivers/metal/direct_command_buffer.h
@@ -13,6 +13,7 @@
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/metal/api.h"
 #include "iree/hal/drivers/metal/builtin_executables.h"
+#include "iree/hal/drivers/metal/refcount_block_pool.h"
 #include "iree/hal/drivers/metal/staging_buffer.h"
 
 #ifdef __cplusplus
@@ -42,7 +43,7 @@ iree_status_t iree_hal_metal_direct_command_buffer_create(
     iree_host_size_t binding_capacity,
     iree_hal_metal_command_buffer_resource_reference_mode_t
         resource_reference_mode,
-    id<MTLCommandQueue> queue, iree_arena_block_pool_t* block_pool,
+    id<MTLCommandQueue> queue, iree_hal_metal_arena_block_pool_t* block_pool,
     iree_hal_metal_staging_buffer_t* staging_buffer,
     iree_hal_metal_builtin_executable_t* builtin_executable,
     iree_allocator_t host_allocator,

--- a/runtime/src/iree/hal/drivers/metal/refcount_block_pool.h
+++ b/runtime/src/iree/hal/drivers/metal/refcount_block_pool.h
@@ -1,0 +1,44 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_METAL_REFCOUNT_BLOCK_POOL_H_
+#define IREE_HAL_DRIVERS_METAL_REFCOUNT_BLOCK_POOL_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "iree/base/internal/atomics.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// An arena block pool with reference counting for the Metal driver.
+//
+// In Metal we use command buffer completion handler to release resource sets
+// tracking resources used in command buffers. It's not possible to guarantee
+// the completion handler's timing; so we need to use reference counting to make
+// sure we don't destroy the block pool prematurely.
+typedef struct iree_hal_metal_arena_block_pool_t {
+  iree_atomic_ref_count_t ref_count;
+  iree_allocator_t host_allocator;
+  iree_arena_block_pool_t block_pool;
+} iree_hal_metal_arena_block_pool_t;
+
+// Retains the given |pool| by increasing its reference count.
+void iree_hal_metal_arena_block_pool_retain(
+    iree_hal_metal_arena_block_pool_t* pool);
+
+// Releases the given |pool| by decreasing its reference count.
+//
+// |pool| will be destroyed when the reference count is 0.
+void iree_hal_metal_arena_block_pool_release(
+    iree_hal_metal_arena_block_pool_t* pool);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_METAL_REFCOUNT_BLOCK_POOL_H_


### PR DESCRIPTION
We use resource sets in `iree_hal_metal_device_queue_execute` to keep track of command buffers and semaphores and release them when the command buffers complete. It would require the underlying block pool backing the resource sets to have a larger lifetime to make sure we don't access destroyed data structures.

Fixes https://github.com/openxla/iree/issues/14814