### PR TITLE
Fix experimental/webgpu build by setting binary dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,6 +616,8 @@ iree_register_external_hal_driver(
     webgpu
   SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/experimental/webgpu"
+  BINARY_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/experimental/webgpu"
   DRIVER_TARGET
     iree::experimental::webgpu::registration
   REGISTER_FN


### PR DESCRIPTION
This fixes includes for generated files.

Compilation of the experimental webgpu HAL driver was broken by https://github.com/openxla/iree/pull/15551. I noticed early enough with the nightly CI on https://github.com/openxla/iree/actions/workflows/samples.yml to spot the relevant change 😅 

* Sample failing build: https://github.com/openxla/iree/actions/runs/6845559524/job/18610940992#step:4:644
  * `/work/experimental/webgpu/builtins.c:9:10: fatal error: 'experimental/webgpu/shaders/builtin_shaders.h' file not found`
* Sample success: https://github.com/openxla/iree/actions/runs/6897958650/job/18767101116