### PR TITLE
[CodeGen] Implement MemoryEffectsOpInterface for ukernel ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
@@ -28,28 +28,6 @@ namespace mlir::iree_compiler::IREE::Codegen {
 // Helpers
 //===---------------------------------------------------------------------===//
 
-static void getEffectsImpl(
-    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
-        &effects,
-    ValueRange inputOperands, ValueRange outputOperands) {
-  for (Value value : inputOperands) {
-    if (!llvm::isa<MemRefType>(value.getType())) {
-      continue;
-    }
-    effects.emplace_back(MemoryEffects::Read::get(), value,
-                         SideEffects::DefaultResource::get());
-  }
-  for (Value value : outputOperands) {
-    if (!llvm::isa<MemRefType>(value.getType())) {
-      continue;
-    }
-    effects.emplace_back(MemoryEffects::Read::get(), value,
-                         SideEffects::DefaultResource::get());
-    effects.emplace_back(MemoryEffects::Write::get(), value,
-                         SideEffects::DefaultResource::get());
-  }
-}
-
 /// Helper method to generate a function declaration at a module scope,
 /// and a call to that function
 static FailureOr<func::CallOp>
@@ -204,16 +182,28 @@ UKernelGenericOp::lowerToFunctionCall(RewriterBase &rewriter) {
                                            getStridedOuterDimsAttr());
 }
 
-#define DEFINE_OP_GET_EFFECTS(OP_NAME)                                         \
-  void OP_NAME::getEffects(                                                    \
-      SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>      \
-          &effects) {                                                          \
-    getEffectsImpl(effects, getDpsInputs(), getDpsInits());                    \
+void UKernelGenericOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  SmallVector<Value> readOnlyOperands = getDpsInputs();
+  readOnlyOperands.append(getOtherOperands().begin(), getOtherOperands().end());
+  for (Value value : readOnlyOperands) {
+    if (!llvm::isa<MemRefType>(value.getType())) {
+      continue;
+    }
+    effects.emplace_back(MemoryEffects::Read::get(), value,
+                         SideEffects::DefaultResource::get());
   }
-
-DEFINE_OP_GET_EFFECTS(UKernelGenericOp)
-
-#undef DEFINE_OP_GET_EFFECTS
+  for (Value value : getDpsInits()) {
+    if (!llvm::isa<MemRefType>(value.getType())) {
+      continue;
+    }
+    effects.emplace_back(MemoryEffects::Read::get(), value,
+                         SideEffects::DefaultResource::get());
+    effects.emplace_back(MemoryEffects::Write::get(), value,
+                         SideEffects::DefaultResource::get());
+  }
+}
 
 } // namespace mlir::iree_compiler::IREE::Codegen
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.td
@@ -10,12 +10,14 @@
 include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td"
 include "iree/compiler/Codegen/Interfaces/UKernelOpInterface.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class IREECodegen_UKernelOp<string mnemonic, list<Trait> traits = []> : 
   Op<IREECodegen_Dialect, mnemonic, !listconcat(traits,
     [DeclareOpInterfaceMethods<UKernelOpInterface,
         ["lowerToFunctionCall"]>,
-     DeclareOpInterfaceMethods<DestinationStyleOpInterface>])> {}
+     DeclareOpInterfaceMethods<DestinationStyleOpInterface>,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>])> {}
   
 def IREECodegen_UKernelGenericOp :
     IREECodegen_UKernelOp<"ukernel.generic", [

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/BUILD.bazel
@@ -21,6 +21,7 @@ iree_lit_test_suite(
             "invalid.mlir",
             "lowering_config_attr.mlir",
             "ukernel_ops.mlir",
+            "ukernel_ops_cse.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "invalid.mlir"
     "lowering_config_attr.mlir"
     "ukernel_ops.mlir"
+    "ukernel_ops_cse.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/ukernel_ops_cse.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/ukernel_ops_cse.mlir
@@ -1,0 +1,73 @@
+// RUN: iree-opt --split-input-file --cse %s | FileCheck %s
+
+func.func @ukernel_generic(
+    %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,
+    %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>,
+    %b0: f32, %b1: i64) -> (tensor<?xf32>, tensor<?x?xf32>) {
+  %0:2 = iree_codegen.ukernel.generic "foo"
+      ins(%in0, %in1: tensor<?x?xf32>, tensor<?xf32>)
+      outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
+      (%b0, %b1 : f32, i64) -> tensor<?xf32>, tensor<?x?xf32>
+  return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
+}
+// CHECK-LABEL: func.func @ukernel_generic
+// CHECK-SAME:     %[[IN0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[IN1:[a-zA-Z0-9]+]]: tensor<?xf32>
+// CHECK-SAME:     %[[OUT0:[a-zA-Z0-9]+]]: tensor<?xf32>
+// CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
+// CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.ukernel.generic
+// CHECK-SAME:       "foo"
+// CHECK-SAME:       ins(%[[IN0]], %[[IN1]] :
+// CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
+// CHECK-SAME:       (%[[B0]], %[[B1]] :
+//      CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
+
+
+// -----
+
+func.func @unused_ukernel_generic(
+    %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,
+    %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>,
+    %b0: f32, %b1: i64) -> (tensor<?xf32>, tensor<?x?xf32>) {
+  %0:2 = iree_codegen.ukernel.generic "foo"
+      ins(%in0, %in1: tensor<?x?xf32>, tensor<?xf32>)
+      outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
+      (%b0, %b1 : f32, i64) -> tensor<?xf32>, tensor<?x?xf32>
+  return %out0, %out1 : tensor<?xf32>, tensor<?x?xf32>
+}
+// CHECK-LABEL: func.func @unused_ukernel_generic
+// CHECK-SAME:     %[[IN0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[IN1:[a-zA-Z0-9]+]]: tensor<?xf32>
+// CHECK-SAME:     %[[OUT0:[a-zA-Z0-9]+]]: tensor<?xf32>
+// CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
+// CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
+// CHECK-NOT:      iree_codegen.ukernel.generic
+// CHECK:          return %[[OUT0]], %[[OUT1]]
+
+// -----
+
+func.func @ukernel_generic_memref(
+    %in0: memref<?x?xf32>, %in1: memref<?xf32>,
+    %out0: memref<?xf32>, %out1 : memref<?x?xf32>,
+    %b0: f32, %b1: i64) {
+  iree_codegen.ukernel.generic "foo"
+      ins(%in0, %in1: memref<?x?xf32>, memref<?xf32>)
+      outs(%out0, %out1 : memref<?xf32>, memref<?x?xf32>)
+      (%b0, %b1 : f32, i64)
+  return
+}
+//      CHECK: func @ukernel_generic_memref(
+// CHECK-SAME:     %[[IN0:[a-zA-Z0-9]+]]: memref<?x?xf32>
+// CHECK-SAME:     %[[IN1:[a-zA-Z0-9]+]]: memref<?xf32>
+// CHECK-SAME:     %[[OUT0:[a-zA-Z0-9]+]]: memref<?xf32>
+// CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: memref<?x?xf32>
+// CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
+// CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
+//      CHECK:   iree_codegen.ukernel.generic
+// CHECK-SAME:       "foo"
+// CHECK-SAME:       ins(%[[IN0]], %[[IN1]] :
+// CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
+// CHECK-SAME:       (%[[B0]], %[[B1]] :


### PR DESCRIPTION
This allows us to DCE ukernel ops if the tensor results are not used. The memref version will not be DCE-ed in this case.