### PR TITLE
Adding optional exported function declaration string to bytecode modules.

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -294,6 +294,102 @@ static LogicalResult wrapImportFunc(IREE::ABI::InvocationModel invocationModel,
   return success();
 }
 
+static StringAttr getNameFromDictAttr(DictionaryAttr attr) {
+  return attr ? attr.getAs<StringAttr>("iree.abi.name") : nullptr;
+}
+
+static StringAttr inferArgumentName(MLIRContext *context, int index,
+                                    DictionaryAttr attrs) {
+  if (auto attrName = getNameFromDictAttr(attrs))
+    return attrName;
+  return StringAttr::get(context, "input" + std::to_string(index));
+}
+
+static StringAttr inferResultName(MLIRContext *context, int index,
+                                  DictionaryAttr attrs) {
+  if (auto attrName = getNameFromDictAttr(attrs))
+    return attrName;
+  return StringAttr::get(context, "output" + std::to_string(index));
+}
+
+static DictionaryAttr getIOAttr(ArrayAttr allAttrs, unsigned i) {
+  if (!allAttrs)
+    return nullptr;
+  return cast_or_null<DictionaryAttr>(allAttrs.getValue()[i]);
+}
+
+static void formatIOAttr(DictionaryAttr attrs, llvm::raw_ostream &os) {
+  if (!attrs || attrs.empty())
+    return;
+  auto shouldIncludeAttr = [](const NamedAttribute &attr) {
+    return attr.getName().getValue() != "iree.abi.name";
+  };
+  if (!llvm::any_of(attrs, shouldIncludeAttr))
+    return;
+  os << " {";
+  llvm::interleaveComma(llvm::make_filter_range(attrs, shouldIncludeAttr), os,
+                        [&](auto argAttr) {
+                          os << argAttr.getName().getValue();
+                          os << " = ";
+                          os << argAttr.getValue();
+                        });
+  os << "}";
+}
+
+// Returns a string representing the |exportOp| in a human-friendly way.
+// This doesn't have to match the exact MLIR (though could) as the intent is for
+// it to be helpful instead of something a user could compile. This means we
+// want to bake away argument/result attributes if we can do something
+// meaningful with them (like names).
+static StringAttr
+formatSourceDeclaration(IREE::ABI::InvocationModel invocationModel,
+                        func::FuncOp exportOp, StringRef publicName,
+                        ArrayAttr allArgAttrs, ArrayAttr allResultAttrs) {
+  std::string decl;
+  llvm::raw_string_ostream os(decl);
+  switch (invocationModel) {
+  default:
+    assert(false && "unhandled invocation model");
+    break;
+  case IREE::ABI::InvocationModel::Sync:
+    os << "sync ";
+    break;
+  case IREE::ABI::InvocationModel::CoarseFences:
+    os << "async ";
+    break;
+  }
+  os << "func @" << publicName;
+  os << "(";
+  for (auto arg : exportOp.getArguments()) {
+    if (arg.getArgNumber() > 0)
+      os << ", ";
+    os << "%";
+    os << inferArgumentName(exportOp.getContext(), arg.getArgNumber(),
+                            getIOAttr(allArgAttrs, arg.getArgNumber()))
+              .getValue();
+    os << ": " << arg.getType();
+    if (auto argAttrs = getIOAttr(allArgAttrs, arg.getArgNumber())) {
+      formatIOAttr(argAttrs, os);
+    }
+  }
+  os << ") -> (";
+  for (auto [resultNumber, resultType] :
+       llvm::enumerate(exportOp.getResultTypes())) {
+    if (resultNumber > 0)
+      os << ", ";
+    os << "%";
+    os << inferResultName(exportOp.getContext(), resultNumber,
+                          getIOAttr(allResultAttrs, resultNumber))
+              .getValue();
+    os << ": " << resultType;
+    if (auto resultAttrs = getIOAttr(allResultAttrs, resultNumber)) {
+      formatIOAttr(resultAttrs, os);
+    }
+  }
+  os << ")";
+  return StringAttr::get(exportOp.getContext(), decl);
+}
+
 // Populates attributes on |wrapperOp| to support runtime reflection.
 // These are attached to the exported function and can be queried at runtime
 // with iree_vm_function_lookup_attr_by_name.
@@ -317,32 +413,24 @@ static void populateReflectionAttrs(IREE::ABI::InvocationModel invocationModel,
     break;
   }
 
+  // If not provided by the user add the source declaration as the MLIR type.
+  // Users in source frontends can override this with something more natural
+  // (python/whatever).
+  if (auto declAttr = exportOp->getAttr("iree.abi.declaration")) {
+    attrs.emplace_back(StringAttr::get(context, "iree.abi.declaration"),
+                       declAttr);
+  } else {
+    attrs.emplace_back(StringAttr::get(context, "iree.abi.declaration"),
+                       formatSourceDeclaration(invocationModel, exportOp,
+                                               wrapperOp.getName(),
+                                               exportOp.getAllArgAttrs(),
+                                               exportOp.getAllResultAttrs()));
+  }
+
   if (!attrs.empty()) {
     auto reflectionAttr = DictionaryAttr::get(context, attrs);
     wrapperOp->setAttr("iree.reflection", reflectionAttr);
   }
-}
-
-static StringAttr getNameFromDictAttr(DictionaryAttr attr, Builder &builder) {
-  // TODO(benvanik): support naming. We could look for iree.abi.name or some
-  // other attribute that gets populated by frontends.
-  return nullptr;
-}
-
-static StringAttr inferArgumentName(int index, ArrayRef<DictionaryAttr> attrs,
-                                    Builder &builder) {
-  if (auto attrName = getNameFromDictAttr(attrs[index], builder)) {
-    return attrName;
-  }
-  return builder.getStringAttr("input " + std::to_string(index));
-}
-
-static StringAttr inferResultName(int index, ArrayRef<DictionaryAttr> attrs,
-                                  Builder &builder) {
-  if (auto attrName = getNameFromDictAttr(attrs[index], builder)) {
-    return attrName;
-  }
-  return builder.getStringAttr("output " + std::to_string(index));
 }
 
 // Creates the corresponding wrapper function for the given export function.
@@ -450,7 +538,8 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
       auto importOp = entryBuilder.create<IREE::HAL::TensorImportOp>(
           arg.getLoc(), oldType, arg,
           encoding ? encoding : TypeAttr::get(oldType), waitFence,
-          inferArgumentName(argIndex, argAttrDict, entryBuilder));
+          inferArgumentName(entryBuilder.getContext(), argIndex,
+                            exportOp.getArgAttrDict(argIndex)));
       arguments.push_back(importOp.getTarget());
     } else {
       arguments.push_back(arg);
@@ -498,7 +587,8 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
           result.getLoc(), newType, result,
           encoding ? encoding : TypeAttr::get(result.getType()), dynamicDims,
           resultStorage,
-          inferResultName(resultIndex, resultAttrDict, entryBuilder)));
+          inferResultName(entryBuilder.getContext(), resultIndex,
+                          exportOp.getResultAttrDict(resultIndex))));
     } else {
       results.push_back(result);
     }

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
@@ -8,16 +8,18 @@
 //  CHECK-SAME:   !hal.buffer_view, !hal.buffer_view
 //  CHECK-SAME: ) attributes {
 //  CHECK-SAME:   iree.abi.stub
+//  CHECK-SAME:   iree.reflection =
+//  CHECK-SAME:       iree.abi.declaration = "sync func @dynamicEntry(%input0: tensor<?x8x8x3xf32>, %input1: tensor<?x8x8x3xf32>) -> (%output0: tensor<?x8x8x3xf32>, %output1: tensor<?x8x8x3xf32>)"
 //  CHECK-SAME: } {
 //  CHECK-NEXT:   %[[ARG0_DIM0:.+]] = hal.buffer_view.dim<%[[ARG0]] : !hal.buffer_view>[0] : index
-//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
+//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] "input0" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
 //  CHECK-NEXT:   %[[ARG1_DIM0:.+]] = hal.buffer_view.dim<%[[ARG1]] : !hal.buffer_view>[0] : index
-//  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import %[[ARG1]] "input 1" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG1_DIM0]]}
+//  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import %[[ARG1]] "input1" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG1_DIM0]]}
 //  CHECK-NEXT:   %[[RET_TENSORS:.+]]:2 = call @_dynamicEntry(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]])
 //       CHECK:   %[[RET0_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#0, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 "output 0" : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 "output0" : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
 //       CHECK:   %[[RET1_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#1, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 "output 1" : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 "output1" : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
 //  CHECK-NEXT:   return %[[RET0_VIEW]], %[[RET1_VIEW]] : !hal.buffer_view, !hal.buffer_view
 //  CHECK-NEXT: }
 
@@ -31,13 +33,41 @@ func.func @dynamicEntry(%arg0: tensor<?x8x8x3xf32>, %arg1: tensor<?x8x8x3xf32>) 
 
 // -----
 
+// Tests that iree.abi.declaration is added when needed and otherwise the user
+// provided value is passed through.
+
+// CHECK-LABEL: func.func @existingDeclaration
+// CHECK-SAME: iree.reflection =
+// CHECK-SAME:     iree.abi.declaration = "some.python.thing(types_are_overrated)"
+func.func @existingDeclaration(%arg0: tensor<i32>) attributes {
+  iree.abi.declaration = "some.python.thing(types_are_overrated)"
+} {
+  return
+}
+
+// -----
+
+// Tests that name overrides propagate into both metadata and assertion IR.
+
+// CHECK-LABEL: func.func @namedEntry
+// CHECK-SAME: iree.reflection =
+// CHECK-SAME:     iree.abi.declaration = "sync func @namedEntry(%my_input_0: tensor<3xf32>, %input1: tensor<3xf32>) -> (%my_output_0: tensor<3xf32>, %output1: tensor<3xf32>)"
+func.func @namedEntry(%arg0: tensor<3xf32> {iree.abi.name = "my_input_0"}, %arg1: tensor<3xf32>) ->
+    (tensor<3xf32> {iree.abi.name = "my_output_0"}, tensor<3xf32>) {
+  %0 = arith.addf %arg0, %arg1 : tensor<3xf32>
+  return %0, %0 : tensor<3xf32>, tensor<3xf32>
+}
+
+// -----
+
 // Tests that exports with encodings specified are propagated to the HAL ops.
 
 // CHECK-LABEL: func.func @exportEncodings
+//  CHECK-SAME:   iree.abi.declaration = "sync func @exportEncodings(%input0: tensor<?x8x8x3xf32> {iree.abi.encoding = tensor<?x8x8x3xi32>}) -> (%output0: tensor<?x8x8x3xf32> {iree.abi.encoding = tensor<?x8x8x3xi32>})"
 // CHECK: hal.tensor.import {{.+}} : !hal.buffer_view -> tensor<?x8x8x3xi32> as tensor<?x8x8x3xf32>{{.+}}
 // CHECK: hal.tensor.export {{.+}} : tensor<?x8x8x3xi32> as tensor<?x8x8x3xf32>{{.+}} -> !hal.buffer_view
 
-// CHECK-LABEL: func.func private @_exportEncodings(
+// CHECK-LABEL: func.func private @_exportEncodings
 func.func @exportEncodings(%arg0: tensor<?x8x8x3xf32> {iree.abi.encoding = tensor<?x8x8x3xi32>}) -> (tensor<?x8x8x3xf32> {iree.abi.encoding = tensor<?x8x8x3xi32>}) {
   return %arg0 : tensor<?x8x8x3xf32>
 }
@@ -46,21 +76,20 @@ func.func @exportEncodings(%arg0: tensor<?x8x8x3xf32> {iree.abi.encoding = tenso
 
 // Tests specifying explicit storage for specific function results.
 
-// CHECK-LABEL: func.func @outputStorage(
-//  CHECK-SAME:   %[[ARG0:.+]]: !hal.buffer_view,
-//  CHECK-SAME:   %[[RET1_STORAGE:.+]]: !hal.buffer
-//  CHECK-SAME: -> (
-//  CHECK-SAME:   !hal.buffer_view, !hal.buffer_view
-//  CHECK-SAME: ) attributes {
+// CHECK-LABEL: func.func @outputStorage
+//  CHECK-SAME:   (%[[ARG0:[a-z0-9]+]]: !hal.buffer_view, %[[RET1_STORAGE:[a-z0-9]+]]: !hal.buffer)
+//  CHECK-SAME: -> (!hal.buffer_view, !hal.buffer_view) attributes {
 //  CHECK-SAME:   iree.abi.stub
+//  CHECK-SAME:   iree.reflection =
+//  CHECK-SAME:       iree.abi.declaration = "sync func @outputStorage(%input0: tensor<?x8x8x3xf32>, %input1: !hal.buffer {iree.abi.output = 1 : index}) -> (%output0: tensor<?x8x8x3xf32>, %output1: tensor<?x8x8x3xf32>)"
 //  CHECK-SAME: } {
 //  CHECK-NEXT:   %[[ARG0_DIM0:.+]] = hal.buffer_view.dim<%[[ARG0]] : !hal.buffer_view>[0] : index
-//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
+//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] "input0" : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
 //  CHECK-NEXT:   %[[RET_TENSORS:.+]]:2 = call @_outputStorage(%[[ARG0_TENSOR]], %[[RET1_STORAGE]])
 //       CHECK:   %[[RET0_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#0, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 "output 0" : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 "output0" : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
 //       CHECK:   %[[RET1_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#1, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 "output 1" into(%[[RET1_STORAGE]] : !hal.buffer) : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 "output1" into(%[[RET1_STORAGE]] : !hal.buffer) : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
 //  CHECK-NEXT:   return %[[RET0_VIEW]], %[[RET1_VIEW]] : !hal.buffer_view, !hal.buffer_view
 //  CHECK-NEXT: }
 

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points_coarse_fences.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points_coarse_fences.mlir
@@ -6,14 +6,15 @@
 //  CHECK-SAME:   !hal.buffer_view, !hal.buffer_view
 //  CHECK-SAME: ) attributes {
 //  CHECK-SAME:   iree.abi.stub
-//  CHECK-SAME:   iree.reflection = {iree.abi.model = "coarse-fences"}
+//  CHECK-SAME:   iree.reflection =
+//  CHECK-SAME:       iree.abi.model = "coarse-fences"
 //  CHECK-SAME: } {
-//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<4xf32>
-//  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG1]] "input 1" : !hal.buffer_view -> tensor<4xf32>
+//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] "input0" : !hal.buffer_view -> tensor<4xf32>
+//  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG1]] "input1" : !hal.buffer_view -> tensor<4xf32>
 //  CHECK-NEXT:   %[[RESULT_TENSORS:.+]]:2 = call @_asyncEntry(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]])
 //  CHECK-NEXT:   %[[READY_TENSORS:.+]]:2 = hal.tensor.barrier join(%[[RESULT_TENSORS]]#0, %[[RESULT_TENSORS]]#1 : tensor<4xf32>, tensor<4xf32>) => %[[SIGNAL]] : !hal.fence
-//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[READY_TENSORS]]#0 "output 0" : tensor<4xf32> -> !hal.buffer_view
-//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[READY_TENSORS]]#1 "output 1" : tensor<4xf32> -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[READY_TENSORS]]#0 "output0" : tensor<4xf32> -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[READY_TENSORS]]#1 "output1" : tensor<4xf32> -> !hal.buffer_view
 //  CHECK-NEXT:   return %[[RET0_VIEW]], %[[RET1_VIEW]] : !hal.buffer_view, !hal.buffer_view
 //  CHECK-NEXT: }
 
@@ -56,7 +57,7 @@ func.func @primitiveArgOnly(%arg0: i32) {
 
 // CHECK-LABEL: func.func @tensorArgOnly
 //  CHECK-SAME: (%[[ARG0:.+]]: !hal.buffer_view, %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence)
-//       CHECK:   %[[ARG0_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<4xf32>
+//       CHECK:   %[[ARG0_TENSOR:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] "input0" : !hal.buffer_view -> tensor<4xf32>
 //  CHECK-NEXT:   call @_tensorArgOnly(%[[ARG0_TENSOR]])
 //  CHECK-NEXT:   hal.fence.signal<%[[SIGNAL]] : !hal.fence>
 //  CHECK-NEXT:   return

--- a/runtime/bindings/python/tests/system_api_test.py
+++ b/runtime/bindings/python/tests/system_api_test.py
@@ -76,7 +76,7 @@ class SystemApiTest(unittest.TestCase):
         f = ctx.modules.arithmetic["simple_mul"]
         f_repr = repr(f)
         logging.info("f_repr: %s", f_repr)
-        self.assertEqual(f_repr, "<VmFunction simple_mul(0rr_r), reflection = {}>")
+        self.assertIn("simple_mul(0rr_r)", f_repr)
 
     def test_duplicate_module(self):
         ctx = iree.runtime.SystemContext()

--- a/runtime/src/iree/tooling/run_module.c
+++ b/runtime/src/iree/tooling/run_module.c
@@ -173,6 +173,17 @@ static iree_status_t iree_tooling_create_run_context(
   return status;
 }
 
+static iree_status_t iree_tooling_annotate_status_with_function_decl(
+    iree_status_t base_status, iree_vm_function_t function) {
+  iree_string_view_t decl = iree_vm_function_lookup_attr_by_name(
+      &function, IREE_SV("iree.abi.declaration"));
+  if (!iree_string_view_is_empty(decl)) {
+    return iree_status_annotate_f(base_status, "`%.*s`", (int)decl.size,
+                                  decl.data);
+  }
+  return base_status;
+}
+
 static iree_status_t iree_tooling_run_function(
     iree_vm_context_t* context, iree_vm_function_t function,
     iree_hal_device_t* device, iree_hal_allocator_t* device_allocator,
@@ -366,6 +377,11 @@ iree_status_t iree_tooling_run_module_with_data(
   iree_status_t status =
       iree_tooling_run_function(context, function, device, device_allocator,
                                 host_allocator, out_exit_code);
+
+  // Annotate errors with the function description.
+  if (!iree_status_is_ok(status)) {
+    status = iree_tooling_annotate_status_with_function_decl(status, function);
+  }
 
   // Release the context and all retained resources (variables, constants, etc).
   iree_vm_context_release(context);

--- a/tests/compiler_driver/preprocessing_flags.mlir
+++ b/tests/compiler_driver/preprocessing_flags.mlir
@@ -13,9 +13,9 @@ func.func @test(%arg0 : tensor<10x20xf32>, %arg1 : tensor<20x30xf32>, %arg2 : te
 //       CHECK: PadLinalgOps (iree-preprocessing-pad-linalg-ops)
 // CHECK-LABEL: module
 //  CHECK-NEXT:   func.func @test(
-//   CHECK-DAG:     %[[ARG0:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input 0" : !hal.buffer_view -> tensor<10x20xf32>
-//   CHECK-DAG:     %[[ARG1:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input 1" : !hal.buffer_view -> tensor<20x30xf32>
-//   CHECK-DAG:     %[[ARG2:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input 2" : !hal.buffer_view -> tensor<10x30xf32>
+//   CHECK-DAG:     %[[ARG0:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input0" : !hal.buffer_view -> tensor<10x20xf32>
+//   CHECK-DAG:     %[[ARG1:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input1" : !hal.buffer_view -> tensor<20x30xf32>
+//   CHECK-DAG:     %[[ARG2:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input2" : !hal.buffer_view -> tensor<10x30xf32>
 //   CHECK-DAG:     %[[PAD0:.+]] = tensor.pad %[[ARG0]] low[0, 0] high[6, 12]
 //   CHECK-DAG:     %[[PAD1:.+]] = tensor.pad %[[ARG1]] low[0, 0] high[12, 2]
 //   CHECK-DAG:     %[[PAD2:.+]] = tensor.pad %[[ARG2]] low[0, 0] high[6, 2]

--- a/tools/iree-dump-module-main.c
+++ b/tools/iree-dump-module-main.c
@@ -242,6 +242,10 @@ static void iree_tooling_print_exported_function_def(
         iree_vm_FunctionSignatureDef_calling_convention(signature_def));
   }
   fprintf(stdout, "\n");
+  if (iree_vm_FunctionSignatureDef_attrs_is_present(signature_def)) {
+    iree_tooling_print_attr_defs(
+        iree_vm_FunctionSignatureDef_attrs(signature_def), 8);
+  }
 }
 
 static void iree_tooling_print_exported_function_defs(

--- a/tools/test/compile_to_phase.mlir
+++ b/tools/test/compile_to_phase.mlir
@@ -4,7 +4,7 @@
 
 // RUN: iree-compile --compile-to=abi %s | FileCheck %s --check-prefix=ABI-PHASE
 // ABI-PHASE: func.func @abs(%[[ARG0:.+]]: !hal.buffer_view)
-// ABI-PHASE: %[[INPUT:.+]] = hal.tensor.import %[[ARG0]] "input 0" : !hal.buffer_view -> tensor<f32>
+// ABI-PHASE: %[[INPUT:.+]] = hal.tensor.import %[[ARG0]] "input0" : !hal.buffer_view -> tensor<f32>
 // ABI-PHASE: math.absf %[[INPUT]] : tensor<f32>
 
 // RUN: iree-compile --compile-to=flow %s | FileCheck %s --check-prefix=FLOW-PHASE


### PR DESCRIPTION
This allows iree-dump-module (and in the future other things) to report the original source declaration for an exported function. This is only intended to aid debugging and not machine interpretation.

Example from iree-dump-module:
```
Exported Functions:
  [  0] predict(!vm.ref<?>) -> (!vm.ref<?>)
        iree.abi.declaration: sync func @predict(%input0: tensor<1x28x28x1xf32>) -> (%output0: tensor<1x10xf32>)
```

Example from iree-run-module with invalid args:
```
D:\Dev\iree\runtime\src\iree\vm\invocation.c:95: INVALID_ARGUMENT; input list and function mismatch; expected 1 arguments but passed 0; invoking function 'predict'; `sync func @predict(%input0: tensor<1x28x28x1xf32>) -> (%output0: tensor<1x10xf32>)`
```

Frontends can attach an `iree.abi.declaration` attribute to public functions to override the automatically generated string or add `iree.abi.name` attributes to args/results to have them used instead of the defaults.