### PR TITLE
Correct the example demonstrating the use of iree-opt

### DIFF
--- a/docs/website/docs/developers/general/developer-overview.md
+++ b/docs/website/docs/developers/general/developer-overview.md
@@ -88,7 +88,7 @@ Here's an example of a small compiler pass running on a
 $ ../iree-build/tools/iree-opt \
   --split-input-file \
   --mlir-print-ir-before-all \
-  --iree-drop-compiler-hints \
+  --iree-util-drop-compiler-hints \
   $PWD/compiler/src/iree/compiler/Dialect/Util/Transforms/test/drop_compiler_hints.mlir
 ```
 


### PR DESCRIPTION
In the developer overview documentation, and in the example for using iree-opt, the argument --iree-drop-compiler-hints has to be updated to --iree-util-drop-compiler-hints.