### PR TITLE
Replacing hal.ex.shared_device with hal.devices.* ops.

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -130,8 +130,12 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
     // HACK: this is relying on the fact that there's only one HAL device.
     // We should instead have a way of creating fences on the device that
     // is used to produce the tensors we're wrapping.
-    auto device =
-        entryBuilder.create<IREE::HAL::ExSharedDeviceOp>(importOp.getLoc());
+    //
+    // TODO(multi-device): emit get with derived ordinal or lookup with attr. We
+    // could always say device 0 for now but could instead look for an
+    // iree.abi.affinity/iree.abi.device/etc.
+    Value device =
+        IREE::HAL::DeviceType::resolveAny(importOp.getLoc(), entryBuilder);
 
     // When exporting a fence we need to put a barrier between the rest of the
     // program and the tensors consumed by the import.

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points_coarse_fences.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points_coarse_fences.mlir
@@ -117,7 +117,7 @@ func.func private @import(tensor<?x2xi32>, tensor<?x3xi32>) -> (tensor<2x?xi32>,
 // CHECK: func.func private @_import(%[[ARG0_TENSOR:.+]]: tensor<?x2xi32>, %[[ARG1_TENSOR:.+]]: tensor<?x3xi32>) -> (tensor<2x?xi32>, tensor<3x?xi32>) {
 
 // Prepare fences and put a barrier on input arguments:
-// CHECK:   %[[DEVICE:.+]] = hal.ex.shared_device
+// CHECK:   %[[DEVICE:.+]] = hal.devices.get %{{.+}}
 // CHECK:   %[[WAIT_FENCE:.+]] = hal.fence.create device(%[[DEVICE]]
 // CHECK:   %[[ARG_BARRIER:.+]]:2 = hal.tensor.barrier join(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]] : tensor<?x2xi32>, tensor<?x3xi32>) => %[[WAIT_FENCE]] : !hal.fence
 // CHECK:   %[[SIGNAL_FENCE:.+]] = hal.fence.create device(%[[DEVICE]]
@@ -186,7 +186,7 @@ func.func private @importI32Effects(tensor<4xf32>) -> i32 attributes {
 // CHECK: func.func private @_importI32Effects(%[[ARG0_TENSOR:.+]]: tensor<4xf32>) -> i32 {
 
 // Wait for the inputs to be ready and create the signal fence to wait on.
-// CHECK:   %[[DEVICE:.+]] = hal.ex.shared_device
+// CHECK:   %[[DEVICE:.+]] = hal.devices.get %{{.+}}
 // CHECK:   %[[WAIT_FENCE:.+]] = hal.fence.create device(%[[DEVICE]]
 // CHECK:   %[[ARG0_BARRIER:.+]] = hal.tensor.barrier join(%[[ARG0_TENSOR]] : tensor<4xf32>) => %[[WAIT_FENCE]] : !hal.fence
 // CHECK:   %[[SIGNAL_FENCE:.+]] = hal.fence.create device(%[[DEVICE]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
@@ -73,7 +73,8 @@ func.func @basic_linking() -> () attributes {
   testing.func.b = @dispatch_0::@spirv,
   testing.func.c = @dispatch_0::@spirv::@dispatch_0
 } {
-  %device = hal.ex.shared_device : !hal.device
+  %c0 = arith.constant 0 : index
+  %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer attributes {
     testing.op.a = @dispatch_0,
     testing.op.b = @dispatch_0::@spirv,
@@ -86,7 +87,8 @@ func.func @basic_linking() -> () attributes {
   return
 }
 util.initializer {
-  %device = hal.ex.shared_device : !hal.device
+  %c0 = arith.constant 0 : index
+  %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
   %c1 = arith.constant 1 : index
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@spirv::@dispatch_0) workgroups([%c1, %c1, %c1])
@@ -237,7 +239,8 @@ hal.executable private @dispatch_3 {
   }
 }
 func.func @two_target_environments_1() -> () {
-  %device = hal.ex.shared_device : !hal.device
+  %c0 = arith.constant 0 : index
+  %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
   %c1 = arith.constant 1 : index
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@spirv::@dispatch_0) workgroups([%c1, %c1, %c1])
@@ -245,7 +248,8 @@ func.func @two_target_environments_1() -> () {
   return
 }
 func.func @two_target_environments_2() -> () {
-  %device = hal.ex.shared_device : !hal.device
+  %c0 = arith.constant 0 : index
+  %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
   %c1 = arith.constant 1 : index
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@spirv::@dispatch_1) workgroups([%c1, %c1, %c1])

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
@@ -72,7 +72,8 @@ func.func @basic_linking() -> () attributes {
   testing.func.b = @dispatch_0::@vmvx,
   testing.func.c = @dispatch_0::@vmvx::@dispatch_0
 } {
-  %device = hal.ex.shared_device : !hal.device
+  %c0 = arith.constant 0 : index
+  %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer attributes {
     testing.op.a = @dispatch_0,
     testing.op.b = @dispatch_0::@vmvx,
@@ -85,7 +86,8 @@ func.func @basic_linking() -> () attributes {
   return
 }
 util.initializer {
-  %device = hal.ex.shared_device : !hal.device
+  %c0 = arith.constant 0 : index
+  %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
   %c1 = arith.constant 1 : index
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@vmvx::@dispatch_0) workgroups([%c1, %c1, %c1])

--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -440,9 +440,10 @@ void CompiledBinary::initialize(void *data, size_t length) {
   iree_hal_driver_release(driver);
 
   // Create hal module.
-  IREE_CHECK_OK(iree_hal_module_create(runtime.instance.get(), device.get(),
-                                       IREE_HAL_MODULE_FLAG_NONE,
-                                       iree_allocator_system(), &hal_module));
+  iree_hal_device_t *device_ptr = device.get();
+  IREE_CHECK_OK(iree_hal_module_create(
+      runtime.instance.get(), /*device_count=*/1, &device_ptr,
+      IREE_HAL_MODULE_FLAG_NONE, iree_allocator_system(), &hal_module));
 
   // Bytecode module.
   IREE_CHECK_OK(iree_vm_bytecode_module_create(

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD.bazel
@@ -21,6 +21,7 @@ iree_compiler_cc_library(
         "ConvertChannelOps.cpp",
         "ConvertCommandBufferOps.cpp",
         "ConvertDeviceOps.cpp",
+        "ConvertDevicesOps.cpp",
         "ConvertExecutableOps.cpp",
         "ConvertExperimentalOps.cpp",
         "ConvertFenceOps.cpp",

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "ConvertChannelOps.cpp"
     "ConvertCommandBufferOps.cpp"
     "ConvertDeviceOps.cpp"
+    "ConvertDevicesOps.cpp"
     "ConvertExecutableOps.cpp"
     "ConvertExperimentalOps.cpp"
     "ConvertFenceOps.cpp"

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertDevicesOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertDevicesOps.cpp
@@ -1,0 +1,23 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/VM/Conversion/ImportUtils.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::iree_compiler {
+
+void populateHALDevicesToVMPatterns(MLIRContext *context,
+                                    SymbolTable &importSymbols,
+                                    TypeConverter &typeConverter,
+                                    RewritePatternSet &patterns) {
+  patterns.insert<VMImportOpConversion<IREE::HAL::DevicesCountOp>>(
+      context, importSymbols, typeConverter, "hal.devices.count");
+  patterns.insert<VMImportOpConversion<IREE::HAL::DevicesGetOp>>(
+      context, importSymbols, typeConverter, "hal.devices.get");
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExperimentalOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExperimentalOps.cpp
@@ -14,8 +14,6 @@ void populateHALExperimentalToVMPatterns(MLIRContext *context,
                                          SymbolTable &importSymbols,
                                          TypeConverter &typeConverter,
                                          RewritePatternSet &patterns) {
-  patterns.insert<VMImportOpConversion<IREE::HAL::ExSharedDeviceOp>>(
-      context, importSymbols, typeConverter, "hal.ex.shared_device");
   patterns.insert<VMImportOpConversion<IREE::HAL::ExFileFromMemoryOp>>(
       context, importSymbols, typeConverter, "hal.ex.file.from_memory");
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/Patterns.cpp
@@ -51,6 +51,10 @@ extern void populateHALDeviceToVMPatterns(MLIRContext *context,
                                           SymbolTable &importSymbols,
                                           TypeConverter &typeConverter,
                                           RewritePatternSet &patterns);
+extern void populateHALDevicesToVMPatterns(MLIRContext *context,
+                                           SymbolTable &importSymbols,
+                                           TypeConverter &typeConverter,
+                                           RewritePatternSet &patterns);
 extern void populateHALExecutableToVMPatterns(MLIRContext *context,
                                               SymbolTable &importSymbols,
                                               TypeConverter &typeConverter,
@@ -79,6 +83,8 @@ void populateHALToVMPatterns(MLIRContext *context, SymbolTable &importSymbols,
                                        patterns);
   populateHALDeviceToVMPatterns(context, importSymbols, typeConverter,
                                 patterns);
+  populateHALDevicesToVMPatterns(context, importSymbols, typeConverter,
+                                 patterns);
   populateHALExecutableToVMPatterns(context, importSymbols, typeConverter,
                                     patterns);
   populateHALExperimentalToVMPatterns(context, importSymbols, typeConverter,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/BUILD.bazel
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "channel_ops.mlir",
             "command_buffer_ops.mlir",
             "device_ops.mlir",
+            "devices_ops.mlir",
             "executable_ops.mlir",
             "fence_ops.mlir",
         ],

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "channel_ops.mlir"
     "command_buffer_ops.mlir"
     "device_ops.mlir"
+    "devices_ops.mlir"
     "executable_ops.mlir"
     "fence_ops.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/devices_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/devices_ops.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-opt --split-input-file --iree-convert-hal-to-vm --canonicalize --iree-vm-target-index-bits=32 %s | FileCheck %s
+
+// CHECK-LABEL: @devices_count
+func.func @devices_count() -> index {
+  // CHECK: = vm.call @hal.devices.count() {nosideeffects} : () -> i32
+  %device_count = hal.devices.count : index
+  return %device_count : index
+}
+
+// -----
+
+// CHECK-LABEL: @devices_get
+// CHECK-SAME: (%[[INDEX:.+]]: i32)
+func.func @devices_get(%index: index) -> !hal.device {
+  // CHECK: = vm.call @hal.devices.get(%[[INDEX]]) {nosideeffects} : (i32) -> !vm.ref<!hal.device>
+  %device = hal.devices.get %index : !hal.device
+  return %device : !hal.device
+}

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/channel_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/channel_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @channel_create
 //  CHECK-SAME: () -> !hal.channel
 func.func @channel_create() -> !stream.channel {
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device : !hal.device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}} : !hal.device
   // CHECK-DAG: %[[AFFINITY:.+]] = arith.constant 3
   // CHECK-DAG: %[[ID:.+]] = util.null : !util.buffer
   // CHECK-DAG: %[[GROUP:.+]] = util.buffer.constant : !util.buffer = "group"

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/context_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/context_ops.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @contextResolveAllocator
 func.func @contextResolveAllocator() -> !hal.allocator {
-  // CHECK: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK: %[[ALLOCATOR:.+]] = hal.device.allocator<%[[DEVICE]] : !hal.device> : !hal.allocator
   %allocator = stream.context.resolve : !hal.allocator
   // CHECK: return %[[ALLOCATOR]]
@@ -13,7 +13,7 @@ func.func @contextResolveAllocator() -> !hal.allocator {
 
 // CHECK-LABEL: @contextResolveDevice
 func.func @contextResolveDevice() -> !hal.device {
-  // CHECK: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   %device = stream.context.resolve : !hal.device
   // CHECK: return %[[DEVICE]]
   return %device : !hal.device
@@ -23,7 +23,7 @@ func.func @contextResolveDevice() -> !hal.device {
 
 // CHECK-LABEL: @contextResolveDeviceQueueAffinityAny
 func.func @contextResolveDeviceQueueAffinityAny() -> (!hal.device, i64) {
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[QUEUE_AFFINITY:.+]] = arith.constant -1 : i64
   %device, %queue_affinity_any = stream.context.resolve on(#hal.affinity.queue<*>) : !hal.device, i64
   // CHECK: return %[[DEVICE]], %[[QUEUE_AFFINITY]]
@@ -34,7 +34,7 @@ func.func @contextResolveDeviceQueueAffinityAny() -> (!hal.device, i64) {
 
 // CHECK-LABEL: @contextResolveDeviceQueueAffinity45
 func.func @contextResolveDeviceQueueAffinity45() -> (!hal.device, i64) {
-  // CHECK: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[QUEUE_AFFINITY:.+]] = arith.constant 48 : i64
   %device, %queue_affinity_45 = stream.context.resolve on(#hal.affinity.queue<[4, 5]>) : !hal.device, i64
   // CHECK: return %[[DEVICE]], %[[QUEUE_AFFINITY]]

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/file_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/file_ops.mlir
@@ -5,7 +5,8 @@
 func.func @file_constant(%buffer: !util.buffer) {
   %c0 = arith.constant 0 : index
   %c1088 = arith.constant 1088 : index
-  // CHECK: = hal.ex.file.from_memory device(%device : !hal.device) affinity(%c-1_i64) access(Read) buffer(%[[BUFFER]] : !util.buffer)[%c0 for %c1088] flags(%c0_i32) : !hal.file
+  // CHECK: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
+  // CHECK: = hal.ex.file.from_memory device(%[[DEVICE]] : !hal.device) affinity(%c-1_i64) access(Read) buffer(%[[BUFFER]] : !util.buffer)[%c0 for %c1088] flags(%c0_i32) : !hal.file
   %file = stream.file.constant %buffer[%c0 for %c1088] : !util.buffer{%c1088} -> !stream.file
   return
 }
@@ -18,8 +19,9 @@ func.func @file_read(%wait: !stream.timepoint, %file: !stream.file, %resource: !
   %c0 = arith.constant 0 : index
   %c0_i64 = arith.constant 0 : i64
   %c1088 = arith.constant 1088 : index
+  // CHECK: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK: %[[SIGNAL:.+]] = hal.fence.create
-  // CHECK: hal.device.queue.read<%device : !hal.device> affinity(%c-1_i64) wait(%[[WAIT]]) signal(%[[SIGNAL]]) source(%[[FILE]] : !hal.file)[%c0_i64] target(%[[RESOURCE]] : !hal.buffer)[%c0] length(%c1088) flags(0)
+  // CHECK: hal.device.queue.read<%[[DEVICE]] : !hal.device> affinity(%c-1_i64) wait(%[[WAIT]]) signal(%[[SIGNAL]]) source(%[[FILE]] : !hal.file)[%c0_i64] target(%[[RESOURCE]] : !hal.buffer)[%c0] length(%c1088) flags(0)
   %signal = stream.file.read await(%wait) => %file[%c0_i64], %resource[%c0], %c1088 : !stream.file -> !stream.resource<variable>{%c1088} => !stream.timepoint
   // CHECK: return %[[SIGNAL]]
   return %signal : !stream.timepoint
@@ -33,8 +35,9 @@ func.func @file_write(%wait: !stream.timepoint, %file: !stream.file, %resource: 
   %c0 = arith.constant 0 : index
   %c0_i64 = arith.constant 0 : i64
   %c1088 = arith.constant 1088 : index
+  // CHECK: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK: %[[SIGNAL:.+]] = hal.fence.create
-  // CHECK: hal.device.queue.write<%device : !hal.device> affinity(%c-1_i64) wait(%[[WAIT]]) signal(%[[SIGNAL]]) source(%[[RESOURCE]] : !hal.buffer)[%c0] target(%[[FILE]] : !hal.file)[%c0_i64] length(%c1088) flags(0)
+  // CHECK: hal.device.queue.write<%[[DEVICE]] : !hal.device> affinity(%c-1_i64) wait(%[[WAIT]]) signal(%[[SIGNAL]]) source(%[[RESOURCE]] : !hal.buffer)[%c0] target(%[[FILE]] : !hal.file)[%c0_i64] length(%c1088) flags(0)
   %signal = stream.file.write await(%wait) => %resource[%c0], %file[%c0_i64], %c1088 : !stream.resource<variable>{%c1088} -> !stream.file => !stream.timepoint
   // CHECK: return %[[SIGNAL]]
   return %signal : !stream.timepoint

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/timepoint_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/timepoint_ops.mlir
@@ -45,7 +45,7 @@ func.func @timepointExportFence(%arg0: !stream.timepoint) -> !hal.fence {
 // CHECK-LABEL: @timepointChainExternal
 //  CHECK-SAME: (%[[TIMEPOINT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence)
 func.func @timepointChainExternal(%timepoint: !stream.timepoint, %signal: !hal.fence) {
-  // CHECK: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK: hal.device.queue.execute<%[[DEVICE]] : !hal.device> affinity(%c-1_i64) wait(%[[TIMEPOINT]]) signal(%[[SIGNAL]])
   stream.timepoint.chain_external %timepoint => (%signal : !hal.fence)
   return

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -332,11 +332,6 @@ static void printWorkgroupCountRegion(OpAsmPrinter &p, Operation *op,
 // hal.ex.*
 //===----------------------------------------------------------------------===//
 
-void ExSharedDeviceOp::getAsmResultNames(
-    function_ref<void(Value, StringRef)> setNameFn) {
-  setNameFn(getResult(), "device");
-}
-
 void ExFileFromMemoryOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   setNameFn(getResult(), "memory_file");
@@ -921,6 +916,27 @@ LogicalResult DeviceQueueWriteOp::verify() {
 
 LogicalResult DeviceQueueExecuteOp::verify() {
   return verifyDeviceQueueFences(*this, getWaitFence(), getSignalFence());
+}
+
+//===----------------------------------------------------------------------===//
+// hal.devices.*
+//===----------------------------------------------------------------------===//
+
+void DevicesCountOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(getResult(), "device_count");
+}
+
+void DevicesGetOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  APInt index;
+  if (matchPattern(getIndex(), m_ConstantInt(&index))) {
+    llvm::SmallString<16> str("device_");
+    index.toStringUnsigned(str);
+    setNameFn(getResult(), str);
+  } else {
+    setNameFn(getResult(), "device_n");
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -37,24 +37,6 @@ def OpGroupExperimentalOps : OpDocGroup {
 
 let opDocGroup = OpGroupExperimentalOps in {
 
-def HAL_ExSharedDeviceOp : HAL_PureOp<"ex.shared_device", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
-  let results = (outs
-    HAL_Device:$result
-  );
-
-  let assemblyFormat = "attr-dict `:` type($result)";
-
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins),
-    [{
-      $_state.addTypes({DeviceType::get($_builder.getContext())});
-    }]>,
-  ];
-}
-
 def HAL_ExFileFromMemoryOp : HAL_Op<"ex.file.from_memory", [
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   ]> {
@@ -1862,6 +1844,57 @@ def HAL_DeviceQueueFlushOp : HAL_Op<"device.queue.flush"> {
 }
 
 } // OpGroupDeviceOps
+
+//===----------------------------------------------------------------------===//
+// !hal.device management
+//===----------------------------------------------------------------------===//
+
+def OpGroupDeviceManagementOps : OpDocGroup {
+  let summary = "Device management ops";
+  let description = "Device availability and selection support.";
+}
+
+let opDocGroup = OpGroupDeviceManagementOps in {
+
+def HAL_DevicesCountOp : HAL_PureOp<"devices.count", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
+  let summary = [{returns the number of available devices}];
+  let description = [{
+    Returns the total number of available devices registered at runtime.
+  }];
+
+  let results = (outs
+    Index:$result
+  );
+
+  let assemblyFormat = [{
+    attr-dict `:` type($result)
+  }];
+}
+
+def HAL_DevicesGetOp : HAL_PureOp<"devices.get", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
+  let summary = [{returns the device with the given index}];
+  let description = [{
+    Returns the device with the given index in the [0, hal.devices.count) range.
+    Devices may be lazily initialized upon first use.
+  }];
+
+  let arguments = (ins
+    Index:$index
+  );
+  let results = (outs
+    HAL_Device:$result
+  );
+
+  let assemblyFormat = [{
+    $index attr-dict `:` type($result)
+  }];
+}
+
+}  // OpGroupDeviceManagementOps
 
 //===----------------------------------------------------------------------===//
 // !hal.executable / iree_hal_executable_t

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -218,6 +218,13 @@ Value BufferViewType::inferSizeFromValue(Location loc, Value value,
           loc, builder.getType<IREE::HAL::BufferType>(), value));
 }
 
+// static
+Value DeviceType::resolveAny(Location loc, OpBuilder &builder) {
+  Value deviceIndex = builder.create<arith::ConstantIndexOp>(loc, 0);
+  return builder.create<IREE::HAL::DevicesGetOp>(
+      loc, builder.getType<IREE::HAL::DeviceType>(), deviceIndex);
+}
+
 //===----------------------------------------------------------------------===//
 // #hal.device.target
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
@@ -125,6 +125,12 @@ struct DeviceType
   using Base::Base;
 
   static constexpr StringLiteral name = "hal.device";
+
+  // Resolves to any device at runtime.
+  // This is unlikely to be what any particular caller wants and should be
+  // avoided outside of testing/debugging passes that don't care about
+  // multi-targeting.
+  static Value resolveAny(Location loc, OpBuilder &builder);
 };
 
 struct EventType : public Type::TypeBase<EventType, Type, TypeStorage> {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/BUILD.bazel
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "descriptor_set_ops.mlir",
             "device_folding.mlir",
             "device_ops.mlir",
+            "devices_ops.mlir",
             "executable_folding.mlir",
             "executable_ops.mlir",
             "executable_targets.mlir",

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "descriptor_set_ops.mlir"
     "device_folding.mlir"
     "device_ops.mlir"
+    "devices_ops.mlir"
     "executable_folding.mlir"
     "executable_ops.mlir"
     "executable_targets.mlir"

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_folding.mlir
@@ -1,18 +1,17 @@
 // RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
 
 // CHECK-LABEL: @skip_command_buffer_device
-func.func @skip_command_buffer_device() -> !hal.executable {
-  // CHECK: %[[DEVICE:.+]] = hal.ex.shared_device
-  %dev = hal.ex.shared_device : !hal.device
-  %cmd = hal.command_buffer.create device(%dev : !hal.device)
+// CHECK-SAME: (%[[DEVICE:.+]]: !hal.device)
+func.func @skip_command_buffer_device(%device: !hal.device) -> !hal.executable {
+  %cmd = hal.command_buffer.create device(%device : !hal.device)
                                      mode(OneShot)
-                                     categories("Transfer|Dispatch") : !hal.command_buffer
+                               categories("Transfer|Dispatch") : !hal.command_buffer
 
   // CHECK-NOT: hal.command_buffer.device
   //      CHECK: = hal.executable.lookup device(%[[DEVICE]] : !hal.device)
   // CHECK-SAME:     executable(@executable_name) : !hal.executable
-  %0 = hal.command_buffer.device<%cmd : !hal.command_buffer> : !hal.device
-  %exe = hal.executable.lookup device(%dev : !hal.device)
+  %device2 = hal.command_buffer.device<%cmd : !hal.command_buffer> : !hal.device
+  %exe = hal.executable.lookup device(%device2 : !hal.device)
                            executable(@executable_name) : !hal.executable
 
   return %exe : !hal.executable

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/devices_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/devices_ops.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+
+// CHECK-LABEL: @devices_count
+func.func @devices_count() -> index {
+  // CHECK: = hal.devices.count : index
+  %device_count = hal.devices.count : index
+  return %device_count : index
+}
+
+// -----
+
+// CHECK-LABEL: @devices_get
+// CHECK-SAME: (%[[INDEX:.+]]: index)
+func.func @devices_get(%index: index) -> !hal.device {
+  // CHECK: = hal.devices.get %[[INDEX]] : !hal.device
+  %device = hal.devices.get %index : !hal.device
+  return %device : !hal.device
+}

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/experimental_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/experimental_ops.mlir
@@ -1,14 +1,5 @@
 // RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
 
-// CHECK-LABEL: @shared_device
-func.func @shared_device() -> !hal.device {
-  // CHECK: %device = hal.ex.shared_device : !hal.device
-  %device = hal.ex.shared_device : !hal.device
-  return %device : !hal.device
-}
-
-// -----
-
 // CHECK-LABEL: @file_from_memory
 // CHECK-SAME: (%[[DEVICE:.+]]: !hal.device, %[[BUFFER:.+]]: !util.buffer)
 func.func @file_from_memory(%device: !hal.device, %buffer: !util.buffer) -> !hal.file {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -173,8 +173,8 @@ appendGlobalBuffer(Location loc, StringRef baseName,
   auto initBuilder = OpBuilder::atBlockBegin(initOp.addEntryBlock());
   IndexSet indexSet(loc, initBuilder);
 
-  // TODO(benvanik): real device lookup.
-  auto device = initBuilder.create<IREE::HAL::ExSharedDeviceOp>(loc);
+  // TODO(multi-device): support multiple devices in benchmark generation.
+  Value device = IREE::HAL::DeviceType::resolveAny(loc, initBuilder);
   auto allocator =
       initBuilder.create<IREE::HAL::DeviceAllocatorOp>(loc, device).getResult();
 
@@ -242,8 +242,8 @@ static void appendDispatchBenchmark(IREE::HAL::ExecutableOp executableOp,
   auto batchSizeArg = funcBuilder.create<arith::IndexCastOp>(
       loc, funcBuilder.getIndexType(), entryBlock->getArgument(0));
 
-  // TODO(benvanik): real device lookup.
-  auto device = funcBuilder.create<IREE::HAL::ExSharedDeviceOp>(loc);
+  // TODO(multi-device): support multiple devices in benchmark generation.
+  Value device = IREE::HAL::DeviceType::resolveAny(loc, funcBuilder);
 
   // Create and begin command buffer.
   // TODO(benvanik): reuse the command buffer (initialize once and store).

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
@@ -44,6 +44,7 @@ public:
         auto fullKey = ArrayAttr::get(
             moduleOp.getContext(),
             {
+                // TODO(multi-device): add attr key on device resolve source.
                 StringAttr::get(moduleOp.getContext(),
                                 queryOp.getCategory() + queryOp.getKey()),
                 queryOp.getDefaultValue().has_value()
@@ -90,8 +91,8 @@ public:
       auto initializerOp =
           moduleBuilder.create<IREE::Util::InitializerOp>(fusedLoc);
       auto funcBuilder = OpBuilder::atBlockBegin(initializerOp.addEntryBlock());
-      auto device =
-          funcBuilder.createOrFold<IREE::HAL::ExSharedDeviceOp>(fusedLoc);
+      // TODO(multi-device): pass in resolve info to the call and reuse.
+      Value device = IREE::HAL::DeviceType::resolveAny(fusedLoc, funcBuilder);
       auto queryOp = funcBuilder.create<IREE::HAL::DeviceQueryOp>(
           fusedLoc, funcBuilder.getI1Type(), queryType, device,
           anyQueryOp.getCategoryAttr(), anyQueryOp.getKeyAttr(),

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -59,7 +59,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
     // CHECK: %[[ARG0_BUFFER:.+]] = hal.buffer_view.buffer<%[[ARG0]] : !hal.buffer_view> : !hal.buffer
 
     // (annoyingly out of order)
-    // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device : !hal.device
+    // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
     // CHECK-DAG: %[[ALLOCATOR:.+]] = hal.device.allocator<%[[DEVICE]] : !hal.device> : !hal.allocator
 
     // CHECK: hal.buffer.assert<%[[ARG0_BUFFER]] : !hal.buffer>

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/memoize_device_queries.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/memoize_device_queries.mlir
@@ -3,7 +3,7 @@
 //      CHECK: util.global private @_device_query_0 : i1
 // CHECK-NEXT: util.global private @_device_query_0_ok : i1
 // CHECK-NEXT: util.initializer {
-// CHECK-NEXT:   %[[DEVICE:.+]] = hal.ex.shared_device : !hal.device
+//  CHECK-DAG:   %[[DEVICE:.+]] = hal.devices.get %{{.+}}
 // CHECK-NEXT:   %[[OK0:.+]], %[[VALUE0:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "id0*") : i1, i1 = false
 // CHECK-NEXT:   util.global.store %[[OK0]], @_device_query_0_ok : i1
 // CHECK-NEXT:   util.global.store %[[VALUE0]], @_device_query_0 : i1
@@ -11,7 +11,7 @@
 //      CHECK: util.global private @_device_query_1 : i1
 // CHECK-NEXT: util.global private @_device_query_1_ok : i1
 // CHECK-NEXT: util.initializer {
-// CHECK-NEXT:   %[[DEVICE:.+]] = hal.ex.shared_device : !hal.device
+//  CHECK-DAG:   %[[DEVICE:.+]] = hal.devices.get %{{.+}}
 // CHECK-NEXT:   %[[OK1:.+]], %[[VALUE1:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "id1") : i1, i1 = false
 // CHECK-NEXT:   util.global.store %[[OK1]], @_device_query_1_ok : i1
 // CHECK-NEXT:   util.global.store %[[VALUE1]], @_device_query_1 : i1

--- a/compiler/src/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -8,9 +8,6 @@ vm.module @hal {
 // Experimental/temporary ops
 //===----------------------------------------------------------------------===//
 
-vm.import private @ex.shared_device() -> !vm.ref<!hal.device>
-attributes {nosideeffects}
-
 // Creates a file mapped into a byte range of a host buffer.
 // EXPERIMENTAL: may be removed in future versions.
 vm.import private @ex.file.from_memory(
@@ -417,6 +414,22 @@ vm.import private @device.queue.flush(
   %device : !vm.ref<!hal.device>,
   %queue_affinity : i64
 )
+
+//===----------------------------------------------------------------------===//
+// iree_hal_device_t management
+//===----------------------------------------------------------------------===//
+
+vm.import private @devices.count() -> i32
+attributes {
+  minimum_version = 2 : i32,
+  nosideeffects
+}
+
+vm.import private @devices.get(%index : i32) -> !vm.ref<!hal.device>
+attributes {
+  minimum_version = 2 : i32,
+  nosideeffects
+}
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_t

--- a/compiler/src/iree/compiler/Modules/Check/Conversion/ConversionPatterns.cpp
+++ b/compiler/src/iree/compiler/Modules/Check/Conversion/ConversionPatterns.cpp
@@ -68,7 +68,8 @@ static LogicalResult applyDefaultCheckBufferRewrite(
   state.addAttributes(srcOp->getAttrs());
 
   // Add device argument.
-  Value device = rewriter.create<IREE::HAL::ExSharedDeviceOp>(srcOp->getLoc());
+  // TODO(multi-device): support multiple devices in check tests .
+  Value device = IREE::HAL::DeviceType::resolveAny(srcOp->getLoc(), rewriter);
   state.addOperands({device});
 
   for (auto [srcOperand, dstOperand] :

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/test/parameter_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/test/parameter_ops.mlir
@@ -7,7 +7,7 @@ func.func @parameterLoad(%wait: !stream.timepoint) -> (!stream.resource<constant
   %c51_i64 = arith.constant 51 : i64
   %c100 = arith.constant 100 : index
   %c101 = arith.constant 101 : index
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[AFFINITY:.+]] = arith.constant -1
   // CHECK-DAG: %[[SIGNAL:.+]] = hal.fence.create device(%[[DEVICE]] : !hal.device)
   // CHECK: %[[BUFFERS:.+]]:2 = io_parameters.load<%[[DEVICE]] : !hal.device> affinity(%[[AFFINITY]])
@@ -30,7 +30,7 @@ func.func @parameterLoad(%wait: !stream.timepoint) -> (!stream.resource<constant
 func.func @parameterLoadNoScope(%wait: !stream.timepoint) -> (!stream.resource<constant>, !stream.timepoint) {
   %c50_i64 = arith.constant 50 : i64
   %c100 = arith.constant 100 : index
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[AFFINITY:.+]] = arith.constant -1
   // CHECK-DAG: %[[SIGNAL:.+]] = hal.fence.create device(%[[DEVICE]] : !hal.device)
   // CHECK: %[[BUFFER:.+]] = io_parameters.load<%[[DEVICE]] : !hal.device> affinity(%[[AFFINITY]])
@@ -53,7 +53,7 @@ func.func @parameterRead(%wait: !stream.timepoint, %target: !stream.resource<tra
   %c100 = arith.constant 100 : index
   %c200 = arith.constant 200 : index
   %c300 = arith.constant 300 : index
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[AFFINITY:.+]] = arith.constant -1
   // CHECK-DAG: %[[SIGNAL:.+]] = hal.fence.create device(%[[DEVICE]] : !hal.device)
   // CHECK: io_parameters.gather<%[[DEVICE]] : !hal.device> affinity(%[[AFFINITY]])
@@ -73,7 +73,7 @@ func.func @parameterWrite(%wait: !stream.timepoint, %source: !stream.resource<tr
   %c100 = arith.constant 100 : index
   %c200 = arith.constant 200 : index
   %c300 = arith.constant 300 : index
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[AFFINITY:.+]] = arith.constant -1
   // CHECK-DAG: %[[SIGNAL:.+]] = hal.fence.create device(%[[DEVICE]] : !hal.device)
   // CHECK: io_parameters.scatter<%[[DEVICE]] : !hal.device> affinity(%[[AFFINITY]])
@@ -99,7 +99,7 @@ func.func @parameterGather(%wait: !stream.timepoint, %target: !stream.resource<t
   %c201 = arith.constant 201 : index
   %c202 = arith.constant 202 : index
   %c300 = arith.constant 300 : index
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[AFFINITY:.+]] = arith.constant -1
   // CHECK-DAG: %[[SIGNAL:.+]] = hal.fence.create device(%[[DEVICE]] : !hal.device)
   // CHECK: io_parameters.gather<%[[DEVICE]] : !hal.device> affinity(%[[AFFINITY]])
@@ -128,7 +128,7 @@ func.func @parameterGatherNoScope(%wait: !stream.timepoint, %target: !stream.res
   %c200 = arith.constant 200 : index
   %c201 = arith.constant 201 : index
   %c300 = arith.constant 300 : index
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[AFFINITY:.+]] = arith.constant -1
   // CHECK-DAG: %[[SIGNAL:.+]] = hal.fence.create device(%[[DEVICE]] : !hal.device)
   // CHECK: io_parameters.gather<%[[DEVICE]] : !hal.device> affinity(%[[AFFINITY]])
@@ -158,7 +158,7 @@ func.func @parameterScatter(%wait: !stream.timepoint, %source: !stream.resource<
   %c201 = arith.constant 201 : index
   %c202 = arith.constant 202 : index
   %c300 = arith.constant 300 : index
-  // CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device
+  // CHECK-DAG: %[[DEVICE:.+]] = hal.devices.get %{{.+}}
   // CHECK-DAG: %[[AFFINITY:.+]] = arith.constant -1
   // CHECK-DAG: %[[SIGNAL:.+]] = hal.fence.create device(%[[DEVICE]] : !hal.device)
   // CHECK: io_parameters.scatter<%[[DEVICE]] : !hal.device> affinity(%[[AFFINITY]])

--- a/docs/website/docs/developers/general/developer-tips.md
+++ b/docs/website/docs/developers/general/developer-tips.md
@@ -123,8 +123,8 @@ Module Dependencies:
   hal, version >= 0, required
 
 Imported Functions:
-  [  0] hal.ex.shared_device() -> (!vm.ref<?>)
-  [  1] hal.allocator.allocate(!vm.ref<?>, i32, i32, i64) -> (!vm.ref<?>)
+  [  0] hal.allocator.allocate(!vm.ref<?>, i32, i32, i64) -> (!vm.ref<?>)
+  [  1] hal.devices.get(i32) -> (!vm.ref<?>)
   ...
 
 Exported Functions:

--- a/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
@@ -1597,8 +1597,8 @@ iree_status_t ClientInstance::PopulateVMModules(
   // HAL module.
   modules.push_back({});
   IREE_RETURN_IF_ERROR(iree_hal_module_create(
-      vm_instance(), hal_device, IREE_HAL_MODULE_FLAG_NONE, host_allocator(),
-      &modules.back()));
+      vm_instance(), /*device_count=*/1, &hal_device, IREE_HAL_MODULE_FLAG_NONE,
+      host_allocator(), &modules.back()));
 
   // Main module.
   modules.push_back(main_module);

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -768,10 +768,12 @@ HalDevice HalDriver::CreateDeviceByURI(std::string& device_uri,
 // HAL module
 //------------------------------------------------------------------------------
 
+// TODO(multi-device): allow for multiple devices to be passed in.
 VmModule CreateHalModule(VmInstance* instance, HalDevice* device) {
+  iree_hal_device_t* device_ptr = device->raw_ptr();
   iree_vm_module_t* module = NULL;
-  CheckApiStatus(iree_hal_module_create(instance->raw_ptr(), device->raw_ptr(),
-                                        IREE_HAL_MODULE_FLAG_NONE,
+  CheckApiStatus(iree_hal_module_create(instance->raw_ptr(), /*device_count=*/1,
+                                        &device_ptr, IREE_HAL_MODULE_FLAG_NONE,
                                         iree_allocator_system(), &module),
                  "Error creating hal module");
   return VmModule::StealFromRawPtr(module);

--- a/runtime/bindings/tflite/interpreter.c
+++ b/runtime/bindings/tflite/interpreter.c
@@ -60,9 +60,10 @@ static iree_status_t _TfLiteInterpreterPrepareHAL(
       "failed creating the default device for driver '%.*s'",
       (int)driver_name.size, driver_name.data);
 
-  IREE_RETURN_IF_ERROR(iree_hal_module_create(
-      interpreter->instance, interpreter->device, IREE_HAL_MODULE_FLAG_NONE,
-      interpreter->allocator, &interpreter->hal_module));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_module_create(interpreter->instance, /*device_count=*/1,
+                             &interpreter->device, IREE_HAL_MODULE_FLAG_NONE,
+                             interpreter->allocator, &interpreter->hal_module));
 
   return iree_ok_status();
 }

--- a/runtime/src/iree/modules/check/check_test.cc
+++ b/runtime/src/iree/modules/check/check_test.cc
@@ -44,9 +44,9 @@ class CheckTest : public ::testing::Test {
     }
     IREE_ASSERT_OK(iree_hal_driver_create_default_device(
         hal_driver, iree_allocator_system(), &device_));
-    IREE_ASSERT_OK(
-        iree_hal_module_create(instance_, device_, IREE_HAL_MODULE_FLAG_NONE,
-                               iree_allocator_system(), &hal_module_));
+    IREE_ASSERT_OK(iree_hal_module_create(
+        instance_, /*device_count=*/1, &device_, IREE_HAL_MODULE_FLAG_NONE,
+        iree_allocator_system(), &hal_module_));
     iree_hal_driver_release(hal_driver);
 
     IREE_ASSERT_OK(iree_check_module_create(instance_, iree_allocator_system(),

--- a/runtime/src/iree/modules/check/test/success.mlir
+++ b/runtime/src/iree/modules/check/test/success.mlir
@@ -13,7 +13,8 @@ func.func @expect_false() {
 }
 
 func.func @expect_all_true() {
-  %device = hal.ex.shared_device : !hal.device
+  %c0 = arith.constant 0 : index
+  %device = hal.devices.get %c0 : !hal.device
   %all_true = util.unfoldable_constant dense<1> : tensor<2x2xi32>
   %all_true_view = hal.tensor.export %all_true : tensor<2x2xi32> -> !hal.buffer_view
   check.expect_all_true<%device>(%all_true_view) : !hal.buffer_view

--- a/runtime/src/iree/modules/hal/exports.inl
+++ b/runtime/src/iree/modules/hal/exports.inl
@@ -71,8 +71,10 @@ EXPORT_FN("device.queue.flush", iree_hal_module_device_queue_flush, rI, v)
 EXPORT_FN("device.queue.read", iree_hal_module_device_queue_read, rIrrrIrIIi, v)
 EXPORT_FN("device.queue.write", iree_hal_module_device_queue_write, rIrrrIrIIi, v)
 
+EXPORT_FN("devices.count", iree_hal_module_devices_count, v, i)
+EXPORT_FN("devices.get", iree_hal_module_devices_get, i, r)
+
 EXPORT_FN("ex.file.from_memory", iree_hal_module_ex_file_from_memory, rIirIIi, r)
-EXPORT_FN("ex.shared_device", iree_hal_module_ex_shared_device, v, r)
 
 EXPORT_FN("executable.create", iree_hal_module_executable_create, rrrrCrD, r)
 

--- a/runtime/src/iree/modules/hal/module.h
+++ b/runtime/src/iree/modules/hal/module.h
@@ -26,18 +26,23 @@ enum iree_hal_module_flag_bits_t {
 };
 typedef uint32_t iree_hal_module_flags_t;
 
-// Creates the HAL module initialized to use a specific |device|.
-// Each context using this module will share the device and have compatible
+// Creates the HAL module initialized to use one or more |devices|.
+// Each context using this module will share the devices and have compatible
 // allocations.
 IREE_API_EXPORT iree_status_t iree_hal_module_create(
-    iree_vm_instance_t* instance, iree_hal_device_t* device,
-    iree_hal_module_flags_t flags, iree_allocator_t host_allocator,
-    iree_vm_module_t** out_module);
+    iree_vm_instance_t* instance, iree_host_size_t device_count,
+    iree_hal_device_t** devices, iree_hal_module_flags_t flags,
+    iree_allocator_t host_allocator, iree_vm_module_t** out_module);
 
-// Returns the device currently in use by the HAL module.
-// Returns NULL if no device has been initialized yet.
-IREE_API_EXPORT iree_hal_device_t* iree_hal_module_state_device(
-    iree_vm_module_state_t* module_state);
+// Returns the total number of available devices registered with the HAL module.
+IREE_API_EXPORT iree_host_size_t
+iree_hal_module_state_device_count(iree_vm_module_state_t* module_state);
+
+// Returns the device at |index| currently in use by the HAL module.
+// Returns NULL if no device has been initialized yet or the index is out of
+// bounds.
+IREE_API_EXPORT iree_hal_device_t* iree_hal_module_state_device_get(
+    iree_vm_module_state_t* module_state, iree_host_size_t index);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/runtime/session.c
+++ b/runtime/src/iree/runtime/session.c
@@ -94,8 +94,9 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_create_with_device(
   iree_vm_module_t* hal_module = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_module_create(iree_runtime_instance_vm_instance(instance),
-                                    device, IREE_HAL_MODULE_FLAG_NONE,
-                                    host_allocator, &hal_module);
+                                    /*device_count=*/1, &device,
+                                    IREE_HAL_MODULE_FLAG_NONE, host_allocator,
+                                    &hal_module);
   }
   if (iree_status_is_ok(status)) {
     status = iree_vm_context_register_modules(
@@ -163,7 +164,8 @@ IREE_API_EXPORT iree_vm_context_t* iree_runtime_session_context(
 IREE_API_EXPORT iree_hal_device_t* iree_runtime_session_device(
     const iree_runtime_session_t* session) {
   IREE_ASSERT_ARGUMENT(session);
-  return iree_hal_module_state_device(session->hal_module_state);
+  // NOTE: only one device is supported via this API today.
+  return iree_hal_module_state_device_get(session->hal_module_state, 0);
 }
 
 IREE_API_EXPORT iree_hal_allocator_t* iree_runtime_session_device_allocator(

--- a/runtime/src/iree/runtime/session.h
+++ b/runtime/src/iree/runtime/session.h
@@ -116,6 +116,8 @@ IREE_API_EXPORT iree_vm_context_t* iree_runtime_session_context(
 //
 // NOTE: this device will not be available until initialized by a user module
 // and will return NULL if queried prior.
+//
+// NOTE: this API does not support multiple devices.
 IREE_API_EXPORT iree_hal_device_t* iree_runtime_session_device(
     const iree_runtime_session_t* session);
 
@@ -125,6 +127,8 @@ IREE_API_EXPORT iree_hal_device_t* iree_runtime_session_device(
 //
 // NOTE: this device allocator will not be available until initialized by a
 // user module and will return NULL if queried prior.
+//
+// NOTE: this API does not support multiple devices.
 IREE_API_EXPORT iree_hal_allocator_t* iree_runtime_session_device_allocator(
     const iree_runtime_session_t* session);
 

--- a/runtime/src/iree/tooling/context_util.c
+++ b/runtime/src/iree/tooling/context_util.c
@@ -196,6 +196,8 @@ static iree_status_t iree_tooling_load_hal_async_module(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_module_register_all_types(instance));
 
+  // TODO(multi-device): create multiple devices (maybe with an
+  // iree_hal_device_list_t helper for retaining/managing the dynamic list).
   // Create the device to use.
   // In the future this will change to a set of available devices instead.
   if (iree_string_view_is_empty(default_device_uri)) {
@@ -214,8 +216,8 @@ static iree_status_t iree_tooling_load_hal_async_module(
   // Create HAL module wrapping the device created above.
   iree_hal_module_flags_t flags = IREE_HAL_MODULE_FLAG_NONE;
   iree_vm_module_t* module = NULL;
-  iree_status_t status =
-      iree_hal_module_create(instance, device, flags, host_allocator, &module);
+  iree_status_t status = iree_hal_module_create(
+      instance, /*device_count=*/1, &device, flags, host_allocator, &module);
 
   if (iree_status_is_ok(status)) {
     *out_module = module;

--- a/runtime/src/iree/tooling/trace_replay.c
+++ b/runtime/src/iree/tooling/trace_replay.c
@@ -176,8 +176,8 @@ static iree_status_t iree_trace_replay_load_builtin_module(
     IREE_RETURN_IF_ERROR(iree_trace_replay_create_device(
         replay, device_node, replay->host_allocator, &replay->device));
     IREE_RETURN_IF_ERROR(iree_hal_module_create(
-        replay->instance, replay->device, IREE_HAL_MODULE_FLAG_NONE,
-        replay->host_allocator, &module));
+        replay->instance, /*device_count=*/1, &replay->device,
+        IREE_HAL_MODULE_FLAG_NONE, replay->host_allocator, &module));
   }
   if (!module) {
     return iree_make_status(

--- a/runtime/src/iree/vm/shims.c
+++ b/runtime/src/iree/vm/shims.c
@@ -7,6 +7,7 @@
 #include "iree/vm/shims.h"
 
 IREE_VM_ABI_DEFINE_SHIM(irIi, v);
+IREE_VM_ABI_DEFINE_SHIM(i, r);
 IREE_VM_ABI_DEFINE_SHIM(r, i);
 IREE_VM_ABI_DEFINE_SHIM(r, I);
 IREE_VM_ABI_DEFINE_SHIM(r, ii);

--- a/runtime/src/iree/vm/shims.h
+++ b/runtime/src/iree/vm/shims.h
@@ -614,6 +614,7 @@ IREE_VM_ABI_VLA_STRUCT(iCrD, a1_count, a1, {
 //===----------------------------------------------------------------------===//
 
 IREE_VM_ABI_DECLARE_SHIM(irIi, v);
+IREE_VM_ABI_DECLARE_SHIM(i, r);
 IREE_VM_ABI_DECLARE_SHIM(r, i);
 IREE_VM_ABI_DECLARE_SHIM(r, I);
 IREE_VM_ABI_DECLARE_SHIM(r, ii);

--- a/samples/simple_embedding/simple_embedding.c
+++ b/samples/simple_embedding/simple_embedding.c
@@ -40,9 +40,9 @@ iree_status_t Run() {
   IREE_RETURN_IF_ERROR(create_sample_device(iree_allocator_system(), &device),
                        "create device");
   iree_vm_module_t* hal_module = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_module_create(instance, device, IREE_HAL_MODULE_FLAG_SYNCHRONOUS,
-                             iree_allocator_system(), &hal_module));
+  IREE_RETURN_IF_ERROR(iree_hal_module_create(
+      instance, /*device_count=*/1, &device, IREE_HAL_MODULE_FLAG_SYNCHRONOUS,
+      iree_allocator_system(), &hal_module));
 
   // Load bytecode module from the embedded data.
   const iree_const_byte_span_t module_data = load_bytecode_module_data();


### PR DESCRIPTION
This bumps the HAL version as the existing hal.ex.shared_device op is removed. The runtime HAL module still only reports a single device and the compiler code is still selecting the "default" device (0). Future changes will support multiple `--device=` flags to register multiple available devices in tools and add attributes/lookup for mapping stream/device affinity to device ordinals.

The plan is to have a `hal.devices.lookup` op that is hoisted into an initializer to enumerate devices and store the selected ones in globals. The enumeration code will emit a loop over `hal.devices.count` and use `hal.devices.get` and the various device query methods to match the requested devices.