### PR TITLE
[CodeGen] Refactor verifying identical translation_info to a common method.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenAttrs.h
@@ -56,6 +56,18 @@ getTranslationInfo(func::FuncOp funcOp) {
   return getTranslationInfo(*exportOp);
 }
 
+/// Returns the identical TranslationInfoAttr. Returns nullptr if entry point
+/// functions have different TranslationInfoAttr.
+/// There might be multiple entry points in the module. Currently, all of them
+/// need to have the same translation info.
+/// TODO(ravishankarm): This is strange that this is not enforced
+/// structurally, but something to address later on. The main issue is how
+/// to invoke separate dynamic pass pipelines on  entry point functions,
+/// when the passes might have module level changes. For now this
+/// restriction is fine.
+std::optional<IREE::Codegen::TranslationInfoAttr>
+getIdenticalTranslationInfo(IREE::HAL::ExecutableVariantOp variantOp);
+
 // TODO(ravishankarm, benvanik): Eventually all the information needed for the
 // lowering will be consolidated into a single attribute with richer
 // information.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1226,7 +1226,13 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
     }
 
     if (!rootOperation) {
-      // No root operation found. Allow it to pass through without a config.
+      // No root operation found, set it to default.
+      auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
+          funcOp.getContext(),
+          IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDefault);
+      if (failed(setTranslationInfo(funcOp, translationInfo))) {
+        return failure();
+      }
       continue;
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1226,10 +1226,10 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
     }
 
     if (!rootOperation) {
-      // No root operation found, set it to default.
+      // No root operation found, set it to none.
       auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
           funcOp.getContext(),
-          IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDefault);
+          IREE::Codegen::DispatchLoweringPassPipeline::None);
       if (failed(setTranslationInfo(funcOp, translationInfo))) {
         return failure();
       }


### PR DESCRIPTION
The comments and the implementations are duplicated for all the backends. The revision makes `*LowerExecutableTarget` and `*SelectLoweringStrategy` use the common util.

It also unifies the variable naming in `*LowerExecutableTarget`, which replaces `executableLoweringPipeline` with `pipeline`; set LLVMGPU strategy to `None` if there are no compute ops.