### PR TITLE
[CPU] Improve vector tile sizes for sub-byte matmuls on Aarch64

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1074,8 +1074,7 @@ static SizesAndScalableFlags getMatmulVectorSizes(func::FuncOp entryPointFn,
       // Note: This may not pick any sizes (which will fallback to the default
       // SVE) sizes below.
       getMatmulAArch64SMEVectorSizes(op, matmulTileSizes, matmulScalableFlags);
-    }
-    else {
+    } else {
       getMatmulAArch64NeonSVEVectorSizes(entryPointFn, op, vectorSize,
                                          matmulTileSizes, matmulScalableFlags);
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1018,9 +1018,8 @@ static void getMatmulAArch64NeonSVEVectorSizes(
   }
 
   LLVM_DEBUG(KD_DBGS() << "Smallest type found: " << minSize << " bits\n");
-
-  if (minSize < 0 || minSize == std::numeric_limits<int64_t>::max())
-    return;
+  assert(minSize > 0 && minSize < std::numeric_limits<int64_t>::max() &&
+         "Min size couldn't be computed");
 
   // Make sure that the smallest type can at least fill a full vector register
   // given the tile size of the main vector dimension (N).
@@ -1074,7 +1073,9 @@ static SizesAndScalableFlags getMatmulVectorSizes(func::FuncOp entryPointFn,
       // Note: This may not pick any sizes (which will fallback to the default
       // SVE) sizes below.
       getMatmulAArch64SMEVectorSizes(op, matmulTileSizes, matmulScalableFlags);
-    } else {
+    }
+
+    if (matmulTileSizes.empty()) {
       getMatmulAArch64NeonSVEVectorSizes(entryPointFn, op, vectorSize,
                                          matmulTileSizes, matmulScalableFlags);
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1010,6 +1010,8 @@ static void getFullRegisterHeuristicsMatmulVectorSizes(
 /// size N would be at least 128/8=16.
 ///
 /// NOTE: This function should not contain target-specific conditional code.
+/// TODO: Currently it's only use on Aarch64. We should generalize it to other
+/// targets.
 static void getMatmulVectorSizesUsingFullVectorHeuristics(
     func::FuncOp entryPointFn, linalg::LinalgOp op, int64_t vectorSize,
     SmallVectorImpl<int64_t> &sizes, SmallVectorImpl<bool> &scalableSizeFlags) {
@@ -1090,13 +1092,13 @@ static SizesAndScalableFlags getMatmulVectorSizes(func::FuncOp entryPointFn,
       // heuristics below).
       getMatmulAArch64SMEVectorSizes(op, matmulTileSizes, matmulScalableFlags);
     }
-  }
 
-  // Try to maximize the vector register utilization for all the matmul element
-  // types.
-  if (matmulTileSizes.empty()) {
-    getMatmulVectorSizesUsingFullVectorHeuristics(
-        entryPointFn, op, vectorSize, matmulTileSizes, matmulScalableFlags);
+    // Try to maximize the vector register utilization for all the matmul
+    // element types.
+    if (matmulTileSizes.empty()) {
+      getMatmulVectorSizesUsingFullVectorHeuristics(
+          entryPointFn, op, vectorSize, matmulTileSizes, matmulScalableFlags);
+    }
   }
 
   // If tile sizes were not computed by previous heuristics, use default

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1070,8 +1070,8 @@ static SizesAndScalableFlags getMatmulVectorSizes(func::FuncOp entryPointFn,
 
   if (isAArch64(targetAttr)) {
     if (hasSMEFeature(targetAttr)) {
-      // Note: This may not pick any sizes (which will fallback to the default
-      // SVE) sizes below.
+      // Note: This may not pick any sizes (which will fallback to the SVE
+      // heuristics below).
       getMatmulAArch64SMEVectorSizes(op, matmulTileSizes, matmulScalableFlags);
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
@@ -62,6 +62,60 @@ hal.executable private @matmul_tensors_default  {
     #hal.descriptor_set.binding<3, storage_buffer>
   ]>
 ]>
+hal.executable private @i4_i4_i32_matmul  {
+  hal.executable.variant @llvm target(<"llvm-cpu", "embedded-elf-arm_64", {
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    native_vector_size = 16 : index,
+    target_triple = "aarch64-none-elf"
+  }>) {
+    hal.executable.export @i4_i4_i32_matmul layout(#pipeline_layout)
+    builtin.module {
+      func.func @i4_i4_i32_matmul() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %M = hal.interface.constant.load[0] : index
+        %N = hal.interface.constant.load[1] : index
+        %K = hal.interface.constant.load[2] : index
+        %lhs_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xi4>>{%M, %K}
+        %rhs_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xi4>>{%K, %N}
+        %init_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xi32>>{%M, %N}
+        %result_binding = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer)
+            : !flow.dispatch.tensor<writeonly:tensor<?x?xi32>>{%M, %N}
+        %lhs = flow.dispatch.tensor.load %lhs_binding, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xi4>>{%M, %K} -> tensor<?x?xi4>
+        %rhs = flow.dispatch.tensor.load %rhs_binding, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xi4>>{%K, %N} -> tensor<?x?xi4>
+        %init = flow.dispatch.tensor.load %init_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xi32>>{%M, %N} -> tensor<?x?xi32>
+        %gemm = linalg.matmul ins(%lhs, %rhs : tensor<?x?xi4>, tensor<?x?xi4>) outs(%init : tensor<?x?xi32>) -> tensor<?x?xi32>
+        flow.dispatch.tensor.store %gemm, %result_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xi32>>{%M, %N}
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [64, 64, 0], [0, 0, 0], [8, 32, 0], [0, 0, 1], [0, 0, 0]]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
+//       CHECK: hal.executable.export public @i4_i4_i32_matmul
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
 hal.executable private @matmul_tensors_sve  {
   hal.executable.variant @llvm target(<"llvm-cpu", "embedded-elf-arm_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",


### PR DESCRIPTION
This PR introduces a simple heuristic to make sure that we at least fill one vector register for the smallest data type used in the matmul. For example, given a 128-bit vector and a `i32 <- i4, i4` matmul, we used 16 tile size for the main vector dimension (16x4 = 64 bits, half vector). With this PR we use 32 (32x4 = 128 bits, full vector).