### PR TITLE
Enforce CUDA >= 12 and fix its CMake search procedure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,9 @@ option(IREE_BUILD_EXPERIMENTAL_WEB_SAMPLES "Builds experimental web samples." OF
 #-------------------------------------------------------------------------------
 
 set(IREE_CUDA_AVAILABLE OFF)
-find_package(CUDAToolkit)
+# The IREE cuda2 driver requires CUDA >= 12.
+set(IREE_CUDA_MIN_VERSION_REQUIRED 12)
+find_package(CUDAToolkit ${IREE_CUDA_MIN_VERSION_REQUIRED})
 if(CUDAToolkit_FOUND)
   set(IREE_CUDA_AVAILABLE ON)
 else()

--- a/build_tools/third_party/cuda/CMakeLists.txt
+++ b/build_tools/third_party/cuda/CMakeLists.txt
@@ -19,6 +19,16 @@ function(fetch_cuda_toolkit)
   set(CUDAToolkit_ROOT ${_ACTUAL_DOWNLOAD_PATH} PARENT_SCOPE)
 endfunction()
 
+function(clear_cuda_toolkit_cache_garbage)
+  # This is a workaround for CMake bug
+  # when having a older than required system version of CUDA.
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/22010
+  unset(CUDAToolkit_BIN_DIR CACHE)
+  unset(CUDAToolkit_NVCC_EXECUTABLE CACHE)
+  unset(_cmake_CUDAToolkit_implicit_link_directories CACHE)
+  unset(_cmake_CUDAToolkit_include_directories CACHE)
+endfunction()
+
 if(DEFINED ENV{IREE_CUDA_DEPS_DIR})
   # We define the magic IREE_CUDA_DEPS_DIR env var in our CI docker images if we
   # have a stripped down CUDA toolkit suitable for compiling available. We
@@ -44,15 +54,13 @@ else()
         # Download succeeded.
         message(STATUS "Using downloaded CUDA toolkit: ${CUDAToolkit_ROOT}")
         set(CUDAToolkit_ROOT "${CUDAToolkit_ROOT}" PARENT_SCOPE)
-        # For some reason having the BIN_DIR set wrong can cause mayhem. Just make
-        # sure it is right.
-        set(CUDAToolkit_BIN_DIR "${CUDAToolkit_ROOT}/bin" PARENT_SCOPE)
+        clear_cuda_toolkit_cache_garbage()
       else()
         message(SEND_ERROR "Failed to download a CUDA toolkit. Check the logs and/or set CUDAToolkit_ROOT to an existing installation.")
       endif()
     endif()
   endif()
-  find_package(CUDAToolkit REQUIRED)
+  find_package(CUDAToolkit ${IREE_CUDA_MIN_VERSION_REQUIRED} REQUIRED)
 endif()
 
 # Locate the libdevice file.


### PR DESCRIPTION
The IREE cuda2 driver depends on CUDA version >= 12. It uses the define CU_DEVICE_ATTRIBUTE_MEM_SYNC_DOMAIN_COUNT that appears in CUDA 12.

Also address a bug in CMake's procedure to find CUDA when the wrong system version is available.