### PR TITLE
Revert "Freeze all statuses emitted by calls into dynamic modules

### DIFF
--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -442,12 +442,6 @@ IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t iree_status_allocate_vf(
 IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t
 iree_status_clone(iree_status_t status);
 
-// Freezes |status| into a new status instance. Formats all attached
-// annotations, payloads included, into a single message string allocated to
-// the new status. This always frees the original status.
-IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t
-iree_status_freeze(iree_status_t status);
-
 // Frees |status| if it has any associated storage.
 IREE_API_EXPORT void iree_status_free(iree_status_t status);
 

--- a/runtime/src/iree/vm/dynamic/module.c
+++ b/runtime/src/iree/vm/dynamic/module.c
@@ -49,9 +49,9 @@ static iree_status_t iree_vm_dynamic_module_instantiate(
   // Try to create the module, which may fail if the version is incompatible or
   // the parameters are invalid.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_status_freeze(create_fn(
-              IREE_VM_DYNAMIC_MODULE_VERSION_LATEST, instance, param_count,
-              params, module->allocator, &module->user_module)));
+      z0,
+      create_fn(IREE_VM_DYNAMIC_MODULE_VERSION_LATEST, instance, param_count,
+                params, module->allocator, &module->user_module));
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -91,16 +91,16 @@ iree_vm_dynamic_module_signature(void* self) {
 static iree_status_t IREE_API_PTR iree_vm_dynamic_module_get_module_attr(
     void* self, iree_host_size_t index, iree_string_pair_t* out_attr) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  return iree_status_freeze(module->user_module->get_module_attr(
-      module->user_module->self, index, out_attr));
+  return module->user_module->get_module_attr(module->user_module->self, index,
+                                              out_attr);
 }
 
 static iree_status_t iree_vm_dynamic_module_enumerate_dependencies(
     void* self, iree_vm_module_dependency_callback_t callback,
     void* user_data) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  return iree_status_freeze(module->user_module->enumerate_dependencies(
-      module->user_module->self, callback, user_data));
+  return module->user_module->enumerate_dependencies(module->user_module->self,
+                                                     callback, user_data);
 }
 
 static iree_status_t IREE_API_PTR iree_vm_dynamic_module_get_function(
@@ -108,9 +108,9 @@ static iree_status_t IREE_API_PTR iree_vm_dynamic_module_get_function(
     iree_vm_function_t* out_function, iree_string_view_t* out_name,
     iree_vm_function_signature_t* out_signature) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  IREE_RETURN_IF_ERROR(iree_status_freeze(module->user_module->get_function(
+  IREE_RETURN_IF_ERROR(module->user_module->get_function(
       module->user_module->self, linkage, ordinal, out_function, out_name,
-      out_signature)));
+      out_signature));
   if (out_function) out_function->module = (iree_vm_module_t*)self;
   return iree_ok_status();
 }
@@ -119,8 +119,8 @@ static iree_status_t IREE_API_PTR iree_vm_dynamic_module_get_function_attr(
     void* self, iree_vm_function_linkage_t linkage, iree_host_size_t ordinal,
     iree_host_size_t index, iree_string_pair_t* out_attr) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  return iree_status_freeze(module->user_module->get_function_attr(
-      module->user_module->self, linkage, ordinal, index, out_attr));
+  return module->user_module->get_function_attr(
+      module->user_module->self, linkage, ordinal, index, out_attr);
 }
 
 static iree_status_t IREE_API_PTR iree_vm_dynamic_module_lookup_function(
@@ -128,9 +128,9 @@ static iree_status_t IREE_API_PTR iree_vm_dynamic_module_lookup_function(
     const iree_vm_function_signature_t* expected_signature,
     iree_vm_function_t* out_function) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  IREE_RETURN_IF_ERROR(iree_status_freeze(module->user_module->lookup_function(
+  IREE_RETURN_IF_ERROR(module->user_module->lookup_function(
       module->user_module->self, linkage, name, expected_signature,
-      out_function)));
+      out_function));
   out_function->module = (iree_vm_module_t*)self;
   return iree_ok_status();
 }
@@ -141,8 +141,8 @@ iree_vm_dynamic_module_resolve_source_location(
     iree_vm_source_location_t* out_source_location) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
   if (module->user_module->resolve_source_location) {
-    return iree_status_freeze(module->user_module->resolve_source_location(
-        module->user_module->self, function, pc, out_source_location));
+    return module->user_module->resolve_source_location(
+        module->user_module->self, function, pc, out_source_location);
   }
   return iree_status_from_code(IREE_STATUS_UNAVAILABLE);
 }
@@ -151,8 +151,8 @@ static iree_status_t IREE_API_PTR
 iree_vm_dynamic_module_alloc_state(void* self, iree_allocator_t allocator,
                                    iree_vm_module_state_t** out_module_state) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  return iree_status_freeze(module->user_module->alloc_state(
-      module->user_module->self, allocator, out_module_state));
+  return module->user_module->alloc_state(module->user_module->self, allocator,
+                                          out_module_state);
 }
 
 static void IREE_API_PTR iree_vm_dynamic_module_free_state(
@@ -166,29 +166,29 @@ static iree_status_t IREE_API_PTR iree_vm_dynamic_module_resolve_import(
     const iree_vm_function_t* function,
     const iree_vm_function_signature_t* signature) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  return iree_status_freeze(module->user_module->resolve_import(
-      module->user_module->self, module_state, ordinal, function, signature));
+  return module->user_module->resolve_import(
+      module->user_module->self, module_state, ordinal, function, signature);
 }
 
 static iree_status_t IREE_API_PTR iree_vm_dynamic_module_notify(
     void* self, iree_vm_module_state_t* module_state, iree_vm_signal_t signal) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  return iree_status_freeze(module->user_module->notify(
-      module->user_module->self, module_state, signal));
+  return module->user_module->notify(module->user_module->self, module_state,
+                                     signal);
 }
 
 static iree_status_t IREE_API_PTR iree_vm_dynamic_module_begin_call(
     void* self, iree_vm_stack_t* stack, iree_vm_function_call_t call) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  return iree_status_freeze(
-      module->user_module->begin_call(module->user_module->self, stack, call));
+  return module->user_module->begin_call(module->user_module->self, stack,
+                                         call);
 }
 
 static iree_status_t IREE_API_PTR iree_vm_dynamic_module_resume_call(
     void* self, iree_vm_stack_t* stack, iree_byte_span_t call_results) {
   iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
-  return iree_status_freeze(module->user_module->resume_call(
-      module->user_module->self, stack, call_results));
+  return module->user_module->resume_call(module->user_module->self, stack,
+                                          call_results);
 }
 
 static iree_status_t iree_vm_dynamic_module_create(

--- a/samples/custom_module/dynamic/module.cc
+++ b/samples/custom_module/dynamic/module.cc
@@ -148,11 +148,6 @@ class CustomModuleState final {
     return OkStatus();
   }
 
-  // Prints the contents of the string to stdout.
-  Status ThrowError() {
-    return iree_make_status(IREE_STATUS_UNKNOWN, "Forced failure");
-  }
-
  private:
   // Allocator that the caller requested we use for any allocations we need to
   // perform during operation.
@@ -164,7 +159,6 @@ static const vm::NativeFunction<CustomModuleState> kCustomModuleFunctions[] = {
     vm::MakeNativeFunction("string.from_tensor",
                            &CustomModuleState::StringFromTensor),
     vm::MakeNativeFunction("string.print", &CustomModuleState::StringPrint),
-    vm::MakeNativeFunction("error", &CustomModuleState::ThrowError),
 };
 
 // The module instance that will be allocated and reused across contexts.

--- a/samples/custom_module/dynamic/test/example.mlir
+++ b/samples/custom_module/dynamic/test/example.mlir
@@ -6,14 +6,6 @@
 // RUN:     --function=main | \
 // RUN: FileCheck %s
 
-// RUN: ( iree-compile %s --iree-hal-target-backends=vmvx | \
-// RUN: iree-run-module \
-// RUN:     --device=local-sync \
-// RUN:     --module=$IREE_BINARY_DIR/samples/custom_module/dynamic/module$IREE_DYLIB_EXT@create_custom_module \
-// RUN:     --module=- \
-// RUN:     --function=error 2>&1 || [[ $? == 1 ]] ) | \
-// RUN: FileCheck %s --check-prefix=CERROR
-
 module @example {
   //===--------------------------------------------------------------------===//
   // Imports
@@ -28,9 +20,6 @@ module @example {
 
   // Prints the contents of the string to stdout.
   func.func private @custom.string.print(!custom.string)
-
-  // Always returns unknown status with a custom annotation.
-  func.func private @custom.error()
 
   //===--------------------------------------------------------------------===//
   // Sample methods
@@ -52,13 +41,4 @@ module @example {
 
     return
   }
-
-  // CERROR-LABEL: EXEC @error
-  func.func @error() {
-    // Show an example of dumping a custom error message.
-    // CERROR-NEXT: samples/custom_module/dynamic/module.cc:153: UNKNOWN; Forced failure; while invoking C++ function custom.error;
-    call @custom.error() : () -> ()
-    return
-  }
-
 }


### PR DESCRIPTION
This reverts commit 37e65de8d29eb961777dbf39cda93217d1d12add due to CI failures on mac and windows.

https://github.com/openxla/iree/actions/runs/7632630125/job/20799143734