### PR TITLE
[CPU][NFC] Move user config materialization logics out of lit tests.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_masking.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_masking.mlir
@@ -1,9 +1,6 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy, iree-llvmcpu-lower-executable-target)))' -split-input-file %s | FileCheck %s
 
 
-#compilation = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[127, 255], [8, 32], [0, 0]]>,
-    translation_info  = <CPUDoubleTilingExpert>>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -70,9 +67,6 @@ hal.executable private @preset_config_generic_add  {
 
 // -----
 
-#compilation = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[127, 255], [8, 0], [0, 32]]>,
-    translation_info  = <CPUDoubleTilingExpert>>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -127,9 +121,6 @@ hal.executable private @preset_config_reduction  {
 
 // -----
 
-#compilation = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[127, 255], [8, 32], [0, 0]]>,
-    translation_info  = <CPUDoubleTilingExpert>>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -196,9 +187,6 @@ hal.executable private @preset_config_generic_add  {
 
 // -----
 
-#compilation = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[127, 255], [8, 32], [0, 0]]>,
-    translation_info  = <CPUDoubleTilingExpert>>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -317,9 +305,6 @@ hal.executable private @preset_config_matmul  {
 
 // -----
 
-#compilation = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[127, 255], [8, 32], [0, 0]]>,
-    translation_info  = <CPUDoubleTilingExpert>>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,


### PR DESCRIPTION
We used to preset compilation_info to drive codegen pipeline. Now the logic is moved out to CommonDialectRegistration pass. The preset configuration is materialized by the pass. The revisions adapts the lit tests to use materialized form. This completely removes the needs of running `--iree-codegen-materialize-user-configs` before other passes.

Also removes compilation_info attributes from vector_masking.mlir because they are not used at all.