### PR TITLE
Fix MacOS pjrt build for cuda/rocm/vulkan

### DIFF
--- a/integrations/pjrt/src/iree_pjrt/cuda/CMakeLists.txt
+++ b/integrations/pjrt/src/iree_pjrt/cuda/CMakeLists.txt
@@ -45,8 +45,8 @@ set_target_properties(iree_pjrt_cuda_dylib
 # TODO: Find a better way to decide whether can link with undefined symbols.
 if(NOT IREE_ENABLE_ASAN)
   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_link_options(iree_pjrt_cpu_dylib PRIVATE "-Wl,-undefined,error")
+    target_link_options(iree_pjrt_cuda_dylib PRIVATE "-Wl,-undefined,error")
   else()
-    target_link_options(iree_pjrt_cpu_dylib PRIVATE "-Wl,--no-undefined")
+    target_link_options(iree_pjrt_cuda_dylib PRIVATE "-Wl,--no-undefined")
   endif()
 endif()

--- a/integrations/pjrt/src/iree_pjrt/rocm/CMakeLists.txt
+++ b/integrations/pjrt/src/iree_pjrt/rocm/CMakeLists.txt
@@ -46,8 +46,8 @@ set_target_properties(iree_pjrt_rocm_dylib
 # TODO: Find a better way to decide whether can link with undefined symbols.
 if(NOT IREE_ENABLE_ASAN)
   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_link_options(iree_pjrt_cpu_dylib PRIVATE "-Wl,-undefined,error")
+    target_link_options(iree_pjrt_rcom_dylib PRIVATE "-Wl,-undefined,error")
   else()
-    target_link_options(iree_pjrt_cpu_dylib PRIVATE "-Wl,--no-undefined")
+    target_link_options(iree_pjrt_rcom_dylib PRIVATE "-Wl,--no-undefined")
   endif()
 endif()

--- a/integrations/pjrt/src/iree_pjrt/rocm/CMakeLists.txt
+++ b/integrations/pjrt/src/iree_pjrt/rocm/CMakeLists.txt
@@ -46,8 +46,8 @@ set_target_properties(iree_pjrt_rocm_dylib
 # TODO: Find a better way to decide whether can link with undefined symbols.
 if(NOT IREE_ENABLE_ASAN)
   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_link_options(iree_pjrt_rcom_dylib PRIVATE "-Wl,-undefined,error")
+    target_link_options(iree_pjrt_rocm_dylib PRIVATE "-Wl,-undefined,error")
   else()
-    target_link_options(iree_pjrt_rcom_dylib PRIVATE "-Wl,--no-undefined")
+    target_link_options(iree_pjrt_rocm_dylib PRIVATE "-Wl,--no-undefined")
   endif()
 endif()

--- a/integrations/pjrt/src/iree_pjrt/vulkan/CMakeLists.txt
+++ b/integrations/pjrt/src/iree_pjrt/vulkan/CMakeLists.txt
@@ -46,8 +46,8 @@ set_target_properties(iree_pjrt_vulkan_dylib
 # TODO: Find a better way to decide whether can link with undefined symbols.
 if(NOT IREE_ENABLE_ASAN)
   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_link_options(iree_pjrt_cpu_dylib PRIVATE "-Wl,-undefined,error")
+    target_link_options(iree_pjrt_vulkan_dylib PRIVATE "-Wl,-undefined,error")
   else()
-    target_link_options(iree_pjrt_cpu_dylib PRIVATE "-Wl,--no-undefined")
+    target_link_options(iree_pjrt_vulkan_dylib PRIVATE "-Wl,--no-undefined")
   endif()
 endif()


### PR DESCRIPTION
Correct copy/paste typos from Commit #15280 where cpu cmake target name  was copied to vulkan, rcom, cuda in

integrations/pjrt/src/iree_pjrt/cuda/CMakeLists.txt
integrations/pjrt/src/iree_pjrt/rocm/CMakeLists.txt
integrations/pjrt/src/iree_pjrt/vulkan/CMakeLists.txt


cuda and rocm targets are currently not available for macOS, but Vulkan can be run, and fails with pre-corrected version.