### PR TITLE
Fix the compiler.api/MLIR-python interop.

### DIFF
--- a/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
+++ b/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
@@ -383,6 +383,12 @@ class Invocation:
 
     def export_module(self):
         """Exports the module."""
+        if self.session._owned_context is None:
+            raise RuntimeError(
+                "In order to export a module, the context must first be exported from "
+                "the session (i.e. `session.context`)."
+            )
+
         from .. import ir
 
         if self._retained_module_op:

--- a/compiler/bindings/python/test/api/CMakeLists.txt
+++ b/compiler/bindings/python/test/api/CMakeLists.txt
@@ -13,6 +13,13 @@ iree_py_test(
 
 iree_py_test(
   NAME
+    mlir_interop_reference_test
+  SRCS
+    "mlir_interop_reference_test.py"
+)
+
+iree_py_test(
+  NAME
     output_buffer_reference_test
   SRCS
     "output_buffer_reference_test.py"

--- a/compiler/bindings/python/test/api/api_test.py
+++ b/compiler/bindings/python/test/api/api_test.py
@@ -15,6 +15,7 @@ import unittest
 from iree.compiler.api import *
 from iree.compiler import ir
 
+
 class DlFlagsTest(unittest.TestCase):
     def testDefaultFlags(self):
         session = Session()
@@ -42,6 +43,7 @@ class DlFlagsTest(unittest.TestCase):
         session = Session()
         with self.assertRaises(ValueError):
             session.set_flags("--does-not-exist=1")
+
 
 class DlInvocationTest(unittest.TestCase):
     def testCreate(self):
@@ -126,6 +128,7 @@ class DlInvocationTest(unittest.TestCase):
         inv.output_vm_bytecode(out)
         out.close()
 
+
 class DlOutputTest(unittest.TestCase):
     def testOpenMembuffer(self):
         out = Output.open_membuffer()
@@ -169,6 +172,7 @@ class DlOutputTest(unittest.TestCase):
         finally:
             Path(file_path).unlink()
 
+
 class DlInteropTest(unittest.TestCase):
     def testContextFromSession(self):
         s = Session()
@@ -209,6 +213,7 @@ class DlInteropTest(unittest.TestCase):
             contents = bytes(output.map_memory()).decode()
             print(contents)
             self.assertIn('test.test = "working"', contents)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/compiler/bindings/python/test/api/api_test.py
+++ b/compiler/bindings/python/test/api/api_test.py
@@ -4,216 +4,211 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# TODO: Upstream this to IREE.
-
 import platform
 
-if platform.system() == "Windows":
-    print("WARNING: Test disabled on Windows due to suspected MSVC bug")
-else:
-    from contextlib import closing
-    import os
-    from pathlib import Path
-    import tempfile
-    import unittest
+from contextlib import closing
+import os
+from pathlib import Path
+import tempfile
+import unittest
 
-    from iree.compiler.api import *
-    from iree.compiler import ir
+from iree.compiler.api import *
+from iree.compiler import ir
 
-    class DlFlagsTest(unittest.TestCase):
-        def testDefaultFlags(self):
-            session = Session()
-            flags = session.get_flags()
-            print(flags)
-            self.assertIn("--iree-input-type=auto", flags)
+class DlFlagsTest(unittest.TestCase):
+    def testDefaultFlags(self):
+        session = Session()
+        flags = session.get_flags()
+        print(flags)
+        self.assertIn("--iree-input-type=auto", flags)
 
-        def testNonDefaultFlags(self):
-            session = Session()
-            flags = session.get_flags(non_default_only=True)
-            self.assertEqual(flags, [])
-            session.set_flags("--iree-input-type=none")
-            flags = session.get_flags(non_default_only=True)
-            self.assertIn("--iree-input-type=none", flags)
+    def testNonDefaultFlags(self):
+        session = Session()
+        flags = session.get_flags(non_default_only=True)
+        self.assertEqual(flags, [])
+        session.set_flags("--iree-input-type=none")
+        flags = session.get_flags(non_default_only=True)
+        self.assertIn("--iree-input-type=none", flags)
 
-        def testFlagsAreScopedToSession(self):
-            session1 = Session()
-            session2 = Session()
-            session1.set_flags("--iree-input-type=tosa")
-            session2.set_flags("--iree-input-type=none")
-            self.assertIn("--iree-input-type=tosa", session1.get_flags())
-            self.assertIn("--iree-input-type=none", session2.get_flags())
+    def testFlagsAreScopedToSession(self):
+        session1 = Session()
+        session2 = Session()
+        session1.set_flags("--iree-input-type=tosa")
+        session2.set_flags("--iree-input-type=none")
+        self.assertIn("--iree-input-type=tosa", session1.get_flags())
+        self.assertIn("--iree-input-type=none", session2.get_flags())
 
-        def testFlagError(self):
-            session = Session()
-            with self.assertRaises(ValueError):
-                session.set_flags("--does-not-exist=1")
+    def testFlagError(self):
+        session = Session()
+        with self.assertRaises(ValueError):
+            session.set_flags("--does-not-exist=1")
 
-    class DlInvocationTest(unittest.TestCase):
-        def testCreate(self):
-            session = Session()
-            inv = session.invocation()
+class DlInvocationTest(unittest.TestCase):
+    def testCreate(self):
+        session = Session()
+        inv = session.invocation()
 
-        def testInputFile(self):
-            session = Session()
-            inv = session.invocation()
-            with tempfile.NamedTemporaryFile("w", delete=False) as tf:
-                tf.write("module {}")
-                tf.close()
-            try:
-                source = Source.open_file(session, tf.name)
-                inv.parse_source(source)
-            finally:
-                os.unlink(tf.name)
-            out = Output.open_membuffer()
-            inv.output_ir(out)
-            mem = out.map_memory()
-            self.assertIn(b"module", bytes(mem))
-            out.close()
-
-        def testInputBuffer(self):
-            session = Session()
-            inv = session.invocation()
-            source = Source.wrap_buffer(session, b"builtin.module {}")
+    def testInputFile(self):
+        session = Session()
+        inv = session.invocation()
+        with tempfile.NamedTemporaryFile("w", delete=False) as tf:
+            tf.write("module {}")
+            tf.close()
+        try:
+            source = Source.open_file(session, tf.name)
             inv.parse_source(source)
-            out = Output.open_membuffer()
-            inv.output_ir(out)
-            mem = out.map_memory()
-            self.assertIn(b"module", bytes(mem))
-            out.close()
+        finally:
+            os.unlink(tf.name)
+        out = Output.open_membuffer()
+        inv.output_ir(out)
+        mem = out.map_memory()
+        self.assertIn(b"module", bytes(mem))
+        out.close()
 
-        def testOutputBytecode(self):
-            session = Session()
-            inv = session.invocation()
-            source = Source.wrap_buffer(session, b"builtin.module {}")
-            inv.parse_source(source)
-            out = Output.open_membuffer()
-            inv.output_ir_bytecode(out)
-            mem = out.map_memory()
-            self.assertIn(b"module", bytes(mem))
-            out.close()
+    def testInputBuffer(self):
+        session = Session()
+        inv = session.invocation()
+        source = Source.wrap_buffer(session, b"builtin.module {}")
+        inv.parse_source(source)
+        out = Output.open_membuffer()
+        inv.output_ir(out)
+        mem = out.map_memory()
+        self.assertIn(b"module", bytes(mem))
+        out.close()
 
-        def testExecutePassPipeline(self):
-            session = Session()
-            inv = session.invocation()
-            source = Source.wrap_buffer(
-                session,
-                b"""
-                builtin.module {
-                    func.func private @foobar() -> ()
+    def testOutputBytecode(self):
+        session = Session()
+        inv = session.invocation()
+        source = Source.wrap_buffer(session, b"builtin.module {}")
+        inv.parse_source(source)
+        out = Output.open_membuffer()
+        inv.output_ir_bytecode(out)
+        mem = out.map_memory()
+        self.assertIn(b"module", bytes(mem))
+        out.close()
+
+    def testExecutePassPipeline(self):
+        session = Session()
+        inv = session.invocation()
+        source = Source.wrap_buffer(
+            session,
+            b"""
+            builtin.module {
+                func.func private @foobar() -> ()
+            }
+            """,
+        )
+        inv.parse_source(source)
+        inv.execute_text_pass_pipeline("symbol-dce")
+        out = Output.open_membuffer()
+        inv.output_ir(out)
+        mem = out.map_memory()
+        self.assertNotIn(b"func", bytes(mem))
+        out.close()
+
+    def testExecuteStdPipeline(self):
+        session = Session()
+        session.set_flags("--iree-hal-target-backends=vmvx")
+        inv = session.invocation()
+        source = Source.wrap_buffer(
+            session,
+            b"""
+            builtin.module {
+                func.func @main(%arg0: i32) -> (i32) {
+                    return %arg0 : i32
                 }
-                """,
-            )
-            inv.parse_source(source)
-            inv.execute_text_pass_pipeline("symbol-dce")
-            out = Output.open_membuffer()
-            inv.output_ir(out)
-            mem = out.map_memory()
-            self.assertNotIn(b"func", bytes(mem))
-            out.close()
+            }
+            """,
+        )
+        inv.parse_source(source)
+        inv.execute()
+        out = Output.open_membuffer()
+        inv.output_vm_bytecode(out)
+        out.close()
 
-        def testExecuteStdPipeline(self):
-            session = Session()
-            session.set_flags("--iree-hal-target-backends=vmvx")
-            inv = session.invocation()
-            source = Source.wrap_buffer(
-                session,
-                b"""
-                builtin.module {
-                    func.func @main(%arg0: i32) -> (i32) {
-                        return %arg0 : i32
-                    }
-                }
-                """,
-            )
-            inv.parse_source(source)
-            inv.execute()
-            out = Output.open_membuffer()
-            inv.output_vm_bytecode(out)
-            out.close()
+class DlOutputTest(unittest.TestCase):
+    def testOpenMembuffer(self):
+        out = Output.open_membuffer()
 
-    class DlOutputTest(unittest.TestCase):
-        def testOpenMembuffer(self):
-            out = Output.open_membuffer()
+    def testOpenMembufferExplicitClose(self):
+        out = Output.open_membuffer()
+        out.close()
 
-        def testOpenMembufferExplicitClose(self):
-            out = Output.open_membuffer()
-            out.close()
+    def testOpenMembufferWrite(self):
+        out = Output.open_membuffer()
+        out.write(b"foobar")
+        mem = out.map_memory()
+        self.assertEqual(b"foobar", bytes(mem))
+        out.close()
 
-        def testOpenMembufferWrite(self):
-            out = Output.open_membuffer()
+    def testOpenFileNoKeep(self):
+        file_path = tempfile.mktemp()
+        out = Output.open_file(file_path)
+        try:
             out.write(b"foobar")
-            mem = out.map_memory()
-            self.assertEqual(b"foobar", bytes(mem))
+            self.assertTrue(Path(file_path).exists())
+        finally:
             out.close()
+            # Didn't call keep, so should be deleted.
+        self.assertFalse(Path(file_path).exists())
 
-        def testOpenFileNoKeep(self):
-            file_path = tempfile.mktemp()
-            out = Output.open_file(file_path)
+    def testOpenFileKeep(self):
+        file_path = tempfile.mktemp()
+        out = Output.open_file(file_path)
+        try:
             try:
                 out.write(b"foobar")
-                self.assertTrue(Path(file_path).exists())
+                out.keep()
             finally:
                 out.close()
                 # Didn't call keep, so should be deleted.
-            self.assertFalse(Path(file_path).exists())
 
-        def testOpenFileKeep(self):
-            file_path = tempfile.mktemp()
-            out = Output.open_file(file_path)
-            try:
-                try:
-                    out.write(b"foobar")
-                    out.keep()
-                finally:
-                    out.close()
-                    # Didn't call keep, so should be deleted.
+            with open(file_path, "rb") as f:
+                contents = f.read()
+                self.assertEqual(b"foobar", contents)
+        finally:
+            Path(file_path).unlink()
 
-                with open(file_path, "rb") as f:
-                    contents = f.read()
-                    self.assertEqual(b"foobar", contents)
-            finally:
-                Path(file_path).unlink()
+class DlInteropTest(unittest.TestCase):
+    def testContextFromSession(self):
+        s = Session()
+        # TODO: Test that multiple calls return the same context.
+        # TODO: Do gc stuff to verify memory.
+        context1 = s.context
+        context2 = s.context
+        self.assertIsNotNone(context1)
+        self.assertIs(context1, context2)
 
-    class DlInteropTest(unittest.TestCase):
-        def testContextFromSession(self):
-            s = Session()
-            # TODO: Test that multiple calls return the same context.
-            # TODO: Do gc stuff to verify memory.
-            context1 = s.context
-            context2 = s.context
-            self.assertIsNotNone(context1)
-            self.assertIs(context1, context2)
+    def testImportModule(self):
+        s = Session()
+        with ir.Location.unknown(s.context):
+            module_op = ir.Module.create().operation
+            module_op.attributes["test.test"] = ir.Attribute.parse('"working"')
+            inv = s.invocation()
+            inv.import_module(module_op)
+            # Round-trip it back through an Output and verify that the attribute
+            # we set is still there.
+            output = Output.open_membuffer()
+            inv.output_ir(output)
+            contents = bytes(output.map_memory()).decode()
+            print(contents)
+            self.assertIn('test.test = "working"', contents)
 
-        def testImportModule(self):
-            s = Session()
-            with ir.Location.unknown(s.context):
-                module_op = ir.Module.create().operation
-                module_op.attributes["test.test"] = ir.Attribute.parse('"working"')
-                inv = s.invocation()
-                inv.import_module(module_op)
-                # Round-trip it back through an Output and verify that the attribute
-                # we set is still there.
-                output = Output.open_membuffer()
-                inv.output_ir(output)
-                contents = bytes(output.map_memory()).decode()
-                print(contents)
-                self.assertIn('test.test = "working"', contents)
+    def testExportModule(self):
+        s = Session()
+        with ir.Location.unknown(s.context):
+            source = Source.wrap_buffer(s, b"builtin.module {}")
+            inv = s.invocation()
+            self.assertTrue(inv.parse_source(source))
+            module_op = inv.export_module()
+            module_op.attributes["test.test"] = ir.Attribute.parse('"working"')
+            # Round-trip it back through an Output and verify that the attribute
+            # we set is still there.
+            output = Output.open_membuffer()
+            inv.output_ir(output)
+            contents = bytes(output.map_memory()).decode()
+            print(contents)
+            self.assertIn('test.test = "working"', contents)
 
-        def testExportModule(self):
-            s = Session()
-            with ir.Location.unknown(s.context):
-                source = Source.wrap_buffer(s, b"builtin.module {}")
-                inv = s.invocation()
-                self.assertTrue(inv.parse_source(source))
-                module_op = inv.export_module()
-                module_op.attributes["test.test"] = ir.Attribute.parse('"working"')
-                # Round-trip it back through an Output and verify that the attribute
-                # we set is still there.
-                output = Output.open_membuffer()
-                inv.output_ir(output)
-                contents = bytes(output.map_memory()).decode()
-                print(contents)
-                self.assertIn('test.test = "working"', contents)
-
-    if __name__ == "__main__":
-        unittest.main()
+if __name__ == "__main__":
+    unittest.main()

--- a/compiler/bindings/python/test/api/mlir_interop_reference_test.py
+++ b/compiler/bindings/python/test/api/mlir_interop_reference_test.py
@@ -1,0 +1,105 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# The iree compiler API includes facilities for importing/exporting
+# contexts and modules from the MLIR Python bindings. This is a tricky
+# interchange and we test some explicit access patterns for issues.
+
+import gc
+
+from iree.compiler.api import (
+    Invocation,
+    Session,
+    Source,
+    Output,
+)
+
+from iree.compiler import ir
+
+
+def test_context_interchange():
+    print("*** test_context_interchange")
+    s = Session()
+    start_live_contexts = ir.Context._get_live_count()
+    print("LIVE PY CONTEXTS:", start_live_contexts)
+    print("GETTING PYTHON CONTEXT")
+    context = s.context
+
+    print("DELETING SESSION")
+    s = None
+    gc.collect()
+
+    print("LIVE PY CONTEXTS:", ir.Context._get_live_count())
+    context = None
+    gc.collect()
+    end_live_contexts = ir.Context._get_live_count()
+    print("LIVE PY CONTEXTS:", end_live_contexts)
+    assert start_live_contexts == end_live_contexts
+
+
+def test_import_module():
+    print("*** test_import_module")
+    s = Session()
+    context = s.context
+    with ir.Location.unknown(context):
+        module_op = ir.Module.create().operation
+        inv = s.invocation()
+        inv.import_module(module_op)
+
+    gc.collect()
+    module_op = None
+    gc.collect()
+
+    session = None
+    gc.collect()
+
+    inv = None
+    gc.collect()
+    print("All done:", context._get_live_module_count())
+
+
+def test_export_module():
+    print("*** test_export_module")
+    s = Session()
+    start_live_operations = 0
+    # Make it known to Python.
+    s.context
+    source = Source.wrap_buffer(s, b"builtin.module {}")
+    inv = s.invocation()
+    assert inv.parse_source(source)
+
+    module_op = inv.export_module()
+    print(module_op)
+
+    context = None
+    gc.collect()
+    print("Exported live operations:", module_op.context._get_live_operation_count())
+
+    inv = None
+    gc.collect()
+    print("Exported live operations:", module_op.context._get_live_operation_count())
+
+    source = None
+    gc.collect()
+    print("Exported live operations:", module_op.context._get_live_operation_count())
+
+    s = None
+    gc.collect()
+    print("Exported live operations:", module_op.context._get_live_operation_count())
+
+    context = module_op.context
+    module_op = None
+    gc.collect()
+    print("Exported live operations:", context._get_live_operation_count())
+    assert start_live_operations == context._get_live_operation_count()
+
+    context = None
+    gc.collect()
+
+
+test_context_interchange()
+test_import_module()
+test_export_module()


### PR DESCRIPTION
It was previously thought that this was only an issue on Windows, but some subtle bugs in the ownership semantics upstream were merely manifesting there most prominently.

Includes https://github.com/llvm/llvm-project/pull/76010 for testing on CI.

ci-extra: build_test_all_windows