### PR TITLE
[spirv] Respect entry point ordinal when serializing executables

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -183,7 +183,6 @@ public:
     }
 
     DenseMap<StringRef, uint64_t> entryPointOrdinals;
-    uint64_t ordinalCount = 0;
 
     SmallVector<IREE::HAL::ExecutableExportOp> exportOps =
         llvm::to_vector(variantOp.getOps<IREE::HAL::ExecutableExportOp>());
@@ -199,8 +198,8 @@ public:
         }
       }
       entryPointOrdinals[exportOp.getSymName()] = ordinal;
-      ordinalCount = std::max(ordinalCount, ordinal + 1);
     }
+    uint64_t ordinalCount = entryPointOrdinals.size();
 
     FlatbufferBuilder builder;
     iree_hal_spirv_ExecutableDef_start_as_root(builder);


### PR DESCRIPTION
We have assigned ordinals to various entry points when linking; need to respect the order there when serializing. We were lucky before because hal.executable.export op are sorted in ascending order w.r.t. ordinals thus far, and spirv.module ops follow the same order of hal.executable.export ops. But it's not guaranteed to be so.