### PR TITLE
[python] Expose python bindings for scf in iree.compiler.dialects

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -185,6 +185,7 @@ set(_SOURCE_COMPONENTS
   MLIRPythonSources.Dialects.math
   MLIRPythonSources.Dialects.memref
   MLIRPythonSources.Dialects.pdl
+  MLIRPythonSources.Dialects.scf
   MLIRPythonSources.Dialects.shape
   MLIRPythonSources.Dialects.structured_transform
   MLIRPythonSources.Dialects.tensor


### PR DESCRIPTION
This patch exposes scf python bindings as part of iree.compiler.dialect package, allowing:

```
from iree.compiler.dialects import scf
```

Allowing scf in input to compilation will be done in a different patch.