### PR TITLE
Adding util.func/util.call to allow for richer functions.

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/torch_to_iree.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/torch_to_iree.mlir
@@ -24,8 +24,8 @@ module {
     %6 = torch.aten.add.Tensor %3, %5, %int1_2 : !torch.vtensor<[128,30],f32>, !torch.vtensor<[30],f32>, !torch.int -> !torch.vtensor<[128,30],f32>
     return %6 : !torch.vtensor<[128,30],f32>
   }
-  util.global private @_params.classifier.weight {noinline} : tensor<30x20xf32>
-  util.global private @_params.classifier.bias {noinline} : tensor<30xf32>
+  util.global private @_params.classifier.weight {inlining_policy = #util.inline.never} : tensor<30x20xf32>
+  util.global private @_params.classifier.bias {inlining_policy = #util.inline.never} : tensor<30xf32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/convert_streamable_ops.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/convert_streamable_ops.mlir
@@ -121,7 +121,7 @@ func.func private @callerWithTies(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
 
 // Tests that attrs we don't know about are passed through to the new ops.
 
-// CHECK: flow.func private @importPassThroughAttrs(%arg0: tensor<1xi32> {some.arg_attr}) -> tensor<1xi8> {some.result_attr} attributes {some.import_attr}
+// CHECK: flow.func private @importPassThroughAttrs(%arg0: tensor<1xi32> {some.arg_attr}) -> (tensor<1xi8> {some.result_attr}) attributes {some.import_attr}
 func.func private @importPassThroughAttrs(tensor<1xi32> {some.arg_attr}) -> (tensor<1xi8> {some.result_attr}) attributes {
   iree.abi.streamable,
   some.import_attr

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
@@ -100,7 +100,7 @@ util.initializer {
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@spirv::@dispatch_0) workgroups([%c1, %c1, %c1])
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@spirv::@dispatch_1) workgroups([%c1, %c1, %c1])
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@spirv::@dispatch_2) workgroups([%c1, %c1, %c1])
-  util.initializer.return
+  util.return
 }
 
 //  CHECK-NOT: hal.executable private @dispatch_0

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
@@ -93,7 +93,7 @@ util.initializer {
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@vmvx::@dispatch_0) workgroups([%c1, %c1, %c1])
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@vmvx::@dispatch_1) workgroups([%c1, %c1, %c1])
   hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@vmvx::@dispatch_2) workgroups([%c1, %c1, %c1])
-  util.initializer.return
+  util.return
 }
 
 // All executables (including their interfaces and entry points) should be

--- a/compiler/src/iree/compiler/ConstEval/test/compile_regressions.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/compile_regressions.mlir
@@ -42,7 +42,7 @@ module @hoisted_tensor_i1_input {
       linalg.yield %2 : i32
     } -> tensor<4xi32>
     util.global.store %1, @hoisted : tensor<4xi32>
-    util.initializer.return
+    util.return
   }
 }
 

--- a/compiler/src/iree/compiler/ConstEval/test/failing.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/failing.mlir
@@ -15,6 +15,6 @@ module @eval_i64_scalar {
     %offset = util.global.load @offset : f64
     %sum = arith.addf %cst, %offset : f64
     util.global.store %sum, @hoisted : f64
-    util.initializer.return
+    util.return
   }
 }

--- a/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
@@ -36,7 +36,7 @@ module @linalg_tensor_jit {
       linalg.yield %4 : f32
     } -> tensor<5x6xf32>
     util.global.store %3, @hoisted : tensor<5x6xf32>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -52,7 +52,7 @@ module @eval_splat_detection {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<[2, 2]> : tensor<2xi32>
     util.global.store %cst, @hoisted : tensor<2xi32>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -69,7 +69,7 @@ module @eval_f16_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<2.0e+2> : tensor<5x6xf16>
     util.global.store %cst, @hoisted : tensor<5x6xf16>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -86,7 +86,7 @@ module @eval_bf16_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<2.0e+2> : tensor<5x6xbf16>
     util.global.store %cst, @hoisted : tensor<5x6xbf16>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -102,7 +102,7 @@ module @eval_f32_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<[2.0e+2, 3.2e+3]> : tensor<2xf32>
     util.global.store %cst, @hoisted : tensor<2xf32>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -118,7 +118,7 @@ module @eval_f64_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<[2.0e+2, 3.2e+3]> : tensor<2xf64>
     util.global.store %cst, @hoisted : tensor<2xf64>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -137,7 +137,7 @@ module @eval_i1_tensor {
     %cst = arith.constant dense<[0, 1, 0, 1, 1, 0]> : tensor<6xi8>
     %casted = arith.trunci %cst : tensor<6xi8> to tensor<6xi1>
     util.global.store %casted, @hoisted : tensor<6xi1>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -153,7 +153,7 @@ module @eval_i4_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<3> : tensor<5x6xi4>
     util.global.store %cst, @hoisted : tensor<5x6xi4>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -169,7 +169,7 @@ module @eval_i8_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<[2, 3]> : tensor<2xi8>
     util.global.store %cst, @hoisted : tensor<2xi8>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -185,7 +185,7 @@ module @eval_i16_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<[2, 3]> : tensor<2xi16>
     util.global.store %cst, @hoisted : tensor<2xi16>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -201,7 +201,7 @@ module @eval_i32_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<[2, 3]> : tensor<2xi32>
     util.global.store %cst, @hoisted : tensor<2xi32>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -217,7 +217,7 @@ module @eval_i64_tensor {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<[2, 3]> : tensor<2xi64>
     util.global.store %cst, @hoisted : tensor<2xi64>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -234,7 +234,7 @@ module @eval_i64_tensor_splat {
   util.initializer attributes {iree.compiler.consteval} {
     %cst = arith.constant dense<2> : tensor<2xi64>
     util.global.store %cst, @hoisted : tensor<2xi64>
-    util.initializer.return
+    util.return
   }
 }
 
@@ -260,6 +260,6 @@ module @serializable_attrs {
       linalg.yield %2 : i8
     } -> tensor<5x6xi8>
     util.global.store %1, @hoisted : tensor<5x6xi8>
-    util.initializer.return
+    util.return
   }
 }

--- a/compiler/src/iree/compiler/ConstEval/test/scalar_values.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/scalar_values.mlir
@@ -14,7 +14,7 @@ module @eval_i8_scalar {
     %offset = util.global.load @offset : i8
     %sum = arith.addi %cst, %offset : i8
     util.global.store %sum, @hoisted : i8
-    util.initializer.return
+    util.return
   }
 }
 
@@ -33,7 +33,7 @@ module @eval_i16_scalar {
     %offset = util.global.load @offset : i16
     %sum = arith.addi %cst, %offset : i16
     util.global.store %sum, @hoisted : i16
-    util.initializer.return
+    util.return
   }
 }
 
@@ -52,7 +52,7 @@ module @eval_i32_scalar {
     %offset = util.global.load @offset : i32
     %sum = arith.addi %cst, %offset : i32
     util.global.store %sum, @hoisted : i32
-    util.initializer.return
+    util.return
   }
 }
 
@@ -71,7 +71,7 @@ module @eval_i64_scalar {
     %offset = util.global.load @offset : i64
     %sum = arith.addi %cst, %offset : i64
     util.global.store %sum, @hoisted : i64
-    util.initializer.return
+    util.return
   }
 }
 
@@ -90,6 +90,6 @@ module @eval_f32_scalar {
     %offset = util.global.load @offset : f32
     %sum = arith.addf %cst, %offset : f32
     util.global.store %sum, @hoisted : f32
-    util.initializer.return
+    util.return
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/call_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/call_ops.mlir
@@ -17,14 +17,14 @@ flow.func private @externArg2Attrs(%arg0: tensor<4x?xi32> {arg.attr0}, %arg1: i3
 flow.func private @externRet0()
 // CHECK-NEXT: flow.func private @externRet1() -> tensor<4x?xi32>
 flow.func private @externRet1() -> tensor<4x?xi32>
-// CHECK-NEXT: flow.func private @externRet1Attrs() -> tensor<4x?xi32> {arg.attr}
-flow.func private @externRet1Attrs() -> tensor<4x?xi32> {arg.attr}
+// CHECK-NEXT: flow.func private @externRet1Attrs() -> (tensor<4x?xi32> {ret.attr})
+flow.func private @externRet1Attrs() -> (tensor<4x?xi32> {ret.attr})
 // CHECK-NEXT: flow.func private @externRet2() -> (tensor<4x?xi32>, i32)
 flow.func private @externRet2() -> (tensor<4x?xi32>, i32)
-// CHECK-NEXT: flow.func private @externRet2Attrs() -> (tensor<4x?xi32> {arg.attr0}, i32 {arg.attr1})
-flow.func private @externRet2Attrs() -> (tensor<4x?xi32> {arg.attr0}, i32 {arg.attr1})
-// CHECK-NEXT: flow.func private @externRetAttributes() -> tensor<4x?xi32> {arg.attr} attributes {some.attr = 123 : index}
-flow.func private @externRetAttributes() -> tensor<4x?xi32> {arg.attr} attributes {some.attr = 123 : index}
+// CHECK-NEXT: flow.func private @externRet2Attrs() -> (tensor<4x?xi32> {ret.attr0}, i32 {ret.attr1})
+flow.func private @externRet2Attrs() -> (tensor<4x?xi32> {ret.attr0}, i32 {ret.attr1})
+// CHECK-NEXT: flow.func private @externRetAttributes() -> (tensor<4x?xi32> {ret.attr}) attributes {some.attr = 123 : index}
+flow.func private @externRetAttributes() -> (tensor<4x?xi32> {ret.attr}) attributes {some.attr = 123 : index}
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -45,7 +45,8 @@ createPrimitiveDefaultGlobalOp(std::string name, Location loc, Type type,
       loc, name,
       /*isMutable=*/false, type, initialValue);
   globalOp.setPrivate();
-  globalOp->setAttr("noinline", moduleBuilder.getUnitAttr());
+  globalOp.setGlobalInliningPolicy(
+      moduleBuilder.getAttr<IREE::Util::InlineNeverAttr>());
   symbolTable.insert(globalOp);
   return globalOp;
 }
@@ -61,7 +62,8 @@ createBufferLikeGlobalOp(std::string name, Location loc, Type globalType,
       loc, name,
       /*isMutable=*/false, globalType);
   globalOp.setPrivate();
-  globalOp->setAttr("noinline", moduleBuilder.getUnitAttr());
+  globalOp.setGlobalInliningPolicy(
+      moduleBuilder.getAttr<IREE::Util::InlineNeverAttr>());
   symbolTable.insert(globalOp);
 
   // Create an initializer that allocates the buffer storage.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -85,7 +85,7 @@ createBufferLikeGlobalOp(std::string name, Location loc, Type globalType,
   // util.global.store
   initializerBuilder.create<IREE::Util::GlobalStoreOp>(
       loc, barrierOp.getResult(0), globalOp.getName());
-  initializerBuilder.create<IREE::Util::InitializerReturnOp>(loc);
+  initializerBuilder.create<IREE::Util::ReturnOp>(loc);
 
   return globalOp;
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.h
@@ -33,7 +33,7 @@ private:
 
 } // namespace mlir
 
-namespace mlir ::iree_compiler::IREE::Flow {
+namespace mlir::iree_compiler::IREE::Flow {
 
 /// Computes the workload and provides a workload region builder for the given
 /// root op.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-flow-form-dispatch-regions{fuse-multi-use=true}, iree-flow-clone-producers-into-dispatch-regions, iree-flow-collapse-dimensions, cse))" %s | FileCheck %s
 !type = tensor<2x4x8x16x32x64xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type
 
 func.func @collapse1() -> !type {
   %cst = arith.constant 0.000000e+00 : f32
@@ -35,7 +35,7 @@ func.func @collapse1() -> !type {
 // -----
 
 !type = tensor<2x4x8x32x32x64x128xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type
 
 func.func @collapse2() -> !type {
   %cst = arith.constant 0.000000e+00 : f32
@@ -70,7 +70,7 @@ func.func @collapse2() -> !type {
 
 // -----
 !type = tensor<2x4x8x16x32x64x128x256xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type
 
 func.func @collapse3() -> !type {
   %cst = arith.constant 0.000000e+00 : f32
@@ -105,7 +105,7 @@ func.func @collapse3() -> !type {
 // -----
 
 !type = tensor<2x4x8x16x64x64x128x256xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type
 func.func @collapse4() -> !type {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
@@ -140,7 +140,7 @@ func.func @collapse4() -> !type {
 // -----
 
 !type = tensor<2x4x32x32x32x64x128x256xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type
 func.func @collapse5() -> !type {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
@@ -183,7 +183,7 @@ func.func @collapse5() -> !type {
 // -----
 
 !type = tensor<32x2x4x8x16x16x64x128xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type
 func.func @collapse6() -> !type {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
@@ -219,7 +219,7 @@ func.func @collapse6() -> !type {
 
 !type_out = tensor<2x4x8x16xf32>
 !type_in = tensor<2x4x8xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type_in
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type_in
 func.func @collapse7() -> !type_out {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
@@ -310,7 +310,7 @@ func.func @dont_collapse() -> !type_out {
 
 !type_in = tensor<2x4x8x16x32x64x128x256xf32>
 !type_out = tensor<2x4x16x64x32x128x256xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type_in
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type_in
 
 func.func @collapse9() -> !type_out {
   %cst = arith.constant 0.000000e+00 : f32
@@ -421,7 +421,7 @@ func.func @dont_collapse_dueto_index(%height : index, %width : index) -> !type {
 // -----
 
 !type = tensor<2x4x8x16x32x64xf32>
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type
 
 func.func @collapse12() -> (!type,!type,!type,!type) {
   %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/deduplicate_executables.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/deduplicate_executables.mlir
@@ -72,7 +72,7 @@ util.initializer {
   // CHECK: {{.*}} = flow.dispatch @duplicate_executables_ex_0::@duplicate_executables_entry_0(%[[CST]]) : (tensor<4xf32>) -> tensor<4xf32>
   %0 = flow.dispatch @duplicate_executables_ex_1::@duplicate_executables_entry_1(%cst) : (tensor<4xf32>) -> tensor<4xf32>
   util.optimization_barrier %0 : tensor<4xf32>
-  util.initializer.return
+  util.return
 }
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
@@ -11,8 +11,8 @@ func.func @simpleMul(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view) -> !hal.b
   return %3 : !hal.buffer_view
 }
 
-//      CHECK: util.global private @[[GLOBAL_ARG0:.+]] {noinline} : !hal.buffer_view
-//      CHECK: util.global private @[[GLOBAL_ARG1:.+]] {noinline} : !hal.buffer_view
+//      CHECK: util.global private @[[GLOBAL_ARG0:.+]] {inlining_policy = #util.inline.never} : !hal.buffer_view
+//      CHECK: util.global private @[[GLOBAL_ARG1:.+]] {inlining_policy = #util.inline.never} : !hal.buffer_view
 
 //      CHECK: func.func @simpleMul_benchmark() attributes {iree.abi.stub, iree.reflection = {iree.benchmark = "entry"}} {
 //  CHECK-DAG:   %[[ARG0:.+]] = util.global.load @[[GLOBAL_ARG0]] : !hal.buffer_view
@@ -37,8 +37,8 @@ func.func @while(%start: i32, %bound: i32) -> i32 {
   return %5 : i32
 }
 
-//     CHECK: util.global private @[[GLOBAL_ARG0:.+]] {noinline} = 0 : i32
-//     CHECK: util.global private @[[GLOBAL_ARG1:.+]] {noinline} = 0 : i32
+//     CHECK: util.global private @[[GLOBAL_ARG0:.+]] {inlining_policy = #util.inline.never} = 0 : i32
+//     CHECK: util.global private @[[GLOBAL_ARG1:.+]] {inlining_policy = #util.inline.never} = 0 : i32
 
 //     CHECK: func.func @while_benchmark()
 // CHECK-DAG:   %[[ARG0:.+]] = util.global.load @[[GLOBAL_ARG0]] : i32
@@ -59,7 +59,7 @@ func.func @importBufferViewBitcasting(%view: !hal.buffer_view) -> !hal.buffer_vi
   return %2 : !hal.buffer_view
 }
 
-//      CHECK: util.global private @[[GLOBAL_ARG0:.+]] {noinline} : !hal.buffer_view
+//      CHECK: util.global private @[[GLOBAL_ARG0:.+]] {inlining_policy = #util.inline.never} : !hal.buffer_view
 //      CHECK: util.initializer {
 //  CHECK-DAG:   %[[SPLAT:.+]] = flow.tensor.splat %c0_i32
 //  CHECK-DAG:   %[[EXPORT:.+]] = hal.tensor.export %[[SPLAT]] : tensor<4xi32> -> !hal.buffer_view
@@ -99,14 +99,14 @@ func.func @exportBufferViewInPlace(%view: !hal.buffer_view, %storage: !hal.buffe
   return %2 : !hal.buffer_view
 }
 
-//      CHECK: util.global private @[[GLOBAL_ARG0:.+]] {noinline} : !hal.buffer_view
+//      CHECK: util.global private @[[GLOBAL_ARG0:.+]] {inlining_policy = #util.inline.never} : !hal.buffer_view
 //      CHECK: util.initializer {
 //  CHECK-DAG:   %[[SPLAT0:.+]] = flow.tensor.splat %c0_i32
 //  CHECK-DAG:   %[[EXPORT0:.+]] = hal.tensor.export %[[SPLAT0]] : tensor<4xi32> -> !hal.buffer_view
 //  CHECK-DAG:   %[[DNO0:.+]] = util.optimization_barrier %[[EXPORT0]]
 // CHECK-NEXT:   util.global.store %[[DNO0]], @[[GLOBAL_ARG0]]
 
-//      CHECK: util.global private @[[GLOBAL_ARG1:.+]] {noinline} : !hal.buffer
+//      CHECK: util.global private @[[GLOBAL_ARG1:.+]] {inlining_policy = #util.inline.never} : !hal.buffer
 //      CHECK: util.initializer {
 //  CHECK-DAG:   %[[SPLAT1:.+]] = flow.tensor.splat %c0_i32
 //  CHECK-DAG:   %[[EXPORT1:.+]] = hal.tensor.export %[[SPLAT1]] : tensor<4xi32> -> !hal.buffer

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -194,7 +194,7 @@ appendGlobalBuffer(Location loc, StringRef baseName,
 
   initBuilder.create<IREE::Util::GlobalStoreOp>(loc, allocateOp.getResult(),
                                                 globalOp.getNameAttr());
-  initBuilder.create<IREE::Util::InitializerReturnOp>(loc);
+  initBuilder.create<IREE::Util::ReturnOp>(loc);
 
   return globalOp;
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
@@ -152,7 +152,7 @@ struct MaterializeDispatchInstrumentationPass
           /*uninitialized=*/true, /*affinity=*/nullptr);
       initializerBuilder.create<IREE::Util::GlobalStoreOp>(loc, buffer,
                                                            globalOp);
-      initializerBuilder.create<IREE::Util::InitializerReturnOp>(loc);
+      initializerBuilder.create<IREE::Util::ReturnOp>(loc);
     }
 
     FlatbufferBuilder metadataBuilder;

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -131,7 +131,7 @@ private:
         loc, layoutType, device, flags, bindingAttrs);
     blockBuilder.create<IREE::Util::GlobalStoreOp>(loc, layout,
                                                    globalOp.getName());
-    blockBuilder.create<IREE::Util::InitializerReturnOp>(loc);
+    blockBuilder.create<IREE::Util::ReturnOp>(loc);
 
     return globalOp;
   }
@@ -186,7 +186,7 @@ private:
         setLayoutValues);
     blockBuilder.create<IREE::Util::GlobalStoreOp>(loc, layout,
                                                    globalOp.getName());
-    blockBuilder.create<IREE::Util::InitializerReturnOp>(loc);
+    blockBuilder.create<IREE::Util::ReturnOp>(loc);
 
     return globalOp;
   }
@@ -283,7 +283,7 @@ private:
     auto executableValue = switchOp.getResult(0);
     blockBuilder.create<IREE::Util::GlobalStoreOp>(loc, executableValue,
                                                    globalOp.getName());
-    blockBuilder.create<IREE::Util::InitializerReturnOp>(loc);
+    blockBuilder.create<IREE::Util::ReturnOp>(loc);
   }
 
   // Inlines a constant block as a function in |moduleBuilder| and then inserts

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
@@ -101,7 +101,7 @@ struct MemoizeDeviceQueriesPass
                                                     okGlobalOp.getName());
       funcBuilder.create<IREE::Util::GlobalStoreOp>(
           fusedLoc, queryOp.getValue(), valueGlobalOp.getName());
-      funcBuilder.create<IREE::Util::InitializerReturnOp>(fusedLoc);
+      funcBuilder.create<IREE::Util::ReturnOp>(fusedLoc);
 
       for (auto queryOp : queryOps) {
         OpBuilder replaceBuilder(queryOp);

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -250,7 +250,7 @@ util.initializer {
   %device = hal.devices.get %c0 : !hal.device
   %descriptor_set_layout = hal.descriptor_set_layout.create device(%device : !hal.device) flags("None") bindings([#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>]) : !hal.descriptor_set_layout
   util.global.store %descriptor_set_layout, @_descriptor_set_layout_0 : !hal.descriptor_set_layout
-  util.initializer.return
+  util.return
 }
 
 util.global private @_pipeline_layout_0 : !hal.pipeline_layout
@@ -260,7 +260,7 @@ util.initializer {
   %device = hal.devices.get %c0 : !hal.device
   %pipeline_layout = hal.pipeline_layout.create device(%device : !hal.device) push_constants(0) layouts([%_descriptor_set_layout_0]) : !hal.pipeline_layout
   util.global.store %pipeline_layout, @_pipeline_layout_0 : !hal.pipeline_layout
-  util.initializer.return
+  util.return
 }
 
 util.global private @_executable_exe : !hal.executable
@@ -281,7 +281,7 @@ util.initializer {
     scf.yield %null : !hal.executable
   }
   util.global.store %selected, @_executable_exe : !hal.executable
-  util.initializer.return
+  util.return
 }
 
 hal.executable @exe {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -142,7 +142,7 @@ struct GlobalOpExpansion
           globalOp.getLoc(), initialValue, resourceOp.getSymName());
       rewriter.create<IREE::Util::GlobalStoreOp>(
           globalOp.getLoc(), initialValueSize, resourceSizeOp.getSymName());
-      rewriter.create<IREE::Util::InitializerReturnOp>(globalOp.getLoc());
+      rewriter.create<IREE::Util::ReturnOp>(globalOp.getLoc());
     }
 
     expansionState->globalMap[globalOp.getSymName()] = ExpandedGlobalResource{
@@ -256,7 +256,7 @@ void populateUtilToStreamConversionPatterns(MLIRContext *context,
       });
 
   conversionTarget
-      .addLegalOp<IREE::Util::InitializerOp, IREE::Util::InitializerReturnOp>();
+      .addLegalOp<IREE::Util::InitializerOp, IREE::Util::ReturnOp>();
   conversionTarget.addDynamicallyLegalOp<IREE::Util::GlobalOp>(
       [&](IREE::Util::GlobalOp op) {
         return typeConverter.isLegal(op.getType()) &&

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/dump_statistics.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/dump_statistics.mlir
@@ -43,7 +43,7 @@ util.initializer {
   %did_map, %result = stream.resource.try_map %1[%c0] : !util.buffer -> i1, !stream.resource<constant>{%c192}
   util.global.store %result, @_constant : !stream.resource<constant>
   util.global.store %0, @_constant__timepoint : !stream.timepoint
-  util.initializer.return
+  util.return
 }
 
 stream.executable private @func_a_ex_0 {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/elide_timepoints_coverage.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/elide_timepoints_coverage.mlir
@@ -12,7 +12,7 @@ util.initializer {
   util.global.store %t0, @global0 : !stream.timepoint
   %t1 = stream.cmd.execute await(%t0) => with() {} => !stream.timepoint
   util.global.store %t1, @global1 : !stream.timepoint
-  util.initializer.return
+  util.return
 }
 
 // CHECK-LABEL: @initializedGlobals

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/materialize_builtins.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/materialize_builtins.mlir
@@ -82,7 +82,7 @@ util.initializer {
   %c0_i64 = arith.constant 0 : i64
   // CHECK: = stream.async.dispatch @__builtin_splat_i64::@__builtin_splat_i64
   %0 = stream.async.splat %c0_i64 : i64 -> !stream.resource<*>{%c128}
-  util.initializer.return
+  util.return
 }
 
 // CHECK: stream.executable private @__builtin_splat_i64

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
@@ -148,8 +148,7 @@ struct ConvertMemRefGlobalOp : public OpConversionPattern<memref::GlobalOp> {
         alignmentAttr, /*mimeType=*/nullptr);
     initializerBuilder.create<IREE::Util::GlobalStoreOp>(
         globalOp.getLoc(), constantOp.getResult(), newOp.getName());
-    initializerBuilder.create<IREE::Util::InitializerReturnOp>(
-        globalOp.getLoc());
+    initializerBuilder.create<IREE::Util::ReturnOp>(globalOp.getLoc());
 
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/test/structural_ops.mlir
@@ -11,7 +11,7 @@ util.initializer {
   cf.br ^bb1(%value : memref<?xi8>)
 // CHECK: ^bb1(%[[ARG:.+]]: !util.buffer)
 ^bb1(%block_arg: memref<?xi8>):
-  util.initializer.return
+  util.return
 }
 func.func private @extern() -> memref<?xi8>
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/BUILD.bazel
@@ -80,6 +80,8 @@ iree_compiler_cc_library(
         "UtilAttrs.h.inc",
         "UtilAttrInterfaces.cpp.inc",
         "UtilAttrInterfaces.h.inc",
+        "UtilEnums.cpp.inc",
+        "UtilEnums.h.inc",
         "UtilOpInterfaces.cpp.inc",
         "UtilOpInterfaces.h.inc",
         "UtilOps.cpp.inc",
@@ -124,6 +126,14 @@ iree_gentbl_cc_library(
         (
             ["--gen-attrdef-defs"],
             "UtilAttrs.cpp.inc",
+        ),
+        (
+            ["--gen-enum-decls"],
+            "UtilEnums.h.inc",
+        ),
+        (
+            ["--gen-enum-defs"],
+            "UtilEnums.cpp.inc",
         ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",

--- a/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
@@ -42,6 +42,8 @@ iree_cc_library(
     "UtilAttrInterfaces.h.inc"
     "UtilAttrs.cpp.inc"
     "UtilAttrs.h.inc"
+    "UtilEnums.cpp.inc"
+    "UtilEnums.h.inc"
     "UtilOpInterfaces.cpp.inc"
     "UtilOpInterfaces.h.inc"
     "UtilOps.cpp.inc"
@@ -90,6 +92,8 @@ iree_tablegen_library(
   OUTS
     --gen-attrdef-decls UtilAttrs.h.inc
     --gen-attrdef-defs UtilAttrs.cpp.inc
+    --gen-enum-decls UtilEnums.h.inc
+    --gen-enum-defs UtilEnums.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
@@ -111,6 +111,48 @@ def Util_CompositeAttr : AttrDef<Util_Dialect, "Composite", [
 }
 
 //===----------------------------------------------------------------------===//
+// #util.inline.*
+//===----------------------------------------------------------------------===//
+
+def Util_InlineNeverAttr : AttrDef<Util_Dialect, "InlineNever", [
+  Util_InliningPolicyAttrInterface,
+]> {
+  let mnemonic = "inline.never";
+  let summary = [{disables inlining on the associated function}];
+  let description = [{
+    Disables inlining of the function the attribute is associated with into
+    any call-site.
+  }];
+  let parameters = (ins);
+  let assemblyFormat = [{}];
+  let extraClassDeclaration = [{
+    bool isLegalToInline(Operation *inlineSite, Operation *inlinable) {
+      return false;
+    }
+  }];
+}
+
+def Util_InlineAlwaysAttr : AttrDef<Util_Dialect, "InlineAlways", [
+  Util_InliningPolicyAttrInterface,
+]> {
+  let mnemonic = "inline.always";
+  let summary = [{forces inlining on the associated function when possible}];
+  let description = [{
+    Skips any cost-model decisions as to whether a function should be inlined
+    into call-sites and allows the inlining to happen. Any policies that prevent
+    inlining will still be observed and inlining may fail if any are not
+    satisfied.
+  }];
+  let parameters = (ins);
+  let assemblyFormat = [{}];
+  let extraClassDeclaration = [{
+    bool isLegalToInline(Operation *inlineSite, Operation *inlinable) {
+      return true;
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // #util.uninitialized
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
@@ -65,7 +65,7 @@ struct UtilInlinerInterface : public DialectInlinerInterface {
   }
 
   void handleTerminator(Operation *op, Block *newDest) const final {
-    auto returnOp = dyn_cast<IREE::Util::InitializerReturnOp>(op);
+    auto returnOp = dyn_cast<IREE::Util::ReturnOp>(op);
     if (!returnOp)
       return;
     // util.initialize.return takes no args - just branch to the new block.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
@@ -100,14 +100,30 @@ struct GlobalOpInterfaceExternalModel
     ml_program::GlobalOp::attachInterface<GlobalOpInterfaceExternalModel>(*ctx);
   }
 
-  Attribute getGlobalInitialValue(::mlir::Operation *op) const {
+  Attribute getGlobalInitialValue(Operation *op) const {
     return cast<ml_program::GlobalOp>(op).getValueAttr();
   }
-  void setGlobalInitialValue(::mlir::Operation *op, Attribute value) const {
+  void setGlobalInitialValue(Operation *op, Attribute value) const {
     if (value) {
       cast<ml_program::GlobalOp>(op).setValueAttr(value);
     } else {
       cast<ml_program::GlobalOp>(op).removeValueAttr();
+    }
+  }
+
+  IREE::Util::InliningPolicyAttrInterface
+  getGlobalInliningPolicy(Operation *op) const {
+    if (op->hasAttr("noinline"))
+      return IREE::Util::InlineNeverAttr::get(op->getContext());
+    return {};
+  }
+  void
+  setGlobalInliningPolicy(Operation *op,
+                          IREE::Util::InliningPolicyAttrInterface value) const {
+    if (isa_and_nonnull<IREE::Util::InlineNeverAttr>(value)) {
+      op->setAttr("noinline", UnitAttr::get(op->getContext()));
+    } else {
+      op->removeAttr("noinline");
     }
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -150,7 +150,8 @@ def Util_GlobalOpInterface : OpInterface<"GlobalOpInterface"> {
         // Assumed by accessors:
         TypeAttr:$type,
         UnitAttr:$is_mutable,
-        OptionalAttr<AnyAttr>:$initial_value
+        OptionalAttr<AnyAttr>:$initial_value,
+        OptionalAttr<Util_InliningPolicyAttrInterface>:$inlining_policy
       );
     ```
   }];
@@ -264,6 +265,34 @@ def Util_GlobalOpInterface : OpInterface<"GlobalOpInterface"> {
           $_op->setAttr("initial_value", (value));
         } else {
           $_op.removeInitialValueAttr();
+        }
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns an optional inlining policy for the global.
+      }],
+      /*retTy=*/"IREE::Util::InliningPolicyAttrInterface",
+      /*methodName=*/"getGlobalInliningPolicy",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return $_op.getInliningPolicyAttr();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Sets (or clears) the inlining policy of the global.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"setGlobalInliningPolicy",
+      /*args=*/(ins "IREE::Util::InliningPolicyAttrInterface":$value),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        if (value) {
+          $_op.setInliningPolicyAttr(value);
+        } else {
+          $_op.removeInliningPolicyAttr();
         }
       }]
     >,
@@ -1194,6 +1223,35 @@ def Util_SubrangeOperandOpInterface : OpInterface<"SubrangeOperandOpInterface"> 
         "unsigned":$operandIndex,
         "IREE::Util::SubrangeOperand":$operand
       )
+    >,
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// IREE::Util::InliningPolicyAttrInterface
+//===----------------------------------------------------------------------===//
+
+def Util_InliningPolicyAttrInterface : AttrInterface<"InliningPolicyAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Util";
+
+  let description = [{
+    Interface allowing attributes to control the inlining behavior of functions
+    and globals they are associated with.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if the inlinable operation (function, global, etc) is
+        allowed to be inlined into the inline site (caller, accessor, etc).
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isLegalToInline",
+      /*args=*/(ins
+        "Operation *":$inlineSite,
+        "Operation *":$inlinable
+      ),
+      /*methodBody=*/[{}]
     >,
   ];
 }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -538,7 +538,7 @@ struct DropEmptyInitializerOp : public OpRewritePattern<InitializerOp> {
     if (op.getBody().getBlocks().size() != 1)
       return failure();
     auto &block = op.getBody().front();
-    if (block.empty() || isa<InitializerReturnOp>(block.front())) {
+    if (block.empty() || isa<IREE::Util::ReturnOp>(block.front())) {
       rewriter.eraseOp(op);
       return success();
     }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -1014,6 +1014,32 @@ Block *InitializerOp::addBlock() {
 }
 
 //===----------------------------------------------------------------------===//
+// util.return
+//===----------------------------------------------------------------------===//
+
+LogicalResult ReturnOp::verify() {
+  Operation *op = getOperation();
+  auto parentOp = cast<FunctionOpInterface>(op->getParentOp());
+  auto expectedTypes = parentOp.getResultTypes();
+  if (getNumOperands() != expectedTypes.size()) {
+    return emitOpError("has ")
+           << getNumOperands()
+           << " operands, but enclosing function-like op returns "
+           << expectedTypes.size();
+  }
+  for (auto [i, expectedType, actualType] :
+       llvm::enumerate(expectedTypes, getOperandTypes())) {
+    if (expectedType != actualType) {
+      return emitOpError() << "type of return operand " << i << " ("
+                           << actualType
+                           << ") doesn't match function result type ("
+                           << expectedType << ")";
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // util.global
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -64,6 +65,35 @@ ArrayAttr deduplicateArrayElements(ArrayAttr arrayAttr) {
   if (attrsSet.size() == arrayAttr.size())
     return arrayAttr;
   return ArrayAttr::get(arrayAttr.getContext(), attrsSet.takeVector());
+}
+
+// Finds the operand index in |operands| that |tiedResult| references.
+// Returns TiedOpInterface::kUntiedIndex if no operand is found.
+static int64_t
+findTiedOperand(OpAsmParser::UnresolvedOperand tiedResult,
+                ArrayRef<OpAsmParser::UnresolvedOperand> operands) {
+  int64_t operandIndex = IREE::Util::TiedOpInterface::kUntiedIndex;
+  for (int64_t i = 0; i < operands.size(); ++i) {
+    if (operands[i].name == tiedResult.name &&
+        operands[i].number == tiedResult.number) {
+      operandIndex = i;
+      break;
+    }
+  }
+  return operandIndex;
+}
+
+static int64_t findTiedArgument(OpAsmParser::UnresolvedOperand tiedResult,
+                                ArrayRef<OpAsmParser::Argument> arguments) {
+  int64_t operandIndex = IREE::Util::TiedOpInterface::kUntiedIndex;
+  for (int64_t i = 0; i < arguments.size(); ++i) {
+    if (arguments[i].ssaName.name == tiedResult.name &&
+        arguments[i].ssaName.number == tiedResult.number) {
+      operandIndex = i;
+      break;
+    }
+  }
+  return operandIndex;
 }
 
 //===----------------------------------------------------------------------===//
@@ -289,6 +319,227 @@ void printSizeAwareType(OpAsmPrinter &p, Operation *op, Type type, Value size) {
 }
 
 //===----------------------------------------------------------------------===//
+// custom<OperandTypeList>
+//===----------------------------------------------------------------------===//
+// ()
+// (type, type)
+
+ParseResult parseOperandTypeList(OpAsmParser &parser,
+                                 SmallVectorImpl<Type> &operandTypes) {
+  if (failed(parser.parseLParen()))
+    return failure();
+  while (!succeeded(parser.parseOptionalRParen())) {
+    Type type;
+    if (failed(parser.parseType(type)))
+      return failure();
+    operandTypes.push_back(type);
+  }
+  return success();
+}
+
+void printOperandTypeList(OpAsmPrinter &p, Operation *op,
+                          TypeRange operandTypes) {
+  p << '(';
+  llvm::interleaveComma(operandTypes, p.getStream());
+  p << ')';
+}
+
+//===----------------------------------------------------------------------===//
+// custom<TiedResultList>
+//===----------------------------------------------------------------------===//
+// type, %operand0, %operand1 as type
+
+ParseResult
+parseTiedResultList(OpAsmParser &parser,
+                    ArrayRef<OpAsmParser::UnresolvedOperand> operands,
+                    TypeRange operandTypes, SmallVectorImpl<Type> &resultTypes,
+                    ArrayAttr &tiedOperands) {
+  SmallVector<int64_t> tiedOperandIndices;
+  do {
+    OpAsmParser::UnresolvedOperand tiedResult;
+    auto res = parser.parseOptionalOperand(tiedResult);
+    Type type;
+    int64_t tiedOperandIndex = IREE::Util::TiedOpInterface::kUntiedIndex;
+    if (res.has_value() && succeeded(res.value())) {
+      tiedOperandIndex = findTiedOperand(tiedResult, operands);
+      if (tiedOperandIndex == IREE::Util::TiedOpInterface::kUntiedIndex) {
+        return parser.emitError(tiedResult.location,
+                                "tied operand not found for result reference ")
+               << tiedResult.name;
+      }
+      if (succeeded(parser.parseOptionalKeyword("as"))) {
+        // Type _may_ differ from the operand.
+        if (failed(parser.parseType(type)))
+          return failure();
+      } else {
+        // Use the operands type.
+        type = operandTypes[tiedOperandIndex];
+      }
+    } else if (failed(parser.parseType(type))) {
+      return failure();
+    }
+    resultTypes.push_back(type);
+    tiedOperandIndices.push_back(tiedOperandIndex);
+  } while (succeeded(parser.parseOptionalComma()));
+  if (!tiedOperandIndices.empty()) {
+    tiedOperands = parser.getBuilder().getIndexArrayAttr(tiedOperandIndices);
+  }
+  return success();
+}
+
+void printTiedResultList(OpAsmPrinter &p, Operation *op, ValueRange operands,
+                         TypeRange operandTypes, TypeRange resultTypes,
+                         ArrayAttr tiedOperands) {
+  auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op);
+  for (unsigned i = 0; i < resultTypes.size(); ++i) {
+    auto resultType = resultTypes[i];
+    auto tiedOperandIndex =
+        tiedOp ? tiedOp.getTiedResultOperandIndex(i) : std::nullopt;
+    bool printType = true;
+    if (tiedOperandIndex.has_value()) {
+      auto tiedOperand = op->getOperand(tiedOperandIndex.value());
+      p.printOperand(tiedOperand);
+      if (tiedOperand.getType() != resultType) {
+        p << " as ";
+      } else {
+        // Type elided as it matches the operand.
+        printType = false;
+      }
+    }
+    if (printType) {
+      p.printType(resultType);
+    }
+    if (i < resultTypes.size() - 1)
+      p << ", ";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// custom<TiedFunctionResultList>
+//===----------------------------------------------------------------------===//
+// ()
+// type
+// (type, %operand0 {some.attr}, %operand1 as type)
+
+static ParseResult
+parseTiedFunctionResultListImpl(OpAsmParser &parser,
+                                ArrayRef<OpAsmParser::Argument> arguments,
+                                SmallVectorImpl<Type> &resultTypes,
+                                SmallVectorImpl<DictionaryAttr> &resultAttrs,
+                                ArrayAttr &tiedOperands, bool allowAttrs) {
+  SmallVector<int64_t> tiedOperandIndices;
+  do {
+    OpAsmParser::UnresolvedOperand tiedResult;
+    auto res = parser.parseOptionalOperand(tiedResult);
+    Type type;
+    int64_t tiedOperandIndex = IREE::Util::TiedOpInterface::kUntiedIndex;
+    if (res.has_value() && succeeded(res.value())) {
+      tiedOperandIndex = findTiedArgument(tiedResult, arguments);
+      if (tiedOperandIndex == IREE::Util::TiedOpInterface::kUntiedIndex) {
+        return parser.emitError(tiedResult.location,
+                                "tied operand not found for result reference ")
+               << tiedResult.name;
+      }
+      if (succeeded(parser.parseOptionalKeyword("as"))) {
+        // Type _may_ differ from the operand.
+        if (failed(parser.parseType(type)))
+          return failure();
+      } else {
+        // Use the operands type.
+        type = arguments[tiedOperandIndex].type;
+      }
+    } else if (failed(parser.parseType(type))) {
+      return failure();
+    }
+    DictionaryAttr resultAttrDict;
+    if (allowAttrs) {
+      NamedAttrList resultAttrList;
+      if (succeeded(parser.parseOptionalAttrDict(resultAttrList))) {
+        resultAttrDict = parser.getBuilder().getDictionaryAttr(resultAttrList);
+      }
+    }
+    resultTypes.push_back(type);
+    resultAttrs.push_back(resultAttrDict);
+    tiedOperandIndices.push_back(tiedOperandIndex);
+  } while (succeeded(parser.parseOptionalComma()));
+  if (!tiedOperandIndices.empty()) {
+    tiedOperands = parser.getBuilder().getIndexArrayAttr(tiedOperandIndices);
+  }
+  return success();
+}
+
+static ParseResult parseTiedFunctionResultList(
+    OpAsmParser &parser, ArrayRef<OpAsmParser::Argument> arguments,
+    SmallVectorImpl<Type> &resultTypes,
+    SmallVectorImpl<DictionaryAttr> &resultAttrs, ArrayAttr &tiedOperands) {
+  SmallVector<OpAsmParser::UnresolvedOperand> operands;
+  SmallVector<Type> operandTypes;
+  operands.reserve(arguments.size());
+  operandTypes.reserve(arguments.size());
+  for (auto argument : arguments) {
+    operands.push_back(argument.ssaName);
+    operandTypes.push_back(argument.type);
+  }
+  if (succeeded(parser.parseOptionalLParen())) {
+    if (succeeded(parser.parseOptionalRParen())) {
+      // Empty list/no results `()`.
+    } else {
+      // One or more result types.
+      if (failed(parseTiedFunctionResultListImpl(parser, arguments, resultTypes,
+                                                 resultAttrs, tiedOperands,
+                                                 /*allowAttrs=*/true)) ||
+          failed(parser.parseRParen())) {
+        return failure();
+      }
+    }
+  } else {
+    // Single result with omitted `()`.
+    if (failed(parseTiedFunctionResultListImpl(parser, arguments, resultTypes,
+                                               resultAttrs, tiedOperands,
+                                               /*allowAttrs=*/false))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+ParseResult parseTiedFunctionResultList(
+    OpAsmParser &parser, ArrayRef<OpAsmParser::UnresolvedOperand> operands,
+    ArrayRef<Type> operandTypes, SmallVectorImpl<Type> &resultTypes,
+    ArrayAttr &tiedOperands) {
+  if (succeeded(parser.parseOptionalLParen())) {
+    if (succeeded(parser.parseOptionalRParen())) {
+      // Empty list/no results `()`.
+    } else {
+      // One or more result types.
+      if (failed(parseTiedResultList(parser, operands, operandTypes,
+                                     resultTypes, tiedOperands)) ||
+          failed(parser.parseRParen())) {
+        return failure();
+      }
+    }
+  } else {
+    // Single result with omitted `()`.
+    if (failed(parseTiedResultList(parser, operands, operandTypes, resultTypes,
+                                   tiedOperands))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+void printTiedFunctionResultList(OpAsmPrinter &p, Operation *op,
+                                 ValueRange operands, TypeRange operandTypes,
+                                 TypeRange resultTypes,
+                                 ArrayAttr tiedOperands) {
+  if (resultTypes.size() != 1)
+    p << "(";
+  printTiedResultList(p, op, operands, operandTypes, resultTypes, tiedOperands);
+  if (resultTypes.size() != 1)
+    p << ")";
+}
+
+//===----------------------------------------------------------------------===//
 // custom<ShapedTypeList>
 //===----------------------------------------------------------------------===//
 // type{%size0}, type, type{%size1}
@@ -458,22 +709,6 @@ void printShapedTiedResult(OpAsmPrinter &p, Operation *op, Type resultType,
 // custom<ShapedResultList>
 //===----------------------------------------------------------------------===//
 // type{%dim2}, %operand4
-
-// Finds the operand index in |operands| that |tiedResult| references.
-// Returns TiedOpInterface::kUntiedIndex if no operand is found.
-static int64_t
-findTiedOperand(OpAsmParser::UnresolvedOperand tiedResult,
-                ArrayRef<OpAsmParser::UnresolvedOperand> operands) {
-  int64_t operandIndex = IREE::Util::TiedOpInterface::kUntiedIndex;
-  for (int64_t i = 0; i < operands.size(); ++i) {
-    if (operands[i].name == tiedResult.name &&
-        operands[i].number == tiedResult.number) {
-      operandIndex = i;
-      break;
-    }
-  }
-  return operandIndex;
-}
 
 ParseResult parseShapedResultList(
     OpAsmParser &parser, ArrayRef<OpAsmParser::UnresolvedOperand> operands,
@@ -675,7 +910,7 @@ static ParseResult parseShapedFunctionArgumentList(
 static ParseResult parseShapedFunctionResultList(
     OpAsmParser &parser, ArrayRef<OpAsmParser::UnresolvedOperand> args,
     TypeRange argTypes, SmallVectorImpl<Type> &resultTypes,
-    ArrayAttr &resultAttrs, ArrayAttr &tiedOperands) {
+    ArrayAttr &resultAttrs, ArrayAttr &tiedOperands, bool allowResultAttrs) {
   SmallVector<Attribute> resultAttrsVec;
   SmallVector<int64_t> tiedOperandIndices;
   do {
@@ -702,7 +937,7 @@ static ParseResult parseShapedFunctionResultList(
       return failure();
     }
     NamedAttrList attrs;
-    if (failed(parser.parseOptionalAttrDict(attrs))) {
+    if (allowResultAttrs && failed(parser.parseOptionalAttrDict(attrs))) {
       return failure();
     }
     resultTypes.push_back(type);
@@ -771,16 +1006,16 @@ ParseResult parseShapedFunctionSignature(OpAsmParser &parser,
   }
   if (succeeded(parser.parseOptionalArrow())) {
     if (succeeded(parser.parseOptionalLParen())) {
-      if (failed(parseShapedFunctionResultList(parser, args, argTypes,
-                                               resultTypes, resultAttrs,
-                                               tiedOperands)) ||
+      if (failed(parseShapedFunctionResultList(
+              parser, args, argTypes, resultTypes, resultAttrs, tiedOperands,
+              /*allowResultAttrs=*/true)) ||
           failed(parser.parseRParen())) {
         return failure();
       }
     } else {
-      if (failed(parseShapedFunctionResultList(parser, args, argTypes,
-                                               resultTypes, resultAttrs,
-                                               tiedOperands))) {
+      if (failed(parseShapedFunctionResultList(
+              parser, args, argTypes, resultTypes, resultAttrs, tiedOperands,
+              /*allowResultAttrs=*/false))) {
         return failure();
       }
     }
@@ -805,9 +1040,8 @@ void printShapedFunctionSignature(OpAsmPrinter &p, Operation *op,
     if (argAttrs) {
       auto attrs =
           dyn_cast_if_present<DictionaryAttr>(argAttrs.getValue()[argIndex]);
-      if (attrs && !attrs.empty()) {
+      if (attrs && !attrs.empty())
         p.printOptionalAttrDict(attrs.getValue());
-      }
     }
     ++argIndex;
   });
@@ -815,18 +1049,22 @@ void printShapedFunctionSignature(OpAsmPrinter &p, Operation *op,
   auto resultTypes = functionType.getResults();
   if (!resultTypes.empty()) {
     p << " -> ";
-    if (resultTypes.size() != 1)
+    bool anyResultAttrs =
+        resultAttrs && !resultAttrs.empty() &&
+        llvm::any_of(resultAttrs.getAsValueRange<DictionaryAttr>(),
+                     [](auto attr) { return !attr.empty(); });
+    if (resultTypes.size() != 1 || anyResultAttrs)
       p << "(";
     printShapedFunctionResultList(p, op, functionType.getInputs(), resultTypes,
                                   resultAttrs, tiedOperands);
-    if (resultTypes.size() != 1)
+    if (resultTypes.size() != 1 || anyResultAttrs)
       p << ")";
   }
 }
 
 } // namespace mlir::iree_compiler
 
-namespace mlir ::iree_compiler::IREE::Util {
+namespace mlir::iree_compiler::IREE::Util {
 
 //===----------------------------------------------------------------------===//
 // util.optimization_barrier
@@ -1011,6 +1249,210 @@ Block *InitializerOp::addBlock() {
   assert(!empty() && "function should at least have an entry block");
   push_back(new Block());
   return &back();
+}
+
+//===----------------------------------------------------------------------===//
+// util.func
+//===----------------------------------------------------------------------===//
+
+FuncOp FuncOp::create(Location location, StringRef name, FunctionType type,
+                      ArrayRef<int64_t> tiedOperands,
+                      ArrayRef<NamedAttribute> attrs,
+                      ArrayRef<DictionaryAttr> argAttrs,
+                      ArrayRef<DictionaryAttr> resAttrs) {
+  OpBuilder builder(location->getContext());
+  OperationState state(location, getOperationName());
+  FuncOp::build(builder, state, name, type,
+                builder.getIndexArrayAttr(tiedOperands), attrs, argAttrs,
+                resAttrs);
+  return cast<FuncOp>(Operation::create(state));
+}
+
+void FuncOp::build(OpBuilder &builder, OperationState &state, StringRef name,
+                   FunctionType type, ArrayAttr tiedOperands,
+                   ArrayRef<NamedAttribute> attrs,
+                   ArrayRef<DictionaryAttr> argAttrs,
+                   ArrayRef<DictionaryAttr> resAttrs) {
+  state.addAttribute(SymbolTable::getSymbolAttrName(),
+                     builder.getStringAttr(name));
+  state.addAttribute(SymbolTable::getVisibilityAttrName(),
+                     builder.getStringAttr("private"));
+  state.addAttribute("function_type", TypeAttr::get(type));
+  state.attributes.append(attrs.begin(), attrs.end());
+  state.attributes.erase(IREE::Util::TiedOpInterface::getStorageAttrName());
+  state.addAttribute(IREE::Util::TiedOpInterface::getStorageAttrName(),
+                     tiedOperands);
+  state.addRegion();
+  if (!argAttrs.empty() || !resAttrs.empty()) {
+    assert(type.getNumInputs() == argAttrs.size());
+    assert(type.getNumResults() == resAttrs.size());
+    function_interface_impl::addArgAndResultAttrs(
+        builder, state, argAttrs, resAttrs, builder.getStringAttr("arg_attrs"),
+        builder.getStringAttr("res_attrs"));
+  }
+}
+
+static ParseResult
+parseFunctionArgumentList(OpAsmParser &parser,
+                          SmallVectorImpl<OpAsmParser::Argument> &arguments) {
+  return parser.parseCommaSeparatedList(
+      OpAsmParser::Delimiter::Paren, [&]() -> ParseResult {
+        OpAsmParser::Argument argument;
+        auto argPresent = parser.parseOptionalArgument(
+            argument, /*allowType=*/true, /*allowAttrs=*/true);
+        if (argPresent.has_value()) {
+          if (failed(argPresent.value()))
+            return failure(); // Present but malformed.
+          if (!arguments.empty() && arguments.back().ssaName.name.empty())
+            return parser.emitError(argument.ssaName.location,
+                                    "expected type instead of SSA identifier");
+
+        } else {
+          argument.ssaName.location = parser.getCurrentLocation();
+          if (!arguments.empty() && !arguments.back().ssaName.name.empty())
+            return parser.emitError(argument.ssaName.location,
+                                    "expected SSA identifier");
+          NamedAttrList attrs;
+          if (parser.parseType(argument.type) ||
+              parser.parseOptionalAttrDict(attrs) ||
+              parser.parseOptionalLocationSpecifier(argument.sourceLoc))
+            return failure();
+          argument.attrs = attrs.getDictionary(parser.getContext());
+        }
+        arguments.push_back(argument);
+        return success();
+      });
+}
+
+ParseResult FuncOp::parse(OpAsmParser &parser, OperationState &result) {
+  auto &builder = parser.getBuilder();
+
+  StringAttr symVisibilityAttr;
+  if (failed(parseSymbolVisibility(parser, symVisibilityAttr)))
+    return failure();
+  if (symVisibilityAttr)
+    result.addAttribute(SymbolTable::getVisibilityAttrName(),
+                        symVisibilityAttr);
+
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr, SymbolTable::getSymbolAttrName(),
+                             result.attributes))
+    return failure();
+
+  SmallVector<OpAsmParser::Argument> arguments;
+  if (parseFunctionArgumentList(parser, arguments))
+    return failure();
+
+  SmallVector<Type> resultTypes;
+  SmallVector<DictionaryAttr> resultAttrs;
+  ArrayAttr tiedOperands;
+  if (succeeded(parser.parseOptionalArrow())) {
+    if (failed(parseTiedFunctionResultList(parser, arguments, resultTypes,
+                                           resultAttrs, tiedOperands)))
+      return failure();
+  }
+  if (tiedOperands)
+    result.addAttribute("tied_operands", tiedOperands);
+
+  SmallVector<Type> argumentTypes;
+  for (auto argument : arguments)
+    argumentTypes.push_back(argument.type);
+  result.addAttribute("function_type", TypeAttr::get(builder.getFunctionType(
+                                           argumentTypes, resultTypes)));
+
+  NamedAttrList parsedAttributes;
+  SMLoc attributeDictLocation = parser.getCurrentLocation();
+  if (parser.parseOptionalAttrDictWithKeyword(parsedAttributes))
+    return failure();
+  for (StringRef disallowed : {
+           SymbolTable::getVisibilityAttrName(),
+           SymbolTable::getSymbolAttrName(),
+           StringRef("function_type"),
+       }) {
+    if (parsedAttributes.get(disallowed))
+      return parser.emitError(attributeDictLocation, "'")
+             << disallowed
+             << "' is an inferred attribute and should not be specified in the "
+                "explicit attribute dictionary";
+  }
+  result.attributes.append(parsedAttributes);
+
+  assert(resultAttrs.size() == resultTypes.size());
+  function_interface_impl::addArgAndResultAttrs(
+      builder, result, arguments, resultAttrs,
+      builder.getStringAttr("arg_attrs"), builder.getStringAttr("res_attrs"));
+
+  auto *body = result.addRegion();
+  SMLoc loc = parser.getCurrentLocation();
+  auto parseResult = parser.parseOptionalRegion(*body, arguments,
+                                                /*enableNameShadowing=*/false);
+  if (parseResult.has_value()) {
+    if (failed(*parseResult))
+      return failure();
+    if (body->empty())
+      return parser.emitError(loc, "expected non-empty function body");
+  }
+  return success();
+}
+
+void FuncOp::print(OpAsmPrinter &p) {
+  p << ' ';
+  printSymbolVisibility(p, *this, getSymVisibilityAttr());
+  p << ' ';
+  p.printSymbolName(getSymName());
+  printShapedFunctionSignature(p, *this, getFunctionTypeAttr(),
+                               getTiedOperandsAttr(), getArgAttrsAttr(),
+                               getResAttrsAttr());
+  p.printOptionalAttrDictWithKeyword((*this)->getAttrs(),
+                                     /*elidedAttrs=*/{
+                                         "sym_name",
+                                         "function_type",
+                                         "tied_operands",
+                                         "sym_visibility",
+                                         "arg_attrs",
+                                         "res_attrs",
+                                     });
+  if (!getBody().empty()) {
+    p << ' ';
+    p.printRegion(getBody(), /*printEntryBlockArgs=*/false);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// util.call
+//===----------------------------------------------------------------------===//
+
+FunctionType CallOp::getCalleeType() {
+  return FunctionType::get(getContext(), getOperandTypes(), getResultTypes());
+}
+
+LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *op = getOperation();
+
+  // Only support calls to util.func.
+  auto calleeOp = symbolTable.lookupNearestSymbolFrom<IREE::Util::FuncOp>(
+      op, getCalleeAttr());
+  if (!calleeOp) {
+    return op->emitOpError("undefined/incompatible callee: ") << getCallee();
+  }
+
+  // Ensure that the arg/result types match.
+  auto expectedType = getCalleeType();
+  auto calleeType = calleeOp.getFunctionType();
+  if (calleeType != expectedType) {
+    return emitOpError("function type mismatch; expected ")
+           << expectedType << " but callee is " << calleeType;
+  }
+
+  // Ensure tied operands are consistent.
+  auto expectedTiedOperands = getTiedOperandsAttr();
+  auto calleeTiedOperands = calleeOp.getTiedOperandsAttr();
+  if (calleeTiedOperands != expectedTiedOperands) {
+    return emitOpError("function tied operands mismatch; expected ")
+           << expectedTiedOperands << " but callee is " << calleeTiedOperands;
+  }
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
@@ -109,6 +109,46 @@ ParseResult parseSizeAwareType(OpAsmParser &parser, Type &type,
 void printSizeAwareType(OpAsmPrinter &p, Operation *op, Type type, Value size);
 
 //===----------------------------------------------------------------------===//
+// custom<OperandTypeList>
+//===----------------------------------------------------------------------===//
+// ()
+// (type, type)
+
+ParseResult parseOperandTypeList(OpAsmParser &parser,
+                                 SmallVectorImpl<Type> &operandTypes);
+void printOperandTypeList(OpAsmPrinter &p, Operation *op,
+                          TypeRange operandTypes);
+
+//===----------------------------------------------------------------------===//
+// custom<TiedResultList>
+//===----------------------------------------------------------------------===//
+// type, %operand4
+
+ParseResult
+parseTiedResultList(OpAsmParser &parser,
+                    ArrayRef<OpAsmParser::UnresolvedOperand> operands,
+                    TypeRange operandTypes, SmallVectorImpl<Type> &resultTypes,
+                    ArrayAttr &tiedOperands);
+void printTiedResultList(OpAsmPrinter &p, Operation *op, ValueRange operands,
+                         TypeRange operandTypes, TypeRange resultTypes,
+                         ArrayAttr tiedOperands);
+
+//===----------------------------------------------------------------------===//
+// custom<TiedFunctionResultList>
+//===----------------------------------------------------------------------===//
+// ()
+// type
+// (type, %operand0, %operand1 as type)
+
+ParseResult parseTiedFunctionResultList(
+    OpAsmParser &parser, ArrayRef<OpAsmParser::UnresolvedOperand> operands,
+    ArrayRef<Type> operandTypes, SmallVectorImpl<Type> &resultTypes,
+    ArrayAttr &tiedOperands);
+void printTiedFunctionResultList(OpAsmPrinter &p, Operation *op,
+                                 ValueRange operands, TypeRange operandTypes,
+                                 TypeRange resultTypes, ArrayAttr tiedOperands);
+
+//===----------------------------------------------------------------------===//
 // custom<ShapedTiedResult>
 //===----------------------------------------------------------------------===//
 // type{%dim0, %dim1}

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -7,6 +7,7 @@
 #ifndef IREE_DIALECT_UTIL_IR_UTIL_OPS
 #define IREE_DIALECT_UTIL_IR_UTIL_OPS
 
+include "iree/compiler/Dialect/Util/IR/UtilAttrs.td"
 include "iree/compiler/Dialect/Util/IR/UtilBase.td"
 include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilTypes.td"
@@ -600,7 +601,8 @@ def Util_FuncOp : Util_Op<"func", [
     OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
     OptionalAttr<StrAttr>:$sym_visibility,
     OptionalAttr<DictArrayAttr>:$arg_attrs,
-    OptionalAttr<DictArrayAttr>:$res_attrs
+    OptionalAttr<DictArrayAttr>:$res_attrs,
+    OptionalAttr<Util_InliningPolicyAttrInterface>:$inlining_policy
   );
 
   let regions = (region AnyRegion:$body);
@@ -625,7 +627,7 @@ def Util_FuncOp : Util_Op<"func", [
 
     bool isDeclaration() { return isExternal(); }
 
-    ::mlir::Region *getCallableRegion() { return nullptr; }
+    ::mlir::Region *getCallableRegion() { return &getBody(); }
     ArrayRef<Type> getCallableResults() { return getFunctionType().getResults(); }
     ::mlir::ArrayAttr getCallableArgAttrs() { return getArgAttrs().value_or(nullptr); }
     ::mlir::ArrayAttr getCallableResAttrs() { return getResAttrs().value_or(nullptr); }
@@ -758,7 +760,8 @@ def Util_GlobalOp : Util_Op<"global", [
     SymbolNameAttr:$sym_name,
     TypeAttr:$type,
     UnitAttr:$is_mutable,
-    OptionalAttr<TypedAttrInterface>:$initial_value
+    OptionalAttr<TypedAttrInterface>:$initial_value,
+    OptionalAttr<Util_InliningPolicyAttrInterface>:$inlining_policy
   );
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -63,10 +63,10 @@ def Util_NullOp : Util_PureOp<"null"> {
 def Util_CastOp : Util_PureOp<"cast", [
   DeclareOpInterfaceMethods<CastOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
-      "getTiedResult",
-      "getTiedResultOperand",
-      "getTiedResultOperandIndex",
-      "getTiedResultOperandIndices",
+    "getTiedResult",
+    "getTiedResultOperand",
+    "getTiedResultOperandIndex",
+    "getTiedResultOperandIndices",
   ]>,
 ]> {
   let summary = [{casts one util type to another ala static_cast/dynamic_cast}];
@@ -294,7 +294,7 @@ def Util_RangeExtentsOp : Util_PureOp<"range.extents", [
 } // OpGroupRangeArithmeticOps
 
 //===----------------------------------------------------------------------===//
-// Address/offset Arithmetic
+// Address/offset arithmetic
 //===----------------------------------------------------------------------===//
 
 def OpGroupAddressOffsetArithmeticOps : OpDocGroup {
@@ -306,7 +306,7 @@ let opDocGroup = OpGroupAddressOffsetArithmeticOps in {
 
 def Util_AlignOp : Util_PureOp<"align", [
   SameOperandsAndResultType
-  ]> {
+]> {
   let summary = "Aligns up to a power-of-two alignment if required";
   let description = [{
      Aligns |value| up to the given power-of-two |alignment| if required.
@@ -474,10 +474,10 @@ def Util_UnfoldableConstantOp : Util_Op<"unfoldable_constant"> {
 }
 
 def Util_UnreachableOp : Util_Op<"unreachable", [
-    NoMemoryEffect,
-    ReturnLike,
-    Terminator
-  ]> {
+  NoMemoryEffect,
+  ReturnLike,
+  Terminator
+]> {
   let summary = [{unreachable assertion op}];
   let description = [{
     Signals to the compiler that the parent block should not be reachable.
@@ -516,11 +516,11 @@ def OpGroupStructuralOps : OpDocGroup {
 let opDocGroup = OpGroupStructuralOps in {
 
 def Util_InitializerOp : Util_Op<"initializer", [
-    IsolatedFromAbove,
-    FunctionOpInterface,
-    CallableOpInterface,
-    Util_InitializerOpInterface,
-  ]> {
+  IsolatedFromAbove,
+  FunctionOpInterface,
+  CallableOpInterface,
+  Util_InitializerOpInterface,
+]> {
   let summary = [{global initialization function}];
   let description = [{
     A function that is called in definition order upon module initialization.
@@ -579,8 +579,10 @@ def Util_InitializerOp : Util_Op<"initializer", [
   let hasCanonicalizer = 1;
 }
 
-def Util_InitializerReturnOp : Util_Op<"initializer.return", [
-  HasParent<"IREE::Util::InitializerOp">,
+def Util_ReturnOp : Util_Op<"return", [
+  ParentOneOf<[
+    "IREE::Util::InitializerOp",
+  ]>,
   Pure,
   ReturnLike,
   Terminator,
@@ -590,9 +592,22 @@ def Util_InitializerReturnOp : Util_Op<"initializer.return", [
     Returns control from an initializer function.
   }];
 
-  let arguments = (ins);
+  let arguments = (ins
+    Variadic<AnyType>:$operands
+  );
 
-  let assemblyFormat = "attr-dict";
+  let builders = [
+    OpBuilder<(ins), [{
+      build($_builder, $_state, std::nullopt);
+    }]>,
+  ];
+
+  let assemblyFormat = [{
+    attr-dict
+    ($operands^ `:` type($operands))?
+  }];
+
+  let hasVerifier = 1;
 }
 
 } // OpGroupStructuralOps
@@ -821,8 +836,9 @@ def OpGroupListOps : OpDocGroup {
 
 let opDocGroup = OpGroupListOps in {
 
-def Util_ListCreateOp : Util_PureOp<
-    "list.create", [MemoryEffects<[MemAlloc]>]> {
+def Util_ListCreateOp : Util_PureOp<"list.create", [
+  MemoryEffects<[MemAlloc]>,
+]> {
   let summary = [{creates a new empty list}];
   let description = [{
     Creates a new empty list with an optional initial capacity.
@@ -838,7 +854,9 @@ def Util_ListCreateOp : Util_PureOp<
   let assemblyFormat = "($initial_capacity^)? attr-dict `:` qualified(type($result))";
 }
 
-def Util_ListSizeOp : Util_Op<"list.size", [MemoryEffects<[MemRead]>]> {
+def Util_ListSizeOp : Util_Op<"list.size", [
+  MemoryEffects<[MemRead]>,
+]> {
   let summary = [{the size of the list in elements}];
   let description = [{
     Returns the current size of the list in elements.
@@ -854,7 +872,9 @@ def Util_ListSizeOp : Util_Op<"list.size", [MemoryEffects<[MemRead]>]> {
   let assemblyFormat = "operands attr-dict `:` qualified(type($list))";
 }
 
-def Util_ListResizeOp : Util_Op<"list.resize", [MemoryEffects<[MemWrite]>]> {
+def Util_ListResizeOp : Util_Op<"list.resize", [
+  MemoryEffects<[MemWrite]>,
+]> {
   let summary = [{resizes the list to a new count in elements}];
   let description = [{
     Resizes the list to contain `new_size` elements. This will either truncate
@@ -870,7 +890,9 @@ def Util_ListResizeOp : Util_Op<"list.resize", [MemoryEffects<[MemWrite]>]> {
   let assemblyFormat = "operands attr-dict `:` qualified(type($list))";
 }
 
-def Util_ListGetOp : Util_Op<"list.get", [MemoryEffects<[MemRead]>]> {
+def Util_ListGetOp : Util_Op<"list.get", [
+  MemoryEffects<[MemRead]>,
+]> {
   let summary = [{element accessor}];
   let description = [{
     Returns the value of the element at the given index. Note that the value
@@ -890,7 +912,9 @@ def Util_ListGetOp : Util_Op<"list.get", [MemoryEffects<[MemRead]>]> {
   let hasVerifier = 1;
 }
 
-def Util_ListSetOp : Util_Op<"list.set", [MemoryEffects<[MemWrite]>]> {
+def Util_ListSetOp : Util_Op<"list.set", [
+  MemoryEffects<[MemWrite]>,
+]> {
   let summary = [{element mutator}];
   let description = [{
     Sets the element at the given index to the new value.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -579,9 +579,128 @@ def Util_InitializerOp : Util_Op<"initializer", [
   let hasCanonicalizer = 1;
 }
 
+def Util_FuncOp : Util_Op<"func", [
+  AffineScope,
+  AutomaticAllocationScope,
+  FunctionOpInterface,
+  IsolatedFromAbove,
+  OpAsmOpInterface,
+]> {
+  let summary = [{function operation containing a CFG region}];
+  let description = [{
+    An operation declaring a callable function.
+
+    An external function declaration (used when referring to a function declared
+    in some other module) has no body.
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    OptionalAttr<StrAttr>:$sym_visibility,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+
+  let regions = (region AnyRegion:$body);
+
+  let builders = [
+    OpBuilder<(ins
+      "StringRef":$name,
+      "FunctionType":$type,
+      CArg<"ArrayAttr", "{}">:$tiedOperands,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$resAttrs
+    )>,
+  ];
+
+  let extraClassDeclaration = [{
+    static FuncOp create(Location location, StringRef name, FunctionType type,
+                         ArrayRef<int64_t> tiedOperands = {},
+                         ArrayRef<NamedAttribute> attrs = {},
+                         ArrayRef<DictionaryAttr> argAttrs = {},
+                         ArrayRef<DictionaryAttr> resAttrs = {});
+
+    bool isDeclaration() { return isExternal(); }
+
+    ::mlir::Region *getCallableRegion() { return nullptr; }
+    ArrayRef<Type> getCallableResults() { return getFunctionType().getResults(); }
+    ::mlir::ArrayAttr getCallableArgAttrs() { return getArgAttrs().value_or(nullptr); }
+    ::mlir::ArrayAttr getCallableResAttrs() { return getResAttrs().value_or(nullptr); }
+
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
+def Util_CallOp : Util_Op<"call", [
+  CallOpInterface,
+  Util_TiedOpInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+]> {
+  let summary = [{function call operation}];
+  let description = [{
+    Represents a direct call to a function that is within the same symbol scope
+    as the call. The operands and result types of the call must match the
+    specified function type.
+
+    Calls support tied operands which indicate that specific results alias
+    a specific operand. The operand and result types are allowed to differ if
+    a cast is performed within the callee.
+
+    Example:
+    ```mlir
+    util.func @fn(%arg0: i32, %arg1: tensor<f32>) -> (f32, %arg1 as tensor<i32>)
+    ...
+    %0 = util.call @fn(%0, %1) : (i32, tensor<f32>) -> (f32, %1 as tensor<i32>)
+    ```
+  }];
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$callee,
+    Variadic<AnyType>:$operands,
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands
+  );
+  let results = (outs
+    Variadic<AnyType>:$results
+  );
+
+  let assemblyFormat = [{
+    $callee `(` $operands `)`
+    attr-dict `:`
+    custom<OperandTypeList>(type($operands))
+    `->`
+    custom<TiedFunctionResultList>(ref($operands),
+                                   ref(type($operands)),
+                                   type($results),
+                                   $tied_operands)
+  }];
+
+  let extraClassDeclaration = [{
+    FunctionType getCalleeType();
+
+    operand_range getArgOperands() { return {arg_operand_begin(), arg_operand_end()}; }
+    MutableOperandRange getArgOperandsMutable() { return getOperandsMutable(); }
+    operand_iterator arg_operand_begin() { return operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+    }
+    void setCalleeFromCallable(CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
+    }
+  }];
+}
+
 def Util_ReturnOp : Util_Op<"return", [
   ParentOneOf<[
     "IREE::Util::InitializerOp",
+    "IREE::Util::FuncOp",
   ]>,
   Pure,
   ReturnLike,

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -25,6 +25,10 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Parser/Parser.h"
 
+// clang-format off: must be included after all LLVM/MLIR headers.
+#include "iree/compiler/Dialect/Util/IR/UtilEnums.cpp.inc" // IWYU pragma: keep
+// clang-format on
+
 namespace mlir::iree_compiler::IREE::Util {
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -21,6 +21,10 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/Types.h"
 
+// clang-format off: must be included after all LLVM/MLIR headers.
+#include "iree/compiler/Dialect/Util/IR/UtilEnums.h.inc" // IWYU pragma: keep
+// clang-format on
+
 namespace mlir::iree_compiler::IREE::Util {
 
 class GlobalOpInterface;

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/BUILD.bazel
@@ -32,6 +32,7 @@ iree_lit_test_suite(
             "range_folding.mlir",
             "range_ops.mlir",
             "structural_folding.mlir",
+            "structural_inlining.mlir",
             "structural_ops.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_lit_test_suite(
     "range_folding.mlir"
     "range_ops.mlir"
     "structural_folding.mlir"
+    "structural_inlining.mlir"
     "structural_ops.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/global_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/global_folding.mlir
@@ -21,7 +21,7 @@ func.func @unused_load() {
 
 // -----
 
-util.global private @v_const {noinline} = dense<1.0> : tensor<8xf32>
+util.global private @v_const {inlining_policy = #util.inline.never} = dense<1.0> : tensor<8xf32>
 // CHECK-LABEL: @no_fold_noinline_immutable_const
 func.func @no_fold_noinline_immutable_const() -> tensor<8xf32> {
   // CHECK-NEXT: = util.global.load @v_const : tensor<8xf32>

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/global_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/global_folding.mlir
@@ -6,7 +6,7 @@ util.global private @v_initialized : tensor<4xi32>
 util.initializer {
   %0 = arith.constant dense<4> : tensor<4xi32>
   util.global.store %0, @v_initialized : tensor<4xi32>
-  util.initializer.return
+  util.return
 }
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/global_ops.mlir
@@ -35,7 +35,7 @@ util.initializer {
   %0 = func.call @initializer() : () -> tensor<4xi32>
   // CHECK-NEXT: util.global.store %[[VALUE]], @v_initialized : tensor<4xi32>
   util.global.store %0, @v_initialized : tensor<4xi32>
-  util.initializer.return
+  util.return
 }
 func.func private @initializer() -> tensor<4xi32>
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_folding.mlir
@@ -2,5 +2,5 @@
 
 // CHECK-NOT: util.initializer
 util.initializer {
-  util.initializer.return
+  util.return
 }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_inlining.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_inlining.mlir
@@ -1,0 +1,63 @@
+// RUN: iree-opt --split-input-file --inline %s | FileCheck %s
+
+// Tests inlining a call into an initializer.
+
+// CHECK: util.initializer
+util.initializer {
+  // CHECK: %[[VALUE:.+]] = arith.constant 123
+  %0 = arith.constant 123 : i32
+  // CHECK-NOT: util.call @from_initializer
+  %1 = util.call @from_initializer(%0) : (i32) -> i32
+  // CHECK: util.optimization_barrier %[[VALUE]]
+  util.optimization_barrier %1 : i32
+  util.return
+}
+// CHECK-NOT: util.func private @from_initializer
+util.func private @from_initializer(%arg0: i32) -> i32 {
+  util.return %arg0 : i32
+}
+
+// -----
+
+// Tests inlining a call into another call.
+
+// CHECK: util.func public @caller(%[[ARG0:.+]]: i32) -> i32
+util.func public @caller(%arg0: i32) -> i32 {
+  // CHECK-NOT: util.call @callee
+  %0 = util.call @callee(%arg0) : (i32) -> i32
+  // CHECK: util.return %[[ARG0]]
+  util.return %0 : i32
+}
+// CHECK-NOT: util.func private @callee
+util.func private @callee(%arg0: i32) -> i32 {
+  util.return %arg0 : i32
+}
+
+// -----
+
+// Tests that `#util.inline.never` blocks inlining a call into another call
+// when placed on the callee.
+
+// CHECK: util.func public @noinline_caller
+util.func public @noinline_caller(%arg0: i32) -> i32 {
+  // CHECK: util.call @noinline_callee
+  %0 = util.call @noinline_callee(%arg0) : (i32) -> i32
+  util.return %0 : i32
+}
+// CHECK: util.func private @noinline_callee
+util.func private @noinline_callee(%arg0: i32) -> i32 attributes {
+  inlining_policy = #util.inline.never
+} {
+  util.return %arg0 : i32
+}
+
+// -----
+
+// Tests inlining a recursive function doesn't explode.
+
+// CHECK: util.func public @recursive_fn(%[[ARG0:.+]]: i32) -> i32
+util.func public @recursive_fn(%arg0: i32) -> i32 {
+  // CHECK: util.call @recursive_fn
+  %0 = util.call @recursive_fn(%arg0) : (i32) -> i32
+  util.return %0 : i32
+}

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file %s | FileCheck %s
 
 //      CHECK: util.initializer {
 // CHECK-NEXT:   util.return
@@ -28,4 +28,101 @@ util.initializer {
 ^bb1(%0: i32):
   // CHECK-NEXT:   util.return
   util.return
+}
+
+// -----
+
+// CHECK: util.func private @externArg0()
+util.func private @externArg0()
+// CHECK-NEXT: util.func private @externArg1(%arg0: tensor<4x?xi32>)
+util.func private @externArg1(%arg0: tensor<4x?xi32>)
+// CHECK-NEXT: util.func private @externArg1Attrs(%arg0: tensor<4x?xi32> {arg.attr})
+util.func private @externArg1Attrs(%arg0: tensor<4x?xi32> {arg.attr})
+// CHECK-NEXT: util.func private @externArg2(%arg0: tensor<4x?xi32>, %arg1: i32)
+util.func private @externArg2(%arg0: tensor<4x?xi32>, %arg1: i32)
+// CHECK-NEXT: util.func private @externArg2Attrs(%arg0: tensor<4x?xi32> {arg.attr0}, %arg1: i32 {arg.attr1})
+util.func private @externArg2Attrs(%arg0: tensor<4x?xi32> {arg.attr0}, %arg1: i32 {arg.attr1})
+
+// -----
+
+// CHECK: util.func private @externRet0()
+util.func private @externRet0()
+// CHECK-NEXT: util.func private @externRet1() -> tensor<4x?xi32>
+util.func private @externRet1() -> tensor<4x?xi32>
+// CHECK-NEXT: util.func private @externRet1Attrs() -> (tensor<4x?xi32> {ret.attr})
+util.func private @externRet1Attrs() -> (tensor<4x?xi32> {ret.attr})
+// CHECK-NEXT: util.func private @externRet2() -> (tensor<4x?xi32>, i32)
+util.func private @externRet2() -> (tensor<4x?xi32>, i32)
+// CHECK-NEXT: util.func private @externRet2Attrs() -> (tensor<4x?xi32> {ret.attr0}, i32 {ret.attr1})
+util.func private @externRet2Attrs() -> (tensor<4x?xi32> {ret.attr0}, i32 {ret.attr1})
+// CHECK-NEXT: util.func private @externRetAttributes() -> (tensor<4x?xi32> {ret.attr}) attributes {some.attr = 123 : index}
+util.func private @externRetAttributes() -> (tensor<4x?xi32> {ret.attr}) attributes {some.attr = 123 : index}
+
+// -----
+
+// CHECK: util.func private @externTied(%arg0: i32, %arg1: tensor<4x?xi32>, %arg2: tensor<4x?xi32>) -> (%arg1, %arg2 as tensor<?x4xf32>)
+util.func private @externTied(%arg0: i32, %arg1: tensor<4x?xi32>, %arg2: tensor<4x?xi32>) -> (%arg1, %arg2 as tensor<?x4xf32>)
+// CHECK-NEXT: util.func private @externTiedAttrs(%arg0: i32, %arg1: tensor<4x?xi32>, %arg2: tensor<4x?xi32>) -> (%arg1 {ret.attr0}, %arg2 as tensor<?x4xf32> {ret.attr1})
+util.func private @externTiedAttrs(%arg0: i32, %arg1: tensor<4x?xi32>, %arg2: tensor<4x?xi32>) -> (%arg1 {ret.attr0}, %arg2 as tensor<?x4xf32> {ret.attr1})
+
+// -----
+
+// CHECK: util.func private @basicFunc(%arg0: tensor<?xf32>) -> i32
+util.func private @basicFunc(%arg0: tensor<?xf32>) -> i32 {
+  %c0 = arith.constant 0 : i32
+  // CHECK: util.return
+  util.return %c0 : i32
+}
+
+// -----
+
+// CHECK: util.func private @no_args_callee
+util.func private @no_args_callee() -> ()
+// CHECK: util.func private @no_args_caller
+util.func private @no_args_caller() -> () {
+  // CHECK: util.call @no_args_callee() : () -> ()
+  util.call @no_args_callee() : () -> ()
+  util.return
+}
+
+// -----
+
+// CHECK: util.func private @basicExtern
+util.func private @basicExtern(%arg0: tensor<?xf32>) -> (tensor<?xf32>, i32)
+
+// CHECK-LABEL: util.func public @basicCall
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<?xf32>) -> (tensor<?xf32>, i32)
+util.func @basicCall(%arg0: tensor<?xf32>) -> (tensor<?xf32>, i32) {
+  // CHECK: %[[CALL:.+]]:2 = util.call @basicExtern(%[[ARG0]]) : (tensor<?xf32>) -> (tensor<?xf32>, i32)
+  %call:2 = util.call @basicExtern(%arg0) : (tensor<?xf32>) -> (tensor<?xf32>, i32)
+  // CHECK: return %[[CALL]]#0, %[[CALL]]#1
+  util.return %call#0, %call#1 : tensor<?xf32>, i32
+}
+
+// -----
+
+// CHECK: util.func private @inplaceExtern
+util.func private @inplaceExtern(%arg0: tensor<?xf32>) -> %arg0
+
+// CHECK-LABEL: util.func public @inplaceCall
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<?xf32>) -> tensor<?xf32>
+util.func @inplaceCall(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+  // CHECK: %[[CALL:.+]] = util.call @inplaceExtern(%[[ARG0]]) : (tensor<?xf32>) -> %[[ARG0]]
+  %call = util.call @inplaceExtern(%arg0) : (tensor<?xf32>) -> %arg0
+  // CHECK: return %[[CALL]]
+  util.return %call : tensor<?xf32>
+}
+
+// -----
+
+// CHECK: util.func private @inplaceTypeChangeExtern
+util.func private @inplaceTypeChangeExtern(%arg0: tensor<?x4xf32>) -> %arg0 as tensor<4x?xi32>
+
+// CHECK-LABEL: util.func public @inplaceTypeChangeCall
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<?x4xf32>) -> tensor<4x?xi32>
+util.func public @inplaceTypeChangeCall(%arg0: tensor<?x4xf32>) -> tensor<4x?xi32> {
+  // CHECK: %[[CALL:.+]] = util.call @inplaceTypeChangeExtern(%[[ARG0]]) : (tensor<?x4xf32>) -> %[[ARG0]] as tensor<4x?xi32>
+  %call = util.call @inplaceTypeChangeExtern(%arg0) : (tensor<?x4xf32>) -> %arg0 as tensor<4x?xi32>
+  // CHECK: return %[[CALL]]
+  util.return %call : tensor<4x?xi32>
 }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_ops.mlir
@@ -1,19 +1,19 @@
 // RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
 
 //      CHECK: util.initializer {
-// CHECK-NEXT:   util.initializer.return
+// CHECK-NEXT:   util.return
 // CHECK-NEXT: }
 util.initializer {
-  util.initializer.return
+  util.return
 }
 
 // -----
 
 //      CHECK: util.initializer attributes {foo} {
-// CHECK-NEXT:   util.initializer.return
+// CHECK-NEXT:   util.return
 // CHECK-NEXT: }
 util.initializer attributes {foo} {
-  util.initializer.return
+  util.return
 }
 
 // -----
@@ -26,6 +26,6 @@ util.initializer {
   cf.br ^bb1(%zero: i32)
   // CHECK-NEXT: ^bb1(%0: i32):
 ^bb1(%0: i32):
-  // CHECK-NEXT:   util.initializer.return
-  util.initializer.return
+  // CHECK-NEXT:   util.return
+  util.return
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
@@ -70,7 +70,7 @@ public:
       builder.setInsertionPointToEnd(&newOp.back());
       initializerOp.erase();
     }
-    builder.create<IREE::Util::InitializerReturnOp>(fusedLoc);
+    builder.create<IREE::Util::ReturnOp>(fusedLoc);
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -284,8 +284,6 @@ static bool inlineConstantGlobalLoads(GlobalTable &globalTable) {
       return GlobalAction::PRESERVE;
     if (global.op.isGlobalMutable())
       return GlobalAction::PRESERVE;
-    if (global.op->hasAttr("noinline"))
-      return GlobalAction::PRESERVE;
     if (!global.op.getGlobalInitialValue())
       return GlobalAction::PRESERVE;
 
@@ -296,23 +294,34 @@ static bool inlineConstantGlobalLoads(GlobalTable &globalTable) {
     }
 
     // Inline initial value into all loads.
-    for (auto loadOp : global.loadOps) {
+    auto inliningPolicy = global.op.getGlobalInliningPolicy();
+    SmallVector<IREE::Util::GlobalLoadOpInterface> loadOps = global.loadOps;
+    global.loadOps.clear();
+    for (auto loadOp : loadOps) {
+      if (inliningPolicy &&
+          !inliningPolicy.isLegalToInline(loadOp, global.op)) {
+        // Global not allowed to be inlined at this site so preserve the load.
+        global.loadOps.push_back(loadOp);
+        continue;
+      }
+
       OpBuilder builder(loadOp);
       auto loadedValue = loadOp.getLoadedGlobalValue();
       auto constantValue =
           tryMaterializeConstant(loadOp.getLoc(), loadedValue.getType(),
                                  global.op.getGlobalInitialValue(), builder);
       if (!constantValue) {
-        // Failed to materialize the constant. This is going to fail for all the
-        // others as well so we bail here. This may be intentional for example
-        // if some value-type has no default value (similar to a deleted default
-        // constructor in C++) - in which case the global is preserved as-is.
-        return GlobalAction::PRESERVE;
+        // Failed to materialize the constant at this site so preserve the load.
+        global.loadOps.push_back(loadOp);
+        continue;
       }
       loadedValue.replaceAllUsesWith(constantValue);
       loadOp.erase();
     }
-    global.loadOps.clear();
+
+    // If not all loads could be removed we need to preserve the global.
+    if (!global.loadOps.empty())
+      return GlobalAction::PRESERVE;
 
     // Only delete if private.
     return global.op.isGlobalPrivate() ? GlobalAction::DELETE

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
@@ -35,9 +35,7 @@ struct Global {
   SmallVector<IREE::Util::GlobalLoadOpInterface> loadOps;
   SmallVector<IREE::Util::GlobalStoreOpInterface> storeOps;
 
-  bool isCandidate() {
-    return !isIndirect && op.isGlobalPrivate() && !op->hasAttr("noinline");
-  }
+  bool isCandidate() { return !isIndirect && op.isGlobalPrivate(); }
 };
 
 struct GlobalTable {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -267,7 +267,7 @@ public:
       builder.create<GlobalStoreOp>(loc, clonedResult, globalSymbol);
     }
 
-    builder.create<InitializerReturnOp>(loc);
+    builder.create<IREE::Util::ReturnOp>(loc);
     return success();
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OutlineConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OutlineConstants.cpp
@@ -93,7 +93,8 @@ public:
       // By the time we've outlined things here we are sure we want them
       // outlined even if the user runs an arbitrary number of passes between
       // now and when we may use that information (HAL constant pooling, etc).
-      globalOp->setAttr("noinline", moduleBuilder.getUnitAttr());
+      globalOp.setInliningPolicyAttr(
+          moduleBuilder.getAttr<IREE::Util::InlineNeverAttr>());
     }
 
     // Replace all of the constants with lookups for the new variables.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/annotate_op_ordinals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/annotate_op_ordinals.mlir
@@ -15,8 +15,8 @@ util.initializer {
   // CHECK-NEXT: cf.br {{.+}} {util.ordinal = 5 : index}
   cf.br ^bb2
 ^bb2:
-  // CHECK: util.initializer.return {util.ordinal = 6 : index}
-  util.initializer.return
+  // CHECK: util.return {util.ordinal = 6 : index}
+  util.return
 }
 
 // CHECK: util.global private mutable @globalB {util.ordinal = 7 : index}

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/combine_initializers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/combine_initializers.mlir
@@ -9,7 +9,7 @@ util.global private mutable @global0 : index
 util.initializer {
   %value0 = func.call @extern() : () -> index
   util.global.store %value0, @global0 : index
-  util.initializer.return
+  util.return
 }
 // CHECK-NEXT: util.global private @global1 : index
 util.global private @global1 : index
@@ -20,7 +20,7 @@ util.initializer {
   util.global.store %value1, @global1 : index
   %value2 = func.call @extern() : () -> index
   util.global.store %value2, @global2 : index
-  util.initializer.return
+  util.return
 }
 // CHECK-NEXT: util.initializer {
 // CHECK-NEXT: %[[VALUE0:.+]] = func.call @extern()
@@ -29,7 +29,7 @@ util.initializer {
 // CHECK-NEXT: util.global.store %[[VALUE1]], @global1
 // CHECK-NEXT: %[[VALUE2:.+]] = func.call @extern()
 // CHECK-NEXT: util.global.store %[[VALUE2]], @global2
-// CHECK-NEXT: util.initializer.return
+// CHECK-NEXT: util.return
 
 // CHECK-LABEL: @orderedCombining
 func.func @orderedCombining(%arg0: index) -> (index, index, index) {
@@ -59,14 +59,14 @@ util.initializer {
   util.global.store %c200, @globalA : index
   cf.br ^bb3
 ^bb3:
-  util.initializer.return
+  util.return
 }
 // CHECK-NEXT: util.global private @globalB : index
 util.global private @globalB : index
 util.initializer {
   %c300 = arith.constant 300 : index
   util.global.store %c300, @globalB : index
-  util.initializer.return
+  util.return
 }
 // CHECK: util.initializer {
 // CHECK: ^bb1:
@@ -76,5 +76,5 @@ util.initializer {
 // CHECK: ^bb3:
 // CHECK:   cf.br ^bb4
 // CHECK: ^bb4:
-// CHECK:   util.initializer.return
+// CHECK:   util.return
 // CHECK: }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
@@ -162,7 +162,7 @@ util.initializer {
   %0 = func.call @initializer() : () -> tensor<4xi64>
   // CHECK: util.global.store %[[VALUE]], @v_initializer : tensor<4xi32>
   util.global.store %0, @v_initializer : tensor<4xi64>
-  util.initializer.return
+  util.return
 }
 // CHECK: func.func private @initializer() -> tensor<4xi32>
 func.func private @initializer() -> tensor<4xi64>

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
@@ -81,7 +81,7 @@ util.global private mutable @mutable : index
 util.initializer {
   %c6 = arith.constant 6 : index
   util.global.store %c6, @immutable1 : index
-  util.initializer.return
+  util.return
 }
 func.func @foo(%arg0: index) -> (index, index, index) {
   // CHECK-DAG: %[[C5:.+]] = arith.constant 5
@@ -125,7 +125,7 @@ util.initializer {
   %c6 = arith.constant 6 : index
   // CHECK-NOT: util.global.store %c6, @unused1 : index
   util.global.store %c6, @unused1 : index
-  util.initializer.return
+  util.return
 }
 
 // -----
@@ -153,7 +153,7 @@ util.global private @nondupeCst1 = 6 : index
 util.initializer {
   %c7 = arith.constant 7 : index
   util.global.store %c7, @nondupeCst1 : index
-  util.initializer.return
+  util.return
 }
 func.func @foo() -> (index, index) {
   // CHECK-DAG: %[[C6:.+]] = arith.constant 6 : index

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
@@ -130,10 +130,10 @@ util.initializer {
 
 // -----
 
-// CHECK: util.global private @dupeCst0 {noinline} = 5 : index
-util.global private @dupeCst0 {noinline} = 5 : index
+// CHECK: util.global private @dupeCst0 {inlining_policy = #util.inline.never} = 5 : index
+util.global private @dupeCst0 {inlining_policy = #util.inline.never} = 5 : index
 // CHECK-NOT: util.global private @dupeCst1
-util.global private @dupeCst1 {noinline} = 5 : index
+util.global private @dupeCst1 {inlining_policy = #util.inline.never} = 5 : index
 func.func @foo() -> (index, index) {
   // CHECK-DAG: %[[VALUE0:.+]] = util.global.load @dupeCst0
   %0 = util.global.load @dupeCst0 : index

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fuse_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fuse_globals.mlir
@@ -43,7 +43,7 @@ func.func @nonuniform_b(%arg0: index) {
 util.initializer {
   %0 = "some.op"() : () -> index
   util.global.store %0, @unfusable1 : index
-  util.initializer.return
+  util.return
 }
 
 // -----
@@ -101,7 +101,7 @@ util.initializer {
   util.global.store %v, @fusableSubset1 : index
   // CHECK-NEXT: util.global.store %[[V]], @unfusableSubset2
   util.global.store %v, @unfusableSubset2 : index
-  util.initializer.return
+  util.return
 }
 // CHECK: func.func @mutate_unfusable(%[[ARG0:.+]]: index)
 func.func @mutate_unfusable(%arg0: index) {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -19,7 +19,7 @@ module @hoist_simple_const_expr {
   // CHECK:   %[[C1:.*]] = arith.constant 1 : i32
   // CHECK:   %[[CE0:.*]] = "iree_unregistered.const_expr"(%[[C0]], %[[C1]])
   // CHECK:   util.global.store %[[CE0]], @[[HOISTED_SYM]] : i32
-  // CHECK:   util.initializer.return
+  // CHECK:   util.return
   // CHECK: }
 }
 
@@ -131,14 +131,14 @@ module @hoist_tree_const_expr {
   // CHECK:   %[[C1:.*]] = arith.constant 1 : i32
   // CHECK:   %[[CE0:.*]] = "iree_unregistered.const_expr"(%[[C0]], %[[C1]])
   // CHECK:   util.global.store %[[CE0]], @[[HOISTED_0]] : i32
-  // CHECK:   util.initializer.return
+  // CHECK:   util.return
   // CHECK: }
   // CHECK: util.initializer attributes {iree.compiler.consteval} {
   // CHECK:   %[[LOAD_HOISTED_0:.*]] = util.global.load @[[HOISTED_0]] : i32
   // CHECK:   %[[LOAD_LATENT_GLOBAL:.*]] = util.global.load @latent_global : i32
   // CHECK:   %[[CE1:.*]] = "iree_unregistered.const_expr"(%[[LOAD_HOISTED_0]], %[[LOAD_LATENT_GLOBAL]])
   // CHECK:   util.global.store %[[CE1]], @[[HOISTED_1]] : i32
-  // CHECK:   util.initializer.return
+  // CHECK:   util.return
   // CHECK: }
 }
 
@@ -163,7 +163,7 @@ module @hoist_const_expr_with_ineligible_consumer {
   // CHECK:   %[[C1:.*]] = arith.constant 1 : i32
   // CHECK:   %[[CE0:.*]] = "iree_unregistered.const_expr"(%[[C0]], %[[C1]])
   // CHECK:   util.global.store %[[CE0]], @[[HOISTED_0]] : i32
-  // CHECK:   util.initializer.return
+  // CHECK:   util.return
   // CHECK: }
 }
 
@@ -192,7 +192,7 @@ module @hoist_non_leaf_const_expr {
   // CHECK:   %[[CE0:.*]] = "iree_unregistered.non_leaf_const_expr"(%[[C0]], %[[C1]])
   // CHECK:   %[[CE1:.*]] = "iree_unregistered.const_expr"(%[[CE0]])
   // CHECK:   util.global.store %[[CE1]], @[[HOISTED]] : i32
-  // CHECK:   util.initializer.return
+  // CHECK:   util.return
   // CHECK: }
 }
 
@@ -224,7 +224,7 @@ module @hoist_implicit_capture {
   // CHECK:         ^bb0(%[[B0:.*]]: i32):
   // CHECK:         arith.addi %[[B0]], %[[C1]]
   // CHECK:       util.global.store %[[CE0]], @[[HOISTED_SYM]] : i32
-  // CHECK:       util.initializer.return
+  // CHECK:       util.return
   // CHECK: }
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/outline_constants.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/outline_constants.mlir
@@ -18,8 +18,8 @@ func.func @splatConstant() {
 
 // -----
 
-//       CHECK: util.global private @_constant {noinline} = dense<[0.0287729427, 0.0297581609]> : tensor<2xf32>
-//  CHECK-NEXT: util.global private @_constant_0 {noinline} = dense<[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00]> : tensor<8xf32>
+//       CHECK: util.global private @_constant {inlining_policy = #util.inline.never} = dense<[0.0287729427, 0.0297581609]> : tensor<2xf32>
+//  CHECK-NEXT: util.global private @_constant_0 {inlining_policy = #util.inline.never} = dense<[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00]> : tensor<8xf32>
 // CHECK-LABEL: @denseConstants
 func.func @denseConstants() {
   // CHECK: = util.global.load @_constant : tensor<2xf32>

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -94,7 +94,6 @@ static void copyFuncAttrs(func::FuncOp srcOp, Operation *dstOp) {
   constexpr const char *kRetainedAttributes[] = {
       "iree.reflection",
       "sym_visibility",
-      "noinline",
       "nosideeffects",
   };
   auto retainedAttributes = ArrayRef<const char *>(
@@ -106,6 +105,10 @@ static void copyFuncAttrs(func::FuncOp srcOp, Operation *dstOp) {
     if (attr) {
       dstOp->setAttr(attrName, attr);
     }
+  }
+  if (srcOp->hasAttr("noinline")) {
+    dstOp->setAttr("inlining_policy",
+                   IREE::Util::InlineNeverAttr::get(dstOp->getContext()));
   }
 }
 
@@ -168,7 +171,6 @@ class FuncOpConversion : public OpConversionPattern<func::FuncOp> {
 // override behavior during conversion and don't want to propagate them.
 static void copyImportAttrs(func::FuncOp srcOp, IREE::VM::ImportOp dstOp) {
   constexpr const char *kRetainedAttributes[] = {
-      "noinline",
       "nosideeffects",
       "vm.fallback",
   };

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/structural_ops.mlir
@@ -8,7 +8,7 @@ module @t001_module_all_options {
 
 // CHECK: vm.module public @my_module {
 module @my_module {
-  // CHECK: vm.func private @my_fn(%[[ARG0:[a-zA-Z0-9$._-]+]]: i32) -> i32
+  // CHECK: vm.func private @my_fn(%[[ARG0:.+]]: i32) -> i32
   func.func @my_fn(%arg0: i32) -> (i32) {
     // CHECK: vm.return %[[ARG0]] : i32
     return %arg0 : i32

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/BUILD.bazel
@@ -21,6 +21,7 @@ iree_compiler_cc_library(
         "ConvertGlobalOps.cpp",
         "ConvertListOps.cpp",
         "ConvertStatusOps.cpp",
+        "ConvertStructuralOps.cpp",
         "ConvertUtilToVM.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "ConvertGlobalOps.cpp"
     "ConvertListOps.cpp"
     "ConvertStatusOps.cpp"
+    "ConvertStructuralOps.cpp"
     "ConvertUtilToVM.cpp"
   DEPS
     MLIRArithDialect

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
@@ -38,12 +38,11 @@ struct InitializerOpConversion
   }
 };
 
-struct InitializerReturnOpConversion
-    : public OpConversionPattern<IREE::Util::InitializerReturnOp> {
+struct ReturnOpConversion : public OpConversionPattern<IREE::Util::ReturnOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(IREE::Util::InitializerReturnOp op, OpAdaptor adaptor,
+  matchAndRewrite(IREE::Util::ReturnOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<IREE::VM::ReturnOp>(op);
     return success();
@@ -282,10 +281,10 @@ void populateUtilGlobalToVMPatterns(MLIRContext *context,
                                     ConversionTarget &conversionTarget,
                                     TypeConverter &typeConverter,
                                     RewritePatternSet &patterns) {
-  conversionTarget.addIllegalOp<IREE::Util::InitializerOp,
-                                IREE::Util::InitializerReturnOp>();
-  patterns.insert<InitializerOpConversion, InitializerReturnOpConversion>(
-      typeConverter, context);
+  conversionTarget
+      .addIllegalOp<IREE::Util::InitializerOp, IREE::Util::ReturnOp>();
+  patterns.insert<InitializerOpConversion, ReturnOpConversion>(typeConverter,
+                                                               context);
 
   conversionTarget.addIllegalOp<
       IREE::Util::GlobalOp, IREE::Util::GlobalAddressOp,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
@@ -1,0 +1,416 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/Dialect/VM/Conversion/ImportUtils.h"
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "iree/compiler/Dialect/VM/IR/VMTypes.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+struct InitializerOpConversion
+    : public OpConversionPattern<IREE::Util::InitializerOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(IREE::Util::InitializerOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto newOp = rewriter.create<IREE::VM::InitializerOp>(op.getLoc());
+    rewriter.cloneRegionBefore(op.getBody(), newOp.getBody(),
+                               newOp.getBody().begin());
+
+    // Tell the rewriter to convert the region signature.
+    const TypeConverter &typeConverter = *getTypeConverter();
+    TypeConverter::SignatureConversion signatureConversion(0);
+    if (failed(rewriter.convertRegionTypes(&newOp.getBody(), typeConverter,
+                                           &signatureConversion))) {
+      return rewriter.notifyMatchFailure(op, "failed to convert region types");
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// Converts a function signature with the given |signatureConversion| util.
+static FailureOr<FunctionType>
+convertFuncSignature(IREE::Util::FuncOp srcOp,
+                     const TypeConverter &typeConverter,
+                     TypeConverter::SignatureConversion &signatureConversion,
+                     ConversionPatternRewriter &rewriter) {
+  FunctionType srcFuncType = srcOp.getFunctionType();
+  for (unsigned i = 0, e = srcFuncType.getNumInputs(); i < e; ++i) {
+    if (failed(typeConverter.convertSignatureArg(i, srcFuncType.getInput(i),
+                                                 signatureConversion))) {
+      return rewriter.notifyMatchFailure(srcOp, "argument failed to convert");
+    }
+  }
+  SmallVector<Type, 1> convertedResultTypes;
+  if (failed(typeConverter.convertTypes(srcFuncType.getResults(),
+                                        convertedResultTypes))) {
+    return rewriter.notifyMatchFailure(srcOp, "results failed to convert");
+  }
+  return mlir::FunctionType::get(srcOp.getContext(),
+                                 signatureConversion.getConvertedTypes(),
+                                 convertedResultTypes);
+}
+
+// Copies attributes from |srcOp| to |dstOp| that we preserve during conversion.
+// There may be any number of attributes on srcOp but we don't always want to
+// preserve them as they may come from dialects we are removing.
+static void copyFuncAttrs(IREE::Util::FuncOp srcOp, Operation *dstOp) {
+  constexpr const char *kRetainedAttributes[] = {
+      "iree.reflection",
+      "sym_visibility",
+      "inlining_policy",
+      "nosideeffects",
+  };
+  auto retainedAttributes = ArrayRef<const char *>(
+      kRetainedAttributes,
+      sizeof(kRetainedAttributes) / sizeof(kRetainedAttributes[0]));
+  for (auto retainAttrName : retainedAttributes) {
+    StringRef attrName(retainAttrName);
+    Attribute attr = srcOp->getAttr(attrName);
+    if (attr) {
+      dstOp->setAttr(attrName, attr);
+    }
+  }
+}
+
+class FuncOpConversion : public OpConversionPattern<IREE::Util::FuncOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(IREE::Util::FuncOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Handled by import-specific conversion.
+    if (srcOp.isExternal())
+      return failure();
+
+    // Convert function signature.
+    TypeConverter::SignatureConversion signatureConversion(
+        srcOp.getNumArguments());
+    auto newFuncType = convertFuncSignature(srcOp, *getTypeConverter(),
+                                            signatureConversion, rewriter);
+    if (failed(newFuncType))
+      return failure();
+
+    // Create new function with converted argument and result types.
+    // Note that attributes are dropped. Consider preserving some if needed.
+    auto newFuncOp = rewriter.create<IREE::VM::FuncOp>(
+        srcOp.getLoc(), srcOp.getName(), *newFuncType);
+    rewriter.inlineRegionBefore(srcOp.getBody(), newFuncOp.getFunctionBody(),
+                                newFuncOp.end());
+
+    // Tell the rewriter to convert the region signature.
+    const TypeConverter &typeConverter = *getTypeConverter();
+    if (failed(rewriter.convertRegionTypes(&newFuncOp.getFunctionBody(),
+                                           typeConverter,
+                                           &signatureConversion))) {
+      return failure();
+    }
+
+    // Retain function attributes in the allowlist.
+    copyFuncAttrs(srcOp, newFuncOp);
+
+    // Also add an export for the "raw" form of this function, which operates
+    // on low level VM types and does no verification. A later pass will
+    // materialize high level API-friendly wrappers.
+    if (srcOp.isPublic()) {
+      StringRef exportName = newFuncOp.getName();
+      auto exportOp = rewriter.create<IREE::VM::ExportOp>(
+          srcOp.getLoc(), newFuncOp, exportName);
+      exportOp->setDialectAttrs(srcOp->getDialectAttrs());
+    }
+
+    // VM functions are private by default and exported via the dedicated
+    // vm.export ops.
+    newFuncOp.setPrivate();
+
+    rewriter.eraseOp(srcOp);
+    return success();
+  }
+};
+
+// Copies attributes from |srcOp| to |dstOp| that we preserve during conversion.
+// We allow external functions to have some special vm-specific attributes that
+// override behavior during conversion and don't want to propagate them.
+static void copyImportAttrs(IREE::Util::FuncOp srcOp,
+                            IREE::VM::ImportOp dstOp) {
+  constexpr const char *kRetainedAttributes[] = {
+      "nosideeffects",
+      "vm.fallback",
+  };
+  auto retainedAttributes = ArrayRef<const char *>(
+      kRetainedAttributes,
+      sizeof(kRetainedAttributes) / sizeof(kRetainedAttributes[0]));
+  for (auto retainAttrName : retainedAttributes) {
+    StringRef attrName(retainAttrName);
+    Attribute attr = srcOp->getAttr(attrName);
+    if (attr) {
+      dstOp->setAttr(attrName, attr);
+    }
+  }
+}
+
+class ExternalFuncOpConversion
+    : public OpConversionPattern<IREE::Util::FuncOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(IREE::Util::FuncOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Handled by internal-specific conversion.
+    if (!srcOp.isExternal())
+      return failure();
+
+    // If the user declared an intended signature then we can use that instead
+    // of running conversion ourselves. This can be used in cases where the
+    // types of the import differ from the expected conversion results like
+    // index -> i32 or i64 depending on VM mode.
+    FunctionType newSignature;
+    auto signatureAttr = srcOp->getAttrOfType<TypeAttr>("vm.signature");
+    if (signatureAttr) {
+      // Directly use the signature from the user.
+      newSignature = llvm::dyn_cast<FunctionType>(signatureAttr.getValue());
+      if (!newSignature) {
+        return rewriter.notifyMatchFailure(srcOp, "invalid vm.signature");
+      }
+    } else {
+      // Convert function signature.
+      TypeConverter::SignatureConversion signatureConversion(
+          srcOp.getNumArguments());
+      auto convertedSignature = convertFuncSignature(
+          srcOp, *getTypeConverter(), signatureConversion, rewriter);
+      if (failed(convertedSignature))
+        return failure();
+      newSignature = *convertedSignature;
+    }
+
+    // Create new function with converted argument and result types.
+    // Note that attributes are dropped. Consider preserving some if needed.
+    auto importOp = rewriter.create<IREE::VM::ImportOp>(
+        srcOp.getLoc(), srcOp.getName(), newSignature);
+    importOp.setSymVisibilityAttr(srcOp.getSymVisibilityAttr());
+
+    // If there is a fallback then the import is optional.
+    if (srcOp->hasAttr("vm.fallback")) {
+      importOp.setIsOptionalAttr(rewriter.getUnitAttr());
+    }
+
+    // By default imports are unversioned but we allow the user to specify one.
+    if (auto minimumVersion = srcOp->getAttrOfType<IntegerAttr>("vm.version")) {
+      importOp.setMinimumVersionAttr(minimumVersion);
+    }
+
+    // Retain function attributes in the allowlist.
+    copyImportAttrs(srcOp, importOp);
+
+    rewriter.eraseOp(srcOp);
+    return success();
+  }
+};
+
+class CallOpConversion : public OpConversionPattern<IREE::Util::CallOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(IREE::Util::CallOp callOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Regardless of what the call (or import) does we need to match the
+    // result types defined by the type converter. We will insert casts as
+    // needed to these types before replacing the op.
+    SmallVector<Type> resultTypes;
+    for (auto resultType : callOp.getResultTypes()) {
+      resultType = getTypeConverter()->convertType(resultType);
+      if (!resultType) {
+        return rewriter.notifyMatchFailure(callOp, "unsupported result type");
+      }
+      resultTypes.push_back(resultType);
+    }
+
+    // We change the call behavior based on whether we are targeting an import
+    // or an internal function. This may include recursively calling the
+    // conversion if imports have fallbacks that are themselves imports.
+    auto callResults = convertCallOp(
+        callOp->getParentOfType<IREE::VM::ModuleOp>(), callOp.getLoc(),
+        callOp.getCallee(), adaptor.getOperands(), resultTypes, rewriter);
+    if (failed(callResults)) {
+      return rewriter.notifyMatchFailure(
+          callOp, "unable to convert call (results mismatch)");
+    }
+
+    rewriter.replaceOp(callOp, *callResults);
+    return success();
+  }
+
+  // Converts a call to some function which may be internal or an import.
+  // Returns the new converted call results.
+  FailureOr<SmallVector<Value>>
+  convertCallOp(Operation *rootOp, Location loc, StringRef calleeName,
+                ValueRange operands, TypeRange resultTypes,
+                ConversionPatternRewriter &rewriter) const {
+    // (Slow) lookup of the target function, which may be an import that we need
+    // to perform type conversion for.
+    auto calleeOp = SymbolTable::lookupSymbolIn(rootOp, calleeName);
+    if (auto funcOp = dyn_cast_or_null<IREE::Util::FuncOp>(calleeOp)) {
+      if (funcOp.isExternal()) {
+        // Import that may require conversion.
+        // This case handles when funcs are declared after the call.
+        FunctionType convertedSignature;
+        if (auto signatureAttr =
+                funcOp->getAttrOfType<TypeAttr>("vm.signature")) {
+          if (auto importSignature =
+                  llvm::dyn_cast<FunctionType>(signatureAttr.getValue())) {
+            convertedSignature = importSignature;
+          }
+        }
+        if (!convertedSignature) {
+          convertedSignature =
+              rewriter.getFunctionType(TypeRange(operands), resultTypes);
+        }
+        return convertImportCallOp(rootOp, loc, calleeName, operands,
+                                   resultTypes, convertedSignature, funcOp,
+                                   rewriter);
+      }
+    } else if (auto importOp = dyn_cast_or_null<IREE::VM::ImportOp>(calleeOp)) {
+      // Calling an import.
+      // This case handles when funcs are declared before the call and have
+      // already been converted.
+      return convertImportCallOp(rootOp, loc, calleeName, operands, resultTypes,
+                                 importOp.getFunctionType(), importOp,
+                                 rewriter);
+    }
+
+    // Otherwise this is a direct call to an internal function.
+    auto newOp = rewriter.create<IREE::VM::CallOp>(loc, calleeName, resultTypes,
+                                                   operands);
+    return SmallVector<Value>(newOp.result_begin(), newOp.result_end());
+  }
+
+  // Converts a call to an import that may be optional.
+  // Returns the new converted call results.
+  FailureOr<SmallVector<Value>>
+  convertImportCallOp(Operation *rootOp, Location loc, StringRef calleeName,
+                      ValueRange operands, TypeRange resultTypes,
+                      FunctionType importSignature, Operation *calleeOp,
+                      ConversionPatternRewriter &rewriter) const {
+    auto fallbackAttr = calleeOp->getAttrOfType<SymbolRefAttr>("vm.fallback");
+    return fallbackAttr
+               ? convertOptionalImportCallOp(
+                     rootOp, loc, calleeName, operands, resultTypes,
+                     importSignature,
+                     fallbackAttr.getLeafReference().getValue(), rewriter)
+               : convertMandatoryImportCallOp(rootOp, loc, calleeName, operands,
+                                              resultTypes, importSignature,
+                                              rewriter);
+  }
+
+  // Converts a call to an optional import by adding logic to check whether it
+  // resolves at runtime and otherwise calling a fallback.
+  // Returns the new converted call results.
+  FailureOr<SmallVector<Value>> convertOptionalImportCallOp(
+      Operation *rootOp, Location loc, StringRef calleeName,
+      ValueRange operands, TypeRange resultTypes, FunctionType importSignature,
+      StringRef fallbackName, ConversionPatternRewriter &rewriter) const {
+    // Check whether the import resolved and if so call it. Otherwise we call
+    // the fallback which should not require any conversion.
+    Value resolved = rewriter.create<IREE::VM::ImportResolvedOp>(
+        loc, rewriter.getI32Type(), calleeName);
+
+    // We'll be making the call via two blocks and then joining again on a block
+    // that takes the results in target form.
+    SmallVector<Location> resultLocs(resultTypes.size(), loc);
+    auto *exitBlock = rewriter.splitBlock(rewriter.getInsertionBlock(),
+                                          rewriter.getInsertionPoint());
+    auto exitResults =
+        llvm::map_to_vector(exitBlock->addArguments(resultTypes, resultLocs),
+                            [](BlockArgument arg) -> Value { return arg; });
+
+    auto *resolvedBlock = rewriter.createBlock(exitBlock);
+    auto *fallbackBlock = rewriter.createBlock(exitBlock);
+
+    // Insert the branch to each block.
+    rewriter.setInsertionPointAfterValue(resolved);
+    rewriter.create<IREE::VM::CondBranchOp>(loc, resolved, resolvedBlock,
+                                            ValueRange{}, fallbackBlock,
+                                            ValueRange{});
+
+    // Resolved: make call to the import as normal.
+    rewriter.setInsertionPointToStart(resolvedBlock);
+    auto importResults =
+        convertMandatoryImportCallOp(rootOp, loc, calleeName, operands,
+                                     resultTypes, importSignature, rewriter);
+    rewriter.create<IREE::VM::BranchOp>(loc, exitBlock, importResults);
+
+    // Not resolved: call fallback as a normal function.
+    rewriter.setInsertionPointToStart(fallbackBlock);
+    auto fallbackResults = convertCallOp(rootOp, loc, fallbackName, operands,
+                                         resultTypes, rewriter);
+    if (failed(fallbackResults))
+      return failure();
+    rewriter.create<IREE::VM::BranchOp>(loc, exitBlock, *fallbackResults);
+
+    return exitResults;
+  }
+
+  // Converts a call to a mandatory import that is guaranteed to be resolved at
+  // runtime. Handles potential import signature overrides that change type
+  // conversion behavior.
+  // Returns the new converted call results.
+  SmallVector<Value> convertMandatoryImportCallOp(
+      Operation *rootOp, Location loc, StringRef calleeName,
+      ValueRange operands, TypeRange resultTypes, FunctionType importSignature,
+      ConversionPatternRewriter &rewriter) const {
+    // Marshal arguments to import types.
+    SmallVector<Value> importArgs;
+    for (auto [operand, importType] :
+         llvm::zip_equal(operands, importSignature.getInputs())) {
+      importArgs.push_back(castToImportType(operand, importType, rewriter));
+    }
+
+    // Direct call to mandatory import.
+    auto newOp = rewriter.create<IREE::VM::CallOp>(
+        loc, calleeName, importSignature.getResults(), importArgs);
+
+    // Marshal results from import types.
+    SmallVector<Value> callResults;
+    for (auto [importResult, resultType] :
+         llvm::zip_equal(newOp.getResults(), resultTypes)) {
+      callResults.push_back(
+          castFromImportType(importResult, resultType, rewriter));
+    }
+    return callResults;
+  }
+};
+
+struct ReturnOpConversion : public OpConversionPattern<IREE::Util::ReturnOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(IREE::Util::ReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<IREE::VM::ReturnOp>(op, adaptor.getOperands());
+    return success();
+  }
+};
+
+} // namespace
+
+void populateUtilStructuralToVMPatterns(MLIRContext *context,
+                                        ConversionTarget &conversionTarget,
+                                        TypeConverter &typeConverter,
+                                        RewritePatternSet &patterns) {
+  conversionTarget.addIllegalOp<IREE::Util::InitializerOp, IREE::Util::FuncOp,
+                                IREE::Util::CallOp, IREE::Util::ReturnOp>();
+  patterns
+      .insert<InitializerOpConversion, FuncOpConversion,
+              ExternalFuncOpConversion, CallOpConversion, ReturnOpConversion>(
+          typeConverter, context);
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertUtilToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertUtilToVM.cpp
@@ -43,6 +43,10 @@ void populateUtilStatusToVMPatterns(MLIRContext *context,
                                     ConversionTarget &conversionTarget,
                                     TypeConverter &typeConverter,
                                     RewritePatternSet &patterns);
+void populateUtilStructuralToVMPatterns(MLIRContext *context,
+                                        ConversionTarget &conversionTarget,
+                                        TypeConverter &typeConverter,
+                                        RewritePatternSet &patterns);
 
 namespace {
 
@@ -122,6 +126,8 @@ void populateUtilToVMPatterns(MLIRContext *context,
                                patterns);
   populateUtilStatusToVMPatterns(context, conversionTarget, typeConverter,
                                  patterns);
+  populateUtilStructuralToVMPatterns(context, conversionTarget, typeConverter,
+                                     patterns);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "hint_ops.mlir",
             "list_ops.mlir",
             "status_ops.mlir",
+            "structural_ops.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "hint_ops.mlir"
     "list_ops.mlir"
     "status_ops.mlir"
+    "structural_ops.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/global_ops.mlir
@@ -24,7 +24,7 @@ util.global public @v_initialized : !hal.buffer
 util.initializer {
   %0 = func.call @initializer() : () -> !hal.buffer
   util.global.store %0, @v_initialized : !hal.buffer
-  util.initializer.return
+  util.return
 }
 // CHECK-NEXT: vm.import private @initializer() -> !vm.ref<!hal.buffer>
 func.func private @initializer() -> !hal.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/structural_ops.mlir
@@ -1,0 +1,178 @@
+// RUN: iree-opt --split-input-file --iree-vm-conversion --iree-vm-target-index-bits=32 --allow-unregistered-dialect %s | FileCheck %s
+
+//      CHECK: vm.initializer {
+// CHECK-NEXT:  vm.return
+// CHECK-NEXT: }
+util.initializer {
+  util.return
+}
+
+// -----
+
+// CHECK: vm.func private @fn(%[[ARG0:.+]]: i32) -> i32
+util.func private @fn(%arg0: i32) -> (i32) {
+  // CHECK: vm.return %[[ARG0]] : i32
+  util.return %arg0 : i32
+}
+
+// -----
+
+// CHECK: vm.func private @fn_noinline(%[[ARG0:.+]]: i32) -> i32
+// CHECK-SAME: attributes {inlining_policy = #util.inline.never}
+util.func private @fn_noinline(%arg0: i32) -> i32 attributes {
+  inlining_policy = #util.inline.never
+} {
+  // CHECK: vm.return %[[ARG0]] : i32
+  util.return %arg0 : i32
+}
+
+// -----
+
+// CHECK: vm.func private @fn_reflection
+// CHECK-SAME: iree.reflection = {f = "FOOBAR"}
+util.func @fn_reflection(%arg0: i32) -> i32 attributes {
+  iree.reflection = {f = "FOOBAR"}
+} {
+  util.return %arg0 : i32
+}
+
+// -----
+
+// CHECK: vm.func private @internal_function_name
+// CHECK: vm.export @internal_function_name
+util.func @internal_function_name(%arg0: i32) -> i32 {
+  util.return %arg0 : i32
+}
+
+// -----
+
+// CHECK: vm.import private @some.import(i32) -> !vm.buffer
+// CHECK-SAME: attributes {minimum_version = 4 : i32}
+util.func private @some.import(%arg0: index) -> !util.buffer attributes {
+  vm.version = 4 : i32
+}
+// CHECK: vm.func private @my_fn(%[[ARG0:.+]]: i32) -> !vm.buffer
+util.func @my_fn(%arg0: index) -> !util.buffer {
+  // CHECK: %[[RET:.+]] = vm.call @some.import(%[[ARG0]]) : (i32) -> !vm.buffer
+  %0 = util.call @some.import(%arg0) : (index) -> !util.buffer
+  // CHECK: vm.return %[[RET]]
+  util.return %0 : !util.buffer
+}
+
+// -----
+
+// CHECK: vm.import private @signatured.import(i64) -> i64
+util.func private @signatured.import(%arg0: index) -> index attributes {
+  vm.signature = (i64) -> i64
+}
+// CHECK: vm.func private @my_fn(%[[ARG0:.+]]: i32) -> i32
+util.func @my_fn(%arg0: index) -> index {
+  // CHECK: %[[IMPORT_ARG:.+]] = vm.ext.i32.i64.s %[[ARG0]]
+  // CHECK: %[[IMPORT_RET:.+]] = vm.call @signatured.import(%[[IMPORT_ARG]]) : (i64) -> i64
+  %0 = util.call @signatured.import(%arg0) : (index) -> index
+  // CHECK: %[[RET:.+]] = vm.trunc.i64.i32 %[[IMPORT_RET]]
+  // CHECK: vm.return %[[RET]] : i32
+  util.return %0 : index
+}
+
+// -----
+
+util.func private @other.fn_i32(%arg0: i32) -> i32
+// CHECK: vm.func private @my_fn
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
+util.func @my_fn(%arg0 : i32) -> i32 {
+  // CHECK: vm.call @other.fn_i32(%[[ARG0]]) : (i32) -> i32
+  %0 = util.call @other.fn_i32(%arg0) : (i32) -> i32
+  util.return %0 : i32
+}
+
+// -----
+
+util.func private @other.fn_i1(%arg0: i1) -> i1
+// CHECK: vm.func private @my_fn
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
+util.func @my_fn(%arg0 : i1) -> i1 {
+  // CHECK: vm.call @other.fn_i1(%[[ARG0]]) : (i32) -> i32
+  %0 = util.call @other.fn_i1(%arg0) : (i1) -> i1
+  util.return %0 : i1
+}
+
+// -----
+
+// NOTE: we require conversion for the import but not the fallback!
+// CHECK: vm.import private optional @optional.import(i64) -> i64
+util.func private @optional.import(%arg0: index) -> index attributes {
+  vm.signature = (i64) -> i64,
+  vm.fallback = @some_fallback
+}
+// CHECK: vm.func private @some_fallback(%{{.+}}: i32) -> i32
+util.func private @some_fallback(%arg0: index) -> index {
+  util.return %arg0 : index
+}
+// CHECK: vm.func private @my_fn(%[[ARG0:.+]]: i32) -> i32
+util.func @my_fn(%arg0: index) -> index {
+  // CHECK: %[[RESOLVED:.+]] = vm.import.resolved @optional.import
+  // CHECK: vm.cond_br %[[RESOLVED]], ^bb1, ^bb2
+  %0 = util.call @optional.import(%arg0) : (index) -> index
+
+  // CHECK: ^bb1:
+  // CHECK: %[[IMPORT_ARG:.+]] = vm.ext.i32.i64.s %[[ARG0]]
+  // CHECK: %[[IMPORT_RET:.+]] = vm.call @optional.import(%[[IMPORT_ARG]]) : (i64) -> i64
+  // CHECK: %[[BB1_RET:.+]] = vm.trunc.i64.i32 %[[IMPORT_RET]]
+  // CHECK: vm.br ^bb3(%[[BB1_RET]] : i32)
+
+  // CHECK: ^bb2:
+  // CHECK: %[[FALLBACK_RET:.+]] = vm.call @some_fallback(%[[ARG0]]) : (i32) -> i32
+  // CHECK: vm.br ^bb3(%[[FALLBACK_RET]] : i32)
+
+  // CHECK: ^bb3(%[[RET:.+]]: i32):
+  // CHECK: vm.return %[[RET]]
+  util.return %0 : index
+}
+
+// -----
+
+// NOTE: we require conversion for the import but not the fallback!
+// CHECK: vm.import private optional @optional.import(i64) -> i64
+util.func private @optional.import(%arg0: index) -> index attributes {
+  vm.signature = (i64) -> i64,
+  vm.fallback = @fallback.import
+}
+// CHECK: vm.import private @fallback.import(i64) -> i64
+util.func private @fallback.import(%arg0: index) -> index attributes {
+  vm.signature = (i64) -> i64
+}
+// CHECK: vm.func private @my_fn(%[[ARG0:.+]]: i32) -> i32
+util.func @my_fn(%arg0: index) -> index {
+  // CHECK: %[[RESOLVED:.+]] = vm.import.resolved @optional.import
+  // CHECK: vm.cond_br %[[RESOLVED]], ^bb1, ^bb2
+  %0 = util.call @optional.import(%arg0) : (index) -> index
+
+  // CHECK: ^bb1:
+  // CHECK: %[[IMPORT_ARG:.+]] = vm.ext.i32.i64.s %[[ARG0]]
+  // CHECK: %[[IMPORT_RET:.+]] = vm.call @optional.import(%[[IMPORT_ARG]]) : (i64) -> i64
+  // CHECK: %[[BB1_RET:.+]] = vm.trunc.i64.i32 %[[IMPORT_RET]]
+  // CHECK: vm.br ^bb3(%[[BB1_RET]] : i32)
+
+  // CHECK: ^bb2:
+  // CHECK: %[[FALLBACK_ARG:.+]] = vm.ext.i32.i64.s %[[ARG0]]
+  // CHECK: %[[FALLBACK_RET:.+]] = vm.call @fallback.import(%[[FALLBACK_ARG]]) : (i64) -> i64
+  // CHECK: %[[BB2_RET:.+]] = vm.trunc.i64.i32 %[[FALLBACK_RET]]
+  // CHECK: vm.br ^bb3(%[[BB2_RET]] : i32)
+
+  // CHECK: ^bb3(%[[RET:.+]]: i32):
+  // CHECK: vm.return %[[RET]]
+  util.return %0 : index
+}
+
+// -----
+
+// CHECK: vm.import private @opaque.import() -> !vm.ref<!some.type<foo>>
+util.func private @opaque.import() -> !some.type<foo>
+// CHECK: vm.func private @my_fn() -> !vm.ref<!some.type<foo>>
+util.func @my_fn() -> !some.type<foo> {
+  // CHECK: %[[RET:.+]] = vm.call @opaque.import() : () -> !vm.ref<!some.type<foo>>
+  %0 = util.call @opaque.import() : () -> !some.type<foo>
+  // CHECK: vm.return %[[RET]]
+  util.return %0 : !some.type<foo>
+}

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
@@ -68,35 +68,32 @@ namespace {
 struct VMInlinerInterface : public DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
 
-  // Allow all call operations to be inlined.
   bool isLegalToInline(Operation *call, Operation *callable,
                        bool wouldBeCloned) const final {
+    // Check the inlining policy specified on the callable first.
+    if (auto inliningPolicy =
+            callable->getAttrOfType<IREE::Util::InliningPolicyAttrInterface>(
+                "inlining_policy")) {
+      if (!inliningPolicy.isLegalToInline(call, callable))
+        return false;
+    }
+    // Sure!
     return true;
   }
 
   bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
                        IRMapping &valueMapping) const final {
-    // TODO(benvanik): disallow inlining across async calls.
-
-    // Don't inline functions with the 'noinline' attribute.
-    // Useful primarily for benchmarking.
-    if (auto funcOp = dyn_cast<VM::FuncOp>(src->getParentOp())) {
-      if (funcOp.getNoinline()) {
-        return false;
-      }
-    }
-
+    // Sure!
     return true;
   }
 
   bool isLegalToInline(Operation *op, Region *dest, bool wouldBeCloned,
                        IRMapping &valueMapping) const final {
-    // TODO(benvanik): disallow inlining across async calls.
+    // Sure!
     return true;
   }
 
   void handleTerminator(Operation *op, Block *newDest) const final {
-    // TODO(benvanik): handle other terminators (break/etc).
     auto returnOp = dyn_cast<VM::ReturnOp>(op);
     if (!returnOp) {
       return;

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -121,7 +121,7 @@ def VM_FuncOp : VM_Op<"func", [
   let arguments = (ins
     TypeAttrOf<FunctionType>:$function_type,
     OptionalAttr<VM_Ordinal>:$ordinal,
-    OptionalAttr<UnitAttr>:$noinline,
+    OptionalAttr<Util_InliningPolicyAttrInterface>:$inlining_policy,
     OptionalAttr<DictArrayAttr>:$arg_attrs,
     OptionalAttr<DictArrayAttr>:$res_attrs
   );
@@ -387,6 +387,7 @@ class VM_PrimitiveGlobalOp<string mnemonic, Attr attr_type, list<Trait> traits =
     TypeAttr:$type,
     UnitAttr:$is_mutable,
     OptionalAttr<attr_type>:$initial_value,
+    OptionalAttr<Util_InliningPolicyAttrInterface>:$inlining_policy,
     OptionalAttr<VM_Ordinal>:$ordinal
   );
 
@@ -495,6 +496,7 @@ def VM_GlobalRefOp :
     SymbolNameAttr:$sym_name,
     TypeAttr:$type,
     UnitAttr:$is_mutable,
+    OptionalAttr<Util_InliningPolicyAttrInterface>:$inlining_policy,
     OptionalAttr<VM_Ordinal>:$ordinal
   );
 

--- a/compiler/src/iree/compiler/GlobalOptimization/test/flow_hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/flow_hoist_into_globals.mlir
@@ -19,7 +19,7 @@ module @hoist_sub_byte_tensor_store {
 // CHECK:   %[[CEXPR:.+]] = "iree_unregistered.const_expr"
 // CHECK:   %[[CASTED_GLOBAL:.+]] = flow.tensor.bitcast %[[CEXPR]] : tensor<64xi4> -> tensor<32xi8>
 // CHECK:   util.global.store %[[CASTED_GLOBAL]]
-// CHECK:   util.initializer.return
+// CHECK:   util.return
 
 // -----
 
@@ -52,7 +52,7 @@ module @hoist_tree_const_expr_i4 {
   // CHECK:   %[[CE0:.*]] = "iree_unregistered.const_expr"(%[[C0]], %[[C1]])
   // CHECK:   %[[BITCAST_2:.*]] = flow.tensor.bitcast %[[CE0]] : tensor<8xi4> -> tensor<4xi8>
   // CHECK:   util.global.store %[[BITCAST_2]], @[[HOISTED_0]] : tensor<4xi8>
-  // CHECK:   util.initializer.return
+  // CHECK:   util.return
   // CHECK: }
   // CHECK: util.initializer attributes {iree.compiler.consteval} {
   // CHECK:   %[[LOAD_HOISTED_0:.*]] = util.global.load @[[HOISTED_0]] : tensor<4xi8>
@@ -61,7 +61,7 @@ module @hoist_tree_const_expr_i4 {
   // CHECK:   %[[CE1:.*]] = "iree_unregistered.const_expr"(%[[BITCAST_3]], %[[LOAD_LATENT_GLOBAL]])
   // CHECK:   %[[BITCAST_4:.*]] = flow.tensor.bitcast %[[CE1]] : tensor<8xi4> -> tensor<4xi8>
   // CHECK:   util.global.store %[[BITCAST_4]], @[[HOISTED_1]] : tensor<4xi8>
-  // CHECK:   util.initializer.return
+  // CHECK:   util.return
   // CHECK: }
 }
 

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -376,7 +376,7 @@ class GlobalOpPattern : public OpConversionPattern<IREE::Input::GlobalOp> {
           srcOp.getLoc(), srcOp.getInitializerAttr(), TypeRange{newType});
       rewriter.create<IREE::Util::GlobalStoreOp>(
           srcOp.getLoc(), callOp.getResult(0), srcOp.getName());
-      rewriter.create<IREE::Util::InitializerReturnOp>(srcOp.getLoc());
+      rewriter.create<IREE::Util::ReturnOp>(srcOp.getLoc());
       rewriter.restoreInsertionPoint(ip);
     }
     return success();

--- a/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
@@ -304,7 +304,7 @@ builtin.module @globals {
   // CHECK-NEXT: util.initializer {
   // CHECK-NEXT:   %[[VALUE:.+]] = func.call @initializer() : () -> tensor<4xi32>
   // CHECK-NEXT:   util.global.store %[[VALUE]], @global5 : tensor<4xi32>
-  // CHECK-NEXT:   util.initializer.return
+  // CHECK-NEXT:   util.return
   // CHECK-NEXT: }
   // CHECK: func.func private @initializer() -> tensor<4xi32>
   func.func private @initializer() -> tensor<4xi32>

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/test/inline_executables.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/test/inline_executables.mlir
@@ -27,7 +27,7 @@ hal.executable private @ex {
       util.initializer {
         %buffer_cst = util.buffer.constant : !util.buffer = dense<[1, 2, 3, 4, 5]> : tensor<5xi32>
         util.global.store %buffer_cst, @global_constant : !util.buffer
-        util.initializer.return
+        util.return
       }
       func.func @dispatch_0(
           %local_memory: !util.buffer,

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/MaterializeExecutables.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/MaterializeExecutables.cpp
@@ -57,7 +57,7 @@ static void replaceExecutableWithGlobal(IREE::HAL::ExecutableOp executableOp) {
         loc, status,
         "none of the executable binaries in the module are supported by the "
         "runtime");
-    failBuilder.create<IREE::Util::InitializerReturnOp>(loc);
+    failBuilder.create<IREE::Util::ReturnOp>(loc);
   }
 
   // Exit block takes the loaded executable and stores it.
@@ -67,7 +67,7 @@ static void replaceExecutableWithGlobal(IREE::HAL::ExecutableOp executableOp) {
     auto executableArg = exitBlock->addArgument(executableType, loc);
     exitBuilder.create<IREE::Util::GlobalStoreOp>(loc, executableArg,
                                                   globalOp.getName());
-    exitBuilder.create<IREE::Util::InitializerReturnOp>(loc);
+    exitBuilder.create<IREE::Util::ReturnOp>(loc);
   }
 
   // Start with the first try.

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/test/materialize_executables.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/test/materialize_executables.mlir
@@ -14,10 +14,10 @@
 // CHECK:   cf.br ^bb4(%[[EXECUTABLE]] : !hal.executable)
 // CHECK: ^bb3:
 // CHECK:   util.status.check_ok
-// CHECK:   util.initializer.return
+// CHECK:   util.return
 // CHECK: ^bb4(%[[STORE_VALUE:.+]]: !hal.executable):
 // CHECK:   util.global.store %[[STORE_VALUE]], @ex0 : !hal.executable
-// CHECK:   util.initializer.return
+// CHECK:   util.return
 // CHECK: }
 hal.executable private @ex0 {
   hal.executable.binary public @binary attributes {data = dense<123> : vector<64xi8>, format = "embedded-elf-x86_64", mime_type = "application/x-elf"}

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -21,8 +21,8 @@ MM_TEST_ASM = r"""
   #map1 = affine_map<(d0, d1) -> (d1, d0)>
   #map2 = affine_map<(d0, d1) -> (d1)>
   module @main {
-    util.global private @_params.classifier.weight {noinline} = #stream.parameter.named<"params"::"weight"> : tensor<30x20xf32>
-    util.global private @_params.classifier.bias {noinline} = #stream.parameter.named<"params"::"bias"> : tensor<30xf32>
+    util.global private @_params.classifier.weight {inlining_policy = #util.inline.never} = #stream.parameter.named<"params"::"weight"> : tensor<30x20xf32>
+    util.global private @_params.classifier.bias {inlining_policy = #util.inline.never} = #stream.parameter.named<"params"::"bias"> : tensor<30xf32>
   func.func @run(%arg0: tensor<128x20xf32>) -> tensor<128x30xf32> {
     %0 = call @forward(%arg0) : (tensor<128x20xf32>) -> tensor<128x30xf32>
     return %0 : tensor<128x30xf32>

--- a/runtime/src/iree/vm/bytecode/module_benchmark.mlir
+++ b/runtime/src/iree/vm/bytecode/module_benchmark.mlir
@@ -6,7 +6,7 @@ vm.module @bytecode_module_benchmark {
   }
 
   // Measures the cost of a call an internal function.
-  vm.func @internal_func(%arg0 : i32) -> i32 attributes {noinline} {
+  vm.func @internal_func(%arg0 : i32) -> i32 attributes {inlining_policy = #util.inline.never} {
     vm.return %arg0 : i32
   }
   vm.export @call_internal_func

--- a/runtime/src/iree/vm/test/call_ops.mlir
+++ b/runtime/src/iree/vm/test/call_ops.mlir
@@ -83,27 +83,27 @@ vm.module @call_ops {
     vm.return
   }
 
-  vm.func @_i_v(%arg : i32) attributes {noinline} {
+  vm.func @_i_v(%arg : i32) attributes {inlining_policy = #util.inline.never} {
     %c1 = vm.const.i32 1
     vm.check.eq %arg, %c1, "Expected %arg to be 1" : i32
     vm.return
   }
 
-  vm.func @_r_v(%arg : !vm.ref<?>) attributes {noinline} {
+  vm.func @_r_v(%arg : !vm.ref<?>) attributes {inlining_policy = #util.inline.never} {
     %ref = vm.const.ref.zero : !vm.ref<?>
     %ref_dno = util.optimization_barrier %ref : !vm.ref<?>
     vm.check.eq %arg, %ref_dno, "Expected %arg to be NULL" : !vm.ref<?>
     vm.return
   }
 
-  vm.func @_r_v_reuse_reg(%arg : !vm.ref<?>, %unused : !vm.ref<?>) attributes {noinline} {
+  vm.func @_r_v_reuse_reg(%arg : !vm.ref<?>, %unused : !vm.ref<?>) attributes {inlining_policy = #util.inline.never} {
     %ref = vm.const.ref.zero : !vm.ref<?>
     %ref_dno = util.optimization_barrier %ref : !vm.ref<?>
     vm.check.eq %arg, %ref_dno, "Expected %arg to be NULL" : !vm.ref<?>
     vm.return
   }
 
-  vm.func @_r_v_preserve_reg(%arg1 : !vm.ref<?>, %arg2 : !vm.ref<?>) attributes {noinline} {
+  vm.func @_r_v_preserve_reg(%arg1 : !vm.ref<?>, %arg2 : !vm.ref<?>) attributes {inlining_policy = #util.inline.never} {
     %ref = vm.const.ref.zero : !vm.ref<?>
     %ref_dno = util.optimization_barrier %ref : !vm.ref<?>
     vm.check.eq %arg1, %ref_dno, "Expected %arg1 to be NULL" : !vm.ref<?>
@@ -111,27 +111,27 @@ vm.module @call_ops {
     vm.return
   }
 
-  vm.func @_v_i() -> i32 attributes {noinline} {
+  vm.func @_v_i() -> i32 attributes {inlining_policy = #util.inline.never} {
     %c1 = vm.const.i32 1
     vm.return %c1 : i32
   }
 
-  vm.func @_v_r() -> !vm.ref<?> attributes {noinline} {
+  vm.func @_v_r() -> !vm.ref<?> attributes {inlining_policy = #util.inline.never} {
     %ref = vm.const.ref.zero : !vm.ref<?>
     vm.return %ref : !vm.ref<?>
   }
 
-  vm.func @_v_ii() -> (i32, i32) attributes {noinline} {
+  vm.func @_v_ii() -> (i32, i32) attributes {inlining_policy = #util.inline.never} {
     %c1 = vm.const.i32 1
     %c2 = vm.const.i32 2
     vm.return %c1, %c2 : i32, i32
   }
 
-  vm.func @_v_v() attributes {noinline} {
+  vm.func @_v_v() attributes {inlining_policy = #util.inline.never} {
     vm.return
   }
 
-  vm.func @_v_v_fail() attributes {noinline} {
+  vm.func @_v_v_fail() attributes {inlining_policy = #util.inline.never} {
     %c2 = vm.const.i32 2
     vm.fail %c2
   }

--- a/runtime/src/iree/vm/test/control_flow_ops.mlir
+++ b/runtime/src/iree/vm/test/control_flow_ops.mlir
@@ -181,7 +181,7 @@ vm.module @control_flow_ops {
 
   vm.func private @_return_arg_cycling(%arg0 : !vm.buffer, %arg1: !vm.buffer,
                                        %arg2: !vm.buffer)
-      -> (!vm.buffer, !vm.buffer, !vm.buffer) attributes {noinline} {
+      -> (!vm.buffer, !vm.buffer, !vm.buffer) attributes {inlining_policy = #util.inline.never} {
     vm.return %arg1, %arg2, %arg0 : !vm.buffer, !vm.buffer, !vm.buffer
   }
 
@@ -203,7 +203,7 @@ vm.module @control_flow_ops {
 
   vm.func private @_branch_arg_cycling(%arg0 : !vm.buffer, %arg1: !vm.buffer,
                                        %arg2: !vm.buffer, %arg3: i32)
-      -> (!vm.buffer, !vm.buffer, !vm.buffer) attributes {noinline} {
+      -> (!vm.buffer, !vm.buffer, !vm.buffer) attributes {inlining_policy = #util.inline.never} {
     vm.cond_br %arg3,
                ^bb1(%arg0, %arg1, %arg2: !vm.buffer, !vm.buffer, !vm.buffer),
                ^bb2(%arg1, %arg2, %arg0, %arg3: !vm.buffer, !vm.buffer, !vm.buffer, i32)
@@ -214,7 +214,7 @@ vm.module @control_flow_ops {
     vm.return %d, %e, %f : !vm.buffer, !vm.buffer, !vm.buffer
   }
 
-  vm.func private @_side_effect(%arg0: i32) attributes {noinline}
+  vm.func private @_side_effect(%arg0: i32) attributes {inlining_policy = #util.inline.never}
   {
     vm.return
   }

--- a/samples/colab/pytorch_aot_advanced.ipynb
+++ b/samples/colab/pytorch_aot_advanced.ipynb
@@ -355,8 +355,8 @@
           "name": "stdout",
           "text": [
             "module @compiled_linear {\n",
-            "  util.global private mutable @_params.weight {noinline} = dense<[[1.54099607, -0.293428898, -2.17878938], [0.568431258, -1.08452237, -1.39859545], [0.403346837, 0.838026344, -0.719257593], [-0.403343529, -0.596635341, 0.182036489]]> : tensor<4x3xf32>\n",
-            "  util.global private mutable @_params.bias {noinline} = dense<[-0.856674611, 1.10060418, -1.07118738]> : tensor<3xf32>\n",
+            "  util.global private mutable @_params.weight {inlining_policy = #util.inline.never} = dense<[[1.54099607, -0.293428898, -2.17878938], [0.568431258, -1.08452237, -1.39859545], [0.403346837, 0.838026344, -0.719257593], [-0.403343529, -0.596635341, 0.182036489]]> : tensor<4x3xf32>\n",
+            "  util.global private mutable @_params.bias {inlining_policy = #util.inline.never} = dense<[-0.856674611, 1.10060418, -1.07118738]> : tensor<3xf32>\n",
             "  func.func @main(%arg0: tensor<4xf32>) -> tensor<3xf32> attributes {torch.args_schema = \"[1, {\\22type\\22: \\22builtins.tuple\\22, \\22context\\22: \\22null\\22, \\22children_spec\\22: [{\\22type\\22: \\22builtins.list\\22, \\22context\\22: \\22null\\22, \\22children_spec\\22: [{\\22type\\22: null, \\22context\\22: null, \\22children_spec\\22: []}]}, {\\22type\\22: \\22builtins.dict\\22, \\22context\\22: \\22[]\\22, \\22children_spec\\22: []}]}]\", torch.return_schema = \"[1, {\\22type\\22: null, \\22context\\22: null, \\22children_spec\\22: []}]\"} {\n",
             "    %0 = torch_c.from_builtin_tensor %arg0 : tensor<4xf32> -> !torch.vtensor<[4],f32>\n",
             "    %1 = call @forward(%0) : (!torch.vtensor<[4],f32>) -> !torch.vtensor<[3],f32>\n",

--- a/samples/colab/pytorch_aot_simple.ipynb
+++ b/samples/colab/pytorch_aot_simple.ipynb
@@ -367,8 +367,8 @@
           "name": "stdout",
           "text": [
             "module @LinearModule {\n",
-            "  util.global private @_params.weight {noinline} = dense<[[1.54099607, -0.293428898, -2.17878938], [0.568431258, -1.08452237, -1.39859545], [0.403346837, 0.838026344, -0.719257593], [-0.403343529, -0.596635341, 0.182036489]]> : tensor<4x3xf32>\n",
-            "  util.global private @_params.bias {noinline} = dense<[-0.856674611, 1.10060418, -1.07118738]> : tensor<3xf32>\n",
+            "  util.global private @_params.weight {inlining_policy = #util.inline.never} = dense<[[1.54099607, -0.293428898, -2.17878938], [0.568431258, -1.08452237, -1.39859545], [0.403346837, 0.838026344, -0.719257593], [-0.403343529, -0.596635341, 0.182036489]]> : tensor<4x3xf32>\n",
+            "  util.global private @_params.bias {inlining_policy = #util.inline.never} = dense<[-0.856674611, 1.10060418, -1.07118738]> : tensor<3xf32>\n",
             "  func.func @main(%arg0: tensor<4xf32>) -> tensor<3xf32> attributes {torch.args_schema = \"[1, {\\22type\\22: \\22builtins.tuple\\22, \\22context\\22: \\22null\\22, \\22children_spec\\22: [{\\22type\\22: \\22builtins.list\\22, \\22context\\22: \\22null\\22, \\22children_spec\\22: [{\\22type\\22: null, \\22context\\22: null, \\22children_spec\\22: []}]}, {\\22type\\22: \\22builtins.dict\\22, \\22context\\22: \\22[]\\22, \\22children_spec\\22: []}]}]\", torch.return_schema = \"[1, {\\22type\\22: null, \\22context\\22: null, \\22children_spec\\22: []}]\"} {\n",
             "    %0 = torch_c.from_builtin_tensor %arg0 : tensor<4xf32> -> !torch.vtensor<[4],f32>\n",
             "    %1 = call @forward(%0) : (!torch.vtensor<[4],f32>) -> !torch.vtensor<[3],f32>\n",

--- a/samples/emitc_modules/add.mlir
+++ b/samples/emitc_modules/add.mlir
@@ -1,5 +1,5 @@
 vm.module @add_module {
-  vm.func @add_and_double(%arg0 : i32, %arg1 : i32) -> i32 attributes {noinline} {
+  vm.func @add_and_double(%arg0 : i32, %arg1 : i32) -> i32 attributes {inlining_policy = #util.inline.never} {
     %0 = vm.add.i32 %arg0, %arg1 : i32
     %1 = vm.add.i32 %0, %0 : i32
     vm.return %1 : i32

--- a/samples/py_custom_module/main.mlir
+++ b/samples/py_custom_module/main.mlir
@@ -8,7 +8,7 @@ module @main {
     %capacity = arith.constant 25 : index
     %0 = util.list.create %capacity : !util.list<?>
     util.global.store %0, @tokens_list : !util.list<?>
-    util.initializer.return
+    util.return
   }
 
   func.func public @add_tokens(%ids : tensor<?xi32>) -> i32 {

--- a/tests/e2e/stablehlo_models/mnist_fake_weights.mlir
+++ b/tests/e2e/stablehlo_models/mnist_fake_weights.mlir
@@ -6,10 +6,10 @@
 // RUN: [[ $IREE_METAL_DISABLE == 1 ]] || (iree-run-mlir --Xcompiler,iree-input-type=stablehlo --Xcompiler,iree-hal-target-backends=metal-spirv %s --input=1x28x28x1xf32 | FileCheck %s)
 
 module {
-  util.global private @"__iree_flow___sm_node17__model.layer-1.kernel" {noinline} = #util.byte_pattern<1> : tensor<784x128xf32>
-  util.global private @"__iree_flow___sm_node18__model.layer-1.bias" {noinline} = #util.byte_pattern<2> : tensor<128xf32>
-  util.global private @"__iree_flow___sm_node24__model.layer-2.kernel" {noinline} = #util.byte_pattern<3> : tensor<128x10xf32>
-  util.global private @"__iree_flow___sm_node25__model.layer-2.bias" {noinline} = #util.byte_pattern<4> : tensor<10xf32>
+  util.global private @"__iree_flow___sm_node17__model.layer-1.kernel" {inlining_policy = #util.inline.never} = #util.byte_pattern<1> : tensor<784x128xf32>
+  util.global private @"__iree_flow___sm_node18__model.layer-1.bias" {inlining_policy = #util.inline.never} = #util.byte_pattern<2> : tensor<128xf32>
+  util.global private @"__iree_flow___sm_node24__model.layer-2.kernel" {inlining_policy = #util.inline.never} = #util.byte_pattern<3> : tensor<128x10xf32>
+  util.global private @"__iree_flow___sm_node25__model.layer-2.bias" {inlining_policy = #util.inline.never} = #util.byte_pattern<4> : tensor<10xf32>
   func.func @predict(%arg0: tensor<1x28x28x1xf32>) -> tensor<1x10xf32> attributes {iree.module.export, iree.reflection = {abi = "sip", abiv = 1 : i32, sip = "I8!S5!k0_0R3!_0"}} {
     %ptr___iree_flow___sm_node17__model.layer-1.kernel = util.global.address @"__iree_flow___sm_node17__model.layer-1.kernel" : !util.ptr<tensor<784x128xf32>>
     %ptr___iree_flow___sm_node18__model.layer-1.bias = util.global.address @"__iree_flow___sm_node18__model.layer-1.bias" : !util.ptr<tensor<128xf32>>

--- a/tests/microbenchmarks/linalg_transpose.mlir
+++ b/tests/microbenchmarks/linalg_transpose.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-util.global private @"__transpose_10_input" {noinline} = dense<1.0> : tensor<512x1024xf32>
+util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<512x1024xf32>
 
 func.func @transpose_10() -> tensor<1024x512xf32> {
   %cst = arith.constant 0.000000e+00 : f32
@@ -26,7 +26,7 @@ func.func @transpose_10() -> tensor<1024x512xf32> {
   return %6: tensor<1024x512xf32>
 }
 
-util.global private @"__transpose_021_input" {noinline} = dense<1.0> : tensor<64x96x128xf32>
+util.global private @"__transpose_021_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<64x96x128xf32>
 
 func.func @transpose_021() -> tensor<64x128x96xf32> {
   %cst = arith.constant 0.000000e+00 : f32
@@ -44,7 +44,7 @@ func.func @transpose_021() -> tensor<64x128x96xf32> {
   return %6: tensor<64x128x96xf32>
 }
 
-util.global private @"__transpose_201_input" {noinline} = dense<1.0> : tensor<64x96x128xf32>
+util.global private @"__transpose_201_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<64x96x128xf32>
 
 func.func @transpose_201() -> tensor<128x64x96xf32> {
   %cst = arith.constant 0.000000e+00 : f32
@@ -62,7 +62,7 @@ func.func @transpose_201() -> tensor<128x64x96xf32> {
   return %6: tensor<128x64x96xf32>
 }
 
-util.global private @"__transpose_210_input" {noinline} = dense<1.0> : tensor<64x96x128xf32>
+util.global private @"__transpose_210_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<64x96x128xf32>
 
 func.func @transpose_210() -> tensor<128x96x64xf32> {
   %cst = arith.constant 0.000000e+00 : f32
@@ -80,7 +80,7 @@ func.func @transpose_210() -> tensor<128x96x64xf32> {
   return %6: tensor<128x96x64xf32>
 }
 
-util.global private @"__transpose_120_input" {noinline} = dense<1.0> : tensor<64x96x128xf32>
+util.global private @"__transpose_120_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<64x96x128xf32>
 
 func.func @transpose_120() -> tensor<96x128x64xf32> {
   %cst = arith.constant 0.000000e+00 : f32
@@ -98,7 +98,7 @@ func.func @transpose_120() -> tensor<96x128x64xf32> {
   return %6: tensor<96x128x64xf32>
 }
 
-util.global private @"__transpose_102_input" {noinline} = dense<1.0> : tensor<64x96x128xf32>
+util.global private @"__transpose_102_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<64x96x128xf32>
 
 func.func @transpose_102() -> tensor<96x64x128xf32> {
   %cst = arith.constant 0.000000e+00 : f32

--- a/tests/microbenchmarks/shared_mem_transpose.mlir
+++ b/tests/microbenchmarks/shared_mem_transpose.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-util.global private @"__transpose_4096_4096_input" {noinline} = dense<1.0> : tensor<4096x4096xf32>
+util.global private @"__transpose_4096_4096_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<4096x4096xf32>
 
 func.func @transpsoe_4096_4096() -> tensor<4096x4096xf32> {
   %input_ptr = util.global.address @"__transpose_4096_4096_input" : !util.ptr<tensor<4096x4096xf32>>
@@ -24,7 +24,7 @@ func.func @transpsoe_4096_4096() -> tensor<4096x4096xf32> {
  return %result : tensor<4096x4096xf32>
 }
 
-util.global private @"__transpose_10_2048_1024_input" {noinline} = dense<1.0> : tensor<10x2048x1024xf32>
+util.global private @"__transpose_10_2048_1024_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<10x2048x1024xf32>
 
 func.func @transpsoe_10_1024_2048() -> tensor<10x1024x2048xf32> {
   %input_ptr = util.global.address @"__transpose_10_2048_1024_input" : !util.ptr<tensor<10x2048x1024xf32>>
@@ -40,8 +40,8 @@ func.func @transpsoe_10_1024_2048() -> tensor<10x1024x2048xf32> {
  return %result : tensor<10x1024x2048xf32>
 }
 
-util.global private @"__transpose_10_2048_1024_lhs" {noinline} = dense<1.0> : tensor<10x2048x1024xf32>
-util.global private @"__transpose_10_2048_1024_rhs" {noinline} = dense<1.0> : tensor<10x2048x1024xf32>
+util.global private @"__transpose_10_2048_1024_lhs" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<10x2048x1024xf32>
+util.global private @"__transpose_10_2048_1024_rhs" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<10x2048x1024xf32>
 
 func.func @transpsoe_10_1024_2048_fusion() -> tensor<10x1024x2048xf32> {
   %lhs_ptr = util.global.address @"__transpose_10_2048_1024_lhs" : !util.ptr<tensor<10x2048x1024xf32>>
@@ -60,7 +60,7 @@ func.func @transpsoe_10_1024_2048_fusion() -> tensor<10x1024x2048xf32> {
  return %result : tensor<10x1024x2048xf32>
 }
 
-util.global private @"__transpose_10_2064_1024_input" {noinline} = dense<1.0> : tensor<10x2064x1024xf32>
+util.global private @"__transpose_10_2064_1024_input" {inlining_policy = #util.inline.never} = dense<1.0> : tensor<10x2064x1024xf32>
 
 func.func @transpsoe_10_1024_2064_unaligned() -> tensor<10x1024x2064xf32> {
   %input_ptr = util.global.address @"__transpose_10_2064_1024_input" : !util.ptr<tensor<10x2064x1024xf32>>


### PR DESCRIPTION
This adds util.func/util.call ops that are supersets of func.func/func.call. Indirect calls are not yet implemented as we don't support indirect func.call either. The new ops allow us to enhance the calling convention with tied operands so that we can model in-place function calls on tensors. A new inlining policy attr interface has been added that can be used on both util.func and util.global to control how both are inlined. Today we have the `#util.inline.never` to do what the ad-hoc `noinline` used to but as we refine inlining we can have differing cost models we control both from frontends and from our own generated code (memoized command buffers/etc). The inlining control also supports dialect attrs that can do context-aware inlining control and this will be used in subsequent PRs to avoid inlining functions or globals that are pinned to different devices.

In this first PR the ops and interfaces are added but we are still using func.func/func.call exclusively. Future changes will enable support in current func-aware pass (IPO, stream usage refinement, allocation, etc) and convert func->util as part of the input pipeline.

Progress on #16187.