### PR TITLE
Remove Pixel 4 target from CI test workflow

### DIFF
--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -106,7 +106,7 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    # if: (! inputs.is-pr)
+    if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -111,10 +111,6 @@ jobs:
     strategy:
       matrix:
         target:
-          # Pixel 4 ships an old Adreno GPU driver. There are quite a few bugs
-          # triggered by our tests. Disable running tests entirely on Pixel 4.
-          - device-name: pixel-4
-            label-exclude: "vulkan"
           - device-name: pixel-6-pro
             label-exclude: "^requires-gpu"
           - device-name: moto-edge-x30

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -106,7 +106,7 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    if: (! inputs.is-pr)
+    # if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:


### PR DESCRIPTION
Pixel 4 is quite outdated and not on the focused targets right now. Remove it from the tests to reduce hardware maintenance.
