### PR TITLE
use getTypeBitWidth() to get the element type's bit width

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
@@ -103,7 +103,7 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
 bool hasByteAlignedElementTypes(linalg::LinalgOp linalgOp) {
   return llvm::all_of(linalgOp->getOperands(), [](Value operand) {
     auto bitwidth =
-        getElementTypeOrSelf(operand.getType()).getIntOrFloatBitWidth();
+        IREE::Util::getTypeBitWidth(getElementTypeOrSelf(operand.getType()));
     return bitwidth % 8 == 0;
   });
 }


### PR DESCRIPTION
getTypeBitWidth() supports ComplexType too.