### PR TITLE
[CPU] Add a matmul test suite for data-tiling codegen.

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -24,6 +24,43 @@ py_binary(
 ##
 ###########################################################################
 
+# LLVMCPU, non-data-tiling, no microkernels
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_nondt_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
+    compiler_flags = [
+        "--iree-opt-data-tiling=false",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=%s" % lhs_rhs_type,
+        "--acc_type=%s" % acc_type,
+        "--shapes=%s" % size,
+    ],
+    tags = [
+        # f16/bf16 trigger internal LLVM assertion errors on riscv and wasm.
+        "noriscv",
+        "nowasm",
+    ] if (lhs_rhs_type == "f16" or lhs_rhs_type == "bf16") else [],
+    target_backends_and_drivers = [
+        ("llvm-cpu", "local-task"),
+    ],
+    target_cpu_features_variants = ["default"] +
+                                   # Widening matmuls fail to lower for SVE.
+                                   (["arm_64:sve:+sve"] if lhs_rhs_type == acc_type else []),
+    trace_runner = "//tools:iree-e2e-matmul-test",
+) for (lhs_rhs_type, acc_type) in [
+    ("i8", "i32"),
+    ("f32", "f32"),
+    ("f16", "f16"),
+    ("f16", "f32"),
+    # TODO(#15258): enable bf16 tests when that bug is fixed.
+    # ("bf16", "bf16"),
+    # ("bf16", "f32"),
+] for size in [
+    "small",
+    "large",
+]]
+
 X86_64_AVX2 = [
     "+avx",
     "+avx2",
@@ -47,9 +84,12 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     "+avx512bf16",
 ]
 
-# LLVMCPU, default.
+# LLVMCPU, data-tiling.
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_default_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
+    name = "e2e_matmul_dt_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
+    compiler_flags = [
+        "--iree-opt-data-tiling",
+    ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
@@ -102,17 +142,19 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ("f32", "f32"),
     ("f16", "f16"),
     ("f16", "f32"),
-    ("bf16", "bf16"),
-    ("bf16", "f32"),
+    # TODO(#15258): enable bf16 tests when that bug is fixed.
+    # ("bf16", "bf16"),
+    # ("bf16", "f32"),
 ] for size in [
     "small",
     "large",
 ]]
 
-# LLVMCPU, microkernels.
+# LLVMCPU, data-tiling + microkernels.
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_default_uk_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
+    name = "e2e_matmul_dt_uk_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
     compiler_flags = [
+        "--iree-opt-data-tiling",
         "--iree-llvmcpu-enable-ukernels=all",
     ],
     generator = ":generate_e2e_matmul_tests",
@@ -169,43 +211,6 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ("f16", "f32"),
     ("bf16", "bf16"),
     ("bf16", "f32"),
-] for size in [
-    "small",
-    "large",
-]]
-
-# LLVMCPU, non-data-tiling, no microkernels
-[iree_generated_trace_runner_test(
-    name = "e2e_matmul_nondt_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
-    compiler_flags = [
-        "--iree-opt-data-tiling=false",
-    ],
-    generator = ":generate_e2e_matmul_tests",
-    generator_args = [
-        "--lhs_rhs_type=%s" % lhs_rhs_type,
-        "--acc_type=%s" % acc_type,
-        "--shapes=%s" % size,
-    ],
-    tags = [
-        # f16/bf16 trigger internal LLVM assertion errors on riscv and wasm.
-        "noriscv",
-        "nowasm",
-    ] if (lhs_rhs_type == "f16" or lhs_rhs_type == "bf16") else [],
-    target_backends_and_drivers = [
-        ("llvm-cpu", "local-task"),
-    ],
-    target_cpu_features_variants = ["default"] +
-                                   # Widening matmuls fail to lower for SVE.
-                                   (["arm_64:sve:+sve"] if lhs_rhs_type == acc_type else []),
-    trace_runner = "//tools:iree-e2e-matmul-test",
-) for (lhs_rhs_type, acc_type) in [
-    ("i8", "i32"),
-    ("f32", "f32"),
-    ("f16", "f16"),
-    ("f16", "f32"),
-    # TODO(#15258): enable bf16 tests when that bug is fixed.
-    # ("bf16", "bf16"),
-    # ("bf16", "f32"),
 ] for size in [
     "small",
     "large",

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -29,6 +29,7 @@ py_binary(
     name = "e2e_matmul_nondt_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
     compiler_flags = [
         "--iree-opt-data-tiling=false",
+        "--iree-llvmcpu-enable-ukernels=none",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -94,7 +95,7 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ),
     compiler_flags = [
         "--iree-opt-data-tiling",
-    ] + (["--iree-llvmcpu-enable-ukernels=all"] if use_uk else []),
+    ] + ["--iree-llvmcpu-enable-ukernels=%s" % ("all" if use_uk else "none")],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -84,12 +84,12 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     "+avx512bf16",
 ]
 
-# LLVMCPU, data-tiling.
+# LLVMCPU, data-tiling, data-tiling + ukernels.
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_dt_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
+    name = "e2e_matmul_dt%s_%s_%s_%s" % (("_uk" if use_uk else ""), lhs_rhs_type, acc_type, size),
     compiler_flags = [
         "--iree-opt-data-tiling",
-    ],
+    ] + (["--iree-llvmcpu-enable-ukernels=all"] if use_uk else []),
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
@@ -137,81 +137,20 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
                                        "arm_64:bf16:+bf16",
                                    ] if lhs_rhs_type == "bf16" and acc_type == "f32" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
-) for (lhs_rhs_type, acc_type) in [
+) for use_uk in [
+    False,
+    True,
+] for (lhs_rhs_type, acc_type) in ([
     ("i8", "i32"),
     ("f32", "f32"),
     ("f16", "f16"),
     ("f16", "f32"),
-    # TODO(#15258): enable bf16 tests when that bug is fixed.
-    # ("bf16", "bf16"),
-    # ("bf16", "f32"),
-] for size in [
-    "small",
-    "large",
-]]
-
-# LLVMCPU, data-tiling + microkernels.
-[iree_generated_trace_runner_test(
-    name = "e2e_matmul_dt_uk_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
-    compiler_flags = [
-        "--iree-opt-data-tiling",
-        "--iree-llvmcpu-enable-ukernels=all",
-    ],
-    generator = ":generate_e2e_matmul_tests",
-    generator_args = [
-        "--lhs_rhs_type=%s" % lhs_rhs_type,
-        "--acc_type=%s" % acc_type,
-        "--shapes=%s" % size,
-    ],
-    tags = ([
-        # "--shapes=large" can cause timeouts on sanitizers.
-        "noasan",
-        "notsan",
-    ] if size == "large" else []) + ([
-        # "--shapes=large" can cause timeouts on RISC-V emulator.
-        # f16/bf16 trigger internal LLVM assertion errors on riscv and wasm.
-        "noriscv",
-        "nowasm",
-    ] if (lhs_rhs_type == "f16" or lhs_rhs_type == "bf16") else []),
-    target_backends_and_drivers = [
-        ("llvm-cpu", "local-task"),
-    ],
-    target_cpu_features_variants = ["default"] +
-                                   ([
-                                       "arm_64:dotprod:+dotprod",
-                                       "arm_64:i8mm:+i8mm",
-                                       "x86_64:avx512vnni:" + ",".join(X86_64_AVX512_VNNI),
-                                   ] if lhs_rhs_type == "i8" and acc_type == "i32" else [
-                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
-                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
-                                   ] if lhs_rhs_type == "f32" and acc_type == "f32" else [
-                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
-                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
-                                       "arm_64:fullfp16:+fullfp16",
-                                   ] if lhs_rhs_type == "f16" and acc_type == "f16" else [
-                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
-                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
-                                       "arm_64:fp16fml:+fp16fml",
-                                   ] if lhs_rhs_type == "f16" and acc_type == "f32" else [
-                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
-                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
-                                       "x86_64:avx512bf16:" + ",".join(X86_64_AVX512_BF16),
-                                       "arm_64:bf16:+bf16",
-                                   ] if lhs_rhs_type == "bf16" and acc_type == "bf16" else [
-                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
-                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
-                                       "x86_64:avx512bf16:" + ",".join(X86_64_AVX512_BF16),
-                                       "arm_64:bf16:+bf16",
-                                   ] if lhs_rhs_type == "bf16" and acc_type == "f32" else []),
-    trace_runner = "//tools:iree-e2e-matmul-test",
-) for (lhs_rhs_type, acc_type) in [
-    ("i8", "i32"),
-    ("f32", "f32"),
-    ("f16", "f16"),
-    ("f16", "f32"),
+] + ([
+    # TODO(#15258): enable bf16 tests for !use_uk when that bug is fixed.
     ("bf16", "bf16"),
     ("bf16", "f32"),
-] for size in [
+] if use_uk else [])
+) for size in [
     "small",
     "large",
 ]]

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -86,7 +86,12 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
 
 # LLVMCPU, data-tiling, data-tiling + ukernels.
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_dt%s_%s_%s_%s" % (("_uk" if use_uk else ""), lhs_rhs_type, acc_type, size),
+    name = "e2e_matmul_dt%s_%s_%s_%s" % (
+        ("_uk" if use_uk else ""),
+        lhs_rhs_type,
+        acc_type,
+        size,
+    ),
     compiler_flags = [
         "--iree-opt-data-tiling",
     ] + (["--iree-llvmcpu-enable-ukernels=all"] if use_uk else []),
@@ -140,16 +145,17 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
 ) for use_uk in [
     False,
     True,
-] for (lhs_rhs_type, acc_type) in ([
-    ("i8", "i32"),
-    ("f32", "f32"),
-    ("f16", "f16"),
-    ("f16", "f32"),
-] + ([
-    # TODO(#15258): enable bf16 tests for !use_uk when that bug is fixed.
-    ("bf16", "bf16"),
-    ("bf16", "f32"),
-] if use_uk else [])
+] for (lhs_rhs_type, acc_type) in (
+    [
+        ("i8", "i32"),
+        ("f32", "f32"),
+        ("f16", "f16"),
+        ("f16", "f32"),
+    ] + ([
+        # TODO(#15258): enable bf16 tests for !use_uk when that bug is fixed.
+        ("bf16", "bf16"),
+        ("bf16", "f32"),
+    ] if use_uk else [])
 ) for size in [
     "small",
     "large",

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -24,43 +24,6 @@ py_binary(
 ##
 ###########################################################################
 
-# LLVMCPU, non-data-tiling, no microkernels
-[iree_generated_trace_runner_test(
-    name = "e2e_matmul_nondt_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
-    compiler_flags = [
-        "--iree-opt-data-tiling=false",
-    ],
-    generator = ":generate_e2e_matmul_tests",
-    generator_args = [
-        "--lhs_rhs_type=%s" % lhs_rhs_type,
-        "--acc_type=%s" % acc_type,
-        "--shapes=%s" % size,
-    ],
-    tags = [
-        # f16/bf16 trigger internal LLVM assertion errors on riscv and wasm.
-        "noriscv",
-        "nowasm",
-    ] if (lhs_rhs_type == "f16" or lhs_rhs_type == "bf16") else [],
-    target_backends_and_drivers = [
-        ("llvm-cpu", "local-task"),
-    ],
-    target_cpu_features_variants = ["default"] +
-                                   # Widening matmuls fail to lower for SVE.
-                                   (["arm_64:sve:+sve"] if lhs_rhs_type == acc_type else []),
-    trace_runner = "//tools:iree-e2e-matmul-test",
-) for (lhs_rhs_type, acc_type) in [
-    ("i8", "i32"),
-    ("f32", "f32"),
-    ("f16", "f16"),
-    ("f16", "f32"),
-    # TODO(#15258): enable bf16 tests when that bug is fixed.
-    # ("bf16", "bf16"),
-    # ("bf16", "f32"),
-] for size in [
-    "small",
-    "large",
-]]
-
 X86_64_AVX2 = [
     "+avx",
     "+avx2",
@@ -84,13 +47,72 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     "+avx512bf16",
 ]
 
-# LLVMCPU, data-tiling + microkernels.
-# TODO(#15241, #15215): also test data-tiling alone without microkernels. This currently
-# fails (#15241), which needs to be resolved to unblock data-tiling-by-default (#15215).
+# LLVMCPU, default.
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_dt_uk_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
+    name = "e2e_matmul_default_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=%s" % lhs_rhs_type,
+        "--acc_type=%s" % acc_type,
+        "--shapes=%s" % size,
+    ],
+    tags = ([
+        # "--shapes=large" can cause timeouts on sanitizers.
+        "noasan",
+        "notsan",
+    ] if size == "large" else []) + ([
+        # "--shapes=large" can cause timeouts on RISC-V emulator.
+        # f16/bf16 trigger internal LLVM assertion errors on riscv and wasm.
+        "noriscv",
+        "nowasm",
+    ] if (lhs_rhs_type == "f16" or lhs_rhs_type == "bf16") else []),
+    target_backends_and_drivers = [
+        ("llvm-cpu", "local-task"),
+    ],
+    target_cpu_features_variants = ["default"] +
+                                   ([
+                                       "arm_64:dotprod:+dotprod",
+                                       "arm_64:i8mm:+i8mm",
+                                       "x86_64:avx512vnni:" + ",".join(X86_64_AVX512_VNNI),
+                                   ] if lhs_rhs_type == "i8" and acc_type == "i32" else [
+                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
+                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
+                                   ] if lhs_rhs_type == "f32" and acc_type == "f32" else [
+                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
+                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
+                                       "arm_64:fullfp16:+fullfp16",
+                                   ] if lhs_rhs_type == "f16" and acc_type == "f16" else [
+                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
+                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
+                                       "arm_64:fp16fml:+fp16fml",
+                                   ] if lhs_rhs_type == "f16" and acc_type == "f32" else [
+                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
+                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
+                                       "x86_64:avx512bf16:" + ",".join(X86_64_AVX512_BF16),
+                                       "arm_64:bf16:+bf16",
+                                   ] if lhs_rhs_type == "bf16" and acc_type == "bf16" else [
+                                       "x86_64:avx2:" + ",".join(X86_64_AVX2),
+                                       "x86_64:avx512:" + ",".join(X86_64_AVX512),
+                                       "x86_64:avx512bf16:" + ",".join(X86_64_AVX512_BF16),
+                                       "arm_64:bf16:+bf16",
+                                   ] if lhs_rhs_type == "bf16" and acc_type == "f32" else []),
+    trace_runner = "//tools:iree-e2e-matmul-test",
+) for (lhs_rhs_type, acc_type) in [
+    ("i8", "i32"),
+    ("f32", "f32"),
+    ("f16", "f16"),
+    ("f16", "f32"),
+    ("bf16", "bf16"),
+    ("bf16", "f32"),
+] for size in [
+    "small",
+    "large",
+]]
+
+# LLVMCPU, microkernels.
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_default_uk_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
     compiler_flags = [
-        "--iree-opt-data-tiling",
         "--iree-llvmcpu-enable-ukernels=all",
     ],
     generator = ":generate_e2e_matmul_tests",
@@ -147,6 +169,43 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ("f16", "f32"),
     ("bf16", "bf16"),
     ("bf16", "f32"),
+] for size in [
+    "small",
+    "large",
+]]
+
+# LLVMCPU, non-data-tiling, no microkernels
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_nondt_%s_%s_%s" % (lhs_rhs_type, acc_type, size),
+    compiler_flags = [
+        "--iree-opt-data-tiling=false",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=%s" % lhs_rhs_type,
+        "--acc_type=%s" % acc_type,
+        "--shapes=%s" % size,
+    ],
+    tags = [
+        # f16/bf16 trigger internal LLVM assertion errors on riscv and wasm.
+        "noriscv",
+        "nowasm",
+    ] if (lhs_rhs_type == "f16" or lhs_rhs_type == "bf16") else [],
+    target_backends_and_drivers = [
+        ("llvm-cpu", "local-task"),
+    ],
+    target_cpu_features_variants = ["default"] +
+                                   # Widening matmuls fail to lower for SVE.
+                                   (["arm_64:sve:+sve"] if lhs_rhs_type == acc_type else []),
+    trace_runner = "//tools:iree-e2e-matmul-test",
+) for (lhs_rhs_type, acc_type) in [
+    ("i8", "i32"),
+    ("f32", "f32"),
+    ("f16", "f16"),
+    ("f16", "f32"),
+    # TODO(#15258): enable bf16 tests when that bug is fixed.
+    # ("bf16", "bf16"),
+    # ("bf16", "f32"),
 ] for size in [
     "small",
     "large",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -12,646 +12,6 @@ iree_add_all_subdirs()
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_default_i8_i32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=i8"
-    "--acc_type=i32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "arm_64:dotprod:+dotprod"
-    "arm_64:i8mm:+i8mm"
-    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_i8_i32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=i8"
-    "--acc_type=i32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noasan"
-    "notsan"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "arm_64:dotprod:+dotprod"
-    "arm_64:i8mm:+i8mm"
-    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_f32_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_f32_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noasan"
-    "notsan"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_f16_f16_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f16"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fullfp16:+fullfp16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_f16_f16_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f16"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fullfp16:+fullfp16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_f16_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fp16fml:+fp16fml"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_f16_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fp16fml:+fp16fml"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_bf16_bf16_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=bf16"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_bf16_bf16_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=bf16"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_bf16_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_bf16_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_i8_i32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=i8"
-    "--acc_type=i32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "arm_64:dotprod:+dotprod"
-    "arm_64:i8mm:+i8mm"
-    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_i8_i32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=i8"
-    "--acc_type=i32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "arm_64:dotprod:+dotprod"
-    "arm_64:i8mm:+i8mm"
-    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_f32_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_f32_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_f16_f16_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f16"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fullfp16:+fullfp16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_f16_f16_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f16"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fullfp16:+fullfp16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_f16_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fp16fml:+fp16fml"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_f16_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fp16fml:+fp16fml"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_bf16_bf16_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=bf16"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_bf16_bf16_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=bf16"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_bf16_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_default_uk_bf16_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
     e2e_matmul_nondt_i8_i32_small
   GENERATOR
     "generate_e2e_matmul_tests.py"
@@ -840,6 +200,566 @@ iree_generated_trace_runner_test(
     "nowasm"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_i8_i32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_i8_i32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  LABELS
+    "noasan"
+    "notsan"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_f32_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_f32_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  LABELS
+    "noasan"
+    "notsan"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_f16_f16_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fullfp16:+fullfp16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_f16_f16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fullfp16:+fullfp16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_f16_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fp16fml:+fp16fml"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_f16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fp16fml:+fp16fml"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_i8_i32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_i8_i32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_f32_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_f32_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_f16_f16_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fullfp16:+fullfp16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_f16_f16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fullfp16:+fullfp16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_f16_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fp16fml:+fp16fml"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_f16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fp16fml:+fp16fml"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_bf16_bf16_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=bf16"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_bf16_bf16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=bf16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_bf16_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_uk_bf16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
 )
 
 iree_generated_trace_runner_test(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -12,6 +12,646 @@ iree_add_all_subdirs()
 
 iree_generated_trace_runner_test(
   NAME
+    e2e_matmul_default_i8_i32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_i8_i32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noasan"
+    "notsan"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_f32_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_f32_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noasan"
+    "notsan"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_f16_f16_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fullfp16:+fullfp16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_f16_f16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fullfp16:+fullfp16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_f16_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fp16fml:+fp16fml"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_f16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fp16fml:+fp16fml"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_bf16_bf16_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=bf16"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_bf16_bf16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=bf16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_bf16_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_bf16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_i8_i32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_i8_i32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "arm_64:dotprod:+dotprod"
+    "arm_64:i8mm:+i8mm"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_f32_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_f32_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_f16_f16_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fullfp16:+fullfp16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_f16_f16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fullfp16:+fullfp16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_f16_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fp16fml:+fp16fml"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_f16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "arm_64:fp16fml:+fp16fml"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_bf16_bf16_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=bf16"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_bf16_bf16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=bf16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_bf16_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_default_uk_bf16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-enable-ukernels=all"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
     e2e_matmul_nondt_i8_i32_small
   GENERATOR
     "generate_e2e_matmul_tests.py"
@@ -200,350 +840,6 @@ iree_generated_trace_runner_test(
     "nowasm"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_i8_i32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=i8"
-    "--acc_type=i32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "arm_64:dotprod:+dotprod"
-    "arm_64:i8mm:+i8mm"
-    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_i8_i32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=i8"
-    "--acc_type=i32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "arm_64:dotprod:+dotprod"
-    "arm_64:i8mm:+i8mm"
-    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_f32_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_f32_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_f16_f16_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f16"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fullfp16:+fullfp16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_f16_f16_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f16"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fullfp16:+fullfp16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_f16_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fp16fml:+fp16fml"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_f16_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "arm_64:fp16fml:+fp16fml"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_bf16_bf16_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=bf16"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_bf16_bf16_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=bf16"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_bf16_f32_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=f32"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_dt_uk_bf16_f32_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=bf16"
-    "--acc_type=f32"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling"
-    "--iree-llvmcpu-enable-ukernels=all"
-  LABELS
-    "noasan"
-    "notsan"
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
-    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
-    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
-    "arm_64:bf16:+bf16"
 )
 
 iree_generated_trace_runner_test(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
 
   TARGET_CPU_FEATURES_VARIANTS
@@ -50,6 +51,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
 
   TARGET_CPU_FEATURES_VARIANTS
@@ -73,6 +75,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
 
   TARGET_CPU_FEATURES_VARIANTS
@@ -97,6 +100,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
 
   TARGET_CPU_FEATURES_VARIANTS
@@ -121,6 +125,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
     "nowasm"
@@ -146,6 +151,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
     "nowasm"
@@ -171,6 +177,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
     "nowasm"
@@ -195,6 +202,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
     "nowasm"
@@ -219,6 +227,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
 
   TARGET_CPU_FEATURES_VARIANTS
@@ -245,6 +254,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noasan"
     "notsan"
@@ -272,6 +282,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
 
   TARGET_CPU_FEATURES_VARIANTS
@@ -297,6 +308,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noasan"
     "notsan"
@@ -323,6 +335,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
     "nowasm"
@@ -350,6 +363,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noasan"
     "notsan"
@@ -379,6 +393,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
     "nowasm"
@@ -406,6 +421,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noasan"
     "notsan"


### PR DESCRIPTION
Similar to nondt test suite, the test suite disables bf16 types because of https://github.com/openxla/iree/issues/15258