### PR TITLE
Create MLIRContexts with a custom threadpool and strategy.

### DIFF
--- a/compiler/bindings/python/IREECompilerRegistration.cpp
+++ b/compiler/bindings/python/IREECompilerRegistration.cpp
@@ -33,4 +33,11 @@ PYBIND11_MODULE(_site_initialize_0, m) {
   m.def("register_dialects", [](MlirDialectRegistry registry) {
     ireeCompilerRegisterDialects(registry);
   });
+
+  m.def("context_init_hook",
+        [](MlirContext context) { ireeCompilerInitializeContext(context); });
+
+  // Multi-threading is configured as part of the context_init_hook and
+  // not left to default MLIR heuristics.
+  m.attr("disable_multithreading") = true;
 }

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -61,6 +61,7 @@
 #include "llvm/Support/SMLoc.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/CAPI/IR.h"
@@ -169,6 +170,57 @@ private:
   }
 };
 
+llvm::ThreadPoolStrategy getGlobalThreadPoolStrategy() {
+  // We allow two environment variables to control the compiler thread pool.
+  //   IREE_COMPILER_THREAD_COUNT: If present (and not empty or 0), will
+  //     create a thread pool with the requested number of threads, even
+  //     if this is unwise or beyond the limit limit of hardware concurrency.
+  //   IREE_COMPILER_TASK_COUNT: Specifies a target maximum number of
+  //     concurrent tasks to support at any given time. The actual number
+  //     of threads will be limited to the hardware concurrency if in
+  //     excess. If zero, then the hardware concurrency is used.
+  // In the absence of any environment variables, the behavior is as if
+  // IREE_COMPILER_TASK_COUNT was specified with a hard-coded value that
+  // has been chosen by project developers. If a number greater than
+  // zero IREE_COMPILER_THREAD_COUNT will take precedence.
+  const char *envThreadCount = getenv("IREE_COMPILER_THREAD_COUNT");
+  const char *envTaskCount = getenv("IREE_COMPILER_TASK_COUNT");
+
+  // As of 2023-11-11, the compiler was capable of exploiting ~12x parallelism
+  // on large workloads, and this does not cause much increased latency or
+  // memory usage on untuned build system jobs which are dispatching large
+  // numbers of compilation commands or single-kernel, complicated compilation.
+  unsigned threadCount = 0;
+  unsigned taskCount = 12;
+
+  if (envThreadCount) {
+    StringRef srThreadCount(envThreadCount);
+    if (!srThreadCount.empty() && srThreadCount.getAsInteger(10, threadCount)) {
+      llvm::errs() << "IREE COMPILER: Ignoring malformed value for "
+                      "IREE_COMPILER_THREAD_COUNT ('"
+                   << envThreadCount << "')\n";
+    }
+  }
+  if (envTaskCount) {
+    StringRef srTaskCount(envTaskCount);
+    if (!srTaskCount.empty() && srTaskCount.getAsInteger(10, taskCount)) {
+      llvm::errs() << "IREE COMPILER: Ignoring malformed value for "
+                      "IREE_COMPILER_TASK_COUNT ('"
+                   << envTaskCount << "')\n";
+    }
+  }
+
+  llvm::ThreadPoolStrategy strategy;
+  if (threadCount != 0) {
+    strategy.ThreadsRequested = threadCount;
+  } else {
+    strategy.ThreadsRequested = taskCount;
+    strategy.Limit = true;
+  }
+
+  return strategy;
+}
+
 struct Error {
   Error(std::string message) : message(std::move(message)) {}
   std::string message;
@@ -178,10 +230,13 @@ struct GlobalInit {
   GlobalInit();
   ~GlobalInit() { llvm::llvm_shutdown(); }
   void registerCommandLineOptions();
+  std::unique_ptr<MLIRContext> createContext();
+  void initializeContext(MLIRContext &context);
 
   // Reference count of balanced calls to ireeCompilerGlobalInitialize
   // and ireeCompilerGlobalShutdown. Upon reaching zero, must be deleted.
   std::atomic<int> refCount{1};
+  llvm::ThreadPool threadPool;
   llvm::BumpPtrAllocator alloc;
   mlir::DialectRegistry registry;
   PluginManager pluginManager;
@@ -209,7 +264,7 @@ struct GlobalInit {
   IREE::VM::BytecodeTargetOptions *clBytecodeTargetOptions = nullptr;
 };
 
-GlobalInit::GlobalInit() {
+GlobalInit::GlobalInit() : threadPool(getGlobalThreadPoolStrategy()) {
   // Global/static registrations.
   // Allegedly need to register passes to get good reproducers
   // TODO: Verify this (I think that this was fixed some time ago).
@@ -253,6 +308,22 @@ void GlobalInit::registerCommandLineOptions() {
   clBytecodeTargetOptions = &IREE::VM::BytecodeTargetOptions::FromFlags::get();
 
   pluginManager.initializeCLI();
+}
+
+std::unique_ptr<MLIRContext> GlobalInit::createContext() {
+  auto context =
+      std::make_unique<MLIRContext>(MLIRContext::Threading::DISABLED);
+  initializeContext(*context);
+  return context;
+}
+
+void GlobalInit::initializeContext(MLIRContext &context) {
+  if (!context.isMultithreadingEnabled()) {
+    // Configure out threading for the context. Note that an arbitrary context
+    // may already have threading enabled, so we conservatively do nothing
+    // in this case.
+    context.setThreadPool(threadPool);
+  }
 }
 
 struct Session {
@@ -341,7 +412,7 @@ struct Session {
 };
 
 Session::Session(GlobalInit &globalInit)
-    : globalInit(globalInit), ownedContext(std::make_unique<MLIRContext>()),
+    : globalInit(globalInit), ownedContext(globalInit.createContext()),
       context(*ownedContext), binder(OptionsBinder::local()),
       pluginSession(globalInit.pluginManager, binder, pluginManagerOptions) {
   context.allowUnregisteredDialects();
@@ -1474,6 +1545,14 @@ void ireeCompilerRegisterDialects(MlirDialectRegistry registry) {
     llvm::errs() << "error: Failed to initialize IREE compiler plugins\n";
   }
   pluginSession.registerDialects(*cppRegistry);
+}
+
+void ireeCompilerInitializeContext(MlirContext context) {
+  if (!globalInit) {
+    llvm::errs() << "FATAL ERROR: Not initialized\n";
+    abort();
+  }
+  globalInit->initializeContext(*unwrap(context));
 }
 
 MlirContext ireeCompilerSessionBorrowContext(iree_compiler_session_t *session) {

--- a/compiler/src/iree/compiler/API/MLIRInterop.h
+++ b/compiler/src/iree/compiler/API/MLIRInterop.h
@@ -26,6 +26,11 @@ extern "C" {
 MLIR_CAPI_EXPORTED void
 ireeCompilerRegisterDialects(MlirDialectRegistry registry);
 
+// Performs post-creation initialization of an externally derived context.
+// This configures things such as threading behavior. Dialect registration
+// is done via ireeCompilerRegisterDialects.
+MLIR_CAPI_EXPORTED void ireeCompilerInitializeContext(MlirContext context);
+
 // Gets the MlirContext that the session manages. The context is owned by the
 // session and valid until it is destroyed.
 // This implicitly "activates" the session: make sure that any configuration


### PR DESCRIPTION
Adds two new environment variables:

* IREE_COMPILER_TASK_COUNT: If present, overrides the default value for the estimated maximum number of parallel tasks for which to optimize. This results in a thread pool of the given size, shared by all contexts in the process, so long as it does not exceed hardware concurrency.
* IREE_COMPILER_THREAD_COUNT: If present, trumps other settings and creates a thread pool of the given size (for all contexts in the process) regardless of hardware concurrency.

I have defaulted IREE_COMPILER_TASK_COUNT to 12 based on a rough analysis of latency and memory usage across a parallel process use case (ninja iree-test-deps), single process compilation of a large single-kernel module, and single-process compilation of a large LLM.

Data (THREAD_COUNT/TASK_COUNT: latency, estimated total RSS):

```
ninja iree-test-deps:
---------------------
0/1: 20.1s, 8.8GB
0/5: 21.4s, 9.5GB
0/10: 22.3s, 9.6GB
0/15: 23.3s, 10.2GB
64/0: 31.7s, 15.2GB
128/0: 44s, 18GB

e2e_matmul_dt_uk_f16_f32_large_llvm-cpu_local-task_avx2.vmfb:
-------------------------------------------------------------
0/1: 4.7s
0/2: 4.2s
0/3: 4.1s
0/4: 3.9
0/5: 3.8s
0/6: 3.8s
0/7: 3.8s
0/8: 3.8s
0/9: 3.8s
0/10: 3.9s
0/15: 4.1s
0/64: 7.5s

global_mapped_test_Llama_2_7b_chat_hf_torch.mlir:
-------------------------------------------------
0/1: 40.6s, 785MB
0/10: 35s, 830MB
0/12: 33.7s
0/15: 33s
0/20: 33s
0/64: 37s, 1GB
```

Optimizing for 12 concurrent tasks seems to produce good single-process LLM compilation while not pushing the other two cases into significantly degraded behavior. I have little confidence that this will not require some more tuning for specific environments, but given that I tested on a 32 core/64 thread system and the gains trailed off far short of the hardware concurrency (which is what the prior configuration is doing), clamping it to a low number seems like the best first step.

RSS sizes were estimated based on watching atop in process-grouped memory stats mode. They are presented to show relative effects only versus being the most principled collection methodology.

This patch is enhanced by https://github.com/llvm/llvm-project/pull/72042, which when landed, will also opt Python created contexts into the same threadpool. It does not require the upstream patch.