### PR TITLE
Only include conv tests in winograd test suites.

### DIFF
--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -92,7 +92,7 @@ iree_check_single_backend_test_suite(
 )
 
 WINOGRAD_CONV_SRCS = [
-  "conv2d.mlir",
+    "conv2d.mlir",
 ]
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -53,16 +53,6 @@ iree_check_single_backend_test_suite(
     target_backend = "llvm-cpu",
 )
 
-iree_check_single_backend_test_suite(
-    name = "check_winograd_llvm-cpu_local-task",
-    srcs = LLVM_SRCS,
-    compiler_flags = [
-        "--iree-preprocessing-pass-pipeline=builtin.module\\(func.func\\(iree-linalg-ext-convert-conv2d-to-winograd\\)\\)",
-    ],
-    driver = "local-task",
-    target_backend = "llvm-cpu",
-)
-
 VMVX_SRCS = enforce_glob(
     [
         "conv2d.mlir",
@@ -101,9 +91,23 @@ iree_check_single_backend_test_suite(
     target_backend = "vulkan-spirv",
 )
 
+WINOGRAD_CONV_SRCS = [
+  "conv2d.mlir",
+]
+
+iree_check_single_backend_test_suite(
+    name = "check_winograd_llvm-cpu_local-task",
+    srcs = WINOGRAD_CONV_SRCS,
+    compiler_flags = [
+        "--iree-preprocessing-pass-pipeline=builtin.module\\(func.func\\(iree-linalg-ext-convert-conv2d-to-winograd\\)\\)",
+    ],
+    driver = "local-task",
+    target_backend = "llvm-cpu",
+)
+
 iree_check_single_backend_test_suite(
     name = "check_winograd_vulkan-spirv_vulkan",
-    srcs = VULKAN_SRCS,
+    srcs = WINOGRAD_CONV_SRCS,
     compiler_flags = [
         "--iree-preprocessing-pass-pipeline=builtin.module\\(func.func\\(iree-linalg-ext-convert-conv2d-to-winograd\\)\\)",
     ],

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -37,20 +37,6 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_winograd_llvm-cpu_local-task
-  SRCS
-    "conv2d.mlir"
-    "i4_to_f32.mlir"
-  TARGET_BACKEND
-    "llvm-cpu"
-  DRIVER
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-preprocessing-pass-pipeline=builtin.module\(func.func\(iree-linalg-ext-convert-conv2d-to-winograd\)\)"
-)
-
-iree_check_single_backend_test_suite(
-  NAME
     check_vmvx_local-task
   SRCS
     "conv2d.mlir"
@@ -74,10 +60,22 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
+    check_winograd_llvm-cpu_local-task
+  SRCS
+    "conv2d.mlir"
+  TARGET_BACKEND
+    "llvm-cpu"
+  DRIVER
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-preprocessing-pass-pipeline=builtin.module\(func.func\(iree-linalg-ext-convert-conv2d-to-winograd\)\)"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
     check_winograd_vulkan-spirv_vulkan
   SRCS
     "conv2d.mlir"
-    "i4_to_f32.mlir"
   TARGET_BACKEND
     "vulkan-spirv"
   DRIVER


### PR DESCRIPTION
It is a follow-up for https://github.com/openxla/iree/pull/15539#discussion_r1390041147

We notice that the test suite has a preprocessing about convolution. We should only test convolutions with the suite. Otherwise, we have duplicated tests.