### PR TITLE
[VectorDistribution] Add patterns for distributing transfer_read/transfer_write

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -8,7 +8,9 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Common/VectorLayoutAnalysis.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Rewrite/PatternApplicator.h"
@@ -19,6 +21,84 @@ using namespace mlir::iree_compiler::IREE::VectorExt;
 using VectorValue = TypedValue<VectorType>;
 
 namespace {
+
+static std::optional<int64_t> findDimInLayout(LayoutAttr layout,
+                                              LayoutDimension dim) {
+  for (PerDimLayoutAttr dimLayout : layout.getLayouts()) {
+    if (std::optional<int64_t> shape = dimLayout.getShape(dim)) {
+      return shape;
+    }
+  }
+  return std::nullopt;
+}
+
+static SmallVector<Value> computeSIMDIndex(const LayoutIterator::State &state,
+                                           LayoutAttr layout,
+                                           ArrayRef<Value> threadGrid,
+                                           RewriterBase &rewriter) {
+  MLIRContext *ctx = layout.getContext();
+  AffineExpr threadX, threadY, threadZ;
+  bindSymbols(ctx, threadX, threadY, threadZ);
+
+  SmallVector<Value> simdIndex;
+  // Calculate the index for each dim separately.
+  for (PerDimLayoutAttr dimLayout : layout.getLayouts()) {
+    AffineExpr offset = getAffineConstantExpr(0, ctx);
+    AffineExpr stride = getAffineConstantExpr(1, ctx);
+    for (const auto &[label, shape] : llvm::reverse(
+             llvm::zip(dimLayout.getLabels(), dimLayout.getShapes()))) {
+      int64_t position = state.lookup(label.getValue()).getPosition();
+
+      switch (label.getValue()) {
+      case LayoutDimension::LANEX:
+        offset = offset + stride * threadX;
+        break;
+      case LayoutDimension::LANEY:
+        offset = offset + stride * threadY;
+        break;
+      case LayoutDimension::LANEZ:
+        offset = offset + stride * threadZ;
+        break;
+      default:
+        offset = offset + stride * getAffineConstantExpr(position, ctx);
+        break;
+      }
+      stride = stride * getAffineConstantExpr(shape, ctx);
+    }
+
+    // Compute the index for the dim.
+    offset.dump();
+    stride.dump();
+    rewriter.getUnknownLoc().dump();
+    Value index = rewriter.create<affine::AffineApplyOp>(
+        rewriter.getUnknownLoc(), offset, threadGrid);
+    simdIndex.push_back(index);
+  }
+
+  return simdIndex;
+}
+
+// Get the offset into the SIMT vector corresponding to the iterator on the
+// layout.
+static SmallVector<int64_t> computeSIMTIndex(const LayoutIterator::State &state,
+                                             LayoutAttr layout) {
+  constexpr LayoutDimension labels[] = {
+      LayoutDimension::BATCHX, LayoutDimension::BATCHY,
+      LayoutDimension::VECTORZ, LayoutDimension::VECTORY,
+      LayoutDimension::VECTORX};
+
+  SmallVector<int64_t> offset;
+  for (auto label : labels) {
+    std::optional shape = findDimInLayout(layout, label);
+    if (!shape) {
+      continue;
+    }
+    // Get current position for the label.
+    int64_t position = state.lookup(label).getPosition();
+    offset.push_back(position);
+  }
+  return offset;
+}
 
 struct DistributeConstants final : OpDistributionPattern<arith::ConstantOp> {
   using OpDistributionPattern::OpDistributionPattern;
@@ -99,6 +179,158 @@ struct DistributeElementwise final : OpDistributionPattern<OpTy> {
   }
 };
 
+/// Given a projected permutation, get a reduced permutation, i.e. without
+/// the projected dimensions.
+static SmallVector<int64_t> getReducedPermutation(AffineMap permutationMap) {
+  assert(permutationMap.isProjectedPermutation() &&
+         "permutation map should be a projected permutation.");
+  // TODO: The permutation map may also have broadcasting. Currently, we do not
+  // handle it. This can be fixed by adding a "BROADCAST" dimension in the
+  // layout.
+
+  SmallVector<int64_t> permutation;
+  permutation.reserve(permutationMap.getNumResults());
+
+  unsigned leadingUnitDims =
+      permutationMap.getNumDims() - permutationMap.getNumResults();
+  for (AffineExpr dim : permutationMap.getResults()) {
+    // Get this dim's position in the permutation map.
+    auto dimExpr = dyn_cast<AffineDimExpr>(dim);
+    if (!dimExpr) {
+      llvm::report_fatal_error("permutation map is not a projected "
+                               "permutation.");
+    }
+
+    unsigned pos = dimExpr.getPosition();
+    assert(pos >= leadingUnitDims && "invalid permutation map");
+    pos -= leadingUnitDims;
+    permutation.push_back(pos);
+  }
+  return permutation;
+}
+
+template <typename OpTy>
+struct DistributeXferLayoutAttr : OpDistributionPattern<OpTy> {
+  static_assert(std::is_same<OpTy, vector::TransferReadOp>::value ||
+                    std::is_same<OpTy, vector::TransferWriteOp>::value,
+                "expected vector::TransferReadOp or vector::TransferWriteOp");
+
+  DistributeXferLayoutAttr(MLIRContext *context, ArrayRef<Value> threadGrid,
+                           PatternBenefit benefit = 1)
+      : OpDistributionPattern<OpTy>(context, benefit), threadGrid(threadGrid) {}
+
+  void accessMemory(OpTy xferOp, VectorValue accumulator,
+                    LayoutAttr vectorLayout, PatternRewriter &rewriter) const {
+    // We need to take special consideration of the permutation map when
+    // lowering. When accessing memory, we use the memoryLayout, because that
+    // is how the data is accessed in memory. The data is stored in the vector
+    // according to vectorLayout.
+    SmallVector<int64_t> permutation =
+        getReducedPermutation(xferOp.getPermutationMap());
+    LayoutAttr memoryLayout =
+        cast<LayoutAttr>(vectorLayout.permute(permutation));
+
+    int loadWidth = getLoadStoreWidth(memoryLayout);
+    DenseMap<LayoutDimension, int64_t> steps;
+    steps[LayoutDimension::VECTORX] = loadWidth;
+    LayoutIterator iterator(vectorLayout, steps);
+
+    iterator.apply([&](const LayoutIterator::State &state) {
+      SmallVector<Value> memoryIndices =
+          getMemoryIndices(state, memoryLayout, xferOp.getIndices(), rewriter);
+      SmallVector<Value> accIndices =
+          getAccumulatorIndices(state, vectorLayout, rewriter);
+      accumulator = accessUnit(xferOp, memoryIndices, accIndices, accumulator,
+                               vectorLayout, rewriter);
+    });
+  }
+
+  SmallVector<Value> getMemoryIndices(const LayoutIterator::State &state,
+                                      LayoutAttr memoryLayout,
+                                      SmallVector<Value> indices,
+                                      RewriterBase &rewriter) const {
+    SmallVector<Value> simdIndices =
+        computeSIMDIndex(state, memoryLayout, threadGrid, rewriter);
+    SmallVector<Value> memoryIndices(indices);
+
+    // The memory layout has some projected leading dims that indices doesn't.
+    int leadingProjectedDims = memoryIndices.size() - simdIndices.size();
+    for (int i = leadingProjectedDims, e = memoryIndices.size(); i < e; ++i) {
+      memoryIndices[i] = rewriter.create<arith::AddIOp>(
+          rewriter.getUnknownLoc(), memoryIndices[i],
+          simdIndices[i - leadingProjectedDims]);
+    }
+
+    return memoryIndices;
+  }
+
+  SmallVector<Value> getAccumulatorIndices(const LayoutIterator::State &state,
+                                           LayoutAttr vectorLayout,
+                                           RewriterBase &rewriter) const {
+    SmallVector<int64_t> simtIndices = computeSIMTIndex(state, vectorLayout);
+    SmallVector<Value> simt(simtIndices.size());
+
+    for (int i = 0, e = simtIndices.size(); i < e; ++i) {
+      simt[i] = rewriter.create<arith::ConstantIndexOp>(
+          rewriter.getUnknownLoc(), simtIndices[i]);
+    }
+
+    return simt;
+  }
+
+  virtual VectorValue accessUnit(OpTy xferOp, SmallVector<Value> &memoryIndices,
+                                 SmallVector<Value> &accIndices,
+                                 VectorValue accumulator,
+                                 LayoutAttr vectorLayout,
+                                 PatternRewriter &rewriter) const = 0;
+
+  int getLoadStoreWidth(LayoutAttr layout) const {
+    int width = 1;
+    return width;
+  }
+
+  SmallVector<Value> threadGrid;
+};
+
+struct DistributeTransferReadLayoutAttr
+    : DistributeXferLayoutAttr<vector::TransferReadOp> {
+  using DistributeXferLayoutAttr<
+      vector::TransferReadOp>::DistributeXferLayoutAttr;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                DistributionSignature &signature,
+                                PatternRewriter &rewriter) const override {
+    VectorValue result = readOp.getResult();
+    LayoutAttr vectorLayout = dyn_cast<LayoutAttr>(signature.results[0]);
+    if (!vectorLayout) {
+      return failure();
+    }
+
+    Type elementType = readOp.getSource().getType().getElementType();
+    auto vectorType = VectorType::get(
+        vectorLayout.getDistributedShape(result.getType()), elementType);
+    Value zero = rewriter.create<arith::ConstantOp>(
+        readOp.getLoc(), vectorType, rewriter.getZeroAttr(vectorType));
+    VectorValue acc = cast<VectorValue>(zero);
+
+    accessMemory(readOp, acc, vectorLayout, rewriter);
+
+    replaceOpWithDistributedValues(rewriter, readOp, result);
+    return success();
+  }
+
+  VectorValue accessUnit(vector::TransferReadOp readOp,
+                         SmallVector<Value> &memoryIndices,
+                         SmallVector<Value> &accIndices,
+                         VectorValue accumulator, LayoutAttr vectorLayout,
+                         PatternRewriter &rewriter) const override {
+    auto unitType = VectorType::get({getLoadStoreWidth(vectorLayout)},
+                                    accumulator.getType().getElementType());
+    return rewriter.create<vector::LoadOp>(readOp.getLoc(), unitType,
+                                           readOp.getSource(), memoryIndices);
+  }
+};
+
 }; // namespace
 
 void populateGPUDistributionPatterns(RewritePatternSet &patterns) {
@@ -106,6 +338,12 @@ void populateGPUDistributionPatterns(RewritePatternSet &patterns) {
                DistributeElementwise<arith::MulFOp>,
                DistributeElementwise<arith::AddIOp>,
                DistributeElementwise<arith::AddFOp>>(patterns.getContext());
+}
+
+void populateGPUDistributionLayoutAttrPatterns(ArrayRef<Value> threadGrid,
+                                               RewritePatternSet &patterns) {
+  patterns.add<DistributeTransferReadLayoutAttr>(patterns.getContext(),
+                                                 threadGrid);
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
@@ -31,6 +31,9 @@ void populateDropSharedMemoryDeallocOpPatterns(RewritePatternSet &patterns);
 
 void populateGPUDistributionPatterns(RewritePatternSet &patterns);
 
+void populateGPUDistributionLayoutAttrPatterns(ArrayRef<Value> threadGrid,
+                                               RewritePatternSet &patterns);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_GPUPATTERNS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -166,6 +166,7 @@ static void applyVectorDistribution(Operation *root,
   SmallVector<Operation *> worklist;
 
   VectorDistributionRewriter rewriter(root->getContext());
+  rewriter.getUnknownLoc().dump();
   PatternApplicator applicator(patterns);
   applicator.applyDefaultCostModel();
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -166,7 +166,6 @@ static void applyVectorDistribution(Operation *root,
   SmallVector<Operation *> worklist;
 
   VectorDistributionRewriter rewriter(root->getContext());
-  rewriter.getUnknownLoc().dump();
   PatternApplicator applicator(patterns);
   applicator.applyDefaultCostModel();
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -130,3 +130,86 @@ builtin.module attributes { transform.with_named_sequence } {
     transform.yield
   }
 }
+
+// -----
+
+#layout_row_major = #iree_vector_ext.layout<<[BATCHX, LANEY], [2, 8]>, <[BATCHY, LANEX, VECTORX], [2, 1, 8]>>
+#layout_col_major = #iree_vector_ext.layout<<[BATCHX, LANEY, VECTORX], [1, 4, 4]>, <[BATCHY, LANEX], [2, 8]>>
+
+builtin.module attributes { transform.with_named_sequence } {
+  // CHECK-LABEL: @distribute_transfer_write_row_major
+  func.func @distribute_transfer_write_row_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
+    %c0 = arith.constant 0 : index
+    vector.transfer_write %root, %alloc[%c0, %c0]
+            {in_bounds = [true, true],
+             "__vector_layout_test_anchor_operand_0" = #layout_row_major}
+                    : vector<16x16xf16>, memref<64x64xf16>
+    // CHECK-COUNT-4: vector.store {{.*}}, vector<8xf16>
+    func.return
+  }
+
+  // CHECK-LABEL: @distribute_transfer_write_col_major
+  func.func @distribute_transfer_write_col_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
+    %c0 = arith.constant 0 : index
+    vector.transfer_write %root, %alloc[%c0, %c0]
+            {in_bounds = [true, true],
+             "__vector_layout_test_anchor_operand_0" = #layout_col_major}
+                    : vector<16x16xf16>, memref<64x64xf16>
+    // CHECK-COUNT-8: vector.store {{.*}}, vector<1xf16>
+    func.return
+  }
+
+  // CHECK-LABEL: @distribute_transfer_write_row_major_with_broadcast
+  func.func @distribute_transfer_write_row_major_with_broadcast(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
+    %c0 = arith.constant 0 : index
+    vector.transfer_write %root, %alloc[%c0, %c0, %a, %b]
+            {in_bounds = [true, true],
+             permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
+             "__vector_layout_test_anchor_operand_0" = #layout_row_major}
+                    : vector<16x16xf16>, memref<32x32x32x32xf16>
+    // CHECK-COUNT-4: vector.store {{.*}}, vector<8xf16>
+    func.return
+  }
+
+  // CHECK-LABEL: @distribute_transfer_write_col_major_with_broadcast
+  func.func @distribute_transfer_write_col_major_with_broadcast(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
+    %c0 = arith.constant 0 : index
+    vector.transfer_write %root, %alloc[%c0, %c0, %a, %b]
+            {in_bounds = [true, true],
+             permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
+             "__vector_layout_test_anchor_operand_0" = #layout_col_major}
+                    : vector<16x16xf16>, memref<32x32x32x32xf16>
+    // CHECK-COUNT-8: vector.store {{.*}}, vector<1xf16>
+    func.return
+  }
+
+  // CHECK-LABEL: @distribute_transfer_write_row_major_transpose
+  func.func @distribute_transfer_write_row_major_transpose(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
+    %c0 = arith.constant 0 : index
+    vector.transfer_write %root, %alloc[%c0, %c0, %a, %b]
+            {in_bounds = [true, true],
+             permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>,
+             "__vector_layout_test_anchor_operand_0" = #layout_row_major}
+                    : vector<16x16xf16>, memref<32x32x32x32xf16>
+    // CHECK-COUNT-32: vector.store {{.*}}, vector<1xf16>
+    func.return
+  }
+
+  // CHECK-LABEL: @distribute_transfer_write_col_major_transpose
+  func.func @distribute_transfer_write_col_major_transpose(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
+    %c0 = arith.constant 0 : index
+    vector.transfer_write %root, %alloc[%c0, %c0, %a, %b]
+            {in_bounds = [true, true],
+             permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>,
+             "__vector_layout_test_anchor_operand_0" = #layout_col_major}
+                    : vector<16x16xf16>, memref<32x32x32x32xf16>
+    // CHECK-COUNT-2: vector.store {{.*}}, vector<4xf16>
+    func.return
+  }
+
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -1019,6 +1019,7 @@ transform_dialect::TestGpuVectorDistribution::applyToOne(
   TestVectorLayoutOptions options(target);
   RewritePatternSet patterns(target.getContext());
 
+  rewriter.setInsertionPointToStart(&target.getBody().front());
   SmallVector<Value> threadGrid = {
       rewriter.create<gpu::ThreadIdOp>(target.getLoc(), gpu::Dimension::x),
       rewriter.create<gpu::ThreadIdOp>(target.getLoc(), gpu::Dimension::y),

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -1018,7 +1018,15 @@ transform_dialect::TestGpuVectorDistribution::applyToOne(
     transform::TransformState &state) {
   TestVectorLayoutOptions options(target);
   RewritePatternSet patterns(target.getContext());
+
+  SmallVector<Value> threadGrid = {
+      rewriter.create<gpu::ThreadIdOp>(target.getLoc(), gpu::Dimension::x),
+      rewriter.create<gpu::ThreadIdOp>(target.getLoc(), gpu::Dimension::y),
+      rewriter.create<gpu::ThreadIdOp>(target.getLoc(), gpu::Dimension::z),
+  };
+
   populateGPUDistributionPatterns(patterns);
+  populateGPUDistributionLayoutAttrPatterns(threadGrid, patterns);
   distributeVectorOps(target, patterns, options);
   return DiagnosedSilenceableFailure::success();
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h
@@ -42,6 +42,8 @@ public:
     return position < other.position;
   }
 
+  int64_t getPosition() const { return position; }
+
 private:
   int64_t position, stride;
 };


### PR DESCRIPTION
This patch adds distribution patterns for transfer_read/transfer_write and lowers them to vector.load/vector.store per thread. 

These distribution patterns do the lowering for transfer_read/transfer_write in one-shot, which is different from how transfer_read/transfer_write are lowered in upstream mlir. The upstream patterns unroll one dimension at a time and apply the patterns recursively. We do this lowering in one-shot because we have the layout attribute which defines the iteration space for the lowering.