### PR TITLE
Fix producer-consumer graph in `ConstExprAnalysis`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -89,12 +89,13 @@ public:
   struct ConstValueInfo {
     ConstValueInfo(Value constValue) : constValue(constValue) {}
 
+    // UNANALYZED: The value hasn't been analyzed.
     // UNKNOWN: Not all producers have been validated.
     // CONSTANT: Producers have all been validated as constants.
     // NON_CONSTANT: The op is not eligible to be treated as a constant or
     //   one or more producers is non constant.
-    enum State { UNKNOWN, CONSTANT, NON_CONSTANT };
-    State state = UNKNOWN;
+    enum State { UNANALYZED, UNKNOWN, CONSTANT, NON_CONSTANT };
+    State state = UNANALYZED;
 
     // The presumed constant value.
     Value constValue;


### PR DESCRIPTION
Build the complete producer and consumer lists of `ConstValueInfo` by always populating all the producers of a value info.

Here is the reason we want the complete producer and consumer lists:

To decide if a const expr can be hoisted, [ConstExprHoistingPolicy::makeDecision](https://github.com/openxla/iree/blob/7606729a6d0f067c9f356d19c3b63453124672f5/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp#L385) looks into its consumer list to find if there is a consumer that won't be hoisted (a valid escape).

However, currently the consumer list might be incomplete after [being built from the producers](https://github.com/openxla/iree/blob/7606729a6d0f067c9f356d19c3b63453124672f5/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp#L170). This is because the producers are populated in [ConstExprAnalysis::expandToOp](https://github.com/openxla/iree/blob/7606729a6d0f067c9f356d19c3b63453124672f5/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp#L187) and there are some early returns when a value is found to be non-constant, which results in an empty or incomplete producers of the value.

The new test demos this situation. Previously `iree_unregistered.var_expr` was decided to be `ineligible` in `expandToOp` and directly returned, so its producer list was empty. Later `makeDecision` couldn't find the non-hoisted consumer for `iree_unregistered.const_expr` and decided not to hoist it. However it should be good to hoist in this case.