### PR TITLE
Revert "[CPU] Deprecate LLVMCPUEmitVectorizationRemarks pass."

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -54,6 +54,7 @@ iree_compiler_cc_library(
         "LLVMCPUAssignConstantOrdinals.cpp",
         "LLVMCPUAssignImportOrdinals.cpp",
         "LLVMCPUCheckIRBeforeLLVMConversion.cpp",
+        "LLVMCPUEmitVectorizationRemarks.cpp",
         "LLVMCPULinkExecutables.cpp",
         "LLVMCPULowerExecutableTarget.cpp",
         "LLVMCPUMmt4dVectorLowering.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_cc_library(
     "LLVMCPUAssignConstantOrdinals.cpp"
     "LLVMCPUAssignImportOrdinals.cpp"
     "LLVMCPUCheckIRBeforeLLVMConversion.cpp"
+    "LLVMCPUEmitVectorizationRemarks.cpp"
     "LLVMCPULinkExecutables.cpp"
     "LLVMCPULowerExecutableTarget.cpp"
     "LLVMCPUMmt4dVectorLowering.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUEmitVectorizationRemarks.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUEmitVectorizationRemarks.cpp
@@ -1,0 +1,40 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
+#include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+struct LLVMCPUEmitVectorizationRemarksPass
+    : LLVMCPUEmitVectorizationRemarksBase<LLVMCPUEmitVectorizationRemarksPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void LLVMCPUEmitVectorizationRemarksPass::runOnOperation() {
+  auto funcOp = getOperation();
+  bool dump = false;
+  funcOp.walk([&](linalg::LinalgOp op) {
+    op.emitWarning("op is not vectorized");
+    dump = true;
+  });
+  if (dump) {
+    funcOp.emitWarning("found one or more ops not vectorized");
+  }
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMCPUEmitVectorizationRemarksPass() {
+  return std::make_unique<LLVMCPUEmitVectorizationRemarksPass>();
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -37,6 +37,12 @@ static llvm::cl::opt<bool> clCheckIRBeforeLLVMConversion(
                    "before conversion to LLVM IR"),
     llvm::cl::init(true));
 
+static llvm::cl::opt<bool> clCheckLinalgVectorization(
+    "iree-llvmcpu-check-linalg-vectorization",
+    llvm::cl::desc(
+        "Runs the pass to check if all the Linalg ops are vectorized"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool> clUseFastMinMaxOps(
     "iree-llvmcpu-use-fast-min-max-ops",
     llvm::cl::desc(
@@ -605,6 +611,10 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
 
   // Linalg -> SCF
   passManager.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+  if (clCheckLinalgVectorization) {
+    passManager.addNestedPass<func::FuncOp>(
+        createLLVMCPUEmitVectorizationRemarksPass());
+  }
   passManager.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
   passManager.addPass(createConvertBf16ArithToF32Pass());
   passManager.addPass(createConvertBf16ToUInt16BuffersPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -28,6 +28,9 @@ createConvertToLLVMPass(bool reassociateFpReordering = false);
 std::unique_ptr<OperationPass<ModuleOp>>
 createLLVMCPUCheckIRBeforeLLVMConversionPass();
 
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMCPUEmitVectorizationRemarksPass();
+
 /// Pass to select a lowering strategy for a hal.executable.variant operation.
 /// The variant is annotated with the selected strategies, which are
 /// subsequently ingested by LLVMCPULowerExecutableTargetPass.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -51,6 +51,13 @@ def LLVMCPUCheckIRBeforeLLVMConversion :
   let constructor = "mlir::iree_compiler::createLLVMCPUCheckIRBeforeLLVMConversionPass()";
 }
 
+def LLVMCPUEmitVectorizationRemarks :
+    Pass<"iree-llvmcpu-emit-vectorization-remarks", "func::FuncOp"> {
+  let summary = "Emit vectorization remarks on Linalg ops";
+  let constructor =
+      "mlir::iree_compiler::createLLVMCPUEmitVectorizationRemarksPass()";
+}
+
 def LLVMCPULinkExecutables :
     Pass<"iree-llvmcpu-link-executables", "mlir::ModuleOp"> {
   let summary = "Links LLVMCPU HAL executables within the top-level program module.";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "check_ir_before_llvm_conversion_not_fail_unbound.mlir",
             "convert_to_llvm.mlir",
             "data_tiling_pipeline.mlir",
+            "emit_vectorization_remarks.mlir",
             "expand_f16_op_to_f32.mlir",
             "hal_executable_constants.mlir",
             "hal_interface_bindings.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     "check_ir_before_llvm_conversion_not_fail_unbound.mlir"
     "convert_to_llvm.mlir"
     "data_tiling_pipeline.mlir"
+    "emit_vectorization_remarks.mlir"
     "expand_f16_op_to_f32.mlir"
     "hal_executable_constants.mlir"
     "hal_interface_bindings.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/emit_vectorization_remarks.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/emit_vectorization_remarks.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-opt --iree-llvmcpu-emit-vectorization-remarks %s --verify-diagnostics -split-input-file
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  // expected-warning @+1 {{found one or more ops not vectorized}}
+  func.func @dynamic_abs(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+    %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+    %2 = tensor.empty(%0, %1) : tensor<?x?xf32>
+    // expected-warning @+1 {{op is not vectorized}}
+    %3 = linalg.generic {indexing_maps = [#map, #map],
+                         iterator_types = ["parallel", "parallel"]}
+      ins(%arg0 : tensor<?x?xf32>)
+      outs(%2 : tensor<?x?xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %4 = math.absf %arg1 : f32
+      linalg.yield %4 : f32
+    } -> tensor<?x?xf32>
+    return %3 : tensor<?x?xf32>
+  }
+}


### PR DESCRIPTION
Reverts openxla/iree#15722 because other developers are using the option.