### PR TITLE
[VM] Add a vm.rodata.table.inline op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilBase.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilBase.td
@@ -76,6 +76,11 @@ def Util_AnySerializableAttr : Attr<Or<[
   let convertFromStorage = "$_self";
 }
 
+def Util_AnySerializableArrayAttr :
+  TypedArrayAttrBase<Util_AnySerializableAttr,
+                     "array attribute of serializable attributes"
+  >;
+
 class Util_AliasedSymbolRefAttr : Attr<CPred<"$_self.isa<FlatSymbolRefAttr>()">,
                                        "symbol reference attribute"> {
   let storageType = [{ FlatSymbolRefAttr }];

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -345,6 +345,8 @@ def VM_AnyType : AnyTypeOf<[
   VM_AnyRef,
 ]>;
 
+def VM_AnyIntegerType : AnyIntOfWidths<[32, 64]>;
+
 def VM_PrimitiveType : AnyTypeOf<[
   AnyIntOfWidths<[8, 16, 32, 64]>,
   FloatOfWidths<[16, 32, 64]>,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -808,7 +808,7 @@ void RodataInlineOp::build(OpBuilder &builder, OperationState &result,
         /*mimeType=*/nullptr);
 }
 
-void RodataInlineTableOp::build(OpBuilder &builder, OperationState &result,
+void RodataTableInlineOp::build(OpBuilder &builder, OperationState &result,
                                 StringAttr name, IntegerType tableType,
                                 ArrayAttr value) {
   // Make an identifier-friendly version of the string so that the value is
@@ -826,7 +826,7 @@ void RodataInlineTableOp::build(OpBuilder &builder, OperationState &result,
         /*alignment=*/nullptr, /*dataAlignment=*/nullptr, /*mimeType=*/nullptr);
 }
 
-void RodataInlineTableOp::build(OpBuilder &builder, OperationState &result,
+void RodataTableInlineOp::build(OpBuilder &builder, OperationState &result,
                                 IntegerType tableType, ArrayAttr value) {
   auto refType =
       IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext()));

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -809,7 +809,8 @@ void RodataInlineOp::build(OpBuilder &builder, OperationState &result,
 }
 
 void RodataTableOp::build(OpBuilder &builder, OperationState &result,
-                          StringAttr name, IREE::Util::CompositeAttr value) {
+                          StringAttr name, IntegerType tableType,
+                          ArrayAttr value) {
   // Make an identifier-friendly version of the string so that the value is
   // more readable in IR (so "I'm some string" becomes "im_some_string", etc).
   auto safeIdentifier = makeSafeIdentifier(name.getValue());
@@ -820,16 +821,17 @@ void RodataTableOp::build(OpBuilder &builder, OperationState &result,
       IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext()));
   build(builder, result, TypeRange{refType, refType},
         /*tableName=*/builder.getStringAttr(tableName),
-        /*dataName=*/builder.getStringAttr(dataName), /*dataArray=*/value,
+        /*dataName=*/builder.getStringAttr(dataName), /*tableType=*/tableType,
+        /*dataArray=*/value,
         /*alignment=*/nullptr, /*dataAlignment=*/nullptr, /*mimeType=*/nullptr);
 }
 
 void RodataTableOp::build(OpBuilder &builder, OperationState &result,
-                          IREE::Util::CompositeAttr value) {
+                          IntegerType tableType, ArrayAttr value) {
   auto refType =
       IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext()));
   build(builder, result, TypeRange{refType, refType},
-        /*tableName=*/nullptr, /*dataName=*/nullptr,
+        /*tableName=*/nullptr, /*dataName=*/nullptr, /*tableType=*/tableType,
         /*dataArray=*/value, /*alignment=*/nullptr, /*dataAlignment=*/nullptr,
         /*mimeType=*/nullptr);
 }

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -808,9 +808,9 @@ void RodataInlineOp::build(OpBuilder &builder, OperationState &result,
         /*mimeType=*/nullptr);
 }
 
-void RodataTableOp::build(OpBuilder &builder, OperationState &result,
-                          StringAttr name, IntegerType tableType,
-                          ArrayAttr value) {
+void RodataInlineTableOp::build(OpBuilder &builder, OperationState &result,
+                                StringAttr name, IntegerType tableType,
+                                ArrayAttr value) {
   // Make an identifier-friendly version of the string so that the value is
   // more readable in IR (so "I'm some string" becomes "im_some_string", etc).
   auto safeIdentifier = makeSafeIdentifier(name.getValue());
@@ -826,8 +826,8 @@ void RodataTableOp::build(OpBuilder &builder, OperationState &result,
         /*alignment=*/nullptr, /*dataAlignment=*/nullptr, /*mimeType=*/nullptr);
 }
 
-void RodataTableOp::build(OpBuilder &builder, OperationState &result,
-                          IntegerType tableType, ArrayAttr value) {
+void RodataInlineTableOp::build(OpBuilder &builder, OperationState &result,
+                                IntegerType tableType, ArrayAttr value) {
   auto refType =
       IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext()));
   build(builder, result, TypeRange{refType, refType},

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -808,6 +808,32 @@ void RodataInlineOp::build(OpBuilder &builder, OperationState &result,
         /*mimeType=*/nullptr);
 }
 
+void RodataTableOp::build(OpBuilder &builder, OperationState &result,
+                          StringAttr name, IREE::Util::CompositeAttr value) {
+  // Make an identifier-friendly version of the string so that the value is
+  // more readable in IR (so "I'm some string" becomes "im_some_string", etc).
+  auto safeIdentifier = makeSafeIdentifier(name.getValue());
+  // Make names for the table and data based on the safe identifier.
+  std::string tableName = safeIdentifier + "_table";
+  std::string dataName = safeIdentifier + "_data";
+  auto refType =
+      IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext()));
+  build(builder, result, TypeRange{refType, refType},
+        /*tableName=*/builder.getStringAttr(tableName),
+        /*dataName=*/builder.getStringAttr(dataName), /*dataArray=*/value,
+        /*alignment=*/nullptr, /*dataAlignment=*/nullptr, /*mimeType=*/nullptr);
+}
+
+void RodataTableOp::build(OpBuilder &builder, OperationState &result,
+                          IREE::Util::CompositeAttr value) {
+  auto refType =
+      IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext()));
+  build(builder, result, TypeRange{refType, refType},
+        /*tableName=*/nullptr, /*dataName=*/nullptr,
+        /*dataArray=*/value, /*alignment=*/nullptr, /*dataAlignment=*/nullptr,
+        /*mimeType=*/nullptr);
+}
+
 //===----------------------------------------------------------------------===//
 // Lists
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1204,10 +1204,10 @@ def VM_RodataTableOp : VM_PureOp<"rodata.table", [
   let description = [{
     vm.rodata with another associated vm.rodata table specifying byte offsets
     and sizes as a subview into the flattened data. The table is a flat array
-    of 32-bit integers storing (offset, size) in element order.
+    of 32 or 64-bit integers storing (offset, size) in element order.
 
     The optional alignment attribute applies to both the table and data rodata.
-    The dataAligment attribute can be used to specify an alignment for the
+    The data_alignment attribute can be used to specify an alignment for the
     elements of the table, padding to the data alignment with zeros. The element
     sizes reflect the unpadded attribute storage sizes.
 
@@ -1217,7 +1217,8 @@ def VM_RodataTableOp : VM_PureOp<"rodata.table", [
   let arguments = (ins
     OptionalAttr<StrAttr>:$table_name,
     OptionalAttr<StrAttr>:$data_name,
-    Util_CompositeAttr:$data_array,
+    TypeAttrOf<VM_AnyIntegerType>:$table_type,
+    Util_AnySerializableArrayAttr:$data_array,
     OptionalAttr<I64Attr>:$alignment,
     OptionalAttr<I64Attr>:$data_alignment,
     OptionalAttr<StrAttr>:$mime_type
@@ -1229,17 +1230,12 @@ def VM_RodataTableOp : VM_PureOp<"rodata.table", [
   );
 
   let assemblyFormat = [{
-    attr-dict `:` type($table_result) `,` type($data_result) `=` $data_array
+    $table_type attr-dict `:` type($table_result) `,` type($data_result) `=` $data_array
   }];
 
   let builders = [
-    OpBuilder<(ins "TypeRange":$resultTypes, "ArrayAttr":$value),
-    [{
-      $_state.addTypes(resultTypes);
-      $_state.addAttribute("data_array", value);
-    }]>,
-    OpBuilder<(ins "Util::CompositeAttr":$value)>,
-    OpBuilder<(ins "StringAttr":$name, "Util::CompositeAttr":$value)>
+    OpBuilder<(ins "IntegerType":$table_type, "ArrayAttr":$value)>,
+    OpBuilder<(ins "StringAttr":$name, "IntegerType":$table_type, "ArrayAttr":$value)>
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -16,6 +16,7 @@ include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilTypes.td"
+include "iree/compiler/Dialect/Util/IR/UtilAttrs.td"
 include "iree/compiler/Dialect/VM/IR/VMBase.td"
 
 // Trial ops do not have any memory effects but may invoke Undefine Behavior on
@@ -1193,6 +1194,52 @@ def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
       $_state.addAttribute("value", value);
     }]>,
     OpBuilder<(ins "StringAttr":$value)>
+  ];
+}
+
+def VM_RodataTableOp : VM_PureOp<"rodata.table", [
+    VM_PseudoOp,
+  ]> {
+  let summary = [{inlined constant rodata table}];
+  let description = [{
+    vm.rodata with another associated vm.rodata table specifying byte offsets
+    and sizes as a subview into the flattened data. The table is a flat array
+    of 32-bit integers storing (offset, size) in element order.
+
+    The optional alignment attribute applies to both the table and data rodata.
+    The dataAligment attribute can be used to specify an alignment for the
+    elements of the table, padding to the data alignment with zeros. The element
+    sizes reflect the unpadded attribute storage sizes.
+
+    See vm.rodata for more information.
+  }];
+
+  let arguments = (ins
+    OptionalAttr<StrAttr>:$table_name,
+    OptionalAttr<StrAttr>:$data_name,
+    Util_CompositeAttr:$data_array,
+    OptionalAttr<I64Attr>:$alignment,
+    OptionalAttr<I64Attr>:$data_alignment,
+    OptionalAttr<StrAttr>:$mime_type
+  );
+
+  let results = (outs
+    VM_RefOf<VM_BufferType>:$table_result,
+    VM_RefOf<VM_BufferType>:$data_result
+  );
+
+  let assemblyFormat = [{
+    attr-dict `:` type($table_result) `,` type($data_result) `=` $data_array
+  }];
+
+  let builders = [
+    OpBuilder<(ins "TypeRange":$resultTypes, "ArrayAttr":$value),
+    [{
+      $_state.addTypes(resultTypes);
+      $_state.addAttribute("data_array", value);
+    }]>,
+    OpBuilder<(ins "Util::CompositeAttr":$value)>,
+    OpBuilder<(ins "StringAttr":$name, "Util::CompositeAttr":$value)>
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1197,7 +1197,7 @@ def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
   ];
 }
 
-def VM_RodataTableOp : VM_PureOp<"rodata.table", [
+def VM_RodataInlineTableOp : VM_PureOp<"rodata.inline.table", [
     VM_PseudoOp,
   ]> {
   let summary = [{inlined constant rodata table}];

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1197,7 +1197,7 @@ def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
   ];
 }
 
-def VM_RodataInlineTableOp : VM_PureOp<"rodata.inline.table", [
+def VM_RodataTableInlineOp : VM_PureOp<"rodata.table.inline", [
     VM_PseudoOp,
   ]> {
   let summary = [{inlined constant rodata table}];

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
@@ -54,3 +54,21 @@ vm.module @my_module {
     vm.return %0 : !vm.buffer
   }
 }
+
+// -----
+
+// CHECK: #[[$DATA:.+]] = #util.composite<10xi8, [
+#table_data = #util.composite<10xi8, [
+  dense<[2, 3]> : vector<2xi8>,
+  "hello",
+  dense<4> : tensor<3xi8>
+]>
+
+vm.module @my_module {
+  // CHECK-LABEL: @rodata_table
+  vm.func @rodata_table() -> !vm.buffer {
+    // CHECK-NEXT: = vm.rodata.table : !vm.buffer, !vm.buffer = #[[$DATA]]
+    %0:2 = vm.rodata.table : !vm.buffer, !vm.buffer = #table_data
+    vm.return %0#1 : !vm.buffer
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
@@ -57,18 +57,18 @@ vm.module @my_module {
 
 // -----
 
-// CHECK: #[[$DATA:.+]] = #util.composite<10xi8, [
-#table_data = #util.composite<10xi8, [
+#table_data = [
   dense<[2, 3]> : vector<2xi8>,
   "hello",
   dense<4> : tensor<3xi8>
-]>
+]
 
 vm.module @my_module {
   // CHECK-LABEL: @rodata_table
   vm.func @rodata_table() -> !vm.buffer {
-    // CHECK-NEXT: = vm.rodata.table : !vm.buffer, !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.table : !vm.buffer, !vm.buffer = #table_data
+    // CHECK-NEXT: = vm.rodata.table i32 : !vm.buffer, !vm.buffer
+    // CHECK-SAME: = [dense<[2, 3]> : vector<2xi8>, "hello", dense<4> : tensor<3xi8>]
+    %0:2 = vm.rodata.table i32 : !vm.buffer, !vm.buffer = #table_data
     vm.return %0#1 : !vm.buffer
   }
 }

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
@@ -64,11 +64,11 @@ vm.module @my_module {
 ]
 
 vm.module @my_module {
-  // CHECK-LABEL: @rodata_inline_table
-  vm.func @rodata_inline_table() -> !vm.buffer {
-    // CHECK-NEXT: = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer
+  // CHECK-LABEL: @rodata_table_inline
+  vm.func @rodata_table_inline() -> !vm.buffer {
+    // CHECK-NEXT: = vm.rodata.table.inline i32 : !vm.buffer, !vm.buffer
     // CHECK-SAME: = [dense<[2, 3]> : vector<2xi8>, "hello", dense<4> : tensor<3xi8>]
-    %0:2 = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.table.inline i32 : !vm.buffer, !vm.buffer = #table_data
     vm.return %0#1 : !vm.buffer
   }
 }

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
@@ -64,11 +64,11 @@ vm.module @my_module {
 ]
 
 vm.module @my_module {
-  // CHECK-LABEL: @rodata_table
-  vm.func @rodata_table() -> !vm.buffer {
-    // CHECK-NEXT: = vm.rodata.table i32 : !vm.buffer, !vm.buffer
+  // CHECK-LABEL: @rodata_inline_table
+  vm.func @rodata_inline_table() -> !vm.buffer {
+    // CHECK-NEXT: = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer
     // CHECK-SAME: = [dense<[2, 3]> : vector<2xi8>, "hello", dense<4> : tensor<3xi8>]
-    %0:2 = vm.rodata.table i32 : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = #table_data
     vm.return %0#1 : !vm.buffer
   }
 }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/BUILD.bazel
@@ -22,6 +22,7 @@ iree_compiler_cc_library(
         "HoistInlinedRodata.cpp",
         "OrdinalAllocation.cpp",
         "Passes.cpp",
+        "ReifyRodataTables.cpp",
         "ResolveRodataLoads.cpp",
         "SinkDefiningOps.cpp",
     ],

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
     "HoistInlinedRodata.cpp"
     "OrdinalAllocation.cpp"
     "Passes.cpp"
+    "ReifyRodataTables.cpp"
     "ResolveRodataLoads.cpp"
     "SinkDefiningOps.cpp"
   DEPS

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -92,6 +92,7 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(createConversionPass(targetOptions));
 
   // Hoist globals and get the final set that need to be initialized.
+  passManager.addNestedPass<IREE::VM::ModuleOp>(createReifyRodataTablesPass());
   passManager.addNestedPass<IREE::VM::ModuleOp>(createHoistInlinedRodataPass());
   passManager.addNestedPass<IREE::VM::ModuleOp>(createDeduplicateRodataPass());
   addCleanupPatterns(passManager);

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.h
@@ -48,7 +48,7 @@ createConversionPass(TargetOptions targetOptions);
 // Module layout
 //===----------------------------------------------------------------------===//
 
-// Reifies and pads vm.rodata.table ops as two vm.rodata.inline ops.
+// Reifies and pads vm.rodata.inline.table ops as two vm.rodata.inline ops.
 std::unique_ptr<OperationPass<IREE::VM::ModuleOp>>
 createReifyRodataTablesPass();
 

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.h
@@ -48,7 +48,7 @@ createConversionPass(TargetOptions targetOptions);
 // Module layout
 //===----------------------------------------------------------------------===//
 
-// Reifies and pads vm.rodata.inline.table ops as two vm.rodata.inline ops.
+// Reifies and pads vm.rodata.table.inline ops as two vm.rodata.inline ops.
 std::unique_ptr<OperationPass<IREE::VM::ModuleOp>>
 createReifyRodataTablesPass();
 

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.h
@@ -48,6 +48,10 @@ createConversionPass(TargetOptions targetOptions);
 // Module layout
 //===----------------------------------------------------------------------===//
 
+// Reifies and pads vm.rodata.table ops as two vm.rodata.inline ops.
+std::unique_ptr<OperationPass<IREE::VM::ModuleOp>>
+createReifyRodataTablesPass();
+
 // Hoists inline vm.rodata.inline values to module-level constant storage.
 std::unique_ptr<OperationPass<IREE::VM::ModuleOp>>
 createHoistInlinedRodataPass();

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
@@ -1,0 +1,117 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <utility>
+
+#include "iree/compiler/Dialect/VM/IR/VMDialect.h"
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "iree/compiler/Dialect/VM/IR/VMTypes.h"
+#include "iree/compiler/Dialect/VM/Transforms/Passes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::VM {
+
+// Replaces a vm.rodata.table op with two vm.rodata.inline ops, one for the
+// indexing table, and the second for the padded data.
+static void reifyRodataTable(RewriterBase &rewriter,
+                             IREE::VM::RodataTableOp tableOp) {
+  SmallVector<int32_t> table;
+  SmallVector<Attribute> dataAttrs;
+  size_t dataSize = 0;
+  size_t dataAlignment =
+      tableOp.getDataAlignment() ? *tableOp.getDataAlignment() : 1;
+  for (auto value : tableOp.getDataArray().getValues()) {
+    auto serializableAttr =
+        llvm::cast<IREE::Util::SerializableAttrInterface>(value);
+    size_t storageSize = serializableAttr.getStorageSize();
+    dataAttrs.push_back(value);
+
+    // Pad to the (byte) data alignment.
+    size_t padding =
+        (dataAlignment - storageSize % dataAlignment) % dataAlignment;
+    if (padding) {
+      SmallVector<int8_t> zeros(padding, 0);
+      VectorType paddingType = VectorType::get({static_cast<int64_t>(padding)},
+                                               rewriter.getIntegerType(8));
+      dataAttrs.push_back(rewriter.getZeroAttr(paddingType));
+    }
+
+    // The running data size is the offset of the current value.
+    table.push_back(dataSize);
+    // The table specifies the (unpadded) storage size for this element.
+    table.push_back(storageSize);
+
+    // Increment the total storage size by the (padded) storage size.
+    dataSize += storageSize + padding;
+  }
+
+  auto refType =
+      IREE::VM::RefType::get(rewriter.getType<IREE::VM::BufferType>());
+  auto tableRodata = rewriter.create<IREE::VM::RodataInlineOp>(
+      tableOp.getLoc(), refType, rewriter.getI32VectorAttr(table));
+  if (auto tableNameAttr = tableOp.getTableNameAttr()) {
+    tableRodata.setNameAttr(tableNameAttr);
+  }
+
+  auto dataRodata = rewriter.create<IREE::VM::RodataInlineOp>(
+      tableOp.getLoc(), refType,
+      IREE::Util::CompositeAttr::get(rewriter.getContext(), dataAttrs));
+  if (auto dataNameAttr = tableOp.getDataNameAttr()) {
+    dataRodata.setNameAttr(dataNameAttr);
+  }
+
+  if (auto alignmentAttr = tableOp.getAlignmentAttr()) {
+    tableRodata.setAlignmentAttr(alignmentAttr);
+    dataRodata.setAlignmentAttr(alignmentAttr);
+  }
+  if (auto mimeTypeAttr = tableOp.getMimeTypeAttr()) {
+    tableRodata.setMimeTypeAttr(mimeTypeAttr);
+    dataRodata.setMimeTypeAttr(mimeTypeAttr);
+  }
+  rewriter.replaceOp(tableOp, {tableRodata, dataRodata});
+}
+
+class ReifyRodataTablesPass
+    : public PassWrapper<ReifyRodataTablesPass,
+                         OperationPass<IREE::VM::ModuleOp>> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::VM::VMDialect>();
+  }
+
+  StringRef getArgument() const override {
+    return "iree-vm-reify-rodata-tables";
+  }
+
+  StringRef getDescription() const override {
+    return "Converts vm.rodata.table into two rodata, one for the flat data and"
+           "the other for a newly constructed table for the element subviews.";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    // Walk all of the rodata table ops and convert to rodata.inline
+    IRRewriter rewriter(moduleOp.getContext());
+    moduleOp.walk([&](IREE::VM::RodataTableOp tableOp) {
+      rewriter.setInsertionPoint(tableOp);
+      reifyRodataTable(rewriter, tableOp);
+    });
+  }
+};
+
+std::unique_ptr<OperationPass<IREE::VM::ModuleOp>>
+createReifyRodataTablesPass() {
+  return std::make_unique<ReifyRodataTablesPass>();
+}
+
+static PassRegistration<ReifyRodataTablesPass> pass;
+
+} // namespace mlir::iree_compiler::IREE::VM

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
@@ -18,11 +18,11 @@
 
 namespace mlir::iree_compiler::IREE::VM {
 
-// Replaces a vm.rodata.inline.table op with two vm.rodata.inline ops, one for
+// Replaces a vm.rodata.table.inline op with two vm.rodata.inline ops, one for
 // the indexing table, and the second for the padded data.
 template <typename IntTy>
 static void reifyRodataTable(RewriterBase &rewriter,
-                             IREE::VM::RodataInlineTableOp tableOp) {
+                             IREE::VM::RodataTableInlineOp tableOp) {
   SmallVector<IntTy> table;
   SmallVector<Attribute> dataAttrs;
   size_t dataSize = 0;
@@ -98,7 +98,7 @@ public:
   }
 
   StringRef getDescription() const override {
-    return "Converts vm.rodata.inline.table into two rodata, one for the flat "
+    return "Converts vm.rodata.table.inline into two rodata, one for the flat "
            "data and"
            "the other for a newly constructed table for the element subviews.";
   }
@@ -108,7 +108,7 @@ public:
 
     // Walk all of the rodata table ops and convert to rodata.inline
     IRRewriter rewriter(moduleOp.getContext());
-    moduleOp.walk([&](IREE::VM::RodataInlineTableOp tableOp) {
+    moduleOp.walk([&](IREE::VM::RodataTableInlineOp tableOp) {
       rewriter.setInsertionPoint(tableOp);
       size_t tableBitwidth = tableOp.getTableType().getIntOrFloatBitWidth();
       if (tableBitwidth == 32) {

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
@@ -18,11 +18,11 @@
 
 namespace mlir::iree_compiler::IREE::VM {
 
-// Replaces a vm.rodata.table op with two vm.rodata.inline ops, one for the
-// indexing table, and the second for the padded data.
+// Replaces a vm.rodata.inline.table op with two vm.rodata.inline ops, one for
+// the indexing table, and the second for the padded data.
 template <typename IntTy>
 static void reifyRodataTable(RewriterBase &rewriter,
-                             IREE::VM::RodataTableOp tableOp) {
+                             IREE::VM::RodataInlineTableOp tableOp) {
   SmallVector<IntTy> table;
   SmallVector<Attribute> dataAttrs;
   size_t dataSize = 0;
@@ -98,7 +98,8 @@ public:
   }
 
   StringRef getDescription() const override {
-    return "Converts vm.rodata.table into two rodata, one for the flat data and"
+    return "Converts vm.rodata.inline.table into two rodata, one for the flat "
+           "data and"
            "the other for a newly constructed table for the element subviews.";
   }
 
@@ -107,7 +108,7 @@ public:
 
     // Walk all of the rodata table ops and convert to rodata.inline
     IRRewriter rewriter(moduleOp.getContext());
-    moduleOp.walk([&](IREE::VM::RodataTableOp tableOp) {
+    moduleOp.walk([&](IREE::VM::RodataInlineTableOp tableOp) {
       rewriter.setInsertionPoint(tableOp);
       size_t tableBitwidth = tableOp.getTableType().getIntOrFloatBitWidth();
       if (tableBitwidth == 32) {

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/BUILD.bazel
@@ -21,6 +21,7 @@ iree_lit_test_suite(
             "global_initialization.mlir",
             "hoist_inlined_rodata.mlir",
             "ordinal_allocation.mlir",
+            "reify_rodata_tables.mlir",
             "resolve_rodata_loads.mlir",
             "sink_defining_ops.mlir",
         ],

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "global_initialization.mlir"
     "hoist_inlined_rodata.mlir"
     "ordinal_allocation.mlir"
+    "reify_rodata_tables.mlir"
     "resolve_rodata_loads.mlir"
     "sink_defining_ops.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/reify_rodata_tables.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/reify_rodata_tables.mlir
@@ -1,0 +1,64 @@
+// RUN: iree-opt --split-input-file --iree-vm-reify-rodata-tables %s | FileCheck %s
+
+// CHECK: #[[$DATA:.+]] = #util.composite<4xi8, [
+#table_data = #util.composite<4xi8, [
+// CHECK-NEXT: dense<0> : vector<1xi8>,
+  dense<0> : vector<1xi8>,
+// CHECK-NEXT: dense<1> : vector<1xi8>,
+  dense<1> : vector<1xi8>,
+// CHECK-NEXT: dense<[2, 3]> : vector<2xi8>,
+  dense<[2, 3]> : vector<2xi8>,
+]>
+
+vm.module @module {
+  // CHECK-LABEL: vm.func @fn
+  vm.func @fn() {
+    // CHECK-DAG: = vm.rodata.inline : !vm.buffer = dense<[0, 1, 1, 1, 2, 2]> : vector<6xi32>
+    // CHECK-DAG: = vm.rodata.inline : !vm.buffer = #[[$DATA]]
+    %0:2 = vm.rodata.table : !vm.buffer, !vm.buffer = #table_data
+    vm.return
+  }
+}
+
+// -----
+
+// CHECK: #[[$DATA:.+]] = #util.composite<2xi8, [
+#table_data = #util.composite<2xi8, [
+// CHECK-NEXT: dense<[2, 3]> : vector<2xi8>,
+  dense<[2, 3]> : vector<2xi8>,
+]>
+
+vm.module @module {
+  // CHECK-LABEL: vm.func @fn
+  vm.func @fn() {
+    // CHECK-DAG: = vm.rodata.inline "table" {alignment = 64 : i64} : !vm.buffer = dense<[0, 2]>
+    // CHECK-DAG: = vm.rodata.inline "data" {alignment = 64 : i64} : !vm.buffer = #[[$DATA]]
+    %0:2 = vm.rodata.table {table_name = "table", data_name = "data", alignment = 64 : i64} : !vm.buffer, !vm.buffer = #table_data
+    vm.return
+  }
+}
+
+// -----
+
+// CHECK: #[[$DATA:.+]] = #util.composite<15xi8, [
+#table_data = #util.composite<12xi8, [
+// CHECK-NEXT: dense<[2, 3]> : vector<2xi8>,
+// CHECK-NEXT: dense<0> : vector<1xi8>,
+  dense<[2, 3]> : vector<2xi8>,
+// CHECK-NEXT: "hello",
+// CHECK-NEXT: dense<0> : vector<1xi8>,
+  "hello",
+// CHECK-NEXT: "world",
+// CHECK-NEXT: dense<0> : vector<1xi8>,
+  "world",
+]>
+
+vm.module @module {
+  // CHECK-LABEL: vm.func @fn
+  vm.func @fn() {
+    // CHECK-DAG: = vm.rodata.inline : !vm.buffer = dense<[0, 2, 3, 5, 9, 5]>
+    // CHECK-DAG: = vm.rodata.inline : !vm.buffer = #[[$DATA]]
+    %0:2 = vm.rodata.table {data_alignment = 3 : i64} : !vm.buffer, !vm.buffer = #table_data
+    vm.return
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/reify_rodata_tables.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/reify_rodata_tables.mlir
@@ -1,21 +1,21 @@
 // RUN: iree-opt --split-input-file --iree-vm-reify-rodata-tables %s | FileCheck %s
 
 // CHECK: #[[$DATA:.+]] = #util.composite<4xi8, [
-#table_data = #util.composite<4xi8, [
+#table_data = [
 // CHECK-NEXT: dense<0> : vector<1xi8>,
   dense<0> : vector<1xi8>,
 // CHECK-NEXT: dense<1> : vector<1xi8>,
   dense<1> : vector<1xi8>,
 // CHECK-NEXT: dense<[2, 3]> : vector<2xi8>,
-  dense<[2, 3]> : vector<2xi8>,
-]>
+  dense<[2, 3]> : vector<2xi8>
+]
 
 vm.module @module {
   // CHECK-LABEL: vm.func @fn
   vm.func @fn() {
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = dense<[0, 1, 1, 1, 2, 2]> : vector<6xi32>
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.table : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.table i32 : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }
@@ -23,17 +23,17 @@ vm.module @module {
 // -----
 
 // CHECK: #[[$DATA:.+]] = #util.composite<2xi8, [
-#table_data = #util.composite<2xi8, [
+#table_data = [
 // CHECK-NEXT: dense<[2, 3]> : vector<2xi8>,
-  dense<[2, 3]> : vector<2xi8>,
-]>
+  dense<[2, 3]> : vector<2xi8>
+]
 
 vm.module @module {
   // CHECK-LABEL: vm.func @fn
   vm.func @fn() {
-    // CHECK-DAG: = vm.rodata.inline "table" {alignment = 64 : i64} : !vm.buffer = dense<[0, 2]>
+    // CHECK-DAG: = vm.rodata.inline "table" {alignment = 64 : i64} : !vm.buffer = dense<[0, 2]> : vector<2xi64>
     // CHECK-DAG: = vm.rodata.inline "data" {alignment = 64 : i64} : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.table {table_name = "table", data_name = "data", alignment = 64 : i64} : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.table i64 {table_name = "table", data_name = "data", alignment = 64 : i64} : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }
@@ -41,7 +41,7 @@ vm.module @module {
 // -----
 
 // CHECK: #[[$DATA:.+]] = #util.composite<15xi8, [
-#table_data = #util.composite<12xi8, [
+#table_data = [
 // CHECK-NEXT: dense<[2, 3]> : vector<2xi8>,
 // CHECK-NEXT: dense<0> : vector<1xi8>,
   dense<[2, 3]> : vector<2xi8>,
@@ -50,15 +50,15 @@ vm.module @module {
   "hello",
 // CHECK-NEXT: "world",
 // CHECK-NEXT: dense<0> : vector<1xi8>,
-  "world",
-]>
+  "world"
+]
 
 vm.module @module {
   // CHECK-LABEL: vm.func @fn
   vm.func @fn() {
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = dense<[0, 2, 3, 5, 9, 5]>
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.table {data_alignment = 3 : i64} : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.table i32 {data_alignment = 3 : i64} : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/reify_rodata_tables.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/reify_rodata_tables.mlir
@@ -15,7 +15,7 @@ vm.module @module {
   vm.func @fn() {
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = dense<[0, 1, 1, 1, 2, 2]> : vector<6xi32>
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.table i32 : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }
@@ -33,7 +33,7 @@ vm.module @module {
   vm.func @fn() {
     // CHECK-DAG: = vm.rodata.inline "table" {alignment = 64 : i64} : !vm.buffer = dense<[0, 2]> : vector<2xi64>
     // CHECK-DAG: = vm.rodata.inline "data" {alignment = 64 : i64} : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.table i64 {table_name = "table", data_name = "data", alignment = 64 : i64} : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.inline.table i64 {table_name = "table", data_name = "data", alignment = 64 : i64} : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }
@@ -58,7 +58,7 @@ vm.module @module {
   vm.func @fn() {
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = dense<[0, 2, 3, 5, 9, 5]>
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.table i32 {data_alignment = 3 : i64} : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.inline.table i32 {data_alignment = 3 : i64} : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/reify_rodata_tables.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/reify_rodata_tables.mlir
@@ -15,7 +15,7 @@ vm.module @module {
   vm.func @fn() {
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = dense<[0, 1, 1, 1, 2, 2]> : vector<6xi32>
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.table.inline i32 : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }
@@ -33,7 +33,7 @@ vm.module @module {
   vm.func @fn() {
     // CHECK-DAG: = vm.rodata.inline "table" {alignment = 64 : i64} : !vm.buffer = dense<[0, 2]> : vector<2xi64>
     // CHECK-DAG: = vm.rodata.inline "data" {alignment = 64 : i64} : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.inline.table i64 {table_name = "table", data_name = "data", alignment = 64 : i64} : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.table.inline i64 {table_name = "table", data_name = "data", alignment = 64 : i64} : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }
@@ -58,7 +58,7 @@ vm.module @module {
   vm.func @fn() {
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = dense<[0, 2, 3, 5, 9, 5]>
     // CHECK-DAG: = vm.rodata.inline : !vm.buffer = #[[$DATA]]
-    %0:2 = vm.rodata.inline.table i32 {data_alignment = 3 : i64} : !vm.buffer, !vm.buffer = #table_data
+    %0:2 = vm.rodata.table.inline i32 {data_alignment = 3 : i64} : !vm.buffer, !vm.buffer = #table_data
     vm.return
   }
 }

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/Patterns.cpp
@@ -35,7 +35,7 @@ static Value getStringRodata(Location loc, StringAttr attr,
 
 static std::pair<Value, Value> buildKeyTable(Location loc, ArrayAttr keysAttr,
                                              OpBuilder &builder) {
-  auto tableOp = builder.create<IREE::VM::RodataInlineTableOp>(
+  auto tableOp = builder.create<IREE::VM::RodataTableInlineOp>(
       loc, builder.getIntegerType(32), keysAttr);
   return {tableOp.getTableResult(), tableOp.getDataResult()};
 }

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/Patterns.cpp
@@ -35,7 +35,7 @@ static Value getStringRodata(Location loc, StringAttr attr,
 
 static std::pair<Value, Value> buildKeyTable(Location loc, ArrayAttr keysAttr,
                                              OpBuilder &builder) {
-  auto tableOp = builder.create<IREE::VM::RodataTableOp>(
+  auto tableOp = builder.create<IREE::VM::RodataInlineTableOp>(
       loc, builder.getIntegerType(32), keysAttr);
   return {tableOp.getTableResult(), tableOp.getDataResult()};
 }

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/Patterns.cpp
@@ -35,9 +35,8 @@ static Value getStringRodata(Location loc, StringAttr attr,
 
 static std::pair<Value, Value> buildKeyTable(Location loc, ArrayAttr keysAttr,
                                              OpBuilder &builder) {
-  auto compositeAttr =
-      IREE::Util::CompositeAttr::get(builder.getContext(), keysAttr.getValue());
-  auto tableOp = builder.create<IREE::VM::RodataTableOp>(loc, compositeAttr);
+  auto tableOp = builder.create<IREE::VM::RodataTableOp>(
+      loc, builder.getIntegerType(32), keysAttr);
   return {tableOp.getTableResult(), tableOp.getDataResult()};
 }
 

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/test/parameter_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/test/parameter_ops.mlir
@@ -8,7 +8,7 @@ func.func @parameterLoad(%device: !hal.device, %queue_affinity: i64, %wait: !hal
   %c51_i64 = arith.constant 51 : i64
   %c100 = arith.constant 100 : index
   %c101 = arith.constant 101 : index
-  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1"]
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 0, 100, 51, 0, 101]> : vector<6xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   // CHECK: %[[TARGET_BUFFERS:.+]] = vm.call @io_parameters.load
@@ -33,7 +33,7 @@ func.func @parameterLoad(%device: !hal.device, %queue_affinity: i64, %wait: !hal
 func.func @parameterLoadNoScope(%device: !hal.device, %queue_affinity: i64, %wait: !hal.fence, %signal: !hal.fence) -> !hal.buffer {
   %c50_i64 = arith.constant 50 : i64
   %c100 = arith.constant 100 : index
-  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table i32 : !vm.buffer, !vm.buffer = ["key"]
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = ["key"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 0, 100]> : vector<3xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.const.ref.zero : !vm.buffer
   // CHECK: %[[TARGET_BUFFERS:.+]] = vm.call @io_parameters.load
@@ -62,7 +62,7 @@ func.func @parameterGather(%device: !hal.device, %queue_affinity: i64, %wait: !h
   %c200 = arith.constant 200 : index
   %c201 = arith.constant 201 : index
   %c202 = arith.constant 202 : index
-  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 100, 200, 51, 101, 201, 52, 102, 202]> : vector<9xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   //      CHECK: vm.call @io_parameters.gather
@@ -90,7 +90,7 @@ func.func @parameterScatter(%device: !hal.device, %queue_affinity: i64, %wait: !
   %c200 = arith.constant 200 : index
   %c201 = arith.constant 201 : index
   %c202 = arith.constant 202 : index
-  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 100, 200, 51, 101, 201, 52, 102, 202]> : vector<9xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   //      CHECK: vm.call @io_parameters.scatter

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/test/parameter_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/test/parameter_ops.mlir
@@ -8,11 +8,7 @@ func.func @parameterLoad(%device: !hal.device, %queue_affinity: i64, %wait: !hal
   %c51_i64 = arith.constant 51 : i64
   %c100 = arith.constant 100 : index
   %c101 = arith.constant 101 : index
-  //  CHECK-DAG: %[[KEY_TABLE:.+]] = vm.rodata.inline : !vm.buffer = dense<[0, 4, 4, 4]> : vector<4xi32>
-  //  CHECK-DAG: %[[KEY_DATA:.+]] = vm.rodata.inline : !vm.buffer = #util.composite<8xi8, [
-  // CHECK-NEXT:  "key0",
-  // CHECK-NEXT:  "key1",
-  // CHECK-NEXT: ]>
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 0, 100, 51, 0, 101]> : vector<6xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   // CHECK: %[[TARGET_BUFFERS:.+]] = vm.call @io_parameters.load
@@ -37,10 +33,7 @@ func.func @parameterLoad(%device: !hal.device, %queue_affinity: i64, %wait: !hal
 func.func @parameterLoadNoScope(%device: !hal.device, %queue_affinity: i64, %wait: !hal.fence, %signal: !hal.fence) -> !hal.buffer {
   %c50_i64 = arith.constant 50 : i64
   %c100 = arith.constant 100 : index
-  //  CHECK-DAG: %[[KEY_TABLE:.+]] = vm.rodata.inline : !vm.buffer = dense<[0, 3]> : vector<2xi32>
-  //  CHECK-DAG: %[[KEY_DATA:.+]] = vm.rodata.inline : !vm.buffer = #util.composite<3xi8, [
-  // CHECK-NEXT:  "key",
-  // CHECK-NEXT: ]>
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table i32 : !vm.buffer, !vm.buffer = ["key"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 0, 100]> : vector<3xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.const.ref.zero : !vm.buffer
   // CHECK: %[[TARGET_BUFFERS:.+]] = vm.call @io_parameters.load
@@ -69,12 +62,7 @@ func.func @parameterGather(%device: !hal.device, %queue_affinity: i64, %wait: !h
   %c200 = arith.constant 200 : index
   %c201 = arith.constant 201 : index
   %c202 = arith.constant 202 : index
-  //  CHECK-DAG: %[[KEY_TABLE:.+]] = vm.rodata.inline : !vm.buffer = dense<[0, 4, 4, 4, 8, 4]> : vector<6xi32>
-  //  CHECK-DAG: %[[KEY_DATA:.+]] = vm.rodata.inline : !vm.buffer = #util.composite<12xi8, [
-  // CHECK-NEXT:  "key0",
-  // CHECK-NEXT:  "key1",
-  // CHECK-NEXT:  "key2",
-  // CHECK-NEXT: ]>
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 100, 200, 51, 101, 201, 52, 102, 202]> : vector<9xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   //      CHECK: vm.call @io_parameters.gather
@@ -102,12 +90,7 @@ func.func @parameterScatter(%device: !hal.device, %queue_affinity: i64, %wait: !
   %c200 = arith.constant 200 : index
   %c201 = arith.constant 201 : index
   %c202 = arith.constant 202 : index
-  //  CHECK-DAG: %[[KEY_TABLE:.+]] = vm.rodata.inline : !vm.buffer = dense<[0, 4, 4, 4, 8, 4]> : vector<6xi32>
-  //  CHECK-DAG: %[[KEY_DATA:.+]] = vm.rodata.inline : !vm.buffer = #util.composite<12xi8, [
-  // CHECK-NEXT:  "key0",
-  // CHECK-NEXT:  "key1",
-  // CHECK-NEXT:  "key2",
-  // CHECK-NEXT: ]>
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 100, 200, 51, 101, 201, 52, 102, 202]> : vector<9xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   //      CHECK: vm.call @io_parameters.scatter

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/test/parameter_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/test/parameter_ops.mlir
@@ -8,7 +8,7 @@ func.func @parameterLoad(%device: !hal.device, %queue_affinity: i64, %wait: !hal
   %c51_i64 = arith.constant 51 : i64
   %c100 = arith.constant 100 : index
   %c101 = arith.constant 101 : index
-  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1"]
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table.inline i32 : !vm.buffer, !vm.buffer = ["key0", "key1"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 0, 100, 51, 0, 101]> : vector<6xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   // CHECK: %[[TARGET_BUFFERS:.+]] = vm.call @io_parameters.load
@@ -33,7 +33,7 @@ func.func @parameterLoad(%device: !hal.device, %queue_affinity: i64, %wait: !hal
 func.func @parameterLoadNoScope(%device: !hal.device, %queue_affinity: i64, %wait: !hal.fence, %signal: !hal.fence) -> !hal.buffer {
   %c50_i64 = arith.constant 50 : i64
   %c100 = arith.constant 100 : index
-  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = ["key"]
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table.inline i32 : !vm.buffer, !vm.buffer = ["key"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 0, 100]> : vector<3xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.const.ref.zero : !vm.buffer
   // CHECK: %[[TARGET_BUFFERS:.+]] = vm.call @io_parameters.load
@@ -62,7 +62,7 @@ func.func @parameterGather(%device: !hal.device, %queue_affinity: i64, %wait: !h
   %c200 = arith.constant 200 : index
   %c201 = arith.constant 201 : index
   %c202 = arith.constant 202 : index
-  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table.inline i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 100, 200, 51, 101, 201, 52, 102, 202]> : vector<9xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   //      CHECK: vm.call @io_parameters.gather
@@ -90,7 +90,7 @@ func.func @parameterScatter(%device: !hal.device, %queue_affinity: i64, %wait: !
   %c200 = arith.constant 200 : index
   %c201 = arith.constant 201 : index
   %c202 = arith.constant 202 : index
-  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.inline.table i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
+  //      CHECK: %[[KEY_TABLE:.+]], %[[KEY_DATA:.+]] = vm.rodata.table.inline i32 : !vm.buffer, !vm.buffer = ["key0", "key1", "key2"]
   //  CHECK-DAG: %[[SPANS:.+]] = vm.rodata.inline : !vm.buffer = dense<[50, 100, 200, 51, 101, 201, 52, 102, 202]> : vector<9xi64>
   //  CHECK-DAG: %[[SCOPE:.+]] = vm.rodata.inline {{.+}} = "scope"
   //      CHECK: vm.call @io_parameters.scatter


### PR DESCRIPTION
Tables are a vm pseudo op for flattened data indexed by subviews stored as independent read-only data as an array of (offset, size) values. This op is expected to be decomposed into two vm.rodata.inline ops.

There might be room to add another non-inline version of this op and do global program analysis to pack other read only data into a single table with a set of views.