### PR TITLE
[Util] Disable consteval for globals without serializable initial values

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h"
 #include "iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "iree/compiler/Dialect/Util/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "llvm/Support/Debug.h"
@@ -28,6 +29,47 @@ static llvm::cl::opt<std::string> clPrintDotGraphToFile(
         "Prints a dot graph representing the const-expr analysis. The red "
         "nodes represent roots and the green nodes represent hoisted values."),
     llvm::cl::value_desc("filename"));
+
+template <typename AccessorTy>
+static inline bool isAccessorParameterized(SymbolTable moduleSymbols,
+                                           AccessorTy op) {
+  auto global = moduleSymbols.lookup(op.getGlobalName());
+  if (!global) {
+    return true;
+  }
+  auto utilGlobal = cast<Util::GlobalOpInterface>(global);
+  if (!utilGlobal.getGlobalInitialValue()) {
+    return false;
+  }
+  return !isa<Util::SerializableAttrInterface>(
+      utilGlobal.getGlobalInitialValue());
+}
+
+// Today the only way to interact with a global is with loads, stores, and
+// addresses, and globals are the only way to reference parameters given where
+// const-eval is run today. This is a workaround until we have proper dialect
+// interfaces for detecting whether something is evaluatable at compile time.
+static bool isParameterized(SymbolTable moduleSymbols, Operation *initializer) {
+  WalkResult res = initializer->walk([&](Operation *op) {
+    if (auto accessor = dyn_cast<GlobalLoadOpInterface>(op)) {
+      if (isAccessorParameterized(moduleSymbols, accessor)) {
+        return WalkResult::interrupt();
+      }
+    }
+    if (auto accessor = dyn_cast<GlobalStoreOpInterface>(op)) {
+      if (isAccessorParameterized(moduleSymbols, accessor)) {
+        return WalkResult::interrupt();
+      }
+    }
+    if (auto accessor = dyn_cast<GlobalAddressOpInterface>(op)) {
+      if (isAccessorParameterized(moduleSymbols, accessor)) {
+        return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+  return res.wasInterrupted();
+}
 
 // Maps an original value in the program to the symbol name of a global.
 using HoistedValueMap = llvm::DenseMap<Value, GlobalOp>;
@@ -149,9 +191,6 @@ public:
       Location loc = originalValue.getLoc();
       OpBuilder builder = getModuleEndBuilder();
       auto initializerOp = builder.create<InitializerOp>(loc);
-      // Signals that this initializer is eligible for constant evaluation
-      // at compile time.
-      initializerOp->setAttr("iree.compiler.consteval", builder.getUnitAttr());
       Block *entryBlock = initializerOp.addEntryBlock();
       OpBuilder initBuilder = OpBuilder::atBlockEnd(entryBlock);
       IRMapping valueMapping;
@@ -162,6 +201,13 @@ public:
       }
 
       existingGlobal = hoistedMap.lookup(originalValue);
+
+      // Signals that this initializer is eligible for constant evaluation
+      // at compile time.
+      if (!isParameterized(moduleSymbols, initializerOp)) {
+        initializerOp->setAttr("iree.compiler.consteval",
+                               builder.getUnitAttr());
+      }
     }
     assert(existingGlobal &&
            "hoisting const-expr should have mapped a global for the requested "

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -343,3 +343,19 @@ module @nested_program_const_expr {
     }
   }
 }
+
+// -----
+
+// CHECK-LABEL: @parameterized_const_expr
+module @parameterized_const_expr {
+// Verify that the initializer does not get labelled as evaluatable by
+// const-eval.
+//      CHECK: util.initializer {
+// CHECK-NEXT:   util.global.load @parameter_constant
+  util.global private @parameter_constant = #stream.parameter.named<"compile"::"constant_hoisted_0"> : i32
+  func.func @main() -> (i32) {
+    %load = util.global.load @parameter_constant : i32
+    %1 = "iree_unregistered.const_expr"(%load) : (i32) -> i32
+    return %1 : i32
+  }
+}


### PR DESCRIPTION
Today this comes up in parameterized models, where the initial value of a global being parameter backed means that const-eval cannot evaluate the initializer (it's not available until module load time).

This is a workaround until we have proper dialect interfaces for controlling const-expr hoisting.