### PR TITLE
Run llvm-external-projects tests in CI

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -168,7 +168,10 @@ if (( ${#excluded_tests[@]} )); then
   ctest_args+=("--exclude-regex ${excluded_tests_regex}")
 fi
 
-echo "*************** Running CTest ***************"
-
 set -x
+
+echo "*************** Running CTest ***************"
 ctest ${ctest_args[@]}
+
+echo "**************** llvm-external-projects tests ***************"
+cmake --build . --target check-iree-dialects -- -k 0


### PR DESCRIPTION
These tests were previously only running as part of ASAN build. This patch runs them from `ctest_all.sh`, which is used in most CIs which test everything.

The newly added line is directly adapted from `build_tools/cmake/test.sh``