### PR TITLE
Quote path to Python executable for lit tests on Windows.

### DIFF
--- a/tools/test/iree-run-module-outputs.mlir
+++ b/tools/test/iree-run-module-outputs.mlir
@@ -39,7 +39,7 @@ func.func @default() -> (i32, tensor<f32>, tensor<?x4xi32>) {
 // RUN:                  --output= \
 // RUN:                  --output=@%t \
 // RUN:                  --output=+%t) && \
-// RUN:  %PYTHON %S/echo_npy.py %t | \
+// RUN:  "%PYTHON" %S/echo_npy.py %t | \
 // RUN: FileCheck --check-prefix=OUTPUT-NUMPY %s
 func.func @numpy() -> (i32, tensor<f32>, tensor<?x4xi32>) {
   // Output skipped:

--- a/tools/test/iree-run-trace.mlir
+++ b/tools/test/iree-run-trace.mlir
@@ -10,7 +10,7 @@
 // RUN:                 --input=4xf32=4,4,4,4 \
 // RUN:                 --output=@%t \
 // RUN:                 --output=+%t) && \
-// RUN:  %PYTHON %S/echo_npy.py %t | \
+// RUN:  "%PYTHON" %S/echo_npy.py %t | \
 // RUN: FileCheck %s --check-prefix=RUN-TRACE
 //      RUN-TRACE{LITERAL}: [ 0. 4. 8. 12.]
 // RUN-TRACE-NEXT{LITERAL}: [ 0. 12. 24. 36.]


### PR DESCRIPTION
This should fix errors like
```
C:\a\iree\iree\build-windows\test_tmpdir\iree\tools\test\iree-run-module-outputs.mlir.test_test_tmpdir\test\Output\iree-run-module-outputs.mlir.script: line 3: C:hostedtoolcachewindowsPython3.10.11x64python3.exe: command not found
```

([logs here](https://github.com/openxla/iree/actions/runs/7200380440/job/19614205192#step:9:1202))

ci-extra: build_test_all_windows