### PR TITLE
[CPU] Remove special distribution tile size adjustment from generic ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -335,7 +335,7 @@ static void reduceDistributionWorkgroups(
   while (numWorkgroups > numWorkgroupsLimit && currDim > 0) {
     unsigned index = currDim - 1;
     int64_t currSize = distributedTileSizes[index];
-    if (ShapedType::isDynamic(workload[index]) ||
+    if (ShapedType::isDynamic(workload[index]) || currSize == 0 ||
         (maxTileSizes && currSize >= maxTileSizes.value()[index]) ||
         currSize >= workload[index]) {
       currDim--;


### PR DESCRIPTION
We have a general fix in https://github.com/openxla/iree/commit/d99527b94d4f69f22982288625cec7c715cdca49. It reduces the number of workgroups in cases where we are dividing the work too much. We no longer need the specialization for elementwise generic ops. 