### PR TITLE
Run check-iree-dialects tests in test_all job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
       - name: "Testing all"
         run: |
           ./build_tools/github_actions/docker_run.sh \
+            --env IREE_CTEST_IREE_DIALECTS_TESTS_DISABLE=0 \
             --env IREE_CUDA_DISABLE=1 \
             gcr.io/iree-oss/base@sha256:61e9aae211007dbad95e1f429e9e5121fd5968c204791038424979c21146cf75 \
             ./build_tools/cmake/ctest_all.sh \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,6 @@ jobs:
       - name: "Testing IREE"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env IREE_CUDA_DISABLE=1 \
-            --env IREE_VULKAN_DISABLE=1 \
             gcr.io/iree-oss/base-arm64@sha256:942d01a396f81bff06c5ef4643ba3c9f4500a09010cd30d9ed9be691ddaf1353 \
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
@@ -109,7 +107,6 @@ jobs:
         shell: bash
     env:
       BUILD_DIR: build-windows
-      IREE_VULKAN_DISABLE: 1
     steps:
       # actions/checkout is for some reason unusably slow on the large managed
       # Windows GitHub runners so we roll our own. See
@@ -295,7 +292,6 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env IREE_CTEST_IREE_DIALECTS_TESTS_DISABLE=0 \
-            --env IREE_CUDA_DISABLE=1 \
             gcr.io/iree-oss/base@sha256:61e9aae211007dbad95e1f429e9e5121fd5968c204791038424979c21146cf75 \
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
@@ -422,7 +418,6 @@ jobs:
       - name: "Testing runtime"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_DISABLE=1 \
             gcr.io/iree-oss/base@sha256:61e9aae211007dbad95e1f429e9e5121fd5968c204791038424979c21146cf75 \
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
@@ -453,7 +448,6 @@ jobs:
       - name: "Testing runtime"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_DISABLE=1 \
             gcr.io/iree-oss/base-arm64@sha256:942d01a396f81bff06c5ef4643ba3c9f4500a09010cd30d9ed9be691ddaf1353 \
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
@@ -467,7 +461,6 @@ jobs:
         shell: bash
     env:
       BUILD_DIR: build-runtime-windows
-      IREE_VULKAN_DISABLE: 1
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -699,7 +692,6 @@ jobs:
       - name: "Testing runtime"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_DISABLE=1 \
             gcr.io/iree-oss/base@sha256:61e9aae211007dbad95e1f429e9e5121fd5968c204791038424979c21146cf75 \
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -49,7 +49,7 @@ export IREE_CTEST_TESTS_REGEX="${IREE_CTEST_TESTS_REGEX:-}"
 # Respect the user setting, default to no --label-regex
 export IREE_CTEST_LABEL_REGEX="${IREE_CTEST_LABEL_REGEX:-}"
 # Respect the user setting, default to skipping check-iree-dialects tests.
-export IREE_CTEST_IREE_DIALECTS_TESTS_DISABLE="${IREE_CTEST_RUN_IREE_DIALECTS_TESTS:-1}"
+export IREE_CTEST_IREE_DIALECTS_TESTS_DISABLE="${IREE_CTEST_IREE_DIALECTS_TESTS_DISABLE:-1}"
 
 # Tests to exclude by label. In addition to any custom labels (which are carried
 # over from Bazel tags), every test should be labeled with its directory.

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -48,6 +48,8 @@ export IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT="${IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT:
 export IREE_CTEST_TESTS_REGEX="${IREE_CTEST_TESTS_REGEX:-}"
 # Respect the user setting, default to no --label-regex
 export IREE_CTEST_LABEL_REGEX="${IREE_CTEST_LABEL_REGEX:-}"
+# Respect the user setting, default to skipping check-iree-dialects tests.
+export IREE_CTEST_IREE_DIALECTS_TESTS_DISABLE="${IREE_CTEST_RUN_IREE_DIALECTS_TESTS:-1}"
 
 # Tests to exclude by label. In addition to any custom labels (which are carried
 # over from Bazel tags), every test should be labeled with its directory.
@@ -169,7 +171,12 @@ if (( ${#excluded_tests[@]} )); then
   ctest_args+=("--exclude-regex ${excluded_tests_regex}")
 fi
 
-echo "*************** Running CTest ***************"
-
 set -x
+
+echo "*************** Running CTest ***************"
 ctest ${ctest_args[@]}
+
+if (( IREE_CTEST_IREE_DIALECTS_TESTS_DISABLE != 1 )); then
+  echo "**************** Running llvm-external-projects tests ***************"
+  cmake --build ${BUILD_DIR} --target check-iree-dialects -- -k 0
+fi


### PR DESCRIPTION
This supersedes https://github.com/openxla/iree/pull/15530.

The tests in `llvm-external-projects/iree-dialects/` were previously only run in the `asan` CI job.