### PR TITLE
Rename "torch_iree" plugin to "input_torch".

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/CMakeLists.txt
@@ -27,7 +27,7 @@ iree_cc_library(
 
 iree_compiler_register_plugin(
   PLUGIN_ID
-    torch_iree
+    input_torch
   TARGET
     ::registration
 )

--- a/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
@@ -102,8 +102,8 @@ struct TorchSession
 
 IREE_DEFINE_COMPILER_OPTION_FLAGS(::mlir::iree_compiler::TorchOptions);
 
-extern "C" bool iree_register_compiler_plugin_torch_iree(
+extern "C" bool iree_register_compiler_plugin_input_torch(
     mlir::iree_compiler::PluginRegistrar *registrar) {
-  registrar->registerPlugin<::mlir::iree_compiler::TorchSession>("torch_iree");
+  registrar->registerPlugin<::mlir::iree_compiler::TorchSession>("input_torch");
   return true;
 }

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -51,10 +51,10 @@ void InputDialectOptions::bindOptions(OptionsBinder &binder) {
 #ifdef IREE_COMPILER_PLUGIN_HAVE_STATIC_INPUT_TOSA
           "  =tosa          - Legalize from TOSA ops.\n"
 #endif  // IREE_COMPILER_PLUGIN_HAVE_STATIC_INPUT_TOSA
-#ifdef IREE_COMPILER_PLUGIN_HAVE_STATIC_TORCH_IREE
+#ifdef IREE_COMPILER_PLUGIN_HAVE_STATIC_INPUT_TORCH
           "  =tm_tensor     - Legalize a subset of Torch input ops.\n"
           "  =torch         - Legalize from the 'torch' dialect.\n"
-#endif  // IREE_COMPILER_PLUGIN_HAVE_STATIC_TORCH_IREE
+#endif  // IREE_COMPILER_PLUGIN_HAVE_STATIC_INPUT_TORCH
           "  =*             - An extensible input type defined in a plugin."
           // clang-format on
           ),


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/15468

Bikeshedding galore. Most of the non-mechanical parts of the code moves for input dialect plugins have been completed, so now we can see the plugins side-by-side and decide on how we want them to look.

We have top level plugin folders:

* `compiler/plugins/input/Torch`
* `compiler/plugins/input/TOSA`
* `compiler/plugins/input/StableHLO`
* `compiler/plugins/target/CUDA`
* `compiler/plugins/target/...` (coming soon)

Then each input plugin has `compiler/plugins/input/[DIALECT]/[dialect]-iree/PluginRegistration.cpp` with the `input_[dialect]` plugin name.

* I'm also considering making the folder name match what the plugin is called directly, so we'd have e.g. `compiler/plugins/input/Torch/input-torch/PluginRegistration.cpp` (name "input-torch" with a dash?)
* Alternately, we could have plugins called `torch-iree`, `stablehlo-iree`, and `tosa-iree`. IMO since these are all IREE compiler plugins the "iree" is redundant and we should instead highlight "input" in the name.

![image](https://github.com/openxla/iree/assets/4010439/36b60478-250f-46a1-8664-6752f2bdb26a)

We could further collapse these trees if we wanted, but Torch currently also has sibling `torch-mlir/` and `torch-mlir-dialect/` folders.