### PR TITLE
Fix CUDA MMA transform dialect tests

### DIFF
--- a/tests/transform_dialect/cuda/mma_elemwise_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_elemwise_layout_analysis_codegen_spec.mlir
@@ -6,8 +6,12 @@ module attributes { transform.with_named_sequence } {
     // Step 1. Find the fill, matmul and generic ops
     // ===========================================================================
     %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    %matmul = transform.structured.match ops{["linalg.matmul_transpose_b"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    %generic = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %matmul = transform.structured.match ops{["linalg.generic"]}
+                attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]}
+                in %variant_op : (!transform.any_op) -> !transform.any_op
+    %generic = transform.structured.match ops{["linalg.generic"]}
+                attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]}
+                in %variant_op : (!transform.any_op) -> !transform.any_op
 
     // Step 2. Tile the generic and fuse the fill and matmul
     // ===========================================================================
@@ -58,7 +62,7 @@ module attributes { transform.with_named_sequence } {
     // ===========================================================================
     %func_10 = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
     %func_11 = transform.iree.layout_analysis_and_distribution %func_10 : (!transform.any_op) -> (!transform.any_op)
-    transform.yield 
+    transform.yield
   }
 } // module
 


### PR DESCRIPTION
We generalized linalg.matmul_transposed_b ops into linalg.generic ops with https://github.com/openxla/iree/pull/15678. This commits updates the tests to match linalg.generic ops accordingly.