### PR TITLE
Adding `immutable` to global load ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -85,8 +85,7 @@ createBufferLikeGlobalOp(std::string name, Location loc, Type globalType,
   auto barrierOp = initializerBuilder.create<IREE::Util::OptimizationBarrierOp>(
       loc, bufferExportOp.getTarget());
   // util.global.store
-  initializerBuilder.create<IREE::Util::GlobalStoreOp>(
-      loc, barrierOp.getResult(0), globalOp.getName());
+  globalOp.createStoreOp(loc, barrierOp.getResult(0), initializerBuilder);
   initializerBuilder.create<IREE::Util::ReturnOp>(loc);
 
   return globalOp;
@@ -233,8 +232,9 @@ createEntryPointBenchmarkFunc(mlir::ModuleOp moduleOp,
   auto blockBuilder = OpBuilder::atBlockBegin(block);
   SmallVector<Value> args;
   for (int i = 0, e = entryFuncOp.getNumArguments(); i < e; ++i) {
-    args.push_back(blockBuilder.createOrFold<IREE::Util::GlobalLoadOp>(
-        loc, dummyInputVariableOps[i]));
+    args.push_back(dummyInputVariableOps[i]
+                       .createLoadOp(loc, blockBuilder)
+                       .getLoadedGlobalValue());
   }
   auto callOp = blockBuilder.create<mlir::func::CallOp>(loc, entryFuncOp, args);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -193,8 +193,7 @@ appendGlobalBuffer(Location loc, StringRef baseName,
       loc, globalOp.getType(), allocator, queueAffinity, memoryTypes,
       bufferUsage, indexSet.get(totalLength));
 
-  initBuilder.create<IREE::Util::GlobalStoreOp>(loc, allocateOp.getResult(),
-                                                globalOp.getNameAttr());
+  globalOp.createStoreOp(loc, allocateOp.getResult(), initBuilder);
   initBuilder.create<IREE::Util::ReturnOp>(loc);
 
   return globalOp;
@@ -289,9 +288,8 @@ static void appendDispatchBenchmark(IREE::HAL::ExecutableOp executableOp,
   }
 
   // Push descriptor sets.
-  auto buffer =
-      funcBuilder.create<IREE::Util::GlobalLoadOp>(loc, bufferGlobalOp)
-          .getResult();
+  Value buffer =
+      bufferGlobalOp.createLoadOp(loc, funcBuilder).getLoadedGlobalValue();
   int64_t currentSet = -1;
   SmallVector<IREE::HAL::DescriptorSetBindingValue> bindingValues;
   auto flushSet = [&]() {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
@@ -97,21 +97,18 @@ struct MemoizeDeviceQueriesPass
           fusedLoc, funcBuilder.getI1Type(), queryType, device,
           anyQueryOp.getCategoryAttr(), anyQueryOp.getKeyAttr(),
           anyQueryOp.getDefaultValueAttr());
-      funcBuilder.create<IREE::Util::GlobalStoreOp>(fusedLoc, queryOp.getOk(),
-                                                    okGlobalOp.getName());
-      funcBuilder.create<IREE::Util::GlobalStoreOp>(
-          fusedLoc, queryOp.getValue(), valueGlobalOp.getName());
+      okGlobalOp.createStoreOp(fusedLoc, queryOp.getOk(), funcBuilder);
+      valueGlobalOp.createStoreOp(fusedLoc, queryOp.getValue(), funcBuilder);
       funcBuilder.create<IREE::Util::ReturnOp>(fusedLoc);
 
       for (auto queryOp : queryOps) {
         OpBuilder replaceBuilder(queryOp);
-        auto okLoadOp = replaceBuilder.create<IREE::Util::GlobalLoadOp>(
-            fusedLoc, okGlobalOp.getType(), okGlobalOp.getName());
-        auto resultLoadOp = replaceBuilder.create<IREE::Util::GlobalLoadOp>(
-            fusedLoc, valueGlobalOp.getType(), valueGlobalOp.getName());
+        auto okLoadOp = okGlobalOp.createLoadOp(fusedLoc, replaceBuilder);
+        auto resultLoadOp =
+            valueGlobalOp.createLoadOp(fusedLoc, replaceBuilder);
         queryOp.replaceAllUsesWith(ValueRange{
-            okLoadOp.getResult(),
-            resultLoadOp.getResult(),
+            okLoadOp.getLoadedGlobalValue(),
+            resultLoadOp.getLoadedGlobalValue(),
         });
         queryOp.erase();
       }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -137,10 +137,9 @@ struct GlobalOpExpansion
         initialValueSize = rewriter.create<IREE::Stream::ResourceSizeOp>(
             globalOp.getLoc(), indexType, initialValue);
       }
-      rewriter.create<IREE::Util::GlobalStoreOp>(
-          globalOp.getLoc(), initialValue, resourceOp.getSymName());
-      rewriter.create<IREE::Util::GlobalStoreOp>(
-          globalOp.getLoc(), initialValueSize, resourceSizeOp.getSymName());
+      resourceOp.createStoreOp(globalOp.getLoc(), initialValue, rewriter);
+      resourceSizeOp.createStoreOp(globalOp.getLoc(), initialValueSize,
+                                   rewriter);
       rewriter.create<IREE::Util::ReturnOp>(globalOp.getLoc());
     }
 
@@ -162,7 +161,7 @@ struct GlobalLoadOpExpansion
     // Only apply to expanded types (tensors/etc).
     if (!isExpandedType(loadOp.getType()))
       return failure();
-    auto &expandedGlobal = expansionState->globalMap[adaptor.getGlobal()];
+    auto &expandedGlobal = this->expansionState->globalMap[adaptor.getGlobal()];
 
     // Insert a load/transfer to the unknown resource lifetime.
     auto unknownType = IREE::Stream::ResourceType::get(rewriter.getContext());

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -67,12 +67,12 @@ ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp) {
     if (!isLegalConstExprRootType(info->op.getGlobalType()))
       return;
     for (auto *use : info->uses) {
-      auto loadOp = llvm::dyn_cast<GlobalLoadOp>(use);
+      auto loadOp = llvm::dyn_cast<GlobalLoadOpInterface>(use);
       if (!loadOp)
         continue;
       if (!isHoistableToRootOp(rootOp, loadOp))
         continue;
-      constantRoots[loadOp.getResult()] = loadOp;
+      constantRoots[loadOp.getLoadedGlobalValue()] = loadOp;
     }
   });
 

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
@@ -145,8 +145,8 @@ struct ConvertMemRefGlobalOp : public OpConversionPattern<memref::GlobalOp> {
     auto constantOp = initializerBuilder.create<IREE::Util::BufferConstantOp>(
         globalOp.getLoc(), /*name=*/nullptr, globalOp.getInitialValueAttr(),
         alignmentAttr, /*mimeType=*/nullptr);
-    initializerBuilder.create<IREE::Util::GlobalStoreOp>(
-        globalOp.getLoc(), constantOp.getResult(), newOp.getName());
+    newOp.createStoreOp(globalOp.getLoc(), constantOp.getResult(),
+                        initializerBuilder);
     initializerBuilder.create<IREE::Util::ReturnOp>(globalOp.getLoc());
 
     return success();

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
@@ -126,6 +126,35 @@ struct GlobalOpInterfaceExternalModel
       op->removeAttr("noinline");
     }
   }
+
+  IREE::Util::GlobalLoadOpInterface createLoadOp(Operation *op, Location loc,
+                                                 OpBuilder &builder) const {
+    auto globalOp = cast<ml_program::GlobalOp>(op);
+    if (globalOp.getIsMutable()) {
+      return cast<IREE::Util::GlobalLoadOpInterface>(
+          builder
+              .create<ml_program::GlobalLoadOp>(
+                  loc, globalOp.getType(), FlatSymbolRefAttr::get(globalOp))
+              .getOperation());
+    } else {
+      return cast<IREE::Util::GlobalLoadOpInterface>(
+          builder
+              .create<ml_program::GlobalLoadConstOp>(
+                  loc, globalOp.getType(), FlatSymbolRefAttr::get(globalOp))
+              .getOperation());
+    }
+  }
+
+  IREE::Util::GlobalStoreOpInterface createStoreOp(Operation *op, Location loc,
+                                                   Value value,
+                                                   OpBuilder &builder) const {
+    auto globalOp = cast<ml_program::GlobalOp>(op);
+    return cast<IREE::Util::GlobalStoreOpInterface>(
+        builder
+            .create<ml_program::GlobalStoreOp>(
+                loc, FlatSymbolRefAttr::get(globalOp), value)
+            .getOperation());
+  }
 };
 
 } // namespace

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -296,6 +296,22 @@ def Util_GlobalOpInterface : OpInterface<"GlobalOpInterface"> {
         }
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Creates an operation loading the value of the global.
+      }],
+      /*retTy=*/"IREE::Util::GlobalLoadOpInterface",
+      /*methodName=*/"createLoadOp",
+      /*args=*/(ins "Location":$loc, "OpBuilder &":$builder)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Creates an operation storing the value of the global.
+      }],
+      /*retTy=*/"IREE::Util::GlobalStoreOpInterface",
+      /*methodName=*/"createStoreOp",
+      /*args=*/(ins "Location":$loc, "Value":$value, "OpBuilder &":$builder)
+    >,
   ];
 
   let verify = [{
@@ -349,6 +365,35 @@ def Util_GlobalAddressOpInterface : Util_GlobalAccessorOpInterface<"GlobalAddres
         return $_op->getResult(0);
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if the global whose address is taken is immutable outside
+        of initializers.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isGlobalImmutable",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return $_op.getIsImmutable();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Sets whether the global is immutable outside of initializers.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"setGlobalImmutable",
+      /*args=*/(ins "bool":$value),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        if (value) {
+          $_op.setIsImmutableAttr(UnitAttr::get($_op.getContext()));
+        } else {
+          $_op.removeIsImmutableAttr();
+        }
+      }]
+    >,
   ];
 }
 
@@ -386,6 +431,34 @@ def Util_GlobalLoadOpInterface : Util_GlobalAccessorOpInterface<"GlobalLoadOpInt
         return $_op->getResult(0);
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if the global loaded is immutable outside of initializers.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isGlobalImmutable",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return $_op.getIsImmutable();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Sets whether the global is immutable outside of initializers.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"setGlobalImmutable",
+      /*args=*/(ins "bool":$value),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        if (value) {
+          $_op.setIsImmutableAttr(UnitAttr::get($_op.getContext()));
+        } else {
+          $_op.removeIsImmutableAttr();
+        }
+      }]
+    >,
   ];
 }
 
@@ -421,6 +494,18 @@ def Util_GlobalStoreOpInterface : Util_GlobalAccessorOpInterface<"GlobalStoreOpI
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
         return $_op.getValue();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Sets the value stored by the operation.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"setStoredGlobalValue",
+      /*args=*/(ins "Value":$value),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return $_op.getValueMutable().assign(value);
       }]
     >,
   ];
@@ -483,6 +568,18 @@ def Util_GlobalStoreIndirectOpInterface : Util_GlobalIndirectAccessorOpInterface
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
         return $_op.getValue();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Sets the value stored by the operation.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"setStoredGlobalValue",
+      /*args=*/(ins "Value":$value),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return $_op.getValueMutable().assign(value);
       }]
     >,
   ];

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -789,6 +789,11 @@ def Util_GlobalOp : Util_Op<"global", [
     )>,
   ];
 
+  let extraClassDeclaration = [{
+    IREE::Util::GlobalLoadOpInterface createLoadOp(Location loc, OpBuilder &builder);
+    IREE::Util::GlobalStoreOpInterface createStoreOp(Location loc, Value value, OpBuilder &builder);
+  }];
+
   let hasCanonicalizer = 1;
 }
 
@@ -804,13 +809,15 @@ def Util_GlobalAddressOp : Util_PureOp<"global.address", [
   }];
 
   let arguments = (ins
-    Util_GlobalRefAttr:$global
+    Util_GlobalRefAttr:$global,
+    UnitAttr:$is_immutable
   );
   let results = (outs
     Util_AnyGlobalPtr:$result
   );
 
   let assemblyFormat = [{
+    (`immutable` $is_immutable^)?
     $global attr-dict `:` qualified(type($result))
   }];
 
@@ -834,13 +841,15 @@ def Util_GlobalLoadOp : Util_Op<"global.load", [
   }];
 
   let arguments = (ins
-    Arg<Util_GlobalRefAttr, "", []>:$global
+    Arg<Util_GlobalRefAttr, "", []>:$global,
+    UnitAttr:$is_immutable
   );
   let results = (outs
     AnyType:$result
   );
 
   let assemblyFormat = [{
+    (`immutable` $is_immutable^)?
     $global attr-dict `:` type($result)
   }];
 
@@ -867,13 +876,15 @@ def Util_GlobalLoadIndirectOp : Util_Op<"global.load.indirect", [
   }];
 
   let arguments = (ins
-    Arg<Util_AnyGlobalPtr, "", []>:$global
+    Arg<Util_AnyGlobalPtr, "", []>:$global,
+    UnitAttr:$is_immutable
   );
   let results = (outs
     AnyType:$result
   );
 
   let assemblyFormat = [{
+    (`immutable` $is_immutable^)?
     $global attr-dict `:` qualified(type($global)) `->` type($result)
   }];
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -287,6 +287,10 @@ detail::verifyGlobalAddressOp(GlobalAddressOpInterface addressOp,
   }
   // TODO(benvanik): allow type conversion here? probably better on the indirect
   // access ops instead as it's then easier to fold the conversion.
+  if (addressOp.isGlobalImmutable() && globalOp.isGlobalMutable()) {
+    return addressOp->emitOpError()
+           << "is marked as immutable but the global is mutable";
+  }
   return success();
 }
 
@@ -302,6 +306,10 @@ LogicalResult detail::verifyGlobalLoadOp(GlobalLoadOpInterface loadOp,
     return loadOp->emitOpError()
            << "global type mismatch; global " << globalOp.getGlobalName()
            << " is " << globalOp.getGlobalType() << " but load is " << loadType;
+  }
+  if (loadOp.isGlobalImmutable() && globalOp.isGlobalMutable()) {
+    return loadOp->emitOpError()
+           << "is marked as immutable but the global is mutable";
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OutlineConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OutlineConstants.cpp
@@ -101,14 +101,12 @@ public:
       auto globalOp = pair.second;
       OpBuilder builder(moduleOp.getContext());
       builder.setInsertionPoint(originalOp);
-      auto loadOp = builder.create<IREE::Util::GlobalLoadOp>(
-          originalOp->getLoc(), globalOp.getType(),
-          SymbolRefAttr::get(globalOp));
+      auto loadOp = globalOp.createLoadOp(originalOp->getLoc(), builder);
 
       Value replacement;
       if (auto constantOp = dyn_cast<arith::ConstantOp>(originalOp)) {
         // Directly replace constant with global constant value.
-        replacement = loadOp.getResult();
+        replacement = loadOp.getLoadedGlobalValue();
       } else {
         assert(false && "unhandled constant op type");
       }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
@@ -39,7 +39,7 @@ util.global private mutable @chained0 : index
 // CHECK-NOT: util.global private mutable @chained1 : index
 util.global private mutable @chained1 : index
 func.func @foo() -> index {
-  // CHECK: %[[VALUE:.+]] = util.global.load @chained0 : index
+  // CHECK: %[[VALUE:.+]] = util.global.load immutable @chained0 : index
   %0 = util.global.load @chained0 : index
   // CHECK-NOT: util.global.store
   util.global.store %0, @chained1 : index
@@ -135,9 +135,9 @@ util.global private @dupeCst0 {inlining_policy = #util.inline.never} = 5 : index
 // CHECK-NOT: util.global private @dupeCst1
 util.global private @dupeCst1 {inlining_policy = #util.inline.never} = 5 : index
 func.func @foo() -> (index, index) {
-  // CHECK-DAG: %[[VALUE0:.+]] = util.global.load @dupeCst0
+  // CHECK-DAG: %[[VALUE0:.+]] = util.global.load immutable @dupeCst0
   %0 = util.global.load @dupeCst0 : index
-  // CHECK-DAG: %[[VALUE1:.+]] = util.global.load @dupeCst0
+  // CHECK-DAG: %[[VALUE1:.+]] = util.global.load immutable @dupeCst0
   %1 = util.global.load @dupeCst1 : index
   // CHECK: return %[[VALUE0]], %[[VALUE1]]
   return %0, %1 : index, index

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -202,8 +202,9 @@ struct PropagateGlobalLoadAddress : public OpRewritePattern<INDIRECT> {
                                 PatternRewriter &rewriter) const override {
     if (auto addressOp = dyn_cast_or_null<IREE::Util::GlobalAddressOpInterface>(
             op.getGlobal().getDefiningOp())) {
-      rewriter.replaceOpWithNewOp<DIRECT>(op, op.getValue().getType(),
-                                          addressOp.getGlobalAttr());
+      rewriter.replaceOpWithNewOp<DIRECT>(
+          op, op.getValue().getType(), addressOp.getGlobalAttr(),
+          addressOp.isGlobalImmutable() ? rewriter.getUnitAttr() : UnitAttr{});
       return success();
     }
     return failure();

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -419,6 +419,60 @@ Block *InitializerOp::addBlock() {
 // Globals
 //===----------------------------------------------------------------------===//
 
+IREE::Util::GlobalLoadOpInterface
+GlobalI32Op::createLoadOp(Location loc, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalLoadI32Op>(loc, builder.getI32Type(),
+                                                   getGlobalName());
+}
+IREE::Util::GlobalStoreOpInterface
+GlobalI32Op::createStoreOp(Location loc, Value value, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalStoreI32Op>(loc, value,
+                                                    getGlobalName());
+}
+
+IREE::Util::GlobalLoadOpInterface
+GlobalI64Op::createLoadOp(Location loc, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalLoadI64Op>(loc, builder.getI64Type(),
+                                                   getGlobalName());
+}
+IREE::Util::GlobalStoreOpInterface
+GlobalI64Op::createStoreOp(Location loc, Value value, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalStoreI64Op>(loc, value,
+                                                    getGlobalName());
+}
+
+IREE::Util::GlobalLoadOpInterface
+GlobalF32Op::createLoadOp(Location loc, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalLoadF32Op>(loc, builder.getF32Type(),
+                                                   getGlobalName());
+}
+IREE::Util::GlobalStoreOpInterface
+GlobalF32Op::createStoreOp(Location loc, Value value, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalStoreF32Op>(loc, value,
+                                                    getGlobalName());
+}
+
+IREE::Util::GlobalLoadOpInterface
+GlobalF64Op::createLoadOp(Location loc, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalLoadF64Op>(loc, builder.getF64Type(),
+                                                   getGlobalName());
+}
+IREE::Util::GlobalStoreOpInterface
+GlobalF64Op::createStoreOp(Location loc, Value value, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalStoreF64Op>(loc, value,
+                                                    getGlobalName());
+}
+
+IREE::Util::GlobalLoadOpInterface
+GlobalRefOp::createLoadOp(Location loc, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalLoadRefOp>(loc, getType(),
+                                                   getSymName());
+}
+IREE::Util::GlobalStoreOpInterface
+GlobalRefOp::createStoreOp(Location loc, Value value, OpBuilder &builder) {
+  return builder.create<IREE::VM::GlobalStoreRefOp>(loc, value, getSymName());
+}
+
 template <typename T>
 static void addMemoryEffectsForGlobal(
     Operation *op, mlir::FlatSymbolRefAttr global,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -379,7 +379,10 @@ class VM_PrimitiveGlobalOp<string mnemonic, Attr attr_type, list<Trait> traits =
       IsolatedFromAbove,
       HasParent<"IREE::VM::ModuleOp">,
       Symbol,
-      Util_GlobalOpInterface,
+      DeclareOpInterfaceMethods<Util_GlobalOpInterface, [
+        "createLoadOp",
+        "createStoreOp",
+      ]>
     ])> {
   let arguments = (ins
     OptionalAttr<StrAttr>:$sym_visibility,
@@ -545,13 +548,15 @@ def VM_GlobalAddressOp : VM_PureOp<"global.address", [
   }];
 
   let arguments = (ins
-    VM_GlobalRefAttr:$global
+    VM_GlobalRefAttr:$global,
+    UnitAttr:$is_immutable
   );
   let results = (outs
     AnyTypeOf<[VM_Ptr, Util_AnyPtrType]>:$result
   );
 
   let assemblyFormat = [{
+    (`immutable` $is_immutable^)?
     $global attr-dict `:` type($result)
   }];
 
@@ -571,13 +576,15 @@ class VM_GlobalLoadOp<Type type, string mnemonic, list<Trait> traits = []> :
       DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     ])> {
   let arguments = (ins
-    VM_GlobalRefAttr:$global
+    VM_GlobalRefAttr:$global,
+    UnitAttr:$is_immutable
   );
   let results = (outs
     type:$value
   );
 
   let assemblyFormat = [{
+    (`immutable` $is_immutable^)?
     $global attr-dict `:` type($value)
   }];
 
@@ -645,13 +652,15 @@ class VM_GlobalLoadIndirectOp<Type type, string mnemonic,
       Util_GlobalLoadIndirectOpInterface,
     ])> {
   let arguments = (ins
-    AnyTypeOf<[VM_Ptr, Util_PtrOf<type>]>:$global
+    AnyTypeOf<[VM_Ptr, Util_PtrOf<type>]>:$global,
+    UnitAttr:$is_immutable
   );
   let results = (outs
     type:$value
   );
 
   let assemblyFormat = [{
+    (`immutable` $is_immutable^)?
     $global attr-dict `:` type($global) `->` type($value)
   }];
 }

--- a/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
@@ -174,9 +174,8 @@ public:
       auto funcOp = b.create<func::FuncOp>(getterName, funcType);
       funcOp.setPublic();
       b.setInsertionPointToStart(funcOp.addEntryBlock());
-      auto val = b.create<IREE::Util::GlobalLoadOp>(
-          newType, SymbolRefAttr::get(globalOp.getSymNameAttr()));
-      b.create<func::ReturnOp>(val.getResult());
+      auto val = globalOp.createLoadOp(globalOp.getLoc(), b);
+      b.create<func::ReturnOp>(val.getLoadedGlobalValue());
     }
 
     if (!setterName.empty() && isMutable) {
@@ -187,8 +186,7 @@ public:
       auto funcOp = b.create<func::FuncOp>(setterName, funcType);
       funcOp.setPublic();
       b.setInsertionPointToStart(funcOp.addEntryBlock());
-      b.create<IREE::Util::GlobalStoreOp>(funcOp.getArgument(0),
-                                          globalOp.getSymNameAttr());
+      globalOp.createStoreOp(globalOp.getLoc(), funcOp.getArgument(0), b);
       b.create<func::ReturnOp>();
     }
 

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ExportParameters.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ExportParameters.cpp
@@ -72,8 +72,8 @@ static void hoistConstantsIntoGlobals(mlir::ModuleOp moduleOp,
     arith::ConstantOp originalConstant = it.first;
     Util::GlobalOp globalOp = it.second;
     rewriter.setInsertionPointAfterValue(originalConstant);
-    Value load =
-        rewriter.create<Util::GlobalLoadOp>(globalOp->getLoc(), globalOp);
+    Value load = globalOp.createLoadOp(globalOp.getLoc(), rewriter)
+                     .getLoadedGlobalValue();
     rewriter.replaceOp(originalConstant, load);
   }
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -35,8 +35,9 @@ std::optional<int64_t> PerDimLayoutAttr::getShape(const LayoutDimension &dim) {
 bool LayoutAttr::isValidLayout(ArrayRef<int64_t> shape) const {
   for (auto perDimLayout : llvm::enumerate(getLayouts())) {
     ArrayRef<int64_t> layoutShape = perDimLayout.value().getShapes();
-    int64_t computedShape = std::reduce(layoutShape.begin(), layoutShape.end(),
-                                        1, std::multiplies<int64_t>());
+    int64_t computedShape =
+        std::reduce(layoutShape.begin(), layoutShape.end(),
+                    static_cast<int64_t>(1), std::multiplies<int64_t>());
     int64_t expectedShape = shape[perDimLayout.index()];
     if (computedShape != expectedShape) {
       return false;


### PR DESCRIPTION
This allows us to locally know whether a load is of an immutable global or not. We only ever make globals immutable during FoldGlobals and perform the fixup of all loads we can.

On programs with lots of globals this speeds things up quite a bit by dropping propagateLiveness from e.g. 20s->12s (sdxl_turbo_unet).