### PR TITLE
Reorder ML frameworks and support matrix items on website.

### DIFF
--- a/docs/website/docs/guides/ml-frameworks/index.md
+++ b/docs/website/docs/guides/ml-frameworks/index.md
@@ -27,10 +27,10 @@ graph LR
 
 See end-to-end examples of how to use each framework with IREE:
 
-* [:simple-tensorflow: TensorFlow](./tensorflow.md) and
-  [:simple-tensorflow: TensorFlow Lite](./tflite.md)
 * [:simple-python: JAX](./jax.md)
 * [:simple-pytorch: PyTorch](./pytorch.md)
+* [:simple-tensorflow: TensorFlow](./tensorflow.md) and
+  [:simple-tensorflow: TensorFlow Lite](./tflite.md)
 
 Importing from other frameworks is planned - stay tuned!
 

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -5,7 +5,6 @@ tags:
   - Python
   - PyTorch
 icon: simple/pytorch
-status: new
 ---
 
 # PyTorch + IREE = :octicons-heart-16:

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -25,11 +25,11 @@ considerations of mobile and edge deployments.
 
 IREE supports importing from a variety of ML frameworks:
 
-- [x] TensorFlow
-- [x] TensorFlow Lite
 - [x] JAX
 - [x] PyTorch
-- [ ] ONNX (hoped for)
+- [x] TensorFlow
+- [x] TensorFlow Lite
+- [ ] ONNX (experimental)
 
 The IREE compiler tools run on :fontawesome-brands-linux: Linux,
 :fontawesome-brands-windows: Windows, and :fontawesome-brands-apple: macOS
@@ -37,11 +37,11 @@ and can generate efficient code for a variety of runtime platforms:
 
 - [x] Linux
 - [x] Windows
-- [x] Android
 - [x] macOS
+- [x] Android
 - [x] iOS
 - [x] Bare metal
-- [ ] WebAssembly (planned)
+- [ ] WebAssembly (experimental)
 
 and architectures:
 
@@ -54,7 +54,9 @@ Support for hardware accelerators and APIs is also included:
 - [x] Vulkan
 - [x] CUDA
 - [x] Metal (for Apple silicon devices)
-- [ ] WebGPU (planned)
+- [ ] ROCm (experimental)
+- [ ] AMD AIE (experimental)
+- [ ] WebGPU (experimental)
 
 ## Project architecture
 
@@ -96,10 +98,10 @@ Using IREE involves the following general steps:
 IREE supports importing models from a growing list of ML frameworks and model
 formats:
 
-* [TensorFlow](./guides/ml-frameworks/tensorflow.md) and
-  [TensorFlow Lite](./guides/ml-frameworks/tflite.md)
 * [JAX](./guides/ml-frameworks/jax.md)
 * [PyTorch](./guides/ml-frameworks/pytorch.md)
+* [TensorFlow](./guides/ml-frameworks/tensorflow.md) and
+  [TensorFlow Lite](./guides/ml-frameworks/tflite.md)
 
 ### Selecting deployment configurations
 

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -127,10 +127,10 @@ nav:
       - "guides/index.md"
       - "ML frameworks":
           - "guides/ml-frameworks/index.md"
-          - TensorFlow: "guides/ml-frameworks/tensorflow.md"
-          - TensorFlow Lite: "guides/ml-frameworks/tflite.md"
           - JAX: "guides/ml-frameworks/jax.md"
           - PyTorch: "guides/ml-frameworks/pytorch.md"
+          - TensorFlow: "guides/ml-frameworks/tensorflow.md"
+          - TensorFlow Lite: "guides/ml-frameworks/tflite.md"
       - "Deployment configurations":
           - "guides/deployment-configurations/index.md"
           - CPU: "guides/deployment-configurations/cpu.md"


### PR DESCRIPTION
* Alphabetize ML frameworks
  * The JAX docs are sparse, so I could also see putting PyTorch at the top of the list
* Change "ONNX" from "(hoped for)" to "(experimental)" and apply the same "(experimental)" to a few other targets