### PR TITLE
[GlobalOpt] Fix extract_slice transpose propagation bug

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -211,8 +211,6 @@ public:
       // the transposed domain.
       int64_t transposedIdx = perm[idx];
       if (!rankReducingMask.contains(transposedIdx)) {
-        llvm::dbgs() << "rankReducedMap[" << invPerm[transposedIdx]
-                     << "]: " << dim << "\n";
         // Domain of `rankReducedMap` is in pre-transposed domain
         rankReducedMap[idx] = dim++;
       }

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -201,11 +201,20 @@ public:
     }
     llvm::SmallDenseSet<unsigned> rankReducingMask = *maybeRankReducingMask;
 
+    // Find rank reducing map in the pre-transposed domain.
     int64_t dim = 0;
     llvm::SmallDenseMap<int64_t, int64_t> rankReducedMap;
-    for (int64_t i = 0, e = perm.size(); i < e; ++i) {
-      if (!rankReducingMask.contains(i)) {
-        rankReducedMap[i] = dim++;
+    // Since `dim` is in the pre-transposed domain, and is incrementing each
+    // iteration, `idx` must also be in the pre-transposed domain
+    for (int64_t idx = 0, e = perm.size(); idx < e; ++idx) {
+      // Get index in the transposed domain, since `rankReducingMask` is in
+      // the transposed domain.
+      int64_t transposedIdx = perm[idx];
+      if (!rankReducingMask.contains(transposedIdx)) {
+        llvm::dbgs() << "rankReducedMap[" << invPerm[transposedIdx]
+                     << "]: " << dim << "\n";
+        // Domain of `rankReducedMap` is in pre-transposed domain
+        rankReducedMap[idx] = dim++;
       }
     }
 

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -205,13 +205,12 @@ public:
     int64_t dim = 0;
     llvm::SmallDenseMap<int64_t, int64_t> rankReducedMap;
     // Since `dim` is in the pre-transposed domain, and is incrementing each
-    // iteration, `idx` must also be in the pre-transposed domain
+    // iteration, `idx` must also be in the pre-transposed domain.
     for (int64_t idx = 0, e = perm.size(); idx < e; ++idx) {
       // Get index in the transposed domain, since `rankReducingMask` is in
       // the transposed domain.
-      int64_t transposedIdx = perm[idx];
-      if (!rankReducingMask.contains(transposedIdx)) {
-        // Domain of `rankReducedMap` is in pre-transposed domain
+      if (!rankReducingMask.contains(perm[idx])) {
+        // Domain of `rankReducedMap` is in pre-transposed domain.
         rankReducedMap[idx] = dim++;
       }
     }


### PR DESCRIPTION
Fixes a bug with propagating a `linalg.transpose` through a `tensor.extract_slice` when there is a unit dim being transposed that is folded by the extract_slice.