### PR TITLE
[CPU] Remove "clamping" when calculating vec tile sizes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -779,23 +779,14 @@ static LogicalResult setMatmulPeelingRootConfig(
     int vectorSize) {
 
   // 0. Preprocess for scalable vectors
-  // Clamp vector tile sizes to have better hint about peeling + masking. This
-  // is critical for scalable vectorization, so it can resolve correct scalable
-  // vector sizes.
-  SmallVector<int64_t> clampedVecTileSizes(vecTileSizes);
-  for (const auto &[index, size] : llvm::enumerate(cacheTileSizes)) {
-    if (!size) {
-      continue;
-    }
-    clampedVecTileSizes[index] = std::min(clampedVecTileSizes[index], size);
-  }
+  SmallVector<int64_t> roundedVecTileSizes(vecTileSizes);
 
   // The LLVM backend struggles to legalize non-power-of-two scalable vectors,
   // hence the extra rounding up.
-  for (const auto &[index, size] : llvm::enumerate(clampedVecTileSizes)) {
+  for (const auto &[index, size] : llvm::enumerate(roundedVecTileSizes)) {
     if (!size)
       continue;
-    clampedVecTileSizes[index] =
+    roundedVecTileSizes[index] =
         roundUpToPow2(size,
                       /*predicate=*/inputVecScalableTileFlags[index]);
   }
@@ -810,8 +801,8 @@ static LogicalResult setMatmulPeelingRootConfig(
   SmallVector<int64_t> cacheReductionTileSizes(numTilingDims, 0);
   std::swap(cacheParallelTileSizes.back(), cacheReductionTileSizes.back());
 
-  SmallVector<int64_t> vectorParallelTileSizes(clampedVecTileSizes.begin(),
-                                               clampedVecTileSizes.end());
+  SmallVector<int64_t> vectorParallelTileSizes(roundedVecTileSizes.begin(),
+                                               roundedVecTileSizes.end());
   SmallVector<int64_t> vectorReductionTileSizes(numTilingDims, 0);
   std::swap(vectorParallelTileSizes.back(), vectorReductionTileSizes.back());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
@@ -87,7 +87,7 @@ hal.executable private @matmul_static_tensors_sve  {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 7, 0], [5, 7, 0], [0, 0, 0], [5, [8], 0], [0, 0, 1], [0, 0, 0]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[5, 7, 0], [5, 7, 0], [0, 0, 0], [8, [16], 0], [0, 0, 1], [0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
 //       CHECK: hal.executable.export public @static_tensors_non_pow_two_sizes
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -418,7 +418,7 @@ hal.executable private @matmul_partially_peel  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[43, 8, 0], [43, 8, 0], [0, 0, 0], [8, 8, 0], [0, 0, 16], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[43, 8, 0], [43, 8, 0], [0, 0, 0], [8, 32, 0], [0, 0, 16], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
 //      CHECK: hal.executable.export public @matmul_partially_peel
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
This is currently kept specifically for SVE. However, we disable
distribution in our SVE experiments, so this is effectively not used. I
also don't have any data indicating that this is needed. Hence removing
to simplify the logic.

Relevant discussion/comments:
  * https://github.com/openxla/iree/pull/16058#discussion_r1459579805
  * https://github.com/openxla/iree/pull/16113
