### PR TITLE
[ConstExprHoisting] Set the default threshold for hoisting to 0

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -378,7 +378,7 @@ static bool doesHoistingIncreaseSizeSignificantly(
         getRoundedPhysicalStorageSize(elementCount, type.getElementType());
   }
 
-  return outSize > inSize + threshold;
+  return outSize - threshold > inSize;
 }
 
 void ConstExprHoistingPolicy::makeInvariantDecision(

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -46,7 +46,7 @@ struct ExprHoistingOptions {
 
   // Threshold for controlling the maximum allowed increase in the stored size
   // of a single global as a result of hoisting.
-  int64_t maxSizeIncreaseThreshold = 2147483647;
+  int64_t maxSizeIncreaseThreshold = 0;
 };
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createHoistIntoGlobalsPass(const ExprHoistingOptions &options);

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -107,9 +107,9 @@ def HoistIntoGlobals : Pass<"iree-util-hoist-into-globals", "mlir::ModuleOp"> {
   }];
   let options = [
     Option<"maxSizeIncreaseThreshold", "max-size-increase-threshold", "int64_t",
-      /*default=*/"1048576",
+      /*default=*/"0",
       "Maximum byte size increase allowed for constant expr hoisting policy to"
-      "allow hoisting. The threshold is 1MB by default.">
+      "allow hoisting. By default no size increase is hoisted.">
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_linalg.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_linalg.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-util-hoist-into-globals %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-util-hoist-into-globals{max-size-increase-threshold=1024})' %s | FileCheck %s
 // Spot verification that policies for linalg ops is respected.
 
 // CHECK-LABEL: @compute_hoisted

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -92,7 +92,7 @@ struct GlobalOptimizationOptions {
 
   // Maximum byte size increase allowed for constant expr hoisting policy to
   // allow hoisting. The threshold is 1MB by default.
-  int64_t constExprMaxSizeIncreaseThreshold = 1024 * 1024;
+  int64_t constExprMaxSizeIncreaseThreshold = 0;
 
   // File path to create a parameter archive out of global initial values.
   std::string parameterArchiveExportPath = "";


### PR DESCRIPTION
Without a proper dialect interface for something safe to hoist, letting the hoisting logic ever increase the maximum size can produce unfortunate initializers given that it runs before fusion. For example,

```
  util.initializer attributes {iree.compiler.consteval} {
    %__elided__ = util.global.load @__elided__ : tensor<640xf16>
    %0 = flow.dispatch @main_dispatch_6::@main_dispatch_6_generic_640_f16xf32() : (tensor<640xf16>) -> tensor<640xf32>
    util.global.store %0, @hoisted_983 : tensor<640xf32>
    util.return
  }
```

Really small expression trees (i.e. on scalars) are the realm of op folders anyway.