### PR TITLE
Add icons and tags to most website/docs/developers/ pages.

### DIFF
--- a/docs/website/docs/developers/building/bazel.md
+++ b/docs/website/docs/developers/building/bazel.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/sliders-16
+---
+
 # Building with Bazel
 
 This page walks through building IREE from source using the

--- a/docs/website/docs/developers/building/cmake-options.md
+++ b/docs/website/docs/developers/building/cmake-options.md
@@ -1,6 +1,10 @@
-# CMake options and variables
+---
+icon: simple/cmake
+---
 
-## Frequently-used CMake variables
+# CMake options
+
+## Frequently-used CMake options
 
 ### `CMAKE_BUILD_TYPE`
 
@@ -17,7 +21,7 @@ This is the command that will be used as the `<LANG>` compiler, which are `C`
 and `CXX` in IREE. These variables are set to compile IREE with `clang` or
 rather `clang++`. Once set, these variables can not be changed.
 
-## IREE-specific CMake options and variables
+## IREE-specific CMake options
 
 This gives a brief explanation of IREE specific CMake options and variables.
 

--- a/docs/website/docs/developers/building/cmake-with-ccache.md
+++ b/docs/website/docs/developers/building/cmake-with-ccache.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/rocket-16
+---
+
 # CMake with `ccache`
 
 [`ccache`](https://ccache.dev/) is a compilation cache. In principle, just

--- a/docs/website/docs/developers/building/cmake-with-ccache.md
+++ b/docs/website/docs/developers/building/cmake-with-ccache.md
@@ -1,5 +1,5 @@
 ---
-icon: octicons/rocket-16
+icon: simple/cmake
 ---
 
 # CMake with `ccache`

--- a/docs/website/docs/developers/building/emscripten.md
+++ b/docs/website/docs/developers/building/emscripten.md
@@ -1,3 +1,11 @@
+---
+hide:
+  - tags
+tags:
+  - Web
+icon: simple/webassembly
+---
+
 # Building with Emscripten
 
 [Emscripten](https://emscripten.org/index.html) is a complete compiler

--- a/docs/website/docs/developers/debugging/android-with-lldb.md
+++ b/docs/website/docs/developers/debugging/android-with-lldb.md
@@ -1,7 +1,15 @@
-# Android debugging with LLDB
+---
+hide:
+  - tags
+tags:
+  - Android
+icon: simple/android
+---
 
-This doc shows how to use LLDB to debug native binaries on Android. For a more
-complete explanation, see the
+# Android LLDB debugging
+
+This doc shows how to use [LLDB](https://lldb.llvm.org/index.html) to debug
+native binaries on Android. For a more complete explanation, see the
 [official LLDB documentation on remote debugging](https://lldb.llvm.org/use/remote.html).
 
 ## Prerequisites

--- a/docs/website/docs/developers/debugging/compile-time-regressions.md
+++ b/docs/website/docs/developers/debugging/compile-time-regressions.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/bug-16
+---
+
 # Compile time regression debugging
 
 So the IREE compiler used to compile a program quickly, but it is now slower.

--- a/docs/website/docs/developers/debugging/integration-tests.md
+++ b/docs/website/docs/developers/debugging/integration-tests.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/bug-16
+---
+
 # Integration test debugging
 
 This document includes tips for triaging integration test correctness issues.

--- a/docs/website/docs/developers/debugging/releases.md
+++ b/docs/website/docs/developers/debugging/releases.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/package-16
+---
+
 # Release debugging playbook
 
 ## Tools and Locations

--- a/docs/website/docs/developers/debugging/sanitizers.md
+++ b/docs/website/docs/developers/debugging/sanitizers.md
@@ -1,3 +1,7 @@
+---
+icon: material/broom
+---
+
 # Sanitizers (ASan/MSan/TSan)
 
 [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html),

--- a/docs/website/docs/developers/design-docs/cuda-backend.md
+++ b/docs/website/docs/developers/design-docs/cuda-backend.md
@@ -1,4 +1,12 @@
-# CUDA backend
+---
+hide:
+  - tags
+tags:
+  - GPU
+  - CUDA
+---
+
+# CUDA backend design
 
 !!! note - "Authored March, 2021"
 

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/code-review-16
+---
+
 # Contributing
 
 This is a more detailed version of the top-level

--- a/docs/website/docs/developers/general/developer-overview.md
+++ b/docs/website/docs/developers/general/developer-overview.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/book-16
+---
+
 # Developer overview
 
 This guide provides an overview of IREE's project structure and main tools for

--- a/docs/website/docs/developers/general/developer-tips.md
+++ b/docs/website/docs/developers/general/developer-tips.md
@@ -1,7 +1,6 @@
-<!-- TODO(scotttodd): add icons to all developers/ pages -->
-<!-- ---
+---
 icon: material/lightbulb-on
---- -->
+---
 
 # Developer tips and tricks
 

--- a/docs/website/docs/developers/general/release-management.md
+++ b/docs/website/docs/developers/general/release-management.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/package-16
+---
+
 # Release management
 
 IREE cuts automated releases via a workflow that is

--- a/docs/website/docs/developers/general/testing-guide.md
+++ b/docs/website/docs/developers/general/testing-guide.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/code-16
+---
+
 # Testing guide
 
 Like the IREE project in general, IREE tests are divided into a few different

--- a/docs/website/docs/developers/performance/benchmark-suites.md
+++ b/docs/website/docs/developers/performance/benchmark-suites.md
@@ -1,5 +1,5 @@
 ---
-icon: octicons/stack-16
+icon: simple/speedtest
 ---
 
 # Benchmark suites

--- a/docs/website/docs/developers/performance/benchmark-suites.md
+++ b/docs/website/docs/developers/performance/benchmark-suites.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/stack-16
+---
+
 # Benchmark suites
 
 IREE Benchmarks Suites is a collection of benchmarks for IREE developers to

--- a/docs/website/docs/developers/performance/benchmarking.md
+++ b/docs/website/docs/developers/performance/benchmarking.md
@@ -1,3 +1,7 @@
+---
+icon: simple/speedtest
+---
+
 # Benchmarking
 
 IREE uses benchmarks to inspect performance at varying levels of granularity.

--- a/docs/website/docs/developers/performance/profiling-cpu-events.md
+++ b/docs/website/docs/developers/performance/profiling-cpu-events.md
@@ -1,3 +1,11 @@
+---
+hide:
+  - tags
+tags:
+  - CPU
+icon: material/chart-line
+---
+
 # Profiling CPUs
 
 CPUs are able to

--- a/docs/website/docs/developers/performance/profiling-gpu-vulkan.md
+++ b/docs/website/docs/developers/performance/profiling-gpu-vulkan.md
@@ -1,3 +1,12 @@
+---
+hide:
+  - tags
+tags:
+  - GPU
+  - Vulkan
+icon: material/chart-line
+---
+
 # Profiling GPUs using Vulkan
 
 [Tracy](./profiling-with-tracy.md) offers great insights into CPU/GPU

--- a/docs/website/docs/developers/performance/profiling-with-tracy.md
+++ b/docs/website/docs/developers/performance/profiling-with-tracy.md
@@ -1,3 +1,7 @@
+---
+icon: material/chart-line
+---
+
 # Profiling with Tracy
 
 [Tracy](https://github.com/wolfpld/tracy) is a profiler that puts together in a

--- a/docs/website/docs/developers/performance/profiling.md
+++ b/docs/website/docs/developers/performance/profiling.md
@@ -1,5 +1,5 @@
 ---
-icon: octicons/bookmark-16
+icon: material/chart-line
 ---
 
 # Profiling overview

--- a/docs/website/docs/developers/performance/profiling.md
+++ b/docs/website/docs/developers/performance/profiling.md
@@ -1,3 +1,7 @@
+---
+icon: octicons/bookmark-16
+---
+
 # Profiling overview
 
 IREE [benchmarking](./benchmarking.md) gives us an accurate and reproducible
@@ -5,10 +9,12 @@ view of program performance at specific levels of granularity. To analyze system
 behavior in more depth, there are various ways to
 [profile](https://en.wikipedia.org/wiki/Profiling_(computer_programming)) IREE.
 
-## Tracy
+## CPU cache and other CPU event profiling
 
-Tracy is a profiler that's been used for a wide range of profiling tasks on
-IREE. Refer to [Profiling with Tracy](./profiling-with-tracy.md).
+For some advanced CPU profiling needs such as querying CPU cache and other
+events, one may need to use some OS-specific profilers. See
+[Profiling CPUs](./profiling-cpu-events.md).
+
 
 ## Vulkan GPU Profiling
 
@@ -18,8 +24,7 @@ granularity, especially inside a particular shader dispatch, is missing. To
 supplement general purpose tools like Tracy, vendor-specific tools can be used.
 Refer to [Profiling GPUs using Vulkan](./profiling-gpu-vulkan.md).
 
-## CPU cache and other CPU event profiling
+## Tracy
 
-For some advanced CPU profiling needs such as querying CPU cache and other
-events, one may need to use some OS-specific profilers. See
-[Profiling CPUs](./profiling-cpu-events.md).
+Tracy is a profiler that's been used for a wide range of profiling tasks on
+IREE. Refer to [Profiling with Tracy](./profiling-with-tracy.md).

--- a/docs/website/docs/developers/performance/profiling.md
+++ b/docs/website/docs/developers/performance/profiling.md
@@ -15,7 +15,6 @@ For some advanced CPU profiling needs such as querying CPU cache and other
 events, one may need to use some OS-specific profilers. See
 [Profiling CPUs](./profiling-cpu-events.md).
 
-
 ## Vulkan GPU Profiling
 
 [Tracy](./profiling-with-tracy.md) offers great insights into CPU/GPU

--- a/docs/website/docs/developers/usage-best-practices.md
+++ b/docs/website/docs/developers/usage-best-practices.md
@@ -1,3 +1,7 @@
+---
+icon: material/lightbulb-on
+---
+
 # Usage best practices
 
 This page contains a list of best practices for getting the most out of IREE,

--- a/docs/website/docs/developers/vulkan-environment-setup.md
+++ b/docs/website/docs/developers/vulkan-environment-setup.md
@@ -1,3 +1,12 @@
+---
+hide:
+  - tags
+tags:
+  - GPU
+  - Vulkan
+icon: octicons/server-16
+---
+
 # Vulkan environment setup
 
 [Vulkan](https://www.khronos.org/vulkan/) is a new generation graphics and

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -178,7 +178,7 @@ nav:
       - "Building":
           - "developers/building/bazel.md"
           - "developers/building/emscripten.md"
-          - "developers/building/cmake-options-and-variables.md"
+          - "developers/building/cmake-options.md"
           - "developers/building/cmake-with-ccache.md"
       - "Debugging":
           - "developers/debugging/android-with-lldb.md"
@@ -258,3 +258,4 @@ plugins:
 
         # "Developers" section was added
         "guides/developer-tips.md": "developers/general/developer-tips.md"
+        "developers/building/cmake-options-and-variables.md": "developers/building/cmake-options.md"


### PR DESCRIPTION
Might be a little too busy? Thoughts? Could reuse icons more in each group.

| before | after 1 | after 2
| -- | -- | -- |
| ![image](https://github.com/openxla/iree/assets/4010439/55053e53-0a80-41e1-92d2-a55881332132) | ![image](https://github.com/openxla/iree/assets/4010439/cc21bfad-3682-4364-a88c-48829caa6bcf) | ![image](https://github.com/openxla/iree/assets/4010439/6071483a-1335-448f-871c-2835fad0852d)

