### PR TITLE
Setting worker local memory size based on L2 cache size by default.

### DIFF
--- a/runtime/src/iree/task/api.c
+++ b/runtime/src/iree/task/api.c
@@ -34,15 +34,15 @@ IREE_FLAG(
     "the stack for storage over ~16-32KB and instead use local workgroup\n"
     "memory.");
 
-// TODO(benvanik): enable this when we use it - though hopefully we don't!
 IREE_FLAG(
-    int32_t, task_worker_local_memory, 0,  // 64 * 1024,
-    "Specifies the bytes of per-worker local memory allocated for use by\n"
+    int32_t, task_worker_local_memory, 0,
+    "Overrides the bytes of per-worker local memory allocated for use by\n"
     "dispatched tiles. Tiles may use less than this but will fail to dispatch\n"
     "if they require more. Conceptually it is like a stack reservation and\n"
     "should be treated the same way: the source programs must be built to\n"
     "only use a specific maximum amount of local memory and the runtime must\n"
-    "be configured to make at least that amount of local memory available.");
+    "be configured to make at least that amount of local memory available.\n"
+    "By default the CPU L2 cache size is used if such queries are supported.");
 
 iree_status_t iree_task_executor_options_initialize_from_flags(
     iree_task_executor_options_t* out_options) {
@@ -214,7 +214,11 @@ static void iree_task_flags_dump_task_topology(
       fprintf(stdout, "(unspecified)");
     }
     fprintf(stdout, "\n");
-    fprintf(stdout, "#  cache sharing: ");
+
+    fprintf(stdout, "#  caches: l1d=%u, l2d=%u\n", group->caches.l1_data,
+            group->caches.l2_data);
+
+    fprintf(stdout, "#  last level cache sharing: ");
     if (group->constructive_sharing_mask == 0) {
       fprintf(stdout, "(none)\n");
     } else if (group->constructive_sharing_mask ==
@@ -233,6 +237,7 @@ static void iree_task_flags_dump_task_topology(
       }
       fprintf(stdout, "\n");
     }
+
     fprintf(stdout, "#\n");
   }
 }

--- a/runtime/src/iree/task/executor.h
+++ b/runtime/src/iree/task/executor.h
@@ -301,6 +301,7 @@ typedef struct iree_task_executor_options_t {
   // Dispatches performed will be able to request up to this amount of memory
   // for their invocations and no more. May be 0 if no worker local memory is
   // required.
+  // By default the CPU L2 cache size is used if such queries are supported.
   iree_host_size_t worker_local_memory_size;
 } iree_task_executor_options_t;
 

--- a/runtime/src/iree/task/topology.c
+++ b/runtime/src/iree/task/topology.c
@@ -99,6 +99,10 @@ void iree_task_topology_initialize_from_group_count(
   for (iree_host_size_t i = 0; i < group_count; ++i) {
     iree_task_topology_group_t* group = &out_topology->groups[i];
     iree_task_topology_group_initialize(i, group);
+    // NOTE: without platform queries we can't figure out cache sizes and just
+    // make a conservative guess.
+    group->caches.l1_data = 32 * 1024;
+    group->caches.l2_data = 128 * 1024;
   }
   out_topology->group_count = group_count;
 

--- a/runtime/src/iree/task/topology.h
+++ b/runtime/src/iree/task/topology.h
@@ -49,6 +49,17 @@ typedef uint64_t iree_task_topology_group_mask_t;
 #define IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT \
   (sizeof(iree_task_topology_group_mask_t) * 8)
 
+// Total cache sizes (that we care about).
+// More information may be available but we shouldn't be specializing on it
+// unless absolutely required. Values should ideally be a power-of-two if
+// that's what the hardware has. Values of 0 indicate the particular cache is
+// not present (or not queried).
+typedef struct iree_task_topology_caches_t {
+  uint32_t l1_data;
+  uint32_t l2_data;
+  uint32_t l3_data;
+} iree_task_topology_caches_t;
+
 // Information about a particular group within the topology.
 // Groups may be of varying levels of granularity even within the same topology
 // based on how the topology is defined.
@@ -62,6 +73,9 @@ typedef struct iree_task_topology_group_t {
 
   // Processor index in the cpuinfo set.
   uint32_t processor_index;
+
+  // Total cache sizes (that we care about).
+  iree_task_topology_caches_t caches;
 
   // Ideal thread affinity for threads within this group.
   // All threads within the group share the same affinity and this is what

--- a/runtime/src/iree/task/topology_cpuinfo.c
+++ b/runtime/src/iree/task/topology_cpuinfo.c
@@ -66,6 +66,11 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
     iree_task_topology_group_initialize(i, group);
     group->processor_index = cpu_ids[i];
 
+    // NOTE: without cpuinfo we can't get cache sizes so we just guess some
+    // conservative values.
+    group->caches.l1_data = 32 * 1024;
+    group->caches.l2_data = 128 * 1024;
+
     // NOTE: without cpuinfo we can't get SMT and node info but this isn't
     // really used on Linux today anyway.
     iree_thread_affinity_t* affinity = &group->ideal_thread_affinity;
@@ -191,6 +196,12 @@ static void iree_task_topology_group_initialize_from_processor(
   out_group->processor_index =
       processor->core->processor_start + processor->smt_id;
 #endif  // __linux__
+  out_group->caches.l1_data =
+      processor->cache.l1d ? processor->cache.l1d->size : 0;
+  out_group->caches.l2_data =
+      processor->cache.l2 ? processor->cache.l2->size : 0;
+  out_group->caches.l3_data =
+      processor->cache.l3 ? processor->cache.l3->size : 0;
   iree_task_topology_set_affinity_from_processor(
       processor, &out_group->ideal_thread_affinity);
 }


### PR DESCRIPTION
Users can override this with --task_worker_local_memory= as before (or when programmatically creating the executors) but on systems where we have cpuinfo or Windows we'll pick it up automatically. Mac, bare-metal, etc will need to pass the flag for now until topology query support is implemented for them.

Fixes #15440.