### PR TITLE
Revert "Disable loop unrolling in LLVM IR optimization passes"

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.h
@@ -35,7 +35,7 @@ struct LLVMTarget {
   static constexpr bool DEFAULT_LINK_STATIC = false;
   static constexpr bool DEFAULT_LOOP_INTERLEAVING = false;
   static constexpr bool DEFAULT_LOOP_VECTORIZATION = false;
-  static constexpr bool DEFAULT_LOOP_UNROLLING = false;
+  static constexpr bool DEFAULT_LOOP_UNROLLING = true;
   static constexpr bool DEFAULT_SLP_VECTORIZATION = false;
   static constexpr llvm::FloatABI::ABIType DEFAULT_FLOAT_ABI =
       llvm::FloatABI::ABIType::Hard;


### PR DESCRIPTION
Reverts openxla/iree#16092

Further discussion on that PR calls for a revert while we figure out the best path forward.

Note: since #16153 was merged today, even after this reverts lands, we will still be able to disable llvm loop unrolling by passing `--iree-llvmcpu-loop-unrolling=false`.