### PR TITLE
[NFC] Explicitly disable data-tiling for specific matmul tests.

### DIFF
--- a/tests/e2e/tosa_ops/BUILD.bazel
+++ b/tests/e2e/tosa_ops/BUILD.bazel
@@ -181,6 +181,9 @@ iree_check_single_backend_test_suite(
     name = "check_vmvx_local-sync_microkernels",
     srcs = VMVX_MICROKERNELS_SRCS,
     compiler_flags = [
+        # TODO(15314): Remove the flag once vmvx supports batch_matmul on
+        # ukernel path.
+        "--iree-opt-data-tiling=false",
         "--iree-vmvx-enable-microkernels",
     ],
     # Sync has more strict runtime error checking for mis-compiled programs.

--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -165,6 +165,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "local-sync"
   COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
     "--iree-vmvx-enable-microkernels"
   INPUT_TYPE
     "tosa"

--- a/tests/transform_dialect/cpu/matmul.mlir
+++ b/tests/transform_dialect/cpu/matmul.mlir
@@ -26,6 +26,7 @@ func.func @matmul_static(
 // CODEGEN-DEFAULT:         hal.return %[[C2]], %[[C1]], %[[C1]]
 
 // RUN: iree-compile %s --iree-hal-target-backends=llvm-cpu \
+// RUN:   --iree-opt-data-tiling=false \
 // RUN:   --iree-codegen-use-transform-dialect-strategy=%p/matmul_codegen_default_spec.mlir | \
 // RUN: iree-run-module --module=- --function=matmul_static \
 // RUN:   --input="3x5xf32=1" \

--- a/tests/transform_dialect/cpu/matmul_library_call.mlir
+++ b/tests/transform_dialect/cpu/matmul_library_call.mlir
@@ -13,6 +13,7 @@ module {
 }
 
 // RUN: iree-compile %s --iree-hal-target-backends=llvm-cpu \
+// RUN:   --iree-opt-data-tiling=false \
 // RUN:   --iree-codegen-use-transform-dialect-strategy=custom_matmul \
 // RUN:   --iree-codegen-transform-dialect-library=%p/transform_library.mlir \
 // RUN:   --compile-to=executable-targets | \
@@ -24,6 +25,7 @@ module {
 // CODEGEN-DEFAULT:         hal.return %[[C2]], %[[C1]], %[[C1]]
 
 // RUN: iree-compile %s --iree-hal-target-backends=llvm-cpu \
+// RUN:   --iree-opt-data-tiling=false \
 // RUN:   --iree-codegen-transform-dialect-library=%p/transform_library.mlir \
 // RUN:   --iree-codegen-use-transform-dialect-strategy=custom_matmul | \
 // RUN: iree-run-module --module=- --function=matmul_static \


### PR DESCRIPTION
- transform dialect tests aim to be applied on regular matmul.
- vmvx micorkernels does not support batch_matmul on data-tiling path