### PR TITLE
Use `c2-standard-16` VM to run x86_64 e2e benchmark tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1027,12 +1027,13 @@ jobs:
             arch: x86_64
             docker_image: "gcr.io/iree-oss/base@sha256:796fb81a11ff7e7d057c93de468b74e48b6a9641aa19b7f7673c2772e8ea3b33"
             run_scripts: "./build_tools/cmake/test_benchmark_suites_on_linux.sh"
+            # Requires Intel CascadeLake CPU.
             host_machine: c2s16
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=${{ needs.setup.outputs.runner-env }}
-      - ${{ matrix.target.host_machine || 'cpu' }}
+      - ${{ matrix.target.host_machine || 'cpu' }} # Default to generic x86_64 VM.
     env:
       PLATFORM: ${{ matrix.target.platform }}
       ARCH: ${{ matrix.target.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1012,12 +1012,6 @@ jobs:
   test_benchmark_suites:
     needs: [setup, build_all, build_e2e_test_artifacts]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_benchmark_suites')
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
     strategy:
       matrix:
         target:
@@ -1033,6 +1027,12 @@ jobs:
             arch: x86_64
             docker_image: "gcr.io/iree-oss/base@sha256:796fb81a11ff7e7d057c93de468b74e48b6a9641aa19b7f7673c2772e8ea3b33"
             run_scripts: "./build_tools/cmake/test_benchmark_suites_on_linux.sh"
+            host_machine: c2s16
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - ${{ matrix.target.host_machine || 'cpu' }}
     env:
       PLATFORM: ${{ matrix.target.platform }}
       ARCH: ${{ matrix.target.arch }}


### PR DESCRIPTION
The e2e benchmark tests are compiled for the specific target machine and requires the compatible host VM to run them.

This change uses `c2-standard-16` VM to run x86_64 benchmark tests compiled for `Intel CascadeLake`; otherwise it might result in illegal instruction errors.