### PR TITLE
[stablehlo] Disable absorption of int4 Operation into dot and Convolution

### DIFF
--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -1218,9 +1218,9 @@ struct FuseWidenOperands final : OpRewritePattern<Op> {
               op, "non-integer or floating point type");
           ;
         }
-
-        if (inputType.getIntOrFloatBitWidth() <
-            castedType.getIntOrFloatBitWidth()) {
+        unsigned int inputBitWidth = inputType.getIntOrFloatBitWidth();
+        if (inputBitWidth >= 8 &&
+            inputBitWidth < castedType.getIntOrFloatBitWidth()) {
           operands.push_back(convertOp.getOperand());
           continue;
         }


### PR DESCRIPTION
Int4 computation is not supported on all operations, just converts and load/stores. This patch disables absorption into convolution, dot and dot_general operations that pull in smaller bit-width computation when there is a conversion from small bit-width to a larger one right before the operation.