### PR TITLE
QOL fixes for portable and cross-compiling builds.

### DIFF
--- a/build_tools/cmake/iree_import_binary.cmake
+++ b/build_tools/cmake/iree_import_binary.cmake
@@ -31,7 +31,7 @@ include(CMakeParseArguments)
 function(iree_import_binary)
   cmake_parse_arguments(
     _RULE
-    ""
+    "OPTIONAL"
     "NAME"
     ""
     ${ARGN}
@@ -58,9 +58,15 @@ function(iree_import_binary)
        BASE_DIRECTORY ${IREE_ROOT_DIR} EXPAND_TILDE)
 
   if(NOT EXISTS ${_BINARY_PATH})
-    message(FATAL_ERROR "Could not find '${_FULL_BINARY_NAME}' under "
-            "'${IREE_HOST_BIN_DIR}'\n(Expanded to '${_BINARY_PATH}').\n"
-            "Ensure that IREE_HOST_BIN_DIR points to a complete binary directory.")
+    if(_RULE_OPTIONAL)
+      message(WARNING "Could not find optional '${_FULL_BINARY_NAME}' under "
+              "'${IREE_HOST_BIN_DIR}'. Features that depend on it may fail to "
+              "build.")
+    else()
+      message(FATAL_ERROR "Could not find '${_FULL_BINARY_NAME}' under "
+              "'${IREE_HOST_BIN_DIR}'\n(Expanded to '${_BINARY_PATH}').\n"
+              "Ensure that IREE_HOST_BIN_DIR points to a complete binary directory.")
+    endif()
   endif()
 
   add_executable(${_RULE_NAME} IMPORTED GLOBAL)

--- a/build_tools/cmake/iree_import_binary.cmake
+++ b/build_tools/cmake/iree_import_binary.cmake
@@ -14,6 +14,7 @@ include(CMakeParseArguments)
 #
 # Parameters:
 # NAME: name of target/binary (see Usage below)
+# OPTIONAL: Don't fail if not found (but will issue a warning)
 #
 # Usage:
 #   if(BUILD_AWESOME_TOOL)

--- a/build_tools/embed_data/CMakeLists.txt
+++ b/build_tools/embed_data/CMakeLists.txt
@@ -16,7 +16,10 @@ endif()
 
 add_executable(generate_embed_data)
 target_sources(generate_embed_data PRIVATE generate_embed_data_main.cc)
-set_target_properties(generate_embed_data PROPERTIES OUTPUT_NAME generate_embed_data)
+set_target_properties(generate_embed_data PROPERTIES 
+  OUTPUT_NAME generate_embed_data
+  RUNTIME_OUTPUT_DIRECTORY "${IREE_BINARY_DIR}/tools"
+)
 
 install(TARGETS generate_embed_data
         COMPONENT IREETools-CompilerExtra

--- a/build_tools/third_party/flatcc/CMakeLists.txt
+++ b/build_tools/third_party/flatcc/CMakeLists.txt
@@ -63,7 +63,7 @@ external_cc_library(
     parsing
   ROOT
     ${FLATCC_ROOT}
-  INCLUDES
+  SYSTEM_INCLUDES
     "${FLATCC_ROOT}/include"
   SRCS
     "config/config.h"
@@ -122,6 +122,10 @@ add_executable(iree-flatcc-cli
   "${FLATCC_ROOT}/src/runtime/builder.c"
   "${FLATCC_ROOT}/src/runtime/emitter.c"
   "${FLATCC_ROOT}/src/runtime/refmap.c"
+)
+set_target_properties(iree-flatcc-cli
+  PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${IREE_BINARY_DIR}/tools"
 )
 target_include_directories(iree-flatcc-cli SYSTEM
   PUBLIC

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -32,16 +32,27 @@ set(IREE_PACKAGE_ROOT_PREFIX "iree/tools")
 iree_add_all_subdirs()
 set(IREE_PACKAGE_ROOT_PREFIX "")
 
-# TODO(scotttodd): Should this be checking IREE_BUILD_COMPILER?
-#   Maybe we should disallow setting both at the same time, since it's
-#   ambigious which should be used
+# If cross-compiling and not building the compiler, then attempt to find
+# the compiler tools.
+# This is actual broken because the situation is tri-state:
+#   1. Cross-compiling with no built compiler: Should work the same as
+#      IREE_BUILD_COMPILER=OFF in a host build (i.e. nothing depending
+#      on the compiler should be built).
+#   2. Cross-compiling with a compiler built for the target: Anything
+#      on the host which needs the compiler, still must have host tools.
+#   3. Normal host build.
+# This simplistic setup makes #2 impossible and it overloads #1 to
+# also support building things that depend on the compiler. The targets
+# need to be aliased/forked for host variants to fully support. For now
+# we just make all of these as OPTIONAL and let things break if not set up
+# right.
 if(IREE_HOST_BIN_DIR AND NOT IREE_BUILD_COMPILER)
-  iree_import_binary(NAME iree-tblgen)
-  iree_import_binary(NAME iree-compile)
-  iree_import_binary(NAME iree-opt)
-  iree_import_binary(NAME iree-run-mlir)
-  iree_import_binary(NAME clang)
-  iree_import_binary(NAME llvm-link)
+  iree_import_binary(NAME iree-tblgen OPTIONAL)
+  iree_import_binary(NAME iree-compile OPTIONAL)
+  iree_import_binary(NAME iree-opt OPTIONAL)
+  iree_import_binary(NAME iree-run-mlir OPTIONAL)
+  iree_import_binary(NAME clang OPTIONAL)
+  iree_import_binary(NAME llvm-link OPTIONAL)
 endif()
 
 # TODO(#6353): Tools has thread dependencies in gtest, benchmark, yaml, etc.


### PR DESCRIPTION
* generate_embed_data outputs to tools/ in the build tree (matches bin/ in install).
* iree-flatcc-cli outputs to tools/ in the build tree (matches bin/ in install).
* Imported compiler binaries are optional/warn if not found. This is sub-optimal and notes were left for the future.
* flatcc switched back to SYSTEM_INCLUDES. Reported on discord as unexpected warning regressions and experienced when building with arm-none-eabi.

With this, it is now possible to set IREE_HOST_BIN_DIR to the `tools/` directory of a build tree and the cross-compiled runtime can be built without compiler tools (same as the host).

Progress on #16109.
