### PR TITLE
Re-enable `regression_test_amdgpu_rocm` build.

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -47,9 +47,8 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_vulkan')
     uses: ./.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
 
-  # Disabled while the build bot needs debugging.
-  # regression_test_amdgpu_rocm:
-  #   name: Regression Test AMDGPU-ROCm
-  #   needs: [setup, build_packages]
-  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_rocm')
-  #   uses: ./.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+  regression_test_amdgpu_rocm:
+    name: Regression Test AMDGPU-ROCm
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_rocm')
+    uses: ./.github/workflows/pkgci_regression_test_amdgpu_rocm.yml


### PR DESCRIPTION
Partial revert of https://github.com/openxla/iree/pull/15617, now that the bot is working (hopefully?)

Context [on Discord here](https://discord.com/channels/689900678990135345/689957613152239638/1174781546545283165) (a machine was registered as a runner for this configuration without having compatible hardware/software?)