### PR TITLE
[Flow] CollapseDimensions after CloneProducersIntoDispatchRegions

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -169,14 +169,14 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
             clEnableFusePaddingIntoLinalgConsumerOps,
             clEnableFusePaddingIntoLinalgProducerOps});
       })
-      // Collapse dimensions of linalg Ops.
-      .addPass(createCollapseDimensionsPass)
       // Clone all producers into the dispatch region to perpare for being
       // isolated from above. This enables running additional transformations
       // afterwards that would need the full dispatch content but don't want to
       // handle explicit captures as materialized as dispatch workgroup operands
       // and block arguments.
       .addPass(createCloneProducersIntoDispatchRegionsPass)
+      // Collapse dimensions of linalg Ops.
+      .addPass(createCollapseDimensionsPass)
       // Form dispatch region into dispatch workgroups
       .addPass([&]() {
         return createFormDispatchWorkgroupsPass(


### PR DESCRIPTION
The CollapseDimensions pass can introduce reshapes that can prevent clonable ops from being cloned into dispatch regions. Specifically, dequantization ops, which are becoming clonable with https://github.com/openxla/iree/pull/15662, will not get fused. Moving CollapseDimensions to after CloneProducersIntoDispatchRegions will prevent anything like this from ever happening.