### PR TITLE
[bf16] Rework to decompose `bf16` `truncf` and `extf` for LLVM

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -265,6 +265,7 @@ struct ConvertBf16ToUInt16BuffersPass final
                                                      Operation *op) {
         return typeConverter.isLegal(cast<func::FuncOp>(op).getFunctionType());
       });
+      target.addLegalOp<arith::TruncFOp, arith::ExtFOp>();
       target.addDynamicallyLegalDialect<arith::ArithDialect, func::FuncDialect,
                                         IREE::HAL::HALDialect,
                                         memref::MemRefDialect, scf::SCFDialect>(
@@ -296,7 +297,6 @@ struct ConvertBf16ToUInt16BuffersPass final
       });
 
       RewritePatternSet patterns(ctx);
-      arith::populateExpandBFloat16Patterns(patterns);
       populateIreeBf16EmulationPatterns(patterns, typeConverter);
 
       if (failed(applyPartialConversion(op, target, std::move(patterns))))

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -171,7 +171,7 @@ struct GenericTypeConversionPattern : public ConversionPattern {
                                            "argument type conversion failed");
       }
 
-      rewriter.applySignatureConversion(newRegion, result);
+      rewriter.applySignatureConversion(newRegion, result, typeConverter);
     }
 
     Operation *newOp = rewriter.create(state);

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_to_uint16_buffers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_to_uint16_buffers.mlir
@@ -92,3 +92,21 @@ func.func @outerproduct_bf16_preserved(%arg0 : vector<1xbf16>, %arg1 : vector<1x
   %0 = vector.outerproduct %arg0, %arg1, %arg2 {kind = #vector.kind<add>} : vector<1xbf16>, vector<1xbf16>
   return %0 : vector<1x1xbf16>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @load_trunc_f32_bf16
+func.func @load_trunc_f32_bf16(%arg0 : memref<32xf32>, %arg1 : memref<32xbf16>) {
+  // CHECK-SAME:  %[[ARG0:.+]]: memref<32xf32>
+  // CHECK-SAME:  %[[ARG1:.+]]: memref<32xi16>
+  // CHECK: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK: %[[LOAD:.+]] = vector.load %[[ARG0]][%[[C0]]] : memref<32xf32>, vector<4xf32>
+  // CHECK: %[[TRUNC:.+]] = arith.truncf %[[LOAD]] : vector<4xf32> to vector<4xbf16>
+  // CHECK: %[[CAST:.+]] = arith.bitcast %[[TRUNC]] : vector<4xbf16> to vector<4xi16>
+  // CHECK: vector.store %[[CAST]], %[[ARG1]][%[[C0]]] : memref<32xi16>, vector<4xi16>
+  %c0 = arith.constant 0 : index
+  %load = vector.load %arg0[%c0] : memref<32xf32>, vector<4xf32>
+  %trunc = arith.truncf %load : vector<4xf32> to vector<4xbf16>
+  vector.store %trunc, %arg1[%c0] : memref<32xbf16>, vector<4xbf16>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -1045,6 +1045,7 @@ void ConvertToLLVMPass::runOnOperation() {
   populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);
   arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
+  arith::populateExpandBFloat16Patterns(patterns);
   populateVectorToSCFConversionPatterns(patterns);
   populateVectorToLLVMMatrixConversionPatterns(typeConverter, patterns);
   populateVectorToLLVMConversionPatterns(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Conversion/NVGPUToNVVM/NVGPUToNVVM.h"
 #include "mlir/Conversion/NVVMToLLVM/NVVMToLLVM.h"
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
@@ -128,6 +129,7 @@ struct ConvertToNVVMPass : public ConvertToNVVMBase<ConvertToNVVMPass> {
       vector::populateVectorTransposeLoweringPatterns(
           patterns, vector::VectorTransformsOptions());
       vector::populateVectorTransferLoweringPatterns(patterns);
+      arith::populateExpandBFloat16Patterns(patterns);
       if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
@@ -161,6 +162,7 @@ struct ConvertToROCDLPass : public ConvertToROCDLBase<ConvertToROCDLPass> {
       vector::populateVectorTransposeLoweringPatterns(
           patterns, vector::VectorTransformsOptions());
       vector::populateVectorTransferLoweringPatterns(patterns);
+      arith::populateExpandBFloat16Patterns(patterns);
       if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -453,6 +453,17 @@ void ConvertToSPIRVPass::runOnOperation() {
   options.use64bitIndex = use64bitIndex;
 
   SPIRVTypeConverter typeConverter(targetAttr, options);
+
+  typeConverter.addConversion(
+      [typeConverter](FloatType floatType) -> std::optional<Type> {
+        if (floatType.isBF16()) {
+          return typeConverter.convertType(
+              IntegerType::get(floatType.getContext(), 16));
+        }
+
+        return floatType;
+      });
+
   // Additionally pull in conversion rules for GPU subgroup MMA ops.
   populateMMAToSPIRVCoopMatrixTypeConversion(typeConverter);
   RewritePatternSet patterns(&getContext());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -435,13 +435,10 @@ void ConvertToSPIRVPass::runOnOperation() {
     RewritePatternSet patterns(context);
     arith::populateExpandBFloat16Patterns(patterns);
     arith::BitcastOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(moduleOp,
-                                            std::move(patterns)))) {
-      moduleOp.emitOpError() << "failed running expansion patterns";
+    if (failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns)))) {
+      moduleOp.emitOpError() << "failed running bf16 extf/trunc patterns";
       return signalPassFailure();
     }
-    moduleOp.dump();
-
   }
 
   spirv::TargetEnvAttr targetAttr = getSPIRVTargetEnvAttr(moduleOp);
@@ -487,7 +484,6 @@ void ConvertToSPIRVPass::runOnOperation() {
   // Pull in standard/math patterns to convert arithmetic ops and others.
   arith::populateCeilFloorDivExpandOpsPatterns(patterns);
   arith::populateArithToSPIRVPatterns(typeConverter, patterns);
-  arith::populateExpandBFloat16Patterns(patterns);
   populateFuncToSPIRVPatterns(typeConverter, patterns);
   populateMathToSPIRVPatterns(typeConverter, patterns);
   populateComplexToSPIRVPatterns(typeConverter, patterns);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -472,6 +472,7 @@ void ConvertToSPIRVPass::runOnOperation() {
   // Pull in standard/math patterns to convert arithmetic ops and others.
   arith::populateCeilFloorDivExpandOpsPatterns(patterns);
   arith::populateArithToSPIRVPatterns(typeConverter, patterns);
+  arith::populateExpandBFloat16Patterns(patterns);
   populateFuncToSPIRVPatterns(typeConverter, patterns);
   populateMathToSPIRVPatterns(typeConverter, patterns);
   populateComplexToSPIRVPatterns(typeConverter, patterns);


### PR DESCRIPTION
We should only materialize out the `bf16` truncation and extension
operations at `ConvertToLLVM` as they can be potentially materialized
earlier in the pipeline.