### PR TITLE
Fix relative link to `python.md#profiling`.

### DIFF
--- a/docs/website/docs/developers/performance/profiling-with-tracy.md
+++ b/docs/website/docs/developers/performance/profiling-with-tracy.md
@@ -197,7 +197,7 @@ cmake --build .
     $ IREE_PY_RUNTIME=tracy iree-run-module ...
     ```
 
-    See [this section](../../../reference/bindings/python#profiling) in the
+    See [this section](../../reference/bindings/python.md#profiling) in the
     Python bindings documentation for more details.
 
 ### Additional steps for Sampling


### PR DESCRIPTION
This fixes a warning:

```
INFO    -  Doc file 'developers/performance/profiling-with-tracy.md' contains an unrecognized
           relative link '../../../reference/bindings/python#profiling', it was left as is. Did you
           mean '../../reference/bindings/python.md#profiling'?
```