### PR TITLE
Re-enable Pixel 6 tests and benchmarks

### DIFF
--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -94,14 +94,12 @@ jobs:
           #     },
           #     ...
           #   ]
-          # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
           echo benchmark-matrix="$(jq -c '[ . | to_entries[]
             | .key as $device_name
             | .value.host_environment as $host_environment
             | (.value.shards | length) as $count
             | .value.shards[]
             | {$device_name, $host_environment, shard: {index, $count}}
-            | select(.device_name != "pixel-6-pro")
             ]' "${BENCHMARK_CONFIG}")" >> "${GITHUB_OUTPUT}"
 
   run_benchmarks:

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -115,9 +115,8 @@ jobs:
           # triggered by our tests. Disable running tests entirely on Pixel 4.
           - device-name: pixel-4
             label-exclude: "vulkan"
-          # TODO(pzread): Re-enable Pixel 6 once the device is fixed.
-          # - device-name: pixel-6-pro
-          #   label-exclude: "^requires-gpu"
+          - device-name: pixel-6-pro
+            label-exclude: "^requires-gpu"
           - device-name: moto-edge-x30
             label-exclude: "^requires-gpu"
     name: test_on_${{ matrix.target.device-name }}


### PR DESCRIPTION
The Pixel 6 runners are fixed and online now. 