### PR TITLE
[stablehlo] Remove potential double-free in ReorderBroadcastInDimOpAndElementwiseOp

### DIFF
--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -1186,12 +1186,16 @@ struct ReorderBroadcastInDimOpAndElementwiseOp final
     rewriter.replaceOpWithNewOp<mlir::stablehlo::BroadcastInDimOp>(
         op, op.getType(), result, bcastOps[0].getBroadcastDimensions());
 
+    llvm::SetVector<Operation*> opsToErase;
     for (auto bcastOp : bcastOps) {
       if (bcastOp.getOperation()->use_empty()) {
-        rewriter.eraseOp(bcastOp);
+        opsToErase.insert(bcastOp.getOperation());
       }
     }
 
+    for(auto opToErase: opsToErase) {
+      rewriter.eraseOp(opToErase);
+    }
     return success();
   }
 };

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -1186,14 +1186,14 @@ struct ReorderBroadcastInDimOpAndElementwiseOp final
     rewriter.replaceOpWithNewOp<mlir::stablehlo::BroadcastInDimOp>(
         op, op.getType(), result, bcastOps[0].getBroadcastDimensions());
 
-    llvm::SetVector<Operation*> opsToErase;
+    llvm::SetVector<Operation *> opsToErase;
     for (auto bcastOp : bcastOps) {
       if (bcastOp.getOperation()->use_empty()) {
         opsToErase.insert(bcastOp.getOperation());
       }
     }
 
-    for(auto opToErase: opsToErase) {
+    for (auto opToErase : opsToErase) {
       rewriter.eraseOp(opToErase);
     }
     return success();


### PR DESCRIPTION
This fix a double free that occurs when the two Broadcast operations are the same operation.