### PR TITLE
[experimental][ROCM] Add rocm direct command buffer update

### DIFF
--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -30,9 +30,6 @@ iree_hal_cts_test_suite(
   DEPS
     iree::experimental::rocm::registration
   EXCLUDED_TESTS
-    # This test depends on iree_hal_rocm_direct_command_buffer_update_buffer
-    # via iree_hal_buffer_view_allocate_buffer_copy, which is not implemented yet.
-    "command_buffer_dispatch"
     # Semaphores are not implemented in the ROCm backend yet.
     "semaphore_submission"
     "semaphore"


### PR DESCRIPTION
Enable command_buffer_dispatch_test for rocm hal cts tests (as it is now passing because of the implemented function)

Closes #15718 