### PR TITLE
[ROCM] Fix `addPreloadKernArgHint`

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -118,7 +118,7 @@ static std::string translateModuleToISA(llvm::Module &module,
 // Adds argument hints to preload kernel arguments to SGPRs.
 // TODO: Query max number of user SGPRs from target machine.
 static void addPreloadKernArgHint(llvm::Function *F) {
-  constexpr unsigned long maxSGPRs = 16;
+  static constexpr size_t maxSGPRs = 16;
   for (size_t i = 0, e = std::min(F->arg_size(), maxSGPRs); i != e; ++i) {
     llvm::Argument *Arg = F->getArg(i);
     // Check for incompatible attributes.

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -119,7 +119,7 @@ static std::string translateModuleToISA(llvm::Module &module,
 // TODO: Query max number of user SGPRs from target machine.
 static void addPreloadKernArgHint(llvm::Function *F) {
   constexpr unsigned long maxSGPRs = 16;
-  for (unsigned i = 0; i < std::min(F->arg_size(), maxSGPRs); ++i) {
+  for (size_t i = 0, e = std::min(F->arg_size(), maxSGPRs); i != e; ++i) {
     llvm::Argument *Arg = F->getArg(i);
     // Check for incompatible attributes.
     if (Arg->hasByRefAttr() || Arg->hasNestAttr())


### PR DESCRIPTION
Use `size_t` to avoid type mismatches on Windows. Do not recalculate the trip count.

ci-extra: build_test_all_windows