### PR TITLE
Check null for non-linalg op in `ExpandVectors`

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
@@ -28,7 +28,7 @@ struct ExpandVectors
   LogicalResult matchAndRewrite(linalg::ContractionOpInterface op,
                                 PatternRewriter &rewriter) const override {
     auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
-    if (!linalgOp.hasTensorSemantics()) {
+    if (!linalgOp || !linalgOp.hasTensorSemantics()) {
       return failure();
     }
 


### PR DESCRIPTION
Check if `dyn_cast<linalg::LinalgOp>` returns null first in `ExpandVectors`.