### PR TITLE
Fix benchmark_large.yml to use install-dir with workflows.

### DIFF
--- a/.github/workflows/benchmark_large.yml
+++ b/.github/workflows/benchmark_large.yml
@@ -59,9 +59,9 @@ jobs:
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
       runner-env: ${{ needs.setup.outputs.runner-env }}
-      build-dir: ${{ needs.build_all.outputs.build-dir }}
-      build-dir-archive: ${{ needs.build_all.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      install-dir: ${{ needs.build_all.outputs.install-dir }}
+      install-dir-archive: ${{ needs.build_all.outputs.install-dir-archive }}
+      install-dir-gcs-artifact: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
 
   build_e2e_test_artifacts:
     needs: [setup, build_all]
@@ -70,9 +70,9 @@ jobs:
     with:
       runner-group: ${{ needs.setup.outputs.runner-group }}
       runner-env: ${{ needs.setup.outputs.runner-env }}
-      build-dir: ${{ needs.build_all.outputs.build-dir }}
-      build-dir-archive: ${{ needs.build_all.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      install-dir: ${{ needs.build_all.outputs.install-dir }}
+      install-dir-archive: ${{ needs.build_all.outputs.install-dir-archive }}
+      install-dir-gcs-artifact: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
       benchmark-presets: cuda-large,comp-stats-large,x86_64-large
       build-default-benchmark-suites: 0
       # Please keep the shard count default value in sync with on.workflow_dispatch.shard-count.default


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/16203

This was broken by https://github.com/openxla/iree/pull/16296. See history at https://github.com/openxla/iree/actions/workflows/benchmark_large.yml, sample logs: https://github.com/openxla/iree/actions/runs/7761526983: `The workflow is not valid. .github/workflows/benchmark_large.yml (Line: 58, Col: 11): Input install-dir is required, but not provided while calling. .github/workflows/benchmark_large.yml (Line: 58, Col: 11): Input install-dir-archive is required, but not provided while calling.`

Test run triggered at https://github.com/openxla/iree/actions/runs/7792320576

skip-ci: not covered by presubmit CI