### PR TITLE
Integreate llvm/llvm-project@93e156833b

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -200,6 +200,7 @@ hal.executable @i4_dequant_matvec_f16_subgroup_64 {
 //     CHECK-DAG: %[[C2:.+]] = spirv.Constant 2 : i32
 //     CHECK-DAG: %[[C0:.+]] = spirv.Constant 0 : i32
 //     CHECK-DAG: %[[CSTVEC4XI32:.+]] = spirv.Constant dense<255> : vector<4xi32>
+//     CHECK-DAG: %[[CSTVEC4ONE:.+]] = spirv.Constant dense<1.000000e+00> : vector<4xf16>
 //     CHECK-DAG: %[[CSTVEC4XI320:.+]] = spirv.Constant dense<[15, -16, 15, -16]> : vector<4xi32>
 //     CHECK-DAG: %[[CSTVEC4XI321:.+]] = spirv.Constant dense<[0, 4, 0, 4]> : vector<4xi32>
 
@@ -235,15 +236,9 @@ hal.executable @i4_dequant_matvec_f16_subgroup_64 {
 
 //         CHECK:   spirv.mlir.merge
 
-//         CHECK: %[[LD:.+]]   = spirv.Load "Function" {{.*}} : vector<4xf16>
-//         CHECK: %[[S0:.+]]   = spirv.CompositeExtract %[[LD]][0 : i32] : vector<4xf16>
-//         CHECK: %[[S1:.+]]   = spirv.CompositeExtract %[[LD]][1 : i32] : vector<4xf16>
-//         CHECK: %[[S2:.+]]   = spirv.CompositeExtract %[[LD]][2 : i32] : vector<4xf16>
-//         CHECK: %[[S3:.+]]   = spirv.CompositeExtract %[[LD]][3 : i32] : vector<4xf16>
-//         CHECK: %[[ADD0:.+]] = spirv.FAdd %[[S0]], %[[S1]] : f16
-//         CHECK: %[[ADD1:.+]] = spirv.FAdd %[[ADD0]], %[[S2]] : f16
-//         CHECK: %[[ADD2:.+]] = spirv.FAdd %[[ADD1]], %[[S3]] : f16
+//         CHECK: %[[LD:.+]] = spirv.Load "Function" {{.*}} : vector<4xf16>
+//         CHECK: %[[RES:.+]] = spirv.Dot %[[LD]], %[[CSTVEC4ONE]] : vector<4xf16> -> f16
 
-//         CHECK: spirv.GroupNonUniformFAdd "Subgroup" "Reduce" %[[ADD2]] : f16
+//         CHECK: spirv.GroupNonUniformFAdd "Subgroup" "Reduce" %[[RES]] : f16
 
 //         CHECK: spirv.mlir.selection

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
@@ -52,18 +52,11 @@ hal.executable private @subgroup_reduce {
 // CHECK-DAG:   %[[C8:.+]] = spirv.Constant 8 : i32
 // CHECK-DAG:   %[[F0:.+]] = spirv.Constant 0.000000e+00 : f32
 // CHECK-DAG:   %[[FV0:.+]] = spirv.Constant dense<0.000000e+00> : vector<4xf32>
+// CHECK-DAG:   %[[FV1:.+]] = spirv.Constant dense<1.000000e+00> : vector<4xf32>
 
 // CHECK:   %[[LD:.+]] = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 // CHECK:   %[[ADDV0:.+]] = spirv.FAdd %[[LD]], %[[FV0]] : vector<4xf32>
-
-// CHECK:   %[[E0:.+]] = spirv.CompositeExtract %[[ADDV0]][0 : i32] : vector<4xf32>
-// CHECK:   %[[E1:.+]] = spirv.CompositeExtract %[[ADDV0]][1 : i32] : vector<4xf32>
-// CHECK:   %[[E2:.+]] = spirv.CompositeExtract %[[ADDV0]][2 : i32] : vector<4xf32>
-// CHECK:   %[[E3:.+]] = spirv.CompositeExtract %[[ADDV0]][3 : i32] : vector<4xf32>
-
-// CHECK:   %[[ADD0:.+]] = spirv.FAdd %[[E0]], %[[E1]] : f32
-// CHECK:   %[[ADD1:.+]] = spirv.FAdd %[[ADD0]], %[[E2]] : f32
-// CHECK:   %[[ADD2:.+]] = spirv.FAdd %[[ADD1]], %[[E3]] : f32
+// CHECK:   %[[ADD2:.+]] = spirv.Dot %[[ADDV0]], %[[FV1]] : vector<4xf32> -> f32
 
 // CHECK:   %[[S0:.+]] = spirv.GroupNonUniformShuffleXor <Subgroup> %[[ADD2]], %[[C1]] : f32, i32
 // CHECK:   %[[ADD3:.+]] = spirv.FAdd %[[ADD2]], %[[S0]] : f32

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_conv.mlir
@@ -49,12 +49,12 @@ func.func @nwc_conv_1d_dot_prod(%input: tensor<1x7x3xi8>, %filter: tensor<1x3x4x
 
 //          CHECK:   %[[LHS:.+]] = spirv.CompositeConstruct %{{.+}}, %[[ZERO]] : (vector<3xi8>, i8) -> vector<4xi8>
 //          CHECK:   %[[RHS:.+]] = spirv.CompositeConstruct %{{.+}}, %[[ZERO]] : (vector<3xi8>, i8) -> vector<4xi8>
-//          CHECK:   spirv.SDotAccSat %[[LHS]], %[[RHS]], %{{.+}} : (vector<4xi8>, vector<4xi8>, i32) -> i32
+//          CHECK:   spirv.SDotAccSat %[[LHS]], %[[RHS]], %{{.+}} : vector<4xi8> -> i32
 //  CHECK-COUNT-2:   spirv.CompositeConstruct %{{.+}}, %[[ZERO]] : (vector<3xi8>, i8) -> vector<4xi8>
-//          CHECK:   spirv.SDotAccSat %{{.+}}, %{{.+}}, %{{.+}} : (vector<4xi8>, vector<4xi8>, i32) -> i32
+//          CHECK:   spirv.SDotAccSat %{{.+}}, %{{.+}}, %{{.+}} : vector<4xi8> -> i32
 //  CHECK-COUNT-2:   spirv.CompositeConstruct %{{.+}}, %[[ZERO]] : (vector<3xi8>, i8) -> vector<4xi8>
-//          CHECK:   spirv.SDotAccSat %{{.+}}, %{{.+}}, %{{.+}} : (vector<4xi8>, vector<4xi8>, i32) -> i32
+//          CHECK:   spirv.SDotAccSat %{{.+}}, %{{.+}}, %{{.+}} : vector<4xi8> -> i32
 //  CHECK-COUNT-2:   spirv.CompositeConstruct %{{.+}}, %[[ZERO]] : (vector<3xi8>, i8) -> vector<4xi8>
-//          CHECK:   spirv.SDotAccSat %{{.+}}, %{{.+}}, %{{.+}} : (vector<4xi8>, vector<4xi8>, i32) -> i32
+//          CHECK:   spirv.SDotAccSat %{{.+}}, %{{.+}}, %{{.+}} : vector<4xi8> -> i32
 
-// CHECK-COUNT-12:   spirv.SDotAccSat {{.+}} : (vector<4xi8>, vector<4xi8>, i32) -> i32
+// CHECK-COUNT-12:   spirv.SDotAccSat {{.+}} : vector<4xi8> -> i32


### PR DESCRIPTION
This commit updates LLVM submodule to llvm/llvm-project@93e156833b. It carries a local revert for

* llvm/llvm-project@b7b6d54004ef8a89dc3bad411f11a1ef93319a13

The proper handling of the above patch is still under discussion in upstream.