### PR TITLE
[GlobalOptimization] Support ExpandVectors matvec cases with producer CastOpInterface ops

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/GlobalOptimization/Utils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
@@ -97,10 +98,8 @@ struct ExpandVectors
     std::optional<CastOpInterface> castOp = getDefiningCastOp(vectorIn);
     if (castOp) {
       Value castIn = vectorIn.getDefiningOp()->getOperand(0);
-      Type castSrcElemType = castOp.value()->getOperand(0).getType();
-      if (auto castTensorType = dyn_cast<RankedTensorType>(castSrcElemType)) {
-        castSrcElemType = castTensorType.getElementType();
-      }
+      Type castSrcElemType =
+          getElementTypeOrSelf(castOp.value()->getOperand(0).getType());
       auto newVectorCastInTy =
           RankedTensorType::get(expandedInDims, castSrcElemType);
       expandedIn =

--- a/compiler/src/iree/compiler/GlobalOptimization/test/expand_vectors.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/expand_vectors.mlir
@@ -125,3 +125,93 @@ func.func @batch_vecmat_f16f32f32_dynamic(%arg0 : tensor<3x?xf16>, %arg1 : tenso
 //  CHECK-DAG:  %[[MATMUL:.+]] = linalg.batch_matmul ins(%[[EXPANDED_IN]], %[[ARG1]] : tensor<3x1x?xf16>, tensor<3x?x?xf32>) outs(%[[EXPANDED_OUT]] : tensor<3x1x?xf32>)
 //  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0, 1], [2]] : tensor<3x1x?xf32> into tensor<3x?xf32>
 //      CHECK:  return %[[COLLAPSED]]
+
+// -----
+
+func.func @vecmat_bf16bf16f32_casted_dynamic(%arg0 : tensor<?xbf16>, %arg1 : tensor<?x?xbf16>,
+    %arg2 : tensor<?xf32>) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?xbf16>
+  %0 = tensor.empty(%dim) : tensor<?xf32>
+  %casted0 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, 
+                                              affine_map<(d0) -> (d0)>], 
+                             iterator_types = ["parallel"]} 
+                             ins(%arg0 : tensor<?xbf16>) 
+                             outs(%0 : tensor<?xf32>) {
+  ^bb0(%in: bf16, %out: f32):
+    %2 = arith.extf %in : bf16 to f32
+    linalg.yield %2 : f32
+  } -> tensor<?xf32>
+  %casted1 = arith.extf %arg1 : tensor<?x?xbf16> to tensor<?x?xf32>
+  %1 = linalg.vecmat ins(%casted0, %casted1 : tensor<?xf32>, tensor<?x?xf32>)
+      outs(%arg2 : tensor<?xf32>) -> tensor<?xf32>
+  return %1 : tensor<?xf32>
+}
+//      CHECK:  func @vecmat_bf16bf16f32_casted_dynamic(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<?xbf16>, %[[ARG1:.+]]: tensor<?x?xbf16>, %[[ARG2:.+]]: tensor<?xf32>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG0]] {{\[}}[0, 1]] : tensor<?xbf16> into tensor<1x?xbf16>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1]] : tensor<?xf32> into tensor<1x?xf32>
+//  CHECK-DAG:  %[[CASTED0:.+]] = arith.extf %[[EXPANDED_IN]] : tensor<1x?xbf16> to tensor<1x?xf32>
+//  CHECK-DAG:  %[[CASTED1:.+]] = arith.extf %[[ARG1]] : tensor<?x?xbf16> to tensor<?x?xf32>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.matmul ins(%[[CASTED0]], %[[CASTED1]] : tensor<1x?xf32>, tensor<?x?xf32>) outs(%[[EXPANDED_OUT]] : tensor<1x?xf32>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0, 1]] : tensor<1x?xf32> into tensor<?xf32>
+//      CHECK:  return %[[COLLAPSED]]
+
+// -----
+
+func.func @matvec_i8i8i32_casted_dynamic(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?xi8>,
+    %arg2 : tensor<?xi32>) -> tensor<?xi32> {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg1, %c0 : tensor<?xi8>
+  %0 = tensor.empty(%dim) : tensor<?xi32>
+  %casted0 = arith.extui %arg0 : tensor<?x?xi8> to tensor<?x?xi32>
+  %casted1 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, 
+                                              affine_map<(d0) -> (d0)>], 
+                             iterator_types = ["parallel"]} 
+                             ins(%arg1 : tensor<?xi8>) 
+                             outs(%0 : tensor<?xi32>) {
+  ^bb0(%in: i8, %out: i32):
+    %2 = arith.extsi %in : i8 to i32
+    linalg.yield %2 : i32
+  } -> tensor<?xi32>
+  %1 = linalg.matvec ins(%casted0, %casted1 : tensor<?x?xi32>, tensor<?xi32>)
+      outs(%arg2 : tensor<?xi32>) -> tensor<?xi32>
+  return %1 : tensor<?xi32>
+}
+//      CHECK:  func @matvec_i8i8i32_casted_dynamic(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<?x?xi8>, %[[ARG1:.+]]: tensor<?xi8>, %[[ARG2:.+]]: tensor<?xi32>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0, 1]] : tensor<?xi8> into tensor<?x1xi8>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1]] : tensor<?xi32> into tensor<?x1xi32>
+//  CHECK-DAG:  %[[CASTED0:.+]] = arith.extui %[[ARG0]] : tensor<?x?xi8> to tensor<?x?xi32>
+//  CHECK-DAG:  %[[CASTED1:.+]] = arith.extsi %[[EXPANDED_IN]] : tensor<?x1xi8> to tensor<?x1xi32>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.matmul ins(%[[CASTED0]], %[[CASTED1]] : tensor<?x?xi32>, tensor<?x1xi32>) outs(%[[EXPANDED_OUT]] : tensor<?x1xi32>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0, 1]] : tensor<?x1xi32> into tensor<?xi32>
+//      CHECK:  return %[[COLLAPSED]]
+
+func.func @batch_vecmat_casted_f16f32f32_dynamic(%arg0 : tensor<3x?xf16>, %arg1 : tensor<3x?x?xf32>,
+    %arg2 : tensor<3x?xf32>) -> tensor<3x?xf32> {
+  %c1 = arith.constant 1 : index
+  %dim = tensor.dim %arg0, %c1 : tensor<3x?xf16>
+  %0 = tensor.empty(%dim) : tensor<3x?xf32>
+  %casted0 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, 
+                                              affine_map<(d0, d1) -> (d0, d1)>], 
+                             iterator_types = ["parallel", "parallel"]} 
+                             ins(%arg0 : tensor<3x?xf16>) 
+                             outs(%0 : tensor<3x?xf32>) {
+  ^bb0(%in: f16, %out: f32):
+    %2 = arith.extf %in : f16 to f32
+    linalg.yield %2 : f32
+  } -> tensor<3x?xf32>
+  %1 = linalg.batch_vecmat ins(%casted0, %arg1 : tensor<3x?xf32>, tensor<3x?x?xf32>)
+      outs(%arg2 : tensor<3x?xf32>) -> tensor<3x?xf32>
+  return %1 : tensor<3x?xf32>
+}
+
+//      CHECK:  func @batch_vecmat_casted_f16f32f32_dynamic(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<3x?xf16>, %[[ARG1:.+]]: tensor<3x?x?xf32>, %[[ARG2:.+]]: tensor<3x?xf32>
+//  CHECK-DAG:  %[[EXPANDED_IN:.+]] = tensor.expand_shape %[[ARG0]] {{\[}}[0, 1], [2]] : tensor<3x?xf16> into tensor<3x1x?xf16>
+//  CHECK-DAG:  %[[CASTED0:.+]] = arith.extf %[[EXPANDED_IN]] : tensor<3x1x?xf16> to tensor<3x1x?xf32>
+//  CHECK-DAG:  %[[EXPANDED_OUT:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1], [2]] : tensor<3x?xf32> into tensor<3x1x?xf32>
+//  CHECK-DAG:  %[[MATMUL:.+]] = linalg.batch_matmul ins(%[[CASTED0]], %[[ARG1]] : tensor<3x1x?xf32>, tensor<3x?x?xf32>) outs(%[[EXPANDED_OUT]] : tensor<3x1x?xf32>)
+//  CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MATMUL]] {{\[}}[0, 1], [2]] : tensor<3x1x?xf32> into tensor<3x?xf32>
+//      CHECK:  return %[[COLLAPSED]]


### PR DESCRIPTION
This PR is related to https://github.com/openxla/iree/pull/15371 and https://github.com/openxla/iree/pull/15339. In https://github.com/openxla/iree/pull/15339, we lift `linalg.generic` ops into `linalg.batch_matvec` with the `CastOpInterface` ops as separate producer ops. We need to keep the `CastOpInterface` ops as the producer of the `linalg.batch_matmul` ops in order to recognize this sequence of ops as a matmul with casted types in SetEncoding.