### PR TITLE
[CPU][SME] Add an experimental flag to disable SME tiling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -1,5 +1,7 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy)))' \
-// RUN:   --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s
+// RUN:   --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s --check-prefixes=CHECK,WITH-SME
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-select-lowering-strategy)))' \
+// RUN:   --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file  --iree-experimental-llvmcpu-arm-force-ssve=true %s | FileCheck %s --check-prefixes=CHECK,SSVE-WITHOUT-SME
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -128,4 +130,66 @@ hal.executable private @static_tensors_1x1  {
     }
   }
 }
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors_sme  {
+  hal.executable.variant @llvm target(<"llvm-cpu", "embedded-elf-arm_64", {
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    cpu_features = "+sve,+sme",
+    native_vector_size = 16 : index,
+    target_triple = "aarch64-none-elf"
+  }>) {
+    hal.executable.export @matmul_tensors layout(#pipeline_layout)
+    builtin.module {
+      func.func @matmul_tensors() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %M = hal.interface.constant.load[0] : index
+        %N = hal.interface.constant.load[1] : index
+        %K = hal.interface.constant.load[2] : index
+        %lhs_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K}
+        %rhs_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%K, %N}
+        %init_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %N}
+        %result_binding = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer)
+            : !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%M, %N}
+              %lhs = flow.dispatch.tensor.load %lhs_binding, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K} -> tensor<?x?xf32>
+        %rhs = flow.dispatch.tensor.load %rhs_binding, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%K, %N} -> tensor<?x?xf32>
+        %init = flow.dispatch.tensor.load %init_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %N} -> tensor<?x?xf32>
+        %gemm = linalg.matmul ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+        flow.dispatch.tensor.store %gemm, %result_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%M, %N}
+        return
+      }
+    }
+  }
+}
+
+//  SSVE-WITHOUT-SME-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [8, [16], 0], [0, 0, 1], [0, 0, 0]]>
+//  SSVE-WITHOUT-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//      SSVE-WITHOUT-SME: hal.executable.export public @matmul_tensors
+//  SSVE-WITHOUT-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       SSVE-WITHOUT-SME: linalg.matmul
+//  SSVE-WITHOUT-SME-SAME:     lowering_config = #[[CONFIG]]
+
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], {{\[}}[4], [4], 0], [0, 0, 1], [0, 0, 0]]>
+//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//       WITH-SME: hal.executable.export public @matmul_tensors
+//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       WITH-SME: linalg.matmul
+//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
 


### PR DESCRIPTION
ATM, when lowering `linalg.matmul` with SME and SSVE enabled:
  * --iree-llvmcpu-target-cpu-features="+sve,+sme",

IREE will always configure tiles sizes to be suitable for SME (i.e. scalable in
2D). Since identical target feature flags are used to enable SSVE, there is no
mechanism to make IREE target SSVE instead of SME.

Ideally, one would enable SSVE by changing `+sve,+sme` to e.g. `+ssve`.
However, LLVM does not support plain `+ssve` as a target feature. Since IREE
forwards all CPU target features flags directly to LLVM, this approach is not
really feasible (unless IREE were to filter the attributes).

Instead, this patch adds a flag, `-iree-experimental-llvmcpu-arm-force-ssve`,
that disables "SME tiling". This means that, when using `+sve,+sme`, IREE will:
  * lower linalg.matmul identically to how lowering for SVE works,
  * in addition to regular SVE lowering, SME's streaming mode will be enabled.

Put differently, this flag will make IREE target _SSVE_ rather than _SME_ when
SME+SSVE are enabled