### PR TITLE
Unifying helpers for size/shape-aware dim lookup.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -192,11 +192,11 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
     unsigned mapArgOperandToOpOperand(unsigned i) { return i + getWorkload().size(); };
 
     ValueRange getOperandDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx - getWorkload().size(), getArguments(), getArgumentDims());
+      return IREE::Util::findDynamicDimsInList(idx - getWorkload().size(), getArguments(), getArgumentDims());
     }
 
     ValueRange getResultDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx, getResults(), getResultDims());
+      return IREE::Util::findDynamicDimsInList(idx, getResults(), getResultDims());
     }
 
     /// Returns the BlockArguments corresponding to the inputs in the type
@@ -844,10 +844,10 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
     bool isTransfer() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx - getWorkload().size(), getArguments(), getArgumentDims());
+      return IREE::Util::findDynamicDimsInList(idx - getWorkload().size(), getArguments(), getArgumentDims());
     }
     ValueRange getResultDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx, getResults(), getResultDims());
+      return IREE::Util::findDynamicDimsInList(idx, getResults(), getResultDims());
     }
   }];
 
@@ -1018,10 +1018,10 @@ def FLOW_CallOp : FLOW_Op<"call", [
     bool isTransfer() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx, getArguments(), getArgumentDims());
+      return IREE::Util::findDynamicDimsInList(idx, getArguments(), getArgumentDims());
     }
     ValueRange getResultDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx, getResults(), getResultDims());
+      return IREE::Util::findDynamicDimsInList(idx, getResults(), getResultDims());
     }
 
     /// Get the argument operands to the called function as a mutable range, this is

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -47,7 +47,7 @@ static void appendDynamicDims(OpBuilder &b, Location loc,
 /// Follow the reverse SSA use-def chain of the given value (always taking the
 /// tied operand) and return the first value outside of `regionOp`.
 static std::optional<Value>
-findFirstTiedValueOutsideOfRegionOp(Flow::DispatchRegionOp regionOp,
+findFirstTiedValueOutsideOfRegionOp(IREE::Flow::DispatchRegionOp regionOp,
                                     Value value) {
   // Check if `v` is defined outside of `regionOp`.
   auto isOutside = [&](Value v) {
@@ -80,9 +80,9 @@ findFirstTiedValueOutsideOfRegionOp(Flow::DispatchRegionOp regionOp,
 /// DispatchRegionOp is not isolated from above and may capture any SSA value
 /// that is in scope. The generated DispatchWorkgroupsOp captures all SSA values
 /// explicitly and makes them available inside the region via block arguments.
-FailureOr<Flow::DispatchWorkgroupsOp>
+FailureOr<IREE::Flow::DispatchWorkgroupsOp>
 rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
-    Flow::DispatchRegionOp regionOp, RewriterBase &rewriter) {
+    IREE::Flow::DispatchRegionOp regionOp, RewriterBase &rewriter) {
   Region &region = regionOp.getBody();
   // Currently this does not handle empty `flow.dispatch.region` ops.
   if (region.empty()) {
@@ -117,9 +117,10 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   DenseSet<Value> tiedArgumentsSet;
   SmallVector<int64_t> tiedArguments(numResults,
                                      IREE::Util::TiedOpInterface::kUntiedIndex);
-  SmallVector<Flow::ReturnOp> origTerminators;
-  region.walk(
-      [&](Flow::ReturnOp returnOp) { origTerminators.push_back(returnOp); });
+  SmallVector<IREE::Flow::ReturnOp> origTerminators;
+  region.walk([&](IREE::Flow::ReturnOp returnOp) {
+    origTerminators.push_back(returnOp);
+  });
   assert(!origTerminators.empty() && "expected at least one terminator");
 
   // The logic to find the tied arguments only works for single block regions.
@@ -191,7 +192,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
     }
     auto inputBbArg = workgroupsOp.getInputBlockArgument(it.index());
     auto dims =
-        Util::findVariadicDynamicDims(it.index(), arguments, argumentDims);
+        IREE::Util::findDynamicDimsInList(it.index(), arguments, argumentDims);
     assert(dims.size() == tensorType.getNumDynamicDims() &&
            "dynamic dims not found among arguments");
     SmallVector<Value> bbArgDims =
@@ -216,9 +217,9 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   }
 
   // Update terminator.
-  SmallVector<Flow::ReturnOp> terminators;
+  SmallVector<IREE::Flow::ReturnOp> terminators;
   newBody.walk(
-      [&](Flow::ReturnOp returnOp) { terminators.push_back(returnOp); });
+      [&](IREE::Flow::ReturnOp returnOp) { terminators.push_back(returnOp); });
   for (auto terminator : terminators) {
     rewriter.setInsertionPoint(terminator);
     for (const auto &it : llvm::enumerate(terminator->getOperands())) {
@@ -230,8 +231,8 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
       } else {
         // This assumes that the number of dynamic dims does not change when
         // following an SSA use-def chain of tied values.
-        dims = Util::findVariadicDynamicDims(tiedArguments[it.index()],
-                                             arguments, argumentDims);
+        dims = IREE::Util::findDynamicDimsInList(tiedArguments[it.index()],
+                                                 arguments, argumentDims);
       }
 #ifndef NDEBUG
       auto tensorType = it.value().getType().cast<RankedTensorType>();
@@ -257,15 +258,16 @@ namespace {
 struct ConvertRegionToWorkgroupsPass
     : public ConvertRegionToWorkgroupsBase<ConvertRegionToWorkgroupsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<Flow::FlowDialect, tensor::TensorDialect>();
+    registry.insert<IREE::Flow::FlowDialect, tensor::TensorDialect>();
   }
 
   void runOnOperation() override {
-    SmallVector<Flow::DispatchRegionOp> ops;
-    getOperation()->walk([&](Flow::DispatchRegionOp op) { ops.push_back(op); });
+    SmallVector<IREE::Flow::DispatchRegionOp> ops;
+    getOperation()->walk(
+        [&](IREE::Flow::DispatchRegionOp op) { ops.push_back(op); });
 
     IRRewriter rewriter(getOperation()->getContext());
-    for (Flow::DispatchRegionOp regionOp : ops) {
+    for (IREE::Flow::DispatchRegionOp regionOp : ops) {
       if (failed(rewriteFlowDispatchRegionToFlowDispatchWorkgroups(regionOp,
                                                                    rewriter))) {
         signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertToFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertToFlow.cpp
@@ -14,13 +14,12 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-using namespace mlir;
-using namespace mlir::iree_compiler;
-using namespace mlir::iree_compiler::IREE;
+namespace mlir::iree_compiler::IREE::Flow {
 
 namespace {
+
 // Pass to test conversion to flow patterns.
-struct ConvertToFlowPass : public Flow::ConvertToFlowBase<ConvertToFlowPass> {
+struct ConvertToFlowPass : public ConvertToFlowBase<ConvertToFlowPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, IREE::Flow::FlowDialect,
                     linalg::LinalgDialect, scf::SCFDialect,
@@ -30,8 +29,8 @@ struct ConvertToFlowPass : public Flow::ConvertToFlowBase<ConvertToFlowPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet convertToFlowPatterns(context);
-    Flow::populateTensorToFlowConversionPatterns(context,
-                                                 convertToFlowPatterns);
+    IREE::Flow::populateTensorToFlowConversionPatterns(context,
+                                                       convertToFlowPatterns);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(
         convertToFlowPatterns);
     if (failed(applyPatternsAndFoldGreedily(
@@ -40,8 +39,11 @@ struct ConvertToFlowPass : public Flow::ConvertToFlowBase<ConvertToFlowPass> {
     }
   }
 };
+
 } // namespace
 
-std::unique_ptr<Pass> Flow::createConvertToFlowPass() {
+std::unique_ptr<Pass> createConvertToFlowPass() {
   return std::make_unique<ConvertToFlowPass>();
 }
+
+} // namespace mlir::iree_compiler::IREE::Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -29,6 +29,8 @@
 #include "mlir/Transforms/RegionUtils.h"
 #include "mlir/Transforms/TopologicalSortUtils.h"
 
+#define DEBUG_TYPE "iree-flow-region-op-utils"
+
 // NOTE: These flags are added for experimental purposes only
 // for developer control. These should be treated as internal
 // compiler implementation details.
@@ -38,11 +40,7 @@ static llvm::cl::opt<int> clInlineConstantByteLength(
                    "into a dispatch region or 0 to disable inlining."),
     llvm::cl::init(256));
 
-using namespace mlir;
-using namespace mlir::iree_compiler;
-using namespace mlir::iree_compiler::IREE;
-
-#define DEBUG_TYPE "iree-flow-region-op-utils"
+namespace mlir::iree_compiler::IREE::Flow {
 
 //===----------------------------------------------------------------------===//
 // Methods for getting the workload information for dispatch region creation.
@@ -86,8 +84,8 @@ getLoopRangesImpl(ReifyRankedShapedTypeOpInterface shapedOp, Location loc,
 }
 
 /// For a given operation returns the loop ranges needed to compute the op.
-SmallVector<Range> Flow::getLoopRanges(Operation *op, Location loc,
-                                       OpBuilder &builder) {
+SmallVector<Range> getLoopRanges(Operation *op, Location loc,
+                                 OpBuilder &builder) {
   return llvm::TypeSwitch<Operation *, SmallVector<Range>>(op)
       .Case<LinalgExt::SetEncodingOp, LinalgExt::UnsetEncodingOp,
             tensor::InsertSliceOp>([&](auto op) {
@@ -106,19 +104,20 @@ SmallVector<Range> Flow::getLoopRanges(Operation *op, Location loc,
 
 /// Return `true` if an operation is within a `flow.dispatch.region` or
 /// `flow.dispatch.workgroups` op.
-bool Flow::isNonNullAndOutsideDispatch(Operation *op) {
+bool isNonNullAndOutsideDispatch(Operation *op) {
   if (!op)
     return false;
   Operation *parentOp = op->getParentOp();
   while (parentOp) {
-    if (isa<Flow::DispatchRegionOp, Flow::DispatchWorkgroupsOp>(parentOp)) {
+    if (isa<IREE::Flow::DispatchRegionOp, IREE::Flow::DispatchWorkgroupsOp>(
+            parentOp)) {
       return false;
     }
     parentOp = parentOp->getParentOp();
   }
   return true;
 }
-bool Flow::isNonNullAndOutsideDispatch(ArrayRef<Operation *> operations) {
+bool isNonNullAndOutsideDispatch(ArrayRef<Operation *> operations) {
   return llvm::all_of(operations, [](Operation *op) {
     return isNonNullAndOutsideDispatch(op);
   });
@@ -130,7 +129,8 @@ static SmallVector<Value> getWorkloadForRootOp(OpBuilder &builder,
   // Compute workgroup count to use for the dispatch op. These are the ranges
   // of the outermost parallel loops that can be distributed.
   Location loc = rootOp->getLoc();
-  SmallVector<Range> loopRanges = Flow::getLoopRanges(rootOp, loc, builder);
+  SmallVector<Range> loopRanges =
+      IREE::Flow::getLoopRanges(rootOp, loc, builder);
   AffineExpr s0, s1, s2;
   bindSymbols(builder.getContext(), s0, s1, s2);
   AffineMap workload = AffineMap::get(0, 3, (s1 - s0).ceilDiv(s2));
@@ -196,7 +196,7 @@ static bool checkShapeIsDataDependant(Operation *op) {
 /// These is the legacy path for workgroup count calculation that
 /// arent handled by the current default.
 static void createWorkgroupCountFromDagRootRegion(
-    RewriterBase &rewriter, Flow::DispatchRegionOp &regionOp,
+    RewriterBase &rewriter, IREE::Flow::DispatchRegionOp &regionOp,
     TypeRange workloadTypes, ArrayRef<Location> workloadLocs) {
   Region &countRegion = regionOp.getWorkgroupCount();
   if (!countRegion.empty())
@@ -208,8 +208,9 @@ static void createWorkgroupCountFromDagRootRegion(
   rewriter.setInsertionPointToStart(body);
   Location loc = regionOp.getLoc();
   auto countOp =
-      rewriter.create<Flow::DispatchWorkgroupCountFromDagRootOp>(loc, args);
-  rewriter.create<Flow::ReturnOp>(loc, countOp->getResults());
+      rewriter.create<IREE::Flow::DispatchWorkgroupCountFromDagRootOp>(loc,
+                                                                       args);
+  rewriter.create<IREE::Flow::ReturnOp>(loc, countOp->getResults());
 }
 
 /// Return `true` if the given type is a ShapedType and has at least one
@@ -222,8 +223,8 @@ static bool hasDynamicShape(Type t) {
 }
 
 /// Reify the dynamic dimensions of the given value.
-LogicalResult Flow::reifyDynamicResultDims(OpBuilder &b, Value value,
-                                           SmallVector<Value> &dynamicDims) {
+LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
+                                     SmallVector<Value> &dynamicDims) {
   OpBuilder::InsertionGuard guard(b);
 
   // Case 1: No dynamic result dims.
@@ -292,8 +293,8 @@ LogicalResult Flow::reifyDynamicResultDims(OpBuilder &b, Value value,
 
 // Append a result to the given DispatchRegionOp. The newly created
 // DispatchRegionOp is returned.
-FailureOr<Flow::DispatchRegionOp> Flow::appendDispatchRegionResults(
-    RewriterBase &rewriter, Flow::DispatchRegionOp regionOp,
+FailureOr<IREE::Flow::DispatchRegionOp> appendDispatchRegionResults(
+    RewriterBase &rewriter, IREE::Flow::DispatchRegionOp regionOp,
     ArrayRef<Value> results, ArrayRef<SmallVector<Value>> dynamicDims) {
   if (results.empty()) {
     return regionOp;
@@ -309,7 +310,7 @@ FailureOr<Flow::DispatchRegionOp> Flow::appendDispatchRegionResults(
 
   // Collect the current dispatch yielded values.
   auto returnOp =
-      cast<Flow::ReturnOp>(regionOp.getBody().front().getTerminator());
+      cast<IREE::Flow::ReturnOp>(regionOp.getBody().front().getTerminator());
   SmallVector<Value> returnedValues(returnOp.getOperands().begin(),
                                     returnOp.getOperands().end());
 
@@ -328,7 +329,7 @@ FailureOr<Flow::DispatchRegionOp> Flow::appendDispatchRegionResults(
   rewriter.setInsertionPoint(regionOp);
 
   // Create new DispatchRegionOp and move over the body.
-  auto newRegionOp = rewriter.create<Flow::DispatchRegionOp>(
+  auto newRegionOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
       regionOp->getLoc(), resultTypes, regionDynamicDims,
       regionOp.getWorkload());
   rewriter.inlineRegionBefore(regionOp.getBody(), newRegionOp.getBody(),
@@ -338,34 +339,32 @@ FailureOr<Flow::DispatchRegionOp> Flow::appendDispatchRegionResults(
 
   // Update terminator.
   auto newRegionReturnOp =
-      cast<Flow::ReturnOp>(newRegionOp.getBody().front().getTerminator());
+      cast<IREE::Flow::ReturnOp>(newRegionOp.getBody().front().getTerminator());
   rewriter.setInsertionPoint(newRegionReturnOp);
-  rewriter.replaceOpWithNewOp<Flow::ReturnOp>(newRegionReturnOp,
-                                              returnedValues);
+  rewriter.replaceOpWithNewOp<IREE::Flow::ReturnOp>(newRegionReturnOp,
+                                                    returnedValues);
 
   return newRegionOp;
 }
 
-Flow::DispatchRegionOp Flow::makeEmptyDispatchRegion(OpBuilder &builder,
-                                                     Location loc,
-                                                     ValueRange workload) {
+IREE::Flow::DispatchRegionOp
+makeEmptyDispatchRegion(OpBuilder &builder, Location loc, ValueRange workload) {
   OpBuilder::InsertionGuard guard(builder);
 
   // Create RegionOp.
-  auto regionOp = builder.create<Flow::DispatchRegionOp>(
+  auto regionOp = builder.create<IREE::Flow::DispatchRegionOp>(
       loc, /*resultTypes=*/TypeRange(), /*dynamicDims=*/ValueRange(), workload);
   Block &body = regionOp.getBody().emplaceBlock();
   builder.setInsertionPointToStart(&body);
-  builder.create<Flow::ReturnOp>(loc, ValueRange());
+  builder.create<IREE::Flow::ReturnOp>(loc, ValueRange());
   return regionOp;
 }
 
 // Clone a `target` op that is preceding the given dispatch region op into the
 // dispatch region.
 FailureOr<Operation *>
-Flow::clonePrecedingOpIntoDispatchRegion(RewriterBase &rewriter,
-                                         Operation *target,
-                                         Flow::DispatchRegionOp regionOp) {
+clonePrecedingOpIntoDispatchRegion(RewriterBase &rewriter, Operation *target,
+                                   IREE::Flow::DispatchRegionOp regionOp) {
   Block &body = regionOp.getBody().front();
 
   // Gather all uses of `target`.
@@ -403,10 +402,10 @@ Flow::clonePrecedingOpIntoDispatchRegion(RewriterBase &rewriter,
 
 // Move a `target` op that is preceding the given dispatch region op into the
 // dispatch region.
-FailureOr<Flow::DispatchRegionOp>
-Flow::movePrecedingOpsIntoDispatchRegion(RewriterBase &rewriter,
-                                         ArrayRef<Operation *> targets,
-                                         Flow::DispatchRegionOp regionOp) {
+FailureOr<IREE::Flow::DispatchRegionOp>
+movePrecedingOpsIntoDispatchRegion(RewriterBase &rewriter,
+                                   ArrayRef<Operation *> targets,
+                                   IREE::Flow::DispatchRegionOp regionOp) {
   // Values replaced by moving the `targets` into the dispatch region.
   SmallVector<Value> replacedValues;
 
@@ -455,8 +454,9 @@ Flow::movePrecedingOpsIntoDispatchRegion(RewriterBase &rewriter,
     rewriter.replaceOpWithinBlock(target, clonedTarget->getResults(), &body);
   }
 
-  FailureOr<Flow::DispatchRegionOp> newRegionOp = appendDispatchRegionResults(
-      rewriter, regionOp, yieldedResults, dispatchOpNewResultsDynamicDims);
+  FailureOr<IREE::Flow::DispatchRegionOp> newRegionOp =
+      appendDispatchRegionResults(rewriter, regionOp, yieldedResults,
+                                  dispatchOpNewResultsDynamicDims);
 
   if (failed(newRegionOp)) {
     return regionOp->emitOpError("failed to append results to op");
@@ -473,8 +473,8 @@ Flow::movePrecedingOpsIntoDispatchRegion(RewriterBase &rewriter,
   return newRegionOp.value();
 }
 
-FailureOr<Flow::DispatchRegionOp>
-Flow::wrapOpInDispatchRegion(RewriterBase &rewriter, Operation *op) {
+FailureOr<IREE::Flow::DispatchRegionOp>
+wrapOpInDispatchRegion(RewriterBase &rewriter, Operation *op) {
   OpBuilder::InsertionGuard g(rewriter);
 
   SmallVector<Value> workload;
@@ -485,8 +485,8 @@ Flow::wrapOpInDispatchRegion(RewriterBase &rewriter, Operation *op) {
   }
 
   rewriter.setInsertionPointAfter(op);
-  Flow::DispatchRegionOp regionOp =
-      Flow::makeEmptyDispatchRegion(rewriter, op->getLoc(), workload);
+  IREE::Flow::DispatchRegionOp regionOp =
+      IREE::Flow::makeEmptyDispatchRegion(rewriter, op->getLoc(), workload);
 
   // Move the op into the dispatch region.
   auto newRegionOp = movePrecedingOpsIntoDispatchRegion(rewriter, op, regionOp);
@@ -504,7 +504,7 @@ Flow::wrapOpInDispatchRegion(RewriterBase &rewriter, Operation *op) {
   return newRegionOp;
 }
 
-bool Flow::isDequantizationLikeOp(Operation *op) {
+bool isDequantizationLikeOp(Operation *op) {
   auto genericOp = dyn_cast<linalg::GenericOp>(op);
   if (!genericOp) {
     return false;
@@ -574,7 +574,7 @@ bool Flow::isDequantizationLikeOp(Operation *op) {
 
 /// Operations that are cloned into dispatch regions formed with other
 /// operations as roots.
-bool Flow::isClonableIntoDispatchOp(Operation *op) {
+bool isClonableIntoDispatchOp(Operation *op) {
   // TODO(#8637): `tensor.collapse_shape` and `tensor.expand_shape` are
   // trivially clonable too, but they cause problems
   // with bufferization. Make them clonable when fixed.
@@ -645,7 +645,7 @@ static bool hasUnfusableUseInDispatch(Value v, Operation *dispatchOp) {
 }
 
 SmallVector<Operation *>
-Flow::getCloneableOps(Flow::DispatchRegionOp regionOp) {
+getCloneableOps(IREE::Flow::DispatchRegionOp regionOp) {
   // Find values that are used inside of the dispatch region but defined outside
   // of the dispatch region.
   llvm::SetVector<Value> valuesDefinedAbove;
@@ -667,7 +667,7 @@ Flow::getCloneableOps(Flow::DispatchRegionOp regionOp) {
     visited.insert(outsideValue);
 
     Operation *definingOp = outsideValue.getDefiningOp();
-    if (!definingOp || !Flow::isClonableIntoDispatchOp(definingOp) ||
+    if (!definingOp || !IREE::Flow::isClonableIntoDispatchOp(definingOp) ||
         hasUnfusableUseInDispatch(outsideValue, regionOp)) {
       valuesDefinedAbove.insert(outsideValue);
       continue;
@@ -683,8 +683,8 @@ Flow::getCloneableOps(Flow::DispatchRegionOp regionOp) {
 }
 
 /// Clone producers into the dispatch region.
-LogicalResult Flow::cloneProducersToRegion(RewriterBase &rewriter,
-                                           Flow::DispatchRegionOp regionOp) {
+LogicalResult cloneProducersToRegion(RewriterBase &rewriter,
+                                     IREE::Flow::DispatchRegionOp regionOp) {
   SmallVector<Operation *> cloneableOps = getCloneableOps(regionOp);
   bool sortResult = mlir::computeTopologicalSorting(cloneableOps);
   (void)sortResult;
@@ -699,3 +699,5 @@ LogicalResult Flow::cloneProducersToRegion(RewriterBase &rewriter,
 
   return success();
 }
+
+} // namespace mlir::iree_compiler::IREE::Flow

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -420,10 +420,10 @@ def HAL_DispatchExternOp : HAL_PureOp<"dispatch.extern", [
     unsigned mapArgOperandToOpOperand(unsigned i) { return i + getWorkload().size(); };
 
     ValueRange getOperandDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx - getWorkload().size(), getArguments(), getArgumentDims());
+      return IREE::Util::findDynamicDimsInList(idx - getWorkload().size(), getArguments(), getArgumentDims());
     }
     ValueRange getResultDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx, getResults(), getResultDims());
+      return IREE::Util::findDynamicDimsInList(idx, getResults(), getResultDims());
     }
 
     IREE::HAL::ExecutableObjectsAttr getObjectsAttr() {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2448,10 +2448,10 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
     }
 
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+      return IREE::Util::findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
     }
     Value getResultSize(unsigned idx) {
-      return findValueSizeInList(idx, getResults(), getResultSizes());
+      return IREE::Util::findValueSizeInList(idx, getResults(), getResultSizes());
     }
   }];
 
@@ -2631,10 +2631,10 @@ def Stream_AsyncCallOp : Stream_Op<"async.call", [
     }
 
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+      return IREE::Util::findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
     }
     Value getResultSize(unsigned idx) {
-      return findValueSizeInList(idx, getResults(), getResultSizes());
+      return IREE::Util::findValueSizeInList(idx, getResults(), getResultSizes());
     }
 
     /// Get the argument operands to the called function as a mutable range, this is
@@ -2725,10 +2725,10 @@ def Stream_AsyncExecuteOp : Stream_Op<"async.execute", [
 
   let extraClassDeclaration = [{
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+      return IREE::Util::findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
     }
     Value getResultSize(unsigned idx) {
-      return findValueSizeInList(idx, getResults(), getResultSizes());
+      return IREE::Util::findValueSizeInList(idx, getResults(), getResultSizes());
     }
     SmallVector<Value> getAwaitTimepoints() {
       if (getAwaitTimepoint()) return {getAwaitTimepoint()}; else return {};
@@ -2840,10 +2840,10 @@ def Stream_AsyncConcurrentOp : Stream_Op<"async.concurrent", [
 
   let extraClassDeclaration = [{
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+      return IREE::Util::findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
     }
     Value getResultSize(unsigned idx) {
-      return findValueSizeInList(idx, getResults(), getResultSizes());
+      return IREE::Util::findValueSizeInList(idx, getResults(), getResultSizes());
     }
   }];
 
@@ -3104,7 +3104,7 @@ def Stream_CmdCollectiveOp : Stream_Op<"cmd.collective", [
 
   let extraClassDeclaration = [{
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(
+      return IREE::Util::findValueSizeInList(
           idx - getODSOperandIndexAndLength(4).first,
           getResources(), getResourceSizes());
     }
@@ -3163,7 +3163,7 @@ def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
     }
 
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(
+      return IREE::Util::findValueSizeInList(
           idx - getODSOperandIndexAndLength(2).first,
           getResources(), getResourceSizes());
     }
@@ -3311,7 +3311,7 @@ def Stream_CmdCallOp : Stream_Op<"cmd.call", [
     }
 
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+      return IREE::Util::findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
     }
     Value getResultSize(unsigned idx) { return {}; }
 
@@ -3388,7 +3388,7 @@ def Stream_CmdExecuteOp : Stream_Op<"cmd.execute", [
 
   let extraClassDeclaration = [{
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+      return IREE::Util::findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
     }
     Value getResultSize(unsigned idx) {
       return {};
@@ -3791,7 +3791,7 @@ def Stream_TimepointAwaitOp : Stream_PureOp<"timepoint.await", [
     (`on` `(` $affinity^ `)`)?
     $await_timepoint `=` `` `>`
     $resource_operands `:`
-    custom<SizeAwareTypeList>(type($resource_operands),
+    custom<ShapedTypeList>(type($resource_operands),
                               type($results), $resource_operand_sizes)
     attr-dict-with-keyword
   }];
@@ -4270,7 +4270,7 @@ def Stream_YieldOp : Stream_Op<"yield", [
   let assemblyFormat = [{
     attr-dict
     ($resource_operands^ `:`
-        custom<SizeAwareTypeList>(type($resource_operands),
+        custom<ShapedTypeList>(type($resource_operands),
                                   $resource_operand_sizes))?
   }];
 
@@ -4283,7 +4283,7 @@ def Stream_YieldOp : Stream_Op<"yield", [
 
   let extraClassDeclaration = [{
     Value getOperandSize(unsigned idx) {
-      return findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
+      return IREE::Util::findValueSizeInList(idx, getOperands(), getResourceOperandSizes());
     }
     Value getResultSize(unsigned idx) { return {}; }
   }];

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -66,15 +66,6 @@ ArrayAttr deduplicateArrayElements(ArrayAttr arrayAttr) {
   return ArrayAttr::get(arrayAttr.getContext(), attrsSet.takeVector());
 }
 
-Value findValueSizeInList(unsigned index, ValueRange values, ValueRange sizes) {
-  assert(values[index].getType().isa<IREE::Util::SizeAwareTypeInterface>() &&
-         "must be a size-aware type to get dims");
-  unsigned sizeIndex = llvm::count_if(values.take_front(index), [](auto value) {
-    return isa<IREE::Util::SizeAwareTypeInterface>(value.getType());
-  });
-  return sizes[sizeIndex];
-}
-
 //===----------------------------------------------------------------------===//
 // custom<SymbolVisibility>($sym_visibility)
 //===----------------------------------------------------------------------===//
@@ -119,7 +110,7 @@ ParseResult parseTypeOrAttr(OpAsmParser &parser, TypeAttr &typeAttr,
              << "expected attribute";
     }
 
-    if (auto typedAttr = llvm::dyn_cast<TypedAttr>(attr)) {
+    if (auto typedAttr = dyn_cast<TypedAttr>(attr)) {
       typeAttr = TypeAttr::get(typedAttr.getType());
     }
     return success();
@@ -144,7 +135,7 @@ ParseResult parseTypeOrAttr(OpAsmParser &parser, TypeAttr &typeAttr,
 void printTypeOrAttr(OpAsmPrinter &p, Operation *op, TypeAttr type,
                      Attribute attr) {
   bool needsSpace = false;
-  auto typedAttr = llvm::dyn_cast_if_present<TypedAttr>(attr);
+  auto typedAttr = dyn_cast_if_present<TypedAttr>(attr);
   if (!typedAttr || typedAttr.getType() != type.getValue()) {
     p << ": ";
     p.printAttribute(type);
@@ -298,56 +289,80 @@ void printSizeAwareType(OpAsmPrinter &p, Operation *op, Type type, Value size) {
 }
 
 //===----------------------------------------------------------------------===//
-// custom<SizeAwareTypeList>
+// custom<ShapedTypeList>
 //===----------------------------------------------------------------------===//
 // type{%size0}, type, type{%size1}
 
 ParseResult
-parseSizeAwareTypeList(OpAsmParser &parser, SmallVectorImpl<Type> &types,
-                       SmallVectorImpl<OpAsmParser::UnresolvedOperand> &sizes) {
+parseShapedTypeList(OpAsmParser &parser, SmallVectorImpl<Type> &types,
+                    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &dims) {
   do {
     Type type;
     if (failed(parser.parseType(type)))
       return failure();
-    if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(type)) {
+    if (auto shapedType = dyn_cast<ShapedType>(type)) {
+      if (!shapedType.hasStaticShape()) {
+        SmallVector<OpAsmParser::UnresolvedOperand> dynamicDims;
+        if (failed(parser.parseLBrace()) ||
+            failed(parser.parseOperandList(dynamicDims,
+                                           shapedType.getNumDynamicDims(),
+                                           OpAsmParser::Delimiter::None)) ||
+            failed(parser.parseRBrace())) {
+          return failure();
+        }
+        dims.append(dynamicDims);
+      }
+    } else if (isa<IREE::Util::SizeAwareTypeInterface>(type)) {
       OpAsmParser::UnresolvedOperand size;
       if (failed(parser.parseLBrace()) || failed(parser.parseOperand(size)) ||
           failed(parser.parseRBrace())) {
         return failure();
       }
-      sizes.push_back(size);
+      dims.push_back(size);
     }
     types.push_back(type);
   } while (succeeded(parser.parseOptionalComma()));
   return success();
 }
 
-void printSizeAwareTypeList(OpAsmPrinter &p, Operation *op, TypeRange types,
-                            OperandRange sizes) {
-  int sizeIndex = 0;
+void printShapedTypeList(OpAsmPrinter &p, Operation *op, TypeRange types,
+                         ValueRange dims) {
   llvm::interleaveComma(types, p, [&](Type type) {
     p.printType(type);
-    if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(type)) {
+    if (auto shapedType = dyn_cast<ShapedType>(type)) {
+      if (!shapedType.hasStaticShape()) {
+        if (dims.empty()) {
+          p << "{<<INVALID>>}";
+          return;
+        }
+        p << "{";
+        llvm::interleaveComma(dims.take_front(shapedType.getNumDynamicDims()),
+                              p, [&](Value value) { p.printOperand(value); });
+        p << "}";
+        dims = dims.drop_front(shapedType.getNumDynamicDims());
+      }
+    } else if (isa<IREE::Util::SizeAwareTypeInterface>(type)) {
       p << "{";
-      p.printOperand(sizes[sizeIndex++]);
+      p.printOperand(dims.front());
       p << "}";
+      dims = dims.drop_front(1);
     }
   });
 }
 
 ParseResult
-parseSizeAwareTypeList(OpAsmParser &parser, SmallVectorImpl<Type> &types0,
-                       SmallVectorImpl<Type> &types1,
-                       SmallVectorImpl<OpAsmParser::UnresolvedOperand> &sizes) {
-  if (failed(parseSizeAwareTypeList(parser, types0, sizes)))
+parseShapedTypeList(OpAsmParser &parser, SmallVectorImpl<Type> &types0,
+                    SmallVectorImpl<Type> &types1,
+                    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &dims) {
+  if (failed(parseShapedTypeList(parser, types0, dims)))
     return failure();
   types1 = types0;
   return success();
 }
 
-void printSizeAwareTypeList(OpAsmPrinter &p, Operation *op, TypeRange types0,
-                            TypeRange types1, OperandRange sizes) {
-  printSizeAwareTypeList(p, op, types0, sizes);
+void printShapedTypeList(OpAsmPrinter &p, Operation *op, TypeRange types0,
+                         TypeRange types1, ValueRange dims) {
+  printShapedTypeList(p, op, types0, dims);
 }
 
 //===----------------------------------------------------------------------===//
@@ -377,7 +392,7 @@ ParseResult parseShapedTiedResult(
   }
   if (failed(parser.parseType(resultType)))
     return failure();
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(resultType)) {
+  if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
     if (!shapedType.hasStaticShape()) {
       SmallVector<OpAsmParser::UnresolvedOperand> dynamicDims;
       if (failed(parser.parseLBrace()) ||
@@ -390,8 +405,7 @@ ParseResult parseShapedTiedResult(
       resultDims.append(dynamicDims);
     }
   } else if (auto sizedType =
-                 llvm::dyn_cast<IREE::Util::SizeAwareTypeInterface>(
-                     resultType)) {
+                 dyn_cast<IREE::Util::SizeAwareTypeInterface>(resultType)) {
     OpAsmParser::UnresolvedOperand size;
     if (failed(parser.parseLBrace()) || failed(parser.parseOperand(size)) ||
         failed(parser.parseRBrace())) {
@@ -413,7 +427,7 @@ void printShapedTiedResult(OpAsmPrinter &p, Operation *op, Type resultType,
     p << " as ";
   }
   p.printType(resultType);
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(resultType)) {
+  if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
     if (!shapedType.hasStaticShape()) {
       if (resultDims.empty()) {
         p << "{<<INVALID>>}";
@@ -427,8 +441,7 @@ void printShapedTiedResult(OpAsmPrinter &p, Operation *op, Type resultType,
       resultDims = resultDims.drop_front(shapedType.getNumDynamicDims());
     }
   } else if (auto sizedType =
-                 llvm::dyn_cast<IREE::Util::SizeAwareTypeInterface>(
-                     resultType)) {
+                 dyn_cast<IREE::Util::SizeAwareTypeInterface>(resultType)) {
     p << "{";
     p.printOperand(resultDims.front());
     p << "}";
@@ -442,42 +455,9 @@ void printShapedTiedResult(OpAsmPrinter &p, Operation *op, Type resultType,
 }
 
 //===----------------------------------------------------------------------===//
-// custom<ShapedFunctionType>
+// custom<ShapedResultList>
 //===----------------------------------------------------------------------===//
-// (type, type{%dim0, %dim1}, type) -> (type{%dim2}, %operand4)
-
-static ParseResult
-parseShapedOperandList(OpAsmParser &parser, SmallVectorImpl<Type> &types,
-                       SmallVectorImpl<OpAsmParser::UnresolvedOperand> &dims) {
-  do {
-    Type type;
-    if (failed(parser.parseType(type)))
-      return failure();
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
-      if (!shapedType.hasStaticShape()) {
-        SmallVector<OpAsmParser::UnresolvedOperand> dynamicDims;
-        if (failed(parser.parseLBrace()) ||
-            failed(parser.parseOperandList(dynamicDims,
-                                           shapedType.getNumDynamicDims(),
-                                           OpAsmParser::Delimiter::None)) ||
-            failed(parser.parseRBrace())) {
-          return failure();
-        }
-        dims.append(dynamicDims);
-      }
-    } else if (auto sizedType =
-                   llvm::dyn_cast<IREE::Util::SizeAwareTypeInterface>(type)) {
-      OpAsmParser::UnresolvedOperand size;
-      if (failed(parser.parseLBrace()) || failed(parser.parseOperand(size)) ||
-          failed(parser.parseRBrace())) {
-        return failure();
-      }
-      dims.push_back(size);
-    }
-    types.push_back(type);
-  } while (succeeded(parser.parseOptionalComma()));
-  return success();
-}
+// type{%dim2}, %operand4
 
 // Finds the operand index in |operands| that |tiedResult| references.
 // Returns TiedOpInterface::kUntiedIndex if no operand is found.
@@ -526,7 +506,7 @@ ParseResult parseShapedResultList(
     } else if (failed(parser.parseType(type))) {
       return failure();
     }
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
+    if (auto shapedType = dyn_cast<ShapedType>(type)) {
       if (!shapedType.hasStaticShape()) {
         SmallVector<OpAsmParser::UnresolvedOperand> dynamicDims;
         if (failed(parser.parseLBrace()) ||
@@ -539,7 +519,7 @@ ParseResult parseShapedResultList(
         resultDims.append(dynamicDims);
       }
     } else if (auto sizedType =
-                   llvm::dyn_cast<IREE::Util::SizeAwareTypeInterface>(type)) {
+                   dyn_cast<IREE::Util::SizeAwareTypeInterface>(type)) {
       OpAsmParser::UnresolvedOperand size;
       if (failed(parser.parseLBrace()) || failed(parser.parseOperand(size)) ||
           failed(parser.parseRBrace())) {
@@ -579,7 +559,7 @@ void printShapedResultList(OpAsmPrinter &p, Operation *op, ValueRange operands,
     if (printType) {
       p.printType(resultType);
     }
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(resultType)) {
+    if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
       if (!shapedType.hasStaticShape()) {
         if (resultDims.empty()) {
           p << "{<<INVALID>>}";
@@ -593,8 +573,7 @@ void printShapedResultList(OpAsmPrinter &p, Operation *op, ValueRange operands,
         resultDims = resultDims.drop_front(shapedType.getNumDynamicDims());
       }
     } else if (auto sizedType =
-                   llvm::dyn_cast<IREE::Util::SizeAwareTypeInterface>(
-                       resultType)) {
+                   dyn_cast<IREE::Util::SizeAwareTypeInterface>(resultType)) {
       p << "{";
       p.printOperand(resultDims.front());
       p << "}";
@@ -604,6 +583,11 @@ void printShapedResultList(OpAsmPrinter &p, Operation *op, ValueRange operands,
       p << ", ";
   }
 }
+
+//===----------------------------------------------------------------------===//
+// custom<ShapedFunctionType>
+//===----------------------------------------------------------------------===//
+// (type, type{%dim0, %dim1}, type) -> (type{%dim2}, %operand4)
 
 ParseResult parseShapedFunctionType(
     OpAsmParser &parser, ArrayRef<OpAsmParser::UnresolvedOperand> operands,
@@ -615,7 +599,7 @@ ParseResult parseShapedFunctionType(
   if (failed(parser.parseLParen()))
     return failure();
   if (failed(parser.parseOptionalRParen())) {
-    if (failed(parseShapedOperandList(parser, operandTypes, operandDims)) ||
+    if (failed(parseShapedTypeList(parser, operandTypes, operandDims)) ||
         failed(parser.parseRParen())) {
       return failure();
     }
@@ -650,29 +634,7 @@ void printShapedFunctionType(OpAsmPrinter &p, Operation *op,
                              OperandRange operandDims, TypeRange resultTypes,
                              OperandRange resultDims, ArrayAttr tiedOperands) {
   p << "(";
-  llvm::interleaveComma(operandTypes, p, [&](Type type) {
-    p.printType(type);
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
-      if (!shapedType.hasStaticShape()) {
-        if (operandDims.empty()) {
-          p << "{<<INVALID>>}";
-          return;
-        }
-        p << "{";
-        llvm::interleaveComma(
-            operandDims.take_front(shapedType.getNumDynamicDims()), p,
-            [&](Value value) { p.printOperand(value); });
-        p << "}";
-        operandDims = operandDims.drop_front(shapedType.getNumDynamicDims());
-      }
-    } else if (auto sizedType =
-                   llvm::dyn_cast<IREE::Util::SizeAwareTypeInterface>(type)) {
-      p << "{";
-      p.printOperand(operandDims.front());
-      p << "}";
-      operandDims = operandDims.drop_front(1);
-    }
-  });
+  printShapedTypeList(p, op, operandTypes, operandDims);
   p << ") -> ";
   if (resultTypes.size() != 1)
     p << "(";
@@ -780,7 +742,7 @@ static void printShapedFunctionResultList(OpAsmPrinter &p, Operation *op,
     }
     if (resultAttrs) {
       auto attrs =
-          llvm::dyn_cast_if_present<DictionaryAttr>(resultAttrs.getValue()[i]);
+          dyn_cast_if_present<DictionaryAttr>(resultAttrs.getValue()[i]);
       if (attrs && !attrs.empty()) {
         p.printOptionalAttrDict(attrs.getValue());
       }
@@ -832,7 +794,7 @@ void printShapedFunctionSignature(OpAsmPrinter &p, Operation *op,
                                   TypeAttr functionTypeAttr,
                                   ArrayAttr tiedOperands, ArrayAttr argAttrs,
                                   ArrayAttr resultAttrs) {
-  auto functionType = llvm::cast<FunctionType>(functionTypeAttr.getValue());
+  auto functionType = cast<FunctionType>(functionTypeAttr.getValue());
   p << "(";
   int argIndex = 0;
   llvm::interleaveComma(functionType.getInputs(), p, [&](auto type) {
@@ -841,8 +803,8 @@ void printShapedFunctionSignature(OpAsmPrinter &p, Operation *op,
     p << ": ";
     p.printType(type);
     if (argAttrs) {
-      auto attrs = llvm::dyn_cast_if_present<DictionaryAttr>(
-          argAttrs.getValue()[argIndex]);
+      auto attrs =
+          dyn_cast_if_present<DictionaryAttr>(argAttrs.getValue()[argIndex]);
       if (attrs && !attrs.empty()) {
         p.printOptionalAttrDict(attrs.getValue());
       }
@@ -913,8 +875,8 @@ ParseResult UnfoldableConstantOp::parse(OpAsmParser &parser,
 
   // If the attribute is a symbol reference, then we expect a trailing type.
   Type type;
-  if (!llvm::isa<SymbolRefAttr>(valueAttr))
-    type = llvm::cast<TypedAttr>(valueAttr).getType();
+  if (!isa<SymbolRefAttr>(valueAttr))
+    type = cast<TypedAttr>(valueAttr).getType();
   else if (parser.parseColonType(type))
     return failure();
 
@@ -932,7 +894,7 @@ void UnfoldableConstantOp::print(OpAsmPrinter &p) {
   p << getValue();
 
   // If the value is a symbol reference, print a trailing type.
-  if (llvm::isa<SymbolRefAttr>(getValue()))
+  if (isa<SymbolRefAttr>(getValue()))
     p << " : " << getType();
 }
 
@@ -948,8 +910,7 @@ bool CastOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
     // Both types are the same.
     return true;
   }
-  if (llvm::isa<IREE::Util::ObjectType>(a) ||
-      llvm::isa<IREE::Util::ObjectType>(b)) {
+  if (isa<IREE::Util::ObjectType>(a) || isa<IREE::Util::ObjectType>(b)) {
     // Either type is an opaque object.
     return true;
   }
@@ -1063,11 +1024,11 @@ Block *InitializerOp::addBlock() {
 static bool isGlobalTypeCompatible(Type globalType, Type accessType) {
   // If one is a shaped type, then they both must be and have compatible
   // shapes.
-  if (llvm::isa<ShapedType>(globalType) && llvm::isa<ShapedType>(accessType)) {
+  if (isa<ShapedType>(globalType) && isa<ShapedType>(accessType)) {
     return succeeded(mlir::verifyCompatibleShape(globalType, accessType));
   }
 
-  if (auto knownType = llvm::dyn_cast<GlobalTypeInterface>(globalType)) {
+  if (auto knownType = dyn_cast<GlobalTypeInterface>(globalType)) {
     return knownType.isAccessStorageCompatible(accessType);
   }
 
@@ -1130,7 +1091,7 @@ void GlobalLoadOp::getEffects(
 LogicalResult GlobalLoadIndirectOp::verify() {
   Operation *op = getOperation();
   auto globalType =
-      llvm::cast<IREE::Util::PtrType>(getGlobal().getType()).getTargetType();
+      cast<IREE::Util::PtrType>(getGlobal().getType()).getTargetType();
   auto loadType = getResult().getType();
   if (!isGlobalTypeCompatible(globalType, loadType)) {
     return op->emitOpError() << "global type mismatch; global pointer is "
@@ -1150,7 +1111,7 @@ void GlobalStoreOp::build(OpBuilder &builder, OperationState &state,
 LogicalResult GlobalStoreIndirectOp::verify() {
   Operation *op = getOperation();
   auto globalType =
-      llvm::cast<IREE::Util::PtrType>(getGlobal().getType()).getTargetType();
+      cast<IREE::Util::PtrType>(getGlobal().getType()).getTargetType();
   auto storeType = getValue().getType();
   if (!isGlobalTypeCompatible(globalType, storeType)) {
     return op->emitOpError() << "global type mismatch; global pointer is "
@@ -1169,7 +1130,7 @@ static ParseResult parseListTypeGet(OpAsmParser &parser, Type &listType,
     return parser.emitError(parser.getCurrentLocation(),
                             "expected !util.list<T> type");
   }
-  auto listElementType = llvm::cast<ListType>(listType).getElementType();
+  auto listElementType = cast<ListType>(listType).getElementType();
   if (succeeded(parser.parseOptionalArrow())) {
     // Use overridden type - required for variants only.
     if (failed(parser.parseType(elementType))) {
@@ -1193,7 +1154,7 @@ static ParseResult parseListTypeGet(OpAsmParser &parser, Type &listType,
 static void printListTypeGet(OpAsmPrinter &printer, Operation *, Type listType,
                              Type elementType) {
   printer.printType(listType);
-  auto listElementType = llvm::cast<ListType>(listType).getElementType();
+  auto listElementType = cast<ListType>(listType).getElementType();
   if (listElementType != elementType) {
     printer.printArrowTypeList(ArrayRef<Type>{elementType});
   }
@@ -1208,24 +1169,24 @@ static ParseResult parseListTypeSet(OpAsmParser &parser, Type &listType,
   }
   if (succeeded(parser.parseOptionalArrow())) {
     elementType = leadingType;
-    if (failed(parser.parseType(listType)) || !llvm::isa<ListType>(listType)) {
+    if (failed(parser.parseType(listType)) || !isa<ListType>(listType)) {
       return parser.emitError(parser.getCurrentLocation(),
                               "expected an !util.list<T> type");
     }
   } else {
-    if (!llvm::isa<ListType>(leadingType)) {
+    if (!isa<ListType>(leadingType)) {
       return parser.emitError(parser.getCurrentLocation(),
                               "expected an !util.list<T> type");
     }
     listType = leadingType;
-    elementType = llvm::cast<ListType>(listType).getElementType();
+    elementType = cast<ListType>(listType).getElementType();
   }
   return success();
 }
 
 static void printListTypeSet(OpAsmPrinter &printer, Operation *, Type listType,
                              Type elementType) {
-  auto listElementType = llvm::cast<ListType>(listType).getElementType();
+  auto listElementType = cast<ListType>(listType).getElementType();
   if (listElementType != elementType) {
     printer.printType(elementType);
     printer.printArrowTypeList(ArrayRef<Type>{listType});
@@ -1236,7 +1197,7 @@ static void printListTypeSet(OpAsmPrinter &printer, Operation *, Type listType,
 
 LogicalResult ListGetOp::verify() {
   Operation *op = getOperation();
-  auto listType = llvm::cast<IREE::Util::ListType>(getList().getType());
+  auto listType = cast<IREE::Util::ListType>(getList().getType());
   auto elementType = listType.getElementType();
   auto resultType = getResult().getType();
   if (!ListType::canImplicitlyCast(elementType, resultType)) {
@@ -1248,7 +1209,7 @@ LogicalResult ListGetOp::verify() {
 
 LogicalResult ListSetOp::verify() {
   Operation *op = getOperation();
-  auto listType = llvm::cast<IREE::Util::ListType>(getList().getType());
+  auto listType = cast<IREE::Util::ListType>(getList().getType());
   auto elementType = listType.getElementType();
   auto valueType = getValue().getType();
   if (!ListType::canImplicitlyCast(valueType, elementType)) {
@@ -1268,7 +1229,7 @@ void BufferConstantOp::getAsmResultNames(
 }
 
 LogicalResult BufferConstantOp::verify() {
-  if (!llvm::isa<IREE::Util::SerializableAttrInterface>(getValue())) {
+  if (!isa<IREE::Util::SerializableAttrInterface>(getValue())) {
     return emitOpError("unsupported non-serializable constant attribute type");
   }
   if (auto minAlignmentAttr = getAlignmentAttr()) {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
@@ -24,9 +24,6 @@
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-#define GET_OP_CLASSES
-#include "iree/compiler/Dialect/Util/IR/UtilOps.h.inc" // IWYU pragma: export
-
 namespace mlir::iree_compiler {
 
 //===----------------------------------------------------------------------===//
@@ -49,9 +46,6 @@ Value buildIfElseTree(
 
 // Removes duplicate attributes in the array (if any).
 ArrayAttr deduplicateArrayElements(ArrayAttr arrayAttr);
-
-// Returns the dynamic size of the value at |index|.
-Value findValueSizeInList(unsigned index, ValueRange values, ValueRange sizes);
 
 //===----------------------------------------------------------------------===//
 // custom<SymbolVisibility>($sym_visibility)
@@ -115,23 +109,6 @@ ParseResult parseSizeAwareType(OpAsmParser &parser, Type &type,
 void printSizeAwareType(OpAsmPrinter &p, Operation *op, Type type, Value size);
 
 //===----------------------------------------------------------------------===//
-// custom<SizeAwareTypeList>
-//===----------------------------------------------------------------------===//
-// (type{%size0}, type, type{%size1})
-
-ParseResult
-parseSizeAwareTypeList(OpAsmParser &parser, SmallVectorImpl<Type> &types,
-                       SmallVectorImpl<OpAsmParser::UnresolvedOperand> &sizes);
-void printSizeAwareTypeList(OpAsmPrinter &p, Operation *op, TypeRange types,
-                            OperandRange sizes);
-ParseResult
-parseSizeAwareTypeList(OpAsmParser &parser, SmallVectorImpl<Type> &types0,
-                       SmallVectorImpl<Type> &types1,
-                       SmallVectorImpl<OpAsmParser::UnresolvedOperand> &sizes);
-void printSizeAwareTypeList(OpAsmPrinter &p, Operation *op, TypeRange types0,
-                            TypeRange types1, OperandRange sizes);
-
-//===----------------------------------------------------------------------===//
 // custom<ShapedTiedResult>
 //===----------------------------------------------------------------------===//
 // type{%dim0, %dim1}
@@ -179,6 +156,27 @@ inline void printShapedTiedResult(OpAsmPrinter &p, Operation *op,
                                   ArrayAttr tiedOperands) {
   printShapedTiedResult(p, op, resultType, ValueRange{resultDim}, tiedOperands);
 }
+//===----------------------------------------------------------------------===//
+// custom<ShapedTypeList>
+//===----------------------------------------------------------------------===//
+// i32, type{%size}, type{%dim0, %dim1}
+
+ParseResult
+parseShapedTypeList(OpAsmParser &parser, SmallVectorImpl<Type> &types,
+                    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &dims);
+void printShapedTypeList(OpAsmPrinter &p, Operation *op, TypeRange types,
+                         ValueRange dims);
+ParseResult
+parseShapedTypeList(OpAsmParser &parser, SmallVectorImpl<Type> &types0,
+                    SmallVectorImpl<Type> &types1,
+                    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &dims);
+void printShapedTypeList(OpAsmPrinter &p, Operation *op, TypeRange types0,
+                         TypeRange types1, ValueRange dims);
+
+//===----------------------------------------------------------------------===//
+// custom<ShapedResultList>
+//===----------------------------------------------------------------------===//
+// type{%dim2}, %operand4
 
 ParseResult parseShapedResultList(
     OpAsmParser &parser, ArrayRef<OpAsmParser::UnresolvedOperand> operands,
@@ -225,5 +223,8 @@ void printShapedFunctionSignature(OpAsmPrinter &p, Operation *op,
                                   ArrayAttr resultAttrs);
 
 } // namespace mlir::iree_compiler
+
+#define GET_OP_CLASSES
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h.inc" // IWYU pragma: export
 
 #endif // IREE_COMPILER_DIALECT_UTIL_IR_UTILOPS_H_

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -347,7 +347,7 @@ detail::getTiedResultOperandIndex(Operation *op, unsigned resultIndex) {
   auto valueAttrs = storageAttr.getValue();
   if (valueAttrs.empty())
     return std::nullopt;
-  if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op)) {
+  if (auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(op)) {
     auto indexAndLength = tiedOp.getTiedResultsIndexAndLength();
     if (resultIndex < indexAndLength.first)
       return std::nullopt;
@@ -358,7 +358,7 @@ detail::getTiedResultOperandIndex(Operation *op, unsigned resultIndex) {
   int64_t value = llvm::cast<IntegerAttr>(valueAttrs[resultIndex]).getInt();
   if (value == IREE::Util::TiedOpInterface::kUntiedIndex)
     return std::nullopt;
-  if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op)) {
+  if (auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(op)) {
     unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
     return tiedOperandsOffset + static_cast<unsigned>(value);
   } else {
@@ -368,13 +368,14 @@ detail::getTiedResultOperandIndex(Operation *op, unsigned resultIndex) {
 
 void detail::setTiedResultOperandIndex(Operation *op, unsigned resultIndex,
                                        std::optional<unsigned> operandIndex) {
-  auto tiedOp = cast<TiedOpInterface>(op);
+  auto tiedOp = llvm::cast<IREE::Util::TiedOpInterface>(op);
   auto resultRange = tiedOp.getTiedResultsIndexAndLength();
   resultIndex -= resultRange.first;
 
   auto indices = getTiedResultOperandIndices(op);
   if (indices.empty()) {
-    indices.resize(resultRange.second, TiedOpInterface::kUntiedIndex);
+    indices.resize(resultRange.second,
+                   IREE::Util::TiedOpInterface::kUntiedIndex);
   } else {
     // Well, getTiedResultOperandIndices() returns indices into the full range
     // of the op, but in the attribute, we expect to store ranges into the range
@@ -386,29 +387,30 @@ void detail::setTiedResultOperandIndex(Operation *op, unsigned resultIndex,
     }
   }
 
-  indices[resultIndex] = operandIndex.value_or(TiedOpInterface::kUntiedIndex);
-  op->setAttr(TiedOpInterface::getStorageAttrName(),
+  indices[resultIndex] =
+      operandIndex.value_or(IREE::Util::TiedOpInterface::kUntiedIndex);
+  op->setAttr(IREE::Util::TiedOpInterface::getStorageAttrName(),
               Builder(op).getIndexArrayAttr(indices));
 }
 
 SmallVector<int64_t> detail::getTiedResultOperandIndices(Operation *op) {
   SmallVector<int64_t> indices;
-  auto storageAttr =
-      op->getAttrOfType<ArrayAttr>(TiedOpInterface::getStorageAttrName());
+  auto storageAttr = op->getAttrOfType<ArrayAttr>(
+      IREE::Util::TiedOpInterface::getStorageAttrName());
   if (!storageAttr)
     return indices;
   auto valueAttrs = storageAttr.getValue();
   if (valueAttrs.empty())
     return indices;
-  auto tiedOp = cast<TiedOpInterface>(op);
+  auto tiedOp = llvm::cast<IREE::Util::TiedOpInterface>(op);
   auto resultRange = tiedOp.getTiedResultsIndexAndLength();
   unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
   indices.resize(resultRange.second);
   for (unsigned i = 0; i < valueAttrs.size(); ++i) {
     int64_t index = llvm::cast<IntegerAttr>(valueAttrs[i]).getInt();
-    indices[i] = index != TiedOpInterface::kUntiedIndex
+    indices[i] = index != IREE::Util::TiedOpInterface::kUntiedIndex
                      ? tiedOperandsOffset + index
-                     : TiedOpInterface::kUntiedIndex;
+                     : IREE::Util::TiedOpInterface::kUntiedIndex;
   }
   return indices;
 }
@@ -416,8 +418,8 @@ SmallVector<int64_t> detail::getTiedResultOperandIndices(Operation *op) {
 // static
 Value TiedOpInterface::findTiedBaseValue(Value derivedValue) {
   Value baseValue = derivedValue;
-  while (auto definingOp =
-             dyn_cast_or_null<TiedOpInterface>(baseValue.getDefiningOp())) {
+  while (auto definingOp = llvm::dyn_cast_or_null<IREE::Util::TiedOpInterface>(
+             baseValue.getDefiningOp())) {
     auto tiedValue = definingOp.getTiedResultOperand(baseValue);
     if (!tiedValue)
       break;
@@ -429,7 +431,8 @@ Value TiedOpInterface::findTiedBaseValue(Value derivedValue) {
 // static
 bool TiedOpInterface::hasAnyTiedUses(Value value) {
   return llvm::any_of(value.getUses(), [](auto &use) {
-    if (auto tiedOp = dyn_cast<TiedOpInterface>(use.getOwner())) {
+    if (auto tiedOp =
+            llvm::dyn_cast<IREE::Util::TiedOpInterface>(use.getOwner())) {
       return tiedOp.isOperandTied(use.getOperandNumber());
     }
     return false;
@@ -437,7 +440,7 @@ bool TiedOpInterface::hasAnyTiedUses(Value value) {
 }
 
 bool detail::isOperandTied(Operation *op, unsigned operandIndex) {
-  if (auto tiedOp = dyn_cast<TiedOpInterface>(op)) {
+  if (auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(op)) {
     auto tiedIndices = tiedOp.getTiedResultOperandIndices();
     return llvm::find(tiedIndices, operandIndex) != tiedIndices.end();
   }
@@ -446,7 +449,7 @@ bool detail::isOperandTied(Operation *op, unsigned operandIndex) {
 
 SmallVector<Value> detail::getOperandTiedResults(Operation *op,
                                                  unsigned operandIndex) {
-  auto tiedOp = dyn_cast<TiedOpInterface>(op);
+  auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(op);
   if (!tiedOp)
     return {};
   auto resultRange = tiedOp.getTiedResultsIndexAndLength();
@@ -460,7 +463,7 @@ SmallVector<Value> detail::getOperandTiedResults(Operation *op,
   return results;
 }
 
-LogicalResult detail::verifyTiedOp(TiedOpInterface tiedOp) {
+LogicalResult detail::verifyTiedOp(IREE::Util::TiedOpInterface tiedOp) {
   auto tiedOperandIndices = tiedOp.getTiedResultOperandIndices();
   if (tiedOperandIndices.empty())
     return success();
@@ -499,12 +502,12 @@ void excludeTiedOperandAndResultIndices(
     }
 
     int64_t tiedOperandIndex = it.value();
-    if (tiedOperandIndex != TiedOpInterface::kUntiedIndex) {
+    if (tiedOperandIndex != IREE::Util::TiedOpInterface::kUntiedIndex) {
       // Check whether this operand is removed. If so, untie. We need to do this
       // before calculating the new operand index given `excludedOperandIndices`
       // contains the old indices.
       if (llvm::is_contained(excludedOperandIndices, tiedOperandIndex)) {
-        tiedOperandIndex = TiedOpInterface::kUntiedIndex;
+        tiedOperandIndex = IREE::Util::TiedOpInterface::kUntiedIndex;
       }
 
       // Count up the number of removed operands prior to this one.
@@ -590,7 +593,7 @@ Value SizeAwareTypeInterface::queryValueSize(Location loc, Value resourceValue,
   // TODO(benvanik): make this cleaner.
   auto *definingOp = resourceValue.getDefiningOp();
   if (auto sizeAwareOp =
-          llvm::dyn_cast_or_null<IREE::Util::SizeAwareOpInterface>(
+          llvm::dyn_cast_if_present<IREE::Util::SizeAwareOpInterface>(
               definingOp)) {
     return sizeAwareOp.getResultSizeFromValue(resourceValue);
   } else if (auto inferSizeType =
@@ -606,19 +609,24 @@ Value SizeAwareTypeInterface::queryValueSize(Location loc, Value resourceValue,
 //===----------------------------------------------------------------------===//
 
 std::optional<ValueRange> findDynamicDims(Value workValue) {
-
   // Look up the use-def chain: always safe, as any value we reach dominates
   // {|block|, |insertionPoint|} implicitly.
   while (workValue) {
     auto workOp = workValue.getDefiningOp();
     if (!workOp)
       break;
-    if (auto shapeAwareOp = dyn_cast<ShapeAwareOpInterface>(workOp))
+    if (auto shapeAwareOp =
+            llvm::dyn_cast<IREE::Util::ShapeAwareOpInterface>(workOp)) {
       return shapeAwareOp.getResultDynamicDimsFromValue(workValue);
-    else if (auto tiedOp = dyn_cast<TiedOpInterface>(workOp)) {
+    } else if (auto sizeAwareOp =
+                   llvm::dyn_cast<IREE::Util::SizeAwareOpInterface>(workOp)) {
+      return sizeAwareOp.getResultSizeFromValue(workValue);
+    } else if (auto tiedOp =
+                   llvm::dyn_cast<IREE::Util::TiedOpInterface>(workOp)) {
       workValue = tiedOp.getTiedResultOperand(workValue);
-    } else
+    } else {
       break;
+    }
   }
   return std::nullopt;
 }
@@ -636,7 +644,8 @@ std::optional<ValueRange> findDynamicDims(Value shapedValue, Block *block,
   // bit, though, as {|block|, |insertionPoint|} may be a user of |shapedValue|
   // and be able to provide the shape itself.
   for (auto &use : shapedValue.getUses()) {
-    if (auto shapeAwareOp = dyn_cast<ShapeAwareOpInterface>(use.getOwner())) {
+    if (auto shapeAwareOp =
+            llvm::dyn_cast<ShapeAwareOpInterface>(use.getOwner())) {
       auto dynamicDims =
           shapeAwareOp.getOperandDynamicDims(use.getOperandNumber());
       if (llvm::all_of(dynamicDims, [&](Value dim) {
@@ -644,33 +653,52 @@ std::optional<ValueRange> findDynamicDims(Value shapedValue, Block *block,
           })) {
         return dynamicDims;
       }
+    } else if (auto sizeAwareOp =
+                   llvm::dyn_cast<SizeAwareOpInterface>(use.getOwner())) {
+      auto size = sizeAwareOp.getOperandSize(use.getOperandNumber());
+      if (isValueUsableForOp(size, block, insertionPoint)) {
+        return size;
+      }
     }
   }
 
   return std::nullopt;
 }
 
-ValueRange findVariadicDynamicDims(unsigned idx, ValueRange values,
-                                   ValueRange dynamicDims) {
+ValueRange findDynamicDimsInList(unsigned idx, ValueRange values,
+                                 ValueRange dynamicDims) {
+  // Get the total number of dynamic dimensions for the value. Note that this
+  // may be 0 if all dimensions are static.
   auto value = values[idx];
-  auto shapedType = llvm::dyn_cast<ShapedType>(value.getType());
-  if (!shapedType)
-    return ValueRange{};
-
-  // Bail immediately if the shape is static.
-  if (shapedType.hasStaticShape())
+  unsigned dynamicDimCount = 0;
+  if (auto shapedType = llvm::dyn_cast<ShapedType>(value.getType())) {
+    dynamicDimCount = shapedType.getNumDynamicDims();
+  } else if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(value.getType())) {
+    dynamicDimCount = 1;
+  }
+  if (!dynamicDimCount)
     return ValueRange{};
 
   // Find where the dynamic dims start in the flattened list.
   unsigned offset = 0;
   for (unsigned i = 0; i < idx; ++i) {
-    if (auto type = llvm::dyn_cast<ShapedType>(values[i].getType())) {
-      offset += type.getNumDynamicDims();
+    auto prefixValueType = values[i].getType();
+    if (auto shapedType = llvm::dyn_cast<ShapedType>(prefixValueType)) {
+      offset += shapedType.getNumDynamicDims();
+    } else if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(prefixValueType)) {
+      offset += 1; // fixed 1 dynamic dim
     }
   }
 
   // Return the subrange of dynamic dims for the value being queried.
-  return dynamicDims.slice(offset, shapedType.getNumDynamicDims());
+  return dynamicDims.slice(offset, dynamicDimCount);
+}
+
+Value findValueSizeInList(unsigned idx, ValueRange values,
+                          ValueRange dynamicDims) {
+  auto dims = findDynamicDimsInList(idx, values, dynamicDims);
+  assert(dims.size() == 1 && "expected exactly one dynamic dimension");
+  return dims.front();
 }
 
 SmallVector<Value> buildDynamicDimsForValue(Location loc, Value value,
@@ -698,8 +726,9 @@ SmallVector<Value> buildDynamicDimsForValue(Location loc, Value value,
 
   // Slower path that materializes the entire shape for a result. Some
   // implementations may only support this (vs the fast find above).
-  if (auto shapeAwareOp = dyn_cast_or_null<IREE::Util::ShapeAwareOpInterface>(
-          value.getDefiningOp())) {
+  if (auto shapeAwareOp =
+          llvm::dyn_cast_or_null<IREE::Util::ShapeAwareOpInterface>(
+              value.getDefiningOp())) {
     return shapeAwareOp.buildResultValueShape(value, builder);
   }
 
@@ -746,7 +775,7 @@ static SmallVector<Value> buildShape(Location loc, ShapedType type,
   return dims;
 }
 
-SmallVector<Value> buildOperandShape(ShapeAwareOpInterface op,
+SmallVector<Value> buildOperandShape(IREE::Util::ShapeAwareOpInterface op,
                                      unsigned operandIdx, OpBuilder &builder) {
   auto operand = op->getOperand(operandIdx);
   auto type = llvm::cast<ShapedType>(operand.getType());
@@ -754,7 +783,7 @@ SmallVector<Value> buildOperandShape(ShapeAwareOpInterface op,
   return buildShape(op.getLoc(), type, dynamicDims, builder);
 }
 
-SmallVector<Value> buildResultShape(ShapeAwareOpInterface op,
+SmallVector<Value> buildResultShape(IREE::Util::ShapeAwareOpInterface op,
                                     unsigned resultIdx, OpBuilder &builder) {
   auto result = op->getResult(resultIdx);
   auto type = llvm::cast<ShapedType>(result.getType());

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -159,8 +159,18 @@ std::optional<ValueRange> findDynamicDims(Value shapedValue, Block *block,
                                           Block::iterator insertionPoint);
 
 // Returns the dynamic dimensions for the value at |idx|.
-ValueRange findVariadicDynamicDims(unsigned idx, ValueRange values,
-                                   ValueRange dynamicDims);
+// |dynamicDims| is zero or more dynamic dimensions corresponding to the
+// |values| list of arbitrary types.
+// Shaped types will return zero or more dynamic dimension values.
+// Sized types will return exactly one value.
+ValueRange findDynamicDimsInList(unsigned idx, ValueRange values,
+                                 ValueRange dynamicDims);
+
+// Returns the size of the size-aware typed value at |idx| in |values|.
+// |dynamicDims| is zero or more dynamic dimensions corresponding to the
+// |values| list of arbitrary types.
+Value findValueSizeInList(unsigned idx, ValueRange values,
+                          ValueRange dynamicDims);
 
 // Returns dimension values for each dynamic dimension of the given |value|.
 // |value| must be a ShapedType. The returned value range will be empty if the


### PR DESCRIPTION
This enables ops that have both size and shape aware types. There are likely a few places that still need cleanup and I'm not happy with any of the naming but that'll be easier to fix now that things are unified.

Also fixing style inconsistencies in some flow passes.

Progress on #16081.