### PR TITLE
Always print x86 in Intel syntax

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -1231,7 +1231,10 @@ void ireeCompilerSetupGlobalCL(int argc, const char **argv, const char *banner,
     llvm::install_out_of_memory_new_handler();
   }
 
-  llvm::cl::ParseCommandLineOptions(argc, argv, banner);
+  llvm::SmallVector<const char *> args(argv, argv + argc);
+  args.push_back("--x86-asm-syntax=intel");
+
+  llvm::cl::ParseCommandLineOptions(args.size(), args.data(), banner);
 }
 
 void ireeCompilerGlobalInitialize() {


### PR DESCRIPTION
Crazy old AT&T syntax is still the LLVM default, but no one wants that.