### PR TITLE
[onnx] Enable --iree-input-type=onnx

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
     torch-mlir::TorchConversionDialectIR
     torch-mlir::TorchDialectIR
     torch-mlir::TorchDialectPasses
+    torch-mlir::TorchOnnxToTorchPasses
     torch-mlir::ConversionPasses
     torch-mlir-dialects::TMTensorDialectIR
   PUBLIC

--- a/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
@@ -200,6 +200,41 @@ iree_tablegen_library(
 )
 
 ###############################################################################
+# TorchOnnxToTorch
+###############################################################################
+
+file(GLOB _TorchOnnxToTorchPasses_SRCS
+  "${TORCH_MLIR_ROOT_DIR}/lib/Conversion/TorchOnnxToTorch/*.cpp"
+)
+iree_cc_library(
+  NAME
+    TorchOnnxToTorchPasses
+  SRCS
+    "${TORCH_MLIR_ROOT_DIR}/lib/Conversion/TorchOnnxToTorch/Passes.cpp"
+    ${_TorchOnnxToTorchPasses_SRCS}
+  DEPS
+    ::defs
+    ::TorchConversionDialectIR
+    ::TorchDialectIR
+    ::TorchOnnxToTorchPassesGen
+    MLIRArithDialect
+    MLIRFuncDialect
+    MLIRIR
+    MLIRPass
+)
+
+iree_tablegen_library(
+  NAME
+    TorchOnnxToTorchPassesGen
+  TD_FILE
+    "${TORCH_MLIR_ROOT_DIR}/include/torch-mlir/Conversion/TorchOnnxToTorch/Passes.td"
+  OUTS
+    -gen-pass-decls Conversion/TorchOnnxToTorch/Passes.h.inc
+    -gen-pass-capi-header Conversion/TorchOnnxToTorch/Passes.capi.h.inc
+    -gen-pass-capi-impl Conversion/TorchOnnxToTorch/Passes.capi.cpp.inc
+)
+
+###############################################################################
 # CAPI
 ###############################################################################
 


### PR DESCRIPTION
Includes a one-line fix to torch-mlir (already landed) that fixes an unused variable warning.

With this, the following now works (for a model.onnx from the test suite):

```
python -m iree.compiler.tools.import_onnx ~/tmp/model.onnx | ./tools/iree-compile --iree-input-type=onnx --iree-hal-target-backends=vmvx - -o /dev/null
```

We've still got a way to go on the conversions before there is enough coverage to be generally usable.