### PR TITLE
[Flow] Relax dynamic shape restrictions on slice -> Flow patterns

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/BUILD.bazel
@@ -25,6 +25,7 @@ iree_compiler_cc_library(
     deps = [
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_cc_library(
     "Utils.cpp"
   DEPS
     LLVMSupport
+    MLIRAnalysis
     MLIRArithDialect
     MLIRArithUtils
     MLIRFuncDialect

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Utils/Utils.h"
@@ -38,10 +39,37 @@ getShapeFromSizes(ArrayRef<OpFoldResult> valueOrAttrList) {
       });
 }
 
-bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
-                                         ArrayRef<OpFoldResult> sizes,
-                                         ArrayRef<OpFoldResult> strides,
-                                         ArrayRef<int64_t> baseShape) {
+// This is not a complete heuristic for whether a particular index value
+// depends on something expected to require a host-device sync to use, but
+// works for most inputs we can expect today.
+static bool producedByValueExtract(OpFoldResult index) {
+  Value indexVal = dyn_cast<Value>(index);
+  if (!indexVal) {
+    return false;
+  }
+
+  BackwardSliceOptions options;
+  bool hasExtract = false;
+  options.inclusive = false;
+  options.omitBlockArguments = true;
+  options.filter = [&](Operation *op) {
+    if (isa<tensor::ExtractOp, TensorLoadOp>(op)) {
+      hasExtract = true;
+      return false;
+    }
+    return true;
+  };
+
+  // Get the backward slice of the index.
+  SetVector<Operation *> backwardSlice;
+  getBackwardSlice(indexVal, &backwardSlice, options);
+  return hasExtract;
+}
+
+static bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
+                                                ArrayRef<OpFoldResult> sizes,
+                                                ArrayRef<OpFoldResult> strides,
+                                                ArrayRef<int64_t> baseShape) {
   if (offsets.size() != baseShape.size()) {
     // Unhanded rank-reducing case.
     return false;
@@ -57,26 +85,33 @@ bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
 
   bool fullSlices = true;
   for (size_t dim = offsets.size(); dim > 0; dim--) {
-    int64_t staticOffset = getVal(offsets[dim - 1], ShapedType::kDynamic);
-    int64_t staticSize = getVal(sizes[dim - 1], ShapedType::kDynamic);
-    int64_t staticStride = getVal(strides[dim - 1], ShapedType::kDynamic);
+    OpFoldResult offset = offsets[dim - 1];
+    OpFoldResult size = sizes[dim - 1];
+    OpFoldResult stride = strides[dim - 1];
 
-    if (staticStride != 1)
-      return false;
     // The offsets and sizes dont have to be static for all dimensions. When
-    // `fullSlices` is true, the offset and sizes can be dynamic. But many
+    // `fullSlices` is true, the offset and sizes can be dynamic. But in some
     // cases, the dynamic offset/size value is obtained by computing from
     // another tensor which lives on the device. To avoid host-round tripping
-    // enforce that offset/size is also static.
-    if (ShapedType::isDynamic(staticSize))
+    // try to infer when a value is extracted from a tensor.
+    if (producedByValueExtract(offset) || producedByValueExtract(stride) ||
+        producedByValueExtract(size)) {
       return false;
-    if (ShapedType::isDynamic(staticOffset))
+    }
+
+    int64_t staticOffset = getVal(offset, ShapedType::kDynamic);
+    int64_t staticSize = getVal(size, ShapedType::kDynamic);
+    int64_t staticStride = getVal(stride, ShapedType::kDynamic);
+
+    if (staticStride != 1)
       return false;
 
     if (fullSlices == false) {
       if (staticSize != 1)
         return false;
     } else {
+      // TODO: Use ValueBoundsAnalysis to check whether two dynamic values
+      // are equal.
       if (!(staticOffset == 0 && !ShapedType::isDynamic(staticSize) &&
             !ShapedType::isDynamic(baseShape[dim - 1]) &&
             staticSize == baseShape[dim - 1])) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
@@ -66,10 +66,10 @@ static bool producedByValueExtract(OpFoldResult index) {
   return hasExtract;
 }
 
-static bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
-                                                ArrayRef<OpFoldResult> sizes,
-                                                ArrayRef<OpFoldResult> strides,
-                                                ArrayRef<int64_t> baseShape) {
+bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
+                                         ArrayRef<OpFoldResult> sizes,
+                                         ArrayRef<OpFoldResult> strides,
+                                         ArrayRef<int64_t> baseShape) {
   if (offsets.size() != baseShape.size()) {
     // Unhanded rank-reducing case.
     return false;

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/extract_slice.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/extract_slice.mlir
@@ -60,8 +60,16 @@ func.func @extract_slice5(%arg0 : tensor<5x24x48xf32>, %arg1 : index) -> tensor<
       : tensor<5x24x48xf32> to tensor<2x48xf32>
   return %0 : tensor<2x48xf32>
 }
-// CHECK-LABEL: func.func @extract_slice5
-//       CHECK:   tensor.extract_slice
+// CHECK-LABEL: func.func @extract_slice5(
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<5x24x48xf32>
+//  CHECK-SAME:   %[[ARG1:.+]]: index)
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C48:.+]] = arith.constant 48 : index
+//       CHECK:   %[[SLICE:.+]] = flow.tensor.slice %[[ARG0]][%[[C2]], %[[ARG1]], %[[C0]] for %[[C1]], %[[C2]], %[[C48]]]
+//       CHECK:   %[[RESULT:.+]] = flow.tensor.reshape %[[SLICE]]
+//       CHECK:   return %[[RESULT]]
 
 // -----
 
@@ -70,8 +78,17 @@ func.func @extract_slice6(%arg0 : tensor<5x24x48xf32>, %arg1 : index) -> tensor<
       : tensor<5x24x48xf32> to tensor<?x48xf32>
   return %0 : tensor<?x48xf32>
 }
-// CHECK-LABEL: func.func @extract_slice6
-//       CHECK:   tensor.extract_slice
+// CHECK-LABEL: func.func @extract_slice6(
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<5x24x48xf32>
+//  CHECK-SAME:   %[[ARG1:.+]]: index)
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:   %[[C3:.+]] = arith.constant 3 : index
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C48:.+]] = arith.constant 48 : index
+//       CHECK:   %[[SLICE:.+]] = flow.tensor.slice %[[ARG0]][%[[C2]], %[[C3]], %[[C0]] for %[[C1]], %[[ARG1]], %[[C48]]]
+//       CHECK:   %[[RESULT:.+]] = flow.tensor.reshape %[[SLICE]]
+//       CHECK:   return %[[RESULT]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/insert_slice.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/insert_slice.mlir
@@ -55,6 +55,7 @@ func.func @rank_reducing_insert_slice_trailing_unit_dims
 
 // -----
 
+// CHECK-LABEL: func.func @insert_slice_within_dispatch_workgroups_not_converted
 func.func @insert_slice_within_dispatch_workgroups_not_converted() -> tensor<f32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<f32>) = () {
@@ -67,4 +68,44 @@ func.func @insert_slice_within_dispatch_workgroups_not_converted() -> tensor<f32
     flow.return
   }
   return %0 : tensor<f32>
+}
+
+// -----
+
+func.func @insert_slice_convert_dynamic_offset_and_size
+    (%target: tensor<?x24x48xf32>, %slice: tensor<1x?x48xf32>, %offset: index, %size: index) ->
+    tensor<?x24x48xf32> {
+  %0 = tensor.insert_slice %slice into %target[%offset, 2, 0] [1, %size, 48] [1, 1, 1] :
+      tensor<1x?x48xf32> into tensor<?x24x48xf32>
+  return %0 : tensor<?x24x48xf32>
+}
+// CHECK-LABEL: func.func @insert_slice_convert_dynamic_offset_and_size
+//  CHECK-SAME:   %[[TARGET:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[SLICE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[OFFSET:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[SIZE:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2
+//   CHECK-DAG:   %[[DIM0:.+]] = tensor.dim %[[TARGET]], %[[C0]]
+//       CHECK:   %[[UPDATE:.+]] = flow.tensor.update %[[SLICE]], %[[TARGET]][%[[OFFSET]], %[[C2]], %[[C0]]]
+//  CHECK-SAME:     : tensor<1x?x48xf32>{%[[SIZE]]} -> %[[TARGET]] as tensor<?x24x48xf32>{%[[DIM0]]}
+
+// -----
+
+// CHECK-LABEL: func.func @insert_slice_dynamic_tensor_result_not_converted
+func.func @insert_slice_dynamic_tensor_result_not_converted
+    (%arg0: tensor<?x24x48xf32>, %arg1: tensor<1x4x48xf32>, %offset: index) ->
+    tensor<?x24x48xf32> {
+  %x = arith.constant 100 : index
+  %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<i64>) = () {
+    flow.return
+  }
+  %idx_i64 = tensor.extract %0[] : tensor<i64>
+  %idx = arith.index_cast %idx_i64 : i64 to index
+  // CHECK-NOT: flow.tensor.update
+  // CHECK: %[[INSERTED_TENSOR:.+]] = tensor.insert_slice %{{.*}} into %{{.*}}[%{{.*}}, 2, 0] [1, 4, 48] [1, 1, 1]
+  %2 = tensor.insert_slice %arg1 into %arg0[%idx, 2, 0] [1, 4, 48] [1, 1, 1] :
+      tensor<1x4x48xf32> into tensor<?x24x48xf32>
+  // CHECK: return %[[INSERTED_TENSOR]] : tensor<?x24x48xf32>
+  return %2 : tensor<?x24x48xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1021,13 +1021,10 @@ func.func @dynamic_slice(%arg0 : i32, %arg1 : i32, %arg2 : tensor<?xi32>,
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
+//       CHECK:   %[[RESHAPE:.+]] = flow.tensor.reshape %[[ARG2]] : tensor<?xi32>{%[[D0]]} -> tensor<1x?xi32>{%[[D0]]}
 //   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG3]], %[[C0]]
 //   CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG3]], %[[C1]]
-//       CHECK:   flow.dispatch.workgroups[%[[D0]], %[[D1]], %[[D2]]]
-//  CHECK-SAME:       tensor<?xi32>{%[[D0]]}
-//  CHECK-SAME:       tensor<?x?xi32>{%[[D1]], %[[D2]]}
-//  CHECK-NEXT:     !flow.dispatch.tensor<readonly:tensor<?xi32>>
-//  CHECK-SAME:     !flow.dispatch.tensor<readwrite:tensor<?x?xi32>>
+//       CHECK:   flow.tensor.update %[[RESHAPE]], %[[ARG3]]{{.*}} : tensor<1x?xi32>{%[[D0]]} -> %[[ARG3]] as tensor<?x?xi32>{%[[D1]], %[[D2]]}
 
 // -----
 


### PR DESCRIPTION
Dynamic offsets/strides/sizes can come from values expected to later live either on the host or the device. If it is a dynamic value known at command buffer setup time (e.g. a loop iterator) we should not block on converting dynamic slices to flow ops.