### PR TITLE
Recommend `-G Ninja` in all in-tree documentation.

### DIFF
--- a/samples/custom_module/async/README.md
+++ b/samples/custom_module/async/README.md
@@ -28,7 +28,7 @@ work.
 2. Build the `iree_samples_custom_module_async_run` CMake target :
 
     ```
-    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
+    cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
         -DCMAKE_C_FLAGS=-DIREE_VM_EXECUTION_TRACING_FORCE_ENABLE=1
     cmake --build ../iree-build/ --target iree_samples_custom_module_async_run
     ```

--- a/samples/custom_module/basic/README.md
+++ b/samples/custom_module/basic/README.md
@@ -50,7 +50,7 @@ are implemented using this mechanism.
 3. Build the `iree_samples_custom_module_run` CMake target :
 
     ```
-    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
+    cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
         -DCMAKE_C_FLAGS=-DIREE_VM_EXECUTION_TRACING_FORCE_ENABLE=1
     cmake --build ../iree-build/ --target iree_samples_custom_module_basic_run
     ```

--- a/samples/custom_module/dynamic/README.md
+++ b/samples/custom_module/dynamic/README.md
@@ -45,7 +45,7 @@ dynamic modules should be carefully considered.
 3. Build the `iree_samples_custom_module_dynamic_module` CMake target :
 
     ```
-    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
+    cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
         -DCMAKE_C_FLAGS=-DIREE_VM_EXECUTION_TRACING_FORCE_ENABLE=1
     cmake --build ../iree-build/ \
         --target iree-run-module \

--- a/samples/custom_module/static/README.md
+++ b/samples/custom_module/static/README.md
@@ -50,7 +50,7 @@ the same module code between all various modes with minor differences.
 3. Configure the IREE tools to include the custom module:
 
     ```
-    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
+    cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
         -DCMAKE_C_FLAGS=-DIREE_VM_EXECUTION_TRACING_FORCE_ENABLE=1 \
         -DIREE_EXTERNAL_TOOLING_MODULES=static_sample \
         -DIREE_EXTERNAL_TOOLING_MODULE_STATIC_SAMPLE_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/samples/custom_module/static \

--- a/samples/custom_module/sync/README.md
+++ b/samples/custom_module/sync/README.md
@@ -28,7 +28,7 @@ custom calls that work asynchronously.
 2. Build the `iree_samples_custom_module_sync_run` CMake target :
 
     ```
-    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
+    cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
         -DCMAKE_C_FLAGS=-DIREE_VM_EXECUTION_TRACING_FORCE_ENABLE=1
     cmake --build ../iree-build/ --target iree_samples_custom_module_sync_run
     ```

--- a/samples/dynamic_shapes/README.md
+++ b/samples/dynamic_shapes/README.md
@@ -93,7 +93,7 @@ them.
     for general instructions on building using CMake)
 
     ```
-    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+    cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo .
     cmake --build ../iree-build/ --target iree-compile
     ```
 

--- a/samples/static_library/README.md
+++ b/samples/static_library/README.md
@@ -37,7 +37,7 @@ compiler target backend, and the `local-sync` runtime HAL driver (see
 for general instructions on building using CMake):
 
   ```shell
-  cmake -B ../iree-build/ \
+  cmake -B ../iree-build/ -G Ninja \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo .
     -DIREE_BUILD_SAMPLES=ON \
     -DIREE_TARGET_BACKEND_DEFAULTS=OFF \

--- a/samples/variables_and_state/README.md
+++ b/samples/variables_and_state/README.md
@@ -66,7 +66,7 @@ functions in the compiled programs.
     for general instructions on building using CMake)
 
     ```
-    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+    cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo .
     cmake --build ../iree-build/ --target iree_samples_variables_and_state
     ```
 


### PR DESCRIPTION
We strongly recommend using https://ninja-build.org/. Other generators typically work, but ninja is fast by default and is portable to all of our supported platforms.

Found these with a few regex searches (mainly `cmake -B` and `^\s*cmake.*-B`)