### PR TITLE
Clone export op during linking to retain regions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
@@ -55,8 +55,7 @@ struct LLVMCPULinkExecutablesPass
       // Try linking together all executables in moduleOp.
       if (failed(linkExecutablesInto(
               moduleOp, sourceExecutableOps, linkedExecutableOp, linkedTargetOp,
-              [](mlir::ModuleOp moduleOp) { return moduleOp; },
-              targetBuilder))) {
+              [](mlir::ModuleOp moduleOp) { return moduleOp; }))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
@@ -54,8 +54,7 @@ struct SPIRVLinkExecutablesPass final
       // Try linking together all executables in moduleOp.
       if (failed(linkExecutablesInto(
               moduleOp, sourceExecutableOps, linkedExecutableOp, linkedTargetOp,
-              [](mlir::ModuleOp moduleOp) { return moduleOp; },
-              targetBuilder))) {
+              [](mlir::ModuleOp moduleOp) { return moduleOp; }))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.h
@@ -8,7 +8,6 @@
 #define IREE_COMPILER_CODEGEN_UTILS_LINKINGUTILS_H_
 
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
@@ -25,8 +24,7 @@ LogicalResult linkExecutablesInto(
     ArrayRef<IREE::HAL::ExecutableOp> sourceExecutableOps,
     IREE::HAL::ExecutableOp linkedExecutableOp,
     IREE::HAL::ExecutableVariantOp linkedTargetOp,
-    std::function<Operation *(mlir::ModuleOp moduleOp)> getInnerModuleFn,
-    OpBuilder &builder);
+    std::function<Operation *(mlir::ModuleOp moduleOp)> getInnerModuleFn);
 
 } // namespace iree_compiler
 } // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
@@ -63,8 +63,7 @@ struct VMVXLinkExecutablesPass
               moduleOp, sourceExecutableOps, linkedExecutableOp, linkedTargetOp,
               [](mlir::ModuleOp moduleOp) {
                 return *moduleOp.getOps<IREE::VM::ModuleOp>().begin();
-              },
-              nestedBuilder))) {
+              }))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
@@ -104,7 +104,8 @@ util.initializer {
 // CHECK-NEXT:      hal.executable.constant.block(%arg0: !hal.device) -> i32 as "foo"
 // CHECK-NEXT:        = arith.constant 1
 //      CHECK:      hal.executable.export public @dispatch_0 ordinal(0)
-// CHECK-NEXT:      hal.executable.constant.block(%arg0: !hal.device) -> i32 as "baz"
+//      CHECK:        hal.return %c1, %c1, %c1
+//      CHECK:      hal.executable.constant.block(%arg0: !hal.device) -> i32 as "baz"
 // CHECK-NEXT:        = arith.constant 2
 //      CHECK:      hal.executable.export public @dispatch_1 ordinal(1)
 //      CHECK:      hal.executable.export public @dispatch_2 ordinal(2)


### PR DESCRIPTION
We should not silently drop the workgroup count calculation region when merging export ops from multiple executables.

Progress towards https://github.com/openxla/iree/issues/7824
