### PR TITLE
Deduplicate device target attributes on assignment

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignTargetDevices.cpp
@@ -76,6 +76,7 @@ public:
       return;
     }
 
+    llvm::SmallDenseSet<Attribute> targetAttrSet;
     SmallVector<Attribute> targetAttrs;
     for (const auto &targetName : targets) {
       auto targetBackend = targetRegistry.getTargetBackend(targetName);
@@ -99,7 +100,10 @@ public:
       // Ask the target backend for its default device specification attribute.
       auto targetAttr =
           targetBackend->getDefaultDeviceTarget(moduleOp.getContext());
-      targetAttrs.push_back(targetAttr);
+      if (!targetAttrSet.contains(targetAttr)) {
+        targetAttrSet.insert(targetAttr);
+        targetAttrs.push_back(targetAttr);
+      }
     }
 
     moduleOp->setAttr("hal.device.targets",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_target_devices.mlir
@@ -1,11 +1,14 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices)' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-0
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vmvx,vmvx-inline})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vulkan,vulkan-spirv})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
 
 // TARGET-1: #device_target_vmvx = #hal.device.target<"vmvx"
 
 // TARGET-2: #device_target_vmvx = #hal.device.target<"vmvx"
 // TARGET-2: #device_target_vmvx_inline = #hal.device.target<"vmvx-inline"
+
+// TARGET-EQ: #device_target_vulkan = #hal.device.target<"vulkan"
 
 // CHECK: module
 // TARGET-0: @module {
@@ -13,6 +16,8 @@
 // TARGET-1-SAME: hal.device.targets = [#device_target_vmvx]
 // TARGET-2: @module attributes {
 // TARGET-2-SAME: hal.device.targets = [#device_target_vmvx, #device_target_vmvx_inline]}
+// TARGET-EQ: @module attributes {
+// TARGET-EQ-SAME: hal.device.targets = [#device_target_vulkan]}
 module @module {}
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_target_devices.mlir
@@ -1,14 +1,14 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices)' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-0
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vmvx,vmvx-inline})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vulkan,vulkan-spirv})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targets=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
 
 // TARGET-1: #device_target_vmvx = #hal.device.target<"vmvx"
 
 // TARGET-2: #device_target_vmvx = #hal.device.target<"vmvx"
 // TARGET-2: #device_target_vmvx_inline = #hal.device.target<"vmvx-inline"
 
-// TARGET-EQ: #device_target_vulkan = #hal.device.target<"vulkan"
+// TARGET-EQ: #device_target_vmvx = #hal.device.target<"vmvx"
 
 // CHECK: module
 // TARGET-0: @module {
@@ -17,7 +17,7 @@
 // TARGET-2: @module attributes {
 // TARGET-2-SAME: hal.device.targets = [#device_target_vmvx, #device_target_vmvx_inline]}
 // TARGET-EQ: @module attributes {
-// TARGET-EQ-SAME: hal.device.targets = [#device_target_vulkan]}
+// TARGET-EQ-SAME: hal.device.targets = [#device_target_vmvx]}
 module @module {}
 
 // -----


### PR DESCRIPTION
Currently if two targets resolve to the same device attribute, they won't be deduplicated and we will end up carrying them through Flow.