### PR TITLE
Use setup.yml in pkgci, allowing for CI configuration/skipping.

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -24,23 +24,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    uses: ./.github/workflows/setup.yml
+
   build_packages:
     name: Build Packages
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_packages')
     uses: ./.github/workflows/pkgci_build_packages.yml
     with:
       package_version: 0.dev1
 
   regression_test_cpu:
     name: Regression Test CPU
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_cpu')
     uses: ./.github/workflows/pkgci_regression_test_cpu.yml
-    needs: [build_packages]
 
   regression_test_amdgpu_vulkan:
     name: Regression Test AMDGPU-Vulkan
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_vulkan')
     uses: ./.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
-    needs: [build_packages]
 
   regression_test_amdgpu_rocm:
     name: Regression Test AMDGPU-ROCm
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_rocm')
     uses: ./.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
-    needs: [build_packages]


### PR DESCRIPTION
This will skip running pkgci when PRs only modify files that do not affect CI builds.
* I mainly want to skip running these workflows when only modifying markdown files
* Note that changes to `experimental/*` also count as "not affecting CI builds", so we might want to carve out a case for `regression_test_amdgpu_rocm` and https://github.com/openxla/iree/tree/main/experimental/rocm.

References/docs:

* https://iree.dev/developers/general/contributing/#ci-behavior-manipulation
* https://github.com/openxla/iree/blob/main/.github/workflows/setup.yml
* https://github.com/openxla/iree/blob/main/build_tools/github_actions/configure_ci.py