### PR TITLE
[CPU] Unifly LLVMCPU cmd flags and variable names in KernelDisatpch.cpp

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_lowering_strategy_without_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_lowering_strategy_without_distribution.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy)))' --iree-codegen-llvm-disable-distribution --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy)))' --iree-llvmcpu-disable-distribution --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [

--- a/tests/transform_dialect/cpu/eltwise_reduction_eltwise.mlir
+++ b/tests/transform_dialect/cpu/eltwise_reduction_eltwise.mlir
@@ -50,11 +50,11 @@ func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
 // RUN:     --iree-stream-transformation-pipeline \
 // RUN:     --iree-hal-configuration-pipeline | \
 // RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-materialize-user-configs, iree-llvmcpu-select-lowering-strategy, iree-llvmcpu-lower-executable-target)))' \
-// RUN:     --iree-codegen-llvmcpu-enable-transform-dialect-jit | \
+// RUN:     --iree-llvmcpu-enable-transform-dialect-jit | \
 // RUN: FileCheck %s
 
 // RUN: iree-compile %s --iree-hal-target-backends=llvm-cpu  \
-// RUN:     --iree-codegen-llvmcpu-enable-transform-dialect-jit | \
+// RUN:     --iree-llvmcpu-enable-transform-dialect-jit | \
 // RUN: iree-run-module --module=- --function=reduce --device=local-task --input="32x256xf32=1" |\
 // RUN: FileCheck %s --check-prefix=EXEC
 


### PR DESCRIPTION
We follow `--iree-llvmcpu-*` prefix for CPU targets. And all the variable names start with `cl*`. There are other backends (like LLVMGPU) using `LLVM` and it makes a distinction betwen LLVMCPU and LLVMGPU backends.