### PR TITLE
Resolve `host` CPU to `generic` outside of x86

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.cpp
@@ -45,7 +45,7 @@ bool resolveCPUAndCPUFeatures(llvm::StringRef inCpu,
              "be either also `host` or the default value\n";
       return false;
     }
-    outCpu = llvm::sys::getHostCPUName().str();
+    outCpu = triple.isX86() ? llvm::sys::getHostCPUName().str() : "";
     llvm::SubtargetFeatures features;
     llvm::StringMap<bool> hostFeatures;
     if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
@@ -69,7 +69,8 @@ bool resolveCPUAndCPUFeatures(llvm::StringRef inCpu,
 
   // If CPU is non-host and non-generic then we need to populate the
   // corresponding features.
-  if (inCpu == "host" || inCpu == "generic" || inCpu.starts_with("generic-")) {
+  if (outCpu.empty() || inCpu == "host" || inCpu == "generic" ||
+      inCpu.starts_with("generic-")) {
     return true;
   }
   if (triple.isX86()) {


### PR DESCRIPTION
Following https://github.com/openxla/iree/pull/15477, `cpu` is treated as a x86-only thing, except for the special value `host` that gets resolved to the actual host CPU and CPU features.

JitGlobals creates a host target, that gets resolved accordingly. The resolved CPU is then recorded in a `hal.devices.targets` attribute. If the CPU field is set to the actual host CPU identifier there, then that will trigger the error message about that being a x86-only thing:

```
error: Resolution of target CPU to target CPU features is not implemented on this target architecture. Pass explicit CPU features instead of a CPU on this architecture, or implement that.
```

 So this needs to be set to "generic" in that case. No functional difference, as that CPU is just ignored anyway (which is what the error message is about).