### PR TITLE
[python] Add python bindings for creating IRPA files.

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -97,6 +97,7 @@ target_link_libraries(iree_runtime_bindings_python_PyExtRt
   iree::io::scope_map
   iree::modules::io::parameters
   iree::modules::hal
+  iree::schemas::parameter_archive
   iree::tooling::device_util
   iree::tooling::modules
   iree::vm
@@ -132,6 +133,7 @@ iree_py_library(
     "iree/runtime/benchmark.py"
     "iree/runtime/flags.py"
     "iree/runtime/function.py"
+    "iree/runtime/io.py"
     "iree/runtime/system_api.py"
     "iree/runtime/system_setup.py"
     "iree/runtime/tracing.py"

--- a/runtime/bindings/python/io.cc
+++ b/runtime/bindings/python/io.cc
@@ -15,10 +15,12 @@
 #include "iree/base/internal/file_io.h"
 #include "iree/base/internal/path.h"
 #include "iree/io/formats/gguf/gguf_parser.h"
+#include "iree/io/formats/irpa/irpa_builder.h"
 #include "iree/io/formats/irpa/irpa_parser.h"
 #include "iree/io/formats/safetensors/safetensors_parser.h"
 #include "iree/io/parameter_index_provider.h"
 #include "iree/modules/io/parameters/module.h"
+#include "iree/schemas/parameter_archive.h"
 
 namespace iree::python {
 
@@ -267,7 +269,74 @@ void SetupIoBindings(py::module_ &m) {
             return ParameterProvider::StealFromRawPtr(created);
           },
           py::arg("scope") = std::string(),
-          py::arg("max_concurrent_operations") = py::none());
+          py::arg("max_concurrent_operations") = py::none())
+      .def(
+          "create_archive_file",
+          [](ParameterIndex &self, std::string file_path,
+             iree_io_physical_offset_t file_offset,
+             ParameterIndex *explicit_target_index) {
+            // If no target index was given, RAII manage a local target index.
+            iree_io_parameter_index_t *target_index = nullptr;
+            ParameterIndex default_target_index;
+            if (explicit_target_index) {
+              target_index = explicit_target_index->raw_ptr();
+            } else {
+              iree_io_parameter_index_t *created;
+              CheckApiStatus(iree_io_parameter_index_create(
+                                 iree_allocator_system(), &created),
+                             "Could not create IO parameter index");
+              default_target_index = ParameterIndex::StealFromRawPtr(created);
+              target_index = default_target_index.raw_ptr();
+            }
+
+            // Open the file via callback.
+            struct OpenParams {
+              const char *path;
+            };
+            OpenParams file_open_user_data{file_path.c_str()};
+            auto file_open_callback =
+                +[](void *user_data, iree_io_physical_offset_t archive_offset,
+                    iree_io_physical_size_t archive_length,
+                    iree_io_file_handle_t **out_file_handle) -> iree_status_t {
+              OpenParams *params = static_cast<OpenParams *>(user_data);
+              iree_file_contents_t *file_contents = NULL;
+              IREE_RETURN_IF_ERROR(iree_file_create_mapped(
+                  params->path, archive_offset + archive_length, archive_offset,
+                  (iree_host_size_t)archive_length, iree_allocator_system(),
+                  &file_contents));
+              iree_io_file_handle_release_callback_t release_callback;
+              memset(&release_callback, 0, sizeof(release_callback));
+              release_callback.fn =
+                  +[](void *user_data,
+                      iree_io_file_handle_primitive_t handle_primitive) {
+                    iree_file_contents_free(
+                        static_cast<iree_file_contents_t *>(user_data));
+                  };
+              release_callback.user_data = file_contents;
+              iree_status_t status = iree_io_file_handle_wrap_host_allocation(
+                  IREE_IO_FILE_ACCESS_WRITE, file_contents->buffer,
+                  release_callback, iree_allocator_system(), out_file_handle);
+              if (!iree_status_is_ok(status)) {
+                iree_file_contents_free(file_contents);
+              }
+              return status;
+            };
+
+            // Write the archive.
+            CheckApiStatus(iree_io_build_parameter_archive(
+                               self.raw_ptr(), target_index,
+                               iree_io_parameter_archive_file_open_callback_t{
+                                   file_open_callback,
+                                   &file_open_user_data,
+                               },
+                               file_offset, iree_allocator_system()),
+                           "Error building parameter archive");
+
+            // Return the target index.
+            return ParameterIndex::BorrowFromRawPtr(target_index);
+          },
+          py::arg("file_path"), py::arg("file_offset") = 0,
+          py::arg("target_index") = nullptr);
 }
 
 }  // namespace iree::python

--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -63,6 +63,7 @@ from .system_setup import (
     query_available_drivers,
 )
 from .function import *
+from .io import *
 from .tracing import *
 
 from . import flags

--- a/runtime/bindings/python/iree/runtime/_binding.pyi
+++ b/runtime/bindings/python/iree/runtime/_binding.pyi
@@ -324,6 +324,12 @@ class ParameterIndex:
         writable: bool = False,
         mmap: bool = True
     ) -> None: ...
+    def create_archive_file(
+        self,
+        file_path: str,
+        file_offset: int = 0,
+        target_index: Optional[ParameterIndex] = None,
+    ) -> ParameterIndex: ...
     def create_provider(
         self, *, scope: str = "", max_concurrent_operations: Optional[int] = None
     ) -> ParameterProvider: ...

--- a/runtime/bindings/python/iree/runtime/io.py
+++ b/runtime/bindings/python/iree/runtime/io.py
@@ -22,7 +22,7 @@ __all__ = [
 
 class SplatValue:
     def __init__(
-        self, pattern: Union[array.array, numpy.array], count: Union[Sequence[int], int]
+        self, pattern: Union[array.array, numpy.ndarray], count: Union[Sequence[int], int]
     ):
         if hasattr(pattern, "shape"):
             shape = pattern.shape

--- a/runtime/bindings/python/iree/runtime/io.py
+++ b/runtime/bindings/python/iree/runtime/io.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Any, Union
+from typing import Any, Sequence, Union
 
 import array
 from functools import reduce
@@ -21,7 +21,9 @@ __all__ = [
 
 
 class SplatValue:
-    def __init__(self, pattern: Union[array.array, numpy.array], count: int):
+    def __init__(
+        self, pattern: Union[array.array, numpy.array], count: Union[Sequence[int], int]
+    ):
         if hasattr(pattern, "shape"):
             shape = pattern.shape
             if not shape:
@@ -34,7 +36,13 @@ class SplatValue:
         if total_elements != 1:
             raise ValueError(f"SplatValue requires an array of a single element")
         self.pattern = pattern
-        self.total_length = count * item_size
+        if isinstance(count, int):
+            logical_length = count
+        elif len(count) == 1:
+            logical_length = count[0]
+        else:
+            logical_length = reduce(lambda x, y: x * y, count)
+        self.total_length = logical_length * item_size
 
     def __repr__(self):
         return f"SplatValue({self.pattern} of {self.total_length})"

--- a/runtime/bindings/python/iree/runtime/io.py
+++ b/runtime/bindings/python/iree/runtime/io.py
@@ -22,7 +22,9 @@ __all__ = [
 
 class SplatValue:
     def __init__(
-        self, pattern: Union[array.array, numpy.ndarray], count: Union[Sequence[int], int]
+        self,
+        pattern: Union[array.array, numpy.ndarray],
+        count: Union[Sequence[int], int],
     ):
         if hasattr(pattern, "shape"):
             shape = pattern.shape

--- a/runtime/bindings/python/iree/runtime/io.py
+++ b/runtime/bindings/python/iree/runtime/io.py
@@ -1,0 +1,56 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Any, Union
+
+import array
+from functools import reduce
+import numpy
+from os import PathLike
+from pathlib import Path
+
+from ._binding import ParameterIndex
+
+__all__ = [
+    "SplatValue",
+    "save_archive_file",
+]
+
+
+class SplatValue:
+    def __init__(self, pattern: Union[array.array, numpy.array], count: int):
+        if hasattr(pattern, "shape"):
+            shape = pattern.shape
+            if not shape:
+                total_elements = 1
+            else:
+                total_elements = reduce(lambda x, y: x * y, pattern.shape)
+        else:
+            total_elements = len(pattern)
+        item_size = pattern.itemsize
+        if total_elements != 1:
+            raise ValueError(f"SplatValue requires an array of a single element")
+        self.pattern = pattern
+        self.total_length = count * item_size
+
+    def __repr__(self):
+        return f"SplatValue({self.pattern} of {self.total_length})"
+
+
+def save_archive_file(entries: dict[str, Union[Any, SplatValue]], file_path: PathLike):
+    """Creates an IRPA (IREE Parameter Archive) from contents.
+
+    Similar to the safetensors.numpy.save_file function, this takes
+    a dictionary of key-value pairs where the value is a buffer. It
+    writes a file with the contents.
+    """
+    index = ParameterIndex()
+    for key, value in entries.items():
+        if isinstance(value, SplatValue):
+            index.add_splat(key, value.pattern, value.total_length)
+        else:
+            index.add_buffer(key, value)
+    index.create_archive_file(str(file_path))

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -8,6 +8,7 @@ import array
 import logging
 import numpy as np
 from pathlib import Path
+import tempfile
 import unittest
 
 import iree.compiler
@@ -67,6 +68,35 @@ def _float_constant(val: float) -> array.array:
     return array.array("f", [val])
 
 
+class ParameterArchiveTest(unittest.TestCase):
+    def testCreateArchiveFile(self):
+        splat_index = rt.ParameterIndex()
+        splat_index.add_splat("weight", _float_constant(2.0), 30 * 20 * 4)
+        splat_index.add_splat("bias", _float_constant(1.0), 30 * 4)
+
+        with tempfile.TemporaryDirectory() as td:
+            file_path = Path(td) / "archive.irpa"
+            target_index = splat_index.create_archive_file(str(file_path))
+            print(target_index)
+            self.assertTrue(file_path.exists())
+            self.assertGreater(file_path.stat().st_size, 0)
+
+    def testSaveArchiveFile(self):
+        index = rt.ParameterIndex()
+        with tempfile.TemporaryDirectory() as td:
+            file_path = Path(td) / "archive.irpa"
+            rt.save_archive_file(
+                {
+                    "weight": rt.SplatValue(np.float32(2.0), 30 * 20),
+                    "bias": rt.SplatValue(array.array("f", [1.0]), 30),
+                    "array": np.asarray([1, 2, 3]),
+                },
+                file_path,
+            )
+            self.assertTrue(file_path.exists())
+            self.assertGreater(file_path.stat().st_size, 0)
+
+
 class ParameterTest(unittest.TestCase):
     def setUp(self):
         self.instance = rt.VmInstance()
@@ -109,6 +139,34 @@ class ParameterTest(unittest.TestCase):
         # TODO: Fix splat in the parameter code so it is not all zeros.
         # expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
         # np.testing.assert_array_almost_equal(result, expected_result)
+
+    def testSplatsFromBuiltIrpaFile(self):
+        with tempfile.TemporaryDirectory() as td:
+            file_path = Path(td) / "archive.irpa"
+            rt.save_archive_file(
+                {
+                    "weight": rt.SplatValue(np.float32(2.0), 30 * 20),
+                    "bias": rt.SplatValue(np.float32(1.0), 30),
+                },
+                file_path,
+            )
+
+            index = rt.ParameterIndex()
+            index.load(str(file_path))
+        modules = rt.load_vm_modules(
+            rt.create_io_parameters_module(
+                self.instance, index.create_provider(scope="params")
+            ),
+            rt.create_hal_module(self.instance, self.device),
+            create_mm_test_module(self.instance),
+            config=self.config,
+        )
+        main = modules[-1]
+        input = np.zeros([128, 20], dtype=np.float32) + 2.0
+        result = main.run(input)
+        print(result.to_host())
+        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
+        np.testing.assert_array_almost_equal(result, expected_result)
 
     def testBuffers(self):
         index = rt.ParameterIndex()

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -87,7 +87,7 @@ class ParameterArchiveTest(unittest.TestCase):
             file_path = Path(td) / "archive.irpa"
             rt.save_archive_file(
                 {
-                    "weight": rt.SplatValue(np.float32(2.0), 30 * 20),
+                    "weight": rt.SplatValue(np.float32(2.0), [30, 20]),
                     "bias": rt.SplatValue(array.array("f", [1.0]), 30),
                     "array": np.asarray([1, 2, 3]),
                 },


### PR DESCRIPTION
New APIs:

* `ParameterIndex.create_archive_file`: Low-level, dumps an in-flight index to an archive file.
* `save_archive_file`: Dict-based, one-shot construction like safetensors.numpy.save_file. Also supports special `SplatValue`.
* `SplatValue`: Special type to carry a splatted value, instantiated from a typed array (array.array or numpy.array) and total element count.