### PR TITLE
Fix a few remaining uses of "cuda2" to "cuda".

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,6 +78,6 @@
 # Runtime
 /runtime/src/iree/ @benvanik
 /runtime/src/iree/hal/cts/ @ScottTodd
-/runtime/src/iree/hal/drivers/cuda2/ @antiagainst
+/runtime/src/iree/hal/drivers/cuda/ @antiagainst
 /runtime/src/iree/hal/drivers/metal/ @antiagainst
 /runtime/src/iree/hal/drivers/vulkan/ @antiagainst @ScottTodd

--- a/tests/e2e/stablehlo_ops/BUILD.bazel
+++ b/tests/e2e/stablehlo_ops/BUILD.bazel
@@ -409,7 +409,7 @@ CUDA_SRCS = enforce_glob(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_cuda2_graph",
+    name = "check_cuda_graph",
     srcs = CUDA_SRCS,
     compiler_flags = [
         # TODO(#13984): memset emulation required for graphs.
@@ -418,7 +418,7 @@ iree_check_single_backend_test_suite(
     ],
     driver = "cuda",
     input_type = "stablehlo",
-    runner_args = ["--cuda2_use_streams=false"],
+    runner_args = ["--cuda_use_streams=false"],
     tags = [
         # CUDA cuInit fails with sanitizer on.
         "noasan",
@@ -431,14 +431,14 @@ iree_check_single_backend_test_suite(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_cuda2_stream",
+    name = "check_cuda_stream",
     srcs = CUDA_SRCS,
     compiler_flags = [
         "--iree-hal-cuda-enable-legacy-sync=false",
     ],
     driver = "cuda",
     input_type = "stablehlo",
-    runner_args = ["--cuda2_use_streams=true"],
+    runner_args = ["--cuda_use_streams=true"],
     tags = [
         # CUDA cuInit fails with sanitizer on.
         "noasan",

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -304,7 +304,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_cuda2_graph
+    check_cuda_graph
   SRCS
     "abs.mlir"
     "add.mlir"
@@ -377,7 +377,7 @@ iree_check_single_backend_test_suite(
   INPUT_TYPE
     "stablehlo"
   RUNNER_ARGS
-    "--cuda2_use_streams=false"
+    "--cuda_use_streams=false"
   LABELS
     "noasan"
     "nomsan"
@@ -388,7 +388,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_cuda2_stream
+    check_cuda_stream
   SRCS
     "abs.mlir"
     "add.mlir"
@@ -460,7 +460,7 @@ iree_check_single_backend_test_suite(
   INPUT_TYPE
     "stablehlo"
   RUNNER_ARGS
-    "--cuda2_use_streams=true"
+    "--cuda_use_streams=true"
   LABELS
     "noasan"
     "nomsan"

--- a/tests/e2e/tosa_ops/BUILD.bazel
+++ b/tests/e2e/tosa_ops/BUILD.bazel
@@ -296,7 +296,7 @@ CUDA_SRCS = enforce_glob(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_cuda2_graph",
+    name = "check_cuda_graph",
     srcs = CUDA_SRCS,
     compiler_flags = [
         # TODO(#13984): memset emulation required for graphs.
@@ -305,7 +305,7 @@ iree_check_single_backend_test_suite(
     ],
     driver = "cuda",
     input_type = "tosa",
-    runner_args = ["--cuda2_use_streams=false"],
+    runner_args = ["--cuda_use_streams=false"],
     tags = [
         # CUDA cuInit fails with sanitizer on.
         "noasan",
@@ -318,14 +318,14 @@ iree_check_single_backend_test_suite(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_cuda2_stream",
+    name = "check_cuda_stream",
     srcs = CUDA_SRCS,
     compiler_flags = [
         "--iree-hal-cuda-enable-legacy-sync=false",
     ],
     driver = "cuda",
     input_type = "tosa",
-    runner_args = ["--cuda2_use_streams=true"],
+    runner_args = ["--cuda_use_streams=true"],
     tags = [
         # CUDA cuInit fails with sanitizer on.
         "noasan",
@@ -340,8 +340,8 @@ iree_check_single_backend_test_suite(
 test_suite(
     name = "check",
     tests = [
-        ":check_cuda2_graph",
-        ":check_cuda2_stream",
+        ":check_cuda_graph",
+        ":check_cuda_stream",
         ":check_llvm-cpu_local-task",
         ":check_vmvx_local-task",
         ":check_vulkan-spirv_vulkan",

--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -224,7 +224,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_cuda2_graph
+    check_cuda_graph
   SRCS
     "abs.mlir"
     "add.mlir"
@@ -276,7 +276,7 @@ iree_check_single_backend_test_suite(
   INPUT_TYPE
     "tosa"
   RUNNER_ARGS
-    "--cuda2_use_streams=false"
+    "--cuda_use_streams=false"
   LABELS
     "noasan"
     "nomsan"
@@ -287,7 +287,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_cuda2_stream
+    check_cuda_stream
   SRCS
     "abs.mlir"
     "add.mlir"
@@ -338,7 +338,7 @@ iree_check_single_backend_test_suite(
   INPUT_TYPE
     "tosa"
   RUNNER_ARGS
-    "--cuda2_use_streams=true"
+    "--cuda_use_streams=true"
   LABELS
     "noasan"
     "nomsan"


### PR DESCRIPTION
Saw these in logs and when browsing the CODEOWNERS file.