### PR TITLE
Add tests for iree-run-module inputs.

### DIFF
--- a/docs/website/docs/developers/general/developer-overview.md
+++ b/docs/website/docs/developers/general/developer-overview.md
@@ -121,12 +121,12 @@ $ ../iree-build/tools/iree-compile \
 ### iree-run-module
 
 The `iree-run-module` program takes an already translated IREE module as input
-and executes an exported main function using the provided inputs.
+and executes an exported function using the provided inputs.
 
 This program can be used in sequence with `iree-compile` to translate a
 `.mlir` file to an IREE module and then execute it. Here is an example command
 that executes the simple `simple_abs_vmvx.vmfb` compiled from `simple_abs.mlir`
-above on IREE's VMVX driver:
+above on IREE's local-task CPU device:
 
 ```shell
 $ ../iree-build/tools/iree-run-module \
@@ -135,6 +135,19 @@ $ ../iree-build/tools/iree-run-module \
   --function=abs \
   --input=f32=-2
 ```
+
+Input scalars are passed as `value` and input buffers are passed as
+`[shape]xtype=[value]`.
+
+* Input buffers may also be read from raw binary files or Numpy npy files.
+
+MLIR type | Description | Input example
+-- | -- | --
+`i32` | Scalar | `--input=1234`
+`tensor<i32>` | 0-D tensor | `--input=i32=1234`
+`tensor<1xi32>` | 1-D tensor (shape [1]) | `--input=1xi32=1234`
+`tensor<2xi32>` | 1-D tensor (shape [2]) | `--input="2xi32=12 34"`
+`tensor<2x3xi32>` | 2-D tensor (shape [2, 3]) | `--input="2x3xi32=[1 2 3][4 5 6]"`
 
 ???+ example "Other usage examples"
 
@@ -185,7 +198,7 @@ runner for the IREE [check framework](./testing-guide.md#end-to-end-tests).
 $ ../iree-build/tools/iree-compile \
   --iree-input-type=stablehlo \
   --iree-hal-target-backends=vmvx \
-  $PWD/tests/e2e/xla_ops/abs.mlir \
+  $PWD/tests/e2e/stablehlo_ops/abs.mlir \
   -o /tmp/abs.vmfb
 ```
 

--- a/docs/website/docs/developers/general/developer-overview.md
+++ b/docs/website/docs/developers/general/developer-overview.md
@@ -136,6 +136,44 @@ $ ../iree-build/tools/iree-run-module \
   --input=f32=-2
 ```
 
+???+ example "Other usage examples"
+
+    See these test files for advanced usage examples:
+
+    <!-- TODO(scotttodd): switch these to 'mlir' syntax when available -->
+
+    === "Basic tests"
+
+        Source file: [`tools/test/iree-run-module.mlir`](https://github.com/openxla/iree/tree/main/tools/test/iree-run-module.mlir)
+
+        ```c++ title="tools/test/iree-run-module.mlir" linenums="1"
+        --8<-- "tools/test/iree-run-module.mlir"
+        ```
+
+    === "Inputs"
+
+        Source file: [`tools/test/iree-run-module-inputs.mlir`](https://github.com/openxla/iree/tree/main/tools/test/iree-run-module-inputs.mlir)
+
+        ```c++ title="tools/test/iree-run-module-inputs.mlir" linenums="1"
+        --8<-- "tools/test/iree-run-module-inputs.mlir"
+        ```
+
+    === "Outputs"
+
+        Source file: [`tools/test/iree-run-module-outputs.mlir`](https://github.com/openxla/iree/tree/main/tools/test/iree-run-module-outputs.mlir)
+
+        ```c++ title="tools/test/iree-run-module-outputs.mlir" linenums="1"
+        --8<-- "tools/test/iree-run-module-outputs.mlir"
+        ```
+
+    === "Expected"
+
+        Source file: [`tools/test/iree-run-module-expected.mlir`](https://github.com/openxla/iree/tree/main/tools/test/iree-run-module-expected.mlir)
+
+        ```c++ title="tools/test/iree-run-module-expected.mlir" linenums="1"
+        --8<-- "tools/test/iree-run-module-expected.mlir"
+        ```
+
 ### iree-check-module
 
 The `iree-check-module` program takes an already translated IREE module as input

--- a/docs/website/docs/developers/general/testing-guide.md
+++ b/docs/website/docs/developers/general/testing-guide.md
@@ -227,7 +227,7 @@ cmake --build . --target iree-test-deps
 ```
 
 To run e2e model tests in
-[generated_e2e_model_tests.cmake](https://github.com/openxla/iree/tree/main/tests/e2e/stablehlo_models/generated_e2e_model_tests.cmake),
+[generated_e2e_model_tests.cmake](https://github.com/openxla/iree/blob/main/tests/e2e/stablehlo_models/generated_e2e_model_tests.cmake),
 because of their dependencies, `-DIREE_BUILD_E2E_TEST_ARTIFACTS=ON` needs to be
 set when configuring CMake. Also see
 [IREE Benchmark Suite Prerequisites](../performance/benchmark-suites.md#prerequisites)
@@ -236,7 +236,7 @@ for required packages.
 ### Running a Test
 
 For the test
-[`tests/e2e/xla_ops/floor.mlir`](https://github.com/openxla/iree/tree/main/tests/e2e/xla_ops/floor.mlir)
+[`tests/e2e/stablehlo_ops/floor.mlir`](https://github.com/openxla/iree/blob/main/tests/e2e/stablehlo_ops/floor.mlir)
 compiled for the VMVX target backend and running on the VMVX driver (here they
 match exactly, but in principle there's a many-to-many mapping from backends to
 drivers).
@@ -244,13 +244,13 @@ drivers).
 With CMake, run this from the build directory:
 
 ```shell
-ctest -R tests/e2e/xla_ops/check_vmvx_local-task_floor.mlir
+ctest -R tests/e2e/stablehlo_ops/check_vmvx_local-task_floor.mlir
 ```
 
 With Bazel, run this from the repo root:
 
 ```shell
-bazel test tests/e2e/xla_ops:check_vmvx_local-task_floor.mlir
+bazel test tests/e2e/stablehlo_ops:check_vmvx_local-task_floor.mlir
 ```
 
 ### Setting test environments

--- a/tools/test/BUILD.bazel
+++ b/tools/test/BUILD.bazel
@@ -29,6 +29,7 @@ iree_lit_test_suite(
             "iree-dump-parameters.txt",
             "iree-run-mlir.mlir",
             "iree-run-module-expected.mlir",
+            "iree-run-module-inputs.mlir",
             "iree-run-module-outputs.mlir",
             "iree-run-module.mlir",
             "iree-run-trace.mlir",

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -83,9 +83,9 @@ if(IREE_BUILD_TESTS AND
       "local-sync"
     RUNNER_ARGS
       "--function=abs"
-      "--input=f32=-10"
+      "--input=2xf32=-10 -5"
     EXPECTED_OUTPUT
-      "f32=10"
+      "2xf32=10 5"
     DEPS
       iree_tools_test_iree_run_module_bytecode_module_vmvx
   )

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "iree-dump-parameters.txt"
     "iree-run-mlir.mlir"
     "iree-run-module-expected.mlir"
+    "iree-run-module-inputs.mlir"
     "iree-run-module-outputs.mlir"
     "iree-run-module.mlir"
     "iree-run-trace.mlir"

--- a/tools/test/iree-run-module-inputs.mlir
+++ b/tools/test/iree-run-module-inputs.mlir
@@ -1,0 +1,74 @@
+// Passing no inputs is okay.
+
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | \
+// RUN:  iree-run-module --device=local-sync --module=- --function=no_input) | \
+// RUN: FileCheck --check-prefix=NO-INPUT %s
+// NO-INPUT-LABEL: EXEC @no_input
+func.func @no_input() {
+  return
+}
+
+// -----
+
+// Scalars use the form `--input=value`. Type (float/int) should be omitted.
+//   * Type conversions between bit depths (e.g. i8 -> i32) may occur!
+
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | \
+// RUN:  iree-run-module --device=local-sync --module=- --function=scalars \
+// RUN:  --input=1 --input=5 --input=1234 --input=-3.14) | \
+// RUN: FileCheck --check-prefix=INPUT-SCALARS %s
+// INPUT-SCALARS-LABEL: EXEC @scalars
+func.func @scalars(%arg0: i1, %arg1: i8, %arg2 : i32, %arg3 : f32) -> (i1, i8, i32, f32) {
+  // INPUT-SCALARS: result[0]: i32=1
+  // INPUT-SCALARS: result[1]: i32=5
+  // INPUT-SCALARS: result[2]: i32=1234
+  // INPUT-SCALARS: result[3]: f32=-3.14
+  return %arg0, %arg1, %arg2, %arg3 : i1, i8, i32, f32
+}
+
+// -----
+
+// Buffers ("tensors") use the form `--input=[shape]xtype=[value]`.
+//   * If any values are omitted, zeroes will be used.
+//   * Quotes should be used around values with spaces.
+//   * Brackets may also be used to separate element values.
+
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | \
+// RUN:  iree-run-module --device=local-sync --module=- --function=buffers \
+// RUN:  --input=i32=5 --input=2xi32 --input="2x3xi32=1 2 3 4 5 6") | \
+// RUN: FileCheck --check-prefix=INPUT-BUFFERS %s
+// INPUT-BUFFERS-LABEL: EXEC @buffers
+func.func @buffers(%arg0: tensor<i32>, %arg1: tensor<2xi32>, %arg2: tensor<2x3xi32>) -> (tensor<i32>, tensor<2xi32>, tensor<2x3xi32>) {
+  // INPUT-BUFFERS: result[0]: hal.buffer_view
+  // INPUT-BUFFERS-NEXT: i32=5
+  // INPUT-BUFFERS: result[1]: hal.buffer_view
+  // INPUT-BUFFERS-NEXT: 2xi32=0 0
+  // INPUT-BUFFERS: result[2]: hal.buffer_view
+  // INPUT-BUFFERS-NEXT: 2x3xi32=[1 2 3][4 5 6]
+  return %arg0, %arg1, %arg2 : tensor<i32>, tensor<2xi32>, tensor<2x3xi32>
+}
+
+// -----
+
+// Buffer values can be read from binary files with `@some/file.bin`.
+//   * numpy npy files from numpy.save or previous tooling output can be read to
+//     provide 1+ values.
+//   * Some data types may be converted (i32 -> si32 here)
+
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s -o %t.vmfb
+//
+// RUN: iree-run-module --device=local-sync --module=%t.vmfb --function=npy_round_trip \
+// RUN:   --input="2xi32=11 12" --input="3xi32=1 2 3" --output=@%t.npy --output=+%t.npy
+//
+// RUN: iree-run-module --device=local-sync --module=%t.vmfb --function=npy_round_trip \
+// RUN:   --input=@%t.npy | \
+// RUN: FileCheck --check-prefix=INPUT-NPY_FILES %s
+
+// INPUT-NPY_FILES-LABEL: EXEC @npy_round_trip
+func.func @npy_round_trip(%arg0: tensor<2xi32>, %arg1: tensor<3xi32>) -> (tensor<2xi32>, tensor<3xi32>) {
+  // INPUT-NPY_FILES: result[0]: hal.buffer_view
+  // INPUT-NPY_FILES-NEXT: 2xsi32=11 12
+  // INPUT-NPY_FILES: result[1]: hal.buffer_view
+  // INPUT-NPY_FILES-NEXT: 3xsi32=1 2 3
+  return %arg0, %arg1 : tensor<2xi32>, tensor<3xi32>
+}

--- a/tools/test/iree-run-module-inputs.mlir
+++ b/tools/test/iree-run-module-inputs.mlir
@@ -11,7 +11,7 @@ func.func @no_input() {
 // -----
 
 // Scalars use the form `--input=value`. Type (float/int) should be omitted.
-//   * Type conversions between bit depths (e.g. i8 -> i32) may occur!
+//   * The VM does not use i1/i8 types, so i32 VM types are returned instead.
 
 // RUN: (iree-compile --iree-hal-target-backends=vmvx %s | \
 // RUN:  iree-run-module --device=local-sync --module=- --function=scalars \
@@ -53,7 +53,7 @@ func.func @buffers(%arg0: tensor<i32>, %arg1: tensor<2xi32>, %arg2: tensor<2x3xi
 // Buffer values can be read from binary files with `@some/file.bin`.
 //   * numpy npy files from numpy.save or previous tooling output can be read to
 //     provide 1+ values.
-//   * Some data types may be converted (i32 -> si32 here)
+//   * Some data types may be converted (i32 -> si32 here) - bug?
 
 // RUN: iree-compile --iree-hal-target-backends=vmvx %s -o %t.vmfb
 //

--- a/tools/test/iree-run-module.mlir
+++ b/tools/test/iree-run-module.mlir
@@ -1,9 +1,10 @@
-// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --device=local-task --module=- --function=abs --input=f32=-2) | FileCheck %s
-// RUN: (iree-compile --iree-hal-target-backends=llvm-cpu %s | iree-run-module --device=local-task --module=- --function=abs --input=f32=-2) | FileCheck %s
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --device=local-task --module=- --function=abs --input="2xf32=-2 3") | FileCheck %s
+// RUN: (iree-compile --iree-hal-target-backends=llvm-cpu %s | iree-run-module --device=local-task --module=- --function=abs --input="2xf32=-2 3") | FileCheck %s
 
 // CHECK-LABEL: EXEC @abs
-func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {
-  %result = math.absf %input : tensor<f32>
-  return %result : tensor<f32>
+func.func @abs(%input : tensor<2xf32>) -> (tensor<2xf32>) {
+  %result = math.absf %input : tensor<2xf32>
+  return %result : tensor<2xf32>
 }
-// CHECK: f32=2
+  // INPUT-BUFFERS: result[1]: hal.buffer_view
+  // INPUT-BUFFERS-NEXT: 2xf32=-2.0 3.0


### PR DESCRIPTION
A few people have asked about scalar inputs, i1 inputs, and npy inputs/outputs. This gives a test we can point people at.

Also updated the "developer overview" docs ([preview site here](https://scotttodd.github.io/iree/developers/general/developer-overview/#iree-run-module)):
![image](https://github.com/openxla/iree/assets/4010439/48ce3a72-9e84-442b-a82f-44cd1e90e4cd)

Fixes https://github.com/openxla/iree/issues/14911