### PR TITLE
[gpu] NFC: Tidy up the VectorReduceToGPU pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -83,9 +83,9 @@ def GPUTileReduction :
   let constructor = "mlir::iree_compiler::createGPUTileReductionPass()";
 }
 
-def VectorReduceToGPU :
-    Pass<"iree-codegen-reduction-to-gpu", "func::FuncOp"> {
-  let summary = "Convert vector reduction to gpu ops.";
+def VectorReductionToGPU :
+    Pass<"iree-codegen-vector-reduction-to-gpu", "func::FuncOp"> {
+  let summary = "Convert vector reduction to GPU ops.";
   let constructor = "mlir::iree_compiler::createConvertVectorReductionToGPUPass()";
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "gpu_tile_reduction.mlir",
             "reduce_bank_conflicts.mlir",
             "transform_gpu_workgroup_swizzle.mlir",
+            "vector_reduction_to_gpu.mlir",
         ],
         include = ["*.mlir"],
         exclude = [

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_lit_test_suite(
     "gpu_workgroup_swizzle.mlir"
     "reduce_bank_conflicts.mlir"
     "transform_gpu_workgroup_swizzle.mlir"
+    "vector_reduction_to_gpu.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reduction-to-gpu, cse)))))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-vector-reduction-to-gpu, cse)))))' %s | FileCheck %s
 
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -66,7 +66,6 @@ iree_lit_test_suite(
             "type_propagation.mlir",
             "type_propagation_packing.mlir",
             "vectorize_tensor_pad.mlir",
-            "warp_reduction.mlir",
             "workgroup_specialization.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -62,7 +62,6 @@ iree_lit_test_suite(
     "type_propagation.mlir"
     "type_propagation_packing.mlir"
     "vectorize_tensor_pad.mlir"
-    "warp_reduction.mlir"
     "workgroup_specialization.mlir"
   TOOLS
     FileCheck


### PR DESCRIPTION
1. Make pass/debug/file name consistent.
2. Improve debugging print.