### PR TITLE
[HAL] Add initialization check for device support

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -281,6 +281,12 @@ private:
     // Fallback for no available variant.
     auto &defaultBlock = switchOp.getDefaultRegion().emplaceBlock();
     auto defaultBuilder = OpBuilder::atBlockBegin(&defaultBlock);
+    Value status = defaultBuilder.create<arith::ConstantIntOp>(
+        loc, static_cast<int>(IREE::Util::StatusCode::Unavailable), 32);
+    defaultBuilder.create<IREE::Util::StatusCheckOkOp>(
+        loc, status,
+        "none of the executable binaries in the module are supported by the "
+        "runtime");
     auto nullValue =
         defaultBuilder.createOrFold<IREE::Util::NullOp>(loc, executableType);
     defaultBuilder.create<scf::YieldOp>(loc, nullValue);

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -192,6 +192,8 @@ hal.executable @exe {
 // CHECK:     scf.yield %[[EXE]] : !hal.executable
 // CHECK:   }
 // CHECK:   default {
+// CHECK:     %[[C14:.+]] = arith.constant 14 : i32
+// CHECK:     util.status.check_ok %[[C14]], "none of the executable binaries in the module are supported by the runtime"
 // CHECK:     %[[NULL:.+]] = util.null : !hal.executable
 // CHECK:     scf.yield %[[NULL]] : !hal.executable
 // CHECK:   }


### PR DESCRIPTION
Currently after the addition of a selection region for dispatches, there is no check that the compiled module is actually supported by the device, meaning the command buffer will only pick up the fills + allocs, leading to a very confusing situation where your model will seemingly run in an unsupported configuration.

This is a huge performance regression for anyone relying on running their models on unsupported devices though :P

Co-authored-by: Ben Vanik <ben.vanik@gmail.com>