### PR TITLE
[GPU] Simplify gpu warp reduction lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorDistribution.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -288,6 +289,7 @@ public:
       vector::populateDistributeTransferWriteOpPatterns(
           patterns, distributionFn, maxWriteElementsToExtract);
       patterns.add<WarpOpBarrier>(patterns.getContext(), 3);
+      vector::ReductionOp::getCanonicalizationPatterns(patterns, ctx);
       (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
@@ -54,7 +54,7 @@ hal.executable private @simple_reduce  {
 //   CHECK-DAG:     %[[E:.*]] = vector.extractelement %[[V0]][%[[C0]] : index] : vector<1xf32>
 //   CHECK-DAG:     %[[ID:.*]] = affine.apply
 //   CHECK-DAG:     %[[V1:.*]] = vector.transfer_read %{{.*}}[%{{.*}}, %[[ID]]], %{{.*}} {in_bounds = [true]} : memref<128x384xf32>, vector<1xf32>
-//       CHECK:     %[[S:.*]] = vector.reduction <add>, %[[V1]] : vector<1xf32> into f32
+//       CHECK:     %[[S:.*]] = vector.extract %[[V1]][0] : f32 from vector<1xf32>
 //       CHECK:     %[[S0:.*]], %{{.*}} = gpu.shuffle  xor %[[S]], %[[C1]], %[[C32]] : f32
 //       CHECK:     %[[S1:.*]] = arith.addf %[[S]], %[[S0]] : f32
 //       CHECK:     %[[S2:.*]], %{{.*}} = gpu.shuffle  xor %[[S1]], %[[C2]], %[[C32]] : f32
@@ -141,8 +141,8 @@ hal.executable private @reduce_uniform_buffer_offset  {
 //         CHECK:   hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%[[OFFSET0]])
 //         CHECK:   hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%[[OFFSET1]])
 //         CHECK:   scf.for
-//         CHECK:     vector.reduction
 // CHECK-COUNT-5:     gpu.shuffle
+//         CHECK:     arith.addf
 //         CHECK:     scf.yield
 
 // -----
@@ -210,8 +210,8 @@ hal.executable private @reduce_storage_buffer_offset  {
 //         CHECK:   hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%[[OFFSET0]])
 //         CHECK:   hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%[[OFFSET1]])
 //         CHECK:   scf.for
-//         CHECK:     vector.reduction
 // CHECK-COUNT-5:     gpu.shuffle
+//         CHECK:     arith.addf
 //         CHECK:     scf.yield
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform_cuda.mlir
@@ -379,15 +379,14 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb", {t
 //         CHECK: gpu.barrier
 
 //     CHECK-NOT: vector.transfer_read
-// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}vector.broadcast{{.*}}{{[[:space:]].*}}vector.bitcast{{.*}}{{[[:space:]].*}}arith.addi{{.*}}vector<4xi8>
-//         CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<32xvector<4xi8>, #gpu.address_space<workgroup>>
+// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}arith.trunci{{.*}}{{[[:space:]].*}}arith.addi{{.*}}i8
+//         CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
 //         CHECK: scf.if
-//         CHECK:   memref.store %{{.*}}, %[[ALLOC]][%{{.*}}] : memref<32xvector<4xi8>, #gpu.address_space<workgroup>>
+//         CHECK:   memref.store %{{.*}}, %[[ALLOC]][%{{.*}}] : memref<32xi8, #gpu.address_space<workgroup>>
 //         CHECK: }
-// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}vector.broadcast{{.*}}{{[[:space:]].*}}vector.bitcast{{.*}}{{[[:space:]].*}}arith.addi{{.*}}vector<4xi8>
+// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}arith.trunci{{.*}}{{[[:space:]].*}}arith.addi{{.*}}i8
 
-//         CHECK: %[[RES:.*]] = vector.reduction <add>, %59 : vector<4xi8> into i8
-//         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : i8 to vector<1xi8>
+//         CHECK: %[[RES_VEC:.*]] = vector.broadcast %{{.+}} : i8 to vector<1xi8>
 //         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK: scf.if %[[CONDXIS0]]
 //         CHECK:   vector.transfer_write %[[RES_VEC]], %[[ALLOC0]][%[[C0]]] {in_bounds = [true]} : vector<1xi8>, memref<1xi8, #gpu.address_space<workgroup>>
@@ -524,8 +523,7 @@ hal.executable private @i4_dequant_matvec {
 //         CHECK:     %[[ADD:.+]] = arith.addf %[[MUL1]], %[[ARG]] : vector<1x8xf16>
 
 //         CHECK:   %[[SCAST:.+]] = vector.shape_cast %[[FOR]] : vector<1x8xf16> to vector<8xf16>
-//         CHECK:   %[[EXTRACT:.+]] = vector.extract_strided_slice %[[SCAST]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
-//         CHECK:   vector.reduction <add>, %[[EXTRACT]] : vector<4xf16> into f16
+//         CHECK:   vector.reduction <add>, %[[SCAST]] : vector<8xf16> into f16
 // CHECK-COUNT-6:   gpu.shuffle  xor
 //         CHECK:   scf.if
 //         CHECK:     vector.transfer_write

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform_rocm.mlir
@@ -145,8 +145,7 @@ hal.executable private @i4_dequant_matvec {
 //         CHECK:     %[[ADD:.+]] = arith.addf %[[MUL1]], %[[ARG]] : vector<1x8xf16>
 
 //         CHECK:   %[[SCAST:.+]] = vector.shape_cast %[[FOR]] : vector<1x8xf16> to vector<8xf16>
-//         CHECK:   %[[EXTRACT:.+]] = vector.extract_strided_slice %[[SCAST]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
-//         CHECK:   vector.reduction <add>, %[[EXTRACT]] : vector<4xf16> into f16
+//         CHECK:   vector.reduction <add>, %[[SCAST]] : vector<8xf16> into f16
 // CHECK-COUNT-6:   gpu.shuffle  xor
 //         CHECK:   scf.if
 //         CHECK:     vector.transfer_write
@@ -259,7 +258,7 @@ hal.executable private @matvec_fp16 {
 //          CHECK:     %[[MUL:.+]] = arith.mulf %[[VEC]], %[[MAT]] : vector<8x8xf16>
 //          CHECK:     %[[ADD:.+]] = arith.addf %[[ARG]], %[[MUL]] : vector<8x8xf16>
 
-//          CHECK:   vector.reduction <add>, %{{.+}} : vector<4xf16> into f16
+//          CHECK:   vector.reduction <add>, %{{.+}} : vector<8xf16> into f16
 // CHECK-COUNT-24:   gpu.shuffle xor
 //          CHECK:   scf.if
 //          CHECK:     vector.transfer_write {{.+}} : vector<8xf16>, memref<1x32000xf16, #hal.descriptor_type<storage_buffer>>
@@ -317,7 +316,7 @@ hal.executable private @matvec_fp16 {
 //          CHECK:     %[[MUL:.+]] = arith.mulf %[[VEC]], %[[MAT]] : vector<8x8xf16>
 //          CHECK:     %[[ADD:.+]] = arith.addf %[[ARG]], %[[MUL]] : vector<8x8xf16>
 
-//          CHECK:   vector.reduction <add>, %{{.+}} : vector<4xf16> into f16
+//          CHECK:   vector.reduction <add>, %{{.+}} : vector<8xf16> into f16
 // CHECK-COUNT-24:   gpu.shuffle xor
 //          CHECK:   scf.if
 //          CHECK:     vector.transfer_write {{.+}} : vector<8xf16>, memref<1x32000xf16, #hal.descriptor_type<storage_buffer>>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -173,8 +173,9 @@ hal.executable @warp_reduction_dispatch {
 //         CHECK:    %{{.+}}, %{{.+}} = gpu.shuffle  xor %{{.+}}, %[[I1]], %[[I32]] : i32
 //         CHECK:    %{{.+}}, %{{.+}} = gpu.shuffle  xor %{{.+}}, %[[I2]], %[[I32]] : i32
 //         CHECK:    %{{.+}}, %{{.+}} = gpu.shuffle  idx %{{.+}}, %[[I0]], %[[I32]] : i32
-//         CHECK:    %[[ADD:.+]] = vector.reduction <add>, %{{.+}} : vector<2xf16> into f16
-//         CHECK:    %[[ADD1:.+]] = arith.addf %[[ADD]], %[[F0]] : f16
+//         CHECK:    %[[TRUNC:.+]] = arith.trunci %{{.+}} : i32 to i16
+//         CHECK:    %[[BCAST:.+]] = arith.bitcast %[[TRUNC]] : i16 to f16
+//         CHECK:    %[[ADD1:.+]] = arith.addf %[[BCAST]], %[[F0]] : f16
 //         CHECK:    %[[SPLAT:.+]] = vector.splat %[[ADD1]] : vector<4xf16>
 //         CHECK:    scf.for %[[IV:.+]] = %[[C0]] to %[[C9216]] step %[[C1024]] {
 //         CHECK:      %[[OFFSET:.+]] = affine.apply #[[$MAP]](%[[IV]])[%[[TIDX]]]

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -15,9 +15,12 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+#include <cassert>
+#include <cstdint>
 #include <optional>
 
 #define DEBUG_TYPE "iree-codegen-gpu-utils"
@@ -318,7 +321,7 @@ void insertBarriersAroundSharedMemoryCopy(func::FuncOp funcOp) {
 // Reduction utils
 //===----------------------------------------------------------------------===//
 
-/// Packs scalar element to it's vector equivalent.
+/// Packs scalar element to its vector equivalent.
 /// (i.e f16 -> vector<1xf16> and f32 -> vector<1xf32>)
 static Value promoteElementToVector(Location loc, OpBuilder &builder,
                                     Value input) {
@@ -362,43 +365,63 @@ Value unpackToVector(Location loc, OpBuilder &builder, Value packedInput,
   return unpackedVector;
 }
 
-/// Emit warp reduction code sequence for a given input.
+/// Emit warp reduction code sequence for a given scalar input value.
 static Value warpReduction(Location loc, OpBuilder &builder, Value input,
                            vector::CombiningKind kind, uint32_t warpSize,
                            uint32_t numLaneToReduce) {
-  VectorType unpackedType = llvm::dyn_cast<VectorType>(input.getType());
-  Value laneVal = input;
   assert(llvm::isPowerOf2_32(numLaneToReduce));
+  assert((llvm::isa<IntegerType, FloatType>(input.getType())) &&
+         "Input must be a scalar");
+  IntegerType shuffleIntType = builder.getIntegerType(kShuffleBitWidth);
+  Type origInputType = input.getType();
+  const unsigned origBitWidth = origInputType.getIntOrFloatBitWidth();
+  assert(origBitWidth <= kShuffleBitWidth && "Unsupported input type bitwidth");
+
+  const bool needsPacking = kShuffleBitWidth != origBitWidth;
+  IntegerType equivIntType = builder.getIntegerType(origBitWidth);
+
+  // Always perform the shuffles over the supported scalar type. For inputs of
+  // smaller bitwidth, perform packing and unpacking via the supported integer
+  // type.
+  auto unpack = [loc, &builder, needsPacking, equivIntType,
+                 origInputType](Value packedVal) -> Value {
+    if (!needsPacking)
+      return packedVal;
+    auto asInt = builder.create<arith::TruncIOp>(loc, equivIntType, packedVal);
+    return builder.create<arith::BitcastOp>(loc, origInputType, asInt);
+  };
+
+  auto pack = [loc, &builder, needsPacking, equivIntType,
+               shuffleIntType](Value unpackedVal) -> Value {
+    if (!needsPacking)
+      return unpackedVal;
+    auto asInt =
+        builder.create<arith::BitcastOp>(loc, equivIntType, unpackedVal);
+    return builder.create<arith::ExtUIOp>(loc, shuffleIntType, asInt);
+  };
+
+  // Lane value always stays in the original type. We use it to perform arith
+  // reductions.
+  Value laneVal = input;
   // Parallel reduction using butterfly shuffles.
   for (uint64_t i = 1; i < numLaneToReduce; i <<= 1) {
-    Value shuffleInput = laneVal;
-    if (unpackedType) {
-      shuffleInput = packVectorToSupportedWidth(loc, builder, laneVal);
-    }
     Value shuffled = builder
-                         .create<gpu::ShuffleOp>(loc, shuffleInput, i,
+                         .create<gpu::ShuffleOp>(loc, pack(laneVal), i,
                                                  /*width=*/warpSize,
                                                  /*mode=*/gpu::ShuffleMode::XOR)
                          .getShuffleResult();
-    if (unpackedType) {
-      shuffled = unpackToVector(loc, builder, shuffled, unpackedType);
-    }
-    laneVal = makeArithReduction(builder, loc, kind, laneVal, shuffled);
+    laneVal = makeArithReduction(builder, loc, kind, laneVal, unpack(shuffled));
   }
   // Broadcast the result to all the lanes.
   if (warpSize != numLaneToReduce) {
-    if (unpackedType) {
-      laneVal = packVectorToSupportedWidth(loc, builder, laneVal);
-    }
-    laneVal = builder
-                  .create<gpu::ShuffleOp>(loc, laneVal, 0,
-                                          /*width=*/warpSize,
-                                          /*mode=*/gpu::ShuffleMode::IDX)
-                  .getShuffleResult();
-    if (unpackedType) {
-      laneVal = unpackToVector(loc, builder, laneVal, unpackedType);
-    }
+    Value shuffled = builder
+                         .create<gpu::ShuffleOp>(loc, pack(laneVal), 0,
+                                                 /*width=*/warpSize,
+                                                 /*mode=*/gpu::ShuffleMode::IDX)
+                         .getShuffleResult();
+    laneVal = unpack(shuffled);
   }
+
   return laneVal;
 }
 
@@ -441,59 +464,6 @@ static TypedAttr getCombiningKindIdentity(OpBuilder &builder,
   }
   }
   return TypedAttr();
-}
-
-/// Compute the value on a single thread to get per lane reduction value.
-/// If bit-width is not supported on shuffle operations, and a lower precision,
-/// we represent them as a vector S.T we can pack them into a single 32-bit
-/// width for shuffles.
-static Value reduceToSupportedWidth(Location loc, OpBuilder &builder,
-                                    Value input, vector::CombiningKind kind) {
-  auto vecType = llvm::cast<VectorType>(input.getType());
-  Type elementType = vecType.getElementType();
-  int64_t vecSize = vecType.getDimSize(0);
-  unsigned bitWidth = elementType.getIntOrFloatBitWidth();
-  // Simply reduce if it's already 32 bits.
-  if (bitWidth == kShuffleBitWidth) {
-    return builder.create<vector::ReductionOp>(loc, kind, input);
-  }
-  assert(kShuffleBitWidth % bitWidth == 0 &&
-         "Bitwidth needs to be able to be packed into shuffle-bitwidth.");
-  int64_t unrollCount = kShuffleBitWidth / bitWidth;
-  // Original size needs to be divisble by or less than unroll count to
-  // determine slice size.
-  assert(vecSize % unrollCount == 0 || vecSize < unrollCount);
-  unsigned sliceSize = vecSize / unrollCount;
-  VectorType unrolledLaneValType = VectorType::get({unrollCount}, elementType);
-  Value perLaneReduction = builder.create<arith::ConstantOp>(
-      loc, builder.getZeroAttr(unrolledLaneValType));
-  if (vecSize % unrollCount == 0) {
-    // Unroll reductions s.t we can pack into a supported 32-bitWidth format.
-    for (int64_t i = 0; i < unrollCount; i++) {
-      Value laneValSlice = builder.create<vector::ExtractStridedSliceOp>(
-          loc, input,
-          /*offsets=*/ArrayRef<int64_t>{sliceSize * i},
-          /*sizes=*/ArrayRef<int64_t>{sliceSize},
-          /*strides=*/ArrayRef<int64_t>{1});
-      Value reductionSlice =
-          builder.create<vector::ReductionOp>(loc, kind, laneValSlice);
-      SmallVector<int64_t> perLaneUnrollId = {i};
-      perLaneReduction = builder.create<vector::InsertOp>(
-          loc, reductionSlice, perLaneReduction, perLaneUnrollId);
-    }
-  } else {
-    // In cases where vecSize < unrollCount, we would pad the vector
-    // with identity elements until it's total bit size is 32.
-    TypedAttr identityAttr =
-        getCombiningKindIdentity(builder, kind, elementType);
-    identityAttr = DenseElementsAttr::get(unrolledLaneValType, identityAttr);
-    Value identity = builder.create<arith::ConstantOp>(loc, unrolledLaneValType,
-                                                       identityAttr);
-    perLaneReduction = builder.create<vector::InsertStridedSliceOp>(
-        loc, input, identity, /*offsets=*/ArrayRef<int64_t>{0},
-        /*strides=*/ArrayRef<int64_t>{1});
-  }
-  return perLaneReduction;
 }
 
 /// Emit identity variable.
@@ -561,7 +531,7 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
   // butterfly shuffle algorithm).
   //
   // First reduce on a single thread to get per lane reduction value.
-  Value laneVal = reduceToSupportedWidth(loc, builder, input, kind);
+  Value laneVal = builder.create<vector::ReductionOp>(loc, kind, input);
   laneVal = warpReduction(loc, builder, laneVal, kind, warpSize, warpSize);
   // if we have more than one warp, reduce across warps.
   if (size > warpSize) {
@@ -608,10 +578,7 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
     }
     laneVal = warpReduction(loc, builder, loadVal, kind, warpSize, numWarp);
   }
-  // Handles cases for sub-32bit precision where output is still in vector form.
-  if (llvm::isa<VectorType>(laneVal.getType())) {
-    laneVal = builder.create<vector::ReductionOp>(loc, kind, laneVal);
-  }
+
   return laneVal;
 }
 


### PR DESCRIPTION
Always perform a single warp reduction, even when the reduced element type is not 32-bits wide. This way we do not split reductions into n parallel ones and remove one initial and one final vector reduction.

Instead, pack small types into a single `i32` and perform a single vector reduction upfront.

This results in less IR, less workgroup memory usage (when required), and simpler logic.