### PR TITLE
Disable loop unrolling in LLVM IR optimization passes

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.h
@@ -35,7 +35,7 @@ struct LLVMTarget {
   static constexpr bool DEFAULT_LINK_STATIC = false;
   static constexpr bool DEFAULT_LOOP_INTERLEAVING = false;
   static constexpr bool DEFAULT_LOOP_VECTORIZATION = false;
-  static constexpr bool DEFAULT_LOOP_UNROLLING = true;
+  static constexpr bool DEFAULT_LOOP_UNROLLING = false;
   static constexpr bool DEFAULT_SLP_VECTORIZATION = false;
   static constexpr llvm::FloatABI::ABIType DEFAULT_FLOAT_ABI =
       llvm::FloatABI::ABIType::Hard;


### PR DESCRIPTION
We've been discussing that for a long time and have been using that locally for benchmarking.

With LLVM loop unrolling, the reduction loop in the mmt4d ukernel gets 8x-partially unrolled and pipelined, a large code size increase for no observable performance benefit.