### PR TITLE
Add crosscompile utility binaries back to iree-dist tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1160,9 +1160,21 @@ if(IREE_BUILD_COMPILER)
   )
 
   iree_add_install_target(
+    NAME iree-install-tools-compiler-extra
+    COMPONENT IREETools-CompilerExtra
+    ADD_TO iree-install-tools
+  )
+
+  iree_add_install_target(
+    NAME iree-install-tools-generate-embed-data
+    COMPONENT generate_embed_data
+    ADD_TO iree-install-tools
+  )
+
+  iree_add_install_target(
     NAME iree-install-runtime-libraries-compiler
     COMPONENT IREERuntimeLibraries-Compiler
-    ADD_TO 
+    ADD_TO
       iree-install-runtime-libraries
       iree-install-tools-compiler
       iree-install-dev-libraries-compiler

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1097,7 +1097,7 @@ endif()
 #-------------------------------------------------------------------------------
 # Install/exports
 # Note that with no further options, install convenience targets install to
-# CMAKE_INSTALL_PREFIX. Per usual, this can be further prefixed with an 
+# CMAKE_INSTALL_PREFIX. Per usual, this can be further prefixed with an
 # environment variable "DESTDIST" on a per invocation basis (i.e. to place under
 # a versioned path, etc).
 #
@@ -1162,12 +1162,8 @@ if(IREE_BUILD_COMPILER)
   iree_add_install_target(
     NAME iree-install-tools-compiler-extra
     COMPONENT IREETools-CompilerExtra
-    ADD_TO iree-install-tools
-  )
-
-  iree_add_install_target(
-    NAME iree-install-tools-generate-embed-data
-    COMPONENT generate_embed_data
+    # TODO: Remove the ADD_TO here and include the component in the iree-dist
+    # tarball build stage.
     ADD_TO iree-install-tools
   )
 

--- a/build_tools/embed_data/CMakeLists.txt
+++ b/build_tools/embed_data/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(generate_embed_data PRIVATE generate_embed_data_main.cc)
 set_target_properties(generate_embed_data PROPERTIES OUTPUT_NAME generate_embed_data)
 
 install(TARGETS generate_embed_data
-        COMPONENT generate_embed_data
+        COMPONENT IREETools-CompilerExtra
         RUNTIME DESTINATION bin
         BUNDLE DESTINATION bin)
 


### PR DESCRIPTION
add `generate_embed_data`, `llvm-link`, and `clang` to iree-dist tarball to support crosscompile targets that use ukernel and/or embedded modules.