### PR TITLE
Drop vulkan-spirv test cases from modules/check/test/*.

### DIFF
--- a/runtime/src/iree/modules/check/test/failure.mlir
+++ b/runtime/src/iree/modules/check/test/failure.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-check-module --module=- --expect_failure | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-check-module --device=vulkan --module=- --expect_failure | FileCheck %s)
 
 // CHECK-LABEL: expect_failure.expect_true_of_false
 // CHECK: Expected 0 to be nonzero

--- a/runtime/src/iree/modules/check/test/success.mlir
+++ b/runtime/src/iree/modules/check/test/success.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-check-module --device=local-task --module=-
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-check-module --device=vulkan --module=-)
 
 func.func @expect_true() {
   %true = util.unfoldable_constant 1 : i32


### PR DESCRIPTION
These tests were not tagged (in the build system) as using Vulkan / a GPU, and I don't think testing Vulkan with them adds much value.