### PR TITLE
[stablehlo] Add a pass to force scatters to legal areas

### DIFF
--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Passes.cpp
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Passes.cpp
@@ -51,6 +51,10 @@ void buildStableHLOInputConversionPassPipelineImpl(
   }
 
   passManager.addPass(createStableHLOToStableHLOPreprocessing());
+
+  // TODO(suderman): Enable once scatter supports multiple targets:
+  //    passManager.addNestedPass<func::FuncOp>(createLimitScatterBounds());
+
   passManager.addNestedPass<func::FuncOp>(createStableHLOCanonicalize());
 
   // Various shape functions may have been materialized in the `shape.shape_of`

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/BUILD.bazel
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/BUILD.bazel
@@ -66,6 +66,7 @@ iree_compiler_cc_library(
         "FlattenTuplesInCFG.cpp",
         "FlattenTuplesInSCF.cpp",
         "GatherToTorchIndexSelect.cpp",
+        "LimitScatterBounds.cpp",
         "LowerComplex.cpp",
         "Passes.cpp",
         "StableHLOToStableHLO.cpp",

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/BUILD.bazel
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/BUILD.bazel
@@ -89,6 +89,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/CMakeLists.txt
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_cc_library(
     "FlattenTuplesInCFG.cpp"
     "FlattenTuplesInSCF.cpp"
     "GatherToTorchIndexSelect.cpp"
+    "LimitScatterBounds.cpp"
     "LowerComplex.cpp"
     "Passes.cpp"
     "StableHLOToStableHLO.cpp"

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/CMakeLists.txt
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/CMakeLists.txt
@@ -76,6 +76,7 @@ iree_cc_library(
     MLIRControlFlowDialect
     MLIRFuncDialect
     MLIRIR
+    MLIRLinalgDialect
     MLIRMathDialect
     MLIRPass
     MLIRSCFDialect

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/LimitScatterBounds.cpp
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/LimitScatterBounds.cpp
@@ -67,9 +67,9 @@ LogicalResult replaceScatter(mlir::stablehlo::ScatterOp op) {
   llvm::SmallVector<Value> windowBounds;
   {
     int j = 0;
-    for (auto it : llvm::enumerate(isUpdatedWindowDim)) {
-      Value dstSz = b.create<tensor::DimOp>(dest, it.index());
-      if (!it.value()) {
+    for (auto [idx, val] : llvm::enumerate(isUpdatedWindowDim)) {
+      Value dstSz = b.create<tensor::DimOp>(dest, idx);
+      if (!val) {
         windowBounds.push_back(
             b.create<arith::SubIOp>(b.getIndexType(), dstSz, oneIdx));
         continue;

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/LimitScatterBounds.cpp
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/LimitScatterBounds.cpp
@@ -1,0 +1,279 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Implements logic for lowering StableHLO einsum op to dot_general ops.
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo-iree/Conversion/Preprocessing/Passes.h"
+#include "stablehlo-iree/Conversion/Preprocessing/Rewriters.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::iree_compiler::stablehlo {
+
+#define GEN_PASS_DEF_LIMITSCATTERBOUNDS
+#include "stablehlo-iree/Conversion/Preprocessing/Passes.h.inc"
+
+namespace {
+
+LogicalResult replaceScatter(mlir::stablehlo::ScatterOp op) {
+  IRRewriter builder(op.getContext());
+  ImplicitLocOpBuilder b(op.getLoc(), builder);
+  b.setInsertionPoint(op);
+
+  auto dest = op.getInputs().front();
+  auto indices = op.getScatterIndices();
+  auto update0 = op.getUpdates().front();
+
+  auto destTy = cast<ShapedType>(dest.getType());
+  auto indicesTy = cast<ShapedType>(indices.getType());
+  auto update0Ty = cast<ShapedType>(update0.getType());
+
+  auto indicesETy = indicesTy.getElementType();
+  auto indicesShape = indicesTy.getShape();
+
+  auto dimnums = op.getScatterDimensionNumbers();
+  const int64_t rank = destTy.getRank();
+
+  int64_t indexVectorDim = dimnums.getIndexVectorDim();
+
+  // Determine the bound limits for each index:
+  auto updateWindowDims = dimnums.getUpdateWindowDims();
+  auto toOperandDims = dimnums.getScatterDimsToOperandDims();
+  auto insertedWindowDims = dimnums.getInsertedWindowDims();
+
+  llvm::SmallVector<bool> isUpdatedWindowDim(rank, true);
+  for (auto dim : insertedWindowDims) {
+    isUpdatedWindowDim[dim] = false;
+  }
+
+  // This is grabbing all of the update shapes with indices removed:
+  llvm::SmallVector<Value> updateWindowShape;
+  for (auto dim : updateWindowDims) {
+    updateWindowShape.push_back(b.create<tensor::DimOp>(update0, dim));
+  }
+
+  Value oneIdx = b.create<arith::ConstantIndexOp>(1);
+
+  // We subtract the width of the update for each index. For inserted dimensions this is 1.
+  llvm::SmallVector<Value> windowBounds;
+  {
+    int j = 0;
+    for (auto it : llvm::enumerate(isUpdatedWindowDim)) {
+      Value dstSz = b.create<tensor::DimOp>(dest, it.index());
+      if (!it.value()) {
+          windowBounds.push_back(b.create<arith::SubIOp>(b.getIndexType(), dstSz, oneIdx));
+          continue;
+      }
+
+      windowBounds.push_back(b.create<arith::SubIOp>(b.getIndexType(), dstSz, updateWindowShape[j]));
+      ++j;
+    }
+  }
+
+  // Reorder / select the dimensions to the index ordering:
+  llvm::SmallVector<Value> reorderedBounds;
+  for (auto dim : toOperandDims) {
+    reorderedBounds.push_back(b.create<arith::IndexCastOp>(
+        indicesETy, windowBounds[dim]));
+  }
+
+  // Combine the selected dimensions into a small vector for the bounds check:
+  Value dimLimits = b.create<tensor::FromElementsOp>(reorderedBounds);
+
+
+  Value bounded = b.create<tensor::EmptyOp>(indicesShape, indicesETy);
+  Value inbounds =
+      b.create<tensor::EmptyOp>(indicesShape, b.getI1Type());
+  AffineMap boundedMap = b.getMultiDimIdentityMap(indicesTy.getRank());
+
+  llvm::SmallVector<AffineExpr> boundsExpr{b.getAffineDimExpr(indicesTy.getRank() - 1)};
+  AffineMap boundsMap =
+        AffineMap::get(indicesTy.getRank(), 0, boundsExpr, b.getContext());
+
+  SmallVector<utils::IteratorType> indicesIter(indicesTy.getRank(),
+                                               utils::IteratorType::parallel);
+  auto applyLimits = b.create<linalg::GenericOp>(
+      TypeRange{indicesTy, inbounds.getType()}, ValueRange{indices, dimLimits},
+      ValueRange{bounded, inbounds},
+      ArrayRef<AffineMap>{boundedMap, boundsMap, boundedMap, boundedMap}, indicesIter,
+      [](OpBuilder &bb, Location loc, ValueRange args) {
+        ImplicitLocOpBuilder b(loc, bb);
+        Value zero =
+            b.create<arith::ConstantOp>(b.getZeroAttr(args[0].getType()));
+        Value lower =
+            b.create<arith::CmpIOp>(arith::CmpIPredicate::sge, args[0], zero);
+        Value upper =
+            b.create<arith::CmpIOp>(arith::CmpIPredicate::sle, args[0], args[1]);
+        Value within = b.create<arith::AndIOp>(lower, upper);
+        Value sel = b.create<arith::SelectOp>(within, args[0], zero);
+        b.create<linalg::YieldOp>(ValueRange{sel, within});
+      });
+
+  bounded = applyLimits.getResult(0);
+  inbounds = applyLimits.getResult(1);
+
+  // If the index is not implicit we need to reduce away the index vector dim:
+  if (indexVectorDim < indicesTy.getRank()) {
+    ShapedType inTy = cast<ShapedType>(inbounds.getType());
+
+    llvm::SmallVector<AffineExpr> inExprs;
+    llvm::SmallVector<AffineExpr> outExprs;
+    llvm::SmallVector<int64_t> outShape;
+    for (int i = 0; i < inTy.getRank(); ++i) {
+      if (i < indexVectorDim) {
+        inExprs.push_back(b.getAffineDimExpr(outShape.size()));
+        outExprs.push_back(b.getAffineDimExpr(outShape.size()));
+        outShape.push_back(inTy.getDimSize(i));
+      } else {
+        // We need to do a reduction across the last dimension:
+        inExprs.push_back(b.getAffineDimExpr(inTy.getRank() - 1));
+      }
+    }
+
+    AffineMap inMap =
+        AffineMap::get(inExprs.size(), 0, inExprs, b.getContext());
+    AffineMap outMap =
+        AffineMap::get(inExprs.size(), 0, outExprs, b.getContext());
+    Value trueval = b.create<arith::ConstantIntOp>(1, b.getI1Type());
+    Value empty = b.create<tensor::SplatOp>(inTy.clone(outShape), trueval);
+
+    SmallVector<utils::IteratorType> reduceIter(outExprs.size(),
+                                                utils::IteratorType::parallel);
+    reduceIter.push_back(utils::IteratorType::reduction);
+
+    inbounds =
+        b.create<linalg::GenericOp>(
+             TypeRange{empty.getType()}, ValueRange{inbounds},
+             ValueRange{empty}, ArrayRef<AffineMap>{inMap, outMap}, reduceIter,
+             [](OpBuilder &bb, Location loc, ValueRange args) {
+               Value andOp = bb.create<arith::AndIOp>(loc, args[0], args[1]);
+               bb.create<linalg::YieldOp>(loc, andOp);
+             })
+            .getResult(0);
+  }
+
+  if (cast<ShapedType>(inbounds.getType()).getRank() < update0Ty.getRank()) {
+    llvm::SmallVector<bool> isBatchDim(update0Ty.getRank(), true);
+    for (auto dim : updateWindowDims) {
+      isBatchDim[dim] = false;
+    }
+
+    llvm::SmallVector<AffineExpr> inExprs;
+    for (int i = 0; i < isBatchDim.size(); i++) {
+      if (isBatchDim[i]) {
+        inExprs.push_back(b.getAffineDimExpr(i));
+      }
+    }
+
+    ShapedType outTy = update0Ty.clone(b.getI1Type());
+    AffineMap inMap =
+        AffineMap::get(outTy.getRank(), 0, inExprs, b.getContext());
+    AffineMap outMap = b.getMultiDimIdentityMap(outTy.getRank());
+
+    SmallVector<utils::IteratorType> iters(outTy.getRank(),
+                                           utils::IteratorType::parallel);
+
+    Value empty =
+        b.create<tensor::EmptyOp>(outTy.getShape(), outTy.getElementType());
+    inbounds =
+        b.create<linalg::GenericOp>(
+             TypeRange{empty.getType()}, ValueRange{inbounds},
+             ValueRange{empty}, ArrayRef<AffineMap>{inMap, outMap}, iters,
+             [](OpBuilder &bb, Location loc, ValueRange args) {
+               bb.create<linalg::YieldOp>(loc, args[0]);
+             })
+            .getResult(0);
+  }
+
+  llvm::SmallVector<Value> newInputs(op.getInputs());
+
+  ShapedType inputTy = cast<ShapedType>(newInputs.front().getType());
+  Value emptyBool =
+      b.create<tensor::EmptyOp>(inputTy.getShape(), b.getI1Type());
+  newInputs.push_back(emptyBool);
+
+  llvm::SmallVector<Value> newUpdates(op.getUpdates());
+  newUpdates.push_back(inbounds);
+
+  llvm::SmallVector<Type> newResultTys(op.getResultTypes());
+  newResultTys.push_back(emptyBool.getType());
+
+  auto scatter = b.create<mlir::stablehlo::ScatterOp>(
+      newResultTys, newInputs, bounded, newUpdates, dimnums,
+      op.getIndicesAreSorted(), op.getUniqueIndices());
+
+  // Replace the existing yield with conditional results and the boolean update:
+  for (int i = 0; i < op.getNumResults(); ++i) {
+    op.getResult(i).replaceAllUsesWith(scatter.getResult(i));
+  }
+
+  // Clone the region into the new scatter and insert the new boolean udpates:
+  Region &srcRegion = op.getUpdateComputation();
+  Region &dstRegion = scatter.getUpdateComputation();
+
+  IRMapping mapping;
+  srcRegion.cloneInto(&dstRegion, mapping);
+
+  const int64_t numUpdates = op.getUpdates().size();
+  dstRegion.front().insertArgument(
+      numUpdates * 2, RankedTensorType::get({}, b.getI1Type()), op.getLoc());
+  dstRegion.front().insertArgument(
+      numUpdates, RankedTensorType::get({}, b.getI1Type()), op.getLoc());
+
+  // Update the return to only conditionally return the new value:
+  Operation *terminator = dstRegion.front().getTerminator();
+  b.setInsertionPoint(terminator);
+
+  Value argInbounds = dstRegion.front().getArguments().back();
+  llvm::SmallVector<Value> terminatorOperands;
+  for (int i = 0; i < terminator->getNumOperands(); ++i) {
+    auto newArg =
+        b.create<arith::SelectOp>(argInbounds, terminator->getOperand(i),
+                                  dstRegion.front().getArgument(i));
+
+    terminatorOperands.push_back(newArg);
+  }
+
+  terminatorOperands.push_back(argInbounds);
+  b.create<mlir::stablehlo::ReturnOp>(op.getLoc(), terminatorOperands);
+
+  // Cleanup the no longer needed operations:
+  terminator->erase();
+  op.erase();
+
+  return success();
+}
+
+struct LimitScatterBounds final
+    : impl::LimitScatterBoundsBase<LimitScatterBounds> {
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, mlir::arith::ArithDialect,
+                    tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    auto operation = getOperation();
+    llvm::SmallVector<mlir::stablehlo::ScatterOp> scatters;
+    operation.walk([&scatters](mlir::stablehlo::ScatterOp scatter) {
+      scatters.push_back(scatter);
+    });
+
+    for (auto scatter : scatters) {
+      if (failed(replaceScatter(scatter))) {
+        return signalPassFailure();
+      }
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler::stablehlo

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/Passes.td
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/Passes.td
@@ -53,6 +53,11 @@ def LowerComplex :
   let summary = "Lowers complex operations into non-complex operations";
 }
 
+def LimitScatterBounds :
+    Pass<"iree-stablehlo-limit-scatter-bounds", "func::FuncOp"> {
+  let summary = "Forces scatters to be within bounds";
+}
+
 def UnfuseBatchNorm :
     Pass<"iree-stablehlo-preprocessing-unfuse-batch-norm", "func::FuncOp"> {
   let summary = "Materializes 'broadcast_dimensions' attributes";

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/BUILD.bazel
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/BUILD.bazel
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "flatten_tuples_in_cfg.mlir",
             "flatten_tuples_in_scf.mlir",
             "gather_to_torch_index_select.mlir",
+            "limit_scatter.mlir",
             "stablehlo_to_stablehlo.mlir",
             "unfuse_batch_norm.mlir",
         ],

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/CMakeLists.txt
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "flatten_tuples_in_cfg.mlir"
     "flatten_tuples_in_scf.mlir"
     "gather_to_torch_index_select.mlir"
+    "limit_scatter.mlir"
     "stablehlo_to_stablehlo.mlir"
     "unfuse_batch_norm.mlir"
   TOOLS

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/limit_scatter.mlir
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/limit_scatter.mlir
@@ -65,7 +65,7 @@ func.func @limit_scatter(%arg0 : tensor<10x3x8xi32>, %arg1 : tensor<4x2xi32>, %a
   // CHECK: %[[SCATTER:.+]]:2 = "stablehlo.scatter"(%arg0, %[[SCATTER_BOUND]], %[[BOUND]]#0, %arg2, %[[BROADCAST]])
 
   // CHECK: ^bb0(%[[A0:.+]]: tensor<i32>, %[[A1:.+]]: tensor<i1>, %[[A2:.+]]: tensor<i32>, %[[A3:.+]]: tensor<i1>):
-  // CHECK:   %[[SEL:.+]] = arith.select %[[A3]], %[[A2]], %[[A0]]
+  // CHECK:   %[[SEL:.+]] = stablehlo.select %[[A3]], %[[A2]], %[[A0]]
   // CHECK:   stablehlo.return %[[SEL]], %[[A3]]
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ( {
   ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/limit_scatter.mlir
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/limit_scatter.mlir
@@ -1,12 +1,12 @@
 // RUN: iree-opt --iree-stablehlo-limit-scatter-bounds --cse %s | FileCheck %s
 
-// CHECK: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
-// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d1)>
-// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
-// CHECK: #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0)>
-// CHECK: #[[MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 
-// CHECK-LABEL: @limit_scatter
+// CHECK: @limit_scatter
 func.func @limit_scatter(%arg0 : tensor<10x3x8xi32>, %arg1 : tensor<4x2xi32>, %arg2 : tensor<4x2x8xi32>) -> tensor<10x3x8xi32> {
   // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
   // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/limit_scatter.mlir
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/limit_scatter.mlir
@@ -1,0 +1,86 @@
+// RUN: iree-opt --iree-stablehlo-limit-scatter-bounds --cse %s | FileCheck %s
+
+// CHECK: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK: #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0)>
+// CHECK: #[[MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+// CHECK-LABEL: @limit_scatter
+func.func @limit_scatter(%arg0 : tensor<10x3x8xi32>, %arg1 : tensor<4x2xi32>, %arg2 : tensor<4x2x8xi32>) -> tensor<10x3x8xi32> {
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+  // CHECK-DAG: %[[IND0:.+]] = tensor.dim %arg0, %[[C0]]
+  // CHECK-DAG: %[[IND1:.+]] = tensor.dim %arg0, %[[C1]]
+  // CHECK-DAG: %[[IND2:.+]] = tensor.dim %arg0, %[[C2]]
+  // CHECK-DAG: %[[UPD1:.+]] = tensor.dim %arg2, %[[C1]]
+  // CHECK-DAG: %[[UPD2:.+]] = tensor.dim %arg2, %[[C2]]
+  // CHECK-DAG: %[[SUB0:.+]] = arith.subi %[[IND0]], %[[UPD1]]
+  // CHECK-DAG: %[[SUB1:.+]] = arith.subi %[[IND1]], %[[C1]]
+  // CHECK-DAG: %[[CAST0:.+]] = arith.index_cast %[[SUB1]]
+  // CHECK-DAG: %[[CAST1:.+]] = arith.index_cast %[[SUB0]]
+  // CHECK: %[[LIMITS:.+]] = tensor.from_elements %[[CAST0]], %[[CAST1]]
+
+
+  // We check the indices agains the bounds and save out whether a bound was
+  // violated and force it within bounds if it was:
+  // CHECK: %[[EMPTY_IND:.+]] = tensor.empty() : tensor<4x2xi32>
+  // CHECK: %[[EMPTY_BOUNDS:.+]] = tensor.empty() : tensor<4x2xi1>
+
+  // CHECK: %[[BOUND:.+]]:2 = linalg.generic 
+  // CHECK-SAME: indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP0]], #[[MAP0]]]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel"]}
+  // CHECK-SAME: ins(%arg1, %[[LIMITS]] : tensor<4x2xi32>, tensor<2xi32>)
+  // CHECK-SAME: outs(%[[EMPTY_IND]], %[[EMPTY_BOUNDS]] : tensor<4x2xi32>, tensor<4x2xi1>)
+  // CHECK: ^bb0(%[[IN0:.+]]: i32, %[[IN1:.+]]: i32, %[[OUT0:.+]]: i32, %[[OUT1:.+]]: i1):
+  // CHECK:   %[[I0:.+]] = arith.constant 0 : i32
+  // CHECK:   %[[GE:.+]] = arith.cmpi sge, %[[IN0]], %[[I0]]
+  // CHECK:   %[[LE:.+]] = arith.cmpi sle, %[[IN0]], %[[IN1]]
+  // CHECK:   %[[AND:.+]] = arith.andi %[[GE]], %[[LE]]
+  // CHECK:   %[[SEL:.+]] = arith.select %[[AND]], %[[IN0]], %[[I0]] : i32
+  // CHECK:   linalg.yield %[[SEL]], %[[AND]] : i32, i1
+
+  // CHECK: %[[TRUE:.+]] = arith.constant true
+  // CHECK: %[[SPLAT:.+]] = tensor.splat %[[TRUE]]
+  // CHECK: %[[REDUCE:.+]] = linalg.generic
+  // CHECK-SAME: indexing_maps = [#[[MAP0]], #[[MAP2]]]
+  // CHECK-SAME: iterator_types = ["parallel", "reduction"]}
+  // CHECK-SAME: ins(%[[BOUND]]#1 : tensor<4x2xi1>)
+  // CHECK-SAME: outs(%[[SPLAT]] : tensor<4xi1>)
+  // CHECK: ^bb0(%[[IN:.+]]: i1, %[[OUT:.+]]: i1):
+  // CHECK:   %[[AND:.+]] = arith.andi %[[IN]], %[[OUT]] : i1
+  // CHECK:   linalg.yield %[[AND]]
+
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<4x2x8xi1>
+  // CHECK: %[[BROADCAST:.+]] = linalg.generic
+  // CHECK-SAME: indexing_maps = [#map3, #map4]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel"]}
+  // CHECK-SAME: ins(%[[REDUCE]] : tensor<4xi1>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<4x2x8xi1>)
+  // CHECK: ^bb0(%[[IN:.+]]: i1, %[[OUT:.+]]: i1):
+  // CHECK:   linalg.yield %[[IN]]
+
+  // CHECK:  %[[SCATTER_BOUND:.+]] = tensor.empty() : tensor<10x3x8xi1>
+  // CHECK: %[[SCATTER:.+]]:2 = "stablehlo.scatter"(%arg0, %[[SCATTER_BOUND]], %[[BOUND]]#0, %arg2, %[[BROADCAST]])
+
+  // CHECK: ^bb0(%[[A0:.+]]: tensor<i32>, %[[A1:.+]]: tensor<i1>, %[[A2:.+]]: tensor<i32>, %[[A3:.+]]: tensor<i1>):
+  // CHECK:   %[[SEL:.+]] = arith.select %[[A3]], %[[A2]], %[[A0]]
+  // CHECK:   stablehlo.return %[[SEL]], %[[A3]]
+  %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "stablehlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1, 2],
+      inserted_window_dims = [1],
+      scatter_dims_to_operand_dims = [1, 0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = false
+  } : (tensor<10x3x8xi32>, tensor<4x2xi32>, tensor<4x2x8xi32>) -> tensor<10x3x8xi32>
+
+  // CHECK: return %[[SCATTER]]#0
+  return %0 : tensor<10x3x8xi32>
+}


### PR DESCRIPTION
`stablehlo.scatter` allows scattering outside of the tensor bounds. In these cases the scatter is a no-op, even if only partially outside of the bounds. Make this change by validating indices, forcing within bounds and conditionally updating values. This also forces non-unique indices as multiple out of bounds regions may overlap when conditionally applied.