### PR TITLE
[GlobalOptimization] No-op all materialized encodings in default cases

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/MaterializeHomogeneousEncodings.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/MaterializeHomogeneousEncodings.cpp
@@ -34,17 +34,27 @@ public:
     registry.insert<IREE::HAL::HALDialect>();
   }
 
+  void runNopPipeline(ModuleOp &moduleOp) {
+    OpPassManager passManager(moduleOp.getOperationName());
+    passManager.addNestedPass<func::FuncOp>(
+        createMaterializeEncodingIntoNopPass());
+    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    if (failed(runPipeline(passManager, moduleOp))) {
+      return signalPassFailure();
+    }
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
     auto targetsAttr = moduleOp->getAttrOfType<ArrayAttr>("hal.device.targets");
     if (!targetsAttr || targetsAttr.size() != 1) {
-      return;
+      return runNopPipeline(moduleOp);
     }
     auto deviceTarget = cast<IREE::HAL::DeviceTargetAttr>(targetsAttr[0]);
     SmallVector<IREE::HAL::ExecutableTargetAttr, 4> executableTargets =
         deviceTarget.getExecutableTargets();
     if (executableTargets.size() != 1) {
-      return;
+      return runNopPipeline(moduleOp);
     }
     // TODO: vmvx has its own logic about supporting dynamic tile
     // sizes. It is not fully integrated into the pipeline, so we remain the
@@ -55,18 +65,15 @@ public:
     }
 
     // Only llvm-cpu backends handle encodings for now, others just go with nop.
-    OpPassManager passManager(moduleOp.getOperationName());
-    if (executableTarget.getBackend() == "llvm-cpu") {
-      passManager.addNestedPass<func::FuncOp>(
-          createCPUMaterializeUpperBoundTileSizePass(executableTargets));
-      passManager.addNestedPass<func::FuncOp>(
-          createCPUMaterializeEncodingPass(executableTarget));
-    } else {
-      passManager.addNestedPass<func::FuncOp>(
-          createMaterializeEncodingIntoNopPass());
-      passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    if (executableTarget.getBackend() != "llvm-cpu") {
+      return runNopPipeline(moduleOp);
     }
 
+    OpPassManager passManager(moduleOp.getOperationName());
+    passManager.addNestedPass<func::FuncOp>(
+        createCPUMaterializeUpperBoundTileSizePass(executableTargets));
+    passManager.addNestedPass<func::FuncOp>(
+        createCPUMaterializeEncodingPass(executableTarget));
     if (failed(runPipeline(passManager, moduleOp))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/GlobalOptimization/test/materialize_homogeneous_encodings.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/materialize_homogeneous_encodings.mlir
@@ -55,3 +55,35 @@ module attributes {hal.device.targets = [#device_target_vulkan]} {
 // CHECK-LABEL: func.func @lhs_encoding
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         return %[[ARG0]]
+
+// -----
+
+#map = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {target_triple = "x86_64-none-elf", cpu_features = "+avx512f"}>
+#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#executable_target_embedded_elf_x86_64_]}>
+#executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan", "vulkan-spirv-fb">
+#device_target_vulkan = #hal.device.target<"vulkan", {executable_targets = [#executable_target_vulkan_spirv_fb], legacy_sync}>
+module attributes {hal.device.targets = [#device_target_vulkan, #device_target_llvm_cpu]} {
+  func.func @lhs_encoding(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+    %dim_0 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+    %0:2 = iree_linalg_ext.upper_bound_tile_size tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = LHS, element_types = [f32, f32, f32]>> -> index, index
+    %1 = affine.apply #map()[%0#0, %dim]
+    %2 = affine.apply #map()[%0#1, %dim_0]
+    %padded = tensor.pad %arg0 low[0, 0] high[%1, %2] {
+    ^bb0(%arg1: index, %arg2: index):
+      tensor.yield %cst : f32
+    } : tensor<?x?xf32> to tensor<?x?xf32>
+    %3 = iree_linalg_ext.set_encoding %padded : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = LHS, element_types = [f32, f32, f32]>>
+    %4 = iree_linalg_ext.unset_encoding %3 : tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL, role = LHS, element_types = [f32, f32, f32]>> -> tensor<?x?xf32>
+    return %4 : tensor<?x?xf32>
+  }
+}
+
+// Multiple targets are currently unsupported.
+// CHECK-LABEL: func.func @lhs_encoding
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         return %[[ARG0]]


### PR DESCRIPTION
Currently unsupported cases, such as multiple targets, currently do not support encodings. This turns all encodings for such cases into no-ops rather than crashing the compiler.