### PR TITLE
Changing ConstExprAnalysis expansion to use a worklist.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -104,9 +104,8 @@ ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp) {
     for (auto &use : constOp->getUses()) {
       Operation *useOp = use.getOwner();
       // For now ignore operations that are not in the same scope.
-      if (constOp->getParentOp() != useOp->getParentOp()) {
+      if (constOp->getParentOp() != useOp->getParentOp())
         continue;
-      }
       expandToOp(useOp);
     }
   }
@@ -161,9 +160,8 @@ ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp) {
         for (auto &use : definingOp->getUses()) {
           Operation *useOp = use.getOwner();
           // Skip expanding of ops within dispatch or nested regions.
-          if (definingOp->getParentOp() != useOp->getParentOp()) {
+          if (definingOp->getParentOp() != useOp->getParentOp())
             continue;
-          }
           expandToOp(useOp);
         }
       }
@@ -188,6 +186,15 @@ ConstExprAnalysis::addInfo(Value constValue) {
 }
 
 void ConstExprAnalysis::expandToOp(Operation *op) {
+  SmallVector<Operation *> expandWorklist;
+  expandWorklist.push_back(op);
+  do {
+    expandToOpStep(expandWorklist.pop_back_val(), expandWorklist);
+  } while (!expandWorklist.empty());
+}
+
+void ConstExprAnalysis::expandToOpStep(
+    Operation *op, SmallVectorImpl<Operation *> &expandWorklist) {
   ConstExprOpInfo opInfo = ConstExprOpInfo::getForOp(op);
   for (auto result : op->getResults()) {
     auto *valueInfo = constInfoMap.lookup(result);
@@ -229,7 +236,7 @@ void ConstExprAnalysis::expandToOp(Operation *op) {
         valueInfo->state = ConstValueInfo::NON_CONSTANT;
         break;
       }
-      expandToOp(definingOp);
+      expandWorklist.push_back(definingOp);
     }
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -152,8 +152,10 @@ public:
 private:
   // Expands the frontier to include all results of a given op in an UNKNOWN
   // state. This also checks that all of its operands are known, adding
-  // them recusrively if not.
+  // them recursively if not.
   void expandToOp(Operation *op);
+  void expandToOpStep(Operation *op,
+                      SmallVectorImpl<Operation *> &expandWorklist);
 
   // Add a new info record for a value to analyze for const-ness.
   ConstValueInfo *addInfo(Value constValue);


### PR DESCRIPTION
It was doing a recursive expandToOp call that would blow the stack on non-trivial inputs (sdxl_turbo_unet).