### PR TITLE
Simplify how mmt4d ukernels deal with the K=0 case.

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -25,7 +25,6 @@ static inline void iree_uk_mmt4d_tile_f32f32f32_1x8x1_to_8x8x1_arm_64(
       acc[i] = vdupq_n_f32(0);
     }
   }
-  IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
     float32x4_t rhs[2];
     for (int i = 0; i < 2; ++i) {
@@ -110,7 +109,6 @@ static inline void iree_uk_mmt4d_tile_f16f16fXX_1x8x1_to_8x8x1_arm_64(
       acc[i] = vdupq_n_f32(0);
     }
   }
-  IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
     float32x4_t rhs[2];
     for (int i = 0; i < 2; ++i) {
@@ -218,7 +216,6 @@ static inline void iree_uk_mmt4d_tile_s8s8s32_1x8x1_to_8x8x1_arm_64(
       acc[i] = vdupq_n_s32(0);
     }
   }
-  IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
     int16x8_t rhs = vmovl_s8(vld1_s8(rhs_ptr));
     rhs_ptr += 8;

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
@@ -75,7 +75,6 @@ static inline void iree_uk_mmt4d_tile_bf16bf16fXX_1x8x4_to_8x8x4_arm_64_bf16(
     }
   }
 
-  IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
     bfloat16x8_t rhs[4];
     for (int i = 0; i < 4; ++i) {

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
@@ -25,7 +25,6 @@ static inline void iree_uk_mmt4d_tile_s8s8s32_1x8x4_to_8x8x4_arm_64_dotprod(
       acc[i] = vdupq_n_s32(0);
     }
   }
-  IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
     int8x16_t rhs[2];
     for (int i = 0; i < 2; ++i) {

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
@@ -51,7 +51,6 @@ void iree_uk_mmt4d_tile_f16f16f32_1x8x1_to_8x8x1_arm_64_fp16fml(
       acc[i] = vdupq_n_f32(0);
     }
   }
-  IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
     float16x8_t rhs = vld1q_f16(rhs_ptr);
     rhs_ptr += 8;

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fullfp16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fullfp16.c
@@ -25,7 +25,6 @@ void iree_uk_mmt4d_tile_f16f16f16_1x8x1_to_8x8x1_arm_64_fullfp16(
       acc[i] = vdupq_n_f16(0);
     }
   }
-  IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
     float16x8_t rhs = vld1q_f16(rhs_ptr);
     rhs_ptr += 8;

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c
@@ -58,8 +58,6 @@ void iree_uk_mmt4d_tile_s8s8s32_1x8x8_to_8x8x8_arm_64_i8mm(
       }
     }
   }
-
-  IREE_UK_ASSUME(params->K >= 1);
   for (int k = 0; k < params->K; ++k) {
     int8x16_t rhs[4];
     for (int i = 0; i < 4; ++i) {

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
@@ -307,7 +307,6 @@ void iree_uk_mmt4d_tile_s16u4s32_1x32x8_x86_64_avx512_vnni(
   const __m128i idx_2_mod_4 = _mm_set1_epi32(0x0e0a0602);
   const __m128i idx_3_mod_4 = _mm_set1_epi32(0x0f0b0703);
   const __m512i mask_0f = _mm512_set1_epi8(0x0f);
-  IREE_UK_ASSUME(params->K >= 1);
   for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     // Load 8xs16 LHS data.
     __m128i lhs = _mm_loadu_si128((const __m128i*)lhs_ptr);

--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -155,13 +155,6 @@
 #define IREE_UK_ASSUME_UNREACHABLE
 #endif  // IREE_UK_HAVE_BUILTIN(__builtin_unreachable)
 
-#define IREE_UK_ASSUME(condition) \
-  do {                            \
-    if (!(condition)) {           \
-      IREE_UK_ASSUME_UNREACHABLE; \
-    }                             \
-  } while (false)
-
 #if IREE_UK_HAVE_ATTRIBUTE(noinline) || defined(IREE_UK_COMPILER_GCC)
 #define IREE_UK_ATTRIBUTE_NOINLINE __attribute__((noinline))
 #else


### PR DESCRIPTION
The case of K=0 is vacuous when accumulating, so we just early-return. This doesn't change.

When not accumulating, it amounts to clearing the accumulator. We used to have dedicated code for that in `mmt4d.c`. That then allowed our ukernels tile-functions to `IREE_UK_ASSUME(K >= 1);`. That makes the asm a little simpler. However, that only really mattered when we thought we would be hand-writing that assembly. Now that we're not, it doesn't really matter, and the slightly smaller tile function code size is outweighed by the additional code in `mmt4d.c`.

Overall, this PR drops 40 lines of source code and makes bitcode 2% smaller.