### PR TITLE
Exclude RISC-V from OSS benchmark CI workflow

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -142,7 +142,12 @@ PRESUBMIT_TOUCH_ONLY_JOBS = [
 ]
 
 # Default presets enabled in CI.
-DEFAULT_BENCHMARK_PRESET_GROUP = benchmark_presets.DEFAULT_PRESETS + ["comp-stats"]
+DEFAULT_BENCHMARK_PRESET_GROUP = [
+    preset
+    for preset in benchmark_presets.DEFAULT_PRESETS
+    # RISC-V benchmarks haven't been supported in CI workflow.
+    if preset not in [benchmark_presets.RISCV]
+] + ["comp-stats"]
 DEFAULT_BENCHMARK_PRESET = "default"
 LARGE_BENCHMARK_PRESET_GROUP = benchmark_presets.LARGE_PRESETS
 # All available benchmark preset options including experimental presets.


### PR DESCRIPTION
Fix #15875 which accidentally enables RISC-V benchmarks in OSS CI workflow and there is no Github CI runner.

benchmark-extra: default