### PR TITLE
Post partial comparison if a fully matched previous results not found

### DIFF
--- a/build_tools/benchmarks/generate_benchmark_comment.py
+++ b/build_tools/benchmarks/generate_benchmark_comment.py
@@ -312,6 +312,9 @@ def main(args):
             for mapper in benchmark_presentation.COMPILATION_METRICS_TO_TABLE_MAPPERS:
                 required_benchmark_keys.add(mapper.get_series_id(target_id))
 
+        # Try to fine the superset results first to make sure we won't compare
+        # to partially uploaded results (as the current uploading process is not
+        # transactional).
         comparable_results = _find_comparable_benchmark_results(
             start_commit=pr_base_commit,
             required_benchmark_keys=required_benchmark_keys,


### PR DESCRIPTION
Currently there is no comparison results if we add new benchmarks as the tool is trying to find a superset in the previous results. This change fallbacks to partial results to at least we can get some comparison information.