### PR TITLE
Bump LLVM to llvm/llvm-project@374629445137

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -265,7 +265,7 @@ struct ConvertBf16ToUInt16BuffersPass final
                                                      Operation *op) {
         return typeConverter.isLegal(cast<func::FuncOp>(op).getFunctionType());
       });
-      target.addLegalOp<arith::TruncFOp, arith::ExtFOp>();
+      target.addLegalOp<arith::TruncFOp, arith::ExtFOp, ModuleOp>();
       target.addDynamicallyLegalDialect<arith::ArithDialect, func::FuncDialect,
                                         IREE::HAL::HALDialect,
                                         memref::MemRefDialect, scf::SCFDialect>(

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_arith_to_f32.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_arith_to_f32.mlir
@@ -76,10 +76,9 @@ func.func @truncf_vector(%arg0 : vector<4xbf16>) -> vector<4xbf16> {
 }
 
 // CHECK-LABEL: @truncf_vector
-// CHECK: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<4xbf16>
+// CHECK: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<4xf32>
 // CHECK: %[[VAL0:.+]] = arith.extf %arg0 : vector<4xbf16> to vector<4xf32>
-// CHECK: %[[VAL1:.+]] = arith.extf %[[CST]] : vector<4xbf16> to vector<4xf32>
-// CHECK: %[[VAL2:.+]] = arith.addf %[[VAL1]], %[[VAL0]] : vector<4xf32>
+// CHECK: %[[VAL2:.+]] = arith.addf %[[VAL0]], %[[CST]] : vector<4xf32>
 // CHECK: %[[VAL3:.+]] = arith.truncf %[[VAL2]] : vector<4xf32> to vector<4xbf16>
 // CHECK: return %[[VAL3]] : vector<4xbf16>
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -749,7 +749,7 @@ struct MergeExecutableConstantBlocks
                targetRegion.getOps<IREE::HAL::ReturnOp>())) {
         llvm::append_range(resultValues, returnOp.getOperands());
         OpBuilder(returnOp).create<cf::BranchOp>(returnOp.getLoc(), nextBlock);
-        returnOp.erase();
+        rewriter.eraseOp(returnOp);
       }
     }
 


### PR DESCRIPTION
Additional fixes:
- Updated the bf16-to-uint16 pass to not apply to `module` operations
- updated bf16_arith_to_f32 test for new `vector` folder