### PR TITLE
bump LLVM to acc6f3e9c1af6c7445aae6f10d4b016ac84112d3

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
@@ -190,9 +190,15 @@ struct MaterializeUserConfigsPass
     /// the same time. Because the strategy is rooted on the variant op, the
     /// strategy can change the translation info on the exports if needed, else
     /// back to default IREE codegen.
+    StringRef entryPoint = libraryFunc->getLeafReference();
+    Operation *transformRoot = transform::detail::findTransformEntryPoint(
+        variantOp, *transformLibrary, entryPoint);
+    if (!transformRoot) {
+      return;
+    }
     if (failed(transform::applyTransformNamedSequence(
-            variantOp, *transformLibrary, options.enableExpensiveChecks(true),
-            libraryFunc->getLeafReference()))) {
+            variantOp, transformRoot, *transformLibrary,
+            options.enableExpensiveChecks(true)))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -1011,7 +1011,8 @@ Value HALDispatchABI::loadExecutableConstant(Operation *forOp, StringRef key,
 
   // Load the placeholder global ordinal.
   Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, globalOp);
-  Value ordinalValue = builder.create<LLVM::LoadOp>(loc, globalPtr);
+  Value ordinalValue =
+      builder.create<LLVM::LoadOp>(loc, globalOp.getType(), globalPtr);
 
   // Load constant from the executable constants struct.
   auto constantsPtrValue =
@@ -1051,7 +1052,7 @@ Value HALDispatchABI::loadImportOrdinal(Operation *forOp, StringRef importName,
 
   // Load the placeholder global ordinal.
   Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, globalOp);
-  return builder.create<LLVM::LoadOp>(loc, globalPtr);
+  return builder.create<LLVM::LoadOp>(loc, globalOp.getType(), globalPtr);
 }
 
 std::pair<Value, Value> HALDispatchABI::loadImportFunc(Operation *forOp,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_executable_constants.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_executable_constants.mlir
@@ -3,7 +3,7 @@
 // CHECK-DAG: llvm.mlir.global internal @__constant_ordinal_foo() {{.+}}hal.executable.constant.key = "foo"{{.+}} : i32
 // CHECK-LABEL: llvm.func @constant_values
 func.func @constant_values() {
-  // CHECK: %[[FOO_ORDINAL_PTR:.+]] = llvm.mlir.addressof @__constant_ordinal_foo : !llvm.ptr<i32>
+  // CHECK: %[[FOO_ORDINAL_PTR:.+]] = llvm.mlir.addressof @__constant_ordinal_foo : !llvm.ptr
   // CHECK: %[[FOO_ORDINAL:.+]] = llvm.load %[[FOO_ORDINAL_PTR]]
   // CHECK: %[[FOO_PTR:.+]] = llvm.getelementptr %{{.+}}[%[[FOO_ORDINAL]]]
   // CHECK: %[[FOO:.+]] = llvm.load %[[FOO_PTR]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -76,7 +76,7 @@ void ConvertToDynamicSharedMemory(ModuleOp moduleOp) {
         loc, IntegerType::get(builder.getContext(), 64),
         builder.getI64IntegerAttr(offset));
     Value shiftedPtr = builder.create<LLVM::GEPOp>(
-        loc, globalPtr.getType(), globalOp.getGlobalType(), globalPtr,
+        loc, globalPtr.getType(), global.getGlobalType(), globalPtr,
         ValueRange({zero, offsetValue}));
     addressOfOp.replaceAllUsesWith(shiftedPtr);
     addressOfOp.erase();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -76,8 +76,7 @@ void ConvertToDynamicSharedMemory(ModuleOp moduleOp) {
         loc, IntegerType::get(builder.getContext(), 64),
         builder.getI64IntegerAttr(offset));
     Value shiftedPtr = builder.create<LLVM::GEPOp>(
-        loc, globalPtr.getType(),
-        LLVM::LLVMPointerType::get(globalOp.getContext()), globalPtr,
+        loc, globalPtr.getType(), globalOp.getGlobalType(), globalPtr,
         ValueRange({zero, offsetValue}));
     addressOfOp.replaceAllUsesWith(shiftedPtr);
     addressOfOp.erase();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -212,18 +212,18 @@ hal.executable @shared_memory_lowering {
 }
 //       CHECK: llvm.mlir.global external @__dynamic_shared_memory__() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
 // CHECK-LABEL: llvm.func @shared_memory_lowering() {
-//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<array<0 x i8>, 3>
+//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<3>
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
-//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<array<0 x i8>, 3>, i64, i64) -> !llvm.ptr<array<0 x i8>, 3>
-//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<array<0 x i8>, 3>
+//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<3>, i64, i64) -> !llvm.ptr<3>
+//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<3>
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(2048 : i64) : i64
-//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<array<0 x i8>, 3>, i64, i64) -> !llvm.ptr<array<0 x i8>, 3>
-//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<array<0 x i8>, 3>
+//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<3>, i64, i64) -> !llvm.ptr<3>
+//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<3>
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(4096 : i64) : i64
-//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<array<0 x i8>, 3>, i64, i64) -> !llvm.ptr<array<0 x i8>, 3>
+//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<3>, i64, i64) -> !llvm.ptr<3>
 
 // -----
 
@@ -240,7 +240,7 @@ hal.executable @shared_memory_dealloc_elision {
       func.func @shared_memory_dealloc_elision() {
         %f0 = arith.constant 0.0 : f32
         %c0 = arith.constant 0 : index
-        //     CHECK: llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<array<0 x i8>, 3>
+        //     CHECK: llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<3>
         %0 = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
         memref.store %f0, %0[%c0] : memref<1xf32, #gpu.address_space<workgroup>>
         // CHECK-NOT: free
@@ -277,14 +277,14 @@ hal.executable @shared_memory_lowering_aligned_alloc {
 }
 // CHECK-LABEL: llvm.mlir.global external @__dynamic_shared_memory__() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
 // CHECK-LABEL: llvm.func @shared_memory_lowering_aligned_alloc() {
-//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<array<0 x i8>, 3>
+//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<3>
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
-//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<array<0 x i8>, 3>, i64, i64) -> !llvm.ptr<array<0 x i8>, 3>
-//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<array<0 x i8>, 3>
+//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<3>, i64, i64) -> !llvm.ptr<3>
+//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<3>
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(4 : i64) : i64
-//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<array<0 x i8>, 3>, i64, i64) -> !llvm.ptr<array<0 x i8>, 3>
+//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<3>, i64, i64) -> !llvm.ptr<3>
 
 // -----
 
@@ -392,7 +392,7 @@ hal.executable @shared_memory_lowering_index {
 }
 //       CHECK: llvm.mlir.global external @__dynamic_shared_memory__() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
 // CHECK-LABEL: llvm.func @shared_memory_lowering_index() {
-//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<array<0 x i8>, 3>
+//       CHECK: %{{.*}} = llvm.mlir.addressof @__dynamic_shared_memory__ : !llvm.ptr<3>
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
 //  CHECK-NEXT: %{{.*}} = llvm.mlir.constant(0 : i64) : i64
-//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<array<0 x i8>, 3>, i64, i64) -> !llvm.ptr<array<0 x i8>, 3>
+//  CHECK-NEXT: %{{.*}} = llvm.getelementptr %{{.*}} : (!llvm.ptr<3>, i64, i64) -> !llvm.ptr<3>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseDimensions.cpp
@@ -421,8 +421,8 @@ static bool collapseDimensions(IRRewriter &rewriter,
   rewriter.setInsertionPoint(genericOp.value());
 
   FailureOr<SmallVector<Value>> maybeReplacements =
-      mlir::linalg::collapseGenericOpIterationDims(genericOp.value(),
-                                                   collapseIndices, rewriter);
+      mlir::linalg::collapseOpIterationDims(genericOp.value(), collapseIndices,
+                                            rewriter);
   if (failed(maybeReplacements))
     return false;
   rewriter.replaceOp(genericOp.value(), maybeReplacements.value());

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseReductionDims.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseReductionDims.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -44,19 +45,19 @@ static bool hasContiguousDims(AffineMap map, ArrayRef<unsigned> dims) {
 }
 
 static SmallVector<ReassociationIndices>
-collapseDimensions(linalg::GenericOp genericOp) {
+collapseDimensions(linalg::LinalgOp linalgOp) {
   SmallVector<ReassociationIndices> collapseIndices;
 
-  if (!isNonNullAndOutsideDispatch(genericOp)) {
+  if (!isNonNullAndOutsideDispatch(linalgOp)) {
     return collapseIndices;
   }
 
   SmallVector<unsigned> reductionDims;
-  genericOp.getReductionDims(reductionDims);
+  linalgOp.getReductionDims(reductionDims);
   if (reductionDims.size() < 2)
     return collapseIndices;
 
-  for (AffineMap map : genericOp.getIndexingMapsArray()) {
+  for (AffineMap map : linalgOp.getIndexingMapsArray()) {
     if (!hasContiguousDims(map, reductionDims))
       return collapseIndices;
   }

--- a/compiler/src/iree/compiler/InputConversion/TOSA/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/TOSA/Passes.cpp
@@ -49,7 +49,10 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
       iree_compiler::createTosaToLinalgExt());
   passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
-  tosa::addTosaToLinalgPasses(passManager, TosaToLinalgOptions());
+  TosaToLinalgNamedOptions tosaToLinalgNamedOptions;
+  tosaToLinalgNamedOptions.preferConv2DKernelLayoutHWCF = true;
+  tosa::addTosaToLinalgPasses(passManager, TosaToLinalgOptions(),
+                              tosaToLinalgNamedOptions);
   passManager.addNestedPass<func::FuncOp>(
       iree_compiler::createConverti48Toi64());
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/decompose_softmax.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/decompose_softmax.mlir
@@ -11,7 +11,7 @@ func.func @softmax(%arg0: tensor<2x16x32xf32>) -> tensor<2x16x32xf32> {
 // CHECK:      func.func @softmax(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x16x32xf32>) -> tensor<2x16x32xf32> {
 // CHECK:        %[[D0:.+]] = tensor.empty() : tensor<2x16x32xf32>
 // CHECK:        %[[D1:.+]] = tensor.empty() : tensor<2x16xf32>
-// CHECK:        %[[CST:.+]] = arith.constant -1.401300e-45 : f32
+// CHECK:        %[[CST:.+]] = arith.constant -3.40282347E+38 : f32
 // CHECK:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<2x16xf32>) -> tensor<2x16xf32>
 // CHECK:        %[[D3:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
 // CHECK-SAME:     "parallel", "reduction"]} ins(%[[ARG0]] : tensor<2x16x32xf32>) outs(%[[D2]] : tensor<2x16xf32>) {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/70218 just missed the last integrate, and cherry-picks are frowned upon.

The good thing with just missing an integrate is that just bumping the submodule shouldn't be too hard still. I just had to fix up one small thing in CollapseDimensions.

ci-extra:build_test_all_windows,build_test_all_macos_arm64,build_test_all_macos_x86_64