### PR TITLE
[python] Enable enum generation for flow, hal, stream, util, and vm.

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -59,6 +59,7 @@ declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT IREEPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
   TD_FILE dialects/FlowBinding.td
+  GEN_ENUM_BINDINGS
   SOURCES dialects/flow.py
   DIALECT_NAME flow
 )
@@ -67,6 +68,7 @@ declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT IREEPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
   TD_FILE dialects/HALBinding.td
+  GEN_ENUM_BINDINGS
   SOURCES dialects/hal.py
   DIALECT_NAME hal
 )
@@ -75,6 +77,7 @@ declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT IREEPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
   TD_FILE dialects/StreamBinding.td
+  GEN_ENUM_BINDINGS
   SOURCES dialects/stream.py
   DIALECT_NAME stream
 )
@@ -83,6 +86,7 @@ declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT IREEPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
   TD_FILE dialects/UtilBinding.td
+  GEN_ENUM_BINDINGS
   SOURCES dialects/util.py
   DIALECT_NAME util
 )
@@ -91,6 +95,7 @@ declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT IREEPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
   TD_FILE dialects/VMBinding.td
+  GEN_ENUM_BINDINGS
   SOURCES dialects/vm.py
   DIALECT_NAME vm
 )

--- a/compiler/bindings/python/iree/compiler/dialects/flow.py
+++ b/compiler/bindings/python/iree/compiler/dialects/flow.py
@@ -5,3 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._flow_ops_gen import *
+from ._flow_enum_gen import *

--- a/compiler/bindings/python/iree/compiler/dialects/hal.py
+++ b/compiler/bindings/python/iree/compiler/dialects/hal.py
@@ -5,3 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._hal_ops_gen import *
+from ._hal_enum_gen import *

--- a/compiler/bindings/python/iree/compiler/dialects/stream.py
+++ b/compiler/bindings/python/iree/compiler/dialects/stream.py
@@ -5,3 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._stream_ops_gen import *
+from ._stream_enum_gen import *

--- a/compiler/bindings/python/iree/compiler/dialects/vm.py
+++ b/compiler/bindings/python/iree/compiler/dialects/vm.py
@@ -5,3 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._vm_ops_gen import *
+from ._vm_enum_gen import *


### PR DESCRIPTION
I'm not completely clear why MLIR separates these into so many small little pieces, but c'est la vie.