### PR TITLE
Warn instead of assert on unknown jobs.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -362,9 +362,9 @@ def parse_jobs_trailer(
     jobs = set(jobs)
     unknown_jobs = jobs - all_jobs
     if unknown_jobs:
-        raise ValueError(
-            f"Received unknown jobs '{','.join(unknown_jobs)}' in trailer '{key}'"
-        )
+        # Unknown jobs may be for a different workflow. Warn then continue.
+        print(f"::warning::Unknown jobs '{','.join(unknown_jobs)}' in trailer '{key}'")
+        jobs = jobs - unknown_jobs
     return jobs
 
 

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -132,16 +132,14 @@ class ConfigureCITest(unittest.TestCase):
         self.assertIn(bad_text, msg)
 
     def test_parse_jobs_unknown_job(self):
-        unknown_job = "uknown_job"
+        unknown_job = "unknown_job"
         trailers = {"key": f"job1, {unknown_job}"}
         key = "key"
         all_jobs = {"job1", "job2", "job3"}
-        with self.assertRaises(ValueError) as cm:
-            configure_ci.parse_jobs_trailer(trailers, key, all_jobs)
-
-        msg = str(cm.exception)
-        self.assertIn(unknown_job, msg)
-        self.assertIn("unknown", msg)
+        # Unknown jobs log a warning, as multiple workflows use configure_ci
+        # and a name may be recognized by one workflow and not another.
+        jobs = configure_ci.parse_jobs_trailer(trailers, key, all_jobs)
+        self.assertCountEqual(jobs, {"job1"})
 
     def test_get_enabled_jobs_all(self):
         trailers = {}


### PR DESCRIPTION
Follow-up to https://github.com/openxla/iree/pull/15606. With multiple workflows using configure_ci, job names that one workflow uses can be "unknown" in other workflows.

On this PR:

* `pkgci.yml`
  ![image](https://github.com/openxla/iree/assets/4010439/d850bd14-503a-47c8-b986-1de4e06c2e86)
* `ci.yml`
  ![image](https://github.com/openxla/iree/assets/4010439/1a6a21a7-52f6-464a-864c-3a987f27ab48)

ci-skip: regression_test_amdgpu_vulkan, test_tf_integrations_gpu