### PR TITLE
Fix tosa axis type in layernorm mlir comment

### DIFF
--- a/tests/e2e/regression/layernorm.mlir
+++ b/tests/e2e/regression/layernorm.mlir
@@ -6,12 +6,12 @@
 // func.func @layernorm() {
 //   %x = util.unfoldable_constant dense<5.0> : tensor<128x384xf32>
 //   %c384 = util.unfoldable_constant dense<384.0> : tensor<128x1xf32>
-//   %sum = tosa.reduce_sum %x {axis = 1 : i64} : (tensor<128x384xf32>) -> tensor<128x1xf32>
+//   %sum = tosa.reduce_sum %x {axis = 1 : i32} : (tensor<128x384xf32>) -> tensor<128x1xf32>
 //   %r384 = tosa.reciprocal %c384 : (tensor<128x1xf32>) -> tensor<128x1xf32>
 //   %mean = tosa.mul %sum, %r384 {shift = 0 : i8} : (tensor<128x1xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
 //   %x_sub_mean = tosa.sub %x, %mean : (tensor<128x384xf32>, tensor<128x1xf32>) -> tensor<128x384xf32>
 //   %square = tosa.mul %x_sub_mean, %x_sub_mean {shift = 0 : i8} : (tensor<128x384xf32>, tensor<128x384xf32>) -> tensor<128x384xf32>
-//   %square_sum = tosa.reduce_sum %square {axis = 1 : i64} : (tensor<128x384xf32>) -> tensor<128x1xf32>
+//   %square_sum = tosa.reduce_sum %square {axis = 1 : i32} : (tensor<128x384xf32>) -> tensor<128x1xf32>
 //   %variance = tosa.mul %square_sum, %r384 {shift = 0 : i8} : (tensor<128x1xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
 //   %epsilon = util.unfoldable_constant dense<9.99999996E-13> : tensor<128x1xf32>
 //   %var_eps = tosa.add %variance, %epsilon : (tensor<128x1xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>


### PR DESCRIPTION
The axis type in `tosa.reduce_sum` should be i32.