### PR TITLE
Make iree.compiler.api.Output.map_memory() retain its backing reference.

### DIFF
--- a/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
+++ b/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
@@ -48,6 +48,8 @@ def _init_dylib():
         None,
         [c_int, POINTER(c_char_p), c_char_p, c_bool],
     )
+    _setsig(_dylib.ireeCompilerGlobalInitialize, None, [])
+    _setsig(_dylib.ireeCompilerGlobalShutdown, None, [])
 
     # Setup signatures.
     # Error
@@ -222,7 +224,7 @@ class Session:
         )
         return results
 
-    def set_flags(self, *flags: Sequence[str]):
+    def set_flags(self, *flags: str):
         argv_type = c_char_p * len(flags)
         argv = argv_type(*[flag.encode("UTF-8") for flag in flags])
         _handle_error(
@@ -261,6 +263,7 @@ class Output:
 
     def keep(self) -> "Output":
         _dylib.ireeCompilerOutputKeep(self._output_p)
+        return self
 
     def write(self, buffer):
         _handle_error(
@@ -291,7 +294,7 @@ class Source:
     """Wraps an iree_compiler_source_t."""
 
     def __init__(self, session: Session, source_p: c_void_p, backing_ref):
-        self._session: c_void_p = session  # Keeps ref alive.
+        self._session: Session = session  # Keeps ref alive.
         self._source_p: c_void_p = source_p
         self._backing_ref = backing_ref
         self._local_dylib = _dylib

--- a/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
+++ b/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
@@ -9,7 +9,7 @@
 from ctypes import *
 from enum import IntEnum
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
 
 import ctypes
 import logging
@@ -41,7 +41,7 @@ def _init_dylib():
     if dylib_path is None:
         # TODO: Look for a bundled dylib.
         raise RuntimeError("Could not find libIREECompiler.so")
-    _dylib = cdll.LoadLibrary(dylib_path)
+    _dylib: Any = cdll.LoadLibrary(dylib_path)
 
     _setsig(
         _dylib.ireeCompilerSetupGlobalCL,
@@ -293,8 +293,8 @@ class Output:
 class Source:
     """Wraps an iree_compiler_source_t."""
 
-    def __init__(self, session: Session, source_p: c_void_p, backing_ref):
-        self._session: Session = session  # Keeps ref alive.
+    def __init__(self, session: c_void_p, source_p: c_void_p, backing_ref):
+        self._session: c_void_p = session  # Keeps ref alive.
         self._source_p: c_void_p = source_p
         self._backing_ref = backing_ref
         self._local_dylib = _dylib

--- a/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
+++ b/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
@@ -41,7 +41,7 @@ def _init_dylib():
     if dylib_path is None:
         # TODO: Look for a bundled dylib.
         raise RuntimeError("Could not find libIREECompiler.so")
-    _dylib: Any = cdll.LoadLibrary(dylib_path)
+    _dylib = cdll.LoadLibrary(dylib_path)
 
     _setsig(
         _dylib.ireeCompilerSetupGlobalCL,

--- a/compiler/bindings/python/test/api/CMakeLists.txt
+++ b/compiler/bindings/python/test/api/CMakeLists.txt
@@ -11,3 +11,9 @@ iree_py_test(
     "api_test.py"
 )
 
+iree_py_test(
+  NAME
+    output_buffer_reference_test
+  SRCS
+    "output_buffer_reference_test.py"
+)

--- a/compiler/bindings/python/test/api/output_buffer_reference_test.py
+++ b/compiler/bindings/python/test/api/output_buffer_reference_test.py
@@ -1,0 +1,80 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This test specifically exercises the VmModule.wrap_buffer method in combination with
+# the memory mapped buffers produced by the in-process compile API.
+# The ownership transfers can be tricky and this exercises some of the corners.
+
+import gc
+
+import iree.compiler
+from iree.compiler.api import (
+    Session,
+    Source,
+    Output,
+)
+
+from iree.runtime import (
+    VmContext,
+    VmInstance,
+    VmModule,
+)
+
+
+def compile_simple_mul_binary() -> Output:
+    asm = b"""
+    module @arithmetic {
+    func.func @simple_mul(%arg0: f32, %arg1: f32) -> f32 {
+        %0 = arith.mulf %arg0, %arg1 : f32
+        return %0 : f32
+    }
+    }
+    """
+
+    output = Output.open_membuffer()
+    session = Session()
+    source = Source.wrap_buffer(session, asm)
+    session.set_flags(
+        f"--iree-hal-target-backends={iree.compiler.core.DEFAULT_TESTING_BACKENDS[0]}"
+    )
+    inv = session.invocation()
+    inv.parse_source(source)
+    inv.execute()
+    inv.output_vm_bytecode(output)
+    return output
+
+
+vmfb_contents = bytes(compile_simple_mul_binary().map_memory())
+# This print is a load bearing part of the test. It ensures that the memory
+# is readable.
+print("VMFB Length =", len(vmfb_contents), vmfb_contents)
+
+
+def run_mmap_free_before_context_test():
+    instance = VmInstance()
+    output = Output.open_membuffer()
+    output.write(vmfb_contents)
+    mapped_memory = output.map_memory()
+    module = VmModule.wrap_buffer(instance, mapped_memory)
+    context = VmContext(instance, modules=[module])
+    # Shutdown in the most egregious way possible.
+    # Note that during context destruction, the context needs some final
+    # access to the mapped memory to run destructors. It is easy for the
+    # reference to the backing memory to be invalid at this point, thus
+    # this test.
+    gc.collect()
+    output = None
+    gc.collect()
+    mapped_memory = None
+    gc.collect()
+    module = None
+    gc.collect()
+    context = None
+    gc.collect()
+
+
+for i in range(10):
+    run_mmap_free_before_context_test()

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -271,7 +271,22 @@ VmModule VmModule::MMap(VmInstance* instance, std::string filepath,
 VmModule VmModule::WrapBuffer(VmInstance* instance, py::object buffer_obj,
                               py::object destroy_callback, bool close_buffer) {
   IREE_TRACE_SCOPE_NAMED("VmModule::FromAlignedMemory");
-  PyBufferRequest buffer_info(buffer_obj, PyBUF_SIMPLE);
+  // Bridge to the C-based deallocator API.
+  struct BufferState {
+    BufferState(py::object buffer_obj, py::object destroy_callback,
+                bool close_buffer)
+        : buffer_info(buffer_obj, PyBUF_SIMPLE),
+          buffer_obj(std::move(buffer_obj)),
+          destroy_callback(std::move(destroy_callback)),
+          close_buffer(close_buffer) {}
+    PyBufferRequest buffer_info;
+    py::object buffer_obj;
+    py::object destroy_callback;
+    bool close_buffer;
+  };
+  BufferState* state =
+      new BufferState(buffer_obj, destroy_callback, close_buffer);
+  PyBufferRequest& buffer_info = state->buffer_info;
   if (!iree_host_size_has_alignment((uintptr_t)buffer_info.view().buf,
                                     IREE_HAL_HEAP_BUFFER_ALIGNMENT)) {
     std::stringstream err;
@@ -282,26 +297,12 @@ VmModule VmModule::WrapBuffer(VmInstance* instance, py::object buffer_obj,
   }
 
   iree_vm_module_t* module = nullptr;
-
-  // Bridge to the C-based deallocator API.
-  struct DeallocateState {
-    DeallocateState(py::object buffer_obj, py::object destroy_callback,
-                    bool close_buffer)
-        : buffer_obj(std::move(buffer_obj)),
-          destroy_callback(std::move(destroy_callback)),
-          close_buffer(close_buffer) {}
-    py::object buffer_obj;
-    py::object destroy_callback;
-    bool close_buffer;
-  };
-  DeallocateState* state =
-      new DeallocateState(buffer_obj, destroy_callback, close_buffer);
   auto ctl_fn = +([](void* self, iree_allocator_command_t command,
                      const void* params, void** inout_ptr) {
     py::gil_scoped_acquire gil;
     assert(command == IREE_ALLOCATOR_COMMAND_FREE);
     try {
-      DeallocateState* state = static_cast<DeallocateState*>(self);
+      BufferState* state = static_cast<BufferState*>(self);
       if (state->close_buffer) {
         state->buffer_obj.attr("close")();
       }


### PR DESCRIPTION
Depending on the precise structure of the code and state of the garbage collector, this could cause very long-range crashes that appeared to have nothing to do with the allocation mechanism.

* Adds a retaining finalizer to the map_memory() pointer return.
* Adds a test that grinds two patterns that I found which produce bugs.
* Fixes VmModule::WrapBuffer to close over its Py_buffer. I noticed this when auditing and it is subtly wrong: it will not break in this specific case but in cases where the backing memory has to be copied or re-organized, it could result in a use-after-free.

Fixes #15407