### PR TITLE
[GlobalOptimization] Support SetEncoding on batch matmul cases with p…

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -53,9 +53,11 @@ iree_compiler_cc_library(
         "Passes.cpp",
         "RemoveZeroExtentTensors.cpp",
         "SetEncoding.cpp",
+        "Utils.cpp",
     ],
     hdrs = [
         "Passes.h",
+        "Utils.h",
     ],
     deps = [
         ":PassHeaders",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
     GlobalOptimization
   HDRS
     "Passes.h"
+    "Utils.h"
   SRCS
     "Convert1X1FilterConv2DToMatmul.cpp"
     "DetachElementwiseFromNamedOps.cpp"
@@ -48,6 +49,7 @@ iree_cc_library(
     "Passes.cpp"
     "RemoveZeroExtentTensors.cpp"
     "SetEncoding.cpp"
+    "Utils.cpp"
   DEPS
     ::PassHeaders
     ::PassesIncGen

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -139,12 +139,12 @@ makeEncoding(OpBuilder &builder, IREE::LinalgExt::EncodingUser user,
 }
 
 static Value castEncodedResult(OpBuilder &builder, Location loc, Value encoded,
-                               Value castResult, CastOpInterface castOp,
+                               CastOpInterface castOp,
                                IREE::LinalgExt::EncodingAttr encodingAttr) {
   auto encodedType = cast<RankedTensorType>(encoded.getType());
-  auto castResultType = cast<RankedTensorType>(castResult.getType());
-  auto castedType = RankedTensorType::get(
-      encodedType.getShape(), castResultType.getElementType(), encodingAttr);
+  auto castResultElemType = getElementTypeOrSelf(castOp->getResultTypes()[0]);
+  auto castedType = RankedTensorType::get(encodedType.getShape(),
+                                          castResultElemType, encodingAttr);
   return builder
       .create(loc, castOp->getName().getIdentifier(), encoded, castedType,
               castOp->getAttrs())
@@ -177,7 +177,7 @@ padAndSetEncoding(OpBuilder &builder, Location loc, Value source,
   }
   Value encoded = setEncoding(builder, loc, padded, encodingForSetEncoding);
   if (castOp) {
-    encoded = castEncodedResult(builder, loc, encoded, source, castOp.value(),
+    encoded = castEncodedResult(builder, loc, encoded, castOp.value(),
                                 encodingForSetEncoding);
   }
   return encoded;

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -201,8 +201,8 @@ padAndSetEncoding(OpBuilder &builder, Location loc, Value source,
   // the tensor type that the encoding is applied to.
   auto encodingForSetEncoding = encodingForPad;
   if (padded.getType() != padSource.getType()) {
-    encodingForSetEncoding =
-        makeEncoding(builder, user, role, operandTypes, padSource.getType(), narrow);
+    encodingForSetEncoding = makeEncoding(builder, user, role, operandTypes,
+                                          padSource.getType(), narrow);
   }
   Value encoded = setEncoding(builder, loc, padded, encodingForSetEncoding);
   if (castOp) {
@@ -370,15 +370,15 @@ struct SetBatchMatmulEncoding : public OpRewritePattern<linalg::BatchMatmulOp> {
         cast<RankedTensorType>(operandTypes[0]).clone(lhsElemType);
     operandTypes[1] =
         cast<RankedTensorType>(operandTypes[1]).clone(rhsElemType);
-    Value encodedLhs = padAndSetEncoding(rewriter, loc, origLhs, user,
-                                         IREE::LinalgExt::EncodingRole::LHS,
-                                         operandTypes, narrowSizes, maybeLhsCastOp);
-    Value encodedRhs = padAndSetEncoding(rewriter, loc, origRhs, user,
-                                         IREE::LinalgExt::EncodingRole::RHS,
-                                         operandTypes, narrowSizes, maybeRhsCastOp);
-    Value encodedOut =
-        padAndSetEncoding(rewriter, loc, origOut, user,
-                          IREE::LinalgExt::EncodingRole::RESULT, operandTypes, narrowSizes);
+    Value encodedLhs = padAndSetEncoding(
+        rewriter, loc, origLhs, user, IREE::LinalgExt::EncodingRole::LHS,
+        operandTypes, narrowSizes, maybeLhsCastOp);
+    Value encodedRhs = padAndSetEncoding(
+        rewriter, loc, origRhs, user, IREE::LinalgExt::EncodingRole::RHS,
+        operandTypes, narrowSizes, maybeRhsCastOp);
+    Value encodedOut = padAndSetEncoding(rewriter, loc, origOut, user,
+                                         IREE::LinalgExt::EncodingRole::RESULT,
+                                         operandTypes, narrowSizes);
 
     Value matmulTiled = rewriter
                             .create<linalg::BatchMatmulOp>(

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
@@ -1,0 +1,83 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/GlobalOptimization/Utils.h"
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace GlobalOptimization {
+
+// If the producer is a CastOpInterface, or a linalg::GenericOp that performs
+// only a CastOpInterface on its input, return the CastOpInterface op.
+//
+// **Note: If the CastOpInterface has been generalized, the return Operation
+//         is the body CastOpInterface op, not the linalg::GenericOp.
+Operation *getDefiningCastOp(Value input) {
+  Operation *op = input.getDefiningOp();
+  if (!op) {
+    return nullptr;
+  }
+  auto castOp = dyn_cast<CastOpInterface>(op);
+  if (castOp) {
+    return op;
+  }
+  auto genericOp = dyn_cast<linalg::GenericOp>(op);
+  if (!genericOp || genericOp.getNumDpsInputs() != 1 ||
+      genericOp.getNumDpsInits() != 1 ||
+      genericOp.getBody()->getOperations().size() != 2 ||
+      !isElementwise(genericOp)) {
+    return nullptr;
+  }
+  auto yieldOp = cast<linalg::YieldOp>(genericOp.getBody()->getTerminator());
+  castOp = yieldOp->getOperand(0).getDefiningOp<CastOpInterface>();
+  if (!castOp) {
+    return nullptr;
+  }
+  Value castIn = castOp->getOperand(0);
+  if (castIn.isa<BlockArgument>() &&
+      castIn.cast<BlockArgument>().getArgNumber() != 0) {
+    return nullptr;
+  }
+  return castOp;
+}
+
+// Returns an IntegerType with the specified bitwidth and signedness.
+IntegerType getIntegerTypeWithSignedness(MLIRContext *ctx, int bitWidth,
+                                         bool isSigned) {
+  return IntegerType::get(ctx, bitWidth,
+                          isSigned
+                              ? IntegerType::SignednessSemantics::Signed
+                              : IntegerType::SignednessSemantics::Unsigned);
+}
+
+// Returns the source element type of the defining CastOpInterface of `input`,
+// if there is one.
+Type getCastElemType(Value input) {
+  if (auto tensorType = llvm::dyn_cast<RankedTensorType>(input.getType())) {
+    Operation *castOp = getDefiningCastOp(input);
+    if (!castOp) {
+      return {};
+    }
+    Type castSrcElemType = castOp->getOperand(0).getType();
+    if (auto castTensorType = dyn_cast<RankedTensorType>(castSrcElemType)) {
+      castSrcElemType = castTensorType.getElementType();
+    }
+    if (isa<arith::ExtUIOp>(castOp)) {
+      int64_t bitWidth = castSrcElemType.getIntOrFloatBitWidth();
+      castSrcElemType =
+          getIntegerTypeWithSignedness(castOp->getContext(), bitWidth, false);
+    }
+    return castSrcElemType;
+  }
+  return {};
+}
+
+} // namespace GlobalOptimization
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.h
@@ -6,30 +6,27 @@
 #ifndef IREE_COMPILER_GLOBALOPTIMIZATION_UTILS_H_
 #define IREE_COMPILER_GLOBALOPTIMIZATION_UTILS_H_
 
+#include <optional>
+
 namespace mlir {
-class MLIRContext;
-class IntegerType;
 class Type;
-class Operation;
 class Value;
+class CastOpInterface;
 
 namespace iree_compiler {
 namespace GlobalOptimization {
 
 // If the producer is a CastOpInterface, or a linalg::GenericOp that performs
 // only a CastOpInterface on its input, return the CastOpInterface op.
+// Otherwise, return std::nullopt.
 //
 // **Note: If the CastOpInterface has been generalized, the return Operation
 //         is the body CastOpInterface op, not the linalg::GenericOp.
-Operation *getDefiningCastOp(Value input);
-
-// Returns an IntegerType with the specified bitwidth and signedness.
-IntegerType getIntegerTypeWithSignedness(MLIRContext *ctx, int bitWidth,
-                                         bool isSigned);
+std::optional<CastOpInterface> getDefiningCastOp(Value input);
 
 // Returns the source element type of the defining CastOpInterface of `input`,
-// if there is one.
-Type getCastElemType(Value input);
+// if there is one. Otherwise return std::nullopt.
+std::optional<Type> getCastElemType(Value input);
 
 } // namespace GlobalOptimization
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.h
@@ -1,0 +1,38 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#ifndef IREE_COMPILER_GLOBALOPTIMIZATION_UTILS_H_
+#define IREE_COMPILER_GLOBALOPTIMIZATION_UTILS_H_
+
+namespace mlir {
+class MLIRContext;
+class IntegerType;
+class Type;
+class Operation;
+class Value;
+
+namespace iree_compiler {
+namespace GlobalOptimization {
+
+// If the producer is a CastOpInterface, or a linalg::GenericOp that performs
+// only a CastOpInterface on its input, return the CastOpInterface op.
+//
+// **Note: If the CastOpInterface has been generalized, the return Operation
+//         is the body CastOpInterface op, not the linalg::GenericOp.
+Operation *getDefiningCastOp(Value input);
+
+// Returns an IntegerType with the specified bitwidth and signedness.
+IntegerType getIntegerTypeWithSignedness(MLIRContext *ctx, int bitWidth,
+                                         bool isSigned);
+
+// Returns the source element type of the defining CastOpInterface of `input`,
+// if there is one.
+Type getCastElemType(Value input);
+
+} // namespace GlobalOptimization
+} // namespace iree_compiler
+} // namespace mlir
+
+#endif // IREE_COMPILER_GLOBALOPTIMIZATION_UTILS_H_


### PR DESCRIPTION
…roducer CastOpInterface ops

This commit allows SetEncoding to match on CastOpInterface ops that are producers of BatchMatmulOps. This allows inferring the correct input types when the input casting is not implicit inside the BatchMatmul body. This also gives a way to infer signedness on input types through the specific CastOpInterface op types.