### PR TITLE
Skip downloading submodules in test_tf_integrations jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,8 +502,6 @@ jobs:
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          submodules: true
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
@@ -532,8 +530,6 @@ jobs:
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          submodules: true
       - name: "Downloading build dir archive"
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"

--- a/build_tools/cmake/run_tf_tests.sh
+++ b/build_tools/cmake/run_tf_tests.sh
@@ -19,14 +19,17 @@ IREE_LLVM_CPU_DISABLE="${IREE_LLVM_CPU_DISABLE:-0}"
 # Disable the tests by default to reduce the test time.
 IREE_VMVX_DISABLE="${IREE_VMVX_DISABLE:-1}"
 
+# TODO(scotttodd): use build_tools/pkgci/setup_venv.py here instead of BUILD_DIR
 source "${BUILD_DIR}/.env" && export PYTHONPATH
 source build_tools/cmake/setup_tf_python.sh
 
+python3 -m pip install lit
+LIT_SCRIPT=$(which lit)
+
 echo "***** Running TensorFlow integration tests *****"
+
 # TODO: Use "--timeout 900" instead of --max-time below. Requires that
 # `psutil` python package be installed in the VM for per test timeout.
-LIT_SCRIPT="${ROOT_DIR}/third_party/llvm-project/llvm/utils/lit/lit.py"
-
 CMD=(
   python3
   "${LIT_SCRIPT}"

--- a/build_tools/cmake/run_tf_tests.sh
+++ b/build_tools/cmake/run_tf_tests.sh
@@ -24,7 +24,7 @@ source "${BUILD_DIR}/.env" && export PYTHONPATH
 source build_tools/cmake/setup_tf_python.sh
 
 python3 -m pip install lit
-LIT_SCRIPT=$(which lit)
+LIT_SCRIPT="$(which lit)"
 
 echo "***** Running TensorFlow integration tests *****"
 


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/16203.

Low-hanging fruit to shave some time (about 1 minute) off of these jobs. Steering towards having Python tests use the iree-compiler Python package, as in https://github.com/openxla/iree/blob/main/.github/workflows/pkgci.yml.

ci-exactly: build_all, test_tf_integrations, test_tf_integrations_gpu