### PR TITLE
 [VMVX] Rework on vmvx lowering strategy.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
@@ -55,51 +55,6 @@ bool hasSMEFeature(IREE::HAL::ExecutableTargetAttr targetAttr) {
   return hasFeature(targetAttr, "+sme");
 }
 
-FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
-  Operation *rootOperation = nullptr;
-  for (auto op : llvm::reverse(computeOps)) {
-    if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
-      // Do not treat linalg ops that are all parallel as root operations in
-      // this sweep.
-      if (linalgOp.getNumLoops() == linalgOp.getNumParallelLoops())
-        continue;
-
-      // All other linalg ops are root ops.
-      rootOperation = op;
-      break;
-    }
-
-    if (isa<TilingInterface>(op) &&
-        !isa<tensor::PadOp, tensor::PackOp, tensor::UnPackOp>(op)) {
-      // All other operations that implement this interface are root ops.
-      rootOperation = op;
-      break;
-    }
-  }
-
-  if (!rootOperation) {
-    // Check for elementwise operations.
-    for (auto op : llvm::reverse(computeOps)) {
-      if (isa<linalg::LinalgOp>(op)) {
-        rootOperation = op;
-        break;
-      }
-    }
-  }
-
-  if (!rootOperation) {
-    // Check for pad/pack/unpack ops by themselves.
-    for (auto op : llvm::reverse(computeOps)) {
-      if (isa<tensor::PadOp, tensor::PackOp, tensor::UnPackOp>(op)) {
-        rootOperation = op;
-        break;
-      }
-    }
-  }
-
-  return rootOperation;
-}
-
 void setSCFTileSizes(scf::SCFTilingOptions &options, TilingInterface consumerOp,
                      SmallVector<int64_t> tileSizes,
                      SmallVector<bool> tileScalableFlags) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
@@ -45,14 +45,6 @@ bool hasAnySVEFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 /// Returns true if the 'targetAttr' contains '+sme' in its cpu features.
 bool hasSMEFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 
-/// Find the root operation for the dispatch region. The priority is:
-///   1. A Linalg operation that has reduction loops.
-///   2. Any other Linalg op or LinalgExt op.
-///   3. An operation that implements TilingInterface.
-/// If there are multiple operations meeting the same priority, the one closer
-/// to the end of the function is the root op.
-FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
-
 /// Sets the tile sizes of the SCFTilingOptions. If `tileScalableFlags` are
 /// provided the corresponding tile size will be multiplied by a vector.vscale
 /// op.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -38,7 +38,6 @@ iree_lit_test_suite(
             "materialize_aarch64_launch_configuration.mlir",
             "materialize_configuration_without_distribution.mlir",
             "materialize_riscv_launch_configuration.mlir",
-            "materialize_vmvx_launch_configuration.mlir",
             "materialize_x86_64_launch_configuration.mlir",
             "pad_conv_pipeline_tests.mlir",
             "pad_pipeline_tests.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -33,7 +33,6 @@ iree_lit_test_suite(
     "materialize_aarch64_launch_configuration.mlir"
     "materialize_configuration_without_distribution.mlir"
     "materialize_riscv_launch_configuration.mlir"
-    "materialize_vmvx_launch_configuration.mlir"
     "materialize_x86_64_launch_configuration.mlir"
     "pad_conv_pipeline_tests.mlir"
     "pad_pipeline_tests.mlir"

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -17,6 +17,7 @@ package(
 iree_compiler_cc_library(
     name = "Utils",
     srcs = [
+        "CPUUtils.cpp",
         "GPUUtils.cpp",
         "LinalgOpInfo.cpp",
         "LinkingUtils.cpp",
@@ -24,6 +25,7 @@ iree_compiler_cc_library(
         "Utils.cpp",
     ],
     hdrs = [
+        "CPUUtils.h",
         "GPUUtils.h",
         "LinalgOpInfo.h",
         "LinkingUtils.h",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -14,12 +14,14 @@ iree_cc_library(
   NAME
     Utils
   HDRS
+    "CPUUtils.h"
     "GPUUtils.h"
     "LinalgOpInfo.h"
     "LinkingUtils.h"
     "MarkerUtils.h"
     "Utils.h"
   SRCS
+    "CPUUtils.cpp"
     "GPUUtils.cpp"
     "LinalgOpInfo.cpp"
     "LinkingUtils.cpp"

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -1,0 +1,143 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
+
+#include <numeric>
+
+#include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+#define DEBUG_TYPE "iree-codegen-cpu-utils"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+namespace mlir {
+namespace iree_compiler {
+
+using IREE::Codegen::DispatchLoweringPassPipeline;
+
+template <typename T>
+static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const llvm::SmallVectorImpl<T> &vector) {
+  for (T element : vector) {
+    os << element << " ";
+  }
+
+  return os;
+}
+
+FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
+  Operation *rootOperation = nullptr;
+  for (auto op : llvm::reverse(computeOps)) {
+    if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
+      // Do not treat linalg ops that are all parallel as root operations in
+      // this sweep.
+      if (linalgOp.getNumLoops() == linalgOp.getNumParallelLoops())
+        continue;
+
+      // All other linalg ops are root ops.
+      rootOperation = op;
+      break;
+    }
+
+    if (isa<TilingInterface>(op) &&
+        !isa<tensor::PadOp, tensor::PackOp, tensor::UnPackOp>(op)) {
+      // All other operations that implement this interface are root ops.
+      rootOperation = op;
+      break;
+    }
+  }
+
+  if (!rootOperation) {
+    // Check for elementwise operations.
+    for (auto op : llvm::reverse(computeOps)) {
+      if (isa<linalg::LinalgOp>(op)) {
+        rootOperation = op;
+        break;
+      }
+    }
+  }
+
+  if (!rootOperation) {
+    // Check for pad/pack/unpack ops by themselves.
+    for (auto op : llvm::reverse(computeOps)) {
+      if (isa<tensor::PadOp, tensor::PackOp, tensor::UnPackOp>(op)) {
+        rootOperation = op;
+        break;
+      }
+    }
+  }
+
+  return rootOperation;
+}
+
+LogicalResult adjustTileSizesForUnPackOp(func::FuncOp entryPointFn,
+                                         Operation *rootOp) {
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp);
+  if (!linalgOp)
+    return success();
+
+  auto loweringConfig = getLoweringConfig(linalgOp);
+  TileSizesListType tileSizesList = loweringConfig.getTileSizeVals();
+
+  bool foundUnPackOp = false;
+  SmallVector<int64_t> alignedSizes(linalgOp.getNumLoops(), 1);
+  for (OpOperand *opOperand : linalgOp.getDpsInputOperands()) {
+    auto unpackOp = opOperand->get().getDefiningOp<tensor::UnPackOp>();
+    if (!unpackOp)
+      continue;
+
+    foundUnPackOp = true;
+    auto idxMap = linalgOp.getMatchingIndexingMap(opOperand);
+    LLVM_DEBUG(DBGS() << "Find unpack op candidate: " << unpackOp << "\n"
+                      << "The corresponding indexing map is: " << idxMap
+                      << "\n");
+
+    SmallVector<int64_t> innerTiles = unpackOp.getStaticTiles();
+    ArrayRef<int64_t> dimPos = unpackOp.getInnerDimsPos();
+    for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
+      if (ShapedType::isDynamic(size))
+        continue;
+      auto dimExpr = dyn_cast<AffineDimExpr>(idxMap.getResult(pos));
+      if (!dimExpr)
+        return failure();
+      int mappedPos = dimExpr.getPosition();
+      alignedSizes[mappedPos] = std::lcm(alignedSizes[mappedPos], size);
+    }
+  }
+
+  if (!foundUnPackOp)
+    return success();
+
+  LLVM_DEBUG(DBGS() << "The tile sizes for each dimension should be aligned to "
+                    << alignedSizes);
+
+  // Fixup for making tileSizes be multiple of inner_tile_sizes.
+  for (SmallVectorImpl<int64_t> &tileSizes : tileSizesList) {
+    for (auto idx : llvm::seq<int64_t>(0, tileSizes.size())) {
+      if (tileSizes[idx] == 0)
+        continue;
+      tileSizes[idx] = llvm::alignTo(tileSizes[idx], alignedSizes[idx]);
+    }
+  }
+
+  auto pipeline = getTranslationInfo(entryPointFn).getPassPipeline().getValue();
+  if (pipeline == DispatchLoweringPassPipeline::CPUDoubleTilingPeelingExpert) {
+    LLVM_DEBUG(DBGS() << "unpack fusion does not work with peeling, falling "
+                         "back to non-peeling path");
+    pipeline = DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
+  }
+
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPointFn, rootOp, tileSizesList,
+      loweringConfig.getScalableTileFlagVals(), pipeline);
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -8,7 +8,6 @@
 
 #include <numeric>
 
-#include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -19,18 +18,6 @@
 
 namespace mlir {
 namespace iree_compiler {
-
-using IREE::Codegen::DispatchLoweringPassPipeline;
-
-template <typename T>
-static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                     const llvm::SmallVectorImpl<T> &vector) {
-  for (T element : vector) {
-    os << element << " ";
-  }
-
-  return os;
-}
 
 FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
   Operation *rootOperation = nullptr;
@@ -75,68 +62,6 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
   }
 
   return rootOperation;
-}
-
-LogicalResult adjustTileSizesForUnPackOp(func::FuncOp entryPointFn,
-                                         Operation *rootOp) {
-  auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp);
-  if (!linalgOp)
-    return success();
-
-  auto loweringConfig = getLoweringConfig(linalgOp);
-  TileSizesListType tileSizesList = loweringConfig.getTileSizeVals();
-
-  bool foundUnPackOp = false;
-  SmallVector<int64_t> alignedSizes(linalgOp.getNumLoops(), 1);
-  for (OpOperand *opOperand : linalgOp.getDpsInputOperands()) {
-    auto unpackOp = opOperand->get().getDefiningOp<tensor::UnPackOp>();
-    if (!unpackOp)
-      continue;
-
-    foundUnPackOp = true;
-    auto idxMap = linalgOp.getMatchingIndexingMap(opOperand);
-    LLVM_DEBUG(DBGS() << "Find unpack op candidate: " << unpackOp << "\n"
-                      << "The corresponding indexing map is: " << idxMap
-                      << "\n");
-
-    SmallVector<int64_t> innerTiles = unpackOp.getStaticTiles();
-    ArrayRef<int64_t> dimPos = unpackOp.getInnerDimsPos();
-    for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
-      if (ShapedType::isDynamic(size))
-        continue;
-      auto dimExpr = dyn_cast<AffineDimExpr>(idxMap.getResult(pos));
-      if (!dimExpr)
-        return failure();
-      int mappedPos = dimExpr.getPosition();
-      alignedSizes[mappedPos] = std::lcm(alignedSizes[mappedPos], size);
-    }
-  }
-
-  if (!foundUnPackOp)
-    return success();
-
-  LLVM_DEBUG(DBGS() << "The tile sizes for each dimension should be aligned to "
-                    << alignedSizes);
-
-  // Fixup for making tileSizes be multiple of inner_tile_sizes.
-  for (SmallVectorImpl<int64_t> &tileSizes : tileSizesList) {
-    for (auto idx : llvm::seq<int64_t>(0, tileSizes.size())) {
-      if (tileSizes[idx] == 0)
-        continue;
-      tileSizes[idx] = llvm::alignTo(tileSizes[idx], alignedSizes[idx]);
-    }
-  }
-
-  auto pipeline = getTranslationInfo(entryPointFn).getPassPipeline().getValue();
-  if (pipeline == DispatchLoweringPassPipeline::CPUDoubleTilingPeelingExpert) {
-    LLVM_DEBUG(DBGS() << "unpack fusion does not work with peeling, falling "
-                         "back to non-peeling path");
-    pipeline = DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
-  }
-
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, rootOp, tileSizesList,
-      loweringConfig.getScalableTileFlagVals(), pipeline);
 }
 
 } // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
@@ -20,13 +20,6 @@ namespace iree_compiler {
 /// to the end of the function is the root op.
 FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
 
-/// Adjusts the tile sizes (carried by `rootOp`) to be aligned with
-/// tensor.unpack inner tile sizes, if there are tensor.unpack producers. If the
-/// tile sizes are not aligned, a stack buffer is needed because of
-/// tensor.unpack tiling implementations.
-LogicalResult adjustTileSizesForUnPackOp(func::FuncOp entryPointFn,
-                                         Operation *rootOp);
-
 } // namespace iree_compiler
 } // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
@@ -1,0 +1,33 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_UTILS_CPUUTILS_H_
+#define IREE_COMPILER_CODEGEN_UTILS_CPUUTILS_H_
+
+#include "iree/compiler/Codegen/Utils/Utils.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Find the root operation for the dispatch region. The priority is:
+///   1. A Linalg operation that has reduction loops.
+///   2. Any other Linalg op or LinalgExt op.
+///   3. An operation that implements TilingInterface.
+/// If there are multiple operations meeting the same priority, the one closer
+/// to the end of the function is the root op.
+FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
+
+/// Adjusts the tile sizes (carried by `rootOp`) to be aligned with
+/// tensor.unpack inner tile sizes, if there are tensor.unpack producers. If the
+/// tile sizes are not aligned, a stack buffer is needed because of
+/// tensor.unpack tiling implementations.
+LogicalResult adjustTileSizesForUnPackOp(func::FuncOp entryPointFn,
+                                         Operation *rootOp);
+
+} // namespace iree_compiler
+} // namespace mlir
+
+#endif // IREE_COMPILER_CODEGEN_UTILS_CPUUTILS_H_

--- a/compiler/src/iree/compiler/Codegen/VMVX/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/VMVX/BUILD.bazel
@@ -47,13 +47,16 @@ iree_compiler_cc_library(
 iree_compiler_cc_library(
     name = "VMVX",
     srcs = [
+        "KernelDispatch.cpp",
         "LowerLinalgMicrokernels.cpp",
         "Passes.cpp",
         "VMVXAssignConstantOrdinals.cpp",
         "VMVXLinkExecutables.cpp",
         "VMVXLowerExecutableTargetPass.cpp",
+        "VMVXSelectLoweringStrategy.cpp",
     ],
     hdrs = [
+        "KernelDispatch.h",
         "Passes.h",
     ],
     deps = [

--- a/compiler/src/iree/compiler/Codegen/VMVX/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/VMVX/CMakeLists.txt
@@ -42,13 +42,16 @@ iree_cc_library(
   NAME
     VMVX
   HDRS
+    "KernelDispatch.h"
     "Passes.h"
   SRCS
+    "KernelDispatch.cpp"
     "LowerLinalgMicrokernels.cpp"
     "Passes.cpp"
     "VMVXAssignConstantOrdinals.cpp"
     "VMVXLinkExecutables.cpp"
     "VMVXLowerExecutableTargetPass.cpp"
+    "VMVXSelectLoweringStrategy.cpp"
   DEPS
     ::PassHeaders
     ::PassesIncGen

--- a/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
@@ -113,10 +113,6 @@ static LogicalResult setConfigForKernel(func::FuncOp entryPointFn) {
     return failure();
   }
 
-  if (failed(adjustTileSizesForUnPackOp(entryPointFn, rootOperation))) {
-    return failure();
-  }
-
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
@@ -1,0 +1,145 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/VMVX/KernelDispatch.h"
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+#define DEBUG_TYPE "vmvx-kernel-dispatch"
+#define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+
+namespace mlir {
+namespace iree_compiler {
+
+constexpr int kDefaultDistTileSize = 64;
+
+static SmallVector<int64_t>
+getDefaultDistributionTileSizes(TilingInterface op) {
+  unsigned numLoops = op.getLoopIteratorTypes().size();
+  auto partitionedLoops = cast<PartitionableLoopsInterface>(op.getOperation())
+                              .getPartitionableLoops(kNumMaxParallelDims);
+  SmallVector<int64_t> distTileSizes(numLoops, kDefaultDistTileSize);
+  llvm::DenseSet<unsigned> partitionedLoopsSet(partitionedLoops.begin(),
+                                               partitionedLoops.end());
+  for (auto dim : llvm::seq<int64_t>(0, distTileSizes.size())) {
+    if (!partitionedLoopsSet.count(dim))
+      distTileSizes[dim] = 0;
+  }
+
+  return distTileSizes;
+}
+
+/// Sets the lowering configuration for dispatch region for linalg_ext.fft
+/// root op.
+static LogicalResult setRootConfig(func::FuncOp entryPointFn,
+                                   IREE::LinalgExt::FftOp fftOp) {
+  assert(!getLoweringConfig(fftOp) && "expected lowering_config is not set");
+  SmallVector<int64_t> distTileSizes = getDefaultDistributionTileSizes(fftOp);
+  auto rank = fftOp.getOperandRank();
+  if (distTileSizes.size() >= rank && distTileSizes[rank - 1] != 0) {
+    APInt value;
+    if (matchPattern(fftOp.getStage(), m_ConstantInt(&value))) {
+      distTileSizes[rank - 1] = 1ll << value.getSExtValue();
+      distTileSizes[rank - 1] = std::max(
+          distTileSizes[rank - 1], static_cast<int64_t>(kDefaultDistTileSize));
+    } else {
+      return fftOp.emitOpError("non-constant stage might not work for fft op");
+    }
+  }
+  TileSizesListType tileSizes = {distTileSizes};
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPointFn, fftOp, tileSizes,
+      IREE::Codegen::DispatchLoweringPassPipeline::VMVXDefault);
+}
+
+static LogicalResult setRootConfig(func::FuncOp entryPointFn,
+                                   TilingInterface tilingInterfaceOp) {
+  assert(!getLoweringConfig(tilingInterfaceOp) &&
+         "expected lowering_config is not set");
+
+  SmallVector<int64_t> distTileSizes =
+      getDefaultDistributionTileSizes(tilingInterfaceOp);
+  TileSizesListType tileSizes = {distTileSizes};
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPointFn, tilingInterfaceOp, tileSizes,
+      IREE::Codegen::DispatchLoweringPassPipeline::VMVXDefault);
+}
+
+static LogicalResult setVMVXRootConfigImpl(func::FuncOp entryPointFn,
+                                           Operation *op) {
+  auto setRootConfigFn = [&](Operation *op) -> LogicalResult {
+    return TypeSwitch<Operation *, LogicalResult>(op)
+        .Case<IREE::LinalgExt::FftOp>(
+            [&](auto op) { return setRootConfig(entryPointFn, op); })
+        .Case<TilingInterface>(
+            [&](auto op) { return setRootConfig(entryPointFn, op); })
+        .Default([&](Operation *op) { return success(); });
+  };
+  return setRootConfigFn(op);
+}
+
+static LogicalResult lowerUsingNonePipeline(func::FuncOp op) {
+  auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
+      op.getContext(), IREE::Codegen::DispatchLoweringPassPipeline::None);
+  return setTranslationInfo(op, translationInfo);
+}
+
+/// Sets the translation information to use for a dispatch region.
+static LogicalResult setConfigForKernel(func::FuncOp entryPointFn) {
+  SmallVector<Operation *> computeOps = getComputeOps(entryPointFn);
+  if (computeOps.empty()) {
+    return lowerUsingNonePipeline(entryPointFn);
+  }
+
+  FailureOr<Operation *> rootOp = getRootOperation(computeOps);
+  if (failed(rootOp)) {
+    return failure();
+  }
+
+  // Handle the case with no known root operation.
+  Operation *rootOperation = rootOp.value();
+  if (!rootOperation) {
+    return lowerUsingNonePipeline(entryPointFn);
+  }
+
+  if (failed(setVMVXRootConfigImpl(entryPointFn, rootOperation))) {
+    return failure();
+  }
+
+  if (failed(adjustTileSizesForUnPackOp(entryPointFn, rootOperation))) {
+    return failure();
+  }
+
+  return success();
+}
+
+LogicalResult initVMVXLaunchConfig(ModuleOp moduleOp) {
+  llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
+      getAllEntryPoints(moduleOp);
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+    auto exportOp = exportOps.lookup(funcOp.getName());
+    if (!exportOp) {
+      continue;
+    }
+
+    if (getTranslationInfo(exportOp)) {
+      continue;
+    }
+
+    if (failed(setConfigForKernel(funcOp))) {
+      return failure();
+    }
+  }
+
+  return success();
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.h
+++ b/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.h
@@ -1,0 +1,21 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_VMVX_KERNELDISPATCH_H_
+#define IREE_COMPILER_CODEGEN_VMVX_KERNELDISPATCH_H_
+
+#include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+LogicalResult initVMVXLaunchConfig(ModuleOp moduleOp);
+
+} // namespace iree_compiler
+} // namespace mlir
+
+#endif // IREE_COMPILER_CODEGEN_VMVX_KERNELDISPATCH_H_

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.h
@@ -32,6 +32,10 @@ std::unique_ptr<Pass> createVMVXLowerLinalgMicrokernelsPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createVMVXMaterializeEncodingPass();
 
+/// Pass to select a lowering strategy for a hal.executable.variant operation.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createVMVXSelectLoweringStrategyPass();
+
 /// Pass to lower the module an hal.executable.variant operation to external
 /// dialect.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.td
@@ -19,6 +19,15 @@ def VMVXAssignConstantOrdinals :
   let constructor = "mlir::iree_compiler::createVMVXAssignConstantOrdinalsPass()";
 }
 
+def VMVXSelectLoweringStrategy :
+    Pass<"iree-vmvx-select-lowering-strategy",
+         "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {
+  let summary =
+      "Select a IREE::HAL::DispatchLoweringPassPipeline for lowering the variant";
+  let constructor =
+      "mlir::iree_compiler::createVMVXSelectLoweringStrategyPass()";
+}
+
 def VMVXLinkExecutables :
     Pass<"iree-vmvx-link-executables", "mlir::ModuleOp"> {
   let summary = "Links VMVX HAL executables within the top-level program module.";

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXSelectLoweringStrategy.cpp
@@ -1,0 +1,78 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/VMVX/KernelDispatch.h"
+#include "iree/compiler/Codegen/VMVX/PassDetail.h"
+#include "iree/compiler/Codegen/VMVX/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
+
+using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+/// Selects the lowering strategy for a hal.executable.variant operation.
+class VMVXSelectLoweringStrategyPass
+    : public VMVXSelectLoweringStrategyBase<VMVXSelectLoweringStrategyPass> {
+public:
+  VMVXSelectLoweringStrategyPass() = default;
+  VMVXSelectLoweringStrategyPass(const VMVXSelectLoweringStrategyPass &pass) {}
+  void getDependentDialects(DialectRegistry &registry) const override {
+    // TODO(qedawkins): Once TransformStrategies is deprecated, drop the
+    // unnecessary dialect registrations.
+    // clang-format off
+    registry.insert<IREE::Codegen::IREECodegenDialect,
+                    IREE::HAL::HALDialect,
+                    IREE::LinalgExt::IREELinalgExtDialect,
+                    bufferization::BufferizationDialect,
+                    linalg::LinalgDialect,
+                    scf::SCFDialect,
+                    tensor::TensorDialect,
+                    vector::VectorDialect>();
+    // clang-format on
+  }
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void VMVXSelectLoweringStrategyPass::runOnOperation() {
+  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  ModuleOp moduleOp = variantOp.getInnerModule();
+
+  // Set the strategy with default heuristics.
+  if (failed(initVMVXLaunchConfig(moduleOp))) {
+    return signalPassFailure();
+  }
+
+  std::optional<IREE::Codegen::TranslationInfoAttr> translationInfo =
+      getIdenticalTranslationInfo(variantOp);
+  if (!translationInfo) {
+    moduleOp.emitOpError(
+        "unhandled compilation of entry point functions with different "
+        "translation info");
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createVMVXSelectLoweringStrategyPass() {
+  return std::make_unique<VMVXSelectLoweringStrategyPass>();
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "link_executables.mlir",
             "lower_linalg_microkernels.mlir",
             "pipeline.mlir",
+            "select_lowering_strategy.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "link_executables.mlir"
     "lower_linalg_microkernels.mlir"
     "pipeline.mlir"
+    "select_lowering_strategy.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt  --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy, iree-vmvx-lower-executable-target)))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt  --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-vmvx-select-lowering-strategy, iree-vmvx-lower-executable-target)))" --split-input-file %s | FileCheck %s
 
 hal.executable private @mmt4d_ukernel {
   hal.executable.variant public @vmvx_bytecode_fb target(<"vmvx", "vmvx-bytecode-fb", {ukernels = "all"}>) {

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/select_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/select_lowering_strategy.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy)))' -split-input-file %s | FileCheck %s
+// RUN: iree-opt -pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-vmvx-select-lowering-strategy)))' -split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -176,7 +176,7 @@ hal.executable @fusion_quant_matmul_generic {
     }
   }
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 16, 0]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
 //       CHECK: hal.executable.export public @fusion_quant_matmul_generic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -219,7 +219,7 @@ hal.executable private @unpack_outer_dynamic  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [32, 16]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
 //      CHECK: hal.executable.export public @unpack_outer_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
@@ -18,18 +18,18 @@ stream.executable public @add_dispatch_0 {
   builtin.module  {
     func.func @add_dispatch_0(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding, %arg2_binding: !stream.binding) {
       %c0 = arith.constant 0 : index
-      %arg0 = stream.binding.subspan %arg0_binding[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<16xf32>>
-      %arg1 = stream.binding.subspan %arg1_binding[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<16xf32>>
-      %arg2 = stream.binding.subspan %arg2_binding[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:tensor<16xf32>>
-      %0 = tensor.empty() : tensor<16xf32>
-      %1 = flow.dispatch.tensor.load %arg0, offsets=[0], sizes=[16], strides=[1] : !flow.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
-      %2 = flow.dispatch.tensor.load %arg1, offsets=[0], sizes=[16], strides=[1] : !flow.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
-      %3 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%1, %2 : tensor<16xf32>, tensor<16xf32>) outs(%0 : tensor<16xf32>) {
+      %arg0 = stream.binding.subspan %arg0_binding[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<128xf32>>
+      %arg1 = stream.binding.subspan %arg1_binding[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<128xf32>>
+      %arg2 = stream.binding.subspan %arg2_binding[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:tensor<128xf32>>
+      %0 = tensor.empty() : tensor<128xf32>
+      %1 = flow.dispatch.tensor.load %arg0, offsets=[0], sizes=[128], strides=[1] : !flow.dispatch.tensor<readonly:tensor<128xf32>> -> tensor<128xf32>
+      %2 = flow.dispatch.tensor.load %arg1, offsets=[0], sizes=[128], strides=[1] : !flow.dispatch.tensor<readonly:tensor<128xf32>> -> tensor<128xf32>
+      %3 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%1, %2 : tensor<128xf32>, tensor<128xf32>) outs(%0 : tensor<128xf32>) {
       ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
         %4 = arith.addf %arg3, %arg4 : f32
         linalg.yield %4 : f32
-      } -> tensor<16xf32>
-      flow.dispatch.tensor.store %3, %arg2, offsets=[0], sizes=[16], strides=[1] : tensor<16xf32> -> !flow.dispatch.tensor<writeonly:tensor<16xf32>>
+      } -> tensor<128xf32>
+      flow.dispatch.tensor.store %3, %arg2, offsets=[0], sizes=[128], strides=[1] : tensor<128xf32> -> !flow.dispatch.tensor<writeonly:tensor<128xf32>>
       return
     }
   }

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/BUILD.bazel
@@ -52,7 +52,6 @@ iree_compiler_cc_library(
         ":PassHeaders",
         "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Common/CPU:CommonCPUPasses",
-        "//compiler/src/iree/compiler/Codegen/LLVMCPU",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/VMVX",

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/CMakeLists.txt
@@ -74,7 +74,6 @@ iree_cc_library(
     MLIRVectorToSCF
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::CPU::CommonCPUPasses
-    iree::compiler::Codegen::LLVMCPU
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils
     iree::compiler::Codegen::VMVX

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -11,7 +11,6 @@
 #include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree/compiler/Codegen/Common/CPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
-#include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/VMVX/Passes.h"
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
@@ -44,7 +43,7 @@ void buildVMVXConfigurationPassPipeline(OpPassManager &passManager) {
   // TODO: Remove the following pass the plumb support for #hal.descriptor_type
   // memory space through the stack.
   passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
-  passManager.addPass(createLLVMCPUSelectLoweringStrategyPass());
+  passManager.addPass(createVMVXSelectLoweringStrategyPass());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The strategy has two entry points. One for linalg_ext.fft ops (which needs special logic), and the other for TilingInterface ops. All the compute ops implement TilingInterface, so it is okay to have a single entry point for all the ops.

- It moves `getRootOperation` and `adjustTileSizesForUnPackOp` methods
  to Codegen/CPUUtils.
- It removes all the VMVX logic from LLVMCPU/
- It drops Codegen/LLVMCPU dependency from Dialect/VMVX/Transforms
- It moves the vmvx tests to Codegen/VMVX/test
- Most of the distribution heuristics are removed in VMVX backend. They
  are not critical for VMVX. They were added just because we mixed
  LLVMCPU and VMVX logics in the past.