### PR TITLE
conv2d-to-img-to-col pattern failure diagnostic improvements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ llvm-external-projects/iree-dialects/.cache
 
 # pkgci artifacts
 artifacts/
+
+iree_venv

--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,3 @@ llvm-external-projects/iree-dialects/.cache
 
 # pkgci artifacts
 artifacts/
-
-iree_venv

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -87,7 +87,9 @@ public:
     auto outputType = llvm::cast<ShapedType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
-      return failure();
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "expected 'filterType' and 'inputType' to have static shapes.";
+      });
     }
 
     // TODO: Support dilation.
@@ -224,8 +226,8 @@ public:
 };
 
 // Similar to the conv pattern above except there is no reduction among the
-// input channles so each convolution can be a matrix-vector product and
-// by transposing both input filter so channles are outer most the computation
+// input channels so each convolution can be a matrix-vector product and
+// by transposing both input filter so channels are outer most the computation
 // is a batched matrix-vector product.
 class ConvertDepthwiseConv2DNhwcHwc final
     : public OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcOp> {
@@ -242,6 +244,9 @@ public:
         llvm::cast<RankedTensorType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "expected 'filterType' and 'inputType' to have static shapes.";
+      });
       return failure();
     }
 
@@ -396,7 +401,9 @@ public:
     auto outputType = llvm::cast<ShapedType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
-      return failure();
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "expected 'filterType' and 'inputType' to have static shapes.";
+      });
     }
 
     // TODO: Support dilation.

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -88,14 +88,16 @@ public:
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
-        diag << "expected 'filterType' and 'inputType' to have static shapes.";
+        diag << "[unimplemented] "
+             << "expected 'filterType' and 'inputType' to have static shapes.";
       });
     }
 
     // TODO: Support dilation.
     if (!hasAllOneValues(convOp.getDilations())) {
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
-        diag << "expected no dilations (expected dilations to all be one).";
+        diag << "[unimplemented] "
+             << "expected no dilations (expected dilations to all be one).";
       });
     }
 
@@ -248,14 +250,16 @@ public:
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
-        diag << "expected 'filterType' and 'inputType' to have static shapes.";
+        diag << "[unimplemented] "
+             << "expected 'filterType' and 'inputType' to have static shapes.";
       });
     }
 
     // TODO: Support dilation.
     if (!hasAllOneValues(convOp.getDilations()))
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
-        diag << "expected no dilations (expected dilations to all be one).";
+        diag << "[unimplemented] "
+             << "expected no dilations (expected dilations to all be one).";
       });
 
     auto loc = convOp.getLoc();
@@ -406,14 +410,16 @@ public:
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
-        diag << "expected 'filterType' and 'inputType' to have static shapes.";
+        diag << "[unimplemented] "
+             << "expected 'filterType' and 'inputType' to have static shapes.";
       });
     }
 
     // TODO: Support dilation.
     if (!hasAllOneValues(convOp.getDilations()))
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
-        diag << "expected no dilations (expected dilations to all be one).";
+        diag << "[unimplemented] "
+             << "expected no dilations (expected dilations to all be one).";
       });
 
     Value input = convOp.getInputs()[0];

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -46,7 +46,7 @@ namespace {
 // and linalg.matmul.
 //
 // A convolution operaton can be written as a matrix-matrix multiplication by
-// unfolding the cross corrolation between input and filter and explicitly copy
+// unfolding the cross correlation between input and filter and explicitly copy
 // overlapped sliding window inputs.
 //
 // Consider 2D input X with single channel input and output and 2x2 filter W:
@@ -93,8 +93,11 @@ public:
     }
 
     // TODO: Support dilation.
-    if (!hasAllOneValues(convOp.getDilations()))
-      return failure();
+    if (!hasAllOneValues(convOp.getDilations())) {
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "expected no dilations (expected dilations to all be one).";
+      });
+    }
 
     Value input = convOp.getInputs()[0];
     Value filter = convOp.getInputs()[1];
@@ -247,12 +250,13 @@ public:
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
         diag << "expected 'filterType' and 'inputType' to have static shapes.";
       });
-      return failure();
     }
 
     // TODO: Support dilation.
     if (!hasAllOneValues(convOp.getDilations()))
-      return failure();
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "expected no dilations (expected dilations to all be one).";
+      });
 
     auto loc = convOp.getLoc();
 
@@ -408,7 +412,9 @@ public:
 
     // TODO: Support dilation.
     if (!hasAllOneValues(convOp.getDilations()))
-      return failure();
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "expected no dilations (expected dilations to all be one).";
+      });
 
     Value input = convOp.getInputs()[0];
     Value filter = convOp.getInputs()[1];


### PR DESCRIPTION
Useful when diagnosing why a pattern did not match (when running iree-opt with --debug flag). 

The 2 cases:
- dilations not 1.
- either of inputs not static. 