### PR TITLE
Bump LLVM to llvm/llvm-project@f5145f4dc819

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-cpu-lower-to-ukernels{skip-intermediate-roundings=true},cse,canonicalize))" %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-cpu-lower-to-ukernels{skip-intermediate-roundings=false},cse,canonicalize))" %s | FileCheck %s --check-prefix=NOSKIPROUND
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-cpu-lower-to-ukernels{skip-intermediate-roundings=true},cse,canonicalize))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-cpu-lower-to-ukernels{skip-intermediate-roundings=false},cse,canonicalize))" %s | FileCheck %s --check-prefix=NOSKIPROUND
 
 func.func @mmt4d_f32f32f32(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>,
     %arg2 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> attributes {
@@ -13,11 +13,11 @@ func.func @mmt4d_f32f32f32(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1281 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1281 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -130,11 +130,11 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1282 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1282 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -164,11 +164,11 @@ func.func @mmt4d_i16i16i32(%arg0 : tensor<?x?x?x?xi16>, %arg1 : tensor<?x?x?x?xi
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1287 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1287 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -198,11 +198,11 @@ func.func @mmt4d_i16i8i32(%arg0 : tensor<?x?x?x?xi16>, %arg1 : tensor<?x?x?x?xi8
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1289 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1289 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -232,11 +232,11 @@ func.func @mmt4d_f16f16f32(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1283 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1283 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -266,11 +266,11 @@ func.func @mmt4d_f16f16f16(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1284 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1284 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -290,11 +290,11 @@ func.func @mmt4d_f16f16f16(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 // NOSKIPROUND-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // NOSKIPROUND-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // NOSKIPROUND-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
+//  NOSKIPROUND-DAG:   %[[FLAGS:.+]] = arith.constant 260 : i32
 //  NOSKIPROUND-DAG:   %[[C0:.+]] = arith.constant 0
 //  NOSKIPROUND-DAG:   %[[C1:.+]] = arith.constant 1
 //  NOSKIPROUND-DAG:   %[[C2:.+]] = arith.constant 2
 //  NOSKIPROUND-DAG:   %[[C3:.+]] = arith.constant 3
-//  NOSKIPROUND-DAG:   %[[FLAGS:.+]] = arith.constant 260 : i32
 //  NOSKIPROUND-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  NOSKIPROUND-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  NOSKIPROUND-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -324,11 +324,11 @@ func.func @mmt4d_bf16bf16f32(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?x
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1285 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1285 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -358,11 +358,11 @@ func.func @mmt4d_bf16bf16bf16(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1286 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1286 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -682,11 +682,11 @@ func.func @mmt4d_i8i8i32_extend_producers(%arg0: tensor<?x?x?x?xi8>, %arg1: tens
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1282 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1282 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -702,7 +702,7 @@ func.func @mmt4d_i8i8i32_extend_producers(%arg0: tensor<?x?x?x?xi8>, %arg1: tens
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
 //      CHECK:   return %[[MICRO_KERNEL]]
 
-// ----
+// -----
 
 func.func @mmt4d_i16u4i32_extend_producers(%arg0: tensor<?x?x?x?xi16>, %arg1: tensor<?x?x?x?xi4>, %arg2: tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32> attributes {
   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {ukernels = "all"}>
@@ -744,11 +744,11 @@ func.func @mmt4d_i16u4i32_extend_producers(%arg0: tensor<?x?x?x?xi16>, %arg1: te
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi4>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1288 : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
 //  CHECK-DAG:   %[[C3:.+]] = arith.constant 3
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1288 : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
@@ -130,8 +130,8 @@ hal.executable private @reduce_uniform_buffer_offset  {
 }
 
 //   CHECK-LABEL: func.func @reduce_uniform_buffer_offset()
-//         CHECK:   %[[C0:.+]] = arith.constant 0 : index
-//         CHECK:   %[[C1:.+]] = arith.constant 1 : index
+//     CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//     CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //         CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan set(0) binding(2) type(uniform_buffer)
 //         CHECK:   %[[LOAD:.+]] = memref.load %[[SUBSPAN]][%[[C0]]]
 //         CHECK:   %[[EXT0:.+]] = vector.extractelement %[[LOAD]][%[[C0]] : index] : vector<4xi32>
@@ -199,8 +199,8 @@ hal.executable private @reduce_storage_buffer_offset  {
 }
 
 //   CHECK-LABEL: func.func @reduce_storage_buffer_offset()
-//         CHECK:   %[[C0:.+]] = arith.constant 0 : index
-//         CHECK:   %[[C1:.+]] = arith.constant 1 : index
+//     CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//     CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //         CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
 //         CHECK:   %[[LOAD:.+]] = memref.load %[[SUBSPAN]][%[[C0]]]
 //         CHECK:   %[[EXT0:.+]] = vector.extractelement %[[LOAD]][%[[C0]] : index] : vector<4xi32>

--- a/compiler/src/iree/compiler/Codegen/Common/test/affinemin_canonicalization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/affinemin_canonicalization.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-affinemin-scf-canonicalization %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-affinemin-scf-canonicalization -canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: scf_for_distributed
 func.func @scf_for_distributed(%A : memref<i64>, %id1 : index, %count1 : index,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -174,7 +174,7 @@ struct ConvertHALEntryPointFuncOp
     // order to get any debug information (including just line tables) from MLIR
     // into LLVM IR.
     auto scopeAttr = HALDispatchABI::buildScopeAttr(
-        llvmFuncOp->getParentOfType<mlir::ModuleOp>(), llvmFuncOp.getName(),
+        llvmFuncOp->getParentOfType<mlir::ModuleOp>(), llvmFuncOp,
         getTypeConverter());
     llvmFuncOp->setLoc(FusedLoc::get(llvmFuncOp.getContext(),
                                      {llvmFuncOp->getLoc()}, scopeAttr));

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -499,9 +499,9 @@ HALDispatchABI::buildScopeAttr(mlir::ModuleOp moduleOp, StringRef funcName,
       LLVM::DIFileAttr::get(context, llvm::sys::path::filename(inputFilePath),
                             llvm::sys::path::parent_path(inputFilePath));
   auto compileUnitAttr = LLVM::DICompileUnitAttr::get(
-      context, llvm::dwarf::DW_LANG_C17, fileAttr,
-      builder.getStringAttr("IREE"), /*isOptimized=*/true,
-      LLVM::DIEmissionKind::Full);
+      context, DistinctAttr::create(UnitAttr::get(context)),
+      llvm::dwarf::DW_LANG_C17, fileAttr, builder.getStringAttr("IREE"),
+      /*isOptimized=*/true, LLVM::DIEmissionKind::Full);
 
   auto int32TypeAttr =
       LLVM::DIBasicTypeAttr::get(context, llvm::dwarf::DW_TAG_base_type, "int",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -485,7 +485,8 @@ HALDispatchABI::getInputTypes(MLIRContext *context,
 
 // static
 LLVM::DISubprogramAttr
-HALDispatchABI::buildScopeAttr(mlir::ModuleOp moduleOp, StringRef funcName,
+HALDispatchABI::buildScopeAttr(mlir::ModuleOp moduleOp,
+                               LLVM::LLVMFuncOp llvmFuncOp,
                                const LLVMTypeConverter *typeConverter) {
   auto *context = &typeConverter->getContext();
   Builder builder(context);
@@ -516,13 +517,18 @@ HALDispatchABI::buildScopeAttr(mlir::ModuleOp moduleOp, StringRef funcName,
           di.getPtrOf(di.getConstOf(di.getWorkgroupStateV0T())),
       });
 
-  auto funcNameAttr = builder.getStringAttr(funcName);
-  return LLVM::DISubprogramAttr::get(
-      context, compileUnitAttr, fileAttr, funcNameAttr, funcNameAttr, fileAttr,
-      /*line=*/1,
-      /*scopeline=*/1,
-      LLVM::DISubprogramFlags::Definition | LLVM::DISubprogramFlags::Optimized,
-      subroutineTypeAttr);
+  auto funcNameAttr = builder.getStringAttr(llvmFuncOp.getName());
+  DistinctAttr id;
+  if (!llvmFuncOp.isExternal()) {
+    id = DistinctAttr::create(UnitAttr::get(context));
+  }
+  return LLVM::DISubprogramAttr::get(context, id, compileUnitAttr, fileAttr,
+                                     funcNameAttr, funcNameAttr, fileAttr,
+                                     /*line=*/1,
+                                     /*scopeline=*/1,
+                                     LLVM::DISubprogramFlags::Definition |
+                                         LLVM::DISubprogramFlags::Optimized,
+                                     subroutineTypeAttr);
 }
 
 // Returns the most local DISubprogramAttr starting from |forOp|.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.h
@@ -200,13 +200,13 @@ public:
   static SmallVector<Type, 5>
   getInputTypes(MLIRContext *context, const LLVMTypeConverter *typeConverter);
 
-  // Builds a DISubprogram for a function in |moduleOp| named |funcName|.
+  // Builds a DISubprogram for |llvmFuncOp| function in |moduleOp|.
   // This is required in order to get any debug information (including line
   // tables) from MLIR into LLVM IR. It does not need to match the exact
   // definition but the closer we can make it to the real thing the more useful
   // downstream tools will be.
   static LLVM::DISubprogramAttr
-  buildScopeAttr(mlir::ModuleOp moduleOp, StringRef funcName,
+  buildScopeAttr(mlir::ModuleOp moduleOp, LLVM::LLVMFuncOp llvmFuncOp,
                  const LLVMTypeConverter *typeConverter);
 
   explicit HALDispatchABI(LLVMTypeConverter *typeConverter)

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/break_down_large_vector.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/break_down_large_vector.mlir
@@ -44,7 +44,7 @@ func.func @bitcast_extract_extend_0(%input: vector<1xi32>) -> vector<4xi32> {
 
 // CHECK-LABEL: func @bitcast_extract_extend_0
 //  CHECK-SAME:  (%[[INPUT:.+]]: vector<1xi32>)
-//       CHECK:   %[[ZERO:.+]] = arith.constant dense<0> : vector<4xi32>
+//   CHECK-DAG:   %[[ZERO:.+]] = arith.constant dense<0> : vector<4xi32>
 //   CHECK-DAG:   %[[MASK:.+]] = arith.constant 15 : i32
 //   CHECK-DAG:   %[[OFF1:.+]] = arith.constant 4 : i32
 //   CHECK-DAG:   %[[OFF2:.+]] = arith.constant 8 : i32
@@ -75,7 +75,7 @@ func.func @bitcast_extract_extend_1(%input: vector<4xi32>) -> vector<4xi32> {
 
 // CHECK-LABEL: func.func @bitcast_extract_extend_1
 //  CHECK-SAME: (%[[INPUT:.+]]: vector<4xi32>)
-//       CHECK:   %[[ZERO:.+]] = arith.constant dense<0> : vector<4xi32>
+//   CHECK-DAG:   %[[ZERO:.+]] = arith.constant dense<0> : vector<4xi32>
 //   CHECK-DAG:   %[[MASK:.+]] = arith.constant 15 : i32
 //   CHECK-DAG:   %[[OFF0:.+]] = arith.constant 16 : i32
 //   CHECK-DAG:   %[[OFF1:.+]] = arith.constant 20 : i32

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseDimensions.cpp
@@ -450,7 +450,18 @@ void CollapseDimensionsPass::runOnOperation() {
   // Move all the `tensor.collapse_shape` leafs  and `tensor.expand_shape` roots
   // of the modified dispatches out of the dispatch.
   for (auto dispatchOp : modifiedDispatchOps) {
-    Region &body = dispatchOp.getBody();
+    // Hoist tensor reshape ops out of dispatch region first. Otherwise, the
+    // reshape(cst) will be folded into a constant living in the dispatch. It
+    // could introduce big constants inlined in the dispatch.
+    FailureOr<DispatchRegionOp> newDispatchOp =
+        hoistTensorReshapesOutOfDispatchRegion(
+            rewriter, cast<DispatchRegionOp>(dispatchOp));
+    if (failed(newDispatchOp)) {
+      dispatchOp->emitOpError("failed to hoist reshapes out of dispatch");
+      return signalPassFailure();
+    }
+
+    Region &body = newDispatchOp.value().getBody();
     assert(llvm::hasSingleElement(body) && "expected op with a single body");
     Block &block = body.front();
     RewritePatternSet moveReshapeOps(&getContext());
@@ -467,12 +478,6 @@ void CollapseDimensionsPass::runOnOperation() {
             applyOpPatternsAndFold(candidateOps, std::move(moveReshapeOps)))) {
       funcOp.emitOpError(
           "failed to propagate reshape ops introduced during collapse");
-      return signalPassFailure();
-    }
-
-    if (failed(hoistTensorReshapesOutOfDispatchRegion(
-            rewriter, cast<DispatchRegionOp>(dispatchOp)))) {
-      dispatchOp->emitOpError("failed to hoist reshapes out of dispatch");
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
             "capture_dispatch_dynamic_dims.mlir",
             "cleanup_tensor_shapes.mlir",
             "clone_producers_into_dispatch_regions.mlir",
+            "collapse_dimensions.mlir",
             "collapse_reduction.mlir",
             "convert_region_to_workgroups.mlir",
             "deduplicate_executables.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "capture_dispatch_dynamic_dims.mlir"
     "cleanup_tensor_shapes.mlir"
     "clone_producers_into_dispatch_regions.mlir"
+    "collapse_dimensions.mlir"
     "collapse_linalg_generic_on_tensors.mlir"
     "collapse_reduction.mlir"
     "convert_region_to_workgroups.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_dimensions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_dimensions.mlir
@@ -1,0 +1,26 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-flow-collapse-dimensions))" %s | FileCheck %s
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+func.func @do_not_collapse_cst_in_place(%arg0: tensor<1x1x2304xf32>) {
+  %cst = arith.constant dense<0.000000e+00> : tensor<1x1x2304xf32>
+  %0 = tensor.empty() : tensor<1x1x2304xf32>
+  %1 = flow.dispatch.region -> (tensor<1x1x2304xf32>) {
+    %2 = tensor.empty() : tensor<1x1x2304xf32>
+    %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %cst : tensor<1x1x2304xf32>, tensor<1x1x2304xf32>) outs(%2 : tensor<1x1x2304xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %4 = arith.addf %in, %in_0 : f32
+      linalg.yield %4 : f32
+    } -> tensor<1x1x2304xf32>
+    flow.return %3 : tensor<1x1x2304xf32>
+  }
+  return
+}
+// CHECK-LABEL: func.func @do_not_collapse_cst_in_place
+// CHECK-SAME:    %[[ARG0:[0-9a-zA-Z]]]
+// CHECK-DAG:     %[[CST:.+]] = arith.constant
+// CHECK-DAG:     %[[COLLAPSED_ARG0:.+]] = tensor.collapse_shape %[[ARG0]]
+// CHECK-DAG:     %[[COLLAPSED_CST:.+]] = tensor.collapse_shape %[[CST]]
+// CHECK:         %{{.+}} = flow.dispatch.region
+// CHECK:            %[[RES:.+]] = linalg.generic
+// CHECK-SAME:         ins(%[[COLLAPSED_ARG0]], %[[COLLAPSED_CST]]
+// CHECK:            flow.return %[[RES]]

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/comparison_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/comparison_folding.mlir
@@ -50,9 +50,9 @@ vm.module @cmp_eq_i32_folds {
 vm.module @cmp_eq_f32_near_folds {
   // CHECK-LABEL: @eq_near_f32
   vm.func @eq_near_f32(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT:   %zero = vm.const.f32.zero
-    // CHECK-NEXT:   %c1 = vm.const.i32 1
-    // CHECK-NEXT:   [[THRESHOLD:%.+]] = vm.const.i32
+    //  CHECK-DAG:   %zero = vm.const.f32.zero
+    //  CHECK-DAG:   %c1 = vm.const.i32 1
+    //  CHECK-DAG:   [[THRESHOLD:%.+]] = vm.const.i32
     // CHECK-NEXT:   %0 = vm.cmp.lt.f32.o %arg0, %zero : f32
     // CHECK-NEXT:   %1 = vm.xor.i32 %0, %c1 : i32
     // CHECK-NEXT:   %2 = vm.cmp.lt.f32.o %arg1, %zero : f32

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/control_flow_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/control_flow_folding.mlir
@@ -116,10 +116,10 @@ vm.module @check_folds {
 
   // CHECK-LABEL: @check_nearly_eq_f32
   vm.func @check_nearly_eq_f32(%arg0 : f32, %arg1 : f32) {
-    // CHECK-NEXT:   %zero = vm.const.f32.zero
-    // CHECK-NEXT:   %c1 = vm.const.i32 1
-    // CHECK-NEXT:   [[THRESHOLD:%.+]] = vm.const.i32 100
-    // CHECK-NEXT:   %c9 = vm.const.i32 9
+    //  CHECK-DAG:   %zero = vm.const.f32.zero
+    //  CHECK-DAG:   %c1 = vm.const.i32 1
+    //  CHECK-DAG:   [[THRESHOLD:%.+]] = vm.const.i32 100
+    //  CHECK-DAG:   %c9 = vm.const.i32 9
     // CHECK-NEXT:   %0 = vm.cmp.lt.f32.o %arg0, %zero : f32
     // CHECK-NEXT:   %1 = vm.xor.i32 %0, %c1 : i32
     // CHECK-NEXT:   %2 = vm.cmp.lt.f32.o %arg1, %zero : f32

--- a/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_conv_to_conv.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_conv_to_conv.mlir
@@ -171,8 +171,8 @@ func.func @conv2d_dyn(%arg0: tensor<?x?x?x5xi8>, %arg1: tensor<3x4x5x1024xi8>, %
 
 // CHECK-LABEL: @conv2d_dyn_filter_zp
 func.func @conv2d_dyn_filter_zp(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<?x?x5x1024xi8>, %arg2: tensor<1x?x?x1024xi32>) -> tensor<1x?x?x1024xi32> {
-  // CHECK: %[[C1:.+]] = arith.constant 1 : index
-  // CHECK: %[[C2:.+]] = arith.constant 2 : index
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
 
   %iZp = arith.constant 42 : i32
   %fZp = arith.constant 0 : i32
@@ -200,11 +200,11 @@ func.func @conv2d_dyn_input_zp(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<?x?x5x
   %fZp = arith.constant 42 : i32
   %iZp = arith.constant 0 : i32
 
-  // CHECK: %[[C0:.+]] = arith.constant 0 : i32
-  // CHECK: %[[I1:.+]] = arith.constant 1 : index
-  // CHECK: %[[I2:.+]] = arith.constant 2 : index
-  // CHECK: %[[I0:.+]] = arith.constant 0 : index
-  // CHECK: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[I1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[I2:.+]] = arith.constant 2 : index
+  // CHECK-DAG: %[[I0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
   // CHECK: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf
 
   // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x14x16xi32>

--- a/llvm-external-projects/iree-dialects/test/Transforms/test-with-listener.mlir
+++ b/llvm-external-projects/iree-dialects/test/Transforms/test-with-listener.mlir
@@ -5,8 +5,8 @@ func.func @test_canonicalize(%arg0: i32) -> (i32, i32) {
   // CANON: REPLACED arith.addi
   // CANON: REMOVED arith.addi
   %c5 = arith.constant -5 : i32
-  %0 = arith.addi %c5, %arg0 : i32
-  %1 = arith.addi %c5, %0 : i32
+  %0 = arith.addi %arg0, %c5 : i32
+  %1 = arith.addi %0, %c5 : i32
   return %0, %1 : i32, i32
 }
 


### PR DESCRIPTION
This includes a revert for https://github.com/llvm/llvm-project/commit/11ac97c67a9315dce48fd938d68ae991e3559f10
Other fixes:

- Implement https://github.com/openxla/iree/pull/16073/commits/77b777c0c7b7365fc6f676c1fb582b16f99f6d72 which avoids inlining big constants into dispatch.
- Add fixes for https://github.com/llvm/llvm-project/commit/b3037ae1fc6d26459e37f813757ad30872eb2eee, see https://github.com/openxla/iree/pull/16073/commits/7ed5f2976e63170707363ed66a208c9fa712cfab
- Add fixes for https://github.com/llvm/llvm-project/commit/bae1fdea712fcd0b0ea525b115e661f92263f2e7, see https://github.com/openxla/iree/pull/16073/commits/c83cefbd1c78be6b37fe3623c50bd3c9fe8a930b It updates `HALDispatchABI::buildScopeAttr` to take `LLVM::LLVMFuncOp` as inputs, so it can handle if the `DistinctAttr` is needed or not for `DISubprogramAttr`.
- Add fixes for https://github.com/llvm/llvm-project/commit/bb6d5c220004a5d7e466a669324001285a688918
  - Add `--split-input-file` to `lower_to_ukernel_ops.mlir`.
  - Move few `CHECK-DAG` to beginning for fixing lit tests.
  - Replace some `CHECK[-NEXT]` with `CHECK-DAG`
  - Add `--canonicalize` to `affinemin_canonicalization.mlir` which hoists constants out of region.