### PR TITLE
Adding support for splat entries in parameter indices.

### DIFF
--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -405,6 +405,21 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_dealloca(
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_hal_buffer_t* buffer);
 
+// Enqueues a single queue-ordered fill operation.
+//
+// WARNING: individual fills have a high overhead and batching should be
+// performed by the caller instead of calling this multiple times. The
+// iree_hal_create_transfer_command_buffer utility makes it easy to create
+// batches of transfer operations (fill, copy, update) and is only a few lines
+// more code.
+IREE_API_EXPORT iree_status_t iree_hal_device_queue_fill(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, const void* pattern,
+    iree_host_size_t pattern_length);
+
 // Enqueues a single queue-ordered copy operation.
 //
 // WARNING: individual copies have a high overhead and batching should be

--- a/runtime/src/iree/io/formats/gguf/gguf_format.c
+++ b/runtime/src/iree/io/formats/gguf/gguf_format.c
@@ -534,9 +534,16 @@ static iree_status_t iree_io_gguf_append_tensor_info(
   iree_io_parameter_index_entry_t entry = {
       .key = tensor_info->name,
       .metadata = iree_const_byte_span_empty(),
-      .file_handle = parser->file_handle,
-      .offset = parser->tensor_data_offset + begin,
       .length = storage_size,
+      .type = IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_FILE,
+      .storage =
+          {
+              .file =
+                  {
+                      .handle = parser->file_handle,
+                      .offset = parser->tensor_data_offset + begin,
+                  },
+          },
   };
   return iree_io_parameter_index_add(parser->index, &entry);
 }

--- a/runtime/src/iree/io/formats/gguf/gguf_format_test.cc
+++ b/runtime/src/iree/io/formats/gguf/gguf_format_test.cc
@@ -59,7 +59,7 @@ TEST(GgufFormatTest, SingleTensor) {
       iree_io_parameter_index_lookup(index, IREE_SV("tensor0"), &entry0));
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor0"), entry0->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry0->metadata));
-  EXPECT_EQ(entry0->offset, 384);
+  EXPECT_EQ(entry0->storage.file.offset, 384);
   EXPECT_EQ(entry0->length, 16);
 
   iree_io_parameter_index_release(index);
@@ -79,7 +79,7 @@ TEST(GgufFormatTest, MultipleTensors) {
       iree_io_parameter_index_lookup(index, IREE_SV("tensor0"), &entry0));
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor0"), entry0->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry0->metadata));
-  EXPECT_EQ(entry0->offset, 448);
+  EXPECT_EQ(entry0->storage.file.offset, 448);
   EXPECT_EQ(entry0->length, 16);
 
   const iree_io_parameter_index_entry_t* entry1 = NULL;
@@ -87,7 +87,7 @@ TEST(GgufFormatTest, MultipleTensors) {
       iree_io_parameter_index_lookup(index, IREE_SV("tensor1"), &entry1));
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor1"), entry1->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry1->metadata));
-  EXPECT_EQ(entry1->offset, 512);
+  EXPECT_EQ(entry1->storage.file.offset, 512);
   EXPECT_EQ(entry1->length, 8);
 
   const iree_io_parameter_index_entry_t* entry2 = NULL;
@@ -95,7 +95,7 @@ TEST(GgufFormatTest, MultipleTensors) {
       iree_io_parameter_index_lookup(index, IREE_SV("tensor2"), &entry2));
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor2"), entry2->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry2->metadata));
-  EXPECT_EQ(entry2->offset, 576);
+  EXPECT_EQ(entry2->storage.file.offset, 576);
   EXPECT_EQ(entry2->length, 48);
 
   iree_io_parameter_index_release(index);

--- a/runtime/src/iree/io/formats/safetensors/safetensors_format.c
+++ b/runtime/src/iree/io/formats/safetensors/safetensors_format.c
@@ -441,9 +441,16 @@ static iree_status_t iree_io_enumerate_safetensors_entries(
   iree_io_parameter_index_entry_t entry = {
       .key = key,
       .metadata = iree_const_byte_span_empty(),
-      .file_handle = entry_state->file_handle,
-      .offset = entry_state->base_offset + begin,
       .length = end - begin,
+      .type = IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_FILE,
+      .storage =
+          {
+              .file =
+                  {
+                      .handle = entry_state->file_handle,
+                      .offset = entry_state->base_offset + begin,
+                  },
+          },
   };
   return iree_io_parameter_index_add(entry_state->index, &entry);
 }

--- a/runtime/src/iree/io/formats/safetensors/safetensors_format_test.cc
+++ b/runtime/src/iree/io/formats/safetensors/safetensors_format_test.cc
@@ -59,7 +59,7 @@ TEST(SafetensorsFormatTest, SingleTensor) {
       iree_io_parameter_index_lookup(index, IREE_SV("tensor0"), &entry0));
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor0"), entry0->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry0->metadata));
-  EXPECT_EQ(entry0->offset, 72);
+  EXPECT_EQ(entry0->storage.file.offset, 72);
   EXPECT_EQ(entry0->length, 16);
 
   iree_io_parameter_index_release(index);
@@ -79,7 +79,7 @@ TEST(SafetensorsFormatTest, MultipleTensors) {
       iree_io_parameter_index_lookup(index, IREE_SV("tensor0"), &entry0));
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor0"), entry0->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry0->metadata));
-  EXPECT_EQ(entry0->offset, 200);
+  EXPECT_EQ(entry0->storage.file.offset, 200);
   EXPECT_EQ(entry0->length, 16);
 
   const iree_io_parameter_index_entry_t* entry1 = NULL;
@@ -87,7 +87,7 @@ TEST(SafetensorsFormatTest, MultipleTensors) {
       iree_io_parameter_index_lookup(index, IREE_SV("tensor1"), &entry1));
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor1"), entry1->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry1->metadata));
-  EXPECT_EQ(entry1->offset, 216);
+  EXPECT_EQ(entry1->storage.file.offset, 216);
   EXPECT_EQ(entry1->length, 8);
 
   const iree_io_parameter_index_entry_t* entry2 = NULL;
@@ -95,7 +95,7 @@ TEST(SafetensorsFormatTest, MultipleTensors) {
       iree_io_parameter_index_lookup(index, IREE_SV("tensor2"), &entry2));
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor2"), entry2->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry2->metadata));
-  EXPECT_EQ(entry2->offset, 224);
+  EXPECT_EQ(entry2->storage.file.offset, 224);
   EXPECT_EQ(entry2->length, 48);
 
   iree_io_parameter_index_release(index);


### PR DESCRIPTION
Parameters can now either be backed by a file or a splat pattern. Splat parameters are read-only as no storage is reserved for them. This PR adds the handling of different entry types and allows parameter index users to declare them but does not yet add support for producing these via in-tree tools.

Progress on #14987.