### PR TITLE
Executable library call hooks system, and a sample Linux/CPU event implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ endif()
 #-------------------------------------------------------------------------------
 
 option(IREE_BUILD_EXPERIMENTAL_WEB_SAMPLES "Builds experimental web samples." OFF)
+option(IREE_BUILD_EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS "Build experimental hal_executable_library_call hook libraries that can be used with LD_PRELOAD against runtimes built with `-DCMAKE_C_FLAGS=-DIREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK`." OFF)
 
 #-------------------------------------------------------------------------------
 # CUDA Toolkit.
@@ -1025,6 +1026,10 @@ endif()
 
 if(IREE_BUILD_EXPERIMENTAL_WEB_SAMPLES)
   add_subdirectory(experimental/web)
+endif()
+
+if(IREE_BUILD_EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS)
+  add_subdirectory(experimental/hal_executable_library_call_hooks)
 endif()
 
 set(IREE_PUBLIC_INCLUDE_DIRS "${IREE_COMMON_INCLUDE_DIRS}"

--- a/experimental/hal_executable_library_call_hooks/CMakeLists.txt
+++ b/experimental/hal_executable_library_call_hooks/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+
+iree_cc_library(
+  NAME
+    hook_cpu_events_linux
+  SHARED
+  SRCS
+    hook_cpu_events_linux.cc
+    perf_event_linux.cc
+    stats.cc
+  DEPS
+    iree::base::core_headers
+    iree::hal::local::executable_library
+)
+
+endif()  # CMAKE_SYSTEM_NAME STREQUAL "Linux"

--- a/experimental/hal_executable_library_call_hooks/README.md
+++ b/experimental/hal_executable_library_call_hooks/README.md
@@ -1,0 +1,83 @@
+# A `hal_executable_library_call` hook to study CPU event counts on Linux.
+
+To use this, build IREE with:
+1. `cmake -DCMAKE_C_FLAGS=-DIREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK .` to enable the hooks in the IREE runtime. This enables using hooks by `LD_PRELOAD=...some_hooks.so`
+2. `cmake -DIREE_BUILD_EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS=ON .` to enable building this directory, which provides such a hooks `.so` implementation.
+
+Example:
+
+Suppose that we have a program like this `matmul.mlir`:
+
+```mlir
+func.func @matmul_dynamic(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf32>, tensor<?x?xf32>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+```
+
+Compile it like usual, but just make sure that we dump the actual function names of each dispatch function, so that we will be able to filter for it:
+
+```
+tools/iree-compile ~/matmul.mlir -o /tmp/matmul.vmfb \
+  --iree-hal-target-backends=llvm-cpu \
+  --iree-llvmcpu-target-cpu=znver4 \
+  --iree-llvmcpu-enable-ukernels=all \
+  --iree-hal-dump-executable-intermediates-to=/tmp
+```
+
+Thanks to the dumped intermediates in `/tmp` we see, for instance, that the interesting function for us is named `matmul_dynamic_dispatch_3_mmt4d_DxDxDx16x16x1_f32`.
+
+So we run like this:
+
+```
+IREE_HOOK_FILTER_NAME=matmul_dynamic_dispatch_3_mmt4d_DxDxDx16x16x1_f32 \
+IREE_HOOK_PERF_EVENT_TYPES=ls_any_fills_from_sys.all \
+LD_PRELOAD=/home/benoit/iree-build/experimental/hal_executable_library_call_hooks/libiree_experimental_hal_executable_library_call_hooks_hook_cpu_events_linux.so \
+tools/iree-benchmark-module --device_allocator=caching --module=/tmp/matmul.vmfb --function=matmul_dynamic --input=4000x4000xf32 --input=4000x4000xf32 --input=4000x4000xf32
+```
+
+> [!NOTE]
+> This tool relies on the `perf_event_open` system call. Most Linux systems do not give sufficient permissions by default and need to be overridden by writing `0` to the file `/proc/sys/kernel/perf_event_paranoid`
+
+We get output like this:
+
+```
+Statistics for thread iree-worker-15:
+  15536 matching calls, of which:
+    15536 calls on cpu 31
+  duration_ms:
+    mean: 52.7
+    16-ile means: 39.6 44.8 46.5 47.6 48.4 49.1 49.7 50.3 50.8 51.4 52 52.8 53.9 55.4 59 92.6
+  ls_any_fills_from_sys.all_dram_io:
+    mean: 1.57e+03
+    16-ile means: 942 1.24e+03 1.35e+03 1.44e+03 1.5e+03 1.54e+03 1.58e+03 1.61e+03 1.63e+03 1.66e+03 1.68e+03 1.71e+03 1.73e+03 1.77e+03 1.81e+03 2.02e+03
+  correlation of duration_ms vs. ls_any_fills_from_sys.all_dram_io: 0.46
+  conditional probability of duration_ms 16-ile (↓) given ls_any_fills_from_sys.all_dram_io 16-ile (→):
+          0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+       0 ▆▆ ▃▃ ▂▁ ▁▁ ▁_ __ __ _  _  _        _  _  _  _ 
+       1 ▃▃ ▄▄ ▃▃ ▂▂ ▁▁ ▁_ __ __ __ __ _  __ _  _     __
+       2 ▂▁ ▃▃ ▃▃ ▃▂ ▂▂ ▂▁ ▁_ ▁_ ▁_ __ __ __ __ _  _  __
+       3 ▁_ ▂▂ ▂▂ ▂▂ ▂▂ ▂▁ ▂▁ ▂▁ ▁▁ ▁▁ ▁▁ ▁_ ▁_ __ __ __
+       4 __ ▁▁ ▂▁ ▂▂ ▂▁ ▂▂ ▂▁ ▂▁ ▁▁ ▁▁ ▁▁ ▁▁ ▁▁ ▁_ __ __
+       5 _  ▁_ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▁▁ ▂▁ ▁▁ ▁_ __
+       6 _  __ ▁▁ ▁▁ ▁▁ ▂▁ ▂▁ ▁▁ ▂▁ ▂▁ ▂▁ ▂▁ ▁▁ ▂▁ ▂▁ __
+       7 _  __ ▁_ ▁▁ ▁▁ ▁▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▂ ▂▁ ▂▁ ▂▁ ▁▁ ▁_
+       8 _  __ ▁_ ▁_ ▁▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▁▁
+       9 _  _  __ ▁_ ▁▁ ▁▁ ▁▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▁▁
+       a    _  _  ▁_ ▁▁ ▁▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▂ ▂▂ ▂▁
+       b _  _  __ ▁_ ▁▁ ▁▁ ▁▁ ▁▁ ▂▁ ▁▁ ▂▁ ▂▁ ▂▁ ▂▂ ▂▂ ▂▁
+       c    _  _  ▁_ ▁▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁
+       d _  _  _  ▁_ ▁▁ ▁▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▁ ▂▂ ▂▁ ▂▁ ▂▁
+       e _  __ __ ▁_ ▁_ ▁▁ ▁▁ ▂▁ ▂▁ ▂▁ ▁▁ ▂▁ ▂▁ ▂▂ ▂▁ ▂▂
+       f __ _  _  __ ▁_ ▁_ ▁_ ▁_ ▁_ ▁_ ▁▁ ▁▁ ▂▁ ▂▁ ▂▂ ▅▄
+```
+
+As this is a LD_PRELOAD hook, this can't take command-line arguments, so all the settings are controlled by environment variables:
+* `IREE_HOOK_FILTER_NAME`: If specified, will filter executable library calls for this specific function name. Otherwise will gather all calls, which would typically make for hard-to-interpret results. One almost always wants to specify this.
+* `IREE_HOOK_SKIP_START_MS`: How many milliseconds to skip initially before recording data. Think of it as warm-up. Default 0.
+* `IREE_HOOK_PERF_EVENT_TYPES`: Comma-separated list of events to count. The available event names are a subset of the ones available in Linux's `perf`. The exact list is what is dumped by `IREE_HOOK_LIST_EVENT_TYPES=1`. If multiple event types are specified, cross-event conditional probability tables will be printed for each pair of event, so this grows quadratically. In general, one will pass only one event type unless specifically interested in correlating two events. There may also be CPU-specific overhead or limits associated with querying multiple event types simultaneously.
+* `IREE_HOOK_LIST_EVENT_TYPES`: if defined, will dump a list of event type to use in `IREE_HOOK_PERF_EVENT_TYPES`, and exit. Note that some are AMD-specific (indicated by `[AMD]`) while others are generic.
+* `IREE_HOOK_OUTPUT_CSV`: if defined, must point to an existing directory (e.g. `/tmp/csv`) where to dump raw CSV data files. Otherwise, no CSV will be dumped, just overall stats.
+* `IREE_HOOK_BUCKET_COUNT`: controls the number of buckets (i.e. percentiles) to distinguish when printing stats. Higher values result in more detailed but heavier output. Default 16.
+* `IREE_HOOK_NO_PROBABILITY_TABLE`: if defined, skips printing probability tables. Their size is (bucket_count) x (bucket_count).
+* `IREE_HOOK_GAMMA`: gamma-correction factor in the semigraphical probability-table rendering. Default 0.5.

--- a/experimental/hal_executable_library_call_hooks/hook_cpu_events_linux.cc
+++ b/experimental/hal_executable_library_call_hooks/hook_cpu_events_linux.cc
@@ -1,0 +1,291 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <pthread.h>
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <ratio>
+#include <string>
+#include <vector>
+
+#include "experimental/hal_executable_library_call_hooks/perf_event_linux.h"
+#include "experimental/hal_executable_library_call_hooks/stats.h"
+#include "iree/base/api.h"
+#include "iree/base/string_view.h"
+#include "iree/hal/local/executable_library.h"
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+// Records the data obtained about one instrumented call. Each ThreadInfo
+// records essentially a big vector<CallInfo>.
+struct CallInfo {
+  float duration_us = 0;
+  unsigned int cpu = -1;
+  unsigned int node = -1;
+  std::vector<int64_t> perf_event_counts;
+};
+
+// Records all the data obtained about all the calls made in one thread.
+// Outputs statistics and/or CSV files on destruction.
+class ThreadInfo {
+ public:
+  // Constructor: should only be called once per thread to create a
+  // thread-specific singleton.
+  ThreadInfo();
+  // Destructor: this is what prints out all the output.
+  ~ThreadInfo();
+
+  // Public hook: start of a new call.
+  void beginCall(const char *name);
+
+  // Public hook: end of call started by the last beginCall().
+  void endCall();
+
+ private:
+  // Whether we are between a beginCall and an endCall.
+  bool recording_call_ = false;
+  // Timepoint of the current beginCall.
+  Clock::time_point current_call_start_time_;
+  // If not empty, will filter only calls to the specific named function.
+  std::string name_filter_;
+  // The entire record of calls made on this thread.
+  std::vector<CallInfo> entries_;
+  // How many milliseconds to skip initially before actually recording calls.
+  float skip_start_ms_ = 0;
+  // Timepoint of initialization of this class instance.
+  Clock::time_point start_time_;
+  // perf_event_open file descriptors used to query event counts.
+  std::vector<PerfEventFd> perf_event_fds_;
+  // Types of events to query.
+  std::vector<PerfEventType> perf_event_types_;
+  // If not null, will dump CSV there.
+  const char *output_csv_ = nullptr;
+
+  // Helper: show stats.
+  void printStats();
+  // Helper: dump CSV data file.
+  void printCsv(const char *path_base);
+};
+
+// Returns the number of microseconds between `start` and `end`.
+float elapsedMicroseconds(Clock::time_point start, Clock::time_point end) {
+  return std::chrono::duration<float, std::micro>(end - start).count();
+}
+
+// Returns the calling thread's name (platform-specific).
+std::string getThreadName() {
+  char buf[64];
+  pthread_getname_np(pthread_self(), buf, sizeof buf);
+  return buf;
+}
+
+ThreadInfo::ThreadInfo() {
+  const char *name_filter_env = getenv("IREE_HOOK_FILTER_NAME");
+  if (name_filter_env) {
+    name_filter_ = name_filter_env;
+  }
+  const char *skip_start_ms_env = getenv("IREE_HOOK_SKIP_START_MS");
+  if (skip_start_ms_env) {
+    skip_start_ms_ = strtof(skip_start_ms_env, nullptr);
+  }
+  const char *perf_event_types_env = getenv("IREE_HOOK_PERF_EVENT_TYPES");
+  if (perf_event_types_env) {
+    perf_event_types_ = parsePerfEventTypes(perf_event_types_env);
+    for (PerfEventType perf_event_type : perf_event_types_) {
+      perf_event_fds_.emplace_back(perf_event_type);
+    }
+  }
+  output_csv_ = getenv("IREE_HOOK_OUTPUT_CSV");
+  start_time_ = Clock::now();
+}
+ThreadInfo::~ThreadInfo() {
+  if (entries_.empty()) {
+    return;
+  }
+  static std::mutex mutex;
+  std::lock_guard<std::mutex> lock(mutex);
+  if (getenv("IREE_HOOK_LIST_EVENT_TYPES")) {
+    printAllEventTypesAndDescriptions(stderr);
+    exit(0);
+  }
+  std::string thread_name = getThreadName();
+  printStats();
+  if (output_csv_) {
+    printCsv(output_csv_);
+  } else {
+    fprintf(stderr,
+            "Note: to get the whole CSV data, set "
+            "IREE_HOOK_OUTPUT_CSV=/tmp/path\n");
+  }
+  fprintf(stderr, "\n");
+}
+
+void ThreadInfo::printStats() {
+  // duration_us is the 0-th data_vector.
+  const size_t data_vectors_count = perf_event_types_.size() + 1;
+  std::vector<const char *> data_vector_names(data_vectors_count);
+  std::vector<std::vector<float>> data_vectors(data_vectors_count);
+  for (const auto &entry : entries_) {
+    data_vector_names[0] = "duration_ms";
+    data_vectors[0].push_back(entry.duration_us);
+    for (size_t i = 0; i < perf_event_types_.size(); ++i) {
+      data_vector_names[i + 1] = perf_event_types_[i].name;
+      data_vectors[i + 1].push_back(entry.perf_event_counts[i]);
+    }
+  }
+  const char *bucket_count_env = getenv("IREE_HOOK_BUCKET_COUNT");
+  int bucket_count =
+      bucket_count_env ? strtol(bucket_count_env, nullptr, 10) : 16;
+  std::vector<std::vector<float>> data_vector_bucket_means(data_vectors_count);
+  std::vector<std::vector<int>> data_vector_bucket_indices(data_vectors_count);
+  for (size_t i = 0; i < data_vectors_count; ++i) {
+    splitIntoBuckets(data_vectors[i], bucket_count,
+                     &data_vector_bucket_means[i],
+                     &data_vector_bucket_indices[i]);
+  }
+
+  std::string thread_name = getThreadName();
+  printf("Statistics for thread %s:\n", thread_name.c_str());
+  printf("  %zu matching calls, of which:\n", entries_.size());
+  std::map<unsigned int, int> cpu_counts;
+  for (const auto &entry : entries_) {
+    if (cpu_counts.count(entry.cpu))
+      cpu_counts[entry.cpu]++;
+    else
+      cpu_counts[entry.cpu] = 1;
+  }
+  for (auto p : cpu_counts) {
+    printf("    %d calls on cpu %u\n", p.second, p.first);
+  }
+
+  for (size_t i = 0; i < data_vectors_count; ++i) {
+    printf("  %s:\n", data_vector_names[i]);
+    printf("    mean: %.3g\n", mean(data_vectors[i]));
+    printf("    %d-ile means:", bucket_count);
+    for (float m : data_vector_bucket_means[i]) {
+      printf(" %.3g", m);
+    }
+    printf("\n");
+
+    for (size_t j = 0; j < i; ++j) {
+      printf("  correlation of %s vs. %s: %.2g\n", data_vector_names[j],
+             data_vector_names[i],
+             correlation(data_vectors[j], data_vectors[i]));
+
+      if (getenv("IREE_HOOK_NO_PROBABILITY_TABLE")) {
+        continue;
+      }
+      std::vector<float> cond_proba_table;
+      computeConditionalProbabilityTable(
+          bucket_count, data_vector_bucket_indices[i],
+          data_vector_bucket_indices[j], &cond_proba_table);
+      printf(
+          "  conditional probability of %s %d-ile (↓) given "
+          "%s %d-ile (→):\n",
+          data_vector_names[j], bucket_count, data_vector_names[i],
+          bucket_count);
+      printConditionalProbabilityTable(stdout, bucket_count, cond_proba_table);
+    }
+  }
+}
+
+void ThreadInfo::printCsv(const char *path_base) {
+  char path[256];
+  std::string thread_name = getThreadName();
+  snprintf(path, sizeof path, "%s/iree_hook_%s.csv", path_base,
+           thread_name.c_str());
+  FILE *file = fopen(path, "w");
+  if (!file) {
+    fprintf(stderr, "Failed to open %s for write.\n", path);
+    exit(1);
+  }
+  fprintf(file, "thread,cpu,node,duration_us");
+  for (auto perf_event_types : perf_event_types_) {
+    fprintf(file, ",%s", perf_event_types.name);
+  }
+  fprintf(file, "\n");
+  for (const auto &entry : entries_) {
+    fprintf(file, "%s,%u,%u,%g", thread_name.c_str(), entry.cpu, entry.node,
+            entry.duration_us);
+    for (int64_t event_count : entry.perf_event_counts) {
+      fprintf(file, ",%ld", event_count);
+    }
+    fprintf(file, "\n");
+  }
+  fclose(file);
+}
+
+void ThreadInfo::beginCall(const char *name) {
+  if (!name_filter_.empty() && name_filter_ != std::string(name)) {
+    return;
+  }
+  Clock::time_point call_start_time = Clock::now();
+  if (elapsedMicroseconds(start_time_, call_start_time) <
+      skip_start_ms_ * 1000.f) {
+    return;
+  }
+  for (auto &perf_event_fd : perf_event_fds_) {
+    perf_event_fd.reset();
+  }
+  for (auto &perf_event_fd : perf_event_fds_) {
+    perf_event_fd.enable();
+  }
+  recording_call_ = true;
+  current_call_start_time_ = call_start_time;
+}
+
+void ThreadInfo::endCall() {
+  if (!recording_call_) {
+    return;
+  }
+  CallInfo entry;
+  entry.duration_us =
+      elapsedMicroseconds(current_call_start_time_, Clock::now());
+  for (auto &perf_event_fd : perf_event_fds_) {
+    perf_event_fd.disable();
+  }
+  for (size_t i = 0; i < perf_event_fds_.size(); ++i) {
+    entry.perf_event_counts.push_back(perf_event_fds_[i].read());
+  }
+  getcpu(&entry.cpu, &entry.node);
+  entries_.push_back(entry);
+  recording_call_ = false;
+}
+
+// Returns a thread-specific singleton object.
+ThreadInfo &ThreadInfoSingleton() {
+  static thread_local ThreadInfo singleton;
+  return singleton;
+}
+
+}  // namespace
+
+#ifdef __GNUC__
+#define IREE_HOOK_EXPORT extern "C" __attribute__((visibility("default")))
+#else
+#define IREE_HOOK_EXPORT extern "C"
+#endif
+
+IREE_HOOK_EXPORT void iree_hal_executable_library_call_hook_begin(
+    iree_string_view_t executable_identifier,
+    const iree_hal_executable_library_v0_t *library, iree_host_size_t ordinal) {
+  ThreadInfoSingleton().beginCall(library->exports.names[ordinal]);
+}
+
+IREE_HOOK_EXPORT void iree_hal_executable_library_call_hook_end(
+    iree_string_view_t executable_identifier,
+    const iree_hal_executable_library_v0_t *library, iree_host_size_t ordinal) {
+  ThreadInfoSingleton().endCall();
+}

--- a/experimental/hal_executable_library_call_hooks/perf_event_linux.cc
+++ b/experimental/hal_executable_library_call_hooks/perf_event_linux.cc
@@ -1,0 +1,1140 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "experimental/hal_executable_library_call_hooks/perf_event_linux.h"
+
+#include <linux/perf_event.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+PerfEventFd::PerfEventFd(PerfEventType perf_event_type) {
+  perf_event_attr pe;
+  memset(&pe, 0, sizeof pe);
+  pe.size = sizeof(pe);
+  pe.type = perf_event_type.type;
+  pe.config = perf_event_type.config;
+  pe.exclude_kernel = 1;
+  pe.disabled = 1;
+  fd_ = syscall(__NR_perf_event_open, &pe, 0, -1, -1, 0);
+  if (fd_ < 0) {
+    fprintf(stderr,
+            "perf_event_open failed for event %s. Either an unknown perf event "
+            "config, or a permissions issue? need to lower "
+            "`perf_event_paranoid` ?\n",
+            perf_event_type.name);
+    exit(1);
+  }
+}
+
+PerfEventFd::~PerfEventFd() { close(fd_); }
+
+void PerfEventFd::reset() { ioctl(fd_, PERF_EVENT_IOC_RESET, 0); }
+
+void PerfEventFd::enable() { ioctl(fd_, PERF_EVENT_IOC_ENABLE, 0); }
+
+void PerfEventFd::disable() { ioctl(fd_, PERF_EVENT_IOC_DISABLE, 0); }
+
+int64_t PerfEventFd::read() const {
+  int64_t count = 0;
+  if (::read(fd_, &count, sizeof count) != sizeof count) {
+    return 0;
+  }
+  return count;
+}
+
+// Returns a list of all known perf event types.
+static const std::vector<PerfEventType> &listAllPerfEventTypes();
+
+static PerfEventType parsePerfEventType(int type_str_length,
+                                        const char *type_str) {
+  for (PerfEventType event_type : listAllPerfEventTypes()) {
+    if (strncmp(event_type.name, type_str, type_str_length)) {
+      continue;
+    }
+    return event_type;
+  }
+  fprintf(stderr, "Unhandled perf event type: %s\n", type_str);
+  exit(1);
+  return {};
+}
+
+std::vector<PerfEventType> parsePerfEventTypes(const char *types_str) {
+  std::vector<PerfEventType> out_event_types;
+  while (*types_str) {
+    const char *segment_ptr = types_str;
+    int segment_length = 0;
+    const char *comma_ptr = strchr(types_str, ',');
+    if (comma_ptr) {
+      segment_length = comma_ptr - types_str;
+      types_str = comma_ptr + 1;
+    } else {
+      segment_length = strlen(types_str);
+      types_str += segment_length;
+    }
+    out_event_types.push_back(parsePerfEventType(segment_length, segment_ptr));
+  }
+  return out_event_types;
+}
+
+void printAllEventTypesAndDescriptions(FILE *file) {
+  for (PerfEventType event_type : listAllPerfEventTypes()) {
+    fprintf(file, "%-40s [%s] %s\n", event_type.name,
+            strlen(event_type.target) ? event_type.target : "generic",
+            event_type.description);
+  }
+}
+
+static const std::vector<PerfEventType> &listAllPerfEventTypes() {
+  static const std::vector<PerfEventType> sAllPerfEventTypes{
+      // Standard event types, not specific to a target.
+      // These are not always useful, as some targets don't always implement
+      // them. For instance, AMD Zen4 CPUs do not implement LLC-loads,
+      // LLC-load-misses. Table from
+      // https://android.googlesource.com/platform/system/extras/+/refs/heads/main/simpleperf/event_type_table.h
+      {"cpu-cycles", PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, "", ""},
+      {"instructions", PERF_TYPE_HARDWARE, PERF_COUNT_HW_INSTRUCTIONS, "", ""},
+      {"cache-references", PERF_TYPE_HARDWARE, PERF_COUNT_HW_CACHE_REFERENCES,
+       "", ""},
+      {"cache-misses", PERF_TYPE_HARDWARE, PERF_COUNT_HW_CACHE_MISSES, "", ""},
+      {"branch-instructions", PERF_TYPE_HARDWARE,
+       PERF_COUNT_HW_BRANCH_INSTRUCTIONS, "", ""},
+      {"branch-misses", PERF_TYPE_HARDWARE, PERF_COUNT_HW_BRANCH_MISSES, "",
+       ""},
+      {"bus-cycles", PERF_TYPE_HARDWARE, PERF_COUNT_HW_BUS_CYCLES, "", ""},
+      {"stalled-cycles-frontend", PERF_TYPE_HARDWARE,
+       PERF_COUNT_HW_STALLED_CYCLES_FRONTEND, "", ""},
+      {"stalled-cycles-backend", PERF_TYPE_HARDWARE,
+       PERF_COUNT_HW_STALLED_CYCLES_BACKEND, "", ""},
+      {"cpu-clock", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CPU_CLOCK, "", ""},
+      {"task-clock", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_TASK_CLOCK, "", ""},
+      {"page-faults", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_PAGE_FAULTS, "", ""},
+      {"context-switches", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CONTEXT_SWITCHES,
+       "", ""},
+      {"cpu-migrations", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CPU_MIGRATIONS, "",
+       ""},
+      {"minor-faults", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_PAGE_FAULTS_MIN, "",
+       ""},
+      {"major-faults", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_PAGE_FAULTS_MAJ, "",
+       ""},
+      {"alignment-faults", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_ALIGNMENT_FAULTS,
+       "", ""},
+      {"emulation-faults", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_EMULATION_FAULTS,
+       "", ""},
+      {"L1-dcache-loads", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1D) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"L1-dcache-load-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1D) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"L1-dcache-stores", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1D) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"L1-dcache-store-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1D) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"L1-dcache-prefetches", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1D) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"L1-dcache-prefetch-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1D) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"L1-icache-loads", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1I) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"L1-icache-load-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1I) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"L1-icache-stores", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1I) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"L1-icache-store-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1I) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"L1-icache-prefetches", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1I) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"L1-icache-prefetch-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_L1I) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"LLC-loads", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_LL) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"LLC-load-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_LL) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"LLC-stores", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_LL) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"LLC-store-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_LL) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"LLC-prefetches", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_LL) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"LLC-prefetch-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_LL) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"dTLB-loads", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_DTLB) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"dTLB-load-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_DTLB) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"dTLB-stores", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_DTLB) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"dTLB-store-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_DTLB) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"dTLB-prefetches", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_DTLB) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"dTLB-prefetch-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_DTLB) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"iTLB-loads", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_ITLB) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"iTLB-load-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_ITLB) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"iTLB-stores", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_ITLB) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"iTLB-store-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_ITLB) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"iTLB-prefetches", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_ITLB) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"iTLB-prefetch-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_ITLB) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"branch-loads", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_BPU) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"branch-load-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_BPU) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"branch-stores", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_BPU) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"branch-store-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_BPU) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"branch-prefetches", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_BPU) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"branch-prefetch-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_BPU) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"node-loads", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_NODE) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"node-load-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_NODE) | (PERF_COUNT_HW_CACHE_OP_READ << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"node-stores", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_NODE) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"node-store-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_NODE) | (PERF_COUNT_HW_CACHE_OP_WRITE << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+      {"node-prefetches", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_NODE) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16)),
+       "", ""},
+      {"node-prefetch-misses", PERF_TYPE_HW_CACHE,
+       ((PERF_COUNT_HW_CACHE_NODE) | (PERF_COUNT_HW_CACHE_OP_PREFETCH << 8) |
+        (PERF_COUNT_HW_CACHE_RESULT_MISS << 16)),
+       "", ""},
+
+      // Some AMD events, scraped from:
+      // https://elixir.bootlin.com/linux/latest/source/tools/perf/pmu-events/arch/x86/amdzen4
+      // The mapping from (event code, umask) to config value is
+      //   config = (umask << 8) + (event code)  // assuming event code <= 0xff
+      // This is documented under /sys/devices/cpu/format:
+      //   $ cat /sys/devices/cpu/format/event
+      //   config:0-7,32-35
+      //   $ cat /sys/devices/cpu/format/umask
+      //   config:8-15
+      {"bp_l2_btb_correct", PERF_TYPE_RAW, 0x8b, "AMD",
+       "L2 branch prediction overrides existing prediction (speculative)."},
+      {"bp_dyn_ind_pred", PERF_TYPE_RAW, 0x8e, "AMD",
+       "Dynamic indirect predictions (branch used the indirect predictor to "
+       "make a prediction)."},
+      {"bp_de_redirect", PERF_TYPE_RAW, 0x91, "AMD",
+       "Instruction decoder corrects the predicted target and resteers the "
+       "branch predictor."},
+      {"ex_ret_brn", PERF_TYPE_RAW, 0xc2, "AMD",
+       "Retired branch instructions (all types of architectural control flow "
+       "changes, including exceptions and interrupts)."},
+      {"ex_ret_brn_misp", PERF_TYPE_RAW, 0xc3, "AMD",
+       "Retired branch instructions mispredicted."},
+      {"ex_ret_brn_tkn", PERF_TYPE_RAW, 0xc4, "AMD",
+       "Retired taken branch instructions (all types of architectural control "
+       "flow changes, including exceptions and interrupts)."},
+      {"ex_ret_brn_tkn_misp", PERF_TYPE_RAW, 0xc5, "AMD",
+       "Retired taken branch instructions mispredicted."},
+      {"ex_ret_brn_far", PERF_TYPE_RAW, 0xc6, "AMD",
+       "Retired far control transfers (far call/jump/return, IRET, SYSCALL and "
+       "SYSRET, plus exceptions and interrupts). Far control transfers are not "
+       "subject to branch prediction."},
+      {"ex_ret_near_ret", PERF_TYPE_RAW, 0xc8, "AMD",
+       "Retired near returns (RET or RET Iw)."},
+      {"ex_ret_near_ret_mispred", PERF_TYPE_RAW, 0xc9, "AMD",
+       "Retired near returns mispredicted. Each misprediction incurs the same "
+       "penalty as a mispredicted conditional branch instruction."},
+      {"ex_ret_brn_ind_misp", PERF_TYPE_RAW, 0xca, "AMD",
+       "Retired indirect branch instructions mispredicted (only EX "
+       "mispredicts). "
+       "Each misprediction incurs the same penalty as a mispredicted "
+       "conditional branch instruction."},
+      {"ex_ret_ind_brch_instr", PERF_TYPE_RAW, 0xcc, "AMD",
+       "Retired indirect branch instructions."},
+      {"ex_ret_cond", PERF_TYPE_RAW, 0xd1, "AMD",
+       "Retired conditional branch instructions."},
+      {"ex_ret_msprd_brnch_instr_dir_msmtch", PERF_TYPE_RAW, 0x1c7, "AMD",
+       "Retired branch instructions mispredicted due to direction mismatch."},
+      {"ex_ret_uncond_brnch_instr_mispred", PERF_TYPE_RAW, 0x1c8, "AMD",
+       "Retired unconditional indirect branch instructions mispredicted."},
+      {"ex_ret_uncond_brnch_instr", PERF_TYPE_RAW, 0x1c9, "AMD",
+       "Retired unconditional branch instructions."},
+      {"ls_mab_alloc.load_store_allocations", PERF_TYPE_RAW, 0x3f41, "AMD",
+       "Miss Address Buffer (MAB) entries allocated by a Load-Store (LS) pipe "
+       "for load-store allocations."},
+      {"ls_mab_alloc.hardware_prefetcher_allocations", PERF_TYPE_RAW, 0x4041,
+       "AMD",
+       "Miss Address Buffer (MAB) entries allocated by a Load-Store (LS) pipe "
+       "for hardware prefetcher allocations."},
+      {"ls_mab_alloc.all_allocations", PERF_TYPE_RAW, 0x7f41, "AMD",
+       "Miss Address Buffer (MAB) entries allocated by a Load-Store (LS) pipe "
+       "for all types of allocations."},
+      {"ls_dmnd_fills_from_sys.local_l2", PERF_TYPE_RAW, 0x143, "AMD",
+       "Demand data cache fills from local L2 cache."},
+      {"ls_dmnd_fills_from_sys.local_ccx", PERF_TYPE_RAW, 0x243, "AMD",
+       "Demand data cache fills from L3 cache or different L2 cache in the "
+       "same CCX."},
+      {"ls_dmnd_fills_from_sys.near_cache", PERF_TYPE_RAW, 0x443, "AMD",
+       "Demand data cache fills from cache of another CCX when the address was "
+       "in the same NUMA node."},
+      {"ls_dmnd_fills_from_sys.dram_io_near", PERF_TYPE_RAW, 0x843, "AMD",
+       "Demand data cache fills from either DRAM or MMIO in the same NUMA "
+       "node."},
+      {"ls_dmnd_fills_from_sys.far_cache", PERF_TYPE_RAW, 0x1043, "AMD",
+       "Demand data cache fills from cache of another CCX when the address was "
+       "in a different NUMA node."},
+      {"ls_dmnd_fills_from_sys.dram_io_far", PERF_TYPE_RAW, 0x4043, "AMD",
+       "Demand data cache fills from either DRAM or MMIO in a different NUMA "
+       "node (same or different socket)."},
+      {"ls_dmnd_fills_from_sys.alternate_memories", PERF_TYPE_RAW, 0x8043,
+       "AMD", "Demand data cache fills from extension memory."},
+      {"ls_dmnd_fills_from_sys.all", PERF_TYPE_RAW, 0xff43, "AMD",
+       "Demand data cache fills from all types of data sources."},
+      {"ls_any_fills_from_sys.local_l2", PERF_TYPE_RAW, 0x144, "AMD",
+       "Any data cache fills from local L2 cache."},
+      {"ls_any_fills_from_sys.local_ccx", PERF_TYPE_RAW, 0x244, "AMD",
+       "Any data cache fills from L3 cache or different L2 cache in the same "
+       "CCX."},
+      {"ls_any_fills_from_sys.local_all", PERF_TYPE_RAW, 0x344, "AMD",
+       "Any data cache fills from local L2 cache or L3 cache or different L2 "
+       "cache in the same CCX."},
+      {"ls_any_fills_from_sys.near_cache", PERF_TYPE_RAW, 0x444, "AMD",
+       "Any data cache fills from cache of another CCX when the address was in "
+       "the same NUMA node."},
+      {"ls_any_fills_from_sys.dram_io_near", PERF_TYPE_RAW, 0x844, "AMD",
+       "Any data cache fills from either DRAM or MMIO in the same NUMA node."},
+      {"ls_any_fills_from_sys.far_cache", PERF_TYPE_RAW, 0x1044, "AMD",
+       "Any data cache fills from cache of another CCX when the address was in "
+       "a different NUMA node."},
+      {"ls_any_fills_from_sys.remote_cache", PERF_TYPE_RAW, 0x1444, "AMD",
+       "Any data cache fills from cache of another CCX when the address was in "
+       "the same or a different NUMA node."},
+      {"ls_any_fills_from_sys.dram_io_far", PERF_TYPE_RAW, 0x4044, "AMD",
+       "Any data cache fills from either DRAM or MMIO in a different NUMA node "
+       "(same or different socket)."},
+      {"ls_any_fills_from_sys.dram_io_all", PERF_TYPE_RAW, 0x4844, "AMD",
+       "Any data cache fills from either DRAM or MMIO in any NUMA node (same "
+       "or different socket)."},
+      {"ls_any_fills_from_sys.far_all", PERF_TYPE_RAW, 0x5044, "AMD",
+       "Any data cache fills from either cache of another CCX, DRAM or MMIO "
+       "when "
+       "the address was in a different NUMA node (same or different socket)."},
+      {"ls_any_fills_from_sys.all_dram_io", PERF_TYPE_RAW, 0x4844, "AMD",
+       "Any data cache fills from either DRAM or MMIO in any NUMA node (same "
+       "or different socket)."},
+      {"ls_any_fills_from_sys.alternate_memories", PERF_TYPE_RAW, 0x8044, "AMD",
+       "Any data cache fills from extension memory."},
+      {"ls_any_fills_from_sys.all", PERF_TYPE_RAW, 0xff44, "AMD",
+       "Any data cache fills from all types of data sources."},
+      {"ls_pref_instr_disp.prefetch", PERF_TYPE_RAW, 0x14b, "AMD",
+       "Software prefetch instructions dispatched (speculative) of type "
+       "PrefetchT0 (move data to all cache levels), T1 (move data to all cache "
+       "levels except L1) and T2 (move data to all cache levels except L1 and "
+       "L2)."},
+      {"ls_pref_instr_disp.prefetch_w", PERF_TYPE_RAW, 0x24b, "AMD",
+       "Software prefetch instructions dispatched (speculative) of type "
+       "PrefetchW (move data to L1 cache and mark it modifiable)."},
+      {"ls_pref_instr_disp.prefetch_nta", PERF_TYPE_RAW, 0x44b, "AMD",
+       "Software prefetch instructions dispatched (speculative) of type "
+       "PrefetchNTA (move data with minimum cache pollution i.e. non-temporal "
+       "access)."},
+      {"ls_pref_instr_disp.all", PERF_TYPE_RAW, 0x74b, "AMD",
+       "Software prefetch instructions dispatched (speculative) of all types."},
+      {"ls_inef_sw_pref.data_pipe_sw_pf_dc_hit", PERF_TYPE_RAW, 0x152, "AMD",
+       "Software prefetches that did not fetch data outside of the processor "
+       "core as the PREFETCH instruction saw a data cache hit."},
+      {"ls_inef_sw_pref.mab_mch_cnt", PERF_TYPE_RAW, 0x252, "AMD",
+       "Software prefetches that did not fetch data outside of the processor "
+       "core as the PREFETCH instruction saw a match on an already allocated "
+       "Miss Address Buffer (MAB)."},
+      {"ls_inef_sw_pref.all", PERF_TYPE_RAW, 0x352, "AMD", ""},
+      {"ls_sw_pf_dc_fills.local_l2", PERF_TYPE_RAW, 0x159, "AMD",
+       "Software prefetch data cache fills from local L2 cache."},
+      {"ls_sw_pf_dc_fills.local_ccx", PERF_TYPE_RAW, 0x259, "AMD",
+       "Software prefetch data cache fills from L3 cache or different L2 cache "
+       "in the same CCX."},
+      {"ls_sw_pf_dc_fills.near_cache", PERF_TYPE_RAW, 0x459, "AMD",
+       "Software prefetch data cache fills from cache of another CCX in the "
+       "same NUMA node."},
+      {"ls_sw_pf_dc_fills.dram_io_near", PERF_TYPE_RAW, 0x859, "AMD",
+       "Software prefetch data cache fills from either DRAM or MMIO in the "
+       "same NUMA node."},
+      {"ls_sw_pf_dc_fills.far_cache", PERF_TYPE_RAW, 0x1059, "AMD",
+       "Software prefetch data cache fills from cache of another CCX in a "
+       "different NUMA node."},
+      {"ls_sw_pf_dc_fills.dram_io_far", PERF_TYPE_RAW, 0x4059, "AMD",
+       "Software prefetch data cache fills from either DRAM or MMIO in a "
+       "different NUMA node (same or different socket)."},
+      {"ls_sw_pf_dc_fills.alternate_memories", PERF_TYPE_RAW, 0x8059, "AMD",
+       "Software prefetch data cache fills from extension memory."},
+      {"ls_sw_pf_dc_fills.all", PERF_TYPE_RAW, 0xdf59, "AMD",
+       "Software prefetch data cache fills from all types of data sources."},
+      {"ls_hw_pf_dc_fills.local_l2", PERF_TYPE_RAW, 0x15a, "AMD",
+       "Hardware prefetch data cache fills from local L2 cache."},
+      {"ls_hw_pf_dc_fills.local_ccx", PERF_TYPE_RAW, 0x25a, "AMD",
+       "Hardware prefetch data cache fills from L3 cache or different L2 cache "
+       "in the same CCX."},
+      {"ls_hw_pf_dc_fills.near_cache", PERF_TYPE_RAW, 0x45a, "AMD",
+       "Hardware prefetch data cache fills from cache of another CCX when the "
+       "address was in the same NUMA node."},
+      {"ls_hw_pf_dc_fills.dram_io_near", PERF_TYPE_RAW, 0x85a, "AMD",
+       "Hardware prefetch data cache fills from either DRAM or MMIO in the "
+       "same NUMA node."},
+      {"ls_hw_pf_dc_fills.far_cache", PERF_TYPE_RAW, 0x105a, "AMD",
+       "Hardware prefetch data cache fills from cache of another CCX when the "
+       "address was in a different NUMA node."},
+      {"ls_hw_pf_dc_fills.dram_io_far", PERF_TYPE_RAW, 0x405a, "AMD",
+       "Hardware prefetch data cache fills from either DRAM or MMIO in a "
+       "different NUMA node (same or different socket)."},
+      {"ls_hw_pf_dc_fills.alternate_memories", PERF_TYPE_RAW, 0x805a, "AMD",
+       "Hardware prefetch data cache fills from extension memory."},
+      {"ls_hw_pf_dc_fills.all", PERF_TYPE_RAW, 0xdf5a, "AMD",
+       "Hardware prefetch data cache fills from all types of data sources."},
+      {"ls_alloc_mab_count", PERF_TYPE_RAW, 0x5f, "AMD",
+       "In-flight L1 data cache misses i.e. Miss Address Buffer (MAB) "
+       "allocations each cycle."},
+      {"l2_request_g1.group2", PERF_TYPE_RAW, 0x160, "AMD",
+       "L2 cache requests of non-cacheable type (non-cached data and "
+       "instructions reads, self-modifying code checks)."},
+      {"l2_request_g1.l2_hw_pf", PERF_TYPE_RAW, 0x260, "AMD",
+       "L2 cache requests: from hardware prefetchers to prefetch directly into "
+       "L2 (hit or miss)."},
+      {"l2_request_g1.prefetch_l2_cmd", PERF_TYPE_RAW, 0x460, "AMD",
+       "L2 cache requests: prefetch directly into L2."},
+      {"l2_request_g1.change_to_x", PERF_TYPE_RAW, 0x860, "AMD",
+       "L2 cache requests: data cache state change to writable, check L2 for "
+       "current state."},
+      {"l2_request_g1.cacheable_ic_read", PERF_TYPE_RAW, 0x1060, "AMD",
+       "L2 cache requests: instruction cache reads."},
+      {"l2_request_g1.ls_rd_blk_c_s", PERF_TYPE_RAW, 0x2060, "AMD",
+       "L2 cache requests: data cache shared reads."},
+      {"l2_request_g1.rd_blk_x", PERF_TYPE_RAW, 0x4060, "AMD",
+       "L2 cache requests: data cache stores."},
+      {"l2_request_g1.rd_blk_l", PERF_TYPE_RAW, 0x8060, "AMD",
+       "L2 cache requests: data cache reads including hardware and software "
+       "prefetch."},
+      {"l2_request_g1.all_dc", PERF_TYPE_RAW, 0xe860, "AMD",
+       "L2 cache requests of common types from L1 data cache (including "
+       "prefetches)."},
+      {"l2_request_g1.all_no_prefetch", PERF_TYPE_RAW, 0xf960, "AMD",
+       "L2 cache requests of common types not including prefetches."},
+      {"l2_request_g1.all", PERF_TYPE_RAW, 0xff60, "AMD",
+       "L2 cache requests of all types."},
+      {"l2_cache_req_stat.ic_fill_miss", PERF_TYPE_RAW, 0x164, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) with status: "
+       "instruction cache request miss in L2."},
+      {"l2_cache_req_stat.ic_fill_hit_s", PERF_TYPE_RAW, 0x264, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) with status: "
+       "instruction cache hit non-modifiable line in L2."},
+      {"l2_cache_req_stat.ic_fill_hit_x", PERF_TYPE_RAW, 0x464, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) with status: "
+       "instruction cache hit modifiable line in L2."},
+      {"l2_cache_req_stat.ic_hit_in_l2", PERF_TYPE_RAW, 0x664, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) for instruction "
+       "cache hits."},
+      {"l2_cache_req_stat.ic_access_in_l2", PERF_TYPE_RAW, 0x764, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) for instruction "
+       "cache access."},
+      {"l2_cache_req_stat.ls_rd_blk_c", PERF_TYPE_RAW, 0x864, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) with status: "
+       "data cache request miss in L2."},
+      {"l2_cache_req_stat.ic_dc_miss_in_l2", PERF_TYPE_RAW, 0x964, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) for data and "
+       "instruction cache misses."},
+      {"l2_cache_req_stat.ls_rd_blk_x", PERF_TYPE_RAW, 0x1064, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) with status: "
+       "data cache store or state change hit in L2."},
+      {"l2_cache_req_stat.ls_rd_blk_l_hit_s", PERF_TYPE_RAW, 0x2064, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) with status: "
+       "data cache read hit non-modifiable line in L2."},
+      {"l2_cache_req_stat.ls_rd_blk_l_hit_x", PERF_TYPE_RAW, 0x4064, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) with status: "
+       "data cache read hit modifiable line in L2."},
+      {"l2_cache_req_stat.ls_rd_blk_cs", PERF_TYPE_RAW, 0x8064, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) with status: "
+       "data cache shared read hit in L2."},
+      {"l2_cache_req_stat.dc_hit_in_l2", PERF_TYPE_RAW, 0xf064, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) for data cache "
+       "hits."},
+      {"l2_cache_req_stat.ic_dc_hit_in_l2", PERF_TYPE_RAW, 0xf664, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) for data and "
+       "instruction cache hits."},
+      {"l2_cache_req_stat.dc_access_in_l2", PERF_TYPE_RAW, 0xf864, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) for data cache "
+       "access."},
+      {"l2_cache_req_stat.all", PERF_TYPE_RAW, 0xff64, "AMD",
+       "Core to L2 cache requests (not including L2 prefetch) for data and "
+       "instruction cache access."},
+      {"l2_pf_hit_l2.l2_stream", PERF_TYPE_RAW, 0x170, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "type L2Stream (fetch additional sequential lines into L2 cache)."},
+      {"l2_pf_hit_l2.l2_next_line", PERF_TYPE_RAW, 0x270, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "type L2NextLine (fetch the next line into L2 cache)."},
+      {"l2_pf_hit_l2.l2_up_down", PERF_TYPE_RAW, 0x470, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "type L2UpDown (fetch the next or previous line into L2 cache for all "
+       "memory accesses)."},
+      {"l2_pf_hit_l2.l2_burst", PERF_TYPE_RAW, 0x870, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "type L2Burst (aggressively fetch additional sequential lines into L2 "
+       "cache)."},
+      {"l2_pf_hit_l2.l2_stride", PERF_TYPE_RAW, 0x1070, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "type L2Stride (fetch additional lines into L2 cache when each access "
+       "is at a constant distance from the previous)."},
+      {"l2_pf_hit_l2.l1_stream", PERF_TYPE_RAW, 0x2070, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "type L1Stream (fetch additional sequential lines into L1 cache)."},
+      {"l2_pf_hit_l2.l1_stride", PERF_TYPE_RAW, 0x4070, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "type L1Stride (fetch additional lines into L1 cache when each access "
+       "is a constant distance from the previous)."},
+      {"l2_pf_hit_l2.l1_region", PERF_TYPE_RAW, 0x8070, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "type L1Region (fetch additional lines into L1 cache when the data "
+       "access for a given instruction tends to be followed by a consistent "
+       "pattern "
+       "of other accesses within a localized region)."},
+      {"l2_pf_hit_l2.all", PERF_TYPE_RAW, 0xff70, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which hit in the L2 cache of "
+       "all types."},
+      {"l2_pf_miss_l2_hit_l3.l2_stream", PERF_TYPE_RAW, 0x171, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache of type L2Stream (fetch additional sequential "
+       "lines into L2 cache)."},
+      {"l2_pf_miss_l2_hit_l3.l2_next_line", PERF_TYPE_RAW, 0x271, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache of type L2NextLine (fetch the next line into L2 "
+       "cache)."},
+      {"l2_pf_miss_l2_hit_l3.l2_up_down", PERF_TYPE_RAW, 0x471, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache of type L2UpDown (fetch the next or previous line "
+       "into L2 cache for all memory accesses)."},
+      {"l2_pf_miss_l2_hit_l3.l2_burst", PERF_TYPE_RAW, 0x871, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache of type L2Burst (aggressively fetch additional "
+       "sequential lines into L2 cache)."},
+      {"l2_pf_miss_l2_hit_l3.l2_stride", PERF_TYPE_RAW, 0x1071, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache of type L2Stride (fetch additional lines into L2 "
+       "cache when each access is a constant distance from the previous)."},
+      {"l2_pf_miss_l2_hit_l3.l1_stream", PERF_TYPE_RAW, 0x2071, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache of type L1Stream (fetch additional sequential "
+       "lines into L1 cache)."},
+      {"l2_pf_miss_l2_hit_l3.l1_stride", PERF_TYPE_RAW, 0x4071, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache of type L1Stride (fetch additional lines into L1 "
+       "cache when each access is a constant distance from the previous)."},
+      {"l2_pf_miss_l2_hit_l3.l1_region", PERF_TYPE_RAW, 0x8071, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache of type L1Region (fetch additional lines into L1 "
+       "cache when the data access for a given instruction tends to be "
+       "followed by a consistent pattern of other accesses within a localized "
+       "region)."},
+      {"l2_pf_miss_l2_hit_l3.all", PERF_TYPE_RAW, 0xff71, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 cache and "
+       "hit in the L3 cache cache of all types."},
+      {"l2_pf_miss_l2_l3.l2_stream", PERF_TYPE_RAW, 0x172, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of type L2Stream (fetch additional sequential lines into L2 "
+       "cache)."},
+      {"l2_pf_miss_l2_l3.l2_next_line", PERF_TYPE_RAW, 0x272, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of type L2NextLine (fetch the next line into L2 cache)."},
+      {"l2_pf_miss_l2_l3.l2_up_down", PERF_TYPE_RAW, 0x472, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of type L2UpDown (fetch the next or previous line into L2 cache "
+       "for all memory accesses)."},
+      {"l2_pf_miss_l2_l3.l2_burst", PERF_TYPE_RAW, 0x872, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of type L2Burst (aggressively fetch additional sequential lines "
+       "into L2 cache)."},
+      {"l2_pf_miss_l2_l3.l2_stride", PERF_TYPE_RAW, 0x1072, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of type L2Stride (fetch additional lines into L2 cache when "
+       "each access is a constant distance from the previous)."},
+      {"l2_pf_miss_l2_l3.l1_stream", PERF_TYPE_RAW, 0x2072, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of type L1Stream (fetch additional sequential lines into L1 "
+       "cache)."},
+      {"l2_pf_miss_l2_l3.l1_stride", PERF_TYPE_RAW, 0x4072, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of type L1Stride (fetch additional lines into L1 cache when "
+       "each access is a constant distance from the previous)."},
+      {"l2_pf_miss_l2_l3.l1_region", PERF_TYPE_RAW, 0x8072, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of type L1Region (fetch additional lines into L1 cache when the "
+       "data access for a given instruction tends to be followed by a "
+       "consistent "
+       "pattern of other accesses within a localized region)."},
+      {"l2_pf_miss_l2_l3.all", PERF_TYPE_RAW, 0xff72, "AMD",
+       "L2 prefetches accepted by the L2 pipeline which miss the L2 and the L3 "
+       "caches of all types."},
+      {"ic_cache_fill_l2", PERF_TYPE_RAW, 0x82, "AMD",
+       "Instruction cache lines (64 bytes) fulfilled from the L2 cache."},
+      {"ic_cache_fill_sys", PERF_TYPE_RAW, 0x83, "AMD",
+       "Instruction cache lines (64 bytes) fulfilled from system memory or "
+       "another cache."},
+      {"ic_tag_hit_miss.instruction_cache_hit", PERF_TYPE_RAW, 0x88e, "AMD",
+       "Instruction cache hits."},
+      {"ic_tag_hit_miss.instruction_cache_miss", PERF_TYPE_RAW, 0x198e, "AMD",
+       "Instruction cache misses."},
+      {"ic_tag_hit_miss.all_instruction_cache_accesses", PERF_TYPE_RAW, 0x208e,
+       "AMD", "Instruction cache accesses of all types."},
+      {"op_cache_hit_miss.op_cache_hit", PERF_TYPE_RAW, 0x58f, "AMD",
+       "Op cache hits."},
+      {"op_cache_hit_miss.op_cache_miss", PERF_TYPE_RAW, 0x68f, "AMD",
+       "Op cache misses."},
+      {"op_cache_hit_miss.all_op_cache_accesses", PERF_TYPE_RAW, 0x98f, "AMD",
+       "Op cache accesses of all types."},
+      {"l3_lookup_state.l3_miss", PERF_TYPE_RAW, 0x104, "AMD",
+       "L3 cache misses."},
+      {"l3_lookup_state.l3_hit", PERF_TYPE_RAW, 0xfe04, "AMD",
+       "L3 cache hits."},
+      {"l3_lookup_state.all_coherent_accesses_to_l3", PERF_TYPE_RAW, 0xff04,
+       "AMD", "L3 cache requests for all coherent accesses."},
+      {"l3_xi_sampled_latency.dram_near", PERF_TYPE_RAW, 0x1ac, "AMD",
+       "Average sampled latency when data is sourced from DRAM in the same "
+       "NUMA node."},
+      {"l3_xi_sampled_latency.dram_far", PERF_TYPE_RAW, 0x2ac, "AMD",
+       "Average sampled latency when data is sourced from DRAM in a different "
+       "NUMA node."},
+      {"l3_xi_sampled_latency.near_cache", PERF_TYPE_RAW, 0x4ac, "AMD",
+       "Average sampled latency when data is sourced from another CCX's cache "
+       "when the address was in the same NUMA node."},
+      {"l3_xi_sampled_latency.far_cache", PERF_TYPE_RAW, 0x8ac, "AMD",
+       "Average sampled latency when data is sourced from another CCX's cache "
+       "when the address was in a different NUMA node."},
+      {"l3_xi_sampled_latency.ext_near", PERF_TYPE_RAW, 0x10ac, "AMD",
+       "Average sampled latency when data is sourced from extension memory "
+       "(CXL) in the same NUMA node."},
+      {"l3_xi_sampled_latency.ext_far", PERF_TYPE_RAW, 0x20ac, "AMD",
+       "Average sampled latency when data is sourced from extension memory "
+       "(CXL) in a different NUMA node."},
+      {"l3_xi_sampled_latency.all", PERF_TYPE_RAW, 0x3fac, "AMD",
+       "Average sampled latency from all data sources."},
+      {"l3_xi_sampled_latency_requests.dram_near", PERF_TYPE_RAW, 0x1ad, "AMD",
+       "L3 cache fill requests sourced from DRAM in the same NUMA node."},
+      {"l3_xi_sampled_latency_requests.dram_far", PERF_TYPE_RAW, 0x2ad, "AMD",
+       "L3 cache fill requests sourced from DRAM in a different NUMA node."},
+      {"l3_xi_sampled_latency_requests.near_cache", PERF_TYPE_RAW, 0x4ad, "AMD",
+       "L3 cache fill requests sourced from another CCX's cache when the "
+       "address was in the same NUMA node."},
+      {"l3_xi_sampled_latency_requests.far_cache", PERF_TYPE_RAW, 0x8ad, "AMD",
+       "L3 cache fill requests sourced from another CCX's cache when the "
+       "address was in a different NUMA node."},
+      {"l3_xi_sampled_latency_requests.ext_near", PERF_TYPE_RAW, 0x10ad, "AMD",
+       "L3 cache fill requests sourced from extension memory (CXL) in the same "
+       "NUMA node."},
+      {"l3_xi_sampled_latency_requests.ext_far", PERF_TYPE_RAW, 0x20ad, "AMD",
+       "L3 cache fill requests sourced from extension memory (CXL) in a "
+       "different NUMA node."},
+      {"l3_xi_sampled_latency_requests.all", PERF_TYPE_RAW, 0x3fad, "AMD",
+       "L3 cache fill requests sourced from all data sources."},
+      {"ls_locks.bus_lock", PERF_TYPE_RAW, 0x125, "AMD",
+       "Retired Lock instructions which caused a bus lock."},
+      {"ls_ret_cl_flush", PERF_TYPE_RAW, 0x26, "AMD",
+       "Retired CLFLUSH instructions."},
+      {"ls_ret_cpuid", PERF_TYPE_RAW, 0x27, "AMD",
+       "Retired CPUID instructions."},
+      {"ls_smi_rx", PERF_TYPE_RAW, 0x2b, "AMD", "SMIs received."},
+      {"ls_int_taken", PERF_TYPE_RAW, 0x2c, "AMD", "Interrupts taken."},
+      {"ls_not_halted_cyc", PERF_TYPE_RAW, 0x76, "AMD",
+       "Core cycles not in halt."},
+      {"ex_ret_instr", PERF_TYPE_RAW, 0xc0, "AMD", "Retired instructions."},
+      {"ex_ret_ops", PERF_TYPE_RAW, 0xc1, "AMD", "Retired macro-ops."},
+      {"ex_div_busy", PERF_TYPE_RAW, 0xd3, "AMD",
+       "Number of cycles the divider is busy."},
+      {"ex_div_count", PERF_TYPE_RAW, 0xd4, "AMD", "Divide ops executed."},
+      {"ex_no_retire.empty", PERF_TYPE_RAW, 0x1d6, "AMD",
+       "Cycles with no retire due  to the lack of valid ops in the retire "
+       "queue (may be caused by front-end bottlenecks or pipeline redirects)."},
+      {"ex_no_retire.not_complete", PERF_TYPE_RAW, 0x2d6, "AMD",
+       "Cycles with no retire while the oldest op is waiting to be executed."},
+      {"ex_no_retire.other", PERF_TYPE_RAW, 0x8d6, "AMD",
+       "Cycles with no retire caused by other reasons (retire breaks, traps, "
+       "faults, etc.)."},
+      {"ex_no_retire.thread_not_selected", PERF_TYPE_RAW, 0x10d6, "AMD",
+       "Cycles with no retire because thread arbitration did not select the "
+       "thread."},
+      {"ex_no_retire.load_not_complete", PERF_TYPE_RAW, 0xa2d6, "AMD",
+       "Cycles with no retire while the oldest op is waiting for load data."},
+      {"ex_no_retire.all", PERF_TYPE_RAW, 0x1bd6, "AMD",
+       "Cycles with no retire for any reason."},
+      {"ls_not_halted_p0_cyc.p0_freq_cyc", PERF_TYPE_RAW, 0x220, "AMD",
+       "Reference cycles (P0 frequency) not in halt ."},
+      {"ex_ret_ucode_instr", PERF_TYPE_RAW, 0x1c1, "AMD",
+       "Retired microcoded instructions."},
+      {"ex_ret_ucode_ops", PERF_TYPE_RAW, 0x1c2, "AMD",
+       "Retired microcode ops."},
+      {"ex_tagged_ibs_ops.ibs_tagged_ops", PERF_TYPE_RAW, 0x2cf, "AMD",
+       "Ops tagged by IBS."},
+      {"ex_tagged_ibs_ops.ibs_tagged_ops_ret", PERF_TYPE_RAW, 0x3cf, "AMD",
+       "Ops tagged by IBS that retired."},
+      {"ex_ret_fused_instr", PERF_TYPE_RAW, 0x1d0, "AMD",
+       "Retired fused instructions."},
+      {"ls_bad_status2.stli_other", PERF_TYPE_RAW, 0x224, "AMD",
+       "Store-to-load conflicts (load unable to complete due to a "
+       "non-forwardable conflict with an older store)."},
+      {"ls_dispatch.ld_dispatch", PERF_TYPE_RAW, 0x129, "AMD",
+       "Number of memory load operations dispatched to the load-store unit."},
+      {"ls_dispatch.store_dispatch", PERF_TYPE_RAW, 0x229, "AMD",
+       "Number of memory store operations dispatched to the load-store unit."},
+      {"ls_dispatch.ld_st_dispatch", PERF_TYPE_RAW, 0x429, "AMD",
+       "Number of memory load-store operations dispatched to the load-store "
+       "unit."},
+      {"ls_stlf", PERF_TYPE_RAW, 0x35, "AMD",
+       "Store-to-load-forward (STLF) hits."},
+      {"ls_st_commit_cancel2.st_commit_cancel_wcb_full", PERF_TYPE_RAW, 0x137,
+       "AMD",
+       "Non-cacheable store commits cancelled due to the non-cacheable commit "
+       "buffer being full."},
+      {"ls_l1_d_tlb_miss.tlb_reload_4k_l2_hit", PERF_TYPE_RAW, 0x145, "AMD",
+       "L1 DTLB misses with L2 DTLB hits for 4k pages."},
+      {"ls_l1_d_tlb_miss.tlb_reload_coalesced_page_hit", PERF_TYPE_RAW, 0x245,
+       "AMD",
+       "L1 DTLB misses with L2 DTLB hits for coalesced pages. A coalesced page "
+       "is a 16k page created from four adjacent 4k pages."},
+      {"ls_l1_d_tlb_miss.tlb_reload_2m_l2_hit", PERF_TYPE_RAW, 0x445, "AMD",
+       "L1 DTLB misses with L2 DTLB hits for 2M pages."},
+      {"ls_l1_d_tlb_miss.tlb_reload_1g_l2_hit", PERF_TYPE_RAW, 0x845, "AMD",
+       "L1 DTLB misses with L2 DTLB hits for 1G pages."},
+      {"ls_l1_d_tlb_miss.tlb_reload_4k_l2_miss", PERF_TYPE_RAW, 0x1045, "AMD",
+       "L1 DTLB misses with L2 DTLB misses (page-table walks are requested) "
+       "for 4k pages."},
+      {"ls_l1_d_tlb_miss.tlb_reload_coalesced_page_miss", PERF_TYPE_RAW, 0x2045,
+       "AMD",
+       "L1 DTLB misses with L2 DTLB misses (page-table walks are requested) "
+       "for coalesced pages. A coalesced page is a 16k page created from four "
+       "adjacent 4k pages."},
+      {"ls_l1_d_tlb_miss.tlb_reload_2m_l2_miss", PERF_TYPE_RAW, 0x4045, "AMD",
+       "L1 DTLB misses with L2 DTLB misses (page-table walks are requested) "
+       "for 2M pages."},
+      {"ls_l1_d_tlb_miss.tlb_reload_1g_l2_miss", PERF_TYPE_RAW, 0x8045, "AMD",
+       "L1 DTLB misses with L2 DTLB misses (page-table walks are requested) "
+       "for 1G pages."},
+      {"ls_l1_d_tlb_miss.all_l2_miss", PERF_TYPE_RAW, 0xf045, "AMD",
+       "L1 DTLB misses with L2 DTLB misses (page-table walks are requested) "
+       "for all page sizes."},
+      {"ls_l1_d_tlb_miss.all", PERF_TYPE_RAW, 0xff45, "AMD",
+       "L1 DTLB misses for all page sizes."},
+      {"ls_misal_loads.ma64", PERF_TYPE_RAW, 0x147, "AMD",
+       "64B misaligned (cacheline crossing) loads."},
+      {"ls_misal_loads.ma4k", PERF_TYPE_RAW, 0x247, "AMD",
+       "4kB misaligned (page crossing) loads."},
+      {"ls_tlb_flush.all", PERF_TYPE_RAW, 0xff78, "AMD", "All TLB Flushes."},
+      {"bp_l1_tlb_miss_l2_tlb_hit", PERF_TYPE_RAW, 0x84, "AMD",
+       "Instruction fetches that miss in the L1 ITLB but hit in the L2 ITLB."},
+      {"bp_l1_tlb_miss_l2_tlb_miss.if4k", PERF_TYPE_RAW, 0x185, "AMD",
+       "Instruction fetches that miss in both the L1 and L2 ITLBs (page-table "
+       "walks are requested) for 4k pages."},
+      {"bp_l1_tlb_miss_l2_tlb_miss.if2m", PERF_TYPE_RAW, 0x285, "AMD",
+       "Instruction fetches that miss in both the L1 and L2 ITLBs (page-table "
+       "walks are requested) for 2M pages."},
+      {"bp_l1_tlb_miss_l2_tlb_miss.if1g", PERF_TYPE_RAW, 0x485, "AMD",
+       "Instruction fetches that miss in both the L1 and L2 ITLBs (page-table "
+       "walks are requested) for 1G pages."},
+      {"bp_l1_tlb_miss_l2_tlb_miss.coalesced_4k", PERF_TYPE_RAW, 0x885, "AMD",
+       "Instruction fetches that miss in both the L1 and L2 ITLBs (page-table "
+       "walks are requested) for coalesced pages. A coalesced page is a 16k "
+       "page created from four adjacent 4k pages."},
+      {"bp_l1_tlb_miss_l2_tlb_miss.all", PERF_TYPE_RAW, 0xf85, "AMD",
+       "Instruction fetches that miss in both the L1 and L2 ITLBs (page-table "
+       "walks are requested) for all page sizes."},
+      {"bp_l1_tlb_fetch_hit.if4k", PERF_TYPE_RAW, 0x194, "AMD",
+       "Instruction fetches that hit in the L1 ITLB for 4k or coalesced pages. "
+       "A coalesced page is a 16k page created from four adjacent 4k pages."},
+      {"bp_l1_tlb_fetch_hit.if2m", PERF_TYPE_RAW, 0x294, "AMD",
+       "Instruction fetches that hit in the L1 ITLB for 2M pages."},
+      {"bp_l1_tlb_fetch_hit.if1g", PERF_TYPE_RAW, 0x494, "AMD",
+       "Instruction fetches that hit in the L1 ITLB for 1G pages."},
+      {"bp_l1_tlb_fetch_hit.all", PERF_TYPE_RAW, 0x794, "AMD",
+       "Instruction fetches that hit in the L1 ITLB for all page sizes."},
+      {"fp_ret_x87_fp_ops.add_sub_ops", PERF_TYPE_RAW, 0x102, "AMD",
+       "Retired x87 floating-point add and subtract ops."},
+      {"fp_ret_x87_fp_ops.mul_ops", PERF_TYPE_RAW, 0x202, "AMD",
+       "Retired x87 floating-point multiply ops."},
+      {"fp_ret_x87_fp_ops.div_sqrt_ops", PERF_TYPE_RAW, 0x402, "AMD",
+       "Retired x87 floating-point divide and square root ops."},
+      {"fp_ret_x87_fp_ops.all", PERF_TYPE_RAW, 0x702, "AMD",
+       "Retired x87 floating-point ops of all types."},
+      {"fp_ret_sse_avx_ops.add_sub_flops", PERF_TYPE_RAW, 0x103, "AMD",
+       "Retired SSE and AVX floating-point add and subtract ops."},
+      {"fp_ret_sse_avx_ops.mult_flops", PERF_TYPE_RAW, 0x203, "AMD",
+       "Retired SSE and AVX floating-point multiply ops."},
+      {"fp_ret_sse_avx_ops.div_flops", PERF_TYPE_RAW, 0x403, "AMD",
+       "Retired SSE and AVX floating-point divide and square root ops."},
+      {"fp_ret_sse_avx_ops.mac_flops", PERF_TYPE_RAW, 0x803, "AMD",
+       "Retired SSE and AVX floating-point multiply-accumulate ops (each "
+       "operation is counted as 2 ops)."},
+      {"fp_ret_sse_avx_ops.bfloat_mac_flops", PERF_TYPE_RAW, 0x1003, "AMD",
+       "Retired SSE and AVX floating-point bfloat multiply-accumulate ops "
+       "(each operation is counted as 2 ops)."},
+      {"fp_ret_sse_avx_ops.all", PERF_TYPE_RAW, 0x1f03, "AMD",
+       "Retired SSE and AVX floating-point ops of all types."},
+      {"fp_retired_ser_ops.x87_ctrl_ret", PERF_TYPE_RAW, 0x105, "AMD",
+       "Retired x87 control word mispredict traps due to mispredictions in RC "
+       "or PC, or changes in exception mask bits."},
+      {"fp_retired_ser_ops.x87_bot_ret", PERF_TYPE_RAW, 0x205, "AMD",
+       "Retired x87 bottom-executing ops. Bottom-executing ops wait for all "
+       "older ops to retire before executing."},
+      {"fp_retired_ser_ops.sse_ctrl_ret", PERF_TYPE_RAW, 0x405, "AMD",
+       "Retired SSE and AVX control word mispredict traps."},
+      {"fp_retired_ser_ops.sse_bot_ret", PERF_TYPE_RAW, 0x805, "AMD",
+       "Retired SSE and AVX bottom-executing ops. Bottom-executing ops wait "
+       "for all older ops to retire before executing."},
+      {"fp_retired_ser_ops.all", PERF_TYPE_RAW, 0xf05, "AMD",
+       "Retired SSE and AVX serializing ops of all types."},
+      {"fp_ops_retired_by_width.x87_uops_retired", PERF_TYPE_RAW, 0x108, "AMD",
+       "Retired x87 floating-point ops."},
+      {"fp_ops_retired_by_width.mmx_uops_retired", PERF_TYPE_RAW, 0x208, "AMD",
+       "Retired MMX floating-point ops."},
+      {"fp_ops_retired_by_width.scalar_uops_retired", PERF_TYPE_RAW, 0x408,
+       "AMD", "Retired scalar floating-point ops."},
+      {"fp_ops_retired_by_width.pack_128_uops_retired", PERF_TYPE_RAW, 0x808,
+       "AMD", "Retired packed 128-bit floating-point ops."},
+      {"fp_ops_retired_by_width.pack_256_uops_retired", PERF_TYPE_RAW, 0x1008,
+       "AMD", "Retired packed 256-bit floating-point ops."},
+      {"fp_ops_retired_by_width.pack_512_uops_retired", PERF_TYPE_RAW, 0x2008,
+       "AMD", "Retired packed 512-bit floating-point ops."},
+      {"fp_ops_retired_by_width.all", PERF_TYPE_RAW, 0x3f08, "AMD",
+       "Retired floating-point ops of all widths."},
+      {"fp_ops_retired_by_type.scalar_add", PERF_TYPE_RAW, 0x10a, "AMD",
+       "Retired scalar floating-point add ops."},
+      {"fp_ops_retired_by_type.scalar_sub", PERF_TYPE_RAW, 0x20a, "AMD",
+       "Retired scalar floating-point subtract ops."},
+      {"fp_ops_retired_by_type.scalar_mul", PERF_TYPE_RAW, 0x30a, "AMD",
+       "Retired scalar floating-point multiply ops."},
+      {"fp_ops_retired_by_type.scalar_mac", PERF_TYPE_RAW, 0x40a, "AMD",
+       "Retired scalar floating-point multiply-accumulate ops."},
+      {"fp_ops_retired_by_type.scalar_div", PERF_TYPE_RAW, 0x50a, "AMD",
+       "Retired scalar floating-point divide ops."},
+      {"fp_ops_retired_by_type.scalar_sqrt", PERF_TYPE_RAW, 0x60a, "AMD",
+       "Retired scalar floating-point square root ops."},
+      {"fp_ops_retired_by_type.scalar_cmp", PERF_TYPE_RAW, 0x70a, "AMD",
+       "Retired scalar floating-point compare ops."},
+      {"fp_ops_retired_by_type.scalar_cvt", PERF_TYPE_RAW, 0x80a, "AMD",
+       "Retired scalar floating-point convert ops."},
+      {"fp_ops_retired_by_type.scalar_blend", PERF_TYPE_RAW, 0x90a, "AMD",
+       "Retired scalar floating-point blend ops."},
+      {"fp_ops_retired_by_type.scalar_other", PERF_TYPE_RAW, 0xe0a, "AMD",
+       "Retired scalar floating-point ops of other types."},
+      {"fp_ops_retired_by_type.scalar_all", PERF_TYPE_RAW, 0xf0a, "AMD",
+       "Retired scalar floating-point ops of all types."},
+      {"fp_ops_retired_by_type.vector_add", PERF_TYPE_RAW, 0x100a, "AMD",
+       "Retired vector floating-point add ops."},
+      {"fp_ops_retired_by_type.vector_sub", PERF_TYPE_RAW, 0x200a, "AMD",
+       "Retired vector floating-point subtract ops."},
+      {"fp_ops_retired_by_type.vector_mul", PERF_TYPE_RAW, 0x300a, "AMD",
+       "Retired vector floating-point multiply ops."},
+      {"fp_ops_retired_by_type.vector_mac", PERF_TYPE_RAW, 0x400a, "AMD",
+       "Retired vector floating-point multiply-accumulate ops."},
+      {"fp_ops_retired_by_type.vector_div", PERF_TYPE_RAW, 0x500a, "AMD",
+       "Retired vector floating-point divide ops."},
+      {"fp_ops_retired_by_type.vector_sqrt", PERF_TYPE_RAW, 0x600a, "AMD",
+       "Retired vector floating-point square root ops."},
+      {"fp_ops_retired_by_type.vector_cmp", PERF_TYPE_RAW, 0x700a, "AMD",
+       "Retired vector floating-point compare ops."},
+      {"fp_ops_retired_by_type.vector_cvt", PERF_TYPE_RAW, 0x800a, "AMD",
+       "Retired vector floating-point convert ops."},
+      {"fp_ops_retired_by_type.vector_blend", PERF_TYPE_RAW, 0x900a, "AMD",
+       "Retired vector floating-point blend ops."},
+      {"fp_ops_retired_by_type.vector_shuffle", PERF_TYPE_RAW, 0xb00a, "AMD",
+       "Retired vector floating-point shuffle ops (may include instructions "
+       "not necessarily thought of as including shuffles e.g. horizontal add, "
+       "dot "
+       "product, and certain MOV instructions)."},
+      {"fp_ops_retired_by_type.vector_logical", PERF_TYPE_RAW, 0xd00a, "AMD",
+       "Retired vector floating-point logical ops."},
+      {"fp_ops_retired_by_type.vector_other", PERF_TYPE_RAW, 0xe00a, "AMD",
+       "Retired vector floating-point ops of other types."},
+      {"fp_ops_retired_by_type.vector_all", PERF_TYPE_RAW, 0xf00a, "AMD",
+       "Retired vector floating-point ops of all types."},
+      {"fp_ops_retired_by_type.all", PERF_TYPE_RAW, 0xff0a, "AMD",
+       "Retired floating-point ops of all types."},
+      {"sse_avx_ops_retired.mmx_add", PERF_TYPE_RAW, 0x10b, "AMD",
+       "Retired MMX integer add."},
+      {"sse_avx_ops_retired.mmx_sub", PERF_TYPE_RAW, 0x20b, "AMD",
+       "Retired MMX integer subtract ops."},
+      {"sse_avx_ops_retired.mmx_mul", PERF_TYPE_RAW, 0x30b, "AMD",
+       "Retired MMX integer multiply ops."},
+      {"sse_avx_ops_retired.mmx_mac", PERF_TYPE_RAW, 0x40b, "AMD",
+       "Retired MMX integer multiply-accumulate ops."},
+      {"sse_avx_ops_retired.mmx_cmp", PERF_TYPE_RAW, 0x70b, "AMD",
+       "Retired MMX integer compare ops."},
+      {"sse_avx_ops_retired.mmx_shift", PERF_TYPE_RAW, 0x90b, "AMD",
+       "Retired MMX integer shift ops."},
+      {"sse_avx_ops_retired.mmx_mov", PERF_TYPE_RAW, 0xa0b, "AMD",
+       "Retired MMX integer MOV ops."},
+      {"sse_avx_ops_retired.mmx_shuffle", PERF_TYPE_RAW, 0xb0b, "AMD",
+       "Retired MMX integer shuffle ops (may include instructions not "
+       "necessarily thought of as including shuffles e.g. horizontal add, dot "
+       "product, and certain MOV instructions)."},
+      {"sse_avx_ops_retired.mmx_pack", PERF_TYPE_RAW, 0xc0b, "AMD",
+       "Retired MMX integer pack ops."},
+      {"sse_avx_ops_retired.mmx_logical", PERF_TYPE_RAW, 0xd0b, "AMD",
+       "Retired MMX integer logical ops."},
+      {"sse_avx_ops_retired.mmx_other", PERF_TYPE_RAW, 0xe0b, "AMD",
+       "Retired MMX integer multiply ops of other types."},
+      {"sse_avx_ops_retired.mmx_all", PERF_TYPE_RAW, 0xf0b, "AMD",
+       "Retired MMX integer ops of all types."},
+      {"sse_avx_ops_retired.sse_avx_add", PERF_TYPE_RAW, 0x100b, "AMD",
+       "Retired SSE and AVX integer add ops."},
+      {"sse_avx_ops_retired.sse_avx_sub", PERF_TYPE_RAW, 0x200b, "AMD",
+       "Retired SSE and AVX integer subtract ops."},
+      {"sse_avx_ops_retired.sse_avx_mul", PERF_TYPE_RAW, 0x300b, "AMD",
+       "Retired SSE and AVX integer multiply ops."},
+      {"sse_avx_ops_retired.sse_avx_mac", PERF_TYPE_RAW, 0x400b, "AMD",
+       "Retired SSE and AVX integer multiply-accumulate ops."},
+      {"sse_avx_ops_retired.sse_avx_aes", PERF_TYPE_RAW, 0x500b, "AMD",
+       "Retired SSE and AVX integer AES ops."},
+      {"sse_avx_ops_retired.sse_avx_sha", PERF_TYPE_RAW, 0x600b, "AMD",
+       "Retired SSE and AVX integer SHA ops."},
+      {"sse_avx_ops_retired.sse_avx_cmp", PERF_TYPE_RAW, 0x700b, "AMD",
+       "Retired SSE and AVX integer compare ops."},
+      {"sse_avx_ops_retired.sse_avx_clm", PERF_TYPE_RAW, 0x800b, "AMD",
+       "Retired SSE and AVX integer CLM ops."},
+      {"sse_avx_ops_retired.sse_avx_shift", PERF_TYPE_RAW, 0x900b, "AMD",
+       "Retired SSE and AVX integer shift ops."},
+      {"sse_avx_ops_retired.sse_avx_mov", PERF_TYPE_RAW, 0xa00b, "AMD",
+       "Retired SSE and AVX integer MOV ops."},
+      {"sse_avx_ops_retired.sse_avx_shuffle", PERF_TYPE_RAW, 0xb00b, "AMD",
+       "Retired SSE and AVX integer shuffle ops (may include instructions not "
+       "necessarily thought of as including shuffles e.g. horizontal add, dot "
+       "product, and certain MOV instructions)."},
+      {"sse_avx_ops_retired.sse_avx_pack", PERF_TYPE_RAW, 0xc00b, "AMD",
+       "Retired SSE and AVX integer pack ops."},
+      {"sse_avx_ops_retired.sse_avx_logical", PERF_TYPE_RAW, 0xd00b, "AMD",
+       "Retired SSE and AVX integer logical ops."},
+      {"sse_avx_ops_retired.sse_avx_other", PERF_TYPE_RAW, 0xe00b, "AMD",
+       "Retired SSE and AVX integer ops of other types."},
+      {"sse_avx_ops_retired.sse_avx_all", PERF_TYPE_RAW, 0xf00b, "AMD",
+       "Retired SSE and AVX integer ops of all types."},
+      {"sse_avx_ops_retired.all", PERF_TYPE_RAW, 0xff0b, "AMD",
+       "Retired SSE, AVX and MMX integer ops of all types."},
+      {"fp_pack_ops_retired.fp128_add", PERF_TYPE_RAW, 0x10c, "AMD",
+       "Retired 128-bit packed floating-point add ops."},
+      {"fp_pack_ops_retired.fp128_sub", PERF_TYPE_RAW, 0x20c, "AMD",
+       "Retired 128-bit packed floating-point subtract ops."},
+      {"fp_pack_ops_retired.fp128_mul", PERF_TYPE_RAW, 0x30c, "AMD",
+       "Retired 128-bit packed floating-point multiply ops."},
+      {"fp_pack_ops_retired.fp128_mac", PERF_TYPE_RAW, 0x40c, "AMD",
+       "Retired 128-bit packed floating-point multiply-accumulate ops."},
+      {"fp_pack_ops_retired.fp128_div", PERF_TYPE_RAW, 0x50c, "AMD",
+       "Retired 128-bit packed floating-point divide ops."},
+      {"fp_pack_ops_retired.fp128_sqrt", PERF_TYPE_RAW, 0x60c, "AMD",
+       "Retired 128-bit packed floating-point square root ops."},
+      {"fp_pack_ops_retired.fp128_cmp", PERF_TYPE_RAW, 0x70c, "AMD",
+       "Retired 128-bit packed floating-point compare ops."},
+      {"fp_pack_ops_retired.fp128_cvt", PERF_TYPE_RAW, 0x80c, "AMD",
+       "Retired 128-bit packed floating-point convert ops."},
+      {"fp_pack_ops_retired.fp128_blend", PERF_TYPE_RAW, 0x90c, "AMD",
+       "Retired 128-bit packed floating-point blend ops."},
+      {"fp_pack_ops_retired.fp128_shuffle", PERF_TYPE_RAW, 0xb0c, "AMD",
+       "Retired 128-bit packed floating-point shuffle ops (may include "
+       "instructions not necessarily thought of as including shuffles e.g. "
+       "horizontal add, dot product, and certain MOV instructions)."},
+      {"fp_pack_ops_retired.fp128_logical", PERF_TYPE_RAW, 0xd0c, "AMD",
+       "Retired 128-bit packed floating-point logical ops."},
+      {"fp_pack_ops_retired.fp128_other", PERF_TYPE_RAW, 0xe0c, "AMD",
+       "Retired 128-bit packed floating-point ops of other types."},
+      {"fp_pack_ops_retired.fp128_all", PERF_TYPE_RAW, 0xf0c, "AMD",
+       "Retired 128-bit packed floating-point ops of all types."},
+      {"fp_pack_ops_retired.fp256_add", PERF_TYPE_RAW, 0x100c, "AMD",
+       "Retired 256-bit packed floating-point add ops."},
+      {"fp_pack_ops_retired.fp256_sub", PERF_TYPE_RAW, 0x200c, "AMD",
+       "Retired 256-bit packed floating-point subtract ops."},
+      {"fp_pack_ops_retired.fp256_mul", PERF_TYPE_RAW, 0x300c, "AMD",
+       "Retired 256-bit packed floating-point multiply ops."},
+      {"fp_pack_ops_retired.fp256_mac", PERF_TYPE_RAW, 0x400c, "AMD",
+       "Retired 256-bit packed floating-point multiply-accumulate ops."},
+      {"fp_pack_ops_retired.fp256_div", PERF_TYPE_RAW, 0x500c, "AMD",
+       "Retired 256-bit packed floating-point divide ops."},
+      {"fp_pack_ops_retired.fp256_sqrt", PERF_TYPE_RAW, 0x600c, "AMD",
+       "Retired 256-bit packed floating-point square root ops."},
+      {"fp_pack_ops_retired.fp256_cmp", PERF_TYPE_RAW, 0x700c, "AMD",
+       "Retired 256-bit packed floating-point compare ops."},
+      {"fp_pack_ops_retired.fp256_cvt", PERF_TYPE_RAW, 0x800c, "AMD",
+       "Retired 256-bit packed floating-point convert ops."},
+      {"fp_pack_ops_retired.fp256_blend", PERF_TYPE_RAW, 0x900c, "AMD",
+       "Retired 256-bit packed floating-point blend ops."},
+      {"fp_pack_ops_retired.fp256_shuffle", PERF_TYPE_RAW, 0xb00c, "AMD",
+       "Retired 256-bit packed floating-point shuffle ops (may include "
+       "instructions not necessarily thought of as including shuffles e.g. "
+       "horizontal add, dot product, and certain MOV instructions)."},
+      {"fp_pack_ops_retired.fp256_logical", PERF_TYPE_RAW, 0xd00c, "AMD",
+       "Retired 256-bit packed floating-point logical ops."},
+      {"fp_pack_ops_retired.fp256_other", PERF_TYPE_RAW, 0xe00c, "AMD",
+       "Retired 256-bit packed floating-point ops of other types."},
+      {"fp_pack_ops_retired.fp256_all", PERF_TYPE_RAW, 0xf00c, "AMD",
+       "Retired 256-bit packed floating-point ops of all types."},
+      {"fp_pack_ops_retired.all", PERF_TYPE_RAW, 0xff0c, "AMD",
+       "Retired packed floating-point ops of all types."},
+      {"packed_int_op_type.int128_add", PERF_TYPE_RAW, 0x10d, "AMD",
+       "Retired 128-bit packed integer add ops."},
+      {"packed_int_op_type.int128_sub", PERF_TYPE_RAW, 0x20d, "AMD",
+       "Retired 128-bit packed integer subtract ops."},
+      {"packed_int_op_type.int128_mul", PERF_TYPE_RAW, 0x30d, "AMD",
+       "Retired 128-bit packed integer multiply ops."},
+      {"packed_int_op_type.int128_mac", PERF_TYPE_RAW, 0x40d, "AMD",
+       "Retired 128-bit packed integer multiply-accumulate ops."},
+      {"packed_int_op_type.int128_aes", PERF_TYPE_RAW, 0x50d, "AMD",
+       "Retired 128-bit packed integer AES ops."},
+      {"packed_int_op_type.int128_sha", PERF_TYPE_RAW, 0x60d, "AMD",
+       "Retired 128-bit packed integer SHA ops."},
+      {"packed_int_op_type.int128_cmp", PERF_TYPE_RAW, 0x70d, "AMD",
+       "Retired 128-bit packed integer compare ops."},
+      {"packed_int_op_type.int128_clm", PERF_TYPE_RAW, 0x80d, "AMD",
+       "Retired 128-bit packed integer CLM ops."},
+      {"packed_int_op_type.int128_shift", PERF_TYPE_RAW, 0x90d, "AMD",
+       "Retired 128-bit packed integer shift ops."},
+      {"packed_int_op_type.int128_mov", PERF_TYPE_RAW, 0xa0d, "AMD",
+       "Retired 128-bit packed integer MOV ops."},
+      {"packed_int_op_type.int128_shuffle", PERF_TYPE_RAW, 0xb0d, "AMD",
+       "Retired 128-bit packed integer shuffle ops (may include instructions "
+       "not necessarily thought of as including shuffles e.g. horizontal add, "
+       "dot "
+       "product, and certain MOV instructions)."},
+      {"packed_int_op_type.int128_pack", PERF_TYPE_RAW, 0xc0d, "AMD",
+       "Retired 128-bit packed integer pack ops."},
+      {"packed_int_op_type.int128_logical", PERF_TYPE_RAW, 0xd0d, "AMD",
+       "Retired 128-bit packed integer logical ops."},
+      {"packed_int_op_type.int128_other", PERF_TYPE_RAW, 0xe0d, "AMD",
+       "Retired 128-bit packed integer ops of other types."},
+      {"packed_int_op_type.int128_all", PERF_TYPE_RAW, 0xf0d, "AMD",
+       "Retired 128-bit packed integer ops of all types."},
+      {"packed_int_op_type.int256_add", PERF_TYPE_RAW, 0x100d, "AMD",
+       "Retired 256-bit packed integer add ops."},
+      {"packed_int_op_type.int256_sub", PERF_TYPE_RAW, 0x200d, "AMD",
+       "Retired 256-bit packed integer subtract ops."},
+      {"packed_int_op_type.int256_mul", PERF_TYPE_RAW, 0x300d, "AMD",
+       "Retired 256-bit packed integer multiply ops."},
+      {"packed_int_op_type.int256_mac", PERF_TYPE_RAW, 0x400d, "AMD",
+       "Retired 256-bit packed integer multiply-accumulate ops."},
+      {"packed_int_op_type.int256_cmp", PERF_TYPE_RAW, 0x700d, "AMD",
+       "Retired 256-bit packed integer compare ops."},
+      {"packed_int_op_type.int256_shift", PERF_TYPE_RAW, 0x900d, "AMD",
+       "Retired 256-bit packed integer shift ops."},
+      {"packed_int_op_type.int256_mov", PERF_TYPE_RAW, 0xa00d, "AMD",
+       "Retired 256-bit packed integer MOV ops."},
+      {"packed_int_op_type.int256_shuffle", PERF_TYPE_RAW, 0xb00d, "AMD",
+       "Retired 256-bit packed integer shuffle ops (may include instructions "
+       "not necessarily thought of as including shuffles e.g. horizontal add, "
+       "dot "
+       "product, and certain MOV instructions)."},
+      {"packed_int_op_type.int256_pack", PERF_TYPE_RAW, 0xc00d, "AMD",
+       "Retired 256-bit packed integer pack ops."},
+      {"packed_int_op_type.int256_logical", PERF_TYPE_RAW, 0xd00d, "AMD",
+       "Retired 256-bit packed integer logical ops."},
+      {"packed_int_op_type.int256_other", PERF_TYPE_RAW, 0xe00d, "AMD",
+       "Retired 256-bit packed integer ops of other types."},
+      {"packed_int_op_type.int256_all", PERF_TYPE_RAW, 0xf00d, "AMD",
+       "Retired 256-bit packed integer ops of all types."},
+      {"packed_int_op_type.all", PERF_TYPE_RAW, 0xff0d, "AMD",
+       "Retired packed integer ops of all types."},
+      {"fp_disp_faults.x87_fill_fault", PERF_TYPE_RAW, 0x10e, "AMD",
+       "Floating-point dispatch faults for x87 fills."},
+      {"fp_disp_faults.xmm_fill_fault", PERF_TYPE_RAW, 0x20e, "AMD",
+       "Floating-point dispatch faults for XMM fills."},
+      {"fp_disp_faults.ymm_fill_fault", PERF_TYPE_RAW, 0x40e, "AMD",
+       "Floating-point dispatch faults for YMM fills."},
+      {"fp_disp_faults.ymm_spill_fault", PERF_TYPE_RAW, 0x80e, "AMD",
+       "Floating-point dispatch faults for YMM spills."},
+      {"fp_disp_faults.sse_avx_all", PERF_TYPE_RAW, 0xe0e, "AMD",
+       "Floating-point dispatch faults of all types for SSE and AVX ops."},
+      {"fp_disp_faults.all", PERF_TYPE_RAW, 0xf0e, "AMD",
+       "Floating-point dispatch faults of all types."},
+  };
+  return sAllPerfEventTypes;
+}

--- a/experimental/hal_executable_library_call_hooks/perf_event_linux.h
+++ b/experimental/hal_executable_library_call_hooks/perf_event_linux.h
@@ -1,0 +1,49 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS_PERF_EVENT_LINUX_H_
+#define EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS_PERF_EVENT_LINUX_H_
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+// Describes a perf event type. Matches the corresponding data structure in
+// the linux perf source code.
+struct PerfEventType {
+  const char *name;
+  uint32_t type;
+  uint64_t config;
+  const char *target;
+  const char *description;
+};
+
+// A perf-event file-descriptor for querying a specific event count.
+class PerfEventFd {
+ public:
+  PerfEventFd(PerfEventType perf_event_type);
+  ~PerfEventFd();
+
+  // Resets the event counter.
+  void reset();
+  // Enables the event counter.
+  void enable();
+  // Disables the event counter.
+  void disable();
+  // Queries the current value of the event counter.
+  int64_t read() const;
+
+ private:
+  int fd_ = 0;
+};
+
+// Parses a string as a comma-separated list of event types.
+std::vector<PerfEventType> parsePerfEventTypes(const char *types_str);
+
+// Prints all event types and their descriptions.
+void printAllEventTypesAndDescriptions(FILE *file);
+
+#endif  // EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS_PERF_EVENT_LINUX_H_

--- a/experimental/hal_executable_library_call_hooks/stats.cc
+++ b/experimental/hal_executable_library_call_hooks/stats.cc
@@ -1,0 +1,122 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "experimental/hal_executable_library_call_hooks/stats.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+float sum(const std::vector<float> &v) {
+  float s = 0;
+  for (float x : v) {
+    s += x;
+  }
+  return s;
+}
+
+float mean(const std::vector<float> &v) { return sum(v) / v.size(); }
+
+float covariance(const std::vector<float> &u, const std::vector<float> &v) {
+  assert(u.size() == v.size());
+  float mean_u = mean(u);
+  float mean_v = mean(v);
+  float s = 0;
+  for (size_t i = 0; i < u.size(); ++i) {
+    s += (u[i] - mean_u) * (v[i] - mean_v);
+  }
+  return s / u.size();
+}
+
+float variance(const std::vector<float> &v) { return covariance(v, v); }
+
+float correlation(const std::vector<float> &u, const std::vector<float> &v) {
+  return covariance(u, v) / std::sqrt(variance(u) * variance(v));
+}
+
+void splitIntoBuckets(const std::vector<float> &v, int bucket_count,
+                      std::vector<float> *bucket_means,
+                      std::vector<int> *bucket_indices) {
+  bucket_means->resize(bucket_count);
+  bucket_indices->resize(v.size());
+  std::vector<float> sorted(v);
+  std::sort(sorted.begin(), sorted.end());
+  std::vector<int> bucket_delim_sorted_indices(bucket_count + 1);
+  for (int i = 0; i < bucket_count; ++i) {
+    bucket_delim_sorted_indices[i] =
+        std::min<int>(sorted.size() - 1, sorted.size() * i / bucket_count);
+  }
+  bucket_delim_sorted_indices[bucket_count] = sorted.size();
+  for (int i = 0; i < bucket_count; ++i) {
+    (*bucket_means)[i] = mean(std::vector<float>(
+        sorted.begin() + bucket_delim_sorted_indices[i],
+        sorted.begin() + bucket_delim_sorted_indices[i + 1]));
+  }
+  for (size_t i = 0; i < v.size(); ++i) {
+    float val = v[i];
+    int bucket_index = 0;
+    while (bucket_index < bucket_count - 1 &&
+           val > sorted[bucket_delim_sorted_indices[bucket_index + 1]]) {
+      ++bucket_index;
+    }
+    (*bucket_indices)[i] = bucket_index;
+  }
+}
+
+void computeConditionalProbabilityTable(
+    int bucket_count, const std::vector<int> &bucket_indices_x,
+    const std::vector<int> &bucket_indices_y, std::vector<float> *table) {
+  assert(bucket_indices_x.size() == bucket_indices_y.size());
+  int sample_count = bucket_indices_x.size();
+  table->clear();
+  table->resize(bucket_count * bucket_count, 0);
+  std::vector<int> bucket_sizes_x(bucket_count, 0);
+  for (int i = 0; i < sample_count; ++i) {
+    int x = bucket_indices_x[i];
+    int y = bucket_indices_y[i];
+    (*table)[x + bucket_count * y]++;
+    bucket_sizes_x[x]++;
+  }
+  // Normalize each row to sum to one.
+  for (int x = 0; x < bucket_count; ++x) {
+    if (bucket_sizes_x[x] == 0) {
+      continue;
+    }
+    for (int y = 0; y < bucket_count; ++y) {
+      (*table)[x + bucket_count * y] /= bucket_sizes_x[x];
+    }
+  }
+}
+
+void printConditionalProbabilityTable(FILE *file, int bucket_count,
+                                      const std::vector<float> &table) {
+  const char *gamma_env = getenv("IREE_HOOK_GAMMA");
+  float gamma = gamma_env ? strtof(gamma_env, nullptr) : 0.5f;
+
+  const char *shades[] = {"  ", "_ ", "__", "▁_", "▁▁", "▂▁", "▂▂",
+                          "▃▂", "▃▃", "▄▃", "▄▄", "▅▄", "▅▅", "▆▅",
+                          "▆▆", "▇▆", "▇▇", "█▇", "██"};
+  const int shades_count = (sizeof shades) / (sizeof shades[0]);
+  fprintf(file, "        ");
+  for (int x = 0; x < bucket_count; ++x) {
+    fprintf(file, " %2x", x);
+  }
+  fprintf(file, "\n");
+  for (int y = 0; y < bucket_count; ++y) {
+    fprintf(file, "      %2x", y);
+    for (int x = 0; x < bucket_count; ++x) {
+      float probability = table[x + bucket_count * y];
+      int shade_index = std::min(
+          shades_count - 1,
+          static_cast<int>(std::floor(std::pow(probability, gamma) *
+                                      static_cast<float>(shades_count))));
+      fprintf(file, " %s", shades[shade_index]);
+    }
+    fprintf(file, "\n");
+  }
+  fprintf(file, "\n");
+}

--- a/experimental/hal_executable_library_call_hooks/stats.h
+++ b/experimental/hal_executable_library_call_hooks/stats.h
@@ -1,0 +1,45 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS_STATS_H_
+#define EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS_STATS_H_
+
+#include <cstdio>
+#include <vector>
+
+// Returns the sum of all elements.
+float sum(const std::vector<float> &v);
+
+// Returns the mean value.
+float mean(const std::vector<float> &v);
+
+// Returns the covariance between two vectors.
+float covariance(const std::vector<float> &u, const std::vector<float> &v);
+
+// Returns the variance of the vector.
+float variance(const std::vector<float> &v);
+
+// Returns the "Pearson correlation coefficient".
+// Nothing particularly good about that choice of correlation metric.
+// Just done naively.
+float correlation(const std::vector<float> &u, const std::vector<float> &v);
+
+// Split input data `v` into buckets i.e. (100/bucket_count)-percentiles.
+void splitIntoBuckets(const std::vector<float> &v, int bucket_count,
+                      std::vector<float> *bucket_means,
+                      std::vector<int> *bucket_indices);
+
+// Fills `table` with conditional probabilities of an index falling into a
+// y-bucket given that it belongs to a x-bucket.
+void computeConditionalProbabilityTable(
+    int bucket_count, const std::vector<int> &bucket_indices_x,
+    const std::vector<int> &bucket_indices_y, std::vector<float> *table);
+
+// Render a conditional probability table as semi-graphical grayscale.
+void printConditionalProbabilityTable(FILE *file, int bucket_count,
+                                      const std::vector<float> &table);
+
+#endif  // EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS_STATS_H_

--- a/runtime/src/iree/base/attributes.h
+++ b/runtime/src/iree/base/attributes.h
@@ -207,4 +207,20 @@
 #define IREE_ATTRIBUTE_UNUSED
 #endif  // IREE_HAVE_ATTRIBUTE(maybe_unused / unused)
 
+//===----------------------------------------------------------------------===//
+// IREE_ATTRIBUTE_WEAK
+//===----------------------------------------------------------------------===//
+
+// Declares a symbol as weakly-linked, i.e. overridable at linking time.
+// This is only supported on certain toolchains, and has no effect on other
+// toolchains. Support is indicated by IREE_HAVE_ATTRIBUTE_WEAK.
+
+#if IREE_HAVE_ATTRIBUTE(weak) || (defined(__GNUC__) && !defined(__clang__))
+#define IREE_ATTRIBUTE_WEAK __attribute__((weak))
+#define IREE_HAVE_ATTRIBUTE_WEAK 1
+#else
+#define IREE_ATTRIBUTE_WEAK
+#define IREE_HAVE_ATTRIBUTE_WEAK 0
+#endif  // IREE_HAVE_ATTRIBUTE(weak)
+
 #endif  // IREE_BASE_ATTRIBUTES_H_

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -205,9 +205,13 @@ static iree_status_t iree_hal_elf_executable_issue_call(
 
   IREE_HAL_EXECUTABLE_LIBRARY_CALL_TRACE_ZONE_BEGIN(z0, executable->identifier,
                                                     library, ordinal);
+  IREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK_BEGIN(executable->identifier, library,
+                                              ordinal);
   int ret = iree_elf_call_i_ppp(library->exports.ptrs[ordinal],
                                 (void*)&base_executable->environment,
                                 (void*)dispatch_state, (void*)workgroup_state);
+  IREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK_END(executable->identifier, library,
+                                            ordinal);
   IREE_TRACE_ZONE_END(z0);
 
   return ret == 0 ? iree_ok_status()

--- a/runtime/src/iree/hal/local/loaders/static_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/static_library_loader.c
@@ -149,8 +149,12 @@ static iree_status_t iree_hal_static_executable_issue_call(
 
   IREE_HAL_EXECUTABLE_LIBRARY_CALL_TRACE_ZONE_BEGIN(z0, executable->identifier,
                                                     library, ordinal);
+  IREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK_BEGIN(executable->identifier, library,
+                                              ordinal);
   int ret = library->exports.ptrs[ordinal](&base_executable->environment,
                                            dispatch_state, workgroup_state);
+  IREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK_END(executable->identifier, library,
+                                            ordinal);
   IREE_TRACE_ZONE_END(z0);
 
   return ret == 0 ? iree_ok_status()

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -326,8 +326,12 @@ static iree_status_t iree_hal_system_executable_issue_call(
 
   IREE_HAL_EXECUTABLE_LIBRARY_CALL_TRACE_ZONE_BEGIN(z0, executable->identifier,
                                                     library, ordinal);
+  IREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK_BEGIN(executable->identifier, library,
+                                              ordinal);
   int ret = library->exports.ptrs[ordinal](&base_executable->environment,
                                            dispatch_state, workgroup_state);
+  IREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK_END(executable->identifier, library,
+                                            ordinal);
   IREE_TRACE_ZONE_END(z0);
 
   return ret == 0 ? iree_ok_status()


### PR DESCRIPTION
There are two parts to this PR:
* The `runtime/` changes bring a minimal weak-hook extension point around executable library calls. It's behind a C-internal flag: to enable it, configure with `cmake -DCMAKE_C_FLAGS=-DIREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK .` . When enabled, it links to weak symbols and calls them when they are defined. The symbols are `iree_hal_executable_library_call_hook_{begin,end}`.
* The `experimental/` changes bring one such hook implementation, building a shared library defining such `iree_hal_executable_library_call_hook_{begin,end}` symbols, doing Linux event counter queries, with a number of events defined, imported from JSON tables in the Linux source tree. At the moment it only defines AMD-specific events and generic events, but more could be added. See the README.md file there for how it's used.

Context:
This is a clean-up of the tools we had developed last fall to study Llama2 on Zen4 CPUs. It's the most meaningful use of event counters that I've been able to make yet. The difficulty with these is always to find a way to make an apples-to-apples comparison. What we found in that Llama2 work last fall was that some critical dispatch function had a fluctuating latency, as shown graphically in Tracy histograms, which raised the question: if this dispatch function has sometimes higher and sometimes lower latency, can we understand that so that we could perhaps more often fall in the lower-latency case? The next step was to correlate these fluctuating latencies with some specific event counts. This is what this tool is about.
