### PR TITLE
[GlobalOpti] Avoid SetEncoding on non-extending CastOpInterface ops

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
@@ -94,7 +94,8 @@ struct ExpandVectors
         RankedTensorType::get(expandedOutDims, vectorOutTy.getElementType());
     Location loc = linalgOp.getLoc();
     Value expandedIn;
-    std::optional<CastOpInterface> castOp = getDefiningNonI1CastOp(vectorIn);
+    std::optional<CastOpInterface> castOp =
+        getDefiningNonI1ExtendingCastOp(vectorIn);
     if (castOp) {
       Value castIn = vectorIn.getDefiningOp()->getOperand(0);
       Type castSrcElemType =

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -291,9 +291,9 @@ struct setContractionOpEncoding
       return {};
     };
     std::optional<CastOpInterface> maybeLhsCastOp =
-        getDefiningNonI1CastOp(origLhs);
+        getDefiningNonI1ExtendingCastOp(origLhs);
     std::optional<CastOpInterface> maybeRhsCastOp =
-        getDefiningNonI1CastOp(origRhs);
+        getDefiningNonI1ExtendingCastOp(origRhs);
     Type lhsElemType = maybeLhsCastOp ? getCastElemType(origLhs).value()
                                       : getElemType(origLhs);
     Type rhsElemType = maybeRhsCastOp ? getCastElemType(origRhs).value()

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Interfaces/CastInterfaces.h"
 
 namespace mlir::iree_compiler::GlobalOptimization {
 

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
@@ -11,20 +11,28 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Interfaces/CastInterfaces.h"
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
-std::optional<CastOpInterface> getDefiningNonI1CastOp(Value input) {
+std::optional<CastOpInterface> getDefiningNonI1ExtendingCastOp(Value input) {
   // Returns true if the source of cast op has i1 element type.
   auto isI1Src = [](CastOpInterface castOp) -> bool {
     auto elemType = getElementTypeOrSelf(castOp->getOperandTypes()[0]);
     return elemType.getIntOrFloatBitWidth() == 1;
   };
 
+  auto isExtending = [](CastOpInterface castOp) -> bool {
+    auto inElemType = getElementTypeOrSelf(castOp->getOperandTypes()[0]);
+    auto outElemType = getElementTypeOrSelf(castOp->getResultTypes()[0]);
+    return inElemType.getIntOrFloatBitWidth() <
+           outElemType.getIntOrFloatBitWidth();
+  };
+
   std::optional<CastOpInterface> result = std::nullopt;
   auto castOp = input.getDefiningOp<CastOpInterface>();
   if (castOp) {
-    if (!isI1Src(castOp)) {
+    if (!isI1Src(castOp) && isExtending(castOp)) {
       result = castOp;
     }
     return result;
@@ -46,14 +54,15 @@ std::optional<CastOpInterface> getDefiningNonI1CastOp(Value input) {
       castIn.cast<BlockArgument>().getArgNumber() != 0) {
     return std::nullopt;
   }
-  if (!isI1Src(castOp)) {
+  if (!isI1Src(castOp) && isExtending(castOp)) {
     result = castOp;
   }
   return result;
 }
 
 std::optional<Type> getCastElemType(Value input) {
-  std::optional<CastOpInterface> castOp = getDefiningNonI1CastOp(input);
+  std::optional<CastOpInterface> castOp =
+      getDefiningNonI1ExtendingCastOp(input);
   if (!castOp) {
     return std::nullopt;
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.h
@@ -25,6 +25,7 @@ namespace mlir::iree_compiler::GlobalOptimization {
 
 /// Returns a CastOpInterface op, if the producer is a CastOpInterface op, or a
 /// linalg::GenericOp that performs only a CastOpInterface on its input.
+/// The CastOpInterface op should extend the bitwidth of the source.
 /// The bitwidth of the source element type should be greater than 1. If it is
 /// casting from i1 types, a std::nullopt is returned. It is dangerous to mix
 /// boalean concept and i1 subtypes concept at graph optimizatoin level. We
@@ -36,7 +37,7 @@ namespace mlir::iree_compiler::GlobalOptimization {
 ///
 /// **Note: If the CastOpInterface has been generalized, the return Operation
 ///         is the body CastOpInterface op, not the linalg::GenericOp.
-std::optional<CastOpInterface> getDefiningNonI1CastOp(Value input);
+std::optional<CastOpInterface> getDefiningNonI1ExtendingCastOp(Value input);
 
 /// Returns the source element type of the defining CastOpInterface of `input`,
 /// if there is one. Otherwise return std::nullopt.


### PR DESCRIPTION
This is a step towards https://github.com/openxla/iree/issues/15826