### PR TITLE
Include the fx_importer from upstream in IREE compiler API builds.

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -141,6 +141,7 @@ if(IREE_INPUT_TORCH)
     ADD_TO_PARENT IREEPythonSources
     ROOT_DIR "${IREE_SOURCE_DIR}/third_party/torch-mlir/python/torch_mlir"
     SOURCES
+      extras/fx_importer.py
       extras/onnx_importer.py
   )
 

--- a/compiler/bindings/python/test/CMakeLists.txt
+++ b/compiler/bindings/python/test/CMakeLists.txt
@@ -5,5 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_subdirectory(api)
+add_subdirectory(extras)
 add_subdirectory(ir)
 add_subdirectory(tools)

--- a/compiler/bindings/python/test/extras/CMakeLists.txt
+++ b/compiler/bindings/python/test/extras/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if(IREE_INPUT_TORCH)
+  iree_py_test(
+    NAME
+      fx_importer_test
+    SRCS
+      "fx_importer_test.py"
+  )
+
+  iree_py_test(
+    NAME
+      onnx_importer_test
+    SRCS
+      "onnx_importer_test.py"
+  )
+endif()

--- a/compiler/bindings/python/test/extras/fx_importer_test.py
+++ b/compiler/bindings/python/test/extras/fx_importer_test.py
@@ -1,0 +1,18 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+try:
+    from iree.compiler.extras import fx_importer
+except ModuleNotFoundError as e:
+    while e is not None:
+        if isinstance(e, ModuleNotFoundError) and e.name == "torch":
+            break
+        e = e.__cause__
+    else:
+        raise ModuleNotFoundError(
+            "Failed to import the fx_importer (for a reason other than torch "
+            "not being found)"
+        ) from e

--- a/compiler/bindings/python/test/extras/onnx_importer_test.py
+++ b/compiler/bindings/python/test/extras/onnx_importer_test.py
@@ -1,0 +1,18 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+try:
+    from iree.compiler.extras import onnx_importer
+except ModuleNotFoundError as e:
+    while e is not None:
+        if isinstance(e, ModuleNotFoundError) and e.name == "onnx":
+            break
+        e = e.__cause__
+    else:
+        raise ModuleNotFoundError(
+            "Failed to import the fx_importer (for a reason other than onnx "
+            "not being found)"
+        ) from e


### PR DESCRIPTION
We've started to get contributions upstream and I would like to remove the forked code. This was designed to be re-exported from IREE, so just following through on that.

I've added tests for both the onnx importer and fx that validate that we indeed have them available, even if their dependencies aren't met.

Includes a bump of torch-mlir to HEAD to pick up https://github.com/llvm/torch-mlir/pull/2802 (Python 3.9 fix).