### PR TITLE
Add "torch" as an `InputType` in `iree/compiler/tools/core.py`.

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/core.py
+++ b/compiler/bindings/python/iree/compiler/tools/core.py
@@ -47,6 +47,7 @@ class InputType(Enum):
     STABLEHLO_XLA = "stablehlo_xla"
     TOSA = "tosa"
     TM_TENSOR = "tm_tensor"
+    TORCH = "torch"
 
     @staticmethod
     def parse(spec: Union[str, InputType]) -> InputType:

--- a/compiler/bindings/python/test/tools/compiler_core_test.py
+++ b/compiler/bindings/python/test/tools/compiler_core_test.py
@@ -109,7 +109,7 @@ class CompilerTest(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError,
             "For input_type= argument, expected one of: "
-            "NONE, AUTO, STABLEHLO, STABLEHLO_XLA, TOSA",
+            "NONE, AUTO, STABLEHLO, STABLEHLO_XLA, TOSA, TM_TENSOR, TORCH",
         ):
             _ = iree.compiler.tools.compile_str(
                 SIMPLE_MUL_ASM,
@@ -133,7 +133,6 @@ class CompilerTest(unittest.TestCase):
     def testOutputFbTextParsed(self):
         text = iree.compiler.tools.compile_str(
             SIMPLE_MUL_ASM,
-            input_type="stablehlo",
             output_format="flatbuffer_text",
             target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS,
         ).decode("utf-8")


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/15353
* This fixes `binary = iree.compiler.tools.compile_file("path.mlir", input_type="torch", ...)`
* Still need "auto" handling of the "torch" input type

We should also add some tests in-tree that use the torch dialect(s). I can help there, but I need to think through a few details first (how to generate / update test files, where to put the tests, etc.)