### PR TITLE
Allow using iree_lit_test without building the compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -992,9 +992,6 @@ if(IREE_BUILD_E2E_TEST_ARTIFACTS)
   set(IREE_E2E_TEST_ARTIFACTS_DIR "${IREE_BINARY_DIR}/e2e_test_artifacts")
 endif()
 
-# Note: Test deps are not built as part of all (use the iree-test-deps target).
-add_subdirectory(tests EXCLUDE_FROM_ALL)
-
 # tools/ can depend on compiler/ and runtime/.
 # Note: tools sub directory is added before compiler/ so that phony targets for
 # files with the same names from different rules are disambiguated towards
@@ -1002,6 +999,9 @@ add_subdirectory(tests EXCLUDE_FROM_ALL)
 add_subdirectory(tools)
 add_subdirectory(compiler)
 add_subdirectory(runtime)
+
+# Note: Test deps are not built as part of all (use the iree-test-deps target).
+add_subdirectory(tests EXCLUDE_FROM_ALL)
 
 if(IREE_ENABLE_CLANG_TIDY)
   set(CMAKE_CXX_CLANG_TIDY "")

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -21,16 +21,6 @@ include(CMakeParseArguments)
 # LABELS: Additional labels to apply to the test. The package path is added
 #     automatically.
 function(iree_lit_test)
-  if(NOT IREE_BUILD_TESTS)
-    return()
-  endif()
-
-  # Note: lit tests are not *required* to be "compiler" tests, but we only use
-  # them for compiler tests in practice.
-  if(NOT IREE_BUILD_COMPILER)
-    return()
-  endif()
-
   cmake_parse_arguments(
     _RULE
     ""
@@ -39,7 +29,14 @@ function(iree_lit_test)
     ${ARGN}
   )
 
+  if(NOT TARGET FileCheck)
+    # TODO(scotttodd): mark test DISABLED instead of skipping entirely?
+    return()
+  endif()
+
+  # TODO(scotttodd): remove this and make all lit tests "hostonly" implicitly?
   if(CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _RULE_LABELS)
+    # TODO(scotttodd): mark test DISABLED instead of skipping entirely?
     return()
   endif()
 

--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -153,6 +153,8 @@ macro(iree_llvm_set_bundled_cmake_options)
 
   # Unconditionally enable some other cheap LLVM tooling.
   set(IREE_LLVM_LINK_TARGET llvm-link)
+  set(IREE_FILECHECK_TARGET FileCheck)
+  set(IREE_NOT_TARGET not)
 
   # Unconditionally enable mlir.
   list(APPEND LLVM_ENABLE_PROJECTS mlir)

--- a/samples/custom_dispatch/vulkan/shaders/CMakeLists.txt
+++ b/samples/custom_dispatch/vulkan/shaders/CMakeLists.txt
@@ -4,7 +4,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-if(NOT IREE_TARGET_BACKEND_VULKAN_SPIRV OR NOT IREE_HAL_DRIVER_VULKAN)
+# This sample needs runtime support...
+if(NOT IREE_HAL_DRIVER_VULKAN)
+  return()
+endif()
+
+# ... and compiler support, from either a source build or packages.
+if(NOT IREE_HOST_BIN_DIR AND NOT IREE_TARGET_BACKEND_VULKAN_SPIRV)
   return()
 endif()
 

--- a/tests/e2e/parameters/BUILD.bazel
+++ b/tests/e2e/parameters/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     cfg = "//tests:lit.cfg.py",
     tags = [
         "driver=local-task",
+        "hostonly",
     ],
     tools = [
         "//tools:iree-compile",

--- a/tests/e2e/parameters/CMakeLists.txt
+++ b/tests/e2e/parameters/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     iree-run-module
   LABELS
     "driver=local-task"
+    "hostonly"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -264,17 +264,21 @@ if(IREE_BUILD_COMPILER)
     )
   endif()
 
-  install(
-    TARGETS FileCheck
-    COMPONENT IREETools-CompilerDev
-    RUNTIME DESTINATION bin
-  )
+  if(IREE_FILECHECK_TARGET)
+    install(
+      TARGETS FileCheck
+      COMPONENT IREETools-CompilerDev
+      RUNTIME DESTINATION bin
+    )
+  endif()
 
-  install(
-    TARGETS not
-    COMPONENT IREETools-CompilerDev
-    RUNTIME DESTINATION bin
-  )
+  if(IREE_NOT_TARGET)
+    install(
+      TARGETS not
+      COMPONENT IREETools-CompilerDev
+      RUNTIME DESTINATION bin
+    )
+  endif()
 
   # Tablegen binaries are special snowflakes among special snowflakes.
   # They must be statically linked against internal LLVM libraries, and they

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -25,13 +25,6 @@ set(IREE_PACKAGE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 # Write some important CMake options to a file for convenient use from scripts.
 configure_file(build_config_template.txt.in build_config.txt)
 
-# For sub-directories, we want targets fully qualified relative to the
-# root. But after, we want those in *this* directory to be unqualified
-# (i.e. 'iree-compile').
-set(IREE_PACKAGE_ROOT_PREFIX "iree/tools")
-iree_add_all_subdirs()
-set(IREE_PACKAGE_ROOT_PREFIX "")
-
 # If cross-compiling and not building the compiler, then attempt to find
 # the compiler tools.
 # This is actual broken because the situation is tri-state:
@@ -51,9 +44,18 @@ if(IREE_HOST_BIN_DIR AND NOT IREE_BUILD_COMPILER)
   iree_import_binary(NAME iree-compile OPTIONAL)
   iree_import_binary(NAME iree-opt OPTIONAL)
   iree_import_binary(NAME iree-run-mlir OPTIONAL)
+  iree_import_binary(NAME FileCheck OPTIONAL)
+  iree_import_binary(NAME not OPTIONAL)
   iree_import_binary(NAME clang OPTIONAL)
   iree_import_binary(NAME llvm-link OPTIONAL)
 endif()
+
+# For sub-directories, we want targets fully qualified relative to the
+# root. But after, we want those in *this* directory to be unqualified
+# (i.e. 'iree-compile').
+set(IREE_PACKAGE_ROOT_PREFIX "iree/tools")
+iree_add_all_subdirs()
+set(IREE_PACKAGE_ROOT_PREFIX "")
 
 # TODO(#6353): Tools has thread dependencies in gtest, benchmark, yaml, etc.
 # This should be split between runtime/compiler with optional threading support.
@@ -261,6 +263,18 @@ if(IREE_BUILD_COMPILER)
       RUNTIME DESTINATION bin
     )
   endif()
+
+  install(
+    TARGETS FileCheck
+    COMPONENT IREETools-CompilerDev
+    RUNTIME DESTINATION bin
+  )
+
+  install(
+    TARGETS not
+    COMPONENT IREETools-CompilerDev
+    RUNTIME DESTINATION bin
+  )
 
   # Tablegen binaries are special snowflakes among special snowflakes.
   # They must be statically linked against internal LLVM libraries, and they


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/16203.

* Install more tools that are used for lit tests
* Import those installed tools
* Filter based on tools existing (imported or built) rather than based on building the compiler
* Add tests subdirectory _after_ tools are imported/defined

Now I can run more tests from a build that imports compiler tools rather than build them from source:
```
cmake -G Ninja -B ../iree-build-rt/ . \
  -DIREE_BUILD_COMPILER=OFF \
  -DIREE_HOST_BIN_DIR=D:\dev\projects\iree-build\install\bin \
  -DLLVM_EXTERNAL_LIT=D:\dev\projects\iree\third_party\llvm-project\llvm\utils\lit\lit.py
cmake --build ../iree-build-rt
cmake --build --target iree-test-deps
ctest --test-dir ../iree-build-rt
```

New failures that I see are:

* `iree/tests/e2e/regression/libm_linking.mlir.test`
  * WindowsLinkerTool looks for `lld-link`, which we don't install. That appears to be a copy of `lld`, which is different from IREE's `iree-lld` (which complains with `Expected -flavor <gnu|link|darwin|wasm>` when I try to use it in that test)
* `iree/samples/custom_module/dynamic/test/example.mlir.test`
  * Not sure what's happening here - this passes in my regular build and works when run standalone but segfaults when run under ctest in the installed test suite