### PR TITLE
Add `iree-dump-parameters` to test `tools = []`.

### DIFF
--- a/tools/test/BUILD.bazel
+++ b/tools/test/BUILD.bazel
@@ -60,6 +60,7 @@ iree_lit_test_suite(
         "//tools:iree-benchmark-module",
         "//tools:iree-benchmark-trace",
         "//tools:iree-compile",
+        "//tools:iree-dump-parameters",
         "//tools:iree-opt",
         "//tools:iree-run-mlir",
         "//tools:iree-run-module",

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_lit_test_suite(
     iree-benchmark-module
     iree-benchmark-trace
     iree-compile
+    iree-dump-parameters
     iree-opt
     iree-run-mlir
     iree-run-module


### PR DESCRIPTION
ci-exactly: build_test_all_bazel