### PR TITLE
Ignore Clangd configuration files for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,9 @@ imgui.ini
 # Source indexing files
 compile_commands.json
 .cache/clangd
-.clangd/
+
+# Language server configuration files
+.clangd
 
 # Pyenv files
 .python-version


### PR DESCRIPTION
We don't have a shared .clangd file for the whole project yet; ignore personal ones for now.

Also per the doc of clangd, "existing directories named .clangd can be deleted. These were used for temporary storage by clangd before version 11."