### PR TITLE
[VectorExt] Add to_simt and to_simd operations

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 // clang-format off
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.td
@@ -9,6 +9,8 @@
 
 include "iree-dialects/Dialect/VectorExt/IR/VectorExtBase.td"
 include "iree-dialects/Dialect/VectorExt/IR/VectorExtInterfaces.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Base class.
@@ -40,6 +42,42 @@ def IREEVectorExt_LayoutConflictResolutionOp : IREEVectorExt_PureOp<"layout_conf
   let extraClassDeclaration = [{}];
   let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
   let hasVerifier = 1;
+}
+
+def IREEVectorExt_ToSIMDOp : IREEVectorExt_PureOp<"to_simd",
+    [SameOperandsAndResultElementType, Pure]> {
+  let summary = "SIMT to SIMD conversion operation";
+  let description = [{
+    This operation is a temporary operation useful for source/target
+    materializations when doing type conversions between distributed and not
+    distributed vectors.
+  }];
+  let arguments = (ins
+    AnyVector:$input
+  );
+  let results = (outs
+    AnyVector:$output
+  );
+  let extraClassDeclaration = [{}];
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
+}
+
+def IREEVectorExt_ToSIMTOp : IREEVectorExt_PureOp<"to_simt",
+    [SameOperandsAndResultElementType, Pure]> {
+  let summary = "SIMD to SIMT conversion operation";
+  let description = [{
+    This operation is a temporary operation useful for source/target
+    materializations when doing type conversions between distributed and not
+    distributed vectors.
+  }];
+  let arguments = (ins
+    AnyVector:$input
+  );
+  let results = (outs
+    AnyVector:$output
+  );
+  let extraClassDeclaration = [{}];
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
 }
 
 #endif  // IREE_DIALECT_VECTOREXT_OPS

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
@@ -29,3 +29,17 @@ func.func @invalid_source_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf16
 }
 
 // -----
+
+func.func @invalid_to_simd_vector_element_type(%simd : vector<2x2xf16>) -> vector<64xf32> {
+  // expected-error @+1 {{requires the same element type for all operands and results}}
+  %simt = iree_vector_ext.to_simd %simd : vector<2x2xf16> -> vector<64xf32>
+  func.return %simt : vector<64xf32>
+}
+
+// -----
+
+func.func @invalid_to_simt_vector_element_type(%simt : vector<64xf32>) -> vector<2x2xf16> {
+  // expected-error @+1 {{requires the same element type for all operands and results}}
+  %simd = iree_vector_ext.to_simt %simt : vector<64xf32> -> vector<2x2xf16>
+  func.return %simd : vector<2x2xf16>
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
@@ -20,3 +20,19 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-SAME:         sourceLayout = #[[LAYOUT1]]
 
 // -----
+
+func.func @to_simd_op(%simt: vector<4x4x4xf16>) -> vector<64x64xf16> {
+  %simd = iree_vector_ext.to_simd %simt : vector<4x4x4xf16> -> vector<64x64xf16>
+  func.return %simd : vector<64x64xf16>
+}
+// CHECK-LABEL: func.func @to_simd_op
+// CHECK:      iree_vector_ext.to_simd
+
+// -----
+
+func.func @to_simt_op(%simd: vector<64x64xf32>) -> vector<4x4x4xf32> {
+  %simt = iree_vector_ext.to_simd %simd : vector<64x64xf32> -> vector<4x4x4xf32>
+  func.return %simt : vector<4x4x4xf32>
+}
+// CHECK-LABEL: func.func @to_simt_op
+// CHECK:      iree_vector_ext.to_simd


### PR DESCRIPTION
These operations are temporary operations useful for source/target materializations when doing type conversions between distributed and non distributed vectors.