### PR TITLE
Disable Pixel 4 e2e regression benchmarks

### DIFF
--- a/build_tools/python/e2e_test_framework/device_specs/device_collections.py
+++ b/build_tools/python/e2e_test_framework/device_specs/device_collections.py
@@ -52,10 +52,6 @@ class DeviceCollection(object):
 
 
 ALL_DEVICE_SPECS = [
-    # Pixel 4
-    pixel_4_specs.LITTLE_CORES,
-    pixel_4_specs.BIG_CORES,
-    pixel_4_specs.ALL_CORES,
     # Pixel 6 Pro
     pixel_6_pro_specs.LITTLE_CORES,
     pixel_6_pro_specs.BIG_CORES,


### PR DESCRIPTION
We are not currently actively looking into performance on Pixel 4. Disable it in regression tracking to save resources.

We will still run tests on Pixel 4.