### PR TITLE
[CPU][SVE] Update default tiles sizes for matmul ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1008,8 +1008,8 @@ static void getDefaultMatmulVectorSizes(
 
   // Specialisation for SVE.
   if (isAArch64(targetAttr) && hasAnySVEFeature(targetAttr)) {
-    // Mark middle dimensions as scalable, so sizes are (8, [32], 16).
-    sizes.append({8, 32, 16});
+    // Mark middle dimensions as scalable, so sizes are (8, [16], 1).
+    sizes.append({8, 16, 1});
     scalableSizeFlags.append({false, true, false});
     return;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -127,19 +127,17 @@ hal.executable private @matmul_static_tensors_sve  {
       func.func @static_tensors_non_pow_two_sizes() {
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<15x14xf32>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<14x9xf32>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readwrite:tensor<15x9xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<14x7xf32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readwrite:tensor<15x7xf32>>
         %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [15, 14], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<15x14xf32>> -> tensor<15x14xf32>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [14, 9], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<14x9xf32>> -> tensor<14x9xf32>
-        %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [15, 9], strides = [1, 1] : !flow.dispatch.tensor<readwrite:tensor<15x9xf32>> -> tensor<15x9xf32>
-        %6 = linalg.matmul ins(%3, %4 : tensor<15x14xf32>, tensor<14x9xf32>) outs(%5 : tensor<15x9xf32>) -> tensor<15x9xf32>
-        flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [15, 9], strides = [1, 1] : tensor<15x9xf32> -> !flow.dispatch.tensor<readwrite:tensor<15x9xf32>>
-        return
-      }
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [14, 7], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<14x7xf32>> -> tensor<14x7xf32>
+        %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [15, 7], strides = [1, 1] : !flow.dispatch.tensor<readwrite:tensor<15x7xf32>> -> tensor<15x7xf32>
+        %6 = linalg.matmul ins(%3, %4 : tensor<15x14xf32>, tensor<14x7xf32>) outs(%5 : tensor<15x7xf32>) -> tensor<15x7xf32>
+        flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [15, 7], strides = [1, 1] : tensor<15x7xf32> -> !flow.dispatch.tensor<readwrite:tensor<15x7xf32>> return }
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 9, 0], [5, [16], 0], [0, 0, 1], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 7, 0], [5, [8], 0], [0, 0, 1], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @static_tensors_non_pow_two_sizes
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -98,7 +98,7 @@ hal.executable private @matmul_tensors_sve  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [8, [32], 0], [0, 0, 16], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [8, [16], 0], [0, 0, 1], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -139,7 +139,7 @@ hal.executable private @matmul_static_tensors_sve  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 9, 0], [5, [16], 0], [0, 0, 14], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 9, 0], [5, [16], 0], [0, 0, 1], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @static_tensors_non_pow_two_sizes
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
The default tile sizes for SVE for matmuls, [8, 32, 16], are basically a copy of one of the existing configurations. In the case of SVE, that configuration leads to too aggressive unrolling and poor performance due to register spilling. Hence the need to update.

This patch updates the default tile sizes for SVE to [8, 16, 1]. The middle dimension corresponds to vector sizes after vectorisation (that's also the dimension that's configured to be scalable). As the base vector register size for SVE is 128 bits, there will be (depending on the element size):

  * (16 x vscale) elements per vector register for i8,
  * (16 / 2 x vscale) elements per vector registers for i16,
  * (16 / 4 x vscale) elements per vector registers for i32,
  * (...)

So, effectively, 16 is the lowest number that can be used to avoid under utilisation of vector registers (i.e. a lower number might be fine for wider elements, but not for i8).

As for the remaining tile sizes, those were determined experimentally by benchmarking `linalg.matmul` for:

  * square matrices (1020x1020, 1021x1021, 1024x1024),
  * both i8 and f32 element types,
  * input tensors with static and dynamic shapes.

In all the of the above cases, the new configuration improves the performance.

It's probably worth pointing out that during compilation, IREE will reduce the leading tile size from 8 to 6. So, effectively, the tile sizes will be [6, 16, 1].