### PR TITLE
Temporarily disable Pixel 6 tests and benchmarks

### DIFF
--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -101,8 +101,8 @@ jobs:
             | (.value.shards | length) as $count
             | .value.shards[]
             | {$device_name, $host_environment, shard: {index, $count}}
-            ]
-            | select(.device_name != "pixel-6-pro")' "${BENCHMARK_CONFIG}")" >> "${GITHUB_OUTPUT}"
+            | select(.device_name != "pixel-6-pro")
+            ]' "${BENCHMARK_CONFIG}")" >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:
     needs: [generate_matrix]

--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -94,13 +94,15 @@ jobs:
           #     },
           #     ...
           #   ]
+          # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
           echo benchmark-matrix="$(jq -c '[ . | to_entries[]
             | .key as $device_name
             | .value.host_environment as $host_environment
             | (.value.shards | length) as $count
             | .value.shards[]
             | {$device_name, $host_environment, shard: {index, $count}}
-            ]' "${BENCHMARK_CONFIG}")" >> "${GITHUB_OUTPUT}"
+            ]
+            | select(.device_name != "pixel-6-pro")' "${BENCHMARK_CONFIG}")" >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:
     needs: [generate_matrix]

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -115,8 +115,9 @@ jobs:
           # triggered by our tests. Disable running tests entirely on Pixel 4.
           - device-name: pixel-4
             label-exclude: "vulkan"
-          - device-name: pixel-6-pro
-            label-exclude: "^requires-gpu"
+          # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
+          # - device-name: pixel-6-pro
+          #   label-exclude: "^requires-gpu"
           - device-name: moto-edge-x30
             label-exclude: "^requires-gpu"
     name: test_on_${{ matrix.target.device-name }}

--- a/build_tools/python/e2e_test_framework/device_specs/device_collections.py
+++ b/build_tools/python/e2e_test_framework/device_specs/device_collections.py
@@ -53,10 +53,11 @@ class DeviceCollection(object):
 
 ALL_DEVICE_SPECS = [
     # Pixel 6 Pro
-    pixel_6_pro_specs.LITTLE_CORES,
-    pixel_6_pro_specs.BIG_CORES,
-    pixel_6_pro_specs.ALL_CORES,
-    pixel_6_pro_specs.GPU,
+    # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
+    # pixel_6_pro_specs.LITTLE_CORES,
+    # pixel_6_pro_specs.BIG_CORES,
+    # pixel_6_pro_specs.ALL_CORES,
+    # pixel_6_pro_specs.GPU,
     # Moto Edge X30
     moto_edge_x30_specs.GPU,
     # GCP machines

--- a/build_tools/python/e2e_test_framework/device_specs/device_collections.py
+++ b/build_tools/python/e2e_test_framework/device_specs/device_collections.py
@@ -53,11 +53,10 @@ class DeviceCollection(object):
 
 ALL_DEVICE_SPECS = [
     # Pixel 6 Pro
-    # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
-    # pixel_6_pro_specs.LITTLE_CORES,
-    # pixel_6_pro_specs.BIG_CORES,
-    # pixel_6_pro_specs.ALL_CORES,
-    # pixel_6_pro_specs.GPU,
+    pixel_6_pro_specs.LITTLE_CORES,
+    pixel_6_pro_specs.BIG_CORES,
+    pixel_6_pro_specs.ALL_CORES,
+    pixel_6_pro_specs.GPU,
     # Moto Edge X30
     moto_edge_x30_specs.GPU,
     # GCP machines


### PR DESCRIPTION
Temporarily disable Pixel 6 tests and benchmarks to unblock the CI build on the main branch

ci-extra: build_and_test_android