### PR TITLE
Add `chlo` dialect to auto input conversion pipeline

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/AutoInputConversionPipeline.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/AutoInputConversionPipeline.cpp
@@ -82,8 +82,7 @@ static void populateHloFeatures(Operation *op, InputFeatures &features) {
   }
 }
 
-static void populateFeatures(Operation *op,
-                             const Dialect *chloDialect,
+static void populateFeatures(Operation *op, const Dialect *chloDialect,
                              const Dialect *stablehloDialect,
                              const Dialect *tosaDialect,
                              InputFeatures &features) {


### PR DESCRIPTION
`chlo` operations should be checked for with the `stablehlo` part of the auto input conversion pipeline.