### PR TITLE
[Vulkan] Make target triples/envs options lists

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -64,12 +64,12 @@ VulkanSPIRVTargetOptions getVulkanSPIRVTargetOptionsFromFlags() {
       llvm::cl::init(false));
 
   VulkanSPIRVTargetOptions targetOptions;
-  targetOptions.targetEnvs = std::vector<std::string>(
+  targetOptions.targetEnvs = SmallVector<std::string>(
       clVulkanTargetEnvs.begin(), clVulkanTargetEnvs.end());
-  targetOptions.targetTriples = std::vector<std::string>(
+  targetOptions.targetTriples = SmallVector<std::string>(
       clVulkanTargetTriples.begin(), clVulkanTargetTriples.end());
 
-  std::vector<bool> isEnv;
+  SmallVector<bool> isEnv;
   int tripleCount = clVulkanTargetTriples.getNumOccurrences();
   int envCount = clVulkanTargetEnvs.getNumOccurrences();
   int tripleIdx = 0;
@@ -337,16 +337,12 @@ private:
     // Determine the priority for the target environments. If not specified,
     // prioritize target triples over target environments as they are more
     // likely to over-specify requirements.
-    std::vector<bool> isEnvList;
+    SmallVector<bool> isEnvList;
     if (options_.isEnvPriorityOrder) {
       isEnvList = *options_.isEnvPriorityOrder;
     } else {
-      for (int i = 0, e = options_.targetEnvs.size(); i < e; ++i) {
-        isEnvList.push_back(true);
-      }
-      for (int i = 0, e = options_.targetTriples.size(); i < e; ++i) {
-        isEnvList.push_back(false);
-      }
+      isEnvList.append(options_.targetEnvs.size(), true);
+      isEnvList.append(options_.targetTriples.size(), false);
     }
 
     assert((isEnvList.size() ==

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
@@ -8,7 +8,6 @@
 #define IREE_COMPILER_DIALECT_HAL_TARGET_VULKANSPIRV_VULKANSPIRVTARGET_H_
 
 #include <functional>
-#include <optional>
 #include <string>
 
 #include "llvm/ADT/SmallVector.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
@@ -20,13 +20,9 @@ namespace HAL {
 
 // Options controlling the SPIR-V translation.
 struct VulkanSPIRVTargetOptions {
-  // Vulkan target environments as #vk.target_env attribute assembly.
-  llvm::SmallVector<std::string> targetEnvs;
-  // Vulkan target triples.
-  llvm::SmallVector<std::string> targetTriples;
-  // Optional list to indicate how to prioritize the target environments and
-  // triples.
-  std::optional<llvm::SmallVector<bool>> isEnvPriorityOrder = std::nullopt;
+  // Vulkan target environments, either as #vk.target_env attribute assembly
+  // or as a Vulkan target triple.
+  llvm::SmallVector<std::string> targetTriplesAndEnvs;
   // Whether to use indirect bindings for all generated dispatches.
   bool indirectBindings = false;
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
@@ -8,7 +8,9 @@
 #define IREE_COMPILER_DIALECT_HAL_TARGET_VULKANSPIRV_VULKANSPIRVTARGET_H_
 
 #include <functional>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace mlir {
 namespace iree_compiler {
@@ -17,10 +19,13 @@ namespace HAL {
 
 // Options controlling the SPIR-V translation.
 struct VulkanSPIRVTargetOptions {
-  // Vulkan target environment as #vk.target_env attribute assembly.
-  std::string targetEnv;
-  // Vulkan target triple.
-  std::string targetTriple;
+  // Vulkan target environments as #vk.target_env attribute assembly.
+  std::vector<std::string> targetEnvs;
+  // Vulkan target triples.
+  std::vector<std::string> targetTriples;
+  // Optional list to indicate how to prioritize the target environments and
+  // triples.
+  std::optional<std::vector<bool>> isEnvPriorityOrder = std::nullopt;
   // Whether to use indirect bindings for all generated dispatches.
   bool indirectBindings = false;
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
@@ -10,7 +10,8 @@
 #include <functional>
 #include <optional>
 #include <string>
-#include <vector>
+
+#include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
 namespace iree_compiler {
@@ -20,12 +21,12 @@ namespace HAL {
 // Options controlling the SPIR-V translation.
 struct VulkanSPIRVTargetOptions {
   // Vulkan target environments as #vk.target_env attribute assembly.
-  std::vector<std::string> targetEnvs;
+  llvm::SmallVector<std::string> targetEnvs;
   // Vulkan target triples.
-  std::vector<std::string> targetTriples;
+  llvm::SmallVector<std::string> targetTriples;
   // Optional list to indicate how to prioritize the target environments and
   // triples.
-  std::optional<std::vector<bool>> isEnvPriorityOrder = std::nullopt;
+  std::optional<llvm::SmallVector<bool>> isEnvPriorityOrder = std::nullopt;
   // Whether to use indirect bindings for all generated dispatches.
   bool indirectBindings = false;
 };

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/BUILD.bazel
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "multiple_target_env_conversion.mlir",
             "target_env_conversion.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "multiple_target_env_conversion.mlir"
     "target_env_conversion.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/multiple_target_env_conversion.mlir
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/multiple_target_env_conversion.mlir
@@ -1,0 +1,45 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-transformation-pipeline{serialize-executables=false})' \
+// RUN:   --iree-hal-target-backends=vulkan-spirv \
+// RUN:   --iree-vulkan-target-triple=rdna3-7900xtx-windows \
+// RUN:   --iree-vulkan-target-env="#vk.target_env<v1.1, r(120), [VK_KHR_spirv_1_4, VK_KHR_storage_buffer_storage_class], AMD:DiscreteGPU, #vk.caps<maxComputeSharedMemorySize = 16384, maxComputeWorkGroupInvocations = 1024, maxComputeWorkGroupSize = dense<[128, 8, 4]>: vector<3xi32>, subgroupFeatures = 63 : i32, subgroupSize = 4 >>" \
+// RUN:   --iree-vulkan-target-triple=valhall-unknown-android31 \
+// RUN:   %s | FileCheck %s
+
+// CHECK: #[[RDNA3:.+]] = {{.*}} #spirv.target_env<#spirv.vce<v1.6, [Shader, Float64, Float16, Int64, Int16, Int8, StorageBuffer16BitAccess, StorageUniform16, StoragePushConstant16, StorageBuffer8BitAccess, UniformAndStorageBuffer8BitAccess, StoragePushConstant8, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative, GroupNonUniformClustered, GroupNonUniformQuad, VariablePointers, VariablePointersStorageBuffer, DotProduct, DotProductInputAll, DotProductInput4x8BitPacked, DotProductInput4x8Bit, CooperativeMatrixKHR],
+// CHECK-SAME: [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_integer_dot_product, SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers, SPV_KHR_cooperative_matrix]>,
+// CHECK-SAME: api=Vulkan, AMD:DiscreteGPU, #spirv.resource_limits<max_compute_shared_memory_size = 65536, max_compute_workgroup_invocations = 1024, max_compute_workgroup_size = [1024, 1024, 1024], subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64, cooperative_matrix_properties_khr = [#spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = i8, b_type = i8, c_type = i32, result_type = i32, acc_sat = false, scope = <Subgroup>>, #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = f16, b_type = f16, c_type = f16, result_type = f16, acc_sat = false, scope = <Subgroup>>, #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = f16, b_type = f16, c_type = f32, result_type = f32, acc_sat = false, scope = <Subgroup>>]>>
+
+// CHECK: #[[ENV:.+]] = {{.*}} #spirv.target_env<#spirv.vce<v1.4, [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative],
+// CHECK-SAME: [SPV_KHR_storage_buffer_storage_class]>,
+// CHECK-SAME: api=Vulkan, AMD:DiscreteGPU, #spirv.resource_limits<max_compute_workgroup_invocations = 1024, max_compute_workgroup_size = [128, 8, 4], subgroup_size = 4, cooperative_matrix_properties_khr = []>>
+
+// CHECK: #[[VALHALL:.+]] = {{.*}} #spirv.target_env<#spirv.vce<v1.4, [Shader, Float16, Int16, Int8, StorageBuffer16BitAccess, StorageUniform16, StoragePushConstant16, StorageBuffer8BitAccess, UniformAndStorageBuffer8BitAccess, StoragePushConstant8, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative, GroupNonUniformClustered, GroupNonUniformQuad, VariablePointers, VariablePointersStorageBuffer, DotProduct, DotProductInputAll, DotProductInput4x8BitPacked, DotProductInput4x8Bit],
+// CHECK-SAME: [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_integer_dot_product, SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>,
+// CHECK-SAME: api=Vulkan, ARM:IntegratedGPU, #spirv.resource_limits<max_compute_shared_memory_size = 32768, max_compute_workgroup_invocations = 512, max_compute_workgroup_size = [512, 512, 512], subgroup_size = 16, cooperative_matrix_properties_khr = []>>
+
+// Verify the correct priority of target environments.
+
+// CHECK: executable_targets = [#[[RDNA3]], #[[ENV]], #[[VALHALL]]]
+
+stream.executable public @reduce_dispatch {
+  stream.executable.export @reduce_dispatch workgroups(%arg0: index) -> (index, index, index) {
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @reduce_dispatch(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding) {
+      %c0 = arith.constant 0 : index
+      %arg0 = stream.binding.subspan %arg0_binding[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<16xf32>>
+      %arg1 = stream.binding.subspan %arg1_binding[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:tensor<f32>>
+      %0 = tensor.empty() : tensor<f32>
+      %1 = flow.dispatch.tensor.load %arg0, offsets=[0], sizes=[16], strides=[1] : !flow.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
+      %3 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>], iterator_types = ["reduction"]} ins(%1 : tensor<16xf32>) outs(%0 : tensor<f32>) {
+      ^bb0(%arg2: f32, %arg3: f32):
+        %4 = arith.addf %arg2, %arg3 : f32
+        linalg.yield %4 : f32
+      } -> tensor<f32>
+      flow.dispatch.tensor.store %3, %arg1, offsets=[], sizes=[], strides=[] : tensor<f32> -> !flow.dispatch.tensor<writeonly:tensor<f32>>
+      return
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/multiple_target_env_conversion.mlir
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/multiple_target_env_conversion.mlir
@@ -17,7 +17,7 @@
 // CHECK-SAME: [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_integer_dot_product, SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>,
 // CHECK-SAME: api=Vulkan, ARM:IntegratedGPU, #spirv.resource_limits<max_compute_shared_memory_size = 32768, max_compute_workgroup_invocations = 512, max_compute_workgroup_size = [512, 512, 512], subgroup_size = 16, cooperative_matrix_properties_khr = []>>
 
-// Verify the correct priority of target environments.
+// Verify that the order of target environments matches what the user specified.
 
 // CHECK: executable_targets = [#[[RDNA3]], #[[ENV]], #[[VALHALL]]]
 


### PR DESCRIPTION
This makes it easier to specify multiple vulkan targets simultaneously. If there are target triples interleaved with target environments, the order of targets is inferred from the order of flags.

As a follow up, we can do the same to hal device targets, allowing one to specify the full target attribute from the command line or some other downstream project.