### PR TITLE
[spirv] Fix bufferization allocation in subgroup reduction pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -565,7 +565,7 @@ void addSPIRVSubgroupReducePassPipeline(OpPassManager &pm) {
 
   // Bufferize and distribute.
   // We bufferize before distributing to threads there; so we are still at the
-  // block level. Therefore, need to allocate shared memory.
+  // block level. Therefore, need to allocate workgroup memory.
   addSPIRVBufferizePasses(nestedModulePM, gpuAllocateWorkgroupMemoryFn);
 
   // Perform various vector-level cross-op optimizations like load-store

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -564,7 +564,7 @@ void addSPIRVSubgroupReducePassPipeline(OpPassManager &pm) {
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
 
   // Bufferize and distribute.
-  addSPIRVBufferizePasses(nestedModulePM, gpuAllocateFunctionMemoryFn);
+  addSPIRVBufferizePasses(nestedModulePM, gpuAllocateWorkgroupMemoryFn);
 
   // Perform various vector-level cross-op optimizations like load-store
   // forwarding, shape casting and casting op cancelling.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -564,6 +564,8 @@ void addSPIRVSubgroupReducePassPipeline(OpPassManager &pm) {
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
 
   // Bufferize and distribute.
+  // We bufferize before distributing to threads there; so we are still at the
+  // block level. Therefore, need to allocate shared memory.
   addSPIRVBufferizePasses(nestedModulePM, gpuAllocateWorkgroupMemoryFn);
 
   // Perform various vector-level cross-op optimizations like load-store


### PR DESCRIPTION
We bufferize before distributing to threads there; so we are still at the block level; therefore need to allocate shared memory.