### PR TITLE
Disable `regression_test_amdgpu_rocm` build for now.

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -47,8 +47,9 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_vulkan')
     uses: ./.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
 
-  regression_test_amdgpu_rocm:
-    name: Regression Test AMDGPU-ROCm
-    needs: [setup, build_packages]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_rocm')
-    uses: ./.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+  # Disabled while the build bot needs debugging.
+  # regression_test_amdgpu_rocm:
+  #   name: Regression Test AMDGPU-ROCm
+  #   needs: [setup, build_packages]
+  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_rocm')
+  #   uses: ./.github/workflows/pkgci_regression_test_amdgpu_rocm.yml

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -20,5 +20,7 @@ rules:
     # Formatters may do this (e.g. Prettier does) and it seems like the most
     # trivial thing to get a failing check for.
     min-spaces-from-content: 1
+  # This is not a useful check, especially when disabling entire blocks.
+  comments-indentation: disable
 
 ignore: /third_party/*


### PR DESCRIPTION
It is consistently failing to initialize. Machine probably needs a reboot.

Sample logs: https://github.com/openxla/iree/actions/runs/6886652994/job/18732915198#step:6:5099

`experimental/regression_suite/tests/pregenerated/test_llama2.py Downloading https://storage.googleapis.com/shark_tank/llama_regression/09152023/llama2_7b_int4_stripped.mlir -> /_work/iree/iree/artifacts/llama2_7b_f16qi4_stripped/llama2_7b_int4_stripped.mliriree/experimental/rocm/status_util.c:31: INTERNAL; rocm driver error 'hipErrorInvalidDevice' (101): invalid device ordinal; creating device 'rocm'; resolving dependencies for 'module'`