### PR TITLE
Update e2e tracing tests to explicitly use util.optimization_barrier

### DIFF
--- a/tests/e2e/regression/trace_dispatch_tensors.mlir
+++ b/tests/e2e/regression/trace_dispatch_tensors.mlir
@@ -3,35 +3,35 @@
 // RUN:   --Xcompiler,iree-flow-trace-dispatch-tensors \
 // RUN:   %s 2>&1 | FileCheck %s
 
-func.func private @double(%input : tensor<5x3xf32>) -> tensor<5x3xf32> {
-  %init = tensor.empty() : tensor<5x3xf32>
+func.func private @double(%input : tensor<15xf32>) -> tensor<15xf32> {
+  %init = tensor.empty() : tensor<15xf32>
   %res = linalg.generic {
-    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
-                     affine_map<(d0, d1) -> (d0, d1)>],
-    iterator_types = ["parallel", "parallel"]
-  } ins(%input : tensor<5x3xf32>)
-    outs(%init : tensor<5x3xf32>) {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%input : tensor<15xf32>)
+    outs(%init : tensor<15xf32>) {
   ^bb0(%in: f32, %out: f32):
     %0 = arith.addf %in, %in : f32
     linalg.yield %0 : f32
-  } -> tensor<5x3xf32>
-  return %res : tensor<5x3xf32>
+  } -> tensor<15xf32>
+  return %res : tensor<15xf32>
 }
 
-func.func @two_dispatch() -> (tensor<5x3xf32>) {
-  %0 = util.unfoldable_constant dense<1.0> : tensor<5x3xf32>
-  %1 = call @double(%0) : (tensor<5x3xf32>) -> tensor<5x3xf32>
+func.func @two_dispatch() -> (tensor<15xf32>) {
+  %0 = util.unfoldable_constant dense<1.0> : tensor<15xf32>
+  %1 = call @double(%0) : (tensor<15xf32>) -> tensor<15xf32>
 
   // Explicitly disable fusion because we want two dispatches.
-  %barrier = util.optimization_barrier %1 : tensor<5x3xf32>
-  %2 = call @double(%barrier) : (tensor<5x3xf32>) -> tensor<5x3xf32>
-  return %2 : tensor<5x3xf32>
+  %barrier = util.optimization_barrier %1 : tensor<15xf32>
+  %2 = call @double(%barrier) : (tensor<15xf32>) -> tensor<15xf32>
+  return %2 : tensor<15xf32>
 }
 // CHECK: === two_dispatch_dispatch_0::two_dispatch_dispatch_0{{.*}} inputs ===
-// CHECK: 5x3xf32=
+// CHECK: 15xf32=
 // CHECK: === two_dispatch_dispatch_0::two_dispatch_dispatch_0{{.*}} outputs ===
-// CHECK: 5x3xf32=
+// CHECK: 15xf32=
 // CHECK: === two_dispatch_dispatch_1::two_dispatch_dispatch_1{{.*}} inputs ===
-// CHECK: 5x3xf32=
+// CHECK: 15xf32=
 // CHECK: === two_dispatch_dispatch_1::two_dispatch_dispatch_1{{.*}} outputs ===
-// CHECK: 5x3xf32=
+// CHECK: 15xf32=

--- a/tests/e2e/regression/trace_dispatch_tensors.mlir
+++ b/tests/e2e/regression/trace_dispatch_tensors.mlir
@@ -1,23 +1,37 @@
 // RUN: iree-run-mlir \
-// RUN:   --Xcompiler,iree-input-type=stablehlo \
 // RUN:   --Xcompiler,iree-hal-target-backends=vmvx \
 // RUN:   --Xcompiler,iree-flow-trace-dispatch-tensors \
 // RUN:   %s 2>&1 | FileCheck %s
 
-func.func @two_dispatch() -> (tensor<5x5xf32>, tensor<3x5xf32>) {
+func.func private @double(%input : tensor<5x3xf32>) -> tensor<5x3xf32> {
+  %init = tensor.empty() : tensor<5x3xf32>
+  %res = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%input : tensor<5x3xf32>)
+    outs(%init : tensor<5x3xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %0 = arith.addf %in, %in : f32
+    linalg.yield %0 : f32
+  } -> tensor<5x3xf32>
+  return %res : tensor<5x3xf32>
+}
+
+func.func @two_dispatch() -> (tensor<5x3xf32>) {
   %0 = util.unfoldable_constant dense<1.0> : tensor<5x3xf32>
-  %1 = util.unfoldable_constant dense<0.4> : tensor<3x5xf32>
-  %2 = "stablehlo.dot"(%0, %1) : (tensor<5x3xf32>, tensor<3x5xf32>) -> tensor<5x5xf32>
-  %3 = "stablehlo.dot"(%1, %2) : (tensor<3x5xf32>, tensor<5x5xf32>) -> tensor<3x5xf32>
-  return %2, %3 : tensor<5x5xf32>, tensor<3x5xf32>
+  %1 = call @double(%0) : (tensor<5x3xf32>) -> tensor<5x3xf32>
+
+  // Explicitly disable fusion because we want two dispatches.
+  %barrier = util.optimization_barrier %1 : tensor<5x3xf32>
+  %2 = call @double(%barrier) : (tensor<5x3xf32>) -> tensor<5x3xf32>
+  return %2 : tensor<5x3xf32>
 }
 // CHECK: === two_dispatch_dispatch_0::two_dispatch_dispatch_0{{.*}} inputs ===
 // CHECK: 5x3xf32=
-// CHECK: 3x5xf32=
 // CHECK: === two_dispatch_dispatch_0::two_dispatch_dispatch_0{{.*}} outputs ===
-// CHECK: 5x5xf32=
+// CHECK: 5x3xf32=
 // CHECK: === two_dispatch_dispatch_1::two_dispatch_dispatch_1{{.*}} inputs ===
-// CHECK: 3x5xf32=
-// CHECK: 5x5xf32=
+// CHECK: 5x3xf32=
 // CHECK: === two_dispatch_dispatch_1::two_dispatch_dispatch_1{{.*}} outputs ===
-// CHECK: 3x5xf32=
+// CHECK: 5x3xf32=

--- a/tests/e2e/regression/trace_dispatch_tensors.mlir
+++ b/tests/e2e/regression/trace_dispatch_tensors.mlir
@@ -3,28 +3,14 @@
 // RUN:   --Xcompiler,iree-flow-trace-dispatch-tensors \
 // RUN:   %s 2>&1 | FileCheck %s
 
-func.func private @double(%input : tensor<15xf32>) -> tensor<15xf32> {
-  %init = tensor.empty() : tensor<15xf32>
-  %res = linalg.generic {
-    indexing_maps = [affine_map<(d0) -> (d0)>,
-                     affine_map<(d0) -> (d0)>],
-    iterator_types = ["parallel"]
-  } ins(%input : tensor<15xf32>)
-    outs(%init : tensor<15xf32>) {
-  ^bb0(%in: f32, %out: f32):
-    %0 = arith.addf %in, %in : f32
-    linalg.yield %0 : f32
-  } -> tensor<15xf32>
-  return %res : tensor<15xf32>
-}
-
 func.func @two_dispatch() -> (tensor<15xf32>) {
   %0 = util.unfoldable_constant dense<1.0> : tensor<15xf32>
-  %1 = call @double(%0) : (tensor<15xf32>) -> tensor<15xf32>
+  %1 = arith.addf %0, %0 : tensor<15xf32>
 
   // Explicitly disable fusion because we want two dispatches.
   %barrier = util.optimization_barrier %1 : tensor<15xf32>
-  %2 = call @double(%barrier) : (tensor<15xf32>) -> tensor<15xf32>
+  %cst = arith.constant dense<1.0> : tensor<15xf32>
+  %2 = arith.addf %barrier, %cst : tensor<15xf32>
   return %2 : tensor<15xf32>
 }
 // CHECK: === two_dispatch_dispatch_0::two_dispatch_dispatch_0{{.*}} inputs ===


### PR DESCRIPTION
It assumed two matmul ops live in different dispatch by default, which is not reliable. We should use `util.optimization_barrier` to disable fusion when needed. Also, a matmul op could be transformed to a sequence of operations (like data-tiling path). The revision simplifies it to simpler program.