### PR TITLE
[spirv] Trim required executable target environment before linking

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -71,6 +71,7 @@ iree_compiler_cc_library(
         "SPIRVTileAndDistribute.cpp",
         "SPIRVTileAndPromote.cpp",
         "SPIRVTileAndVectorizeToCooperativeOps.cpp",
+        "SPIRVTrimExecutableTargetEnv.cpp",
         "SPIRVVectorToGPUSubgroupMMAOps.cpp",
         "SPIRVVectorizeLoadStore.cpp",
         "Utils.cpp",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -70,6 +70,7 @@ iree_cc_library(
     "SPIRVTileAndDistribute.cpp"
     "SPIRVTileAndPromote.cpp"
     "SPIRVTileAndVectorizeToCooperativeOps.cpp"
+    "SPIRVTrimExecutableTargetEnv.cpp"
     "SPIRVVectorToGPUSubgroupMMAOps.cpp"
     "SPIRVVectorizeLoadStore.cpp"
     "Utils.cpp"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -682,10 +682,12 @@ void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
 // NOTE: this runs on the top-level program module containing all hal.executable
 // ops.
 void buildSPIRVLinkingPassPipeline(OpPassManager &passManager) {
+  auto &nestedExecutablePM = passManager.nest<IREE::HAL::ExecutableOp>();
   // Trim the allowed target environment (version/capability/extension/etc.) to
   // the minimal requirement needed by compiled spirv.module ops. This helps to
   // increase the chance of linking different variant ops together.
-  passManager.addPass(createSPIRVTrimExecutableTargetEnvPass());
+  nestedExecutablePM.addNestedPass<IREE::HAL::ExecutableVariantOp>(
+      createSPIRVTrimExecutableTargetEnvPass());
   // Link together executables. This may produce some IR duplication.
   passManager.addPass(createSPIRVLinkExecutablesPass());
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -682,12 +682,6 @@ void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
 // NOTE: this runs on the top-level program module containing all hal.executable
 // ops.
 void buildSPIRVLinkingPassPipeline(OpPassManager &passManager) {
-  auto &nestedExecutablePM = passManager.nest<IREE::HAL::ExecutableOp>();
-  // Trim the allowed target environment (version/capability/extension/etc.) to
-  // the minimal requirement needed by compiled spirv.module ops. This helps to
-  // increase the chance of linking different variant ops together.
-  nestedExecutablePM.addNestedPass<IREE::HAL::ExecutableVariantOp>(
-      createSPIRVTrimExecutableTargetEnvPass());
   // Link together executables. This may produce some IR duplication.
   passManager.addPass(createSPIRVLinkExecutablesPass());
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -682,6 +682,10 @@ void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
 // NOTE: this runs on the top-level program module containing all hal.executable
 // ops.
 void buildSPIRVLinkingPassPipeline(OpPassManager &passManager) {
+  // Trim the allowed target environment (version/capability/extension/etc.) to
+  // the minimal requirement needed by compiled spirv.module ops. This helps to
+  // increase the chance of linking different variant ops together.
+  passManager.addPass(createSPIRVTrimExecutableTargetEnvPass());
   // Link together executables. This may produce some IR duplication.
   passManager.addPass(createSPIRVLinkExecutablesPass());
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -152,6 +152,11 @@ std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTilePass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVTileToCooperativeOpsPass();
 
+// Trims the SPIR-V target environment of a HAL executable variant to the
+// minimal requirement per the compiled spirv.module op needs.
+std::unique_ptr<OperationPass<ModuleOp>>
+createSPIRVTrimExecutableTargetEnvPass();
+
 /// Converts vector ops to gpu subgroup MMA ops.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVVectorToGPUSubgroupMMAOpsPass();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -154,7 +154,7 @@ createSPIRVTileToCooperativeOpsPass();
 
 // Trims the SPIR-V target environment of a HAL executable variant to the
 // minimal requirement per the compiled spirv.module op needs.
-std::unique_ptr<OperationPass<ModuleOp>>
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createSPIRVTrimExecutableTargetEnvPass();
 
 /// Converts vector ops to gpu subgroup MMA ops.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
@@ -133,6 +133,15 @@ def SPIRVTileToCooperativeOps : Pass<
     "mlir::iree_compiler::createSPIRVTileToCooperativeOpsPass()";
 }
 
+def SPIRVTrimExecutableTargetEnv :
+    Pass<"iree-spirv-trim-executable-target-env", "ModuleOp"> {
+  let summary = "Trim the SPIR-V target environment of a HAL executable "
+                "variant to the minimal requirement per the compiled "
+                "spirv.module op needs";
+  let constructor =
+    "mlir::iree_compiler::createSPIRVTrimExecutableTargetEnvPass()";
+}
+
 def SPIRVVectorizeLoadStore :
     Pass<"iree-spirv-vectorize-load-store", "ModuleOp"> {
   let summary = "Vectorize load/store of memrefs for better memory access";

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
@@ -134,7 +134,8 @@ def SPIRVTileToCooperativeOps : Pass<
 }
 
 def SPIRVTrimExecutableTargetEnv :
-    Pass<"iree-spirv-trim-executable-target-env", "ModuleOp"> {
+    Pass<"iree-spirv-trim-executable-target-env",
+         "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {
   let summary = "Trim the SPIR-V target environment of a HAL executable "
                 "variant to the minimal requirement per the compiled "
                 "spirv.module op needs";

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
@@ -1,0 +1,79 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/SPIRV/PassDetail.h"
+#include "iree/compiler/Codegen/SPIRV/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
+#include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+struct SPIRVTrimExecutableTargetEnvPass final
+    : SPIRVTrimExecutableTargetEnvBase<SPIRVTrimExecutableTargetEnvPass> {
+  void runOnOperation() override {
+    mlir::ModuleOp moduleOp = getOperation();
+
+    for (auto executable : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
+      for (auto variant : executable.getOps<IREE::HAL::ExecutableVariantOp>()) {
+        if (variant.getObjects().has_value()) {
+          // Ignore external executable variants. We need to read spirv.module
+          // ops to get the deduced minimal list of required capability and
+          // extension. External source executables won't have any spirv.module
+          // ops inside.
+          continue;
+        }
+
+        mlir::ModuleOp innerModule = variant.getInnerModule();
+        auto spirvModuleOps = innerModule.getOps<spirv::ModuleOp>();
+        // The SPIR-V CodeGen flow in IREE guarantees that we have exactly one
+        // spirv.module op inside the variant op.
+        if (!llvm::hasSingleElement(spirvModuleOps)) {
+          variant.emitOpError("should contain exactly one spirv.module op");
+          return signalPassFailure();
+        }
+
+        spirv::ModuleOp spvModule = *spirvModuleOps.begin();
+        std::optional<spirv::VerCapExtAttr> vceTriple =
+            spvModule.getVceTriple();
+        // The SPIR-V CodeGen flow in IREE also guarantees that we have deduced
+        // the minimal version/capability/extension requirement.
+        if (!vceTriple) {
+          spvModule.emitError("should have deduced vce triple");
+          return signalPassFailure();
+        }
+
+        // Replace the provided allow list to the minimal requirement deduced
+        // from compilation.
+        IREE::HAL::ExecutableTargetAttr providedTarget = variant.getTarget();
+        auto deducedConfig = providedTarget.getConfiguration().replace(
+            [&](spirv::TargetEnvAttr attr) { return vceTriple; });
+        auto deducedTarget = IREE::HAL::ExecutableTargetAttr::get(
+            providedTarget.getContext(), providedTarget.getBackend(),
+            providedTarget.getFormat(), cast<DictionaryAttr>(deducedConfig));
+        variant.setTargetAttr(deducedTarget);
+
+        // Clean up the spirv.target_env attribute on inner module, which was
+        // used to drive compilation.
+        innerModule->removeAttr(spirv::getTargetEnvAttrName());
+      }
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createSPIRVTrimExecutableTargetEnvPass() {
+  return std::make_unique<SPIRVTrimExecutableTargetEnvPass>();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
@@ -53,12 +53,15 @@ struct SPIRVTrimExecutableTargetEnvPass final
       spvModule.emitError("should have deduced vce triple");
       return signalPassFailure();
     }
+    auto minimalTarget = spirv::TargetEnvAttr::get(
+        vceTriple.value(),
+        spirv::getDefaultResourceLimits(vceTriple->getContext()));
 
     // Replace the provided allow list to the minimal requirement deduced
     // from compilation.
     IREE::HAL::ExecutableTargetAttr providedTarget = variant.getTarget();
     auto deducedConfig = providedTarget.getConfiguration().replace(
-        [&](spirv::TargetEnvAttr attr) { return vceTriple; });
+        [&](spirv::TargetEnvAttr attr) { return minimalTarget; });
     auto deducedTarget = IREE::HAL::ExecutableTargetAttr::get(
         providedTarget.getContext(), providedTarget.getBackend(),
         providedTarget.getFormat(), cast<DictionaryAttr>(deducedConfig));

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Support/LLVM.h"
 
 namespace mlir::iree_compiler {
 
@@ -25,61 +24,55 @@ bool IsSPIRVBasedBackend(StringRef backend) {
 struct SPIRVTrimExecutableTargetEnvPass final
     : SPIRVTrimExecutableTargetEnvBase<SPIRVTrimExecutableTargetEnvPass> {
   void runOnOperation() override {
-    mlir::ModuleOp moduleOp = getOperation();
-
-    for (auto executable : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
-      for (auto variant : executable.getOps<IREE::HAL::ExecutableVariantOp>()) {
-        if (!IsSPIRVBasedBackend(variant.getTarget().getBackend())) {
-          continue;
-        }
-        if (variant.getObjects().has_value()) {
-          // Ignore external executable variants. We need to read spirv.module
-          // ops to get the deduced minimal list of required capability and
-          // extension. External source executables won't have any spirv.module
-          // ops inside.
-          continue;
-        }
-
-        mlir::ModuleOp innerModule = variant.getInnerModule();
-        auto spirvModuleOps = innerModule.getOps<spirv::ModuleOp>();
-        // The SPIR-V CodeGen flow in IREE guarantees that we have exactly one
-        // spirv.module op inside the variant op.
-        if (!llvm::hasSingleElement(spirvModuleOps)) {
-          variant.emitOpError("should contain exactly one spirv.module op");
-          return signalPassFailure();
-        }
-
-        spirv::ModuleOp spvModule = *spirvModuleOps.begin();
-        std::optional<spirv::VerCapExtAttr> vceTriple =
-            spvModule.getVceTriple();
-        // The SPIR-V CodeGen flow in IREE also guarantees that we have deduced
-        // the minimal version/capability/extension requirement.
-        if (!vceTriple) {
-          spvModule.emitError("should have deduced vce triple");
-          return signalPassFailure();
-        }
-
-        // Replace the provided allow list to the minimal requirement deduced
-        // from compilation.
-        IREE::HAL::ExecutableTargetAttr providedTarget = variant.getTarget();
-        auto deducedConfig = providedTarget.getConfiguration().replace(
-            [&](spirv::TargetEnvAttr attr) { return vceTriple; });
-        auto deducedTarget = IREE::HAL::ExecutableTargetAttr::get(
-            providedTarget.getContext(), providedTarget.getBackend(),
-            providedTarget.getFormat(), cast<DictionaryAttr>(deducedConfig));
-        variant.setTargetAttr(deducedTarget);
-
-        // Clean up the spirv.target_env attribute on inner module, which was
-        // used to drive compilation.
-        innerModule->removeAttr(spirv::getTargetEnvAttrName());
-      }
+    IREE::HAL::ExecutableVariantOp variant = getOperation();
+    if (!IsSPIRVBasedBackend(variant.getTarget().getBackend())) {
+      return;
     }
+    if (variant.getObjects().has_value()) {
+      // Ignore external executable variants. We need to read spirv.module
+      // ops to get the deduced minimal list of required capability and
+      // extension. External source executables won't have any spirv.module
+      // ops inside.
+      return;
+    }
+
+    mlir::ModuleOp innerModule = variant.getInnerModule();
+    auto spirvModuleOps = innerModule.getOps<spirv::ModuleOp>();
+    // The SPIR-V CodeGen flow in IREE guarantees that we have exactly one
+    // spirv.module op inside the variant op.
+    if (!llvm::hasSingleElement(spirvModuleOps)) {
+      variant.emitOpError("should contain exactly one spirv.module op");
+      return signalPassFailure();
+    }
+
+    spirv::ModuleOp spvModule = *spirvModuleOps.begin();
+    std::optional<spirv::VerCapExtAttr> vceTriple = spvModule.getVceTriple();
+    // The SPIR-V CodeGen flow in IREE also guarantees that we have deduced
+    // the minimal version/capability/extension requirement.
+    if (!vceTriple) {
+      spvModule.emitError("should have deduced vce triple");
+      return signalPassFailure();
+    }
+
+    // Replace the provided allow list to the minimal requirement deduced
+    // from compilation.
+    IREE::HAL::ExecutableTargetAttr providedTarget = variant.getTarget();
+    auto deducedConfig = providedTarget.getConfiguration().replace(
+        [&](spirv::TargetEnvAttr attr) { return vceTriple; });
+    auto deducedTarget = IREE::HAL::ExecutableTargetAttr::get(
+        providedTarget.getContext(), providedTarget.getBackend(),
+        providedTarget.getFormat(), cast<DictionaryAttr>(deducedConfig));
+    variant.setTargetAttr(deducedTarget);
+
+    // Clean up the spirv.target_env attribute on inner module, which was
+    // used to drive compilation.
+    innerModule->removeAttr(spirv::getTargetEnvAttrName());
   }
 };
 
 } // namespace
 
-std::unique_ptr<OperationPass<mlir::ModuleOp>>
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createSPIRVTrimExecutableTargetEnvPass() {
   return std::make_unique<SPIRVTrimExecutableTargetEnvPass>();
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
@@ -17,6 +17,11 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+bool IsSPIRVBasedBackend(StringRef backend) {
+  return backend.starts_with("vulkan") || backend.starts_with("metal") ||
+         backend.starts_with("webgpu");
+}
+
 struct SPIRVTrimExecutableTargetEnvPass final
     : SPIRVTrimExecutableTargetEnvBase<SPIRVTrimExecutableTargetEnvPass> {
   void runOnOperation() override {
@@ -24,6 +29,9 @@ struct SPIRVTrimExecutableTargetEnvPass final
 
     for (auto executable : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
       for (auto variant : executable.getOps<IREE::HAL::ExecutableVariantOp>()) {
+        if (!IsSPIRVBasedBackend(variant.getTarget().getBackend())) {
+          continue;
+        }
         if (variant.getObjects().has_value()) {
           // Ignore external executable variants. We need to read spirv.module
           // ops to get the deduced minimal list of required capability and

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -70,6 +70,7 @@ iree_lit_test_suite(
             "tile_and_vectorize_pooling.mlir",
             "tile_and_vectorize_to_cooperative_ops.mlir",
             "tile_linalg_ops.mlir",
+            "trim_executable_target_env.mlir",
             "vectorize_conv.mlir",
             "vectorize_elementwise_ops.mlir",
             "vectorize_gather.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -66,6 +66,7 @@ iree_lit_test_suite(
     "tile_and_vectorize_pooling.mlir"
     "tile_and_vectorize_to_cooperative_ops.mlir"
     "tile_linalg_ops.mlir"
+    "trim_executable_target_env.mlir"
     "vectorize_conv.mlir"
     "vectorize_elementwise_ops.mlir"
     "vectorize_gather.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/trim_executable_target_env.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/trim_executable_target_env.mlir
@@ -1,0 +1,65 @@
+// RUN: iree-opt --split-input-file --iree-spirv-trim-executable-target-env %s | FileCheck %s
+
+#executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.6, [Shader, Float64, Float16, Int64, Int16, Int8, GroupNonUniformArithmetic],
+                                      [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_storage_buffer_storage_class]>,
+                                      api=Vulkan, AMD:DiscreteGPU, #spirv.resource_limits<>>}>
+
+
+// CHECK-DAG: #[[$TARGET0:.+]] = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>}>
+// CHECK-DAG: #[[$TARGET1:.+]] = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.vce<v1.3, [Shader, GroupNonUniformArithmetic], [SPV_KHR_storage_buffer_storage_class]>}>
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>
+
+hal.executable private @predict_dispatch_0 {
+  // CHECK-LABEL: hal.executable.variant public @vulkan_spirv_fb0
+  //  CHECK-SAME: target(#[[$TARGET0]])
+  hal.executable.variant public @vulkan_spirv_fb0 target(#executable_target_vulkan_spirv_fb) {
+    hal.executable.export public @predict_dispatch_0_vecmat_128x784_f32 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c2 = arith.constant 2 : index
+      %c1 = arith.constant 1 : index
+      hal.return %c2, %c1, %c1 : index, index, index
+    }
+    // CHECK-NOT: spirv.target_env
+    builtin.module attributes {spirv.target_env = #spirv.target_env<
+        #spirv.vce<v1.6, [Shader, Float64, Float16, Int64, Int16, Int8],
+        [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_storage_buffer_storage_class]>,
+        api=Vulkan, AMD:DiscreteGPU, #spirv.resource_limits<>>} {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
+        spirv.func @predict_dispatch_0_vecmat_128x784_f32() "None" {
+          spirv.Return
+        }
+        spirv.EntryPoint "GLCompute" @predict_dispatch_0_vecmat_128x784_f32
+        spirv.ExecutionMode @predict_dispatch_0_vecmat_128x784_f32 "LocalSize", 64, 1, 1
+      }
+    }
+  }
+}
+
+hal.executable private @predict_dispatch_1 {
+  // CHECK-LABEL: hal.executable.variant public @vulkan_spirv_fb1
+  //  CHECK-SAME: target(#[[$TARGET1]])
+  hal.executable.variant public @vulkan_spirv_fb1 target(#executable_target_vulkan_spirv_fb) {
+    hal.executable.export public @predict_dispatch_1_vecmat_10x128_f32 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c10 = arith.constant 10 : index
+      %c1 = arith.constant 1 : index
+      hal.return %c10, %c1, %c1 : index, index, index
+    }
+    // CHECK-NOT: spirv.target_env
+    builtin.module attributes {spirv.target_env = #spirv.target_env<
+        #spirv.vce<v1.6, [Shader, Float64, Float16, Int64, Int16, Int8],
+        [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_storage_buffer_storage_class]>,
+        api=Vulkan, AMD:DiscreteGPU, #spirv.resource_limits<>>} {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.3, [Shader, GroupNonUniformArithmetic], [SPV_KHR_storage_buffer_storage_class]> {
+        spirv.func @predict_dispatch_1_vecmat_10x128_f32() "None" {
+          spirv.Return
+        }
+        spirv.EntryPoint "GLCompute" @predict_dispatch_1_vecmat_10x128_f32
+        spirv.ExecutionMode @predict_dispatch_1_vecmat_10x128_f32 "LocalSize", 64, 1, 1
+      }
+    }
+  }
+}
+

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/trim_executable_target_env.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/trim_executable_target_env.mlir
@@ -6,8 +6,8 @@
                                       api=Vulkan, AMD:DiscreteGPU, #spirv.resource_limits<>>}>
 
 
-// CHECK-DAG: #[[$TARGET0:.+]] = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>}>
-// CHECK-DAG: #[[$TARGET1:.+]] = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.vce<v1.3, [Shader, GroupNonUniformArithmetic], [SPV_KHR_storage_buffer_storage_class]>}>
+// CHECK-DAG: #[[$TARGET0:.+]] = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, #spirv.resource_limits<>>}>
+// CHECK-DAG: #[[$TARGET1:.+]] = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader, GroupNonUniformArithmetic], [SPV_KHR_storage_buffer_storage_class]>, #spirv.resource_limits<>>}>
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/trim_executable_target_env.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/trim_executable_target_env.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-spirv-trim-executable-target-env %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-spirv-trim-executable-target-env)))' %s | FileCheck %s
 
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.6, [Shader, Float64, Float16, Int64, Int16, Int8, GroupNonUniformArithmetic],


### PR DESCRIPTION
This commit adds a pass to trim the provided target environment to the minimal required one to run the compiled spirv.module op. This increases the chance of linking different executable variants together when giving multiple targets. For the same provided target, it may actually generate more exectuables, given that now each dispatch may see a different set of capability requirements. So we may need to be smarter when linking executables--simply relying on exact target attribute match, which is the current state, is not the best way. But this pass alone should be a good cleanup.