### PR TITLE
[Util] Add decoding for hoisted globals when cloning into initializers

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/test/flow_hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/flow_hoist_into_globals.mlir
@@ -23,6 +23,50 @@ module @hoist_sub_byte_tensor_store {
 
 // -----
 
+// CHECK-LABEL: @hoist_tree_const_expr_i4
+module @hoist_tree_const_expr_i4 {
+  // CHECK: util.global private @[[HOISTED_1:.*]] : tensor<4xi8>
+  // CHECK: util.global private @[[HOISTED_0:.*]] : tensor<4xi8>
+  // CHECK: util.global private @latent_global : tensor<8xi4>
+  util.global private @latent_global : tensor<8xi4>
+
+  // CHECK: func.func @main
+  func.func @main() -> (tensor<8xi4>, tensor<8xi4>, tensor<8xi4>) {
+    // CHECK-DAG: %[[LOAD_HOISTED_0:.*]] = util.global.load @[[HOISTED_0]] : tensor<4xi8>
+    // CHECK-DAG: %[[BITCAST_0:.*]] = flow.tensor.bitcast %[[LOAD_HOISTED_0]] : tensor<4xi8> -> tensor<8xi4>
+    // CHECK-DAG: %[[LOAD_HOISTED_1:.*]] = util.global.load @[[HOISTED_1]] : tensor<4xi8>
+    // CHECK-DAG: %[[BITCAST_1:.*]] = flow.tensor.bitcast %[[LOAD_HOISTED_1]] : tensor<4xi8> -> tensor<8xi4>
+    // CHECK-DAG: %[[RESULT:.*]] = "iree_unregistered.var_expr"(%[[BITCAST_1]])
+    // CHECK: return %[[BITCAST_0]], %[[BITCAST_1]], %[[RESULT]]
+    %0 = arith.constant dense<0> : tensor<8xi4>
+    %1 = arith.constant dense<1> : tensor<8xi4>
+    %2 = "iree_unregistered.const_expr"(%0, %1) : (tensor<8xi4>, tensor<8xi4>) -> tensor<8xi4>
+    %3 = util.global.load @latent_global : tensor<8xi4>
+    %4 = "iree_unregistered.const_expr"(%2, %3) : (tensor<8xi4>, tensor<8xi4>) -> tensor<8xi4>
+    %5 = "iree_unregistered.var_expr"(%4) : (tensor<8xi4>) -> tensor<8xi4>
+    return %2, %4, %5 : tensor<8xi4>, tensor<8xi4>, tensor<8xi4>
+  }
+  // CHECK: util.initializer attributes {iree.compiler.consteval} {
+  // CHECK:   %[[C0:.*]] = arith.constant dense<0> : tensor<8xi4>
+  // CHECK:   %[[C1:.*]] = arith.constant dense<1> : tensor<8xi4>
+  // CHECK:   %[[CE0:.*]] = "iree_unregistered.const_expr"(%[[C0]], %[[C1]])
+  // CHECK:   %[[BITCAST_2:.*]] = flow.tensor.bitcast %[[CE0]] : tensor<8xi4> -> tensor<4xi8>
+  // CHECK:   util.global.store %[[BITCAST_2]], @[[HOISTED_0]] : tensor<4xi8>
+  // CHECK:   util.initializer.return
+  // CHECK: }
+  // CHECK: util.initializer attributes {iree.compiler.consteval} {
+  // CHECK:   %[[LOAD_HOISTED_0:.*]] = util.global.load @[[HOISTED_0]] : tensor<4xi8>
+  // CHECK:   %[[BITCAST_3:.*]] = flow.tensor.bitcast %[[LOAD_HOISTED_0]] : tensor<4xi8> -> tensor<8xi4>
+  // CHECK:   %[[LOAD_LATENT_GLOBAL:.*]] = util.global.load @latent_global : tensor<8xi4>
+  // CHECK:   %[[CE1:.*]] = "iree_unregistered.const_expr"(%[[BITCAST_3]], %[[LOAD_LATENT_GLOBAL]])
+  // CHECK:   %[[BITCAST_4:.*]] = flow.tensor.bitcast %[[CE1]] : tensor<8xi4> -> tensor<4xi8>
+  // CHECK:   util.global.store %[[BITCAST_4]], @[[HOISTED_1]] : tensor<4xi8>
+  // CHECK:   util.initializer.return
+  // CHECK: }
+}
+
+// -----
+
 // CHECK-LABEL: @hoist_sub_byte_tensor_transitive
 // CHECK: util.global
 module @hoist_sub_byte_tensor_transitive {


### PR DESCRIPTION
This fixes a bug that prevented hoisted subbyte globals from being appropriately bitcasted when hoisted globals are loaded within another hoisted global