### PR TITLE
Adding iree_io_stream_t and memory stream implementation.

### DIFF
--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -115,6 +115,17 @@ static inline bool iree_device_size_has_alignment(
   return iree_device_align(value, alignment) == value;
 }
 
+// Returns true if |value| is a power-of-two.
+static inline bool iree_is_power_of_two_uint64(uint64_t value) {
+  return (value != 0) && ((value & (value - 1)) == 0);
+}
+
+// Aligns |value| up to the given power-of-two |alignment| if required.
+// https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+static inline uint64_t iree_align_uint64(uint64_t value, uint64_t alignment) {
+  return (value + (alignment - 1)) & ~(alignment - 1);
+}
+
 // Returns the size of a struct padded out to iree_max_align_t.
 // This must be used when performing manual trailing allocation packing to
 // ensure the alignment requirements of the trailing data are satisfied.

--- a/runtime/src/iree/io/BUILD.bazel
+++ b/runtime/src/iree/io/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -85,5 +85,30 @@ iree_runtime_cc_library(
         ":parameter_index",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",
+    ],
+)
+
+iree_runtime_cc_library(
+    name = "stream",
+    srcs = [
+        "stream.c",
+    ],
+    hdrs = [
+        "stream.h",
+    ],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "stream_test",
+    srcs = ["stream_test.cc"],
+    deps = [
+        ":stream",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )

--- a/runtime/src/iree/io/CMakeLists.txt
+++ b/runtime/src/iree/io/CMakeLists.txt
@@ -81,4 +81,29 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    stream
+  HDRS
+    "stream.h"
+  SRCS
+    "stream.c"
+  DEPS
+    iree::base
+    iree::base::internal
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    stream_test
+  SRCS
+    "stream_test.cc"
+  DEPS
+    ::stream
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/io/formats/gguf/gguf_format.c
+++ b/runtime/src/iree/io/formats/gguf/gguf_format.c
@@ -409,10 +409,6 @@ typedef struct iree_io_gguf_parser_t {
   uint64_t tensor_data_size;
 } iree_io_gguf_parser_t;
 
-static inline uint64_t iree_align_uint64(uint64_t value, uint64_t alignment) {
-  return (value + (alignment - 1)) & ~(alignment - 1);
-}
-
 static iree_status_t iree_io_gguf_calculate_storage_size(
     const gguf_tensor_info_t* tensor_info, uint64_t* out_storage_size) {
   *out_storage_size = 0;

--- a/runtime/src/iree/io/stream.c
+++ b/runtime/src/iree/io/stream.c
@@ -1,0 +1,608 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/io/stream.h"
+
+// This is arbitrary - we should allow dynamic block sizes and such but keeping
+// this small only requires a reasonable fixed size stack alloc.
+#define IREE_IO_STREAM_COPY_BLOCK_SIZE (16 * 1024)
+
+//===----------------------------------------------------------------------===//
+// Stream utilities
+//===----------------------------------------------------------------------===//
+
+static const char* iree_io_stream_seek_mode_string(
+    iree_io_stream_seek_mode_t seek_mode) {
+  switch (seek_mode) {
+    case IREE_IO_STREAM_SEEK_SET:
+      return "set";
+    case IREE_IO_STREAM_SEEK_FROM_CURRENT:
+      return "from-current";
+    case IREE_IO_STREAM_SEEK_FROM_END:
+      return "from-end";
+    default:
+      return "?";
+  }
+}
+
+static iree_string_view_t iree_io_stream_mode_format(
+    iree_io_stream_mode_t value, iree_bitfield_string_temp_t* out_temp) {
+  static const iree_bitfield_string_mapping_t mappings[] = {
+      {IREE_IO_STREAM_MODE_READABLE, IREE_SVL("READABLE")},
+      {IREE_IO_STREAM_MODE_WRITABLE, IREE_SVL("WRITABLE")},
+      {IREE_IO_STREAM_MODE_RESIZABLE, IREE_SVL("RESIZABLE")},
+      {IREE_IO_STREAM_MODE_SEEKABLE, IREE_SVL("SEEKABLE")},
+      {IREE_IO_STREAM_MODE_MAPPABLE, IREE_SVL("MAPPABLE")},
+  };
+  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
+                                     out_temp);
+}
+
+// Validates that all bits in |required_mode| are available in |allowed_mode|.
+static iree_status_t iree_io_stream_validate_mode(
+    iree_io_stream_mode_t allowed_mode, iree_io_stream_mode_t required_mode) {
+  if (!iree_all_bits_set(allowed_mode, required_mode)) {
+#if IREE_STATUS_MODE
+    iree_bitfield_string_temp_t temp0, temp1;
+    iree_string_view_t required_mode_str =
+        iree_io_stream_mode_format(required_mode, &temp0);
+    iree_string_view_t allowed_mode_str =
+        iree_io_stream_mode_format(allowed_mode, &temp1);
+    return iree_make_status(
+        IREE_STATUS_PERMISSION_DENIED,
+        "operation requires mode '%.*s' but stream was opened with '%.*s'",
+        (int)required_mode_str.size, required_mode_str.data,
+        (int)allowed_mode_str.size, allowed_mode_str.data);
+#else
+    return iree_status_from_code(IREE_STATUS_PERMISSION_DENIED);
+#endif  // IREE_STATUS_MODE
+  }
+  return iree_ok_status();
+}
+
+// Validates that at least |access_length| bytes are available at the current
+// stream offset. If the optional |out_available_length| is provided the
+// available length will be returned matching the requested |access_length| or
+// the maximum remaining length to the caller with an OK status even if the full
+// |access_length| is not available and otherwise an error is returned.
+static iree_status_t iree_io_stream_validate_fixed_range(
+    iree_io_stream_pos_t stream_offset, iree_io_stream_pos_t stream_length,
+    iree_io_stream_pos_t access_length,
+    iree_io_stream_pos_t* out_available_length) {
+  if (out_available_length) *out_available_length = 0;
+
+  iree_io_stream_pos_t remaining_length = stream_length - stream_offset;
+  if (access_length > remaining_length) {
+    // Access exceeds remaining length.
+    if (out_available_length) {
+      // Let caller know how much is available and return OK so they can use it.
+      *out_available_length = remaining_length;
+      return iree_ok_status();
+    }
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "access to range [%" PRIu64 ", %" PRIu64
+                            ") (%" PRIu64
+                            " bytes) out of range; stream offset %" PRIu64
+                            " and length %" PRIu64 " insufficient",
+                            stream_offset, stream_offset + access_length,
+                            access_length, stream_offset, stream_length);
+  }
+
+  if (out_available_length) *out_available_length = access_length;
+  return iree_ok_status();
+}
+
+// Applies a seek operation with |seek_mode| and |seek_offset| against a stream.
+// |out_stream_offset| will contain the position after the seek or an error will
+// be returned if the seek could not be completed.
+static iree_status_t iree_io_stream_apply_fixed_seek(
+    iree_io_stream_pos_t stream_offset, iree_io_stream_pos_t stream_length,
+    iree_io_stream_seek_mode_t seek_mode, iree_io_stream_pos_t seek_offset,
+    iree_io_stream_pos_t* out_stream_offset) {
+  *out_stream_offset = stream_offset;
+
+  iree_io_stream_pos_t new_offset = stream_offset;
+  switch (seek_mode) {
+    case IREE_IO_STREAM_SEEK_SET:
+      new_offset = seek_offset;
+      break;
+    case IREE_IO_STREAM_SEEK_FROM_CURRENT:
+      new_offset = stream_offset + seek_offset;
+      break;
+    case IREE_IO_STREAM_SEEK_FROM_END:
+      new_offset = stream_length + seek_offset;
+      break;
+    default:
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "unrecognized seek mode %u", (uint32_t)seek_mode);
+  }
+
+  if (new_offset < 0 || new_offset > stream_length) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "seek %s offset %" PRIi64
+                            " out of stream bounds; expected 0 <= %" PRIi64
+                            " < %" PRIi64,
+                            iree_io_stream_seek_mode_string(seek_mode),
+                            seek_offset, new_offset, stream_length);
+  }
+
+  *out_stream_offset = new_offset;
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_io_stream_t
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT void iree_io_stream_retain(iree_io_stream_t* stream) {
+  if (IREE_LIKELY(stream)) {
+    iree_atomic_ref_count_inc(&stream->ref_count);
+  }
+}
+
+IREE_API_EXPORT void iree_io_stream_release(iree_io_stream_t* stream) {
+  if (IREE_LIKELY(stream) &&
+      iree_atomic_ref_count_dec(&stream->ref_count) == 1) {
+    IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_io_stream_destroy");
+    stream->vtable->destroy(stream);
+    IREE_TRACE_ZONE_END(z0);
+  }
+}
+
+IREE_API_EXPORT iree_io_stream_mode_t
+iree_io_stream_mode(const iree_io_stream_t* stream) {
+  IREE_ASSERT_ARGUMENT(stream);
+  return stream->mode;
+}
+
+IREE_API_EXPORT iree_io_stream_pos_t
+iree_io_stream_offset(iree_io_stream_t* stream) {
+  IREE_ASSERT_ARGUMENT(stream);
+  return stream->vtable->offset(stream);
+}
+
+IREE_API_EXPORT iree_io_stream_pos_t
+iree_io_stream_length(iree_io_stream_t* stream) {
+  IREE_ASSERT_ARGUMENT(stream);
+  return stream->vtable->length(stream);
+}
+
+IREE_API_EXPORT bool iree_io_stream_is_eos(iree_io_stream_t* stream) {
+  IREE_ASSERT_ARGUMENT(stream);
+  return stream->vtable->offset(stream) == stream->vtable->length(stream);
+}
+
+IREE_API_EXPORT iree_status_t iree_io_stream_seek(
+    iree_io_stream_t* stream, iree_io_stream_seek_mode_t seek_mode,
+    iree_io_stream_pos_t offset) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, iree_io_stream_seek_mode_string(seek_mode));
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)offset);
+  iree_status_t status = stream->vtable->seek(stream, seek_mode, offset);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_io_stream_seek_to_alignment(
+    iree_io_stream_t* stream, iree_io_stream_pos_t alignment) {
+  IREE_ASSERT_ARGUMENT(stream);
+  if (alignment == 0) return iree_ok_status();
+  if (!iree_is_power_of_two_uint64(alignment)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "alignment %" PRIu64 " not a power of two",
+                            alignment);
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)alignment);
+  iree_io_stream_pos_t current_offset = iree_io_stream_offset(stream);
+  iree_io_stream_pos_t aligned_offset =
+      iree_align_uint64(current_offset, alignment);
+  iree_status_t status = iree_ok_status();
+  if (current_offset != aligned_offset) {
+    status =
+        iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, aligned_offset);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_io_stream_read(iree_io_stream_t* stream, iree_host_size_t buffer_capacity,
+                    void* buffer, iree_host_size_t* out_buffer_length) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(!buffer_capacity || buffer);
+  if (out_buffer_length) *out_buffer_length = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_io_stream_validate_mode(iree_io_stream_mode(stream),
+                                   IREE_IO_STREAM_MODE_READABLE),
+      "reading from the stream");
+  if (buffer_capacity == 0) return iree_ok_status();
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)buffer_capacity);
+  iree_status_t status =
+      stream->vtable->read(stream, buffer_capacity, buffer, out_buffer_length);
+  if (out_buffer_length) {
+    IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)*out_buffer_length);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_io_stream_write(iree_io_stream_t* stream, iree_host_size_t buffer_length,
+                     const void* buffer) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(!buffer_length || buffer);
+  IREE_RETURN_IF_ERROR(
+      iree_io_stream_validate_mode(iree_io_stream_mode(stream),
+                                   IREE_IO_STREAM_MODE_WRITABLE),
+      "writing to the stream");
+  if (!buffer_length) return iree_ok_status();
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)buffer_length);
+  iree_status_t status = stream->vtable->write(stream, buffer_length, buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_io_stream_fill(iree_io_stream_t* stream, iree_io_stream_pos_t count,
+                    const void* pattern, iree_host_size_t pattern_length) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(!pattern_length || pattern);
+  IREE_RETURN_IF_ERROR(
+      iree_io_stream_validate_mode(iree_io_stream_mode(stream),
+                                   IREE_IO_STREAM_MODE_WRITABLE),
+      "writing to the stream");
+  switch (pattern_length) {
+    case 1:
+    case 2:
+    case 4:
+    case 8:
+      break;
+    default:
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "unsupported fill pattern length: %" PRIhsz,
+                              pattern_length);
+  }
+  if (!count || !pattern_length) return iree_ok_status();
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)pattern_length);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)(count * pattern_length));
+  iree_status_t status =
+      stream->vtable->fill(stream, count, pattern, pattern_length);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_io_stream_map_read(iree_io_stream_t* stream, iree_host_size_t length,
+                        iree_const_byte_span_t* out_span) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(out_span);
+  *out_span = iree_const_byte_span_empty();
+  IREE_RETURN_IF_ERROR(
+      iree_io_stream_validate_mode(
+          iree_io_stream_mode(stream),
+          IREE_IO_STREAM_MODE_READABLE | IREE_IO_STREAM_MODE_MAPPABLE),
+      "mapping the stream for reading");
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)length);
+  iree_status_t status = stream->vtable->map_read(stream, length, out_span);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_io_stream_map_write(iree_io_stream_t* stream, iree_host_size_t length,
+                         iree_byte_span_t* out_span) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(out_span);
+  *out_span = iree_byte_span_empty();
+  IREE_RETURN_IF_ERROR(
+      iree_io_stream_validate_mode(
+          iree_io_stream_mode(stream),
+          IREE_IO_STREAM_MODE_WRITABLE | IREE_IO_STREAM_MODE_MAPPABLE),
+      "mapping the stream for writing");
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)length);
+  iree_status_t status = stream->vtable->map_write(stream, length, out_span);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_io_stream_copy(
+    iree_io_stream_t* source_stream, iree_io_stream_t* target_stream,
+    iree_io_stream_pos_t length) {
+  IREE_ASSERT_ARGUMENT(source_stream);
+  IREE_ASSERT_ARGUMENT(target_stream);
+  if (!length) return iree_ok_status();
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)length);
+
+  iree_status_t status = iree_ok_status();
+
+  uint8_t buffer[IREE_IO_STREAM_COPY_BLOCK_SIZE];
+  iree_io_stream_pos_t remaining_length = length;
+  while (remaining_length) {
+    iree_host_size_t block_length = iree_min(sizeof(buffer), remaining_length);
+    iree_host_size_t read_length = 0;
+    status =
+        iree_io_stream_read(source_stream, block_length, buffer, &read_length);
+    if (!iree_status_is_ok(status)) break;
+    if (read_length != block_length) {
+      status = iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "source stream read underflow, expected to read a block of %" PRIhsz
+          " but stream only provided %" PRIhsz " bytes",
+          block_length, read_length);
+      break;
+    }
+    status = iree_io_stream_write(target_stream, read_length, buffer);
+    if (!iree_status_is_ok(status)) break;
+    remaining_length -= read_length;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// iree_io_memory_stream_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_io_memory_stream_t {
+  iree_io_stream_t base;
+  iree_allocator_t host_allocator;
+  iree_io_memory_stream_release_callback_t release_callback;
+  iree_io_stream_pos_t offset;
+  iree_io_stream_pos_t length;
+  uint8_t* contents;
+} iree_io_memory_stream_t;
+
+static const iree_io_stream_vtable_t iree_io_memory_stream_vtable;
+
+static iree_io_memory_stream_t* iree_io_memory_stream_cast(
+    iree_io_stream_t* IREE_RESTRICT base_stream) {
+  return (iree_io_memory_stream_t*)base_stream;
+}
+
+IREE_API_EXPORT iree_status_t iree_io_memory_stream_wrap(
+    iree_io_stream_mode_t mode, iree_byte_span_t contents,
+    iree_io_memory_stream_release_callback_t release_callback,
+    iree_allocator_t host_allocator, iree_io_stream_t** out_stream) {
+  IREE_ASSERT_ARGUMENT(out_stream);
+  *out_stream = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)contents.data_length);
+
+  iree_io_memory_stream_t* stream = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_allocator_malloc(host_allocator, sizeof(*stream), (void**)&stream));
+  iree_atomic_ref_count_init(&stream->base.ref_count);
+  stream->base.vtable = &iree_io_memory_stream_vtable;
+  stream->base.mode = mode;
+  stream->host_allocator = host_allocator;
+  stream->release_callback = release_callback;
+  stream->offset = 0;
+  stream->length = contents.data_length;
+  stream->contents = contents.data;
+
+  *out_stream = &stream->base;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static void iree_io_memory_stream_destroy(
+    iree_io_stream_t* IREE_RESTRICT base_stream) {
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  iree_allocator_t host_allocator = stream->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (stream->release_callback.fn) {
+    stream->release_callback.fn(stream->release_callback.user_data,
+                                base_stream);
+  }
+
+  iree_allocator_free(host_allocator, stream);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_io_stream_pos_t iree_io_memory_stream_offset(
+    iree_io_stream_t* base_stream) {
+  IREE_ASSERT_ARGUMENT(base_stream);
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  return stream->offset;
+}
+
+static iree_io_stream_pos_t iree_io_memory_stream_length(
+    iree_io_stream_t* base_stream) {
+  IREE_ASSERT_ARGUMENT(base_stream);
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  return stream->length;
+}
+
+static iree_status_t iree_io_memory_stream_seek(
+    iree_io_stream_t* base_stream, iree_io_stream_seek_mode_t seek_mode,
+    iree_io_stream_pos_t offset) {
+  IREE_ASSERT_ARGUMENT(base_stream);
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_io_stream_apply_fixed_seek(
+      stream->offset, stream->length, seek_mode, offset, &stream->offset);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_io_memory_stream_read(
+    iree_io_stream_t* base_stream, iree_host_size_t buffer_capacity,
+    void* buffer, iree_host_size_t* out_buffer_length) {
+  IREE_ASSERT_ARGUMENT(base_stream);
+  IREE_ASSERT_ARGUMENT(buffer);
+  if (out_buffer_length) *out_buffer_length = 0;
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_io_stream_pos_t read_length = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_stream_validate_fixed_range(stream->offset, stream->length,
+                                              buffer_capacity, &read_length));
+  if (!out_buffer_length && read_length != buffer_capacity) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0,
+        iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                         "read of range [%" PRIu64 ", %" PRIu64 ") (%" PRIu64
+                         " bytes) out of range; stream offset %" PRIu64
+                         " and length %" PRIu64 " insufficient",
+                         stream->offset, stream->offset + buffer_capacity,
+                         (iree_io_stream_pos_t)buffer_capacity, stream->offset,
+                         stream->length));
+  }
+
+  memcpy(buffer, stream->contents + stream->offset,
+         (iree_host_size_t)read_length);
+  stream->offset += read_length;
+
+  if (out_buffer_length) *out_buffer_length = (iree_host_size_t)read_length;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_io_memory_stream_write(iree_io_stream_t* base_stream,
+                                                 iree_host_size_t buffer_length,
+                                                 const void* buffer) {
+  IREE_ASSERT_ARGUMENT(base_stream);
+  IREE_ASSERT_ARGUMENT(buffer);
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_stream_validate_fixed_range(stream->offset, stream->length,
+                                              buffer_length, NULL));
+
+  memcpy(stream->contents + stream->offset, buffer, buffer_length);
+  stream->offset += buffer_length;
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_io_memory_stream_fill(
+    iree_io_stream_t* base_stream, iree_io_stream_pos_t count,
+    const void* pattern, iree_host_size_t pattern_length) {
+  IREE_ASSERT_ARGUMENT(base_stream);
+  IREE_ASSERT_ARGUMENT(pattern);
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_io_stream_pos_t access_length = count * pattern_length;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_stream_validate_fixed_range(stream->offset, stream->length,
+                                              access_length, NULL));
+
+  iree_status_t status = iree_ok_status();
+  uint8_t* data_ptr = stream->contents + stream->offset;
+  switch (pattern_length) {
+    case 1: {
+      uint8_t* data = (uint8_t*)data_ptr;
+      uint8_t value_bits = *(const uint8_t*)(pattern);
+      memset(data, value_bits, count);
+      break;
+    }
+    case 2: {
+      uint16_t* data = (uint16_t*)data_ptr;
+      uint16_t value_bits = *(const uint16_t*)(pattern);
+      for (iree_device_size_t i = 0; i < count; ++i) {
+        iree_unaligned_store(&data[i], value_bits);
+      }
+      break;
+    }
+    case 4: {
+      uint32_t* data = (uint32_t*)data_ptr;
+      uint32_t value_bits = *(const uint32_t*)(pattern);
+      for (iree_device_size_t i = 0; i < count; ++i) {
+        iree_unaligned_store(&data[i], value_bits);
+      }
+      break;
+    }
+    case 8: {
+      uint64_t* data = (uint64_t*)data_ptr;
+      uint64_t value_bits = *(const uint64_t*)(pattern);
+      for (iree_device_size_t i = 0; i < count; ++i) {
+        iree_unaligned_store(&data[i], value_bits);
+      }
+      break;
+    }
+    default:
+      IREE_ASSERT_UNREACHABLE("verified in iree_io_stream_fill");
+      break;
+  }
+  if (iree_status_is_ok(status)) {
+    stream->offset += access_length;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_io_memory_stream_map_read(
+    iree_io_stream_t* base_stream, iree_host_size_t length,
+    iree_const_byte_span_t* out_span) {
+  IREE_ASSERT_ARGUMENT(base_stream);
+  IREE_ASSERT_ARGUMENT(out_span);
+  *out_span = iree_const_byte_span_empty();
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_stream_validate_fixed_range(stream->offset, stream->length,
+                                              length, NULL));
+
+  *out_span =
+      iree_make_const_byte_span(stream->contents + stream->offset, length);
+  stream->offset += length;
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_io_memory_stream_map_write(
+    iree_io_stream_t* base_stream, iree_host_size_t length,
+    iree_byte_span_t* out_span) {
+  IREE_ASSERT_ARGUMENT(base_stream);
+  IREE_ASSERT_ARGUMENT(out_span);
+  *out_span = iree_byte_span_empty();
+  iree_io_memory_stream_t* stream = iree_io_memory_stream_cast(base_stream);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_stream_validate_fixed_range(stream->offset, stream->length,
+                                              length, NULL));
+
+  *out_span = iree_make_byte_span(stream->contents + stream->offset, length);
+  stream->offset += length;
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static const iree_io_stream_vtable_t iree_io_memory_stream_vtable = {
+    .destroy = iree_io_memory_stream_destroy,
+    .offset = iree_io_memory_stream_offset,
+    .length = iree_io_memory_stream_length,
+    .seek = iree_io_memory_stream_seek,
+    .read = iree_io_memory_stream_read,
+    .write = iree_io_memory_stream_write,
+    .fill = iree_io_memory_stream_fill,
+    .map_read = iree_io_memory_stream_map_read,
+    .map_write = iree_io_memory_stream_map_write,
+};

--- a/runtime/src/iree/io/stream.h
+++ b/runtime/src/iree/io/stream.h
@@ -1,0 +1,228 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_IO_STREAM_H_
+#define IREE_IO_STREAM_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/atomics.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_io_stream_t
+//===----------------------------------------------------------------------===//
+
+// Stream position; absolute or relative based on how it's used.
+typedef int64_t iree_io_stream_pos_t;
+
+// Bits defining which operations are allowed on a stream.
+enum iree_io_stream_mode_bits_t {
+  // Allows operations that read from the stream.
+  IREE_IO_STREAM_MODE_READABLE = 1u << 0,
+  // Allows operations that write to the stream.
+  IREE_IO_STREAM_MODE_WRITABLE = 1u << 1,
+  // Allows the iree_io_stream_resize operation for extend/truncate.
+  IREE_IO_STREAM_MODE_RESIZABLE = 1u << 2,
+  // Allows the iree_io_stream_seek operation.
+  IREE_IO_STREAM_MODE_SEEKABLE = 1u << 3,
+  // Allows iree_io_stream_map_read/iree_io_stream_map_write operations.
+  IREE_IO_STREAM_MODE_MAPPABLE = 1u << 4,
+};
+typedef uint32_t iree_io_stream_mode_t;
+
+typedef enum iree_io_stream_seek_mode_t {
+  // Like fseek(SEEK_SET): seek to an absolute offset in the stream.
+  // A value of 0 indicates start-of-stream and a value of the total stream
+  // length indicates end-of-stream.
+  IREE_IO_STREAM_SEEK_SET = 0,
+  // Like fseek(SEEK_CUR): seek is a relative offset from the current stream
+  // offset, positive or negative. A value of 0 indicates no change.
+  IREE_IO_STREAM_SEEK_FROM_CURRENT,
+  // Like fseek(SEEK_END): seek is a negative offset from the end of the stream.
+  // A value of 0 indicates end-of-stream (one byte past the end of the stream,
+  // with the offset equalling the total stream length).
+  //
+  // Example:
+  //   0123456789
+  //           ^^^
+  //           ||+- SEEK_FROM_END  0
+  //           |+-- SEEK_FROM_END -1
+  //           +--- SEEK_FROM_END -2
+  IREE_IO_STREAM_SEEK_FROM_END,
+} iree_io_stream_seek_mode_t;
+
+typedef struct iree_io_stream_t iree_io_stream_t;
+
+// Retains the given |stream| for the caller.
+IREE_API_EXPORT void iree_io_stream_retain(iree_io_stream_t* stream);
+
+// Releases the given |stream| from the caller.
+IREE_API_EXPORT void iree_io_stream_release(iree_io_stream_t* stream);
+
+// Returns the mode of the stream indicating what operations may be performed.
+IREE_API_EXPORT iree_io_stream_mode_t
+iree_io_stream_mode(const iree_io_stream_t* stream);
+
+// Returns the position of the stream relative to the stream base offset.
+IREE_API_EXPORT iree_io_stream_pos_t
+iree_io_stream_offset(iree_io_stream_t* stream);
+
+// Returns the total length of the stream in bytes ignoring the current offset.
+IREE_API_EXPORT iree_io_stream_pos_t
+iree_io_stream_length(iree_io_stream_t* stream);
+
+// Returns true if |stream| is positioned at the end of the stream.
+// When at the end of stream reads will fail and writes will append.
+IREE_API_EXPORT bool iree_io_stream_is_eos(iree_io_stream_t* stream);
+
+// Seeks within |stream| to |offset| based on the given |seek_mode|.
+// If IREE_IO_STREAM_MODE_SEEKABLE is not set then only forward relative seeks
+// are supported.
+IREE_API_EXPORT iree_status_t iree_io_stream_seek(
+    iree_io_stream_t* stream, iree_io_stream_seek_mode_t seek_mode,
+    iree_io_stream_pos_t offset);
+
+// Seeks within |stream| to the next offset with the specified |alignment|.
+// The alignment is expected to be a power-of-two value.
+// No-op if the stream offset is already aligned. Valid even if
+// IREE_IO_STREAM_MODE_SEEKABLE is not set as this only performs a forward
+// relative seek.
+IREE_API_EXPORT iree_status_t iree_io_stream_seek_to_alignment(
+    iree_io_stream_t* stream, iree_io_stream_pos_t alignment);
+
+// Reads up to |buffer_capacity| bytes from |stream| into |buffer|.
+// Returns the total number of bytes read in the optional |out_buffer_length|,
+// which may be less than the capacity if the end of stream is reached. If
+// |out_buffer_length| is not provided the read will fail if enough bytes are
+// not available. Requires the stream have IREE_IO_STREAM_MODE_READABLE.
+IREE_API_EXPORT iree_status_t
+iree_io_stream_read(iree_io_stream_t* stream, iree_host_size_t buffer_capacity,
+                    void* buffer, iree_host_size_t* out_buffer_length);
+
+// Writes |buffer_length| bytes from |buffer| to |stream|.
+// Requires the stream have IREE_IO_STREAM_MODE_WRITABLE.
+IREE_API_EXPORT iree_status_t
+iree_io_stream_write(iree_io_stream_t* stream, iree_host_size_t buffer_length,
+                     const void* buffer);
+
+// Writes |count| elements of |pattern_length| with the given |pattern| value.
+// Requires the stream have IREE_IO_STREAM_MODE_WRITABLE.
+IREE_API_EXPORT iree_status_t
+iree_io_stream_fill(iree_io_stream_t* stream, iree_io_stream_pos_t count,
+                    const void* pattern, iree_host_size_t pattern_length);
+
+// Maps a span of |length| bytes for reading. The stream offset is advanced by
+// |length| immediately and the caller can read the returned |out_span| contents
+// prior to closing the file.
+// Requires that IREE_IO_STREAM_MODE_READABLE and IREE_IO_STREAM_MODE_MAPPABLE
+// are set.
+IREE_API_EXPORT iree_status_t
+iree_io_stream_map_read(iree_io_stream_t* stream, iree_host_size_t length,
+                        iree_const_byte_span_t* out_span);
+
+// Maps a span of |length| bytes for writing. The stream offset is advanced by
+// |length| immediately and the caller must fill the returned |out_span| with
+// contents prior to closing the file.
+// Requires that IREE_IO_STREAM_MODE_WRITABLE and IREE_IO_STREAM_MODE_MAPPABLE
+// are set.
+IREE_API_EXPORT iree_status_t
+iree_io_stream_map_write(iree_io_stream_t* stream, iree_host_size_t length,
+                         iree_byte_span_t* out_span);
+
+// Copies |length| bytes from |source_stream| to |target_stream|.
+// Requires |source_stream| have IREE_IO_STREAM_MODE_READABLE and
+// |target_stream| have IREE_IO_STREAM_MODE_WRITABLE.
+IREE_API_EXPORT iree_status_t iree_io_stream_copy(
+    iree_io_stream_t* source_stream, iree_io_stream_t* target_stream,
+    iree_io_stream_pos_t length);
+
+//===----------------------------------------------------------------------===//
+// iree_io_stream_t implementation details
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_io_stream_vtable_t {
+  void(IREE_API_PTR* destroy)(iree_io_stream_t* IREE_RESTRICT stream);
+
+  iree_io_stream_pos_t(IREE_API_PTR* offset)(iree_io_stream_t* stream);
+  iree_io_stream_pos_t(IREE_API_PTR* length)(iree_io_stream_t* stream);
+  iree_status_t(IREE_API_PTR* seek)(iree_io_stream_t* stream,
+                                    iree_io_stream_seek_mode_t seek_mode,
+                                    iree_io_stream_pos_t offset);
+  iree_status_t(IREE_API_PTR* read)(iree_io_stream_t* stream,
+                                    iree_host_size_t buffer_capacity,
+                                    void* buffer,
+                                    iree_host_size_t* out_buffer_length);
+  iree_status_t(IREE_API_PTR* write)(iree_io_stream_t* stream,
+                                     iree_host_size_t buffer_length,
+                                     const void* buffer);
+  iree_status_t(IREE_API_PTR* fill)(iree_io_stream_t* stream,
+                                    iree_io_stream_pos_t count,
+                                    const void* pattern,
+                                    iree_host_size_t pattern_length);
+  iree_status_t(IREE_API_PTR* map_read)(iree_io_stream_t* stream,
+                                        iree_host_size_t length,
+                                        iree_const_byte_span_t* out_span);
+  iree_status_t(IREE_API_PTR* map_write)(iree_io_stream_t* stream,
+                                         iree_host_size_t length,
+                                         iree_byte_span_t* out_span);
+} iree_io_stream_vtable_t;
+
+struct iree_io_stream_t {
+  iree_atomic_ref_count_t ref_count;
+  const iree_io_stream_vtable_t* vtable;
+  iree_io_stream_mode_t mode;
+};
+
+//===----------------------------------------------------------------------===//
+// iree_io_memory_stream_t
+//===----------------------------------------------------------------------===//
+
+typedef void(IREE_API_PTR* iree_io_memory_stream_release_fn_t)(
+    void* user_data, iree_io_stream_t* stream);
+
+// A callback issued when a memory stream is released.
+typedef struct {
+  // Callback function pointer.
+  iree_io_memory_stream_release_fn_t fn;
+  // User data passed to the callback function. Unowned.
+  void* user_data;
+} iree_io_memory_stream_release_callback_t;
+
+// Returns a no-op file release callback that implies that no cleanup is
+// required.
+static inline iree_io_memory_stream_release_callback_t
+iree_io_memory_stream_release_callback_null(void) {
+  iree_io_memory_stream_release_callback_t callback = {NULL, NULL};
+  return callback;
+}
+
+// Wraps a fixed-size host memory allocation |contents| in a stream.
+// |release_callback| can be used to receive a callback when the stream is
+// destroyed and the reference to the contents is no longer required.
+IREE_API_EXPORT iree_status_t iree_io_memory_stream_wrap(
+    iree_io_stream_mode_t mode, iree_byte_span_t contents,
+    iree_io_memory_stream_release_callback_t release_callback,
+    iree_allocator_t host_allocator, iree_io_stream_t** out_stream);
+
+//===----------------------------------------------------------------------===//
+// iree_io_buffer_stream_t
+//===----------------------------------------------------------------------===//
+
+// TODO(benvanik): buffer stream that grows with a specified block size. Provide
+// a iree_io_buffer_stream_enumerate_data_blocks(stream, callback) to enumerate
+// the blocks in order (ala iovecs). Take an iree_allocator_t dedicated to the
+// block storage separate from the iree_io_stream_t metadata.
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_IO_STREAM_H_

--- a/runtime/src/iree/io/stream_test.cc
+++ b/runtime/src/iree/io/stream_test.cc
@@ -1,0 +1,713 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/io/stream.h"
+
+#include <array>
+#include <string>
+#include <string_view>
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+using iree::Status;
+using iree::StatusCode;
+using iree::testing::status::StatusIs;
+using testing::ElementsAre;
+using testing::ElementsAreArray;
+using testing::Eq;
+
+//===----------------------------------------------------------------------===//
+// iree_io_memory_stream_t
+//===----------------------------------------------------------------------===//
+
+TEST(MemoryStreamTest, Wrap) {
+  uint8_t data[5] = {0, 1, 2, 3, 4};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  EXPECT_EQ(iree_io_stream_mode(stream), IREE_IO_STREAM_MODE_READABLE);
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(iree_io_stream_length(stream), sizeof(data));
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, WrapEmpty) {
+  uint8_t data[1] = {0};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, 0),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  EXPECT_EQ(iree_io_stream_mode(stream), IREE_IO_STREAM_MODE_READABLE);
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(iree_io_stream_length(stream), 0);
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, WrapReleaseCallback) {
+  int callback_count = 0;
+  iree_io_memory_stream_release_callback_t release_callback = {
+      +[](void* user_data, iree_io_stream_t* stream) {
+        int* callback_count = (int*)user_data;
+        ++(*callback_count);
+      },
+      &callback_count,
+  };
+
+  ASSERT_EQ(callback_count, 0);
+
+  uint8_t data[1] = {0};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
+      release_callback, iree_allocator_system(), &stream));
+  ASSERT_EQ(callback_count, 0);
+
+  iree_io_stream_release(stream);
+  ASSERT_EQ(callback_count, 1);
+}
+
+TEST(MemoryStreamTest, SeekSet) {
+  uint8_t data[5] = {0, 1, 2, 3, 4};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  // Streams start at origin 0.
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(iree_io_stream_length(stream), sizeof(data));
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // No-op seek to origin.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Seek to end-of-stream.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET,
+                                     iree_io_stream_length(stream)));
+  EXPECT_EQ(iree_io_stream_offset(stream), iree_io_stream_length(stream));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+
+  // Seek to absolute offset 1.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 1));
+  EXPECT_EQ(iree_io_stream_offset(stream), 1);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Seek to absolute offset length-1 (last valid byte).
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 4));
+  EXPECT_EQ(iree_io_stream_offset(stream), 4);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Try seeking out of bounds.
+  EXPECT_THAT(Status(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, -1)),
+              StatusIs(StatusCode::kOutOfRange));
+  EXPECT_THAT(Status(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 6)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, SeekFromCurrent) {
+  uint8_t data[5] = {0, 1, 2, 3, 4};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  // Streams start at origin 0.
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(iree_io_stream_length(stream), sizeof(data));
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Seek to end-of-stream by jumping the full length.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_CURRENT,
+                                     iree_io_stream_length(stream)));
+  EXPECT_EQ(iree_io_stream_offset(stream), iree_io_stream_length(stream));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+
+  // Reset back to origin by seeking back the full length.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_CURRENT,
+                                     -iree_io_stream_length(stream)));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Seek forward to absolute position 1.
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_CURRENT, 1));
+  EXPECT_EQ(iree_io_stream_offset(stream), 1);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // No-op seek to current location (absolute 1).
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_CURRENT, 0));
+  EXPECT_EQ(iree_io_stream_offset(stream), 1);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Seek to absolute offset length-1 (last valid byte) - here (5-1) - 1 = 3.
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_CURRENT, 3));
+  EXPECT_EQ(iree_io_stream_offset(stream), 4);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Seek forward 1 to absolute end-of-stream.
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_CURRENT, 1));
+  EXPECT_EQ(iree_io_stream_offset(stream), iree_io_stream_length(stream));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+
+  // Reset back to origin.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));
+
+  // Try seeking out of bounds.
+  EXPECT_THAT(Status(iree_io_stream_seek(
+                  stream, IREE_IO_STREAM_SEEK_FROM_CURRENT, -100)),
+              StatusIs(StatusCode::kOutOfRange));
+  EXPECT_THAT(Status(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 600)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, SeekFromEnd) {
+  uint8_t data[5] = {0, 1, 2, 3, 4};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  // Streams start at origin 0.
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(iree_io_stream_length(stream), sizeof(data));
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Jump to end-of-stream.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, 0));
+  EXPECT_EQ(iree_io_stream_offset(stream), iree_io_stream_length(stream));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+
+  // Reset back to origin by seeking back the full length.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END,
+                                     -iree_io_stream_length(stream)));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Seek to absolute offset length-1 (last valid byte) - here 5 - 1 = 4.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -1));
+  EXPECT_EQ(iree_io_stream_offset(stream), 4);
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Reset back to origin.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));
+
+  // Try seeking out of bounds.
+  EXPECT_THAT(
+      Status(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -100)),
+      StatusIs(StatusCode::kOutOfRange));
+  EXPECT_THAT(
+      Status(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, 600)),
+      StatusIs(StatusCode::kOutOfRange));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, SeekToAlignment) {
+  uint8_t data[5] = {0, 1, 2, 3, 4};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  // Streams start at origin 0.
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(iree_io_stream_length(stream), sizeof(data));
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  // Alignment must be a power of two.
+  EXPECT_THAT(Status(iree_io_stream_seek_to_alignment(stream, 3)),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(Status(iree_io_stream_seek_to_alignment(stream, 63)),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(Status(iree_io_stream_seek_to_alignment(stream, -2)),
+              StatusIs(StatusCode::kInvalidArgument));
+
+  // Alignment at 0 should always be ok.
+  IREE_EXPECT_OK(iree_io_stream_seek_to_alignment(stream, 0));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  IREE_EXPECT_OK(iree_io_stream_seek_to_alignment(stream, 1));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  IREE_EXPECT_OK(iree_io_stream_seek_to_alignment(stream, 2));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+
+  // Seek forward to an unaligned absolute offset 1.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 1));
+  EXPECT_EQ(iree_io_stream_offset(stream), 1);
+
+  // Seek forward to alignment 2, which should be absolute offset 2.
+  IREE_EXPECT_OK(iree_io_stream_seek_to_alignment(stream, 2));
+  EXPECT_EQ(iree_io_stream_offset(stream), 2);
+
+  // Alignment that matches the current offset (2) should be a no-op.
+  IREE_EXPECT_OK(iree_io_stream_seek_to_alignment(stream, 2));
+  EXPECT_EQ(iree_io_stream_offset(stream), 2);
+
+  // Align up from an aligned value.
+  IREE_EXPECT_OK(iree_io_stream_seek_to_alignment(stream, 4));
+  EXPECT_EQ(iree_io_stream_offset(stream), 4);
+
+  // Try aligning off the end of the stream.
+  EXPECT_THAT(Status(iree_io_stream_seek_to_alignment(stream, 16)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, ReadUpTo) {
+  uint8_t data[5] = {0, 1, 2, 3, 4};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  // Streams start at origin 0.
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(iree_io_stream_length(stream), sizeof(data));
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  uint8_t read_buffer[64] = {0xDD};
+  iree_host_size_t read_length = 0;
+
+  // Reads of zero length should no-op.
+  IREE_EXPECT_OK(iree_io_stream_read(stream, 0, read_buffer, &read_length));
+  EXPECT_EQ(read_length, 0);
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+
+  // Reads should advance the stream offset.
+  memset(read_buffer, 0xDD, sizeof(read_buffer));
+  IREE_EXPECT_OK(iree_io_stream_read(stream, 1, read_buffer, &read_length));
+  EXPECT_EQ(read_length, 1);
+  EXPECT_EQ(iree_io_stream_offset(stream), 1);
+  EXPECT_EQ(read_buffer[0], 0);
+  EXPECT_EQ(read_buffer[1], 0xDD);
+
+  // Read another chunk of 2 bytes.
+  memset(read_buffer, 0xDD, sizeof(read_buffer));
+  IREE_EXPECT_OK(iree_io_stream_read(stream, 2, read_buffer, &read_length));
+  EXPECT_EQ(read_length, 2);
+  EXPECT_EQ(iree_io_stream_offset(stream), 3);
+  EXPECT_EQ(read_buffer[0], 1);
+  EXPECT_EQ(read_buffer[1], 2);
+  EXPECT_EQ(read_buffer[2], 0xDD);
+
+  // Read up to the end of the stream (2 bytes remaining) by reading over.
+  memset(read_buffer, 0xDD, sizeof(read_buffer));
+  IREE_EXPECT_OK(iree_io_stream_read(stream, sizeof(read_buffer), read_buffer,
+                                     &read_length));
+  EXPECT_EQ(read_length, 2);
+  EXPECT_EQ(iree_io_stream_offset(stream), iree_io_stream_length(stream));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+  EXPECT_EQ(read_buffer[0], 3);
+  EXPECT_EQ(read_buffer[1], 4);
+  EXPECT_EQ(read_buffer[2], 0xDD);
+
+  // Reading from the end of the stream should be a no-op.
+  memset(read_buffer, 0xDD, sizeof(read_buffer));
+  IREE_EXPECT_OK(iree_io_stream_read(stream, sizeof(read_buffer), read_buffer,
+                                     &read_length));
+  EXPECT_EQ(read_length, 0);
+  EXPECT_EQ(iree_io_stream_offset(stream), iree_io_stream_length(stream));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+  EXPECT_EQ(read_buffer[0], 0xDD);
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, ReadExact) {
+  uint8_t data[5] = {0, 1, 2, 3, 4};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  // Streams start at origin 0.
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(iree_io_stream_length(stream), sizeof(data));
+  EXPECT_FALSE(iree_io_stream_is_eos(stream));
+
+  uint8_t read_buffer[64] = {0xDD};
+
+  // Reads of zero length should no-op.
+  IREE_EXPECT_OK(iree_io_stream_read(stream, 0, read_buffer, NULL));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+
+  // Reads should advance the stream offset.
+  memset(read_buffer, 0xDD, sizeof(read_buffer));
+  IREE_EXPECT_OK(iree_io_stream_read(stream, 1, read_buffer, NULL));
+  EXPECT_EQ(iree_io_stream_offset(stream), 1);
+  EXPECT_EQ(read_buffer[0], 0);
+  EXPECT_EQ(read_buffer[1], 0xDD);
+
+  // Read another chunk of 2 bytes.
+  memset(read_buffer, 0xDD, sizeof(read_buffer));
+  IREE_EXPECT_OK(iree_io_stream_read(stream, 2, read_buffer, NULL));
+  EXPECT_EQ(iree_io_stream_offset(stream), 3);
+  EXPECT_EQ(read_buffer[0], 1);
+  EXPECT_EQ(read_buffer[1], 2);
+  EXPECT_EQ(read_buffer[2], 0xDD);
+
+  // Read up to the end of the stream (2 bytes remaining) by reading over.
+  memset(read_buffer, 0xDD, sizeof(read_buffer));
+  IREE_EXPECT_OK(iree_io_stream_read(stream, 2, read_buffer, NULL));
+  EXPECT_EQ(iree_io_stream_offset(stream), iree_io_stream_length(stream));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+  EXPECT_EQ(read_buffer[0], 3);
+  EXPECT_EQ(read_buffer[1], 4);
+  EXPECT_EQ(read_buffer[2], 0xDD);
+
+  // Reading from the end of the stream fails with no read length arg.
+  memset(read_buffer, 0xDD, sizeof(read_buffer));
+  EXPECT_THAT(Status(iree_io_stream_read(stream, sizeof(read_buffer),
+                                         read_buffer, NULL)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  // Reset back to the origin and try reading off the end.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));
+  EXPECT_THAT(Status(iree_io_stream_read(stream, sizeof(read_buffer),
+                                         read_buffer, NULL)),
+              StatusIs(StatusCode::kOutOfRange));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, Write) {
+  uint8_t data[5] = {0xDD};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_WRITABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  const uint8_t write_buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  // Writes of zero length should be a no-op.
+  memset(data, 0xDD, sizeof(data));
+  IREE_EXPECT_OK(iree_io_stream_write(stream, 0, write_buffer));
+  EXPECT_EQ(iree_io_stream_offset(stream), 0);
+  EXPECT_EQ(data[0], 0xDD);
+
+  // Writes should advance the stream.
+  memset(data, 0xDD, sizeof(data));
+  IREE_EXPECT_OK(iree_io_stream_write(stream, 1, write_buffer));
+  EXPECT_EQ(iree_io_stream_offset(stream), 1);
+  EXPECT_EQ(data[0], 0);
+  EXPECT_EQ(data[1], 0xDD);
+
+  // Write 2 more bytes and ensure only those are mutated.
+  memset(data, 0xDD, sizeof(data));
+  IREE_EXPECT_OK(iree_io_stream_write(stream, 2, &write_buffer[1]));
+  EXPECT_EQ(iree_io_stream_offset(stream), 1 + 2);
+  EXPECT_EQ(data[0], 0xDD);
+  EXPECT_EQ(data[1], 1);
+  EXPECT_EQ(data[2], 2);
+  EXPECT_EQ(data[3], 0xDD);
+
+  // Writes off the end of the stream should fail.
+  EXPECT_THAT(
+      Status(iree_io_stream_write(stream, sizeof(write_buffer), write_buffer)),
+      StatusIs(StatusCode::kOutOfRange));
+
+  // Seek to the end of the stream and try to write 0 bytes (should be a no-op).
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, 0));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+  IREE_EXPECT_OK(iree_io_stream_write(stream, 0, write_buffer));
+  EXPECT_TRUE(iree_io_stream_is_eos(stream));
+
+  // Writing off the end of the stream should fail.
+  EXPECT_THAT(Status(iree_io_stream_write(stream, 1, write_buffer)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  // Overwrite the entire contents of the storage.
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));
+  IREE_EXPECT_OK(iree_io_stream_write(stream, sizeof(data), write_buffer));
+  EXPECT_THAT(data,
+              ElementsAre(write_buffer[0], write_buffer[1], write_buffer[2],
+                          write_buffer[3], write_buffer[4]));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, Fill) {
+  uint8_t data[16] = {0xDD};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_WRITABLE, iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  uint8_t pattern[] = {0x80, 0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0};
+
+  // Fill patterns must be 1,2,4,8 bytes.
+  EXPECT_THAT(Status(iree_io_stream_fill(stream, 1, pattern, 3)),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(Status(iree_io_stream_fill(stream, 1, pattern, 9)),
+              StatusIs(StatusCode::kInvalidArgument));
+
+  // Fills are bounds checked.
+  EXPECT_THAT(Status(iree_io_stream_fill(stream, 100, pattern, 1)),
+              StatusIs(StatusCode::kOutOfRange));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, 0));
+  EXPECT_THAT(Status(iree_io_stream_fill(stream, 1, pattern, 1)),
+              StatusIs(StatusCode::kOutOfRange));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -1));
+  EXPECT_THAT(Status(iree_io_stream_fill(stream, 2, pattern, 1)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  // Fill with pattern size 1.
+  memset(data, 0xDD, sizeof(data));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 1));
+  IREE_EXPECT_OK(iree_io_stream_fill(stream, 3, pattern, 1));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -2));
+  IREE_EXPECT_OK(iree_io_stream_fill(stream, 2, pattern, 1));
+  EXPECT_THAT(data,
+              ElementsAre(0xDD, 0x80, 0x80, 0x80, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD,
+                          0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0x80, 0x80));
+
+  // Fill with pattern size 2.
+  memset(data, 0xDD, sizeof(data));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 1));
+  IREE_EXPECT_OK(iree_io_stream_fill(stream, 3, pattern, 2));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -4));
+  IREE_EXPECT_OK(iree_io_stream_fill(stream, 2, pattern, 2));
+  EXPECT_THAT(data,
+              ElementsAre(0xDD, 0x80, 0x90, 0x80, 0x90, 0x80, 0x90, 0xDD, 0xDD,
+                          0xDD, 0xDD, 0xDD, 0x80, 0x90, 0x80, 0x90));
+
+  // Fill with pattern size 4.
+  memset(data, 0xDD, sizeof(data));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 1));
+  IREE_EXPECT_OK(iree_io_stream_fill(stream, 2, pattern, 4));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -4));
+  IREE_EXPECT_OK(iree_io_stream_fill(stream, 1, pattern, 4));
+  EXPECT_THAT(data,
+              ElementsAre(0xDD, 0x80, 0x90, 0xA0, 0xB0, 0x80, 0x90, 0xA0, 0xB0,
+                          0xDD, 0xDD, 0xDD, 0x80, 0x90, 0xA0, 0xB0));
+
+  // Fill with pattern size 8.
+  memset(data, 0xDD, sizeof(data));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 1));
+  IREE_EXPECT_OK(iree_io_stream_fill(stream, 1, pattern, 8));
+  EXPECT_THAT(data,
+              ElementsAre(0xDD, 0x80, 0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0,
+                          0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD));
+  memset(data, 0xDD, sizeof(data));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -8));
+  IREE_EXPECT_OK(iree_io_stream_fill(stream, 1, pattern, 8));
+  EXPECT_THAT(data,
+              ElementsAre(0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0x80,
+                          0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, MapRead) {
+  uint8_t data[5] = {0xDD};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE | IREE_IO_STREAM_MODE_MAPPABLE,
+      iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  iree_const_byte_span_t span = iree_const_byte_span_empty();
+
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 1));
+  IREE_EXPECT_OK(iree_io_stream_map_read(stream, 2, &span));
+  EXPECT_EQ(span.data, &data[1]);
+  EXPECT_EQ(span.data_length, 2);
+
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -1));
+  IREE_EXPECT_OK(iree_io_stream_map_read(stream, 1, &span));
+  EXPECT_EQ(span.data, &data[4]);
+  EXPECT_EQ(span.data_length, 1);
+
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));
+  EXPECT_THAT(Status(iree_io_stream_map_read(stream, 100, &span)),
+              StatusIs(StatusCode::kOutOfRange));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, 0));
+  EXPECT_THAT(Status(iree_io_stream_map_read(stream, 1, &span)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  iree_io_stream_release(stream);
+}
+
+TEST(MemoryStreamTest, MapWrite) {
+  uint8_t data[5] = {0xDD};
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_WRITABLE | IREE_IO_STREAM_MODE_MAPPABLE,
+      iree_make_byte_span(data, sizeof(data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &stream));
+
+  iree_byte_span_t span = iree_byte_span_empty();
+
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 1));
+  IREE_EXPECT_OK(iree_io_stream_map_write(stream, 2, &span));
+  EXPECT_EQ(span.data, &data[1]);
+  EXPECT_EQ(span.data_length, 2);
+
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, -1));
+  IREE_EXPECT_OK(iree_io_stream_map_write(stream, 1, &span));
+  EXPECT_EQ(span.data, &data[4]);
+  EXPECT_EQ(span.data_length, 1);
+
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));
+  EXPECT_THAT(Status(iree_io_stream_map_write(stream, 100, &span)),
+              StatusIs(StatusCode::kOutOfRange));
+  IREE_EXPECT_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_FROM_END, 0));
+  EXPECT_THAT(Status(iree_io_stream_map_write(stream, 1, &span)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  iree_io_stream_release(stream);
+}
+
+// Tests copies that fit within a single block.
+TEST(MemoryStreamTest, Copy) {
+  uint8_t source_data[5] = {0xA0, 0xB0, 0xC0, 0xD0, 0xE0};
+  iree_io_stream_t* source_stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE,
+      iree_make_byte_span(source_data, sizeof(source_data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &source_stream));
+
+  uint8_t target_data[5] = {0xDD};
+  iree_io_stream_t* target_stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_WRITABLE,
+      iree_make_byte_span(target_data, sizeof(target_data)),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &target_stream));
+
+  // Bounds checks length.
+  EXPECT_THAT(Status(iree_io_stream_copy(source_stream, target_stream, 100)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  // Bounds check source.
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(source_stream, IREE_IO_STREAM_SEEK_FROM_END, 0));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(target_stream, IREE_IO_STREAM_SEEK_SET, 0));
+  EXPECT_THAT(Status(iree_io_stream_copy(source_stream, target_stream, 1)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  // Bounds check target.
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(source_stream, IREE_IO_STREAM_SEEK_SET, 0));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(target_stream, IREE_IO_STREAM_SEEK_FROM_END, 0));
+  EXPECT_THAT(Status(iree_io_stream_copy(source_stream, target_stream, 1)),
+              StatusIs(StatusCode::kOutOfRange));
+
+  // Copy entire contents.
+  memset(target_data, 0xDD, sizeof(target_data));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(source_stream, IREE_IO_STREAM_SEEK_SET, 0));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(target_stream, IREE_IO_STREAM_SEEK_SET, 0));
+  IREE_EXPECT_OK(
+      iree_io_stream_copy(source_stream, target_stream, sizeof(target_data)));
+  EXPECT_THAT(target_data, ElementsAreArray(source_data));
+
+  // Copy an interior subrange.
+  memset(target_data, 0xDD, sizeof(target_data));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(source_stream, IREE_IO_STREAM_SEEK_SET, 0));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(target_stream, IREE_IO_STREAM_SEEK_SET, 1));
+  IREE_EXPECT_OK(iree_io_stream_copy(source_stream, target_stream, 2));
+  EXPECT_THAT(target_data, ElementsAre(0xDD, 0xA0, 0xB0, 0xDD, 0xDD));
+
+  // Copy to up to the end.
+  memset(target_data, 0xDD, sizeof(target_data));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(source_stream, IREE_IO_STREAM_SEEK_SET, 0));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(target_stream, IREE_IO_STREAM_SEEK_FROM_END, -2));
+  IREE_EXPECT_OK(iree_io_stream_copy(source_stream, target_stream, 2));
+  EXPECT_THAT(target_data, ElementsAre(0xDD, 0xDD, 0xDD, 0xA0, 0xB0));
+
+  iree_io_stream_release(source_stream);
+  iree_io_stream_release(target_stream);
+}
+
+// Tests a copy that should trip into the multi-block code path.
+TEST(MemoryStreamTest, CopyLarge) {
+  std::vector<uint8_t> source_data(1 * 1024 * 1024);
+  for (size_t i = 0; i < source_data.size(); ++i) {
+    source_data[i] = (uint8_t)i;
+  }
+  iree_io_stream_t* source_stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_READABLE,
+      iree_make_byte_span(source_data.data(), source_data.size()),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &source_stream));
+
+  std::vector<uint8_t> target_data(1 * 1024 * 1024);
+  iree_io_stream_t* target_stream = NULL;
+  IREE_ASSERT_OK(iree_io_memory_stream_wrap(
+      IREE_IO_STREAM_MODE_WRITABLE,
+      iree_make_byte_span(target_data.data(), target_data.size()),
+      iree_io_memory_stream_release_callback_null(), iree_allocator_system(),
+      &target_stream));
+
+  // Copy an interior subrange.
+  memset(target_data.data(), 0xDD, target_data.size());
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(source_stream, IREE_IO_STREAM_SEEK_SET, 1));
+  IREE_EXPECT_OK(
+      iree_io_stream_seek(target_stream, IREE_IO_STREAM_SEEK_SET, 2));
+  IREE_EXPECT_OK(iree_io_stream_copy(source_stream, target_stream,
+                                     source_data.size() - 10));
+  for (size_t i = 0; i < target_data.size(); ++i) {
+    if (i < 2) {
+      // Before the copy range.
+      EXPECT_EQ(target_data[i], 0xDD);
+    } else if (i < source_data.size() - 10 + 2) {
+      // In the copy range.
+      EXPECT_EQ(target_data[i], source_data[1 + i - 2]);
+    } else {
+      // After the copy range.
+      EXPECT_EQ(target_data[i], 0xDD);
+    }
+  }
+
+  iree_io_stream_release(source_stream);
+  iree_io_stream_release(target_stream);
+}
+
+}  // namespace


### PR DESCRIPTION
This will enable cleanup of existing code (numpy I/O, gguf/safetensors parameters, etc) to use an abstracted stream interface that can either be served from memory (like today), platform file handles, or custom user resources.

Future changes alongside iree_io_file_handle_t will support actual files but for now this is focused just on removing the assumption of host memory access from the I/O focused code.

Progress on #15521.