### PR TITLE
[Codegen][ROCM] Add flag for 32 bit indices

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -37,6 +37,11 @@
 namespace mlir {
 namespace iree_compiler {
 
+static llvm::cl::opt<int>
+    clROCMIndexingBits("iree-rocm-index-bits",
+                       llvm::cl::desc("Set the bit width of indices in ROCm."),
+                       llvm::cl::init(64));
+
 namespace {
 
 static StringRef getTargetArch(func::FuncOp entryPoint) {
@@ -95,9 +100,17 @@ struct ConvertToROCDLPass : public ConvertToROCDLBase<ConvertToROCDLPass> {
   void runOnOperation() override {
     ModuleOp m = getOperation();
 
+    if (clROCMIndexingBits != 32 && clROCMIndexingBits != 64) {
+      m.emitOpError() << "unsupported: ROCm index bit widths must either be "
+                         "64 or 32, got "
+                      << clROCMIndexingBits;
+      return signalPassFailure();
+    }
+    bool use32BitIndices = clROCMIndexingBits == 32;
+
     /// Customize the bitwidth used for the device side index computations.
     LowerToLLVMOptions options(m.getContext(), DataLayout(m));
-    options.overrideIndexBitwidth(64);
+    options.overrideIndexBitwidth(use32BitIndices ? 32 : 64);
     LLVMTypeConverter converter(m.getContext(), options);
     populateGpuMemorySpaceAttributeConversions(
         converter, [](gpu::AddressSpace space) {
@@ -132,7 +145,7 @@ struct ConvertToROCDLPass : public ConvertToROCDLBase<ConvertToROCDLPass> {
       // We currently always use 64 bit indices, thus ensure the bit width of
       // the mask compare is consistent.
       vector::populateVectorMaskMaterializationPatterns(
-          patterns, /*force32BitVectorIndices=*/false);
+          patterns, /*force32BitVectorIndices=*/use32BitIndices);
       vector::populateVectorShapeCastLoweringPatterns(patterns);
       // TODO: doubtful that the "default" does what one want here, it is likely
       // better to use something else.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-convert-to-rocdl))))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-convert-to-rocdl))))" --iree-rocm-index-bits=32 %s | FileCheck %s --check-prefix=INDEX32
 
 // Test that that standard and GPU ops are converted to LLVM and NVVM.
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
@@ -33,12 +34,15 @@ hal.executable @abs_ex_dispatch_0 {
     }
   }
 }
-// CHECK-LABEL: llvm.func @abs_ex_dispatch_0
-//  CHECK-SAME: (%{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.readonly},
-//  CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias},
-//  CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias})
-//      CHECK:    rocdl.workgroup.dim.x
-//      CHECK:    llvm.fadd
+//   CHECK-LABEL: llvm.func @abs_ex_dispatch_0
+// INDEX32-LABEL: llvm.func @abs_ex_dispatch_0
+//    CHECK-SAME: (%{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.readonly},
+//    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias},
+//    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias})
+//         CHECK:    rocdl.workgroup.dim.x
+//         CHECK:    llvm.getelementptr %{{.*}} : (!llvm.ptr, i64) -> !llvm.ptr, f32
+//       INDEX32:    llvm.getelementptr %{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, f32
+//         CHECK:    llvm.fadd
 
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTargetUtils.cpp
@@ -217,7 +217,7 @@ std::string createHsaco(Location loc, const std::string isa, StringRef name) {
 
   // Invoke lld. Expect a true return value from lld.
   // Searching for LLD
-  const SmallVector<std::string> &toolNames{"iree-lld", "lld"};
+  const SmallVector<std::string> &toolNames{"lld"};
   std::string lldProgram = findTool(toolNames);
   if (lldProgram.empty()) {
     mlir::emitError(loc) << "unable to find iree-lld";

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTargetUtils.cpp
@@ -217,7 +217,7 @@ std::string createHsaco(Location loc, const std::string isa, StringRef name) {
 
   // Invoke lld. Expect a true return value from lld.
   // Searching for LLD
-  const SmallVector<std::string> &toolNames{"lld"};
+  const SmallVector<std::string> &toolNames{"iree-lld", "lld"};
   std::string lldProgram = findTool(toolNames);
   if (lldProgram.empty()) {
     mlir::emitError(loc) << "unable to find iree-lld";


### PR DESCRIPTION
When possible, 32-bit indices are noticeably faster. This just exposes a flag for it, but in the future we could try to infer it from the offsets + memref sizes (?)