### PR TITLE
[cuda] Break cyclic retain between device and device event pool

### DIFF
--- a/experimental/cuda2/cuda_device.c
+++ b/experimental/cuda2/cuda_device.c
@@ -258,7 +258,7 @@ iree_status_t iree_hal_cuda2_device_create(
   iree_hal_cuda2_event_pool_t* device_event_pool = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_cuda2_event_pool_allocate(
-        *out_device, cuda_symbols, params->event_pool_capacity, host_allocator,
+        cuda_symbols, params->event_pool_capacity, host_allocator,
         &device_event_pool);
   }
 

--- a/experimental/cuda2/event_pool.h
+++ b/experimental/cuda2/event_pool.h
@@ -9,7 +9,6 @@
 
 #include "experimental/cuda2/cuda_dynamic_symbols.h"
 #include "iree/base/api.h"
-#include "iree/hal/api.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,7 +52,6 @@ typedef struct iree_hal_cuda2_event_pool_t iree_hal_cuda2_event_pool_t;
 // Extra events requested beyond the capability are directly created and
 // destroyed without pooling.
 iree_status_t iree_hal_cuda2_event_pool_allocate(
-    iree_hal_device_t* owning_device,
     const iree_hal_cuda2_dynamic_symbols_t* symbols,
     iree_host_size_t available_capacity, iree_allocator_t host_allocator,
     iree_hal_cuda2_event_pool_t** out_event_pool);


### PR DESCRIPTION
The device already retains the devic event pool, so the device event pool should not retain the device again. Otherwise, they both have at least one retain and will never trigger proper free naturally.

Progress towards https://github.com/openxla/iree/issues/13245
