### PR TITLE
[spirv] Use `gpu.subgrup_reduce` in SPIR-V vector reduction pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -113,6 +113,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createGPUTileReductionPass();
 // If nullptr, warp size 32 will be used.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertVectorReductionToGPUPass(
+    bool expandSubgroupReduction = true,
     std::function<int(func::FuncOp)> getWarpSize = nullptr);
 
 /// Pass to specialize workgroup distribution loops

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -173,31 +173,6 @@ class WarpOpBarrier : public OpRewritePattern<vector::WarpExecuteOnLane0Op> {
   }
 };
 
-/// Returns a matching GPU reduction operations.
-static std::optional<gpu::AllReduceOperation>
-combiningKindToAllReduce(vector::CombiningKind kind) {
-  using gpu::AllReduceOperation;
-  using vector::CombiningKind;
-
-  switch (kind) {
-  case CombiningKind::ADD:
-    return AllReduceOperation::ADD;
-  case CombiningKind::AND:
-    return AllReduceOperation::AND;
-  case CombiningKind::MUL:
-    return AllReduceOperation::MUL;
-  case CombiningKind::OR:
-    return AllReduceOperation::OR;
-  case CombiningKind::XOR:
-    return AllReduceOperation::XOR;
-  // Currently, the min/max reductions are not well-defined in the gpu dialect.
-  // See https://github.com/llvm/llvm-project/issues/72354.
-  default:
-    return std::nullopt;
-  }
-  llvm_unreachable("unhandled");
-}
-
 static Value simpleWarpShuffleFunction(Location loc, OpBuilder &builder,
                                        Value val, Value srcIdx,
                                        int64_t warpSz) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -428,7 +428,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
 
   // vector -> simt gpu + vector
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createConvertVectorReductionToGPUPass());
+      createConvertVectorReductionToGPUPass(/*expandSubgroupReduction=*/true));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -566,12 +566,13 @@ static void populatePropagateVectorDistribution(Operation *target,
                                                 RewritePatternSet &patterns,
                                                 PatternBenefit benefit,
                                                 unsigned subgroupSize) {
-  auto groupReductionFn = [subgroupSize](
-                              Location loc, OpBuilder &builder, Value input,
-                              vector::CombiningKind kind, uint32_t size) {
-    return mlir::iree_compiler::emitGPUGroupReduction(loc, builder, input, kind,
-                                                      size, subgroupSize);
-  };
+  auto groupReductionFn =
+      [subgroupSize](Location loc, OpBuilder &builder, Value input,
+                     vector::CombiningKind kind, uint32_t size) {
+        return mlir::iree_compiler::emitGPUGroupReduction(
+            loc, builder, input, kind, size, subgroupSize,
+            /*expandSubgroupReduce=*/true);
+      };
   assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
   vector::populatePropagateWarpVectorDistributionPatterns(
       patterns, simpleDistributionFunction, simpleWarpShuffleFunction, benefit);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -593,7 +593,8 @@ void addSPIRVSubgroupReducePassPipeline(OpPassManager &pm) {
 
   // Handle vector reduction operations specifically.
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createConvertVectorReductionToGPUPass(getWarpSize));
+      createConvertVectorReductionToGPUPass(/*expandSubgroupReduction=*/false,
+                                            getWarpSize));
   // Perform normal vector unrolling and lowering transformations. This breaks
   // vectors down to native machine size.
   addSPIRVVectorLoweringPasses(nestedModulePM);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
@@ -80,7 +80,7 @@ hal.executable @i4_dequant_matvec_f32 {
 //         CHECK:     scf.yield %[[BCAST]] : vector<1x4xf32>
 
 //         CHECK:   %[[SCAST:.+]] = vector.shape_cast %[[FOR]] : vector<1x4xf32> to vector<4xf32>
-//         CHECK:   vector.reduction <add>, %[[SCAST]] : vector<4xf32> into f32
-// CHECK-COUNT-6:   gpu.shuffle  xor
+//         CHECK:   %[[REDUCE:.+]] = vector.reduction <add>, %[[SCAST]] : vector<4xf32> into f32
+//         CHECK:   gpu.subgroup_reduce add %[[REDUCE]] : (f32) -> f32
 //         CHECK:   scf.if
 //         CHECK:     vector.transfer_write

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -333,17 +333,17 @@ hal.executable private @dynamic_softmax {
         %c32_i64 = arith.constant 32 : i64
         %c0 = arith.constant 0 : index
         %0 = hal.interface.constant.load[0] : i32
-        %1 = hal.interface.constant.load[1] : i32 
+        %1 = hal.interface.constant.load[1] : i32
         %2 = arith.extui %0 : i32 to i64
         %3 = arith.extui %1 : i32 to i64
-        %4 = arith.shli %3, %c32_i64 : i64 
+        %4 = arith.shli %3, %c32_i64 : i64
         %5 = arith.ori %2, %4 : i64
         %6 = arith.index_castui %5 : i64 to index
         %7 = flow.dispatch.workload.ordinal %6, 0 : index
         %8 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32x?xf16>>{%7}
         %9 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<32x?xf16>>{%7}
         %10 = flow.dispatch.tensor.load %8, offsets = [0, 0], sizes = [32, %7], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32x?xf16>>{%7} -> tensor<32x?xf16>
-        %11 = tensor.empty(%7) : tensor<32x?xf16> 
+        %11 = tensor.empty(%7) : tensor<32x?xf16>
         %12 = linalg.softmax dimension(1) ins(%10 : tensor<32x?xf16>) outs(%11 : tensor<32x?xf16>) -> tensor<32x?xf16>
         flow.dispatch.tensor.store %12, %9, offsets = [0, 0], sizes = [32, %7], strides = [1, 1] : tensor<32x?xf16> -> !flow.dispatch.tensor<writeonly:tensor<32x?xf16>>{%7}
         return
@@ -371,8 +371,8 @@ hal.executable private @dynamic_softmax {
 // CHECK:         vector.transfer_write %[[MIN_F16]], %{{.*}} : vector<1xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>
 // CHECK:         scf.for {{.*}} %[[C0]] to %[[DYNAMIC_SIZE]] step %[[C64]]
 // CHECK:           %[[MASK:.+]] = vector.create_mask %{{.*}} : vector<1xi1>
-// CHECK:           %[[ACC:.+]] = vector.transfer_read %{{.*}}, %cst_3, %[[MASK]] {{.*}} : memref<1x64xf16, #gpu.address_space<workgroup>>, vector<1xf16>
-// CHECK:           %[[NEW:.+]] = vector.transfer_read %{{.*}}, %cst_3, %[[MASK]] {{.*}} : memref<32x?xf16, #hal.descriptor_type<storage_buffer>>, vector<1xf16>
+// CHECK-DAG:       %[[ACC:.+]] = vector.transfer_read %{{.*}}, %cst_2, %[[MASK]] {{.*}} : memref<1x64xf16, #gpu.address_space<workgroup>>, vector<1xf16>
+// CHECK-DAG:       %[[NEW:.+]] = vector.transfer_read %{{.*}}, %cst_2, %[[MASK]] {{.*}} : memref<32x?xf16, #hal.descriptor_type<storage_buffer>>, vector<1xf16>
 // CHECK:           %[[MAX:.+]] = arith.maximumf %[[NEW]], %[[ACC]] : vector<1xf16>
 // CHECK:           vector.transfer_write %[[MAX]], %{{.*}}, %[[MASK]] {{.*}} : vector<1xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>
 // CHECK:           gpu.barrier
@@ -394,7 +394,7 @@ hal.executable private @dynamic_softmax {
 // CHECK:           gpu.barrier
 
 // Finish the second reduction.
-// CHECK-COUNT-6: gpu.shuffle  xor {{.*}} : i32
+// CHECK:         gpu.subgroup_reduce add {{.*}} : (f16) -> f16
 
 // Store the result back to global memory in a loop, recomputing the
 // elementwise part.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -371,8 +371,8 @@ hal.executable private @dynamic_softmax {
 // CHECK:         vector.transfer_write %[[MIN_F16]], %{{.*}} : vector<1xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>
 // CHECK:         scf.for {{.*}} %[[C0]] to %[[DYNAMIC_SIZE]] step %[[C64]]
 // CHECK:           %[[MASK:.+]] = vector.create_mask %{{.*}} : vector<1xi1>
-// CHECK-DAG:       %[[ACC:.+]] = vector.transfer_read %{{.*}}, %cst_2, %[[MASK]] {{.*}} : memref<1x64xf16, #gpu.address_space<workgroup>>, vector<1xf16>
-// CHECK-DAG:       %[[NEW:.+]] = vector.transfer_read %{{.*}}, %cst_2, %[[MASK]] {{.*}} : memref<32x?xf16, #hal.descriptor_type<storage_buffer>>, vector<1xf16>
+// CHECK-DAG:       %[[ACC:.+]] = vector.transfer_read %{{.*}}, %[[C0_F16]], %[[MASK]] {{.*}} : memref<1x64xf16, #gpu.address_space<workgroup>>, vector<1xf16>
+// CHECK-DAG:       %[[NEW:.+]] = vector.transfer_read %{{.*}}, %[[C0_F16]], %[[MASK]] {{.*}} : memref<32x?xf16, #hal.descriptor_type<storage_buffer>>, vector<1xf16>
 // CHECK:           %[[MAX:.+]] = arith.maximumf %[[NEW]], %[[ACC]] : vector<1xf16>
 // CHECK:           vector.transfer_write %[[MAX]], %{{.*}}, %[[MASK]] {{.*}} : vector<1xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>
 // CHECK:           gpu.barrier

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -1,4 +1,6 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file \
+// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)))' \
+// RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -11,11 +13,16 @@
 ]>
 hal.executable @i4_dequant_unit_matmul_f16 {
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {
-      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader, Float16, StorageBuffer16BitAccess, GroupNonUniform, GroupNonUniformShuffle], [SPV_KHR_16bit_storage]>, Unknown:IntegratedGPU, #spirv.resource_limits<
-        max_compute_shared_memory_size = 32768,
-        max_compute_workgroup_invocations = 1024,
-        max_compute_workgroup_size = [1024, 1024, 64],
-        subgroup_size = 32>>
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [
+          Shader, Float16, StorageBuffer16BitAccess, GroupNonUniform,
+          GroupNonUniformArithmetic, GroupNonUniformShuffle
+        ], [SPV_KHR_16bit_storage]>, Unknown:IntegratedGPU,
+        #spirv.resource_limits<
+          max_compute_shared_memory_size = 32768,
+          max_compute_workgroup_invocations = 1024,
+          max_compute_workgroup_size = [1024, 1024, 64],
+          subgroup_size = 32
+        >>
     }>) {
     hal.executable.export @i4_dequant_unit_matmul_f16 layout(#pipeline_layout) {
     ^bb0(%arg0: !hal.device):
@@ -105,7 +112,7 @@ hal.executable @i4_dequant_unit_matmul_f16 {
 //         CHECK: %[[VS1:.+]] = spirv.VectorShuffle [2 : i32, 3 : i32] %[[LD]]
 //         CHECK: spirv.Bitcast %[[VS1]] : vector<2xi32> to vector<4xf16>
 
-// CHECK-COUNT-5: spirv.GroupNonUniformShuffleXor <Subgroup>
+//         CHECK: spirv.GroupNonUniformFAdd "Subgroup" "Reduce" {{.*}} : f16
 
 //         CHECK: spirv.mlir.selection
 
@@ -122,11 +129,16 @@ hal.executable @i4_dequant_unit_matmul_f16 {
 ]>
 hal.executable @i4_dequant_matvec_f16_subgroup_64 {
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {
-      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader, Float16, StorageBuffer16BitAccess, GroupNonUniform, GroupNonUniformShuffle], [SPV_KHR_16bit_storage]>, Unknown:IntegratedGPU, #spirv.resource_limits<
-        max_compute_shared_memory_size = 32768,
-        max_compute_workgroup_invocations = 1024,
-        max_compute_workgroup_size = [1024, 1024, 64],
-        subgroup_size = 64>>
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [
+          Shader, Float16, StorageBuffer16BitAccess, GroupNonUniform,
+          GroupNonUniformArithmetic, GroupNonUniformShuffle
+        ], [SPV_KHR_16bit_storage]>, Unknown:IntegratedGPU,
+        #spirv.resource_limits<
+          max_compute_shared_memory_size = 32768,
+          max_compute_workgroup_invocations = 1024,
+          max_compute_workgroup_size = [1024, 1024, 64],
+          subgroup_size = 64
+        >>
     }>) {
     hal.executable.export @i4_dequant_matvec_f16_subgroup_64 layout(#pipeline_layout) {
     ^bb0(%arg0: !hal.device):
@@ -211,7 +223,7 @@ hal.executable @i4_dequant_matvec_f16_subgroup_64 {
 //         CHECK:   %[[ACCESS:.+]] = spirv.AccessChain %[[RADDR]][{{.*}}, %[[OFFSET]]] : !spirv.ptr<!spirv.struct<(!spirv.rtarray<i32, stride=4> [0])>, StorageBuffer>, i32, i32
 //         CHECK:   spirv.Load "StorageBuffer" %[[ACCESS]] : i32
 
-//         CHECK:   spirv.VectorShuffle [0 : i32, 0 : i32, 1 : i32, 1 : i32] %{{.*}} : vector<2xi32>, %106 : vector<2xi32> -> vector<4xi32>
+//         CHECK:   spirv.VectorShuffle [0 : i32, 0 : i32, 1 : i32, 1 : i32] %{{.*}} : vector<2xi32>, {{.*}} : vector<2xi32> -> vector<4xi32>
 //         CHECK:   spirv.BitwiseAnd %{{.*}}, %[[CSTVEC4XI320]] : vector<4xi32>
 //         CHECK:   spirv.ShiftRightLogical %{{.*}}, %[[CSTVEC4XI321]] : vector<4xi32>, vector<4xi32>
 //         CHECK:   spirv.BitwiseAnd %{{.*}}, %[[CSTVEC4XI32]] : vector<4xi32>
@@ -223,6 +235,15 @@ hal.executable @i4_dequant_matvec_f16_subgroup_64 {
 
 //         CHECK:   spirv.mlir.merge
 
-// CHECK-COUNT-6: spirv.GroupNonUniformShuffleXor <Subgroup>
+//         CHECK: %[[LD:.+]]   = spirv.Load "Function" {{.*}} : vector<4xf16>
+//         CHECK: %[[S0:.+]]   = spirv.CompositeExtract %[[LD]][0 : i32] : vector<4xf16>
+//         CHECK: %[[S1:.+]]   = spirv.CompositeExtract %[[LD]][1 : i32] : vector<4xf16>
+//         CHECK: %[[S2:.+]]   = spirv.CompositeExtract %[[LD]][2 : i32] : vector<4xf16>
+//         CHECK: %[[S3:.+]]   = spirv.CompositeExtract %[[LD]][3 : i32] : vector<4xf16>
+//         CHECK: %[[ADD0:.+]] = spirv.FAdd %[[S0]], %[[S1]] : f16
+//         CHECK: %[[ADD1:.+]] = spirv.FAdd %[[ADD0]], %[[S2]] : f16
+//         CHECK: %[[ADD2:.+]] = spirv.FAdd %[[ADD1]], %[[S3]] : f16
+
+//         CHECK: spirv.GroupNonUniformFAdd "Subgroup" "Reduce" %[[ADD2]] : f16
 
 //         CHECK: spirv.mlir.selection

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -534,10 +534,11 @@ combiningKindToAllReduce(vector::CombiningKind kind) {
   case CombiningKind::XOR:
     return AllReduceOperation::XOR;
   // Currently, the min/max reductions are not well-defined in the gpu dialect.
+  // See https://github.com/llvm/llvm-project/issues/72354.
   default:
-    return std::nullopt;
+    break;
   }
-  llvm_unreachable("unhandled");
+  return std::nullopt;
 }
 
 /// Emit reduction across a group for a given input.

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -9,12 +9,16 @@
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include <optional>
 
 #define DEBUG_TYPE "iree-codegen-gpu-utils"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -512,13 +516,50 @@ static Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
   return identity;
 }
 
+/// Return a matching GPU reduction operations.
+static std::optional<gpu::AllReduceOperation>
+combiningKindToAllReduce(vector::CombiningKind kind) {
+  using gpu::AllReduceOperation;
+  using vector::CombiningKind;
+
+  switch (kind) {
+  case CombiningKind::ADD:
+    return AllReduceOperation::ADD;
+  case CombiningKind::AND:
+    return AllReduceOperation::AND;
+  case CombiningKind::MUL:
+    return AllReduceOperation::MUL;
+  case CombiningKind::OR:
+    return AllReduceOperation::OR;
+  case CombiningKind::XOR:
+    return AllReduceOperation::XOR;
+  // Currently, the min/max reductions are not well-defined in the gpu dialect.
+  default:
+    return std::nullopt;
+  }
+  llvm_unreachable("unhandled");
+}
+
 /// Emit reduction across a group for a given input.
 Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
                             vector::CombiningKind kind, uint32_t size,
-                            const int warpSize) {
+                            int warpSize, bool expandSubgroupReduce) {
   assert(
       size % warpSize == 0 &&
       "Group reduction only support for sizes aligned on warp size for now.");
+
+  if (!expandSubgroupReduce && size == warpSize) {
+    if (auto gpuReduceKind = combiningKindToAllReduce(kind)) {
+      // Simple case -- emit `gpu.subgroup_reduce` directly.
+      Value laneVal = builder.create<vector::ReductionOp>(loc, kind, input);
+      return builder.create<gpu::SubgroupReduceOp>(loc, laneVal,
+                                                   *gpuReduceKind);
+    }
+  }
+
+  // More-involved case -- generate `gpu.shuffle` ops over i32 values (using the
+  // butterfly shuffle algorithm).
+  //
   // First reduce on a single thread to get per lane reduction value.
   Value laneVal = reduceToSupportedWidth(loc, builder, input, kind);
   laneVal = warpReduction(loc, builder, laneVal, kind, warpSize, warpSize);

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -77,10 +77,11 @@ void propagateSharedMemoryCopy(func::FuncOp funcOp);
 /// Inserts barriers before and after shared memory copy.
 void insertBarriersAroundSharedMemoryCopy(func::FuncOp funcOp);
 
-/// Emit reduction across a group for a given input.
+/// Emit reduction across a group for a given input. Emits `gpu.shuffle`
+/// based reduction only when `expandSubgroupReduce` is set.
 Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
                             vector::CombiningKind kind, uint32_t size,
-                            const int warpSize);
+                            int warpSize, bool expandSubgroupReduce);
 
 /// Return the native size of an operation used in contraction calculation.
 // TODO: Make this take HW specific sizes.


### PR DESCRIPTION
This reduces the total number of supgroup ops from ~6 (with `gpu.shuffle xor`) to 1 for supported full-warp reductions.

As an alternative to the new pass constructor argument, I considered always emiting `gpu.subgroup_reduce` and later expanding it on targets that do not support it (e.g., CUDA, ROCM). This was, however, more difficult because of necessary type casts (required by `gpu.shuffle`), and duplicated code accross the expansion and odd-sized warp reductions.

It may be possible replace some more shuffles with subgroup reductions, but this can be a follow-up change.