### PR TITLE
[CPU] Fix multiconfig bug with tensor.pack op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2292,8 +2292,10 @@ setLoweringConfigForComputeOps(func::FuncOp entryPointFn,
                   continue;
                 tileSizes[pos] = tileSizes[pos] / size;
               }
-              if (!outerDimsPerm.empty())
+              if (!outerDimsPerm.empty()) {
+                tileSizes.resize(numLoops, 0);
                 applyPermutationToVector(tileSizes, outerDimsPerm);
+              }
             }
           })
           .Default([&](auto) {


### PR DESCRIPTION
When `tensor.pack` is fused with a reduction, the distribution tile size vector is too large, and fails an assert when trying to applyPermutationToVector. This fixes the bug by resizing before permuting.