### PR TITLE
Retire unused RISCV compile flag

### DIFF
--- a/build_tools/cmake/riscv.toolchain.cmake
+++ b/build_tools/cmake/riscv.toolchain.cmake
@@ -76,7 +76,6 @@ if(RISCV_CPU STREQUAL "linux-riscv_64")
   set(RISCV_LINKER_FLAGS "${RISCV_LINKER_FLAGS} -lstdc++ -lpthread -lm -ldl")
   set(RISCV64_TEST_DEFAULT_LLVM_FLAGS
     "--iree-llvmcpu-target-triple=riscv64"
-    "--iree-llvmcpu-target-cpu=generic-rv64"
     "--iree-llvmcpu-target-abi=lp64d"
     "--iree-llvmcpu-target-cpu-features=+m,+a,+f,+d,+c,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
@@ -102,7 +101,6 @@ elseif(RISCV_CPU STREQUAL "linux-riscv_32")
   set(RISCV_LINKER_FLAGS "${RISCV_LINKER_FLAGS} -lstdc++ -lpthread -lm -ldl -latomic")
   set(RISCV32_TEST_DEFAULT_LLVM_FLAGS
     "--iree-llvmcpu-target-triple=riscv32"
-    "--iree-llvmcpu-target-cpu=generic-rv32"
     "--iree-llvmcpu-target-abi=ilp32d"
     "--iree-llvmcpu-target-cpu-features=+m,+a,+f,+d,+zvl512b,+zve32f"
     "--riscv-v-fixed-length-vector-lmul-max=8"

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -157,11 +157,10 @@ The SIMD code can be generated following the
 [IREE CPU flow](../guides/deployment-configurations/cpu.md)
 with the additional command-line flags
 
-```shell hl_lines="3 4 5 6 7 8"
+```shell hl_lines="3 4 5 6"
 tools/iree-compile \
   --iree-hal-target-backends=llvm-cpu \
   --iree-llvmcpu-target-triple=riscv64 \
-  --iree-llvmcpu-target-cpu=generic-rv64 \
   --iree-llvmcpu-target-abi=lp64d \
   --iree-llvmcpu-target-cpu-features="+m,+a,+f,+d,+zvl512b,+v" \
   --riscv-v-fixed-length-vector-lmul-max=8 \

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -157,7 +157,7 @@ The SIMD code can be generated following the
 [IREE CPU flow](../guides/deployment-configurations/cpu.md)
 with the additional command-line flags
 
-```shell hl_lines="3 4 5 6"
+```shell hl_lines="3-6"
 tools/iree-compile \
   --iree-hal-target-backends=llvm-cpu \
   --iree-llvmcpu-target-triple=riscv64 \

--- a/samples/simple_embedding/BUILD.bazel
+++ b/samples/simple_embedding/BUILD.bazel
@@ -125,7 +125,6 @@ iree_bytecode_module(
     flags = [
         "--iree-hal-target-backends=llvm-cpu",
         "--iree-llvmcpu-target-triple=riscv32-pc-linux-elf",
-        "--iree-llvmcpu-target-cpu=generic-rv32",
         "--iree-llvmcpu-target-cpu-features=+m,+f",
         "--iree-llvmcpu-target-abi=ilp32",
         "--iree-llvmcpu-debug-symbols=false",
@@ -141,7 +140,6 @@ iree_bytecode_module(
     flags = [
         "--iree-hal-target-backends=llvm-cpu",
         "--iree-llvmcpu-target-triple=riscv64-pc-linux-elf",
-        "--iree-llvmcpu-target-cpu=generic-rv64",
         "--iree-llvmcpu-target-cpu-features=+m,+a,+f,+d,+c",
         "--iree-llvmcpu-target-abi=lp64d",
         "--iree-llvmcpu-debug-symbols=false",

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -115,7 +115,6 @@ iree_bytecode_module(
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-llvmcpu-target-triple=riscv32-pc-linux-elf"
-    "--iree-llvmcpu-target-cpu=generic-rv32"
     "--iree-llvmcpu-target-cpu-features=+m,+f"
     "--iree-llvmcpu-target-abi=ilp32"
     "--iree-llvmcpu-debug-symbols=false"
@@ -134,7 +133,6 @@ iree_bytecode_module(
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-llvmcpu-target-triple=riscv64-pc-linux-elf"
-    "--iree-llvmcpu-target-cpu=generic-rv64"
     "--iree-llvmcpu-target-cpu-features=+m,+a,+f,+d,+c"
     "--iree-llvmcpu-target-abi=lp64d"
     "--iree-llvmcpu-debug-symbols=false"


### PR DESCRIPTION
`--iree-llvmcpu-target-cpu` is not used in LLVM RISCV backend. Remove the flag from the codebase