### PR TITLE
[NFC] Use AttrTypeReplacer for replacing memory space

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EraseHALDescriptorTypeFromMemRef.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EraseHALDescriptorTypeFromMemRef.cpp
@@ -27,69 +27,6 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-//===----------------------------------------------------------------------===//
-// Type Converter
-//===----------------------------------------------------------------------===//
-
-struct MemRefTypeConverter final : public TypeConverter {
-  MemRefTypeConverter() {
-    // Pass through for all other types.
-    addConversion([](Type type) { return type; });
-
-    addConversion([](BaseMemRefType memRefType) -> std::optional<Type> {
-      // Expect #hal.descriptor_type memory spaces.
-      Attribute spaceAttr = memRefType.getMemorySpace();
-      if (!spaceAttr)
-        return std::nullopt;
-      auto dtAttr = llvm::dyn_cast<IREE::HAL::DescriptorTypeAttr>(spaceAttr);
-      if (!dtAttr)
-        return std::nullopt;
-
-      // Erase the #hal.descriptor_type memory space.
-      if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
-        return MemRefType::get(memRefType.getShape(),
-                               memRefType.getElementType(),
-                               rankedType.getLayout());
-      }
-      return UnrankedMemRefType::get(memRefType.getElementType(),
-                                     /*memorySpace=*/0);
-    });
-  }
-};
-
-struct GPUMemRefTypeConverter final : public TypeConverter {
-  GPUMemRefTypeConverter() {
-    // Pass through for all other types.
-    addConversion([](Type type) { return type; });
-
-    addConversion([](BaseMemRefType memRefType) -> std::optional<Type> {
-      // Expect #hal.descriptor_type memory spaces.
-      Attribute spaceAttr = memRefType.getMemorySpace();
-      if (!spaceAttr)
-        return std::nullopt;
-      auto dtAttr = llvm::dyn_cast<IREE::HAL::DescriptorTypeAttr>(spaceAttr);
-      if (!dtAttr)
-        return std::nullopt;
-
-      Attribute globalSpace = gpu::AddressSpaceAttr::get(
-          memRefType.getContext(), gpu::AddressSpace::Global);
-
-      // Erase the #hal.descriptor_type memory space.
-      if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
-        return MemRefType::get(memRefType.getShape(),
-                               memRefType.getElementType(),
-                               rankedType.getLayout(), globalSpace);
-      }
-      return UnrankedMemRefType::get(memRefType.getElementType(),
-                                     /*memorySpace=*/globalSpace);
-    });
-  }
-};
-
-//===----------------------------------------------------------------------===//
-// Conversion Target
-//===----------------------------------------------------------------------===//
-
 /// Returns true if the given `type` is considered as legal.
 static bool isLegalType(Type type) {
   if (auto memRefType = llvm::dyn_cast<BaseMemRefType>(type)) {
@@ -99,101 +36,31 @@ static bool isLegalType(Type type) {
   return true;
 }
 
-/// Returns true if the given `op` is considered as legal.
-static bool isLegalOp(Operation *op) {
-  if (!llvm::all_of(op->getOperandTypes(), isLegalType) ||
-      !llvm::all_of(op->getResultTypes(), isLegalType)) {
-    return false;
-  }
-
-  for (Region &region : op->getRegions()) {
-    for (Block &block : region) {
-      if (!llvm::all_of(block.getArgumentTypes(), isLegalType)) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
-
-//===----------------------------------------------------------------------===//
-// Conversion Pattern
-//===----------------------------------------------------------------------===//
-
-struct EraseMemorySpacePattern final : public ConversionPattern {
-  EraseMemorySpacePattern(MLIRContext *context, TypeConverter &converter)
-      : ConversionPattern(converter, MatchAnyOpTypeTag(), 1, context) {}
-
-  LogicalResult
-  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
-                  ConversionPatternRewriter &rewriter) const override;
-};
-
-LogicalResult EraseMemorySpacePattern::matchAndRewrite(
-    Operation *op, ArrayRef<Value> operands,
-    ConversionPatternRewriter &rewriter) const {
-  const TypeConverter &typeConverter = *getTypeConverter();
-  llvm::SmallVector<Type> newResults;
-  if (failed(typeConverter.convertTypes(op->getResultTypes(), newResults))) {
-    op->emitError("Can't convert results");
-  }
-
-  OperationState state(op->getLoc(), op->getName().getStringRef(), operands,
-                       newResults, op->getAttrs(), op->getSuccessors());
-
-  for (Region &region : op->getRegions()) {
-    Region *newRegion = state.addRegion();
-    rewriter.inlineRegionBefore(region, *newRegion, newRegion->begin());
-    if (failed(rewriter.convertRegionTypes(newRegion, typeConverter))) {
-      return op->emitError("Cant'convert region types");
-    }
-  }
-
-  Operation *newOp = rewriter.create(state);
-  rewriter.replaceOp(op, newOp->getResults());
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// Rewrite Patterns
-//===----------------------------------------------------------------------===//
-
-static LogicalResult eraseHALDescriptorTypeFromMemRef(Operation *op) {
-  MLIRContext *context = op->getContext();
-  ConversionTarget target(*context);
-  target.markUnknownOpDynamicallyLegal(isLegalOp);
-
-  MemRefTypeConverter typeConverter;
-  RewritePatternSet patterns(context);
-  patterns.add<EraseMemorySpacePattern>(context, typeConverter);
-
-  return applyFullConversion(op, target, std::move(patterns));
-}
-
-static LogicalResult convertHALDescriptorTypeToGPUAddressSpace(Operation *op) {
-  MLIRContext *context = op->getContext();
-  ConversionTarget target(*context);
-  target.markUnknownOpDynamicallyLegal(isLegalOp);
-
-  GPUMemRefTypeConverter typeConverter;
-  RewritePatternSet patterns(context);
-  patterns.add<EraseMemorySpacePattern>(context, typeConverter);
-
-  return applyFullConversion(op, target, std::move(patterns));
-}
-
-//===----------------------------------------------------------------------===//
-// Conversion Passes
-//===----------------------------------------------------------------------===//
-
 struct EraseHALDescriptorTypeFromMemRefPass final
     : public EraseHALDescriptorTypeFromMemRefBase<
           EraseHALDescriptorTypeFromMemRefPass> {
   void runOnOperation() override {
+    AttrTypeReplacer replacer;
+    replacer.addReplacement(
+        [](BaseMemRefType memRefType) -> std::optional<BaseMemRefType> {
+          if (isLegalType(memRefType))
+            return std::nullopt;
+
+          // Erase the #hal.descriptor_type memory space.
+          if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
+            return MemRefType::get(memRefType.getShape(),
+                                   memRefType.getElementType(),
+                                   rankedType.getLayout());
+          }
+          return UnrankedMemRefType::get(memRefType.getElementType(),
+                                         /*memorySpace=*/0);
+        });
+
     Operation *op = getOperation();
-    if (failed(eraseHALDescriptorTypeFromMemRef(op)))
-      return signalPassFailure();
+
+    replacer.recursivelyReplaceElementsIn(op, /*replaceAttrs=*/false,
+                                          /*replaceLocs=*/false,
+                                          /*replaceTypes=*/true);
   }
 };
 
@@ -201,9 +68,30 @@ struct ConvertHALDescriptorTypeToGPUAddressSpacePass final
     : public ConvertHALDescriptorTypeToGPUAddressSpaceBase<
           ConvertHALDescriptorTypeToGPUAddressSpacePass> {
   void runOnOperation() override {
+    AttrTypeReplacer replacer;
+    replacer.addReplacement(
+        [](BaseMemRefType memRefType) -> std::optional<BaseMemRefType> {
+          if (isLegalType(memRefType))
+            return std::nullopt;
+
+          Attribute globalSpace = gpu::AddressSpaceAttr::get(
+              memRefType.getContext(), gpu::AddressSpace::Global);
+
+          // Erase the #hal.descriptor_type memory space.
+          if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
+            return MemRefType::get(memRefType.getShape(),
+                                   memRefType.getElementType(),
+                                   rankedType.getLayout(), globalSpace);
+          }
+          return UnrankedMemRefType::get(memRefType.getElementType(),
+                                         /*memorySpace=*/globalSpace);
+        });
+
     Operation *op = getOperation();
-    if (failed(convertHALDescriptorTypeToGPUAddressSpace(op)))
-      return signalPassFailure();
+
+    replacer.recursivelyReplaceElementsIn(op, /*replaceAttrs=*/false,
+                                          /*replaceLocs=*/false,
+                                          /*replaceTypes=*/true);
   }
 };
 


### PR DESCRIPTION
The current implementation uses a custom dialect conversion to replace the memory space of the memref. This patch makes the implementation use upstream AttrTypeReplacer to replace the types.