### PR TITLE
Remove SYSTEM scope from transitive includes.

### DIFF
--- a/build_tools/bazel/build_defs.oss.bzl
+++ b/build_tools/bazel/build_defs.oss.bzl
@@ -60,14 +60,19 @@ def iree_cmake_extra_content(content = "", inline = False):
     """
     pass
 
-def iree_cc_library(**kwargs):
+def iree_cc_library(includes = [], system_includes = [], **kwargs):
     """Base function for all cc_library targets.
 
     This is a pass-through to the native cc_library, which integrators can
     customize with additional flags as needed. Prefer to use the compiler
     and runtime versions instead.
+
+    Note that Bazel does not distinguish between includes and system_includes,
+    but CMake does. So we allow them to be separate and glom them together
+    here.
     """
     native.cc_library(
+        includes = includes + system_includes,
         **kwargs
     )
 

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -394,6 +394,7 @@ class BuildFileFunctions(object):
         testonly=None,
         linkopts=None,
         includes=None,
+        system_includes=None,
         **kwargs,
     ):
         if self._should_skip_target(**kwargs):
@@ -412,6 +413,9 @@ class BuildFileFunctions(object):
         deps_block = self._convert_target_list_block("DEPS", deps)
         testonly_block = self._convert_option_block("TESTONLY", testonly)
         includes_block = self._convert_includes_block(includes)
+        system_includes_block = self._convert_string_list_block(
+            "SYSTEM_INCLUDES", system_includes
+        )
 
         self._converter.body += (
             f"iree_cc_library(\n"
@@ -425,6 +429,7 @@ class BuildFileFunctions(object):
             f"{defines_block}"
             f"{testonly_block}"
             f"{includes_block}"
+            f"{system_includes_block}"
             f"  PUBLIC\n)\n\n"
         )
 

--- a/build_tools/cmake/external_cc_library.cmake
+++ b/build_tools/cmake/external_cc_library.cmake
@@ -111,7 +111,7 @@ function(external_cc_library)
         ${_RULE_SRCS}
         ${_RULE_HDRS}
     )
-    target_include_directories(${_NAME} SYSTEM
+    target_include_directories(${_NAME}
       PUBLIC
         "$<BUILD_INTERFACE:${IREE_SOURCE_DIR}>"
         "$<BUILD_INTERFACE:${IREE_BINARY_DIR}>"
@@ -152,7 +152,7 @@ function(external_cc_library)
   else()
     # Generating header-only library
     add_library(${_NAME} INTERFACE)
-    target_include_directories(${_NAME} SYSTEM
+    target_include_directories(${_NAME}
       INTERFACE
         "$<BUILD_INTERFACE:${IREE_SOURCE_DIR}>"
         "$<BUILD_INTERFACE:${IREE_BINARY_DIR}>"

--- a/build_tools/cmake/flatbuffer_c_library.cmake
+++ b/build_tools/cmake/flatbuffer_c_library.cmake
@@ -114,7 +114,7 @@ function(flatbuffer_c_library)
 
   add_library(${_NAME} INTERFACE)
   add_dependencies(${_NAME} ${_GEN_TARGET})
-  target_include_directories(${_NAME} SYSTEM
+  target_include_directories(${_NAME}
     INTERFACE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     )

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -184,12 +184,9 @@ function(iree_cc_library)
     # We also forward link libraries -- not because the OBJECT libraries do
     # linking but because they get transitive compile definitions from them.
     # Yes. This is state of the art.
-    # Note that SYSTEM scope matches here, in the property name and in the
-    # include directories below on the main rule. If ever removing this,
-    # remove it from all places.
-    target_include_directories(${_OBJECTS_NAME} SYSTEM
+    target_include_directories(${_OBJECTS_NAME}
       PUBLIC
-        $<TARGET_PROPERTY:${_NAME},INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:${_NAME},INTERFACE_INCLUDE_DIRECTORIES>
     )
     target_include_directories(${_OBJECTS_NAME}
       PUBLIC
@@ -208,7 +205,7 @@ function(iree_cc_library)
         $<TARGET_PROPERTY:${_NAME},INTERFACE_LINK_LIBRARIES>
     )
 
-    target_include_directories(${_NAME} SYSTEM
+    target_include_directories(${_NAME}
       PUBLIC
         "$<BUILD_INTERFACE:${IREE_SOURCE_DIR}>"
         "$<BUILD_INTERFACE:${IREE_BINARY_DIR}>"
@@ -269,7 +266,7 @@ function(iree_cc_library)
   else()
     # Generating header-only library.
     add_library(${_NAME} INTERFACE)
-    target_include_directories(${_NAME} SYSTEM
+    target_include_directories(${_NAME}
       INTERFACE
         "$<BUILD_INTERFACE:${IREE_SOURCE_DIR}>"
         "$<BUILD_INTERFACE:${IREE_BINARY_DIR}>"
@@ -411,12 +408,9 @@ function(iree_cc_unified_library)
   )
 
   # Forward compile usage requirements from the root library.
-  # Note that SYSTEM scope matches here, in the property name and in the
-  # include directories below on the main rule. If ever removing this,
-  # remove it from all places.
-  target_include_directories(${_NAME} SYSTEM
+  target_include_directories(${_NAME}
     PUBLIC
-      $<TARGET_PROPERTY:${_RULE_ROOT},INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+      $<TARGET_PROPERTY:${_RULE_ROOT},INTERFACE_INCLUDE_DIRECTORIES>
   )
   target_include_directories(${_NAME}
     PUBLIC

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -55,6 +55,8 @@ endfunction()
 # COPTS: List of private compile options
 # DEFINES: List of public defines
 # INCLUDES: Include directories to add to dependencies
+# SYSTEM_INCLUDES: Include directories that should be used with "SYSTEM" scope,
+#   which makes them more tolerant to certain classes of warnings and issues.
 # LINKOPTS: List of link options
 # PUBLIC: Add this so that this library will be exported under iree::
 # Also in IDE, target will appear in IREE folder while non PUBLIC will be in IREE/internal.
@@ -97,7 +99,7 @@ function(iree_cc_library)
     _RULE
     "PUBLIC;TESTONLY;SHARED;DISABLE_LLVM_LINK_LLVM_DYLIB"
     "PACKAGE;NAME;WINDOWS_DEF_FILE"
-    "HDRS;TEXTUAL_HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS;INCLUDES"
+    "HDRS;TEXTUAL_HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS;INCLUDES;SYSTEM_INCLUDES"
     ${ARGN}
   )
 
@@ -146,6 +148,8 @@ function(iree_cc_library)
   # generator.
   list(TRANSFORM _RULE_INCLUDES PREPEND "$<BUILD_INTERFACE:")
   list(TRANSFORM _RULE_INCLUDES APPEND ">")
+  list(TRANSFORM _RULE_SYSTEM_INCLUDES PREPEND "$<BUILD_INTERFACE:")
+  list(TRANSFORM _RULE_SYSTEM_INCLUDES APPEND ">")
 
   # Implicit deps.
   if(IREE_IMPLICIT_DEFS_CC_DEPS)
@@ -188,6 +192,10 @@ function(iree_cc_library)
       PUBLIC
         $<TARGET_PROPERTY:${_NAME},INTERFACE_INCLUDE_DIRECTORIES>
     )
+    target_include_directories(${_OBJECTS_NAME} SYSTEM
+      PUBLIC
+        $<TARGET_PROPERTY:${_NAME},INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+    )
     target_include_directories(${_OBJECTS_NAME}
       PUBLIC
         $<TARGET_PROPERTY:${_NAME},INTERFACE_INCLUDE_DIRECTORIES>
@@ -213,6 +221,10 @@ function(iree_cc_library)
     target_include_directories(${_NAME}
       PUBLIC
         ${_RULE_INCLUDES}
+    )
+    target_include_directories(${_NAME}
+      SYSTEM PUBLIC
+        ${_RULE_SYSTEM_INCLUDES}
     )
     target_compile_options(${_NAME}
       PRIVATE
@@ -271,6 +283,10 @@ function(iree_cc_library)
         "$<BUILD_INTERFACE:${IREE_SOURCE_DIR}>"
         "$<BUILD_INTERFACE:${IREE_BINARY_DIR}>"
         ${_RULE_INCLUDES}
+    )
+    target_include_directories(${_NAME}
+      SYSTEM INTERFACE
+        ${_RULE_SYSTEM_INCLUDES}
     )
     target_link_options(${_NAME}
       INTERFACE

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -280,11 +280,12 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "/wd4065"  # allow: switch statement contains 'default' but no 'case' labels
     "/wd4141"  # allow: inline used more than once
     "/wd4624"  # allow: destructor was implicitly defined as deleted
+    "/wd4576"  # allow: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
 
     # TODO(benvanik): confirm these are all still required and document:
     "/wd4146"  # operator applied to unsigned type, result still unsigned
     "/wd4244"  # possible loss of data
-    "/wd4267"  # initializing: possible loss of data
+    "/wd4267"  # initializing: possible loss of data    
     "/wd5105"  # allow: macro expansion producing 'defined' has undefined behavior
 )
 

--- a/build_tools/third_party/tracy_client/CMakeLists.txt
+++ b/build_tools/third_party/tracy_client/CMakeLists.txt
@@ -21,7 +21,7 @@ external_cc_library(
   HDRS
     "tracy/Tracy.hpp"
     "tracy/TracyC.h"
-  INCLUDES
+  SYSTEM_INCLUDES
     "${IREE_ROOT_DIR}/third_party/tracy/public"
   DEPS
     ${CMAKE_DL_LIBS}

--- a/experimental/hip/native_executable.c
+++ b/experimental/hip/native_executable.c
@@ -228,7 +228,9 @@ iree_status_t iree_hal_hip_native_executable_create(
         status = IREE_HIP_RESULT_TO_STATUS(
             symbols,
             hipFuncSetAttribute(
-                function, HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                function,
+                (hipFuncAttribute)
+                    HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                 shared_memory_sizes_vec[i]),
             "hipFuncSetAttribute");
       }

--- a/experimental/rocm/native_executable.c
+++ b/experimental/rocm/native_executable.c
@@ -134,7 +134,9 @@ iree_status_t iree_hal_rocm_native_executable_create(
           status = ROCM_RESULT_TO_STATUS(
               context->syms,
               hipFuncSetAttribute(
-                  function, HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                  function,
+                  (hipFuncAttribute)
+                      HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                   shared_memory_sizes[i]),
               "hipFuncSetAttribute");
         }


### PR DESCRIPTION
Warnings should be fixed or handled as needed, not just by disabling them for arbitrary portions of the codebase.

This was originally added to match Bazel, but Bazel builds are undesirably more permissive because of it. This makes the CMake build more correct.

We add an explicit SYSTEM_INCLUDES which preserves the old behavior and use it for Tracy+related headers, which include things that are not warning clean. Everything else is fine (after some of the newly uncovered warnings were fixed).

Fixes #16017.