### PR TITLE
[VectorLayoutAnalysis] Refactor VectorLayoutAnalysis to be an online analysis

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -934,7 +934,8 @@ static void setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
             .getAsInteger(/*Radix=*/10, operandNum);
         assert(operandNum < op->getNumOperands() &&
                "operand number out of range");
-        analysis.setAnchor(op->getOperand(operandNum), attr.getValue());
+        analysis.setAnchorForOperand(op->getOpOperand(operandNum),
+                                     attr.getValue());
       }
       if (name.find("__vector_layout_test_anchor_result_") !=
           std::string::npos) {
@@ -942,7 +943,8 @@ static void setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
         name.substr(name.find_last_of("_") + 1)
             .getAsInteger(/*Radix=*/10, resultNum);
         assert(resultNum < op->getNumResults() && "result number out of range");
-        analysis.setAnchor(op->getResult(resultNum), attr.getValue());
+        auto resVal = cast<TypedValue<VectorType>>(op->getResult(resultNum));
+        analysis.setAnchorForResult(resVal, attr.getValue());
       }
     }
   });
@@ -957,7 +959,11 @@ static void emitLayoutRemarks(VectorLayoutAnalysis &analysis,
     }
 
     for (OpResult result : op->getOpResults()) {
-      if (auto layout = analysis.getLayout<Attribute>(result)) {
+      auto resVal = dyn_cast<TypedValue<VectorType>>(result);
+      if (!resVal)
+        continue;
+
+      if (auto layout = analysis.getLayout<Attribute>(resVal)) {
         // Print layout attr to a string.
         std::string layoutStr;
         llvm::raw_string_ostream s(layoutStr);
@@ -977,10 +983,6 @@ transform_dialect::TestVectorLayoutAnalysisOp::applyToOne(
     transform::TransformState &state) {
   VectorLayoutAnalysis analysis(target);
   setAnchorOpsFromAttributes(analysis, target);
-  if (failed(analysis.run())) {
-    target.emitError("layout analysis failed");
-    return emitDefaultSilenceableFailure(target);
-  }
   emitLayoutRemarks(analysis, target);
   return DiagnosedSilenceableFailure::success();
 }


### PR DESCRIPTION
This converts the VectorLayoutAnalysis into an online analysis, where any information provided as an anchor is immediately analysed pushed throught the IR.

The flow looks like:

start --> (analysis: no information)
setAnchor --> (analysis: compute everything it can)
setAnchor --> (analysis: compute everything it can with this added information now)
rewrite --> (analysis: compute analysis values for the new IR values)
end

As a side-effect, I also stopped using mlir's DataFlowAnalysis framework as it's too generic.