### PR TITLE
Substitute expanding vectors for expansion/collapse in MaterializeEncoding

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
@@ -441,8 +441,8 @@ materializeEncodingForTarget(RankedTensorType tensorType,
       chooseMatmulTile(enumeratedTileMxNxK, matmulNarrowM, matmulNarrowN);
   // Map the matmul TileMxNxK to an actual tile shape for the tensor at hand,
   // based on its role in the matmul.
-  auto role = encoding.getRole().getValue();
-  return getEncodingInfoForMatmul(user, role, chosenTileMxNxK);
+  auto rank = tensorType.getRank();
+  return getEncodingInfoForMatmul(encoding, rank, chosenTileMxNxK);
 }
 
 static MaterializeEncodingFn

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -96,7 +96,9 @@ bool isBatchMatmulEncodingUser(EncodingUser user) {
   return user == EncodingUser::BATCH_MATMUL;
 }
 
-bool getIntOrZero(IntegerAttr a) { return a == IntegerAttr() ? 0 : a.getInt(); }
+int64_t getIntOrZero(IntegerAttr a) {
+  return a == IntegerAttr() ? 0 : a.getInt();
+}
 
 bool isVecmatEncoding(EncodingAttr encoding) {
   return encoding.getUser().getValue() == EncodingUser::MATMUL &&

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -96,20 +96,66 @@ bool isBatchMatmulEncodingUser(EncodingUser user) {
   return user == EncodingUser::BATCH_MATMUL;
 }
 
-MaterializeEncodingInfo getEncodingInfoForMatmul(EncodingUser user,
-                                                 EncodingRole role,
+bool getIntOrZero(IntegerAttr a) { return a == IntegerAttr() ? 0 : a.getInt(); }
+
+bool isVecmatEncoding(EncodingAttr encoding) {
+  return encoding.getUser().getValue() == EncodingUser::MATMUL &&
+         getIntOrZero(encoding.getMatmulNarrow_M()) == 1;
+}
+
+bool isMatvecEncoding(EncodingAttr encoding) {
+  return encoding.getUser().getValue() == EncodingUser::MATMUL &&
+         getIntOrZero(encoding.getMatmulNarrow_N()) == 1;
+}
+
+bool isBatchVecmatEncoding(EncodingAttr encoding) {
+  return encoding.getUser().getValue() == EncodingUser::BATCH_MATMUL &&
+         getIntOrZero(encoding.getMatmulNarrow_M()) == 1;
+}
+
+bool isBatchMatvecEncoding(EncodingAttr encoding) {
+  return encoding.getUser().getValue() == EncodingUser::BATCH_MATMUL &&
+         getIntOrZero(encoding.getMatmulNarrow_N()) == 1;
+}
+
+bool isVectorEncoding(int64_t rank, EncodingUser user) {
+  return rank == 1 || (isBatchMatmulEncodingUser(user) && rank == 2);
+}
+
+MaterializeEncodingInfo getEncodingInfoForMatmul(EncodingAttr encoding,
+                                                 int64_t rank,
                                                  TileMxNxK tileMxNxK) {
+  EncodingUser user = encoding.getUser().getValue();
+  EncodingRole role = encoding.getRole().getValue();
+  bool isVector = isVectorEncoding(rank, user);
+  bool isVecmatVector = (isVector && (isVecmatEncoding(encoding) ||
+                                      isBatchVecmatEncoding(encoding)));
+  bool isMatvecVector = (isVector && (isMatvecEncoding(encoding) ||
+                                      isBatchMatvecEncoding(encoding)));
   // Start dim of the MxK (LHS), KxN (RHS), or MxN (RESULT) 2D matrix.
   int64_t matmulDimBase = isBatchMatmulEncodingUser(user) ? 1 : 0;
 
   MaterializeEncodingInfo encodingInfo;
-  encodingInfo.innerDimsPos = {matmulDimBase, matmulDimBase + 1};
+  if (isVector) {
+    encodingInfo.innerDimsPos = {matmulDimBase};
+  } else {
+    encodingInfo.innerDimsPos = {matmulDimBase, matmulDimBase + 1};
+  }
+
   switch (role) {
   case (EncodingRole::LHS): {
+    if (isVecmatVector) {
+      encodingInfo.innerTileSizes = {tileMxNxK.K};
+      break;
+    }
     encodingInfo.innerTileSizes = {tileMxNxK.M, tileMxNxK.K};
     break;
   }
   case (EncodingRole::RHS): {
+    if (isMatvecVector) {
+      encodingInfo.innerTileSizes = {tileMxNxK.K};
+      break;
+    }
     encodingInfo.innerTileSizes = {tileMxNxK.N, tileMxNxK.K};
     encodingInfo.innerDimsPos = {matmulDimBase + 1, matmulDimBase};
     encodingInfo.outerDimsPerm =
@@ -119,6 +165,14 @@ MaterializeEncodingInfo getEncodingInfoForMatmul(EncodingUser user,
     break;
   }
   case (EncodingRole::RESULT): {
+    if (isVecmatVector) {
+      encodingInfo.innerTileSizes = {tileMxNxK.N};
+      break;
+    }
+    if (isMatvecVector) {
+      encodingInfo.innerTileSizes = {tileMxNxK.M};
+      break;
+    }
     encodingInfo.innerTileSizes = {tileMxNxK.M, tileMxNxK.N};
     break;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -84,7 +84,7 @@ RankedTensorType getOriginalTypeWithEncoding(RankedTensorType type);
 RankedTensorType dropEncoding(RankedTensorType type);
 
 /// Returns the integer contained in an IntegerAttr, or zero if it has none.
-bool getIntOrZero(IntegerAttr a);
+int64_t getIntOrZero(IntegerAttr a);
 
 /// Returns true if encoding user is one of matmul encodings.
 bool isMatmulEncodingUser(IREE::LinalgExt::EncodingUser user);

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -83,11 +83,29 @@ RankedTensorType getOriginalTypeWithEncoding(RankedTensorType type);
 /// Returns the RankedTensorType without encodings.
 RankedTensorType dropEncoding(RankedTensorType type);
 
+/// Returns the integer contained in an IntegerAttr, or zero if it has none.
+bool getIntOrZero(IntegerAttr a);
+
 /// Returns true if encoding user is one of matmul encodings.
 bool isMatmulEncodingUser(IREE::LinalgExt::EncodingUser user);
 
-/// Returns if encoding user is one of batch matmul encodings.
+/// Returns true if encoding user is one of batch matmul encodings.
 bool isBatchMatmulEncodingUser(IREE::LinalgExt::EncodingUser user);
+
+/// Returns true if the encoding is a vecmat.
+bool isVecmatEncoding(IREE::LinalgExt::EncodingAttr encoding);
+
+/// Returns true if the encoding is a matvec.
+bool isMatvecEncoding(IREE::LinalgExt::EncodingAttr encoding);
+
+/// Returns true if the encoding is a batch_vecmat.
+bool isBatchVecmatEncoding(IREE::LinalgExt::EncodingAttr encoding);
+
+/// Returns true if the encoding is a batch_matvec.
+bool isBatchMatvecEncoding(IREE::LinalgExt::EncodingAttr encoding);
+
+/// Returns true if the encoded type is a vector.
+bool isVectorEncoding(int64_t rank, IREE::LinalgExt::EncodingUser user);
 
 struct TileMxNxK {
   int64_t M = 1;
@@ -96,8 +114,7 @@ struct TileMxNxK {
 };
 
 MaterializeEncodingInfo
-getEncodingInfoForMatmul(IREE::LinalgExt::EncodingUser user,
-                         IREE::LinalgExt::EncodingRole role,
+getEncodingInfoForMatmul(IREE::LinalgExt::EncodingAttr encoding, int64_t rank,
                          TileMxNxK tileMxNxK);
 
 MaterializeEncodingValueFn

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
@@ -84,6 +84,92 @@ getInnerTileSizesOfr(OpBuilder &rewriter, Location loc,
   return result;
 }
 
+RankedTensorType getExpandedType(RankedTensorType type, bool isBatched,
+                                 bool isTransposed,
+                                 SmallVectorImpl<ReassociationIndices> &ri) {
+  if (!isBatched) {
+    ri.assign({{0, 1}, {2, 3}});
+    if (!isTransposed) {
+      return RankedTensorType::get(
+          {1, type.getDimSize(0), 1, type.getDimSize(1)},
+          type.getElementType());
+    }
+    return RankedTensorType::get({type.getDimSize(0), 1, type.getDimSize(1), 1},
+                                 type.getElementType());
+  }
+  ri.assign({{0}, {1, 2}, {3, 4}});
+  if (!isTransposed) {
+    return RankedTensorType::get(
+        {type.getDimSize(0), 1, type.getDimSize(1), 1, type.getDimSize(2)},
+        type.getElementType());
+  }
+  return RankedTensorType::get(
+      {type.getDimSize(0), type.getDimSize(1), 1, type.getDimSize(2), 1},
+      type.getElementType());
+}
+
+Value getMmt4dLhs(Value value, linalg::ContractionOpInterface op,
+                  RewriterBase &rewriter,
+                  SmallVectorImpl<ReassociationIndices> &ri) {
+  RankedTensorType type = value.getType().cast<RankedTensorType>();
+  RankedTensorType newType;
+  if (op.isVecmat()) {
+    newType =
+        getExpandedType(type, /*isBatched=*/false, /*isTransposed=*/false, ri);
+  } else if (op.isBatchVecmat()) {
+    newType =
+        getExpandedType(type, /*isBatched=*/true, /*isTransposed=*/false, ri);
+  } else {
+    return value;
+  }
+  return rewriter
+      .create<tensor::ExpandShapeOp>(op->getLoc(), newType, value, ri)
+      .getResult();
+}
+
+Value getMmt4dRhs(Value value, linalg::ContractionOpInterface op,
+                  RewriterBase &rewriter,
+                  SmallVectorImpl<ReassociationIndices> &ri) {
+  RankedTensorType type = value.getType().cast<RankedTensorType>();
+  RankedTensorType newType;
+  if (op.isMatvec()) {
+    newType =
+        getExpandedType(type, /*isBatched=*/false, /*isTransposed=*/false, ri);
+  } else if (op.isBatchMatvec()) {
+    newType =
+        getExpandedType(type, /*isBatched=*/true, /*isTransposed=*/false, ri);
+  } else {
+    return value;
+  }
+  return rewriter
+      .create<tensor::ExpandShapeOp>(op->getLoc(), newType, value, ri)
+      .getResult();
+}
+
+Value getMmt4dResult(Value value, linalg::ContractionOpInterface op,
+                     RewriterBase &rewriter,
+                     SmallVectorImpl<ReassociationIndices> &ri) {
+  // For vecmat/batch_vecmat we can rely on the same functionality as LHS.
+  if (op.isVecmat() || op.isBatchVecmat()) {
+    return getMmt4dLhs(value, op, rewriter, ri);
+  }
+
+  auto type = value.getType().cast<RankedTensorType>();
+  RankedTensorType newType;
+  if (op.isMatvec()) {
+    newType =
+        getExpandedType(type, /*isBatched=*/false, /*isTransposed=*/true, ri);
+  } else if (op.isBatchMatvec()) {
+    newType =
+        getExpandedType(type, /*isBatched=*/true, /*isTransposed=*/true, ri);
+  } else {
+    return value;
+  }
+  return rewriter
+      .create<tensor::ExpandShapeOp>(op->getLoc(), newType, value, ri)
+      .getResult();
+}
+
 //===---------------------------------------------------------------------===//
 // Methods to convert `set_encoding` and `unset_encoding` operations
 // to `pack` and `unpack` operations respectively.
@@ -209,32 +295,38 @@ static FailureOr<SmallVector<Value>> lowerUpperBoundTileSizeOpToConstants(
   return results;
 }
 
-/// Utility method to convert from `linalg.matmul` with
+/// Utility method to convert from linalg contraction ops with
 /// - lhs encoding with role=LHS
 /// - rhs encoding with role=RHS
 /// - result encoding with role=RESULT
-/// to linalg.mmt4d op.
+/// to linalg.mmt4d or linalg.batch_mmt4d ops.
 static FailureOr<Operation *> lowerOpWithEncoding(
-    RewriterBase &rewriter, linalg::MatmulOp matmulOp,
-    ValueRange convertedInputOperands, ValueRange convertedOutputOperands,
-    MaterializeEncodingFn materializeEncodingFn, MaterializeEncodingValueFn) {
-  if (!matmulOp.hasTensorSemantics()) {
+    RewriterBase &rewriter, mlir::linalg::ContractionOpInterface op,
+    ArrayRef<Value> operands, MaterializeEncodingFn materializeEncodingFn,
+    MaterializeEncodingValueFn) {
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
+  if (!linalgOp.hasTensorSemantics())
     return failure();
-  }
-  auto inputs = matmulOp.getDpsInputOperands();
-  auto outputs = matmulOp.getDpsInits();
-  auto lhsEncoding =
-      getEncodingAttr(inputs[0]->get().getType().cast<RankedTensorType>());
-  auto rhsEncoding =
-      getEncodingAttr(inputs[1]->get().getType().cast<RankedTensorType>());
-  auto resultEncoding =
-      getEncodingAttr(outputs[0].getType().cast<RankedTensorType>());
+
+  auto inputs = linalgOp.getDpsInputOperands();
+  auto outputs = linalgOp.getDpsInits();
+
+  auto lhsType = inputs[0]->get().getType().cast<RankedTensorType>();
+  auto rhsType = inputs[1]->get().getType().cast<RankedTensorType>();
+  auto resultType = outputs[0].getType().cast<RankedTensorType>();
+  auto lhsEncoding = getEncodingAttr(lhsType);
+  auto rhsEncoding = getEncodingAttr(rhsType);
+  auto resultEncoding = getEncodingAttr(resultType);
   if (!lhsEncoding || !rhsEncoding || !resultEncoding) {
     return failure();
   }
-  if (!isMatmulEncodingUser(lhsEncoding.getUser().getValue()) ||
-      !isMatmulEncodingUser(rhsEncoding.getUser().getValue()) ||
-      !isMatmulEncodingUser(resultEncoding.getUser().getValue()) ||
+
+  if (((!isMatmulEncodingUser(lhsEncoding.getUser().getValue()) ||
+        !isMatmulEncodingUser(rhsEncoding.getUser().getValue()) ||
+        !isMatmulEncodingUser(resultEncoding.getUser().getValue())) &&
+       (!isBatchMatmulEncodingUser(lhsEncoding.getUser().getValue()) ||
+        !isBatchMatmulEncodingUser(rhsEncoding.getUser().getValue()) ||
+        !isBatchMatmulEncodingUser(resultEncoding.getUser().getValue()))) ||
       lhsEncoding.getRole().getValue() !=
           mlir::iree_compiler::IREE::LinalgExt::EncodingRole::LHS ||
       rhsEncoding.getRole().getValue() !=
@@ -246,62 +338,34 @@ static FailureOr<Operation *> lowerOpWithEncoding(
 
   FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
       materializeEncodingFn(getOriginalTypeWithEncoding(
-          matmulOp.getResultTypes()[0].cast<RankedTensorType>()));
+          linalgOp->getResultTypes()[0].cast<RankedTensorType>()));
+
   Operation *result;
   if (failed(materializeEncodingInfo)) {
-    result = dropEncodingAndCloneOp(rewriter, matmulOp, convertedInputOperands,
-                                    convertedOutputOperands);
+    result = dropEncodingAndCloneOp(rewriter, linalgOp,
+                                    operands.take_front(inputs.size()),
+                                    operands.drop_front(inputs.size()));
   } else {
-    result = rewriter.create<linalg::Mmt4DOp>(
-        matmulOp.getLoc(), convertedOutputOperands[0].getType(),
-        convertedInputOperands, convertedOutputOperands);
-  }
-  return result;
-}
+    SmallVector<ReassociationIndices> ri;
+    Value newLhs = getMmt4dLhs(operands[0], op, rewriter, ri);
+    Value newRhs = getMmt4dRhs(operands[1], op, rewriter, ri);
+    Value newResult = getMmt4dResult(operands[2], op, rewriter, ri);
 
-/// Utility method to convert from `linalg.batch_matmul` with
-/// - lhs encoding with user=BATCH_MATMUL_*, role=LHS
-/// - rhs encoding with user=BATCH_MATMUL_*, role=RHS
-/// - result encoding with user=BATCH_MATMUL_*, role=RESULT
-/// to linalg.batch_mmt4d op.
-static FailureOr<Operation *> lowerOpWithEncoding(
-    RewriterBase &rewriter, linalg::BatchMatmulOp batchMatmulOp,
-    ValueRange convertedInputOperands, ValueRange convertedOutputOperands,
-    MaterializeEncodingFn materializeEncodingFn, MaterializeEncodingValueFn) {
-  if (!batchMatmulOp.hasTensorSemantics())
-    return failure();
-  auto inputs = batchMatmulOp.getDpsInputOperands();
-  auto outputs = batchMatmulOp.getDpsInits();
-  auto lhsEncoding =
-      getEncodingAttr(inputs[0]->get().getType().cast<RankedTensorType>());
-  auto rhsEncoding =
-      getEncodingAttr(inputs[1]->get().getType().cast<RankedTensorType>());
-  auto resultEncoding =
-      getEncodingAttr(outputs[0].getType().cast<RankedTensorType>());
-  if (!lhsEncoding || !rhsEncoding || !resultEncoding) {
-    return failure();
-  }
+    Type newResultType = newResult.getType();
 
-  if (!isBatchMatmulEncodingUser(lhsEncoding.getUser().getValue()) ||
-      !isBatchMatmulEncodingUser(rhsEncoding.getUser().getValue()) ||
-      !isBatchMatmulEncodingUser(resultEncoding.getUser().getValue()) ||
-      lhsEncoding.getRole().getValue() != EncodingRole::LHS ||
-      rhsEncoding.getRole().getValue() != EncodingRole::RHS ||
-      resultEncoding.getRole().getValue() != EncodingRole::RESULT) {
-    return failure();
-  }
-  FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
-      materializeEncodingFn(getOriginalTypeWithEncoding(
-          batchMatmulOp.getResultTypes()[0].cast<RankedTensorType>()));
-  Operation *result;
-  if (failed(materializeEncodingInfo)) {
-    result =
-        dropEncodingAndCloneOp(rewriter, batchMatmulOp, convertedInputOperands,
-                               convertedOutputOperands);
-  } else {
-    result = rewriter.create<linalg::BatchMmt4DOp>(
-        batchMatmulOp.getLoc(), convertedOutputOperands[0].getType(),
-        convertedInputOperands, convertedOutputOperands);
+    if (isMatmulEncodingUser(resultEncoding.getUser().getValue())) {
+      result = rewriter.create<linalg::Mmt4DOp>(
+          linalgOp.getLoc(), newResultType, ValueRange{newLhs, newRhs},
+          ValueRange{newResult});
+    } else {
+      result = rewriter.create<linalg::BatchMmt4DOp>(
+          linalgOp.getLoc(), newResultType, ValueRange{newLhs, newRhs},
+          ValueRange{newResult});
+    }
+    if (!ri.empty()) {
+      result = rewriter.create<tensor::CollapseShapeOp>(
+          linalgOp->getLoc(), operands[2].getType(), result->getResult(0), ri);
+    }
   }
   return result;
 }
@@ -770,6 +834,41 @@ struct MaterializeOperation : public OpMaterializeEncodingPattern<OpTy> {
   }
 };
 
+/// Pattern to convert contraction operations.
+class MaterializeContractionOp : public OpInterfaceConversionPattern<
+                                     mlir::linalg::ContractionOpInterface> {
+public:
+  MaterializeContractionOp(
+      MLIRContext *context,
+      const MaterializeEncodingTypeConverter &typeConverter,
+      MaterializeEncodingValueFn materializeEncodingValueFn = {},
+      PatternBenefit benefit = 1)
+      : OpInterfaceConversionPattern<mlir::linalg::ContractionOpInterface>(
+            typeConverter, context, benefit),
+        materializeEncodingValueFn(materializeEncodingValueFn) {}
+
+  LogicalResult
+  matchAndRewrite(mlir::linalg::ContractionOpInterface op,
+                  ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    MaterializeEncodingFn materializeEncodingFn =
+        static_cast<const MaterializeEncodingTypeConverter *>(
+            this->getTypeConverter())
+            ->getMaterializeEncodingFn();
+    FailureOr<Operation *> convertedOp =
+        lowerOpWithEncoding(rewriter, op, operands, materializeEncodingFn,
+                            this->materializeEncodingValueFn);
+    if (failed(convertedOp)) {
+      return failure();
+    }
+    rewriter.replaceOp(op.getOperation(), convertedOp.value()->getResult(0));
+    return success();
+  }
+
+protected:
+  const MaterializeEncodingValueFn materializeEncodingValueFn;
+};
+
 } // namespace
 
 static FailureOr<MaterializeEncodingValueInfo>
@@ -821,11 +920,9 @@ void populateMaterializeEncodingIntoPackUnPackPatterns(
   // Add all patterns for converting from encoded type to the materialized
   // type.
   patterns.insert<MaterializeDPSOperation<linalg::FillOp>,
-                  MaterializeDPSOperation<linalg::MatmulOp>,
-                  MaterializeDPSOperation<linalg::BatchMatmulOp>,
                   MaterializeDPSOperation<linalg::GenericOp>,
                   MaterializeOperation<tensor::EmptyOp>,
-                  SetEncodingOpToPackOpConversion,
+                  MaterializeContractionOp, SetEncodingOpToPackOpConversion,
                   UnsetEncodingOpToUnPackOpConversion>(
       patterns.getContext(), typeConverter, materializeEncodingValueFn);
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
@@ -97,6 +97,7 @@ RankedTensorType getExpandedType(RankedTensorType type, bool isBatched,
     return RankedTensorType::get({type.getDimSize(0), 1, type.getDimSize(1), 1},
                                  type.getElementType());
   }
+
   ri.assign({{0}, {1, 2}, {3, 4}});
   if (!isTransposed) {
     return RankedTensorType::get(

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -95,7 +95,7 @@ void buildGlobalOptimizationPassPipeline(
   if (transformOptions.options.dataTiling) {
     mainPassManager.addPass(createLiftGenericToTransposeBatchMatmulPass());
     // Expand all vectors in vecmat/matvec ops into matrices for tiling.
-    mainPassManager.addPass(createExpandVectorsPass());
+    // mainPassManager.addPass(createExpandVectorsPass());
     mainPassManager.addPass(createSetEncodingPass());
     mainPassManager.addPass(createMaterializeHomogeneousEncodingsPass());
     mainPassManager.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -25,6 +25,11 @@ static llvm::cl::opt<bool> clEnableQuantizedMatmulReassociation(
         "Enables reassociation of quantized matmul ops (experimental)."),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clEnableExpandVectors(
+    "iree-global-opt-enable-expand-vectors",
+    llvm::cl::desc("Enables vector expansion in vector/matrix operations."),
+    llvm::cl::init(false));
+
 void buildGlobalOptExprHoistingPassPipeline(
     OpPassManager &passManager, const TransformOptions &transformOptions) {
   IREE::Util::ExprHoistingOptions options;
@@ -95,7 +100,9 @@ void buildGlobalOptimizationPassPipeline(
   if (transformOptions.options.dataTiling) {
     mainPassManager.addPass(createLiftGenericToTransposeBatchMatmulPass());
     // Expand all vectors in vecmat/matvec ops into matrices for tiling.
-    // mainPassManager.addPass(createExpandVectorsPass());
+    if (clEnableExpandVectors) {
+      mainPassManager.addPass(createExpandVectorsPass());
+    }
     mainPassManager.addPass(createSetEncodingPass());
     mainPassManager.addPass(createMaterializeHomogeneousEncodingsPass());
     mainPassManager.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -131,7 +131,7 @@ static MatmulNarrowSizes getMatmulNarrowSizes(ShapedType outType,
     M = outType.getDimSize(rank - 2);
     N = outType.getDimSize(rank - 1);
     break;
-  } 
+  }
   case ContractionOpType::kVecmat:
   case ContractionOpType::kBatchVecmat: {
     M = 1;

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -88,15 +88,65 @@ Value setEncoding(OpBuilder &builder, Location loc, Value source,
                                                         source);
 };
 
+enum class ContractionOpType {
+  kInvalid,
+  kMatmul,
+  kBatchMatmul,
+  kVecmat,
+  kBatchVecmat,
+  kMatvec,
+  kBatchMatvec,
+};
+
+static ContractionOpType
+getContractionOpType(linalg::ContractionOpInterface op) {
+  if (op.isRowMajorMatmul() || op.isColumnMajorMatmul())
+    return ContractionOpType::kMatmul;
+  if (op.isRowMajorBatchMatmul())
+    return ContractionOpType::kBatchMatmul;
+  if (op.isVecmat())
+    return ContractionOpType::kVecmat;
+  if (op.isBatchVecmat())
+    return ContractionOpType::kBatchVecmat;
+  if (op.isMatvec())
+    return ContractionOpType::kMatvec;
+  if (op.isBatchMatvec())
+    return ContractionOpType::kBatchMatvec;
+  return ContractionOpType::kInvalid;
+}
+
 struct MatmulNarrowSizes {
   std::optional<int64_t> M, N;
 };
 
 // Returns the minimum of static sizes of the M-dimension in the types of the
 // LHS and/or the Output operand of a matmul, whichever is static.
-static MatmulNarrowSizes getMatmulNarrowSizes(ShapedType outType) {
-  int64_t M = outType.getDimSize(outType.getRank() - 2);
-  int64_t N = outType.getDimSize(outType.getRank() - 1);
+static MatmulNarrowSizes getMatmulNarrowSizes(ShapedType outType,
+                                              ContractionOpType opType) {
+  int64_t M, N;
+  int64_t rank = outType.getRank();
+  switch (opType) {
+  case ContractionOpType::kMatmul:
+  case ContractionOpType::kBatchMatmul: {
+    M = outType.getDimSize(rank - 2);
+    N = outType.getDimSize(rank - 1);
+    break;
+  }
+  case ContractionOpType::kVecmat:
+  case ContractionOpType::kBatchVecmat: {
+    M = 1;
+    N = outType.getDimSize(outType.getRank() - 1);
+    break;
+  }
+  case ContractionOpType::kMatvec:
+  case ContractionOpType::kBatchMatvec: {
+    M = outType.getDimSize(outType.getRank() - 1);
+    N = 1;
+    break;
+  }
+  case ContractionOpType::kInvalid:
+    return MatmulNarrowSizes();
+  }
 
   MatmulNarrowSizes narrow;
   // Threshold below which a M/N size is considered "narrow", making it
@@ -206,24 +256,24 @@ static Value unsetEncodingAndExtractSlice(OpBuilder &builder, Location loc,
 
 namespace {
 
-/// Rewrites the matmul op to work on tensors with encoding. Optionally
-/// also pads the operands.
-struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
-  SetMatmulEncoding(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern<linalg::MatmulOp>(context, benefit) {}
-
-  LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
+struct setContractionOpEncoding
+    : public OpInterfaceRewritePattern<linalg::ContractionOpInterface> {
+  using OpInterfaceRewritePattern<
+      linalg::ContractionOpInterface>::OpInterfaceRewritePattern;
+  LogicalResult matchAndRewrite(linalg::ContractionOpInterface op,
                                 PatternRewriter &rewriter) const override {
-    if (!matmulOp.hasTensorSemantics())
+    auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
+    if (!linalgOp.hasTensorSemantics()) {
       return failure();
-
-    if (getCompilationInfo(matmulOp)) {
+    }
+    if (getCompilationInfo(linalgOp)) {
       return rewriter.notifyMatchFailure(
-          matmulOp, "the op has preset compilation strategy, skip SetEncoding");
+          linalgOp, "the op has preset compilation strategy, skip SetEncoding");
     }
 
-    auto inputs = matmulOp.getDpsInputs();
-    auto outputs = matmulOp.getDpsInits();
+    auto inputs = linalgOp.getDpsInputs();
+    auto outputs = linalgOp.getDpsInits();
+
     auto hasEncoding = [](Value operand) -> bool {
       auto type = llvm::dyn_cast<RankedTensorType>(operand.getType());
       return type && type.getEncoding();
@@ -232,7 +282,6 @@ struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
         llvm::any_of(outputs, hasEncoding)) {
       return failure();
     }
-
     Value origLhs = inputs[0];
     Value origRhs = inputs[1];
     Value origOut = outputs[0];
@@ -257,11 +306,28 @@ struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
       return failure();
     }
 
-    IREE::LinalgExt::EncodingUser user = IREE::LinalgExt::EncodingUser::MATMUL;
+    ContractionOpType opType = getContractionOpType(op);
+    IREE::LinalgExt::EncodingUser user;
+    switch (opType) {
+    case ContractionOpType::kMatmul:
+    case ContractionOpType::kVecmat:
+    case ContractionOpType::kMatvec:
+      user = IREE::LinalgExt::EncodingUser::MATMUL;
+      break;
+    case ContractionOpType::kBatchMatmul:
+    case ContractionOpType::kBatchVecmat:
+    case ContractionOpType::kBatchMatvec:
+      user = IREE::LinalgExt::EncodingUser::BATCH_MATMUL;
+      break;
+    case ContractionOpType::kInvalid:
+      return rewriter.notifyMatchFailure(op, "unsupported contraction op");
+    }
+
     MatmulNarrowSizes narrowSizes =
-        getMatmulNarrowSizes(origOut.getType().cast<ShapedType>());
-    Location loc = matmulOp.getLoc();
-    SmallVector<Type> operandTypes(matmulOp->getOperandTypes());
+        getMatmulNarrowSizes(origOut.getType().cast<ShapedType>(), opType);
+
+    Location loc = linalgOp.getLoc();
+    SmallVector<Type> operandTypes(linalgOp->getOperandTypes());
     operandTypes[0] =
         cast<RankedTensorType>(operandTypes[0]).clone(lhsElemType);
     operandTypes[1] =
@@ -275,116 +341,23 @@ struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
     Value encodedOut = padAndSetEncoding(rewriter, loc, origOut, user,
                                          IREE::LinalgExt::EncodingRole::RESULT,
                                          operandTypes, narrowSizes);
-
-    Value matmulTiled = rewriter
-                            .create<linalg::MatmulOp>(
-                                loc, encodedOut.getType(),
-                                ValueRange{encodedLhs, encodedRhs}, encodedOut)
-                            .getResult(0);
+    Value opTiled;
+    opTiled = clone(rewriter, linalgOp, encodedOut.getType(),
+                    ValueRange{encodedLhs, encodedRhs, encodedOut})
+                  ->getResult(0);
 
     // Sizes are computed by original output size.
     FailureOr<SmallVector<OpFoldResult>> origOutSizes =
         IREE::LinalgExt::getDims(rewriter, loc, origOut);
     if (failed(origOutSizes)) {
-      return rewriter.notifyMatchFailure(matmulOp,
+      return rewriter.notifyMatchFailure(linalgOp,
                                          "failed to get shape of result");
     }
 
-    Value result = unsetEncodingAndExtractSlice(rewriter, loc, matmulTiled,
+    Value result = unsetEncodingAndExtractSlice(rewriter, loc, opTiled,
                                                 origOutSizes.value());
 
-    rewriter.replaceOp(matmulOp, result);
-    return success();
-  }
-};
-
-struct SetBatchMatmulEncoding : public OpRewritePattern<linalg::BatchMatmulOp> {
-  SetBatchMatmulEncoding(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern<linalg::BatchMatmulOp>(context, benefit) {}
-
-  LogicalResult matchAndRewrite(linalg::BatchMatmulOp matmulOp,
-                                PatternRewriter &rewriter) const override {
-    if (!matmulOp.hasTensorSemantics())
-      return failure();
-
-    if (getCompilationInfo(matmulOp)) {
-      return rewriter.notifyMatchFailure(
-          matmulOp, "the op has preset compilation strategy, skip SetEncoding");
-    }
-
-    auto inputs = matmulOp.getDpsInputs();
-    auto outputs = matmulOp.getDpsInits();
-    auto hasEncoding = [](Value operand) -> bool {
-      auto type = llvm::dyn_cast<RankedTensorType>(operand.getType());
-      return type && type.getEncoding();
-    };
-    if (llvm::any_of(inputs, hasEncoding) ||
-        llvm::any_of(outputs, hasEncoding)) {
-      return failure();
-    }
-
-    Value origLhs = inputs[0];
-    Value origRhs = inputs[1];
-    Value origOut = outputs[0];
-
-    auto getElemType = [](Value v) -> Type {
-      if (auto tensorType = llvm::dyn_cast<RankedTensorType>(v.getType())) {
-        return tensorType.getElementType();
-      }
-      return {};
-    };
-    std::optional<CastOpInterface> maybeLhsCastOp =
-        getDefiningNonI1CastOp(origLhs);
-    std::optional<CastOpInterface> maybeRhsCastOp =
-        getDefiningNonI1CastOp(origRhs);
-    Type lhsElemType = maybeLhsCastOp ? getCastElemType(origLhs).value()
-                                      : getElemType(origLhs);
-    Type rhsElemType = maybeRhsCastOp ? getCastElemType(origRhs).value()
-                                      : getElemType(origRhs);
-    Type outElemType = getElemType(origOut);
-
-    if (!lhsElemType || !rhsElemType || !outElemType) {
-      return failure();
-    }
-
-    IREE::LinalgExt::EncodingUser user =
-        IREE::LinalgExt::EncodingUser::BATCH_MATMUL;
-    MatmulNarrowSizes narrowSizes =
-        getMatmulNarrowSizes(origOut.getType().cast<ShapedType>());
-    Location loc = matmulOp.getLoc();
-    SmallVector<Type> operandTypes(matmulOp->getOperandTypes());
-    operandTypes[0] =
-        cast<RankedTensorType>(operandTypes[0]).clone(lhsElemType);
-    operandTypes[1] =
-        cast<RankedTensorType>(operandTypes[1]).clone(rhsElemType);
-    Value encodedLhs = padAndSetEncoding(
-        rewriter, loc, origLhs, user, IREE::LinalgExt::EncodingRole::LHS,
-        operandTypes, narrowSizes, maybeLhsCastOp);
-    Value encodedRhs = padAndSetEncoding(
-        rewriter, loc, origRhs, user, IREE::LinalgExt::EncodingRole::RHS,
-        operandTypes, narrowSizes, maybeRhsCastOp);
-    Value encodedOut = padAndSetEncoding(rewriter, loc, origOut, user,
-                                         IREE::LinalgExt::EncodingRole::RESULT,
-                                         operandTypes, narrowSizes);
-
-    Value matmulTiled = rewriter
-                            .create<linalg::BatchMatmulOp>(
-                                loc, encodedOut.getType(),
-                                ValueRange{encodedLhs, encodedRhs}, encodedOut)
-                            .getResult(0);
-
-    // Sizes are computed by original output size.
-    FailureOr<SmallVector<OpFoldResult>> origOutSizes =
-        IREE::LinalgExt::getDims(rewriter, loc, origOut);
-    if (failed(origOutSizes)) {
-      return rewriter.notifyMatchFailure(matmulOp,
-                                         "failed to get shape of result");
-    }
-
-    Value result = unsetEncodingAndExtractSlice(rewriter, loc, matmulTiled,
-                                                origOutSizes.value());
-
-    rewriter.replaceOp(matmulOp, result);
+    rewriter.replaceOp(linalgOp, result);
     return success();
   }
 };
@@ -428,7 +401,7 @@ void SetEncodingPass::runOnOperation() {
   MLIRContext *context = &getContext();
   {
     RewritePatternSet patterns(context);
-    patterns.insert<SetBatchMatmulEncoding, SetMatmulEncoding>(context);
+    patterns.insert<setContractionOpEncoding>(context);
     linalg::FillOp::getCanonicalizationPatterns(patterns, context);
     patterns.insert<FoldFillWithSetEncoding>(context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -119,8 +119,8 @@ struct MatmulNarrowSizes {
   std::optional<int64_t> M, N;
 };
 
-// Returns the minimum of static sizes of the M-dimension in the types of the
-// LHS and/or the Output operand of a matmul, whichever is static.
+// Returns the minimum of static sizes of the M/N-dimensions in the types of the
+// Ouput.
 static MatmulNarrowSizes getMatmulNarrowSizes(ShapedType outType,
                                               ContractionOpType opType) {
   int64_t M, N;

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -131,7 +131,7 @@ static MatmulNarrowSizes getMatmulNarrowSizes(ShapedType outType,
     M = outType.getDimSize(rank - 2);
     N = outType.getDimSize(rank - 1);
     break;
-  }
+  } 
   case ContractionOpType::kVecmat:
   case ContractionOpType::kBatchVecmat: {
     M = 1;

--- a/compiler/src/iree/compiler/GlobalOptimization/test/set_encoding.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/set_encoding.mlir
@@ -603,6 +603,187 @@ func.func @batch_matmul_i8i8i32(%arg0 : tensor<64x100x250xi8>, %arg1 : tensor<64
 
 // -----
 
+func.func @vecmat_f32f32f32(%arg0 : tensor<250xf32>, %arg1 : tensor<250x500xf32>,
+    %arg2 : tensor<500xf32>) -> tensor<500xf32> {
+  %0 = linalg.vecmat ins(%arg0, %arg1 : tensor<250xf32>, tensor<250x500xf32>)
+      outs(%arg2 : tensor<500xf32>) -> tensor<500xf32>
+  return %0 : tensor<500xf32>
+}
+
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @vecmat_f32f32f32(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<250xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<250x500xf32>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<500xf32>
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//  CHECK-DAG:     %[[C500:.+]] = arith.constant 500 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]] = iree_linalg_ext.upper_bound_tile_size tensor<250xf32, #iree_linalg_ext.encoding<user = MATMUL, role = LHS, element_types = [f32, f32, f32], matmul_narrow_M = 1 : index>> -> index
+//      CHECK:   %[[LHS_PADDING_SIZE:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]], %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0] high[%[[LHS_PADDING_SIZE]]]
+//      CHECK:       tensor<250xf32> to tensor<?xf32>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = LHS, element_types = [f32, f32, f32], original_type = tensor<250xf32>, matmul_narrow_M = 1 : index>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:2 = iree_linalg_ext.upper_bound_tile_size tensor<250x500xf32, #iree_linalg_ext.encoding<user = MATMUL, role = RHS, element_types = [f32, f32, f32], matmul_narrow_M = 1 : index>> -> index, index
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[C250]]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[C500]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]]]
+//      CHECK:       tensor<250x500xf32> to tensor<?x?xf32>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = RHS, element_types = [f32, f32, f32], original_type = tensor<250x500xf32>, matmul_narrow_M = 1 : index>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]] = iree_linalg_ext.upper_bound_tile_size tensor<500xf32, #iree_linalg_ext.encoding<user = MATMUL, role = RESULT, element_types = [f32, f32, f32], matmul_narrow_M = 1 : index>> -> index
+//      CHECK:   %[[OUTS_PADDING_SIZE:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]], %[[C500]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0] high[%[[OUTS_PADDING_SIZE]]]
+//      CHECK:       tensor<500xf32> to tensor<?xf32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = RESULT, element_types = [f32, f32, f32], original_type = tensor<500xf32>, matmul_narrow_M = 1 : index>>
+//      CHECK:   %[[VECMAT:.+]] = linalg.vecmat
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[VECMAT]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0] [500] [1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @matvec_f32f32f32(%arg0 : tensor<100x250xf32>, %arg1 : tensor<250xf32>,
+    %arg2 : tensor<100xf32>) -> tensor<100xf32> {
+  %0 = linalg.matvec ins(%arg0, %arg1 : tensor<100x250xf32>, tensor<250xf32>)
+      outs(%arg2 : tensor<100xf32>) -> tensor<100xf32>
+  return %0 : tensor<100xf32>
+}
+
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @matvec_f32f32f32(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<100x250xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<250xf32>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<100xf32>
+//  CHECK-DAG:     %[[C100:.+]] = arith.constant 100 : index
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:2 = iree_linalg_ext.upper_bound_tile_size tensor<100x250xf32, #iree_linalg_ext.encoding<user = MATMUL, role = LHS, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>> -> index, index
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[C100]]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]]]
+//      CHECK:       tensor<100x250xf32> to tensor<?x?xf32>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = LHS, element_types = [f32, f32, f32], original_type = tensor<100x250xf32>, matmul_narrow_N = 1 : index>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]] = iree_linalg_ext.upper_bound_tile_size tensor<250xf32, #iree_linalg_ext.encoding<user = MATMUL, role = RHS, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>> -> index
+//      CHECK:   %[[RHS_PADDING_SIZE:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]], %[[C250]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0] high[%[[RHS_PADDING_SIZE]]]
+//      CHECK:       tensor<250xf32> to tensor<?xf32>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = RHS, element_types = [f32, f32, f32], original_type = tensor<250xf32>, matmul_narrow_N = 1 : index>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]] = iree_linalg_ext.upper_bound_tile_size tensor<100xf32, #iree_linalg_ext.encoding<user = MATMUL, role = RESULT, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>> -> index
+//      CHECK:   %[[OUTS_PADDING_SIZE:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]], %[[C100]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0] high[%[[OUTS_PADDING_SIZE]]]
+//      CHECK:       tensor<100xf32> to tensor<?xf32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = RESULT, element_types = [f32, f32, f32], original_type = tensor<100xf32>, matmul_narrow_N = 1 : index>>
+//      CHECK:   %[[MATVEC:.+]] = linalg.matvec
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[MATVEC]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0] [100] [1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @batch_vecmat_f32f32f32(%arg0 : tensor<3x250xf32>, %arg1 : tensor<3x250x500xf32>,
+    %arg2 : tensor<3x500xf32>) -> tensor<3x500xf32> {
+  %0 = linalg.batch_vecmat ins(%arg0, %arg1 : tensor<3x250xf32>, tensor<3x250x500xf32>)
+      outs(%arg2 : tensor<3x500xf32>) -> tensor<3x500xf32>
+  return %0 : tensor<3x500xf32>
+}
+
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_vecmat_f32f32f32(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<3x250xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<3x250x500xf32>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<3x500xf32>
+//  CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//  CHECK-DAG:     %[[C500:.+]] = arith.constant 500 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:2 = iree_linalg_ext.upper_bound_tile_size tensor<3x250xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = LHS, element_types = [f32, f32, f32], matmul_narrow_M = 1 : index>> -> index, index
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[C3]]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]]]
+//      CHECK:       tensor<3x250xf32> to tensor<?x?xf32>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = LHS, element_types = [f32, f32, f32], original_type = tensor<3x250xf32>, matmul_narrow_M = 1 : index>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<3x250x500xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = RHS, element_types = [f32, f32, f32], matmul_narrow_M = 1 : index>> -> index, index, index
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[C3]]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[RHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]], %[[RHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<3x250x500xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = RHS, element_types = [f32, f32, f32], original_type = tensor<3x250x500xf32>, matmul_narrow_M = 1 : index>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:2 = iree_linalg_ext.upper_bound_tile_size tensor<3x500xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = RESULT, element_types = [f32, f32, f32], matmul_narrow_M = 1 : index>> -> index, index
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[C3]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[C500]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]]]
+//      CHECK:       tensor<3x500xf32> to tensor<?x?xf32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = RESULT, element_types = [f32, f32, f32], original_type = tensor<3x500xf32>, matmul_narrow_M = 1 : index>>
+//      CHECK:   %[[VECMAT:.+]] = linalg.batch_vecmat
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[VECMAT]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0] [3, 500] [1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @batch_matvec_f32f32f32_dynamic(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?x?xf32>,
+    %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = linalg.batch_matvec ins(%arg0, %arg1 : tensor<?x?x?xf32>, tensor<?x?xf32>)
+      outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_matvec_f32f32f32_dynamic(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?x?xf32>, %[[ARG1:.+]]: tensor<?x?xf32>, %[[ARG2:.+]]: tensor<?x?xf32>
+//  CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = LHS, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>> -> index, index, index
+//      CHECK:   %[[LHS_DIM0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[LHS_DIM0]]]
+//      CHECK:   %[[LHS_DIM1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[LHS_DIM1]]]
+//      CHECK:   %[[LHS_DIM2:.+]] = tensor.dim %[[ARG0]], %[[C2]]
+//      CHECK:   %[[LHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#2, %[[LHS_DIM2]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]], %[[LHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<?x?x?xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = LHS, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:2 = iree_linalg_ext.upper_bound_tile_size tensor<?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = RHS, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>> -> index, index
+//      CHECK:   %[[RHS_DIM0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[RHS_DIM0]]]
+//      CHECK:   %[[RHS_DIM1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[RHS_DIM1]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]]]
+//      CHECK:       tensor<?x?xf32> to tensor<?x?xf32>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = RHS, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:2 = iree_linalg_ext.upper_bound_tile_size tensor<?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = RESULT, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>> -> index, index
+//      CHECK:   %[[OUTS_DIM0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[OUTS_DIM0]]]
+//      CHECK:   %[[OUTS_DIM1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[OUTS_DIM1]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]]]
+//      CHECK:       tensor<?x?xf32> to tensor<?x?xf32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL, role = RESULT, element_types = [f32, f32, f32], matmul_narrow_N = 1 : index>>
+//      CHECK:   %[[BATCH_MATVEC:.+]] = linalg.batch_matvec
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[BATCH_MATVEC]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0] [{{.*}}] [1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
 func.func @fold_fill_with_set_encoding(%arg0 : index, %arg1 : index)
   -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = LHS, element_types = [f32, f32, f32]>> {
   %cst = arith.constant 0.0 : f32


### PR DESCRIPTION
This PR is missing testing (although the existing test pass + I ran a few IR examples locally) and a bit of cleanup, but I'd like to get feedback on it before I commit to exhaustive testing.

Fixes https://github.com/openxla/iree/issues/15641