### PR TITLE
[CPU][SME] Enable SSVE in DoubleTilingExpert

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -172,7 +172,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
     addMultiTilingExpertPassPipeline(pipeline, tilingConfig,
                                      /*enablePeeling=*/false,
-                                     enableVectorMasking, lowerToAVX2);
+                                     enableVectorMasking, lowerToAVX2,
+                                     enableAArch64SSVE);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -562,6 +562,7 @@ hal.executable private @unsupported_ukernel_fallback_to_vectorization {
 //
 //   * CPUBufferOpsTileAndVectorize
 //   * CPUDoubleTilingPeelingExpert
+//   * CPUDoubleTilingExpert
 //   * CPUConvTileAndDecomposeExpert
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 2, sets = [
@@ -633,6 +634,34 @@ hal.executable private @aarch64_ssve__cpu_double_tiling_peeling_expert {
 }
 
 // CHECK-LABEL: @aarch64_ssve__cpu_double_tiling_peeling_expert
+// CHECK: func.func @dispatch() attributes {arm_locally_streaming}
+
+hal.executable private @aarch64_ssve__cpu_double_tiling_expert {
+  hal.executable.variant public @embedded_elf_arm_64 target(#executable_target_embedded_elf_arm_64_) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[0], [1], [0], [0]]>,
+      translation_info = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+    } {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+      hal.return %arg1, %arg2, %arg2 : index, index, index
+    }
+    builtin.module {
+      func.func @dispatch() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %cst_0 = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load[0] : i32
+        %6 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readwrite:tensor<1xf32>>
+        %7 = tensor.empty() : tensor<1xf32>
+        %8 = linalg.fill ins(%cst_0 : f32) outs(%7 : tensor<1xf32>) -> tensor<1xf32>
+        flow.dispatch.tensor.store %8, %6, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !flow.dispatch.tensor<readwrite:tensor<1xf32>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: @aarch64_ssve__cpu_double_tiling_expert
 // CHECK: func.func @dispatch() attributes {arm_locally_streaming}
 
 hal.executable private @aarch64_ssve__cpu_conv_tile_and_decompose_expert {


### PR DESCRIPTION
This "expert" was ommited when SSVE was originally introduced (#13558)
as we didn't use it in our pipelines. This has since changed (it's used
for e.g. linalg.matmul).
