### PR TITLE
Add riscv vector extension in cpu feature using hwcap

### DIFF
--- a/runtime/src/iree/schemas/cpu_feature_bits.inl
+++ b/runtime/src/iree/schemas/cpu_feature_bits.inl
@@ -114,3 +114,11 @@ IREE_CPU_FEATURE_BIT(X86_64, 0, 32, AVX512FP16, "avx512fp16")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 50, AMXTILE, "amx-tile")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 51, AMXINT8, "amx-int8")
 IREE_CPU_FEATURE_BIT(X86_64, 0, 52, AMXBF16, "amx-bf16")
+
+//===----------------------------------------------------------------------===//
+// IREE_ARCH_RISCV_64 / riscv64
+//===----------------------------------------------------------------------===//
+
+// General features and high-level switches.
+// RISCV vector extension. bit: 'V' - 'A' = 21
+IREE_CPU_FEATURE_BIT(RISCV_64, 0, 21, RVV, "rvv")

--- a/runtime/src/iree/schemas/cpu_feature_bits.inl
+++ b/runtime/src/iree/schemas/cpu_feature_bits.inl
@@ -120,5 +120,5 @@ IREE_CPU_FEATURE_BIT(X86_64, 0, 52, AMXBF16, "amx-bf16")
 //===----------------------------------------------------------------------===//
 
 // General features and high-level switches.
-// RISCV vector extension. bit: 'V' - 'A' = 21
-IREE_CPU_FEATURE_BIT(RISCV_64, 0, 21, RVV, "rvv")
+// RISCV vector extension.
+IREE_CPU_FEATURE_BIT(RISCV_64, 0, 0, RVV, "rvv")


### PR DESCRIPTION
Similar to #15275 but use hwcap to get riscv vector extension.