### PR TITLE
[CPU] Move tensor.pad to use common util to get distribution tile sizes.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -2139,3 +2139,48 @@ hal.executable private @batch_mmt4d {
 //      CHECK: func.func @batch_mmt4d()
 //      CHECK:   linalg.batch_mmt4d
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+hal.executable private @pad_only {
+  hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {
+      cpu = "generic", cpu_features = "",
+      data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+      native_vector_size = 16 : index, target_triple = "x86_64-none-elf"}>) {
+    hal.executable.export public @pad_only ordinal(0)
+        layout(#hal.pipeline.layout<push_constants = 0,
+            sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @pad_only() {
+        %c634816 = arith.constant 634816 : index
+        %c3846080 = arith.constant 3846080 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c634816) flags(ReadOnly)
+            : !flow.dispatch.tensor<readonly:tensor<1x112x112x64xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c3846080)
+            : !flow.dispatch.tensor<writeonly:tensor<1x114x114x64xf32>>
+        %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 64], strides = [1, 1, 1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<1x112x112x64xf32>> -> tensor<1x112x112x64xf32>
+        %padded = tensor.pad %2 low[0, 1, 1, 0] high[0, 1, 1, 0] {
+        ^bb0(%arg0: index, %arg1: index, %arg2: index, %arg3: index):
+          tensor.yield %cst : f32
+        } : tensor<1x112x112x64xf32> to tensor<1x114x114x64xf32>
+        flow.dispatch.tensor.store %padded, %1, offsets = [0, 0, 0, 0], sizes = [1, 114, 114, 64], strides = [1, 1, 1, 1]
+            : tensor<1x114x114x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x114x114x64xf32>>
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 19, 19, 64], [1, 1, 1, 4], [0, 0, 0, 0], [0, 0, 0, 0]]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//       CHECK: hal.executable.export public @pad_only
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK: func.func @pad_only()
+//      CHECK:   tensor.pad {{.+}} {
+//      CHECK:     tensor.yield
+// CHECK-NEXT:   } {lowering_config = #[[CONFIG]]}


### PR DESCRIPTION
It adds a missing strategy selection test. It was only tested through pipeline tests.