### PR TITLE
Adding support for `#util.uninitialized` globals.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/global_ops.mlir
@@ -50,6 +50,27 @@ func.func @initializedGlobal() {
 
 // -----
 
+//  CHECK-DAG: util.global private mutable @var_with_tensor_uninitialized : !stream.resource<variable>
+//  CHECK-DAG: util.global private mutable @var_with_tensor_uninitialized__size : index
+// CHECK-NEXT: util.initializer {
+// CHECK-NEXT:   %[[SIZE:.+]] = stream.tensor.sizeof tensor<4xf32>
+// CHECK-NEXT:   %[[EMPTY:.+]] = stream.tensor.empty : tensor<4xf32> in !stream.resource<variable>{%[[SIZE]]}
+//  CHECK-DAG:   util.global.store %[[EMPTY]], @var_with_tensor_uninitialized : !stream.resource<variable>
+//  CHECK-DAG:   util.global.store %[[SIZE]], @var_with_tensor_uninitialized__size : index
+util.global private mutable @var_with_tensor_uninitialized = #util.uninitialized : tensor<4xf32>
+// CHECK-LABEL: @uninitializedGlobalTensor
+func.func @uninitializedGlobalTensor() {
+  // CHECK-DAG: = util.global.load @var_with_tensor_uninitialized : !stream.resource<variable>
+  // CHECK-DAG: = util.global.load @var_with_tensor_uninitialized__size : index
+  %0 = util.global.load @var_with_tensor_uninitialized : tensor<4xf32>
+  // CHECK-DAG: util.global.store %{{.+}}, @var_with_tensor_uninitialized : !stream.resource<variable>
+  // CHECK-DAG: util.global.store %{{.+}}, @var_with_tensor_uninitialized__size : index
+  util.global.store %0, @var_with_tensor_uninitialized : tensor<4xf32>
+  return
+}
+
+// -----
+
 // Checks that the implicit cast allowing a buffer_view to store into a variable
 // that maps to a buffer is permitted.
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -714,6 +714,18 @@ LogicalResult CompositeAttr::serializeToStream(Location loc,
 }
 
 //===----------------------------------------------------------------------===//
+// #util.uninitialized
+//===----------------------------------------------------------------------===//
+
+int64_t UninitializedAttr::getStorageSize() const {
+  if (auto shapedType = getType().dyn_cast<ShapedType>()) {
+    return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
+  } else {
+    return IREE::Util::getTypePhysicalStorageBitWidth(getType());
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // SizedStorageAttr implementations
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
@@ -110,4 +110,30 @@ def Util_CompositeAttr : AttrDef<Util_Dialect, "Composite", [
   let hasCustomAssemblyFormat = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// #util.uninitialized
+//===----------------------------------------------------------------------===//
+
+def Util_UninitializedAttr : AttrDef<Util_Dialect, "Uninitialized", [
+  TypedAttrInterface,
+  DeclareAttrInterfaceMethods<Util_SizedStorageAttr, [
+    "getStorageSize",
+  ]>,
+]> {
+  let mnemonic = "uninitialized";
+  let summary = [{an attribute specifying uninitialized storage}];
+  let description = [{
+    The contents of the storage backing this attribute _may_ be uninitialized at
+    runtime. This is a hint to implementations that if policy allows memory
+    allocated for the storage of this attribute type is allowed to have
+    undefined contents upon return.
+  }];
+
+  let parameters = (ins
+    AttributeSelfTypeParameter<"">:$type
+  );
+
+  let assemblyFormat = [{}];
+}
+
 #endif  // IREE_DIALECT_UTIL_IR_UTIL_ATTRS

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/attributes.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/attributes.mlir
@@ -39,3 +39,13 @@ builtin.module @composite attributes {
     dense<[2, 3]> : vector<2xi8>,
   ]>
 } {}
+
+// -----
+
+// CHECK-LABEL: @uninitialized
+builtin.module @uninitialized attributes {
+  // CHECK: util.i32 = #util.uninitialized : i32
+  util.i32 = #util.uninitialized : i32,
+  // CHECK: util.tensor = #util.uninitialized : tensor<4xf32>
+  util.tensor = #util.uninitialized : tensor<4xf32>
+} {}

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
@@ -60,6 +60,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Operation *newOp = nullptr;
     auto convertedType = typeConverter.convertType(op.getType());
+    const bool isInitialized =
+        op.getInitialValueAttr() &&
+        !isa<IREE::Util::UninitializedAttr>(op.getInitialValueAttr());
     if (llvm::isa<IREE::VM::RefType>(convertedType) ||
         IREE::VM::RefType::isCompatible(convertedType)) {
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalRefOp>(
@@ -67,7 +70,7 @@ public:
           llvm::to_vector(op->getDialectAttrs()));
     } else if (convertedType.isInteger(32)) {
       std::optional<TypedAttr> convertedValue = std::nullopt;
-      if (op.getInitialValue().has_value()) {
+      if (isInitialized) {
         convertedValue = rewriter.getI32IntegerAttr(static_cast<int32_t>(
             llvm::cast<IntegerAttr>(op.getInitialValue().value()).getInt()));
       }
@@ -76,7 +79,7 @@ public:
           llvm::to_vector(op->getDialectAttrs()));
     } else if (convertedType.isInteger(64)) {
       std::optional<TypedAttr> convertedValue = std::nullopt;
-      if (op.getInitialValue().has_value()) {
+      if (isInitialized) {
         convertedValue = rewriter.getI64IntegerAttr(
             llvm::cast<IntegerAttr>(op.getInitialValue().value()).getInt());
       }
@@ -85,7 +88,7 @@ public:
           llvm::to_vector(op->getDialectAttrs()));
     } else if (convertedType.isF32()) {
       std::optional<TypedAttr> convertedValue = std::nullopt;
-      if (op.getInitialValue().has_value()) {
+      if (isInitialized) {
         convertedValue = rewriter.getF32FloatAttr(static_cast<float>(
             llvm::cast<FloatAttr>(op.getInitialValue().value())
                 .getValueAsDouble()));
@@ -95,7 +98,7 @@ public:
           llvm::to_vector(op->getDialectAttrs()));
     } else if (convertedType.isF64()) {
       std::optional<TypedAttr> convertedValue = std::nullopt;
-      if (op.getInitialValue().has_value()) {
+      if (isInitialized) {
         convertedValue = rewriter.getF64FloatAttr(
             llvm::cast<FloatAttr>(op.getInitialValue().value())
                 .getValueAsDouble());

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/global_ops.mlir
@@ -6,6 +6,12 @@ util.global @v_initialized_const = 4 : i32
 // CHECK: vm.global.i32 private @v_private_const = 5 : i32
 util.global private @v_private_const = 5 : i32
 
+// CHECK: vm.global.i32 private @v_uninitialized : i32
+util.global private @v_uninitialized = #util.uninitialized : i32
+
+// CHECK: vm.global.ref private @v_uninitialized_ref : !vm.ref<!hal.buffer>
+util.global private @v_uninitialized_ref = #util.uninitialized : !vm.ref<!hal.buffer>
+
 // -----
 
 // CHECK: vm.global.ref public @v_initialized : !vm.ref<!hal.buffer>


### PR DESCRIPTION
This allows global tensors to be initialized with `tensor.empty` semantics useful for model state that will be overwritten by the model itself prior to any reads. HAL implementations are still allowed to initialize the memory but use of the attr in the compiler indicates the program doesn't require them to do so.