### PR TITLE
[HAL] Add configuration stage in executable lowerings

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -400,6 +400,16 @@ public:
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
+  void buildConfigurationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                      OpPassManager &passManager) override {
+    // For now we disable configuration if the variant has external object
+    // files.
+    if (variantOp.isExternal())
+      return;
+
+    buildLLVMGPUCodegenConfigurationPassPipeline(passManager);
+  }
+
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpPassManager &passManager) override {
     // For now we disable translation if the variant has external object files.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -751,8 +751,7 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
   passManager.addNestedPass<LLVM::LLVMFuncOp>(createAddFastMathFlagsPass());
 }
 
-void buildLLVMCPUCodegenStrategyInitializationPassPipeline(
-    OpPassManager &passManager) {
+void buildLLVMCPUCodegenConfigurationPassPipeline(OpPassManager &passManager) {
   {
     addCommonTargetExecutablePreprocessingPasses(passManager);
     OpPassManager &modulePassManager = passManager.nest<ModuleOp>();
@@ -773,7 +772,6 @@ void buildLLVMCPUCodegenStrategyInitializationPassPipeline(
 }
 
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
-  buildLLVMCPUCodegenStrategyInitializationPassPipeline(passManager);
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   addLowerToLLVMPasses(nestedModulePM);
@@ -814,6 +812,13 @@ namespace {
 void registerCodegenLLVMCPUPasses() {
   // Generated.
   registerPasses();
+
+  static PassPipelineRegistration<> LLVMCPUConfigPipeline(
+      "iree-codegen-llvmcpu-configuration-pipeline",
+      "Runs the progressive lowering pipeline from Linalg to LLVM",
+      [](OpPassManager &passManager) {
+        buildLLVMCPUCodegenConfigurationPassPipeline(passManager);
+      });
 
   static PassPipelineRegistration<> LinalgLLVMPipeline(
       "iree-codegen-linalg-to-llvm-pipeline",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -815,7 +815,7 @@ void registerCodegenLLVMCPUPasses() {
 
   static PassPipelineRegistration<> LLVMCPUConfigPipeline(
       "iree-codegen-llvmcpu-configuration-pipeline",
-      "Runs the progressive lowering pipeline from Linalg to LLVM",
+      "Runs the translation strategy configuration pipeline on Linalg for CPU",
       [](OpPassManager &passManager) {
         buildLLVMCPUCodegenConfigurationPassPipeline(passManager);
       });

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -191,7 +191,7 @@ LogicalResult verifyTensorToVectorsPassPipelineConfig(
 
 /// Populates passes needed for preprocessing before codegen lowerings, as well
 /// as high level lowering strategy selection.
-void buildLLVMCPUCodegenRoutingPassPipeline(OpPassManager &passManager);
+void buildLLVMCPUCodegenConfigurationPassPipeline(OpPassManager &passManager);
 
 /// Populates passes needed to lower a XLA HLO op to LLVM dialect via the
 /// structured ops path. The pass manager `pm` in here should operate on the

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -633,8 +633,7 @@ void registerCodegenLLVMGPUPasses() {
 
   static PassPipelineRegistration<> LLVMGPUConfigPipeline(
       "iree-codegen-llvmgpu-configuration-pipeline",
-      "Runs the translation strategy configuration pipeline for lowering "
-      "Linalg",
+      "Runs the translation strategy configuration pipeline on Linalg for GPU",
       [](OpPassManager &passManager) {
         buildLLVMGPUCodegenConfigurationPassPipeline(passManager);
       });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -594,13 +594,12 @@ void addGPUTransformDialectPasses(OpPassManager &passManager) {
   passManager.addPass(createDropSchedulePass());
 }
 
-void buildLLVMGPUCodegenStrategyInitializationPassPipeline(OpPassManager &pm) {
+void buildLLVMGPUCodegenConfigurationPassPipeline(OpPassManager &pm) {
   addCommonTargetExecutablePreprocessingPasses(pm);
   pm.addPass(createLLVMGPUSelectLoweringStrategyPass());
 }
 
 void buildLLVMGPUCodegenPassPipeline(OpPassManager &pm, bool useROCM) {
-  buildLLVMGPUCodegenStrategyInitializationPassPipeline(pm);
   pm.addPass(createLLVMGPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = pm.nest<ModuleOp>();
   //===--------------------------------------------------------------------===//
@@ -631,6 +630,13 @@ namespace {
 void registerCodegenLLVMGPUPasses() {
   // Generated.
   registerPasses();
+
+  static PassPipelineRegistration<> LLVMGPUConfigPipeline(
+      "iree-codegen-llvmgpu-configuration-pipeline",
+      "Runs the strategy configuration pipeline for lowering Linalg",
+      [](OpPassManager &passManager) {
+        buildLLVMGPUCodegenConfigurationPassPipeline(passManager);
+      });
 
   static PassPipelineRegistration<> LinalgNVVMPipeline(
       "iree-codegen-linalg-to-nvvm-pipeline",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -633,7 +633,8 @@ void registerCodegenLLVMGPUPasses() {
 
   static PassPipelineRegistration<> LLVMGPUConfigPipeline(
       "iree-codegen-llvmgpu-configuration-pipeline",
-      "Runs the strategy configuration pipeline for lowering Linalg",
+      "Runs the translation strategy configuration pipeline for lowering "
+      "Linalg",
       [](OpPassManager &passManager) {
         buildLLVMGPUCodegenConfigurationPassPipeline(passManager);
       });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -56,7 +56,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm);
 /// Default pass pipeline on GPU, currently used only for the ukernel path.
 void addGPUDefaultPassPipeline(OpPassManager &pm);
 
-/// Populates passes needed to preprocess and select the strategy for lowering.
+/// Populates passes needed to preprocess and select the translation strategy.
 void buildLLVMGPUCodegenConfigurationPassPipeline(OpPassManager &pm);
 
 /// Populates passes needed to lower a XLA HLO op to NVVM/ROCDL dialect via

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -57,7 +57,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm);
 void addGPUDefaultPassPipeline(OpPassManager &pm);
 
 /// Populates passes needed to preprocess and select the strategy for lowering.
-void buildLLVMGPUCodegenStrategyInitializationPassPipeline(OpPassManager &pm);
+void buildLLVMGPUCodegenConfigurationPassPipeline(OpPassManager &pm);
 
 /// Populates passes needed to lower a XLA HLO op to NVVM/ROCDL dialect via
 /// the structured ops path. The pass manager `pm` in here should operate on

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-nvvm-pipeline)))' -split-input-file %s -o - | FileCheck %s
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-nvvm-pipeline)))' -split-input-file %s -o - | FileCheck %s
 
 // This test checks that the lowering of nvvm includes the extraction
 // and optimization of address computations.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-mma-sync %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-mma-sync %s | FileCheck %s
 
 // Verify that a simple element wise op gets lowered succefully all the way to
 // nvvm/llvm dialect via mma.sync path.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s
 
 // Verify that a simple element wise op gets lowered succefully all the way to
 // nvvm/llvm dialect.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s
 
 // Verify that a simple element wise op gets lowered succefully all the way to
 // nvvm/llvm dialect.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -656,7 +656,7 @@ void addSPIRVTransformDialectPassPipeline(OpPassManager &pm) {
 // Entry Point
 //===----------------------------------------------------------------------===//
 
-void buildSPIRVCodegenStrategyInitializationPassPipeline(OpPassManager &pm) {
+void buildSPIRVCodegenConfigurationPassPipeline(OpPassManager &pm) {
   addCommonTargetExecutablePreprocessingPasses(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
@@ -665,7 +665,6 @@ void buildSPIRVCodegenStrategyInitializationPassPipeline(OpPassManager &pm) {
 }
 
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
-  buildSPIRVCodegenStrategyInitializationPassPipeline(pm);
   pm.addPass(createSPIRVLowerExecutableTargetPass());
 
   addMemRefLoweringPasses(pm.nest<ModuleOp>());
@@ -690,6 +689,13 @@ namespace {
 void registerCodegenSPIRVPasses() {
   // Generated.
   registerPasses();
+
+  static PassPipelineRegistration<> SPIRVConfigPipeline(
+      "iree-codegen-spirv-configuration-pipeline",
+      "Runs the pipeline for configuring the lowering from linalg to SPIR-V",
+      [](OpPassManager &passManager) {
+        buildSPIRVCodegenConfigurationPassPipeline(passManager);
+      });
 
   static PassPipelineRegistration<> LinalgSPIRVPipeline(
       "iree-codegen-linalg-to-spirv-pipeline",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -52,7 +52,7 @@ void addSPIRVWinogradVectorizePassPipeline(OpPassManager &pm);
 
 /// Populates passes needed to preprocess the input variant before lowering
 /// and select lowering strategies.
-void buildSPIRVCodegenStrategyInitializationPassPipeline(OpPassManager &pm);
+void buildSPIRVCodegenConfigurationPassPipeline(OpPassManager &pm);
 
 /// Populates passes needed to lower linalg/arith/math ops to SPIR-V ops via
 /// the structured ops path. The pass manager `pm` here operate on the module

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file \
-// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)))' \
+// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)))' \
 // RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -214,6 +214,11 @@ public:
     return getDeviceTargetFromTarget(context, *maybeTarget, defaultAddlConfig_);
   }
 
+  void buildConfigurationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                      OpPassManager &passManager) override {
+    buildLLVMCPUCodegenConfigurationPassPipeline(passManager);
+  }
+
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpPassManager &passManager) override {
     buildLLVMCPUCodegenPassPipeline(passManager);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -126,6 +126,16 @@ public:
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
+  void buildConfigurationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                      OpPassManager &passManager) override {
+    // For now we disable configuration if the variant has external object
+    // files.
+    if (variantOp.isExternal())
+      return;
+
+    buildSPIRVCodegenConfigurationPassPipeline(passManager);
+  }
+
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpPassManager &passManager) override {
     // For now we disable translation if the variant has external object files.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -104,6 +104,16 @@ public:
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
+  void buildConfigurationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                      OpPassManager &passManager) override {
+    // For now we disable configuration if the variant has external object
+    // files.
+    if (variantOp.isExternal())
+      return;
+
+    buildLLVMGPUCodegenConfigurationPassPipeline(passManager);
+  }
+
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpPassManager &passManager) override {
     // For now we disable translation if the variant has external object files.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -50,6 +50,8 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::callback([&](const std::string &path) {
         if (executableSourcesPath.empty())
           executableSourcesPath = path;
+        if (executableConfigurationsPath.empty())
+          executableConfigurationsPath = path;
         if (executableBenchmarksPath.empty())
           executableBenchmarksPath = path;
         if (executableIntermediatesPath.empty())
@@ -63,6 +65,13 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
       "iree-hal-dump-executable-sources-to", executableSourcesPath,
       llvm::cl::desc("Path to write individual hal.executable input "
                      "source listings into (- for stdout)."),
+      llvm::cl::cat(halTargetOptionsCategory));
+
+  binder.opt<std::string>(
+      "iree-hal-dump-executable-configurations-to",
+      executableConfigurationsPath,
+      llvm::cl::desc("Path to write individual hal.executable input source "
+                     "listings into, after configuration (- for stdout)."),
       llvm::cl::cat(halTargetOptionsCategory));
 
   binder.opt<std::string>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -71,7 +71,8 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
       "iree-hal-dump-executable-configurations-to",
       executableConfigurationsPath,
       llvm::cl::desc("Path to write individual hal.executable input source "
-                     "listings into, after configuration (- for stdout)."),
+                     "listings into, after translation strategy selection and "
+                     "before starting translation (- for stdout)."),
       llvm::cl::cat(halTargetOptionsCategory));
 
   binder.opt<std::string>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -158,12 +158,12 @@ public:
   // for translation. The pass manager will be nested on `hal.executable` such
   // that the pipeline will only run on executable contents.
   //
-  // The primary purpose of this pipeline is to do the minimum necessary
-  // preprocessing on variants necessary for translation, as well as set any
-  // strategy specific information needed for translation. This is to inform
-  // later passes on how to expand/contract variants for multiple targets that
-  // might be known to translate to the same thing. As such, this pipeline is
-  // optional.
+  // The primary purpose of this pipeline is to preprocess then annotate all
+  // `hal.executable.variant` ops with the information necessary for
+  // translation. This can include specifying the set of required and/or
+  // irrelevant target features, allowing for an additional deduplication step
+  // when the only difference between two variants is a set of irrelevant
+  // features. As a result, this pipeline is optional.
   //
   // The expected input to this pipeline might look like:
   //   hal.executable @some_executable {
@@ -175,7 +175,26 @@ public:
   //       hal.executable.export @main interface(@main_io) {
   //         ordinal = 0 : index
   //       }
-  //       module { ... }
+  //       module {
+  //         func.func @main ...
+  //       }
+  //     }
+  //   }
+  //
+  // As output, structurally the variant should be very similar:
+  //   hal.executable @some_executable {
+  //     hal.interface @main_io {
+  //       hal.interface.binding @arg0, set=0, binding=0, ...
+  //       hal.interface.binding @arg1, set=0, binding=1, ...
+  //     }
+  //     hal.executable.variant @target, target="target-backend" {
+  //       hal.executable.export @main interface(@main_io)
+  //         {attrs = #target_specific_translation_attr<...>} {
+  //         ordinal = 0 : index
+  //       }
+  //       module {
+  //         func.func @main ...
+  //       }
   //     }
   //   }
   virtual void

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
@@ -85,6 +85,11 @@ public:
     return vmOptions;
   }
 
+  void buildConfigurationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                      OpPassManager &passManager) override {
+    IREE::VMVX::buildVMVXConfigurationPassPipeline(passManager);
+  }
+
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpPassManager &passManager) override {
     IREE::VMVX::buildVMVXTransformPassPipeline(passManager);
@@ -186,6 +191,11 @@ public:
     auto configAttr = b.getDictionaryAttr(configItems);
     return IREE::HAL::DeviceTargetAttr::get(
         context, b.getStringAttr(deviceID()), configAttr);
+  }
+
+  void buildConfigurationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                      OpPassManager &passManager) override {
+    IREE::VMVX::buildVMVXConfigurationPassPipeline(passManager);
   }
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -149,6 +149,17 @@ public:
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
+  void buildConfigurationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                      OpPassManager &passManager) override {
+    // For now we disable translation if the variant has external object files.
+    // We could instead perform linking with those objects (if they're .spv
+    // files we could use spirv-link or import them into MLIR and merge here).
+    if (variantOp.isExternal())
+      return;
+
+    buildSPIRVCodegenConfigurationPassPipeline(passManager);
+  }
+
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpPassManager &passManager) override {
     // For now we disable translation if the variant has external object files.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.cpp
@@ -90,6 +90,16 @@ public:
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
+  void buildConfigurationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                      OpPassManager &passManager) override {
+    // For now we disable configuration if the variant has external object
+    // files.
+    if (variantOp.isExternal())
+      return;
+
+    buildSPIRVCodegenConfigurationPassPipeline(passManager);
+  }
+
   void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpPassManager &passManager) override {
     // For now we disable translation if the variant has external object files.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -17,6 +17,7 @@ iree_compiler_cc_library(
     srcs = [
         "AssignTargetDevices.cpp",
         "BenchmarkBatchDispatches.cpp",
+        "ConfigureExecutables.cpp",
         "ConvertToHAL.cpp",
         "DumpExecutableBenchmarks.cpp",
         "DumpExecutableSources.cpp",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
   SRCS
     "AssignTargetDevices.cpp"
     "BenchmarkBatchDispatches.cpp"
+    "ConfigureExecutables.cpp"
     "ConvertToHAL.cpp"
     "DumpExecutableBenchmarks.cpp"
     "DumpExecutableSources.cpp"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConfigureExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConfigureExecutables.cpp
@@ -70,7 +70,7 @@ public:
 
     // This pipeline is optional, and the default is no passes, in which case
     // nothing is needed.
-    if (!passManager.empty()) {
+    if (passManager.empty()) {
       return;
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConfigureExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConfigureExecutables.cpp
@@ -1,0 +1,165 @@
+// Copyright 2020 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+#include <utility>
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetBackend.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
+#include "iree/compiler/Utils/TracingUtils.h"
+#include "llvm/ADT/StringSet.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+class ConfigureTargetExecutableVariantsPass
+    : public PassWrapper<ConfigureTargetExecutableVariantsPass,
+                         OperationPass<IREE::HAL::ExecutableVariantOp>> {
+public:
+  ConfigureTargetExecutableVariantsPass()
+      : targetRegistry(TargetBackendRegistry::getGlobal()) {}
+  ConfigureTargetExecutableVariantsPass(
+      const ConfigureTargetExecutableVariantsPass &pass)
+      : targetRegistry(pass.targetRegistry) {}
+  ConfigureTargetExecutableVariantsPass(
+      const TargetBackendRegistry &targetRegistry, StringRef target)
+      : targetRegistry(targetRegistry) {
+    this->target = target.str();
+  }
+
+  StringRef getArgument() const override {
+    return "iree-hal-configure-target-executable-variants";
+  }
+
+  StringRef getDescription() const override {
+    return "Configures a hal.executable.variant op for translation";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::HAL::HALDialect>();
+    auto targetBackend = targetRegistry.getTargetBackend(target);
+    if (targetBackend) {
+      targetBackend->getDependentDialects(registry);
+    }
+  }
+  void runOnOperation() override {
+    auto variantOp = getOperation();
+    if (variantOp.getTarget().getBackend().getValue() != target)
+      return;
+
+    auto targetBackend = targetRegistry.getTargetBackend(target);
+    if (!targetBackend) {
+      variantOp.emitError() << "unregistered target backend '" << target << "'";
+      return signalPassFailure();
+    }
+
+    OpPassManager passManager(variantOp.getOperationName());
+    targetBackend->buildConfigurationPassPipeline(variantOp, passManager);
+
+    // This pipeline is optional, and the default is no passes, in which case
+    // nothing is needed.
+    if (!passManager.empty()) {
+      if (failed(runPipeline(passManager, variantOp))) {
+        variantOp.emitError() << "failed to run translation of source "
+                                 "executable to target executable for backend "
+                              << variantOp.getTarget();
+        return signalPassFailure();
+      }
+    }
+  }
+
+private:
+  Option<std::string> target{
+      *this, "target",
+      llvm::cl::desc(
+          "Target backend name whose executables will be translated by "
+          "this pass.")};
+
+  const TargetBackendRegistry &targetRegistry;
+};
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createConfigureTargetExecutableVariantsPass(
+    const TargetBackendRegistry &targetRegistry, StringRef target) {
+  return std::make_unique<ConfigureTargetExecutableVariantsPass>(targetRegistry,
+                                                                 target);
+}
+
+static PassRegistration<ConfigureTargetExecutableVariantsPass> linkTargetPass(
+    [] { return std::make_unique<ConfigureTargetExecutableVariantsPass>(); });
+
+class ConfigureExecutablesPass
+    : public PassWrapper<ConfigureExecutablesPass,
+                         OperationPass<IREE::HAL::ExecutableOp>> {
+public:
+  ConfigureExecutablesPass()
+      : targetRegistry(TargetBackendRegistry::getGlobal()) {}
+  ConfigureExecutablesPass(const ConfigureExecutablesPass &pass)
+      : targetRegistry(pass.targetRegistry) {}
+  ConfigureExecutablesPass(const TargetBackendRegistry &targetRegistry)
+      : targetRegistry(targetRegistry) {}
+
+  StringRef getArgument() const override {
+    return "iree-hal-configure-executables";
+  }
+
+  StringRef getDescription() const override {
+    return "Configures hal.executable.variant ops for translation to "
+           "hal.executable.binary ops";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::HAL::HALDialect>();
+    auto targetBackends = targetRegistry.getTargetBackends(
+        targetRegistry.getRegisteredTargetBackends());
+    for (auto &targetBackend : targetBackends) {
+      targetBackend->getDependentDialects(registry);
+    }
+  }
+
+  void runOnOperation() override {
+    auto executableOp = getOperation();
+    OpPassManager passManager(executableOp.getOperationName());
+    for (const auto &targetName : gatherExecutableTargetNames(executableOp)) {
+      passManager.addNestedPass<IREE::HAL::ExecutableVariantOp>(
+          createConfigureTargetExecutableVariantsPass(targetRegistry,
+                                                      targetName));
+    }
+
+    IREE_COMPILER_TRACE_MESSAGE_DYNAMIC(INFO, executableOp.getSymName().str());
+
+    if (failed(runPipeline(passManager, executableOp))) {
+      executableOp.emitError() << "failed to configure executables";
+      return signalPassFailure();
+    }
+  }
+
+private:
+  const TargetBackendRegistry &targetRegistry;
+};
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
+createConfigureExecutablesPass(const TargetBackendRegistry &targetRegistry) {
+  return std::make_unique<ConfigureExecutablesPass>(targetRegistry);
+}
+
+static PassRegistration<ConfigureExecutablesPass> translatePass([] {
+  return std::make_unique<ConfigureExecutablesPass>();
+});
+
+} // namespace HAL
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConfigureExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConfigureExecutables.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 The IREE Authors
+// Copyright 2023 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -71,12 +71,14 @@ public:
     // This pipeline is optional, and the default is no passes, in which case
     // nothing is needed.
     if (!passManager.empty()) {
-      if (failed(runPipeline(passManager, variantOp))) {
-        variantOp.emitError() << "failed to run translation of source "
-                                 "executable to target executable for backend "
-                              << variantOp.getTarget();
-        return signalPassFailure();
-      }
+      return;
+    }
+
+    if (failed(runPipeline(passManager, variantOp))) {
+      variantOp.emitError() << "failed to run configuration of source "
+                               "executable to target executable for backend "
+                            << variantOp.getTarget();
+      return signalPassFailure();
     }
   }
 
@@ -84,7 +86,7 @@ private:
   Option<std::string> target{
       *this, "target",
       llvm::cl::desc(
-          "Target backend name whose executables will be translated by "
+          "Target backend name whose executables will be configured by "
           "this pass.")};
 
   const TargetBackendRegistry &targetRegistry;

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -86,9 +86,9 @@ static llvm::cl::opt<std::string> clSubstituteExecutableSourcesFrom{
 static llvm::cl::list<std::string> clSubstituteExecutableConfiguration{
     "iree-hal-substitute-executable-configuration",
     llvm::cl::desc(
-        "A `executable_name=object_file.xxx` pair specifying a "
-        "hal.executable symbol name that will be substituted with the source "
-        "object file at the given path. Source object paths are relative to "
+        "A `executable_name=object_file.xxx` pair specifying a hal.executable "
+        "symbol name that will be substituted with the configured executable "
+        "file at the given path. Configured execuable paths are relative to "
         "those specified on `--iree-hal-executable-object-search-path=`. If a "
         "`.mlir` or `.mlirbc` file is specified the entire executable will be "
         "replaced with an equivalently named hal.executable in the referenced "
@@ -256,10 +256,11 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   //----------------------------------------------------------------------------
 
   if (compileFrom < PipelinePhase::ExecutableConfigurations) {
-    // Select a strategy for each hal.executable.variant and generate the IR to
-    // condition on support for the variant. In the future, this or neighboring
-    // passes can expand/contract variants based on the selected strategies and
-    // the features each strategy are known to require or not require.
+    // Select a translation strategy for each hal.executable.variant and
+    // generate the IR to condition on support for the variant. In the future,
+    // this or neighboring passes can expand/contract variants based on the
+    // selected translation strategies and the features each translation
+    // strategy are known to require or not require.
     passManager.addNestedPass<IREE::HAL::ExecutableOp>(
         createConfigureExecutablesPass(targetRegistry));
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -31,6 +31,9 @@ enum class PipelinePhase {
   Start,
   // Runs the transform pipeline up to executable sources (pre translation).
   ExecutableSources,
+  // Runs the transform pipeline up to executable configurations (before
+  // strategy selection).
+  ExecutableConfigurations,
   // Runs the transform pipeline until just after executable translation.
   ExecutableTargets,
   // Runs the full pipeline.
@@ -105,7 +108,7 @@ createMaterializeInterfacesPass();
 
 // Dumps individual hal.executable source listings to |path|.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
-createDumpExecutableSourcesPass(StringRef path);
+createDumpExecutableSourcesPass(StringRef path, StringRef prefix = "");
 
 // Dumps standalone hal.executable benchmarks to |path|.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
@@ -130,6 +133,15 @@ createPreprocessExecutablesWithPipelinePass(std::string pipeline);
 // Preprocesses each executable with an external tool.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
 createPreprocessExecutablesWithToolPass(std::string command);
+
+// Configures hal.executable.variant ops via a nested translation pipeline.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
+createConfigureExecutablesPass(const TargetBackendRegistry &targetRegistry);
+
+// Configures hal.executable.variant ops for the specified |target| backend.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createConfigureTargetExecutableVariantsPass(
+    const TargetBackendRegistry &targetRegistry, StringRef target);
 
 // Translates hal.executable.variant ops via a nested translation pipeline.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
@@ -202,6 +214,9 @@ inline void registerHALPasses() {
   auto targetOptions = TargetOptions::FromFlags::get();
   createAssignTargetDevicesPass(TargetBackendRegistry::getGlobal(), {});
   createBenchmarkBatchDispatchesPass(/*repeatCount=*/1);
+  createConfigureExecutablesPass(TargetBackendRegistry::getGlobal());
+  createConfigureTargetExecutableVariantsPass(
+      TargetBackendRegistry::getGlobal(), "");
   createConvertToHALPass();
   createDumpExecutableSourcesPass("");
   createElideRedundantCommandsPass();

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -32,7 +32,7 @@ enum class PipelinePhase {
   // Runs the transform pipeline up to executable sources (pre translation).
   ExecutableSources,
   // Runs the transform pipeline up to executable configurations (before
-  // strategy selection).
+  // translation strategy selection).
   ExecutableConfigurations,
   // Runs the transform pipeline until just after executable translation.
   ExecutableTargets,
@@ -134,7 +134,8 @@ createPreprocessExecutablesWithPipelinePass(std::string pipeline);
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
 createPreprocessExecutablesWithToolPass(std::string command);
 
-// Configures hal.executable.variant ops via a nested translation pipeline.
+// Configures hal.executable.variant ops in all hal.executable ops via a nested
+// translation pipeline.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
 createConfigureExecutablesPass(const TargetBackendRegistry &targetRegistry);
 

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -30,7 +30,11 @@ namespace iree_compiler {
 namespace IREE {
 namespace VMVX {
 
-static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
+// ---------------------------------------------------------------------------
+// Variant configuration
+// ---------------------------------------------------------------------------
+
+void buildVMVXConfigurationPassPipeline(OpPassManager &passManager) {
   // ---------------------------------------------------------------------------
   // Tensor-level optimization, kernel dispatch and lower to buffers.
   // ---------------------------------------------------------------------------
@@ -41,6 +45,16 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
   // memory space through the stack.
   passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   passManager.addPass(createLLVMCPUSelectLoweringStrategyPass());
+}
+
+// ---------------------------------------------------------------------------
+// Variant Translation
+// ---------------------------------------------------------------------------
+
+static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
+  // ---------------------------------------------------------------------------
+  // Tensor-level optimization, kernel dispatch and lower to buffers.
+  // ---------------------------------------------------------------------------
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
@@ -138,6 +152,13 @@ namespace {
 void registerVMVXPasses() {
   // Generated.
   registerPasses();
+
+  static PassPipelineRegistration<> configurationPassPipeline(
+      "iree-vmvx-configuration-pipeline",
+      "Runs the full IREE VMVX dialect configuration pipeline",
+      [](OpPassManager &passManager) {
+        buildVMVXConfigurationPassPipeline(passManager);
+      });
 
   static PassPipelineRegistration<> transformPassPipeline(
       "iree-vmvx-transformation-pipeline",

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.h
@@ -24,6 +24,10 @@ namespace VMVX {
 // Helpers
 //===----------------------------------------------------------------------===//
 
+// Adds a set of passes to the given pass manager that configure the required
+// VMVX transforms and tiling parameters.
+void buildVMVXConfigurationPassPipeline(OpPassManager &passManager);
+
 // Adds a set of passes to the given pass manager that run the required VMVX
 // transforms in the canonical order.
 //
@@ -32,6 +36,7 @@ namespace VMVX {
 //
 // The expected usage is:
 //   <run conversion from TF/HLO/etc to flow>
+//   buildVMVXConfigurationPassPipeline & run
 //   buildVMVXTransformPassPipeline & run
 //   <serialize VM module>
 void buildVMVXTransformPassPipeline(OpPassManager &passManager);

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/Passes.cpp
@@ -64,6 +64,8 @@ void buildHALInlineStaticTransformPassPipeline(
 
   // Translate each executable down to common MLIR dialects.
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
+      IREE::HAL::createConfigureExecutablesPass(targetRegistry));
+  passManager.addNestedPass<IREE::HAL::ExecutableOp>(
       IREE::HAL::createTranslateExecutablesPass(targetRegistry));
 
   // Inline the translated executable functions.

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Passes.cpp
@@ -69,6 +69,8 @@ void buildHALInlineDynamicTransformPassPipeline(
   // After this point the executables are opaque blobs and we cannot change
   // their interfaces.
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
+      IREE::HAL::createConfigureExecutablesPass(targetRegistry));
+  passManager.addNestedPass<IREE::HAL::ExecutableOp>(
       IREE::HAL::createTranslateExecutablesPass(targetRegistry));
 
   //----------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -256,6 +256,9 @@ void buildIREEVMTransformPassPipeline(
   case IREEVMPipelinePhase::ExecutableSources:
     halCompileFrom = IREE::HAL::PipelinePhase::ExecutableSources;
     break;
+  case IREEVMPipelinePhase::ExecutableConfigurations:
+    halCompileFrom = IREE::HAL::PipelinePhase::ExecutableConfigurations;
+    break;
   case IREEVMPipelinePhase::ExecutableTargets:
     halCompileFrom = IREE::HAL::PipelinePhase::ExecutableTargets;
     break;
@@ -268,6 +271,9 @@ void buildIREEVMTransformPassPipeline(
     break;
   case IREEVMPipelinePhase::ExecutableSources:
     halCompileTo = IREE::HAL::PipelinePhase::ExecutableSources;
+    break;
+  case IREEVMPipelinePhase::ExecutableConfigurations:
+    halCompileTo = IREE::HAL::PipelinePhase::ExecutableConfigurations;
     break;
   case IREEVMPipelinePhase::ExecutableTargets:
     halCompileTo = IREE::HAL::PipelinePhase::ExecutableTargets;

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -42,6 +42,7 @@ enum class IREEVMPipelinePhase {
   Flow,
   Stream,
   ExecutableSources,
+  ExecutableConfigurations,
   ExecutableTargets,
   HAL,
   VM,
@@ -68,8 +69,12 @@ inline static void enumerateIREEVMPipelinePhases(
   callback(IREEVMPipelinePhase::Stream, "stream",
            "Compiles up to the `stream` dialect.");
   callback(IREEVMPipelinePhase::ExecutableSources, "executable-sources",
-           "Compiles up to just before `hal.executable`s are translated, "
+           "Compiles up to just before `hal.executable`s are configured, "
            "excluding codegen.");
+  callback(IREEVMPipelinePhase::ExecutableConfigurations,
+           "executable-configurations",
+           "Compiles up to just before `hal.executable`s are translated, "
+           "including selection of strategies for codegen.");
   callback(IREEVMPipelinePhase::ExecutableTargets, "executable-targets",
            "Compiles up to translated `hal.executable`s, including codegen.");
   callback(IREEVMPipelinePhase::HAL, "hal",

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -74,7 +74,7 @@ inline static void enumerateIREEVMPipelinePhases(
   callback(IREEVMPipelinePhase::ExecutableConfigurations,
            "executable-configurations",
            "Compiles up to just before `hal.executable`s are translated, "
-           "including selection of strategies for codegen.");
+           "including selection of translation strategies for codegen.");
   callback(IREEVMPipelinePhase::ExecutableTargets, "executable-targets",
            "Compiles up to translated `hal.executable`s, including codegen.");
   callback(IREEVMPipelinePhase::HAL, "hal",

--- a/tools/test/BUILD.bazel
+++ b/tools/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "compile_to_continuation.mlir",
             "compile_to_phase.mlir",
             "executable_benchmarks.mlir",
+            "executable_configurations.mlir",
             "executable_sources.mlir",
             "iree-benchmark-module.mlir",
             "iree-dump-parameters.txt",

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "compile_to_continuation.mlir"
     "compile_to_phase.mlir"
     "executable_benchmarks.mlir"
+    "executable_configurations.mlir"
     "executable_sources.mlir"
     "iree-benchmark-module.mlir"
     "iree-dump-parameters.txt"

--- a/tools/test/executable_configurations.mlir
+++ b/tools/test/executable_configurations.mlir
@@ -6,7 +6,7 @@
 // RUN:     --mlir-print-ir-before=iree-hal-serialize-executables 2>&1 | \
 // RUN: FileCheck %s
 
-// This test relies on us piping stdout and that there's only a single
+// This test relies on piping stdout and that there is only a single
 // executable (otherwise we'd need to look at files and that's harder
 // cross-platform). Real automation of this requires xargs: compile and dump a
 // directory of .mlir sources by specifying a path to the dump flag instead

--- a/tools/test/executable_configurations.mlir
+++ b/tools/test/executable_configurations.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-compile %s -o ignored.mlir \
+// RUN:     --iree-hal-target-backends=vmvx \
+// RUN:     --iree-hal-dump-executable-configurations-to=- | \
+// RUN: iree-compile - -o /dev/null \
+// RUN:     --compile-mode=hal-executable \
+// RUN:     --mlir-print-ir-before=iree-hal-serialize-executables 2>&1 | \
+// RUN: FileCheck %s
+
+// This test relies on us piping stdout and that there's only a single
+// executable (otherwise we'd need to look at files and that's harder
+// cross-platform). Real automation of this requires xargs: compile and dump a
+// directory of .mlir sources by specifying a path to the dump flag instead
+// of `-` (indicating stdout) and then ls | xargs them to iree-compile or
+// iree-opt.
+//
+// Example of dumping per-dispatch executable configurations and compiling each
+// to their platform binary form, dumping their MLIR prior to lowering into the
+// backend representation (SPIR-V/LLVM-IR/etc):
+//  iree-compile some_input.mlir -o ignored.mlir \
+//      --iree-hal-target-backends=vmvx \
+//      --iree-hal-dump-executable-configurations-to=configs/ | \
+//  ls -1 sources/ | xargs -i sh -c "iree-compile configs/{}
+//      --compile-mode=hal-executable
+//      --mlir-print-ir-before=iree-hal-serialize-executables"
+//
+// NOTE: executable configurations are not runnable: they only exist to allow
+// for iteration on executable translation. If you want to run them you need
+// corresponding host code to dispatch them and can use benchmarks instead.
+//
+// If modifying the configs and wanting to see the changes in a full program the
+// --iree-hal-substitute-executable-configurations-from= flag can be used to
+// substitute one or more executables dumped with this command from a path or
+// for individual executables one or more `executable_name=file.mlir` pairs can
+// be repeated in `--iree-hal-substitute-executable-configuration=`.
+
+func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {
+  %result = math.absf %input : tensor<f32>
+  return %result : tensor<f32>
+}
+
+// CHECK: IR Dump Before mlir::iree_compiler::IREE::HAL::SerializeExecutablesPass
+// CHECK: hal.executable public @abs_dispatch_0
+// CHECK:   hal.executable.variant public @vmvx_bytecode_fb
+// CHECK:     vm.func private @abs_dispatch_0_generic


### PR DESCRIPTION
The core idea behind this split is to allow for passes to be added in between strategy selection and translation, thereby expanding and contracting the set of variants per executable based on the known feature requirements for those strategies.

The reason a split is needed is because strategy selection itself should not care what other variants of the executable are being compiled, however to deduplicate them we need to nest at the executable level. Codegen was already partially structured to enable this (by way of encoding the lowering pipelines as an IR attribute). This PR just recovers the separation that was already there.

In terms of immediate benefits, this adds an option to dump executable configurations (essentially post-kernel config dispatches) and substitute them in, making it significantly easier to get the default lowering configuration for a dispatch from the compiler, tweak it, and plug it back in. Additionally benchmark dumps now happen after this stage for the same reason.