### PR TITLE
[CodeGen] Drop ad-hoc patterns for pack/unapck decomposition. 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -62,66 +62,6 @@ struct LowerUnPackPattern : public OpRewritePattern<tensor::UnPackOp> {
   }
 };
 
-/// Folding trailing unit dims away from transpose op if they are not
-/// transposed.
-/// TODO(hanchung): Remove the workaround after we materialize encoding to do 1D
-/// data tiling instead of 2D with unit dimension for AVX512 targets. This is a
-/// workaround for 1D data tiling which is represented in 2D with an unit
-/// dimension form.
-struct FoldTrailingUnitTranspose
-    : public OpRewritePattern<linalg::TransposeOp> {
-  using OpRewritePattern<linalg::TransposeOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(linalg::TransposeOp op,
-                                PatternRewriter &rewriter) const override {
-    auto inputTy = llvm::cast<ShapedType>(op.getInput().getType());
-    int numDropDims = 0;
-    ArrayRef<int64_t> perm = op.getPermutation();
-    for (int idx = inputTy.getRank() - 1; idx >= 0; idx--) {
-      if (idx != perm[idx] || inputTy.getDimSize(idx) != 1)
-        break;
-      numDropDims++;
-    }
-    if (numDropDims == 0)
-      return failure();
-
-    // Dropping all dims. Elide now to avoid corner cases.
-    if (numDropDims == inputTy.getRank()) {
-      rewriter.replaceOp(op, op.getInput());
-      return success();
-    }
-
-    Location loc = op.getLoc();
-    SmallVector<OpFoldResult> srcMixedSizes =
-        tensor::getMixedSizes(rewriter, loc, op.getInput());
-    SmallVector<OpFoldResult> mixedStride(inputTy.getRank(),
-                                          rewriter.getIndexAttr(1));
-    SmallVector<OpFoldResult> mixedOffsets(inputTy.getRank(),
-                                           rewriter.getIndexAttr(0));
-    auto src = rewriter.create<tensor::ExtractSliceOp>(
-        loc,
-        RankedTensorType::get(inputTy.getShape().drop_back(numDropDims),
-                              inputTy.getElementType()),
-        op.getInput(), mixedOffsets, srcMixedSizes, mixedStride);
-
-    SmallVector<OpFoldResult> destMixedSizes =
-        tensor::getMixedSizes(rewriter, loc, op.getInit());
-    auto initTy = llvm::cast<ShapedType>(op.getInit().getType());
-    destMixedSizes.resize(initTy.getRank() - numDropDims);
-    auto dest = rewriter.create<tensor::EmptyOp>(loc, destMixedSizes,
-                                                 initTy.getElementType());
-    auto transp = rewriter.create<linalg::TransposeOp>(
-        loc, src, dest, perm.drop_back(numDropDims));
-    destMixedSizes.resize(initTy.getRank(), rewriter.getIndexAttr(1));
-    auto insertSliceOp = rewriter.create<tensor::InsertSliceOp>(
-        loc, transp.getResult()[0], op.getInit(), mixedOffsets, destMixedSizes,
-        mixedStride);
-    rewriter.replaceOp(op, insertSliceOp.getResult());
-
-    return success();
-  }
-};
-
 struct DecomposePackUnPackOpsPass
     : public DecomposePackUnPackOpsBase<DecomposePackUnPackOpsPass> {
   DecomposePackUnPackOpsPass(bool tileOuterToOne) {
@@ -255,15 +195,6 @@ void DecomposePackUnPackOpsPass::runOnOperation() {
     RewritePatternSet patterns(ctx);
     patterns.add<linalg::GeneralizeOuterUnitDimsPackOpPattern,
                  linalg::GeneralizeOuterUnitDimsUnPackOpPattern>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-      return signalPassFailure();
-    }
-  }
-
-  // Fold trailing unit dims away for linalg.transpose ops.
-  {
-    RewritePatternSet patterns(ctx);
-    patterns.add<FoldTrailingUnitTranspose>(ctx);
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_pack_unpack_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_pack_unpack_ops.mlir
@@ -233,14 +233,11 @@ func.func @pack_matmul_DYN_LHS(%src: tensor<?x?xf32>, %dest: tensor<?x?x16x1xf32
 // CHECK:        %[[PAD:.+]] = tensor.pad %[[IN]] low[0, 0] high[%[[H0]], %[[H1]]]
 // CHECK:        %[[EXPANDED:.+]] = tensor.expand_shape %[[PAD]]
 // CHECK-SAME:     {{\[}}[0, 1], [2, 3]] : tensor<?x?xf32> into tensor<?x16x?x1xf32>
-// CHECK:        %[[TILE:.+]] = tensor.extract_slice %expanded
-// CHECK-SAME:     : tensor<?x16x?x1xf32> to tensor<?x16x?xf32>
-// CHECK:        %[[EMPTY:.+]] = tensor.empty({{.+}}) : tensor<?x?x16xf32>
 // CHECK:        %[[TRANSP:.+]] = linalg.transpose
-// CHECK-SAME:     ins(%[[TILE]] : tensor<?x16x?xf32>)
-// CHECK-SAME:     outs(%[[EMPTY]] : tensor<?x?x16xf32>)
-// CHECK-SAME:   permutation = [0, 2, 1]
-// CHECK:        %{{.+}} = tensor.insert_slice %[[TRANSP]] into %[[OUT]]
+// CHECK-SAME:     ins(%[[EXPANDED]] : tensor<?x16x?x1xf32>)
+// CHECK-SAME:     outs(%[[OUT]] : tensor<?x?x16x1xf32>)
+// CHECK-SAME:   permutation = [0, 2, 1, 3]
+// CHECK:        return %[[TRANSP]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUDropVectorUnitDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUDropVectorUnitDims.cpp
@@ -21,7 +21,7 @@ public:
   using LLVMCPUDropVectorUnitDimsBase::LLVMCPUDropVectorUnitDimsBase;
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<vector::VectorDialect>();
+    registry.insert<memref::MemRefDialect, vector::VectorDialect>();
   }
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -302,6 +302,10 @@ void buildLLVMCPUVectorLoweringPipeline(
       createLLVMCPUVectorTransposeLoweringPass(
           options.lowerVectorTransposeToAVX2));
 
+  // Potentially removes shape_cast and broadcast on unit dims before shape_cast
+  // lowering.
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+
   // 'vector.shape_cast' are very expensive operations that are even generated
   // by some of the lowerings above (e.g., transpose lowering). There are
   // chances to cancel them out if they are not lowered too early so we lower


### PR DESCRIPTION
They are no longer needed because we have better support in vector
lowering today.