### PR TITLE
[SPIRV] Implements SPIRVTileAndDistribute as walk-based manner.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -259,22 +259,7 @@ static LogicalResult replaceAllStoresWithTiledVersion(
   return success();
 }
 
-namespace {
-/// Result of the tiled operation.
-struct IREETilingResult {
-  SmallVector<Operation *> tiledOps;
-  SmallVector<Value> tiledValues;
-  SmallVector<scf::ForOp> loops;
-  SmallVector<Value> workgroupCount;
-  // TODO(ravishankarm): Cleanup the following returns. We should not need
-  // these.
-  llvm::SmallBitVector tiledLoops;
-  SmallVector<OpFoldResult> tileOffsets;
-  SmallVector<OpFoldResult> tileSizes;
-};
-} // namespace
-
-static FailureOr<IREETilingResult>
+FailureOr<IREETilingResult>
 tileDispatchUsingSCFFopOp(RewriterBase &rewriter, TilingInterface op,
                           linalg::LinalgTilingOptions options) {
   OpBuilder::InsertionGuard guard(rewriter);

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -42,8 +42,24 @@ FailureOr<IREETileAndFuseResult>
 tileAndFuseDispatchUsingSCFForOp(RewriterBase &rewriter, TilingInterface op,
                                  linalg::LinalgTilingOptions tilingOptions);
 
-/// Populate patterns related to clean up the IR after tile and distribute to
-/// workgroups.
+/// Result of the tiled operation.
+struct IREETilingResult {
+  SmallVector<Operation *> tiledOps;
+  SmallVector<Value> tiledValues;
+  SmallVector<scf::ForOp> loops;
+  SmallVector<Value> workgroupCount;
+  // TODO(ravishankarm): Cleanup the following returns. We should not need
+  // these.
+  llvm::SmallBitVector tiledLoops;
+  SmallVector<OpFoldResult> tileOffsets;
+  SmallVector<OpFoldResult> tileSizes;
+};
+FailureOr<IREETilingResult>
+tileDispatchUsingSCFFopOp(RewriterBase &rewriter, TilingInterface op,
+                          linalg::LinalgTilingOptions options);
+
+/// Populate patterns related to clean up the IR after tile and distribute
+/// to workgroups.
 void populateTileAndDistributeToWorkgroupsCleanupPatterns(
     RewritePatternSet &patterns, linalg::LinalgTilingOptions options);
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -175,7 +175,7 @@ void SPIRVTileAndDistributePass::runOnOperation() {
 
   { // Tile and distribute to invocations.
     if (failed(tileToInvocation(funcOp, *threadTileComputeFn))) {
-      funcOp.emitOpError() << "failure in tiling to invocations";
+      funcOp.emitOpError() << "failed to tile to invocations";
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -56,8 +56,8 @@ namespace mlir::iree_compiler {
 
 /// Tiles LinalgOp to target invocations.
 static LogicalResult
-tileToInvocationPatterns(func::FuncOp funcOp,
-                         const linalg::TileSizeComputationFunction &computeFn) {
+tileToInvocation(func::FuncOp funcOp,
+                 const linalg::TileSizeComputationFunction &computeFn) {
   auto getThreadProcInfoFn = [](OpBuilder &builder, Location loc,
                                 ArrayRef<Range> parallelLoopRanges) {
     return getGPUProcessorIdsAndCounts<gpu::ThreadIdOp, gpu::BlockDimOp>(
@@ -174,7 +174,7 @@ void SPIRVTileAndDistributePass::runOnOperation() {
     return signalPassFailure();
 
   { // Tile and distribute to invocations.
-    if (failed(tileToInvocationPatterns(funcOp, *threadTileComputeFn))) {
+    if (failed(tileToInvocation(funcOp, *threadTileComputeFn))) {
       funcOp.emitOpError() << "failure in tiling to invocations";
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -81,26 +81,14 @@ tileToInvocationPatterns(func::FuncOp funcOp,
   funcOp.walk([&](TilingInterface op) { candidates.push_back(op); });
 
   for (auto op : candidates) {
-#if 0
-    FailureOr<linalg::TiledLinalgOp> res =
-        linalg::tileLinalgOp(rewriter, op, tilingOptions);
-    if (failed(res)) {
-      return failure();
-    }
-    filter.replaceLinalgTransformationFilter(rewriter, res->op);
-    if (res->tensorResults.empty()) {
-      rewriter.eraseOp(op);
-    } else {
-      rewriter.replaceOp(op, res->tensorResults);
-    }
-#endif
     FailureOr<IREETilingResult> res =
         tileDispatchUsingSCFFopOp(rewriter, op, tilingOptions);
     if (failed(res)) {
       return failure();
     }
-    for (auto tiledOp : res->tiledOps)
+    for (auto tiledOp : res->tiledOps) {
       filter.replaceLinalgTransformationFilter(rewriter, tiledOp);
+    }
   }
 
   return success();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -267,10 +267,9 @@ hal.executable private @conv_2d {
 //         CHECK:             scf.for %[[IV_IC:.+]] = %[[C0]] to %{{.+}} step %[[C4]]
 //         CHECK:               %[[INPUT:.+]] = memref.subview %[[INPUT_THREAD]]
 //         CHECK:               %[[FILTER:.+]] = memref.subview %[[FILTER_THREAD]]
-//         CHECK:               %[[OUTPUT_SUBVIEW:.+]] = memref.subview %[[OUTPUT]]
 //         CHECK:               linalg.conv_2d_nhwc_hwcf
 //    CHECK-SAME:                 ins(%[[INPUT]], %[[FILTER]]
-//    CHECK-SAME:                 outs(%[[OUTPUT_SUBVIEW]]
+//    CHECK-SAME:                 outs(%[[OUTPUT]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -65,12 +65,9 @@ hal.executable private @static_scatter_update_slice  {
 //       CHECK:     scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
 //       CHECK:       scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
 //       CHECK:         %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][%[[IV_Y]], %[[IV_X]]] [1, 1] [1, 1]
-//       CHECK:         %[[T_UPDATE_CAST:.+]] = memref.cast %[[T_UPDATE]]
 //       CHECK:         %[[T_INDEX:.+]] = memref.subview %[[WG_INDEX]][%[[IV_Y]], 0] [1, 1] [1, 1]
-//       CHECK:         %[[T_INDEX_CAST:.+]] = memref.cast %[[T_INDEX]]
 //       CHECK:         %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
-//       CHECK:         %[[T_TARGET_CAST:.+]] = memref.cast %[[T_TARGET]]
 //       CHECK:         iree_linalg_ext.scatter
 //  CHECK-SAME:           unique_indices(true)
-//  CHECK-SAME:           ins(%[[T_UPDATE_CAST]], %[[T_INDEX_CAST]]
-//  CHECK-SAME:           outs(%[[T_TARGET_CAST]]
+//  CHECK-SAME:           ins(%[[T_UPDATE]], %[[T_INDEX]]
+//  CHECK-SAME:           outs(%[[T_TARGET]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -4,8 +4,7 @@
 #translation = #iree_codegen.translation_info<SPIRVBaseDistribute>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>
+    #hal.descriptor_set.binding<0, storage_buffer>
   ]>
 ]>
 hal.executable private @static_3d_sort  {
@@ -16,35 +15,17 @@ hal.executable private @static_3d_sort  {
     }
     builtin.module {
       func.func @static_3d_sort() {
-        %c64 = arith.constant 64 : index
-        %c128 = arith.constant 128 : index
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<64x32x128xi32>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<64x32x128xi32>
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : memref<64x32x128xi32, #hal.descriptor_type<storage_buffer>>
+        memref.assume_alignment %0, 64 : memref<64x32x128xi32, #hal.descriptor_type<storage_buffer>>
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_count_x = hal.interface.workgroup.count[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
-        %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        scf.for %arg0 = %workgroup_id_y to %c64 step %workgroup_count_y {
-          %2 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%workgroup_id_x]
-          %3 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%workgroup_count_x]
-          scf.for %arg1 = %2 to %c128 step %3 {
-            %4 = memref.subview %0[%arg0, 0, %arg1] [1, 32, 16] [1, 1, 1] : memref<64x32x128xi32> to memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
-            %5 = memref.cast %4 : memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>> to memref<?x?x?xi32>
-            %6 = memref.subview %1[%arg0, 0, %arg1] [1, 32, 16] [1, 1, 1] : memref<64x32x128xi32> to memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
-            %7 = memref.cast %6 : memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>> to memref<?x32x?xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
-            linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]}
-              ins(%5 : memref<?x?x?xi32>)
-              outs(%6 : memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>) {
-              ^bb0(%arg4: i32, %s: i32):  // no predecessors
-                linalg.yield %arg4 : i32
-            }
-            iree_linalg_ext.sort {lowering_config = #config} dimension(1) outs(%7 : memref<?x32x?xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>)  {
-            ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
-              %8 = arith.cmpi slt, %arg2, %arg3 : i32
-              iree_linalg_ext.yield %8 : i1
-            }
-          }
+        %1 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+        %subview = memref.subview %0[%workgroup_id_y, 0, %1] [1, 32, 64] [1, 1, 1] : memref<64x32x128xi32, #hal.descriptor_type<storage_buffer>> to memref<1x32x64xi32, strided<[4096, 128, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+        iree_linalg_ext.sort {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 0, 64], [1, 0, 1]]>} dimension(1) outs(%subview : memref<1x32x64xi32, strided<[4096, 128, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>) {
+        ^bb0(%arg0: i32, %arg1: i32):
+          %2 = arith.cmpi slt, %arg0, %arg1 : i32
+          iree_linalg_ext.yield %2 : i1
         }
         return
       }
@@ -54,24 +35,14 @@ hal.executable private @static_3d_sort  {
 
 // CHECK-LABEL: func.func @static_3d_sort()
 //       CHECK: %[[ARG0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-//       CHECK: %[[ARG1:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-//       CHECK: scf.for
-//       CHECK:   scf.for
-//       CHECK:     %[[WG_INPUT:.+]] = memref.subview %[[ARG0]]
-//       CHECK:     %[[WG_OUTPUT:.+]] = memref.subview %[[ARG1]]
-//       CHECK:     %[[TID_X:.+]] = gpu.thread_id x
-//       CHECK:     %[[DIM_X:.+]] = gpu.block_dim x
-//       CHECK:     %[[TID_Y:.+]] = gpu.thread_id y
-//       CHECK:     %[[DIM_Y:.+]] = gpu.block_dim y
-//       CHECK:     scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
-//       CHECK:       scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
-//       CHECK:         %[[COPY_SOURCE:.+]] = memref.subview %[[WG_INPUT]][%[[IV_Y]], 0, %[[IV_X]]]
-//       CHECK:         %[[COPY_DEST:.+]] = memref.subview %[[WG_OUTPUT]][%[[IV_Y]], 0, %[[IV_X]]]
-//       CHECK:         linalg.generic {{.*}} ins(%[[COPY_SOURCE]] {{.*}} outs(%[[COPY_DEST]]
-//       CHECK:     scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
-//       CHECK:       scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
-//       CHECK:         %[[COPY_DEST:.+]] = memref.subview %[[WG_OUTPUT]][%[[IV_Y]], 0, %[[IV_X]]]
-//       CHECK:         %[[T_OUTPUT_CAST:.+]] = memref.cast %[[COPY_DEST]]
-//       CHECK:         iree_linalg_ext.sort
-//  CHECK-SAME:           dimension(1)
-//  CHECK-SAME:           outs(%[[T_OUTPUT_CAST]]
+//       CHECK: %[[WG_OUTPUT:.+]] = memref.subview %[[ARG0]]
+//       CHECK: %[[TID_X:.+]] = gpu.thread_id x
+//       CHECK: %[[DIM_X:.+]] = gpu.block_dim x
+//       CHECK: %[[TID_Y:.+]] = gpu.thread_id y
+//       CHECK: %[[DIM_Y:.+]] = gpu.block_dim y
+//       CHECK: scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
+//       CHECK:   scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
+//       CHECK:     %[[DEST:.+]] = memref.subview %[[WG_OUTPUT]][%[[IV_Y]], 0, %[[IV_X]]]
+//       CHECK:     iree_linalg_ext.sort
+//  CHECK-SAME:       dimension(1)
+//  CHECK-SAME:       outs(%[[DEST]]


### PR DESCRIPTION
For distribution, it is supported through `scf.forall`, but it is not available through `scf::tileUsingSCFForOp`. IREE implements the feature in `tileDispatchUsingSCFFopOp`. The revision exposes the method and use it for scf.for distribution.

It refreshes `tile_and_distribute_sort.mlir` because the memory copy is no longer the case. We are doing in-place update today. The test is generated through `iree-compile`.

It removes the check for `memref.cast` from `tile_and_distribute_scatter` because of different implementation. Both are correct. 

It is a step towards removing LinalgExt::TilingPatterns and TilingInterfaceTilingPattern.