### PR TITLE
[CPU] Skip tiling if the compute op is not a TilingInterface op.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -60,8 +60,8 @@ void LLVMCPUTilePass::runOnOperation() {
   }
 
   for (auto computeOp : computeOps) {
-    auto op = cast<TilingInterface>(computeOp);
-    if (op.getLoopIteratorTypes().empty())
+    auto op = dyn_cast<TilingInterface>(computeOp);
+    if (!op || op.getLoopIteratorTypes().empty())
       continue;
 
     // For now do not tile `tensor.pad` operations. The `tensor.pad`

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile.mlir
@@ -69,3 +69,28 @@ func.func @scalable_lowering_config_with_no_1s(%A: tensor<?x?xf32>, %B: tensor<?
             outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
   return %1 : tensor<?x?xf32>
 }
+
+// -----
+
+func.func @do_not_tile_ukernel(%arg0: tensor<?x?x16x1xf32>, %arg1: tensor<?x?x16x1xf32>, %arg2: tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c16_i32 = arith.constant 16 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c1025_i32 = arith.constant 1025 : i32
+  %dim = tensor.dim %arg0, %c0 : tensor<?x?x16x1xf32>
+  %dim_0 = tensor.dim %arg1, %c0 : tensor<?x?x16x1xf32>
+  %dim_1 = tensor.dim %arg1, %c1 : tensor<?x?x16x1xf32>
+  %0 = iree_codegen.ukernel.generic {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
+    "iree_uk_mmt4d"
+    ins(%arg0, %arg1 : tensor<?x?x16x1xf32>, tensor<?x?x16x1xf32>)
+    outs(%arg2 : tensor<?x?x16x16xf32>)
+    (%dim, %dim_0, %dim_1, %c16_i32, %c16_i32, %c1_i32, %c1025_i32 : index, index, index, i32, i32, i32, i32)
+    fn_def_attrs {hal.import.bitcode = true, hal.import.cconv = 1 : i32, hal.import.fields = ["processor_data"]}
+    strided_outer_dims(1) -> tensor<?x?x16x16xf32>
+  return %0 : tensor<?x?x16x16xf32>
+}
+
+// CHECK-LABEL: func.func @do_not_tile_ukernel
+// CHECK-NOT:     scf.for
+// CHECK:         iree_codegen.ukernel.generic


### PR DESCRIPTION
The ukernel op is treated as a valid compute op, but they don't (and can't) implement TilingInterface. The revision skips the case to avoid crash.

https://github.com/openxla/iree/blob/b3200c859dc2446124fd19b038c50b82433c9032/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp#L630-L638

It is a step towards https://github.com/openxla/iree/issues/16025 