### PR TITLE
Remove `c2-standard-16` from codebase

### DIFF
--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -259,7 +259,7 @@ def _parse_arguments():
         "--shard_count",
         type=_parse_shard_count,
         default={},
-        help="Accepts a comma-separated list of device-name to shard-count mappings. Use reserved keyword 'default' for setting a default shard count: c2-standard-16=3,default=2",
+        help="Accepts a comma-separated list of device-name to shard-count mappings. Use reserved keyword 'default' for setting a default shard count: c2-standard-60=3,default=2",
     )
 
     compilation_parser = subparser.add_parser(

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -52,7 +52,7 @@ if [[ "${TARGET_DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
         # --traced_benchmark_tool_dir="${TRACED_BENCHMARK_TOOLS_DIR}" \
         # --trace_capture_tool="${TRACY_CAPTURE_TOOL}" \
         # --capture_tarball="${BENCHMARK_TRACES}" \
-elif [[ "${TARGET_DEVICE_NAME}" =~ ^(c2-standard-16|c2-standard-60)$ ]]; then
+elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-60" ]]; then
   ${DOCKER_WRAPPER} \
     gcr.io/iree-oss/base-bleeding-edge@sha256:14200dacca3a0f3a66f8aa87c6f64729b83a2eeb403b689c24204074ad157418 \
       ./build_tools/benchmarks/run_benchmarks_on_linux.py \

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -162,13 +162,6 @@ function create_template() {
         --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${DISK_SIZE_GB},type=pd-ssd"
       )
       ;;
-    c2s16)
-      cmd+=(
-        --machine-type=c2-standard-16
-        --maintenance-policy=MIGRATE
-        --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${DISK_SIZE_GB},type=pd-ssd"
-      )
-      ;;
     c2s601t)
       cmd+=(
         --machine-type=c2-standard-60
@@ -201,7 +194,7 @@ function create_template() {
 
 for group in presubmit postsubmit; do
   # TODO(#14661): Remove c2s601t if we decide not to migrate benchmarks to it.
-  for type in gpu a100 cpu c2s16 c2s601t arm64; do
+  for type in gpu a100 cpu c2s601t arm64; do
     create_template "${group}" "${type}"
   done
 done

--- a/docs/website/docs/developers/performance/benchmark-suites.md
+++ b/docs/website/docs/developers/performance/benchmark-suites.md
@@ -113,7 +113,7 @@ build_tools/benchmarks/run_benchmarks_on_linux.py \
   --normal_benchmark_tool_dir="${IREE_BUILD_DIR?}/tools" \
   --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR?}" \
   --execution_benchmark_config="${E2E_TEST_ARTIFACTS_DIR?}/exec_config.json" \
-  --target_device_name="<target_device_name, e.g. c2-standard-16>" \
+  --target_device_name="<target_device_name, e.g. c2-standard-60>" \
   --output="${E2E_TEST_ARTIFACTS_DIR?}/benchmark_results.json" \
   --verbose \
   --cpu_uarch="<host CPU uarch, e.g. CascadeLake>"
@@ -127,7 +127,7 @@ Note that:
 
 - `<target_device_name>` selects a benchmark group targets a specific device:
     - Common options:
-        - `c2-standard-16` for x86_64 CPU benchmarks.
+        - `c2-standard-60` for x86_64 CPU benchmarks.
         - `a2-highgpu-1g` for NVIDIA GPU benchmarks.
     - All device names are defined under
         [build_tools/python/e2e_test_framework/device_specs](https://github.com/openxla/iree/tree/main/build_tools/python/e2e_test_framework/device_specs).
@@ -143,7 +143,7 @@ build_tools/benchmarks/run_benchmarks_on_linux.py \
   --normal_benchmark_tool_dir="${IREE_BUILD_DIR?}/tools" \
   --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR?}" \
   --execution_benchmark_config="${E2E_TEST_ARTIFACTS_DIR?}/exec_config.json" \
-  --target_device_name="c2-standard-16" \
+  --target_device_name="c2-standard-60" \
   --output="${E2E_TEST_ARTIFACTS_DIR?}/benchmark_results.json" \
   --verbose \
   --cpu_uarch="CascadeLake" \


### PR DESCRIPTION
Remove the remaining c2-standard-16 in codebase. All workload has been moved to c2-standard-60 runners

Fix #14661