### PR TITLE
[GlobalOpt] Add pass for transposing and decomposing tensor.concat

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -46,6 +46,7 @@ iree_compiler_cc_library(
     srcs = [
         "CleanupNumericNarrowing.cpp",
         "Convert1X1FilterConv2DToMatmul.cpp",
+        "DecomposeConcat.cpp",
         "DetachElementwiseFromNamedOps.cpp",
         "EraseUnusedLinalgOperands.cpp",
         "ExpandTensorShapes.cpp",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
   SRCS
     "CleanupNumericNarrowing.cpp"
     "Convert1X1FilterConv2DToMatmul.cpp"
+    "DecomposeConcat.cpp"
     "DetachElementwiseFromNamedOps.cpp"
     "EraseUnusedLinalgOperands.cpp"
     "ExpandTensorShapes.cpp"

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -1,0 +1,109 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/GlobalOptimization/PassDetail.h"
+#include "iree/compiler/GlobalOptimization/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::GlobalOptimization {
+
+namespace {
+
+static Value createTranspose(OpBuilder &builder, Value source,
+                             SmallVector<int64_t> perm) {
+  SmallVector<OpFoldResult> mixedSizes =
+      tensor::getMixedSizes(builder, source.getLoc(), source);
+  applyPermutationToVector(mixedSizes, perm);
+  Type elemType = cast<RankedTensorType>(source.getType()).getElementType();
+  Value empty =
+      builder.create<tensor::EmptyOp>(source.getLoc(), mixedSizes, elemType)
+          .getResult();
+  return builder
+      .create<linalg::TransposeOp>(source.getLoc(), source, empty, perm)
+      ->getResult(0);
+}
+
+// For narrowable inputs, selects
+struct TransposeInnerConcatenation : public OpRewritePattern<tensor::ConcatOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ConcatOp concatOp,
+                                PatternRewriter &rewriter) const override {
+    // Get the outer most non-unit dim to transpose to.
+    RankedTensorType concatType = concatOp.getResultType();
+    ArrayRef<int64_t> concatShape = concatType.getShape();
+    int64_t outerMostNonUnitDim = 0;
+    while (outerMostNonUnitDim < concatOp.getRank()) {
+      if (concatShape[outerMostNonUnitDim] != 1)
+        break;
+      outerMostNonUnitDim++;
+    }
+
+    // Nothing to do if the concat is already the outer most non-unit
+    int64_t dim = concatOp.getDim();
+    if (dim <= outerMostNonUnitDim) {
+      return failure();
+    }
+
+    SmallVector<int64_t> permutation = computePermutationVector(
+        concatOp.getRank(), {dim}, {outerMostNonUnitDim});
+    SmallVector<Value> transposedInputs;
+    for (auto input : concatOp.getInputs()) {
+      transposedInputs.push_back(createTranspose(rewriter, input, permutation));
+    }
+
+    SmallVector<int64_t> newShape = applyPermutation(concatShape, permutation);
+    auto newConcatType = RankedTensorType::get(
+        newShape, concatOp.getResultType().getElementType());
+    Value newConcat = rewriter.create<tensor::ConcatOp>(
+        concatOp.getLoc(), newConcatType, /*dim=*/outerMostNonUnitDim,
+        transposedInputs);
+    auto invPerm = invertPermutationVector(permutation);
+    Value transposedConcat = createTranspose(rewriter, newConcat, invPerm);
+    rewriter.replaceOp(concatOp, transposedConcat);
+    return success();
+  }
+};
+
+struct DecomposeConcatPass : public DecomposeConcatBase<DecomposeConcatPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+  }
+  DecomposeConcatPass(bool enableConcatTransposition) {
+    this->enableConcatTransposition = enableConcatTransposition;
+  }
+  DecomposeConcatPass(const DecomposeConcatPass &pass)
+      : DecomposeConcatPass(pass.enableConcatTransposition) {}
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+
+    if (enableConcatTransposition) {
+      patterns.insert<TransposeInnerConcatenation>(context, /*benefit=*/2);
+    }
+    tensor::populateDecomposeTensorConcatPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass>
+createDecomposeConcatPass(bool enableConcatTransposition) {
+  return std::make_unique<DecomposeConcatPass>(enableConcatTransposition);
+}
+
+} // namespace mlir::iree_compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -32,7 +32,11 @@ static Value createTranspose(OpBuilder &builder, Value source,
       ->getResult(0);
 }
 
-// For narrowable inputs, selects
+// Transposes the concatenation dimension to happen along the inner most
+// non-unit dim of the inputs. The idea is that outer dim concatentations
+// can lower to `flow.tensor.update` and ideally disappear, in the worst case
+// becoming a sequence of copies. The hope then is that the transposes on the
+// inputs and output is then fusable with surrounding operations.
 struct TransposeInnerConcatenation : public OpRewritePattern<tensor::ConcatOp> {
   using OpRewritePattern::OpRewritePattern;
 

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -32,7 +32,7 @@ static Value createTranspose(OpBuilder &builder, Value source,
       ->getResult(0);
 }
 
-// Transposes the concatenation dimension to happen along the inner most
+// Transposes the concatenation dimension to happen along the outer most
 // non-unit dim of the inputs. The idea is that outer dim concatentations
 // can lower to `flow.tensor.update` and ideally disappear, in the worst case
 // becoming a sequence of copies. The hope then is that the transposes on the

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -48,6 +48,10 @@ std::unique_ptr<Pass> createCleanupNumericNarrowingPass();
 // linalg.matmul
 std::unique_ptr<Pass> createConvert1X1FilterConv2DToMatmulPass();
 
+// A pass to fuse dequantization and matmul linalg.generic ops
+std::unique_ptr<Pass>
+createDecomposeConcatPass(bool enableConcatTransposition = false);
+
 // Create a pass to detach elementwise ops from named Linalg ops.
 std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();
 

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -21,6 +21,17 @@ def Convert1X1FilterConv2DToMatmul:
   let constructor = "mlir::iree_compiler::GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass()";
 }
 
+def DecomposeConcat :
+    Pass<"iree-global-opt-decompose-concat", ""> {
+  let summary = "Decomposes concatenations into a destination and a sequence of slice inserts";
+  let constructor = "mlir::iree_compiler::GlobalOptimization::createDecomposeConcatPass()";
+  let options = [
+    Option<"enableConcatTransposition", "enable-concat-transposition", "bool",
+           /*default=*/"false", "Allows transposing concatenations such that "
+                                "they occur on the inner most dims">,
+  ];
+}
+
 def DetachElementwiseFromNamedOps :
     Pass<"iree-global-opt-detach-elementwise-from-named-ops", ""> {
   let summary = "Detaches elementwise ops from named Linalg ops";

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -32,6 +32,7 @@ iree_lit_test_suite(
             "remove_zero_extent_tensors.mlir",
             "set_encoding.mlir",
             "transformation_pipeline.mlir",
+            "transpose_and_decompose_concat.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_lit_test_suite(
     "remove_zero_extent_tensors.mlir"
     "set_encoding.mlir"
     "transformation_pipeline.mlir"
+    "transpose_and_decompose_concat.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/GlobalOptimization/test/transpose_and_decompose_concat.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/transpose_and_decompose_concat.mlir
@@ -1,0 +1,28 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-global-opt-decompose-concat{enable-concat-transposition=true}, cse))" %s | FileCheck %s
+
+func.func @test_inner_dim_concat(%arg0: tensor<32x?x64xf16>, %arg1: tensor<32x?x64xf16>) -> tensor<32x?x128xf16> {
+  %concat = tensor.concat dim(2) %arg0, %arg1 : (tensor<32x?x64xf16>, tensor<32x?x64xf16>) -> tensor<32x?x128xf16>
+  return %concat : tensor<32x?x128xf16>
+}
+// CHECK-LABEL: func.func @test_inner_dim_concat
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]: tensor<32x?x64xf16>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: tensor<32x?x64xf16>
+//       CHECK:   %[[T0:.+]] = linalg.transpose ins(%[[ARG0]] : tensor<32x?x64xf16>) {{.*}} permutation = [2, 0, 1]
+//       CHECK:   %[[T1:.+]] = linalg.transpose ins(%[[ARG1]] : tensor<32x?x64xf16>) {{.*}} permutation = [2, 0, 1]
+//       CHECK:   %[[SLICE0:.+]] = tensor.insert_slice %[[T0]] {{.*}}[0, 0, 0] [64, 32, %{{.*}}] [1, 1, 1]
+//       CHECK:   %[[SLICE1:.+]] = tensor.insert_slice %[[T1]] into %[[SLICE0]][64, 0, 0] [64, 32, %{{.*}}] [1, 1, 1]
+//       CHECK:   %[[T2:.+]] = linalg.transpose ins(%[[SLICE1]] : tensor<128x32x?xf16>) {{.*}} permutation = [1, 2, 0]
+//       CHECK:   return %[[T2]] : tensor<32x?x128xf16>
+
+// -----
+
+func.func @test_outer_dim_concat(%arg0: tensor<32x?x64xf16>, %arg1: tensor<32x?x64xf16>) -> tensor<64x?x64xf16> {
+  %concat = tensor.concat dim(0) %arg0, %arg1 : (tensor<32x?x64xf16>, tensor<32x?x64xf16>) -> tensor<64x?x64xf16>
+  return %concat : tensor<64x?x64xf16>
+}
+// CHECK-LABEL: func.func @test_outer_dim_concat
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]: tensor<32x?x64xf16>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: tensor<32x?x64xf16>
+//       CHECK:   %[[SLICE0:.+]] = tensor.insert_slice %[[ARG0]] {{.*}}[0, 0, 0] [32, %{{.*}}, 64] [1, 1, 1]
+//       CHECK:   %[[SLICE1:.+]] = tensor.insert_slice %[[ARG1]] into %[[SLICE0]][32, 0, 0] [32, %{{.*}}, 64] [1, 1, 1]
+//       CHECK:   return %[[SLICE1]] : tensor<64x?x64xf16>

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -99,6 +99,10 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::desc("Converts all i64 ops and values into i32 counterparts "
                      "unconditionally before main global optimizations."),
       llvm::cl::cat(category));
+  binder.opt<bool>("iree-opt-enable-outer-dim-concat", outerDimConcat,
+                   llvm::cl::desc("Enables transposing all concatenations to "
+                                  "the outer most dimension."),
+                   llvm::cl::cat(category));
 
   binder.opt<bool>("iree-opt-data-tiling", dataTiling,
                    llvm::cl::desc("Enables data tiling path."),

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -67,6 +67,9 @@ struct GlobalOptimizationOptions {
   bool promoteBF16ToF32 = false;
   bool demoteI64ToI32 = false;
 
+  // Enables transposing all concatenations to the outer most dimension.
+  bool outerDimConcat = false;
+
   // Enables data tiling.
   bool dataTiling = true;
 


### PR DESCRIPTION
Before adding frontend lowerings to tensor.concat, we need to be able to somehow handle the op. This adds an early decomposition for it to unblock upstream lowerings, as well as an opt-in pattern that allows us to fuse away tensor.concat ops as transposes + flow.tensor.update ops. Because the actual performance impact of that change can't be measured until we have model IR with it, this keeps it off for now with the expectation that it will be turned on by default at some later point. This is worthwhile as a flag regardless as there are specific cases where we would rather codegen and/or fuse the concat as-is, but finding a good heuristic/rule for when that is the case is left as TODO.