### PR TITLE
[Util] Add HoistableOpInterface to prevent hoisting metadata ops

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -62,6 +62,7 @@ class TargetConverter:
                 "@llvm-project//mlir:DialectUtils": [""],
                 "@llvm-project//mlir:GPUDialect": ["MLIRGPUDialect"],
                 "@llvm-project//mlir:GPUTransforms": ["MLIRGPUTransforms"],
+                "@llvm-project//mlir:LinalgOpsIncGen": ["MLIRLinalgOpsIncGenLib"],
                 "@llvm-project//mlir:LinalgStructuredOpsIncGen": [
                     "MLIRLinalgStructuredOpsIncGenLib"
                 ],

--- a/build_tools/third_party/llvm-project/CMakeLists.txt
+++ b/build_tools/third_party/llvm-project/CMakeLists.txt
@@ -12,3 +12,7 @@ add_library(MLIRLinalgStructuredOpsIncGenLib INTERFACE)
 add_dependencies(MLIRLinalgStructuredOpsIncGenLib
   MLIRLinalgStructuredOpsIncGen
 )
+add_library(MLIRLinalgOpsIncGenLib INTERFACE)
+add_dependencies(MLIRLinalgOpsIncGenLib
+  MLIRLinalgOpsIncGen
+)

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowInterfaces.td
@@ -13,30 +13,4 @@ include "iree/compiler/Dialect/Util/IR/UtilBase.td"
 // IREE::Flow::StreamableOpInterface
 //===----------------------------------------------------------------------===//
 
-def FLOW_StreamableOp : OpInterface<"StreamableOpInterface"> {
-  let description = [{
-    Interface for ops that can be used within a stream.
-
-    Some ops can exist both within a stream and outside of a stream. This allows
-    optimizations to place certain ops such that they are performed in a
-    synchronous (outside of a stream) or asynchronous (inside of a stream)
-    fashion.
-
-    The goal of the stream forming process is to move as many operations that
-    can be used within a stream into one and only using non-streamed ops as a
-    last resort.
-  }];
-
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/[{
-        Returns true if the op is transfer operation (as defined by the HAL).
-      }],
-      /*retTy=*/"bool",
-      /*methodName=*/"isTransfer",
-      /*args=*/(ins)
-    >,
-  ];
-}
-
 #endif  // IREE_DIALECT_FLOW_INTERFACES

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -749,7 +749,6 @@ let opDocGroup = OpGroupDispatchOps in {
 
 def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
   AttrSizedOperandSegments,
-  FLOW_StreamableOp,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
     "getTiedOperandsIndexAndLength",
@@ -839,9 +838,6 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
     // Returns a human-friendly string name for what is being dispatched.
     // May not be unique or a valid reference to an executable.
     std::string getEntryPointName();
-
-    // StreamableOpInterface:
-    bool isTransfer() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) {
       return IREE::Util::findDynamicDimsInList(idx - getWorkload().size(), getArguments(), getArgumentDims());
@@ -936,7 +932,6 @@ def FLOW_FuncOp : FLOW_Op<"func", [
 def FLOW_CallOp : FLOW_Op<"call", [
   AttrSizedOperandSegments,
   CallOpInterface,
-  FLOW_StreamableOp,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
     "getTiedOperandsIndexAndLength",
@@ -1013,9 +1008,6 @@ def FLOW_CallOp : FLOW_Op<"call", [
     void setCalleeFromCallable(CallInterfaceCallable callee) {
       (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
     }
-
-    // StreamableOpInterface:
-    bool isTransfer() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) {
       return IREE::Util::findDynamicDimsInList(idx, getArguments(), getArgumentDims());
@@ -1108,9 +1100,9 @@ def FLOW_TensorTieShapeOp : FLOW_PureOp<"tensor.tie_shape", [
 }
 
 def FLOW_TensorReshapeOp : FLOW_PureOp<"tensor.reshape", [
-  FLOW_StreamableOp,
   AllElementTypesMatch<["source", "result"]>,
   AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
       "getTiedResult",
       "getTiedResultOperandIndex",
@@ -1152,8 +1144,7 @@ def FLOW_TensorReshapeOp : FLOW_PureOp<"tensor.reshape", [
   ];
 
   let extraClassDeclaration = [{
-    // StreamableOpInterface:
-    bool isTransfer() { return true; }
+    bool isHoistableLeafOp() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) { return getSourceDims(); }
     ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
@@ -1165,8 +1156,8 @@ def FLOW_TensorReshapeOp : FLOW_PureOp<"tensor.reshape", [
 }
 
 def FLOW_TensorBitCastOp : FLOW_PureOp<"tensor.bitcast", [
-  FLOW_StreamableOp,
   AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
       "getTiedResult",
       "getTiedResultOperandIndex",
@@ -1208,8 +1199,7 @@ def FLOW_TensorBitCastOp : FLOW_PureOp<"tensor.bitcast", [
   ];
 
   let extraClassDeclaration = [{
-    // StreamableOpInterface:
-    bool isTransfer() { return true; }
+    bool isHoistableLeafOp() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) { return getSourceDims(); }
     ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
@@ -1358,7 +1348,7 @@ def FLOW_TensorAllocaOp : FLOW_Op<"tensor.alloca", [
 }
 
 def FLOW_TensorEmptyOp : FLOW_PureOp<"tensor.empty", [
-  FLOW_StreamableOp,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,
 ]> {
   let summary = [{an empty tensor carrying metadata but no contents}];
@@ -1380,8 +1370,7 @@ def FLOW_TensorEmptyOp : FLOW_PureOp<"tensor.empty", [
   }];
 
   let extraClassDeclaration = [{
-    // StreamableOpInterface:
-    bool isTransfer() { return true; }
+    bool isHoistableLeafOp() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) { return ValueRange{}; }
     ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
@@ -1392,10 +1381,10 @@ def FLOW_TensorEmptyOp : FLOW_PureOp<"tensor.empty", [
 }
 
 def FLOW_TensorSplatOp : FLOW_PureOp<"tensor.splat", [
-  FLOW_StreamableOp,
   TypesMatchWith<"value type matches element type of result",
                   "result", "value",
                   "$_self.cast<ShapedType>().getElementType()">,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,
 ]> {
   let summary = [{splats a value into a shaped tensor}];
@@ -1417,8 +1406,7 @@ def FLOW_TensorSplatOp : FLOW_PureOp<"tensor.splat", [
   }];
 
   let extraClassDeclaration = [{
-    // StreamableOpInterface:
-    bool isTransfer() { return true; }
+    bool isHoistableLeafOp() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) { return ValueRange{}; }
     ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
@@ -1429,8 +1417,8 @@ def FLOW_TensorSplatOp : FLOW_PureOp<"tensor.splat", [
 }
 
 def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
-  FLOW_StreamableOp,
   AllTypesMatch<["operand", "result"]>,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,
 ]> {
   let summary = [{performs a full tensor clone operation}];
@@ -1462,8 +1450,7 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
   ];
 
   let extraClassDeclaration = [{
-    // StreamableOpInterface:
-    bool isTransfer() { return true; }
+    bool isHoistableLeafOp() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) { return getArgumentDims(); }
     ValueRange getResultDynamicDims(unsigned idx) { return getArgumentDims(); }
@@ -1475,9 +1462,9 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
 }
 
 def FLOW_TensorSliceOp : FLOW_PureOp<"tensor.slice", [
-  FLOW_StreamableOp,
   AllRanksMatch<["source", "result"]>,
   AllElementTypesMatch<["source", "result"]>,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
@@ -1505,8 +1492,7 @@ def FLOW_TensorSliceOp : FLOW_PureOp<"tensor.slice", [
   }];
 
   let extraClassDeclaration = [{
-    // StreamableOpInterface:
-    bool isTransfer() { return true; }
+    bool isHoistableLeafOp() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) { return getSourceDims(); }
     ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
@@ -1518,11 +1504,11 @@ def FLOW_TensorSliceOp : FLOW_PureOp<"tensor.slice", [
 }
 
 def FLOW_TensorUpdateOp : FLOW_PureOp<"tensor.update", [
-  FLOW_StreamableOp,
   AllRanksMatch<["update", "target", "result"]>,
   AllTypesMatch<["target", "result"]>,
   AllElementTypesMatch<["update", "target", "result"]>,
   AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
       "getTiedResult",
       "getTiedResultOperandIndex",
@@ -1562,8 +1548,7 @@ def FLOW_TensorUpdateOp : FLOW_PureOp<"tensor.update", [
   ];
 
   let extraClassDeclaration = [{
-    // StreamableOpInterface:
-    bool isTransfer() { return true; }
+    bool isHoistableLeafOp() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) {
       return idx == 0 ? getTargetDims() : getUpdateDims();

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/BUILD.bazel
@@ -25,14 +25,11 @@ iree_compiler_cc_library(
     deps = [
         "//compiler/src/iree/compiler/Dialect/Util/Analysis",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
-        "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:TensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/CMakeLists.txt
@@ -20,15 +20,12 @@ iree_cc_library(
     "ConstExpr.cpp"
     "OpOracle.cpp"
   DEPS
-    IREELinalgExtDialect
     LLVMSupport
     MLIRArithDialect
     MLIRFuncDialect
     MLIRFunctionInterfaces
     MLIRIR
-    MLIRLinalgDialect
     MLIRSupport
-    MLIRTensorDialect
     iree::compiler::Dialect::Util::Analysis
     iree::compiler::Dialect::Util::IR
   PUBLIC

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
@@ -6,13 +6,10 @@
 
 #include "iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h"
 
-#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Debug.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace mlir::iree_compiler::IREE::Util {
@@ -71,26 +68,20 @@ bool isLegalConstExprType(Type t) {
   return false;
 }
 
+void registerConstExprDependentDialects(DialectRegistry &registry) {
+  registry.insert<IREE::Util::UtilDialect>();
+}
+
+bool isLegalConstExprRootType(Type t) { return isLegalConstExprType(t); }
+
 // Check if the op can be an eligible const expr.
 bool isEligibleConstExpr(Operation *op) {
-  // We have a specific allow-list for Linalg ops because we want to consider
-  // new additions carefully.
-  if (op->getDialect() ==
-      op->getContext()->getOrLoadDialect<linalg::LinalgDialect>()) {
-    // Structured op implementations and a handful of pure ops are included.
-    // Notably: IndexOp is not included because it establishes a hidden
-    // dependency to the iterator and is non-const.
-    if (llvm::isa<linalg::LinalgOp>(op) || llvm::isa<tensor::PadOp>(op) ||
-        llvm::isa<tensor::EmptyOp>(op)) {
+  // If implementing the HoistableOpInterface, just use the decision made by
+  // the interface.
+  if (auto hoistableOp = dyn_cast<IREE::Util::HoistableOpInterface>(op)) {
+    if (hoistableOp.isHoistableOp()) {
       return true;
     }
-    return false;
-  }
-
-  // Target-dependent ops are not const-expr.
-  // TODO(#14887): Use trait/interface instead.
-  if (isa<IREE::LinalgExt::UpperBoundTileSizeOp,
-          IREE::LinalgExt::SetEncodingOp>(op)) {
     return false;
   }
 
@@ -107,8 +98,12 @@ bool isEligibleConstExpr(Operation *op) {
   }
 
   // Forbid if part of a parent that should be treated atomically.
-  if (op->getParentOfType<linalg::LinalgOp>()) {
-    return false;
+  Operation *parent = op;
+  while (auto hoistableParent =
+             parent->getParentOfType<IREE::Util::HoistableOpInterface>()) {
+    if (hoistableParent.isAtomicallyHoistableOp())
+      return false;
+    parent = hoistableParent;
   }
 
   // Optimization barriers cannot be folded.
@@ -146,7 +141,6 @@ bool isEligibleConstExpr(Operation *op) {
 
 void registerConstExprDependentDialects(DialectRegistry &registry) {
   registry.insert<IREE::Util::UtilDialect>();
-  registry.insert<linalg::LinalgDialect>();
 }
 
 bool isLegalConstExprRootType(Type t) { return isLegalConstExprType(t); }
@@ -172,31 +166,15 @@ bool isHoistableConstExprLeaf(const ConstExprAnalysis::ConstValueInfo *info) {
   // First check whether we should hoist this kind of operation. Type local
   // decisions should always come last.
 
-  // Generally, we prefer to not hoist broadcasts.
-  if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
-    // Detect op that only broadcast input as fusing them makes the new
-    // op cheaper.
-    if (genericOp.getNumParallelLoops() == genericOp.getNumLoops() &&
-        isa<linalg::YieldOp>(genericOp.getBody()->front())) {
-      for (OpOperand *opOperand : genericOp.getDpsInputOperands()) {
-        AffineMap indexingMap = genericOp.getMatchingIndexingMap(opOperand);
-        if (indexingMap.isProjectedPermutation() &&
-            indexingMap.getNumDims() != indexingMap.getNumResults()) {
-          return false;
-        }
-      }
-    }
+  // If implementing the HoistableOpInterface, check whether the op is legal to
+  // hoist. We still need to check for type legality afterwards though.
+  if (auto hoistableOp = dyn_cast<IREE::Util::HoistableOpInterface>(op)) {
+    if (!hoistableOp.isHoistableLeafOp())
+      return false;
   }
 
-  // Never hoist empty. These are sometimes used for pure shape metadata
-  // and must not be separated from their consumers.
-  if (isa<tensor::EmptyOp, tensor::ExpandShapeOp, tensor::CollapseShapeOp>(
-          op)) {
-    return false;
-  }
-
-  // If implementing the HoistableTypeInterface, just return what the interface
-  // says.
+  // If implementing the HoistableTypeInterface, at this point we can just
+  // return what the interface says.
   if (auto hoistableType = dyn_cast<IREE::Util::HoistableTypeInterface>(
           info->constValue.getType())) {
     return hoistableType.isHoistableLeafType();
@@ -216,9 +194,8 @@ bool isHoistableConstExprLeaf(const ConstExprAnalysis::ConstValueInfo *info) {
 
 bool isHoistableConstExprConsumingOperand(OpOperand *operand) {
   Operation *op = operand->getOwner();
-  // For linalg ops, we only want to hoist inputs.
-  if (auto structuredOp = dyn_cast<linalg::LinalgOp>(op)) {
-    return operand->getOperandNumber() < structuredOp.getNumDpsInputs();
+  if (auto hoistableOp = dyn_cast<IREE::Util::HoistableOpInterface>(op)) {
+    return hoistableOp.isOperandHoistable(operand);
   }
 
   // Fallback to yes.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -1113,8 +1113,71 @@ def Util_GlobalType : TypeInterface<"GlobalTypeInterface"> {
 }
 
 //===----------------------------------------------------------------------===//
-// IREE::Util::HoistableTypeInterface
+// IREE::Util::Hoistable*Interface
 //===----------------------------------------------------------------------===//
+
+def Util_HoistableOpInterface : OpInterface<"HoistableOpInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Util";
+
+  let description = [{
+    Interface used to control hoisting of ops into globals.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if this op is valid to hoist as a transient value in the
+        global initializer.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isHoistableOp",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return true;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if this op is valid to hoist as a leaf value in the
+        global initializer.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isHoistableLeafOp",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return true;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if this op is should be treated as atomic from the
+        perspective of the hoisting analysis. This causes all nested ops to
+        share hoistability with this op.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isAtomicallyHoistableOp",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return false;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if the operand for this op is hoistable.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isOperandHoistable",
+      /*args=*/(ins "OpOperand *":$operand),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return true;
+      }]
+    >,
+  ];
+}
 
 def Util_HoistableType : TypeInterface<"HoistableTypeInterface"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Util";

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
@@ -25,7 +25,6 @@ iree_lit_test_suite(
             "fold_globals.mlir",
             "fuse_globals.mlir",
             "hoist_into_globals.mlir",
-            "hoist_into_globals_linalg.mlir",
             "import_resources.mlir",
             "ipo.mlir",
             "outline_constants.mlir",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
@@ -23,7 +23,6 @@ iree_lit_test_suite(
     "fold_globals.mlir"
     "fuse_globals.mlir"
     "hoist_into_globals.mlir"
-    "hoist_into_globals_linalg.mlir"
     "import_resources.mlir"
     "ipo.mlir"
     "outline_constants.mlir"

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/BUILD.bazel
@@ -21,23 +21,31 @@ iree_compiler_cc_library(
         "Interfaces.h",
     ],
     deps = [
-        ":HoistableTypeInterface",
+        ":HoistableInterfaces",
         "@llvm-project//mlir:IR",
     ],
 )
 
 iree_compiler_cc_library(
-    name = "HoistableTypeInterface",
+    name = "HoistableInterfaces",
     srcs = [
+        "HoistableOpInterface.cpp",
         "HoistableTypeInterface.cpp",
     ],
     hdrs = [
+        "HoistableOpInterface.h",
         "HoistableTypeInterface.h",
     ],
     deps = [
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
+        "//compiler/src/iree/compiler/Dialect/Flow/IR:FlowOpsGen",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgOpsIncGen",
+        "@llvm-project//mlir:LinalgStructuredOpsIncGen",
+        "@llvm-project//mlir:TensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/CMakeLists.txt
@@ -18,22 +18,30 @@ iree_cc_library(
   SRCS
     "Interfaces.cpp"
   DEPS
-    ::HoistableTypeInterface
+    ::HoistableInterfaces
     MLIRIR
   PUBLIC
 )
 
 iree_cc_library(
   NAME
-    HoistableTypeInterface
+    HoistableInterfaces
   HDRS
+    "HoistableOpInterface.h"
     "HoistableTypeInterface.h"
   SRCS
+    "HoistableOpInterface.cpp"
     "HoistableTypeInterface.cpp"
   DEPS
+    IREELinalgExtDialect
     LLVMSupport
     MLIRIR
+    MLIRLinalgDialect
+    MLIRLinalgOpsIncGenLib
+    MLIRLinalgStructuredOpsIncGenLib
+    MLIRTensorDialect
     iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::Flow::IR::FlowOpsGen
     iree::compiler::Dialect::Util::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableOpInterface.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableOpInterface.cpp
@@ -1,0 +1,153 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/GlobalOptimization/Interfaces/HoistableOpInterface.h"
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+template <typename OpTy>
+struct UnhoistableOpInterface
+    : public IREE::Util::HoistableOpInterface::ExternalModel<
+          UnhoistableOpInterface<OpTy>, OpTy> {
+  bool isHoistableOp(Operation *) const { return false; }
+  bool isHoistableLeafOp(Operation *) const { return false; }
+};
+
+template <typename OpTy>
+struct HoistableNonLeafOpInterface
+    : public IREE::Util::HoistableOpInterface::ExternalModel<
+          HoistableNonLeafOpInterface<OpTy>, OpTy> {
+  bool isHoistableLeafOp(Operation *) const { return false; }
+};
+
+// The default interface is always hoistable. This acts as an override
+// for other default hoistability checks as the interface is checked
+// first.
+template <typename OpTy>
+struct AlwaysHoistableOpInterface
+    : public IREE::Util::HoistableOpInterface::ExternalModel<
+          AlwaysHoistableOpInterface<OpTy>, OpTy> {};
+
+template <typename OpTy>
+struct HoistableLinalgOpInterface
+    : public IREE::Util::HoistableOpInterface::ExternalModel<
+          HoistableLinalgOpInterface<OpTy>, OpTy> {
+  bool isHoistableOp(Operation *) const { return true; }
+  bool isHoistableLeafOp(Operation *op) const {
+    auto genericOp = llvm::dyn_cast<linalg::GenericOp>(op);
+    if (!genericOp)
+      return true;
+    // Generally, we prefer to not hoist broadcasts.
+    // Detect op that only broadcast input as fusing them makes the new
+    // op cheaper.
+    if (genericOp.getNumParallelLoops() == genericOp.getNumLoops() &&
+        isa<linalg::YieldOp>(genericOp.getBody()->front())) {
+      for (OpOperand *opOperand : genericOp.getDpsInputOperands()) {
+        AffineMap indexingMap = genericOp.getMatchingIndexingMap(opOperand);
+        if (indexingMap.isProjectedPermutation() &&
+            indexingMap.getNumDims() != indexingMap.getNumResults()) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+  bool isAtomicallyHoistableOp(Operation *) const { return true; }
+  bool isOperandHoistable(Operation *op, OpOperand *operand) const {
+    linalg::LinalgOp linalgOp = llvm::cast<linalg::LinalgOp>(op);
+    // For linalg ops, we only want to hoist inputs.
+    return operand->getOperandNumber() < linalgOp.getNumDpsInputs();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Interface Registration
+//===----------------------------------------------------------------------===//
+
+/// Helper structures that iterates over all Op types in `OpTys` and registers
+/// the associated Hoistable___OpInterface.
+template <typename... Ops>
+struct UnhoistableOpInterfaceHelper {
+  static void registerOpInterface(MLIRContext *ctx) {
+    (Ops::template attachInterface<UnhoistableOpInterface<Ops>>(*ctx), ...);
+  }
+};
+
+template <typename... Ops>
+struct HoistableNonLeafOpInterfaceHelper {
+  static void registerOpInterface(MLIRContext *ctx) {
+    (Ops::template attachInterface<HoistableNonLeafOpInterface<Ops>>(*ctx),
+     ...);
+  }
+};
+
+template <typename... Ops>
+struct AlwaysHoistableOpInterfaceHelper {
+  static void registerOpInterface(MLIRContext *ctx) {
+    (Ops::template attachInterface<AlwaysHoistableOpInterface<Ops>>(*ctx), ...);
+  }
+};
+
+template <typename... Ops>
+struct HoistableLinalgOpInterfaceHelper {
+  static void registerOpInterface(MLIRContext *ctx) {
+    (Ops::template attachInterface<HoistableLinalgOpInterface<Ops>>(*ctx), ...);
+  }
+};
+
+void registerHoistableOpInterfaces(DialectRegistry &registry) {
+  // Register hoistable type interfaces for LinalgExt ops.
+  registry.addExtension(
+      +[](MLIRContext *ctx, IREE::LinalgExt::IREELinalgExtDialect *dialect) {
+        UnhoistableOpInterfaceHelper<
+            IREE::LinalgExt::SetEncodingOp,
+            IREE::LinalgExt::UpperBoundTileSizeOp>::registerOpInterface(ctx);
+      });
+  // Register hoistable type interfaces for linalg ops.
+  // We have a specific allow-list for Linalg ops because we want to consider
+  // new additions carefully.
+  registry.addExtension(+[](MLIRContext *ctx, linalg::LinalgDialect *dialect) {
+    // Structured op implementations and a handful of pure ops are included.
+    // Notably: IndexOp is not included because it establishes a hidden
+    // dependency to the iterator and is non-const.
+
+    // Register all LinalgOps ops. `LinalgOp` is an interface and it is
+    // not possible to attach an external interface to an existing interface.
+    // Therefore, attach the `HoistableLinalgOpInterface` to all ops one-by-one.
+    HoistableLinalgOpInterfaceHelper<
+#define GET_OP_LIST
+#include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
+        >::registerOpInterface(ctx);
+    UnhoistableOpInterfaceHelper<
+#define GET_OP_LIST
+#include "mlir/Dialect/Linalg/IR/LinalgOps.cpp.inc"
+        >::registerOpInterface(ctx);
+  });
+  // Register hoistable type interfaces for tensor ops.
+  registry.addExtension(+[](MLIRContext *ctx, tensor::TensorDialect *dialect) {
+    // Never hoist empty and other pure metadata ops as a leaf. It's fine to
+    // hoist them as a part of a larger constant tree that does actual work.
+    HoistableNonLeafOpInterfaceHelper<
+        tensor::EmptyOp, tensor::ExpandShapeOp,
+        tensor::CollapseShapeOp>::registerOpInterface(ctx);
+    // Cases of trivial pack/unpack should be handled as canonicalizations
+    // before we get here, thus we're safe to always hoist.
+    AlwaysHoistableOpInterfaceHelper<
+        tensor::PadOp, tensor::PackOp,
+        tensor::UnPackOp>::registerOpInterface(ctx);
+  });
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableOpInterface.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableOpInterface.h
@@ -1,0 +1,21 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_GLOBALOPTIMIZATION_INTERFACES_HOISTABLEOPINTERFACE_H_
+#define IREE_COMPILER_GLOBALOPTIMIZATION_INTERFACES_HOISTABLEOPINTERFACE_H_
+
+#include "mlir/IR/Dialect.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+// Register all interfaces needed for hoisting constant expressions.
+void registerHoistableOpInterfaces(DialectRegistry &registry);
+
+} // namespace iree_compiler
+} // namespace mlir
+
+#endif // IREE_COMPILER_GLOBALOPTIMIZATION_INTERFACES_HOISTABLEOPINTERFACE_H_

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The IREE Authors
+// Copyright 2023 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/Interfaces.cpp
@@ -5,12 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/GlobalOptimization/Interfaces/Interfaces.h"
+#include "iree/compiler/GlobalOptimization/Interfaces/HoistableOpInterface.h"
 #include "iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.h"
 
 namespace mlir::iree_compiler {
 
 void registerGlobalOptimizationInterfaces(DialectRegistry &registry) {
   registerHoistableTypeInterfaces(registry);
+  registerHoistableOpInterfaces(registry);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "fuse_dequantization_matmul.mlir",
             "fuse_silu_horizontal_matmul.mlir",
             "generalize_named_ops.mlir",
+            "hoist_into_globals_linalg.mlir",
             "infer_numeric_narrowing.mlir",
             "materialize_homogeneous_encodings.mlir",
             "optimize_numerics.mlir",

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     "fuse_dequantization_matmul.mlir"
     "fuse_silu_horizontal_matmul.mlir"
     "generalize_named_ops.mlir"
+    "hoist_into_globals_linalg.mlir"
     "infer_numeric_narrowing.mlir"
     "materialize_homogeneous_encodings.mlir"
     "optimize_numerics.mlir"

--- a/compiler/src/iree/compiler/GlobalOptimization/test/flow_hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/flow_hoist_into_globals.mlir
@@ -78,3 +78,16 @@ module @hoist_sub_byte_tensor_transitive {
 }
 // We do not need to cast for transitive sub-byte values.
 // CHECK-NOT: flow.tensor.bitcast
+
+// -----
+
+// We should not hoist metadata ops alone.
+// CHECK-LABEL: @do_not_hoist_metadata_leaf
+// CHECK-NOT: util.global
+module @do_not_hoist_metadata_leaf {
+  func.func @main() -> (tensor<1xi32>) {
+    %0 = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi8>
+    %1 = flow.tensor.bitcast %0 : tensor<4xi8> -> tensor<1xi32>
+    return %1 : tensor<1xi32>
+  }
+}

--- a/compiler/src/iree/compiler/GlobalOptimization/test/hoist_into_globals_linalg.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/hoist_into_globals_linalg.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-util-hoist-into-globals %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-global-optimization-hoist-constant-expressions %s | FileCheck %s
 // Spot verification that policies for linalg ops is respected.
 
 // CHECK-LABEL: @compute_hoisted


### PR DESCRIPTION
This is mostly NFC, decoupling the linalg and tensor dialects from Util/Analysis/Constant, but this also registers the interface on Flow ops, preventing leaf hoisting for metadata only ops like bitcast and reshape.