### PR TITLE
[SPIRV] Fix vector masking for transfer scalarization patterns

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -32,7 +32,7 @@
 
 #define DEBUG_TYPE "iree-spirv-vectorize-load-store"
 
-#define DO_NOTHING [](OpBuilder &b, Location loc) { return ValueRange{}; }
+#define DO_NOTHING [](OpBuilder &b, Location loc) {}
 
 constexpr int kMaxVectorNumBits = 128;
 constexpr int kMaxVectorNumElements = 4;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -32,13 +32,13 @@
 
 #define DEBUG_TYPE "iree-spirv-vectorize-load-store"
 
-#define DO_NOTHING [](OpBuilder &b, Location loc) {}
-
 constexpr int kMaxVectorNumBits = 128;
 constexpr int kMaxVectorNumElements = 4;
 
 namespace mlir {
 namespace iree_compiler {
+
+static void doNothing(OpBuilder &, Location) {}
 
 //===----------------------------------------------------------------------===//
 // Utility Functions
@@ -937,7 +937,7 @@ struct ScalarizeVectorTransferWrite final
 
       (void)predicateMaybeMaskedScalarTransfer(
           rewriter, loc, maybeMaskBit, TypeRange{}, thenCond,
-          /*elseCond=*/DO_NOTHING, /*hasElse=*/false);
+          /*elseCond=*/doNothing, /*hasElse=*/false);
       rewriter.eraseOp(writeOp);
       return success();
     }
@@ -972,7 +972,7 @@ struct ScalarizeVectorTransferWrite final
       };
       (void)predicateMaybeMaskedScalarTransfer(
           rewriter, loc, maybeMaskBit, TypeRange{}, thenCond,
-          /*elseCond=*/DO_NOTHING, /*hasElse=*/false);
+          /*elseCond=*/doNothing, /*hasElse=*/false);
     }
     rewriter.eraseOp(writeOp);
     return success();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -32,6 +32,8 @@
 
 #define DEBUG_TYPE "iree-spirv-vectorize-load-store"
 
+#define DO_NOTHING [](OpBuilder &b, Location loc) { return ValueRange{}; }
+
 constexpr int kMaxVectorNumBits = 128;
 constexpr int kMaxVectorNumElements = 4;
 
@@ -99,6 +101,9 @@ calculateMemRefVectorNumBits(SmallVectorImpl<Operation *> &uses) {
     }
     auto transferOp = dyn_cast<VectorTransferOpInterface>(op);
     if (!transferOp)
+      return 0;
+    // Masked transfers must be scalarized.
+    if (transferOp.getMask())
       return 0;
     std::optional<unsigned> transferSize =
         getBitWidth(transferOp.getVectorType());
@@ -739,6 +744,37 @@ public:
   }
 };
 
+// Helper function to optionally predicate a scalar load/store if there is a
+// mask present.
+static ValueRange predicateMaybeMaskedScalarTransfer(
+    OpBuilder &b, Location loc, Value maybeMaskBit, TypeRange resultTypes,
+    function_ref<ValueRange(OpBuilder &, Location)> thenConditionBuilder,
+    function_ref<void(OpBuilder &, Location)> elseConditionBuilder,
+    bool hasElse) {
+  OpBuilder::InsertionGuard guard(b);
+  if (maybeMaskBit) {
+    OpBuilder::InsertionGuard guard1(b);
+    scf::IfOp ifOp;
+    if (hasElse) {
+      ifOp = b.create<scf::IfOp>(loc, resultTypes, maybeMaskBit, /*else=*/true);
+    } else {
+      ifOp = b.create<scf::IfOp>(loc, maybeMaskBit, /*else=*/false);
+    }
+    b.setInsertionPointToStart(&ifOp.getThenRegion().front());
+    ValueRange thenRes = thenConditionBuilder(b, loc);
+    if (hasElse) {
+      // An if with results must have an else region.
+      b.create<scf::YieldOp>(loc, thenRes);
+
+      OpBuilder::InsertionGuard guard2(b);
+      b.setInsertionPointToStart(&ifOp.getElseRegion().front());
+      elseConditionBuilder(b, loc);
+    }
+    return ifOp->getResults();
+  }
+  return thenConditionBuilder(b, loc);
+}
+
 /// Scalarizes remaining vector transfer that couldn't be converted to
 /// vevtor load operations.
 
@@ -756,10 +792,28 @@ struct ScalarizeVectorTransferRead final
       return failure();
 
     Location loc = readOp.getLoc();
+    Value maybeMask = readOp.getMask();
     if (vectorType.getRank() == 0) {
-      Value scalar = rewriter.create<memref::LoadOp>(loc, readOp.getSource(),
-                                                     readOp.getIndices());
-      rewriter.replaceOpWithNewOp<vector::SplatOp>(readOp, vectorType, scalar);
+      Value maybeMaskBit;
+      if (maybeMask) {
+        Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask, zero);
+      }
+
+      auto thenCond = [&](OpBuilder &b, Location loc) {
+        return ValueRange{b.create<memref::LoadOp>(loc, readOp.getSource(),
+                                                   readOp.getIndices())
+                              .getResult()};
+      };
+      auto elseCond = [&](OpBuilder &b, Location loc) {
+        b.create<scf::YieldOp>(loc, readOp.getPadding());
+      };
+
+      ValueRange scalar = predicateMaybeMaskedScalarTransfer(
+          rewriter, loc, maybeMaskBit, TypeRange{vectorType.getElementType()},
+          thenCond, elseCond, /*hasElse=*/true);
+      rewriter.replaceOpWithNewOp<vector::SplatOp>(readOp, vectorType,
+                                                   scalar[0]);
       return success();
     }
 
@@ -778,11 +832,33 @@ struct ScalarizeVectorTransferRead final
         loc, vectorType, rewriter.getZeroAttr(vectorType));
     for (int i = 0; i < vectorType.getDimSize(0); ++i) {
       Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
-      indices[dimPos] = rewriter.create<affine::AffineApplyOp>(
-          loc, addMap, ValueRange{oldIndex, iVal});
-      Value scalar =
-          rewriter.create<memref::LoadOp>(loc, readOp.getSource(), indices);
-      newVector = rewriter.create<vector::InsertOp>(loc, scalar, newVector, i);
+
+      // Extract the mask bit for this value if present.
+      Value maybeMaskBit;
+      if (maybeMask) {
+        // The result vector is 1-D and we have a projected permutation, meaning
+        // we can just extract the mask bit using the same index as the loaded
+        // vector.
+        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask, iVal);
+      }
+
+      auto thenCond = [&](OpBuilder &b, Location loc) {
+        SmallVector<Value> newIndices(indices);
+        newIndices[dimPos] = b.create<affine::AffineApplyOp>(
+            loc, addMap, ValueRange{oldIndex, iVal});
+        Value scalar =
+            b.create<memref::LoadOp>(loc, readOp.getSource(), newIndices);
+        return ValueRange{scalar};
+      };
+      auto elseCond = [&](OpBuilder &b, Location loc) {
+        b.create<scf::YieldOp>(loc, readOp.getPadding());
+      };
+
+      ValueRange scalar = predicateMaybeMaskedScalarTransfer(
+          rewriter, loc, maybeMaskBit, TypeRange{vectorType.getElementType()},
+          thenCond, elseCond, /*hasElse=*/true);
+      newVector =
+          rewriter.create<vector::InsertOp>(loc, scalar[0], newVector, i);
     }
     rewriter.replaceOp(readOp, newVector);
     return success();
@@ -844,11 +920,26 @@ struct ScalarizeVectorTransferWrite final
       return failure();
 
     Location loc = writeOp.getLoc();
+    Value maybeMask = writeOp.getMask();
     if (vectorType.getRank() == 0) {
-      Value scalar =
-          rewriter.create<vector::ExtractElementOp>(loc, writeOp.getVector());
-      rewriter.create<memref::StoreOp>(loc, scalar, writeOp.getSource(),
-                                       writeOp.getIndices());
+
+      Value maybeMaskBit;
+      if (maybeMask) {
+        Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask, zero);
+      }
+
+      auto thenCond = [&](OpBuilder &b, Location loc) {
+        Value scalar =
+            b.create<vector::ExtractElementOp>(loc, writeOp.getVector());
+        b.create<memref::StoreOp>(loc, scalar, writeOp.getSource(),
+                                  writeOp.getIndices());
+        return ValueRange{};
+      };
+
+      (void)predicateMaybeMaskedScalarTransfer(
+          rewriter, loc, maybeMaskBit, TypeRange{}, thenCond,
+          /*elseCond=*/DO_NOTHING, /*hasElse=*/false);
       rewriter.eraseOp(writeOp);
       return success();
     }
@@ -858,19 +949,33 @@ struct ScalarizeVectorTransferWrite final
     bindSymbols(context, sym0, sym1);
     auto addMap = AffineMap::get(0, 2, {sym0 + sym1}, context);
 
-    // The result vector is 1-D and we have a projected permutation.
+    // The written vector is 1-D and we have a projected permutation.
     unsigned dimPos = map.getDimPosition(0);
 
     auto indices = llvm::to_vector(writeOp.getIndices());
     Value oldIndex = indices[dimPos];
     for (int i = 0; i < vectorType.getDimSize(0); ++i) {
       Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
-      indices[dimPos] = rewriter.create<affine::AffineApplyOp>(
-          loc, addMap, ValueRange{oldIndex, iVal});
-      Value scalar =
-          rewriter.create<vector::ExtractOp>(loc, writeOp.getVector(), i);
-      rewriter.create<memref::StoreOp>(loc, scalar, writeOp.getSource(),
-                                       indices);
+
+      Value maybeMaskBit;
+      if (maybeMask) {
+        // The result vector is 1-D and we have a projected permutation, meaning
+        // we can just extract the mask bit using the same index as the written
+        // vector.
+        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask, iVal);
+      }
+
+      auto thenCond = [&](OpBuilder &b, Location loc) {
+        SmallVector<Value> newIndices(indices);
+        newIndices[dimPos] = b.create<affine::AffineApplyOp>(
+            loc, addMap, ValueRange{oldIndex, iVal});
+        Value scalar = b.create<vector::ExtractOp>(loc, writeOp.getVector(), i);
+        b.create<memref::StoreOp>(loc, scalar, writeOp.getSource(), newIndices);
+        return ValueRange{};
+      };
+      (void)predicateMaybeMaskedScalarTransfer(
+          rewriter, loc, maybeMaskBit, TypeRange{}, thenCond,
+          /*elseCond=*/DO_NOTHING, /*hasElse=*/false);
     }
     rewriter.eraseOp(writeOp);
     return success();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
@@ -537,3 +537,58 @@ func.func @transfer_write_vector2_vector8(%x: index, %val0: vector<2xi32>, %val1
 //       CHECK:   %[[SLICE3:.+]] = vector.extract_strided_slice %[[VAL1]] {offsets = [6], sizes = [2], strides = [1]} : vector<8xi32> to vector<2xi32>
 //       CHECK:   %[[OFFSET3:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 2 + 3)>()[%[[INDEX]]]
 //       CHECK:   memref.store %[[SLICE3]], %[[SUBSPAN]][%[[OFFSET3]]]
+
+// -----
+
+func.func @scalarize_masked_vector_transfer_op(%arg: vector<3xf32>, %mask: vector<3xi1>) -> (vector<3xf32>) {
+  %c0 = arith.constant 0: index
+  %c3 = arith.constant 3: index
+  %f0 = arith.constant 0.0 : f32
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<20xf32>
+  %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<20xf32>
+  %3 = vector.transfer_read %0[%c3], %f0, %mask : memref<20xf32>, vector<3xf32>
+  vector.transfer_write %arg, %2[%c3], %mask : vector<3xf32>, memref<20xf32>
+  return %3: vector<3xf32>
+}
+
+// CHECK-LABEL: func.func @scalarize_masked_vector_transfer_op
+// CHECK-DAG: %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<3xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
+// CHECK-DAG: %[[C5:.+]] = arith.constant 5 : index
+// CHECK-DAG: %[[C3:.+]] = arith.constant 3 : index
+// CHECK-DAG: %[[PAD:.+]] = arith.constant 0.000000e+00 : f32
+
+/// Transfer read.
+//     CHECK: %[[MB0:.+]] = vector.extract %{{.*}}[%[[C0]]] : i1 from vector<3xi1>
+//     CHECK: %[[MASK_LD0:.+]] = scf.if %[[MB0]] -> (f32) {
+//     CHECK:   %[[LD0:.+]] = memref.load {{.*}}[%[[C3]]] : memref<20xf32>
+//     CHECK:   scf.yield %[[LD0]] : f32
+//     CHECK: } else {
+//     CHECK:   scf.yield %[[PAD]] : f32
+//     CHECK: }
+//     CHECK: vector.insert %[[MASK_LD0]], %[[INIT]] [0] : f32 into vector<3xf32>
+//     CHECK: vector.extract %{{.*}}[%[[C1]]] : i1 from vector<3xi1>
+//     CHECK: scf.if %{{.*}} -> (f32) {
+//     CHECK:   memref.load %{{.*}}[%[[C4]]] : memref<20xf32>
+//     CHECK: vector.extract %{{.*}}[%[[C2]]] : i1 from vector<3xi1>
+//     CHECK: scf.if %{{.*}} -> (f32) {
+//     CHECK:   memref.load %{{.*}}[%[[C5]]] : memref<20xf32>
+//     CHECK: %[[MASK_TR:.+]] = vector.insert {{.*}} [2] : f32 into vector<3xf32>
+
+/// Transfer write.
+//     CHECK: scf.if %[[MB0]] {
+//     CHECK:   %[[E0:.+]] = vector.extract {{.*}}[0] : f32 from vector<3xf32>
+//     CHECK:   memref.store %[[E0]], %{{.*}}[%[[C3]]] : memref<20xf32>
+//     CHECK: }
+//     CHECK: scf.if %{{.*}} {
+//     CHECK:   %[[E1:.+]] = vector.extract {{.*}}[1] : f32 from vector<3xf32>
+//     CHECK:   memref.store %[[E1]], %{{.*}}[%[[C4]]] : memref<20xf32>
+//     CHECK: }
+//     CHECK: scf.if %{{.*}} {
+//     CHECK:   %[[E2:.+]] = vector.extract {{.*}}[2] : f32 from vector<3xf32>
+//     CHECK:   memref.store %[[E2]], %{{.*}}[%[[C5]]] : memref<20xf32>
+//     CHECK: }
+//     CHECK: return %[[MASK_TR]] : vector<3xf32>


### PR DESCRIPTION
Previously the transfer scalarization patterns ignored masks and thus miscompiled. Handle masks by predicating the load/store on the extracted mask bit.