### PR TITLE
Update vector layout attribute and add helper functions

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtBase.td
@@ -36,6 +36,42 @@ def IREEVectorExt_Dialect : Dialect {
 class IREEVectorExt_Attr<string name, list<Trait> traits = []>
   : AttrDef<IREEVectorExt_Dialect, name, traits>;
 
+class IREEVectorExt_I32EnumAttr<string name, string summary, list<I32EnumAttrCase> cases>
+    : I32EnumAttr<name, summary, cases> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::VectorExt";
+  let genSpecializedAttr = 0;
+}
+
+class IREEVectorExt_EnumAttr<EnumAttrInfo enumInfo, string name = "">
+  : EnumAttr<IREEVectorExt_Dialect, enumInfo, name>;
+
+// Defines the batch dimensions for the original SIMD tensor.
+// By convention, X is along rows and Y along columns.
+def BATCHX : I32EnumAttrCase<"BATCHX", 0>;
+def BATCHY : I32EnumAttrCase<"BATCHY", 1>;
+// Defines the vector dimension.
+def VECTORX : I32EnumAttrCase<"VECTORX", 2>;
+def VECTORY : I32EnumAttrCase<"VECTORY", 3>;
+def VECTORZ : I32EnumAttrCase<"VECTORZ", 4>;
+// Defines the lane dimensions.
+def LANEX : I32EnumAttrCase<"LANEX", 5>;
+def LANEY : I32EnumAttrCase<"LANEY", 6>;
+def LANEZ : I32EnumAttrCase<"LANEZ", 7>;
+
+def LayoutDimension : IREEVectorExt_I32EnumAttr<"LayoutDimension",
+    "Describes the dimension of the high-dimensional layout", [
+      BATCHX,
+      BATCHY,
+      VECTORX,
+      VECTORY,
+      VECTORZ,
+      LANEX,
+      LANEY,
+      LANEZ,
+    ]>;
+
+def LayoutDimensionAttr : IREEVectorExt_EnumAttr<LayoutDimension, "dimension">;
+
 def PerDimLayoutAttr : IREEVectorExt_Attr<"PerDimLayout"> {
    let mnemonic = "per_dim_layout";
    let summary = [{high-dimensional vector register layout for a given vector dimension}];
@@ -47,11 +83,15 @@ def PerDimLayoutAttr : IREEVectorExt_Attr<"PerDimLayout"> {
     we can reason about layouts, propagating layouts and layout conflicts.
    }];
    let parameters = (ins
-     ArrayRefParameter<"std::string", "labels for the high dimensional layout dims">:$labels,
+     ArrayRefParameter<"LayoutDimensionAttr", "labels for the high dimensional layout dims">:$labels,
      ArrayRefParameter<"int64_t", "shapes for the high dimensional layout dims">:$shapes
    );
-   let hasCustomAssemblyFormat = 1;
+   let assemblyFormat = "`<` `[` $labels `]` `,` `[` $shapes `]` `>`";
    let genVerifyDecl = 0;
+   let extraClassDeclaration = [{
+      std::optional<int64_t> getShape(const LayoutDimension &dim);
+      bool contains(const LayoutDimension &dim);
+   }];
 }
 
 def LayoutAttr : IREEVectorExt_Attr<"Layout"> {
@@ -64,8 +104,11 @@ def LayoutAttr : IREEVectorExt_Attr<"Layout"> {
   let parameters = (ins
     ArrayRefParameter<"PerDimLayoutAttr", "layout for each dimension of the vector">:$layouts
   );
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "`<`$layouts`>`";
   let genVerifyDecl = 0;
+  let extraClassDeclaration = [{
+    SmallVector<int64_t> getSIMTVectorShape(ArrayRef<LayoutDimension> dims);
+  }];
 }
 
 #endif // IREE_DIALECT_VECTOREXT_BASE

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtDialect.cpp
@@ -32,59 +32,33 @@ void IREEVectorExtDialect::initialize() {
 
 #include "iree-dialects/Dialect/VectorExt/IR/VectorExtDialect.cpp.inc"
 
-// Parses an attribute with syntax
-// <"BatchX"<"VecX", 2>, 4>
-Attribute PerDimLayoutAttr::parse(AsmParser &parser, Type type) {
-  SmallVector<std::string> dimNames;
-  SmallVector<int64_t> dimShapes;
-  std::string name;
-  while (!(parser.parseOptionalLess() || parser.parseOptionalString(&name))) {
-    dimNames.push_back(name);
+bool PerDimLayoutAttr::contains(const LayoutDimension &dim) {
+  for (LayoutDimensionAttr label : getLabels()) {
+    if (label.getValue() == dim)
+      return true;
   }
-  int64_t dim;
-  while (!(parser.parseOptionalComma() || parser.parseInteger(dim) ||
-           parser.parseGreater())) {
-    dimShapes.push_back(dim);
-  }
-  std::reverse(dimShapes.begin(), dimShapes.end());
-  return PerDimLayoutAttr::get(parser.getContext(), dimNames, dimShapes);
+  return false;
 }
 
-void PerDimLayoutAttr::print(AsmPrinter &printer) const {
-  for (auto label : getLabels())
-    printer << "<" << label;
-  for (auto shape : llvm::reverse(getShapes()))
-    printer << ", " << shape << ">";
-}
-
-// Parses an attribute with syntax
-// #layout<<"BatchX"<"VecX", 2>, 4>, <"BatchY"<"VecZ", 4>,2>>>
-Attribute LayoutAttr::parse(AsmParser &parser, Type type) {
-  if (parser.parseLess())
-    return {};
-  SmallVector<PerDimLayoutAttr> layout;
-  PerDimLayoutAttr perDimLayout;
-  while (!(parser.parseAttribute<PerDimLayoutAttr>(perDimLayout, type))) {
-    layout.push_back(perDimLayout);
-    if (parser.parseOptionalComma())
-      break;
+std::optional<int64_t> PerDimLayoutAttr::getShape(const LayoutDimension &dim) {
+  for (auto value : llvm::zip(getLabels(), getShapes())) {
+    if (dim == std::get<0>(value).getValue())
+      return std::get<1>(value);
   }
-  if ((parser.parseGreater()))
-    return {};
-  return LayoutAttr::get(parser.getContext(), layout);
+  return std::nullopt;
 }
 
-static void printArray(AsmPrinter &printer,
-                       ArrayRef<PerDimLayoutAttr> layouts) {
-  printer << "<";
-  for (auto layout : llvm::enumerate(layouts)) {
-    printer << layout.value();
-    if (layout.index() < layouts.size() - 1)
-      printer << ", ";
+// Get the SIMT Vector shape in the order specified by dims. If no dims are
+// specified, then return an empty vector.
+SmallVector<int64_t>
+LayoutAttr::getSIMTVectorShape(ArrayRef<LayoutDimension> dims) {
+  SmallVector<int64_t> simtVectorShape;
+  for (LayoutDimension dim : dims) {
+    for (auto layout : getLayouts()) {
+      if (!layout.contains(dim))
+        continue;
+      simtVectorShape.push_back(layout.getShape(dim).value());
+    }
   }
-  printer << ">";
-}
-
-void LayoutAttr::print(AsmPrinter &printer) const {
-  printArray(printer, getLayouts());
+  return simtVectorShape;
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-dialects-opt --split-input-file --verify-diagnostics %s
 
-#row_layout1 = #iree_vector_ext.per_dim_layout<"BatchX"<"LaneX"<"VecY", 1>, 1>, 1>
-#col_layout1 = #iree_vector_ext.per_dim_layout<"BatchY"<"LaneY"<"VecX", 4>, 2>, 4>
+#row_layout1 = #iree_vector_ext.per_dim_layout<[BATCHX, LANEX, VECTORY], [1, 1, 1]>
+#col_layout1 = #iree_vector_ext.per_dim_layout<[BATCHY, LANEY, VECTORX], [4, 2, 4]>
 #layout1 = #iree_vector_ext.layout<#row_layout1, #col_layout1>
 #layout2 = #iree_vector_ext.layout<#col_layout1, #col_layout1>
 func.func @invalid_desired_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf16>) -> vector<32x32xf16> {
@@ -15,8 +15,8 @@ func.func @invalid_desired_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf1
 
 // -----
 
-#row_layout1 = #iree_vector_ext.per_dim_layout<"BatchX"<"LaneX"<"VecY", 1>, 1>, 1>
-#col_layout1 = #iree_vector_ext.per_dim_layout<"BatchY"<"LaneY"<"VecX", 4>, 2>, 4>
+#row_layout1 = #iree_vector_ext.per_dim_layout<[BATCHX, LANEX, VECTORY], [1, 1, 1]>
+#col_layout1 = #iree_vector_ext.per_dim_layout<[BATCHY, LANEY, VECTORX], [4, 2, 4]>
 #layout1 = #iree_vector_ext.layout<#row_layout1, #col_layout1>
 #layout2 = #iree_vector_ext.layout<#col_layout1, #col_layout1>
 func.func @invalid_source_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf16>) -> vector<32x32xf16> {

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
@@ -1,10 +1,10 @@
 // RUN: iree-dialects-opt --split-input-file %s | FileCheck %s
 
-#row_layout1 = #iree_vector_ext.per_dim_layout<"BatchX"<"LaneX"<"VecY", 2>, 4>, 4>
-#col_layout1 = #iree_vector_ext.per_dim_layout<"BatchY"<"LaneY"<"VecX", 4>, 2>, 4>
+#row_layout1 = #iree_vector_ext.per_dim_layout<[BATCHX, LANEX, VECTORY], [2, 4, 4]>
+#col_layout1 = #iree_vector_ext.per_dim_layout<[BATCHY, LANEY, VECTORX], [4, 2, 4]>
 #layout1 = #iree_vector_ext.layout<#row_layout1, #col_layout1>
 #layout2 = #iree_vector_ext.layout<#col_layout1, #row_layout1>
-func.func @specify_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf16>) -> vector<32x32xf16> {
+func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   %cst_0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
   %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<32x32xf16>, vector<32x32xf16>
@@ -14,9 +14,9 @@ func.func @specify_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf16>) -> v
 
 // CHECK-LABEL: func.func @specify_layout
 // CHECK:      iree_vector_ext.layout_conflict_resolution
-// CHECK:         desiredLayout = #iree_vector_ext.layout<#iree_vector_ext.per_dim_layout<BatchY<LaneY<VecX, 4>, 2>, 4>,
-// CHECK-SAME:                                            #iree_vector_ext.per_dim_layout<BatchX<LaneX<VecY, 2>, 4>, 4>>
-// CHECK:         sourceLayout = #iree_vector_ext.layout<#iree_vector_ext.per_dim_layout<BatchX<LaneX<VecY, 2>, 4>, 4>,
-// CHECK-SAME:                                           #iree_vector_ext.per_dim_layout<BatchY<LaneY<VecX, 4>, 2>, 4>>
+// CHECK:         desiredLayout = #iree_vector_ext.layout<<[ BATCHY, LANEY, VECTORX], [4, 2, 4]>,
+// CHECK-SAME:                                            <[ BATCHX, LANEX, VECTORY], [2, 4, 4]>>
+// CHECK:         sourceLayout = #iree_vector_ext.layout<<[ BATCHX, LANEX, VECTORY], [2, 4, 4]>,
+// CHECK-SAME:                                           <[ BATCHY, LANEY, VECTORX], [4, 2, 4]>>
 
 // -----


### PR DESCRIPTION
This PR updates the layout attribute to use the more generic assembly format for printing and parsing. It also restricts the dimension names to pre-defined enums instead of strings. Finally, we add a helper function to return the shape of the SIMT vector in the order of the dims passes in by the helper function.