### PR TITLE
Drop `-Wno-unused-function` on Clang, find out about actually unused functions, silence false positives.

### DIFF
--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -91,6 +91,11 @@ function(iree_c_module)
     DEPENDS ${_COMPILE_TOOL} ${_SRC_PATH}
   )
 
+  iree_select_compiler_opts(_NO_WARN_ON_UNUSED_FUNCTION
+    CLANG_OR_GCC
+      "-Wno-unused-function"
+  )
+
   iree_cc_library(
     NAME ${_RULE_NAME}
     HDRS "${_RULE_H_FILE_OUTPUT}"
@@ -99,6 +104,7 @@ function(iree_c_module)
     COPTS
       "-DEMITC_IMPLEMENTATION=\"${_RULE_H_FILE_OUTPUT}\""
       "${_TESTONLY_ARG}"
+      "${_NO_WARN_ON_UNUSED_FUNCTION}"
     DEPS
       # Include paths and options for the runtime sources.
       iree::defs

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -170,7 +170,6 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wno-unknown-warning-option"
     "-Wno-unused-command-line-argument"
     "-Wno-unused-const-variable"
-    "-Wno-unused-function"
     "-Wno-unused-local-typedef"
     "-Wno-unused-private-field"
     "-Wno-user-defined-warnings"

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -705,23 +705,6 @@ struct FoldMemRefReshape final : public OpConversionPattern<ReshapeOpTy> {
   };
 };
 
-/// Returns the number of bytes of the given `type`. Returns std::nullopt if
-/// cannot deduce.
-///
-/// Note that this should be kept consistent with how the byte offset was
-/// calculated in the subspan ops!
-std::optional<int64_t> getNumBytes(Type type) {
-  if (type.isIntOrFloat())
-    return IREE::Util::getRoundedElementByteWidth(type);
-  if (auto vectorType = llvm::dyn_cast<VectorType>(type)) {
-    auto elementBytes = getNumBytes(vectorType.getElementType());
-    if (!elementBytes)
-      return std::nullopt;
-    return elementBytes.value() * vectorType.getNumElements();
-  }
-  return std::nullopt;
-}
-
 /// Erase alignment hints.
 struct RemoveAssumeAlignOp
     : public OpRewritePattern<memref::AssumeAlignmentOp> {

--- a/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
@@ -36,16 +36,6 @@
 namespace mlir {
 namespace iree_compiler {
 
-/// Gets the given `attrOrValue` as a Value by creating constant ops for
-/// attributes.
-static Value getAsValue(OpFoldResult attrOrValue, OpBuilder &builder,
-                        Location loc) {
-  if (Value val = attrOrValue.dyn_cast<Value>())
-    return val;
-  auto attr = llvm::cast<IntegerAttr>(attrOrValue.get<Attribute>());
-  return builder.create<arith::ConstantIndexOp>(loc, attr.getInt());
-}
-
 #ifndef NDEBUG
 inline raw_ostream &operator<<(raw_ostream &os,
                                const LoopTilingAndDistributionInfo &info) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
@@ -80,20 +80,6 @@ static bool transposeOpFilter(Operation *op) {
   return opInfo.isTranspose();
 }
 
-/// Returns true if the index map represents a transpose that benefits from
-/// shared mem.
-static bool isSharedMemTranspose(AffineMap indexMap) {
-  if (!indexMap.isEmpty() && indexMap.isPermutation()) {
-    // Ensure that the fasted moving dimension (the last one) is permuted,
-    // Otherwise shared memory promotion will not benefit the operation.
-    if (indexMap.getDimPosition(indexMap.getNumDims() - 1) !=
-        indexMap.getNumDims() - 1) {
-      return true;
-    }
-  }
-  return false;
-}
-
 namespace {
 /// Swaps bufferization.alloc_tensor with the copied linalg op result when the
 /// linalg op does not use the output initial value during calculation.

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -25,49 +25,6 @@ namespace mlir {
 namespace iree_compiler {
 namespace {
 
-/// Returns the op that contains lowering config. Checks whether the provided op
-/// contains the lowering config and returns it. Otherwise, tries to find the
-/// lowering config across the function. If there are multiple ops with the same
-/// lowering configs, returns the first one found. Returns failure if there are
-/// multiple op with different lowering config.
-static FailureOr<Operation *> getRootOp(Operation *op) {
-  // Check for self first.
-  if (iree_compiler::getLoweringConfig(op)) {
-    return op;
-  }
-
-  // Get the function op.
-  auto funcOp = dyn_cast<func::FuncOp>(op);
-  if (!funcOp) {
-    funcOp = op->getParentOfType<func::FuncOp>();
-  }
-
-  assert(funcOp && "Missing funcOp");
-
-  Operation *rootOp = nullptr;
-  mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr rootLoweringConfig;
-  auto result = funcOp.walk([&](Operation *op) -> WalkResult {
-    auto loweringConfig = iree_compiler::getLoweringConfig(op);
-    if (!loweringConfig) {
-      return WalkResult::advance();
-    }
-    if (rootLoweringConfig) {
-      if (rootLoweringConfig != loweringConfig) {
-        return WalkResult::interrupt();
-      }
-    } else {
-      rootOp = op;
-      rootLoweringConfig = loweringConfig;
-    }
-    return WalkResult::advance();
-  });
-
-  if (!rootOp || result.wasInterrupted()) {
-    return failure();
-  }
-  return rootOp;
-}
-
 /// Tries to infer the vector sizes from an IR using ValueBounds analysis.
 /// Returns failure if vector sizes can't be inferred.
 static FailureOr<SmallVector<int64_t>>

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -92,8 +92,6 @@ private:
 };
 } // namespace
 
-static bool isaTensor(Type t) { return llvm::isa<TensorType>(t); };
-
 // Default allocation functions.
 static FailureOr<Value> defaultAllocationFn(OpBuilder &builder, Location loc,
                                             MemRefType allocationType,

--- a/compiler/src/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
@@ -91,18 +91,6 @@ getWorkgroupRange(Value processorValue, SmallVectorImpl<Value> & /*dims*/,
   return std::nullopt;
 }
 
-/// Return true if the given tiled loop is distributed to workgroups.
-static bool isWorkgroupLoop(const LoopTilingAndDistributionInfo &info) {
-  auto forOp = cast<scf::ForOp>(info.loop);
-  Operation *lbOp = forOp.getLowerBound().getDefiningOp();
-  if (isa<IREE::HAL::InterfaceWorkgroupIDOp>(lbOp))
-    return true;
-  auto applyOp = dyn_cast<affine::AffineApplyOp>(lbOp);
-  return applyOp && llvm::any_of(applyOp.getMapOperands(), [](Value operand) {
-           return operand.getDefiningOp<IREE::HAL::InterfaceWorkgroupIDOp>();
-         });
-}
-
 static LogicalResult removeOneTripTiledLoops(func::FuncOp funcOp,
                                              ArrayRef<int64_t> workgroupSize,
                                              ArrayRef<int64_t> numWorkgroups) {

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -120,26 +120,6 @@ getTileAndDistributeConfig(ArrayRef<Operation *> computeOps,
   return success();
 }
 
-/// Get the materialization information from a `tensor.pack` operation.
-static FailureOr<IREE::LinalgExt::MaterializeEncodingInfo>
-getMaterializationInfo(tensor::PackOp packOp) {
-  IREE::LinalgExt::MaterializeEncodingInfo encodingInfo;
-  SmallVector<OpFoldResult> mixedTileSizes = packOp.getMixedTiles();
-  encodingInfo.innerTileSizes.reserve(mixedTileSizes.size());
-  for (auto tileSize : mixedTileSizes) {
-    if (tileSize.is<Value>()) {
-      encodingInfo.innerTileSizes.push_back(ShapedType::kDynamic);
-    } else {
-      encodingInfo.innerTileSizes.push_back(
-          llvm::cast<IntegerAttr>(tileSize.get<Attribute>()).getInt());
-    }
-  }
-  encodingInfo.innerDimsPos = llvm::to_vector(packOp.getInnerDimsPos());
-  encodingInfo.outerDimsPerm = llvm::to_vector(packOp.getOuterDimsPerm());
-  encodingInfo.srcRank = packOp.getSourceRank();
-  return encodingInfo;
-}
-
 //===---------------------------------------------------------------------===//
 // Patterns to lower operations that are used to compute the number of
 // workgroups.

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -51,14 +51,6 @@ getPartitionableLoopsImpl(linalg::LinalgOp linalgOp,
   return parallelLoops;
 }
 
-static llvm::SmallVector<utils::IteratorType>
-getIteratorTypesFromAttr(ArrayAttr iteratorTypesAttr) {
-  return llvm::map_to_vector(iteratorTypesAttr, [](Attribute attr) {
-    return utils::symbolizeIteratorType(llvm::cast<StringAttr>(attr).getValue())
-        .value();
-  });
-}
-
 /// External model implementation for all LinalgOps.
 template <typename OpTy>
 struct LinalgOpPartitionableLoops

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -113,8 +113,8 @@ enum class VectorPreProcStrategy {
 };
 
 // TODO(dcaballe): Move operator<< to DebugUtils.h.
-static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                     const VectorPreProcStrategy &strategy) {
+[[maybe_unused]] static llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os, const VectorPreProcStrategy &strategy) {
   switch (strategy) {
   case VectorPreProcStrategy::Padding:
     os << "Padding";
@@ -133,8 +133,8 @@ static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 }
 
 template <typename T>
-static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                     const llvm::SmallVectorImpl<T> &vector) {
+[[maybe_unused]] static llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os, const llvm::SmallVectorImpl<T> &vector) {
   for (T element : vector) {
     os << element << " ";
   }
@@ -142,7 +142,7 @@ static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   return os;
 }
 
-static llvm::raw_ostream &
+[[maybe_unused]] static llvm::raw_ostream &
 operator<<(llvm::raw_ostream &os,
            const mlir::iree_compiler::TileSizesListType &tileSizeList) {
   os << "[";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -681,25 +681,6 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
                                                passPipeline, workgroupSize);
 }
 
-/// Return the size of the given dimension in the linalg op.
-// TODO: this should be part of LinalgOp interface, the equivalent member
-// function currently only support the case where all the dimensions are static
-// while we want to support dynamic shapes.
-static std::optional<int64_t> getLinalgDimSize(linalg::LinalgOp op, int64_t d) {
-  for (auto [mapIdx, map] : llvm::enumerate(op.getIndexingMapsArray())) {
-    for (auto [dimIdx, dim] : llvm::enumerate(map.getResults())) {
-      auto expr = dim.dyn_cast<AffineDimExpr>();
-      if (expr && expr.getPosition() == d) {
-        auto type = llvm::cast<ShapedType>(op->getOperand(mapIdx).getType());
-        if (type.isDynamicDim(dimIdx))
-          return std::nullopt;
-        return type.getDimSize(dimIdx);
-      }
-    }
-  }
-  return std::nullopt;
-}
-
 /// Set configuration for transform dialect based strategies.
 static LogicalResult setTransformDialectConfig(func::FuncOp entryPoint,
                                                Operation *op,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPULayoutAnalysisAndDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPULayoutAnalysisAndDistribution.cpp
@@ -35,7 +35,7 @@ static constexpr int VecIdX = 7;
 static constexpr int NumDims = 8;
 } // namespace DimType
 
-static std::string typeToString(int i) {
+[[maybe_unused]] static std::string typeToString(int i) {
   switch (i) {
   case DimType::Batch0:
     return "Batch0";
@@ -754,15 +754,6 @@ static int isSingleLaneIdReduced(std::array<int, 4> &order) {
       count++;
   }
   return count == 1;
-}
-
-static int getVecSizes(std::array<int, 4> &order, const Layout &layout) {
-  int size = 1;
-  for (int i = 0; i < 4; i++) {
-    if (isVectorId(i))
-      size *= layout.shape[i];
-  }
-  return size;
 }
 
 using bodyType = std::function<void(std::array<int, DimType::NumDims> &)>;

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/CPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/CPU/Common.cpp
@@ -138,23 +138,6 @@ std::pair<Value, Value> mlir::iree_compiler::cpu::buildCommonTrailingStrategy(
 // user-friendliness.
 //===----------------------------------------------------------------------===//
 
-/// Placeholder to encode fixed reductions that should take finer-grained
-/// precedence over other heuristics. In the future, this could be lifted to
-/// e.g. `cpuModel` or higher up in some transform dialect database summary of
-/// "known good things".
-static FailureOr<ReductionConfig> applyKnownGoodReductionConfigurations(
-    const transform_ext::MatchedReductionCaptures &captures,
-    const CPUModel &cpuModel) {
-  int64_t reductionSize = captures.reductionOpSizes.back();
-  if (cpuModel.model == CPUModel::kDefaultCPU) {
-    if (captures.reductionOutputElementalTypeBitWidth == 32) {
-      if (reductionSize == 32)
-        return ReductionConfig{/*vectorSize=*/32};
-    }
-  }
-  return failure();
-}
-
 static ReductionConfig
 getReductionConfig(const transform_ext::MatchedReductionCaptures &captures,
                    const CPUModel &cpuModel) {

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/Common/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/Common/Common.cpp
@@ -386,41 +386,6 @@ struct ReductionSplitResult {
 };
 } // namespace
 
-/// Builds transform IR requesting to bubble up the "expand_shape" operation
-/// produced as parent of reduction splitting if necessary for fusion of the
-/// leading elementwise operation.
-// TODO: consider passing a problem-specific struct to control information.
-static ReductionSplitResult
-createBubbleExpand(ImplicitLocOpBuilder &b, Value variantH,
-                   SplitReductionOp splitReductionTransformOp,
-                   bool hasLeadingEltwise, bool hasTrailingEltwise) {
-  ReductionSplitResult result;
-  if (!hasLeadingEltwise) {
-    result.splitFillH = splitReductionTransformOp.getFillOp();
-    result.splitLinalgH = splitReductionTransformOp.getSplitLinalgOp();
-    result.combinerH = splitReductionTransformOp.getCombiningLinalgOp();
-    return result;
-  }
-
-  auto funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
-  b.create<transform::ApplyPatternsOp>(funcH, [](OpBuilder &b, Location loc) {
-    b.create<
-        iree_compiler::IREE::transform_dialect::ApplyBubbleExpandPatternsOp>(
-        loc);
-  });
-  std::tie(result.originalFillH, result.splitFillH) =
-      matchAndUnpack<2>(b, variantH, linalg::FillOp::getOperationName());
-  if (hasTrailingEltwise) {
-    std::tie(result.leadingEltwiseH, result.splitLinalgH, result.combinerH,
-             result.trailingEltwiseH) =
-        matchAndUnpack<4>(b, variantH, linalg::GenericOp::getOperationName());
-  } else {
-    std::tie(result.leadingEltwiseH, result.splitLinalgH, result.combinerH) =
-        matchAndUnpack<3>(b, variantH, linalg::GenericOp::getOperationName());
-  }
-  return result;
-}
-
 /// Build transform IR to split the reduction into a parallel and combiner part.
 /// Then tile the parallel part and map it to `tileSize` threads, each reducing
 /// on `vectorSize` elements.

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -132,23 +132,6 @@ struct ReplaceOpIfTensorOperandEmpty : public OpRewritePattern<Op> {
   }
 };
 
-// Turns a tensor type that may have one or more dynamic dimensions into a
-// static type with dynamic dimensions replaced with 0.
-// Example: tensor<?x0x1xf32> -> tensor<0x0x1xf32>
-static Type makeZeroElementsStaticTensorType(Type type) {
-  auto tensorType = llvm::cast<RankedTensorType>(type);
-  if (tensorType.hasStaticShape())
-    return type;
-  SmallVector<int64_t> dims;
-  dims.resize(tensorType.getRank());
-  for (int64_t i = 0; i < tensorType.getRank(); ++i) {
-    int64_t dim = tensorType.getDimSize(i);
-    dims[i] = dim == ShapedType::kDynamic ? 0 : dim;
-  }
-  return RankedTensorType::get(dims, tensorType.getElementType(),
-                               tensorType.getEncoding());
-}
-
 // Returns a new set of dynamic dimensions for a shape carrying op when a type
 // is being changed. This attempts to reuse the existing dimension values if
 // they are available and will drop/insert new ones as required.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -158,15 +158,6 @@ static void appendToFusionGroup(Operation *op, ArrayRef<int64_t> newGroups) {
   fusionGroups.append(newGroups.begin(), newGroups.end());
   op->setAttr(kFusionGroupsAttr, Builder(op).getI64ArrayAttr(fusionGroups));
 }
-/// Returns true if the given `op` is in the `targetGroup` fusion group.
-static bool isInFusionGroup(Operation *op, unsigned targetGroup) {
-  if (ArrayAttr opGroupAttr = op->getAttrOfType<ArrayAttr>(kFusionGroupsAttr)) {
-    return llvm::any_of(opGroupAttr, [&targetGroup](Attribute attr) {
-      return llvm::cast<IntegerAttr>(attr).getInt() == targetGroup;
-    });
-  }
-  return false;
-}
 /// Removes the fusion groups attribute.
 static void removeFusionGroupsAttribute(Operation *op) {
   op->removeAttr(kFusionGroupsAttr);

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -195,66 +195,6 @@ static void printTargetConditionRegion(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
-// custom<ConditionalTargetRegions>($targets, $objects, $target_regions)
-//===----------------------------------------------------------------------===//
-
-static ParseResult parseConditionalTargetRegions(
-    OpAsmParser &parser, ArrayAttr &targetsAttr, ArrayAttr &objectsAttr,
-    SmallVectorImpl<std::unique_ptr<Region>> &targetRegions) {
-  auto builder = parser.getBuilder();
-  SmallVector<Attribute> targetAttrs;
-  SmallVector<Attribute> objectsAttrs;
-  do {
-    IREE::HAL::ExecutableTargetAttr targetAttr;
-    if (failed(parser.parseAttribute(targetAttr)))
-      return failure();
-    targetAttrs.push_back(targetAttr);
-    std::unique_ptr<Region> targetRegion = std::make_unique<Region>();
-    if (succeeded(parser.parseOptionalKeyword("if"))) {
-      if (failed(parseTargetConditionRegion(parser, *targetRegion)))
-        return failure();
-    }
-    targetRegions.emplace_back(std::move(targetRegion));
-    if (failed(parser.parseEqual()))
-      return failure();
-    ArrayAttr targetObjectsAttr;
-    if (failed(parser.parseAttribute(targetObjectsAttr)))
-      return failure();
-    objectsAttrs.push_back(targetObjectsAttr);
-  } while (succeeded(parser.parseOptionalComma()));
-  targetsAttr = builder.getArrayAttr(targetAttrs);
-  objectsAttr = builder.getArrayAttr(objectsAttrs);
-  return success();
-}
-
-static void
-printConditionalTargetRegions(OpAsmPrinter &p, Operation *op,
-                              ArrayAttr targetsAttr, ArrayAttr objectsAttr,
-                              MutableArrayRef<Region> targetRegions) {
-  p.increaseIndent();
-  p.printNewline();
-  llvm::interleave(
-      llvm::zip_equal(targetsAttr.getAsRange<IREE::HAL::ExecutableTargetAttr>(),
-                      objectsAttr.getAsRange<ArrayAttr>(), targetRegions),
-      [&](auto it) {
-        auto [targetAttr, targetObjectsAttr, targetRegion] = it;
-        p.printAttribute(targetAttr);
-        if (!targetRegion.empty()) {
-          p << " if";
-          printTargetConditionRegion(p, op, targetRegion);
-        }
-        p << " = ";
-        p.printAttribute(targetObjectsAttr);
-      },
-      [&]() {
-        p << ",";
-        p.printNewline();
-      });
-  p.decreaseIndent();
-  p.printNewline();
-}
-
-//===----------------------------------------------------------------------===//
 // custom<WorkgroupCountRegion>($body)
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceHazards.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceHazards.cpp
@@ -33,21 +33,8 @@ namespace Stream {
 
 // TODO(#6972): move to StreamTypes.h.
 
-static bool doesRead(ResourceAccessBitfield access) {
-  return bitEnumContainsAny(access, ResourceAccessBitfield::Read);
-}
-static bool doesWrite(ResourceAccessBitfield access) {
-  return bitEnumContainsAny(access, ResourceAccessBitfield::Write);
-}
 static bool isReadOnly(ResourceAccessBitfield access) {
   return access == ResourceAccessBitfield::Read;
-}
-static bool isWriteOnly(ResourceAccessBitfield access) {
-  return access == ResourceAccessBitfield::Write;
-}
-static bool isReadWrite(ResourceAccessBitfield access) {
-  return bitEnumContainsAny(access, ResourceAccessBitfield::Read |
-                                        ResourceAccessBitfield::Write);
 }
 
 static bool doesRangeOverlap(AsyncAccessRange &lhs, AsyncAccessRange &rhs) {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -362,7 +362,8 @@ struct PropagateClonableOps : public OpRewritePattern<Op> {
 
 // Materialize copy-on-write (🐄) ops where required for |rootValue|.
 // Only valid in tensor/async ops - don't use with stream.cmd.*.
-static bool materializeCOW(Location loc, Value rootValue, OpBuilder &builder) {
+[[maybe_unused]] static bool materializeCOW(Location loc, Value rootValue,
+                                            OpBuilder &builder) {
   auto valueType =
       llvm::dyn_cast<IREE::Stream::ResourceType>(rootValue.getType());
   if (!valueType)

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -81,25 +81,6 @@ verifyDispatchWorkload(Operation *op, IREE::Stream::ExecutableExportOp exportOp,
 }
 
 // Verifies that |dynamicDims| contains the appropriate number of dims for all
-// of the dynamic dimensions in |values|.
-static LogicalResult verifyOpDynamicDims(Operation *op, ValueRange values,
-                                         ValueRange dynamicDims) {
-  unsigned requiredCount = 0;
-  for (auto value : values) {
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(value.getType())) {
-      requiredCount += shapedType.getNumDynamicDims();
-    }
-  }
-  if (dynamicDims.size() != requiredCount) {
-    return op->emitOpError()
-           << "value set has " << requiredCount
-           << " dynamic dimensions but only " << dynamicDims.size()
-           << " dimension values are attached";
-  }
-  return success();
-}
-
-// Verifies that |dynamicDims| contains the appropriate number of dims for all
 // the dynamic dimensions in |type|.
 static LogicalResult verifyOpDynamicDims(Operation *op, TypeRange types,
                                          ValueRange dynamicDims) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
@@ -432,17 +432,6 @@ static bool isSafeToElideCloneOp(IREE::Stream::AsyncCloneOp cloneOp,
   return false;
 }
 
-// Tries to elide |cloneOp| by replacing all uses with its source if safe.
-// Returns true if the op was elided.
-static bool tryElideCloneOp(IREE::Stream::AsyncCloneOp cloneOp,
-                            LastUseAnalysis &analysis) {
-  if (!isSafeToElideCloneOp(cloneOp, analysis))
-    return false;
-  cloneOp.replaceAllUsesWith(cloneOp.getSource());
-  cloneOp.erase();
-  return true;
-}
-
 // Tries to elide copies nested within |region| when safe.
 // Returns true if any ops were elided.
 static bool tryElideAsyncCopiesInRegion(Region &region,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/LayoutSlices.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/LayoutSlices.cpp
@@ -35,35 +35,6 @@ namespace {
 
 using Slice = IREE::Stream::ResourcePackOp::Slice;
 
-// Packs slices back-to-back with no aliasing. Useful when debugging to remove
-// the aliasing that makes data breakpoints useless.
-//
-// Slice packed offset SSA values will be updated and start at the given
-// |baseOffset|. Returns |baseOffset| + the total size of the allocation
-// aligned to the requirements of |resourceConfig|.
-static Value
-packSlicesWithNoAliasing(IREE::Stream::ResourcePackOp packOp, Value baseOffset,
-                         ArrayRef<Slice> slices,
-                         IREE::Stream::ResourceConfigAttr resourceConfig,
-                         IndexSet &indexSet, OpBuilder &builder) {
-  auto loc = packOp.getLoc();
-  int64_t offsetAlignment = resourceConfig.getMinBufferOffsetAlignment();
-  int64_t rangeAlignment = resourceConfig.getMinBufferRangeAlignment();
-
-  Value offset = baseOffset;
-  for (auto &slice : slices) {
-    auto sliceSize = builder.createOrFold<IREE::Util::AlignOp>(
-        loc, slice.dynamicSize, rangeAlignment);
-    slice.packedOffset.replaceAllUsesWith(offset);
-    auto valueToAlign =
-        builder.createOrFold<arith::AddIOp>(loc, offset, sliceSize);
-    offset = builder.createOrFold<IREE::Util::AlignOp>(loc, valueToAlign,
-                                                       offsetAlignment);
-  }
-
-  return builder.createOrFold<IREE::Util::AlignOp>(loc, offset, rangeAlignment);
-}
-
 // Packs a set of statically-sized slices by greedy strip packing.
 //
 // This is the same algorithm used in tflite here:

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -527,8 +527,6 @@ static void expandCondBranchOp(mlir::cf::CondBranchOp op,
   op.erase();
 }
 
-static ValueRange asValueRange(ArrayRef<Value> values) { return values; }
-
 static void expandSwitchOp(mlir::cf::SwitchOp op,
                            IRMapping &resourceTimepointMap) {
   if (!usesResources(op))

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
@@ -236,16 +236,6 @@ static void markStreamAsyncOpsIllegal(Verifier &verifier) {
       });
 }
 
-static void markStreamCmdOpsIllegal(Verifier &verifier) {
-  verifier.addOpVerifier(
-      [](Operation *op) -> std::optional<Verifier::Legality> {
-        if (op->hasTrait<OpTrait::IREE::Stream::CmdPhaseOp>()) {
-          return Verifier::Legality::ILLEGAL;
-        }
-        return std::nullopt;
-      });
-}
-
 //===----------------------------------------------------------------------===//
 // -iree-stream-verify-input
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
@@ -21,7 +21,7 @@ static StringRef getOpName(Operation *op) {
   return symbol ? symbol.getName() : op->getName().getStringRef();
 }
 
-static StringRef getRegionName(Region &region) {
+[[maybe_unused]] static StringRef getRegionName(Region &region) {
   return getOpName(region.getParentOp());
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/ConvertPrimitiveType.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/ConvertPrimitiveType.cpp
@@ -55,8 +55,8 @@ Value convertRankedFloat(OpBuilder &builder, Type type, ValueRange inputs,
   return nullptr;
 };
 
-Value convertRankedInteger(OpBuilder &builder, Type type, ValueRange inputs,
-                           Location loc) {
+[[maybe_unused]] Value convertRankedInteger(OpBuilder &builder, Type type,
+                                            ValueRange inputs, Location loc) {
   Type eTy = getElementTypeOrSelf(type);
   Type inputETy = getElementTypeOrSelf(inputs[0].getType());
   if (!llvm::isa<FloatType>(getElementTypeOrSelf(type)))

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
@@ -79,8 +79,8 @@ struct GlobalTable {
   }
 };
 
-static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                     llvm::BitVector &bits) {
+[[maybe_unused]] static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                                      llvm::BitVector &bits) {
   for (unsigned i = 0; i < bits.size(); ++i) {
     os << (bits.test(i) ? "1" : "0");
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -213,30 +213,6 @@ removeBlockArguments(IREE::VM::ModuleOp moduleOp,
   return success();
 }
 
-FailureOr<int64_t> calculateNumSpans(IREE::VM::CallVariadicOp &callOp) {
-  auto isVariadic = [](APInt segmentSize) {
-    return segmentSize.getSExtValue() != -1;
-  };
-
-  DenseIntElementsAttr segmentSizes = callOp.getSegmentSizes();
-  size_t numSegments = segmentSizes.size();
-  size_t numVariadicSegments = llvm::count_if(segmentSizes, isVariadic);
-
-  if (numVariadicSegments != 1) {
-    callOp.emitError() << "only exactly one variadic segment supported";
-    return failure();
-  }
-
-  auto lastSegmentSize = *(segmentSizes.begin() + (numSegments - 1));
-
-  if (!isVariadic(lastSegmentSize)) {
-    callOp.emitError() << "expected the last segment to be variadic";
-    return failure();
-  }
-
-  return lastSegmentSize.getSExtValue();
-}
-
 std::optional<std::string> buildFunctionName(IREE::VM::ModuleOp &moduleOp,
                                              IREE::VM::ImportOp &importOp) {
   auto callingConvention = makeImportCallingConventionString(importOp);

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -262,19 +262,6 @@ makeFunctionSignatureDef(IREE::VM::FuncOp funcOp,
                                     cconv.value(), attrsRef, fbb);
 }
 
-// Returns a serialized function signature.
-static iree_vm_FunctionSignatureDef_ref_t
-makeInternalFunctionSignatureDef(IREE::VM::FuncOp funcOp,
-                                 llvm::DenseMap<Type, int> &typeTable,
-                                 FlatbufferBuilder &fbb) {
-  // Generate the signature calling convention string based on types.
-  auto cconv = makeCallingConventionString(funcOp);
-  if (!cconv.has_value())
-    return {};
-  return createFunctionSignatureDef(funcOp.getFunctionType(), typeTable,
-                                    cconv.value(), /*attrsRef=*/0, fbb);
-}
-
 // Walks |rootOp| to find all VM features required by it and its children.
 static iree_vm_FeatureBits_enum_t findRequiredFeatures(Operation *rootOp) {
   iree_vm_FeatureBits_enum_t result = 0;

--- a/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/src/iree/compiler/InputConversion/StableHLO/Preprocessing/StableHLOToStableHLO.cpp
@@ -46,12 +46,6 @@ DenseIntElementsAttr make1DElementsAttr(OpBuilder &b,
   return DenseIntElementsAttr::get(type, integers);
 }
 
-DenseIntElementsAttr make1DElementsAttr(OpBuilder &b, int64_t start,
-                                        int64_t num) {
-  return make1DElementsAttr(
-      b, llvm::to_vector(llvm::seq<int64_t>(start, start + num)));
-}
-
 Value getF32Const(ImplicitLocOpBuilder b, ArrayRef<int64_t> shapes,
                   ArrayRef<float> values) {
   RankedTensorType ty = RankedTensorType::get(shapes, b.getF32Type());

--- a/runtime/src/iree/base/internal/atomic_slist.h
+++ b/runtime/src/iree/base/internal/atomic_slist.h
@@ -222,8 +222,8 @@ bool iree_atomic_slist_flush(iree_atomic_slist_t* list,
   static inline void name##_slist_push(name##_slist_t* list, type* entry) {    \
     iree_atomic_slist_push(&list->impl, name##_slist_entry_from_ptr(entry));   \
   }                                                                            \
-  static inline void name##_slist_push_unsafe(name##_slist_t* list,            \
-                                              type* entry) {                   \
+  IREE_ATTRIBUTE_UNUSED static inline void name##_slist_push_unsafe(           \
+      name##_slist_t* list, type* entry) {                                     \
     iree_atomic_slist_push_unsafe(&list->impl,                                 \
                                   name##_slist_entry_from_ptr(entry));         \
   }                                                                            \

--- a/runtime/src/iree/base/internal/flags.c
+++ b/runtime/src/iree/base/internal/flags.c
@@ -510,7 +510,7 @@ static iree_status_t iree_flags_parse_file(iree_string_view_t file_path) {
       "while trying to parse flagfile");
 
   // Run through the file line-by-line.
-  int line_number = 0;
+  IREE_ATTRIBUTE_UNUSED int line_number = 0;
   iree_string_view_t contents =
       iree_make_string_view((const char*)file_contents->buffer.data,
                             file_contents->buffer.data_length);

--- a/runtime/src/iree/base/internal/flags.h
+++ b/runtime/src/iree/base/internal/flags.h
@@ -273,7 +273,8 @@ void iree_flag_string_list_print(iree_string_view_t flag_name, void* storage,
   IREE_FLAG_CALLBACK(iree_flag_##type##_list_parse,                         \
                      iree_flag_##type##_list_print, &FLAG_##name##_storage, \
                      name, description);                                    \
-  static const iree_flag_##type##_list_t FLAG_##name##_list(void) {         \
+  IREE_ATTRIBUTE_UNUSED static const iree_flag_##type##_list_t              \
+      FLAG_##name##_list(void) {                                            \
     const iree_flag_##type##_list_t list = {                                \
         /*.count=*/FLAG_##name##_storage.count,                             \
         /*.values=*/FLAG_##name##_storage.count == 1                        \

--- a/runtime/src/iree/base/internal/path.c
+++ b/runtime/src/iree/base/internal/path.c
@@ -93,6 +93,7 @@ static iree_host_size_t iree_file_path_canonicalize_unix(
   return new_length;
 }
 
+#if defined(IREE_PLATFORM_WINDOWS)
 static iree_host_size_t iree_file_path_canonicalize_win32(
     char* path, iree_host_size_t path_length) {
   char* p = path;
@@ -117,6 +118,7 @@ static iree_host_size_t iree_file_path_canonicalize_win32(
   path[new_length] = 0;  // NUL
   return new_length;
 }
+#endif  // IREE_PLATFORM_WINDOWS
 
 iree_host_size_t iree_file_path_canonicalize(char* path,
                                              iree_host_size_t path_length) {

--- a/runtime/src/iree/base/internal/synchronization.c
+++ b/runtime/src/iree/base/internal/synchronization.c
@@ -65,7 +65,7 @@
 
 // MSVC uses architecture-specific intrinsics.
 
-static inline void iree_processor_yield(void) {
+IREE_ATTRIBUTE_UNUSED static inline void iree_processor_yield(void) {
 #if defined(IREE_ARCH_X86_32) || defined(IREE_ARCH_X86_64)
   // https://docs.microsoft.com/en-us/cpp/intrinsics/x86-intrinsics-list
   _mm_pause();
@@ -81,7 +81,7 @@ static inline void iree_processor_yield(void) {
 
 // Clang/GCC and compatibles use architecture-specific inline assembly.
 
-static inline void iree_processor_yield(void) {
+IREE_ATTRIBUTE_UNUSED static inline void iree_processor_yield(void) {
 #if defined(IREE_ARCH_X86_32) || defined(IREE_ARCH_X86_64)
   asm volatile("pause");
 #elif defined(IREE_ARCH_ARM_32) || defined(IREE_ARCH_ARM_64)

--- a/runtime/src/iree/base/internal/threading_pthreads.c
+++ b/runtime/src/iree/base/internal/threading_pthreads.c
@@ -227,7 +227,8 @@ uintptr_t iree_thread_id(iree_thread_t* thread) {
 // Maps an IREE iree_thread_priority_class_t value to a pthreads priority param.
 // The min/max ranges of the priority are implementation dependent so we need to
 // do this at runtime.
-static struct sched_param iree_thread_sched_param_for_priority_class(
+IREE_ATTRIBUTE_UNUSED static struct sched_param
+iree_thread_sched_param_for_priority_class(
     int policy, iree_thread_priority_class_t priority_class) {
   struct sched_param param;
   memset(&param, 0, sizeof(param));

--- a/runtime/src/iree/base/internal/wait_handle_posix.c
+++ b/runtime/src/iree/base/internal/wait_handle_posix.c
@@ -42,7 +42,7 @@ static iree_status_t iree_wait_primitive_create_eventfd(
 #endif  // IREE_HAVE_WAIT_TYPE_EVENTFD
 
 #if defined(IREE_HAVE_WAIT_TYPE_PIPE)
-static iree_status_t iree_wait_primitive_create_pipe(
+IREE_ATTRIBUTE_UNUSED static iree_status_t iree_wait_primitive_create_pipe(
     bool initial_state, iree_wait_handle_t* out_handle) {
   memset(out_handle, 0, sizeof(*out_handle));
   out_handle->type = IREE_WAIT_PRIMITIVE_TYPE_PIPE;

--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -53,7 +53,8 @@
 #define iree_aligned_free(p) free(p)
 #elif _POSIX_C_SOURCE >= 200112L
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_memalign.html
-static inline void* iree_aligned_alloc(size_t alignment, size_t size) {
+IREE_ATTRIBUTE_UNUSED static inline void* iree_aligned_alloc(size_t alignment,
+                                                             size_t size) {
   void* ptr = NULL;
   return posix_memalign(&ptr, alignment, size) == 0 ? ptr : NULL;
 }
@@ -391,7 +392,7 @@ typedef struct iree_status_storage_t {
   ((iree_status_storage_t*)(((uintptr_t)(status) & ~IREE_STATUS_CODE_MASK)))
 
 // Appends a payload to the storage doubly-linked list.
-static iree_status_t iree_status_append_payload(
+IREE_ATTRIBUTE_UNUSED static iree_status_t iree_status_append_payload(
     iree_status_t status, iree_status_storage_t* storage,
     iree_status_payload_t* payload) {
   if (!storage->payload_tail) {
@@ -408,7 +409,7 @@ static iree_status_t iree_status_append_payload(
 // NUL. If |buffer| is omitted then |out_buffer_length| will be set to the
 // total number of characters in |buffer_capacity| required to contain the
 // entire message.
-static void iree_status_payload_message_formatter(
+IREE_ATTRIBUTE_UNUSED static void iree_status_payload_message_formatter(
     const iree_status_payload_t* base_payload, iree_host_size_t buffer_capacity,
     char* buffer, iree_host_size_t* out_buffer_length) {
   iree_status_payload_message_t* payload =
@@ -758,7 +759,7 @@ static iree_status_t iree_status_attach_stack_trace(
 
 #else
 
-static iree_status_t iree_status_attach_stack_trace(
+IREE_ATTRIBUTE_UNUSED static iree_status_t iree_status_attach_stack_trace(
     iree_status_t status, iree_status_storage_t* storage, int skip_frames) {
   return status;
 }

--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -21,10 +21,6 @@ static inline size_t iree_min_host_size(iree_host_size_t a,
 
 // Here to ensure that we don't pull in locale-specific code:
 static bool iree_isupper(char c) { return (unsigned)c - 'A' < 26; }
-static bool iree_islower(char c) { return (unsigned)c - 'a' < 26; }
-static inline char iree_toupper(char c) {
-  return iree_islower(c) ? (c & 0x5F) : c;
-}
 static inline char iree_tolower(char c) {
   return iree_isupper(c) ? (c | 32) : c;
 }

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
@@ -443,7 +443,8 @@ static void iree_uk_test_mmt4d(iree_uk_uint32_t flags, int M0, int N0, int K0,
   iree_uk_test_mmt4d_impl(flags, M0, N0, K0, cpu_features);
 }
 
-static void iree_uk_test_mmt4d_default_and_skip_intermediate_roundings(
+IREE_ATTRIBUTE_UNUSED static void
+iree_uk_test_mmt4d_default_and_skip_intermediate_roundings(
     iree_uk_uint32_t flags, int M0, int N0, int K0, const char* cpu_features) {
   iree_uk_test_mmt4d(flags, M0, N0, K0, cpu_features);
   iree_uk_test_mmt4d(flags | IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS, M0,

--- a/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
+++ b/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
@@ -14,6 +14,7 @@
 #include "iree/hal/drivers/cuda/status_util.h"
 #include "third_party/nccl/nccl.h"
 
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 // Returns the same value as NCCL's init.cc hashUniqueId.
 // These magic constants were chosen by their implementation and unlikely to
 // be stable as it's not part of their public API. Only to be used for
@@ -28,6 +29,7 @@ static uint64_t iree_hal_cuda_nccl_hash_id(const iree_hal_cuda_nccl_id_t* id) {
   }
   return hash;
 }
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
 iree_status_t iree_hal_cuda_nccl_get_unique_id_from_context(
     iree_hal_cuda_context_wrapper_t* context_wrapper,

--- a/runtime/src/iree/hal/drivers/vulkan/descriptor_set_arena.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/descriptor_set_arena.cc
@@ -85,22 +85,6 @@ static void PopulateDescriptorSetWriteInfos(
   *out_infos = write_infos.data();
 }
 
-static VkDescriptorSetAllocateInfo PopulateDescriptorSetsAllocateInfo(
-    const DescriptorPool& descriptor_pool,
-    iree_hal_descriptor_set_layout_t* set_layout) {
-  VkDescriptorSetAllocateInfo allocate_info;
-  allocate_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-  allocate_info.pNext = nullptr;
-  allocate_info.descriptorPool = descriptor_pool.handle;
-
-  VkDescriptorSetLayout set_layout_handle =
-      iree_hal_vulkan_native_descriptor_set_layout_handle(set_layout);
-  allocate_info.descriptorSetCount = 1;
-  allocate_info.pSetLayouts = &set_layout_handle;
-
-  return allocate_info;
-}
-
 }  // namespace
 
 DescriptorSetArena::DescriptorSetArena(

--- a/runtime/src/iree/modules/hal/inline/module.c
+++ b/runtime/src/iree/modules/hal/inline/module.c
@@ -203,13 +203,6 @@ static iree_status_t IREE_API_PTR iree_hal_inline_module_notify(
 // Utilities
 //===----------------------------------------------------------------------===//
 
-// Casts a VM value to a C host size.
-static iree_host_size_t iree_hal_cast_host_size(int64_t value) {
-  // TODO(benvanik): make this return status and check for overflow if host
-  // size is 32-bits.
-  return (iree_host_size_t)value;
-}
-
 // Casts a VM value to a HAL device size.
 static iree_device_size_t iree_hal_cast_device_size(int64_t value) {
   // TODO(benvanik): make this return status and check for overflow if device

--- a/runtime/src/iree/modules/hal/loader/module.c
+++ b/runtime/src/iree/modules/hal/loader/module.c
@@ -93,13 +93,6 @@ static iree_host_size_t iree_hal_cast_host_size(int64_t value) {
   return (iree_host_size_t)value;
 }
 
-// Casts a VM value to a HAL device size.
-static iree_device_size_t iree_hal_cast_device_size(int64_t value) {
-  // TODO(benvanik): make this return status and check for overflow if device
-  // size is 32-bits.
-  return (iree_device_size_t)value;
-}
-
 //===----------------------------------------------------------------------===//
 // Shared argument shims
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/task/task.c
+++ b/runtime/src/iree/task/task.c
@@ -224,6 +224,7 @@ void iree_task_nop_retire(iree_task_nop_t* task,
 // IREE_TASK_TYPE_CALL
 //==============================================================================
 
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 // Returns an XXBBGGRR color (red in the lowest bits).
 // Must not be 0 (tracy will ignore).
 static uint32_t iree_math_ptr_to_xrgb(const void* ptr) {
@@ -233,6 +234,7 @@ static uint32_t iree_math_ptr_to_xrgb(const void* ptr) {
   uint64_t ptr64 = (uintptr_t)ptr;
   return (uint32_t)ptr64 ^ (uint32_t)(ptr64 >> 32);
 }
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
 void iree_task_call_initialize(iree_task_scope_t* scope,
                                iree_task_call_closure_t closure,
@@ -444,13 +446,9 @@ void iree_task_wait_retire(iree_task_wait_t* task,
 // IREE_TASK_TYPE_DISPATCH_* utilities
 //==============================================================================
 
-// Returns an XXBBGGRR color (red in the lowest bits).
-// Must not be 0 (tracy will ignore).
-static uint32_t iree_task_tile_to_color(
-    const iree_task_tile_context_t* tile_context);
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
 #if defined(IREE_TASK_TRACING_PER_TILE_COLORS)
-
 // TODO(#4017): optimize this to compute entire slices at once and fold in the
 // work grid location code.
 static uint32_t iree_math_hsv_to_xrgb(const uint8_t h, const uint8_t s,
@@ -480,6 +478,8 @@ static uint32_t iree_math_hsv_to_xrgb(const uint8_t h, const uint8_t s,
   return xrgb;
 }
 
+// Returns an XXBBGGRR color (red in the lowest bits).
+// Must not be 0 (tracy will ignore).
 static uint32_t iree_task_tile_to_color(
     const iree_task_tile_context_t* tile_context) {
   // TODO(#4017): optimize such that it's always on when tracing is
@@ -503,14 +503,16 @@ static uint32_t iree_task_tile_to_color(
   return iree_math_hsv_to_xrgb(h, s, v);
 }
 
-#else
+#else  // defined(IREE_TASK_TRACING_PER_TILE_COLORS)
 
 static uint32_t iree_task_tile_to_color(
     const iree_task_tile_context_t* tile_context) {
   return 0;  // use default tracy colors
 }
 
-#endif  // IREE_TASK_TRACING_PER_TILE_COLORS
+#endif  // defined(IREE_TASK_TRACING_PER_TILE_COLORS)
+
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
 void iree_task_dispatch_statistics_merge(
     const iree_task_dispatch_statistics_t* source,

--- a/runtime/src/iree/task/topology_cpuinfo.c
+++ b/runtime/src/iree/task/topology_cpuinfo.c
@@ -323,12 +323,6 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
 typedef bool (*iree_task_topology_core_filter_t)(
     const struct cpuinfo_core* core, uintptr_t user_data);
 
-// Matches all cores.
-static bool iree_task_topology_core_filter_all(const struct cpuinfo_core* core,
-                                               uintptr_t user_data) {
-  return true;
-}
-
 // Matches all cores that have the provided cluster ID.
 static bool iree_task_topology_core_filter_by_cluster_id(
     const struct cpuinfo_core* core, uintptr_t user_data) {

--- a/runtime/src/iree/tooling/numpy_io_test.cc
+++ b/runtime/src/iree/tooling/numpy_io_test.cc
@@ -19,11 +19,6 @@ using iree::testing::status::IsOk;
 using iree::testing::status::StatusIs;
 using ::testing::ElementsAreArray;
 
-std::ostream& operator<<(std::ostream& os, const Status& x) {
-  os << x.ToString();
-  return os;
-}
-
 class NumpyIOTest : public ::testing::Test {
  protected:
   virtual void SetUp() {

--- a/runtime/src/iree/tooling/trace_replay.c
+++ b/runtime/src/iree/tooling/trace_replay.c
@@ -370,23 +370,10 @@ static uint32_t iree_tree_replay_pseudorandom_uint32(uint32_t* state) {
   return *state;
 }
 
-// Returns a random uint8_t in the range of [0, UCHAR_MAX].
-static uint8_t iree_trace_replay_pseudorandom_uint8(uint32_t* state) {
-  // return the second-least-signicant out of the 4 bytes of state. it avoids
-  // some mild issues with the least-significant and most-significant bytes.
-  return iree_tree_replay_pseudorandom_uint32(state) >> 8;
-}
-
 // Returns a random uint32_t in the range [0, range).
 static inline uint32_t iree_trace_replay_pseudorandom_range(uint32_t* state,
                                                             uint32_t range) {
   return iree_tree_replay_pseudorandom_uint32(state) % range;
-}
-
-// Returns a random double in the range of [0, 1.0).
-static double iree_trace_replay_pseudorandom_double(uint32_t* state) {
-  const double inv_modulus = 1.0 / IREE_PRNG_MODULUS;
-  return iree_tree_replay_pseudorandom_uint32(state) * inv_modulus;
 }
 
 // Get minimum and maximum for integer-valued uniform distribution.

--- a/runtime/src/iree/vm/bytecode/module.c
+++ b/runtime/src/iree/vm/bytecode/module.c
@@ -233,6 +233,7 @@ static iree_status_t iree_vm_bytecode_module_enumerate_dependencies(
   return iree_ok_status();
 }
 
+#if IREE_VM_BACKTRACE_ENABLE
 // Tries to return the original function name for internal function |ordinal|.
 // Empty if the debug database has been stripped from the flatbuffer.
 static flatbuffers_string_t
@@ -250,6 +251,7 @@ iree_vm_bytecode_module_lookup_internal_function_name(
   if (!source_map_def) return NULL;
   return iree_vm_FunctionSourceMapDef_local_name(source_map_def);
 }
+#endif  // IREE_VM_BACKTRACE_ENABLE
 
 static iree_status_t iree_vm_bytecode_module_lookup_function(
     void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
@@ -519,7 +521,8 @@ static iree_status_t iree_vm_bytecode_location_format(
   }
 }
 
-static iree_status_t iree_vm_bytecode_module_source_location_format(
+IREE_ATTRIBUTE_UNUSED static iree_status_t
+iree_vm_bytecode_module_source_location_format(
     void* self, uint64_t data[2], iree_vm_source_location_format_flags_t flags,
     iree_string_builder_t* builder) {
   iree_vm_DebugDatabaseDef_table_t debug_database_def =
@@ -551,6 +554,7 @@ static iree_status_t iree_vm_bytecode_module_source_location_format(
   return iree_ok_status();
 }
 
+#if IREE_VM_BACKTRACE_ENABLE
 static iree_status_t iree_vm_bytecode_module_resolve_source_location(
     void* self, iree_vm_function_t function, iree_vm_source_offset_t pc,
     iree_vm_source_location_t* out_source_location) {
@@ -592,6 +596,7 @@ static iree_status_t iree_vm_bytecode_module_resolve_source_location(
   out_source_location->format = iree_vm_bytecode_module_source_location_format;
   return iree_ok_status();
 }
+#endif  // IREE_VM_BACKTRACE_ENABLE
 
 // Lays out the nested tables within a |state| structure.
 // Returns the total size of the structure and all tables with padding applied.

--- a/runtime/src/iree/vm/list_test.cc
+++ b/runtime/src/iree/vm/list_test.cc
@@ -115,11 +115,6 @@ static std::vector<iree_vm_value_t> GetValuesList(iree_vm_list_t* list) {
   return result;
 }
 
-static bool operator==(const iree_vm_ref_t& lhs,
-                       const iree_vm_ref_t& rhs) noexcept {
-  return lhs.type == rhs.type && lhs.ptr == rhs.ptr;
-}
-
 namespace {
 
 using ::iree::Status;

--- a/runtime/src/iree/vm/ref.h
+++ b/runtime/src/iree/vm/ref.h
@@ -271,7 +271,8 @@ IREE_API_EXPORT bool iree_vm_ref_equal(const iree_vm_ref_t* lhs,
   }                                                                         \
   IREE_API_EXPORT iree_vm_ref_t name##_retain_ref(T* value);                \
   IREE_API_EXPORT iree_vm_ref_t name##_move_ref(T* value);                  \
-  static inline T* name##_deref(const iree_vm_ref_t ref) {                  \
+  IREE_ATTRIBUTE_UNUSED static inline T* name##_deref(                      \
+      const iree_vm_ref_t ref) {                                            \
     IREE_VM_REF_ASSERT(name##_registration);                                \
     return IREE_LIKELY(name##_isa(ref)) ? (T*)ref.ptr : NULL;               \
   }                                                                         \

--- a/runtime/src/iree/vm/shims.h
+++ b/runtime/src/iree/vm/shims.h
@@ -31,17 +31,18 @@
   IREE_VM_ABI_VLA_STRUCT_IMPL(types, vla_count, vla_field,        \
                               IREE_VM_ABI_TYPE_NAME(types), body)
 
-#define IREE_VM_ABI_FIXED_STRUCT_IMPL(struct_type, types, body)        \
-  typedef struct iree_vm_abi_##types##_t body IREE_ATTRIBUTE_PACKED    \
-      struct_type;                                                     \
-  static inline struct_type* iree_vm_abi_##types##_checked_deref(      \
-      iree_byte_span_t buffer) {                                       \
-    return IREE_LIKELY(buffer.data_length == sizeof(struct_type))      \
-               ? (struct_type*)buffer.data                             \
-               : NULL;                                                 \
-  }                                                                    \
-  static inline void iree_vm_abi_##types##_reset(struct_type* value) { \
-    memset(value, 0, sizeof(struct_type));                             \
+#define IREE_VM_ABI_FIXED_STRUCT_IMPL(struct_type, types, body)         \
+  typedef struct iree_vm_abi_##types##_t body IREE_ATTRIBUTE_PACKED     \
+      struct_type;                                                      \
+  static inline struct_type* iree_vm_abi_##types##_checked_deref(       \
+      iree_byte_span_t buffer) {                                        \
+    return IREE_LIKELY(buffer.data_length == sizeof(struct_type))       \
+               ? (struct_type*)buffer.data                              \
+               : NULL;                                                  \
+  }                                                                     \
+  IREE_ATTRIBUTE_UNUSED static inline void iree_vm_abi_##types##_reset( \
+      struct_type* value) {                                             \
+    memset(value, 0, sizeof(struct_type));                              \
   }
 
 #define IREE_VM_ABI_FIELD_SIZE(type, member) sizeof(((type*)NULL)->member)
@@ -80,7 +81,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target2_t)(
       void* IREE_RESTRICT module_state);
 
 #define IREE_VM_ABI_DEFINE_SHIM(arg_types, ret_types)                          \
-  iree_status_t iree_vm_shim_##arg_types##_##ret_types(                        \
+  IREE_ATTRIBUTE_UNUSED iree_status_t iree_vm_shim_##arg_types##_##ret_types(  \
       iree_vm_stack_t* IREE_RESTRICT stack,                                    \
       iree_vm_native_function_flags_t flags, iree_byte_span_t args_storage,    \
       iree_byte_span_t rets_storage,                                           \
@@ -101,7 +102,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target2_t)(
   }
 
 #define IREE_VM_ABI_EXPORT(function_name, module_state, arg_types, ret_types) \
-  static iree_status_t function_name(                                         \
+  IREE_ATTRIBUTE_UNUSED static iree_status_t function_name(                   \
       iree_vm_stack_t* IREE_RESTRICT stack, void* IREE_RESTRICT module,       \
       module_state* IREE_RESTRICT state,                                      \
       IREE_VM_ABI_TYPE_NAME(arg_types) * IREE_RESTRICT args,                  \


### PR DESCRIPTION
The annoying part is that clang doesn't track taking the address of functions as uses, so that's the common cause to all the false positives. Still easy enough to silence with unused-attributes and hopefully the lines of code diff makes it worth it.