### PR TITLE
[GlobalOpt][NFC] Follow LLVM comment style and apply few cleanups.

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
@@ -27,7 +27,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 
-#define DEBUG_TYPE "iree-flow-expand-tensor-shapes"
+#define DEBUG_TYPE "iree-global-opt-expand-tensor-shapes"
 
 namespace mlir::iree_compiler::GlobalOptimization {
 namespace {
@@ -580,7 +580,7 @@ static void expandTensorDims(Operation *op, ExpandedGlobalMap &globalMap,
 }
 
 //===----------------------------------------------------------------------===//
-// -iree-flow-expand-tensor-shapes
+// -iree-global-opt-expand-tensor-shapes
 //===----------------------------------------------------------------------===//
 
 // This does a relatively mechanical transformation of a module to expand all

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.h
@@ -11,7 +11,7 @@
 
 namespace mlir::iree_compiler {
 
-// Register all interfaces needed for hoisting constant expressions.
+/// Registers all interfaces needed for hoisting constant expressions.
 void registerHoistableTypeInterfaces(DialectRegistry &registry);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/Interfaces.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/Interfaces.h
@@ -11,7 +11,7 @@
 
 namespace mlir::iree_compiler {
 
-/// Register all global optimization related interfaces.
+/// Registers all global optimization related interfaces.
 void registerGlobalOptimizationInterfaces(DialectRegistry &registry);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -75,7 +75,7 @@ std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createFuseSiluHorizontalMatmulPass();
 
 /// Generalizes some named Linalg ops into `linalg.generic` operations since the
-/// IREE compiler can handle that better.
+/// compiler can handle that better.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createGeneralizeLinalgNamedOpsPass();
 
@@ -96,7 +96,8 @@ std::unique_ptr<Pass> createOptimizeNumericsPass();
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createPropagateLinalgTransposePass(bool enableAggressivePropagation = false);
 
-/// Raises sequence of ops to higher level linalg.ext representation.
+/// Performs specialized raisings of various sequences of ops to a
+/// representation easier for the compiler to handle.
 std::unique_ptr<Pass> createRaiseSpecialOps();
 
 /// Removes tensors that have 0-extents.

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -17,9 +17,9 @@
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
-// We have a layer of indirection around the GlobalOptimizationOptions because
-// we also need a reference to the const-eval builder, which is injected
-// in by callers.
+/// We have a layer of indirection around the GlobalOptimizationOptions because
+/// we also need a reference to the const-eval builder, which is injected
+/// in by callers.
 struct TransformOptions : public PassPipelineOptions<TransformOptions> {
   GlobalOptimizationOptions options;
 
@@ -30,9 +30,9 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
   std::function<void(OpPassManager &passManager)> buildConstEvalPassPipeline;
 };
 
-// Subset of the overall pass pipeline for optimizing globals and numerics.
-// We may ultimately break this out separately so creating a syntactic
-// distinction to keep that as an option.
+/// Subset of the overall pass pipeline for optimizing globals and numerics.
+/// We may ultimately break this out separately so creating a syntactic
+/// distinction to keep that as an option.
 void buildGlobalOptimizationPassPipeline(
     OpPassManager &mainPassManager, const TransformOptions &transformOptions);
 
@@ -40,78 +40,75 @@ void buildGlobalOptimizationPassPipeline(
 // Input canonicalization and legalization
 //===----------------------------------------------------------------------===//
 
-// Cleans up any numeric narrowing ops inserted by
-// iree-global-opt-infer-numeric-narrowing.
+/// Cleans up any numeric narrowing ops inserted by
+/// iree-global-opt-infer-numeric-narrowing.
 std::unique_ptr<Pass> createCleanupNumericNarrowingPass();
 
-// Creates a pass to convert linalg convolution ops with 1x1 kernels into
-// linalg.matmul
+/// Converts linalg convolution ops with 1x1 kernels into linalg.matmul.
 std::unique_ptr<Pass> createConvert1X1FilterConv2DToMatmulPass();
 
-// A pass to fuse dequantization and matmul linalg.generic ops
+/// Fuses dequantization and matmul linalg.generic ops
 std::unique_ptr<Pass>
 createDecomposeConcatPass(bool enableConcatTransposition = false);
 
-// Create a pass to detach elementwise ops from named Linalg ops.
+/// Demotes inputs (LHS, RHS) of linalg matmul-like ops from f32 to bf16.
+std::unique_ptr<Pass> createDemoteContractionInputsToBF16Pass();
+
+/// Detaches elementwise ops from named Linalg ops.
 std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();
 
-// Apply patterns to erase unused linalg operands and remove dead code
-// associated.
+/// Applies patterns to erase unused linalg operands and remove dead code
+/// associated.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createEraseUnusedLinalgOperands();
 
-// Expands tensor shape dimensions into SSA values across the program.
+/// Expands tensor shape dimensions into SSA values across the program.
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createExpandTensorShapesPass();
 
-// A pass to fuse dequantization and matmul linalg.generic ops
+/// Fuses dequantization and matmul linalg.generic ops
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createFuseDequantizationMatmulPass(
     bool enableQuantizedMatmulReassociation = false);
 
-// A pass to fuse two matmul ops and a linalg.generic Silu op
+/// Fuses two matmul ops and a linalg.generic Silu op
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createFuseSiluHorizontalMatmulPass();
 
-// Create a pass that generalizes some named Linalg ops into `linalg.generic`
-// operations since the IREE compiler can handle that better.
+/// Generalizes some named Linalg ops into `linalg.generic` operations since the
+/// IREE compiler can handle that better.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createGeneralizeLinalgNamedOpsPass();
 
-// Infers and inserts util.numeric.optional_narrow ops at points that may be
-// beneficial.
+/// Infers and inserts util.numeric.optional_narrow ops at points that may be
+/// beneficial.
 std::unique_ptr<Pass> createInferNumericNarrowingPass();
 
-// Materializes logical encodings to physical encodings if there is a single
-// device target.
+/// Materializes logical encodings to physical encodings if there is a single
+/// device target.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createMaterializeHomogeneousEncodingsPass();
 
-// Optimizes numerics given annotations added via
-// iree-global-opt-infer-numeric-narrowing.
+/// Optimizes numerics given annotations added via
+/// iree-global-opt-infer-numeric-narrowing.
 std::unique_ptr<Pass> createOptimizeNumericsPass();
 
-// Create a pass that propagates linalg.transpose ops to a restricted set of
-// operations.
+/// Propagates linalg.transpose ops to a restricted set of operations.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createPropagateLinalgTransposePass(bool enableAggressivePropagation = false);
 
-// Create a pass to raise sequence of ops to higher level linalg.ext
-// representation.
+/// Raises sequence of ops to higher level linalg.ext representation.
 std::unique_ptr<Pass> createRaiseSpecialOps();
 
-// Removes tensors that have 0-extents.
+/// Removes tensors that have 0-extents.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createRemoveZeroExtentTensorsPass();
 
-// Sets encoding for tensors to allow tiled execution of operations.
+/// Sets encoding for tensors to allow tiled execution of operations.
 std::unique_ptr<Pass> createSetEncodingPass();
 
-// Convert linalg.generic ops to linalg.batch_matmul, possibly with transposes
-// on operands/result.
+/// Converts linalg.generic ops to linalg.batch_matmul, possibly with transposes
+/// on operands/result.
 std::unique_ptr<Pass> createLiftGenericToTransposeBatchMatmulPass();
-
-// Demote inputs (LHS, RHS) of linalg matmul-like ops from f32 to bf16.
-std::unique_ptr<Pass> createDemoteContractionInputsToBF16Pass();
 
 void registerGlobalOptimizationPipeline();
 

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -32,6 +32,11 @@ def DecomposeConcat :
   ];
 }
 
+def DemoteContractionInputsToBF16 : Pass<"iree-global-opt-demote-contraction-inputs-to-bf16", ""> {
+  let summary = "Demotes inputs (LHS, RHS) of linalg matmul-like ops from f32 to bf16.";
+  let constructor = "mlir::iree_compiler::GlobalOptimization::createDemoteContractionInputsToBF16Pass()";
+}
+
 def DetachElementwiseFromNamedOps :
     Pass<"iree-global-opt-detach-elementwise-from-named-ops", ""> {
   let summary = "Detaches elementwise ops from named Linalg ops";
@@ -40,7 +45,7 @@ def DetachElementwiseFromNamedOps :
 
 def EraseUnusedLinalgOperands :
     Pass<"iree-global-opt-erase-unused-linalg-operands", "mlir::ModuleOp"> {
-  let summary = "Erase unused linalg operand and remove dead code.";
+  let summary = "Erases unused linalg operand and remove dead code.";
   let constructor = "mlir::iree_compiler::GlobalOptimization::createEraseUnusedLinalgOperands()";
 }
 
@@ -52,7 +57,7 @@ def ExpandTensorShapes :
 
 def FuseDequantizationMatmul:
     InterfacePass<"iree-global-opt-fuse-dequantization-matmul", "mlir::FunctionOpInterface"> {
-  let summary = "Fuse dequantization and matmul linalg.generic ops";
+  let summary = "Fuses dequantization and matmul linalg.generic ops";
   let constructor = "mlir::iree_compiler::GlobalOptimization::createFuseDequantizationMatmulPass()";
   let options = [
     Option<"enableQuantizedMatmulReassociation", "enable-quantized-matmul-reassociation", "bool",
@@ -62,7 +67,7 @@ def FuseDequantizationMatmul:
 
 def FuseSiluHorizontalMatmul:
     InterfacePass<"iree-global-opt-fuse-silu-horizontal-matmul", "mlir::FunctionOpInterface"> {
-  let summary = "Fuse matmul ops and silu linalg.generic op";
+  let summary = "Fuses matmul ops and silu linalg.generic op";
   let constructor = "mlir::iree_compiler::GlobalOptimization::createFuseSiluHorizontalMatmulPass()";
 }
 
@@ -80,7 +85,7 @@ def InferNumericNarrowing :
 
 def LiftGenericToTransposeBatchMatmul:
     Pass<"iree-global-opt-lift-generic-to-tranpose-batch-matmul", ""> {
-  let summary = "Convert linalg.generic ops to linalg.batch_matmul, possibly with transposes on operands/result.";
+  let summary = "Converts linalg.generic ops to linalg.batch_matmul, possibly with transposes on operands/result.";
   let constructor = "mlir::iree_compiler::GlobalOptimization::createLiftGenericToTransposeBatchMatmulPass()";
 }
 
@@ -109,24 +114,19 @@ def PropagateLinalgTranspose :
 
 def RaiseSpecialOps :
     Pass<"iree-global-opt-raise-special-ops", ""> {
-  let summary = "raise special ops like softmax to the high level linalg.ext representation";
+  let summary = "Raises special ops like softmax to the high level linalg.ext representation";
   let constructor = "mlir::iree_compiler::GlobalOptimization::createRaiseSpecialOps()";
 }
 
 def RemoveZeroExtentTensors :
     InterfacePass<"iree-global-opt-remove-zero-extent-tensors", "mlir::FunctionOpInterface"> {
-  let summary = "Remove tensors that have 0-extents";
+  let summary = "Removes tensors that have 0-extents";
   let constructor = "mlir::iree_compiler::GlobalOptimization::createRemoveZeroExtentTensorsPass()";
 }
 
 def SetEncoding : Pass<"iree-global-opt-set-encoding", ""> {
-  let summary = "Introduce tensor encoding for compute operations";
+  let summary = "Introduces tensor encoding for compute operations";
   let constructor = "mlir::iree_compiler::GlobalOptimization::createSetEncodingPass()";
-}
-
-def DemoteContractionInputsToBF16 : Pass<"iree-global-opt-demote-contraction-inputs-to-bf16", ""> {
-  let summary = "Demote inputs (LHS, RHS) of linalg matmul-like ops from f32 to bf16.";
-  let constructor = "mlir::iree_compiler::GlobalOptimization::createDemoteContractionInputsToBF16Pass()";
 }
 
 #endif // IREE_COMPILER_GLOBALOPTIMIZATION_PASSES


### PR DESCRIPTION
We follow mixed LLVM/Google style, and the revision fixes the style for consistency.

- Use `///` for comments.
- Sort passes declaration in alphabetical order.
- Replace `flow` with `global-opt`.