### PR TITLE
[Codegen] Allow GPUTileReduction to tile named reduction ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileReduction.cpp
@@ -20,7 +20,7 @@ namespace iree_compiler {
 
 namespace {
 
-static LogicalResult tileReduction(linalg::GenericOp op) {
+static LogicalResult tileReduction(linalg::LinalgOp op) {
   SmallVector<unsigned> dims;
   op.getReductionDims(dims);
   SmallVector<int64_t> tileSize = getTileSizes(op, 1);
@@ -44,7 +44,7 @@ static LogicalResult tileReduction(linalg::GenericOp op) {
   return success();
 }
 
-static LogicalResult tileFusedOps(linalg::GenericOp op) {
+static LogicalResult tileFusedOps(linalg::LinalgOp op) {
   IRRewriter rewriter(op.getContext());
   rewriter.setInsertionPoint(op);
   SmallVector<int64_t> tileSizes = getTileSizes(op, 1);
@@ -68,14 +68,14 @@ struct GPUTileReductionPass
 
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
-    SmallVector<linalg::GenericOp> genericOps;
-    funcOp.walk([&](linalg::GenericOp op) { genericOps.push_back(op); });
-    for (linalg::GenericOp op : genericOps) {
+    SmallVector<linalg::LinalgOp> linalgOps;
+    funcOp.walk([&](linalg::LinalgOp op) { linalgOps.push_back(op); });
+    for (linalg::LinalgOp op : linalgOps) {
       if (op.getNumReductionLoops() > 0) {
         if (failed(tileReduction(op))) {
           return signalPassFailure();
         }
-      } else {
+      } else if (isa<linalg::GenericOp>(op)) {
         if (failed(tileFusedOps(op))) {
           return signalPassFailure();
         }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tile_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tile_reduction.mlir
@@ -44,6 +44,37 @@ func.func @warp_reduction_dispatch() {
 
 // -----
 
+func.func @warp_reduction_batch_matmul() {
+  %cst = arith.constant 1.000000e+00 : f32
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<11x512x512xf32>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<11x512x512xf32>>
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<11x512x512xf32>>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_id_z = hal.interface.workgroup.id[2] : index
+  %3 = flow.dispatch.tensor.load %0, offsets = [%workgroup_id_z, %workgroup_id_y, 0], sizes = [1, 1, 512], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<11x512x512xf32>> -> tensor<1x1x512xf32>
+  %4 = flow.dispatch.tensor.load %1, offsets = [%workgroup_id_z, 0, %workgroup_id_x], sizes = [1, 512, 1], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<11x512x512xf32>> -> tensor<1x512x1xf32>
+  %5 = flow.dispatch.tensor.load %2, offsets = [%workgroup_id_z, %workgroup_id_y, %workgroup_id_x], sizes = [1, 1, 1], strides = [1, 1, 1] : !flow.dispatch.tensor<writeonly:tensor<11x512x512xf32>> -> tensor<1x1x1xf32>
+  %6 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 1, 1], [0, 0, 0, 64]]>} ins(%cst : f32) outs(%5 : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
+  %7 = linalg.batch_matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 1, 1], [0, 0, 0, 64]]>}
+           ins(%3, %4: tensor<1x1x512xf32>, tensor<1x512x1xf32>) outs(%6: tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
+  flow.dispatch.tensor.store %7, %2, offsets = [%workgroup_id_z, %workgroup_id_y, %workgroup_id_x], sizes = [1, 1, 1], strides = [1, 1, 1] : tensor<1x1x1xf32> -> !flow.dispatch.tensor<writeonly:tensor<11x512x512xf32>>
+  return
+}
+
+// CHECK-LABEL: warp_reduction_batch_matmul()
+//       CHECK:   linalg.fill {{.*}} -> tensor<1x1x1xf32>
+//       CHECK:   linalg.fill {{.*}} -> tensor<1x1x1x64xf32>
+//       CHECK:   linalg.generic
+//       CHECK:     arith.mulf
+//       CHECK:     arith.addf
+//       CHECK:   %[[FINAL:.+]] = linalg.generic
+//  CHECK-SAME:                   ins({{.*}} : tensor<1x1x1x64xf32>)
+//       CHECK:     arith.addf
+//       CHECK:   flow.dispatch.tensor.store %[[FINAL]]
+
+// -----
+
 func.func @warp_reduction_broadcast_dispatch() {
   %cst = arith.constant 1.000000e+00 : f32
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<512x10240xf32>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tile_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tile_reduction.mlir
@@ -63,13 +63,20 @@ func.func @warp_reduction_batch_matmul() {
 }
 
 // CHECK-LABEL: warp_reduction_batch_matmul()
+//   CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
+//   CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //       CHECK:   linalg.fill {{.*}} -> tensor<1x1x1xf32>
 //       CHECK:   linalg.fill {{.*}} -> tensor<1x1x1x64xf32>
-//       CHECK:   linalg.generic
-//       CHECK:     arith.mulf
-//       CHECK:     arith.addf
+//       CHECK:   scf.for {{.*}} = %[[C0]] to %[[C512]] step %[[C64]] {{.*}} -> (tensor<1x1x1x64xf32>)
+//       CHECK:     linalg.generic
+//  CHECK-SAME:         ins({{.*}} : tensor<1x1x64xf32>, tensor<1x64x1xf32>)
+//  CHECK-SAME:         outs({{.*}} : tensor<1x1x1x64xf32>)
+//       CHECK:       arith.mulf
+//       CHECK:       arith.addf
 //       CHECK:   %[[FINAL:.+]] = linalg.generic
 //  CHECK-SAME:                   ins({{.*}} : tensor<1x1x1x64xf32>)
+//  CHECK-SAME:                   outs({{.*}} : tensor<1x1x1xf32>)
 //       CHECK:     arith.addf
 //       CHECK:   flow.dispatch.tensor.store %[[FINAL]]
 


### PR DESCRIPTION
We should not need to generalize reductions before tiling them. The doesn't affect fused ops because most fusion cases are elementwise and fill, and elementwise should be a generic already, while fill shouldn't be tiled by this pass.