### PR TITLE
[spirv] Add a pass to link multiple HAL executables together

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -63,6 +63,7 @@ iree_compiler_cc_library(
         "SPIRVEraseStorageBufferStaticShape.cpp",
         "SPIRVFinalVectorLowering.cpp",
         "SPIRVInitialVectorLowering.cpp",
+        "SPIRVLinkExecutables.cpp",
         "SPIRVLowerExecutableTargetPass.cpp",
         "SPIRVMapMemRefStorageClass.cpp",
         "SPIRVSelectLoweringStrategy.cpp",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -96,6 +96,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
+        "//compiler/src/iree/compiler/Utils",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -146,6 +146,7 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::Util::Transforms
+    iree::compiler::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_cc_library(
     "SPIRVEraseStorageBufferStaticShape.cpp"
     "SPIRVFinalVectorLowering.cpp"
     "SPIRVInitialVectorLowering.cpp"
+    "SPIRVLinkExecutables.cpp"
     "SPIRVLowerExecutableTargetPass.cpp"
     "SPIRVMapMemRefStorageClass.cpp"
     "SPIRVSelectLoweringStrategy.cpp"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -107,6 +107,9 @@ createSPIRVFoldProcessorIDUsesPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVInitialVectorLoweringPass();
 
+/// Links SPIR-V HAL executables within the top-level program module.
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createSPIRVLinkExecutablesPass();
+
 /// Pass to set the lowering strategy for the target variant.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createSPIRVSelectLoweringStrategyPass();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
@@ -70,6 +70,12 @@ def SPIRVInitialVectorLowering : Pass<
   let constructor = "mlir::iree_compiler::createSPIRVInitialVectorLoweringPass()";
 }
 
+def SPIRVLinkExecutables :
+    Pass<"iree-spirv-link-executables", "mlir::ModuleOp"> {
+  let summary = "Links SPIR-V HAL executables within the top-level program module.";
+  let constructor = "mlir::iree_compiler::createSPIRVLinkExecutablesPass()";
+}
+
 def SPIRVLowerExecutableTarget :
     Pass<"iree-spirv-lower-executable-target-pass",
          "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
@@ -11,13 +11,12 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Pass/Pass.h"
 
-namespace mlir {
-namespace iree_compiler {
+namespace mlir::iree_compiler {
 
 namespace {
 
-struct SPIRVLinkExecutablesPass
-    : public SPIRVLinkExecutablesBase<SPIRVLinkExecutablesPass> {
+struct SPIRVLinkExecutablesPass final
+    : SPIRVLinkExecutablesBase<SPIRVLinkExecutablesPass> {
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
     OpBuilder moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
@@ -41,7 +40,8 @@ struct SPIRVLinkExecutablesPass
         OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
 
     // Gather all unique executable targets - we may have multiple.
-    auto executableTargetAttrs = gatherExecutableTargets(sourceExecutableOps);
+    SetVector<IREE::HAL::ExecutableTargetAttr> executableTargetAttrs =
+        gatherExecutableTargets(sourceExecutableOps);
     for (auto executableTargetAttr : executableTargetAttrs) {
       // Add our hal.executable.variant with an empty module.
       auto linkedTargetOp =
@@ -69,5 +69,4 @@ createSPIRVLinkExecutablesPass() {
   return std::make_unique<SPIRVLinkExecutablesPass>();
 }
 
-} // namespace iree_compiler
-} // namespace mlir
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
@@ -1,0 +1,73 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/SPIRV/PassDetail.h"
+#include "iree/compiler/Codegen/SPIRV/Passes.h"
+#include "iree/compiler/Codegen/Utils/LinkingUtils.h"
+#include "iree/compiler/Utils/ModuleUtils.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+struct SPIRVLinkExecutablesPass
+    : public SPIRVLinkExecutablesBase<SPIRVLinkExecutablesPass> {
+  void runOnOperation() override {
+    mlir::ModuleOp moduleOp = getOperation();
+    OpBuilder moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
+
+    SmallVector<IREE::HAL::ExecutableOp, 8> sourceExecutableOps =
+        llvm::to_vector<8>(moduleOp.getOps<IREE::HAL::ExecutableOp>());
+    if (sourceExecutableOps.size() <= 1)
+      return;
+
+    // Guess a module name, if needed, to make the output files readable.
+    std::string moduleName = guessModuleName(moduleOp, "spirv_module");
+
+    // Create our new "linked" hal.executable.
+    std::string linkedExecutableName =
+        llvm::formatv("{0}_linked_{1}", moduleName, "spirv");
+    auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
+        moduleOp.getLoc(), linkedExecutableName);
+    linkedExecutableOp.setVisibility(
+        sourceExecutableOps.front().getVisibility());
+    OpBuilder executableBuilder =
+        OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
+
+    // Gather all unique executable targets - we may have multiple.
+    auto executableTargetAttrs = gatherExecutableTargets(sourceExecutableOps);
+    for (auto executableTargetAttr : executableTargetAttrs) {
+      // Add our hal.executable.variant with an empty module.
+      auto linkedTargetOp =
+          executableBuilder.create<IREE::HAL::ExecutableVariantOp>(
+              moduleOp.getLoc(), executableTargetAttr.getSymbolNameFragment(),
+              executableTargetAttr);
+      auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
+      targetBuilder.create<mlir::ModuleOp>(moduleOp.getLoc());
+
+      // Try linking together all executables in moduleOp.
+      if (failed(linkExecutablesInto(
+              moduleOp, sourceExecutableOps, linkedExecutableOp, linkedTargetOp,
+              [](mlir::ModuleOp moduleOp) { return moduleOp; },
+              targetBuilder))) {
+        return signalPassFailure();
+      }
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createSPIRVLinkExecutablesPass() {
+  return std::make_unique<SPIRVLinkExecutablesPass>();
+}
+
+} // namespace iree_compiler
+} // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -43,6 +43,7 @@ iree_lit_test_suite(
             "emulate_i64.mlir",
             "erase_storage_buffer_static_shape.mlir",
             "illegal_configuration.mlir",
+            "link_executables.mlir",
             "lower_masks.mlir",
             "lowering_matmul_fusion.mlir",
             "lowering_matmul_promotion.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_lit_test_suite(
     "emulate_i64.mlir"
     "erase_storage_buffer_static_shape.mlir"
     "illegal_configuration.mlir"
+    "link_executables.mlir"
     "lower_masks.mlir"
     "lowering_matmul_fusion.mlir"
     "lowering_matmul_promotion.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
@@ -1,0 +1,142 @@
+// RUN: iree-opt --split-input-file --iree-spirv-link-executables %s | FileCheck %s
+
+#vulkan_target = #hal.executable.target<"vulkan", "vulkan-spirv-fb">
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 1, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+
+hal.executable private @dispatch_0 {
+  hal.executable.variant @spirv target(#vulkan_target) {
+    hal.executable.constant.block(%device: !hal.device) -> i32 as "foo" {
+      %c1 = arith.constant 1 : i32
+      hal.return %c1 : i32
+    }
+    hal.executable.export @dispatch_0 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.3, [Shader], []> {
+        spirv.func @dispatch_0() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @dispatch_0
+        spirv.ExecutionMode @dispatch_0 "LocalSize", 32, 1, 1
+      }
+    }
+  }
+}
+hal.executable private @dispatch_1 {
+  hal.executable.variant @spirv target(#vulkan_target) {
+    hal.executable.constant.block(%device: !hal.device) -> i32 as "baz" {
+      %c2 = arith.constant 2 : i32
+      hal.return %c2 : i32
+    }
+    hal.executable.export @dispatch_1 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.3, [Shader], []> {
+        spirv.func @dispatch_1() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @dispatch_1
+        spirv.ExecutionMode @dispatch_1 "LocalSize", 32, 1, 1
+      }
+    }
+  }
+}
+hal.executable private @dispatch_2 {
+  hal.executable.variant @spirv target(#vulkan_target) {
+    hal.executable.export @dispatch_2 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.3, [Shader], []> {
+        spirv.func @dispatch_2() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @dispatch_2
+        spirv.ExecutionMode @dispatch_2 "LocalSize", 32, 1, 1
+      }
+    }
+  }
+}
+func.func @basic_linking() -> () attributes {
+  testing.func.a = @dispatch_0,
+  testing.func.b = @dispatch_0::@spirv,
+  testing.func.c = @dispatch_0::@spirv::@dispatch_0
+} {
+  %device = hal.ex.shared_device : !hal.device
+  %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer attributes {
+    testing.op.a = @dispatch_0,
+    testing.op.b = @dispatch_0::@spirv,
+    testing.op.c = @dispatch_0::@spirv::@dispatch_0
+  }
+  %c1 = arith.constant 1 : index
+  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@spirv::@dispatch_0) workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@spirv::@dispatch_1) workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@spirv::@dispatch_2) workgroups([%c1, %c1, %c1])
+  return
+}
+util.initializer {
+  %device = hal.ex.shared_device : !hal.device
+  %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
+  %c1 = arith.constant 1 : index
+  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@spirv::@dispatch_0) workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@spirv::@dispatch_1) workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@spirv::@dispatch_2) workgroups([%c1, %c1, %c1])
+  util.initializer.return
+}
+
+// All executables (including their interfaces and entry points) should be
+// linked together into a single executable.
+
+//  CHECK-NOT: hal.executable private @dispatch_0
+//  CHECK-NOT: hal.executable private @dispatch_1
+//  CHECK-NOT: hal.executable private @dispatch_2
+
+//      CHECK: hal.executable private @link_executables_linked_spirv {
+// CHECK-NEXT:   hal.executable.variant public @vulkan_spirv_fb target(#executable_target_vulkan_spirv_fb) {
+// CHECK-NEXT:     hal.executable.constant.block(%arg0: !hal.device) -> i32 as "foo"
+// CHECK-NEXT:       = arith.constant 1
+//      CHECK:     hal.executable.export public @dispatch_0 ordinal(0)
+// CHECK-NEXT:     hal.executable.constant.block(%arg0: !hal.device) -> i32 as "baz"
+// CHECK-NEXT:       = arith.constant 2
+//      CHECK:     hal.executable.export public @dispatch_1 ordinal(1)
+//      CHECK:     hal.executable.export public @dispatch_2 ordinal(2)
+//      CHECK:     builtin.module {
+//      CHECK:       spirv.module Logical GLSL450 requires #spirv.vce<v1.3, [Shader], []>
+// CHECK-NEXT:         spirv.func @dispatch_0()
+//      CHECK:         spirv.EntryPoint "GLCompute" @dispatch_0
+//      CHECK:         spirv.ExecutionMode @dispatch_0 "LocalSize", 32, 1, 1
+//      CHECK:       spirv.module Logical GLSL450 requires #spirv.vce<v1.3, [Shader], []>
+// CHECK-NEXT:         spirv.func @dispatch_1()
+//      CHECK:         spirv.EntryPoint "GLCompute" @dispatch_1
+//      CHECK:         spirv.ExecutionMode @dispatch_1 "LocalSize", 32, 1, 1
+//      CHECK:       spirv.module Logical GLSL450 requires #spirv.vce<v1.3, [Shader], []>
+// CHECK-NEXT:         spirv.func @dispatch_2()
+//      CHECK:         spirv.EntryPoint "GLCompute" @dispatch_2
+//      CHECK:         spirv.ExecutionMode @dispatch_2 "LocalSize", 32, 1, 1
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+//
+// CHECK:       func.func @basic_linking()
+// CHECK:           testing.func.a = @link_executables_linked_spirv
+// CHECK-SAME:      testing.func.b = @link_executables_linked_spirv::@vulkan_spirv_fb
+// CHECK-SAME:      testing.func.c = @link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0
+// CHECK:           testing.op.a = @link_executables_linked_spirv
+// CHECK-SAME:      testing.op.b = @link_executables_linked_spirv::@vulkan_spirv_fb
+// CHECK-SAME:      testing.op.c = @link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0
+// CHECK:         hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0) workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_1) workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_2) workgroups([%c1, %c1, %c1])
+//
+// CHECK:       util.initializer
+// CHECK:         hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0) workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_1) workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_2) workgroups([%c1, %c1, %c1])

--- a/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Support/Path.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Support/LLVM.h"
 

--- a/compiler/src/iree/compiler/Utils/ModuleUtils.h
+++ b/compiler/src/iree/compiler/Utils/ModuleUtils.h
@@ -7,11 +7,9 @@
 #ifndef IREE_COMPILER_UTILS_MODULEUTILS_H_
 #define IREE_COMPILER_UTILS_MODULEUTILS_H_
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
-#include "mlir/IR/SymbolTable.h"
 
 namespace mlir {
 namespace iree_compiler {


### PR DESCRIPTION
This commit adds a pass to link multiple HAL executables together for the SPIR-V backend. It basically copies the logic for VMVX for now; more modifications to come in future patches.

Overall, the goal is to allow having one single `hal.executable` op to contain a few `hal.executable.variant` ops, where each of them then contains multiple `spirv.module` ops. Different `hal.executable.variant` ops map to different required hardware capabilities. Each `spirv.module` just contain one single entry point for now.

Progress towards https://github.com/openxla/iree/issues/7824