### PR TITLE
[bf16] Rework vector+bf16 support to avoid invalid conversion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
@@ -283,8 +283,8 @@ struct ConvertBf16ArithToF32Pass
     // Some arithmetic operations exist in the vector dialect.
     target.addDynamicallyLegalOp<vector::FMAOp, vector::ReductionOp,
                                  vector::MultiDimReductionOp, vector::MaskOp,
-                                 vector::MatmulOp, vector::OuterProductOp, vector::YieldOp>(
-        checkOp);
+                                 vector::MatmulOp, vector::OuterProductOp,
+                                 vector::YieldOp>(checkOp);
 
     // Some ops are always legal.
     target.addLegalOp<arith::BitcastOp>();

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
@@ -283,7 +283,8 @@ struct ConvertBf16ArithToF32Pass
     // Some arithmetic operations exist in the vector dialect.
     target.addDynamicallyLegalOp<vector::FMAOp, vector::ReductionOp,
                                  vector::MultiDimReductionOp, vector::MaskOp,
-                                 vector::YieldOp>(checkOp);
+                                 vector::MatmulOp, vector::OuterProductOp, vector::YieldOp>(
+        checkOp);
 
     // Some ops are always legal.
     target.addLegalOp<arith::BitcastOp>();

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -275,7 +275,8 @@ struct ConvertBf16ToUInt16BuffersPass final
             return legal;
           });
 
-      // Support the list of all vector operations that do not perform numerical changes:
+      // Support the list of all vector operations that do not perform numerical
+      // changes:
       target.addDynamicallyLegalOp<
           vector::BroadcastOp, vector::ShuffleOp, vector::ExtractElementOp,
           vector::ExtractOp, vector::InsertElementOp, vector::InsertOp,

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -265,15 +265,34 @@ struct ConvertBf16ToUInt16BuffersPass final
                                                      Operation *op) {
         return typeConverter.isLegal(cast<func::FuncOp>(op).getFunctionType());
       });
-      target.addDynamicallyLegalDialect<
-          arith::ArithDialect, func::FuncDialect, IREE::HAL::HALDialect,
-          memref::MemRefDialect, scf::SCFDialect, vector::VectorDialect>(
+      target.addDynamicallyLegalDialect<arith::ArithDialect, func::FuncDialect,
+                                        IREE::HAL::HALDialect,
+                                        memref::MemRefDialect, scf::SCFDialect>(
           [&typeConverter](Operation *op) {
             bool legal = typeConverter.isLegal(op);
             LLVM_DEBUG(if (!legal) llvm::dbgs()
                        << "Bf16Emulation: illegal op: " << *op << "\n");
             return legal;
           });
+
+      // Support the list of all vector operations that do not perform numerical changes:
+      target.addDynamicallyLegalOp<
+          vector::BroadcastOp, vector::ShuffleOp, vector::ExtractElementOp,
+          vector::ExtractOp, vector::InsertElementOp, vector::InsertOp,
+          vector::ScalableInsertOp, vector::ScalableExtractOp,
+          vector::InsertStridedSliceOp, vector::ReshapeOp,
+          vector::ExtractStridedSliceOp, vector::TransferReadOp,
+          vector::TransferWriteOp, vector::LoadOp, vector::StoreOp,
+          vector::MaskedLoadOp, vector::MaskedStoreOp, vector::GatherOp,
+          vector::ScatterOp, vector::ExpandLoadOp, vector::CompressStoreOp,
+          vector::ShapeCastOp, vector::ConstantMaskOp, vector::CreateMaskOp,
+          vector::MaskOp, vector::TransposeOp, vector::FlatTransposeOp,
+          vector::SplatOp, vector::YieldOp>([&typeConverter](Operation *op) {
+        bool legal = typeConverter.isLegal(op);
+        LLVM_DEBUG(if (!legal) llvm::dbgs()
+                   << "Bf16Emulation: illegal op: " << *op << "\n");
+        return legal;
+      });
 
       RewritePatternSet patterns(ctx);
       arith::populateExpandBFloat16Patterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_arith_to_f32.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_arith_to_f32.mlir
@@ -130,3 +130,18 @@ func.func @fma_f32_regression(%a : vector<[32]xf32>, %b : vector<[32]xf32>, %c :
   %res = vector.fma %a, %b, %c : vector<[32]xf32>
   return %res : vector<[32]xf32>
 }
+
+// -----
+
+func.func @outerproduct_bf16(%arg0 : vector<1xbf16>, %arg1 : vector<1xbf16>, %arg2 : vector<1x1xbf16>) -> vector<1x1xbf16> {
+  %0 = vector.outerproduct %arg0, %arg1, %arg2 {kind = #vector.kind<add>} : vector<1xbf16>, vector<1xbf16>
+  return %0 : vector<1x1xbf16>
+}
+
+// CHECK-LABEL: func.func @outerproduct_bf16
+// CHECK-DAG: %[[EXT0:.+]] = arith.extf %arg0
+// CHECK-DAG: %[[EXT1:.+]] = arith.extf %arg1
+// CHECK-DAG: %[[EXT2:.+]] = arith.extf %arg2
+// CHECK: %[[PROD:.+]] = vector.outerproduct %[[EXT0]], %[[EXT1]], %[[EXT2]] {kind = #vector.kind<add>} : vector<1xf32>, vector<1xf32>
+// CHECK: %[[TRUNC:.+]] = arith.truncf %[[PROD]] : vector<1x1xf32> to vector<1x1xbf16>
+// CHECK: return %[[TRUNC]] : vector<1x1xbf16>

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_to_uint16_buffers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_to_uint16_buffers.mlir
@@ -83,3 +83,12 @@ func.func @mmt4d_bf16xbf16xf32() {
   }
   return
 }
+
+// -----
+
+// CHECK-LABEL: func.func @outerproduct_bf16_preserved
+func.func @outerproduct_bf16_preserved(%arg0 : vector<1xbf16>, %arg1 : vector<1xbf16>, %arg2 : vector<1x1xbf16>) -> vector<1x1xbf16> {
+  // CHECK: vector.outerproduct %[[ARG0:.+]], %[[ARG1:.+]], %[[ARG2:.+]] {kind = #vector.kind<add>} : vector<1xbf16>, vector<1xbf16>
+  %0 = vector.outerproduct %arg0, %arg1, %arg2 {kind = #vector.kind<add>} : vector<1xbf16>, vector<1xbf16>
+  return %0 : vector<1x1xbf16>
+}

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -177,11 +177,9 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
         ("f32", "f32"),
         ("f16", "f16"),
         ("f16", "f32"),
-    ] + ([
-        # TODO(#15258): enable bf16 tests for !use_uk when that bug is fixed.
         ("bf16", "bf16"),
         ("bf16", "f32"),
-    ] if use_uk else [])
+    ]
 ) for size in [
     "small",
     "large",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -278,6 +278,126 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
+    e2e_matmul_dt_bf16_bf16_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=bf16"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_bf16_bf16_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=bf16"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_bf16_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
+  LABELS
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_dt_bf16_f32_large
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=large"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
+  LABELS
+    "noasan"
+    "notsan"
+    "noriscv"
+    "nowasm"
+  TARGET_CPU_FEATURES_VARIANTS
+    "default"
+    "x86_64:avx2:+avx,+avx2,+fma,+f16c"
+    "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+    "x86_64:avx512bf16:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512bf16"
+    "arm_64:bf16:+bf16"
+)
+
+iree_generated_trace_runner_test(
+  NAME
     e2e_matmul_dt_uk_i8_i32_small
   GENERATOR
     "generate_e2e_matmul_tests.py"


### PR DESCRIPTION
When new `vector` oeprations are included it is possible for them to be treated as `i16` types instead due to invalid conversion. Made the buffer conversion focus more on non-computational operations.