### PR TITLE
`--iree-llvmcpu-enable-ukernels`, a fine-grained replacement for `--iree-llvmcpu-enable-microkernels`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
@@ -37,7 +37,7 @@ using IREE::HAL::ExecutableTargetAttr;
 // narrow-N cases are handled by transposition in chooseMatmulTile.
 static SmallVector<TileMxNxK>
 enumerateMatmulTilesVMVX(EncodingUser user, ExecutableTargetAttr target) {
-  if (hasMicrokernels(target)) {
+  if (hasUkernel(target)) {
     // TODO(#15314): Remove the check once it is supported. vmvx + ukernel
     // does not support batch_matmul atm.
     if (user == EncodingUser::BATCH_MATMUL) {
@@ -403,7 +403,7 @@ materializeEncodingForTarget(RankedTensorType tensorType,
     return a == IntegerAttr() ? 0 : a.getInt();
   };
   int64_t matmulNarrowM = getIntOrZero(encoding.getMatmulNarrow_M());
-  int64_t matmulNarrowN = hasMicrokernels(targetAttr)
+  int64_t matmulNarrowN = hasUkernel(targetAttr, "mmt4d")
                               ? 0
                               : getIntOrZero(encoding.getMatmulNarrow_N());
   // Choose a final matmul TileMxNxK from the above-enumarated tile shapes,

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/vmvx_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/vmvx_materialize_encoding.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --iree-codegen-cpu-materialize-encoding --canonicalize --cse --split-input-file %s | FileCheck %s
 
 func.func @matmul_lowering_i8i8i32_vmvx_ukernel() attributes {
-  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {ukernels = true}>
+  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {ukernels = "all"}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load[0] : index

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
@@ -281,7 +281,7 @@ chooseDynamicEncodingInfoVMVXMicrokernels(RankedTensorType tensorType,
 
 MaterializeEncodingValueFn
 getMaterializeEncodingValueFn(IREE::HAL::ExecutableTargetAttr targetAttr) {
-  if (isVMVXBackend(targetAttr) && hasMicrokernels(targetAttr)) {
+  if (isVMVXBackend(targetAttr) && hasUkernel(targetAttr)) {
     return chooseDynamicEncodingInfoVMVXMicrokernels;
   }
   return {};

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -193,7 +193,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
           isX86(target) || isRISCV(target) ||
           (isAArch64(target) && hasAnySVEFeature(target));
 
-      bool enableMicrokernels = hasMicrokernels(target);
+      bool enableMicrokernels = hasUkernel(target);
       bool enableAArch64SSVE = isAArch64(target) && hasAnySVEFeature(target) &&
                                hasSMEFeature(target);
       switch (translationInfo.value().getDispatchLoweringPassPipeline()) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -525,7 +525,7 @@ hal.executable private @mmt4d_ukernel {
       {cpu = "generic", cpu_features = "",
        data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
        native_vector_size = 16 : index, target_triple = "x86_64-none-elf",
-       ukernels = true}>) {
+       ukernels = "mmt4d"}>) {
     hal.executable.export public @ukernel_dispatch ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index):
       %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
@@ -562,7 +562,7 @@ hal.executable private @ukernel_pass_through {
       cpu = "generic", cpu_features = "",
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 16 : index, target_triple = "x86_64-none-elf",
-      ukernels = false}>) {
+      ukernels = "all"}>) {
     hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<
       push_constants = 2, sets = [
         <0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>,

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -72,7 +72,12 @@ const char *getIreeArchNameForTargetTriple(llvm::Triple triple);
 
 /// Methods to get target information.
 bool isVMVXBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
-bool hasMicrokernels(IREE::HAL::ExecutableTargetAttr targetAttr);
+
+// Returns true if the ukernel with given `ukernelName` is enabled.
+// If `ukernelName` is empty (the default), returns true if any ukernel
+// is enabled at all.
+bool hasUkernel(IREE::HAL::ExecutableTargetAttr targetAttr,
+                StringRef ukernelName = "");
 
 /// Returns the CPU target features associated with the `targetAttr`, if set.
 std::optional<StringRef>

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt  --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy, iree-llvmcpu-lower-executable-target)))" --split-input-file %s | FileCheck %s
 
 hal.executable private @mmt4d_ukernel {
-  hal.executable.variant public @vmvx_bytecode_fb target(<"vmvx", "vmvx-bytecode-fb", {ukernels = true}>) {
+  hal.executable.variant public @vmvx_bytecode_fb target(<"vmvx", "vmvx-bytecode-fb", {ukernels = "all"}>) {
     hal.executable.export public @mmt4d_i8 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
       %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
         ":LinkerTool",
         ":StaticLibraryGenerator",
         "//compiler/src/iree/compiler/Codegen/Common",
+        "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/LLVMCPU",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/BUILD.bazel
@@ -36,7 +36,6 @@ iree_compiler_cc_library(
         ":LinkerTool",
         ":StaticLibraryGenerator",
         "//compiler/src/iree/compiler/Codegen/Common",
-        "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/LLVMCPU",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
@@ -40,7 +40,9 @@ getVMVXExecutableTarget(MLIRContext *context, StringRef backend,
                         StringRef format) {
   SmallVector<NamedAttribute> config;
   config.emplace_back(StringAttr::get(context, "ukernels"),
-                      BoolAttr::get(context, clEnableMicrokernels));
+                      StringAttr::get(context, clEnableMicrokernels.getValue()
+                                                   ? "all"
+                                                   : "none"));
   return IREE::HAL::ExecutableTargetAttr::get(
       context, StringAttr::get(context, backend),
       StringAttr::get(context, format), DictionaryAttr::get(context, config));


### PR DESCRIPTION
This introduces a new command-line flag, `--iree-llvmcpu-enable-ukernels`, as a replacement for the existing `--iree-llvmcpu-enable-microkernels`, which gets deprecated but temporarily coexists during the transition.

The name ambiguity (only differing by `micro` vs `u` substring) is OK as that's part of a general renaming trend and the old flag should get removed quickly.

The problem with the boolean `--iree-llvmcpu-enable-microkernels` was that our plan was of course to eventually enable it by default, but then that puts a very high bar on any future new ukernel. For now, the only ukernel enabled in LLVMCPU is mmt4d, but the next time that we want to introduce a new ukernel, if that means that all existing codegen users get it while it is still under development, that would be hard.

The new `--iree-llvmcpu-enable-ukernels` is a string. It has the default value `default`, which means let the implementation enable whichever set of ukernels is currently default. Currently, that's no ukernel at all, but we hope in the near team to change that default to including the `mmt4d` ukernel. Other special string values are `none` and `all` with the obvious meanings. Any other string is interpreted as a comma-separated list of individual ukernels to enable.

The old boolean flag `--iree-llvmcpu-enable-microkernels={false,true}` is currently interpreted as  `--iree-llvmcpu-enable-ukernels={none,all}` until it's dropped.