### PR TITLE
ExpandVectors: support the new `linalg.batch_vecmat`

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
@@ -35,10 +35,13 @@ struct ExpandVectors
     Value rhs = linalgOp.getDpsInputs()[1];
 
     Value vectorIn;
-    if (op.isVecmat()) {
+    Value matrixIn;
+    if (op.isVecmat() || op.isBatchVecmat()) {
       vectorIn = lhs;
+      matrixIn = rhs;
     } else if (op.isMatvec() || op.isBatchMatvec()) {
       vectorIn = rhs;
+      matrixIn = lhs;
     } else {
       return rewriter.notifyMatchFailure(linalgOp,
                                          "unsupported contraction op");
@@ -46,38 +49,48 @@ struct ExpandVectors
 
     auto vectorOut = linalgOp.getDpsInits()[0];
     auto vectorInTy = dyn_cast<RankedTensorType>(vectorIn.getType());
+    auto matrixInTy = dyn_cast<RankedTensorType>(matrixIn.getType());
     auto vectorOutTy = dyn_cast<RankedTensorType>(vectorOut.getType());
 
-    if (!vectorInTy || !vectorOutTy) {
+    if (!vectorInTy || !matrixInTy || !vectorOutTy) {
       return failure();
     }
 
-    Type inEType = vectorInTy.getElementType();
-    Type outEType = vectorOutTy.getElementType();
-
     SmallVector<int64_t> expandedInDims, expandedOutDims;
-    bool isBatchMatmul = false;
-    SmallVector<ReassociationIndices> ri = {{0, 1}};
-
+    bool isBatchMatmul = matrixInTy.getRank() == 3;
+    int64_t b = isBatchMatmul ? vectorInTy.getDimSize(0) : 1;
+    int64_t m =
+        (matrixIn == lhs) ? matrixInTy.getDimSize(matrixInTy.getRank() - 2) : 1;
+    int64_t n =
+        (matrixIn == rhs) ? matrixInTy.getDimSize(matrixInTy.getRank() - 1) : 1;
+    int64_t k = vectorInTy.getDimSize(vectorInTy.getRank() - 1);
+    SmallVector<ReassociationIndices> ri;
     if (op.isVecmat()) {
-      // Expand (N * NxM = M) into (1xN * NxM = 1xM)
-      expandedInDims = {1, vectorInTy.getDimSize(0)};
-      expandedOutDims = {1, vectorOutTy.getDimSize(0)};
+      // Expand (K * KxN -> N) into (1xK * KxN -> 1xN)
+      expandedInDims = {1, k};
+      expandedOutDims = {1, n};
+      ri = {{0, 1}};
     } else if (op.isMatvec()) {
-      // Expand (NxM * M = N) into (NxM * Mx1 = Mx1)
-      expandedInDims = {vectorInTy.getDimSize(0), 1};
-      expandedOutDims = {vectorOutTy.getDimSize(0), 1};
-    } else {
-      // Expand (BxNxM * BxM = BxN) into (BxNxM * BxMx1 = BxMx1)
-      expandedInDims = {vectorInTy.getDimSize(0), vectorInTy.getDimSize(1), 1};
-      expandedOutDims = {vectorOutTy.getDimSize(0), vectorOutTy.getDimSize(1),
-                         1};
+      // Expand (MxK * K -> M) into (MxK * Kx1 -> Mx1)
+      expandedInDims = {k, 1};
+      expandedOutDims = {m, 1};
+      ri = {{0, 1}};
+    } else if (op.isBatchVecmat()) {
+      // Expand (BxK * BxKxN -> BxN) into (Bx1xK * BxKxN -> Bx1xN)
+      expandedInDims = {b, 1, k};
+      expandedOutDims = {b, 1, n};
+      ri = {{0, 1}, {2}};
+    } else if (op.isBatchMatvec()) {
+      // Expand (BxMxK * BxK -> BxM) into (BxMxK * BxKx1 -> BxMx1)
+      expandedInDims = {b, k, 1};
+      expandedOutDims = {b, m, 1};
       ri = {{0}, {1, 2}};
-      isBatchMatmul = true;
     }
 
-    auto newVectorInTy = RankedTensorType::get(expandedInDims, inEType);
-    auto newVectorOutTy = RankedTensorType::get(expandedOutDims, outEType);
+    auto newVectorInTy =
+        RankedTensorType::get(expandedInDims, vectorInTy.getElementType());
+    auto newVectorOutTy =
+        RankedTensorType::get(expandedOutDims, vectorOutTy.getElementType());
     Location loc = linalgOp.getLoc();
     Value expandedIn =
         rewriter.create<tensor::ExpandShapeOp>(loc, newVectorInTy, vectorIn, ri)
@@ -88,7 +101,7 @@ struct ExpandVectors
             .getResult();
 
     Value matmul;
-    if (op.isVecmat()) {
+    if (vectorIn == lhs) {
       lhs = expandedIn;
     } else {
       rhs = expandedIn;


### PR DESCRIPTION
This PR is dependent on upstream changes not yet integrated, adding `linalg.batch_vecmat`. For now, just to pass CI, this is based on a not-to-be-merged branch that cherry-picks these changes.