### PR TITLE
Rename `emitc.call` to `emitc.call_opaque`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -80,7 +80,7 @@ Value unaryOperator(OpBuilder builder, Location location, UnaryOperator op,
   auto ctx = builder.getContext();
 
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/resultType,
           /*callee=*/StringAttr::get(ctx, "EMITC_UNARY"),
@@ -98,7 +98,7 @@ Value binaryOperator(OpBuilder builder, Location location, BinaryOperator op,
   auto ctx = builder.getContext();
 
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/resultType,
           /*callee=*/StringAttr::get(ctx, "EMITC_BINARY"),
@@ -159,7 +159,7 @@ Value contentsOf(OpBuilder builder, Location location, Value operand) {
 Value sizeOf(OpBuilder builder, Location loc, Value value) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_host_size_t"),
           /*callee=*/StringAttr::get(ctx, "sizeof"),
@@ -172,7 +172,7 @@ Value sizeOf(OpBuilder builder, Location loc, Value value) {
 Value sizeOf(OpBuilder builder, Location loc, Attribute attr) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_host_size_t"),
           /*callee=*/StringAttr::get(ctx, "sizeof"),
@@ -185,7 +185,7 @@ Value sizeOf(OpBuilder builder, Location loc, Attribute attr) {
 void memcpy(OpBuilder builder, Location location, Value dest, Value src,
             Value count) {
   auto ctx = builder.getContext();
-  builder.create<emitc::CallOp>(
+  builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
       /*callee=*/StringAttr::get(ctx, "memcpy"),
@@ -197,7 +197,7 @@ void memcpy(OpBuilder builder, Location location, Value dest, Value src,
 void memset(OpBuilder builder, Location location, Value dest, int ch,
             Value count) {
   auto ctx = builder.getContext();
-  builder.create<emitc::CallOp>(
+  builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
       /*callee=*/StringAttr::get(ctx, "memset"),
@@ -214,7 +214,7 @@ Value arrayElement(OpBuilder builder, Location location, Type type,
                    size_t index, Value operand) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
           /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT"),
@@ -230,7 +230,7 @@ Value arrayElementAddress(OpBuilder builder, Location location, Type type,
                           IntegerAttr index, Value operand) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
           /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
@@ -245,7 +245,7 @@ Value arrayElementAddress(OpBuilder builder, Location location, Type type,
                           Value index, Value operand) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
           /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
@@ -260,7 +260,7 @@ Value arrayElementAddress(OpBuilder builder, Location location, Type type,
 void arrayElementAssign(OpBuilder builder, Location location, Value array,
                         size_t index, Value value) {
   auto ctx = builder.getContext();
-  builder.create<emitc::CallOp>(
+  builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
       /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ASSIGN"),
@@ -282,7 +282,7 @@ void structDefinition(OpBuilder builder, Location location,
 
   auto ctx = builder.getContext();
 
-  builder.create<emitc::CallOp>(
+  builder.create<emitc::CallOpaqueOp>(
       /*location=*/location, /*type=*/TypeRange{},
       /*callee=*/StringAttr::get(ctx, "EMITC_TYPEDEF_STRUCT"), /*args=*/
       ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, structName),
@@ -294,7 +294,7 @@ Value structMember(OpBuilder builder, Location location, Type type,
                    StringRef memberName, Value operand) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
           /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER"),
@@ -309,7 +309,7 @@ Value structMember(OpBuilder builder, Location location, Type type,
 void structMemberAssign(OpBuilder builder, Location location,
                         StringRef memberName, Value operand, Value data) {
   auto ctx = builder.getContext();
-  builder.create<emitc::CallOp>(
+  builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
       /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER_ASSIGN"),
@@ -324,7 +324,7 @@ void structMemberAssign(OpBuilder builder, Location location,
 void structMemberAssign(OpBuilder builder, Location location,
                         StringRef memberName, Value operand, StringRef data) {
   auto ctx = builder.getContext();
-  builder.create<emitc::CallOp>(
+  builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
       /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER_ASSIGN"),
@@ -340,7 +340,7 @@ Value structPtrMember(OpBuilder builder, Location location, Type type,
                       StringRef memberName, Value operand) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
           /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
@@ -355,7 +355,7 @@ Value structPtrMember(OpBuilder builder, Location location, Type type,
 void structPtrMemberAssign(OpBuilder builder, Location location,
                            StringRef memberName, Value operand, Value data) {
   auto ctx = builder.getContext();
-  builder.create<emitc::CallOp>(
+  builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
       /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ASSIGN"),
@@ -371,7 +371,7 @@ Value ireeMakeCstringView(OpBuilder builder, Location location,
                           std::string str) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_string_view_t"),
           /*callee=*/StringAttr::get(ctx, "iree_make_cstring_view"),
@@ -385,7 +385,7 @@ Value ireeMakeCstringView(OpBuilder builder, Location location,
 Value ireeOkStatus(OpBuilder builder, Location location) {
   auto ctx = builder.getContext();
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
           /*callee=*/StringAttr::get(ctx, "iree_ok_status"),
@@ -400,7 +400,7 @@ Value ireeVmInstanceLookupType(OpBuilder builder, Location location,
   auto ctx = builder.getContext();
   Type refType = emitc::OpaqueType::get(ctx, "iree_vm_ref_type_t");
   return builder
-      .create<emitc::CallOp>(
+      .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/refType,
           /*callee=*/StringAttr::get(ctx, "iree_vm_instance_lookup_type"),
@@ -412,7 +412,7 @@ Value ireeVmInstanceLookupType(OpBuilder builder, Location location,
 
 void ireeVmRefRelease(OpBuilder builder, Location location, Value operand) {
   auto ctx = builder.getContext();
-  builder.create<emitc::CallOp>(
+  builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
       /*callee=*/StringAttr::get(ctx, "iree_vm_ref_release"),

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_add_i32
 vm.module @my_module {
   vm.func @add_i32(%arg0: i32, %arg1: i32) {
-    // CHECK-NEXT: %0 = emitc.call "vm_add_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_add_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.add.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_sub_i32
 vm.module @my_module {
   vm.func @sub_i32(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_sub_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_sub_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.sub.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_mul_i32
 vm.module @my_module {
   vm.func @mul_i32(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_mul_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_mul_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.mul.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_div_i32_s
 vm.module @my_module {
   vm.func @div_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_div_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_div_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.div.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_div_i32_u
 vm.module @my_module {
   vm.func @div_i32_u(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_div_i32u"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_div_i32u"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.div.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_rem_i32_s
 vm.module @my_module {
   vm.func @rem_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_rem_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_rem_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.rem.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_rem_i32_u
 vm.module @my_module {
   vm.func @rem_i32_u(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_rem_i32u"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_rem_i32u"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.rem.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_fma_i32
 vm.module @my_module {
   vm.func @fma_i32(%arg0: i32, %arg1: i32, %arg2: i32) {
-    // CHECK: %0 = emitc.call "vm_fma_i32"(%arg3, %arg4, %arg5) : (i32, i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_fma_i32"(%arg3, %arg4, %arg5) : (i32, i32, i32) -> i32
     %0 = vm.fma.i32 %arg0, %arg1, %arg2 : i32
     vm.return %0 : i32
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_abs_i32
 vm.module @my_module {
   vm.func @abs_i32(%arg0 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_abs_i32"(%arg3) : (i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_abs_i32"(%arg3) : (i32) -> i32
     %0 = vm.abs.i32 %arg0 : i32
     vm.return %0 : i32
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_min_i32_s
 vm.module @my_module {
   vm.func @min_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_min_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_min_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.min.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_not_i32
 vm.module @my_module {
   vm.func @not_i32(%arg0 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_not_i32"(%arg3) : (i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_not_i32"(%arg3) : (i32) -> i32
     %0 = vm.not.i32 %arg0 : i32
     vm.return %0 : i32
   }
@@ -124,7 +124,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_and_i32
 vm.module @my_module {
   vm.func @and_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_and_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_and_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.and.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -135,7 +135,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_or_i32
 vm.module @my_module {
   vm.func @or_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_or_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_or_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.or.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -146,7 +146,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_xor_i32
 vm.module @my_module {
   vm.func @xor_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_xor_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_xor_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.xor.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_f32.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_add_f32
 vm.module @my_module {
   vm.func @add_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_add_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_add_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.add.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_sub_f32
 vm.module @my_module {
   vm.func @sub_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_sub_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_sub_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.sub.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_mul_f32
 vm.module @my_module {
   vm.func @mul_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_mul_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_mul_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.mul.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_div_f32
 vm.module @my_module {
   vm.func @div_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_div_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_div_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.div.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_rem_f32
 vm.module @my_module {
   vm.func @rem_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_rem_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_rem_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.rem.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_fma_f32
 vm.module @my_module {
   vm.func @fma_f32(%arg0: f32, %arg1: f32, %arg2: f32) {
-    // CHECK: %0 = emitc.call "vm_fma_f32"(%arg3, %arg4, %arg5) : (f32, f32, f32) -> f32
+    // CHECK: %0 = emitc.call_opaque "vm_fma_f32"(%arg3, %arg4, %arg5) : (f32, f32, f32) -> f32
     %0 = vm.fma.f32 %arg0, %arg1, %arg2 : f32
     vm.return %0 : f32
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_abs_f32
 vm.module @my_module {
   vm.func @abs_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_abs_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_abs_f32"(%arg3) : (f32) -> f32
     %0 = vm.abs.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_neg_f32
 vm.module @my_module {
   vm.func @neg_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_neg_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_neg_f32"(%arg3) : (f32) -> f32
     %0 = vm.neg.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_ceil_f32
 vm.module @my_module {
   vm.func @ceil_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_ceil_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_ceil_f32"(%arg3) : (f32) -> f32
     %0 = vm.ceil.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_floor_f32
 vm.module @my_module {
   vm.func @floor_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_floor_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_floor_f32"(%arg3) : (f32) -> f32
     %0 = vm.floor.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_min_f32
 vm.module @my_module {
   vm.func @min_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_min_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_min_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.min.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -124,7 +124,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_max_f32
 vm.module @my_module {
   vm.func @max_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_max_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_max_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.max.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -135,7 +135,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_atan_f32
 vm.module @my_module {
   vm.func @atan_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_atan_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_atan_f32"(%arg3) : (f32) -> f32
     %0 = vm.atan.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -146,7 +146,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_atan2_f32
 vm.module @my_module {
   vm.func @atan2_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_atan2_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_atan2_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.atan2.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -157,7 +157,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_cos_f32
 vm.module @my_module {
   vm.func @cos_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cos_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cos_f32"(%arg3) : (f32) -> f32
     %0 = vm.cos.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -168,7 +168,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_sin_f32
 vm.module @my_module {
   vm.func @sin_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_sin_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_sin_f32"(%arg3) : (f32) -> f32
     %0 = vm.sin.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -179,7 +179,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_exp_f32
 vm.module @my_module {
   vm.func @exp_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_exp_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_exp_f32"(%arg3) : (f32) -> f32
     %0 = vm.exp.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -190,7 +190,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_exp2_f32
 vm.module @my_module {
   vm.func @exp2_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_exp2_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_exp2_f32"(%arg3) : (f32) -> f32
     %0 = vm.exp2.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -201,7 +201,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_expm1_f32
 vm.module @my_module {
   vm.func @expm1_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_expm1_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_expm1_f32"(%arg3) : (f32) -> f32
     %0 = vm.expm1.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -212,7 +212,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_log_f32
 vm.module @my_module {
   vm.func @log_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_log_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_log_f32"(%arg3) : (f32) -> f32
     %0 = vm.log.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -223,7 +223,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_log10_f32
 vm.module @my_module {
   vm.func @log10_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_log10_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_log10_f32"(%arg3) : (f32) -> f32
     %0 = vm.log10.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -234,7 +234,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_log1p_f32
 vm.module @my_module {
   vm.func @log1p_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_log1p_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_log1p_f32"(%arg3) : (f32) -> f32
     %0 = vm.log1p.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -245,7 +245,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_log2_f32
 vm.module @my_module {
   vm.func @log2_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_log2_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_log2_f32"(%arg3) : (f32) -> f32
     %0 = vm.log2.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -256,7 +256,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_pow_f32
 vm.module @my_module {
   vm.func @pow_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_pow_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_pow_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.pow.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -267,7 +267,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_rsqrt_f32
 vm.module @my_module {
   vm.func @rsqrt_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_rsqrt_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_rsqrt_f32"(%arg3) : (f32) -> f32
     %0 = vm.rsqrt.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -278,7 +278,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_sqrt_f32
 vm.module @my_module {
   vm.func @sqrt_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_sqrt_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_sqrt_f32"(%arg3) : (f32) -> f32
     %0 = vm.sqrt.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -289,7 +289,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_tanh_f32
 vm.module @my_module {
   vm.func @tanh_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_tanh_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_tanh_f32"(%arg3) : (f32) -> f32
     %0 = vm.tanh.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -300,7 +300,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_erf_f32
 vm.module @my_module {
   vm.func @erf_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_erf_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_erf_f32"(%arg3) : (f32) -> f32
     %0 = vm.erf.f32 %arg0 : f32
     vm.return %0 : f32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_add_i64
 vm.module @my_module {
   vm.func @add_i64(%arg0: i64, %arg1: i64) {
-    // CHECK-NEXT: %0 = emitc.call "vm_add_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_add_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.add.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_sub_i64
 vm.module @my_module {
   vm.func @sub_i64(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_sub_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_sub_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.sub.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_mul_i64
 vm.module @my_module {
   vm.func @mul_i64(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_mul_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_mul_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.mul.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_div_i64_s
 vm.module @my_module {
   vm.func @div_i64_s(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_div_i64s"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_div_i64s"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.div.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_div_i64_u
 vm.module @my_module {
   vm.func @div_i64_u(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_div_i64u"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_div_i64u"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.div.i64.u %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_rem_i64_s
 vm.module @my_module {
   vm.func @rem_i64_s(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_rem_i64s"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_rem_i64s"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.rem.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_rem_i64_u
 vm.module @my_module {
   vm.func @rem_i64_u(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_rem_i64u"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_rem_i64u"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.rem.i64.u %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_fma_i64
 vm.module @my_module {
   vm.func @fma_i64(%arg0: i64, %arg1: i64, %arg2: i64) {
-    // CHECK: %0 = emitc.call "vm_fma_i64"(%arg3, %arg4, %arg5) : (i64, i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_fma_i64"(%arg3, %arg4, %arg5) : (i64, i64, i64) -> i64
     %0 = vm.fma.i64 %arg0, %arg1, %arg2 : i64
     vm.return %0 : i64
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_abs_i64
 vm.module @my_module {
   vm.func @abs_i64(%arg0 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_abs_i64"(%arg3) : (i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_abs_i64"(%arg3) : (i64) -> i64
     %0 = vm.abs.i64 %arg0 : i64
     vm.return %0 : i64
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_min_i64_s
 vm.module @my_module {
   vm.func @min_i64_s(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_min_i64s"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_min_i64s"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.min.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_not_i64
 vm.module @my_module {
   vm.func @not_i64(%arg0 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_not_i64"(%arg3) : (i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_not_i64"(%arg3) : (i64) -> i64
     %0 = vm.not.i64 %arg0 : i64
     vm.return %0 : i64
   }
@@ -124,7 +124,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_and_i64
 vm.module @my_module {
   vm.func @and_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_and_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_and_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.and.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -135,7 +135,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_or_i64
 vm.module @my_module {
   vm.func @or_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_or_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_or_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.or.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -146,7 +146,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_xor_i64
 vm.module @my_module {
   vm.func @xor_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_xor_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_xor_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.xor.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_select_i32
 vm.module @my_module {
   vm.func @select_i32(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_select_i32"(%arg3, %arg4, %arg5) : (i32, i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_select_i32"(%arg3, %arg4, %arg5) : (i32, i32, i32) -> i32
     %0 = vm.select.i32 %arg0, %arg1, %arg2 : i32
     vm.return %0 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_select_f32
 vm.module @my_module {
   vm.func @select_f32(%arg0 : i32, %arg1 : f32, %arg2 : f32) -> f32 {
-    // CHECK: %0 = emitc.call "vm_select_f32"(%arg3, %arg4, %arg5) : (i32, f32, f32) -> f32
+    // CHECK: %0 = emitc.call_opaque "vm_select_f32"(%arg3, %arg4, %arg5) : (i32, f32, f32) -> f32
     %0 = vm.select.f32 %arg0, %arg1, %arg2 : f32
     vm.return %0 : f32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_select_i64
 vm.module @my_module {
   vm.func @select_i64(%arg0 : i32, %arg1 : i64, %arg2 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_select_i64"(%arg3, %arg4, %arg5) : (i32, i64, i64) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_select_i64"(%arg3, %arg4, %arg5) : (i32, i64, i64) -> i64
     %0 = vm.select.i64 %arg0, %arg1, %arg2 : i64
     vm.return %0 : i64
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops.mlir
@@ -7,12 +7,12 @@ vm.module @my_module {
     // CHECK-DAG: %[[ALIGNMENT:.+]] = "emitc.constant"() <{value = 32 : i32}> : () -> i32
     // CHECK-DAG: %[[BUFFER:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
     // CHECK-DAG: %[[BUFFER_PTR:.+]] = emitc.apply "&"(%[[BUFFER]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
-    // CHECK-DAG: %[[ALLOCTOR:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-DAG: %[[ALLOCTOR:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
     // CHECK-DAG: %[[BUFFER_ACCESS:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST">}> : () -> !emitc.opaque<"iree_vm_buffer_access_t">
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "iree_vm_buffer_create"(%[[BUFFER_ACCESS]], %[[SIZE]], %[[ALIGNMENT]], %[[ALLOCTOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_create"(%[[BUFFER_ACCESS]], %[[SIZE]], %[[ALIGNMENT]], %[[ALLOCTOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
 
-    // CHECK: %[[BUFFER_TYPE_ID:.+]] = emitc.call "iree_vm_buffer_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK-NEXT: %[[STATUS2:.+]] = emitc.call "iree_vm_ref_wrap_assign"(%[[BUFFER]], %[[BUFFER_TYPE_ID]], %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[BUFFER_TYPE_ID:.+]] = emitc.call_opaque "iree_vm_buffer_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK-NEXT: %[[STATUS2:.+]] = emitc.call_opaque "iree_vm_ref_wrap_assign"(%[[BUFFER]], %[[BUFFER_TYPE_ID]], %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
 
     %c128 = vm.const.i64 128
     %alignment = vm.const.i32 32
@@ -32,12 +32,12 @@ vm.module @my_module {
 
     // CHECK: %[[BUFFER:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
     // CHECK-DAG: %[[BUFFER_PTR:.+]] = emitc.apply "&"(%[[BUFFER]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
-    // CHECK-DAG: %[[ALLOCATOR:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-DAG: %[[ALLOCATOR:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
     // CHECK-DAG: %[[BUFFER_ACCESS:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST">}> : () -> !emitc.opaque<"iree_vm_buffer_access_t">
     // CHECK-DAG: %[[BUFFER_REF2:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-DAG: %[[BUFFER_PTR2:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-DAG: %[[BUFFER_PTR2:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "iree_vm_buffer_clone"(%[[BUFFER_ACCESS]], %[[BUFFER_PTR2]], %[[C0]], %[[C32]], %[[ALIGNMENT]], %[[ALLOCATOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_clone"(%[[BUFFER_ACCESS]], %[[BUFFER_PTR2]], %[[C0]], %[[C32]], %[[ALIGNMENT]], %[[ALLOCATOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c32 = vm.const.i64 32
     %alignment = vm.const.i32 64
@@ -52,9 +52,9 @@ vm.module @my_module {
 vm.module @my_module {
   vm.func @buffer_length(%buf : !vm.buffer) {
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[LENGTH:.+]] = emitc.call "iree_vm_buffer_length"(%[[BUFFER_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>) -> i64
+    // CHECK: %[[LENGTH:.+]] = emitc.call_opaque "iree_vm_buffer_length"(%[[BUFFER_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>) -> i64
 
     %length = vm.buffer.length %buf : !vm.buffer -> i64
     vm.return
@@ -70,14 +70,14 @@ vm.module @my_module {
     // CHECK: %[[C16:.+]] = "emitc.constant"() <{value = 16 : i64}> : () -> i64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[BUFFER_REF2:.+]] = emitc.apply "*"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i32}> : () -> i32
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (i32) -> !emitc.ptr<i32>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_compare"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_compare"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %cmp = vm.buffer.compare %buf, %c0, %buf2, %c16, %c16 : !vm.buffer, !vm.buffer
@@ -94,12 +94,12 @@ vm.module @my_module {
     // CHECK: %[[C16:.+]] = "emitc.constant"() <{value = 16 : i64}> : () -> i64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[BUFFER_REF2:.+]] = emitc.apply "*"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "iree_vm_buffer_copy_bytes"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_copy_bytes"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     vm.buffer.copy %buf, %c0, %buf2, %c16, %c16 : !vm.buffer -> !vm.buffer
@@ -117,9 +117,9 @@ vm.module @my_module {
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 102 : i32}> : () -> i32
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_fill_i8"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_i8"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.i32 102
@@ -129,7 +129,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_buffer_fill_i16
   vm.func @buffer_fill_i16(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_fill_i16"
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_i16"
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.i32 102
@@ -139,7 +139,7 @@ vm.module @my_module {
 
     // CHECK-LABEL: @my_module_buffer_fill_i32
   vm.func @buffer_fill_i32(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_fill_i32"
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_i32"
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.i32 102
@@ -156,11 +156,11 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i32}> : () -> i32
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%6) : (i32) -> !emitc.ptr<i32>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_load_i8s"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i8s"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
 
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i8.s %buf[%c0] : !vm.buffer -> i32
@@ -169,7 +169,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_buffer_load_i8u
   vm.func @buffer_load_i8u(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_load_i8u"
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i8u"
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i8.u %buf[%c0] : !vm.buffer -> i32
     vm.return
@@ -177,7 +177,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_buffer_load_i16s
   vm.func @buffer_load_i16s(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_load_i16s"
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i16s"
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i16.s %buf[%c0] : !vm.buffer -> i32
     vm.return
@@ -185,7 +185,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_buffer_load_i16u
   vm.func @buffer_load_i16u(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_load_i16u"
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i16u"
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i16.u %buf[%c0] : !vm.buffer -> i32
     vm.return
@@ -193,7 +193,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_buffer_load_i32
   vm.func @buffer_load_i32(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_load_i32"
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i32"
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i32 %buf[%c0] : !vm.buffer -> i32
     vm.return
@@ -209,9 +209,9 @@ vm.module @my_module {
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 102 : i32}> : () -> i32
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_store_i8"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i32) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_i8"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i32) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c102 = vm.const.i32 102
     vm.buffer.store.i8 %c102, %buf[%c0] : i32 -> !vm.buffer
@@ -220,7 +220,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_buffer_store_i16
   vm.func @buffer_store_i16(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_store_i16"
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_i16"
     %c0 = vm.const.i64 0
     %c102 = vm.const.i32 102
     vm.buffer.store.i16 %c102, %buf[%c0] : i32 -> !vm.buffer
@@ -229,7 +229,7 @@ vm.module @my_module {
 
     // CHECK-LABEL: @my_module_buffer_store_i32
   vm.func @buffer_store_i32(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_store_i32"
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_i32"
     %c0 = vm.const.i64 0
     %c102 = vm.const.i32 102
     vm.buffer.store.i32 %c102, %buf[%c0] : i32 -> !vm.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f32.mlir
@@ -8,9 +8,9 @@ vm.module @my_module {
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 1.020000e+02 : f32}> : () -> f32
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_fill_f32"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, f32) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_f32"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, f32) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.f32 102.0
@@ -27,11 +27,11 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0.000000e+00 : f32}> : () -> f32
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%6) : (f32) -> !emitc.ptr<f32>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_load_f32"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f32>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_f32"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f32>) -> !emitc.opaque<"iree_status_t">
 
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.f32 %buf[%c0] : !vm.buffer -> f32
@@ -48,9 +48,9 @@ vm.module @my_module {
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 1.020000e+02 : f32}> : () -> f32
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_store_f32"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, f32) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_f32"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, f32) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c102 = vm.const.f32 102.0
     vm.buffer.store.f32 %c102, %buf[%c0] : f32 -> !vm.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f64.mlir
@@ -8,9 +8,9 @@ vm.module @my_module {
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 1.020000e+02 : f64}> : () -> f64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_fill_f64"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, f64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_f64"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, f64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.f64 102.0
@@ -27,11 +27,11 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0.000000e+00 : f64}> : () -> f64
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%6) : (f64) -> !emitc.ptr<f64>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_load_f64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f64>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_f64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f64>) -> !emitc.opaque<"iree_status_t">
 
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.f64 %buf[%c0] : !vm.buffer -> f64
@@ -48,9 +48,9 @@ vm.module @my_module {
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 1.020000e+02 : f64}> : () -> f64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_store_f64"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, f64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_f64"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, f64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c102 = vm.const.f64 102.0
     vm.buffer.store.f64 %c102, %buf[%c0] : f64 -> !vm.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_i64.mlir
@@ -8,9 +8,9 @@ vm.module @my_module {
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 102 : i64}> : () -> i64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_fill_i64"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_i64"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.i64 102
@@ -27,11 +27,11 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i64}> : () -> i64
     // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%6) : (i64) -> !emitc.ptr<i64>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "vm_buffer_load_i64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i64>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i64>) -> !emitc.opaque<"iree_status_t">
 
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i64 %buf[%c0] : !vm.buffer -> i64
@@ -48,9 +48,9 @@ vm.module @my_module {
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 102 : i64}> : () -> i64
 
     // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call "vm_buffer_store_i64"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_i64"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c102 = vm.const.i64 102
     vm.buffer.store.i64 %c102, %buf[%c0] : i64 -> !vm.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
@@ -3,7 +3,7 @@
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_i32
   vm.func @cmp_eq_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.cmp.eq.i32 %arg0, %arg1 : i32
     vm.return
   }
@@ -14,7 +14,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_ne_i32
   vm.func @cmp_ne_i32(%arg0 : i32, %arg1 : i32) {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.cmp.ne.i32 %arg0, %arg1 : i32
     vm.return
   }
@@ -25,7 +25,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_lt_i32_s
   vm.func @cmp_lt_i32_s(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.cmp.lt.i32.s %arg0, %arg1 : i32
     vm.return
   }
@@ -36,7 +36,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_lt_i32_u
   vm.func @cmp_lt_i32_u(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i32u"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_i32u"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.cmp.lt.i32.u %arg0, %arg1 : i32
     vm.return
   }
@@ -47,7 +47,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_nz_i32
   vm.func @cmp_nz_i32(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nz_i32"(%arg3) : (i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_nz_i32"(%arg3) : (i32) -> i32
     %0 = vm.cmp.nz.i32 %arg0 : i32
     vm.return
   }
@@ -58,7 +58,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_ref
   vm.func @cmp_eq_ref(%arg0 : !vm.ref<?>, %arg1 : !vm.ref<?>) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_ref"(%arg3, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_ref"(%arg3, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
     %0 = vm.cmp.eq.ref %arg0, %arg1 : !vm.ref<?>
     vm.return %0 : i32
   }
@@ -69,7 +69,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_ne_ref
   vm.func @cmp_ne_ref(%arg0 : !vm.ref<?>, %arg1 : !vm.ref<?>) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_ref"(%arg3, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_ref"(%arg3, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
     %0 = vm.cmp.ne.ref %arg0, %arg1 : !vm.ref<?>
     vm.return %0 : i32
   }
@@ -80,7 +80,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_nz_ref
   vm.func @cmp_nz_ref(%arg0 : !vm.ref<?>) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nz_ref"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_nz_ref"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
     %0 = vm.cmp.nz.ref %arg0 : !vm.ref<?>
     vm.return %0 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_f32.mlir
@@ -3,7 +3,7 @@
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_f32o
   vm.func @cmp_eq_f32o(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_f32o"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_f32o"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.eq.f32.o %arg0, %arg1 : f32
     vm.return
   }
@@ -14,7 +14,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_f32u
   vm.func @cmp_eq_f32u(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_f32u"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_f32u"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.eq.f32.u %arg0, %arg1 : f32
     vm.return
   }
@@ -25,7 +25,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_ne_f32o
   vm.func @cmp_ne_f32o(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_f32o"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_f32o"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.ne.f32.o %arg0, %arg1 : f32
     vm.return
   }
@@ -36,7 +36,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_ne_f32u
   vm.func @cmp_ne_f32u(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_f32u"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_f32u"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.ne.f32.u %arg0, %arg1 : f32
     vm.return
   }
@@ -47,7 +47,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_lt_f32o
   vm.func @cmp_lt_f32o(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_f32o"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_f32o"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.lt.f32.o %arg0, %arg1 : f32
     vm.return
   }
@@ -58,7 +58,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_lt_f32u
   vm.func @cmp_lt_f32u(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_f32u"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_f32u"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.lt.f32.u %arg0, %arg1 : f32
     vm.return
   }
@@ -69,7 +69,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_lte_f32o
   vm.func @cmp_lte_f32o(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lte_f32o"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lte_f32o"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.lte.f32.o %arg0, %arg1 : f32
     vm.return
   }
@@ -80,7 +80,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_lte_f32u
   vm.func @cmp_lte_f32u(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lte_f32u"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lte_f32u"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.lte.f32.u %arg0, %arg1 : f32
     vm.return
   }
@@ -91,7 +91,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_nan_f32
   vm.func @cmp_nan_f32(%arg0 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nan_f32"(%arg3) : (f32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_nan_f32"(%arg3) : (f32) -> i32
     %0 = vm.cmp.nan.f32 %arg0 : f32
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
@@ -3,7 +3,7 @@
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_i64
   vm.func @cmp_eq_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_i64"(%arg3, %arg4) : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_i64"(%arg3, %arg4) : (i64, i64) -> i32
     %0 = vm.cmp.eq.i64 %arg0, %arg1 : i64
     vm.return
   }
@@ -14,7 +14,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_ne_i64
   vm.func @cmp_ne_i64(%arg0 : i64, %arg1 : i64) {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i64"(%arg3, %arg4) : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_i64"(%arg3, %arg4) : (i64, i64) -> i32
     %0 = vm.cmp.ne.i64 %arg0, %arg1 : i64
     vm.return
   }
@@ -25,7 +25,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_lt_i64_s
   vm.func @cmp_lt_i64_s(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i64s"(%arg3, %arg4) : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_i64s"(%arg3, %arg4) : (i64, i64) -> i32
     %0 = vm.cmp.lt.i64.s %arg0, %arg1 : i64
     vm.return
   }
@@ -36,7 +36,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_lt_i64_u
   vm.func @cmp_lt_i64_u(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i64u"(%arg3, %arg4) : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_i64u"(%arg3, %arg4) : (i64, i64) -> i32
     %0 = vm.cmp.lt.i64.u %arg0, %arg1 : i64
     vm.return
   }
@@ -47,7 +47,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @module_cmp_nz_i64
   vm.func @cmp_nz_i64(%arg0 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nz_i64"(%arg3) : (i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_nz_i64"(%arg3) : (i64) -> i32
     %0 = vm.cmp.nz.i64 %arg0 : i64
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -32,9 +32,9 @@ vm.module @my_module {
   vm.func @const_ref_zero() {
     // CHECK: %[[REF:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK-NEXT: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: emitc.call "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
-    // CHECK-NEXT: emitc.call "iree_vm_ref_release"(%[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: %[[SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: emitc.call_opaque "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
+    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_release"(%[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
     %null = vm.const.ref.zero : !vm.ref<?>
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
@@ -67,9 +67,9 @@ vm.module @my_module {
   vm.func @call_imported_fn(%arg0 : i32) -> i32 {
 
     // Lookup import from module struct.
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
+    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // Create a variable for the function result.
@@ -93,9 +93,9 @@ vm.module @my_module {
   vm.func @call_imported_fn(%arg0 : i32) -> i32 {
 
     // Lookup import from module struct.
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
+    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // Create a variable for the function result.
@@ -150,9 +150,9 @@ vm.module @my_module {
   vm.func @call_variadic(%arg0 : i32, %arg1 : i32) -> i32 {
 
     // Lookup import from module struct.
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
+    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // This holds the number of variadic arguments.
@@ -183,9 +183,9 @@ vm.module @my_module {
   vm.func @call_variadic() -> i32 {
 
     // Lookup import from module struct.
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
+    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // This holds the number of variadic arguments.
@@ -306,12 +306,12 @@ vm.module @my_module {
     //  CHECK-NOT: vm.br_table
     //      CHECK:  cf.br ^bb1
     // CHECK-NEXT: ^bb1:
-    //      CHECK:  emitc.call "vm_cmp_eq_i32"
-    //      CHECK:  emitc.call "vm_cmp_nz_i32"
+    //      CHECK:  emitc.call_opaque "vm_cmp_eq_i32"
+    //      CHECK:  emitc.call_opaque "vm_cmp_nz_i32"
     //      CHECK:  cf.cond_br %{{.+}}, ^bb5(%arg4 : i32), ^bb2
     //      CHECK: ^bb2:
-    //      CHECK:  emitc.call "vm_cmp_eq_i32"
-    //      CHECK:  emitc.call "vm_cmp_nz_i32"
+    //      CHECK:  emitc.call_opaque "vm_cmp_eq_i32"
+    //      CHECK:  emitc.call_opaque "vm_cmp_nz_i32"
     //      CHECK:  cf.cond_br %{{.+}}, ^bb5(%arg5 : i32), ^bb3
     //      CHECK: ^bb3:
     //      CHECK:  cf.br ^bb4(%arg3 : i32)
@@ -339,19 +339,19 @@ vm.module @my_module {
 
     // In case of success, return ok status.
     // CHECK-NEXT: ^[[OK]]:
-    // CHECK-NEXT: %[[OKSTATUS:.+]] = emitc.call "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[OKSTATUS:.+]] = emitc.call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
     // CHECK-NEXT: return %[[OKSTATUS]] : !emitc.opaque<"iree_status_t">
 
     // In case of fail, return status message.
     // CHECK-NEXT: ^[[FAIL]]:
-    // CHECK-NEXT: %[[MSG:.+]] = emitc.call "iree_make_cstring_view"() {args = [#emitc.opaque<"\22message\22">]}
+    // CHECK-NEXT: %[[MSG:.+]] = emitc.call_opaque "iree_make_cstring_view"() {args = [#emitc.opaque<"\22message\22">]}
     // CHECK-SAME:     : () -> !emitc.opaque<"iree_string_view_t">
-    // CHECK-NEXT: %[[MSGSIZE:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[MSG]]) {args = [0 : index, #emitc.opaque<"size">]}
+    // CHECK-NEXT: %[[MSGSIZE:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[MSG]]) {args = [0 : index, #emitc.opaque<"size">]}
     // CHECK-SAME:     : (!emitc.opaque<"iree_string_view_t">) -> !emitc.opaque<"iree_host_size_t">
     // CHECK-NEXT: %[[MSGSIZEINT:.+]] = emitc.cast %[[MSGSIZE]] : !emitc.opaque<"iree_host_size_t"> to !emitc.opaque<"int">
-    // CHECK-NEXT: %[[MSGDATA:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[MSG]]) {args = [0 : index, #emitc.opaque<"data">]}
+    // CHECK-NEXT: %[[MSGDATA:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[MSG]]) {args = [0 : index, #emitc.opaque<"data">]}
     // CHECK-SAME:     : (!emitc.opaque<"iree_string_view_t">) -> !emitc.ptr<!emitc.opaque<"const char">>
-    // CHECK-NEXT: %[[FAILSTATUS:.+]] = emitc.call "iree_status_allocate_f"(%[[MSGSIZEINT]], %[[MSGDATA]])
+    // CHECK-NEXT: %[[FAILSTATUS:.+]] = emitc.call_opaque "iree_status_allocate_f"(%[[MSGSIZEINT]], %[[MSGDATA]])
     // CHECK-SAME:     {args = [#emitc.opaque<"IREE_STATUS_FAILED_PRECONDITION">, #emitc.opaque<"\22<vm>\22">, 0 : i32, #emitc.opaque<"\22%.*s\22">, 0 : index, 1 : index]}
     // CHECK-SAME:     : (!emitc.opaque<"int">, !emitc.ptr<!emitc.opaque<"const char">>) -> !emitc.opaque<"iree_status_t">
     // CHECK-NEXT: return %[[FAILSTATUS]] : !emitc.opaque<"iree_status_t">
@@ -376,42 +376,42 @@ vm.module @my_module {
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.constant"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_function_call_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
 
   // Allocate space for the arguments.
-  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
+  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
-  // CHECK-NEXT: emitc.call "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
-  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
+  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
-  // CHECK-NEXT: emitc.call "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Check that we don't pack anything into the argument struct.
-  // CHECK-NOT: emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-NOT: %[[ARGSPTR:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%{{.+}}) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NOT: emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
+  // CHECK-NOT: %[[ARGSPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%{{.+}}) {args = [0 : index, #emitc.opaque<"data">]}
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
+  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
+  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
   // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Check that we don't unpack anything from the result struct.
-  // CHECK-NOT: emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-NOT: emitc.call "EMITC_STRUCT_MEMBER"(%{{.+}}) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NOT: emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
+  // CHECK-NOT: emitc.call_opaque "EMITC_STRUCT_MEMBER"(%{{.+}}) {args = [0 : index, #emitc.opaque<"data">]}
 
   // Return ok status.
-  //      CHECK: %[[OK:.+]] = emitc.call "iree_ok_status"()
+  //      CHECK: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
   // CHECK-NEXT: return %[[OK]]
   vm.import private @ref_fn() -> ()
 
@@ -432,89 +432,89 @@ vm.module @my_module {
 
   // Calculate the size of the arguments.
   // CHECK-NEXT: %[[ARGSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE01:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSIZE0]], %[[ARGSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
-  // CHECK-NEXT: %[[ARGSIZE2:.+]] = emitc.call "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE012:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSIZE01]], %[[ARGSIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
-  // CHECK-NEXT: %[[ARGSIZE3:.+]] = emitc.call "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE0123:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSIZE012]], %[[ARGSIZE3]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
-  // CHECK-NEXT: %[[ARGSIZE4:.+]] = emitc.call "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSIZE0123]], %[[ARGSIZE4]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE01:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSIZE0]], %[[ARGSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[ARGSIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE012:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSIZE01]], %[[ARGSIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[ARGSIZE3:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE0123:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSIZE012]], %[[ARGSIZE3]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[ARGSIZE4:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSIZE0123]], %[[ARGSIZE4]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
 
   // Calculate the size of the result.
   // CHECK-NEXT: %[[RESULTSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.call "EMITC_BINARY"(%[[RESULTSIZE0]], %[[RESULTSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[RESULTSIZE0]], %[[RESULTSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
 
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.constant"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_function_call_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
 
   // Allocate space for the arguments.
-  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
+  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call "iree_alloca"(%[[ARGSIZE]])
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]])
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
-  // CHECK-NEXT: emitc.call "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
-  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
+  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call "iree_alloca"(%[[RESULTSIZE]])
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]])
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
-  // CHECK-NEXT: emitc.call "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the arguments into the struct.
   // Here we also create pointers for non-pointer types.
-  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
+  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
-  // CHECK-NEXT: %[[ARGHOSTSIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[ARGHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A1PTR:.+]] = emitc.apply "&"(%arg2) : (i32) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[ARGHOSTSIZE]])
-  // CHECK-NEXT: %[[ARGHOSTSIZE2:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A1ADDR:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSPTR]], %[[ARGHOSTSIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[ARGHOSTSIZE]])
+  // CHECK-NEXT: %[[ARGHOSTSIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A1ADDR:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSPTR]], %[[ARGHOSTSIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
   // CHECK-SAME:     : (!emitc.ptr<ui8>, !emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<ui8>
-  // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A2PTR:.+]] = emitc.apply "&"(%arg3) : (i32) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
-  // CHECK-NEXT: %[[A1SIZE2:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A2ADDR:.+]] = emitc.call "EMITC_BINARY"(%[[A1ADDR]], %[[A1SIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
+  // CHECK-NEXT: %[[A1SIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A2ADDR:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[A1ADDR]], %[[A1SIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
   // CHECK-SAME:     : (!emitc.ptr<ui8>, !emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<ui8>
-  // CHECK-NEXT: %[[A2SIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A2SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A3PTR:.+]] = emitc.apply "&"(%arg4) : (i32) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call "memcpy"(%[[A2ADDR]], %[[A3PTR]], %[[A2SIZE]])
-  // CHECK-NEXT: %[[A2SIZE2:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A3ADDR:.+]] = emitc.call "EMITC_BINARY"(%[[A2ADDR]], %[[A2SIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A2ADDR]], %[[A3PTR]], %[[A2SIZE]])
+  // CHECK-NEXT: %[[A2SIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A3ADDR:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[A2ADDR]], %[[A2SIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
   // CHECK-SAME:     : (!emitc.ptr<ui8>, !emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<ui8>
-  // CHECK-NEXT: %[[A3SIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A3SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A4PTR:.+]] = emitc.apply "&"(%arg5) : (i32) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call "memcpy"(%[[A3ADDR]], %[[A4PTR]], %[[A3SIZE:.+]])
+  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A3ADDR]], %[[A4PTR]], %[[A3SIZE:.+]])
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
+  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
+  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
   // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Unpack the function results.
-  //      CHECK: %[[RES:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
+  //      CHECK: %[[RES:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
-  // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: emitc.call "memcpy"(%arg6, %[[RESPTR]], %[[RESHOSTSIZE]])
+  // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.call_opaque "memcpy"(%arg6, %[[RESPTR]], %[[RESHOSTSIZE]])
 
   // Return ok status.
-  // CHECK-NEXT: %[[OK:.+]] = emitc.call "iree_ok_status"()
+  // CHECK-NEXT: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
   // CHECK-NEXT: return %[[OK]]
   vm.import private @variadic_fn(%arg0 : i32, %arg1 : i32 ...) -> i32
 
@@ -535,73 +535,73 @@ vm.module @my_module {
 
   // Calculate the size of the arguments.
   // CHECK-NEXT: %[[ARGSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE01:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSIZE0]], %[[ARGSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
-  // CHECK-NEXT: %[[ARGSIZE2:.+]] = emitc.call "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSIZE01]], %[[ARGSIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE01:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSIZE0]], %[[ARGSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[ARGSIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSIZE01]], %[[ARGSIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
 
   // Calculate the size of the result.
   // CHECK-NEXT: %[[RESULTSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.call "EMITC_BINARY"(%[[RESULTSIZE0]], %[[RESULTSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[RESULTSIZE0]], %[[RESULTSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
 
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.constant"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_function_call_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
 
   // Allocate space for the arguments.
-  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
+  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call "iree_alloca"(%[[ARGSIZE]])
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]])
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
-  // CHECK-NEXT: emitc.call "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
-  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
+  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call "iree_alloca"(%[[RESULTSIZE]])
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]])
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
-  // CHECK-NEXT: emitc.call "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the arguments into the struct.
   // Here we also create pointers for non-pointer types.
-  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
+  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
-  // CHECK-NEXT: %[[ARGHOSTSIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[ARGHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A1PTR:.+]] = emitc.apply "&"(%arg2) : (i32) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[ARGHOSTSIZE]])
-  // CHECK-NEXT: %[[ARGHOSTSIZE2:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A1ADDR:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSPTR]], %[[ARGHOSTSIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[ARGHOSTSIZE]])
+  // CHECK-NEXT: %[[ARGHOSTSIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A1ADDR:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSPTR]], %[[ARGHOSTSIZE2]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
   // CHECK-SAME:     : (!emitc.ptr<ui8>, !emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<ui8>
-  // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A2PTR:.+]] = emitc.apply "&"(%arg3) : (i32) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
+  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
+  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
+  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
   // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Unpack the function results.
-  //      CHECK: %[[RES:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
+  //      CHECK: %[[RES:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
-  // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: emitc.call "memcpy"(%arg4, %[[RESPTR]], %[[RESHOSTSIZE]])
+  // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.call_opaque "memcpy"(%arg4, %[[RESPTR]], %[[RESHOSTSIZE]])
 
   // Return ok status.
-  // CHECK-NEXT: %[[OK:.+]] = emitc.call "iree_ok_status"()
+  // CHECK-NEXT: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
   // CHECK-NEXT: return %[[OK]]
   vm.import private @variadic_fn(%arg0 : i32, %arg1 : i32 ...) -> i32
 
@@ -622,61 +622,61 @@ vm.module @my_module {
 
   // Calculate the size of the arguments.
   // CHECK-NEXT: %[[ARGSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]}
-  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.call "EMITC_BINARY"(%[[ARGSIZE0]], %[[ARGSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]}
+  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[ARGSIZE0]], %[[ARGSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
 
   // Calculate the size of the result.
   // CHECK-NEXT: %[[RESULTSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]}
-  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.call "EMITC_BINARY"(%[[RESULTSIZE0]], %[[RESULTSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
+  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]}
+  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[RESULTSIZE0]], %[[RESULTSIZE1]]) {args = [#emitc.opaque<"+">, 0 : index, 1 : index]}
 
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.constant"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_function_call_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
 
   // Allocate space for the arguments.
-  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
+  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
-  // CHECK-NEXT: emitc.call "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
-  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
+  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
-  // CHECK-NEXT: emitc.call "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the argument into the struct.
-  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
+  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARG:.+]] = emitc.cast %[[ARGSPTR]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-  // CHECK-NEXT: emitc.call "iree_vm_ref_assign"(%arg2, %[[ARG]])
+  // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_assign"(%arg2, %[[ARG]])
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
+  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
+  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
   // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Unpack the function results.
-  //      CHECK: %[[RES:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
+  //      CHECK: %[[RES:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESREFPTR:.+]] = emitc.cast %[[RESPTR]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-  // CHECK-NEXT: emitc.call "iree_vm_ref_move"(%[[RESREFPTR]], %arg3)
+  // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_move"(%[[RESREFPTR]], %arg3)
 
   // Return ok status.
-  // CHECK-NEXT: %[[OK:.+]] = emitc.call "iree_ok_status"()
+  // CHECK-NEXT: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
   // CHECK-NEXT: return %[[OK]]
   vm.import private @ref_fn(%arg0 : !vm.ref<?>) -> !vm.ref<?>
 
@@ -691,8 +691,8 @@ vm.module @my_module {
 vm.module @my_module {
 
   // Typedef structs for arguments and results
-  // CHECK: emitc.call "EMITC_TYPEDEF_STRUCT"() {args = [#emitc.opaque<"my_module_fn_args_t">, #emitc.opaque<"int32_t arg0;">]} : () -> ()
-  // CHECK: emitc.call "EMITC_TYPEDEF_STRUCT"() {args = [#emitc.opaque<"my_module_fn_result_t">, #emitc.opaque<"int32_t res0;">]} : () -> ()
+  // CHECK: emitc.call_opaque "EMITC_TYPEDEF_STRUCT"() {args = [#emitc.opaque<"my_module_fn_args_t">, #emitc.opaque<"int32_t arg0;">]} : () -> ()
+  // CHECK: emitc.call_opaque "EMITC_TYPEDEF_STRUCT"() {args = [#emitc.opaque<"my_module_fn_result_t">, #emitc.opaque<"int32_t res0;">]} : () -> ()
 
   // Create a new function to export with the adapted signature.
   //      CHECK: func.func @my_module_fn_export_shim(%arg0: !emitc.ptr<!emitc.opaque<"iree_vm_stack_t">>, %arg1: !emitc.opaque<"uint32_t">, %arg2: !emitc.opaque<"iree_byte_span_t">, %arg3: !emitc.opaque<"iree_byte_span_t">,
@@ -704,19 +704,19 @@ vm.module @my_module {
   // CHECK-NEXT: %[[MODSTATECASTED:.+]] = emitc.cast %arg5 : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<!emitc.opaque<"my_module_state_t">>
 
   // Cast argument and result structs.
-  // CHECK-NEXT: %[[ARGDATA:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NEXT: %[[ARGDATA:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"data">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARGS:.+]] = emitc.cast %[[ARGDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"my_module_fn_args_t">>
-  // CHECK-NEXT: %[[RESULTDATA:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%arg3) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NEXT: %[[RESULTDATA:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%arg3) {args = [0 : index, #emitc.opaque<"data">]}
   // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESULTS:.+]] = emitc.cast %[[RESULTDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"my_module_fn_result_t">>
 
   // Unpack the argument from the struct.
-  // CHECK-NEXT: %[[MARG:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"arg0">]}
+  // CHECK-NEXT: %[[MARG:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"arg0">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"my_module_fn_args_t">>) -> i32
 
   // Unpack the result pointer from the struct.
-  // CHECK-NEXT: %[[MRES:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER_ADDRESS"(%[[RESULTS]]) {args = [0 : index, #emitc.opaque<"res0">]}
+  // CHECK-NEXT: %[[MRES:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ADDRESS"(%[[RESULTS]]) {args = [0 : index, #emitc.opaque<"res0">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"my_module_fn_result_t">>) -> !emitc.ptr<i32>
 
   // Call the internal function.
@@ -725,7 +725,7 @@ vm.module @my_module {
   // CHECK-SAME:        !emitc.ptr<!emitc.opaque<"my_module_state_t">>, i32, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
 
   // Return ok status.
-  // CHECK: %[[STATUS:.+]] = emitc.call "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
+  // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
   // CHECK: return %[[STATUS]] : !emitc.opaque<"iree_status_t">
 
   vm.export @fn
@@ -742,21 +742,21 @@ vm.module @my_module {
   vm.func @return(%arg0 : i32, %arg1 : !vm.ref<?>) -> (i32, !vm.ref<?>) {
 
     // Move the i32 value and ref into the result function arguments.
-    // CHECK-NEXT: emitc.call "EMITC_DEREF_ASSIGN_VALUE"(%arg5, %arg3) : (!emitc.ptr<i32>, i32) -> ()
+    // CHECK-NEXT: emitc.call_opaque "EMITC_DEREF_ASSIGN_VALUE"(%arg5, %arg3) : (!emitc.ptr<i32>, i32) -> ()
 
     // Create duplicate ref for
     // CHECK-NEXT: %[[REF:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK-NEXT: %[[REFSIZE:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: emitc.call "memset"(%[[REFPTR]], %[[REFSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
-    // CHECK-NEXT: emitc.call "iree_vm_ref_move"(%arg4, %[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
-    // CHECK-NEXT: emitc.call "iree_vm_ref_move"(%[[REFPTR]], %arg6) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: %[[REFSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: emitc.call_opaque "memset"(%[[REFPTR]], %[[REFSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
+    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_move"(%arg4, %[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_move"(%[[REFPTR]], %arg6) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
 
     // Release the ref.
-    // CHECK-NEXT: emitc.call "iree_vm_ref_release"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_release"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
 
     // Return ok status.
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
     // CHECK-NEXT: return %[[STATUS]] : !emitc.opaque<"iree_status_t">
     vm.return %arg0, %arg1 : i32, !vm.ref<?>
   }
@@ -768,11 +768,11 @@ vm.module @my_module {
   vm.import private optional @optional_import_fn(%arg0 : i32) -> i32
   // CHECK-LABEL: @my_module_call_fn
   vm.func @call_fn() -> i32 {
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[MODULE:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%[[IMPORT]]) {args = [0 : index, #emitc.opaque<"module">]} : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-    // CHECK-NEXT: %[[CONDITION0:.+]] = emitc.call "EMITC_UNARY"(%[[MODULE]]) {args = [#emitc.opaque<"!">, 0 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>) -> i1
-    // CHECK-NEXT: %[[CONDITION1:.+]] = emitc.call "EMITC_UNARY"(%[[CONDITION0]]) {args = [#emitc.opaque<"!">, 0 : index]} : (i1) -> i1
+    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[MODULE:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%[[IMPORT]]) {args = [0 : index, #emitc.opaque<"module">]} : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+    // CHECK-NEXT: %[[CONDITION0:.+]] = emitc.call_opaque "EMITC_UNARY"(%[[MODULE]]) {args = [#emitc.opaque<"!">, 0 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>) -> i1
+    // CHECK-NEXT: %[[CONDITION1:.+]] = emitc.call_opaque "EMITC_UNARY"(%[[CONDITION0]]) {args = [#emitc.opaque<"!">, 0 : index]} : (i1) -> i1
     // CHECK-NEXT: %[[RESULT:.+]] = emitc.cast %[[CONDITION1]] : i1 to i32
     %has_optional_import_fn = vm.import.resolved @optional_import_fn : i32
     vm.return %has_optional_import_fn : i32

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
@@ -3,9 +3,9 @@
 // CHECK-LABEL: @my_module_trunc
 vm.module @my_module {
   vm.func @trunc(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_trunc_i32i8"(%arg3) : (i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_trunc_i32i8"(%arg3) : (i32) -> i32
     %0 = vm.trunc.i32.i8 %arg0 : i32 -> i32
-    // CHECK-NEXT: %1 = emitc.call "vm_trunc_i32i16"(%0) : (i32) -> i32
+    // CHECK-NEXT: %1 = emitc.call_opaque "vm_trunc_i32i16"(%0) : (i32) -> i32
     %1 = vm.trunc.i32.i16 %0 : i32 -> i32
     vm.return %1 : i32
   }
@@ -16,13 +16,13 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_ext
 vm.module @my_module {
   vm.func @ext(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_ext_i8i32s"(%arg3) : (i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_ext_i8i32s"(%arg3) : (i32) -> i32
     %0 = vm.ext.i8.i32.s %arg0 : i32 -> i32
-    // CHECK-NEXT: %1 = emitc.call "vm_ext_i8i32u"(%0) : (i32) -> i32
+    // CHECK-NEXT: %1 = emitc.call_opaque "vm_ext_i8i32u"(%0) : (i32) -> i32
     %1 = vm.ext.i8.i32.u %0 : i32 -> i32
-    // CHECK-NEXT: %2 = emitc.call "vm_ext_i16i32s"(%1) : (i32) -> i32
+    // CHECK-NEXT: %2 = emitc.call_opaque "vm_ext_i16i32s"(%1) : (i32) -> i32
     %2 = vm.ext.i16.i32.s %1 : i32 -> i32
-    // CHECK-NEXT: %3 = emitc.call "vm_ext_i16i32u"(%2) : (i32) -> i32
+    // CHECK-NEXT: %3 = emitc.call_opaque "vm_ext_i16i32u"(%2) : (i32) -> i32
     %3 = vm.ext.i16.i32.u %2 : i32 -> i32
     vm.return %3 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
@@ -3,9 +3,9 @@
 // CHECK-LABEL: @my_module_bitcast
 vm.module @my_module {
   vm.func @bitcast(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_bitcast_i32f32"(%arg3) : (i32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_bitcast_i32f32"(%arg3) : (i32) -> f32
     %0 = vm.bitcast.i32.f32 %arg0 : i32 -> f32
-    // CHECK-NEXT: %1 = emitc.call "vm_bitcast_f32i32"(%0) : (f32) -> i32
+    // CHECK-NEXT: %1 = emitc.call_opaque "vm_bitcast_f32i32"(%0) : (f32) -> i32
     %1 = vm.bitcast.f32.i32 %0 : f32 -> i32
     vm.return %1 : i32
   }
@@ -16,13 +16,13 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_cast
 vm.module @my_module {
   vm.func @cast(%arg0 : i32) -> (i32, i32) {
-    // CHECK-NEXT: %0 = emitc.call "vm_cast_si32f32"(%arg3) : (i32) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cast_si32f32"(%arg3) : (i32) -> f32
     %0 = vm.cast.si32.f32 %arg0 : i32 -> f32
-    // CHECK-NEXT: %1 = emitc.call "vm_cast_ui32f32"(%arg3) : (i32) -> f32
+    // CHECK-NEXT: %1 = emitc.call_opaque "vm_cast_ui32f32"(%arg3) : (i32) -> f32
     %1 = vm.cast.ui32.f32 %arg0 : i32 -> f32
-    // CHECK-NEXT: %2 = emitc.call "vm_cast_f32si32"(%0) : (f32) -> i32
+    // CHECK-NEXT: %2 = emitc.call_opaque "vm_cast_f32si32"(%0) : (f32) -> i32
     %2 = vm.cast.f32.si32 %0 : f32 -> i32
-    // CHECK-NEXT: %3 = emitc.call "vm_cast_f32ui32"(%1) : (f32) -> i32
+    // CHECK-NEXT: %3 = emitc.call_opaque "vm_cast_f32ui32"(%1) : (f32) -> i32
     %3 = vm.cast.f32.ui32 %1 : f32 -> i32
     vm.return %2, %3 : i32, i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_trunc_i64
 vm.module @my_module {
   vm.func @trunc_i64(%arg0 : i64) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_trunc_i64i32"(%arg3) : (i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_trunc_i64i32"(%arg3) : (i64) -> i32
     %0 = vm.trunc.i64.i32 %arg0 : i64 -> i32
     vm.return %0 : i32
   }
@@ -14,9 +14,9 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_ext_i64
 vm.module @my_module {
   vm.func @ext_i64(%arg0 : i32) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_ext_i32i64s"(%arg3) : (i32) -> i64
+    // CHECK-NEXT: %0 = emitc.call_opaque "vm_ext_i32i64s"(%arg3) : (i32) -> i64
     %0 = vm.ext.i32.i64.s %arg0 : i32 -> i64
-    // CHECK-NEXT: %1 = emitc.call "vm_ext_i32i64u"(%arg3) : (i32) -> i64
+    // CHECK-NEXT: %1 = emitc.call_opaque "vm_ext_i32i64u"(%arg3) : (i32) -> i64
     %1 = vm.ext.i32.i64.u %arg0 : i32 -> i64
     vm.return %1 : i64
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops.mlir
@@ -5,8 +5,8 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_global_load_i32
   vm.func @global_load_i32() -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: %1 = emitc.call "vm_global_load_i32"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i32
+    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %1 = emitc.call_opaque "vm_global_load_i32"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i32
     %0 = vm.global.load.i32 @c42 : i32
     vm.return %0 : i32
   }
@@ -19,8 +19,8 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_global_store_i32
   vm.func @global_store_i32(%arg0 : i32) {
-    // CHECK-NEXT: %0 = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: emitc.call "vm_global_store_i32"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i32) -> ()
+    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.call_opaque "vm_global_store_i32"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i32) -> ()
     vm.global.store.i32 %arg0, @c107_mut : i32
     vm.return
   }
@@ -33,10 +33,10 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_global_load_ref
   vm.func @global_load_ref() -> !vm.buffer {
-    // CHECK: %[[A:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"refs">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[B:.+]] = emitc.call "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[A]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[C:.+]] = emitc.call "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %{{.+}} = emitc.call "iree_vm_ref_retain_or_move_checked"(%[[B]], %[[C]], %arg3) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[A:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"refs">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[B:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[A]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[C:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%[[B]], %[[C]], %arg3) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     %0 = vm.global.load.ref @g0 : !vm.buffer
     vm.return %0 : !vm.buffer
   }
@@ -49,10 +49,10 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_global_store_ref
   vm.func @global_store_ref(%arg0 : !vm.buffer) {
-    // CHECK: %[[A:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"refs">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[B:.+]] = emitc.call "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[A]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[C:.+]] = emitc.call "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %{{.+}} = emitc.call "iree_vm_ref_retain_or_move_checked"(%arg3, %[[C]], %[[B]]) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[A:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"refs">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[B:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[A]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[C:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%arg3, %[[C]], %[[B]]) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     vm.global.store.ref %arg0, @g0_mut : !vm.buffer
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_f32.mlir
@@ -5,8 +5,8 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_global_load_f32
   vm.func @global_load_f32() -> f32 {
-    // CHECK-NEXT: %0 = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: %1 = emitc.call "vm_global_load_f32"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> f32
+    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %1 = emitc.call_opaque "vm_global_load_f32"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> f32
     %0 = vm.global.load.f32 @c42 : f32
     vm.return %0 : f32
   }
@@ -19,8 +19,8 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_global_store_f32
   vm.func @global_store_f32(%arg0 : f32) {
-    // CHECK-NEXT: %0 = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: emitc.call "vm_global_store_f32"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, f32) -> ()
+    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.call_opaque "vm_global_store_f32"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, f32) -> ()
     vm.global.store.f32 %arg0, @c107_mut : f32
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_i64.mlir
@@ -5,8 +5,8 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_global_load_i64
   vm.func @global_load_i64() -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: %1 = emitc.call "vm_global_load_i64"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i64
+    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %1 = emitc.call_opaque "vm_global_load_i64"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i64
     %0 = vm.global.load.i64 @c42 : i64
     vm.return %0 : i64
   }
@@ -19,8 +19,8 @@ vm.module @my_module {
 
   // CHECK-LABEL: @my_module_global_store_i64
   vm.func @global_store_i64(%arg0 : i64) {
-    // CHECK-NEXT: %0 = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: emitc.call "vm_global_store_i64"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i64) -> ()
+    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.call_opaque "vm_global_store_i64"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i64) -> ()
     vm.global.store.i64 %arg0, @c107_mut : i64
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops.mlir
@@ -5,13 +5,13 @@ vm.module @my_module {
   vm.func @list_alloc(%arg0: i32) -> !vm.list<i32> {
     // CHECK: %[[LIST:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
     // CHECK: %[[LIST_PTR:.+]] = emitc.apply "&"(%3) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>
-    // CHECK: %[[ALLOCATOR:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
+    // CHECK: %[[ALLOCATOR:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
 
-    // CHECK: %[[TYPE_DEF:.+]] = emitc.call "iree_vm_make_value_type_def"() {args = [#emitc.opaque<"IREE_VM_VALUE_TYPE_I32">]} : () -> !emitc.opaque<"iree_vm_type_def_t">
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call "iree_vm_list_create"(%[[TYPE_DEF]], %arg3, %[[ALLOCATOR]], %[[LIST_PTR]]) : (!emitc.opaque<"iree_vm_type_def_t">, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[TYPE_DEF:.+]] = emitc.call_opaque "iree_vm_make_value_type_def"() {args = [#emitc.opaque<"IREE_VM_VALUE_TYPE_I32">]} : () -> !emitc.opaque<"iree_vm_type_def_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_list_create"(%[[TYPE_DEF]], %arg3, %[[ALLOCATOR]], %[[LIST_PTR]]) : (!emitc.opaque<"iree_vm_type_def_t">, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>) -> !emitc.opaque<"iree_status_t">
 
-    // CHECK: %[[LIST_TYPE_ID:.+]] = emitc.call "iree_vm_list_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK-NEXT:  %[[STATUS2:.+]] = emitc.call "iree_vm_ref_wrap_assign"(%[[LIST]], %[[LIST_TYPE_ID]], %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[LIST_TYPE_ID:.+]] = emitc.call_opaque "iree_vm_list_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK-NEXT:  %[[STATUS2:.+]] = emitc.call_opaque "iree_vm_ref_wrap_assign"(%[[LIST]], %[[LIST_TYPE_ID]], %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
 
     %0 = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     vm.return %0 : !vm.list<i32>
@@ -24,8 +24,8 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_reserve
   vm.func @list_reserve(%arg0: !vm.list<i32>, %arg1: i32) {
     // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_reserve"(%1, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_reserve"(%1, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32) -> !emitc.opaque<"iree_status_t">
     vm.list.reserve %arg0, %arg1 : (!vm.list<i32>, i32)
     vm.return
   }
@@ -37,8 +37,8 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_resize
   vm.func @list_resize(%arg0: !vm.list<i32>, %arg1: i32) {
     // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_resize"(%1, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_resize"(%1, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32) -> !emitc.opaque<"iree_status_t">
     vm.list.resize %arg0, %arg1 : (!vm.list<i32>, i32)
     vm.return
   }
@@ -50,8 +50,8 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_size
   vm.func @list_size(%arg0: !vm.list<i32>) -> i32 {
     // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_size"(%1) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>) -> i32
+    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_size"(%1) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>) -> i32
     %0 = vm.list.size %arg0 : (!vm.list<i32>) -> i32
     vm.return %0 : i32
   }
@@ -65,8 +65,8 @@ vm.module @my_module {
     // CHECK-NEXT: %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_value_t">
     // CHECK-NEXT: %1 = emitc.apply "&"(%0) : (!emitc.opaque<"iree_vm_value_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
     // CHECK-NEXT: %2 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %3 = emitc.call "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_get_value_as"(%3, %arg4, %1) {args = [0 : index, 1 : index, #emitc.opaque<"IREE_VM_VALUE_TYPE_I32">, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %3 = emitc.call_opaque "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_get_value_as"(%3, %arg4, %1) {args = [0 : index, 1 : index, #emitc.opaque<"IREE_VM_VALUE_TYPE_I32">, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
     %0 = vm.list.get.i32 %arg0, %arg1 : (!vm.list<i32>, i32) -> i32
     vm.return %0 : i32
   }
@@ -78,19 +78,19 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_get_ref
   vm.func @list_get_ref(%arg0: !vm.list<!vm.ref<?>>, %arg1: i32) -> !vm.buffer {
     // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_get_ref_retain"(%1, %arg4, %arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
-    // CHECK: %[[A:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg3) {args = [0 : index, #emitc.opaque<"type">]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_get_ref_retain"(%1, %arg4, %arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[A:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg3) {args = [0 : index, #emitc.opaque<"type">]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_type_t">
     // CHECK: %[[B:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_REF_TYPE_NULL">}> : () -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %[[C:.+]] = emitc.call "EMITC_BINARY"(%[[A]], %[[B]]) {args = [#emitc.opaque<"!=">, 0 : index, 1 : index]} : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
-    // CHECK: %[[D:.+]] = emitc.call "iree_vm_type_def_is_value"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> i1
-    // CHECK: %[[E:.+]] = emitc.call "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %[[F:.+]] = emitc.call "EMITC_BINARY"(%[[A]], %[[E]]) {args = [#emitc.opaque<"!=">, 0 : index, 1 : index]} : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
-    // CHECK: %[[G:.+]] = emitc.call "EMITC_BINARY"(%[[D]], %[[F]]) {args = [#emitc.opaque<"||">, 0 : index, 1 : index]} : (i1, i1) -> i1
-    // CHECK: %{{.+}} = emitc.call "EMITC_BINARY"(%[[C]], %[[G]]) {args = [#emitc.opaque<"&&">, 0 : index, 1 : index]} : (i1, i1) -> i1
+    // CHECK: %[[C:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[A]], %[[B]]) {args = [#emitc.opaque<"!=">, 0 : index, 1 : index]} : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
+    // CHECK: %[[D:.+]] = emitc.call_opaque "iree_vm_type_def_is_value"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> i1
+    // CHECK: %[[E:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK: %[[F:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[A]], %[[E]]) {args = [#emitc.opaque<"!=">, 0 : index, 1 : index]} : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
+    // CHECK: %[[G:.+]] = emitc.call_opaque "EMITC_BINARY"(%[[D]], %[[F]]) {args = [#emitc.opaque<"||">, 0 : index, 1 : index]} : (i1, i1) -> i1
+    // CHECK: %{{.+}} = emitc.call_opaque "EMITC_BINARY"(%[[C]], %[[G]]) {args = [#emitc.opaque<"&&">, 0 : index, 1 : index]} : (i1, i1) -> i1
     // CHECK: cf.cond_br %{{.+}}, ^[[FAIL:.+]], ^[[CONTINUE:.+]]
     // CHECK: ^[[FAIL]]:
-    // CHECK-NEXT: emitc.call "iree_vm_ref_release"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_release"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
     // CHECK-NEXT: cf.br ^[[CONTINUE]]
     %0 = vm.list.get.ref %arg0, %arg1 : (!vm.list<!vm.ref<?>>, i32) -> !vm.buffer
     vm.return %0 : !vm.buffer
@@ -102,11 +102,11 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: @my_module_list_set_i32
   vm.func @list_set_i32(%arg0: !vm.list<i32>, %arg1: i32, %arg2: i32) {
-    // CHECK-NEXT: %0 = emitc.call "iree_vm_value_make_i32"(%arg5) : (i32) -> !emitc.opaque<"iree_vm_value_t">
+    // CHECK-NEXT: %0 = emitc.call_opaque "iree_vm_value_make_i32"(%arg5) : (i32) -> !emitc.opaque<"iree_vm_value_t">
     // CHECK-NEXT: %1 = emitc.apply "&"(%0) : (!emitc.opaque<"iree_vm_value_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
     // CHECK-NEXT: %2 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %3 = emitc.call "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_set_value"(%3, %arg4, %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %3 = emitc.call_opaque "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_set_value"(%3, %arg4, %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
     vm.list.set.i32 %arg0, %arg1, %arg2 : (!vm.list<i32>, i32, i32)
     vm.return
   }
@@ -118,8 +118,8 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_set_ref
   vm.func @list_set_ref(%arg0: !vm.list<!vm.ref<?>>, %arg1: i32, %arg2: !vm.buffer) {
     // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_set_ref_retain"(%1, %arg4, %arg5) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_set_ref_retain"(%1, %arg4, %arg5) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     vm.list.set.ref %arg0, %arg1, %arg2 : (!vm.list<!vm.ref<?>>, i32, !vm.buffer)
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops_i64.mlir
@@ -6,8 +6,8 @@ vm.module @my_module {
     // CHECK-NEXT: %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_value_t">
     // CHECK-NEXT: %1 = emitc.apply "&"(%0) : (!emitc.opaque<"iree_vm_value_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
     // CHECK-NEXT: %2 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %3 = emitc.call "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_get_value_as"(%3, %arg4, %1) {args = [0 : index, 1 : index, #emitc.opaque<"IREE_VM_VALUE_TYPE_I64">, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %3 = emitc.call_opaque "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_get_value_as"(%3, %arg4, %1) {args = [0 : index, 1 : index, #emitc.opaque<"IREE_VM_VALUE_TYPE_I64">, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
     %0 = vm.list.get.i64 %arg0, %arg1 : (!vm.list<i64>, i32) -> i64
     vm.return %0 : i64
   }
@@ -18,11 +18,11 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: @my_module_list_set_i64
   vm.func @list_set_i64(%arg0: !vm.list<i64>, %arg1: i32, %arg2: i64) {
-    // CHECK-NEXT: %0 = emitc.call "iree_vm_value_make_i64"(%arg5) : (i64) -> !emitc.opaque<"iree_vm_value_t">
+    // CHECK-NEXT: %0 = emitc.call_opaque "iree_vm_value_make_i64"(%arg5) : (i64) -> !emitc.opaque<"iree_vm_value_t">
     // CHECK-NEXT: %1 = emitc.apply "&"(%0) : (!emitc.opaque<"iree_vm_value_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
     // CHECK-NEXT: %2 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %3 = emitc.call "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call "iree_vm_list_set_value"(%3, %arg4, %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %3 = emitc.call_opaque "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_set_value"(%3, %arg4, %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
     vm.list.set.i64 %arg0, %arg1, %arg2 : (!vm.list<i64>, i32, i64)
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_shl_i32
 vm.module @my_module {
   vm.func @shl_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_shl_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_shl_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.shl.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_shr_i32_s
 vm.module @my_module {
   vm.func @shr_i32_s(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_shr_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_shr_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.shr.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_shr_i32_u
 vm.module @my_module {
   vm.func @shr_i32_u(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_shr_i32u"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call_opaque "vm_shr_i32u"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.shr.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @my_module_shl_i64
 vm.module @my_module {
   vm.func @shl_i64(%arg0 : i64, %arg1 : i32) -> i64 {
-    // CHECK: %0 = emitc.call "vm_shl_i64"(%arg3, %arg4) : (i64, i32) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_shl_i64"(%arg3, %arg4) : (i64, i32) -> i64
     %0 = vm.shl.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_shr_i64_s
 vm.module @my_module {
   vm.func @shr_i64_s(%arg0 : i64, %arg1 : i32) -> i64 {
-    // CHECK: %0 = emitc.call "vm_shr_i64s"(%arg3, %arg4) : (i64, i32) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_shr_i64s"(%arg3, %arg4) : (i64, i32) -> i64
     %0 = vm.shr.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: @my_module_shr_i64_u
 vm.module @my_module {
   vm.func @shr_i64_u(%arg0 : i64, %arg1 : i32) -> i64 {
-    // CHECK: %0 = emitc.call "vm_shr_i64u"(%arg3, %arg4) : (i64, i32) -> i64
+    // CHECK: %0 = emitc.call_opaque "vm_shr_i64u"(%arg3, %arg4) : (i64, i32) -> i64
     %0 = vm.shr.i64.u %arg0, %arg1 : i64
     vm.return %0 : i64
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
@@ -17,7 +17,7 @@ vm.module @my_module {
     // CHECK: %[[REF:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %size = vm.list.size %list : (!vm.list<i32>) -> i32
-    // CHECK: %[[SIZE:.+]] = emitc.call "iree_vm_list_size"(%{{.+}})
+    // CHECK: %[[SIZE:.+]] = emitc.call_opaque "iree_vm_list_size"(%{{.+}})
     %size_dno = util.optimization_barrier %size : i32
     // CHECK: util.optimization_barrier %[[SIZE]] : i32
     vm.return

--- a/compiler/src/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -476,7 +476,7 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
     // TODO(simon-camp): Clean up. We generate calls to a macro that defines a
     // struct. As we declare all variables at the start of the function, the
     // macro call cannot be inlined into the function.
-    if (!isa<mlir::func::FuncOp, emitc::CallOp>(op))
+    if (!isa<mlir::func::FuncOp, emitc::CallOpaqueOp>(op))
       continue;
     if (op.hasAttr("vm.emit_at_end"))
       continue;


### PR DESCRIPTION
With llvm/llvm-project@c4fd1fd the call op was renamed to call.opaque.