### PR TITLE
[GlobalOpt] Unset encodings for non-CPU backends.

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -59,6 +59,7 @@ iree_compiler_cc_library(
     deps = [
         ":PassHeaders",
         ":PassesIncGen",
+        "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Common/CPU:CommonCPUPasses",
         "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -70,6 +70,7 @@ iree_cc_library(
     MLIRTensorTransforms
     MLIRTensorUtils
     MLIRTransforms
+    iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::CPU::CommonCPUPasses
     iree::compiler::Dialect::Flow::Transforms
     iree::compiler::Dialect::HAL::IR

--- a/compiler/src/iree/compiler/GlobalOptimization/test/materialize_homogeneous_encodings.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/materialize_homogeneous_encodings.mlir
@@ -51,7 +51,7 @@ module attributes {hal.device.targets = [#device_target_vulkan]} {
   }
 }
 
-// vulkan does not implement buildMaterializeEncodingsPassPipeline method.
+// vulkan uses default materialization patterns which unsets the encodings.
 // CHECK-LABEL: func.func @lhs_encoding
-// CHECK:         iree_linalg_ext.upper_bound_tile_size
-// CHECK:         iree_linalg_ext.set_encoding
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         return %[[ARG0]]


### PR DESCRIPTION
This is a step toward turning data-tiling on by default.