### PR TITLE
[SPIRV] Add mask lowering patterns to vector lowerings

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
@@ -79,6 +79,8 @@ public:
           patterns, vector::VectorMultiReductionLowering::InnerParallel);
       vector::populateVectorTransposeLoweringPatterns(patterns, options);
       vector::populateVectorGatherLoweringPatterns(patterns);
+      vector::populateVectorMaskOpLoweringPatterns(patterns);
+      vector::CreateMaskOp::getCanonicalizationPatterns(patterns, context);
       if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -43,6 +43,7 @@ iree_lit_test_suite(
             "emulate_i64.mlir",
             "erase_storage_buffer_static_shape.mlir",
             "illegal_configuration.mlir",
+            "lower_masks.mlir",
             "lowering_matmul_fusion.mlir",
             "lowering_matmul_promotion.mlir",
             "lowering_matvec.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_lit_test_suite(
     "emulate_i64.mlir"
     "erase_storage_buffer_static_shape.mlir"
     "illegal_configuration.mlir"
+    "lower_masks.mlir"
     "lowering_matmul_fusion.mlir"
     "lowering_matmul_promotion.mlir"
     "lowering_matvec.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lower_masks.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lower_masks.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(func.func(iree-spirv-final-vector-lowering))' %s | FileCheck %s
+
+func.func @create_mask(%idx: index) -> vector<1xi1> {
+  %c1 = arith.constant 1 : index
+  %0 = vector.create_mask %c1, %idx, %c1 : vector<1x1x1xi1>
+  %1 = vector.shape_cast %0 : vector<1x1x1xi1> to vector<1xi1>
+  return %1 : vector<1xi1>
+}
+
+//   CHECK-LABEL: func.func @create_mask
+//    CHECK-SAME:     %[[IDX:.+]]: index
+//     CHECK-DAG:   %[[TRUE:.+]] = arith.constant dense<true> : vector<1xi1>
+//     CHECK-DAG:   %[[FALSE:.+]] = arith.constant dense<false> : vector<1xi1>
+//     CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//         CHECK:   %[[CMP:.+]] = arith.cmpi sgt, %[[IDX]], %[[C0]] : index
+//         CHECK:   %[[MASK:.+]] = arith.select %[[CMP]], %[[TRUE]], %[[FALSE]] : vector<1xi1>
+//         CHECK:   return %[[MASK]] : vector<1xi1>


### PR DESCRIPTION
Mask lowering patterns progressively lower higher dimensional masks down to 1-D and then lower to some arithmetic to compute the mask. Because of the handling of n-D masks, we do this as a part of vector lowerings.