### PR TITLE
Cleanup parts of the Bazel build and document usage.

### DIFF
--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -14,11 +14,11 @@
 # IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 0
 # BUILD_TAG_FILTERS: Passed to bazel to filter targets to build.
 #   See https://bazel.build/reference/command-line-reference.html#flag--build_tag_filters)
-#   Default: "-nokokoro"
+#   Default: "-nodocker"
 # TEST_TAG_FILTERS: Passed to bazel to filter targets to test. Note that test
 #   targets excluded this way will also not be built.
 #   See https://bazel.build/reference/command-line-reference.html#flag--test_tag_filters)
-#   Default: If IREE_VULKAN_DISABLE=1, "-nokokoro,-driver=vulkan". Else "-nokokoro".
+#   Default: If IREE_VULKAN_DISABLE=1, "-nodocker,-driver=vulkan". Else "-nodocker".
 
 set -xeuo pipefail
 
@@ -57,8 +57,8 @@ if ! [[ -n IREE_LLVM_EMBEDDED_LINKER_PATH ]]; then
   test_env_args+=(--action_env=IREE_LLVM_EMBEDDED_LINKER_PATH="${IREE_LLVM_EMBEDDED_LINKER_PATH}")
 fi
 
-declare -a default_build_tag_filters=("-nokokoro")
-declare -a default_test_tag_filters=("-nokokoro" "-driver=metal")
+declare -a default_build_tag_filters=("-nodocker")
+declare -a default_test_tag_filters=("-nodocker" "-driver=metal")
 
 # The VK_KHR_shader_float16_int8 extension is optional prior to Vulkan 1.2.
 # We test on SwiftShader, which does not support this extension.
@@ -87,14 +87,17 @@ if ! [[ -v TEST_TAG_FILTERS ]]; then
 fi
 
 # Build and test everything in the main workspace (not integrations).
+#
 # Note that somewhat contrary to its name `bazel test` will also build
 # any non-test targets specified.
 # We use `bazel query //...` piped to `bazel test` rather than the simpler
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
-# want them built by CI unless they are excluded with "nokokoro".
+# want them built by CI unless they are excluded with tags.
+#
 # Explicitly list bazelrc so that builds are reproducible and get cache hits
 # when this script is invoked locally.
+#
 # xargs is set to high arg limits to avoid multiple Bazel invocations and will
 # hard fail if the limits are exceeded.
 # See https://github.com/bazelbuild/bazel/issues/12479

--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -62,6 +62,7 @@ def iree_check_test(
         name = bytecode_module_name,
         src = src,
         flags = flags,
+        tags = ["target=%s" % target_backend],
         visibility = ["//visibility:private"],
     )
 
@@ -76,7 +77,7 @@ def iree_check_test(
         ] + runner_args,
         data = [":%s" % bytecode_module_name],
         src = "//tools:iree-check-module",
-        tags = tags + ["driver=%s" % driver],
+        tags = tags + ["driver=%s" % driver, "target=%s" % target_backend],
         timeout = timeout,
         **kwargs
     )
@@ -151,9 +152,7 @@ def iree_check_single_backend_test_suite(
     native.test_suite(
         name = name,
         tests = tests,
-        # Note that only the manual tag really has any effect here. Others are
-        # used for test suite filtering, but all tests are passed the same tags.
-        tags = tags,
+        tags = tags + ["driver=%s" % driver, "target=%s" % target_backend],
         # If there are kwargs that need to be passed here which only apply to
         # the generated tests and not to test_suite, they should be extracted
         # into separate named arguments.

--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -41,8 +41,8 @@ def iree_check_test(
       input_type: Value to pass to --iree-input-type.
       runner_args: additional runner_args to pass to iree-check-module. The
           driver and input file are passed automatically.
-      tags: additional tags to apply to the generated test. A tag
-          "driver=DRIVER" is added automatically.
+      tags: additional tags to apply to the generated test. Tag
+          "driver=DRIVER" and "target=TARGET" are added automatically.
       target_cpu_features: currently unimplemented (must be empty), will
           eventually allow specifying target CPU features.
       timeout: timeout for the generated tests.

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -96,7 +96,7 @@ for asan_in_bytecode_modules_ON_OFF in OFF ON; do
     # Exclude specific labels.
     # Put the whole label with anchors for exact matches.
     ^noasan$
-    ^nokokoro$
+    ^nodocker$
 
     # Exclude all tests in a directory.
     # Put the whole directory with anchors for exact matches.

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -56,9 +56,8 @@ declare -a label_exclude_args=(
   # Exclude specific labels.
   # Put the whole label with anchors for exact matches.
   # For example:
-  #   ^nokokoro$
-  # TODO: update label name as part of dropping Kokoro
-  ^nokokoro$
+  #   ^nodocker$
+  ^nodocker$
 
   # Exclude all tests in a directory.
   # Put the whole directory with anchors for exact matches.

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -34,8 +34,8 @@ declare -a label_exclude_args=(
   # Exclude specific labels.
   # Put the whole label with anchors for exact matches.
   # For example:
-  #   ^nokokoro$
-  ^nokokoro$
+  #   ^nodocker$
+  ^nodocker$
 
   # Exclude all tests in a directory.
   # Put the whole directory with anchors for exact matches.

--- a/build_tools/cmake/test_riscv.sh
+++ b/build_tools/cmake/test_riscv.sh
@@ -32,7 +32,7 @@ ctest_args=(
 )
 
 declare -a label_exclude_args=(
-  "^nokokoro$"
+  "^nodocker$"
   "^driver=vulkan$"
   "^driver=cuda$"
   "^vulkan_uses_vk_khr_shader_float16_int8$"

--- a/build_tools/docker/docker_run.sh
+++ b/build_tools/docker/docker_run.sh
@@ -82,8 +82,7 @@ function docker_run() {
     #   2. This allows us to control the device the home directory is in. Bazel
     #      tends to be IO bound at even moderate levels of CPU parallelism and
     #      the difference between a persistent SSD and a local scratch SSD can
-    #      be huge. In particular, Kokoro has the home directory on the former
-    #      and the work directory on the latter.
+    #      be huge.
     local fake_home_dir="${DOCKER_HOST_TMPDIR}/fake_home"
     mkdir -p "${fake_home_dir}"
 

--- a/docs/website/docs/developers/building/bazel.md
+++ b/docs/website/docs/developers/building/bazel.md
@@ -140,16 +140,36 @@ python3 configure_bazel.py
 
 ### Build
 
-Run all core tests:
+Run all tests:
 
 ```shell
 bazel test -k //...
 ```
 
+Run all tests _except_ those that require CUDA:
+
+```shell
+bazel test -k //... \
+    --iree_drivers=local-sync,local-task,vulkan \
+    --test_tag_filters="-driver=cuda,-target=cuda" \
+    --build_tag_filters="-driver=cuda,-target=cuda"
+```
+
+Run all tests _except_ those that require a GPU (any API):
+
+```shell
+bazel test -k //... \
+    --iree_drivers=local-sync,local-task,vulkan \
+    --test_tag_filters="-driver=vulkan,-driver=metal,-driver=cuda,-target=cuda" \
+    --build_tag_filters="-driver=cuda,-target=cuda"
+```
+
 !!! tip
 
-    You can add flags like `--test_env=IREE_VULKAN_DISABLE=1` to your test
-    command to change how/which tests run.
+    See the
+    [`build_tools/bazel/build_core.sh`](https://github.com/openxla/iree/blob/main/build_tools/bazel/build_core.sh)
+    script for examples of other flags and environment variables that can be
+    used to configure what Bazel runs.
 
 In general, build artifacts will be under the `bazel-bin` directory at the top
 level.

--- a/runtime/src/iree/base/testing/BUILD.bazel
+++ b/runtime/src/iree/base/testing/BUILD.bazel
@@ -32,10 +32,9 @@ iree_runtime_cc_test(
     name = "dynamic_library_test",
     srcs = ["dynamic_library_test.cc"],
     tags = [
-        # Disabled because of unknown CI failures only with bazel on the CI.
-        # This passes locally and with cmake.
-        # See #10034 for more information.
-        "nokokoro",
+        # This test fails with Bazel under Docker.
+        # See https://github.com/openxla/iree/pull/13131 for more information.
+        "nodocker",
     ],
     deps = [
         ":dynamic_library_test_library",

--- a/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
@@ -48,6 +48,7 @@ iree_runtime_cc_library(
     hdrs = [
         "api.h",
     ],
+    tags = ["driver=cuda"],
     deps = [
         ":dynamic_symbols",
         "//runtime/src/iree/base",
@@ -79,6 +80,7 @@ iree_runtime_cc_library(
         "dynamic_symbols.h",
         "status_util.h",
     ],
+    tags = ["driver=cuda"],
     textual_hdrs = [
         "dynamic_symbol_tables.h",
     ],

--- a/runtime/src/iree/hal/drivers/cuda/registration/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/cuda/registration/BUILD.bazel
@@ -23,6 +23,7 @@ iree_runtime_cc_library(
     defines = [
         "IREE_HAVE_HAL_CUDA_DRIVER_MODULE=1",
     ],
+    tags = ["driver=cuda"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:flags",


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/15233

* Rename the 'nokokoro' tag to reflect that the only remaining use is specifically failing under Docker
* Add enough tags to CUDA targets to allow for fully disabling the CUDA HAL and tests using build and test tag filters
* Document build and test tag filters add add a pointer to `build_core.sh`

(tags/labels diverge a bit between Bazel and CMake)