### PR TITLE
Fix experimental/web[gpu] builds after HAL changes.

### DIFF
--- a/experimental/web/sample_static/CMakeLists.txt
+++ b/experimental/web/sample_static/CMakeLists.txt
@@ -45,6 +45,7 @@ target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
 target_link_libraries(${_NAME}
   ${_MNIST_OBJECT_NAME}
   iree_runtime_runtime
+  iree_hal_hal
   iree_hal_local_loaders_static_library_loader
   iree_hal_drivers_local_sync_sync_driver
 )
@@ -89,9 +90,9 @@ target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
 target_link_libraries(${_NAME}
   ${_MNIST_OBJECT_NAME}
   iree_runtime_runtime
+  iree_hal_hal
   iree_hal_local_loaders_static_library_loader
   iree_hal_drivers_local_task_task_driver
-  iree_hal_utils_buffer_transfer
   iree_task_api
 )
 

--- a/experimental/web/sample_static/main.c
+++ b/experimental/web/sample_static/main.c
@@ -7,7 +7,7 @@
 #include <float.h>
 #include <stdio.h>
 
-#include "iree/hal/utils/buffer_transfer.h"
+#include "iree/hal/buffer_transfer.h"
 #include "iree/runtime/api.h"
 #include "iree/vm/bytecode/module.h"
 #include "mnist_bytecode.h"

--- a/experimental/webgpu/CMakeLists.txt
+++ b/experimental/webgpu/CMakeLists.txt
@@ -48,7 +48,6 @@ iree_cc_library(
     iree::hal
     iree::experimental::webgpu::platform
     iree::experimental::webgpu::shaders
-    iree::hal::utils::buffer_transfer
     iree::hal::utils::file_transfer
     iree::hal::utils::memory_file
     iree::schemas::wgsl_executable_def_c_fbs

--- a/experimental/webgpu/buffer.c
+++ b/experimental/webgpu/buffer.c
@@ -12,7 +12,7 @@
 
 #include "experimental/webgpu/webgpu_device.h"
 #include "iree/base/api.h"
-#include "iree/hal/utils/buffer_transfer.h"
+#include "iree/hal/buffer_transfer.h"
 
 // TODO(benvanik): decouple via injection.
 #include "experimental/webgpu/simple_allocator.h"


### PR DESCRIPTION
Noticed on nightly samples build: https://github.com/openxla/iree/actions/runs/7204363409/job/19625690881#step:4:331

Follow-up to https://github.com/openxla/iree/pull/15919