### PR TITLE
[LLVMGPU] Remove createArithExpandOpsPass from lowertoLLVMGPU

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -577,8 +577,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addPass(createConvertBf16ArithToF32Pass());
   pm.addPass(createConvertBf16ToUInt16BuffersPass());
 
-  pm.addNestedPass<func::FuncOp>(arith::createArithExpandOpsPass());
-
   // math dialect elementry functions -> polynomial form.
   pm.addNestedPass<func::FuncOp>(createPolynomialApproximationPass());
 


### PR DESCRIPTION
This PR removes createArithExpandOpsPass because
of performance regressions.