### PR TITLE
Fix benchmark dispatch repetition for nested calls

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
@@ -39,7 +39,10 @@ public:
   }
 
   void runOnOperation() override {
-    auto ops = getOperation().getOps<IREE::HAL::CommandBufferDispatchOp>();
+    // Collect all (nested) command buffer dispatch ops.
+    std::vector<IREE::HAL::CommandBufferDispatchOp> ops;
+    getOperation().walk(
+        [&ops](IREE::HAL::CommandBufferDispatchOp op) { ops.push_back(op); });
     for (auto op : ops) {
       OpBuilder builder(op);
       for (unsigned i = 1; i < repeatCount_; ++i) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/benchmark_batch_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/benchmark_batch_dispatches.mlir
@@ -46,10 +46,10 @@ func.func @duplicate_dispatches(%cmd1 : !hal.command_buffer, %cmd2 : !hal.comman
 
 util.global @_executable : !hal.executable
 
-// CHECK-LABEL: @duplicate_dispatches
+// CHECK-LABEL: @nested_dispatch
 //  CHECK-SAME: (%[[CMD1:.+]]: !hal.command_buffer,
 //  CHECK-SAME:  %[[IDX:.+]]: index)
-func.func @duplicate_dispatches(%cmd1 : !hal.command_buffer, %idx : index) {
+func.func @nested_dispatch(%cmd1 : !hal.command_buffer, %idx : index) {
   // CHECK: %[[EXE:.+]] = util.global.load @_executable
   %exe = util.global.load @_executable : !hal.executable
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/benchmark_batch_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/benchmark_batch_dispatches.mlir
@@ -41,3 +41,32 @@ func.func @duplicate_dispatches(%cmd1 : !hal.command_buffer, %cmd2 : !hal.comman
 // CHECK: hal.command_buffer.execution_barrier<%[[CMD2]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
 // CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[3] workgroups([%c2, %c2, %c2])
 // CHECK: hal.command_buffer.execution_barrier<%[[CMD2]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+
+// -----
+
+util.global @_executable : !hal.executable
+
+// CHECK-LABEL: @duplicate_dispatches
+//  CHECK-SAME: (%[[CMD1:.+]]: !hal.command_buffer,
+//  CHECK-SAME:  %[[IDX:.+]]: index)
+func.func @duplicate_dispatches(%cmd1 : !hal.command_buffer, %idx : index) {
+  // CHECK: %[[EXE:.+]] = util.global.load @_executable
+  %exe = util.global.load @_executable : !hal.executable
+
+  %c1 = arith.constant 1 : index
+  scf.index_switch %idx
+  case 0 {
+    hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+    scf.yield
+  }
+  default {
+  }
+
+  return
+}
+
+// CHECK: scf.index_switch
+// CHECK: case 0 {
+// CHECK:   hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+// CHECK:   hal.command_buffer.execution_barrier<%[[CMD1]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+// CHECK:   hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])


### PR DESCRIPTION
With the introduction of switch statements around dispatch calls, the dispatch repeat pass would fail to collect all of the dispatches.