### PR TITLE
[stablehlo] Add missing nullptr check for unregistered dialects

### DIFF
--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/Canonicalization.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
 #include "mlir/Dialect/CommonFolders.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -1068,7 +1069,7 @@ struct ZeroExtentTensorCanon final : RewritePattern {
                                 PatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
 
-    if (!dyn_cast<::mlir::stablehlo::StablehloDialect>(op->getDialect())) {
+    if (!isa_and_present<mlir::stablehlo::StablehloDialect>(op->getDialect())) {
       return rewriter.notifyMatchFailure(op, "not stablehlo");
     }
 

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/canonicalization.mlir
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/test/canonicalization.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-stablehlo-canonicalize --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-stablehlo-canonicalize --allow-unregistered-dialect --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: func.func @add
 // CHECK-SAME:   ([[ARG0:%.+]]: tensor<2xi32>, [[ARG1:%.+]]: tensor<f32>)
@@ -777,6 +777,19 @@ func.func @do_not_reorder_with_other_uses(%arg0: tensor<2x2xf64>, %arg1: tensor<
   return %3, %2 : tensor<f64>, tensor<4xf32>
 }
 
-// CHECK-LABEL: do_not_reorder_with_other_uses
+// CHECK-LABEL: @do_not_reorder_with_other_uses
 // CHECK: %[[RESHAPE:.+]] = stablehlo.reshape %arg0 : (tensor<2x2xf64>) -> tensor<4xf64>
 // CHECK: %[[CONVERT:.+]] = stablehlo.convert %[[RESHAPE]] : (tensor<4xf64>) -> tensor<4xf32>
+
+// -----
+
+// Make sure we do not crash on unregistered dialects.
+
+func.func @generic_op(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+  %0 = "test_dialect.op"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xf32>)
+  return %0 : tensor<2xf32>
+}
+
+// CHECK-LABEL: func.func @generic_op
+// CHECK-NEXT:    "test_dialect.op"
+// CHECK-NEXT:    return


### PR DESCRIPTION
Fix a stablehlo canon pattern so that it does not crash on ops from unregistered dialects.

Issue: https://github.com/openxla/iree/issues/16021