### PR TITLE
Dump CPU .o files with `--iree-hal-dump-executable-intermediates-to=`.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -669,6 +669,10 @@ public:
         return variantOp.emitError()
                << "failed to compile LLVM-IR module to an object file";
       }
+      if (!options.dumpIntermediatesPath.empty()) {
+        dumpDataToPath(options.dumpIntermediatesPath, options.dumpBaseName,
+                       variantOp.getName(), ".o", objectData);
+      }
       auto objectFile = Artifact::createTemporary(libraryName, "o");
       auto &os = objectFile.outputFile->os();
       os << objectData;


### PR DESCRIPTION
This allows all useful files to be inspected via the standard flag. `--iree-llvmcpu-keep-linker-artifacts` is still useful if trying to reproduce linker command lines as it'll have the exact temp paths and additional object files a copy-paste command line from a link error would need but otherwise when just inspecting dispatches the .s and .o should be sufficient.