### PR TITLE
[SPIRV] Use scf::tileUsingSCFForOp to tile reduction dims.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -267,9 +267,10 @@ hal.executable private @conv_2d {
 //         CHECK:             scf.for %[[IV_IC:.+]] = %[[C0]] to %{{.+}} step %[[C4]]
 //         CHECK:               %[[INPUT:.+]] = memref.subview %[[INPUT_THREAD]]
 //         CHECK:               %[[FILTER:.+]] = memref.subview %[[FILTER_THREAD]]
+//         CHECK:               %[[OUTPUT_SUBVIEW:.+]] = memref.subview %[[OUTPUT]]
 //         CHECK:               linalg.conv_2d_nhwc_hwcf
 //    CHECK-SAME:                 ins(%[[INPUT]], %[[FILTER]]
-//    CHECK-SAME:                 outs(%[[OUTPUT]]
+//    CHECK-SAME:                 outs(%[[OUTPUT_SUBVIEW]]
 
 // -----
 


### PR DESCRIPTION
It also update a lit test because of different implementation. They are both correct.

The original result IR was

```
%subview_16 = memref.subview %subview[0, %34, %35, 0] [%22, %dim_10, %dim_11, %dim_6]
%subview_17 = memref.subview %9[0, 0, 0, %arg5] [%dim_13, %dim_14, %dim_15, 1] [1, 1, 1, 1]
%subview_18 = memref.subview %subview_9[0, %arg3, %arg4, %arg5] [%25, 1, 1, 1] [1, 1, 1, 1]
scf.for
  scf.for
    scf.for
      %subview_19 = memref.subview %subview_16[0, %arg6, %arg7, %arg8] [%22, 1, 1, %36]
      %subview_20 = memref.subview %subview_17[%arg6, %arg7, %arg8, 0] [1, 1, %37, 1]
      linalg.conv_2d_nhwc_hwcf ...
        ins(%subview_19, %subview_20
       outs(%subview_18
```

Here is the spec of linalg.conv_2d_nhwc_hwcf:

```
domain(D.n, D.oh, D.ow, D.f, D.kh, D.kw, D.c)
O[D.n, D.oh, D.ow, D.f] += TypeFn.cast_signed(
    U, I[D.n, D.oh * S.SH + D.kh * S.DH, D.ow * S.SW + D.kw * S.DW, D.c]
) * TypeFn.cast_signed(U, K[D.kh, D.kw, D.c, D.f])
```

`%subview_18` can be used because the leading four dimensions are not
tiled.

The new result IR is:

```
%subview_16 = memref.subview %subview[0, %34, %35, 0] [%22, %dim_10, %dim_11, %dim_6]
%subview_17 = memref.subview %9[0, 0, 0, %arg5] [%dim_13, %dim_14, %dim_15, 1]
%subview_18 = memref.subview %subview_9[0, %arg3, %arg4, %arg5] [%25, 1, 1, 1]
scf.for
  scf.for
    scf.for
      %subview_19 = memref.subview %subview_16[0, %arg6, %arg7, %arg8] [%22, 1, 1, %36]
      %subview_20 = memref.subview %subview_17[%arg6, %arg7, %arg8, 0] [1, 1, %36, 1]
      %subview_21 = memref.subview %subview_18[0, 0, 0, 0] [%22, 1, 1, 1]
      linalg.conv_2d_nhwc_hwcf ...
        ins(%subview_19, %subview_20
       outs(%subview_21
```

This is still correct because the `n` dim in LHS is `%22`; the `n` dim
in outs is also `%22`. The sizes match.