### PR TITLE
[ROCM] Add preload kernel argument hint

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -247,8 +247,8 @@ public:
     std::vector<std::array<int32_t, 3>> workgroupSizes;
     SmallVector<uint32_t> workgroupLocalMemories;
     int32_t subgroupSize = 64;
-    std::string subTarget = options.targetChip.substr(0, 4);
-    const std::string GFX9("gfx9");
+    StringRef subTarget = options.targetChip;
+    StringRef GFX9("gfx9");
     for (auto func : innerModuleOp.getOps<LLVM::LLVMFuncOp>()) {
       int32_t flatWgSize = 1;
       auto *llvmFunc = llvmModule->getFunction(func.getName());
@@ -291,7 +291,7 @@ public:
       if (options.wavesPerEu > 0)
         llvmFunc->addFnAttr("amdgpu-waves-per-eu",
                             std::to_string(options.wavesPerEu));
-      if (subTarget == GFX9)
+      if (subTarget.starts_with(GFX9))
         addPreloadKernArgHint(llvmFunc);
     }
 
@@ -310,7 +310,7 @@ public:
       opt.NoInfsFPMath = false;
       opt.NoNaNsFPMath = true;
       std::string features;
-      if (GFX9 == subTarget) {
+      if (subTarget.starts_with(GFX9)) {
         features = "+sramecc,-xnack";
       } else {
         // GFX 10 or 11.

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -114,6 +114,20 @@ static std::string translateModuleToISA(llvm::Module &module,
   return targetISA;
 }
 
+// Modified from lib/Target/AMDGPU/AMDGPUAttributor.cpp.
+// Adds argument hints to preload kernel arguments to SGPRs.
+// TODO: Query max number of user SGPRs from target machine.
+static void addPreloadKernArgHint(llvm::Function *F) {
+  constexpr unsigned long maxSGPRs = 16;
+  for (unsigned i = 0; i < std::min(F->arg_size(), maxSGPRs); ++i) {
+    llvm::Argument *Arg = F->getArg(i);
+    // Check for incompatible attributes.
+    if (Arg->hasByRefAttr() || Arg->hasNestAttr())
+      break;
+    Arg->addAttr(llvm::Attribute::InReg);
+  }
+}
+
 class ROCMTargetBackend final : public TargetBackend {
 public:
   ROCMTargetBackend(const ROCMOptions &options) : options(options) {}
@@ -233,6 +247,8 @@ public:
     std::vector<std::array<int32_t, 3>> workgroupSizes;
     SmallVector<uint32_t> workgroupLocalMemories;
     int32_t subgroupSize = 64;
+    std::string subTarget = options.targetChip.substr(0, 4);
+    const std::string GFX9("gfx9");
     for (auto func : innerModuleOp.getOps<LLVM::LLVMFuncOp>()) {
       int32_t flatWgSize = 1;
       auto *llvmFunc = llvmModule->getFunction(func.getName());
@@ -275,12 +291,13 @@ public:
       if (options.wavesPerEu > 0)
         llvmFunc->addFnAttr("amdgpu-waves-per-eu",
                             std::to_string(options.wavesPerEu));
+      if (subTarget == GFX9)
+        addPreloadKernArgHint(llvmFunc);
     }
 
     std::unique_ptr<llvm::TargetMachine> targetMachine;
     {
       llvm::Triple triple("amdgcn-amd-amdhsa");
-      const std::string GFX9("gfx9");
       std::string error;
       const llvm::Target *target =
           llvm::TargetRegistry::lookupTarget("", triple, error);
@@ -293,7 +310,6 @@ public:
       opt.NoInfsFPMath = false;
       opt.NoNaNsFPMath = true;
       std::string features;
-      std::string subTarget = options.targetChip.substr(0, 4);
       if (GFX9 == subTarget) {
         features = "+sramecc,-xnack";
       } else {


### PR DESCRIPTION
This PR adds a preload kernel argument hint for GFX9 devices that allows upto a maximum of 16 kernel
arguments to the user SGPRs.