### PR TITLE
Drop slow `vmvx_resnet_50_int8` test.

### DIFF
--- a/integrations/tensorflow/test/iree_tfl_tests/README.md
+++ b/integrations/tensorflow/test/iree_tfl_tests/README.md
@@ -6,19 +6,22 @@ update_tflite_model_documentation.py to update this table.
 
 |       Model        |      Status        |
 | ------------------ | ------------------ |
-mobilenet_v3         | PASS ✓
-llvmcpu_resnet_50_int8 | PASS ✓
-vulkan_mobilebert_tf2_quant | FAIL ✗
 cartoon_gan          | PASS ✓
-llvmcpu_mobilebert_tf2_quant | PASS ✓
-mnasnet              | PASS ✓
-person_detect        | PASS ✓
-vulkan_posenet_i8    | FAIL ✗
 east_text_detector   | PASS ✓
 gpt2                 | PASS ✓
+llvmcpu_mobilebert_tf2_quant | PASS ✓
 llvmcpu_mobilenet_v1 | PASS ✓
-llvmcpu_mobilenet_v3-large_uint8 | PASS ✓
+llvmcpu_mobilenet_v3-large_uint8 | FAIL ✗
+llvmcpu_posenet_i8   | FAIL ✗
+llvmcpu_resnet_50_int8 | PASS ✓
+mnasnet              | PASS ✓
+mobilenet_v3         | PASS ✓
+person_detect        | PASS ✓
+vmvx_mobilebert_tf2_quant | PASS ✓
+vmvx_mobilenet_v3-large_uint8 | FAIL ✗
+vmvx_person_detect   | PASS ✓
+vulkan_mobilebert_tf2_quant | FAIL ✗
 vulkan_mobilenet_v1  | PASS ✓
 vulkan_mobilenet_v3-large_uint8 | FAIL ✗
-llvmcpu_posenet_i8   | FAIL ✗
+vulkan_posenet_i8    | FAIL ✗
 vulkan_resnet_50_int8 | FAIL ✗

--- a/integrations/tensorflow/test/iree_tfl_tests/update_tflite_model_documentation.py
+++ b/integrations/tensorflow/test/iree_tfl_tests/update_tflite_model_documentation.py
@@ -39,7 +39,7 @@ def main():
                 FAILURE_ELEMENT if "XFAIL" in file.read() else SUCCESS_ELEMENT
             )
 
-    with open(readme_file_path, "w") as tflite_model_documentation:
+    with open(readme_file_path, "w", encoding="utf-8") as tflite_model_documentation:
         tflite_model_documentation.write(
             "# TFLite integration tests status\n\n"
             "This dashboard shows the models that are currently being tested on IREE's\n"

--- a/integrations/tensorflow/test/iree_tfl_tests/vmvx_resnet_50_int8.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/vmvx_resnet_50_int8.run
@@ -1,4 +1,0 @@
-# REQUIRES: vmvx
-# RUN: %PYTHON -m iree_tfl_tests.resnet_50_int8_test --target_backend=vmvx -artifacts_dir=%t
-# TODO(#10514): Address vmvx numerical mismatch issue.
-# XFAIL: vmvx


### PR DESCRIPTION
This XFAIL test takes an extra 3 minutes to run ([logs here](https://github.com/openxla/iree/actions/runs/7641771786/job/20820445747#step:6:129)):
```
Wed, 24 Jan 2024 14:56:21 GMT -- Testing: 21 tests, 21 workers --
Wed, 24 Jan 2024 14:56:21 GMT UNSUPPORTED: TENSORFLOW_TESTS :: iree_tfl_tests/llvmcpu_mobilebert_tf2_quant.run (1 of 21)
Wed, 24 Jan 2024 14:56:21 GMT UNSUPPORTED: TENSORFLOW_TESTS :: iree_tfl_tests/vmvx_mobilebert_tf2_quant.run (2 of 21)
Wed, 24 Jan 2024 14:56:21 GMT UNSUPPORTED: TENSORFLOW_TESTS :: iree_tfl_tests/vulkan_mobilebert_tf2_quant.run (3 of 21)
Wed, 24 Jan 2024 14:56:21 GMT UNSUPPORTED: TENSORFLOW_TESTS :: iree_tfl_tests/vulkan_mobilenet_v1.run (4 of 21)
Wed, 24 Jan 2024 14:56:21 GMT UNSUPPORTED: TENSORFLOW_TESTS :: iree_tfl_tests/vulkan_mobilenet_v3-large_uint8.run (5 of 21)
Wed, 24 Jan 2024 14:56:21 GMT UNSUPPORTED: TENSORFLOW_TESTS :: iree_tfl_tests/vulkan_resnet_50_int8.run (6 of 21)
Wed, 24 Jan 2024 14:56:21 GMT UNSUPPORTED: TENSORFLOW_TESTS :: iree_tfl_tests/vulkan_posenet_i8.run (7 of 21)
Wed, 24 Jan 2024 14:56:27 GMT PASS: TENSORFLOW_TESTS :: iree_tf_tests/llvmcpu__simple_arithmetic.run (8 of 21)
Wed, 24 Jan 2024 14:56:29 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/llvmcpu_mobilenet_v1.run (9 of 21)
Wed, 24 Jan 2024 14:56:31 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/vmvx_person_detect.run (10 of 21)
Wed, 24 Jan 2024 14:56:31 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/person_detect.run (11 of 21)
Wed, 24 Jan 2024 14:56:33 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/mnasnet.run (12 of 21)
Wed, 24 Jan 2024 14:56:34 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/cartoon_gan.run (13 of 21)
Wed, 24 Jan 2024 14:56:35 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/mobilenet_v3.run (14 of 21)
Wed, 24 Jan 2024 14:56:37 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/east_text_detector.run (15 of 21)
Wed, 24 Jan 2024 14:56:42 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/llvmcpu_resnet_50_int8.run (16 of 21)
Wed, 24 Jan 2024 14:56:43 GMT XFAIL: TENSORFLOW_TESTS :: iree_tfl_tests/llvmcpu_posenet_i8.run (17 of 21)
Wed, 24 Jan 2024 14:56:44 GMT XFAIL: TENSORFLOW_TESTS :: iree_tfl_tests/vmvx_mobilenet_v3-large_uint8.run (18 of 21)
Wed, 24 Jan 2024 14:56:54 GMT PASS: TENSORFLOW_TESTS :: iree_tfl_tests/gpt2.run (19 of 21)
Wed, 24 Jan 2024 14:56:55 GMT XFAIL: TENSORFLOW_TESTS :: iree_tfl_tests/llvmcpu_mobilenet_v3-large_uint8.run (20 of 21)
Wed, 24 Jan 2024 14:59:51 GMT XFAIL: TENSORFLOW_TESTS :: iree_tfl_tests/vmvx_resnet_50_int8.run (21 of 21)
Wed, 24 Jan 2024 14:59:51 GMT Testing Time: 209.86s
```
(look at the last 3 timestamps)