### PR TITLE
Fix some broken links to benchmark_suites.md.

### DIFF
--- a/build_tools/benchmarks/README.md
+++ b/build_tools/benchmarks/README.md
@@ -1,5 +1,5 @@
 # IREE Benchmark Tools
 
 See
-[IREE Benchmark Suites](/docs/developers/developing_iree/benchmark_suites.md) to
-learn how to run benchmarks locally with the tools under this directory.
+[Benchmark suites](https://iree.dev/developers/performance/benchmark-suites/)
+to learn how to run benchmarks locally with the tools under this directory.

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -6,8 +6,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Collect compilation statistics from benchmark suites.
 
-See docs/developers/developing_iree/benchmark_suites.md for how to build the
-benchmark suites.
+See https://iree.dev/developers/performance/benchmark-suites/ for how to build
+the benchmark suites.
 """
 
 import pathlib

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Utilities for handling the benchmark suite.
 
-See docs/developers/developing_iree/benchmark_suites.md for how to build the
-benchmark suite.
+See https://iree.dev/developers/performance/benchmark-suites/ for how to build
+the benchmark suite.
 """
 
 import pathlib


### PR DESCRIPTION
Related to https://github.com/openxla/iree/issues/15408

Missed these with my regex search across the repo (had `benchmarks/` folders excluded from a prior search :P)

skip-ci: comment-only change