### PR TITLE
Nothing is unreachable

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_entry_point.c
@@ -255,14 +255,7 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
       return iree_uk_mmt4d_select_tile_func_arm_64_bf16bf16bf16(params);
     case iree_uk_mmt4d_type_s8s8s32:
       return iree_uk_mmt4d_select_tile_func_arm_64_i8i8i32(params);
-    case iree_uk_mmt4d_type_s16s16s32:
-      return 0;
-    case iree_uk_mmt4d_type_s16u4s32:
-      return 0;
-    case iree_uk_mmt4d_type_s16s8s32:
-      return 0;
     default:
-      IREE_UK_ASSUME_UNREACHABLE;
       return 0;
   }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/query_tile_sizes_arm_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/query_tile_sizes_arm_64_entry_point.c
@@ -42,8 +42,7 @@ bool iree_uk_query_matmul_tile_sizes_arch(
         iree_uk_query_matmul_tile_sizes_arm_64_i8i8i32(params);
     return true;
   } else {
-    // Can't happen, validated earlier.
-    IREE_UK_ASSUME_UNREACHABLE;
+    // Shouldn't happen, validated earlier.
     return false;
   }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_entry_point.c
@@ -411,10 +411,7 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
       return iree_uk_mmt4d_select_tile_func_x86_64_s16s16s32(params);
     case iree_uk_mmt4d_type_s16u4s32:
       return iree_uk_mmt4d_select_tile_func_x86_64_s16u4s32(params);
-    case iree_uk_mmt4d_type_s16s8s32:
-      return 0;
     default:
-      IREE_UK_ASSUME_UNREACHABLE;
       return 0;
   }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/query_tile_sizes_x86_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/query_tile_sizes_x86_64_entry_point.c
@@ -54,8 +54,7 @@ bool iree_uk_query_matmul_tile_sizes_arch(
         iree_uk_query_matmul_tile_sizes_x86_64_i8i8i32(params);
     return true;
   } else {
-    // Can't happen, validated earlier.
-    IREE_UK_ASSUME_UNREACHABLE;
+    // Shouldn't happen, validated earlier.
     return false;
   }
 }

--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -110,51 +110,6 @@
 #define IREE_UK_RESTRICT restrict
 #endif  // IREE_UK_COMPILER_MSVC_VERSION_AT_LEAST(1900)
 
-// Same as LLVM_BUILTIN_UNREACHABLE. Extremely dangerous. Use only in locations
-// that are provably unreachable (+/- edge case of unreachable-past-assertions
-// discussed below).
-//
-// The potential benefit of UNREACHABLE statements is code size and/or speed
-// optimization. This is an arcane optimization. As such, each use must be
-// carefully justified.
-//
-// There is the edge case of locations that are provably unreachable when
-// optional validation code is enabled, but the validation code may also be
-// disabled, making the location technically reachable. Typically: assertions.
-// Use careful judgement for such cases.
-//
-// A typical use case in microkernels is as follows. A microkernel is
-// parametrized by type triples packed into uint32s, and needs to have a switch
-// statement on those:
-//
-// switch (params->type_triple) {
-//   case iree_uk_mykernel_f32f32f32:  // 0xf5f5f5
-//     return 123;
-//   case iree_uk_mykernel_i8i8i32:  // 0x232325
-//     return 321;
-//   default:
-//     return 0;
-// }
-//
-// As long as the microkernel has validation code (running at least as Debug
-// assertions) validating type_triple, and this code is already past that,
-// and this switch statement covers all valid cases, the `default:` case should
-// be unreachable. Adding an UNREACHABLE statement there can help with code
-// size. This would be negligible if the case constants were small enough to
-// fit in compare-with-immediate instructions, but the 24-bit type triple
-// constants here would typically not, so without UNREACHABLE, the compiler has
-// to fully implement each 24-bit literal separately.
-//
-// https://godbolt.org/z/hTv4qqbx9 shows a snipped similar as above where
-// the __builtin_unreachable shrinks the AArch64 code from 11 to 7 instructions.
-#if IREE_UK_HAVE_BUILTIN(__builtin_unreachable) || defined(IREE_UK_COMPILER_GCC)
-#define IREE_UK_ASSUME_UNREACHABLE __builtin_unreachable()
-#elif defined(IREE_UK_COMPILER_MSVC)
-#define IREE_UK_ASSUME_UNREACHABLE __assume(false)
-#else
-#define IREE_UK_ASSUME_UNREACHABLE
-#endif  // IREE_UK_HAVE_BUILTIN(__builtin_unreachable)
-
 #if IREE_UK_HAVE_ATTRIBUTE(noinline) || defined(IREE_UK_COMPILER_GCC)
 #define IREE_UK_ATTRIBUTE_NOINLINE __attribute__((noinline))
 #else

--- a/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
@@ -51,16 +51,16 @@ static inline iree_uk_mmt4d_type_t iree_uk_mmt4d_type(iree_uk_uint32_t flags) {
     case IREE_UK_FLAG_MMT4D_TYPE_BF16BF16BF16:
       return iree_uk_mmt4d_type_bf16bf16bf16;
     default:
-      // This unreachable statement is not just an optimization, it also works
-      // around a LLVM/riscv32 miscompile.
-
-      // When we used to have a iree_uk_mmt4d_type_none value equal to 0 and
-      // were returning it here, that caused this whole switch statement to be
-      // miscompiled by LLVM/riscv32 as if it were UB. That value was passed to
+      // Work around a LLVM/riscv32 miscompile. Without the unreachable here,
+      // returning (iree_uk_mmt4d_type_t)0 causes this whole switch statement to
+      // be miscompiled by LLVM/riscv32 as if it were UB, as the 0 was passed to
       // `iree_uk_type_bit_count(x)`, which evaluates to `1<<(x - 3)`, which is
-      // UB if x<3. So it was fair to treat that default: clause as UB, but
-      // LLVM/riscv32 was incorrectly treating the whole switch as UB.
-      IREE_UK_ASSUME_UNREACHABLE;
+      // UB if x<3.
+#if defined(IREE_UK_COMPILER_CLANG) && defined(IREE_UK_ARCH_RISCV_32)
+      __builtin_unreachable();
+#endif
+      // Shouldn't happen, validated earlier.
+      return (iree_uk_mmt4d_type_t)0;
   }
 }
 

--- a/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
@@ -437,8 +437,7 @@ static iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(
                  ? iree_uk_mmt4d_tile_bf16bf16bf16_generic_skipround
                  : iree_uk_mmt4d_tile_bf16bf16bf16_generic_noskipround;
     default:
-      // shouldn't happen, validated earlier.
-      IREE_UK_ASSUME_UNREACHABLE;
+      // Shouldn't happen, validated earlier.
       return 0;
   }
 }

--- a/runtime/src/iree/builtins/ukernel/pack_internal.h
+++ b/runtime/src/iree/builtins/ukernel/pack_internal.h
@@ -31,7 +31,8 @@ static inline iree_uk_pack_type_t iree_uk_pack_type(iree_uk_uint32_t flags) {
     case IREE_UK_FLAG_PACK_TYPE_BF16BF16:
       return iree_uk_pack_type_bf16bf16;
     default:
-      IREE_UK_ASSUME_UNREACHABLE;
+      // Shouldn't happen, validated earlier.
+      return (iree_uk_pack_type_t)0;
   }
 }
 

--- a/runtime/src/iree/builtins/ukernel/query_tile_sizes.c
+++ b/runtime/src/iree/builtins/ukernel/query_tile_sizes.c
@@ -58,8 +58,7 @@ static void iree_uk_query_tile_sizes_2d_matmul(
     out_params->tile_size0 = matmul_tile_sizes.M;
     out_params->tile_size1 = matmul_tile_sizes.N;
   } else {
-    // Can't happen, validated earlier.
-    IREE_UK_ASSUME_UNREACHABLE;
+    // Shouldn't happen, validated earlier.
   }
 }
 
@@ -71,8 +70,7 @@ IREE_UK_EXPORT int iree_uk_query_tile_sizes_2d(
   if (iree_uk_query_tile_sizes_operation_is_matmul(params->flags)) {
     iree_uk_query_tile_sizes_2d_matmul(params, out_params);
   } else {
-    // Can't happen, validated earlier.
-    IREE_UK_ASSUME_UNREACHABLE;
+    // Shouldn't happen, validated earlier.
   }
   return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/unpack_internal.h
+++ b/runtime/src/iree/builtins/ukernel/unpack_internal.h
@@ -29,7 +29,8 @@ static inline iree_uk_unpack_type_t iree_uk_unpack_type(
     case IREE_UK_FLAG_UNPACK_TYPE_BF16BF16:
       return iree_uk_unpack_type_bf16bf16;
     default:
-      IREE_UK_ASSUME_UNREACHABLE;
+      // Shouldn't happen, validated earlier.
+      return (iree_uk_unpack_type_t)0;
   }
 }
 


### PR DESCRIPTION
This comes from debugging the mysterious crashes on CI on @mariecwhite 's https://github.com/openxla/iree/pull/16259.

Debugged: https://github.com/openxla/iree/pull/16259#issuecomment-1917417773

The motivation for these unreachable statements was a performance concern that is no longer current on LLVMCPU now that inlining works reliably. The switch variables here are in practice always compile-time constants so the whole switch statement vanishes in post-linking IR optimization passes. The only places where the unreachable still helps are: VMVX and ukernel own micro benchmarks and tests, and the impact is small, so it's not worth keeping.

As a bonus, this makes the fallback now automatic when adding a new mmt4d type not handled by existing architecture-sepcific code, so this just makes ukernels easier to extend, as evidenced by the fact that @mariecwhite did run into this.

One place had to retain an unreachable to work around a specific compiler bug. As it's specific to one compiler, it doesn't need a portable macro to wrap around the unreachable builtin.