### PR TITLE
Standardize/fixup how options are defined in plugins.

### DIFF
--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -33,9 +33,10 @@ namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
+namespace {
 struct MetalSPIRVOptions {
-  MetalTargetPlatform targetPlatform;
-  bool compileToMetalLib;
+  MetalTargetPlatform targetPlatform = MetalTargetPlatform::macOS;
+  bool compileToMetalLib = true;
 
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("MetalSPIRV HAL Target");
@@ -46,17 +47,16 @@ struct MetalSPIRVOptions {
             clEnumValN(MetalTargetPlatform::macOS, "macos", "macOS platform"),
             clEnumValN(MetalTargetPlatform::iOS, "ios", "iOS platform"),
             clEnumValN(MetalTargetPlatform::iOSSimulator, "ios-simulator",
-                       "iOS simulator platform")),
-        llvm::cl::init(MetalTargetPlatform::macOS));
+                       "iOS simulator platform")));
     binder.opt<bool>(
         "iree-metal-compile-to-metallib", compileToMetalLib,
         llvm::cl::cat(category),
         llvm::cl::desc("Compile to .metallib and embed in IREE deployable "
                        "flatbuffer if true; "
-                       "otherwise stop at and embed MSL source code"),
-        llvm::cl::init(true));
+                       "otherwise stop at and embed MSL source code"));
   }
 };
+} // namespace
 
 static spirv::TargetEnvAttr getMetalTargetEnv(MLIRContext *context) {
   using spirv::Capability;
@@ -114,8 +114,8 @@ static spirv::TargetEnvAttr getMetalTargetEnv(MLIRContext *context) {
 
 class MetalSPIRVTargetBackend : public TargetBackend {
 public:
-  MetalSPIRVTargetBackend(MetalSPIRVOptions options)
-      : options_(std::move(options)) {}
+  MetalSPIRVTargetBackend(const MetalSPIRVOptions &options)
+      : options(options) {}
 
   // NOTE: we could vary this based on the options such as 'metal-v2'.
   std::string name() const override { return "metal"; }
@@ -159,16 +159,16 @@ public:
     buildSPIRVCodegenPassPipeline(passManager, /*enableFastMath=*/false);
   }
 
-  LogicalResult serializeExecutable(const SerializationOptions &options,
+  LogicalResult serializeExecutable(const SerializationOptions &serOptions,
                                     IREE::HAL::ExecutableVariantOp variantOp,
                                     OpBuilder &executableBuilder) override {
     ModuleOp innerModuleOp = variantOp.getInnerModule();
     auto spvModuleOp = *innerModuleOp.getOps<spirv::ModuleOp>().begin();
-    if (!options.dumpIntermediatesPath.empty()) {
+    if (!serOptions.dumpIntermediatesPath.empty()) {
       std::string assembly;
       llvm::raw_string_ostream os(assembly);
       spvModuleOp.print(os, OpPrintingFlags().useLocalScope());
-      dumpDataToPath(options.dumpIntermediatesPath, options.dumpBaseName,
+      dumpDataToPath(serOptions.dumpIntermediatesPath, serOptions.dumpBaseName,
                      variantOp.getName(), ".mlir", assembly);
     }
 
@@ -185,9 +185,9 @@ public:
     if (failed(spirv::serialize(spvModuleOp, spvBinary))) {
       return variantOp.emitError() << "failed to serialize spirv.module";
     }
-    if (!options.dumpIntermediatesPath.empty()) {
-      dumpDataToPath<uint32_t>(options.dumpIntermediatesPath,
-                               options.dumpBaseName, variantOp.getName(),
+    if (!serOptions.dumpIntermediatesPath.empty()) {
+      dumpDataToPath<uint32_t>(serOptions.dumpIntermediatesPath,
+                               serOptions.dumpBaseName, variantOp.getName(),
                                ".spv", spvBinary);
     }
 
@@ -200,7 +200,7 @@ public:
       // We can use ArrayRef here given spvBinary reserves 0 bytes on stack.
       ArrayRef spvData(spvBinary.data(), spvBinary.size());
       std::optional<std::pair<MetalShader, std::string>> msl =
-          crossCompileSPIRVToMSL(options_.targetPlatform, spvData, entryPoint);
+          crossCompileSPIRVToMSL(options.targetPlatform, spvData, entryPoint);
       if (!msl) {
         return variantOp.emitError()
                << "failed to cross compile SPIR-V to Metal shader";
@@ -209,10 +209,10 @@ public:
       mslEntryPointNames.push_back(std::move(msl->second));
     }
 
-    if (!options.dumpBinariesPath.empty()) {
+    if (!serOptions.dumpBinariesPath.empty()) {
       for (auto shader : llvm::enumerate(mslShaders)) {
         dumpDataToPath(
-            options.dumpBinariesPath, options.dumpBaseName,
+            serOptions.dumpBinariesPath, serOptions.dumpBaseName,
             (variantOp.getName() + std::to_string(shader.index())).str(),
             ".metal", shader.value().source);
       }
@@ -220,7 +220,7 @@ public:
 
     // 3. Compile MSL to MTLLibrary.
     SmallVector<std::unique_ptr<llvm::MemoryBuffer>> metalLibs;
-    if (options_.compileToMetalLib) {
+    if (options.compileToMetalLib) {
       // We need to use offline Metal shader compilers.
       // TODO(#14048): The toolchain can also exist on other platforms. Probe
       // the PATH instead.
@@ -229,7 +229,7 @@ public:
         for (auto [shader, entryPoint] :
              llvm::zip(mslShaders, mslEntryPointNames)) {
           std::unique_ptr<llvm::MemoryBuffer> lib = compileMSLToMetalLib(
-              options_.targetPlatform, shader.source, entryPoint);
+              options.targetPlatform, shader.source, entryPoint);
           if (!lib) {
             return variantOp.emitError()
                    << "failed to compile to MTLLibrary from MSL:\n\n"
@@ -313,7 +313,7 @@ private:
         configAttr);
   }
 
-  MetalSPIRVOptions options_;
+  const MetalSPIRVOptions &options;
 };
 
 struct MetalSPIRVSession

--- a/compiler/plugins/target/WebGPU/WebGPUTarget.cpp
+++ b/compiler/plugins/target/WebGPU/WebGPUTarget.cpp
@@ -58,7 +58,7 @@ static spirv::TargetEnvAttr getWebGPUTargetEnv(MLIRContext *context) {
 
 class WebGPUTargetBackend : public TargetBackend {
 public:
-  WebGPUTargetBackend(WebGPUOptions options) : options_(std::move(options)) {}
+  WebGPUTargetBackend(const WebGPUOptions &options) : options(options) {}
 
   // NOTE: we could vary this based on the options such as 'webgpu-v2'.
   std::string name() const override { return "webgpu"; }
@@ -132,7 +132,7 @@ public:
         spirv::createSPIRVWebGPUPreparePass());
   }
 
-  LogicalResult serializeExecutable(const SerializationOptions &options,
+  LogicalResult serializeExecutable(const SerializationOptions &serOptions,
                                     IREE::HAL::ExecutableVariantOp variantOp,
                                     OpBuilder &executableBuilder) override {
     ModuleOp innerModuleOp = variantOp.getInnerModule();
@@ -144,11 +144,11 @@ public:
     }
 
     auto spvModuleOp = *spirvModuleOps.begin();
-    if (!options.dumpIntermediatesPath.empty()) {
+    if (!serOptions.dumpIntermediatesPath.empty()) {
       std::string assembly;
       llvm::raw_string_ostream os(assembly);
       spvModuleOp.print(os, OpPrintingFlags().useLocalScope());
-      dumpDataToPath(options.dumpIntermediatesPath, options.dumpBaseName,
+      dumpDataToPath(serOptions.dumpIntermediatesPath, serOptions.dumpBaseName,
                      variantOp.getName(), ".mlir", assembly);
     }
 
@@ -182,17 +182,17 @@ public:
 
     // Serialize the spirv::ModuleOp into binary format.
     SmallVector<uint32_t, 0> spvBinary;
-    spirv::SerializationOptions serializationOptions;
-    serializationOptions.emitSymbolName = options_.debugSymbols;
-    serializationOptions.emitDebugInfo = options_.debugSymbols;
-    if (failed(
-            spirv::serialize(spvModuleOp, spvBinary, serializationOptions)) ||
+    spirv::SerializationOptions spirvSerializationOptions;
+    spirvSerializationOptions.emitSymbolName = options.debugSymbols;
+    spirvSerializationOptions.emitDebugInfo = options.debugSymbols;
+    if (failed(spirv::serialize(spvModuleOp, spvBinary,
+                                spirvSerializationOptions)) ||
         spvBinary.empty()) {
       return variantOp.emitError() << "failed to serialize spirv.module";
     }
-    if (!options.dumpIntermediatesPath.empty()) {
-      dumpDataToPath<uint32_t>(options.dumpIntermediatesPath,
-                               options.dumpBaseName, variantOp.getName(),
+    if (!serOptions.dumpIntermediatesPath.empty()) {
+      dumpDataToPath<uint32_t>(serOptions.dumpIntermediatesPath,
+                               serOptions.dumpBaseName, variantOp.getName(),
                                ".spv", spvBinary);
 
       // Disassemble the shader and save that too.
@@ -204,8 +204,9 @@ public:
               spvBinary.data(), spvBinary.size(), &spvDisassembled,
               SPV_BINARY_TO_TEXT_OPTION_INDENT |
                   SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES)) {
-        dumpDataToPath(options.dumpIntermediatesPath, options.dumpBaseName,
-                       variantOp.getName(), ".spvasm", spvDisassembled);
+        dumpDataToPath(serOptions.dumpIntermediatesPath,
+                       serOptions.dumpBaseName, variantOp.getName(), ".spvasm",
+                       spvDisassembled);
       } else {
         llvm::errs() << "Failed to disassemble SPIR-V binary\n";
       }
@@ -222,8 +223,8 @@ public:
              << "failed to compile SPIR-V to WGSL. Consider inspecting the "
                 "shader program using -iree-hal-dump-executable-intermediates.";
     }
-    if (!options.dumpBinariesPath.empty()) {
-      dumpDataToPath(options.dumpBinariesPath, options.dumpBaseName,
+    if (!serOptions.dumpBinariesPath.empty()) {
+      dumpDataToPath(serOptions.dumpBinariesPath, serOptions.dumpBaseName,
                      variantOp.getName(), ".wgsl", wgsl.value());
     }
 
@@ -283,7 +284,7 @@ private:
         configAttr);
   }
 
-  WebGPUOptions options_;
+  const WebGPUOptions &options;
 };
 
 struct WebGPUSession


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/15468

If `llvm::cl::init(value)` is passed within `OptionsBinder::opt<T>()`, the "init" value will override any values specified on the command line. This initializes struct values instead and then standardizes some variable names and uses of anonymous namespaces.

Tests exercising the options would have helped catch this. I only noticed on https://github.com/openxla/iree/pull/15689 since the `Regression Test AMDGPU-ROCm / Linux (x86_64)` job uses non-default target options during compilation and the tests failed at runtime.