### PR TITLE
[Codegen] Cherry-pick vector transfer write distribution changes. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -280,8 +280,8 @@ public:
       vector::populatePropagateWarpVectorDistributionPatterns(
           patterns, distributionFn, simpleWarpShuffleFunction);
       vector::populateDistributeReduction(patterns, groupReductionFn);
-      vector::populateDistributeTransferWriteOpPatterns(patterns,
-                                                        distributionFn);
+      vector::populateDistributeTransferWriteOpPatterns(
+          patterns, distributionFn, /*maxNumElementsToExtract=*/1);
       patterns.add<WarpOpBarrier>(patterns.getContext(), 3);
       (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -543,7 +543,8 @@ static void populateVectorTransferWriteDistribution(Operation *target,
                                                     PatternBenefit benefit) {
   assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
   vector::populateDistributeTransferWriteOpPatterns(
-      patterns, simpleDistributionFunction, benefit);
+      patterns, simpleDistributionFunction, /*maxNumElementsToExtract=*/1,
+      benefit);
 }
 
 static Value simpleWarpShuffleFunction(Location loc, OpBuilder &builder,


### PR DESCRIPTION
This cherry-picks an MLIR PR: https://github.com/llvm/llvm-project/pull/75122. I need it to unblock upcoming matvec changes.