### PR TITLE
Ukernels: enable limited debug information that is useful in profilers like Tracy.

### DIFF
--- a/build_tools/bazel/iree_bitcode_library.bzl
+++ b/build_tools/bazel/iree_bitcode_library.bzl
@@ -85,6 +85,9 @@ def iree_bitcode_library(
         "-fno-ident",
         "-fdiscard-value-names",
 
+        # Limited debug information that is useful in profilers like Tracy.
+        "-gline-tables-only",
+
         # Set the size of wchar_t to 4 bytes (instead of 2 bytes).
         # This must match what the runtime is built with.
         "-fno-short-wchar",

--- a/build_tools/cmake/iree_bitcode_library.cmake
+++ b/build_tools/cmake/iree_bitcode_library.cmake
@@ -55,6 +55,9 @@ function(iree_bitcode_library)
     "-fno-ident"
     "-fdiscard-value-names"
 
+    # Limited debug information that is useful in profilers like Tracy.
+    "-gline-tables-only"
+
     # Set the size of wchar_t to 4 bytes (instead of 2 bytes).
     # This must match what the runtime is built with.
     "-fno-short-wchar"


### PR DESCRIPTION
This is one of the steps to making Tracy sampling useful with ukernels. It allows tracy to render correct sampling stacks and source view. It does not by itself fix the disasm view but it's a step towards that too.