### PR TITLE
Switch benchmark and crosscompile jobs to use install-dir.

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -23,17 +23,23 @@ on:
         type: string
     outputs:
       build-dir:
-        description: |
-          Local path that stores compiled artifacts.
+        description: Local build directory path.
         value: ${{ jobs.build_all.outputs.build-dir }}
       build-dir-archive:
-        description: |
-          Local path to the zipped build directory.
+        description: Name of the zipped build directory.
         value: ${{ jobs.build_all.outputs.build-dir-archive }}
       build-dir-gcs-artifact:
-        description: |
-          GCS path to the uploaded build archive.
+        description: GCS path to the uploaded build archive.
         value: ${{ jobs.build_all.outputs.build-dir-gcs-artifact }}
+      install-dir:
+        description: Local install directory path.
+        value: ${{ jobs.build_all.outputs.install-dir }}
+      install-dir-archive:
+        description: Name of the zipped install directory.
+        value: ${{ jobs.build_all.outputs.install-dir-archive }}
+      install-dir-gcs-artifact:
+        description: GCS path to the uploaded install archive.
+        value: ${{ jobs.build_all.outputs.install-dir-gcs-artifact }}
 
 env:
   # This duplicates the variable from ci.yml. The variable needs to be in env
@@ -53,10 +59,19 @@ jobs:
       - os-family=Linux
     env:
       BUILD_DIR: full-build-dir
+      INSTALL_DIR: full-build-dir/install
     outputs:
-      # Pass through the build directory as output so it's available to
-      # dependent jobs.
       build-dir: ${{ env.BUILD_DIR }}
+      install-dir: ${{ env.INSTALL_DIR }}
+      # Pass the install directory as output for other jobs to use.
+      # TODO(#16203): replace this with iree-dist packages
+      #   The install directory provides a similar set of files and existing
+      #   jobs are already configured to use the build directory, so this is
+      #   an intermediate step towards a fully package-based CI setup.
+      install-dir-archive: ${{ steps.install-archive.outputs.install-dir-archive }}
+      install-dir-gcs-artifact: ${{ steps.install-upload.outputs.install-dir-gcs-artifact }}
+      # Pass the build directory as output for other jobs to use.
+      # DEPRECATED: prefer to use install-* instead.
       build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
       build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
     steps:
@@ -75,6 +90,7 @@ jobs:
             gcr.io/iree-oss/base@sha256:61e9aae211007dbad95e1f429e9e5121fd5968c204791038424979c21146cf75 \
             ./build_tools/cmake/build_all.sh \
             "${BUILD_DIR}"
+
       # Remove unused files to save disk space.
       # TODO(#16203): Switch to package-based CI
       #   This could also be an allow-list instead of a deny-list, but packages
@@ -83,6 +99,26 @@ jobs:
         run: find "${BUILD_DIR}" -type f -name "*.a" -print -delete
       - name: "Removing unused .o files"
         run: find "${BUILD_DIR}" -type f -name "*.o" -print -delete
+
+      # TODO(#16203): If this (or iree-dist) is small enough, just use GitHub
+      #   artifacts instead of `tar` commands and GCS
+      - name: "Creating install dir archive"
+        id: install-archive
+        env:
+          INSTALL_DIR_ARCHIVE: install_dir.tar.zst
+        run: |
+          tar -I 'zstd -T0' \
+            -cf ${INSTALL_DIR_ARCHIVE} ${INSTALL_DIR}
+          echo "install-dir-archive=${INSTALL_DIR_ARCHIVE}" >> "${GITHUB_OUTPUT}"
+      - name: "Uploading install dir archive"
+        id: install-upload
+        env:
+          INSTALL_DIR_ARCHIVE: ${{ steps.install-archive.outputs.install-dir-archive }}
+          INSTALL_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.install-archive.outputs.install-dir-archive }}
+        run: |
+          gcloud storage cp "${INSTALL_DIR_ARCHIVE}" "${INSTALL_DIR_GCS_ARTIFACT}"
+          echo "install-dir-gcs-artifact=${INSTALL_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+
       # Things get more complicated here than when we're just building the
       # runtime. The build directory is way bigger. We're also using on our own
       # runners on GCE. So uploading to GitHub actions artifact storage hosted

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -25,13 +25,13 @@ on:
       is-pr:
         required: true
         type: boolean
-      build-dir:
+      install-dir:
         required: true
         type: string
-      build-dir-archive:
+      install-dir-archive:
         required: true
         type: string
-      build-dir-gcs-artifact:
+      install-dir-gcs-artifact:
         required: true
         type: string
 
@@ -52,9 +52,9 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      HOST_BUILD_DIR: ${{ inputs.build-dir }}
-      HOST_BUILD_DIR_ARCHIVE: ${{ inputs.build-dir-archive }}
-      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ inputs.build-dir-gcs-artifact }}
+      INSTALL_DIR: ${{ inputs.install-dir }}
+      INSTALL_DIR_ARCHIVE: ${{ inputs.install-dir-archive }}
+      INSTALL_DIR_GCS_ARTIFACT: ${{ inputs.install-dir-gcs-artifact }}
       IREE_WRITE_REMOTE_CCACHE: ${{ inputs.write-caches }}
     outputs:
       target-build-dir: ${{ steps.build.outputs.target-build-dir }}
@@ -65,10 +65,10 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: "Checking out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+      - name: "Downloading install dir archive"
+        run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
+      - name: "Extracting install directory"
+        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Build cross-compiling target"
         id: build
         env:
@@ -80,7 +80,7 @@ jobs:
             --env "CCACHE_NAMESPACE=${DOCKER_IMAGE}" \
             --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
             --env "BUILD_PRESET=test" \
-            --env "IREE_HOST_BIN_DIR=${HOST_BUILD_DIR}/install/bin" \
+            --env "IREE_HOST_BIN_DIR=${INSTALL_DIR}/bin" \
             gcr.io/iree-oss/android@sha256:66bc80fc16e31de0bf64cfcdc65be37a35b7f6c5cd44e89707e35d34da961bb5 \
             build_tools/cmake/build_android.sh
           echo "target-build-dir=${TARGET_BUILD_DIR}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build_benchmark_tools.yml
+++ b/.github/workflows/build_benchmark_tools.yml
@@ -19,13 +19,13 @@ on:
       runner-env:
         required: true
         type: string
-      build-dir:
+      install-dir:
         required: true
         type: string
-      build-dir-archive:
+      install-dir-archive:
         required: true
         type: string
-      build-dir-gcs-artifact:
+      install-dir-gcs-artifact:
         required: true
         type: string
     outputs:
@@ -83,18 +83,18 @@ jobs:
       DOCKER_IMAGE: ${{ matrix.target.docker_image }}
       BUILD_SCRIPT: ${{ matrix.target.build_script }}
       BUILD_TOOLS_DIR: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools-dir
-      BUILD_DIR: ${{ inputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ inputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ inputs.build-dir-gcs-artifact }}
+      INSTALL_DIR: ${{ inputs.install-dir }}
+      INSTALL_DIR_ARCHIVE: ${{ inputs.install-dir-archive }}
+      INSTALL_DIR_GCS_ARTIFACT: ${{ inputs.install-dir-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: "Checking out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting host binaries"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
+      - name: "Downloading install dir archive"
+        run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
+      - name: "Extracting install directory"
+        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Compiling the benchmark tools"
         id: build
         run: |
@@ -102,7 +102,7 @@ jobs:
             --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
             --env "IREE_TARGET_ARCH=${ARCH}" \
             --env "BUILD_PRESET=benchmark" \
-            --env "IREE_HOST_BIN_DIR=${BUILD_DIR}/install/bin" \
+            --env "IREE_HOST_BIN_DIR=${INSTALL_DIR}/bin" \
             "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build"
       - name: "Compiling the benchmark tools with tracing"
         id: build-with-tracing
@@ -111,7 +111,7 @@ jobs:
             --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
             --env "IREE_TARGET_ARCH=${ARCH}" \
             --env "BUILD_PRESET=benchmark-with-tracing" \
-            --env "IREE_HOST_BIN_DIR=${BUILD_DIR}/install/bin" \
+            --env "IREE_HOST_BIN_DIR=${INSTALL_DIR}/bin" \
             "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build-traced"
       - name: "Downloading pre-built tracy capture tool"
         id: download-tracy-capture

--- a/.github/workflows/build_e2e_test_artifacts.yml
+++ b/.github/workflows/build_e2e_test_artifacts.yml
@@ -19,13 +19,13 @@ on:
       runner-env:
         required: true
         type: string
-      build-dir:
+      install-dir:
         required: true
         type: string
-      build-dir-archive:
+      install-dir-archive:
         required: true
         type: string
-      build-dir-gcs-artifact:
+      install-dir-gcs-artifact:
         required: true
         type: string
       benchmark-presets:
@@ -82,9 +82,9 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      HOST_BUILD_DIR: ${{ inputs.build-dir }}
-      HOST_BUILD_DIR_ARCHIVE: ${{ inputs.build-dir-archive }}
-      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ inputs.build-dir-gcs-artifact }}
+      INSTALL_DIR: ${{ inputs.install-dir }}
+      INSTALL_DIR_ARCHIVE: ${{ inputs.install-dir-archive }}
+      INSTALL_DIR_GCS_ARTIFACT: ${{ inputs.install-dir-gcs-artifact }}
     outputs:
       e2e-test-artifacts-dir: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
       e2e-test-artifacts-gcs-artifact-dir: ${{ steps.upload.outputs.e2e-test-artifacts-gcs-artifact-dir }}
@@ -95,10 +95,10 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: "Checking out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-      - name: "Extracting install from build dir archive"
-        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+      - name: "Downloading install dir archive"
+        run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
+      - name: "Extracting install directory"
+        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building e2e test artifacts"
         id: build
         env:
@@ -108,7 +108,7 @@ jobs:
           IREE_SHARD_COUNT: ${{ inputs.shard-count }}
         run: |
           build_tools/github_actions/docker_run.sh \
-            --env "IREE_HOST_BIN_DIR=${HOST_BUILD_DIR}/install/bin" \
+            --env "IREE_HOST_BIN_DIR=${INSTALL_DIR}/bin" \
             --env "IREE_BENCHMARK_PRESETS=${IREE_BENCHMARK_PRESETS}" \
             --env "IREE_BUILD_DEFAULT_BENCHMARK_SUITES=${IREE_BUILD_DEFAULT_BENCHMARK_SUITES}" \
             --env "IREE_SHARD_COUNT=${IREE_SHARD_COUNT}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,9 +829,9 @@ jobs:
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
       runner-env: ${{ needs.setup.outputs.runner-env }}
-      build-dir: ${{ needs.build_all.outputs.build-dir }}
-      build-dir-archive: ${{ needs.build_all.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      install-dir: ${{ needs.build_all.outputs.install-dir }}
+      install-dir-archive: ${{ needs.build_all.outputs.install-dir-archive }}
+      install-dir-gcs-artifact: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
 
   build_e2e_test_artifacts:
     needs: [setup, build_all]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1061,9 +1061,9 @@ jobs:
       runner-env: ${{ needs.setup.outputs.runner-env }}
       write-caches: ${{ needs.setup.outputs.write-caches }}
       is-pr: ${{ fromJson(needs.setup.outputs.is-pr) }}
-      build-dir: ${{ needs.build_all.outputs.build-dir }}
-      build-dir-archive: ${{ needs.build_all.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      install-dir: ${{ needs.build_all.outputs.install-dir }}
+      install-dir-archive: ${{ needs.build_all.outputs.install-dir-archive }}
+      install-dir-gcs-artifact: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
 
   test_benchmark_suites:
     needs: [setup, build_all, build_e2e_test_artifacts]
@@ -1095,9 +1095,9 @@ jobs:
       ARCH: ${{ matrix.target.arch }}
       DOCKER_IMAGE: ${{ matrix.target.docker_image }}
       RUN_SCRIPTS: ${{ matrix.target.run_scripts }}
-      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
+      INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
+      INSTALL_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
       TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
       E2E_TEST_ARTIFACTS_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
       E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
@@ -1106,10 +1106,10 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: "Checking out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+      - name: "Downloading install dir archive"
+        run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
+      - name: "Extracting install directory"
+        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       # TODO(#11136): Only download the needed artifacts instead of everything.
       - name: "Downloading e2e test artifacts"
         run: |
@@ -1122,7 +1122,7 @@ jobs:
             --env "IREE_TARGET_ARCH=${ARCH}" \
             --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
             --env "BUILD_PRESET=benchmark-suite-test" \
-            --env "IREE_HOST_BIN_DIR=${HOST_BUILD_DIR}/install/bin" \
+            --env "IREE_HOST_BIN_DIR=${INSTALL_DIR}/bin" \
             --env "E2E_TEST_ARTIFACTS_DIR=${E2E_TEST_ARTIFACTS_DIR}" \
             "${DOCKER_IMAGE}" \
             bash -euo pipefail -c \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -840,9 +840,9 @@ jobs:
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
       runner-env: ${{ needs.setup.outputs.runner-env }}
-      build-dir: ${{ needs.build_all.outputs.build-dir }}
-      build-dir-archive: ${{ needs.build_all.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      install-dir: ${{ needs.build_all.outputs.install-dir }}
+      install-dir-archive: ${{ needs.build_all.outputs.install-dir-archive }}
+      install-dir-gcs-artifact: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
       benchmark-presets: ${{ needs.setup.outputs.benchmark-presets }}
       shard-count: "c2-standard-60=2,default=1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1007,9 +1007,9 @@ jobs:
       DOCKER_IMAGE: ${{ matrix.target.docker_image }}
       BUILD_SCRIPT: ${{ matrix.target.build_script }}
       TEST_SCRIPT: ${{ matrix.target.test_script }}
-      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
+      INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
+      INSTALL_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
       TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
       IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
     steps:
@@ -1017,10 +1017,10 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: "Checking out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+      - name: "Downloading install dir archive"
+        run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
+      - name: "Extracting install directory"
+        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Build cross-compiling target"
         run: |
           ./build_tools/github_actions/docker_run.sh \
@@ -1032,7 +1032,7 @@ jobs:
             --env "IREE_TARGET_ABI=${ABI}" \
             --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
             --env "BUILD_PRESET=test" \
-            --env "IREE_HOST_BIN_DIR=${HOST_BUILD_DIR}/install/bin" \
+            --env "IREE_HOST_BIN_DIR=${INSTALL_DIR}/bin" \
             "${DOCKER_IMAGE}" \
             "${BUILD_SCRIPT}"
       - name: "Test cross-compiling target"


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/16203

The install directory is substantially smaller than the full build directory (3GB vs 6GB, both with debug symbols) and it is also much closer to a release package. Once all jobs are migrated to use the install directory (or iree-dist native packages / iree-compiler python packages), we can stop creating the "full build directory archive".

Since the directory is half as large, this cuts the download/extract time for each of these jobs from ~70 seconds to ~35 seconds. This does add another 30 seconds onto the end of the `build_all` job for "install-dir-archive", but we'll get 60 seconds back when we drop the "build-dir-archive".