### PR TITLE
Trampoline benchmark.h to make it IREE_ENABLE_THREADING=OFF safe.

### DIFF
--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -200,7 +200,6 @@ cc_binary_benchmark(
         ":fpu_state",
         "//runtime/src/iree/base",
         "//runtime/src/iree/testing:benchmark_main",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 
@@ -296,7 +295,6 @@ cc_binary_benchmark(
     deps = [
         ":synchronization",
         "//runtime/src/iree/testing:benchmark_main",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -206,7 +206,6 @@ iree_cc_binary_benchmark(
     "fpu_state_benchmark.cc"
   DEPS
     ::fpu_state
-    benchmark
     iree::base
     iree::testing::benchmark_main
   TESTONLY
@@ -317,7 +316,6 @@ iree_cc_binary_benchmark(
     "synchronization_benchmark.cc"
   DEPS
     ::synchronization
-    benchmark
     iree::testing::benchmark_main
   TESTONLY
 )

--- a/runtime/src/iree/base/internal/fpu_state_benchmark.cc
+++ b/runtime/src/iree/base/internal/fpu_state_benchmark.cc
@@ -4,11 +4,13 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if !IREE_HAS_NOP_BENCHMARK_LIB
+
 #include <cstddef>
 
-#include "benchmark/benchmark.h"
 #include "iree/base/api.h"
 #include "iree/base/internal/fpu_state.h"
+#include "iree/testing/benchmark_lib.h"
 
 namespace {
 
@@ -122,3 +124,5 @@ void BM_VectorizedDenormalsNotFlushedToZero(benchmark::State& state) {
 BENCHMARK(BM_VectorizedDenormalsNotFlushedToZero);
 
 }  // namespace
+
+#endif  // !IREE_HAS_NOP_BENCHMARK_LIB

--- a/runtime/src/iree/base/internal/synchronization_benchmark.cc
+++ b/runtime/src/iree/base/internal/synchronization_benchmark.cc
@@ -4,11 +4,13 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if !IREE_HAS_NOP_BENCHMARK_LIB
+
 #include <cstddef>
 #include <mutex>
 
-#include "benchmark/benchmark.h"
 #include "iree/base/internal/synchronization.h"
+#include "iree/testing/benchmark_lib.h"
 
 namespace {
 
@@ -254,3 +256,5 @@ BENCHMARK_TEMPLATE(BM_Contended, std::mutex)
 // care beyond that.
 
 }  // namespace
+
+#endif  // !IREE_HAS_NOP_BENCHMARK_LIB

--- a/runtime/src/iree/testing/BUILD.bazel
+++ b/runtime/src/iree/testing/BUILD.bazel
@@ -21,6 +21,7 @@ iree_runtime_cc_library(
     ],
     hdrs = [
         "benchmark.h",
+        "benchmark_lib.h",
     ],
     deps = [
         "//runtime/src/iree/base",
@@ -32,6 +33,7 @@ iree_runtime_cc_library(
     name = "benchmark_main",
     testonly = True,
     srcs = ["benchmark_main.c"],
+    hdrs = ["benchmark_lib.h"],
     deps = [
         ":benchmark",
         "//runtime/src/iree/base/internal:flags",

--- a/runtime/src/iree/testing/CMakeLists.txt
+++ b/runtime/src/iree/testing/CMakeLists.txt
@@ -14,6 +14,7 @@ if(IREE_ENABLE_THREADING)
       benchmark
     HDRS
       "benchmark.h"
+      "benchmark_lib.h"
     SRCS
       "benchmark_full.cc"
     DEPS
@@ -27,8 +28,11 @@ else()
       benchmark
     HDRS
       "benchmark.h"
+      "benchmark_lib.h"
     SRCS
       "benchmark_nop.c"
+    DEFINES
+      IREE_HAS_NOP_BENCHMARK_LIB=1
     DEPS
       iree::base
     PUBLIC

--- a/runtime/src/iree/testing/benchmark_lib.h
+++ b/runtime/src/iree/testing/benchmark_lib.h
@@ -1,0 +1,22 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// This header is a trampoline for including the backing C++ benchmark.h from
+// the native benchmark library. We are trying to move away from this but we
+// still have some benchmarks that use it. Those should include this header
+// instead of benchmark/benchmark.h so we keep the build graph layering clean
+// and can issue an error when it is not available.
+
+#ifndef IREE_TESTING_BENCHMARK_LIB_FULL_H_
+
+#if IREE_HAS_NOP_BENCHMARK_LIB
+#error \
+    "IREE was compiled without threading or benchmark support. Guard this include with IREE_HAS_NOP_BENCHMARK_LIB"
+#else
+#include "benchmark/benchmark.h"
+#endif  // IREE_HAS_NOP_BENCHMARK_LIB
+
+#endif  // IREE_TESTING_BENCHMARK_LIB_FULL_H_

--- a/runtime/src/iree/vm/BUILD.bazel
+++ b/runtime/src/iree/vm/BUILD.bazel
@@ -139,7 +139,6 @@ cc_binary_benchmark(
         ":native_module_test_hdrs",
         "//runtime/src/iree/base",
         "//runtime/src/iree/testing:benchmark_main",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/runtime/src/iree/vm/CMakeLists.txt
+++ b/runtime/src/iree/vm/CMakeLists.txt
@@ -129,7 +129,6 @@ iree_cc_binary_benchmark(
   DEPS
     ::impl
     ::native_module_test_hdrs
-    benchmark
     iree::base
     iree::testing::benchmark_main
   TESTONLY

--- a/runtime/src/iree/vm/bytecode/BUILD.bazel
+++ b/runtime/src/iree/vm/bytecode/BUILD.bazel
@@ -89,7 +89,6 @@ cc_binary_benchmark(
         "//runtime/src/iree/base",
         "//runtime/src/iree/testing:benchmark_main",
         "//runtime/src/iree/vm",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/runtime/src/iree/vm/bytecode/CMakeLists.txt
+++ b/runtime/src/iree/vm/bytecode/CMakeLists.txt
@@ -76,7 +76,6 @@ iree_cc_binary_benchmark(
   DEPS
     ::module
     ::module_benchmark_module_c
-    benchmark
     iree::base
     iree::testing::benchmark_main
     iree::vm

--- a/runtime/src/iree/vm/bytecode/module_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode/module_benchmark.cc
@@ -4,11 +4,13 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if !IREE_HAS_NOP_BENCHMARK_LIB
+
 #include <array>
 #include <vector>
 
-#include "benchmark/benchmark.h"
 #include "iree/base/api.h"
+#include "iree/testing/benchmark_lib.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode/module.h"
 #include "iree/vm/bytecode/module_benchmark_module_c.h"
@@ -371,3 +373,5 @@ static void BM_BufferReduceBytecodeUnrolled(benchmark::State& state) {
 BENCHMARK(BM_BufferReduceBytecodeUnrolled)->Arg(100000);
 
 }  // namespace
+
+#endif  // !IREE_HAS_NOP_BENCHMARK_LIB

--- a/runtime/src/iree/vm/native_module_benchmark.cc
+++ b/runtime/src/iree/vm/native_module_benchmark.cc
@@ -4,8 +4,10 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "benchmark/benchmark.h"
+#if !IREE_HAS_NOP_BENCHMARK_LIB
+
 #include "iree/base/api.h"
+#include "iree/testing/benchmark_lib.h"
 #include "iree/vm/module.h"
 #include "iree/vm/native_module.h"
 #include "iree/vm/native_module_test.h"
@@ -16,3 +18,5 @@ namespace {
 // TODO(benvanik): native module benchmarks.
 
 }  // namespace
+
+#endif  // !IREE_HAS_NOP_BENCHMARK_LIB


### PR DESCRIPTION
We still have a few targets that depend on the full benchmark library, and these fail to build when IREE_ENABLE_THREADING=OFF.

Here we add a trampoline header and define and layer the targets so that the build graph doesn't need to change for those but they will nop-out.

Found incidentally when repro'ing #16109