### PR TITLE
[CPU] Refine the logic to control vectorization pre-processing

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -76,10 +76,12 @@ static llvm::cl::opt<int> clGeneralMatmulTileBytes(
                    "in data-tiled matmuls (mmt4d)."),
     llvm::cl::init(64 * 1024));
 
-static llvm::cl::opt<bool>
-    clEnableVectorPeeling("iree-llvmcpu-enable-vector-peeling",
-                          llvm::cl::desc("Enable peeling for vectorization"),
-                          llvm::cl::init(true));
+static llvm::cl::opt<bool> clDisableVectorPeeling(
+    "iree-codegen-disable-vector-peeling",
+    llvm::cl::desc("Disable peeling as a pre-processing step for "
+                   "vectorization (only relevant when using compiler "
+                   "heuristics to select the strategy)."),
+    llvm::cl::init(false));
 
 // Non-static options are used in other places.
 llvm::cl::opt<bool> clEnableTransformDialectJit(
@@ -100,8 +102,31 @@ enum class VectorPreProcStrategy {
   // be masked-out.
   Masking,
   // Do not apply any vectorization pre-processing transformation.
-  None
+  None,
+  // A hint for the compiler to use its heuristics to determine an
+  // actual pre-processing strategy.
+  Heuristics
 };
+
+llvm::cl::opt<VectorPreProcStrategy> preprocessStrategyFromCL(
+    "iree-codegen-llvmcpu-vector-pproc-strategy",
+    llvm::cl::desc("Set the strategy for pre-processing Linalg operation "
+                   "before vectorization:"),
+    llvm::cl::values(
+        clEnumValN(VectorPreProcStrategy::Peeling, "peel",
+                   "Peel iterations from the vector dimensions so that they "
+                   "become multiple of the vector length"),
+        clEnumValN(
+            VectorPreProcStrategy::Masking, "mask",
+            " Compute vector dimensions assuming vector masking support. "
+            "Vector sizes may be rounded up to the nearest power of two "
+            "and out-of-bounds elements would be masked-out."),
+        clEnumValN(
+            VectorPreProcStrategy::None, "none",
+            "Do not apply any vectorization pre-processing transformation."),
+        clEnumValN(VectorPreProcStrategy::Heuristics, "heurystics",
+                   "To be determined by IREE's heurystics (default).")),
+    llvm::cl::init(VectorPreProcStrategy::Heuristics));
 
 // TODO(dcaballe): Move operator<< to DebugUtils.h.
 static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
@@ -115,6 +140,9 @@ static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
     break;
   case VectorPreProcStrategy::None:
     os << "None";
+    break;
+  case VectorPreProcStrategy::Heuristics:
+    os << "Heuristics";
     break;
   }
   return os;
@@ -173,8 +201,11 @@ static bool isFullyDynamicOp(linalg::LinalgOp op) {
 /// given LinalgOp, depending on the op traits and the target architecture.
 static VectorPreProcStrategy
 getVectorPreProcStrategy(linalg::LinalgOp linalgOp) {
-  // Generic strategies.
+  // 1. Select a strategy based on the input from a user.
+  if (preprocessStrategyFromCL != VectorPreProcStrategy::Heuristics)
+    return preprocessStrategyFromCL;
 
+  // 2. Select a strategy based on heuristics.
   if (linalgOp.hasBufferSemantics()) {
     return VectorPreProcStrategy::None;
   }
@@ -188,7 +219,7 @@ getVectorPreProcStrategy(linalg::LinalgOp linalgOp) {
       return VectorPreProcStrategy::Masking;
     }
 
-    if (clEnableVectorPeeling) {
+    if (!clDisableVectorPeeling) {
       return VectorPreProcStrategy::Peeling;
     }
   }
@@ -199,7 +230,7 @@ getVectorPreProcStrategy(linalg::LinalgOp linalgOp) {
       return VectorPreProcStrategy::Masking;
     }
 
-    if (clEnableVectorPeeling) {
+    if (!clDisableVectorPeeling) {
       return VectorPreProcStrategy::Peeling;
     }
   }
@@ -210,7 +241,7 @@ getVectorPreProcStrategy(linalg::LinalgOp linalgOp) {
       return VectorPreProcStrategy::Masking;
     }
 
-    if (clEnableVectorPeeling) {
+    if (!clDisableVectorPeeling) {
       return VectorPreProcStrategy::Peeling;
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -124,7 +124,7 @@ static llvm::cl::opt<VectorPreProcStrategy> clPProcStrategy(
         clEnumValN(
             VectorPreProcStrategy::None, "none",
             "Do not apply any vectorization pre-processing transformation."),
-        clEnumValN(VectorPreProcStrategy::Heuristics, "heurystics",
+        clEnumValN(VectorPreProcStrategy::Heuristics, "heuristics",
                    "To be determined by IREE's heuristics (default).")),
     llvm::cl::init(VectorPreProcStrategy::Heuristics));
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -46,6 +46,7 @@ iree_lit_test_suite(
             "pipeline_vectorize_nd_extract_tests.mlir",
             "scalable_tile_and_vectorize_matmul.mlir",
             "select_aarch64_lowering_strategy.mlir",
+            "select_aarch64_sve_lowering_strategy_peeling.mlir",
             "select_lowering_strategy_without_distribution.mlir",
             "select_riscv_lowering_strategy.mlir",
             "select_x86_64_lowering_strategy.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_lit_test_suite(
     "pipeline_vectorize_nd_extract_tests.mlir"
     "scalable_tile_and_vectorize_matmul.mlir"
     "select_aarch64_lowering_strategy.mlir"
+    "select_aarch64_sve_lowering_strategy_peeling.mlir"
     "select_lowering_strategy_without_distribution.mlir"
     "select_riscv_lowering_strategy.mlir"
     "select_x86_64_lowering_strategy.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
@@ -1,0 +1,142 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy)))' \
+// RUN: --iree-codegen-llvmcpu-vector-pproc-strategy=peel --split-input-file %s | FileCheck %s
+
+// FIXME - ATM scalability is not propagated when using vector peeling and
+// hence the expected output represents what the compiler generates rather 
+// what it should generate.
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors_sve  {
+  hal.executable.variant @llvm target(<"llvm-cpu", "embedded-elf-arm_64", {
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    cpu_features = "+sve",
+    native_vector_size = 16 : index,
+    target_triple = "aarch64-none-elf"
+  }>) {
+    hal.executable.export @matmul_tensors layout(#pipeline_layout)
+    builtin.module {
+      func.func @matmul_tensors() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %M = hal.interface.constant.load[0] : index
+        %N = hal.interface.constant.load[1] : index
+        %K = hal.interface.constant.load[2] : index
+        %lhs_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K}
+        %rhs_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%K, %N}
+        %init_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %N}
+        %result_binding = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer)
+            : !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%M, %N}
+              %lhs = flow.dispatch.tensor.load %lhs_binding, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K} -> tensor<?x?xf32>
+        %rhs = flow.dispatch.tensor.load %rhs_binding, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%K, %N} -> tensor<?x?xf32>
+        %init = flow.dispatch.tensor.load %init_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %N} -> tensor<?x?xf32>
+        %gemm = linalg.matmul ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+        flow.dispatch.tensor.store %gemm, %result_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%M, %N}
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [128, 128, 0], [0, 0, 0], [8, 16, 0], [0, 0, 1], [0, 0, 0]]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
+//       CHECK: hal.executable.export public @matmul_tensors
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_static_tensors_sve  {
+  hal.executable.variant @llvm target(<"llvm-cpu", "embedded-elf-arm_64", {
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    cpu_features = "+sve",
+    native_vector_size = 16 : index,
+    target_triple = "aarch64-none-elf"
+  }>) {
+    hal.executable.export @static_tensors_non_pow_two_sizes layout(#pipeline_layout)
+    builtin.module {
+      func.func @static_tensors_non_pow_two_sizes() {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<15x14xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<14x7xf32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readwrite:tensor<15x7xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [15, 14], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<15x14xf32>> -> tensor<15x14xf32>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [14, 7], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<14x7xf32>> -> tensor<14x7xf32>
+        %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [15, 7], strides = [1, 1] : !flow.dispatch.tensor<readwrite:tensor<15x7xf32>> -> tensor<15x7xf32>
+        %6 = linalg.matmul ins(%3, %4 : tensor<15x14xf32>, tensor<14x7xf32>) outs(%5 : tensor<15x7xf32>) -> tensor<15x7xf32>
+        flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [15, 7], strides = [1, 1] : tensor<15x7xf32> -> !flow.dispatch.tensor<readwrite:tensor<15x7xf32>> return }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 7, 0], [5, 7, 0], [0, 0, 0], [5, 7, 0], [0, 0, 1], [0, 0, 0]]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
+//       CHECK: hal.executable.export public @static_tensors_non_pow_two_sizes
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+hal.executable private @static_tensors_1x1  {
+  hal.executable.variant @llvm target(<"llvm-cpu", "embedded-elf-arm_64", {
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    cpu_features = "+sve",
+    native_vector_size = 16 : index,
+    target_triple = "aarch64-none-elf"
+  }>) {
+    hal.executable.export @static_tensors_1x1 layout(#pipeline_layout)
+    builtin.module {
+      func.func @static_tensors_1x1() {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x1xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x1xf32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readwrite:tensor<1x1xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 1], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1x1xf32>> -> tensor<1x1xf32>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1, 1], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1x1xf32>> -> tensor<1x1xf32>
+        %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [1, 1], strides = [1, 1] : !flow.dispatch.tensor<readwrite:tensor<1x1xf32>> -> tensor<1x1xf32>
+        %6 = linalg.matmul ins(%3, %4 : tensor<1x1xf32>, tensor<1x1xf32>) outs(%5 : tensor<1x1xf32>) -> tensor<1x1xf32>
+        flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [1, 1], strides = [1, 1] : tensor<1x1xf32> -> !flow.dispatch.tensor<readwrite:tensor<1x1xf32>>
+        return
+      }
+    }
+  }
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0], [0, 0, 0], [0, 0, 0], [1, 16, 0], [0, 0, 1], [0, 0, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
+//      CHECK: hal.executable.export public @static_tensors_1x1
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK: linalg.matmul
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
+


### PR DESCRIPTION
Introduces a new flag to control the vectorization pre-processing strategy:

    -iree-codegen-llvmcpu-vector-pproc-strategy

This new flag overrides all the heuristics that IREE uses by default.
It's primarily meant to facilitate testing.

This patch also renames:

    -iree-codegen-enable-vector-peeling

as:

    -iree-codegen-disable-vector-peeling

The latter better reflects what the flag is intended for, i.e. to
override the behaviour of the heuristics available in IREE. More
specifically, to disable "peeling" even when that's what the logic
inside IREE would otherwise select for pre-processing.

The new tests in "select_aarch64_sve_lowering_strategy_peeling.mlir" are
meant to demonstrate the new flag. The actual lower config that IREE
generates for SVE with peeling is incorrect - scalability flags are not
propagated ATM. This will be fixed in a separate patch.
