### PR TITLE
Fix `complex.bitcast` inputs to not generate bit manipulations

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -87,7 +87,7 @@ static void convertAndDecomposeToI32s(
   if (auto bitcast =
           dyn_cast_or_null<complex::BitcastOp>(operand.getDefiningOp())) {
     auto complexOperand = bitcast.getOperand();
-    auto complexTy = complexOperand.getType().cast<ComplexType>();
+    auto complexTy = cast<ComplexType>(complexOperand.getType());
     auto real = builder.createOrFold<complex::ReOp>(
         loc, complexTy.getElementType(), complexOperand);
     auto imag = builder.createOrFold<complex::ImOp>(


### PR DESCRIPTION
The cast of `complex.create` or `complex.constant` to `complex.bitcast` can be bypassed
by directly grabbing the complex values.