### PR TITLE
Show comparison table for different data-tiling options

### DIFF
--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -413,7 +413,7 @@ def collect_all_compilation_metrics(
     return compile_metrics
 
 
-def _make_series_link(name: str, series_id: str) -> str:
+def make_series_link(name: str, series_id: str) -> str:
     """Add link to the given benchmark name.
 
     Args:
@@ -544,7 +544,7 @@ def _sort_benchmarks_and_get_table(
         base = benchmark.base_mean_time / 1e6
         ratio = abs(current - base) / base
         str_mean = _get_compare_text(current, base)
-        clickable_name = _make_series_link(benchmark.name, series_id)
+        clickable_name = make_series_link(benchmark.name, series_id)
         sorted_rows.append(
             (
                 ratio,
@@ -600,7 +600,7 @@ def categorize_benchmarks_into_tables(
         tables.append(md.header("Raw Latencies", 3))
         raw_list = [
             (
-                _make_series_link(name=v.name, series_id=k),
+                make_series_link(name=v.name, series_id=k),
                 f"{_get_fixed_point_str(v.mean_time / 1e6)}",
                 f"{_get_fixed_point_str(v.median_time / 1e6)}",
                 f"{_get_fixed_point_str(v.stddev_time / 1e6)}",
@@ -641,9 +641,7 @@ def _sort_metrics_objects_and_get_table(
             (
                 ratio,
                 (
-                    _make_series_link(
-                        str(metrics_obj), mapper.get_series_id(target_id)
-                    ),
+                    make_series_link(str(metrics_obj), mapper.get_series_id(target_id)),
                     _get_compare_text(current, base),
                 ),
             )
@@ -714,7 +712,7 @@ def categorize_compilation_metrics_into_tables(
             for mapper in COMPILATION_METRICS_TO_TABLE_MAPPERS:
                 current, base = mapper.get_current_and_base_value(metrics)
                 row.append(
-                    _make_series_link(
+                    make_series_link(
                         _get_compare_text(current, base),
                         mapper.get_series_id(target_id),
                     )

--- a/build_tools/benchmarks/generate_benchmark_comment.py
+++ b/build_tools/benchmarks/generate_benchmark_comment.py
@@ -160,7 +160,7 @@ def _get_git_merge_base_commit(
 
 def _get_experimental_dt_comparison_markdown(
     execution_benchmarks: Dict[str, benchmark_presentation.AggregateBenchmarkLatency],
-):
+) -> Optional[str]:
     """Get the comparison table to compare different data-tiling options."""
 
     dt_tags = {"no-dt": "No-DT (baseline)", "dt-only": "DT-Only", "dt-uk": "DT-UK"}
@@ -177,6 +177,9 @@ def _get_experimental_dt_comparison_markdown(
         compile_targets = gen_tags.split("][")[0] + "]"
         key_name = " ".join([model, compile_targets, remaining])
         latency_map[key_name][dt_tag] = (bench_id, latency.mean_time / 1e6)
+
+    if len(latency_map) == 0:
+        return None
 
     # Compute speedup vs. the baseline.
     table = {}
@@ -231,19 +234,20 @@ def _get_benchmark_result_markdown(
     abbr_table = [md.header(comment_def.title, 2)]
     abbr_table.append(commit_info_md)
 
-    # This is a temporary table to help us compare different data-tiling options.
-    dt_cmp_header = md.header("Data-Tiling Comparison Table", 3)
+    # The temporary table to help compare different data-tiling options.
     dt_cmp_table = _get_experimental_dt_comparison_markdown(
         execution_benchmarks=execution_benchmarks
     )
-    full_table += [dt_cmp_header, dt_cmp_table]
-    abbr_table += [
-        dt_cmp_header,
-        "<details>",
-        "<summary>Click to show</summary>",
-        dt_cmp_table,
-        "</details>",
-    ]
+    if dt_cmp_table is not None:
+        dt_cmp_header = md.header("Data-Tiling Comparison Table", 3)
+        full_table += [dt_cmp_header, dt_cmp_table]
+        abbr_table += [
+            dt_cmp_header,
+            "<details>",
+            "<summary>Click to show</summary>",
+            dt_cmp_table,
+            "</details>",
+        ]
 
     if len(execution_benchmarks) > 0:
         full_table.append(

--- a/build_tools/benchmarks/generate_benchmark_comment.py
+++ b/build_tools/benchmarks/generate_benchmark_comment.py
@@ -170,7 +170,7 @@ def _get_experimental_dt_comparison_markdown(
         if dt_tag is None:
             continue
         # See build_tools/python/e2e_test_framework/definitions/iree_definitions.py
-        # for how benchmark name are constructed.
+        # for how benchmark names are constructed.
         # Format: model_name gen_tags exec_tags ...
         model, gen_tags, remaining = latency.name.split(" ", maxsplit=2)
         # Format: [compile targets][tags]

--- a/build_tools/benchmarks/generate_benchmark_comment.py
+++ b/build_tools/benchmarks/generate_benchmark_comment.py
@@ -16,6 +16,7 @@ import pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
 
 import argparse
+import collections
 import dataclasses
 import json
 from typing import Any, Dict, Optional, Set, Tuple
@@ -157,6 +158,58 @@ def _get_git_merge_base_commit(
     )
 
 
+def _get_experimental_dt_comparison_markdown(
+    execution_benchmarks: Dict[str, benchmark_presentation.AggregateBenchmarkLatency],
+):
+    """Get the comparison table to compare different data-tiling options."""
+
+    dt_tags = {"no-dt": "No-DT (baseline)", "dt-only": "DT-Only", "dt-uk": "DT-UK"}
+    latency_map = collections.defaultdict(dict)
+    for bench_id, latency in execution_benchmarks.items():
+        dt_tag = next((tag for tag in dt_tags if tag in latency.name), None)
+        if dt_tag is None:
+            continue
+        # See build_tools/python/e2e_test_framework/definitions/iree_definitions.py
+        # for how benchmark name are constructed.
+        # Format: model_name gen_tags exec_tags ...
+        model, gen_tags, remaining = latency.name.split(" ", maxsplit=2)
+        # Format: [compile targets][tags]
+        compile_targets = gen_tags.split("][")[0] + "]"
+        key_name = " ".join([model, compile_targets, remaining])
+        latency_map[key_name][dt_tag] = (bench_id, latency.mean_time / 1e6)
+
+    # Compute speedup vs. the baseline.
+    table = {}
+    for key_name, data in latency_map.items():
+        baseline = data.get("no-dt")
+        baseline = None if baseline is None else baseline[1]
+        row = {}
+        for dt_tag in dt_tags:
+            pair = data.get(dt_tag)
+            if pair is None:
+                continue
+            bench_id, mean_time = pair
+            text = f"{mean_time:.03f}"
+            if baseline is not None:
+                text += f" ({(baseline / mean_time):.01f}X)"
+            row[dt_tag] = (bench_id, text)
+        table[key_name] = row
+
+    table_columns = [["Name"] + list(table.keys())]
+    for dt_tag, dt_name in dt_tags.items():
+        column = [dt_name]
+        for key_name, data in table.items():
+            pair = data.get(dt_tag)
+            if pair is None:
+                column.append("N/A")
+                continue
+            bench_id, text = pair
+            column.append(benchmark_presentation.make_series_link(text, bench_id))
+        table_columns.append(column)
+
+    return md.table(table_columns)
+
+
 def _get_benchmark_result_markdown(
     execution_benchmarks: Dict[str, benchmark_presentation.AggregateBenchmarkLatency],
     compilation_metrics: Dict[str, benchmark_presentation.CompilationMetrics],
@@ -177,6 +230,20 @@ def _get_benchmark_result_markdown(
     # Compose the abbreviated benchmark tables.
     abbr_table = [md.header(comment_def.title, 2)]
     abbr_table.append(commit_info_md)
+
+    # This is a temporary table to help us compare different data-tiling options.
+    dt_cmp_header = md.header("Data-Tiling Comparison Table", 3)
+    dt_cmp_table = _get_experimental_dt_comparison_markdown(
+        execution_benchmarks=execution_benchmarks
+    )
+    full_table += [dt_cmp_header, dt_cmp_table]
+    abbr_table += [
+        dt_cmp_header,
+        "<details>",
+        "<summary>Click to show</summary>",
+        dt_cmp_table,
+        "</details>",
+    ]
 
     if len(execution_benchmarks) > 0:
         full_table.append(


### PR DESCRIPTION
Show the comparison table for no-DT, DT-only, and DT-UK. The table also includes speedup comparing to no-DT