### PR TITLE
Set copyright as "The IREE Authors" in recently added torch files.

### DIFF
--- a/compiler/plugins/input/Torch/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 Nod Labs, Inc
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/plugins/input/Torch/torch-iree/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 Nod Labs, Inc
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 Nod Labs, Inc
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Nod Labs, Inc
+// Copyright 2023 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -28,7 +28,7 @@ struct TorchOptions {
   }
 };
 
-// The shark-turbine plugin provides dialects, passes and opt-in options.
+// The torch plugin provides dialects, passes and opt-in options.
 // Therefore, it is appropriate for default activation.
 struct TorchSession
     : public PluginSession<TorchSession, TorchOptions,

--- a/compiler/plugins/input/Torch/torch-mlir-dialects/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-mlir-dialects/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 Nod Labs, Inc
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 Nod Labs, Inc
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
These were contributed under the CLA anyways... just matching up the text with the rest of the project.