### PR TITLE
[VMVX] Do not set lowering_configs on other operations.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2596,16 +2596,12 @@ setTranslationInfoAndRootConfig(func::FuncOp entryPointFn,
     }
 
     // Set vector level tile sizes for other operations individually.
-    // We allow vmvx with micorkernels having failures because it is okay to not
-    // scale tile sizes. The configuration has dynamic inner tile sizes. It
-    // fails only if the compute op is tensor.pack and inner tile sizes are
-    // dynamic.
-    bool isVMVXWithUkernels =
-        isVMVXBackend(targetAttr) && hasMicrokernels(targetAttr);
-
-    if (failed(setLoweringConfigForComputeOps(entryPointFn, computeOps,
-                                              rootOperation)) &&
-        !isVMVXWithUkernels) {
+    // TODO(hanchung): Move VMVX logics to Codegen/VMVX. VMVX only has
+    // distribution tile sizes. It is already set on root op; we don't have to
+    // model other level of tiling.
+    if (!isVMVXBackend(targetAttr) &&
+        failed(setLoweringConfigForComputeOps(entryPointFn, computeOps,
+                                              rootOperation))) {
       return failure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2596,8 +2596,16 @@ setTranslationInfoAndRootConfig(func::FuncOp entryPointFn,
     }
 
     // Set vector level tile sizes for other operations individually.
+    // We allow vmvx with micorkernels having failures because it is okay to not
+    // scale tile sizes. The configuration has dynamic inner tile sizes. It
+    // fails only if the compute op is tensor.pack and inner tile sizes are
+    // dynamic.
+    bool isVMVXWithUkernels =
+        isVMVXBackend(targetAttr) && hasMicrokernels(targetAttr);
+
     if (failed(setLoweringConfigForComputeOps(entryPointFn, computeOps,
-                                              rootOperation))) {
+                                              rootOperation)) &&
+        !isVMVXWithUkernels) {
       return failure();
     }
   }


### PR DESCRIPTION
The ukernel has dynamic inner tile sizes. We cant adjust tile sizes when tensor.pack op has dynamic inner tile sizes.