### PR TITLE
[LLVMGPU] Re-enable multidim distribution on gridDimension.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -86,7 +86,7 @@ static void
 tileAndDistributeToWorkgroup(OpPassManager &pm,
                              bool useWARForCooperativeMatrixCodegen = false) {
   pm.addPass(createTileAndDistributeToWorkgroupsPass(
-      /*maxWorkgroupParallelDims=*/1,
+      kNumMaxParallelDims,
       linalg::DistributionMethod::CyclicNumProcsEqNumIters));
 
   auto &nestedModulePM = pm.nest<ModuleOp>();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
@@ -29,6 +29,7 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb", {t
 
 // CHECK-LABEL: hal.executable.export public @forward_dispatch_0_generic_320x320x3x3
 //     CHECK:     workgroup_size = [3 : index, 3 : index, 7 : index]}
-// CHECK-DAG:     %[[C14720:.*]] = arith.constant 14720 : index
-// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
-//     CHECK:     hal.return %[[C14720]], %[[C1]], %[[C1]] : index, index, index
+// CHECK-DAG:     %[[C46:.+]] = arith.constant 46 : index
+// CHECK-DAG:     %[[C320:.+]] = arith.constant 320 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//     CHECK:     hal.return %[[C46]], %[[C320]], %[[C1]] : index, index, index


### PR DESCRIPTION
When running larger model such as Llama2, we will come across matvecs or matvec like operations with a large batch or parallel dimensions. Since we tile the batch/parallel dim with size 1, and lay it across the grid, we may hit into gridDim overflow on a single axis. This PR re-enables multidim grid distribution to fix that issue.