### PR TITLE
Make metal depends on flags.

### DIFF
--- a/runtime/src/iree/hal/drivers/metal/registration/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/metal/registration/CMakeLists.txt
@@ -13,6 +13,7 @@ iree_cc_library(
     "driver_module.c"
   DEPS
     iree::base
+    iree::base::internal::flags
     iree::base::core_headers
     iree::hal
     iree::hal::drivers::metal


### PR DESCRIPTION
`metal` depends on `flag` but you forgot to declare it.

Always happy to help.