### PR TITLE
Move TOSA StripSignednessPass from Flow to tosa-iree plugin.

### DIFF
--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/BUILD.bazel
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/BUILD.bazel
@@ -55,6 +55,7 @@ iree_compiler_cc_library(
     srcs = [
         "Converti48Toi64.cpp",
         "Passes.cpp",
+        "StripSignedness.cpp",
         "TosaToLinalgExt.cpp",
         "VerifyCompilerTOSAInputLegality.cpp",
     ],
@@ -68,7 +69,6 @@ iree_compiler_cc_library(
     deps = [
         ":PassHeaders",
         ":PassesIncGen",
-        "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
         "//compiler/src/iree/compiler/InputConversion/Common",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/BUILD.bazel
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/BUILD.bazel
@@ -73,6 +73,7 @@ iree_compiler_cc_library(
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:Pass",

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_cc_library(
   SRCS
     "Converti48Toi64.cpp"
     "Passes.cpp"
+    "StripSignedness.cpp"
     "TosaToLinalgExt.cpp"
     "VerifyCompilerTOSAInputLegality.cpp"
   DEPS
@@ -71,7 +72,6 @@ iree_cc_library(
     MLIRTosaToSCF
     MLIRTosaToTensor
     MLIRTransforms
-    iree::compiler::Dialect::Flow::Transforms
     iree::compiler::InputConversion::Common
   PUBLIC
 )

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_cc_library(
     IREELinalgExtDialect
     MLIRArithDialect
     MLIRFuncDialect
+    MLIRFunctionInterfaces
     MLIRIR
     MLIRLinalgDialect
     MLIRPass

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/Passes.cpp
@@ -6,7 +6,6 @@
 
 #include "tosa-iree/InputConversion/Passes.h"
 
-#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/InputConversion/Common/Passes.h"
 #include "mlir/Conversion/TosaToArith/TosaToArith.h"
 #include "mlir/Conversion/TosaToLinalg/TosaToLinalg.h"
@@ -14,6 +13,7 @@
 #include "mlir/Conversion/TosaToTensor/TosaToTensor.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassOptions.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
@@ -60,10 +60,8 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(tosa::createTosaToArith());
   passManager.addNestedPass<func::FuncOp>(tosa::createTosaToTensor());
 
-  // TODO(scotttodd): move IREE::Flow::createStripSignednessPass into plugin
-  //     (should in-tree plugins even depend on other in-tree code?)
   passManager.addNestedPass<func::FuncOp>(
-      IREE::Flow::createStripSignednessPass());
+      iree_compiler::createStripSignednessPass());
   passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
   passManager.addNestedPass<func::FuncOp>(

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/Passes.h
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/Passes.h
@@ -24,22 +24,26 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager);
 void registerTOSAConversionPassPipeline();
 
 //------------------------------------------------------------------------------
-// Conversions into Linalg
+// Conversions from TOSA into Linalg and other core IREE dialects
 //------------------------------------------------------------------------------
-
-// Verifies a module being input to the core compiler pipeline only contains
-// IR structures that are supported at that level.
-std::unique_ptr<OperationPass<ModuleOp>>
-createVerifyCompilerTOSAInputLegality();
 
 // Set of patterns for materializing TOSA operations to linalg_ext.
 void populateTosaToLinalgExtPatterns(RewritePatternSet *patterns);
 
-// Creates a pass that converts TOSA operations to linalg_ext.
+// Converts i48 to i64.
+std::unique_ptr<OperationPass<func::FuncOp>> createConverti48Toi64();
+
+// Strips the signed/unsigned portion off of tensors.
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createStripSignednessPass();
+
+// Converts TOSA operations to linalg_ext.
 std::unique_ptr<OperationPass<func::FuncOp>> createTosaToLinalgExt();
 
-// Creates a pass that converts i48 to i64.
-std::unique_ptr<OperationPass<func::FuncOp>> createConverti48Toi64();
+// Verifies that a module only contains IR structures that are supported by the
+// core compiler.
+std::unique_ptr<OperationPass<ModuleOp>>
+createVerifyCompilerTOSAInputLegality();
 
 //===----------------------------------------------------------------------===//
 // Register all Passes

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/Passes.td
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/Passes.td
@@ -9,6 +9,18 @@
 
 include "mlir/Pass/PassBase.td"
 
+def Converti48Toi64 :
+    Pass<"iree-tosa-convert-i48-to-i64", "mlir::func::FuncOp"> {
+  let summary = "Converts all i48s to i64s";
+  let constructor = "mlir::iree_compiler::createConverti48Toi64()";
+}
+
+def StripSignedness :
+    InterfacePass<"iree-tosa-strip-signedness", "mlir::FunctionOpInterface"> {
+  let summary = "Legalizes ui tensors constants to uis";
+  let constructor = "mlir::iree_compiler::createStripSignednessPass()";
+}
+
 def TosaToLinalgExt :
     Pass<"iree-tosa-to-linalg-ext", "mlir::func::FuncOp"> {
   let summary = "Convert TOSA operations to their equivalent linalg-ext operations.";
@@ -25,12 +37,6 @@ def VerifyCompilerTOSAInputLegality :
     Pass<"iree-tosa-verify-compiler-input-legality", "ModuleOp"> {
   let summary = "Verifies that only supported IR constructs are passed to the compiler.";
   let constructor = "mlir::iree_compiler::createVerifyCompilerTOSAInputLegality()";
-}
-
-def Converti48Toi64 :
-    Pass<"iree-convert-i48-to-i64", "mlir::func::FuncOp"> {
-  let summary = "Converts all i48s to i64s";
-  let constructor = "mlir::iree_compiler::createConverti48Toi64()";
 }
 
 #endif // TOSA_IREE_INPUTCONVERSION_PASSES

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/StripSignedness.cpp
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/StripSignedness.cpp
@@ -4,15 +4,14 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
-#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "tosa-iree/InputConversion/PassDetail.h"
+#include "tosa-iree/InputConversion/Passes.h"
 
 namespace mlir {
 namespace iree_compiler {
-namespace IREE {
-namespace Flow {
 
 namespace {
 
@@ -132,7 +131,5 @@ createStripSignednessPass() {
   return std::make_unique<StripSignednessPass>();
 }
 
-} // namespace Flow
-} // namespace IREE
 } // namespace iree_compiler
 } // namespace mlir

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/test/BUILD.bazel
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/test/BUILD.bazel
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "convert_i48_to_i64.mlir",
+            "strip_signedness.mlir",
             "tosa_to_linalg_ext.mlir",
             "verify_compiler_tosa_input_legality.mlir",
         ],

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/test/CMakeLists.txt
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "convert_i48_to_i64.mlir"
+    "strip_signedness.mlir"
     "tosa_to_linalg_ext.mlir"
     "verify_compiler_tosa_input_legality.mlir"
   TOOLS

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/test/convert_i48_to_i64.mlir
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/test/convert_i48_to_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-convert-i48-to-i64 --verify-diagnostics %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-tosa-convert-i48-to-i64 --verify-diagnostics %s | FileCheck %s
 
 // CHECK-LABEL: @test_all_i48_converted
 func.func @test_all_i48_converted(%arg0: tensor<2x2xi48>) -> tensor<2x2xi48> {

--- a/compiler/plugins/input/TOSA/tosa-iree/InputConversion/test/strip_signedness.mlir
+++ b/compiler/plugins/input/TOSA/tosa-iree/InputConversion/test/strip_signedness.mlir
@@ -1,5 +1,5 @@
 
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(func.func(iree-flow-strip-signedness))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(func.func(iree-tosa-strip-signedness))' %s | FileCheck %s
 
 // CHECK-LABEL: @strip_signedness_arg
 // CHECK-SAME: tensor<4xi8>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -63,7 +63,6 @@ iree_compiler_cc_library(
         "RaiseSpecialOps.cpp",
         "RegionOpUtils.cpp",
         "SplitReduction.cpp",
-        "StripSignedness.cpp",
         "TensorPadToTensorInsertSlice.cpp",
         "TopLevelSCFToCFG.cpp",
         "VerifyInputLegality.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -62,7 +62,6 @@ iree_cc_library(
     "RaiseSpecialOps.cpp"
     "RegionOpUtils.cpp"
     "SplitReduction.cpp"
-    "StripSignedness.cpp"
     "TensorPadToTensorInsertSlice.cpp"
     "TopLevelSCFToCFG.cpp"
     "VerifyInputLegality.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -107,10 +107,6 @@ std::unique_ptr<Pass> createConvertToFlowPass();
 // iree-flow-infer-numeric-narrowing.
 std::unique_ptr<Pass> createOptimizeNumericsPass();
 
-// Strips the signed/unsigned portion off of tensors.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createStripSignednessPass();
-
 // Decomposes top-level SCF operations to CFG.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createTopLevelSCFToCFGPass();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -277,12 +277,6 @@ def SplitReduction :
   let constructor = "mlir::iree_compiler::IREE::Flow::createSplitReductionPass()";
 }
 
-def StripSignedness :
-    InterfacePass<"iree-flow-strip-signedness", "mlir::FunctionOpInterface"> {
-  let summary = "Legalizes ui tensors constants to uis";
-  let constructor = "mlir::iree_compiler::IREE::Flow::createStripSignednessPass()";
-}
-
 def TensorPadToTensorInsertSlice :
     Pass<"iree-flow-tensor-pad-to-tensor-insert-slice", ""> {
   let summary = "Convert tensor.pad into linalg.fill + tensor.insert_slice";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -49,7 +49,6 @@ iree_lit_test_suite(
             "pad_fusion_with_producer.mlir",
             "pipeline_tests.mlir",
             "raise_special_ops.mlir",
-            "strip_signedness.mlir",
             "tensor_pad_to_tensor_insert_slice.mlir",
             "top_level_scf_to_cfg.mlir",
             "transform_dispatch_region_formation.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -47,7 +47,6 @@ iree_lit_test_suite(
     "pad_fusion_with_producer.mlir"
     "pipeline_tests.mlir"
     "raise_special_ops.mlir"
-    "strip_signedness.mlir"
     "tensor_pad_to_tensor_insert_slice.mlir"
     "top_level_scf_to_cfg.mlir"
     "transform_dispatch_region_formation.mlir"


### PR DESCRIPTION
Follow-up to https://github.com/openxla/iree/pull/15495, part of https://github.com/openxla/iree/issues/15468

This pass is only used in TOSA import and has no dependencies on the Flow dialect (https://github.com/openxla/iree/pull/7192 probably predated a bunch of the organization we later applied to some dialects)