### PR TITLE
[CPU] Propagate "scalability" when using peeling for vectorisation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -109,7 +109,7 @@ enum class VectorPreProcStrategy {
 };
 
 static llvm::cl::opt<VectorPreProcStrategy> clPProcStrategy(
-    "iree-codegen-llvmcpu-vector-pproc-strategy",
+    "iree-llvmcpu-vector-pproc-strategy",
     llvm::cl::desc("Set the strategy for pre-processing Linalg operation "
                    "before vectorization:"),
     llvm::cl::values(
@@ -775,7 +775,9 @@ static SmallVector<int64_t> getDefaultMatmulCacheSizes(linalg::LinalgOp op,
 static LogicalResult setMatmulPeelingRootConfig(
     func::FuncOp entryPointFn, linalg::ContractionOpInterface op,
     ArrayRef<int64_t> distTileSizes, ArrayRef<int64_t> cacheTileSizes,
+    const ScalableTileFlagsListTypeRef inputScalableTileFlags,
     ArrayRef<int64_t> vecTileSizes, int vectorSize) {
+
   // Clamp vector tile sizes to have better hint about peeling + masking. This
   // is critical for scalable vectorization, so it can resolve correct scalable
   // vector sizes.
@@ -787,6 +789,7 @@ static LogicalResult setMatmulPeelingRootConfig(
     clampedVecTileSizes[index] = std::min(clampedVecTileSizes[index], size);
   }
 
+  // 1. Compute tile sizes for all tiling levels.
   // The tiling for parallel dims (M and N) and reduction dim (K) should be
   // separated, so we move K dim from parallel tile sizes to reduction tile
   // sizes.
@@ -808,8 +811,52 @@ static LogicalResult setMatmulPeelingRootConfig(
   // No need for tiling inner parallel dims.
   tileSizes.emplace_back(numTilingDims, 0);
 
+  // The backend struggles to legalize non-power-of-two scalable vectors,
+  // hence the extra rounding up.
+  const SmallVectorImpl<bool> &vecScalableDims = inputScalableTileFlags.back();
+  for (const auto &[index, size] : llvm::enumerate(vectorParallelTileSizes)) {
+    if (!size)
+      continue;
+    vectorParallelTileSizes[index] =
+        roundUpToPow2(size,
+                      /*predicate=*/vecScalableDims[index]);
+  }
+
+  // 2. Set scalable flags for all the tiling levels.
+  SmallVector<bool> parallelScalableFlags;
+  for (auto [index, tileSize] : llvm::enumerate(vecTileSizes))
+    parallelScalableFlags.push_back(vecScalableDims[index]);
+  // Ensure there's no zero scalable dims.
+  SmallVector<bool> reductionScalableFlags(numTilingDims, false);
+  for (unsigned i = 0; i < numTilingDims; i++) {
+    if (vectorReductionTileSizes[i] == 0)
+      reductionScalableFlags[i] = false;
+    if (vectorParallelTileSizes[i] == 0)
+      parallelScalableFlags[i] = false;
+  }
+  ScalableTileFlagsListType newScalableTileFlags;
+  // No scalable:
+  // * distribution,
+  // * cache parallel, and
+  // * cache reduction
+  // tile sizes.
+  newScalableTileFlags.emplace_back(numTilingDims, false);
+  newScalableTileFlags.emplace_back(numTilingDims, false);
+  newScalableTileFlags.emplace_back(numTilingDims, false);
+
+  newScalableTileFlags.push_back(parallelScalableFlags);
+  newScalableTileFlags.push_back(reductionScalableFlags);
+
+  // No scalable inner parallel dims.
+  newScalableTileFlags.emplace_back(numTilingDims, false);
+
+  LLVM_DEBUG(KD_DBGS() << "Final tile sizes for contraction: " << tileSizes
+                       << "\n");
+  LLVM_DEBUG(KD_DBGS() << "Final tile scalable flags for contraction: "
+                       << newScalableTileFlags << "\n");
+
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, op, tileSizes,
+      entryPointFn, op, tileSizes, newScalableTileFlags,
       DispatchLoweringPassPipeline::CPUDoubleTilingPeelingExpert);
 }
 
@@ -870,7 +917,7 @@ setMatmulRootConfig(func::FuncOp entryPointFn,
   }
 
   TileSizesListType newTileSizes;
-  // Copy all the tile size levels except the distribution which will be split
+  // Copy all the tile size levels except the vector tile sizes which are split
   // into parallel and reduction.
   std::copy(inputTileSizes.begin(), inputTileSizes.end() - 1,
             std::back_inserter(newTileSizes));
@@ -889,8 +936,8 @@ setMatmulRootConfig(func::FuncOp entryPointFn,
   newScalableTileFlags.emplace_back(numTilingDims, false);
 
   LLVM_DEBUG(KD_DBGS() << "Final tile sizes for contraction: " << newTileSizes
-                       << "\n"
-                       << "Final tile scalable flags for contraction: "
+                       << "\n");
+  LLVM_DEBUG(KD_DBGS() << "Final tile scalable flags for contraction: "
                        << newScalableTileFlags << "\n");
 
   auto pipeline = DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
@@ -1166,24 +1213,28 @@ setRootConfig(func::FuncOp entryPointFn,
   // smaller than `minTileSizes`, so we have to adjust the cache sizes again.
   cacheTileSizes = distTileSizes;
 
+  SmallVector<bool> distScalableTileFlags(distTileSizes.size(), false);
+  ScalableTileFlagsListType scalableTileFlags = {distScalableTileFlags,
+                                                 vecScalableFlags};
+
   LLVM_DEBUG(KD_DBGS() << "Distribution tile sizes: " << distTileSizes << "\n");
+  LLVM_DEBUG(KD_DBGS() << "Distribution scalable tile sizes: "
+                       << distScalableTileFlags << "\n");
   LLVM_DEBUG(KD_DBGS() << "Cache tile sizes: " << cacheTileSizes << "\n");
   LLVM_DEBUG(KD_DBGS() << "Vector tile sizes: " << vecTileSizes << "\n");
+  LLVM_DEBUG(KD_DBGS() << "Vector scalable tile sizes: " << vecTileSizes
+                       << "\n");
   LLVM_DEBUG(KD_DBGS() << "Vector scalable tile flags: " << vecScalableFlags
                        << "\n");
   LLVM_DEBUG(KD_DBGS() << "Vector size: " << vectorSize << "\n");
 
   if (usePeelingPipeline) {
-    // TODO: Use scalable vector sizes.
-    return setMatmulPeelingRootConfig(entryPointFn, contractionOp,
-                                      distTileSizes, cacheTileSizes,
-                                      vecTileSizes, vectorSize);
+    return setMatmulPeelingRootConfig(
+        entryPointFn, contractionOp, distTileSizes, cacheTileSizes,
+        vecScalableFlags, vecTileSizes, vectorSize);
   }
 
-  SmallVector<bool> distScalableTileFlags(distTileSizes.size(), false);
   TileSizesListType tileSizes = {distTileSizes, vecTileSizes};
-  ScalableTileFlagsListType scalableTileFlags = {distScalableTileFlags,
-                                                 vecScalableFlags};
   return setMatmulRootConfig(entryPointFn, contractionOp, tileSizes,
                              scalableTileFlags, vectorSize, vecPreProcStrategy);
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -775,8 +775,8 @@ static SmallVector<int64_t> getDefaultMatmulCacheSizes(linalg::LinalgOp op,
 static LogicalResult setMatmulPeelingRootConfig(
     func::FuncOp entryPointFn, linalg::ContractionOpInterface op,
     ArrayRef<int64_t> distTileSizes, ArrayRef<int64_t> cacheTileSizes,
-    SmallVector<bool> &inputVecScalableTileFlags,
-    ArrayRef<int64_t> vecTileSizes, int vectorSize) {
+    ArrayRef<bool> inputVecScalableTileFlags, ArrayRef<int64_t> vecTileSizes,
+    int vectorSize) {
 
   // Clamp vector tile sizes to have better hint about peeling + masking. This
   // is critical for scalable vectorization, so it can resolve correct scalable

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
@@ -87,7 +87,7 @@ hal.executable private @matmul_static_tensors_sve  {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 7, 0], [5, 7, 0], [0, 0, 0], [8, [16], 0], [0, 0, 1], [0, 0, 0]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 7, 0], [5, 7, 0], [0, 0, 0], [5, [8], 0], [0, 0, 1], [0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
 //       CHECK: hal.executable.export public @static_tensors_non_pow_two_sizes
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
Adds the missing logic to enable scalable vectorisation when using
`CPUDoubleTilingPeelingExpert` (i.e. peeling). This boils down to making
sure that "scalable" flags are correctly propagated when using
"peeling".

While the default strategy for SVE remains "masking", we might change
that in the near future to avoid calculating masks where possible.

Also, additional logging is added to aid debugging. This is mostly to
make sure that similar level of outout is generated for both "masking"
and "peeling".