### PR TITLE
Remove redundant reshape checks in dot general preprocessing

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
@@ -148,6 +148,70 @@ Value processDotArg(Value arg, Location loc, ArrayRef<int64_t> contractDimsAttr,
   return transposeReshape(arg, loc, contractDims, outerDims, shape, rewriter);
 }
 
+struct GeneralDotRemoveBatch final
+    : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::DotGeneralOp op,
+                                PatternRewriter &rewriter) const override {
+    auto lhsTy = op.getLhs().getType().cast<ShapedType>();
+    auto rhsTy = op.getRhs().getType().cast<ShapedType>();
+    auto ty = op.getType().cast<ShapedType>();
+
+    if (!ty.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(op, "Does not have static shape");
+    }
+
+    auto dimNumbers = op.getDotDimensionNumbers();
+    if (dimNumbers.getLhsBatchingDimensions().size() != 1 ||
+        dimNumbers.getLhsBatchingDimensions().size() != 1) {
+        return rewriter.notifyMatchFailure(op, "non-unary batch dimension");
+    }
+
+    if (dimNumbers.getLhsBatchingDimensions().front() != 0 ||    
+        dimNumbers.getRhsBatchingDimensions().front() != 0)  {
+        return rewriter.notifyMatchFailure(op, "not first dim on lhs/rhs");
+    }
+
+    if (lhsTy.getDimSize(0) != 1 ||
+        rhsTy.getDimSize(0) != 1) {
+        return rewriter.notifyMatchFailure(op, "not unary batch size");
+    }
+
+
+    // We no longer include the batch dimension of 1.
+    llvm::SmallVector<int64_t> newLhsContractingDims;
+    for (auto dim : dimNumbers.getLhsContractingDimensions())
+      newLhsContractingDims.push_back(dim - 1);
+
+    llvm::SmallVector<int64_t> newRhsContractingDims;
+    for (auto dim : dimNumbers.getRhsContractingDimensions())
+      newRhsContractingDims.push_back(dim - 1);
+
+    auto lhs = rewriter.create<mlir::stablehlo::ReshapeOp>(
+      op.getLoc(), lhsTy.clone(lhsTy.getShape().drop_front()), op.getLhs());
+
+    auto rhs = rewriter.create<mlir::stablehlo::ReshapeOp>(
+      op.getLoc(), rhsTy.clone(rhsTy.getShape().drop_front()), op.getRhs());
+
+    auto newDimNumbers = mlir::stablehlo::DotDimensionNumbersAttr::get(
+        rewriter.getContext(),
+        /*lhsBatchingDimensions=*/{},
+        /*rhsBatchingDimensions=*/{},
+        /*lhsContractingDimensions=*/
+        newLhsContractingDims,
+        /*rhsContractingDimensions=*/
+        newRhsContractingDims);
+
+    auto dot = rewriter.create<mlir::stablehlo::DotGeneralOp>(
+      op.getLoc(), ty.clone(ty.getShape().drop_front()), lhs, rhs, newDimNumbers,
+        op.getPrecisionConfigAttr());
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(
+      op, ty, dot.getResult());
+    return success();
+  }
+};
+
 struct GeneralDotConvert final
     : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -374,7 +438,7 @@ struct DotGeneralToDot final : impl::DotGeneralToDotBase<DotGeneralToDot> {
 void populatePreprocessingDotGeneralToDotPatterns(mlir::MLIRContext *context,
                                                   RewritePatternSet *patterns,
                                                   PatternBenefit benefit) {
-  patterns->add<GeneralDotConvert, DotVectorOptimization>(context, benefit);
+  patterns->add<GeneralDotConvert, GeneralDotRemoveBatch, DotVectorOptimization>(context, benefit);
 }
 
 } // namespace mlir::iree_compiler::stablehlo

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/DotGeneralToDot.cpp
@@ -154,12 +154,12 @@ struct GeneralDotRemoveBatch final
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DotGeneralOp op,
                                 PatternRewriter &rewriter) const override {
-    auto lhsTy = op.getLhs().getType().cast<ShapedType>();
-    auto rhsTy = op.getRhs().getType().cast<ShapedType>();
-    auto ty = op.getType().cast<ShapedType>();
+    auto lhsTy = cast<ShapedType>(op.getLhs().getType());
+    auto rhsTy = cast<ShapedType>(op.getRhs().getType());
+    auto ty = cast<ShapedType>(op.getType());
 
     if (!ty.hasStaticShape()) {
-      return rewriter.notifyMatchFailure(op, "Does not have static shape");
+      return rewriter.notifyMatchFailure(op, "does not have static shape");
     }
 
     auto dimNumbers = op.getDotDimensionNumbers();

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -418,19 +418,14 @@ struct TransposeReshapeGenericDotGeneral final
     auto lhsNewType = cast<RankedTensorType>(lhs.getType());
     auto rhsNewType = cast<RankedTensorType>(rhs.getType());
 
-    // if lhs's shape or rhs's shape has collapsed, we need reshape the result
-    bool needReshapeResult = lhsNewType.getRank() < lhsShapeType.getRank() ||
-                             rhsNewType.getRank() < rhsShapeType.getRank();
     // batching、lhs parallel、rhs parallel this order is a conversion
     SmallVector<int64_t> newShape = {lhsNewType.getShape()[0],
                                      lhsNewType.getShape()[1]};
     if (rhsNewType.getRank() > 2)
       newShape.push_back(rhsNewType.getDimSize(2));
 
-    TensorType newResultType =
-        needReshapeResult
-            ? RankedTensorType::get(newShape, resultType.getElementType())
-            : op.getType();
+    TensorType newResultType = RankedTensorType::get(
+      newShape, resultType.getElementType());
 
     auto newOp = rewriter.create<mlir::stablehlo::DotGeneralOp>(
         op.getLoc(), newResultType, lhs, rhs, dimensionNumbers,
@@ -446,10 +441,11 @@ struct TransposeReshapeGenericDotGeneral final
     }
 
     Value result = newOp.getResult();
-    if (needReshapeResult) {
-      result = rewriter.create<mlir::stablehlo::ReshapeOp>(op.getLoc(),
-                                                           resultType, result);
+    if (op.getType() != newResultType) {
+      result = rewriter.create<mlir::stablehlo::ReshapeOp>(
+          op.getLoc(), op.getType(), newOp.getResult());
     }
+
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -419,8 +419,11 @@ struct TransposeReshapeGenericDotGeneral final
     auto rhsNewType = cast<RankedTensorType>(rhs.getType());
 
     // batching、lhs parallel、rhs parallel this order is a conversion
-    SmallVector<int64_t> newShape = {lhsNewType.getShape()[0],
-                                     lhsNewType.getShape()[1]};
+    SmallVector<int64_t, 3> newShape = {lhsNewType.getShape()[0]};
+
+    if (lhsNewType.getRank() > 2)
+      newShape.push_back(lhsNewType.getDimSize(1));
+
     if (rhsNewType.getRank() > 2)
       newShape.push_back(rhsNewType.getDimSize(2));
 

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -427,8 +427,8 @@ struct TransposeReshapeGenericDotGeneral final
     if (rhsNewType.getRank() > 2)
       newShape.push_back(rhsNewType.getDimSize(2));
 
-    TensorType newResultType = RankedTensorType::get(
-      newShape, resultType.getElementType());
+    TensorType newResultType =
+        RankedTensorType::get(newShape, resultType.getElementType());
 
     auto newOp = rewriter.create<mlir::stablehlo::DotGeneralOp>(
         op.getLoc(), newResultType, lhs, rhs, dimensionNumbers,

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/stablehlo_to_stablehlo.mlir
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/test/stablehlo_to_stablehlo.mlir
@@ -372,20 +372,6 @@ func.func @dynamic_dot_general(%arg1: tensor<?x1024x16x64xf32>, %arg2: tensor<?x
 
 // -----
 
-// CHECK-LABEL: @unary_out_channel_dot
-func.func public @unary_out_channel_dot(%arg0: tensor<1x3x4xui16>, %arg1: tensor<1x4x3xui16>) -> tensor<1xui16> {
-
-  // CHECK: %[[TRANS:.+]] = stablehlo.transpose %arg0, dims = [0, 2, 1]
-  // CHECK: %[[LHS:.+]] = stablehlo.reshape %[[TRANS]]
-  // CHECK: %[[RHS:.+]] = stablehlo.reshape %arg1 : (tensor<1x4x3xui16>) -> tensor<1x12x1xui16>
-  // CHECK: %[[DOT:.+]] = stablehlo.dot_general %[[LHS]], %[[RHS]], batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [HIGH, HIGH]
-  // CHECK: %[[OUT:.+]] = stablehlo.reshape %[[DOT]] : (tensor<1x1x1xui16>) -> tensor<1xui16>
-  %0 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2, 1] x [1, 2], precision = [HIGH, HIGH] : (tensor<1x3x4xui16>, tensor<1x4x3xui16>) -> tensor<1xui16>
-  return %0 : tensor<1xui16>
-}
-
-// -----
-
 func.func @custom_call_topk_tuple(%arg0: tensor<4x8000xbf16>) -> (tensor<4x40xbf16>, tensor<4x40xi32>) {
   %0 = stablehlo.custom_call @TopK(%arg0) {called_computations = [@comparison], xla_shape = "(bf16[4,40]{1,0}, s32[4,40]{1,0})"} : (tensor<4x8000xbf16>) -> tuple<tensor<4x40xbf16>, tensor<4x40xi32>>
   %1 = stablehlo.get_tuple_element %0[0] : (tuple<tensor<4x40xbf16>, tensor<4x40xi32>>) -> tensor<4x40xbf16>


### PR DESCRIPTION
The final reshape is not required to output the correct size as canonicalizers should clean up any unneeded transforms.