### PR TITLE
Bump website copyright to 2024.

### DIFF
--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -79,7 +79,7 @@ extra_css:
   - assets/stylesheets/extra.css
   - assets/stylesheets/openxla.css
 
-copyright: Copyright &copy; 2023 The IREE Authors
+copyright: Copyright &copy; 2024 The IREE Authors
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
Happy New Year 🎉 

Yes, this is a bit silly. We still like to intentionally update the copyright year in this one location so the website appears fresh.