### PR TITLE
Drop `--iree-llvmcpu-enable-microkernels`, replaced by `--iree-llvmcpu-enable-ukernels`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMCPUTarget.cpp
@@ -43,18 +43,6 @@
 #define DEBUG_TYPE "iree-llvm-cpu-target"
 using llvm::dbgs;
 
-// Deprecated: use iree-llvmcpu-enable-ukernels instead.
-//
-// If set to `true`, has the same effect as --iree-llvmcpu-enable-ukernels=all.
-//
-// TODO(ravishankarm): This is redundant w.r.t `iree-vmvx-enable-microkernels`
-// flag. Fold these into either a single flag, or not have the flag at all.
-static llvm::cl::opt<bool> clEnableCPUMicrokernels(
-    "iree-llvmcpu-enable-microkernels",
-    llvm::cl::desc(
-        "Enables microkernel lowering for llvmcpu backend (experimental)"),
-    llvm::cl::init(false));
-
 static llvm::cl::opt<std::string> clEnableCPUUkernels(
     "iree-llvmcpu-enable-ukernels",
     llvm::cl::desc("Enables microkernels in the llvmcpu backend. May be "
@@ -942,9 +930,7 @@ private:
     configAttrs.emplace_back(b.getStringAttr("native_vector_size"),
                              b.getIndexAttr(addlConfig.vectorSize));
 
-    std::string enableUkernels = clEnableCPUMicrokernels.getValue()
-                                     ? "all"
-                                     : clEnableCPUUkernels.getValue();
+    std::string enableUkernels = clEnableCPUUkernels.getValue();
     // Check if microkernels are to be enabled.
     configAttrs.emplace_back(b.getStringAttr("ukernels"),
                              b.getStringAttr(enableUkernels));


### PR DESCRIPTION
This old flag (`-microkernels`) was a boolean. The new flag (`-ukernels`) is a string.

Porting guide:
- If you were passing `--iree-llvmcpu-enable-microkernels` (or equivalently, `...=true`), the equivalent new flag is  `--iree-llvmcpu-enable-ukernels=all`. You may however choose to do  `--iree-llvmcpu-enable-ukernels=mmt4d` instead if you want to only enable the mmt4d ukernel and not all future ukernels that may be added in the future.
- If you were passing `--iree-llvmcpu-enable-microkernels=false`, that was the default behavior anyway so that wasn't having any effect, so you could drop that; however, if you meant to explicitly opt out of ukernels whenever they would become default, the equivalent of that with the new flag is `--iree-llvmcpu-enable-ukernels=none`.

All occurences of the old flag in the IREE repo have already been replaced. Please confirm when it's OK to proceed with this, @mariecwhite @pzread @dcaballe @jpienaar @lundong @hcindyl @banach-space .