### PR TITLE
[spirv][vulkan] Enable device query generation and execution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -66,6 +66,7 @@ iree_compiler_cc_library(
         "SPIRVLinkExecutables.cpp",
         "SPIRVLowerExecutableTargetPass.cpp",
         "SPIRVMapMemRefStorageClass.cpp",
+        "SPIRVMaterializeExecutableConditions.cpp",
         "SPIRVSelectLoweringStrategy.cpp",
         "SPIRVTile.cpp",
         "SPIRVTileAndDistribute.cpp",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -65,6 +65,7 @@ iree_cc_library(
     "SPIRVLinkExecutables.cpp"
     "SPIRVLowerExecutableTargetPass.cpp"
     "SPIRVMapMemRefStorageClass.cpp"
+    "SPIRVMaterializeExecutableConditions.cpp"
     "SPIRVSelectLoweringStrategy.cpp"
     "SPIRVTile.cpp"
     "SPIRVTileAndDistribute.cpp"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -682,6 +682,16 @@ void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
 // NOTE: this runs on the top-level program module containing all hal.executable
 // ops.
 void buildSPIRVLinkingPassPipeline(OpPassManager &passManager) {
+  auto &nestedExecutablePM = passManager.nest<IREE::HAL::ExecutableOp>();
+  // Trim the allowed target environment (version/capability/extension/etc.) to
+  // the minimal requirement needed by compiled spirv.module ops. This helps to
+  // increase the chance of linking different variant ops together.
+  nestedExecutablePM.addNestedPass<IREE::HAL::ExecutableVariantOp>(
+      createSPIRVTrimExecutableTargetEnvPass());
+  // Materialize the minimal required target environment into proper device
+  // queries to execute in the runtime.
+  nestedExecutablePM.addNestedPass<IREE::HAL::ExecutableVariantOp>(
+      createSPIRVMaterializeExecutableConditionsPass());
   // Link together executables. This may produce some IR duplication.
   passManager.addPass(createSPIRVLinkExecutablesPass());
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -134,6 +134,11 @@ createSPIRVLowerExecutableTargetPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVMapMemRefStorageClassPass();
 
+/// Pass to materialize SPIR-V target requirements of hal.exectuable.variant ops
+/// into hal.executable.condition regions.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createSPIRVMaterializeExecutableConditionsPass();
+
 /// Pass to tile and distribute Linalg ops with buffer semantics to
 /// invocations.
 std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTileAndDistributePass();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
@@ -91,6 +91,15 @@ def SPIRVMapMemRefStorageClass :
   let constructor = "mlir::iree_compiler::createSPIRVMapMemRefStorageClassPass()";
 }
 
+def SPIRVMaterializeExecutableConditions :
+    Pass<"iree-spirv-materialize-executable-conditions",
+         "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Materialize SPIR-V target requirements of hal.exectuable.variant "
+                "ops into hal.executable.condition regions";
+  let constructor =
+      "mlir::iree_compiler::createSPIRVMaterializeExecutableConditionsPass()";
+}
+
 def SPIRVSelectLoweringStrategy :
     Pass<"iree-spirv-select-lowering-strategy-pass",
          "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
@@ -6,15 +6,14 @@
 
 #include "iree/compiler/Codegen/SPIRV/PassDetail.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
+#include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Utils/LinkingUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "iree/compiler/Utils/ModuleUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
-#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
-#include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/Pass/Pass.h"
 
 #define DEBUG_TYPE "iree-spirv-link-executable"
@@ -22,23 +21,19 @@
 namespace mlir::iree_compiler {
 
 namespace IREE::HAL {
-// Compares two ExecutableTargetAttr according to the order of used SPIR-V
-// capabilities.
+// Compares two ExecutableTargetAttr according to the alphabetical order of used
+// SPIR-V features.
 //
 // Note that this is a very specific ordering per the needs of this pass--we
 // guarantee that input ExectuableTargetAttr only differ w.r.t. their used
 // SPIR-V features, and we want a deterministic order when mutating the IR.
 bool operator<(const ExecutableTargetAttr &a, const ExecutableTargetAttr &b) {
-  auto aTarget = a.getConfiguration().getAs<spirv::TargetEnvAttr>(
-      spirv::getTargetEnvAttrName());
-  auto bTarget = b.getConfiguration().getAs<spirv::TargetEnvAttr>(
-      spirv::getTargetEnvAttrName());
-  auto aFeatures = aTarget.getCapabilitiesAttr();
-  auto bFeatures = bTarget.getCapabilitiesAttr();
+  auto aFeatures = a.getConfiguration().getAs<ArrayAttr>("iree.spirv.features");
+  auto bFeatures = b.getConfiguration().getAs<ArrayAttr>("iree.spirv.features");
   for (unsigned i = 0; i < std::min(aFeatures.size(), bFeatures.size()); ++i) {
     if (aFeatures[i] != bFeatures[i]) {
-      return cast<IntegerAttr>(aFeatures[i]).getInt() <
-             cast<IntegerAttr>(bFeatures[i]).getInt();
+      return cast<StringAttr>(aFeatures[i]).getValue() <
+             cast<StringAttr>(bFeatures[i]).getValue();
     }
   }
   return aFeatures.size() < bFeatures.size();
@@ -48,11 +43,6 @@ bool operator<(const ExecutableTargetAttr &a, const ExecutableTargetAttr &b) {
 namespace {
 
 using IREE::HAL::ExecutableTargetAttr;
-
-bool isSPIRVBasedBackend(IREE::HAL::ExecutableVariantOp variantOp) {
-  return variantOp.getTargetAttr().getConfiguration().contains(
-      spirv::getTargetEnvAttrName());
-}
 
 struct SPIRVLinkExecutablesPass final
     : SPIRVLinkExecutablesBase<SPIRVLinkExecutablesPass> {
@@ -104,9 +94,8 @@ struct SPIRVLinkExecutablesPass final
       // sort as the unique key.
       currentTargets.clear();
       for (auto variant : executable.getOps<IREE::HAL::ExecutableVariantOp>()) {
-        ExecutableTargetAttr target = variant.getTarget();
-        if (isSPIRVBasedBackend(variant)) {
-          currentTargets.push_back(target);
+        if (usesSPIRVCodeGen(variant)) {
+          currentTargets.push_back(variant.getTarget());
         }
       }
       llvm::sort(currentTargets);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMaterializeExecutableConditions.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMaterializeExecutableConditions.cpp
@@ -1,0 +1,218 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/SPIRV/PassDetail.h"
+#include "iree/compiler/Codegen/SPIRV/Passes.h"
+#include "iree/compiler/Codegen/SPIRV/Utils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVEnums.h"
+#include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+// Maps the given SPIR-V capability to the corresponding device query used in
+// IREE runtime. Returns failure if unsupported yet. Returns nullptr if no need
+// for device queries.
+//
+// Note that the device queries used here should match the ones used in
+// iree_hal_vulkan_device_query_i64() on the runtime side.
+FailureOr<const char *>
+mapToDeviceQuery(spirv::Capability cap,
+                 IREE::HAL::ExecutableExportOp entryPoint) {
+  switch (cap) {
+  case spirv::Capability::Shader:
+    // The shader capability is the root capability for graphics APIs.
+    // So just ignore.
+    return nullptr;
+
+    //===-------------------------------------------------------------------===//
+    // Compute capabilities
+  case spirv::Capability::Float16:
+    return "compute.f16";
+  case spirv::Capability::Float64:
+    return "compute.f64";
+  case spirv::Capability::Int8:
+    return "compute.i8";
+  case spirv::Capability::Int16:
+    return "compute.i16";
+  case spirv::Capability::Int64:
+    return "compute.i64";
+
+    //===-------------------------------------------------------------------===//
+    // Storage capabilities
+  case spirv::Capability::UniformAndStorageBuffer8BitAccess:
+  case spirv::Capability::StorageBuffer8BitAccess:
+    // These capabilities allow 8-bit types to appear in interface variables of
+    // a particular storage class.
+    // So cluster them together.
+    return "storage.8bit";
+  case spirv::Capability::StorageBuffer16BitAccess:
+  case spirv::Capability::StorageUniform16:
+    // These capabilities allow 16-bit types to appear in interface variables of
+    // a particular storage class.
+    // So cluster them together.
+    return "storage.16bit";
+
+    //===-------------------------------------------------------------------===//
+    // Subgroup capabilities
+  case spirv::Capability::GroupNonUniform:
+    // The basic subgroup capability provides access to builtin variables like
+    // subgroup ID and size.
+    // * In Vulkan, this is mandated starting v1.1.
+    // * In Metal, we have it since v2.2.
+    // So just ignore.
+    return nullptr;
+  case spirv::Capability::GroupNonUniformArithmetic:
+    return "subgroup.arithmetic";
+  case spirv::Capability::GroupNonUniformShuffle:
+    return "subgroup.shuffle";
+
+  case spirv::Capability::DotProduct:
+  case spirv::Capability::DotProductInput4x8Bit:
+    // We only ever use vector<4xi8> -> i32 variant of dot product right now.
+    return "dotprod.4xi8.i32";
+
+    //===-------------------------------------------------------------------===//
+    // Cooperative matrix capabilities
+  case spirv::Capability::CooperativeMatrixKHR: {
+    // Cooperative matrix has many device specific configurations. They are not
+    // directly reflected in the SPIR-V capabilities. We need to be explicit by
+    // looking at the chosen configuration.
+    // Format: "coopmatrix.<input-type>.<output-type>.<m>x<n>x<k>".
+    auto coopmatType =
+        entryPoint->getAttrOfType<ArrayAttr>("iree.spirv.coopmatrix.type");
+    auto coopmatShape = entryPoint->getAttrOfType<DenseI64ArrayAttr>(
+        "iree.spirv.coopmatrix.shape");
+    if (!coopmatType || !coopmatShape)
+      return failure();
+
+    Type inputType = cast<TypeAttr>(coopmatType.getValue().front()).getValue();
+    Type outputType = cast<TypeAttr>(coopmatType.getValue().back()).getValue();
+    int64_t mSize = coopmatShape.asArrayRef()[0];
+    int64_t nSize = coopmatShape.asArrayRef()[1];
+    int64_t kSize = coopmatShape.asArrayRef()[2];
+
+    // We explicitly perform exact match here given that 1) we need to have the
+    // corresponding query in the runtime, and 2) we are not using a lot of
+    // configuarations in CodeGen yet.
+    if (inputType.isF16() && outputType.isF16()) {
+      if (mSize == 16 && nSize == 16 && kSize == 16)
+        return "coopmatrix.f16.f16.16x16x16";
+    }
+
+    return nullptr;
+  }
+
+  default:
+    break;
+  }
+  return failure();
+}
+
+struct SPIRVMaterializeExecutableConditionsPass final
+    : SPIRVMaterializeExecutableConditionsBase<
+          SPIRVMaterializeExecutableConditionsPass> {
+  void runOnOperation() override {
+    IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+    if (!usesSPIRVCodeGen(variantOp))
+      return;
+
+    IREE::HAL::ExecutableTargetAttr executableTarget = variantOp.getTarget();
+    DictionaryAttr configuration = executableTarget.getConfiguration();
+    auto spirvTarget = configuration.getAs<spirv::TargetEnvAttr>(
+        spirv::getTargetEnvAttrName());
+
+    auto exportOps = variantOp.getOps<IREE::HAL::ExecutableExportOp>();
+    if (!llvm::hasSingleElement(exportOps)) {
+      variantOp.emitError("expected to contain exactly one export op");
+      return signalPassFailure();
+    }
+    IREE::HAL::ExecutableExportOp exportOp = *exportOps.begin();
+
+    // Map all required SPIR-V capabilities to device queries and unique them.
+    // Here we only consider capabilities--version/extension is just the spec
+    // "container" for them; so we can ignore.
+    SetVector<const char *> queriesSet;
+    for (spirv::Capability cap : spirvTarget.getCapabilities()) {
+      FailureOr<const char *> query = mapToDeviceQuery(cap, exportOp);
+      if (failed(query)) {
+        variantOp.emitError("failed to handle capability ")
+            << spirv::stringifyCapability(cap);
+        return signalPassFailure();
+      }
+      if (query.value() != nullptr) {
+        queriesSet.insert(query.value());
+      }
+    }
+
+    SmallVector<const char *, 0> queries = queriesSet.takeVector();
+    // Sort the vector so we build the hal.executable.condition region in a
+    // consistent way to allow comparing later.
+    llvm::sort(queries, [](const char *x, const char *y) {
+      return StringRef(x) < StringRef(y);
+    });
+
+    // Build the hal.executable.condition op inside the variant.
+    OpBuilder builder(variantOp);
+    Value device = variantOp.createConditionOp(builder);
+
+    IntegerType boolType = builder.getI1Type();
+    TypedAttr falseAttr = builder.getBoolAttr(false);
+    Location loc = device.getLoc();
+
+    std::string category = "hal.device.";
+    StringRef backend = variantOp.getTarget().getBackend().getValue();
+    category += backend;
+
+    // Build the condition op region.
+    Value result = builder.create<arith::ConstantIntOp>(loc, true, 1);
+    for (const char *query : queries) {
+      auto queryOp = builder.create<IREE::HAL::DeviceQueryOp>(
+          loc, boolType, boolType, device, builder.getStringAttr(category),
+          builder.getStringAttr(query), falseAttr);
+      // Verify that 1) the query succeeds and 2) the capability is supported.
+      auto andOp = builder.create<arith::AndIOp>(loc, queryOp.getOk(),
+                                                 queryOp.getValue());
+      result = builder.create<arith::AndIOp>(loc, result, andOp);
+    }
+    builder.create<IREE::HAL::ReturnOp>(loc, result);
+
+    SmallVector<StringRef> features;
+    features.reserve(queries.size() + 1);
+    features.push_back(backend);
+    for (const char *query : queries) {
+      features.push_back(query);
+    }
+
+    // Drop the fine-grained SPIR-V target and add the course-grained device
+    // queries as a list for the later linking pass to use as a unique key.
+    auto dictKeyValues = llvm::to_vector(llvm::make_filter_range(
+        configuration.getValue(), [](NamedAttribute attr) {
+          return attr.getName() != spirv::getTargetEnvAttrName();
+        }));
+    dictKeyValues.emplace_back(builder.getStringAttr("iree.spirv.features"),
+                               builder.getStrArrayAttr(features));
+    variantOp.setTargetAttr(IREE::HAL::ExecutableTargetAttr::get(
+        executableTarget.getContext(), executableTarget.getBackend(),
+        executableTarget.getFormat(),
+        DictionaryAttr::get(configuration.getContext(), dictKeyValues)));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createSPIRVMaterializeExecutableConditionsPass() {
+  return std::make_unique<SPIRVMaterializeExecutableConditionsPass>();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMaterializeExecutableConditions.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMaterializeExecutableConditions.cpp
@@ -169,9 +169,7 @@ struct SPIRVMaterializeExecutableConditionsPass final
     TypedAttr falseAttr = builder.getBoolAttr(false);
     Location loc = device.getLoc();
 
-    std::string category = "hal.device.";
-    StringRef backend = variantOp.getTarget().getBackend().getValue();
-    category += backend;
+    const char *category = "hal.dispatch";
 
     // Build the condition op region.
     Value result = builder.create<arith::ConstantIntOp>(loc, true, 1);
@@ -188,7 +186,7 @@ struct SPIRVMaterializeExecutableConditionsPass final
 
     SmallVector<StringRef> features;
     features.reserve(queries.size() + 1);
-    features.push_back(backend);
+    features.push_back(variantOp.getTarget().getBackend().getValue());
     for (const char *query : queries) {
       features.push_back(query);
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVSelectLoweringStrategy.cpp
@@ -12,20 +12,14 @@
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
-#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Pass/PassRegistry.h"
-#include "mlir/Transforms/Passes.h"
-
-#define DEBUG_TYPE "iree-spirv-select-lowering-strategy-pass"
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTrimExecutableTargetEnv.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/SPIRV/PassDetail.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
+#include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
@@ -16,23 +17,15 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-bool IsSPIRVBasedBackend(StringRef backend) {
-  return backend.starts_with("vulkan") || backend.starts_with("metal") ||
-         backend.starts_with("webgpu");
-}
-
 struct SPIRVTrimExecutableTargetEnvPass final
     : SPIRVTrimExecutableTargetEnvBase<SPIRVTrimExecutableTargetEnvPass> {
   void runOnOperation() override {
     IREE::HAL::ExecutableVariantOp variant = getOperation();
-    if (!IsSPIRVBasedBackend(variant.getTarget().getBackend())) {
-      return;
-    }
-    if (variant.getObjects().has_value()) {
-      // Ignore external executable variants. We need to read spirv.module
-      // ops to get the deduced minimal list of required capability and
-      // extension. External source executables won't have any spirv.module
-      // ops inside.
+    if (!usesSPIRVCodeGen(variant)) {
+      // Ignore variants not targeting SPIR-V or external executable variants.
+      // We need to read spirv.module ops to get the deduced minimal list of
+      // required capability and extension. External source executables won't
+      // have any spirv.module ops inside.
       return;
     }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -29,7 +29,7 @@ bool usesSPIRVCodeGen(IREE::HAL::ExecutableVariantOp variantOp) {
   // The spirv.target_env attribute is attached if going down SPIR-V CodeGen
   // pipelines. Later we turn spirv.target_env into iree.spirv.features after
   // materializing device queries.
-  return configuration.contains(spirv::getTargetEnvAttrName()) or
+  return configuration.contains(spirv::getTargetEnvAttrName()) ||
          configuration.contains("iree.spirv.features");
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -11,14 +11,27 @@
 #include "iree/compiler/Codegen/Dialect/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
-#include "mlir/Conversion/MemRefToSPIRV/MemRefToSPIRV.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
-#include "mlir/Support/LogicalResult.h"
+#include "mlir/IR/BuiltinAttributes.h"
 
 namespace mlir::iree_compiler {
+
+bool usesSPIRVCodeGen(IREE::HAL::ExecutableVariantOp variantOp) {
+  if (variantOp.getObjects().has_value()) {
+    // Variants containing external executables do not go through CodeGen.
+    return false;
+  }
+
+  DictionaryAttr configuration = variantOp.getTargetAttr().getConfiguration();
+  // The spirv.target_env attribute is attached if going down SPIR-V CodeGen
+  // pipelines. Later we turn spirv.target_env into iree.spirv.features after
+  // materializing device queries.
+  return configuration.contains(spirv::getTargetEnvAttrName()) or
+         configuration.contains("iree.spirv.features");
+}
 
 const char *getSPIRVDistributeAttrName() { return "iree.spirv.distribute_dim"; }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.h
@@ -13,6 +13,7 @@
 #ifndef IREE_COMPILER_CODEGEN_SPIRV_UTILS_H_
 #define IREE_COMPILER_CODEGEN_SPIRV_UTILS_H_
 
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
@@ -20,6 +21,9 @@
 #include "mlir/IR/Builders.h"
 
 namespace mlir::iree_compiler {
+
+// Returns true if the given variant op uses SPIR-V CodeGen.
+bool usesSPIRVCodeGen(IREE::HAL::ExecutableVariantOp variantOp);
 
 /// Returns the attribute name carrying information about distribution.
 const char *getSPIRVDistributeAttrName();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -52,6 +52,7 @@ iree_lit_test_suite(
             "lowering_scalar_dispatch.mlir",
             "lowering_reduction.mlir",
             "map_memref_storage_class.mlir",
+            "materialize_executable_conditions.mlir",
             "pipeline_matmul_cooperative_ops.mlir",
             "pipeline_matmul_promotion.mlir",
             "pipeline_matmul_vectorization.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_lit_test_suite(
     "lowering_reduction.mlir"
     "lowering_scalar_dispatch.mlir"
     "map_memref_storage_class.mlir"
+    "materialize_executable_conditions.mlir"
     "pipeline_matmul_cooperative_ops.mlir"
     "pipeline_matmul_promotion.mlir"
     "pipeline_matmul_vectorization.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
@@ -39,11 +39,11 @@ hal.executable private @dispatch_executable {
   //  CHECK-NEXT:   hal.executable.condition(%[[DEV:.+]]: !hal.device) -> i1 {
   //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
   //  CHECK-NEXT:   %[[OK0:.+]], %[[V0:.+]] = hal.device.query<%[[DEV]] : !hal.device>
-  //  CHECK-SAME:     key("hal.device.vulkan" :: "subgroup.arithmetic") : i1, i1 = false
+  //  CHECK-SAME:     key("hal.dispatch" :: "subgroup.arithmetic") : i1, i1 = false
   //  CHECK-NEXT:   %[[AND0:.+]] = arith.andi %[[OK0]], %[[V0]] : i1
   //  CHECK-NEXT:   %[[AND1:.+]] = arith.andi %[[T]], %[[AND0]] : i1
   //  CHECK-NEXT:   %[[OK1:.+]], %[[V1:.+]] = hal.device.query<%[[DEV]] : !hal.device>
-  //  CHECK-SAME:     key("hal.device.vulkan" :: "subgroup.shuffle") : i1, i1 = false
+  //  CHECK-SAME:     key("hal.dispatch" :: "subgroup.shuffle") : i1, i1 = false
   //  CHECK-NEXT:   %[[AND2:.+]] = arith.andi %[[OK1]], %[[V1]] : i1
   //  CHECK-NEXT:   %[[AND3:.+]] = arith.andi %[[AND1]], %[[AND2]] : i1
   //  CHECK-NEXT:   hal.return %[[AND3]] : i1
@@ -72,7 +72,7 @@ hal.executable private @dispatch_executable {
   //  CHECK-NEXT:   hal.executable.condition(%[[DEV:.+]]: !hal.device) -> i1 {
   //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
   //  CHECK-NEXT:   %[[OK0:.+]], %[[V0:.+]] = hal.device.query<%[[DEV]] : !hal.device>
-  //  CHECK-SAME:     key("hal.device.vulkan" :: "storage.8bit") : i1, i1 = false
+  //  CHECK-SAME:     key("hal.dispatch" :: "storage.8bit") : i1, i1 = false
   //  CHECK-NEXT:   %[[AND0:.+]] = arith.andi %[[OK0]], %[[V0]] : i1
   //  CHECK-NEXT:   %[[AND1:.+]] = arith.andi %[[T]], %[[AND0]] : i1
   //  CHECK-NEXT:   hal.return %[[AND1]] : i1
@@ -100,7 +100,7 @@ hal.executable private @dispatch_executable {
   // CHECK-LABEL: hal.executable.variant public @test_16bit_storage_capabilities
   //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "storage.16bit"]}>)
   //       CHECK:   %{{.+}}, %{{.+}} = hal.device.query<%{{.+}} : !hal.device>
-  //  CHECK-SAME:     key("hal.device.vulkan" :: "storage.16bit") : i1, i1 = false
+  //  CHECK-SAME:     key("hal.dispatch" :: "storage.16bit") : i1, i1 = false
   hal.executable.variant public @test_16bit_storage_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [StorageBuffer16BitAccess, StorageUniform16], []>, #spirv.resource_limits<>>
@@ -123,9 +123,9 @@ hal.executable private @dispatch_executable {
 
   // CHECK-LABEL: hal.executable.variant public @test_int_compute_capabilities
   //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "compute.i16", "compute.i64", "compute.i8"]}>)
-  //      CHECK:    key("hal.device.vulkan" :: "compute.i16")
-  //      CHECK:    key("hal.device.vulkan" :: "compute.i64")
-  //      CHECK:    key("hal.device.vulkan" :: "compute.i8")
+  //      CHECK:    key("hal.dispatch" :: "compute.i16")
+  //      CHECK:    key("hal.dispatch" :: "compute.i64")
+  //      CHECK:    key("hal.dispatch" :: "compute.i8")
   hal.executable.variant public @test_int_compute_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Int64, Int16, Int8], []>, #spirv.resource_limits<>>
@@ -147,8 +147,8 @@ hal.executable private @dispatch_executable {
 
   // CHECK-LABEL: hal.executable.variant public @test_float_compute_capabilities
   //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "compute.f16", "compute.f64"]}>)
-  //      CHECK:    key("hal.device.vulkan" :: "compute.f16")
-  //      CHECK:    key("hal.device.vulkan" :: "compute.f64")
+  //      CHECK:    key("hal.dispatch" :: "compute.f16")
+  //      CHECK:    key("hal.dispatch" :: "compute.f64")
   hal.executable.variant public @test_float_compute_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Float16, Float64], []>, #spirv.resource_limits<>>
@@ -170,7 +170,7 @@ hal.executable private @dispatch_executable {
 
   // CHECK-LABEL: hal.executable.variant public @test_dot_product_capabilities
   //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "dotprod.4xi8.i32"]}>)
-  //      CHECK:    key("hal.device.vulkan" :: "dotprod.4xi8.i32")
+  //      CHECK:    key("hal.dispatch" :: "dotprod.4xi8.i32")
   hal.executable.variant public @test_dot_product_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [DotProduct, DotProductInput4x8Bit], []>, #spirv.resource_limits<>>
@@ -192,7 +192,7 @@ hal.executable private @dispatch_executable {
 
   // CHECK-LABEL: hal.executable.variant public @test_cooperative_matrix_capabilities
   //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "coopmatrix.f16.f16.16x16x16"]}>)
-  //      CHECK:    key("hal.device.vulkan" :: "coopmatrix.f16.f16.16x16x16")
+  //      CHECK:    key("hal.dispatch" :: "coopmatrix.f16.f16.16x16x16")
   hal.executable.variant public @test_cooperative_matrix_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [CooperativeMatrixKHR], []>, #spirv.resource_limits<>>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
@@ -1,0 +1,216 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-spirv-materialize-executable-conditions)))' --mlir-print-local-scope %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  <0, bindings = [
+    <0, storage_buffer, ReadOnly>,
+    <1, storage_buffer, ReadOnly>,
+    <2, storage_buffer>
+  ]>
+]>
+
+hal.executable private @dispatch_executable {
+  // CHECK-LABEL: hal.executable.variant public @test_assumed_capabilities
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan"]}>)
+  //  CHECK-NEXT:   hal.executable.condition(%{{.+}}: !hal.device) -> i1 {
+  //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
+  //  CHECK-NEXT:   hal.return %[[T]] : i1
+  //  CHECK-NEXT: }
+  hal.executable.variant public @test_assumed_capabilities target(
+      #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+        spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Shader, GroupNonUniform], []>, #spirv.resource_limits<>>
+      }>
+    ) {
+    hal.executable.export public @test_assumed_capabilities ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Shader], []> {
+        spirv.func @test_assumed_capabilities() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @test_assumed_capabilities
+        spirv.ExecutionMode @test_assumed_capabilities "LocalSize", 64, 1, 1
+      }
+    }
+  }
+
+  // CHECK-LABEL: hal.executable.variant public @test_subgroup_capabilities
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "subgroup.arithmetic", "subgroup.shuffle"]}>)
+  //  CHECK-NEXT:   hal.executable.condition(%[[DEV:.+]]: !hal.device) -> i1 {
+  //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
+  //  CHECK-NEXT:   %[[OK0:.+]], %[[V0:.+]] = hal.device.query<%[[DEV]] : !hal.device>
+  //  CHECK-SAME:     key("hal.device.vulkan" :: "subgroup.arithmetic") : i1, i1 = false
+  //  CHECK-NEXT:   %[[AND0:.+]] = arith.andi %[[OK0]], %[[V0]] : i1
+  //  CHECK-NEXT:   %[[AND1:.+]] = arith.andi %[[T]], %[[AND0]] : i1
+  //  CHECK-NEXT:   %[[OK1:.+]], %[[V1:.+]] = hal.device.query<%[[DEV]] : !hal.device>
+  //  CHECK-SAME:     key("hal.device.vulkan" :: "subgroup.shuffle") : i1, i1 = false
+  //  CHECK-NEXT:   %[[AND2:.+]] = arith.andi %[[OK1]], %[[V1]] : i1
+  //  CHECK-NEXT:   %[[AND3:.+]] = arith.andi %[[AND1]], %[[AND2]] : i1
+  //  CHECK-NEXT:   hal.return %[[AND3]] : i1
+  //  CHECK-NEXT: }
+  hal.executable.variant public @test_subgroup_capabilities target(
+      #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+        spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [GroupNonUniformShuffle, GroupNonUniformArithmetic], []>, #spirv.resource_limits<>>
+      }>
+    ) {
+    hal.executable.export public @test_subgroup_capabilities ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [GroupNonUniformShuffle, GroupNonUniformArithmetic], []> {
+        spirv.func @test_subgroup_capabilities() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @test_subgroup_capabilities
+        spirv.ExecutionMode @test_subgroup_capabilities "LocalSize", 64, 1, 1
+      }
+    }
+  }
+
+  // CHECK-LABEL: hal.executable.variant public @test_8bit_storage_capabilities
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "storage.8bit"]}>)
+  //  CHECK-NEXT:   hal.executable.condition(%[[DEV:.+]]: !hal.device) -> i1 {
+  //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
+  //  CHECK-NEXT:   %[[OK0:.+]], %[[V0:.+]] = hal.device.query<%[[DEV]] : !hal.device>
+  //  CHECK-SAME:     key("hal.device.vulkan" :: "storage.8bit") : i1, i1 = false
+  //  CHECK-NEXT:   %[[AND0:.+]] = arith.andi %[[OK0]], %[[V0]] : i1
+  //  CHECK-NEXT:   %[[AND1:.+]] = arith.andi %[[T]], %[[AND0]] : i1
+  //  CHECK-NEXT:   hal.return %[[AND1]] : i1
+  //  CHECK-NEXT: }
+  hal.executable.variant public @test_8bit_storage_capabilities target(
+      #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+        spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [UniformAndStorageBuffer8BitAccess, StorageBuffer8BitAccess], []>, #spirv.resource_limits<>>
+      }>
+    ) {
+    hal.executable.export public @test_8bit_storage_capabilities ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires
+        #spirv.vce<v1.0, [UniformAndStorageBuffer8BitAccess, StorageBuffer8BitAccess], []> {
+        spirv.func @test_8bit_storage_capabilities() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @test_8bit_storage_capabilities
+        spirv.ExecutionMode @test_8bit_storage_capabilities "LocalSize", 64, 1, 1
+      }
+    }
+  }
+
+  // CHECK-LABEL: hal.executable.variant public @test_16bit_storage_capabilities
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "storage.16bit"]}>)
+  //       CHECK:   %{{.+}}, %{{.+}} = hal.device.query<%{{.+}} : !hal.device>
+  //  CHECK-SAME:     key("hal.device.vulkan" :: "storage.16bit") : i1, i1 = false
+  hal.executable.variant public @test_16bit_storage_capabilities target(
+      #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+        spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [StorageBuffer16BitAccess, StorageUniform16], []>, #spirv.resource_limits<>>
+      }>
+    ) {
+    hal.executable.export public @test_16bit_storage_capabilities ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires
+        #spirv.vce<v1.0, [StorageBuffer16BitAccess, StorageUniform16], []> {
+        spirv.func @test_16bit_storage_capabilities() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @test_16bit_storage_capabilities
+        spirv.ExecutionMode @test_16bit_storage_capabilities "LocalSize", 64, 1, 1
+      }
+    }
+  }
+
+  // CHECK-LABEL: hal.executable.variant public @test_int_compute_capabilities
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "compute.i16", "compute.i64", "compute.i8"]}>)
+  //      CHECK:    key("hal.device.vulkan" :: "compute.i16")
+  //      CHECK:    key("hal.device.vulkan" :: "compute.i64")
+  //      CHECK:    key("hal.device.vulkan" :: "compute.i8")
+  hal.executable.variant public @test_int_compute_capabilities target(
+      #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+        spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Int64, Int16, Int8], []>, #spirv.resource_limits<>>
+      }>
+    ) {
+    hal.executable.export public @test_int_compute_capabilities ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Int64, Int16, Int8], []> {
+        spirv.func @test_int_compute_capabilities() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @test_int_compute_capabilities
+        spirv.ExecutionMode @test_int_compute_capabilities "LocalSize", 64, 1, 1
+      }
+    }
+  }
+
+  // CHECK-LABEL: hal.executable.variant public @test_float_compute_capabilities
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "compute.f16", "compute.f64"]}>)
+  //      CHECK:    key("hal.device.vulkan" :: "compute.f16")
+  //      CHECK:    key("hal.device.vulkan" :: "compute.f64")
+  hal.executable.variant public @test_float_compute_capabilities target(
+      #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+        spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Float16, Float64], []>, #spirv.resource_limits<>>
+      }>
+    ) {
+    hal.executable.export public @test_float_compute_capabilities ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Float16, Float64], []> {
+        spirv.func @test_float_compute_capabilities() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @test_float_compute_capabilities
+        spirv.ExecutionMode @test_float_compute_capabilities "LocalSize", 64, 1, 1
+      }
+    }
+  }
+
+  // CHECK-LABEL: hal.executable.variant public @test_dot_product_capabilities
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "dotprod.4xi8.i32"]}>)
+  //      CHECK:    key("hal.device.vulkan" :: "dotprod.4xi8.i32")
+  hal.executable.variant public @test_dot_product_capabilities target(
+      #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+        spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [DotProduct, DotProductInput4x8Bit], []>, #spirv.resource_limits<>>
+      }>
+    ) {
+    hal.executable.export public @test_dot_product_capabilities ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [DotProduct, DotProductInput4x8Bit], []> {
+        spirv.func @test_dot_product_capabilities() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @test_dot_product_capabilities
+        spirv.ExecutionMode @test_dot_product_capabilities "LocalSize", 64, 1, 1
+      }
+    }
+  }
+
+  // CHECK-LABEL: hal.executable.variant public @test_cooperative_matrix_capabilities
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "coopmatrix.f16.f16.16x16x16"]}>)
+  //      CHECK:    key("hal.device.vulkan" :: "coopmatrix.f16.f16.16x16x16")
+  hal.executable.variant public @test_cooperative_matrix_capabilities target(
+      #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+        spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [CooperativeMatrixKHR], []>, #spirv.resource_limits<>>
+      }>
+    ) {
+    hal.executable.export public @test_cooperative_matrix_capabilities ordinal(0) layout(#pipeline_layout) attributes {
+      iree.spirv.coopmatrix.shape = array<i64: 16, 16, 16>, iree.spirv.coopmatrix.type = [f16, f16]
+    } {
+    ^bb0(%arg0: !hal.device):
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [CooperativeMatrixKHR], []> {
+        spirv.func @test_cooperative_matrix_capabilities() "None" { spirv.Return }
+        spirv.EntryPoint "GLCompute" @test_cooperative_matrix_capabilities
+        spirv.ExecutionMode @test_cooperative_matrix_capabilities "LocalSize", 64, 1, 1
+      }
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
@@ -11,10 +11,7 @@
 hal.executable private @dispatch_executable {
   // CHECK-LABEL: hal.executable.variant public @test_assumed_capabilities
   //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan"]}>)
-  //  CHECK-NEXT:   hal.executable.condition(%{{.+}}: !hal.device) -> i1 {
-  //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
-  //  CHECK-NEXT:   hal.return %[[T]] : i1
-  //  CHECK-NEXT: }
+  //   CHECK-NOT:   hal.executable.condition
   hal.executable.variant public @test_assumed_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Shader, GroupNonUniform], []>, #spirv.resource_limits<>>
@@ -35,18 +32,18 @@ hal.executable private @dispatch_executable {
   }
 
   // CHECK-LABEL: hal.executable.variant public @test_subgroup_capabilities
-  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "subgroup.arithmetic", "subgroup.shuffle"]}>)
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "subgroup=3"]}>)
   //  CHECK-NEXT:   hal.executable.condition(%[[DEV:.+]]: !hal.device) -> i1 {
   //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
-  //  CHECK-NEXT:   %[[OK0:.+]], %[[V0:.+]] = hal.device.query<%[[DEV]] : !hal.device>
-  //  CHECK-SAME:     key("hal.dispatch" :: "subgroup.arithmetic") : i1, i1 = false
-  //  CHECK-NEXT:   %[[AND0:.+]] = arith.andi %[[OK0]], %[[V0]] : i1
-  //  CHECK-NEXT:   %[[AND1:.+]] = arith.andi %[[T]], %[[AND0]] : i1
-  //  CHECK-NEXT:   %[[OK1:.+]], %[[V1:.+]] = hal.device.query<%[[DEV]] : !hal.device>
-  //  CHECK-SAME:     key("hal.dispatch" :: "subgroup.shuffle") : i1, i1 = false
-  //  CHECK-NEXT:   %[[AND2:.+]] = arith.andi %[[OK1]], %[[V1]] : i1
-  //  CHECK-NEXT:   %[[AND3:.+]] = arith.andi %[[AND1]], %[[AND2]] : i1
-  //  CHECK-NEXT:   hal.return %[[AND3]] : i1
+  //  CHECK-NEXT:   %[[OK:.+]], %[[V:.+]] = hal.device.query<%[[DEV]] : !hal.device>
+  //  CHECK-SAME:     key("hal.dispatch" :: "subgroup") : i1, i32 = 0 : i32
+  //  CHECK-NEXT:   %[[ZERO:.+]] = arith.constant 0 : i32
+  //  CHECK-NEXT:   %[[TARGET:.+]] = arith.constant 3 : i32
+  //  CHECK-NEXT:   %[[CHECK:.+]] = arith.andi %[[V]], %[[TARGET]] : i32
+  //  CHECK-NEXT:   %[[CMP:.+]] = arith.cmpi ne, %[[CHECK]], %[[ZERO]] : i32
+  //  CHECK-NEXT:   %[[AND:.+]] = arith.andi %[[OK]], %[[CMP]] : i1
+  //  CHECK-NEXT:   %[[RESULT:.+]] = arith.andi %[[T]], %[[AND]] : i1
+  //  CHECK-NEXT:   hal.return %[[RESULT]] : i1
   //  CHECK-NEXT: }
   hal.executable.variant public @test_subgroup_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
@@ -68,14 +65,18 @@ hal.executable private @dispatch_executable {
   }
 
   // CHECK-LABEL: hal.executable.variant public @test_8bit_storage_capabilities
-  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "storage.8bit"]}>)
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "storage=1"]}>)
   //  CHECK-NEXT:   hal.executable.condition(%[[DEV:.+]]: !hal.device) -> i1 {
   //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
-  //  CHECK-NEXT:   %[[OK0:.+]], %[[V0:.+]] = hal.device.query<%[[DEV]] : !hal.device>
-  //  CHECK-SAME:     key("hal.dispatch" :: "storage.8bit") : i1, i1 = false
-  //  CHECK-NEXT:   %[[AND0:.+]] = arith.andi %[[OK0]], %[[V0]] : i1
-  //  CHECK-NEXT:   %[[AND1:.+]] = arith.andi %[[T]], %[[AND0]] : i1
-  //  CHECK-NEXT:   hal.return %[[AND1]] : i1
+  //  CHECK-NEXT:   %[[OK:.+]], %[[V:.+]] = hal.device.query<%[[DEV]] : !hal.device>
+  //  CHECK-SAME:     key("hal.dispatch" :: "storage") : i1, i32 = 0 : i32
+  //  CHECK-NEXT:   %[[ZERO:.+]] = arith.constant 0 : i32
+  //  CHECK-NEXT:   %[[TARGET:.+]] = arith.constant 1 : i32
+  //  CHECK-NEXT:   %[[CHECK:.+]] = arith.andi %[[V]], %[[TARGET]] : i32
+  //  CHECK-NEXT:   %[[CMP:.+]] = arith.cmpi ne, %[[CHECK]], %[[ZERO]] : i32
+  //  CHECK-NEXT:   %[[AND:.+]] = arith.andi %[[OK]], %[[CMP]] : i1
+  //  CHECK-NEXT:   %[[RESULT:.+]] = arith.andi %[[T]], %[[AND]] : i1
+  //  CHECK-NEXT:   hal.return %[[RESULT]] : i1
   //  CHECK-NEXT: }
   hal.executable.variant public @test_8bit_storage_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
@@ -98,9 +99,19 @@ hal.executable private @dispatch_executable {
   }
 
   // CHECK-LABEL: hal.executable.variant public @test_16bit_storage_capabilities
-  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "storage.16bit"]}>)
-  //       CHECK:   %{{.+}}, %{{.+}} = hal.device.query<%{{.+}} : !hal.device>
-  //  CHECK-SAME:     key("hal.dispatch" :: "storage.16bit") : i1, i1 = false
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "storage=2"]}>)
+  //  CHECK-NEXT:   hal.executable.condition(%[[DEV:.+]]: !hal.device) -> i1 {
+  //  CHECK-NEXT:   %[[T:.+]] = arith.constant true
+  //  CHECK-NEXT:   %[[OK:.+]], %[[V:.+]] = hal.device.query<%[[DEV]] : !hal.device>
+  //  CHECK-SAME:     key("hal.dispatch" :: "storage") : i1, i32 = 0 : i32
+  //  CHECK-NEXT:   %[[ZERO:.+]] = arith.constant 0 : i32
+  //  CHECK-NEXT:   %[[TARGET:.+]] = arith.constant 2 : i32
+  //  CHECK-NEXT:   %[[CHECK:.+]] = arith.andi %[[V]], %[[TARGET]] : i32
+  //  CHECK-NEXT:   %[[CMP:.+]] = arith.cmpi ne, %[[CHECK]], %[[ZERO]] : i32
+  //  CHECK-NEXT:   %[[AND:.+]] = arith.andi %[[OK]], %[[CMP]] : i1
+  //  CHECK-NEXT:   %[[RESULT:.+]] = arith.andi %[[T]], %[[AND]] : i1
+  //  CHECK-NEXT:   hal.return %[[RESULT]] : i1
+  //  CHECK-NEXT: }
   hal.executable.variant public @test_16bit_storage_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [StorageBuffer16BitAccess, StorageUniform16], []>, #spirv.resource_limits<>>
@@ -122,10 +133,11 @@ hal.executable private @dispatch_executable {
   }
 
   // CHECK-LABEL: hal.executable.variant public @test_int_compute_capabilities
-  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "compute.i16", "compute.i64", "compute.i8"]}>)
-  //      CHECK:    key("hal.dispatch" :: "compute.i16")
-  //      CHECK:    key("hal.dispatch" :: "compute.i64")
-  //      CHECK:    key("hal.dispatch" :: "compute.i8")
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "compute.i=7"]}>)
+  //       CHECK:   %{{.+}}, %[[V:.+]] = hal.device.query<%{{.+}} : !hal.device>
+  //  CHECK-SAME:     key("hal.dispatch" :: "compute.i") : i1, i32 = 0 : i32
+  //       CHECK:   %[[TARGET:.+]] = arith.constant 7 : i32
+  //       CHECK:   %{{.+}} = arith.andi %[[V]], %[[TARGET]] : i32
   hal.executable.variant public @test_int_compute_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Int64, Int16, Int8], []>, #spirv.resource_limits<>>
@@ -146,9 +158,11 @@ hal.executable private @dispatch_executable {
   }
 
   // CHECK-LABEL: hal.executable.variant public @test_float_compute_capabilities
-  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "compute.f16", "compute.f64"]}>)
-  //      CHECK:    key("hal.dispatch" :: "compute.f16")
-  //      CHECK:    key("hal.dispatch" :: "compute.f64")
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "compute.f=3"]}>)
+  //       CHECK:   %{{.+}}, %[[V:.+]] = hal.device.query<%{{.+}} : !hal.device>
+  //  CHECK-SAME:     key("hal.dispatch" :: "compute.f") : i1, i32 = 0 : i32
+  //       CHECK:   %[[TARGET:.+]] = arith.constant 3 : i32
+  //       CHECK:   %{{.+}} = arith.andi %[[V]], %[[TARGET]] : i32
   hal.executable.variant public @test_float_compute_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Float16, Float64], []>, #spirv.resource_limits<>>
@@ -169,8 +183,11 @@ hal.executable private @dispatch_executable {
   }
 
   // CHECK-LABEL: hal.executable.variant public @test_dot_product_capabilities
-  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "dotprod.4xi8.i32"]}>)
-  //      CHECK:    key("hal.dispatch" :: "dotprod.4xi8.i32")
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "dotprod=1"]}>)
+  //       CHECK:   %{{.+}}, %[[V:.+]] = hal.device.query<%{{.+}} : !hal.device>
+  //  CHECK-SAME:     key("hal.dispatch" :: "dotprod") : i1, i32 = 0 : i32
+  //       CHECK:   %[[TARGET:.+]] = arith.constant 1 : i32
+  //       CHECK:   %{{.+}} = arith.andi %[[V]], %[[TARGET]] : i32
   hal.executable.variant public @test_dot_product_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [DotProduct, DotProductInput4x8Bit], []>, #spirv.resource_limits<>>
@@ -191,8 +208,11 @@ hal.executable private @dispatch_executable {
   }
 
   // CHECK-LABEL: hal.executable.variant public @test_cooperative_matrix_capabilities
-  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "coopmatrix.f16.f16.16x16x16"]}>)
-  //      CHECK:    key("hal.dispatch" :: "coopmatrix.f16.f16.16x16x16")
+  //  CHECK-SAME: target(<"vulkan", "vulkan-spirv-fb", {iree.spirv.features = ["vulkan", "coopmatrix=1"]}>)
+  //       CHECK:   %{{.+}}, %[[V:.+]] = hal.device.query<%{{.+}} : !hal.device>
+  //  CHECK-SAME:     key("hal.dispatch" :: "coopmatrix") : i1, i32 = 0 : i32
+  //       CHECK:   %[[TARGET:.+]] = arith.constant 1 : i32
+  //       CHECK:   %{{.+}} = arith.andi %[[V]], %[[TARGET]] : i32
   hal.executable.variant public @test_cooperative_matrix_capabilities target(
       #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [CooperativeMatrixKHR], []>, #spirv.resource_limits<>>

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -38,6 +38,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        "//compiler/src/iree/compiler/Utils",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_cc_library(
     iree::compiler::Codegen::Interfaces::UKernelOpInterface
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
+    iree::compiler::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
@@ -7,6 +7,8 @@
 #include "iree/compiler/Codegen/Utils/LinkingUtils.h"
 
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Utils/EquivalenceUtils.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -234,6 +236,29 @@ LogicalResult linkExecutablesInto(
           SymbolRefAttr::get(context, linkedExecutableOp.getName(),
                              {SymbolRefAttr::get(linkedTargetOp)});
       symbolReplacements.variantRefs[oldVariantRefAttr] = newVariantRefAttr;
+
+      // Move the condition op too. We need to make sure all variant's condition
+      // op has the same content.
+      auto targetConditionOps =
+          linkedTargetOp.getOps<IREE::HAL::ExecutableConditionOp>();
+      if (auto sourceCoditionOp = variantOp.getConditionOp()) {
+        if (targetConditionOps.empty()) {
+          sourceCoditionOp->moveBefore(
+              &*linkedTargetBuilder.getInsertionPoint());
+        } else {
+          assert(llvm::hasSingleElement(targetConditionOps));
+          IREE::HAL::ExecutableConditionOp referenceOp =
+              *targetConditionOps.begin();
+          if (!isStructurallyEquivalentTo(*sourceCoditionOp.getOperation(),
+                                          *referenceOp.getOperation())) {
+            return variantOp.emitError("contains incompatible condition op");
+          }
+        }
+      } else {
+        if (!targetConditionOps.empty()) {
+          return variantOp.emitError("should contain a condition op");
+        }
+      }
 
       // Move any constant blocks that need to be preserved for future host
       // translation. There may be duplicates provided but they'll be cleaned

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1220,6 +1220,18 @@ DenseMap<Attribute, int> ExecutableVariantOp::gatherConstantOrdinals() {
   return map;
 }
 
+Value ExecutableVariantOp::createConditionOp(OpBuilder &builder) {
+  assert(!getConditionOp() && "condition op already exists");
+
+  builder.setInsertionPointToStart(&getRegion().front());
+  auto conditionOp = builder.create<IREE::HAL::ExecutableConditionOp>(getLoc());
+  Block *entryPoint = conditionOp.addEntryBlock();
+  Value device = entryPoint->getArgument(0);
+
+  builder.setInsertionPointToStart(entryPoint);
+  return device;
+}
+
 Value ExecutableVariantOp::buildCondition(Value device, OpBuilder &builder) {
   // Base case dependent on target information.
   // TODO(multi-device): condition on device target ID and other queries that

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2162,6 +2162,11 @@ def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
     // blocks inside the variant.
     DenseMap<Attribute, int> gatherConstantOrdinals();
 
+    // Creates the new `hal.executable.condition` op in this variant op and sets
+    // the insertion point of the provided builder to the beginning of the new
+    // region.
+    Value createConditionOp(OpBuilder &builder);
+
     // Returns an i1 indicating whether this variant should be selected.
     Value buildCondition(Value device, OpBuilder &builder);
   }];

--- a/runtime/src/iree/hal/drivers/vulkan/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/vulkan/dynamic_symbol_tables.h
@@ -319,7 +319,7 @@ namespace vulkan {
   INS_PFN(EXCLUDED, vkGetDisplayPlaneCapabilitiesKHR)                   \
   INS_PFN(EXCLUDED, vkGetDisplayPlaneSupportedDisplaysKHR)              \
   INS_PFN(OPTIONAL, vkGetPhysicalDeviceCalibrateableTimeDomainsEXT)     \
-  INS_PFN(EXCLUDED, vkGetPhysicalDeviceCooperativeMatrixPropertiesNV)   \
+  INS_PFN(OPTIONAL, vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR)  \
   INS_PFN(EXCLUDED, vkGetPhysicalDeviceDisplayPlaneProperties2KHR)      \
   INS_PFN(EXCLUDED, vkGetPhysicalDeviceDisplayPlanePropertiesKHR)       \
   INS_PFN(EXCLUDED, vkGetPhysicalDeviceDisplayProperties2KHR)           \

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
@@ -106,4 +106,42 @@ iree_hal_vulkan_device_extensions_t
 iree_hal_vulkan_infer_enabled_device_extensions(
     const iree::hal::vulkan::DynamicSymbols* device_syms);
 
+// Struct for supported device properties.
+typedef struct iree_hal_vulkan_device_properties_t {
+  // Whether supporting 16-bit floating-point type for computation.
+  // See VkPhysicalDeviceShaderFloat16Int8Features::shaderFloat16.
+  bool compute_f16 : 1;
+  // Whether supporting 64-bit floating-point type for computation.
+  // See VkPhysicalDeviceFeatures::shaderFloat64.
+  bool compute_f64 : 1;
+  // Whether supporting 8-bit integer type for computation.
+  // See VkPhysicalDeviceShaderFloat16Int8Features::shaderInt8.
+  bool compute_i8 : 1;
+  // Whether supporting 16-bit integer type for computation.
+  // See VkPhysicalDeviceFeatures::shaderInt16.
+  bool compute_i16 : 1;
+  // Whether supporting 64-bit integer type for computation.
+  // See VkPhysicalDeviceFeatures::shaderInt64.
+  bool compute_i64 : 1;
+  // Whether supporting 8-bit storage features. True means both
+  // storageBuffer8BitAccess and uniformAndStorageBuffer8BitAccess.
+  // See VkPhysicalDevice8BitStorageFeatures.
+  bool storage_8bit : 1;
+  // Whether supporting 16-bit storage features. True means both
+  // storageBuffer16BitAccess and uniformAndStorageBuffer16BitAccess.
+  // See VkPhysicalDevice16BitStorageFeatures.
+  bool storage_16bit : 1;
+  // Bitfield of supported dot product operations.
+  // Format: "dotprod.<input-type>.<output-type>".
+  // 0x1: dotprod.4xi8.i32
+  uint32_t dot_product_operations : 8;
+  // Bitfield of supported cooperative matrix operations.
+  // Format: "coopmatrix.<input-type>.<output-type>.<m>x<n>x<k>".
+  // 0x1: coopmatrix.f16.f16.16x16x16
+  uint32_t cooperative_matrix_operations : 8;
+  // Bitfield of supported subgroup operations; directly copied from
+  // VkPhysicalDeviceSubgroupProperties::supportedOperations.
+  uint32_t subgroup_operations;
+} iree_hal_vulkan_iree_hal_vulkan_device_properties_t;
+
 #endif  // IREE_HAL_DRIVERS_VULKAN_EXTENSIBILITY_UTIL_H_

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
@@ -107,41 +107,39 @@ iree_hal_vulkan_infer_enabled_device_extensions(
     const iree::hal::vulkan::DynamicSymbols* device_syms);
 
 // Struct for supported device properties.
+//
+// Note that the fields used here should match the ones used in KernelFeatures
+// on the compiler side.
 typedef struct iree_hal_vulkan_device_properties_t {
-  // Whether supporting 16-bit floating-point type for computation.
-  // See VkPhysicalDeviceShaderFloat16Int8Features::shaderFloat16.
-  bool compute_f16 : 1;
-  // Whether supporting 64-bit floating-point type for computation.
-  // See VkPhysicalDeviceFeatures::shaderFloat64.
-  bool compute_f64 : 1;
-  // Whether supporting 8-bit integer type for computation.
-  // See VkPhysicalDeviceShaderFloat16Int8Features::shaderInt8.
-  bool compute_i8 : 1;
-  // Whether supporting 16-bit integer type for computation.
-  // See VkPhysicalDeviceFeatures::shaderInt16.
-  bool compute_i16 : 1;
-  // Whether supporting 64-bit integer type for computation.
-  // See VkPhysicalDeviceFeatures::shaderInt64.
-  bool compute_i64 : 1;
-  // Whether supporting 8-bit storage features. True means both
-  // storageBuffer8BitAccess and uniformAndStorageBuffer8BitAccess.
-  // See VkPhysicalDevice8BitStorageFeatures.
-  bool storage_8bit : 1;
-  // Whether supporting 16-bit storage features. True means both
-  // storageBuffer16BitAccess and uniformAndStorageBuffer16BitAccess.
-  // See VkPhysicalDevice16BitStorageFeatures.
-  bool storage_16bit : 1;
-  // Bitfield of supported dot product operations.
-  // Format: "dotprod.<input-type>.<output-type>".
-  // 0x1: dotprod.4xi8.i32
-  uint32_t dot_product_operations : 8;
-  // Bitfield of supported cooperative matrix operations.
-  // Format: "coopmatrix.<input-type>.<output-type>.<m>x<n>x<k>".
-  // 0x1: coopmatrix.f16.f16.16x16x16
-  uint32_t cooperative_matrix_operations : 8;
-  // Bitfield of supported subgroup operations; directly copied from
-  // VkPhysicalDeviceSubgroupProperties::supportedOperations.
-  uint32_t subgroup_operations;
+  // Floating-point compute related feature bitfield:
+  // * 0b01: f16
+  // * 0b10: f64
+  // Note that f32 is assumed to always exist and does not appear in this
+  // bitfield.
+  uint32_t compute_float : 8;
+  // Integer compute related feature bitfield:
+  // * 0b001: i8
+  // * 0b010: i16
+  // * 0b100: i64
+  // Note that i32 or i1 is assumed to always exist and does not appear in
+  // this bitfield.
+  uint32_t compute_int : 8;
+  // Storage bitwidth requirement bitfiled:
+  // * 0b01: 8-bit
+  // * 0b10: 16-bit
+  uint32_t storage : 8;
+  // Subgroup operation requirement bitfield:
+  // * 0b01: subgroup shuffle operations
+  // * 0b10: subgroup arithmetic operations
+  uint32_t subgroup : 8;
+  // Dot product operation requirement bitfield:
+  // ("dotprod.<input-type>.<output-type>")
+  // * 0b01: dotprod.4xi8.i32
+  uint32_t dot_product : 8;
+  // Cooperative matrix requirement bitfield:
+  // ("coopmatrix.<input-element-type>.<output-element-type>.<m>x<n>x<k>")
+  // * 0b01: coopmatrix.f16.f16.16x16x16
+  uint32_t cooperative_matrix : 8;
 } iree_hal_vulkan_iree_hal_vulkan_device_properties_t;
 
 #endif  // IREE_HAL_DRIVERS_VULKAN_EXTENSIBILITY_UTIL_H_

--- a/runtime/src/iree/hal/drivers/vulkan/handle_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/handle_util.h
@@ -42,12 +42,14 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
   VkDeviceHandle(DynamicSymbols* syms, VkPhysicalDevice physical_device,
                  iree_hal_vulkan_features_t enabled_features,
                  iree_hal_vulkan_device_extensions_t enabled_extensions,
+                 iree_hal_vulkan_device_properties_t supported_properties,
                  bool owns_device, iree_allocator_t host_allocator,
                  const VkAllocationCallbacks* allocator = nullptr)
       : syms_(add_ref(syms)),
         physical_device_(physical_device),
         enabled_features_(enabled_features),
         enabled_extensions_(enabled_extensions),
+        supported_properties_(supported_properties),
         owns_device_(owns_device),
         allocator_(allocator),
         host_allocator_(host_allocator) {}
@@ -62,6 +64,7 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
         value_(exchange(other.value_, static_cast<VkDevice>(VK_NULL_HANDLE))),
         syms_(std::move(other.syms_)),
         enabled_extensions_(other.enabled_extensions_),
+        supported_properties_(other.supported_properties_),
         owns_device_(other.owns_device_),
         allocator_(other.allocator_),
         host_allocator_(other.host_allocator_) {}
@@ -93,12 +96,17 @@ class VkDeviceHandle : public RefObject<VkDeviceHandle> {
     return enabled_extensions_;
   }
 
+  const iree_hal_vulkan_device_properties_t& supported_properties() const {
+    return supported_properties_;
+  }
+
  private:
   VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;
   VkDevice value_ = VK_NULL_HANDLE;
   ref_ptr<DynamicSymbols> syms_;
   iree_hal_vulkan_features_t enabled_features_;
   iree_hal_vulkan_device_extensions_t enabled_extensions_;
+  iree_hal_vulkan_device_properties_t supported_properties_;
   bool owns_device_;
   const VkAllocationCallbacks* allocator_ = nullptr;
   iree_allocator_t host_allocator_;

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1423,7 +1423,7 @@ static iree_status_t iree_hal_vulkan_device_query_i64(
 
   // Note that the device queries used here should match the ones used in
   // mapToDeviceQuery() on the compiler side.
-  if (iree_string_view_equal(category, IREE_SV("hal.device.vulkan"))) {
+  if (iree_string_view_equal(category, IREE_SV("hal.dispatch"))) {
     if (iree_string_view_equal(key, IREE_SV("compute.f16"))) {
       bool v = device->logical_device->supported_properties().compute_f16;
       *out_value = v ? 1 : 0;


### PR DESCRIPTION
This commit adds a pass to materialize executable required SPIR-V
capabilities into proper device queries inside the associated
hal.executable.condition ops. Linking is updated accordingly to
unique and preseve the feature checks. The Vulkan HAL driver
is updated accordingly to probe the implementation and match
against the device queries.

Fixes https://github.com/openxla/iree/issues/15786