### PR TITLE
Pin markdownlint-cli to an old version.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Downloading markdownlint
-        run: npm install -g markdownlint-cli
+        run: npm install -g markdownlint-cli@0.38.0
       - name: Running markdownlint
         run: ./build_tools/scripts/run_markdownlint.sh
 


### PR DESCRIPTION
The latest version has new rules that trigger on some of our files.

skip-ci: unrelated to builds