### PR TITLE
[EmitC] Remove const casts in conversion

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
@@ -8,8 +8,8 @@
 #define IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_EMITCTYPECONVERTER_H_
 
 #include "iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h"
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
 #include "iree/compiler/Dialect/VM/IR/VMTypes.h"
-#include "iree/compiler/Dialect/VM/Utils/TypeTable.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -18,16 +18,7 @@ namespace mlir::iree_compiler::IREE::VM {
 
 class EmitCTypeConverter : public mlir::TypeConverter {
 public:
-  EmitCTypeConverter();
-  FailureOr<std::reference_wrapper<VMAnalysis>>
-  lookupAnalysis(mlir::func::FuncOp &funcOp) {
-    return lookupAnalysis(funcOp.getOperation());
-  }
-  FailureOr<std::reference_wrapper<VMAnalysis>>
-  lookupAnalysis(IREE::VM::FuncOp &funcOp) {
-    return lookupAnalysis(funcOp.getOperation());
-  }
-  std::optional<Value> materializeRef(Value ref);
+  EmitCTypeConverter(ModuleOp module);
 
   // This is the same as convertType, but returns `iree_vm_ref_t` rather than a
   // pointer to it for `vm.ref` types.
@@ -35,25 +26,8 @@ public:
   Type convertTypeAsPointer(Type type) const;
   emitc::OpaqueType convertTypeAsCType(Type type) const;
 
-  void cacheTypeTable(IREE::VM::ModuleOp module) {
-    typeTable = buildTypeTable(module);
-  }
-  void mapType(Type type, size_t index) { typeOrdinalMap[type] = index; }
-  std::optional<size_t> lookupType(Type type) const {
-    auto ptr = typeOrdinalMap.find(type);
-    if (ptr == typeOrdinalMap.end()) {
-      return std::nullopt;
-    }
-    return ptr->second;
-  }
-
   SetVector<Operation *> sourceMaterializations;
-  VMAnalysisCache analysisCache;
-  std::vector<TypeDef> typeTable;
-
-private:
-  llvm::DenseMap<Type, int> typeOrdinalMap;
-  FailureOr<std::reference_wrapper<VMAnalysis>> lookupAnalysis(Operation *op);
+  mutable ModuleAnalysis analysis;
 };
 
 } // namespace mlir::iree_compiler::IREE::VM

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h
@@ -10,25 +10,29 @@
 #include "iree/compiler/Dialect/VM/Analysis/RegisterAllocation.h"
 #include "iree/compiler/Dialect/VM/Analysis/ValueLiveness.h"
 #include "iree/compiler/Dialect/VM/IR/VMTypes.h"
+#include "iree/compiler/Dialect/VM/Utils/TypeTable.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
-namespace mlir::iree_compiler {
+namespace mlir::iree_compiler::IREE::VM {
 
-struct VMAnalysis {
+struct FuncAnalysis {
 public:
-  VMAnalysis() = default;
-  VMAnalysis(IREE::VM::FuncOp &funcOp) {
+  FuncAnalysis() = default;
+  FuncAnalysis(IREE::VM::FuncOp funcOp) {
     Operation *op = funcOp.getOperation();
     registerAllocation = RegisterAllocation(op);
     valueLiveness = ValueLiveness(op);
     originalFunctionType = funcOp.getFunctionType();
   }
-  VMAnalysis(FunctionType functionType) { originalFunctionType = functionType; }
+  FuncAnalysis(FunctionType functionType) {
+    originalFunctionType = functionType;
+  }
 
-  VMAnalysis(VMAnalysis &&) = default;
-  VMAnalysis &operator=(VMAnalysis &&) = default;
-  VMAnalysis(const VMAnalysis &) = delete;
-  VMAnalysis &operator=(const VMAnalysis &) = delete;
+  FuncAnalysis(FuncAnalysis &&) = default;
+  FuncAnalysis &operator=(FuncAnalysis &&) = default;
+  FuncAnalysis(const FuncAnalysis &) = delete;
+  FuncAnalysis &operator=(const FuncAnalysis &) = delete;
 
   FunctionType getFunctionType() { return originalFunctionType; }
 
@@ -39,30 +43,29 @@ public:
   int getNumRefArguments() {
     assert(originalFunctionType);
     return llvm::count_if(originalFunctionType.getInputs(), [](Type inputType) {
-      return inputType.isa<IREE::VM::RefType>();
+      return isa<IREE::VM::RefType>(inputType);
     });
   }
 
   int getNumLocalRefs() { return getNumRefRegisters() - getNumRefArguments(); }
 
-  uint16_t getRefRegisterOrdinal(Value ref) {
-    assert(ref.getType().isa<IREE::VM::RefType>());
+  uint16_t getRefRegisterOrdinal(TypedValue<IREE::VM::RefType> ref) {
     return registerAllocation.mapToRegister(ref).ordinal();
   }
 
   bool isMove(Value ref, Operation *op) {
-    assert(ref.getType().isa<IREE::VM::RefType>());
+    assert(isa<IREE::VM::RefType>(ref.getType()));
     bool lastUse = valueLiveness.isLastValueUse(ref, op);
     return lastUse && false;
   }
 
-  void cacheLocalRef(int64_t ordinal, emitc::ApplyOp &applyOp) {
-    assert(!refs.count(ordinal));
+  void cacheLocalRef(int64_t ordinal, emitc::ApplyOp applyOp) {
+    assert(!refs.count(ordinal) && "ref was already cached");
     refs[ordinal] = applyOp.getOperation();
   }
 
   emitc::ApplyOp lookupLocalRef(int64_t ordinal) {
-    assert(refs.count(ordinal));
+    assert(refs.count(ordinal) && "ref not found in cache");
     Operation *op = refs[ordinal];
     return cast<emitc::ApplyOp>(op);
   }
@@ -76,8 +79,90 @@ private:
   FunctionType originalFunctionType;
 };
 
-using VMAnalysisCache = DenseMap<Operation *, VMAnalysis>;
+struct ModuleAnalysis {
+  ModuleAnalysis(IREE::VM::ModuleOp module) {
+    typeTable = buildTypeTable(module);
+    for (auto func : module.getOps<IREE::VM::FuncOp>()) {
+      functions[func.getOperation()] = FuncAnalysis(func);
+    }
+  }
 
-} // namespace mlir::iree_compiler
+  ModuleAnalysis(ModuleAnalysis &&) = default;
+  ModuleAnalysis &operator=(ModuleAnalysis &&) = default;
+  ModuleAnalysis(const ModuleAnalysis &) = delete;
+  ModuleAnalysis &operator=(const ModuleAnalysis &) = delete;
+
+  void addDummy(mlir::func::FuncOp func) {
+    functions[func.getOperation()] = FuncAnalysis();
+  }
+
+  void add(mlir::func::FuncOp func, FunctionType type) {
+    functions[func.getOperation()] = FuncAnalysis(type);
+  }
+
+  void move(mlir::func::FuncOp newFunc, IREE::VM::FuncOp oldFunc) {
+    auto &analysis = lookupFunction(oldFunc.getOperation());
+
+    functions[newFunc.getOperation()] = std::move(analysis);
+    functions.erase(oldFunc.getOperation());
+  }
+
+  FuncAnalysis &lookupFunction(Operation *op) {
+    auto ptr = functions.find(op);
+    assert(ptr != functions.end() && "analysis lookup failed");
+    return ptr->second;
+  }
+
+  void mapType(Type type, size_t index) { typeOrdinalMap[type] = index; }
+  std::optional<size_t> lookupType(Type type) const {
+    auto ptr = typeOrdinalMap.find(type);
+    if (ptr == typeOrdinalMap.end()) {
+      return std::nullopt;
+    }
+    return ptr->second;
+  }
+
+  Value lookupRef(Value ref) {
+    auto refValue = cast<TypedValue<IREE::VM::RefType>>(ref);
+
+    mlir::func::FuncOp funcOp;
+    if (auto definingOp = ref.getDefiningOp()) {
+      funcOp = definingOp->getParentOfType<mlir::func::FuncOp>();
+    } else {
+      Operation *op = llvm::cast<BlockArgument>(ref).getOwner()->getParentOp();
+      funcOp = cast<mlir::func::FuncOp>(op);
+    }
+
+    auto &analysis = lookupFunction(funcOp);
+
+    int32_t ordinal = analysis.getRefRegisterOrdinal(refValue);
+
+    auto ctx = funcOp.getContext();
+
+    // Search block arguments
+    int refArgCounter = 0;
+    for (BlockArgument arg : funcOp.getArguments()) {
+      assert(!isa<IREE::VM::RefType>(arg.getType()));
+
+      if (arg.getType() == emitc::PointerType::get(
+                               emitc::OpaqueType::get(ctx, "iree_vm_ref_t"))) {
+        if (ordinal == refArgCounter++) {
+          return arg;
+        }
+      }
+    }
+
+    emitc::ApplyOp applyOp = analysis.lookupLocalRef(ordinal);
+    return applyOp.getResult();
+  }
+
+  std::vector<TypeDef> typeTable;
+
+private:
+  DenseMap<Operation *, FuncAnalysis> functions;
+  llvm::DenseMap<Type, int> typeOrdinalMap;
+};
+
+} // namespace mlir::iree_compiler::IREE::VM
 
 #endif // IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_VMANALYSIS_H_


### PR DESCRIPTION
Remove const casts of the type converter introduced in integrate #14678.

This is done by threading all stateful data accesses through a mutable class member.

Fixes #14702.

ci-extra: build_test_all_windows