### PR TITLE
[GlobalOpt] Do not set encodings on cast ops when the source is i1 type.

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
@@ -96,7 +96,7 @@ struct ExpandVectors
         RankedTensorType::get(expandedOutDims, vectorOutTy.getElementType());
     Location loc = linalgOp.getLoc();
     Value expandedIn;
-    std::optional<CastOpInterface> castOp = getDefiningCastOp(vectorIn);
+    std::optional<CastOpInterface> castOp = getDefiningNonI1CastOp(vectorIn);
     if (castOp) {
       Value castIn = vectorIn.getDefiningOp()->getOperand(0);
       Type castSrcElemType =

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -243,8 +243,10 @@ struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
       }
       return {};
     };
-    std::optional<CastOpInterface> maybeLhsCastOp = getDefiningCastOp(origLhs);
-    std::optional<CastOpInterface> maybeRhsCastOp = getDefiningCastOp(origRhs);
+    std::optional<CastOpInterface> maybeLhsCastOp =
+        getDefiningNonI1CastOp(origLhs);
+    std::optional<CastOpInterface> maybeRhsCastOp =
+        getDefiningNonI1CastOp(origRhs);
     Type lhsElemType = maybeLhsCastOp ? getCastElemType(origLhs).value()
                                       : getElemType(origLhs);
     Type rhsElemType = maybeRhsCastOp ? getCastElemType(origRhs).value()
@@ -331,8 +333,10 @@ struct SetBatchMatmulEncoding : public OpRewritePattern<linalg::BatchMatmulOp> {
       }
       return {};
     };
-    std::optional<CastOpInterface> maybeLhsCastOp = getDefiningCastOp(origLhs);
-    std::optional<CastOpInterface> maybeRhsCastOp = getDefiningCastOp(origRhs);
+    std::optional<CastOpInterface> maybeLhsCastOp =
+        getDefiningNonI1CastOp(origLhs);
+    std::optional<CastOpInterface> maybeRhsCastOp =
+        getDefiningNonI1CastOp(origRhs);
     Type lhsElemType = maybeLhsCastOp ? getCastElemType(origLhs).value()
                                       : getElemType(origLhs);
     Type rhsElemType = maybeRhsCastOp ? getCastElemType(origRhs).value()

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.h
@@ -26,6 +26,8 @@ namespace GlobalOptimization {
 /// casting from i1 types, a std::nullopt is returned. It is dangerous to mix
 /// boalean concept and i1 subtypes concept at graph optimizatoin level. We
 /// ignore this type of casting ops intentionally.
+/// TODO(hanchung): Remove the restriction about i1 after we can handle i1
+/// sub-type emulation and deprecate TypePropagation pass.
 ///
 /// If it is not from a casting op, it returns a std::nullopt.
 ///

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.h
@@ -20,13 +20,18 @@ class NamedAttribute;
 namespace iree_compiler {
 namespace GlobalOptimization {
 
-/// If the producer is a CastOpInterface, or a linalg::GenericOp that performs
-/// only a CastOpInterface on its input, return the CastOpInterface op.
-/// Otherwise, return std::nullopt.
+/// Returns a CastOpInterface op, if the producer is a CastOpInterface op, or a
+/// linalg::GenericOp that performs only a CastOpInterface on its input.
+/// The bitwidth of the source element type should be greater than 1. If it is
+/// casting from i1 types, a std::nullopt is returned. It is dangerous to mix
+/// boalean concept and i1 subtypes concept at graph optimizatoin level. We
+/// ignore this type of casting ops intentionally.
+///
+/// If it is not from a casting op, it returns a std::nullopt.
 ///
 /// **Note: If the CastOpInterface has been generalized, the return Operation
 ///         is the body CastOpInterface op, not the linalg::GenericOp.
-std::optional<CastOpInterface> getDefiningCastOp(Value input);
+std::optional<CastOpInterface> getDefiningNonI1CastOp(Value input);
 
 /// Returns the source element type of the defining CastOpInterface of `input`,
 /// if there is one. Otherwise return std::nullopt.


### PR DESCRIPTION
An input program could cast an i1 tensor to f32 tensor and use it in matmul. We do not set encodings on such cast ops because mixing boolean concept and i1 subtype concept is dangerous. We still want to data-tile f32.f32.f32 matmul, but not include the cast op from i1 types.

Fixes https://github.com/openxla/iree/issues/15692