### PR TITLE
[compiler] Fix a bug in DenseMapInfo specialization for SmallVector

### DIFF
--- a/compiler/src/iree/compiler/Utils/SmallVectorDenseMapInfo.h
+++ b/compiler/src/iree/compiler/Utils/SmallVectorDenseMapInfo.h
@@ -29,11 +29,10 @@ struct DenseMapInfo<SmallVector<T, N>> {
   static unsigned getHashValue(const SmallVector<T, N> &v) {
     hash_code hash = llvm::DenseMapInfo<T>::getHashValue(
         llvm::DenseMapInfo<T>::getEmptyKey());
-    std::accumulate(v.begin(), v.end(), hash,
-                    [](hash_code hash, const T &element) {
-                      return hash_combine(hash, element);
-                    });
-    return hash;
+    return std::accumulate(v.begin(), v.end(), hash,
+                           [](hash_code hash, const T &element) {
+                             return hash_combine(hash, element);
+                           });
   }
 
   static bool isEqual(const SmallVector<T, N> &lhs,


### PR DESCRIPTION
Fix a bug in getHashValue that would make all hash values the same.