### PR TITLE
Bump LLVM to https://github.com/llvm/llvm-project/pull/77874

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeBatchMmt4DOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeBatchMmt4DOps.cpp
@@ -182,7 +182,7 @@ void DecomposeBatchMmt4DOpsPass::runOnOperation() {
             scf::SCFTilingOptions().setTileSizes(
                 getAsIndexOpFoldResult(ctx, tileSizes)));
         FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
-            scf::tileConsumerAndFuseProducerGreedilyUsingSCFForOp(
+            scf::tileConsumerAndFuseProducersUsingSCF(
                 rewriter, tilingInterfaceOp, options);
         if (failed(tileAndFuseResult)) {
           errorOp = batchMmt4DOp;

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -194,7 +194,7 @@ void DecomposePackUnPackOpsPass::runOnOperation() {
             }));
     funcOp->walk([&](tensor::PackOp op) {
       FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
-          scf::tileConsumerAndFuseProducerGreedilyUsingSCFForOp(
+          scf::tileConsumerAndFuseProducersUsingSCF(
               rewriter, cast<TilingInterface>(op.getOperation()), packOptions);
       if (failed(tileAndFuseResult))
         return signalPassFailure();
@@ -218,9 +218,9 @@ void DecomposePackUnPackOpsPass::runOnOperation() {
               return tileSizes;
             });
     funcOp->walk([&](tensor::UnPackOp op) {
-      FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
-          rewriter, cast<TilingInterface>(op.getOperation()),
-          unpackTilingOptions);
+      FailureOr<scf::SCFTilingResult> tilingResult =
+          scf::tileUsingSCF(rewriter, cast<TilingInterface>(op.getOperation()),
+                            unpackTilingOptions);
       if (failed(tilingResult))
         return signalPassFailure();
       rewriter.replaceOp(op, tilingResult->replacements);

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -357,7 +357,7 @@ transform_dialect::ShareForallOperandsOp::applyToOne(
       continue;
     }
     // Get the corresponding bbArg.
-    BlockArgument bbArg = forallOp.getOutputBlockArguments()[outputIdx];
+    BlockArgument bbArg = forallOp.getRegionIterArgs()[outputIdx];
 
     // Check if the extract_slice has a matching parallel_insert_slice
     // (i.e., same source/target, offsets, sizes and strides).

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -123,7 +123,7 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
                                              rewriter.getIndexAttr(1));
   tileSizesSVFirst[numLoops - 1] = rewriter.getIndexAttr(0);
   auto options = scf::SCFTilingOptions().setTileSizes(tileSizesSVFirst);
-  FailureOr<scf::SCFTilingResult> tileResFirst = scf::tileUsingSCFForOp(
+  FailureOr<scf::SCFTilingResult> tileResFirst = scf::tileUsingSCF(
       rewriter, cast<TilingInterface>(linalgOp.getOperation()), options);
   if (failed(tileResFirst)) {
     LLVM_DEBUG(llvm::dbgs() << "failed on step 1 (SCFTiling)\n");
@@ -149,7 +149,7 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
   // tile.
   tileSizesSV[numLoops - 1] = rewriter.getIndexAttr(1);
   options = scf::SCFTilingOptions().setTileSizes(tileSizesSV);
-  FailureOr<scf::SCFTilingResult> tileRes = scf::tileUsingSCFForOp(
+  FailureOr<scf::SCFTilingResult> tileRes = scf::tileUsingSCF(
       rewriter, cast<TilingInterface>(splitRes->splitLinalgOp.getOperation()),
       options);
   if (failed(tileRes)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -93,7 +93,7 @@ void LLVMCPUTilePass::runOnOperation() {
     setSCFTileSizes(options, op, std::move(tileSizes),
                     std::move(tileScalableFlags));
     FailureOr<scf::SCFTilingResult> tiledResults =
-        scf::tileUsingSCFForOp(rewriter, op, options);
+        scf::tileUsingSCF(rewriter, op, options);
     if (failed(tiledResults))
       continue;
     rewriter.replaceOp(op, tiledResults->replacements);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
@@ -99,7 +99,8 @@ LogicalResult applyTileAndFuse(RewriterBase &rewriter, Operation *rootOp,
                                scf::SCFTilingOptions options) {
   llvm::SmallDenseSet<Operation *> origTiledAndFusedOps;
   collectTiledAndFusedOps(rootOp, origTiledAndFusedOps);
-  auto isIgnoredUser = [&](Operation *user, scf::ForOp outerMostTiledLoop) {
+  auto isIgnoredUser = [&](Operation *user,
+                           LoopLikeOpInterface outerMostTiledLoop) {
     return origTiledAndFusedOps.count(user) ||
            isa<tensor::DimOp, IREE::Codegen::UKernelGenericOp>(user);
   };
@@ -113,12 +114,10 @@ LogicalResult applyTileAndFuse(RewriterBase &rewriter, Operation *rootOp,
   SmallVector<OpResult> yieldedValuesToOrigValues;
   SmallVector<Operation *> tiledOps;
   FailureOr<scf::SCFTilingResult> tilingResult =
-      scf::tileUsingSCFForOp(rewriter, cast<TilingInterface>(rootOp), options);
+      scf::tileUsingSCF(rewriter, cast<TilingInterface>(rootOp), options);
   if (failed(tilingResult)) {
     return failure();
   }
-  auto forLoops = llvm::to_vector(llvm::map_range(
-      tilingResult->loops, [](Operation *op) { return cast<scf::ForOp>(op); }));
   yieldedValuesToOrigValues.append(rootOp->result_begin(),
                                    rootOp->result_end());
   // A map from untiled value to scf.for iter_arg. The iter_arg is used for DPS
@@ -137,7 +136,8 @@ LogicalResult applyTileAndFuse(RewriterBase &rewriter, Operation *rootOp,
   } else if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(rootOp)) {
     for (auto [init, iterArg] : llvm::zip_equal(
              dpsOp.getDpsInits(),
-             cast<scf::ForOp>(forLoops.back()).getRegionIterArgs())) {
+             cast<scf::ForOp>(tilingResult->loops.back().getOperation())
+                 .getRegionIterArgs())) {
       mapToIterArg[init] = iterArg;
     }
   }
@@ -180,7 +180,8 @@ LogicalResult applyTileAndFuse(RewriterBase &rewriter, Operation *rootOp,
 
     // Materialize the slice of the producer in place.
     std::optional<scf::SCFFuseProducerOfSliceResult> fusedProducer =
-        tileAndFuseProducerOfSlice(rewriter, candidateSliceOp, forLoops);
+        scf::tileAndFuseProducerOfSlice(rewriter, candidateSliceOp,
+                                        tilingResult->loops);
     if (!fusedProducer)
       continue;
 
@@ -188,12 +189,15 @@ LogicalResult applyTileAndFuse(RewriterBase &rewriter, Operation *rootOp,
     // to be yielded from within the tiled loop.
     OpResult untiledProducer = fusedProducer->origProducer;
     if (llvm::any_of(untiledProducer.getUsers(), [&](Operation *user) {
-          return !isIgnoredUser(user, forLoops.front()) &&
-                 !forLoops.front()->isAncestor(user);
+          return !isIgnoredUser(user, tilingResult->loops.front()) &&
+                 !tilingResult->loops.front()->isAncestor(user);
           ;
         })) {
-      yieldReplacementForFusedProducer(rewriter, candidateSliceOp,
-                                       fusedProducer.value(), forLoops);
+      if (failed(scf::yieldReplacementForFusedProducer(
+              rewriter, candidateSliceOp, fusedProducer.value(),
+              tilingResult->loops))) {
+        return failure();
+      }
       yieldedValuesToOrigValues.push_back(untiledProducer);
     }
 
@@ -204,7 +208,7 @@ LogicalResult applyTileAndFuse(RewriterBase &rewriter, Operation *rootOp,
     }
   }
 
-  scf::ForOp outermostLoop = forLoops.front();
+  auto outermostLoop = cast<scf::ForOp>(tilingResult->loops.front());
   for (auto [index, origVal] : llvm::enumerate(yieldedValuesToOrigValues)) {
     Value replacement = outermostLoop.getResult(index);
     rewriter.replaceUsesWithIf(origVal, replacement, [&](OpOperand &use) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -140,7 +140,8 @@ struct ConvertToROCDLPass : public ConvertToROCDLBase<ConvertToROCDLPass> {
       RewritePatternSet patterns(&getContext());
       // These patterns only convert a subset of arith that target specific
       // rocdl intrinsics (e.g. fp8 conversions).
-      arith::populateArithToAMDGPUConversionPatterns(patterns);
+      arith::populateArithToAMDGPUConversionPatterns(
+          patterns, /*saturateFP8Truncf=*/false);
       populateConvertGPUToAMDGPUPatterns(patterns);
       populateConvertSharedMemoryAllocOps(patterns);
       populateDropSharedMemoryDeallocOpPatterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -114,7 +114,7 @@ static LogicalResult tileAndDistributeToThreads(linalg::LinalgOp consumerOp,
   SmallVector<OpFoldResult> tileSizesOfr =
       getAsIndexOpFoldResult(context, tileSizes);
   FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
-      scf::tileConsumerAndFuseProducerGreedilyUsingSCFForOp(
+      scf::tileConsumerAndFuseProducersUsingSCF(
           rewriter, cast<TilingInterface>(consumerOp.getOperation()),
           scf::SCFTileAndFuseOptions().setTilingOptions(
               scf::SCFTilingOptions().setTileSizes(tileSizesOfr)));
@@ -134,7 +134,7 @@ static LogicalResult tileAndDistributeToThreads(linalg::LinalgOp consumerOp,
   // We don't distribute here; instead, it will be done in a later step
   // after bufferization. So add attributes to the tiled loop nest to
   // indicate that they should be distributed to invocations.
-  ArrayRef<Operation *> loops = tileAndFuseResult.value().loops;
+  ArrayRef<LoopLikeOpInterface> loops = tileAndFuseResult.value().loops;
   const char *attrName = getSPIRVDistributeAttrName();
   // We can have more than 3 dimensions being tiled (e.g., for convolutions with
   // non-1 batch). But only the innermost 3 dimensions are distributed.
@@ -207,7 +207,7 @@ static LogicalResult tileAndUnrollConvWindow(func::FuncOp funcOp,
     auto consumerOp = cast<linalg::LinalgOp>(*convOp);
     IRRewriter rewriter(funcOp.getContext());
     FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
-        scf::tileConsumerAndFuseProducerGreedilyUsingSCFForOp(
+        scf::tileConsumerAndFuseProducersUsingSCF(
             rewriter, cast<TilingInterface>(consumerOp.getOperation()),
             scf::SCFTileAndFuseOptions().setTilingOptions(
                 scf::SCFTilingOptions().setTileSizes(tileSizes)));
@@ -228,7 +228,7 @@ static LogicalResult tileAndUnrollConvWindow(func::FuncOp funcOp,
     // for parallel output window dimension, so it helps future vector
     // transformations.
 
-    ArrayRef<Operation *> loops = tileAndFuseResult.value().loops;
+    ArrayRef<LoopLikeOpInterface> loops = tileAndFuseResult.value().loops;
     if (!loops.empty()) {
       assert(loops.size() == 1);
       scf::ForOp loopOp = cast<scf::ForOp>(loops.front());

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -780,7 +780,7 @@ tileLinalgOpsWithFilter(func::FuncOp funcOp, scf::SCFTilingOptions options,
     }
 
     FailureOr<scf::SCFTilingResult> tiledResults =
-        scf::tileUsingSCFForOp(rewriter, target, options);
+        scf::tileUsingSCF(rewriter, target, options);
     if (failed(tiledResults)) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -64,8 +64,9 @@ void TensorDimTrackingRewriter::notifyOperationRemoved(Operation *op) {
     dimOps.erase(op);
 }
 
-void TensorDimTrackingRewriter::notifyOperationInserted(Operation *op) {
-  IRRewriter::Listener::notifyOperationInserted(op);
+void TensorDimTrackingRewriter::notifyOperationInserted(Operation *op,
+                                                        InsertPoint previous) {
+  IRRewriter::Listener::notifyOperationInserted(op, previous);
   if (isa<tensor::DimOp>(op))
     dimOps.insert(op);
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.h
@@ -25,7 +25,7 @@ public:
 
 protected:
   void notifyOperationRemoved(Operation *op) override;
-  void notifyOperationInserted(Operation *op) override;
+  void notifyOperationInserted(Operation *op, InsertPoint previous) override;
 
 private:
   SmallPtrSet<Operation *, 16> dimOps;

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
@@ -33,10 +33,10 @@ transform.sequence failures(propagate) {
 //   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[UPDATES]], %[[C1]]
 //       CHECK:   %[[RESULT:.+]] = scf.for %[[IV0:.+]] = %[[C0]] to %[[D0]] step %[[TILESIZEY]]
 //  CHECK-SAME:       iter_args(%[[INITY:.+]] = %[[ORIGINAL]])
-//   CHECK-DAG:     %[[USED_TILESIZEY:.+]] = affine.min #[[MAP0]](%[[IV0]])[%[[D0]]]
 //       CHECK:     %[[RESULT_INNER:.+]] = scf.for %[[IV1:.+]] = %[[C0]] to %[[D1]] step %[[TILESIZEX]]
 //  CHECK-SAME:         iter_args(%[[INITX:.+]] = %[[INITY]])
-//       CHECK:       %[[USED_TILESIZEX:.+]] = affine.min #[[MAP1]](%[[IV1]])[%[[D1]]]
+//   CHECK-DAG:     %[[USED_TILESIZEY:.+]] = affine.min #[[MAP0]](%[[IV0]])[%[[D0]]]
+//   CHECK-DAG:       %[[USED_TILESIZEX:.+]] = affine.min #[[MAP1]](%[[IV1]])[%[[D1]]]
 //       CHECK:       %[[UPDATE_SLICE:.+]] = tensor.extract_slice %[[UPDATES]][%[[IV0]], %[[IV1]]]
 //  CHECK-SAME:           [%[[USED_TILESIZEY]], %[[USED_TILESIZEX]]]
 //       CHECK:       %[[INDEX_SLICE:.+]] = tensor.extract_slice %[[INDICES]][%[[IV0]], 0]
@@ -89,8 +89,8 @@ transform.sequence failures(propagate) {
 //   CHECK-DAG:   %[[D0:.+]] = memref.dim %[[UPDATES]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = memref.dim %[[UPDATES]], %[[C1]]
 //       CHECK:   scf.for %[[IV0:.+]] = %[[C0]] to %[[D0]] step %[[TILESIZEY]]
-//   CHECK-DAG:     %[[USED_TILESIZEY:.+]] = affine.min #[[MAP0]](%[[IV0]])[%[[D0]]]
 //       CHECK:     scf.for %[[IV1:.+]] = %[[C0]] to %[[D1]] step %[[TILESIZEX]]
+//   CHECK-DAG:       %[[USED_TILESIZEY:.+]] = affine.min #[[MAP0]](%[[IV0]])[%[[D0]]]
 //   CHECK-DAG:       %[[USED_TILESIZEX:.+]] = affine.min #[[MAP1]](%[[IV1]])[%[[D1]]]
 //       CHECK:       %[[UPDATE_SLICE:.+]] = memref.subview %[[UPDATES]][%[[IV0]], %[[IV1]]]
 //  CHECK-SAME:           [%[[USED_TILESIZEY]], %[[USED_TILESIZEX]]]
@@ -533,9 +533,9 @@ transform.sequence failures(propagate) {
 // CHECK:        %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xi32>
 // CHECK:        %[[RES:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[D0]] step %[[C10]]
 // CHECK-SAME:     iter_args(%[[INIT2:.+]] = %[[INIT]]) -> (tensor<?x?xi32>) {
-// CHECK:          %[[SIZE_I:.+]] = affine.min #[[MAP0]](%[[I]])[%[[D0]]]
 // CHECK:          %[[RES2:.+]] = scf.for %[[J:.+]] = %[[C0]] to %[[D1]] step %[[C20]]
 // CHECK-SAME:       iter_args(%[[INIT3:.+]] = %[[INIT2]]) -> (tensor<?x?xi32>) {
+// CHECK-DAG:        %[[SIZE_I:.+]] = affine.min #[[MAP0]](%[[I]])[%[[D0]]]
 // CHECK-DAG:        %[[SIZE_J:.+]] = affine.min #[[MAP1]](%[[J]])[%[[D1]]]
 // CHECK-DAG:        %[[IDX0:.+]] = affine.apply #[[MAP2]]()[%[[D0]], %[[I]], %[[SIZE_I]]]
 // CHECK-DAG:        %[[IDX1:.+]] = affine.apply #[[MAP2]]()[%[[D1]], %[[J]], %[[SIZE_J]]]
@@ -989,10 +989,10 @@ transform.sequence failures(propagate) {
 // CHECK-DAG:    %[[D0:.+]] = tensor.empty() : tensor<192x1024x64xf32>
 // CHECK:        %[[D1:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C192]] step %[[C10]]
 // CHECK-SAME:     iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[D0]]) -> (tensor<192x1024x64xf32>) {
-// CHECK-DAG:        %[[D2:.+]] = affine.min #[[MAP]](%[[ARG3]])
 // CHECK:          %[[D3:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C30]]
 // CHECK-SAME:       iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[ARG4]]) -> (tensor<192x1024x64xf32>) {
-// CHECK-DAG:          %[[D4:.+]] = affine.min #[[MAP1]](%[[ARG5]])
+// CHECK-DAG:        %[[D2:.+]] = affine.min #[[MAP]](%[[ARG3]])
+// CHECK-DAG:        %[[D4:.+]] = affine.min #[[MAP1]](%[[ARG5]])
 // CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
 // CHECK-SAME:         %[[D4]], 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
 // CHECK:            %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
@@ -1035,9 +1035,9 @@ transform.sequence failures(propagate) {
 // CHECK:        %[[C1024:.+]] = arith.constant 1024 : index
 // CHECK:        %[[C10:.+]] = arith.constant 10 : index
 // CHECK:        scf.for %[[ARG4:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C192]] step %[[C10]] {
-// CHECK-DAG:        %[[D0:.+]] = affine.min #[[MAP]](%[[ARG4]])
 // CHECK:          scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C30]] {
-// CHECK-DAG:          %[[D1:.+]] = affine.min #[[MAP1]](%[[ARG5]])
+// CHECK-DAG:        %[[D0:.+]] = affine.min #[[MAP]](%[[ARG4]])
+// CHECK-DAG:        %[[D1:.+]] = affine.min #[[MAP1]](%[[ARG5]])
 // CHECK:            %[[SUBVIEW:.+]] = memref.subview %[[ARG0]][%[[ARG4]], %[[ARG5]], 0] [%[[D0]], %[[D1]], 64] [1, 1,
 // CHECK-SAME:         1] : memref<192x1024x64xf32> to memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>
 // CHECK:            %[[SUBVIEW_0:.+]] = memref.subview %[[ARG1]][%[[ARG4]], 0, 0] [%[[D0]], 1024, 64] [1, 1, 1] :


### PR DESCRIPTION
[Advance LLVM to 76ead96c1d06ee0d828238bce96d0107e650b5fa: [mlir][TilingInterface] Use `LoopLikeOpInterface` in tiling using SCF to unify tiling with `scf.for` and `scf.forall`. (#77874) (MaheshRavishankar on 2024-01-25 21:26:23 -0800) (40 of 41)