### PR TITLE
Avoid fusing transpose linalg op with pack op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -329,18 +329,20 @@ matchIteratorTypes(const llvm::SmallBitVector &rootOuterParallelLoop,
   return true;
 }
 
-/// Method to check if the op with have compatible indexing map on
-/// outer-parallel loops. Currently it means the map needs to be identity on the
-/// those dimensions, ignoring its reduction dimensions.
+// Method to check if the op with have compatible indexing map on outer-parallel
+// loops. Currently it means the map needs to be identity on the those
+// dimensions, ignoring its reduction dimensions.
 static bool hasCompatibleOuterParallelLoops(
     TilingInterface tileOp, AffineMap indexingMap,
     const llvm::SmallBitVector &rootOuterParallelLoops) {
-  if (!indexingMap.isProjectedPermutation())
+  if (!indexingMap.isProjectedPermutation()) {
     return false;
+  }
 
   llvm::SmallBitVector parallelLoops = getOuterParallelLoops(tileOp);
-  if (!matchIteratorTypes(rootOuterParallelLoops, parallelLoops))
+  if (!matchIteratorTypes(rootOuterParallelLoops, parallelLoops)) {
     return false;
+  }
 
   /// Project out the non-parallel dimensions.
   llvm::SmallBitVector projectedDims(rootOuterParallelLoops);
@@ -350,8 +352,8 @@ static bool hasCompatibleOuterParallelLoops(
   return isIdentityMapWithZeros(projectedMap);
 }
 
-/// Method to check if two `linalg.generic` op with producer-consumer
-/// relationship through `operand` have compatible outer-parallel loops.
+// Method to check if two `linalg.generic` op with producer-consumer
+// relationship through `operand` have compatible outer-parallel loops.
 static bool hasCompatibleOuterParallelLoops(
     OpOperand &operand, const llvm::SmallBitVector &rootOuterParallelLoops) {
   auto producer = operand.get().getDefiningOp<linalg::LinalgOp>();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -329,6 +329,9 @@ matchIteratorTypes(const llvm::SmallBitVector &rootOuterParallelLoop,
   return true;
 }
 
+/// Method to check if the op with have compatible indexing map on
+/// outer-parallel loops. Currently it means the map needs to be identity on the
+/// those dimensions, ignoring its reduction dimensions.
 static bool hasCompatibleOuterParallelLoops(
     TilingInterface tileOp, AffineMap indexingMap,
     const llvm::SmallBitVector &rootOuterParallelLoops) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -503,6 +503,8 @@ isFusableWithConsumer(OpOperand &fusedOperand,
         .Case<linalg::LinalgOp>([&](auto linalgOp) {
           auto producerIndexingMap = linalgOp.getIndexingMapMatchingResult(
               llvm::cast<OpResult>(fusedOperand.get()));
+          // Make sure the producer op has an identitiy result indexing map. As
+          // CPU backend currently can't handle tranpose between fused ops.
           return hasCompatibleOuterParallelLoops(
               cast<TilingInterface>(linalgOp.getOperation()),
               producerIndexingMap, rootOuterParallelLoops);
@@ -641,6 +643,8 @@ isFusableWithProducer(OpOperand &operand,
           }
           auto producerIndexingMap = linalgOp.getIndexingMapMatchingResult(
               llvm::cast<OpResult>(operand.get()));
+          // Make sure the producer op has an identitiy result indexing map. As
+          // CPU backend currently can't handle tranpose between fused ops.
           return hasCompatibleOuterParallelLoops(
               cast<TilingInterface>(linalgOp.getOperation()),
               producerIndexingMap, rootOuterParallelLoops);


### PR DESCRIPTION
Currently in `FormDispatchRegions` pass we use `hasCompatibleOuterParallelLoops` to make sure the fused ops have identity mapping between them on the parallel dimensions. The CPU backend uses this assumption on tile size selections and tile-and-fuse.

This change adds the missing check to the special fusion logic on pack ops, to ensure we don't fuse transpose generic op with pack op, which results in the #15574 in CPU backend.

This should be considered as a workaround and eventually we might want to support non-identitiy map fusion in CPU backend to remove these constraints.