### PR TITLE
Data tiling: add tile sizes for riscv32 ukernel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
@@ -53,6 +53,23 @@ enumerateMatmulTilesVMVX(EncodingUser user, ExecutableTargetAttr target) {
   };
 }
 
+// Enumerate tile sizes to choose from on riscv32.
+// For narrow-{M,N} cases, this only enumerates on narrow M. The narrow-N cases
+// are handled by transposition in chooseMatmulTile.
+static SmallVector<TileMxNxK>
+enumerateMatmulTileRiscv32(EncodingUser user, ExecutableTargetAttr target) {
+  if (hasUkernel(target)) {
+    return {
+        TileMxNxK{8, 8, 4}, // Some reasonable tile shape.
+        TileMxNxK{4, 8, 4}, // Truncation of the above.
+        TileMxNxK{2, 8, 4}, // Truncation of the above.
+        TileMxNxK{1, 8, 4}, // Truncation of the above.
+    };
+  }
+  // Fallback - no architecture-optimized tile size for this case.
+  return {};
+}
+
 // Enumerate tile sizes to choose from on arm64.
 // For narrow-{M,N} cases, this only enumerates on narrow M. The narrow-N cases
 // are handled by transposition in chooseMatmulTile.
@@ -327,6 +344,9 @@ SmallVector<TileMxNxK> enumerateMatmulTileMxNxK(EncodingUser user,
   }
   if (isX86_64(target)) {
     return enumerateMatmulTileX86_64(user, elementTypes, target);
+  }
+  if (isRISCV32(target)) {
+    return enumerateMatmulTileRiscv32(user, target);
   }
   return {};
 }

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -234,6 +234,11 @@ bool isRISCV(IREE::HAL::ExecutableTargetAttr targetAttr) {
   return triple && triple.value().isRISCV();
 }
 
+bool isRISCV32(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  std::optional<llvm::Triple> triple = getTargetTriple(targetAttr);
+  return triple && triple.value().isRISCV32();
+}
+
 bool isReadOnly(Value v) {
   Operation *definingOp = v.getDefiningOp();
   if (!definingOp)

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -91,6 +91,7 @@ bool isX86(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isX86_64(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isAArch64(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isRISCV(IREE::HAL::ExecutableTargetAttr targetAttr);
+bool isRISCV32(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Checks if a tensor value is generated from a read-only object, like
 /// and interface binding with read-only attribute or from an `arith.constant`


### PR DESCRIPTION
Created a new function enumerateMatmulTileRiscv32 to define tile sizes for riscv32 ukernel case.