### PR TITLE
Disable const-eval for parameters unit test

### DIFF
--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -56,6 +56,7 @@ def compile_mm_test():
         MM_TEST_COMPILED = iree.compiler.compile_str(
             MM_TEST_ASM,
             target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS,
+            # TODO(#16098): re-enable const eval once parameters are supported.
             extra_args=["--iree-opt-const-eval=false"],
         )
     return MM_TEST_COMPILED

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -54,7 +54,8 @@ def compile_mm_test():
     global MM_TEST_COMPILED
     if not MM_TEST_COMPILED:
         MM_TEST_COMPILED = iree.compiler.compile_str(
-            MM_TEST_ASM, target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS
+            MM_TEST_ASM, target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS,
+            extra_args=["--iree-opt-const-eval=false"]
         )
     return MM_TEST_COMPILED
 

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -54,8 +54,9 @@ def compile_mm_test():
     global MM_TEST_COMPILED
     if not MM_TEST_COMPILED:
         MM_TEST_COMPILED = iree.compiler.compile_str(
-            MM_TEST_ASM, target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS,
-            extra_args=["--iree-opt-const-eval=false"]
+            MM_TEST_ASM,
+            target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS,
+            extra_args=["--iree-opt-const-eval=false"],
         )
     return MM_TEST_COMPILED
 


### PR DESCRIPTION
Const eval is not possible for parameters, so it should be disabled here. The test fails when using const eval with data tiling after transposed cases are supported in https://github.com/openxla/iree/pull/15984