### PR TITLE
Use cast to get LinalgOp in ExpandVectors

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandVectors.cpp
@@ -27,8 +27,8 @@ struct ExpandVectors
       linalg::ContractionOpInterface>::OpInterfaceRewritePattern;
   LogicalResult matchAndRewrite(linalg::ContractionOpInterface op,
                                 PatternRewriter &rewriter) const override {
-    auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
-    if (!linalgOp || !linalgOp.hasTensorSemantics()) {
+    auto linalgOp = cast<linalg::LinalgOp>(op.getOperation());
+    if (!linalgOp.hasTensorSemantics()) {
       return failure();
     }
 


### PR DESCRIPTION
The better fix of #15874, which `linalg::ContractionOpInterface` is always a `linalg::LinalgOp`