### PR TITLE
Add missing header dep for bitcode file codegen

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -512,7 +512,8 @@ class BuildFileFunctions(object):
         name_block = self._convert_string_arg_block("NAME", name, quote=False)
         arch_block = self._convert_string_arg_block("ARCH", arch, quote=False)
         hdrs_block = self._convert_srcs_block(
-                internal_hdrs, name="INTERNAL_HDRS", allowed_suffix=".h")
+            internal_hdrs, name="INTERNAL_HDRS", allowed_suffix=".h"
+        )
         srcs_block = self._convert_srcs_block(srcs)
         copts_block = self._convert_string_list_block("COPTS", copts, sort=False)
 

--- a/build_tools/cmake/iree_bitcode_library.cmake
+++ b/build_tools/cmake/iree_bitcode_library.cmake
@@ -21,7 +21,7 @@ function(iree_bitcode_library)
     _RULE
     ""
     "NAME;OUT;ARCH"
-    "SRCS;COPTS"
+    "INTERNAL_HDRS;SRCS;COPTS"
     ${ARGN}
   )
 
@@ -86,6 +86,7 @@ function(iree_bitcode_library)
       DEPENDS
         "${IREE_CLANG_BINARY}"
         "${_SRC}"
+	"${_RULE_INTERNAL_HDRS}"
       COMMENT
         "Compiling ${_SRC} to ${_BITCODE_FILE}"
       VERBATIM

--- a/build_tools/cmake/iree_bitcode_library.cmake
+++ b/build_tools/cmake/iree_bitcode_library.cmake
@@ -86,7 +86,7 @@ function(iree_bitcode_library)
       DEPENDS
         "${IREE_CLANG_BINARY}"
         "${_SRC}"
-	"${_RULE_INTERNAL_HDRS}"
+        "${_RULE_INTERNAL_HDRS}"
       COMMENT
         "Compiling ${_SRC} to ${_BITCODE_FILE}"
       VERBATIM

--- a/runtime/src/iree/builtins/device/CMakeLists.txt
+++ b/runtime/src/iree/builtins/device/CMakeLists.txt
@@ -31,6 +31,8 @@ iree_bitcode_library(
     libdevice_wasm32_generic
   ARCH
     wasm_32
+  INTERNAL_HDRS
+    "device.h"
   SRCS
     "device_generic.c"
 )
@@ -40,6 +42,8 @@ iree_bitcode_library(
     libdevice_wasm64_generic
   ARCH
     wasm_64
+  INTERNAL_HDRS
+    "device.h"
   SRCS
     "device_generic.c"
 )

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
@@ -18,6 +18,12 @@ iree_bitcode_library(
     ukernel_bitcode_arm_64_entry_points
   ARCH
     wasm_64
+  INTERNAL_HDRS
+    "common_arm_64.h"
+    "common_arm_64_entry_point.h"
+    "mmt4d_arm_64_internal.h"
+    "pack_arm_64_internal.h"
+    "unpack_arm_64_internal.h"
   SRCS
     "mmt4d_arm_64_entry_point.c"
     "pack_arm_64_entry_point.c"
@@ -30,6 +36,12 @@ iree_bitcode_library(
     ukernel_bitcode_arm_64_base
   ARCH
     arm_64
+  INTERNAL_HDRS
+    "common_arm_64.h"
+    "common_arm_64_entry_point.h"
+    "mmt4d_arm_64_internal.h"
+    "pack_arm_64_internal.h"
+    "unpack_arm_64_internal.h"
   SRCS
     "mmt4d_arm_64.c"
     "pack_arm_64.c"
@@ -41,6 +53,12 @@ iree_bitcode_library(
     ukernel_bitcode_arm_64_fp16
   ARCH
     arm_64
+  INTERNAL_HDRS
+    "common_arm_64.h"
+    "common_arm_64_entry_point.h"
+    "mmt4d_arm_64_internal.h"
+    "pack_arm_64_internal.h"
+    "unpack_arm_64_internal.h"
   SRCS
     "mmt4d_arm_64_fp16.c"
   COPTS
@@ -52,6 +70,12 @@ iree_bitcode_library(
     ukernel_bitcode_arm_64_fp16fml
   ARCH
     arm_64
+  INTERNAL_HDRS
+    "common_arm_64.h"
+    "common_arm_64_entry_point.h"
+    "mmt4d_arm_64_internal.h"
+    "pack_arm_64_internal.h"
+    "unpack_arm_64_internal.h"
   SRCS
     "mmt4d_arm_64_fp16fml.c"
   COPTS
@@ -63,6 +87,12 @@ iree_bitcode_library(
     ukernel_bitcode_arm_64_bf16
   ARCH
     arm_64
+  INTERNAL_HDRS
+    "common_arm_64.h"
+    "common_arm_64_entry_point.h"
+    "mmt4d_arm_64_internal.h"
+    "pack_arm_64_internal.h"
+    "unpack_arm_64_internal.h"
   SRCS
     "mmt4d_arm_64_bf16.c"
   COPTS
@@ -74,6 +104,12 @@ iree_bitcode_library(
     ukernel_bitcode_arm_64_dotprod
   ARCH
     arm_64
+  INTERNAL_HDRS
+    "common_arm_64.h"
+    "common_arm_64_entry_point.h"
+    "mmt4d_arm_64_internal.h"
+    "pack_arm_64_internal.h"
+    "unpack_arm_64_internal.h"
   SRCS
     "mmt4d_arm_64_dotprod.c"
   COPTS
@@ -85,6 +121,12 @@ iree_bitcode_library(
     ukernel_bitcode_arm_64_i8mm
   ARCH
     arm_64
+  INTERNAL_HDRS
+    "common_arm_64.h"
+    "common_arm_64_entry_point.h"
+    "mmt4d_arm_64_internal.h"
+    "pack_arm_64_internal.h"
+    "unpack_arm_64_internal.h"
   SRCS
     "mmt4d_arm_64_i8mm.c"
   COPTS

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
@@ -18,6 +18,12 @@ iree_bitcode_library(
     ukernel_bitcode_x86_64_entry_points
   ARCH
     wasm_64
+  INTERNAL_HDRS
+    "common_x86_64.h"
+    "common_x86_64_entry_point.h"
+    "mmt4d_x86_64_internal.h"
+    "pack_x86_64_internal.h"
+    "unpack_x86_64_internal.h"
   SRCS
     "mmt4d_x86_64_entry_point.c"
     "pack_x86_64_entry_point.c"
@@ -30,6 +36,12 @@ iree_bitcode_library(
     ukernel_bitcode_x86_64_avx2_fma
   ARCH
     x86_64
+  INTERNAL_HDRS
+    "common_x86_64.h"
+    "common_x86_64_entry_point.h"
+    "mmt4d_x86_64_internal.h"
+    "pack_x86_64_internal.h"
+    "unpack_x86_64_internal.h"
   SRCS
     "mmt4d_x86_64_avx2_fma.c"
     "pack_x86_64_avx2_fma.c"
@@ -46,6 +58,12 @@ iree_bitcode_library(
     ukernel_bitcode_x86_64_avx512_base
   ARCH
     x86_64
+  INTERNAL_HDRS
+    "common_x86_64.h"
+    "common_x86_64_entry_point.h"
+    "mmt4d_x86_64_internal.h"
+    "pack_x86_64_internal.h"
+    "unpack_x86_64_internal.h"
   SRCS
     "mmt4d_x86_64_avx512_base.c"
     "pack_x86_64_avx512_base.c"
@@ -67,6 +85,12 @@ iree_bitcode_library(
     ukernel_bitcode_x86_64_avx512_vnni
   ARCH
     x86_64
+  INTERNAL_HDRS
+    "common_x86_64.h"
+    "common_x86_64_entry_point.h"
+    "mmt4d_x86_64_internal.h"
+    "pack_x86_64_internal.h"
+    "unpack_x86_64_internal.h"
   SRCS
     "mmt4d_x86_64_avx512_vnni.c"
   COPTS
@@ -87,6 +111,12 @@ iree_bitcode_library(
     ukernel_bitcode_x86_64_avx512_bf16
   ARCH
     x86_64
+  INTERNAL_HDRS
+    "common_x86_64.h"
+    "common_x86_64_entry_point.h"
+    "mmt4d_x86_64_internal.h"
+    "pack_x86_64_internal.h"
+    "unpack_x86_64_internal.h"
   SRCS
     "mmt4d_x86_64_avx512_bf16.c"
   COPTS


### PR DESCRIPTION
The bazel to CMake converter currently ignores internal headers when setting CMake dependencies in rules to build bitcode files. This commit goes toward addressing this problem by adding direct header dependencies. Header dependencies through rules is left for a future patch.