### PR TITLE
Fix embedded builds of IREE. (#15761)

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -141,9 +141,9 @@ class BuildFileFunctions(object):
         if not pkg_root_relative_label:
             return src
         elif os.path.exists(os.path.join(self._build_dir, src)):
-            return f"${{CMAKE_SOURCE_DIR}}/{src}"
+            return f"${{PROJECT_SOURCE_DIR}}/{src}"
         else:
-            return f"${{CMAKE_BINARY_DIR}}/{src}"
+            return f"${{PROJECT_BINARY_DIR}}/{src}"
 
     def _convert_srcs_block(self, srcs, is_generated=False, block_name="SRCS"):
         if not srcs:

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -130,12 +130,12 @@ class BuildFileFunctions(object):
         # ':') or in other packages (leading '//'). We map that to paths by:
         # - dropping any leading ':' as in:
         #      ':generated.c' -> 'generated.c'
-        # - replacing any leading '//' by '${CMAKE_SOURCE_DIR}/' or
-        #   '${CMAKE_BINARY_DIR}/' and any internal ':' by '/', as in:
+        # - replacing any leading '//' by '${PROJECT_SOURCE_DIR}/' or
+        #   '${PROJECT_BINARY_DIR}/' and any internal ':' by '/', as in:
         #      '//path/to/package:source.c'
-        #      -> '${CMAKE_SOURCE_DIR}/path/to/package/source.c'
+        #      -> '${PROJECT_SOURCE_DIR}/path/to/package/source.c'
         #      '//path/to/package:generated.c'
-        #      -> '${CMAKE_BINARY_DIR}/path/to/package/generated.c'
+        #      -> '${PROJECT_BINARY_DIR}/path/to/package/generated.c'
         pkg_root_relative_label = src.startswith("//")
         src = src.lstrip("/").lstrip(":").replace(":", "/")
         if not pkg_root_relative_label:

--- a/runtime/src/iree/builtins/ukernel/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/CMakeLists.txt
@@ -117,7 +117,7 @@ iree_bitcode_library(
   ARCH
     wasm_32
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "internal_headers_filegroup.stamp"
   SRCS
     "mmt4d.c"
@@ -135,7 +135,7 @@ iree_bitcode_library(
   ARCH
     wasm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "internal_headers_filegroup.stamp"
   SRCS
     "mmt4d.c"
@@ -151,10 +151,10 @@ iree_c_embed_data(
   NAME
     embed_ukernel_bitcode
   SRCS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/arch/arm_64/ukernel_bitcode_arm_64.bc"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/arch/arm_64/ukernel_bitcode_arm_64_entry_points.bc"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/arch/x86_64/ukernel_bitcode_x86_64.bc"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/arch/x86_64/ukernel_bitcode_x86_64_entry_points.bc"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/arch/arm_64/ukernel_bitcode_arm_64.bc"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/arch/arm_64/ukernel_bitcode_arm_64_entry_points.bc"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/arch/x86_64/ukernel_bitcode_x86_64.bc"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/arch/x86_64/ukernel_bitcode_x86_64_entry_points.bc"
     "ukernel_bitcode_32bit_base.bc"
     "ukernel_bitcode_64bit_base.bc"
   DEPS

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
@@ -19,8 +19,8 @@ iree_bitcode_library(
   ARCH
     wasm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_arm_64.h"
     "common_arm_64_entry_point.h"
     "mmt4d_arm_64_internal.h"
@@ -39,8 +39,8 @@ iree_bitcode_library(
   ARCH
     arm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_arm_64.h"
     "common_arm_64_entry_point.h"
     "mmt4d_arm_64_internal.h"
@@ -58,8 +58,8 @@ iree_bitcode_library(
   ARCH
     arm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_arm_64.h"
     "common_arm_64_entry_point.h"
     "mmt4d_arm_64_internal.h"
@@ -77,8 +77,8 @@ iree_bitcode_library(
   ARCH
     arm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_arm_64.h"
     "common_arm_64_entry_point.h"
     "mmt4d_arm_64_internal.h"
@@ -96,8 +96,8 @@ iree_bitcode_library(
   ARCH
     arm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_arm_64.h"
     "common_arm_64_entry_point.h"
     "mmt4d_arm_64_internal.h"
@@ -115,8 +115,8 @@ iree_bitcode_library(
   ARCH
     arm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_arm_64.h"
     "common_arm_64_entry_point.h"
     "mmt4d_arm_64_internal.h"
@@ -134,8 +134,8 @@ iree_bitcode_library(
   ARCH
     arm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_arm_64.h"
     "common_arm_64_entry_point.h"
     "mmt4d_arm_64_internal.h"

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/CMakeLists.txt
@@ -19,8 +19,8 @@ iree_bitcode_library(
   ARCH
     wasm_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_x86_64.h"
     "common_x86_64_entry_point.h"
     "mmt4d_x86_64_internal.h"
@@ -39,8 +39,8 @@ iree_bitcode_library(
   ARCH
     x86_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_x86_64.h"
     "common_x86_64_entry_point.h"
     "mmt4d_x86_64_internal.h"
@@ -63,8 +63,8 @@ iree_bitcode_library(
   ARCH
     x86_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_x86_64.h"
     "common_x86_64_entry_point.h"
     "mmt4d_x86_64_internal.h"
@@ -92,8 +92,8 @@ iree_bitcode_library(
   ARCH
     x86_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_x86_64.h"
     "common_x86_64_entry_point.h"
     "mmt4d_x86_64_internal.h"
@@ -120,8 +120,8 @@ iree_bitcode_library(
   ARCH
     x86_64
   INTERNAL_HDRS
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
-    "${CMAKE_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/builtins/ukernel/internal_headers_filegroup.stamp"
+    "${PROJECT_BINARY_DIR}/runtime/src/iree/schemas/cpu_data_headers_filegroup.stamp"
     "common_x86_64.h"
     "common_x86_64_entry_point.h"
     "mmt4d_x86_64_internal.h"


### PR DESCRIPTION
Use PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR to represent path relative to the top of IREE instead of the CMAKE_* counterpart. This fixes builds where IREE is embedded into another project.

Thanks @dpackwood for raising the issue.