### PR TITLE
[Codegen] NFC: Add debug print statements to OptimizeVectorTransfer

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -20,18 +20,12 @@
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 
 #define DEBUG_TYPE "iree-codegen-optimize-vector-transfer"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir {
 namespace iree_compiler {
 namespace {
-
-static void debugPrint(func::FuncOp funcOp, const char *message) {
-  LLVM_DEBUG({
-    llvm::dbgs() << "//--- " << message << " ---//\n";
-    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-    llvm::dbgs() << "\n\n";
-  });
-}
 
 // Pattern to canonialize tranpose where only one dimension is not unit
 // dimension. In this case the transpose is a no-op and should be simplified
@@ -71,7 +65,7 @@ struct OptimizeVectorTransferPass
       : flatten(flatten), dropUnitDims(dropUnitDims) {}
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
-    debugPrint(funcOp, "before optimize vector transfer");
+    LDBG("before optimize vector transfer\n" << funcOp);
     // Generate vector.shape_cast for dropping leading one dimensions in vector
     // ops. This increases the chance that we can forward more transfer writes
     // to transfer reads.
@@ -88,7 +82,7 @@ struct OptimizeVectorTransferPass
       }
     }
 
-    debugPrint(funcOp, "after dropping leading unit dims");
+    LDBG("after dropping leading unit dims\n" << funcOp);
 
     // Workaround, run loop invariant code motion before hoist redudant vector
     // transfer to workaround a bug upstream.
@@ -98,7 +92,7 @@ struct OptimizeVectorTransferPass
     IRRewriter rewriter(funcOp->getContext());
     vector::transferOpflowOpt(rewriter, funcOp);
 
-    debugPrint(funcOp, "after folding redundant vector transfers");
+    LDBG("after folding redundant vector transfers\n" << funcOp);
 
     // Move bitcast inwards from loop region boundaries to increase chances to
     // cancel them.
@@ -110,7 +104,7 @@ struct OptimizeVectorTransferPass
       }
     }
 
-    debugPrint(funcOp, "after bubbling vector bitcasts");
+    LDBG("after bubbling vector bitcasts\n" << funcOp);
 
     // TODO(#14191): SPIR-V can't handle the vector.shape_cast created for
     // dropping unit dims so this option is disabled in SPIR-V pipeline.
@@ -122,7 +116,7 @@ struct OptimizeVectorTransferPass
         return signalPassFailure();
       }
 
-      debugPrint(funcOp, "after dropping vector transfer unit dims");
+      LDBG("after dropping vector transfer unit dims\n" << funcOp);
     }
 
     // Second stage of patterns to flatten transfer ops.
@@ -133,11 +127,11 @@ struct OptimizeVectorTransferPass
         return signalPassFailure();
       }
     }
-    debugPrint(funcOp, "after flattening vector transfers");
+    LDBG("after flattening vector transfers\n" << funcOp);
     // Delete potential dead alloc and associated ops after store to load
     // forwarding.
     memref::eraseDeadAllocAndStores(rewriter, funcOp);
-    debugPrint(funcOp, "after erasing unused allocs and stores");
+    LDBG("after erasing unused allocs and stores\n" << funcOp);
   }
 
   LogicalResult initializeOptions(StringRef options) override {


### PR DESCRIPTION
This pass applies a large number of transformations. Add prints to improve debuggability.