### PR TITLE
Add riscv_64 support for standalone plugin

### DIFF
--- a/samples/custom_dispatch/cpu/plugin/CMakeLists.txt
+++ b/samples/custom_dispatch/cpu/plugin/CMakeLists.txt
@@ -69,9 +69,9 @@ endif(IREE_HAL_EXECUTABLE_PLUGIN_SYSTEM_LIBRARY)
 # compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/EmbeddedLinkerTool.cpp
 if(IREE_HAL_EXECUTABLE_PLUGIN_EMBEDDED_ELF)
 
-# This only builds for x86-64/arm_64 because that's all we have coded in here.
-if(NOT IREE_ARCH STREQUAL "arm_64" AND NOT IREE_ARCH STREQUAL "x86_64")
-  message(STATUS "IREE custom_dispatch/cpu/plugin standalone example ignored -- only builds for x86_64/arm_64 (today)")
+# This only builds for x86-64/arm_64/riscv_64 because that's all we have coded in here.
+if(NOT IREE_ARCH STREQUAL "arm_64" AND NOT IREE_ARCH STREQUAL "x86_64" AND NOT IREE_ARCH STREQUAL "riscv_64")
+  message(STATUS "IREE custom_dispatch/cpu/plugin standalone example ignored -- only builds for x86_64/arm_64/riscv_64 (today)")
   return()
 endif()
 
@@ -87,7 +87,7 @@ endif()
 # architecture (as in IREE_ARCH), and appends the generated library filename to
 # the output-variable _DST_VAR_ARCH_LIBRARIES. Skips if the compiler does not
 # support the specified architecture.
-function(standalone_plugin_library _DST_VAR_ARCH_LIBRARIES _ARCH)
+function(standalone_plugin_library _DST_VAR_ARCH_LIBRARIES _ARCH _CFLAGS)
   iree_compiler_targeting_iree_arch(_ENABLED "${_ARCH}")
   if(NOT _ENABLED)
     return()
@@ -113,6 +113,7 @@ function(standalone_plugin_library _DST_VAR_ARCH_LIBRARIES _ARCH)
       -fdata-sections
       -ffunction-sections
       -funique-section-names
+      ${_CFLAGS}
       -I ${IREE_SOURCE_DIR}/runtime/src/
       -c ${CMAKE_CURRENT_SOURCE_DIR}/standalone_plugin.c
       -o ${CMAKE_CURRENT_BINARY_DIR}/standalone_plugin_${_ARCH}.o
@@ -158,8 +159,11 @@ endfunction()
 # Build the standalone_plugin_*.so files for each architecture we target.
 set(_STANDALONE_PLUGIN_ARCH_LIBRARIES "")
 
-standalone_plugin_library(_STANDALONE_PLUGIN_ARCH_LIBRARIES arm_64)
-standalone_plugin_library(_STANDALONE_PLUGIN_ARCH_LIBRARIES x86_64)
+
+set(RISCV_STANDALONE_PLUGIN_ARCH_C_FLAGS -march=rv64i2p1ma2p1f2p2d2p2c2p0)
+standalone_plugin_library(_STANDALONE_PLUGIN_ARCH_LIBRARIES arm_64 "")
+standalone_plugin_library(_STANDALONE_PLUGIN_ARCH_LIBRARIES x86_64 "")
+standalone_plugin_library(_STANDALONE_PLUGIN_ARCH_LIBRARIES riscv_64 "${RISCV_STANDALONE_PLUGIN_ARCH_C_FLAGS}")
 
 add_custom_command(
   OUTPUT


### PR DESCRIPTION
We use the default march rv64i2p1ma2p1f2p2d2p2c2p0(same in build_tools/cmake/riscv.toolchain.cmake) for riscv_64 target. If the m extension is not set, compiler will try to find '__mulsf3' symbol and failed.