### PR TITLE
Mark tensorflow_resnet.ipynb as xfail.

### DIFF
--- a/samples/colab/test_notebooks.py
+++ b/samples/colab/test_notebooks.py
@@ -33,6 +33,9 @@ NOTEBOOKS_EXPECTED_TO_FAIL = [
     # ```
     # convert_saved_model_v1 may be broken, but convert_saved_model works?
     "tensorflow_hub_import.ipynb",
+    # error: 'stablehlo.pad' op attribute 'edge_padding_low' failed to satisfy
+    # constraint: 64-bit signless integer elements attribute
+    "tensorflow_resnet.ipynb",
 ]
 
 


### PR DESCRIPTION
This notebook started failing two days ago: https://github.com/openxla/iree/actions/runs/7190613243/job/19584017594#step:3:511

TensorFlow notebooks are a lower priority to maintain at the moment and I'm not sure how to triage this particular error, so just marking xfail for now.

skip-ci: only affects a nightly build