### PR TITLE
Data-tiling: never use a generic fallback tile size

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
@@ -49,7 +49,10 @@ enumerateMatmulTilesVMVX(EncodingUser user, ExecutableTargetAttr target) {
   }
 
   return {
-      TileMxNxK{8, 8, 4} // Some vaguely reasonable tile shape
+      TileMxNxK{8, 8, 4}, // Some vaguely reasonable tile shape.
+      TileMxNxK{4, 8, 4}, // Truncation of the above.
+      TileMxNxK{2, 8, 4}, // Truncation of the above.
+      TileMxNxK{1, 8, 4}, // Truncation of the above.
   };
 }
 

--- a/compiler/src/iree/compiler/GlobalOptimization/test/materialize_homogeneous_encodings.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/materialize_homogeneous_encodings.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --iree-global-opt-materialize-homogeneous-encodings %s | FileCheck %s
 
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f"}>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {target_triple = "x86_64-none-elf", cpu_features = "+avx512f"}>
 #map = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
 #device_target_llvm_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#executable_target_embedded_elf_x86_64_]}>
 module attributes {hal.device.targets = [#device_target_llvm_cpu]} {


### PR DESCRIPTION
Since @hanhanW 's recent changes (around https://github.com/openxla/iree/pull/15450), we can let MaterializeEncoding just fail and fall back to undoing the encodings. This is generally much better than going ahead with an arbitrary "generic" tile size, which we had been doing, so this PR switches to doing that consistently.
