### PR TITLE
[Codegen] Switch to Util helper for getting bit widths

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -198,7 +198,8 @@ struct PackForOpInductionVarVector final : public OpRewritePattern<scf::ForOp> {
         continue;
       }
       int64_t numElements = ShapedType::getNumElements(iterType.getShape());
-      int64_t totalBits = IREE::Util::getRoundedPhysicalStorageSize(iterType);
+      int64_t bitWidth = IREE::Util::getTypeBitWidth(iterType.getElementType());
+      int64_t totalBits = numElements * bitWidth;
       if (numElements > 4 && totalBits <= 128 &&
           llvm::isPowerOf2_64(totalBits)) {
         ivIndices.push_back(index);

--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -198,8 +198,7 @@ struct PackForOpInductionVarVector final : public OpRewritePattern<scf::ForOp> {
         continue;
       }
       int64_t numElements = ShapedType::getNumElements(iterType.getShape());
-      int64_t bitWidth = IREE::Util::getTypeBitWidth(iterType.getElementType());
-      int64_t totalBits = numElements * bitWidth;
+      int64_t totalBits = IREE::Util::getRoundedPhysicalStorageSize(iterType);
       if (numElements > 4 && totalBits <= 128 &&
           llvm::isPowerOf2_64(totalBits)) {
         ivIndices.push_back(index);

--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -198,7 +198,7 @@ struct PackForOpInductionVarVector final : public OpRewritePattern<scf::ForOp> {
         continue;
       }
       int64_t numElements = ShapedType::getNumElements(iterType.getShape());
-      int64_t bitWidth = iterType.getElementType().getIntOrFloatBitWidth();
+      int64_t bitWidth = IREE::Util::getTypeBitWidth(iterType.getElementType());
       int64_t totalBits = numElements * bitWidth;
       if (numElements > 4 && totalBits <= 128 &&
           llvm::isPowerOf2_64(totalBits)) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
@@ -58,7 +58,7 @@ shapedTypeStaticSize(memref::AllocOp allocOp, ShapedType shapedType,
              "getIndexBitwidth should have been set earlier");
       allocSize *= getIndexBitwidth(func);
     } else
-      allocSize *= shapedType.getElementType().getIntOrFloatBitWidth();
+      allocSize *= IREE::Util::getTypeBitWidth(shapedType.getElementType());
   }
   return allocSize;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -115,7 +115,8 @@ static int getBaseVectorSize(linalg::GenericOp genericOp) {
   // sure we at least read a full byte for the sub-byte-element operands.
   unsigned operandBW = std::numeric_limits<unsigned>::max();
   for (OpOperand *operand : genericOp.getDpsInputOperands()) {
-    unsigned b = getElementTypeOrSelf(operand->get()).getIntOrFloatBitWidth();
+    unsigned b =
+        IREE::Util::getTypeBitWidth(getElementTypeOrSelf(operand->get()));
     operandBW = std::min(operandBW, b);
   }
   int vectorSize = copyVectorNumBits / resultBW;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
@@ -47,7 +48,7 @@ static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
   std::array<int64_t, 3> threadMNK;
   auto inputType =
       llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
-  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+  if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
     threadMNK = {8, 8, 32};
   } else {
     threadMNK = {8, 4, 16};

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
@@ -13,6 +13,7 @@
 #include <array>
 
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -26,7 +27,7 @@ static LogicalResult setAdrenoMatmulConfig(linalg::LinalgOp op,
   std::array<int64_t, 3> threadMNK;
   auto inputType =
       llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
-  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+  if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
     threadMNK = {16, 8, 8};
   } else {
     threadMNK = {16, 4, 4};

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
@@ -13,6 +13,7 @@
 #include <array>
 
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
@@ -26,7 +27,7 @@ static LogicalResult setAppleMatmulConfig(linalg::LinalgOp op,
   std::array<int64_t, 3> threadMNK;
   auto inputType =
       llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
-  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+  if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
     threadMNK = {4, 8, 8};
   } else {
     threadMNK = {4, 4, 4};

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Strategies.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
@@ -85,7 +86,7 @@ static bool fusedOpMayUseExtraSharedMemory(linalg::LinalgOp matmul) {
 
   auto getResultBits = [](linalg::LinalgOp linalgOp) {
     auto shapedType = llvm::cast<ShapedType>(linalgOp->getResult(0).getType());
-    return shapedType.getElementType().getIntOrFloatBitWidth();
+    return IREE::Util::getTypeBitWidth(shapedType.getElementType());
   };
   auto matmulResultBits = getResultBits(matmul);
 
@@ -636,7 +637,7 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
   auto lhsType = llvm::cast<ShapedType>(lhs->get().getType());
   auto rhsType = llvm::cast<ShapedType>(rhs->get().getType());
   auto elementBits =
-      static_cast<int>(lhsType.getElementType().getIntOrFloatBitWidth());
+      static_cast<int>(IREE::Util::getTypeBitWidth(lhsType.getElementType()));
   if (!llvm::is_contained({8, 16, 32}, elementBits))
     return failure();
 
@@ -1090,7 +1091,7 @@ LogicalResult setCooperativeMatrixConfig(
   auto usedBytes =
       getTileBytes(workgroupTileSizes[mIndex], workgroupTileSizes[nIndex],
                    reductionTileSizes[kIndex],
-                   getElementType(lhs).getIntOrFloatBitWidth(), promoteC);
+                   IREE::Util::getTypeBitWidth(getElementType(lhs)), promoteC);
 
   while (pipelineDepth > 0 &&
          getMultiBufferMemoryUsage(usedBytes, pipelineDepth, storeStage) >
@@ -1279,7 +1280,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
       llvm::cast<ShapedType>(op.getDpsInits()[0].getType()).getElementType();
   if (!elementType.isIntOrFloat())
     return failure();
-  unsigned bitWidth = elementType.getIntOrFloatBitWidth();
+  unsigned bitWidth = IREE::Util::getTypeBitWidth(elementType);
   // Reduction distribution only supports 8/16/32 bit types now.
   if (bitWidth != 32 && bitWidth != 16 && bitWidth != 8)
     return failure();
@@ -1399,11 +1400,12 @@ static int getReductionTilingFactor(int64_t dimSize) {
 static int64_t getMinElementBitwidth(linalg::LinalgOp linalgOp) {
   unsigned bitwidth = std::numeric_limits<unsigned>::max();
   for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
-    unsigned b = getElementTypeOrSelf(operand->get()).getIntOrFloatBitWidth();
+    unsigned b =
+        IREE::Util::getTypeBitWidth(getElementTypeOrSelf(operand->get()));
     bitwidth = std::min(bitwidth, b);
   }
   for (Value result : linalgOp.getDpsInits()) {
-    unsigned b = getElementTypeOrSelf(result).getIntOrFloatBitWidth();
+    unsigned b = IREE::Util::getTypeBitWidth(getElementTypeOrSelf(result));
     bitwidth = std::min(bitwidth, b);
   }
   return bitwidth;
@@ -1475,7 +1477,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
   auto elementHasPowerOfTwoBitwidth = [](Value operand) {
     Type elementType = getElementTypeOrSelf(operand.getType());
     return isa<IntegerType, FloatType>(elementType) &&
-           llvm::isPowerOf2_64(elementType.getIntOrFloatBitWidth());
+           llvm::isPowerOf2_64(IREE::Util::getTypeBitWidth(elementType));
   };
 
   // Whether we can try to use the vectorization pipeline.
@@ -1735,7 +1737,7 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
         std::array<int64_t, 2> workgroupXY = {32, 2};
         std::array<int64_t, 3> threadMNK;
         auto inputType = llvm::cast<ShapedType>(op.getInputs()[0].getType());
-        if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+        if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
           threadMNK = {8, 8, 8};
         } else {
           threadMNK = {8, 8, 4};

--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -13,6 +13,7 @@
 #include <array>
 
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -26,7 +27,7 @@ static LogicalResult setMaliMatmulConfig(linalg::LinalgOp op,
   std::array<int64_t, 3> threadMNK;
   Type inputType = op.getDpsInputOperand(0)->get().getType();
   Type elementType = llvm::cast<ShapedType>(inputType).getElementType();
-  if (elementType.getIntOrFloatBitWidth() == 16) {
+  if (IREE::Util::getTypeBitWidth(elementType) == 16) {
     threadMNK = {2, 8, 8};
   } else if (elementType.isInteger(8)) {
     threadMNK = {4, 4, 16};

--- a/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MathExtras.h"
@@ -44,7 +45,7 @@ static LogicalResult setNVIDIAMatmulConfig(linalg::LinalgOp op,
   std::array<int64_t, 3> threadMNK;
   auto inputType =
       llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
-  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+  if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
     threadMNK = {8, 8, 32};
   } else {
     threadMNK = {4, 4, 32};

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "config_default_linalg_ops.mlir",
             "config_default_matmul.mlir",
             "config_default_matvec.mlir",
+            "config_default_misc.mlir",
             "config_default_reduction.mlir",
             "config_default_sub_byte_types.mlir",
             "config_mali_conv.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_lit_test_suite(
     "config_default_linalg_ops.mlir"
     "config_default_matmul.mlir"
     "config_default_matvec.mlir"
+    "config_default_misc.mlir"
     "config_default_reduction.mlir"
     "config_default_sub_byte_types.mlir"
     "config_mali_conv.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_misc.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_misc.mlir
@@ -1,0 +1,68 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-spirv-select-lowering-strategy-pass)))' %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer, ReadOnly>,
+    #hal.descriptor_set.binding<1, storage_buffer, ReadOnly>,
+    #hal.descriptor_set.binding<2, storage_buffer, ReadOnly>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+hal.executable private @complex_executable {
+  hal.executable.variant @vulkan_spirv_fb target(<"vulkan", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader, GroupNonUniformShuffle], []>, Unknown:IntegratedGPU, #spirv.resource_limits<
+        max_compute_shared_memory_size = 32768,
+        max_compute_workgroup_invocations = 512,
+        max_compute_workgroup_size = [512, 512, 512],
+       subgroup_size = 16>>
+    }>) {
+    hal.executable.export public @complex_view_as_real ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @complex_view_as_real() {
+        %c1 = arith.constant 1 : index
+        %c0 = arith.constant 0 : index
+        %4 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1xi32>>
+        %5 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x50xcomplex<f32>>>
+        %6 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x1x32x50x2xf32>>
+        %7 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<32x50x2xf32>>
+        %8 = flow.dispatch.tensor.load %4, offsets = [0], sizes = [1], strides = [1] : !flow.dispatch.tensor<readonly:tensor<1xi32>> -> tensor<1xi32>
+        %9 = flow.dispatch.tensor.load %6, offsets = [0, 0, 0, 0, 0], sizes = [1, 1, 32, 50, 2], strides = [1, 1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x1x32x50x2xf32>> -> tensor<1x1x32x50x2xf32>
+        %10 = tensor.empty() : tensor<32x50x2xf32>
+        %extracted = tensor.extract %8[%c0] : tensor<1xi32>
+        %11 = arith.extsi %extracted : i32 to i64
+        %19 = arith.index_cast %11 : i64 to index
+        %20 = flow.dispatch.tensor.load %5, offsets = [%19, 0], sizes = [1, 50], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x50xcomplex<f32>>> -> tensor<50xcomplex<f32>>
+        %21 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%20 : tensor<50xcomplex<f32>>) outs(%10 : tensor<32x50x2xf32>) {
+        ^bb0(%in: complex<f32>, %out: f32):
+          %22 = linalg.index 0 : index
+          %23 = linalg.index 1 : index
+          %extracted_0 = tensor.extract %9[%c0, %c0, %22, %23, %c0] : tensor<1x1x32x50x2xf32>
+          %extracted_1 = tensor.extract %9[%c0, %c0, %22, %23, %c1] : tensor<1x1x32x50x2xf32>
+          %24 = complex.create %extracted_0, %extracted_1 : complex<f32>
+          %25 = complex.mul %24, %in : complex<f32>
+          %26 = complex.re %25 : complex<f32>
+          %27 = complex.im %25 : complex<f32>
+          %28 = linalg.index 2 : index
+          %29 = arith.cmpi eq, %28, %c0 : index
+          %30 = arith.select %29, %26, %27 : f32
+          linalg.yield %30 : f32
+        } -> tensor<32x50x2xf32>
+        flow.dispatch.tensor.store %21, %7, offsets = [0, 0, 0], sizes = [32, 50, 2], strides = [1, 1, 1] : tensor<32x50x2xf32> -> !flow.dispatch.tensor<writeonly:tensor<32x50x2xf32>>
+        return
+      }
+    }
+  }
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 2, 2], [1, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseDistribute>
+//      CHECK: hal.executable.export public @complex_view_as_real
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+// CHECK-SAME:   workgroup_size = [2 : index, 2 : index, 4 : index]
+//      CHECK: func.func @complex_view_as_real()
+//      CHECK:   linalg.generic
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/WGSL/WGSLReplacePushConstants.cpp
+++ b/compiler/src/iree/compiler/Codegen/WGSL/WGSLReplacePushConstants.cpp
@@ -37,7 +37,7 @@ static Value convertOpTypeFromI32(IREE::HAL::InterfaceConstantLoadOp loadOp,
   }
 
   unsigned sourceBitWidth = 32;
-  unsigned destBitWidth = opType.getIntOrFloatBitWidth();
+  unsigned destBitWidth = IREE::Util::getTypeBitWidth(opType);
 
   // AnySignlessInteger
   if (llvm::isa<IntegerType>(opType)) {


### PR DESCRIPTION
This is mostly NFC (and mostly targeted at SPIR-V), using a safer utility for getting bit widths that works for complex values as well. There are other places where getIntOrFloatBitWidth is still used, but most of them look to be after we have expected to lower complex values (although I'm certain there are other cases lurking, complex values aren't tested extensively).