### PR TITLE
dlsym on darwin already includes '_' cdecl symbol prefix.

### DIFF
--- a/integrations/pjrt/src/iree_pjrt/partitioner_api/loader/loader.cpp
+++ b/integrations/pjrt/src/iree_pjrt/partitioner_api/loader/loader.cpp
@@ -57,14 +57,15 @@ DlHandle loadLibrary(const char *libraryPath) {
   return lib;
 }
 void *lookupLibrarySymbol(DlHandle lib, const char *symbol) {
-  return dlsym(lib, symbol);
+  //note: on macOS, dlsym already prepends CDECL_SYMBOL_PREFIX _
+  return dlsym(lib, symbol); 
 }
 }  // namespace
 #endif
 
 // Some operating systems have a prefix for cdecl exported symbols.
 #if __APPLE__
-#define OPENXLA_PARTITIONER_CDECL_SYMBOL_PREFIX "_"
+#define OPENXLA_PARTITIONER_CDECL_SYMBOL_PREFIX ""
 #else
 #define OPENXLA_PARTITIONER_CDECL_SYMBOL_PREFIX ""
 #endif

--- a/integrations/pjrt/src/iree_pjrt/partitioner_api/loader/loader.cpp
+++ b/integrations/pjrt/src/iree_pjrt/partitioner_api/loader/loader.cpp
@@ -57,17 +57,10 @@ DlHandle loadLibrary(const char *libraryPath) {
   return lib;
 }
 void *lookupLibrarySymbol(DlHandle lib, const char *symbol) {
-  //note: on macOS, dlsym already prepends CDECL_SYMBOL_PREFIX _
-  return dlsym(lib, symbol); 
+  // note: on macOS, dlsym already prepends CDECL_SYMBOL_PREFIX _
+  return dlsym(lib, symbol);
 }
 }  // namespace
-#endif
-
-// Some operating systems have a prefix for cdecl exported symbols.
-#if __APPLE__
-#define OPENXLA_PARTITIONER_CDECL_SYMBOL_PREFIX ""
-#else
-#define OPENXLA_PARTITIONER_CDECL_SYMBOL_PREFIX ""
 #endif
 
 namespace {
@@ -101,8 +94,7 @@ bool openxlaPartitionerLoadLibrary(const char *libraryPath) {
 
   // Resolve the api version separately.
   int (*apiVersionFn)() = (int (*)())lookupLibrarySymbol(
-      localLibraryHandle, OPENXLA_PARTITIONER_CDECL_SYMBOL_PREFIX
-      "openxlaPartitionerGetAPIVersion");
+      localLibraryHandle, "openxlaPartitionerGetAPIVersion");
   if (!apiVersionFn) {
     fprintf(stderr,
             "OpenXLA partitioner ERROR: Could not find symbol "
@@ -115,13 +107,13 @@ bool openxlaPartitionerLoadLibrary(const char *libraryPath) {
   (void)apiMinor;
   (void)apiMajor;
 
-#define HANDLE_SYMBOL(fn_name)                                               \
-  __##fn_name = (decltype(__##fn_name))lookupLibrarySymbol(                  \
-      localLibraryHandle, OPENXLA_PARTITIONER_CDECL_SYMBOL_PREFIX #fn_name); \
-  if (!__##fn_name) {                                                        \
-    fprintf(stderr, "IREE COMPILER ERROR: Could not find symbol '%s'\n",     \
-            OPENXLA_PARTITIONER_CDECL_SYMBOL_PREFIX #fn_name);               \
-    return false;                                                            \
+#define HANDLE_SYMBOL(fn_name)                                                 \
+  __##fn_name = (decltype(__##fn_name))lookupLibrarySymbol(localLibraryHandle, \
+                                                           #fn_name);          \
+  if (!__##fn_name) {                                                          \
+    fprintf(stderr, "IREE COMPILER ERROR: Could not find symbol '%s'\n",       \
+            #fn_name);                                                         \
+    return false;                                                              \
   }
 #define HANDLE_VERSIONED_SYMBOL(fn_name, availApiMajor, availApiMinor) \
   if (apiMajor > availApiMajor ||                                      \


### PR DESCRIPTION
dlsym on darwin resolves symbols automatically prepending _ cdecl symbol prefix. Code incorrectly prepended it on call to dlsym, thus not correctly resolving the symbol. After this fix, the partitioner dylib is correctly loaded and recognised.

man dlsym:

```
DLSYM(3)                                                       Library Functions Manual                                                       DLSYM(3)

NAME
     dlsym – get address of a symbol

SYNOPSIS
     #include <dlfcn.h>

     void*
     dlsym(void* handle, const char* symbol);
[...]
NOTES
     The symbol name passed to dlsym() is the name used in C source code.  For example to find the address of function foo(), you would pass "foo" as
     the symbol name.  This is unlike the older dyld APIs which required a leading underscore.  If you are looking up a C++ symbol, you need to use
     the mangled C++ symbol name.
```
 

This is similar to #15201
