### PR TITLE
Adding --iree-hal-strip-executable-contents debugging pass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -32,6 +32,7 @@ iree_compiler_cc_library(
         "PreprocessExecutables.cpp",
         "ResolveExportOrdinals.cpp",
         "SerializeExecutables.cpp",
+        "StripExecutableContents.cpp",
         "SubstituteExecutables.cpp",
         "TranslateExecutables.cpp",
         "VerifyTargetEnvironment.cpp",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     "PreprocessExecutables.cpp"
     "ResolveExportOrdinals.cpp"
     "SerializeExecutables.cpp"
+    "StripExecutableContents.cpp"
     "SubstituteExecutables.cpp"
     "TranslateExecutables.cpp"
     "VerifyTargetEnvironment.cpp"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -114,6 +114,10 @@ createDumpExecutableSourcesPass(StringRef path, StringRef prefix = "");
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createDumpExecutableBenchmarksPass(StringRef path);
 
+// Strips executable module contents for reducing IR size during debugging.
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createStripExecutableContentsPass();
+
 // Substitutes hal.executable ops by parsing |substitutions| in
 // `executable_name=file.xxx` strings. File paths may be absolute or relative to
 // the paths specified on `--iree-hal-executable-object-search-path=`.
@@ -232,6 +236,7 @@ inline void registerHALPasses() {
   createResolveExportOrdinalsPass();
   createSerializeExecutablesPass(TargetBackendRegistry::getGlobal());
   createSerializeTargetExecutablesPass(TargetBackendRegistry::getGlobal(), "");
+  createStripExecutableContentsPass();
   createSubstituteExecutablesPass();
   createTranslateExecutablesPass(TargetBackendRegistry::getGlobal());
   createTranslateTargetExecutableVariantsPass(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/StripExecutableContents.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/StripExecutableContents.cpp
@@ -1,0 +1,54 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+struct StripExecutableContentsPass
+    : public PassWrapper<StripExecutableContentsPass,
+                         OperationPass<mlir::ModuleOp>> {
+  StringRef getArgument() const override {
+    return "iree-hal-strip-executable-contents";
+  }
+
+  StringRef getDescription() const override {
+    return "Strips executable module contents for reducing IR size during "
+           "debugging.";
+  }
+
+  void runOnOperation() override {
+    for (auto executableOp : getOperation().getOps<IREE::HAL::ExecutableOp>()) {
+      for (auto variantOp :
+           executableOp.getOps<IREE::HAL::ExecutableVariantOp>()) {
+        if (auto innerModuleOp = variantOp.getInnerModule()) {
+          innerModuleOp.erase();
+        }
+      }
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createStripExecutableContentsPass() {
+  return std::make_unique<StripExecutableContentsPass>();
+}
+
+static PassRegistration<StripExecutableContentsPass> pass;
+
+} // namespace HAL
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
@@ -29,6 +29,7 @@ iree_lit_test_suite(
             "memoize_device_queries.mlir",
             "preprocess_executables.mlir",
             "resolve_export_ordinals.mlir",
+            "strip_executable_contents.mlir",
             "substitute_executables.mlir",
             "verify_target_environment.mlir",
         ],

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_lit_test_suite(
     "memoize_device_queries.mlir"
     "preprocess_executables.mlir"
     "resolve_export_ordinals.mlir"
+    "strip_executable_contents.mlir"
     "substitute_executables.mlir"
     "verify_target_environment.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/strip_executable_contents.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/strip_executable_contents.mlir
@@ -1,0 +1,22 @@
+// RUN: iree-opt --split-input-file --iree-hal-strip-executable-contents %s | FileCheck %s
+
+// CHECK-LABEL: @ex
+hal.executable @ex {
+  // CHECK: hal.executable.variant public @backend
+  hal.executable.variant @backend target(#hal.executable.target<"backend", "format">) {
+    // CHECK: hal.executable.export public @entry0
+    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [
+      #hal.descriptor_set.layout<0, bindings = [
+        #hal.descriptor_set.binding<0, storage_buffer>,
+        #hal.descriptor_set.binding<1, storage_buffer>
+      ]>
+    ]>)
+    // CHECK-NOT: builtin.module
+    builtin.module {
+      // CHECK-NOT: func.func @entry0
+      func.func @entry0() {
+        return
+      }
+    }
+  }
+}


### PR DESCRIPTION
This removes all builtin.module contents from all hal.executables in a module. This can be useful when wanting to minimize IR by removing translated executables (LLVM dialect, etc) that clutter things up when inspecting host code.