### PR TITLE
Support fetching and streaming artifacts in benchmark tools

### DIFF
--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -94,14 +94,12 @@ jobs:
           #     },
           #     ...
           #   ]
-          # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
           echo benchmark-matrix="$(jq -c '[ . | to_entries[]
             | .key as $device_name
             | .value.host_environment as $host_environment
             | (.value.shards | length) as $count
             | .value.shards[]
             | {$device_name, $host_environment, shard: {index, $count}}
-            | select(.device_name != "pixel-6-pro")
             ]' "${BENCHMARK_CONFIG}")" >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:

--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -94,12 +94,14 @@ jobs:
           #     },
           #     ...
           #   ]
+          # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
           echo benchmark-matrix="$(jq -c '[ . | to_entries[]
             | .key as $device_name
             | .value.host_environment as $host_environment
             | (.value.shards | length) as $count
             | .value.shards[]
             | {$device_name, $host_environment, shard: {index, $count}}
+            | select(.device_name != "pixel-6-pro")
             ]' "${BENCHMARK_CONFIG}")" >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:

--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -127,7 +127,6 @@ jobs:
       SHARD_COUNT: ${{ matrix.benchmark.shard.count }}
       PLATFORM_ARCH: ${{ matrix.benchmark.host_environment.platform }}-${{ matrix.benchmark.host_environment.architecture }}
       E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ inputs.e2e-test-artifacts-gcs-artifact-dir }}
-      E2E_TEST_ARTIFACTS_DIR: ${{ inputs.e2e-test-artifacts-dir }}
       BENCHMARK_RESULTS_DIR: benchmark-results
     outputs:
       benchmark-results-dir: ${{ env.BENCHMARK_RESULTS_DIR }}
@@ -153,14 +152,6 @@ jobs:
         id: download-assets
         run: |
           gcloud storage cp "${BENCHMARK_CONFIG_GCS_ARTIFACT}" "${BENCHMARK_CONFIG}"
-          mkdir -p "${E2E_TEST_ARTIFACTS_DIR}"
-          jq -r \
-            --arg DEVICE_NAME "${DEVICE_NAME}" \
-            --arg SHARD_INDEX "${SHARD_INDEX}" \
-            --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
-            '.[$DEVICE_NAME].shards[($SHARD_INDEX | tonumber)] | .module_dir_paths[] | "\($GCS_ARTIFACT_DIR)/\(.)"' \
-            "${BENCHMARK_CONFIG}" | \
-            gcloud storage cp -r --read-paths-from-stdin "${E2E_TEST_ARTIFACTS_DIR}"
           echo "benchmark-config=${BENCHMARK_CONFIG}" >> "${GITHUB_OUTPUT}"
       - name: "Unpacking benchmark tools"
         id: unpack-tools
@@ -191,11 +182,11 @@ jobs:
           IREE_TRACY_CAPTURE_TOOL: ${{ steps.unpack-tools.outputs.tracy-capture-tool }}
           IREE_TARGET_DEVICE_NAME: ${{ env.DEVICE_NAME }}
           IREE_SHARD_INDEX: ${{ matrix.benchmark.shard.index }}
-          IREE_E2E_TEST_ARTIFACTS_DIR: ${{ env.E2E_TEST_ARTIFACTS_DIR }}
           IREE_BENCHMARK_RESULTS: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-results-${{ matrix.benchmark.device_name }}${{ steps.sharding.outputs.suffix }}.json
           IREE_BENCHMARK_TRACES: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-traces-${{ matrix.benchmark.device_name }}${{ steps.sharding.outputs.suffix }}.tar.gz
         run: |
           mkdir -p ${BENCHMARK_RESULTS_DIR}
+          export IREE_E2E_TEST_ARTIFACTS_DIR="${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR/gs:\/\//https://storage.googleapis.com/}"
           ./build_tools/benchmarks/run_benchmarks.sh
       - name: "Uploading benchmark results"
         run: gcloud storage cp -r "${BENCHMARK_RESULTS_DIR}" "${GCS_DIR}/"

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -115,9 +115,8 @@ jobs:
           # triggered by our tests. Disable running tests entirely on Pixel 4.
           - device-name: pixel-4
             label-exclude: "vulkan"
-          # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
-          # - device-name: pixel-6-pro
-          #   label-exclude: "^requires-gpu"
+          - device-name: pixel-6-pro
+            label-exclude: "^requires-gpu"
           - device-name: moto-edge-x30
             label-exclude: "^requires-gpu"
     name: test_on_${{ matrix.target.device-name }}

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -115,8 +115,9 @@ jobs:
           # triggered by our tests. Disable running tests entirely on Pixel 4.
           - device-name: pixel-4
             label-exclude: "vulkan"
-          - device-name: pixel-6-pro
-            label-exclude: "^requires-gpu"
+          # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
+          # - device-name: pixel-6-pro
+          #   label-exclude: "^requires-gpu"
           - device-name: moto-edge-x30
             label-exclude: "^requires-gpu"
     name: test_on_${{ matrix.target.device-name }}

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -9,6 +9,7 @@ from argparse import Namespace
 from dataclasses import dataclass
 from typing import Optional, Union
 import pathlib
+import re
 
 BENCHMARK_RESULTS_REL_PATH = "benchmark-results"
 CAPTURES_REL_PATH = "captures"
@@ -116,7 +117,8 @@ class BenchmarkConfig:
             )
 
         root_benchmark_dir = args.e2e_test_artifacts_dir
-        if not str(root_benchmark_dir).startswith("https://"):
+        # Convert the local path into Path object.
+        if not re.match("^[^:]+://", str(root_benchmark_dir)):
             root_benchmark_dir = pathlib.Path(root_benchmark_dir)
 
         return BenchmarkConfig(

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -7,9 +7,11 @@
 
 from argparse import Namespace
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 import pathlib
 import re
+
+from common import benchmark_definition
 
 BENCHMARK_RESULTS_REL_PATH = "benchmark-results"
 CAPTURES_REL_PATH = "captures"
@@ -62,7 +64,7 @@ class BenchmarkConfig:
     """
 
     tmp_dir: pathlib.Path
-    root_benchmark_dir: Union[str, pathlib.Path]
+    root_benchmark_dir: benchmark_definition.ResourceLocation
     benchmark_results_dir: pathlib.Path
     git_commit_hash: str
 
@@ -118,8 +120,14 @@ class BenchmarkConfig:
 
         root_benchmark_dir = args.e2e_test_artifacts_dir
         # Convert the local path into Path object.
-        if not re.match("^[^:]+://", str(root_benchmark_dir)):
-            root_benchmark_dir = pathlib.Path(root_benchmark_dir)
+        if re.match("^[^:]+://", str(root_benchmark_dir)):
+            root_benchmark_dir = benchmark_definition.ResourceLocation.build_url(
+                root_benchmark_dir
+            )
+        else:
+            root_benchmark_dir = benchmark_definition.ResourceLocation.build_local_path(
+                root_benchmark_dir
+            )
 
         return BenchmarkConfig(
             tmp_dir=per_commit_tmp_dir,

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -116,7 +116,7 @@ class BenchmarkConfig:
             )
 
         root_benchmark_dir = args.e2e_test_artifacts_dir
-        if not str(root_benchmark_dir).startswith("gs://"):
+        if not str(root_benchmark_dir).startswith("https://"):
             root_benchmark_dir = pathlib.Path(root_benchmark_dir)
 
         return BenchmarkConfig(

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -7,7 +7,7 @@
 
 from argparse import Namespace
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 import pathlib
 
 BENCHMARK_RESULTS_REL_PATH = "benchmark-results"
@@ -35,8 +35,9 @@ class TraceCaptureConfig:
 class BenchmarkConfig:
     """Represents the settings to run benchmarks.
 
-    root_benchmark_dir: the root directory containing the built benchmark
-      suites.
+    tmp_dir: per-commit temporary directory.
+    root_benchmark_dir: the root directory path/URL containing the built
+      benchmark suites.
     benchmark_results_dir: the directory to store benchmark results files.
     git_commit_hash: the git commit hash.
     normal_benchmark_tool_dir: the path to the non-traced benchmark tool
@@ -59,7 +60,8 @@ class BenchmarkConfig:
     verify: verify the output if model's expected output is available.
     """
 
-    root_benchmark_dir: pathlib.Path
+    tmp_dir: pathlib.Path
+    root_benchmark_dir: Union[str, pathlib.Path]
     benchmark_results_dir: pathlib.Path
     git_commit_hash: str
 
@@ -113,8 +115,13 @@ class BenchmarkConfig:
                 capture_tmp_dir=per_commit_tmp_dir / CAPTURES_REL_PATH,
             )
 
+        root_benchmark_dir = args.e2e_test_artifacts_dir
+        if not str(root_benchmark_dir).startswith("gs://"):
+            root_benchmark_dir = pathlib.Path(root_benchmark_dir)
+
         return BenchmarkConfig(
-            root_benchmark_dir=args.e2e_test_artifacts_dir,
+            tmp_dir=per_commit_tmp_dir,
+            root_benchmark_dir=root_benchmark_dir,
             benchmark_results_dir=per_commit_tmp_dir / BENCHMARK_RESULTS_REL_PATH,
             git_commit_hash=git_commit_hash,
             normal_benchmark_tool_dir=real_path_or_none(args.normal_benchmark_tool_dir),

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -102,6 +102,23 @@ class BenchmarkConfigTest(unittest.TestCase):
 
         self.assertIsNone(config.trace_capture_config)
 
+    def test_build_from_args_with_test_artifacts_dir_url(self):
+        args = common_arguments.Parser().parse_args(
+            [
+                f"--tmp_dir={self.tmp_dir}",
+                f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
+                f"--e2e_test_artifacts_dir=https://example.com/testdata",
+                f"--execution_benchmark_config={self.execution_config}",
+                "--target_device=test",
+            ]
+        )
+
+        config = benchmark_config.BenchmarkConfig.build_from_args(
+            args=args, git_commit_hash="abcd"
+        )
+
+        self.assertEqual(config.root_benchmark_dir, "https://example.com/testdata")
+
     def test_build_from_args_invalid_capture_args(self):
         args = common_arguments.Parser().parse_args(
             [

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -69,6 +69,7 @@ class BenchmarkConfigTest(unittest.TestCase):
             capture_tmp_dir=per_commit_tmp_dir / "captures",
         )
         expected_config = benchmark_config.BenchmarkConfig(
+            tmp_dir=per_commit_tmp_dir,
             root_benchmark_dir=self.e2e_test_artifacts_dir,
             benchmark_results_dir=per_commit_tmp_dir / "benchmark-results",
             git_commit_hash="abcd",

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -6,12 +6,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import pathlib
-import stat
 import unittest
 import tempfile
-import os
 
-from common import benchmark_config, common_arguments
+from common import benchmark_config, benchmark_definition, common_arguments
 
 
 class BenchmarkConfigTest(unittest.TestCase):
@@ -70,7 +68,9 @@ class BenchmarkConfigTest(unittest.TestCase):
         )
         expected_config = benchmark_config.BenchmarkConfig(
             tmp_dir=per_commit_tmp_dir,
-            root_benchmark_dir=self.e2e_test_artifacts_dir,
+            root_benchmark_dir=benchmark_definition.ResourceLocation.build_local_path(
+                self.e2e_test_artifacts_dir
+            ),
             benchmark_results_dir=per_commit_tmp_dir / "benchmark-results",
             git_commit_hash="abcd",
             normal_benchmark_tool_dir=self.normal_tool_dir,
@@ -117,7 +117,9 @@ class BenchmarkConfigTest(unittest.TestCase):
             args=args, git_commit_hash="abcd"
         )
 
-        self.assertEqual(config.root_benchmark_dir, "https://example.com/testdata")
+        self.assertEqual(
+            config.root_benchmark_dir.get_url(), "https://example.com/testdata"
+        )
 
     def test_build_from_args_invalid_capture_args(self):
         args = common_arguments.Parser().parse_args(

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -14,6 +14,7 @@ import unittest
 from common import benchmark_config
 from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
 from common.benchmark_driver import BenchmarkDriver
+from common import benchmark_definition
 from common.benchmark_definition import (
     IREE_DRIVERS_INFOS,
     DeviceInfo,
@@ -80,7 +81,9 @@ class BenchmarkDriverTest(unittest.TestCase):
 
         self.config = benchmark_config.BenchmarkConfig(
             tmp_dir=self.tmp_dir,
-            root_benchmark_dir=pathlib.Path(self._root_dir_obj.name),
+            root_benchmark_dir=benchmark_definition.ResourceLocation.build_local_path(
+                self._root_dir_obj.name
+            ),
             benchmark_results_dir=self.benchmark_results_dir,
             git_commit_hash="abcd",
             normal_benchmark_tool_dir=self.tmp_dir,
@@ -164,7 +167,7 @@ class BenchmarkDriverTest(unittest.TestCase):
             bench_mode=["sync"],
             target_arch=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
-            module_dir=pathlib.Path("case1"),
+            module_dir=benchmark_definition.ResourceLocation.build_local_path("case1"),
             benchmark_tool_name="tool",
             run_config=run_config_a,
         )
@@ -174,7 +177,7 @@ class BenchmarkDriverTest(unittest.TestCase):
             bench_mode=["task"],
             target_arch=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-            module_dir=pathlib.Path("case2"),
+            module_dir=benchmark_definition.ResourceLocation.build_local_path("case2"),
             benchmark_tool_name="tool",
             run_config=run_config_b,
         )
@@ -211,7 +214,9 @@ class BenchmarkDriverTest(unittest.TestCase):
             bench_mode=["task"],
             target_arch=common_definitions.DeviceArchitecture.RV64_GENERIC,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-            module_dir=pathlib.Path("incompatible_case"),
+            module_dir=benchmark_definition.ResourceLocation.build_local_path(
+                "incompatible_case"
+            ),
             benchmark_tool_name="tool",
             run_config=run_config_incompatible,
         )

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -79,6 +79,7 @@ class BenchmarkDriverTest(unittest.TestCase):
         self.captures_dir.mkdir()
 
         self.config = benchmark_config.BenchmarkConfig(
+            tmp_dir=self.tmp_dir,
             root_benchmark_dir=pathlib.Path(self._root_dir_obj.name),
             benchmark_results_dir=self.benchmark_results_dir,
             git_commit_hash="abcd",
@@ -163,7 +164,7 @@ class BenchmarkDriverTest(unittest.TestCase):
             bench_mode=["sync"],
             target_arch=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
-            benchmark_case_dir=pathlib.Path("case1"),
+            module_dir=pathlib.Path("case1"),
             benchmark_tool_name="tool",
             run_config=run_config_a,
         )
@@ -173,7 +174,7 @@ class BenchmarkDriverTest(unittest.TestCase):
             bench_mode=["task"],
             target_arch=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-            benchmark_case_dir=pathlib.Path("case2"),
+            module_dir=pathlib.Path("case2"),
             benchmark_tool_name="tool",
             run_config=run_config_b,
         )
@@ -210,7 +211,7 @@ class BenchmarkDriverTest(unittest.TestCase):
             bench_mode=["task"],
             target_arch=common_definitions.DeviceArchitecture.RV64_GENERIC,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-            benchmark_case_dir=pathlib.Path("incompatible_case"),
+            module_dir=pathlib.Path("incompatible_case"),
             benchmark_tool_name="tool",
             run_config=run_config_incompatible,
         )

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -207,8 +207,9 @@ class BenchmarkSuite(object):
             if isinstance(root_benchmark_dir, pathlib.Path):
                 module_dir = root_benchmark_dir / module_dir
             else:
-                url_path = urllib.request.pathname2url(str(module_dir))
-                module_dir = urllib.parse.urljoin(root_benchmark_dir, url_path)
+                # urljoin requires the directory URL ended with "/".
+                url_path = urllib.request.pathname2url(str(module_dir)) + "/"
+                module_dir = urllib.parse.urljoin(root_benchmark_dir + "/", url_path)
 
             benchmark_case = BenchmarkCase(
                 model_name=model.name,

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -11,17 +11,16 @@ the benchmark suite.
 
 import pathlib
 import re
+import urllib.parse
+import urllib.request
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 from common.benchmark_definition import IREE_DRIVERS_INFOS, DriverInfo
 from e2e_test_artifacts import iree_artifacts
 from e2e_test_framework.definitions import common_definitions, iree_definitions
 from e2e_test_framework import serialization
-
-MODEL_FLAGFILE_NAME = "flagfile"
-MODEL_TOOLFILE_NAME = "tool"
 
 
 @dataclass
@@ -34,8 +33,8 @@ class BenchmarkCase:
     target_arch: the target CPU/GPU architature.
     driver_info: the IREE driver configuration.
     benchmark_tool_name: the benchmark tool, e.g., 'iree-benchmark-module'.
-    benchmark_case_dir: the path to benchmark case directory.
     run_config: the run config from e2e test framework.
+    module_dir: path/URL of the module directory.
     input_uri: URI to find the input npy.
     expected_output_uri: URI to find the expected output npy.
     """
@@ -46,8 +45,8 @@ class BenchmarkCase:
     target_arch: common_definitions.DeviceArchitecture
     driver_info: DriverInfo
     benchmark_tool_name: str
-    benchmark_case_dir: pathlib.Path
     run_config: iree_definitions.E2EModelRunConfig
+    module_dir: Union[str, pathlib.Path]
     input_uri: Optional[str] = None
     expected_output_uri: Optional[str] = None
     verify_params: List[str] = dataclasses.field(default_factory=list)
@@ -174,7 +173,7 @@ class BenchmarkSuite(object):
     @staticmethod
     def load_from_run_configs(
         run_configs: Sequence[iree_definitions.E2EModelRunConfig],
-        root_benchmark_dir: pathlib.Path,
+        root_benchmark_dir: Union[str, pathlib.Path],
     ):
         """Loads the benchmarks from the run configs.
 
@@ -202,10 +201,14 @@ class BenchmarkSuite(object):
             target_arch = target_device_spec.architecture
             model = module_gen_config.imported_model.model
 
-            module_dir_path = iree_artifacts.get_module_dir_path(
-                module_generation_config=module_gen_config, root_path=root_benchmark_dir
+            module_dir = iree_artifacts.get_module_dir_path(
+                module_generation_config=module_gen_config
             )
-            module_dir_path = pathlib.Path(module_dir_path)
+            if isinstance(root_benchmark_dir, pathlib.Path):
+                module_dir = root_benchmark_dir / module_dir
+            else:
+                url_path = urllib.request.pathname2url(str(module_dir))
+                module_dir = urllib.parse.urljoin(root_benchmark_dir, url_path)
 
             benchmark_case = BenchmarkCase(
                 model_name=model.name,
@@ -214,7 +217,7 @@ class BenchmarkSuite(object):
                 target_arch=target_arch,
                 driver_info=driver_info,
                 benchmark_tool_name=run_config.tool.value,
-                benchmark_case_dir=module_dir_path,
+                module_dir=module_dir,
                 input_uri=model.input_url,
                 expected_output_uri=model.expected_output_url,
                 verify_params=model.verify_params,

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -16,7 +16,8 @@ import urllib.request
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple
+from common import benchmark_definition
 from common.benchmark_definition import IREE_DRIVERS_INFOS, DriverInfo
 from e2e_test_artifacts import iree_artifacts
 from e2e_test_framework.definitions import common_definitions, iree_definitions
@@ -46,7 +47,7 @@ class BenchmarkCase:
     driver_info: DriverInfo
     benchmark_tool_name: str
     run_config: iree_definitions.E2EModelRunConfig
-    module_dir: Union[str, pathlib.Path]
+    module_dir: benchmark_definition.ResourceLocation
     input_uri: Optional[str] = None
     expected_output_uri: Optional[str] = None
     verify_params: List[str] = dataclasses.field(default_factory=list)
@@ -173,7 +174,7 @@ class BenchmarkSuite(object):
     @staticmethod
     def load_from_run_configs(
         run_configs: Sequence[iree_definitions.E2EModelRunConfig],
-        root_benchmark_dir: Union[str, pathlib.Path],
+        root_benchmark_dir: benchmark_definition.ResourceLocation,
     ):
         """Loads the benchmarks from the run configs.
 
@@ -202,15 +203,8 @@ class BenchmarkSuite(object):
             target_arch = target_device_spec.architecture
             model = module_gen_config.imported_model.model
 
-            module_dir = iree_artifacts.get_module_dir_path(module_gen_config)
-            if isinstance(root_benchmark_dir, pathlib.Path):
-                module_dir = root_benchmark_dir / module_dir
-            else:
-                # urljoin requires the directory URL ended with "/".
-                url_path = urllib.request.pathname2url(str(module_dir))
-                module_dir = (
-                    urllib.parse.urljoin(root_benchmark_dir + "/", url_path) + "/"
-                )
+            module_rel_dir = iree_artifacts.get_module_dir_path(module_gen_config)
+            module_dir = root_benchmark_dir / module_rel_dir
 
             benchmark_case = BenchmarkCase(
                 model_name=model.name,

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -179,6 +179,7 @@ class BenchmarkSuite(object):
 
         Args:
           run_configs: list of benchmark run configs.
+          root_benchmark_dir: path/URL of the root benchmark directory.
         Returns:
           A benchmark suite.
         """
@@ -201,15 +202,15 @@ class BenchmarkSuite(object):
             target_arch = target_device_spec.architecture
             model = module_gen_config.imported_model.model
 
-            module_dir = iree_artifacts.get_module_dir_path(
-                module_generation_config=module_gen_config
-            )
+            module_dir = iree_artifacts.get_module_dir_path(module_gen_config)
             if isinstance(root_benchmark_dir, pathlib.Path):
                 module_dir = root_benchmark_dir / module_dir
             else:
                 # urljoin requires the directory URL ended with "/".
-                url_path = urllib.request.pathname2url(str(module_dir)) + "/"
-                module_dir = urllib.parse.urljoin(root_benchmark_dir + "/", url_path)
+                url_path = urllib.request.pathname2url(str(module_dir))
+                module_dir = (
+                    urllib.parse.urljoin(root_benchmark_dir + "/", url_path) + "/"
+                )
 
             benchmark_case = BenchmarkCase(
                 model_name=model.name,

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -7,6 +7,7 @@
 
 import pathlib
 import unittest
+from common import benchmark_definition
 from common.benchmark_definition import IREE_DRIVERS_INFOS
 from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
 from e2e_test_framework.definitions import common_definitions, iree_definitions
@@ -62,7 +63,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             bench_mode=["1-thread", "full-inference"],
             target_arch=common_definitions.DeviceArchitecture.ARMV8_2_A_GENERIC,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-            module_dir=pathlib.Path("case1"),
+            module_dir=benchmark_definition.ResourceLocation.build_local_path("case1"),
             benchmark_tool_name="tool",
             run_config=dummy_run_config,
         )
@@ -72,7 +73,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             bench_mode=["full-inference"],
             target_arch=common_definitions.DeviceArchitecture.ARM_VALHALL,
             driver_info=IREE_DRIVERS_INFOS["iree-vulkan"],
-            module_dir=pathlib.Path("case2"),
+            module_dir=benchmark_definition.ResourceLocation.build_local_path("case2"),
             benchmark_tool_name="tool",
             run_config=dummy_run_config,
         )
@@ -82,7 +83,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             bench_mode=["full-inference"],
             target_arch=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
-            module_dir=pathlib.Path("case3"),
+            module_dir=benchmark_definition.ResourceLocation.build_local_path("case3"),
             benchmark_tool_name="tool",
             run_config=dummy_run_config,
         )
@@ -215,7 +216,10 @@ class BenchmarkSuiteTest(unittest.TestCase):
         root_dir = pathlib.Path("root")
 
         suite = BenchmarkSuite.load_from_run_configs(
-            run_configs=run_configs, root_benchmark_dir=root_dir
+            run_configs=run_configs,
+            root_benchmark_dir=benchmark_definition.ResourceLocation.build_local_path(
+                root_dir
+            ),
         )
 
         loaded_run_configs = [case.run_config for case in suite.filter_benchmarks()]
@@ -248,7 +252,9 @@ class BenchmarkSuiteTest(unittest.TestCase):
                     target_arch=common_definitions.DeviceArchitecture.RV32_GENERIC,
                     driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                     benchmark_tool_name="iree-benchmark-module",
-                    module_dir=run_config_c_case_dir,
+                    module_dir=benchmark_definition.ResourceLocation.build_local_path(
+                        run_config_c_case_dir
+                    ),
                     input_uri=model_tf.input_url,
                     expected_output_uri=model_tf.expected_output_url,
                     run_config=run_config_c,
@@ -300,7 +306,9 @@ class BenchmarkSuiteTest(unittest.TestCase):
 
         suite = BenchmarkSuite.load_from_run_configs(
             run_configs=[run_config_a],
-            root_benchmark_dir="https://example.com/testdata",
+            root_benchmark_dir=benchmark_definition.ResourceLocation.build_url(
+                "https://example.com/testdata"
+            ),
         )
 
         self.assertEqual(
@@ -313,7 +321,9 @@ class BenchmarkSuiteTest(unittest.TestCase):
                     target_arch=common_definitions.DeviceArchitecture.RV64_GENERIC,
                     driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                     benchmark_tool_name="iree-benchmark-module",
-                    module_dir="https://example.com/testdata/iree_module_model_tflite___riscv_64-generic-linux_gnu-llvm_cpu___/",
+                    module_dir=benchmark_definition.ResourceLocation.build_url(
+                        "https://example.com/testdata/iree_module_model_tflite___riscv_64-generic-linux_gnu-llvm_cpu___"
+                    ),
                     run_config=run_config_a,
                 )
             ],

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -62,7 +62,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             bench_mode=["1-thread", "full-inference"],
             target_arch=common_definitions.DeviceArchitecture.ARMV8_2_A_GENERIC,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-            benchmark_case_dir=pathlib.Path("case1"),
+            module_dir=pathlib.Path("case1"),
             benchmark_tool_name="tool",
             run_config=dummy_run_config,
         )
@@ -72,7 +72,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             bench_mode=["full-inference"],
             target_arch=common_definitions.DeviceArchitecture.ARM_VALHALL,
             driver_info=IREE_DRIVERS_INFOS["iree-vulkan"],
-            benchmark_case_dir=pathlib.Path("case2"),
+            module_dir=pathlib.Path("case2"),
             benchmark_tool_name="tool",
             run_config=dummy_run_config,
         )
@@ -82,7 +82,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             bench_mode=["full-inference"],
             target_arch=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
             driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
-            benchmark_case_dir=pathlib.Path("case3"),
+            module_dir=pathlib.Path("case3"),
             benchmark_tool_name="tool",
             run_config=dummy_run_config,
         )
@@ -248,7 +248,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
                     target_arch=common_definitions.DeviceArchitecture.RV32_GENERIC,
                     driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                     benchmark_tool_name="iree-benchmark-module",
-                    benchmark_case_dir=run_config_c_case_dir,
+                    module_dir=run_config_c_case_dir,
                     input_uri=model_tf.input_url,
                     expected_output_uri=model_tf.expected_output_url,
                     run_config=run_config_c,

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -47,7 +47,7 @@ class Parser(argparse.ArgumentParser):
             metavar="<e2e-test-artifacts-dir>",
             type=str,
             required=True,
-            help="Path to the IREE e2e test artifacts directory.",
+            help="Path/URL to the IREE e2e test artifacts directory.",
         )
 
         self.add_argument(

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -45,7 +45,7 @@ class Parser(argparse.ArgumentParser):
         self.add_argument(
             "--e2e_test_artifacts_dir",
             metavar="<e2e-test-artifacts-dir>",
-            type=_check_dir_path,
+            type=str,
             required=True,
             help="Path to the IREE e2e test artifacts directory.",
         )

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -220,9 +220,9 @@ def adb_fetch_and_push_file(
     if verbose:
         print(f"Streaming file {source} to {dest}.")
 
-    resp = requests.get(source, stream=True, timeout=60)
-    if not resp.ok:
-        raise RuntimeError(f"Failed to fetch: {resp.status_code} - {resp.text}")
+    req = requests.get(source, stream=True, timeout=60)
+    if not req.ok:
+        raise RuntimeError(f"Failed to fetch {source}: {req.status_code} - {req.text}")
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(("127.0.0.1", 5037))
@@ -235,7 +235,7 @@ def adb_fetch_and_push_file(
     payload = f"{dest},0644".encode("utf-8")
     sock.sendall(b"SEND" + struct.pack("I", len(payload)) + payload)
 
-    for data in resp.iter_content(chunk_size=64 * 1024):
+    for data in req.iter_content(chunk_size=64 * 1024):
         sock.sendall(b"DATA" + struct.pack("I", len(data)) + data)
 
     sock.sendall(b"DONE" + struct.pack("I", int(time.time())))

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -256,7 +256,7 @@ def adb_fetch_and_push_file(
         # Switch to sync mode.
         sock.sendall(b"0005sync:")
         wait_ack_ok(sock)
-        # Send the dest file path and file permissions.
+        # Send the dest file path and file permissions 0644 (rw-r-r).
         file_attr = f"{dest},{0o644}".encode("utf-8")
         sock.sendall(b"SEND" + struct.pack("I", len(file_attr)) + file_attr)
         # Stream the file chunks. 64k bytes is the max chunk size for adb.

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -19,6 +19,7 @@ import requests
 import shutil
 import subprocess
 import tarfile
+import urllib.parse
 
 from common import benchmark_suite as benchmark_suite_module
 from common.benchmark_driver import BenchmarkDriver
@@ -55,11 +56,16 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         module_dir = benchmark_case.module_dir
         if isinstance(module_dir, pathlib.Path):
             case_tmp_dir = module_dir
+            module_path = module_dir / iree_artifacts.MODULE_FILENAME
         else:
             local_module_dir = iree_artifacts.get_module_dir_path(
                 benchmark_case.run_config.module_generation_config
             )
             case_tmp_dir = self.config.tmp_dir / local_module_dir
+            module_path = self.__fetch_file(
+                uri=urllib.parse.urljoin(module_dir, iree_artifacts.MODULE_FILENAME),
+                dest=case_tmp_dir / iree_artifacts.MODULE_FILENAME,
+            )
 
         inputs_dir = None
         expected_output_dir = None
@@ -71,12 +77,6 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
             expected_output_dir = self.__fetch_and_unpack_npy(
                 uri=benchmark_case.expected_output_uri,
                 dest_dir=case_tmp_dir / "expected_outputs_npy",
-            )
-        if isinstance(module_dir, pathlib.Path):
-            module_path = module_dir / iree_artifacts.MODULE_FILENAME
-        else:
-            module_path = self.__fetch_file(
-                uri=module_dir, dest=case_tmp_dir / iree_artifacts.MODULE_FILENAME
             )
 
         if benchmark_results_filename:

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -52,17 +52,31 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         benchmark_results_filename: Optional[pathlib.Path],
         capture_filename: Optional[pathlib.Path],
     ) -> None:
-        case_dir = benchmark_case.benchmark_case_dir
+        module_dir = benchmark_case.module_dir
+        if isinstance(module_dir, pathlib.Path):
+            case_tmp_dir = module_dir
+        else:
+            local_module_dir = iree_artifacts.get_module_dir_path(
+                benchmark_case.run_config.module_generation_config
+            )
+            case_tmp_dir = self.config.tmp_dir / local_module_dir
+
         inputs_dir = None
         expected_output_dir = None
         if benchmark_case.input_uri:
             inputs_dir = self.__fetch_and_unpack_npy(
-                uri=benchmark_case.input_uri, dest_dir=case_dir / "inputs_npy"
+                uri=benchmark_case.input_uri, dest_dir=case_tmp_dir / "inputs_npy"
             )
         if benchmark_case.expected_output_uri:
             expected_output_dir = self.__fetch_and_unpack_npy(
                 uri=benchmark_case.expected_output_uri,
-                dest_dir=case_dir / "expected_outputs_npy",
+                dest_dir=case_tmp_dir / "expected_outputs_npy",
+            )
+        if isinstance(module_dir, pathlib.Path):
+            module_path = module_dir / iree_artifacts.MODULE_FILENAME
+        else:
+            module_path = self.__fetch_file(
+                uri=module_dir, dest=case_tmp_dir / iree_artifacts.MODULE_FILENAME
             )
 
         if benchmark_results_filename:
@@ -75,6 +89,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
                 self.__run_verify(
                     tool_dir=self.config.normal_benchmark_tool_dir,
                     benchmark_case=benchmark_case,
+                    module_path=module_path,
                     inputs_dir=inputs_dir,
                     expected_outputs_dir=expected_output_dir,
                 )
@@ -82,18 +97,22 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
             self.__run_benchmark(
                 tool_dir=self.config.normal_benchmark_tool_dir,
                 benchmark_case=benchmark_case,
+                module_path=module_path,
                 results_filename=benchmark_results_filename,
             )
 
         if capture_filename:
             self.__run_capture(
-                benchmark_case=benchmark_case, capture_filename=capture_filename
+                benchmark_case=benchmark_case,
+                module_path=module_path,
+                capture_filename=capture_filename,
             )
 
     def __build_tool_cmds(
         self,
         benchmark_case: BenchmarkCase,
         tool_path: pathlib.Path,
+        module_path: pathlib.Path,
         inputs_dir: Optional[pathlib.Path] = None,
     ) -> List[Any]:
         run_config = benchmark_case.run_config
@@ -102,8 +121,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         )
         cmds.append(tool_path)
 
-        module_dir_path = benchmark_case.benchmark_case_dir
-        cmds += [f"--module={module_dir_path / iree_artifacts.MODULE_FILENAME}"]
+        cmds += [f"--module={module_path}"]
         cmds += run_config.materialize_run_flags(
             gpu_id=self.gpu_id,
             inputs_dir=inputs_dir,
@@ -143,12 +161,14 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         self,
         tool_dir: pathlib.Path,
         benchmark_case: BenchmarkCase,
+        module_path: pathlib.Path,
         inputs_dir: pathlib.Path,
         expected_outputs_dir: pathlib.Path,
     ):
         cmd = self.__build_tool_cmds(
             benchmark_case=benchmark_case,
             tool_path=tool_dir / "iree-run-module",
+            module_path=module_path,
             inputs_dir=inputs_dir,
         )
         # Currently only support single output.
@@ -160,11 +180,15 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         self,
         tool_dir: pathlib.Path,
         benchmark_case: BenchmarkCase,
+        module_path: pathlib.Path,
         results_filename: pathlib.Path,
     ):
         tool_name = benchmark_case.benchmark_tool_name
-        tool_path = tool_dir / tool_name
-        cmd = self.__build_tool_cmds(benchmark_case=benchmark_case, tool_path=tool_path)
+        cmd = self.__build_tool_cmds(
+            benchmark_case=benchmark_case,
+            tool_path=tool_dir / tool_name,
+            module_path=module_path,
+        )
 
         if tool_name == "iree-benchmark-module":
             cmd.extend(
@@ -186,18 +210,21 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         results_filename.write_text(json.dumps(benchmark_metrics.to_json_object()))
 
     def __run_capture(
-        self, benchmark_case: BenchmarkCase, capture_filename: pathlib.Path
+        self,
+        benchmark_case: BenchmarkCase,
+        module_path: pathlib.Path,
+        capture_filename: pathlib.Path,
     ):
         capture_config = self.config.trace_capture_config
         if capture_config is None:
             raise ValueError("capture_config can't be None.")
 
         tool_name = benchmark_case.benchmark_tool_name
-        tool_path = (
-            capture_config.traced_benchmark_tool_dir
-            / benchmark_case.benchmark_tool_name
+        cmd = self.__build_tool_cmds(
+            benchmark_case=benchmark_case,
+            tool_path=capture_config.traced_benchmark_tool_dir / tool_name,
+            module_path=module_path,
         )
-        cmd = self.__build_tool_cmds(benchmark_case=benchmark_case, tool_path=tool_path)
 
         if tool_name == "iree-benchmark-module":
             cmd.extend(

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -62,6 +62,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
                 benchmark_case.run_config.module_generation_config
             )
             case_tmp_dir = self.config.tmp_dir / local_module_dir
+            case_tmp_dir.mkdir(parents=True, exist_ok=True)
             module_path = self.__fetch_file(
                 uri=urllib.parse.urljoin(module_dir, iree_artifacts.MODULE_FILENAME),
                 dest=case_tmp_dir / iree_artifacts.MODULE_FILENAME,
@@ -144,6 +145,8 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         if dest.exists():
             return dest
         req = requests.get(uri, stream=True, timeout=60)
+        if not req.ok:
+            raise RuntimeError(f"Failed to fetch {uri}: {req.status_code} - {req.text}")
         with dest.open("wb") as dest_file:
             for data in req.iter_content():
                 dest_file.write(data)

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -148,7 +148,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         if not req.ok:
             raise RuntimeError(f"Failed to fetch {uri}: {req.status_code} - {req.text}")
         with dest.open("wb") as dest_file:
-            for data in req.iter_content():
+            for data in req.iter_content(chunk_size=64 * 1024 * 1024):
                 dest_file.write(data)
         return dest
 

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -58,10 +58,10 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
             case_tmp_dir = module_dir
             module_path = module_dir / iree_artifacts.MODULE_FILENAME
         else:
-            local_module_dir = iree_artifacts.get_module_dir_path(
+            module_rel_dir = iree_artifacts.get_module_dir_path(
                 benchmark_case.run_config.module_generation_config
             )
-            case_tmp_dir = self.config.tmp_dir / local_module_dir
+            case_tmp_dir = self.config.tmp_dir / module_rel_dir
             case_tmp_dir.mkdir(parents=True, exist_ok=True)
             module_path = self.__fetch_file(
                 uri=urllib.parse.urljoin(module_dir, iree_artifacts.MODULE_FILENAME),

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -19,7 +19,6 @@ import requests
 import shutil
 import subprocess
 import tarfile
-import urllib.parse
 
 from common import benchmark_suite as benchmark_suite_module
 from common.benchmark_driver import BenchmarkDriver
@@ -54,18 +53,20 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
         capture_filename: Optional[pathlib.Path],
     ) -> None:
         module_dir = benchmark_case.module_dir
-        if isinstance(module_dir, pathlib.Path):
-            case_tmp_dir = module_dir
-            module_path = module_dir / iree_artifacts.MODULE_FILENAME
+        local_module_dir = module_dir.get_local_path()
+        if local_module_dir:
+            case_tmp_dir = local_module_dir
+            module_path = local_module_dir / iree_artifacts.MODULE_FILENAME
         else:
             module_rel_dir = iree_artifacts.get_module_dir_path(
                 benchmark_case.run_config.module_generation_config
             )
             case_tmp_dir = self.config.tmp_dir / module_rel_dir
             case_tmp_dir.mkdir(parents=True, exist_ok=True)
+            module_url = (module_dir / iree_artifacts.MODULE_FILENAME).get_url()
+            assert module_url is not None
             module_path = self.__fetch_file(
-                uri=urllib.parse.urljoin(module_dir, iree_artifacts.MODULE_FILENAME),
-                dest=case_tmp_dir / iree_artifacts.MODULE_FILENAME,
+                uri=module_url, dest=case_tmp_dir / iree_artifacts.MODULE_FILENAME
             )
 
         inputs_dir = None


### PR DESCRIPTION
This change adds the support of URL as the e2e-test-artifacts-dir source. This allows benchmark tools to pull only needed files and in some cases streaming the artifacts directly to the target device.

The main motivation of this change is to avoid temporary files pulled on the mobile benchmark runner host, which is an RPi and has a quite slow and fragile storage. Currently Pixel 6 benchmark is spending 30mins to download files on host. In general, for CI it is easier for benchmark tools to pull the needed files comparing to resolve the required files and download in advance, which we tried before.

- Support URL in `--e2e-test-artifacts-dir`. The URL should point to a root directory of the artifacts.
- Fetch VMFB modules in Android/Linux benchmark tools on demand.
- Add `adb_fetch_and_push_file` to Android benchmark tool, which support streaming files directly from the source URL to the phone.

The total run time of Pixel 6 benchmark is cut down to 26mins (previously was 1hr): https://github.com/openxla/iree/actions/runs/6775662569/job/18416065202. No time change on the x86_64 benchmarks

This idea was originally experimented in #15344, I decided to separate it out