### PR TITLE
[CPU] Optimize vector transfers for pack/unpack  before vector lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -646,6 +646,9 @@ void addCPUDataTilingPipeline(OpPassManager &passManager,
   addBufferizePasses(nestedModulePM);
 
   {
+    // Fold unit dims before vector lowering.
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createOptimizeVectorTransferPass(/*flatten=*/false));
     LLVMCPUVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "linalg-copy";
     nestedModulePM.addNestedPass<func::FuncOp>(


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/15349