### PR TITLE
[Codegen] Use the lane ID to do transfer distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -81,7 +81,7 @@ static SmallVector<Value> computeSIMDIndex(const LayoutIterator::State &state,
         rewriter.create<arith::ConstantIndexOp>(laneId.getLoc(), laneDimZ),
         rewriter.create<arith::ConstantIndexOp>(laneId.getLoc(), laneDimY),
         rewriter.create<arith::ConstantIndexOp>(laneId.getLoc(), laneDimX)};
-    auto maybeReversedLaneGridVals =
+    FailureOr<SmallVector<Value>> maybeReversedLaneGridVals =
         affine::delinearizeIndex(rewriter, laneId.getLoc(), laneId, laneGrid);
     assert(succeeded(maybeReversedLaneGridVals) &&
            "Failed to delinearize lane index");

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Common/VectorLayoutAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -43,8 +44,7 @@ static std::optional<int64_t> findDimShape(LayoutAttr layout,
 /// that the current iterator state is iterating over. These indices are
 /// parameterized by the thread grid.
 static SmallVector<Value> computeSIMDIndex(const LayoutIterator::State &state,
-                                           LayoutAttr layout,
-                                           ArrayRef<Value> threadGrid,
+                                           LayoutAttr layout, Value laneId,
                                            RewriterBase &rewriter) {
   MLIRContext *ctx = layout.getContext();
   AffineExpr threadX, threadY, threadZ;
@@ -76,10 +76,23 @@ static SmallVector<Value> computeSIMDIndex(const LayoutIterator::State &state,
       stride = stride * getAffineConstantExpr(shape, ctx);
     }
 
+    auto [laneDimX, laneDimY, laneDimZ] = layout.getLaneGrid();
+    SmallVector<Value> laneGrid = {
+        rewriter.create<arith::ConstantIndexOp>(laneId.getLoc(), laneDimZ),
+        rewriter.create<arith::ConstantIndexOp>(laneId.getLoc(), laneDimY),
+        rewriter.create<arith::ConstantIndexOp>(laneId.getLoc(), laneDimX)};
+    auto maybeReversedLaneGridVals =
+        affine::delinearizeIndex(rewriter, laneId.getLoc(), laneId, laneGrid);
+    assert(succeeded(maybeReversedLaneGridVals) &&
+           "Failed to delinearize lane index");
+    SmallVector<Value> laneGridVals = {(*maybeReversedLaneGridVals)[2],
+                                       (*maybeReversedLaneGridVals)[1],
+                                       (*maybeReversedLaneGridVals)[0]};
+
     // Compute the index for the dim.
     AffineMap indexMap = AffineMap::get(0, 3, offset);
     Value index = rewriter.create<affine::AffineApplyOp>(
-        rewriter.getUnknownLoc(), indexMap, threadGrid);
+        rewriter.getUnknownLoc(), indexMap, laneGridVals);
     simdIndex.push_back(index);
   }
 
@@ -198,9 +211,9 @@ struct DistributeXferLayoutAttr : OpDistributionPattern<OpTy> {
                     std::is_same<OpTy, vector::TransferWriteOp>::value,
                 "expected vector::TransferReadOp or vector::TransferWriteOp");
 
-  DistributeXferLayoutAttr(MLIRContext *context, ArrayRef<Value> threadGrid,
+  DistributeXferLayoutAttr(MLIRContext *context, Value laneId,
                            PatternBenefit benefit = 1)
-      : OpDistributionPattern<OpTy>(context, benefit), threadGrid(threadGrid) {}
+      : OpDistributionPattern<OpTy>(context, benefit), laneId(laneId) {}
 
   VectorValue accessMemory(OpTy xferOp, VectorValue accumulator,
                            LayoutAttr vectorLayout,
@@ -235,7 +248,7 @@ struct DistributeXferLayoutAttr : OpDistributionPattern<OpTy> {
                                       SmallVector<Value> indices,
                                       RewriterBase &rewriter) const {
     SmallVector<Value> simdIndices =
-        computeSIMDIndex(state, memoryLayout, threadGrid, rewriter);
+        computeSIMDIndex(state, memoryLayout, laneId, rewriter);
     SmallVector<Value> memoryIndices(indices);
 
     // The memory layout has some projected leading dims that indices doesn't.
@@ -265,7 +278,7 @@ struct DistributeXferLayoutAttr : OpDistributionPattern<OpTy> {
     return 1;
   }
 
-  SmallVector<Value> threadGrid;
+  Value laneId;
 };
 
 struct DistributeTransferReadLayoutAttr final
@@ -366,11 +379,11 @@ void populateGPUDistributionPatterns(RewritePatternSet &patterns) {
                DistributeElementwise<arith::AddFOp>>(patterns.getContext());
 }
 
-void populateGPUDistributionLayoutAttrPatterns(ArrayRef<Value> threadGrid,
+void populateGPUDistributionLayoutAttrPatterns(Value laneId,
                                                RewritePatternSet &patterns) {
   patterns
       .add<DistributeTransferReadLayoutAttr, DistributeTransferWriteLayoutAttr>(
-          patterns.getContext(), threadGrid);
+          patterns.getContext(), laneId);
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
@@ -31,7 +31,7 @@ void populateDropSharedMemoryDeallocOpPatterns(RewritePatternSet &patterns);
 
 void populateGPUDistributionPatterns(RewritePatternSet &patterns);
 
-void populateGPUDistributionLayoutAttrPatterns(ArrayRef<Value> threadGrid,
+void populateGPUDistributionLayoutAttrPatterns(Value laneId,
                                                RewritePatternSet &patterns);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -562,8 +562,8 @@ def TestGpuVectorDistribution :
     "__vector_layout_test_anchor_result_x", where "x" is the operand/result
     number.
 
-    The distribution is done over a 3D thread grid, using the
-    gpu.thread x, y, z thread grid.
+    The distribution is done for a single warp using gpu.thread x as the lane
+    ID.
 
     #### Return modes
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtBase.td
@@ -111,6 +111,9 @@ def LayoutAttr : IREEVectorExt_Attr<"Layout",
   let genVerifyDecl = 0;
   let extraClassDeclaration = [{
     std::optional<int64_t> getBatchDim(int64_t dim);
+
+    // Returns the grid of lane ids. Assumes a valid layout.
+    ::std::tuple<int64_t, int64_t, int64_t> getLaneGrid();
     PerDimLayoutAttr getDimLayout(int64_t dim) const;
   }];
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtDialect.cpp
@@ -153,3 +153,21 @@ std::optional<int64_t> LayoutAttr::getBatchDim(int64_t dim) {
   }
   return std::nullopt;
 }
+
+std::tuple<int64_t, int64_t, int64_t> LayoutAttr::getLaneGrid() {
+  int64_t laneX = 1;
+  int64_t laneY = 1;
+  int64_t laneZ = 1;
+  for (PerDimLayoutAttr dimLayout : getLayouts()) {
+    auto maybeXShape = dimLayout.getShape(LayoutDimension::LANEX);
+    if (maybeXShape)
+      laneX = *maybeXShape;
+    auto maybeYShape = dimLayout.getShape(LayoutDimension::LANEY);
+    if (maybeYShape)
+      laneY = *maybeYShape;
+    auto maybeZShape = dimLayout.getShape(LayoutDimension::LANEZ);
+    if (maybeZShape)
+      laneZ = *maybeZShape;
+  }
+  return std::make_tuple(laneX, laneY, laneZ);
+}

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtDialect.cpp
@@ -159,6 +159,9 @@ std::tuple<int64_t, int64_t, int64_t> LayoutAttr::getLaneGrid() {
   int64_t laneY = 1;
   int64_t laneZ = 1;
   for (PerDimLayoutAttr dimLayout : getLayouts()) {
+    // Note that valid layouts only include at most one instance of each
+    // dimension type, so this is simply doing assignment on the first instance
+    // of each lane index, not an accumulative product.
     auto maybeXShape = dimLayout.getShape(LayoutDimension::LANEX);
     laneX *= maybeXShape.value_or(1);
     auto maybeYShape = dimLayout.getShape(LayoutDimension::LANEY);

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtDialect.cpp
@@ -160,14 +160,11 @@ std::tuple<int64_t, int64_t, int64_t> LayoutAttr::getLaneGrid() {
   int64_t laneZ = 1;
   for (PerDimLayoutAttr dimLayout : getLayouts()) {
     auto maybeXShape = dimLayout.getShape(LayoutDimension::LANEX);
-    if (maybeXShape)
-      laneX = *maybeXShape;
+    laneX *= maybeXShape.value_or(1);
     auto maybeYShape = dimLayout.getShape(LayoutDimension::LANEY);
-    if (maybeYShape)
-      laneY = *maybeYShape;
+    laneY *= maybeYShape.value_or(1);
     auto maybeZShape = dimLayout.getShape(LayoutDimension::LANEZ);
-    if (maybeZShape)
-      laneZ = *maybeZShape;
+    laneZ *= maybeZShape.value_or(1);
   }
   return std::make_tuple(laneX, laneY, laneZ);
 }


### PR DESCRIPTION
Previously the transfer distribution patterns were expecting a list of thread indices to distribute to, but then distributing along the lane dimensions. The lane dimensions are a logical grid based on the lane index, which is the linearized thread index % warp size, so we need to compute the lane index based on the particular layout of the transfer rather than passing in a global grid of threads.