### PR TITLE
Enable sub-type store integration tests for RISC-V.

### DIFF
--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -60,11 +60,11 @@ VULKAN_SRCS = enforce_glob(
     [
         "conv2d.mlir",
         "i4_to_f32.mlir",
-        "f32_to_i4.mlir",
     ],
     include = ["*.mlir"],
     exclude = [
         "large_linalg_matmul.mlir",
+        "f32_to_i4.mlir",
     ],
 )
 

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -22,34 +22,18 @@ LLVM_SRCS = enforce_glob(
     [
         "conv2d.mlir",
         "i4_to_f32.mlir",
+        "f32_to_i4.mlir",
     ],
     include = ["*.mlir"],
     exclude = [
         "large_linalg_matmul.mlir",
-        "f32_to_i4.mlir",
     ],
 )
-
-LLVM_I4_SRCS = [
-    "f32_to_i4.mlir",
-]
 
 iree_check_single_backend_test_suite(
     name = "check_llvm-cpu_local-task",
     srcs = LLVM_SRCS,
     driver = "local-task",
-    target_backend = "llvm-cpu",
-)
-
-iree_check_single_backend_test_suite(
-    name = "check_i4_llvm-cpu_local-task",
-    srcs = LLVM_I4_SRCS,
-    driver = "local-task",
-    tags = [
-        # TODO(#15540): RISC-V needs sub-byte emulation for vector.maskedstore
-        # ops. Enable the test after it is supported.
-        "noriscv",
-    ],
     target_backend = "llvm-cpu",
 )
 
@@ -76,11 +60,11 @@ VULKAN_SRCS = enforce_glob(
     [
         "conv2d.mlir",
         "i4_to_f32.mlir",
+        "f32_to_i4.mlir",
     ],
     include = ["*.mlir"],
     exclude = [
         "large_linalg_matmul.mlir",
-        "f32_to_i4.mlir",
     ],
 )
 

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -19,10 +19,11 @@ package(
 )
 
 LLVM_SRCS = enforce_glob(
+    # keep sorted
     [
         "conv2d.mlir",
-        "i4_to_f32.mlir",
         "f32_to_i4.mlir",
+        "i4_to_f32.mlir",
     ],
     include = ["*.mlir"],
     exclude = [

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -15,24 +15,12 @@ iree_check_single_backend_test_suite(
     check_llvm-cpu_local-task
   SRCS
     "conv2d.mlir"
+    "f32_to_i4.mlir"
     "i4_to_f32.mlir"
   TARGET_BACKEND
     "llvm-cpu"
   DRIVER
     "local-task"
-)
-
-iree_check_single_backend_test_suite(
-  NAME
-    check_i4_llvm-cpu_local-task
-  SRCS
-    "f32_to_i4.mlir"
-  TARGET_BACKEND
-    "llvm-cpu"
-  DRIVER
-    "local-task"
-  LABELS
-    "noriscv"
 )
 
 iree_check_single_backend_test_suite(
@@ -51,6 +39,7 @@ iree_check_single_backend_test_suite(
     check_vulkan-spirv_vulkan
   SRCS
     "conv2d.mlir"
+    "f32_to_i4.mlir"
     "i4_to_f32.mlir"
   TARGET_BACKEND
     "vulkan-spirv"

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -39,7 +39,6 @@ iree_check_single_backend_test_suite(
     check_vulkan-spirv_vulkan
   SRCS
     "conv2d.mlir"
-    "f32_to_i4.mlir"
     "i4_to_f32.mlir"
   TARGET_BACKEND
     "vulkan-spirv"


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/15613