### PR TITLE
Some CMake package install ergonomics.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1096,24 +1096,31 @@ endif()
 
 #-------------------------------------------------------------------------------
 # Install/exports
+# Note that with no further options, install convenience targets install to
+# CMAKE_INSTALL_PREFIX. Per usual, this can be further prefixed with an 
+# environment variable "DESTDIST" on a per invocation basis (i.e. to place under
+# a versioned path, etc).
+#
+# The `iree-install-dist` target includes everthing that is typically included in
+# a distribution tarball.
 #-------------------------------------------------------------------------------
 
 add_subdirectory(build_tools/cmake ${IREE_BINARY_DIR}/lib/cmake/IREE)
 
-# See runtime/src/CMakeLists.txt
-iree_generate_export_targets(
-  EXPORT_SET Runtime
-)
-
-# See compiler/bindings/c/CMakeLists.txt
-iree_generate_export_targets(
-  EXPORT_SET Compiler
-)
-
 # Convenience installation targets.
-iree_add_install_target(NAME iree-install-dev-libraries)
-iree_add_install_target(NAME iree-install-runtime-libraries)
-iree_add_install_target(NAME iree-install-tools)
+iree_add_install_target(NAME iree-install-dist)
+iree_add_install_target(
+  NAME iree-install-dev-libraries
+  ADD_TO iree-install-dist
+)
+iree_add_install_target(
+  NAME iree-install-runtime-libraries
+  ADD_TO iree-install-dist
+)
+iree_add_install_target(
+  NAME iree-install-tools
+  ADD_TO iree-install-dist
+)
 
 iree_add_install_target(
   NAME iree-install-cmake-exports
@@ -1143,6 +1150,12 @@ if(IREE_BUILD_COMPILER)
   iree_add_install_target(
     NAME iree-install-tools-compiler
     COMPONENT IREETools-Compiler
+    ADD_TO iree-install-tools
+  )
+
+  iree_add_install_target(
+    NAME iree-install-tools-compiler-dev
+    COMPONENT IREETools-CompilerDev
     ADD_TO iree-install-tools
   )
 

--- a/build_tools/cmake/CMakeLists.txt
+++ b/build_tools/cmake/CMakeLists.txt
@@ -6,6 +6,19 @@
 
 set(_cmake_installdir "${CMAKE_INSTALL_LIBDIR}/cmake/IREE")
 
+# Generate export sets.
+# See runtime/src/CMakeLists.txt
+iree_generate_export_targets(
+  EXPORT_SET Runtime
+  INSTALL_DESTINATION ${_cmake_installdir}
+)
+
+# See compiler/bindings/c/CMakeLists.txt
+iree_generate_export_targets(
+  EXPORT_SET Compiler
+  INSTALL_DESTINATION ${_cmake_installdir}
+)
+
 if(IREE_BUILD_COMPILER)
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/IREECompilerConfig.cmake.in

--- a/build_tools/cmake/iree_install_support.cmake
+++ b/build_tools/cmake/iree_install_support.cmake
@@ -113,7 +113,7 @@ function(iree_generate_export_targets)
   cmake_parse_arguments(
     _RULE
     ""
-    "COMPONENT;EXPORT_SET"
+    "COMPONENT;EXPORT_SET;INSTALL_DESTINATION"
     ""
     ${ARGN}
   )
@@ -134,13 +134,13 @@ function(iree_generate_export_targets)
   endif()
 
   export(TARGETS ${_export_targets}
-    FILE "${IREE_BINARY_DIR}/lib/cmake/IREE/IREETargets-${_RULE_EXPORT_SET}.cmake")
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/IREETargets-${_RULE_EXPORT_SET}.cmake")
 
   install(
     EXPORT "IREEExported-${_RULE_EXPORT_SET}"
     COMPONENT "${_component}"
     FILE "IREETargets-${_RULE_EXPORT_SET}.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/IREE"
+    DESTINATION "${_RULE_INSTALL_DESTINATION}"
   )
 
   # Clear the export targets so that innocent aggregating projects don't

--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -175,8 +175,7 @@ def build_main_dist():
             "--build",
             BUILD_DIR,
             "--target",
-            "iree-install-dev-libraries-stripped",
-            "iree-install-tools-stripped",
+            "iree-install-dist-stripped",
         ],
         check=True,
     )

--- a/build_tools/third_party/flatcc/CMakeLists.txt
+++ b/build_tools/third_party/flatcc/CMakeLists.txt
@@ -131,7 +131,7 @@ target_include_directories(iree-flatcc-cli SYSTEM
 )
 install(
   TARGETS iree-flatcc-cli
-  COMPONENT iree-flatcc-cli
+  COMPONENT IREETools-Runtime
   RUNTIME DESTINATION bin
   BUNDLE DESTINATION bin
 )


### PR DESCRIPTION
Functional changes:

* Adds the missing iree-flatcc-cli install.
* Includes CompilerDev tools in the distribution.
* Adds an iree-install-dist rollup target and uses that.