### PR TITLE
[AArch64][SVE] Add e2e tests for small and large matmuls

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -26,7 +26,7 @@ py_binary(
 
 # LLVMCPU, non-data-tiling, no microkernels
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_nondt_%s_%s_small" % (lhs_rhs_type, acc_type),
+    name = "e2e_matmul_nondt_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
     compiler_flags = [
         "--iree-opt-data-tiling=false",
     ],
@@ -34,7 +34,7 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--acc_type=%s" % acc_type,
-        "--shapes=small",
+        "--shapes=%s" % size,
     ],
     tags = [
         # f16/bf16 trigger internal LLVM assertion errors on riscv and wasm.
@@ -45,6 +45,9 @@ py_binary(
         ("llvm-cpu", "local-task"),
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
+    target_cpu_features_variants = ["default"]
+        # Widening matmuls fail to lower for SVE.
+        + (["arm_64:sve:+sve"] if lhs_rhs_type == acc_type else [])
 ) for (lhs_rhs_type, acc_type) in [
     ("i8", "i32"),
     ("f32", "f32"),
@@ -53,6 +56,9 @@ py_binary(
     # TODO(#15258): enable bf16 tests when that bug is fixed.
     # ("bf16", "bf16"),
     # ("bf16", "f32"),
+] for size in [
+    "small",
+    "large",
 ]]
 
 X86_64_AVX2 = [

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -44,10 +44,10 @@ py_binary(
     target_backends_and_drivers = [
         ("llvm-cpu", "local-task"),
     ],
+    target_cpu_features_variants = ["default"] +
+                                   # Widening matmuls fail to lower for SVE.
+                                   (["arm_64:sve:+sve"] if lhs_rhs_type == acc_type else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
-    target_cpu_features_variants = ["default"]
-        # Widening matmuls fail to lower for SVE.
-        + (["arm_64:sve:+sve"] if lhs_rhs_type == acc_type else [])
 ) for (lhs_rhs_type, acc_type) in [
     ("i8", "i32"),
     ("f32", "f32"),

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -29,6 +29,31 @@ iree_generated_trace_runner_test(
     "--iree-opt-data-tiling=false"
   LABELS
 
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_nondt_i8_i32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
 )
 
 iree_generated_trace_runner_test(
@@ -50,6 +75,33 @@ iree_generated_trace_runner_test(
     "--iree-opt-data-tiling=false"
   LABELS
 
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:sve:+sve"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_nondt_f32_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:sve:+sve"
 )
 
 iree_generated_trace_runner_test(
@@ -72,6 +124,34 @@ iree_generated_trace_runner_test(
   LABELS
     "noriscv"
     "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:sve:+sve"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_nondt_f16_f16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:sve:+sve"
 )
 
 iree_generated_trace_runner_test(
@@ -94,6 +174,32 @@ iree_generated_trace_runner_test(
   LABELS
     "noriscv"
     "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_nondt_f16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
 )
 
 iree_generated_trace_runner_test(
@@ -847,46 +953,6 @@ iree_generated_trace_runner_test(
     "requires-gpu"
     "requires-gpu-rdna3"
     "vulkan_uses_vk_khr_shader_float16_int8"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_direct_f32_small_arm_sve
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  COMPILER_FLAGS
-    "--iree-llvmcpu-target-cpu-features=+sve"
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  TARGET_CPU_FEATURES_VARIANTS
-    "arm_64:sve:+sve"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_direct_f32_large_arm_sve
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  COMPILER_FLAGS
-    "--iree-llvmcpu-target-cpu-features=+sve"
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  TARGET_CPU_FEATURES_VARIANTS
-    "arm_64:sve:+sve"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -849,4 +849,44 @@ iree_generated_trace_runner_test(
     "vulkan_uses_vk_khr_shader_float16_int8"
 )
 
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f32_small_arm_sve
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  COMPILER_FLAGS
+    "--iree-llvmcpu-target-cpu-features=+sve"
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  TARGET_CPU_FEATURES_VARIANTS
+    "arm_64:sve:+sve"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f32_large_arm_sve
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  COMPILER_FLAGS
+    "--iree-llvmcpu-target-cpu-features=+sve"
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  TARGET_CPU_FEATURES_VARIANTS
+    "arm_64:sve:+sve"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
This requires #15276, which prevents IREE from generating scalable vector types that are poorly supported by the LLVM backend (and will likely result in it aborting).

These tests are tagged as requiring aarch64+sve, so currently won't be run in CI (as there's no SVE capable runners yet). When run locally (on a machine with SVE) these tests pass, and do use scalable vectorization.

ci-extra: build_test_all_windows,build_test_all_macos_arm64,build_test_all_macos_x86_64