### PR TITLE
ignore .orig and .rej files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ llvm-external-projects/iree-dialects/.cache
 
 # pkgci artifacts
 artifacts/
+
+# Side effects of local patching/merging
+*.orig
+*.rej


### PR DESCRIPTION
These are typically created by the `patch` command.

For exampe in https://github.com/openxla/iree/pull/16358 i'm removing an accidentally checked-in .orig file.