### PR TITLE
Annotate dispatches with pure data-movement linalg operations better

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -169,20 +169,12 @@ static std::string summarizeLinalgOp(linalg::LinalgOp op) {
     return WalkResult::interrupt();
   });
 
-  // Check if the indexing maps are only projected permutations.
+  // Check if the indexing maps are only permutations.
   bool hasOnlyPermutation = true;
-  bool hasOnlyIdentity = true;
   for (AffineMap map : op.getIndexingMapsArray()) {
-    if (!map.isIdentity()) {
-      hasOnlyIdentity = false;
-    }
     if (!map.isPermutation()) {
       hasOnlyPermutation = false;
     }
-  }
-
-  if (hasOnlyYield && hasOnlyIdentity) {
-    return "slow_memcpy";
   }
 
   if (hasOnlyYield && hasOnlyPermutation) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -160,6 +160,19 @@ static std::string getOpNameWithoutDialectName(Operation *op) {
 }
 
 static std::string summarizeLinalgOp(linalg::LinalgOp op) {
+  // Check if the body only contains a yield.
+  bool hasOnlyYield = true;
+  op.walk([&](Operation *op) {
+    if (isa<linalg::YieldOp>(op))
+      return WalkResult::advance();
+    hasOnlyYield = false;
+    return WalkResult::interrupt();
+  });
+
+  if (hasOnlyYield) {
+    return "slow_memcpy";
+  }
+
   auto opName = op->getName().getStringRef();
   if (!opName.consume_front("linalg."))
     return "";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -160,33 +160,43 @@ static std::string getOpNameWithoutDialectName(Operation *op) {
 }
 
 static std::string summarizeLinalgOp(linalg::LinalgOp op) {
-  // Check if the body only contains a yield.
-  bool hasOnlyYield = true;
-  op.walk([&](Operation *child) {
-    if (op == child || isa<linalg::YieldOp>(child))
-      return WalkResult::advance();
-    hasOnlyYield = false;
-    return WalkResult::interrupt();
-  });
+  std::string prefix;
 
-  // Check if the indexing maps are only permutations.
-  bool hasOnlyPermutation = true;
-  for (AffineMap map : op.getIndexingMapsArray()) {
-    if (!map.isPermutation()) {
-      hasOnlyPermutation = false;
+  // Check if the op is a transpose and mark it as such for a better summary.
+  {
+    // Check if the body only contains a yield.
+    bool hasOnlyYield = true;
+    op.walk([&](Operation *child) {
+      if (op == child || isa<linalg::YieldOp>(child))
+        return WalkResult::advance();
+      hasOnlyYield = false;
+      return WalkResult::interrupt();
+    });
+
+    // Check if the indexing maps are only permutations.
+    bool hasOnlyPermutation = true;
+    for (AffineMap map : op.getIndexingMapsArray()) {
+      if (!map.isPermutation()) {
+        hasOnlyPermutation = false;
+      }
+    }
+
+    if (hasOnlyYield && hasOnlyPermutation) {
+      prefix = "transpose";
     }
   }
 
-  if (hasOnlyYield && hasOnlyPermutation) {
-    return "transpose";
+  if (prefix.empty()) {
+    // By default, use the op name as prefix.
+    auto opName = op->getName().getStringRef();
+    if (!opName.consume_front("linalg."))
+      return "";
+    prefix = opName.str();
   }
 
-  auto opName = op->getName().getStringRef();
-  if (!opName.consume_front("linalg."))
-    return "";
   std::string opLoopRanges = loopRangesToString(op.getStaticLoopRanges());
   std::string opTypes = opLoopRanges.empty() ? "" : getLinalgDataTypes(op);
-  return opName.str() + (opLoopRanges.empty() ? "" : "_" + opLoopRanges) +
+  return prefix + (opLoopRanges.empty() ? "" : "_" + opLoopRanges) +
          (opTypes.empty() ? "" : "_" + opTypes);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -165,13 +165,7 @@ static std::string summarizeLinalgOp(linalg::LinalgOp op) {
   // Check if the op is a transpose and mark it as such for a better summary.
   {
     // Check if the body only contains a yield.
-    bool hasOnlyYield = true;
-    op.walk([&](Operation *child) {
-      if (op == child || isa<linalg::YieldOp>(child))
-        return WalkResult::advance();
-      hasOnlyYield = false;
-      return WalkResult::interrupt();
-    });
+    bool hasOnlyYield = op.getBlock()->without_terminator().empty();
 
     // Check if the indexing maps are only permutations.
     bool hasOnlyPermutation = true;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
@@ -266,24 +266,3 @@ flow.executable private @ex {
     }
   }
 }
-
-// ------
-
-// Dispatch with only a yield and having indexing_maps only as identity is a slow_memcpy.
-
-flow.executable private @ex {
-  // CHECK: flow.executable.export public @dispatch_slow_memcpy
-  flow.executable.export public @dispatch
-  builtin.module {
-    func.func @dispatch(%arg0: !flow.dispatch.tensor<writeonly:tensor<4x8xf32>>) {
-      %0 = tensor.empty() : tensor<4x8xf32>
-      %1 = tensor.empty() : tensor<4x8xf32>
-      %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<4x8xf32>) outs(%1 : tensor<4x8xf32>) {
-      ^bb0(%in: f32, %out: f32):
-        linalg.yield %in : f32
-      } -> tensor<4x8xf32>
-      flow.dispatch.tensor.store %2, %arg0, offsets = [0, 0], sizes = [4, 8], strides = [1, 1] : tensor<4x8xf32> -> !flow.dispatch.tensor<writeonly:tensor<4x8xf32>>
-      return
-    }
-  }
-}

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
@@ -245,3 +245,45 @@ flow.executable private @ex {
     }
   }
 }
+
+// -----
+
+// Dispatch with only a yield and having indexing_maps only as permutations are transposes.
+
+flow.executable private @ex {
+  // CHECK: flow.executable.export public @dispatch_transpose
+  flow.executable.export public @dispatch
+  builtin.module {
+    func.func @dispatch(%arg0: !flow.dispatch.tensor<writeonly:tensor<8x4xf32>>) {
+      %0 = tensor.empty() : tensor<4x8xf32>
+      %1 = tensor.empty() : tensor<8x4xf32>
+      %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<4x8xf32>) outs(%1 : tensor<8x4xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        linalg.yield %in : f32
+      } -> tensor<8x4xf32>
+      flow.dispatch.tensor.store %2, %arg0, offsets = [0, 0], sizes = [4, 8], strides = [1, 1] : tensor<8x4xf32> -> !flow.dispatch.tensor<writeonly:tensor<8x4xf32>>
+      return
+    }
+  }
+}
+
+// ------
+
+// Dispatch with only a yield and having indexing_maps only as identity is a slow_memcpy.
+
+flow.executable private @ex {
+  // CHECK: flow.executable.export public @dispatch_slow_memcpy
+  flow.executable.export public @dispatch
+  builtin.module {
+    func.func @dispatch(%arg0: !flow.dispatch.tensor<writeonly:tensor<4x8xf32>>) {
+      %0 = tensor.empty() : tensor<4x8xf32>
+      %1 = tensor.empty() : tensor<4x8xf32>
+      %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<4x8xf32>) outs(%1 : tensor<4x8xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        linalg.yield %in : f32
+      } -> tensor<4x8xf32>
+      flow.dispatch.tensor.store %2, %arg0, offsets = [0, 0], sizes = [4, 8], strides = [1, 1] : tensor<4x8xf32> -> !flow.dispatch.tensor<writeonly:tensor<4x8xf32>>
+      return
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
@@ -251,7 +251,7 @@ flow.executable private @ex {
 // Dispatch with only a yield and having indexing_maps only as permutations are transposes.
 
 flow.executable private @ex {
-  // CHECK: flow.executable.export public @dispatch_transpose
+  // CHECK: flow.executable.export public @dispatch_transpose_8x4_f32
   flow.executable.export public @dispatch
   builtin.module {
     func.func @dispatch(%arg0: !flow.dispatch.tensor<writeonly:tensor<8x4xf32>>) {


### PR DESCRIPTION
This patch adds support for annotating dispatches as "transpose", which contain only a linalg.generic operation containing only a yield and it's indexing maps as permutations.