### PR TITLE
[CPU] Enforce masking in DT pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -199,7 +199,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDataTiling: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
-    addCPUDataTilingPipeline(pipeline, tilingConfig, enableVectorMasking);
+    addCPUDataTilingPipeline(pipeline, tilingConfig);
     break;
   }
   // Transform-dialect pipelines.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -18,7 +18,6 @@
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Conversion/VectorToArmSME/VectorToArmSME.h"
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/ArmSME/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -536,8 +535,7 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager,
 }
 
 void addCPUDataTilingPipeline(OpPassManager &passManager,
-                              TilingConfig &tilingConfig,
-                              bool enableVectorMasking) {
+                              TilingConfig &tilingConfig) {
   addTileAndDistributePasses(passManager);
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
@@ -548,7 +546,12 @@ void addCPUDataTilingPipeline(OpPassManager &passManager,
   {
     GenericVectorizationPassOptions options;
     options.vectorizePadding = true;
-    options.enableVectorMasking = enableVectorMasking;
+    // Masking must be unconditionally enabled to generate transfer read ops
+    // with in-bounds accesses when vectorizing `tensor.pad`. Otherwise, there
+    // are patterns down the road that won't trigger and compilation will fail.
+    // TODO: Restore the flag `enableVectorMasking` flag when we have a good
+    // path for vectorizing tensor.pad without masking support.
+    options.enableVectorMasking = true;
     nestedModulePM.addNestedPass<func::FuncOp>(
         createGenericVectorizationPass(options));
     nestedModulePM.addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -141,8 +141,7 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager,
 
 /// Populates the passes to lower ops through data tiling transformations.
 void addCPUDataTilingPipeline(OpPassManager &passManager,
-                              TilingConfig &tilingConfig,
-                              bool enableVectorMasking);
+                              TilingConfig &tilingConfig);
 
 /// Populates the passes to lower to scalars operations for linalg based
 /// code-generation. This pipeline does not vectorize, but instead just


### PR DESCRIPTION
The current vectorization patterns for `tensor.pad` generate out of bounds transfer reads when masking is not enabled (e.g., Arm Neon). This leads to compilation errors down the road as out of bounds transfer reads are mostly unexpected and poorly lowered to LLVM. We should make sure we have a codegen strategy for targets without native masking support.

This PR enforcese masking in DT to make sure we don't accidentally fall into that issue, and let the masking emulation to the backend for those targets that don't support masking.

This fixes #16285