### PR TITLE
[Vulkan] Construct device queries for subgroup operations

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1250,6 +1250,20 @@ Value ExecutableVariantOp::buildCondition(Value device, OpBuilder &builder) {
   return selected;
 }
 
+Value ExecutableVariantOp::emplaceConditionOp(OpBuilder &builder) {
+  assert(!getConditionOp() && "Trying to emplace a condition on a variant that "
+                              "already has a condition.");
+
+  builder.setInsertionPointToStart(&getRegion().front());
+  // Create a default condition op.
+  auto conditionOp = builder.create<IREE::HAL::ExecutableConditionOp>(getLoc());
+  Block *entryPoint = conditionOp.addEntryBlock();
+  Value device = entryPoint->getArgument(0);
+
+  builder.setInsertionPointToStart(entryPoint);
+  return device;
+}
+
 //===----------------------------------------------------------------------===//
 // hal.executable.condition
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2168,6 +2168,10 @@ def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
 
     // Returns an i1 indicating whether this variant should be selected.
     Value buildCondition(Value device, OpBuilder &builder);
+
+    // Creates a new `hal.executable.condition` op and sets the insertion point
+    // for the provided builder to the beginning of the new region.
+    Value emplaceConditionOp(OpBuilder &builder);
   }];
 
   let hasCanonicalizer = 1;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -233,6 +233,14 @@ public:
   buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
                                OpPassManager &passManager) = 0;
 
+  // Constructs the necessary device queries to determine whether the target
+  // config is supported by the target device. This is optional if and only if
+  // the all devices configurations are always supported.
+  virtual LogicalResult
+  buildVariantConditionRegion(Operation *variantOp) const {
+    return success();
+  }
+
   // Inserts passes used to link `hal.executable.variant` ops together.
   // The pass manager will be nested on the parent module of `hal.executable`
   // ops and the pipeline will need to find relevant variant ops itself.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/BUILD.bazel
@@ -23,9 +23,11 @@ endif()
 iree_compiler_cc_library(
     name = "VulkanSPIRV",
     srcs = [
+        "VulkanSPIRVQueryBuilder.cpp",
         "VulkanSPIRVTarget.cpp",
     ],
     hdrs = [
+        "VulkanSPIRVQueryBuilder.h",
         "VulkanSPIRVTarget.h",
     ],
     deps = [
@@ -33,12 +35,14 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/SPIRV",
         "//compiler/src/iree/compiler/Codegen/Utils",
+        "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/Target",
         "//compiler/src/iree/compiler/Dialect/Vulkan/IR",
         "//compiler/src/iree/compiler/Dialect/Vulkan/Utils",
         "//compiler/src/iree/compiler/Utils",
         "//runtime/src/iree/schemas:spirv_executable_def_c_fbs",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:AsmParser",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
@@ -18,11 +18,14 @@ iree_cc_library(
   NAME
     VulkanSPIRV
   HDRS
+    "VulkanSPIRVQueryBuilder.h"
     "VulkanSPIRVTarget.h"
   SRCS
+    "VulkanSPIRVQueryBuilder.cpp"
     "VulkanSPIRVTarget.cpp"
   DEPS
     LLVMSupport
+    MLIRArithDialect
     MLIRAsmParser
     MLIRGPUDialect
     MLIRIR
@@ -34,6 +37,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::IREECodegenDialect
     iree::compiler::Codegen::SPIRV
     iree::compiler::Codegen::Utils
+    iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::Target
     iree::compiler::Dialect::Vulkan::IR
     iree::compiler::Dialect::Vulkan::Utils

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVQueryBuilder.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVQueryBuilder.cpp
@@ -1,0 +1,140 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVQueryBuilder.h"
+
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.h"
+#include "iree/compiler/Dialect/Vulkan/IR/VulkanDialect.h"
+#include "iree/compiler/Dialect/Vulkan/Utils/TargetEnvironment.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Value.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+// Return the subgroup feature bit according to the following table:
+//
+// VK_SUBGROUP_FEATURE_BASIC_BIT = 0x00000001
+// VK_SUBGROUP_FEATURE_VOTE_BIT = 0x00000002
+// VK_SUBGROUP_FEATURE_ARITHMETIC_BIT = 0x00000004
+// VK_SUBGROUP_FEATURE_BALLOT_BIT = 0x00000008
+// VK_SUBGROUP_FEATURE_SHUFFLE_BIT = 0x00000010
+// VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT = 0x00000020
+// VK_SUBGROUP_FEATURE_CLUSTERED_BIT = 0x00000040
+// VK_SUBGROUP_FEATURE_QUAD_BIT = 0x00000080
+// VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV = 0x00000100
+uint32_t processSubgroupCapability(spirv::Capability c) {
+  switch (c) {
+  case spirv::Capability::GroupNonUniform:
+    return 0x00000001;
+  case spirv::Capability::GroupNonUniformVote:
+    return 0x00000002;
+  case spirv::Capability::GroupNonUniformArithmetic:
+    return 0x00000004;
+  case spirv::Capability::GroupNonUniformBallot:
+    return 0x00000008;
+  case spirv::Capability::GroupNonUniformShuffle:
+    return 0x00000010;
+  case spirv::Capability::GroupNonUniformShuffleRelative:
+    return 0x00000020;
+  case spirv::Capability::GroupNonUniformClustered:
+    return 0x00000040;
+  case spirv::Capability::GroupNonUniformQuad:
+    return 0x00000080;
+  case spirv::Capability::GroupNonUniformPartitionedNV:
+    return 0x00000100;
+  default:
+    break;
+  }
+  return 0x00000000;
+}
+
+LogicalResult buildVulkanSPIRVDeviceRequirementQueries(
+    IREE::HAL::ExecutableVariantOp variantOp) {
+
+  MLIRContext *context = variantOp.getContext();
+  DictionaryAttr configuration = variantOp.getTarget().getConfiguration();
+  spirv::TargetEnvAttr defaultEnvAttr = convertTargetEnv(
+      Vulkan::getTargetEnvForTriple(context, "unknown-unknown-unknown"));
+  spirv::TargetEnv defaultEnv(defaultEnvAttr);
+
+  uint32_t subgroupCapabilities = 0x00000001;
+  auto hasModule = false;
+  variantOp.walk([&](spirv::ModuleOp spirvModuleOp) {
+    hasModule = true;
+    if (spirvModuleOp.getVceTriple()) {
+      for (spirv::Capability capability :
+           spirvModuleOp.getVceTriple()->getCapabilities()) {
+        // No need to check if already allowed by the default environment.
+        if (defaultEnv.allows(capability)) {
+          continue;
+        }
+        subgroupCapabilities |= processSubgroupCapability(capability);
+      }
+    }
+  });
+
+  // If there is no module present, assume this is an external dispatch. In this
+  // case we pessimistically use the capabilities/extensions specified on the
+  // variant target attribute.
+  if (!hasModule) {
+    StringAttr spvEnvName =
+        Builder(context).getStringAttr(spirv::getTargetEnvAttrName());
+    Attribute maybeSpvEnv = configuration.get(spvEnvName);
+    // If no attribute present, assume a default configuration.
+    if (!maybeSpvEnv) {
+      return success();
+    }
+    spirv::TargetEnvAttr variantTargetEnv =
+        dyn_cast<spirv::TargetEnvAttr>(maybeSpvEnv);
+    // There is a target env, but it isn't a SPIR-V one ...
+    if (!variantTargetEnv) {
+      return failure();
+    }
+
+    for (auto capability : variantTargetEnv.getCapabilities()) {
+      if (defaultEnv.allows(capability)) {
+        continue;
+      }
+      subgroupCapabilities |= processSubgroupCapability(capability);
+    }
+  }
+
+  // Check if nothing is needed beyond the basic bit.
+  if (subgroupCapabilities == 0x00000001) {
+    return success();
+  }
+
+  // Begin constructing the conditional region. We wait until the end to avoid
+  // creating unless needed.
+  OpBuilder builder(variantOp);
+  Value device = variantOp.emplaceConditionOp(builder);
+  Location loc = device.getLoc();
+
+  auto i1Type = builder.getI1Type();
+  auto subgroupQuery = builder.create<IREE::HAL::DeviceQueryOp>(
+      loc, i1Type, i1Type, device,
+      builder.getStringAttr("hal.device.vulkan.subgroup_operations"),
+      builder.getStringAttr(std::to_string(subgroupCapabilities)),
+      builder.getZeroAttr(i1Type));
+  // Verify that the query succeeds and indicates the correct support.
+  auto querySuccess = builder.create<arith::AndIOp>(
+      loc, subgroupQuery.getResult(0), subgroupQuery.getResult(1));
+  builder.create<IREE::HAL::ReturnOp>(loc, querySuccess.getResult());
+  return success();
+}
+
+} // namespace HAL
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVQueryBuilder.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVQueryBuilder.h
@@ -1,0 +1,31 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_HAL_TARGET_VULKANSPIRV_VULKANSPIRVQUERYBUILDER_H_
+#define IREE_COMPILER_DIALECT_HAL_TARGET_VULKANSPIRV_VULKANSPIRVQUERYBUILDER_H_
+
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Value.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+// Helper to build the required set of device queries to check whether the
+// device supports the given configuration.
+LogicalResult buildVulkanSPIRVDeviceRequirementQueries(
+    IREE::HAL::ExecutableVariantOp variantOp);
+
+} // namespace HAL
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir
+
+#endif // IREE_COMPILER_DIALECT_HAL_TARGET_VULKANSPIRV_VULKANSPIRVQUERYBUILDER_H_

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -5,9 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h"
+#include "iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVQueryBuilder.h"
 
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.h"
 #include "iree/compiler/Dialect/Vulkan/IR/VulkanDialect.h"
@@ -160,6 +162,14 @@ public:
       return;
 
     buildSPIRVCodegenPassPipeline(passManager, /*enableFastMath=*/false);
+  }
+
+  LogicalResult buildVariantConditionRegion(Operation *op) const override {
+    auto variantOp = dyn_cast<IREE::HAL::ExecutableVariantOp>(op);
+    if (!variantOp) {
+      return failure();
+    }
+    return buildVulkanSPIRVDeviceRequirementQueries(variantOp);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) override {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "query_device_support.mlir",
             "smoketest.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "query_device_support.mlir"
     "smoketest.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/query_device_support.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/query_device_support.mlir
@@ -1,0 +1,89 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(iree-hal-translate-executables))" %s | FileCheck %s
+
+hal.executable private @extern_dispatch_all_subgroup {
+  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<
+      #spirv.vce<v1.6, [
+        Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic,
+        GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative,
+        GroupNonUniformClustered, GroupNonUniformQuad], []>,
+        api=Vulkan, AMD:DiscreteGPU,
+        #spirv.resource_limits<>>}>)
+      objects([#hal.executable.object<{path = "/does/not/exist.spv"}>]) {
+    hal.executable.export public @main ordinal(0) layout(
+        #hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+            <0, storage_buffer, ReadOnly>,
+            <1, storage_buffer>
+          ]>]>) {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %c1 = arith.constant 1 : index 
+      hal.return %c1, %c1, %c1 : index, index, index 
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private @extern_dispatch_all_subgroup
+//       CHECK:  hal.executable.condition
+//  CHECK-SAME:    %[[DEVICE:.+]]: !hal.device) -> i1
+//       CHECK:    %[[OK:.+]], %[[QUERY:.+]] = hal.device.query<%arg0 : !hal.device> key("hal.device.vulkan.subgroup_operations" :: "255") : i1, i1 = false
+//       CHECK:    %[[SUCCESS:.+]] = arith.andi %[[OK]], %[[QUERY]] : i1
+//       CHECK:    hal.return %[[SUCCESS]] : i1
+
+// -----
+
+hal.executable private @extern_dispatch_ballot_vote {
+  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<
+      #spirv.vce<v1.6, [
+        Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformBallot], []>,
+        api=Vulkan, AMD:DiscreteGPU,
+        #spirv.resource_limits<>>}>)
+      objects([#hal.executable.object<{path = "/does/not/exist.spv"}>]) {
+    hal.executable.export public @main ordinal(0) layout(
+        #hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+            <0, storage_buffer, ReadOnly>,
+            <1, storage_buffer>
+          ]>]>) {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %c1 = arith.constant 1 : index 
+      hal.return %c1, %c1, %c1 : index, index, index 
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private @extern_dispatch_ballot_vote
+//       CHECK:  hal.executable.condition
+//  CHECK-SAME:    %[[DEVICE:.+]]: !hal.device) -> i1
+//       CHECK:    %[[OK:.+]], %[[QUERY:.+]] = hal.device.query<%arg0 : !hal.device> key("hal.device.vulkan.subgroup_operations" :: "11") : i1, i1 = false
+//       CHECK:    %[[SUCCESS:.+]] = arith.andi %[[OK]], %[[QUERY]] : i1
+//       CHECK:    hal.return %[[SUCCESS]] : i1
+
+// -----
+
+hal.executable private @extern_dispatch_ballot_vote {
+  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<
+      #spirv.vce<v1.6, [
+        Shader, GroupNonUniform], []>,
+        api=Vulkan, AMD:DiscreteGPU,
+        #spirv.resource_limits<>>}>)
+      objects([#hal.executable.object<{path = "/does/not/exist.spv"}>]) {
+    hal.executable.export public @main ordinal(0) layout(
+        #hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+            <0, storage_buffer, ReadOnly>,
+            <1, storage_buffer>
+          ]>]>) {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %c1 = arith.constant 1 : index 
+      hal.return %c1, %c1, %c1 : index, index, index 
+    }
+  }
+}
+
+// Verify that we do not construct a condition region when the only bit set is
+// the basic bit which is implied by the minimum supported SPIR-V version of 1.3
+// CHECK-LABEL: hal.executable private @extern_dispatch_ballot_vote
+//       CHECK-NOT:  hal.executable.condition

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -73,6 +73,19 @@ public:
                             << variantOp.getTarget();
       return signalPassFailure();
     }
+
+    // Currently this is run immediately after variant translation, but in
+    // the future there could be a deduplication phase between translation
+    // (or linking) and building the conditional region. This limits the
+    // amount of repetition in the decision trees for variant conditioning.
+    if (!variantOp.getConditionOp()) {
+      if (failed(targetBackend->buildVariantConditionRegion(variantOp))) {
+        variantOp.emitError()
+            << "failed to construct variant conditional region for backend "
+            << variantOp.getTarget();
+        return signalPassFailure();
+      }
+    }
   }
 
 private:

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
@@ -67,6 +67,23 @@ iree_hal_vulkan_instance_extensions_t
 iree_hal_vulkan_populate_enabled_instance_extensions(
     const iree_hal_vulkan_string_list_t* enabled_extension);
 
+// Struct for miscellaneous device capabilities.
+typedef struct iree_hal_vulkan_device_capabilities_t {
+  // VkSubgroupFeatureFlags from VkPhysicalDeviceSubgroupProperties showing
+  // the set of supported subgroup features. Corresponds to a mask of the
+  // following bitfield. The basic bit should always be set.
+  //   VK_SUBGROUP_FEATURE_BASIC_BIT = 0x00000001,
+  //   VK_SUBGROUP_FEATURE_VOTE_BIT = 0x00000002,
+  //   VK_SUBGROUP_FEATURE_ARITHMETIC_BIT = 0x00000004,
+  //   VK_SUBGROUP_FEATURE_BALLOT_BIT = 0x00000008,
+  //   VK_SUBGROUP_FEATURE_SHUFFLE_BIT = 0x00000010,
+  //   VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT = 0x00000020,
+  //   VK_SUBGROUP_FEATURE_CLUSTERED_BIT = 0x00000040,
+  //   VK_SUBGROUP_FEATURE_QUAD_BIT = 0x00000080,
+  //   VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV = 0x00000100,
+  uint32_t subgroup_operations;
+} iree_hal_vulkan_device_capabilities_t;
+
 // Bits for enabled device extensions.
 // We must use this to query support instead of just detecting symbol names as
 // ICDs will resolve the functions sometimes even if they don't support the

--- a/runtime/src/iree/hal/drivers/vulkan/handle_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/handle_util.h
@@ -41,12 +41,14 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
  public:
   VkDeviceHandle(DynamicSymbols* syms, VkPhysicalDevice physical_device,
                  iree_hal_vulkan_features_t enabled_features,
+                 iree_hal_vulkan_device_capabilities_t device_capabilities,
                  iree_hal_vulkan_device_extensions_t enabled_extensions,
                  bool owns_device, iree_allocator_t host_allocator,
                  const VkAllocationCallbacks* allocator = nullptr)
       : syms_(add_ref(syms)),
         physical_device_(physical_device),
         enabled_features_(enabled_features),
+        device_capabilities_(device_capabilities),
         enabled_extensions_(enabled_extensions),
         owns_device_(owns_device),
         allocator_(allocator),
@@ -61,6 +63,7 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
                      static_cast<VkPhysicalDevice>(VK_NULL_HANDLE))),
         value_(exchange(other.value_, static_cast<VkDevice>(VK_NULL_HANDLE))),
         syms_(std::move(other.syms_)),
+        device_capabilities_(other.device_capabilities_),
         enabled_extensions_(other.enabled_extensions_),
         owns_device_(other.owns_device_),
         allocator_(other.allocator_),
@@ -89,6 +92,10 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
     return enabled_features_;
   }
 
+  iree_hal_vulkan_device_capabilities_t device_capabilities() const {
+    return device_capabilities_;
+  }
+
   const iree_hal_vulkan_device_extensions_t& enabled_extensions() const {
     return enabled_extensions_;
   }
@@ -98,6 +105,7 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
   VkDevice value_ = VK_NULL_HANDLE;
   ref_ptr<DynamicSymbols> syms_;
   iree_hal_vulkan_features_t enabled_features_;
+  iree_hal_vulkan_device_capabilities_t device_capabilities_;
   iree_hal_vulkan_device_extensions_t enabled_extensions_;
   bool owns_device_;
   const VkAllocationCallbacks* allocator_ = nullptr;


### PR DESCRIPTION
This enables selecting between different variant ops in Vulkan based on runtime support for various subgroup operations. This silently ignores extensions/capabilities that doesn't yet have query handling yet, but no need to solve the whole world in one step.

Additionally, this adds an optional callback for target devices to construct this region, and is first prototyped for SPIR-V, but other backends will need similar implementations (minus VMVX).