### PR TITLE
Optionally check Vulkan debug errors opportunistically.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,9 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
@@ -296,8 +299,7 @@ jobs:
           ./build_tools/github_actions/docker_run.sh \
             --env IREE_CUDA_DISABLE=1 \
             gcr.io/iree-oss/swiftshader@sha256:035ac89d3c357787052a836f4cbd227035260c05c95fa9a53d809600c454e819 \
-            ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+            ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
   test_gpu:
     needs: [setup, build_all]
@@ -342,10 +344,7 @@ jobs:
               --env NVIDIA_DRIVER_CAPABILITIES=all \
               --gpus all \
               gcr.io/iree-oss/nvidia@sha256:4bc8f74e6f8dece34184eedfafede9c28ba3af1674e6774f5cd867802beffc9b \
-              bash -euo pipefail -c \
-                "./build_tools/scripts/check_cuda.sh
-                ./build_tools/scripts/check_vulkan.sh
-                ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   test_a100:
     needs: [setup, build_all]
@@ -390,10 +389,7 @@ jobs:
               --env NVIDIA_DRIVER_CAPABILITIES=all \
               --gpus all \
               gcr.io/iree-oss/nvidia@sha256:4bc8f74e6f8dece34184eedfafede9c28ba3af1674e6774f5cd867802beffc9b \
-              bash -euo pipefail -c \
-                "./build_tools/scripts/check_cuda.sh
-                ./build_tools/scripts/check_vulkan.sh
-                ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
@@ -532,6 +528,10 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
@@ -544,10 +544,7 @@ jobs:
             --gpus all \
             --env NVIDIA_DRIVER_CAPABILITIES=all \
             gcr.io/iree-oss/frontends-nvidia@sha256:c3d590c6f1a6369cd34ccf0fc6f9ca2fbf8ee06abdc58a2827fc847718c308b8 \
-            bash -euo pipefail -c \
-              "./build_tools/scripts/check_cuda.sh
-              ./build_tools/scripts/check_vulkan.sh
-              build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
+            build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
 
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,9 +292,13 @@ jobs:
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Testing all"
+        # Note: VK_LOADER_LAYERS_ENABLE is used to disable the
+        # Vulkan Validation Layers (VVL), since we have unresolved errors on
+        # SwiftShader.
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env IREE_CUDA_DISABLE=1 \
+            --env VK_LOADER_LAYERS_ENABLE= \
             gcr.io/iree-oss/swiftshader@sha256:035ac89d3c357787052a836f4cbd227035260c05c95fa9a53d809600c454e819 \
             bash -euo pipefail -c \
               "./build_tools/scripts/check_vulkan.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,8 @@ jobs:
               --env NVIDIA_DRIVER_CAPABILITIES=all \
               --gpus all \
               gcr.io/iree-oss/nvidia@sha256:4bc8f74e6f8dece34184eedfafede9c28ba3af1674e6774f5cd867802beffc9b \
-              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+              ./build_tools/cmake/ctest_all.sh \
+              "${BUILD_DIR}"
 
   test_a100:
     needs: [setup, build_all]
@@ -389,7 +390,8 @@ jobs:
               --env NVIDIA_DRIVER_CAPABILITIES=all \
               --gpus all \
               gcr.io/iree-oss/nvidia@sha256:4bc8f74e6f8dece34184eedfafede9c28ba3af1674e6774f5cd867802beffc9b \
-              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+              ./build_tools/cmake/ctest_all.sh \
+              "${BUILD_DIR}"
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,9 +287,6 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
@@ -299,7 +296,9 @@ jobs:
           ./build_tools/github_actions/docker_run.sh \
             --env IREE_CUDA_DISABLE=1 \
             gcr.io/iree-oss/swiftshader@sha256:035ac89d3c357787052a836f4cbd227035260c05c95fa9a53d809600c454e819 \
-            ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+            bash -euo pipefail -c \
+              "./build_tools/scripts/check_vulkan.sh
+              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   test_gpu:
     needs: [setup, build_all]
@@ -319,10 +318,6 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
@@ -344,8 +339,10 @@ jobs:
               --env NVIDIA_DRIVER_CAPABILITIES=all \
               --gpus all \
               gcr.io/iree-oss/nvidia@sha256:4bc8f74e6f8dece34184eedfafede9c28ba3af1674e6774f5cd867802beffc9b \
-              ./build_tools/cmake/ctest_all.sh \
-              "${BUILD_DIR}"
+              bash -euo pipefail -c \
+                "./build_tools/scripts/check_cuda.sh
+                ./build_tools/scripts/check_vulkan.sh
+                ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   test_a100:
     needs: [setup, build_all]
@@ -365,10 +362,6 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
@@ -390,8 +383,10 @@ jobs:
               --env NVIDIA_DRIVER_CAPABILITIES=all \
               --gpus all \
               gcr.io/iree-oss/nvidia@sha256:4bc8f74e6f8dece34184eedfafede9c28ba3af1674e6774f5cd867802beffc9b \
-              ./build_tools/cmake/ctest_all.sh \
-              "${BUILD_DIR}"
+              bash -euo pipefail -c \
+                "./build_tools/scripts/check_cuda.sh
+                ./build_tools/scripts/check_vulkan.sh
+                ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
@@ -530,10 +525,6 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: true
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
@@ -546,7 +537,10 @@ jobs:
             --gpus all \
             --env NVIDIA_DRIVER_CAPABILITIES=all \
             gcr.io/iree-oss/frontends-nvidia@sha256:c3d590c6f1a6369cd34ccf0fc6f9ca2fbf8ee06abdc58a2827fc847718c308b8 \
-            build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
+            bash -euo pipefail -c \
+              "./build_tools/scripts/check_cuda.sh
+              ./build_tools/scripts/check_vulkan.sh
+              ./build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
 
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration

--- a/build_tools/scripts/check_vulkan.sh
+++ b/build_tools/scripts/check_vulkan.sh
@@ -10,17 +10,16 @@
 
 set -xeuo pipefail
 
-# Print Vulkan related information: SDK version and GPU ICD version
 vulkaninfo 2> /tmp/vulkaninfo.stderr 1> /tmp/vulkaninfo.stdout
-VULKAN_INSTANCE="$(grep "Vulkan Instance" /tmp/vulkaninfo.stdout)"
-VK_PHYSICAL_DEVICE_PROPERTIES="$(grep -A7 "VkPhysicalDeviceProperties" /tmp/vulkaninfo.stdout)"
 
-if [[ -z "${VULKAN_INSTANCE?}" ]] || [[ -z "${VK_PHYSICAL_DEVICE_PROPERTIES?}" ]]; then
+VULKAN_INSTANCE="$(grep "Vulkan Instance" /tmp/vulkaninfo.stdout)"
+
+if [[ -z "${VULKAN_INSTANCE?}" ]]; then
   echo "Vulkan not found!"
   cat /tmp/vulkaninfo.stdout
   cat /tmp/vulkaninfo.stderr
   exit 1
 fi
 
-echo "${VULKAN_INSTANCE?}"
-echo "${VK_PHYSICAL_DEVICE_PROPERTIES?}"
+cat /tmp/vulkaninfo.stdout
+cat /tmp/vulkaninfo.stderr

--- a/runtime/src/iree/hal/cts/command_buffer_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_test.h
@@ -65,7 +65,7 @@ class command_buffer_test : public CtsTestBase {
         command_buffer, device_buffer, target_offset, fill_length, pattern,
         pattern_length));
     IREE_CHECK_OK(iree_hal_command_buffer_end(command_buffer));
-    IREE_CHECK_OK(SubmitCommandBufferAndWait(command_buffer));
+    IREE_EXPECT_OK(SubmitCommandBufferAndWait(command_buffer));
 
     // Read data for returning.
     std::vector<uint8_t> actual_data(buffer_size);

--- a/runtime/src/iree/hal/drivers/vulkan/api.h
+++ b/runtime/src/iree/hal/drivers/vulkan/api.h
@@ -57,8 +57,9 @@ VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkSemaphore);
 // TODO(benvanik): replace with feature list (easier to version).
 // Bitfield that defines sets of Vulkan features.
 enum iree_hal_vulkan_feature_bits_t {
-  // Use VK_LAYER_KHRONOS_standard_validation to validate Vulkan API usage.
+  // Use VK_LAYER_KHRONOS_validation to validate Vulkan API usage.
   // Has a significant performance penalty and is *not* a security mechanism.
+  // https://vulkan.lunarg.com/doc/view/latest/windows/khronos_validation_layer.html
   IREE_HAL_VULKAN_FEATURE_ENABLE_VALIDATION_LAYERS = 1u << 0,
 
   // Use VK_EXT_debug_utils, record markers, and log errors.
@@ -273,6 +274,8 @@ typedef struct iree_hal_vulkan_driver_options_t {
 
   // Cutoff for debug output: 0=none, 1=errors, 2=warnings, 3=info, 4=debug.
   int32_t debug_verbosity;
+  // Check that debug output was clean when destroying the driver.
+  bool debug_check_errors;
 
   // TODO(benvanik): remove this single setting - it would be nice instead to
   // pass a list to force device enumeration/matrix expansion or omit entirely

--- a/runtime/src/iree/hal/drivers/vulkan/debug_reporter.h
+++ b/runtime/src/iree/hal/drivers/vulkan/debug_reporter.h
@@ -34,4 +34,16 @@ iree_status_t iree_hal_vulkan_debug_reporter_allocate(
 void iree_hal_vulkan_debug_reporter_free(
     iree_hal_vulkan_debug_reporter_t* reporter);
 
+// Returns true if the reporter encountered an error.
+// iree_hal_vulkan_debug_reporter_consume_status can be used once to get the
+// full status describing the failure and subsequent calls will return the
+// status code.
+bool iree_hal_vulkan_debug_reporter_has_error(
+    iree_hal_vulkan_debug_reporter_t* reporter);
+
+// Returns the error to the caller (transfering ownership).
+// The reporter will remain in a failed state with the status code.
+iree_status_t iree_hal_vulkan_debug_reporter_consume_status(
+    iree_hal_vulkan_debug_reporter_t* reporter);
+
 #endif  // IREE_HAL_DRIVERS_VULKAN_DEBUG_REPORTER_H_

--- a/runtime/src/iree/hal/drivers/vulkan/debug_reporter.h
+++ b/runtime/src/iree/hal/drivers/vulkan/debug_reporter.h
@@ -26,7 +26,8 @@ typedef struct iree_hal_vulkan_debug_reporter_t
 
 iree_status_t iree_hal_vulkan_debug_reporter_allocate(
     VkInstance instance, iree::hal::vulkan::DynamicSymbols* syms,
-    int32_t min_verbosity, const VkAllocationCallbacks* allocation_callbacks,
+    int32_t min_verbosity, bool check_errors,
+    const VkAllocationCallbacks* allocation_callbacks,
     iree_allocator_t host_allocator,
     iree_hal_vulkan_debug_reporter_t** out_reporter);
 

--- a/runtime/src/iree/hal/drivers/vulkan/handle_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/handle_util.h
@@ -21,6 +21,7 @@
 // clang-format on
 
 #include "iree/base/internal/synchronization.h"
+#include "iree/hal/drivers/vulkan/debug_reporter.h"
 #include "iree/hal/drivers/vulkan/dynamic_symbols.h"
 #include "iree/hal/drivers/vulkan/extensibility_util.h"
 #include "iree/hal/drivers/vulkan/status_util.h"
@@ -43,14 +44,16 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
                  iree_hal_vulkan_features_t enabled_features,
                  iree_hal_vulkan_device_extensions_t enabled_extensions,
                  bool owns_device, iree_allocator_t host_allocator,
-                 const VkAllocationCallbacks* allocator = nullptr)
+                 const VkAllocationCallbacks* allocator = nullptr,
+                 iree_hal_vulkan_debug_reporter_t* debug_reporter = nullptr)
       : syms_(add_ref(syms)),
         physical_device_(physical_device),
         enabled_features_(enabled_features),
         enabled_extensions_(enabled_extensions),
         owns_device_(owns_device),
         allocator_(allocator),
-        host_allocator_(host_allocator) {}
+        host_allocator_(host_allocator),
+        debug_reporter_(debug_reporter) {}
   ~VkDeviceHandle() { reset(); }
 
   VkDeviceHandle(const VkDeviceHandle&) = delete;
@@ -64,7 +67,8 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
         enabled_extensions_(other.enabled_extensions_),
         owns_device_(other.owns_device_),
         allocator_(other.allocator_),
-        host_allocator_(other.host_allocator_) {}
+        host_allocator_(other.host_allocator_),
+        debug_reporter_(other.debug_reporter_) {}
 
   void reset() {
     if (value_ == VK_NULL_HANDLE) return;
@@ -93,6 +97,10 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
     return enabled_extensions_;
   }
 
+  iree_hal_vulkan_debug_reporter_t* debug_reporter() const {
+    return debug_reporter_;
+  }
+
  private:
   VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;
   VkDevice value_ = VK_NULL_HANDLE;
@@ -102,6 +110,8 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
   bool owns_device_;
   const VkAllocationCallbacks* allocator_ = nullptr;
   iree_allocator_t host_allocator_;
+  // Optional debug reporter shared with devices associated with a VkInstance.
+  iree_hal_vulkan_debug_reporter_t* debug_reporter_ = nullptr;
 };
 
 class VkCommandPoolHandle {

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -26,6 +26,8 @@ IREE_FLAG(bool, vulkan_debug_utils, IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT,
 IREE_FLAG(int32_t, vulkan_debug_verbosity, 2,
           "Cutoff for debug output; "
           "0=none, 1=errors, 2=warnings, 3=info, 4=debug.");
+IREE_FLAG(bool, vulkan_debug_check_errors, IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT,
+          "Checks for debug output on exit");
 
 IREE_FLAG(bool, vulkan_tracing, true,
           "Enables Vulkan tracing (if IREE tracing is enabled).");
@@ -74,6 +76,9 @@ static iree_status_t iree_hal_vulkan_create_driver_with_flags(
     driver_options.requested_features |=
         IREE_HAL_VULKAN_FEATURE_ENABLE_DEBUG_UTILS;
     driver_options.debug_verbosity = FLAG_vulkan_debug_verbosity;
+  }
+  if (FLAG_vulkan_debug_check_errors) {
+    driver_options.debug_check_errors = FLAG_vulkan_debug_check_errors;
   }
   if (FLAG_vulkan_tracing) {
     driver_options.requested_features |= IREE_HAL_VULKAN_FEATURE_ENABLE_TRACING;

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -853,6 +853,7 @@ iree_status_t iree_hal_vulkan_device_create(
     const iree_hal_vulkan_device_options_t* options,
     iree_hal_vulkan_syms_t* opaque_syms, VkInstance instance,
     VkPhysicalDevice physical_device, iree_allocator_t host_allocator,
+    iree_hal_vulkan_debug_reporter_t* debug_reporter,
     iree_hal_device_t** out_device) {
   DynamicSymbols* instance_syms = (DynamicSymbols*)opaque_syms;
 
@@ -1104,7 +1105,7 @@ iree_status_t iree_hal_vulkan_device_create(
   auto logical_device = new VkDeviceHandle(
       instance_syms, physical_device, enabled_features,
       enabled_device_extensions,
-      /*owns_device=*/true, host_allocator, /*allocator=*/NULL);
+      /*owns_device=*/true, host_allocator, /*allocator=*/NULL, debug_reporter);
 
   iree_status_t status = VK_RESULT_TO_STATUS(
       instance_syms->vkCreateDevice(physical_device, &device_create_info,

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.h
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.h
@@ -10,6 +10,7 @@
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/vulkan/api.h"
+#include "iree/hal/drivers/vulkan/debug_reporter.h"
 #include "iree/hal/drivers/vulkan/dynamic_symbols.h"
 #include "iree/hal/drivers/vulkan/extensibility_util.h"
 
@@ -29,6 +30,7 @@ iree_status_t iree_hal_vulkan_device_create(
     const iree_hal_vulkan_device_options_t* options,
     iree_hal_vulkan_syms_t* instance_syms, VkInstance instance,
     VkPhysicalDevice physical_device, iree_allocator_t host_allocator,
+    iree_hal_vulkan_debug_reporter_t* debug_reporter,
     iree_hal_device_t** out_device);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -67,6 +67,7 @@ IREE_API_EXPORT void iree_hal_vulkan_driver_options_initialize(
   out_options->api_version = VK_API_VERSION_1_2;
   out_options->requested_features = 0;
   out_options->debug_verbosity = 0;
+  out_options->debug_check_errors = false;
   iree_hal_vulkan_device_options_initialize(&out_options->device_options);
 }
 
@@ -99,13 +100,12 @@ static iree_status_t iree_hal_vulkan_driver_create_internal(
   iree_hal_vulkan_instance_extensions_t instance_extensions =
       iree_hal_vulkan_populate_enabled_instance_extensions(enabled_extensions);
 
-  // The real debug messenger (not just the static one used above) can now be
-  // created as we've loaded all the required symbols.
   // TODO(benvanik): strip in min-size release builds.
   iree_hal_vulkan_debug_reporter_t* debug_reporter = NULL;
   if (instance_extensions.debug_utils) {
     IREE_RETURN_IF_ERROR(iree_hal_vulkan_debug_reporter_allocate(
         instance, instance_syms, options->debug_verbosity,
+        options->debug_check_errors,
         /*allocation_callbacks=*/NULL, host_allocator, &debug_reporter));
   }
 

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -587,7 +587,8 @@ static iree_status_t iree_hal_vulkan_driver_create_device_by_id(
   iree_status_t status = iree_hal_vulkan_device_create(
       base_driver, device_name, driver->enabled_features,
       &driver->device_options, (iree_hal_vulkan_syms_t*)driver->syms.get(),
-      driver->instance, physical_device, host_allocator, out_device);
+      driver->instance, physical_device, host_allocator, driver->debug_reporter,
+      out_device);
 
   IREE_TRACE_ZONE_END(z0);
   return status;


### PR DESCRIPTION
This would help us pin down validation layer warnings/errors on our CI (such as for https://github.com/openxla/iree/issues/15299).

I'm not sure if we want this, but I'm not seeing other ways to get a clear signal from the validation layers.

Sample outputs:
* https://gist.github.com/ScottTodd/322f344ff3dcb2e71e247ab29b8d5f5c
* https://gist.github.com/ScottTodd/041fe9a22295a1b6cced17d726f5c6cc

ci-exactly: build_all,test_all,test_gpu,test_tf_integrations_gpu