### PR TITLE
[CPU] Disable fp16 matmul tests for non-dt test suite.

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -52,7 +52,8 @@ py_binary(
 ) for (lhs_rhs_type, acc_type) in [
     ("i8", "i32"),
     ("f32", "f32"),
-    ("f16", "f16"),
+    # TODO(#15800): enable fp16 tests after the compilation time issue is fixed.
+    # ("f16", "f16"),
     ("f16", "f32"),
     # TODO(#15258): enable bf16 tests when that bug is fixed.
     # ("bf16", "bf16"),

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -110,58 +110,6 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_nondt_f16_f16_small
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f16"
-    "--shapes=small"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling=false"
-    "--iree-llvmcpu-enable-ukernels=none"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "arm_64:sve:+sve"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_nondt_f16_f16_large
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f16"
-    "--shapes=large"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "llvm-cpu"
-  DRIVERS
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-opt-data-tiling=false"
-    "--iree-llvmcpu-enable-ukernels=none"
-  LABELS
-    "noriscv"
-    "nowasm"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "arm_64:sve:+sve"
-)
-
-iree_generated_trace_runner_test(
-  NAME
     e2e_matmul_nondt_f16_f32_small
   GENERATOR
     "generate_e2e_matmul_tests.py"


### PR DESCRIPTION
It takes an hour to compile on some CI jobs. Disable the test suite until the compilation is fixed.

We don't revert https://github.com/openxla/iree/commit/68d0df6d0e54e751c6223044320133bf72e465a6 because there are other development work depends on it and fp16 types are not actively optimized at this moment.