### PR TITLE
[NFC] Remove VMVX deps from Codegen/Transforms.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Transforms/BUILD.bazel
@@ -23,8 +23,8 @@ iree_compiler_cc_library(
         "Transforms.h",
     ],
     deps = [
-        "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Codegen/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Transforms/BUILD.bazel
@@ -27,8 +27,6 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
-        # TODO(#13181) : Remove this dependency on VMVX dialect.
-        "//compiler/src/iree/compiler/Dialect/VMVX/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",

--- a/compiler/src/iree/compiler/Codegen/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Transforms/CMakeLists.txt
@@ -39,7 +39,6 @@ iree_cc_library(
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
-    iree::compiler::Dialect::VMVX::IR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -12,9 +12,7 @@
 
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 
-// TODO(#13038): Remove this dependency on VMVX dialect.
 #include "iree/compiler/Codegen/Dialect/IREECodegenOps.h"
-#include "iree/compiler/Dialect/VMVX/IR/VMVXOps.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Analysis/Presburger/IntegerRelation.h"


### PR DESCRIPTION
The query_tile_size  op is moved to iree_codegen dialect, so it no longer needs to depend on VMVX ops.

Fixes https://github.com/openxla/iree/issues/13181