### PR TITLE
NFC: [Codegen][GPU] Split GPUTensorAlloc into tiling and promotion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         "GPUReduceBankConflicts.cpp",
         "GPUTensorAlloc.cpp",
         "GPUTensorTile.cpp",
+        "GPUTensorTileToSerialLoops.cpp",
         "GPUTileReduction.cpp",
         "GPUVectorDistribution.cpp",
         "Passes.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -59,6 +59,7 @@ iree_cc_library(
     "GPUReduceBankConflicts.cpp"
     "GPUTensorAlloc.cpp"
     "GPUTensorTile.cpp"
+    "GPUTensorTileToSerialLoops.cpp"
     "GPUTileReduction.cpp"
     "GPUVectorDistribution.cpp"
     "Passes.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTileToSerialLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTileToSerialLoops.cpp
@@ -11,8 +11,6 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/Passes.h"
 
-#define DEBUG_TYPE "iree-codegen-gpu-tensor-tile-to-serial-loops"
-
 namespace mlir::iree_compiler {
 
 namespace {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTileToSerialLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTileToSerialLoops.cpp
@@ -11,12 +11,12 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/Passes.h"
 
-#define DEBUG_TYPE "iree-codegen-gpu-tensor-alloc"
+#define DEBUG_TYPE "iree-codegen-gpu-tensor-tile-to-serial-loops"
 
 namespace mlir::iree_compiler {
 
 namespace {
-struct GPUTensorTensorTileToSerialLoopsPass
+struct GPUTensorTensorTileToSerialLoopsPass final
     : public GPUTensorTileToSerialLoopsBase<
           GPUTensorTensorTileToSerialLoopsPass> {
 public:
@@ -24,11 +24,9 @@ public:
     registry.insert<scf::SCFDialect>();
   }
   void runOnOperation() override {
-    auto funcOp = getOperation();
-
     // Tile reductions based on the annotated tiling configuration.
-    if (failed(
-            tileReductionToSerialLoops(funcOp, /*fuseInputProducer=*/true))) {
+    if (failed(tileReductionToSerialLoops(getOperation(),
+                                          /*fuseInputProducer=*/true))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTileToSerialLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTileToSerialLoops.cpp
@@ -1,0 +1,43 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Transforms/Passes.h"
+
+#define DEBUG_TYPE "iree-codegen-gpu-tensor-alloc"
+
+namespace mlir::iree_compiler {
+
+namespace {
+struct GPUTensorTensorTileToSerialLoopsPass
+    : public GPUTensorTileToSerialLoopsBase<
+          GPUTensorTensorTileToSerialLoopsPass> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<scf::SCFDialect>();
+  }
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+
+    // Tile reductions based on the annotated tiling configuration.
+    if (failed(
+            tileReductionToSerialLoops(funcOp, /*fuseInputProducer=*/true))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createGPUTensorTileToSerialLoops() {
+  return std::make_unique<GPUTensorTensorTileToSerialLoopsPass>();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -108,6 +108,9 @@ createGPUTensorAlloc(GPUPromoteSharedMemPattern promoteSharedMemPattern =
 std::unique_ptr<OperationPass<func::FuncOp>>
 createGPUTensorTile(bool distributeToWarp = false);
 
+// Creates a pass to tile tensor (linalg) ops along reduction dimensions.
+std::unique_ptr<OperationPass<func::FuncOp>> createGPUTensorTileToSerialLoops();
+
 /// Tile reductions and generate serial loops around reductions.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUTileReductionPass();
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -80,8 +80,8 @@ def GPUReduceBankConflicts :
 
 def GPUTensorAlloc :
     Pass<"iree-codegen-gpu-tensor-alloc", "func::FuncOp"> {
-  let summary = "Pass to tile reduction dimensions and create allocations for "
-                "some tensor values to use GPU shared memory";
+  let summary = "Pass to create allocations for some tensor values to use"
+                "GPU shared memory";
   let constructor = "mlir::iree_compiler::createGPUTensorAlloc()";
 }
 
@@ -89,6 +89,12 @@ def GPUTensorTile :
     Pass<"iree-codegen-gpu-tensor-tile", "func::FuncOp"> {
   let summary = "Pass to tile tensor (linalg) ops within a GPU workgroup";
   let constructor = "mlir::iree_compiler::createGPUTensorTile()";
+}
+
+def GPUTensorTileToSerialLoops :
+    Pass<"iree-codegen-gpu-tensor-tile-to-serial-loops", "func::FuncOp"> {
+  let summary = "Pass to tile reduction dimensions for certain GPU ops";
+  let constructor = "mlir::iree_compiler::createGPUTensorTileToSerialLoops()";
 }
 
 def GPUTileReduction :

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tensor_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tensor_alloc.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s -allow-unregistered-dialect --split-input-file -iree-codegen-gpu-tensor-alloc | FileCheck %s
+// RUN: iree-opt %s -allow-unregistered-dialect --split-input-file -iree-codegen-gpu-tensor-tile-to-serial-loops -iree-codegen-gpu-tensor-alloc | FileCheck %s
 
 func.func @matmul_2048x512x1024() {
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -170,6 +170,8 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createGPUTensorTileToSerialLoops());
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUTensorAlloc());
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUTensorTile(false));
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -503,6 +503,7 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &topPM,
 
   // Promote to workgroups and tile to threads.
   auto &nestedPM = topPM.nest<ModuleOp>();
+  nestedPM.addNestedPass<func::FuncOp>(createGPUTensorTileToSerialLoops());
   nestedPM.addNestedPass<func::FuncOp>(createGPUTensorAlloc());
   nestedPM.addNestedPass<func::FuncOp>(
       createGPUTensorTile(/*distributeToWarp=*/false));


### PR DESCRIPTION
Currently GPUTensorAlloc tiles reduction dimensions as well as doing promotion, but there is no mechanical reason these two transformations have to happen at the same time. Additionally, the reduction tiling has no relevance to the transpose pipeline that uses this pass today.

This split is in preparation for another form of promotion pass that runs later on.