### PR TITLE
Drop Vulkan driver tests from `tools/test/`.

### DIFF
--- a/tools/test/BUILD.bazel
+++ b/tools/test/BUILD.bazel
@@ -54,7 +54,6 @@ iree_lit_test_suite(
     ],
     tags = [
         "driver=local-task",
-        "driver=vulkan",
         "hostonly",
     ],
     tools = [

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -54,7 +54,6 @@ iree_lit_test_suite(
     parameters_b.safetensors
   LABELS
     "driver=local-task"
-    "driver=vulkan"
     "hostonly"
 )
 

--- a/tools/test/iree-benchmark-module.mlir
+++ b/tools/test/iree-benchmark-module.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-benchmark-module --device=local-task --module=- --function=abs --input=f32=-2 | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-benchmark-module --device=vulkan --module=- --function=abs --input=f32=-2 | FileCheck %s)
 // RUN: iree-compile --iree-hal-target-backends=llvm-cpu %s | iree-benchmark-module --device=local-task --module=- --function=abs --input=f32=-2 | FileCheck %s
 
 // CHECK-LABEL: BM_abs

--- a/tools/test/iree-run-mlir.mlir
+++ b/tools/test/iree-run-mlir.mlir
@@ -1,6 +1,5 @@
 // RUN: (iree-run-mlir --Xcompiler,iree-hal-target-backends=vmvx %s --input=f32=-2) | FileCheck %s
 // RUN: iree-run-mlir --Xcompiler,iree-hal-target-backends=llvm-cpu %s --input=f32=-2 | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --Xcompiler,iree-hal-target-backends=vulkan-spirv %s --input=f32=-2 | FileCheck %s)
 
 // CHECK-LABEL: EXEC @abs
 func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {

--- a/tools/test/iree-run-module.mlir
+++ b/tools/test/iree-run-module.mlir
@@ -1,5 +1,4 @@
 // RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --device=local-task --module=- --function=abs --input=f32=-2) | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || ((iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-run-module --device=vulkan --module=- --function=abs --input=f32=-2) | FileCheck %s)
 // RUN: (iree-compile --iree-hal-target-backends=llvm-cpu %s | iree-run-module --device=local-task --module=- --function=abs --input=f32=-2) | FileCheck %s
 
 // CHECK-LABEL: EXEC @abs

--- a/tools/test/multiple_exported_functions.mlir
+++ b/tools/test/multiple_exported_functions.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-benchmark-module --device=local-task --module=- | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-benchmark-module --device=vulkan --module=- | FileCheck %s)
 
 module {
   func.func @foo1() -> tensor<4xf32> {


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/15299

This directory is for tests of the core project, so we should support the tests on as broad a range of targets as possible. Driver-specific tests (including ones that require specific hardware) are still useful, but this monolithic MLIR lit test suite is not the place for them.

Without a change like this, https://github.com/openxla/iree/pull/15837 would skip the `tools/test/` test suite in the `test_all` job, since SwiftShader is no longer used as a software implementation of Vulkan and all Vulkan tests are skipped on CPU-only machines:
```
# Before:
iree/tools/test                                                       =  59.68 sec*proc (22 tests)

# Drop SwiftShader, without this change:
iree/tools/test                                                       =   0.27 sec*proc (1 test)

# With this change:
iree/tools/test                                                       =  49.66 sec*proc (22 tests)
```
(sample logs: [before](https://github.com/openxla/iree/actions/runs/7198521417/job/19608693537#step:6:3090), [drop SwiftShader without this change](https://github.com/openxla/iree/actions/runs/7171350678/job/19526876959?pr=15837#step:6:2813), [with this change](https://github.com/openxla/iree/actions/runs/7200086847/job/19613475932?pr=15912#step:6:3089))