### PR TITLE
[SPIRV] Use literal extract indices in masked transfers

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -787,8 +787,8 @@ struct ScalarizeVectorTransferRead final
     if (vectorType.getRank() == 0) {
       Value maybeMaskBit;
       if (maybeMask) {
-        Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask, zero);
+        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask,
+                                                          ArrayRef<int64_t>{0});
       }
 
       auto thenCond = [&](OpBuilder &b, Location loc) {
@@ -821,17 +821,17 @@ struct ScalarizeVectorTransferRead final
     Value newVector = rewriter.create<arith::ConstantOp>(
         loc, vectorType, rewriter.getZeroAttr(vectorType));
     for (int i = 0; i < vectorType.getDimSize(0); ++i) {
-      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
-
       // Extract the mask bit for this value if present.
       Value maybeMaskBit;
       if (maybeMask) {
         // The result vector is 1-D and we have a projected permutation, meaning
         // we can just extract the mask bit using the same index as the loaded
         // vector.
-        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask, iVal);
+        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask,
+                                                          ArrayRef<int64_t>{i});
       }
 
+      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
       auto thenCond = [&](OpBuilder &b, Location loc) {
         indices[dimPos] = b.create<affine::AffineApplyOp>(
             loc, addMap, ValueRange{oldIndex, iVal});
@@ -912,8 +912,8 @@ struct ScalarizeVectorTransferWrite final
 
       Value maybeMaskBit;
       if (maybeMask) {
-        Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask, zero);
+        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask,
+                                                          ArrayRef<int64_t>{0});
       }
 
       auto thenCond = [&](OpBuilder &b, Location loc) {
@@ -941,16 +941,16 @@ struct ScalarizeVectorTransferWrite final
     auto indices = llvm::to_vector(writeOp.getIndices());
     Value oldIndex = indices[dimPos];
     for (int i = 0; i < vectorType.getDimSize(0); ++i) {
-      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
-
       Value maybeMaskBit;
       if (maybeMask) {
         // The result vector is 1-D and we have a projected permutation, meaning
         // we can just extract the mask bit using the same index as the written
         // vector.
-        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask, iVal);
+        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask,
+                                                          ArrayRef<int64_t>{i});
       }
 
+      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
       auto thenCond = [&](OpBuilder &b, Location loc) {
         indices[dimPos] = b.create<affine::AffineApplyOp>(
             loc, addMap, ValueRange{oldIndex, iVal});

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
@@ -553,16 +553,13 @@ func.func @scalarize_masked_vector_transfer_op(%arg: vector<3xf32>, %mask: vecto
 
 // CHECK-LABEL: func.func @scalarize_masked_vector_transfer_op
 // CHECK-DAG: %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<3xf32>
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
 // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
 // CHECK-DAG: %[[C5:.+]] = arith.constant 5 : index
 // CHECK-DAG: %[[C3:.+]] = arith.constant 3 : index
 // CHECK-DAG: %[[PAD:.+]] = arith.constant 0.000000e+00 : f32
 
 /// Transfer read.
-//     CHECK: %[[MB0:.+]] = vector.extract %{{.*}}[%[[C0]]] : i1 from vector<3xi1>
+//     CHECK: %[[MB0:.+]] = vector.extract %{{.*}}[0] : i1 from vector<3xi1>
 //     CHECK: %[[MASK_LD0:.+]] = scf.if %[[MB0]] -> (f32) {
 //     CHECK:   %[[LD0:.+]] = memref.load {{.*}}[%[[C3]]] : memref<20xf32>
 //     CHECK:   scf.yield %[[LD0]] : f32
@@ -570,10 +567,10 @@ func.func @scalarize_masked_vector_transfer_op(%arg: vector<3xf32>, %mask: vecto
 //     CHECK:   scf.yield %[[PAD]] : f32
 //     CHECK: }
 //     CHECK: vector.insert %[[MASK_LD0]], %[[INIT]] [0] : f32 into vector<3xf32>
-//     CHECK: vector.extract %{{.*}}[%[[C1]]] : i1 from vector<3xi1>
+//     CHECK: vector.extract %{{.*}}[1] : i1 from vector<3xi1>
 //     CHECK: scf.if %{{.*}} -> (f32) {
 //     CHECK:   memref.load %{{.*}}[%[[C4]]] : memref<20xf32>
-//     CHECK: vector.extract %{{.*}}[%[[C2]]] : i1 from vector<3xi1>
+//     CHECK: vector.extract %{{.*}}[2] : i1 from vector<3xi1>
 //     CHECK: scf.if %{{.*}} -> (f32) {
 //     CHECK:   memref.load %{{.*}}[%[[C5]]] : memref<20xf32>
 //     CHECK: %[[MASK_TR:.+]] = vector.insert {{.*}} [2] : f32 into vector<3xf32>


### PR DESCRIPTION
This increases the chances of later canonicalizations occurring based on the constant extract.