### PR TITLE
[VectorDistribution] Add distribution patterns for scf.for and scf.yield

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -360,6 +360,13 @@ struct DistributeScfYield final : OpDistributionPattern<scf::YieldOp> {
   LogicalResult matchAndRewrite(scf::YieldOp yieldOp,
                                 DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
+    // Check if the yield is a terminator of a distributable operation.
+    // TODO: This is a hack. Ideally, we shouldn't have this and distribution
+    // should just fail if some operation is not distributable.
+    if (!isa<scf::ForOp>(yieldOp->getParentOp())) {
+      return failure();
+    }
+
     // Get the distributed operands.
     SmallVector<Value> operands;
     for (Value operand : yieldOp->getOperands()) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -46,10 +46,8 @@ func.func @distribute_scf_for(%a: vector<16x16xi32>, %b: vector<16x16xi32>) -> v
     // These should be ideally folded if canonicalization was ever ran.
     // Canonicalization currently breaks other tests. If canonicalization
     // is ever ran, this should be updated.
-    // CHECK-DAG: %[[TMP:.*]] = iree_vector_ext.to_simd %[[ARG0]] : vector<16xi32> -> vector<16x16xi32> 
-    // CHECK-DAG: %[[ARG0S:.*]] = iree_vector_ext.to_simt %[[TMP]] : vector<16x16xi32> -> vector<16xi32>
     // CHECK-DAG: %[[B:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<16x16xi32> -> vector<16xi32>
-    // CHECK-DAG: %[[C:.*]] = arith.muli %[[ARG0S]], %[[B]] : vector<16xi32>
+    // CHECK-DAG: %[[C:.*]] = arith.muli %[[ARG0]], %[[B]] : vector<16xi32>
     %c = arith.muli %arg0, %b : vector<16x16xi32>
     // CHECK-DAG: %[[A:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<16x16xi32> -> vector<16xi32>
     // CHECK-DAG: %[[D:.*]] = arith.addi %[[C]], %[[A]] : vector<16xi32>


### PR DESCRIPTION
This patch adds support to distribute scf.for and scf.yield in vector distribution framework.