### PR TITLE
[CPU] Add patterns to drop unit dimensions at vector level

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -58,6 +58,7 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
   // pass. We are abusing OptimizeVectorTransferPass with `flatten=true` in some
   // CPU pipelines.
   vector::populateVectorTransferDropUnitDimsPatterns(patterns);
+  vector::populateDropUnitDimWithShapeCastPatterns(patterns);
   vector::populateVectorGatherLoweringPatterns(patterns);
   vector::populateVectorContractLoweringPatterns(
       patterns, vectorTransformOptions,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
@@ -47,10 +47,10 @@ hal.executable private @split_reduction_pass1_dispatch_0 {
 // CHECK:           scf.for
 // CHECK:             scf.for
 // CHECK:               scf.for %[[ARG3:.+]] = %[[C0]] to %[[C64]] step %[[C1]]
-// CHECK:                 %[[RES:.+]] = arith.addi
-// CHECK:                 scf.yield %[[RES]] : vector<1x1x4xi32>
+// CHECK:                 arith.addi
+// CHECK:                 scf.yield %{{.*}} : vector<1x1x4xi32>
 // CHECK:               vector.reduction <add>, %{{.+}} %{{.+}} : vector<4xi32> into i32
-// CHECK:             arith.addi %{{.+}}, %{{.+}} : vector<1x4xi32>
+// CHECK:             arith.addi %{{.+}}, %{{.+}} : vector<4xi32>
 
 // -----
 
@@ -103,10 +103,10 @@ hal.executable private @split_reduction_pass1_dispatch_0 {
 // REORDERCHECK:           scf.for
 // REORDERCHECK:             scf.for
 // REORDERCHECK:               scf.for %[[ARG3:.+]] = %[[C0]] to %[[C64]] step %[[C1]]
-// REORDERCHECK:                 %[[RES:.+]] = arith.addf
-// REORDERCHECK:                 scf.yield %[[RES]] : vector<1x1x4xf32>
+// REORDERCHECK:                 arith.addf
+// REORDERCHECK:                 scf.yield %{{.*}} : vector<1x1x4xf32>
 // REORDERCHECK:               vector.reduction <add>, %{{.+}} %{{.+}} : vector<4xf32> into f32
-// REORDERCHECK:             arith.addf %{{.+}}, %{{.+}} : vector<1x4xf32>
+// REORDERCHECK:             arith.addf %{{.+}}, %{{.+}} : vector<4xf32>
 
 // -----
 
@@ -152,8 +152,8 @@ hal.executable private @split_reduction_pass2_dispatch_0 {
 // CHECK:            scf.for
 // CHECK:              scf.for
 // CHECK:                scf.for %[[ARG3:.+]] = %[[C0]] to %[[C64]] step %[[C1]]
-// CHECK:                  %[[RES:.+]] = arith.addi
-// CHECK:                  scf.yield %[[RES]] : vector<1x1x4xi32>
+// CHECK:                  arith.addi
+// CHECK:                  scf.yield %{{.*}} : vector<1x1x4xi32>
 // CHECK:                vector.reduction <add>, %{{.+}} %{{.+}} : vector<4xi32> into i32
 
 // -----
@@ -196,8 +196,8 @@ hal.executable private @split_reduction_pass3_dispatch_0 {
 // CHECK:            scf.for
 // CHECK:              scf.for
 // CHECK:                scf.for %[[ARG3:.+]] = %[[C0]] to %[[C64]] step %[[C1]]
-// CHECK:                  %[[RES:.+]] = arith.addi
-// CHECK:                  scf.yield %[[RES]] : vector<1x1x4xi32>
+// CHECK:                  arith.addi
+// CHECK:                  scf.yield %{{.*}} : vector<1x1x4xi32>
 // CHECK:                vector.reduction <add>, %{{.+}} %{{.+}} : vector<4xi32> into i32
 
 // -----


### PR DESCRIPTION
This PR adds patterns to the vector lowering pass to drop unit dimensions for vector elementwise ops.

Co-authored-by: Jerry Wu <cheyuw@google.com>