### PR TITLE
[LLVMGPU] Add AMDGPUToArith conversion patterns to ROCDL lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -101,6 +101,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:AffineToStandard",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ArithToAMDGPU",
         "@llvm-project//mlir:ArithToLLVM",
         "@llvm-project//mlir:ArithTransforms",
         "@llvm-project//mlir:BufferizationDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -80,6 +80,7 @@ iree_cc_library(
     MLIRAffineToStandard
     MLIRAnalysis
     MLIRArithDialect
+    MLIRArithToAMDGPU
     MLIRArithToLLVM
     MLIRArithTransforms
     MLIRBufferizationDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -137,6 +137,8 @@ struct ConvertToROCDLPass : public ConvertToROCDLBase<ConvertToROCDLPass> {
     // Run Vector -> Vector transformations ahead of conversion to LLVM.
     {
       RewritePatternSet patterns(&getContext());
+      // These patterns only convert a subset of arith that target specific
+      // rocdl intrinsics (e.g. fp8 conversions).
       arith::populateArithToAMDGPUConversionPatterns(patterns);
       populateConvertGPUToAMDGPUPatterns(patterns);
       populateConvertSharedMemoryAllocOps(patterns);


### PR DESCRIPTION
The details of the patterns are already tested upstream, this just adds a pipeline check to make sure a simple elementwise arith.extf fp8 -> fp32 example connects all the way. Currently this is only supported for gfx940. For other targets we will need to add emulation patterns.

Additionally adds some debug logging to ConvertToROCDL.