### PR TITLE
[cuda] Collect tracing events after command buffer completion

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda2/pending_queue_actions.h
+++ b/runtime/src/iree/hal/drivers/cuda2/pending_queue_actions.h
@@ -45,11 +45,20 @@ iree_status_t iree_hal_cuda2_pending_queue_actions_create(
 // Destroys the pending |actions| queue.
 void iree_hal_cuda2_pending_queue_actions_destroy(iree_hal_resource_t* actions);
 
+// Callback to execute user code after action completion but before resource
+// releasing.
+//
+// Data behind |user_data| must remain alive before the action is released.
+typedef void(IREE_API_PTR* iree_hal_cuda2_pending_action_cleanup_callback_t)(
+    void* user_data);
+
 // Enqueues the given list of |command_buffers| that waits on
 // |wait_semaphore_list| and signals |signal_semaphore_lsit|.
 iree_status_t iree_hal_cuda2_pending_queue_actions_enqueue_execution(
     iree_hal_device_t* device, CUstream dispatch_stream,
     CUstream callback_stream, iree_hal_cuda2_pending_queue_actions_t* actions,
+    iree_hal_cuda2_pending_action_cleanup_callback_t cleanup_callback,
+    void* callback_user_data,
     const iree_hal_semaphore_list_t wait_semaphore_list,
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_host_size_t command_buffer_count,


### PR DESCRIPTION
Now we have proper async execution in the cuda HAL driver, command buffers may not execute immediately after enqueuing, so we should not collect the tracing events there. Instead, we should collect when we know the command buffers have completed in a deferred and async manner.