### PR TITLE
Patch some Windows C code that breaks under gcc/clang.

### DIFF
--- a/runtime/src/iree/base/allocator.h
+++ b/runtime/src/iree/base/allocator.h
@@ -97,7 +97,7 @@ static inline iree_const_byte_span_t iree_const_cast_byte_span(
 //===----------------------------------------------------------------------===//
 // TODO(benvanik): remove our uses of this or make them more explicit.
 
-#if defined(IREE_COMPILER_MSVC)
+#if defined(IREE_PLATFORM_WINDOWS)
 // The safe malloca that may fall back to heap in the case of stack overflows:
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/malloca?view=vs-2019
 // Because that gets really annoying to deal with during error handling we just

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -63,13 +63,13 @@ static void iree_dynamic_library_init_temp_paths(void) {
   // See:
   // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
   char temp_path[MAX_PATH];
-  DWORD temp_path_length = GetTempPathA(IREE_ARRAYSIZE(temp_path), temp_path);
+  GetTempPathA(IREE_ARRAYSIZE(temp_path), temp_path);
 
   // Append the process ID to the path; this is like what _mktemp does but
   // without all the hoops.
   snprintf(iree_dynamic_library_temp_path_base_,
            sizeof(iree_dynamic_library_temp_path_base_), "%s\\iree_dylib_%08X",
-           temp_path, GetCurrentProcessId());
+           temp_path, (uint32_t)GetCurrentProcessId());
 
   // Canonicalize away any double path separators.
   iree_file_path_canonicalize(iree_dynamic_library_temp_path_base_,

--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -628,8 +628,8 @@ static bool iree_symbol_resolver_format_frame(iree_symbol_resolver_t* resolver,
   if (resolver->SymGetLineFromAddr64(process, (DWORD64)address, &displacement32,
                                      &line)) {
     *buffer_length = iree_string_buffer_append_format(
-        buffer_capacity, buffer, *buffer_length, " (%s:%u)", line.FileName,
-        line.LineNumber);
+        buffer_capacity, buffer, *buffer_length, " (%s:%" PRIu32 ")",
+        line.FileName, (uint32_t)line.LineNumber);
   }
   iree_symbol_resolver_unlock(resolver);
 


### PR DESCRIPTION
Fully supporting gcc and clang on Windows is proving to be tricky. This at least gets the builds a bit further along.

ci-extra: build_test_all_windows