### PR TITLE
Add `GlobalLoopInvariantCodeMotionPass` to hoist constant `tensor.pack` from loops

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -54,6 +54,7 @@ iree_compiler_cc_library(
         "FuseDequantizationMatmul.cpp",
         "FuseSiluHorizontalMatmul.cpp",
         "GeneralizeLinalgNamedOps.cpp",
+        "GlobalLoopInvariantCodeMotion.cpp",
         "InferNumericNarrowing.cpp",
         "MaterializeHomogeneousEncodings.cpp",
         "OptimizeNumerics.cpp",

--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -116,6 +116,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorTransforms",
         "@llvm-project//mlir:TensorUtils",
+        "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
     ],
 )

--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -111,6 +111,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorTransforms",

--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -116,7 +116,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorTransforms",
         "@llvm-project//mlir:TensorUtils",
-        "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
     ],
 )

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -90,7 +90,6 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTensorTransforms
     MLIRTensorUtils
-    MLIRTransformUtils
     MLIRTransforms
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::CPU::CommonCPUPasses

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -90,6 +90,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTensorTransforms
     MLIRTensorUtils
+    MLIRTransformUtils
     MLIRTransforms
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::CPU::CommonCPUPasses

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -85,6 +85,7 @@ iree_cc_library(
     MLIRMemRefTransforms
     MLIRPass
     MLIRSCFDialect
+    MLIRSCFTransforms
     MLIRSupport
     MLIRTensorDialect
     MLIRTensorTransforms

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -50,6 +50,7 @@ iree_cc_library(
     "FuseDequantizationMatmul.cpp"
     "FuseSiluHorizontalMatmul.cpp"
     "GeneralizeLinalgNamedOps.cpp"
+    "GlobalLoopInvariantCodeMotion.cpp"
     "InferNumericNarrowing.cpp"
     "MaterializeHomogeneousEncodings.cpp"
     "OptimizeNumerics.cpp"

--- a/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
@@ -20,15 +20,17 @@
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
-// Check if the op is hoistable (but we might not want to hoist it alone).
-static bool isHoistableOp(Operation *op) {
-  return isMemoryEffectFree(op) && isSpeculatable(op) &&
-         !op->hasTrait<OpTrait::IsTerminator>();
-}
-
 // Check if the op is a leaf op we always want to hoist.
 static bool isHoistableLeafOp(Operation *op) {
-  return isa<tensor::PackOp, tensor::UnPackOp>(op);
+  // Currently it's limited to a small set of ops related to constant pack op.
+  return isa<tensor::PackOp>(op);
+}
+
+// Check if the op is hoistable (but we might not want to hoist it alone).
+static bool isHoistableOp(Operation *op) {
+  // Currently it's limited to a small set of ops related to constant pack op.
+  return op->hasTrait<OpTrait::ConstantLike>() || isa<tensor::EmptyOp>(op) ||
+         isHoistableLeafOp(op);
 }
 
 // Check if the op and its producers are loop invariants and hoistable. Results

--- a/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
@@ -20,38 +20,29 @@ using namespace mlir;
 #define DEBUG_TYPE "global-loop-invariant-code-motion"
 #define LICM_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 
-// Check if the op is a root op we always want to hoist.
-static bool isHoistableRootOp(Operation *op) {
-  // Currently it's limited to a small set of ops related to constant pack op.
-  return isa<tensor::PackOp>(op);
-}
-
-// Check if the op is hoistable (but we might not want to hoist it alone).
-static bool isHoistableOp(Operation *op) {
-  // Currently it's limited to a small set of ops related to constant pack op.
-  return op->hasTrait<OpTrait::ConstantLike>() || isa<tensor::EmptyOp>(op) ||
-         isHoistableRootOp(op);
-}
-
 // Check if the op and its producers are loop invariants and hoistable. Results
-// are cached in hoistableOpMap to avoid repeated traversals.
-static bool isBackwardSliceHoistable(
-    LoopLikeOpInterface loopOp, Operation *op,
-    llvm::SmallDenseMap<Operation *, bool> &hoistableOpMap) {
-  // First check if the op has been analyzed.
-  if (hoistableOpMap.contains(op))
-    return hoistableOpMap[op];
-
+// are cached in hoistableOpMap.
+//
+// It expects the op's producers have been checked and the results exist in
+// `hoistableOpMap`.
+static bool
+isHoistableOp(LoopLikeOpInterface loopOp, Operation *op,
+              llvm::SmallDenseMap<Operation *, bool> &hoistableOpMap) {
   // Currently we don't handle implicit captures, so don't hoist ops with
   // regions.
   if (op->getNumRegions() > 0) {
-    LLVM_DEBUG(LICM_DBGS() << "Non-hoistable: " << *op << "\n");
     hoistableOpMap[op] = false;
     return false;
   }
 
-  bool hoistable = true;
+  // Check if the op type is hoistable.
+  if (!isa<tensor::EmptyOp, tensor::PackOp>(op)) {
+    hoistableOpMap[op] = false;
+    return false;
+  }
+
   // Check if all producers are hoistable.
+  bool hoistable = true;
   for (OpOperand &operand : op->getOpOperands()) {
     Value value = operand.get();
     // Ignore values defined outside the loop.
@@ -59,55 +50,23 @@ static bool isBackwardSliceHoistable(
       continue;
 
     Operation *producer = value.getDefiningOp();
-    // If the producer is not an operation, don't hoist it; otherwise
-    // recursively check if the producer is hoistable.
-    if (!producer ||
-        !isBackwardSliceHoistable(loopOp, producer, hoistableOpMap)) {
+    // If the producer is not an operation, can't hoist it.
+    if (!producer) {
+      hoistable = false;
+      break;
+    }
+
+    auto producerResult = hoistableOpMap.find(producer);
+    assert(producerResult != hoistableOpMap.end() &&
+           "producer should have been checked");
+    if (!producerResult->second) {
       hoistable = false;
       break;
     }
   }
+
   hoistableOpMap[op] = hoistable;
-
-  LLVM_DEBUG(LICM_DBGS() << (hoistable ? "Hoistable: " : "Non-hoistable: ")
-                         << *op << "\n");
   return hoistable;
-}
-
-// Hoist ops and their backward slices out of the loop.
-static LogicalResult hoistOps(LoopLikeOpInterface loopOp,
-                              SmallVectorImpl<Operation *> &opsToHoist) {
-  llvm::SmallDenseSet<Operation *> visitedOps;
-  SmallVector<Operation *> worklist(opsToHoist.begin(), opsToHoist.end());
-  // Collect ops and their backward slices.
-  while (!worklist.empty()) {
-    Operation *op = worklist.back();
-    worklist.pop_back();
-
-    if (visitedOps.contains(op))
-      continue;
-    visitedOps.insert(op);
-
-    assert(op->getNumRegions() == 0 && "don't expect ops with regions yet");
-
-    for (OpOperand &operand : op->getOpOperands()) {
-      if (Operation *producer = operand.get().getDefiningOp()) {
-        // Only include producers inside the loop.
-        if (loopOp->isAncestor(producer))
-          worklist.push_back(producer);
-      }
-    }
-  }
-
-  // Sort the collected ops in topological order.
-  SmallVector<Operation *> orderedOpsToHoist = llvm::to_vector(visitedOps);
-  mlir::computeTopologicalSorting(orderedOpsToHoist);
-
-  // Hoist ops in topological order.
-  for (Operation *op : orderedOpsToHoist) {
-    loopOp.moveOutOfLoop(op);
-  }
-  return success();
 }
 
 static LogicalResult hoistLoopInvariants(LoopLikeOpInterface loopOp,
@@ -115,21 +74,20 @@ static LogicalResult hoistLoopInvariants(LoopLikeOpInterface loopOp,
   // First find the root ops can be hoisted. The root op needs to satisfy:
   // 1. It is a root op having benefits to be hoisted (e.g. tensor.pack)
   // 2. Its backward slice can be hoisted (e.g. they are loop invariant)
-  SmallVector<Operation *> rootOpsToHoist;
+  SmallVector<Operation *> opsToHoist;
   llvm::SmallDenseMap<Operation *, bool> hoistableOpMap;
   for (Region *region : loopOp.getLoopRegions()) {
     // Consider only the top-level ops in the region.
-    for (Operation &rootOp : region->getOps()) {
-      if (!isHoistableRootOp(&rootOp))
-        continue;
-
-      if (isBackwardSliceHoistable(loopOp, &rootOp, hoistableOpMap)) {
-        LLVM_DEBUG(LICM_DBGS() << "Found hoistable root: " << rootOp << "\n");
-        rootOpsToHoist.push_back(&rootOp);
+    // The forward visiting also ensures we are check and add ops in topological
+    // order.
+    for (Operation &op : region->getOps()) {
+      if (isHoistableOp(loopOp, &op, hoistableOpMap)) {
+        LLVM_DEBUG(LICM_DBGS() << "Found hoistable op: " << op << "\n");
+        opsToHoist.push_back(&op);
       }
     }
   }
-  if (rootOpsToHoist.empty())
+  if (opsToHoist.empty())
     return success();
 
   // Wrap the loop in zero-trip-check so the hoisted ops will only run when the
@@ -144,7 +102,12 @@ static LogicalResult hoistLoopInvariants(LoopLikeOpInterface loopOp,
   if (failed(wrappedLoop))
     return failure();
 
-  return hoistOps(*wrappedLoop, rootOpsToHoist);
+  // Hoist ops in their original insertion order, which is the topological
+  // order.
+  for (Operation *op : opsToHoist) {
+    wrappedLoop->moveOutOfLoop(op);
+  }
+  return success();
 }
 
 namespace mlir::iree_compiler::GlobalOptimization {

--- a/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/TopologicalSortUtils.h"
 
 #include "llvm/Support/Debug.h"
 
@@ -20,29 +19,23 @@ using namespace mlir;
 #define DEBUG_TYPE "global-loop-invariant-code-motion"
 #define LICM_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 
-// Check if the op and its producers are loop invariants and hoistable. Results
-// are cached in hoistableOpMap.
-//
-// It expects the op's producers have been checked and the results exist in
-// `hoistableOpMap`.
-static bool
-isHoistableOp(LoopLikeOpInterface loopOp, Operation *op,
-              llvm::SmallDenseMap<Operation *, bool> &hoistableOpMap) {
+// Check if the op and its producers are loop invariants and hoistable. Using
+// `hoistableOps` to check if producers are hoistable. It expects the op's
+// producers have been checked and the results exist in `hoistableOps`.
+static bool isHoistableOp(LoopLikeOpInterface loopOp, Operation *op,
+                          const llvm::SetVector<Operation *> &hoistableOps) {
   // Currently we don't handle implicit captures, so don't hoist ops with
   // regions.
   if (op->getNumRegions() > 0) {
-    hoistableOpMap[op] = false;
     return false;
   }
 
   // Check if the op type is hoistable.
   if (!isa<tensor::EmptyOp, tensor::PackOp>(op)) {
-    hoistableOpMap[op] = false;
     return false;
   }
 
   // Check if all producers are hoistable.
-  bool hoistable = true;
   for (OpOperand &operand : op->getOpOperands()) {
     Value value = operand.get();
     // Ignore values defined outside the loop.
@@ -52,46 +45,41 @@ isHoistableOp(LoopLikeOpInterface loopOp, Operation *op,
     Operation *producer = value.getDefiningOp();
     // If the producer is not an operation, can't hoist it.
     if (!producer) {
-      hoistable = false;
-      break;
+      return false;
     }
-
-    auto producerResult = hoistableOpMap.find(producer);
-    assert(producerResult != hoistableOpMap.end() &&
-           "producer should have been checked");
-    if (!producerResult->second) {
-      hoistable = false;
-      break;
+    if (!hoistableOps.contains(producer)) {
+      return false;
     }
   }
 
-  hoistableOpMap[op] = hoistable;
-  return hoistable;
+  return true;
 }
 
 static LogicalResult hoistLoopInvariants(LoopLikeOpInterface loopOp,
                                          RewriterBase &rewriter) {
-  // First find the root ops can be hoisted. The root op needs to satisfy:
-  // 1. It is a root op having benefits to be hoisted (e.g. tensor.pack)
-  // 2. Its backward slice can be hoisted (e.g. they are loop invariant)
-  SmallVector<Operation *> opsToHoist;
-  llvm::SmallDenseMap<Operation *, bool> hoistableOpMap;
+  // Find hoistable ops in the loop.
+  llvm::SetVector<Operation *> hoistableOps;
   for (Region *region : loopOp.getLoopRegions()) {
-    // Consider only the top-level ops in the region.
-    // The forward visiting also ensures we are check and add ops in topological
-    // order.
-    for (Operation &op : region->getOps()) {
-      if (isHoistableOp(loopOp, &op, hoistableOpMap)) {
+    // Skip loops with multi-block regions to simplify op's dependency.
+    if (!region->hasOneBlock())
+      return failure();
+
+    // Consider only the top-level ops in the region. The forward visiting in a
+    // single block ensures we are check and add ops in topological order.
+    for (Operation &op : region->front()) {
+      if (isHoistableOp(loopOp, &op, hoistableOps)) {
         LLVM_DEBUG(LICM_DBGS() << "Found hoistable op: " << op << "\n");
-        opsToHoist.push_back(&op);
+        hoistableOps.insert(&op);
       }
     }
   }
-  if (opsToHoist.empty())
+  if (hoistableOps.empty())
     return success();
 
   // Wrap the loop in zero-trip-check so the hoisted ops will only run when the
   // loop condition is ever satisfied.
+  // Assume the transformation only moves ops around in loop instead of clone
+  // them.
   FailureOr<LoopLikeOpInterface> wrappedLoop =
       TypeSwitch<Operation *, FailureOr<LoopLikeOpInterface>>(
           loopOp.getOperation())
@@ -102,9 +90,10 @@ static LogicalResult hoistLoopInvariants(LoopLikeOpInterface loopOp,
   if (failed(wrappedLoop))
     return failure();
 
-  // Hoist ops in their original insertion order, which is the topological
-  // order.
-  for (Operation *op : opsToHoist) {
+  // Hoist ops out of the loop in topological order.
+  for (Operation *op : hoistableOps) {
+    assert(wrappedLoop->getOperation()->isAncestor(op) &&
+           "assume hoistable ops still stay in the loop after transformation");
     wrappedLoop->moveOutOfLoop(op);
   }
   return success();

--- a/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
@@ -1,0 +1,178 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/GlobalOptimization/PassDetail.h"
+#include "iree/compiler/GlobalOptimization/Passes.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "global-loop-invariant-code-motion"
+#define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+
+namespace mlir::iree_compiler::GlobalOptimization {
+
+// Check if the op is hoistable (but we might not want to hoist it alone).
+static bool isHoistableOp(Operation *op) {
+  return isMemoryEffectFree(op) && isSpeculatable(op) &&
+         !op->hasTrait<OpTrait::IsTerminator>();
+}
+
+// Check if the op is a leaf op we always want to hoist.
+static bool isHoistableLeafOp(Operation *op) {
+  return isa<tensor::PackOp, tensor::UnPackOp>(op);
+}
+
+// Check if the op and its producers are loop invariants and hoistable. Results
+// are cached in hoistableOpMap to avoid repeated traversals.
+static bool
+checkHoistableTree(LoopLikeOpInterface loopOp, Operation *op,
+                   llvm::SmallDenseMap<Operation *, bool> &hoistableOpMap) {
+  // First check if the op has been analyzed.
+  if (hoistableOpMap.contains(op))
+    return hoistableOpMap[op];
+
+  // Check if the nested ops and the op itself are hoistable. And check if the
+  // producers of all operands are hoistable.
+  auto walkFn = [&](Operation *walkOp) {
+    // Check if the op is hoistable.
+    if (!isHoistableOp(walkOp))
+      return WalkResult::interrupt();
+
+    WalkResult result = WalkResult::advance();
+    // Check if the producers of operands are hoistable.
+    for (OpOperand &operand : walkOp->getOpOperands()) {
+      Value value = operand.get();
+      // Ignore values defined in a nested region or outside the loop.
+      if (walkOp->isAncestor(value.getParentRegion()->getParentOp()) ||
+          loopOp.isDefinedOutsideOfLoop(value)) {
+        continue;
+      }
+
+      Operation *producer = value.getDefiningOp();
+      // If the value is not an operation, we don't hoist it.
+      if (!producer || !checkHoistableTree(loopOp, producer, hoistableOpMap)) {
+        result = WalkResult::interrupt();
+        break;
+      }
+    }
+    return result;
+  };
+
+  bool hoistable = !op->walk(walkFn).wasInterrupted();
+  hoistableOpMap[op] = hoistable;
+
+  LLVM_DEBUG(KD_DBGS() << (hoistable ? "Hoistable: " : "Non-hoistable: ") << *op
+                       << "\n");
+  return hoistable;
+}
+
+// Call `moveOutOfLoop` to hoist op and its producer out of the loop. Ops are
+// hoisted in post-order to handle the dependencies (leaves of the producer tree
+// are hoisted first).
+static LogicalResult hoistProducerTree(Operation *op,
+                                       LoopLikeOpInterface loopOp) {
+  // Check if the op has been hoisted.
+  if (!loopOp->isAncestor(op))
+    return success();
+
+  // Walk all producers and hoist them first.
+  auto result = op->walk([&](Operation *walkOp) {
+    for (OpOperand &operand : walkOp->getOpOperands()) {
+      if (Operation *producer = operand.get().getDefiningOp()) {
+        if (failed(hoistProducerTree(producer, loopOp)))
+          return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+  if (result.wasInterrupted())
+    return failure();
+
+  // Hoist the op itself.
+  loopOp.moveOutOfLoop(op);
+  return success();
+}
+
+static LogicalResult hoistLoopInvariants(LoopLikeOpInterface loopOp,
+                                         RewriterBase &rewriter) {
+  SmallVector<Operation *> opsToHoist;
+
+  llvm::SmallDenseMap<Operation *, bool> hoistableOpMap;
+  for (Region *region : loopOp.getLoopRegions()) {
+    // Check top-level ops.
+    for (Operation &op : region->getOps()) {
+      if (!isHoistableLeafOp(&op))
+        continue;
+      if (checkHoistableTree(loopOp, &op, hoistableOpMap)) {
+        LLVM_DEBUG(KD_DBGS() << "Found hoistable leaf: " << op << "\n");
+        opsToHoist.push_back(&op);
+      }
+    }
+  }
+  if (opsToHoist.empty())
+    return success();
+
+  // Wrap the loop in zero-trip-check so the hoisted ops will only run when the
+  // loop condition is ever satisfied.
+  auto wrappedLoop =
+      TypeSwitch<Operation *, FailureOr<LoopLikeOpInterface>>(
+          loopOp.getOperation())
+          .Case<scf::WhileOp>([&](scf::WhileOp op) {
+            return scf::wrapWhileLoopInZeroTripCheck(op, rewriter);
+          })
+          .Default([&](Operation *op) { return failure(); });
+  if (failed(wrappedLoop))
+    return failure();
+
+  // Hoist ops in order to handle the dependencies.
+  for (Operation *op : opsToHoist) {
+    if (failed(hoistProducerTree(op, wrappedLoop.value())))
+      return failure();
+  }
+
+  return success();
+}
+
+namespace {
+
+struct GlobalLoopInvariantCodeMotionPass
+    : public GlobalLoopInvariantCodeMotionBase<
+          GlobalLoopInvariantCodeMotionPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    FunctionOpInterface funcOp = getOperation();
+
+    SmallVector<LoopLikeOpInterface> candidateLoops;
+    // Candidate loops are visited in post-order so a loop invariant has chances
+    // to move across multiple loop levels.
+    funcOp.walk([&](LoopLikeOpInterface op) {
+      // Check if the loop type is supported.
+      if (isa<scf::WhileOp>(op))
+        candidateLoops.push_back(op);
+      return;
+    });
+
+    IRRewriter rewriter(context);
+    for (auto loopOp : candidateLoops) {
+      if (failed(hoistLoopInvariants(loopOp, rewriter)))
+        return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createGlobalLoopInvariantCodeMotionPass() {
+  return std::make_unique<GlobalLoopInvariantCodeMotionPass>();
+}
+} // namespace mlir::iree_compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 
 #include "llvm/Support/Debug.h"
 

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -145,9 +145,11 @@ void buildGlobalOptimizationPassPipeline(
     mainPassManager.addPass(createCSEPass());
     mainPassManager.addPass(createSimplifyPackUnpackPass());
   }
-  // Generalize transposes and any other remaining named linalg ops that can now
-  // be represented as generics.
-  FunctionLikeNest(mainPassManager).addPass(createGeneralizeLinalgNamedOpsPass);
+  FunctionLikeNest(mainPassManager)
+      // Generalize transposes and any other remaining named linalg ops that can
+      // now be represented as generics.
+      .addPass(createGeneralizeLinalgNamedOpsPass)
+      .addPass(createGlobalLoopInvariantCodeMotionPass);
 
   OpPassManager pipeline(ModuleOp::getOperationName());
   FunctionLikeNest(pipeline)

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -145,11 +145,15 @@ void buildGlobalOptimizationPassPipeline(
     mainPassManager.addPass(createCSEPass());
     mainPassManager.addPass(createSimplifyPackUnpackPass());
   }
+  // Generalize transposes and any other remaining named linalg ops that can
+  // now be represented as generics.
+  FunctionLikeNest(mainPassManager).addPass(createGeneralizeLinalgNamedOpsPass);
+
+  // Hoist loop invariants (e.g. from scf loops) with zero-trip-check.
   FunctionLikeNest(mainPassManager)
-      // Generalize transposes and any other remaining named linalg ops that can
-      // now be represented as generics.
-      .addPass(createGeneralizeLinalgNamedOpsPass)
-      .addPass(createGlobalLoopInvariantCodeMotionPass);
+      .addPass(createGlobalLoopInvariantCodeMotionPass)
+      .addPass(mlir::createCanonicalizerPass)
+      .addPass(mlir::createCSEPass);
 
   OpPassManager pipeline(ModuleOp::getOperationName());
   FunctionLikeNest(pipeline)

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -110,7 +110,7 @@ std::unique_ptr<Pass> createSetEncodingPass();
 /// Simplifies tensor pack/unpack ops to reshape ops.
 std::unique_ptr<Pass> createSimplifyPackUnpackPass();
 
-/// TODO
+/// Hoist loop invariants out of loops with zero-trip-check.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createGlobalLoopInvariantCodeMotionPass();
 

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -110,6 +110,10 @@ std::unique_ptr<Pass> createSetEncodingPass();
 /// Simplifies tensor pack/unpack ops to reshape ops.
 std::unique_ptr<Pass> createSimplifyPackUnpackPass();
 
+/// TODO
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createGlobalLoopInvariantCodeMotionPass();
+
 void registerGlobalOptimizationPipeline();
 
 } // namespace mlir::iree_compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -129,7 +129,7 @@ def SimplifyPackUnpack : Pass<"iree-global-opt-simplify-pack-unpack", ""> {
 }
 
 def GlobalLoopInvariantCodeMotion : InterfacePass<"iree-global-opt-loop-invariant-code-motion", "mlir::FunctionOpInterface"> {
-  let summary = "TODO";
+  let summary = "Hoist loop invariants out of loops with zero-trip-check";
   let constructor = "mlir::iree_compiler::GlobalOptimization::createGlobalLoopInvariantCodeMotionPass()";
 }
 

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -128,4 +128,9 @@ def SimplifyPackUnpack : Pass<"iree-global-opt-simplify-pack-unpack", ""> {
   let constructor = "mlir::iree_compiler::GlobalOptimization::createSimplifyPackUnpackPass()";
 }
 
+def GlobalLoopInvariantCodeMotion : InterfacePass<"iree-global-opt-loop-invariant-code-motion", "mlir::FunctionOpInterface"> {
+  let summary = "TODO";
+  let constructor = "mlir::iree_compiler::GlobalOptimization::createGlobalLoopInvariantCodeMotionPass()";
+}
+
 #endif // IREE_COMPILER_GLOBALOPTIMIZATION_PASSES

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "fuse_dequantization_matmul.mlir",
             "fuse_silu_horizontal_matmul.mlir",
             "generalize_named_ops.mlir",
+            "global_loop_invariant_code_motion.mlir",
             "hoist_into_globals_linalg.mlir",
             "infer_numeric_narrowing.mlir",
             "materialize_homogeneous_encodings.mlir",

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     "fuse_dequantization_matmul.mlir"
     "fuse_silu_horizontal_matmul.mlir"
     "generalize_named_ops.mlir"
+    "global_loop_invariant_code_motion.mlir"
     "hoist_into_globals_linalg.mlir"
     "infer_numeric_narrowing.mlir"
     "materialize_homogeneous_encodings.mlir"

--- a/compiler/src/iree/compiler/GlobalOptimization/test/global_loop_invariant_code_motion.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/global_loop_invariant_code_motion.mlir
@@ -138,7 +138,7 @@ func.func @hoist_pack_op_with_zero_trip_check_in_outer_loop(%bound : i32, %src :
 
 // -----
 
-func.func @not_hoist_loop_variant_and_non_leaf_alone(%bound : i32, %src : tensor<100x100xf32>) -> tensor<100x100xf32> {
+func.func @not_hoist_loop_variant(%bound : i32, %src : tensor<100x100xf32>) -> tensor<100x100xf32> {
   %cst0 = arith.constant 0 : i32
   %cst1 = arith.constant 1 : i32
   %pad0 = arith.constant 0.0 : f32
@@ -159,14 +159,13 @@ func.func @not_hoist_loop_variant_and_non_leaf_alone(%bound : i32, %src : tensor
   return %res#1 : tensor<100x100xf32>
 }
 
-// CHECK-LABEL: func.func @not_hoist_loop_variant_and_non_leaf_alone
-// CHECK-NOT:     tensor.empty
+// CHECK-LABEL: func.func @not_hoist_loop_variant
+// CHECK-DAG:     %[[PACK_DEST:.+]] = tensor.empty
+// CHECK-DAG:     %[[UNPACK_DEST:.+]] = tensor.empty
 // CHECK-NOT:     tensor.pack
 // CHECK-NOT:     tensor.unpack
 // CHECK:         scf.while
-// CHECK:           %[[PACK_DEST:.+]] = tensor.empty
 // CHECK:           tensor.pack {{.*}} into %[[PACK_DEST]]
-// CHECK:           %[[UNPACK_DEST:.+]] = tensor.empty
 // CHECK:           tensor.unpack {{.*}} into %[[UNPACK_DEST]]
 // CHECK:           scf.condition
 // CHECK:         } do {

--- a/compiler/src/iree/compiler/GlobalOptimization/test/global_loop_invariant_code_motion.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/global_loop_invariant_code_motion.mlir
@@ -1,0 +1,128 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-global-opt-loop-invariant-code-motion,cse))" --split-input-file %s | FileCheck %s
+
+func.func @hoist_pack_op_with_zero_trip_check(%bound : i32, %src : tensor<100x100xf32>) -> tensor<13x13x8x8xf32> {
+  %cst0 = arith.constant 0 : i32
+  %cst1 = arith.constant 1 : i32
+  %pad0 = arith.constant 0.0 : f32
+  %init = arith.constant dense<0.0> : tensor<13x13x8x8xf32>
+  %res:2 = scf.while (%iter = %cst0, %val = %init) : (i32, tensor<13x13x8x8xf32>) -> (i32, tensor<13x13x8x8xf32>) {
+    %cond = arith.cmpi slt, %iter, %bound : i32
+    scf.condition(%cond) %iter, %val : i32, tensor<13x13x8x8xf32>
+  } do {
+  ^bb0(%arg1: i32, %arg2: tensor<13x13x8x8xf32>):
+    %dest = tensor.empty() : tensor<13x13x8x8xf32>
+    %pack = tensor.pack %src padding_value(%pad0 : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %dest : tensor<100x100xf32> -> tensor<13x13x8x8xf32>
+    %add = arith.addf %arg2, %pack : tensor<13x13x8x8xf32>
+    %next = arith.addi %arg1, %cst1 : i32
+    scf.yield %next, %add : i32, tensor<13x13x8x8xf32>
+  }
+  return %res#1 : tensor<13x13x8x8xf32>
+}
+
+// CHECK-LABEL: func.func @hoist_pack_op_with_zero_trip_check
+// CHECK-SAME:      (%[[BOUND:.+]]: i32, %[[SRC:.+]]: tensor<100x100xf32>)
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : i32
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-DAG:     %[[PAD:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:     %[[INIT:.+]] = arith.constant dense<0.000000e+00> : tensor<13x13x8x8xf32>
+// CHECK:         %[[PRECOND:.+]] = arith.cmpi slt, %[[C0]], %[[BOUND]] : i32
+// CHECK:         %[[RES:.+]]:2 = scf.if %[[PRECOND]] -> (i32, tensor<13x13x8x8xf32>) {
+// CHECK:           %[[DEST:.+]] = tensor.empty() : tensor<13x13x8x8xf32>
+// CHECK:           %[[PACK:.+]] = tensor.pack %[[SRC]] padding_value(%[[PAD]] : f32)
+// CHECK-SAME:          inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %[[DEST]]
+// CHECK-SAME:          : tensor<100x100xf32> -> tensor<13x13x8x8xf32>
+// CHECK:           %[[LOOP:.+]]:2 = scf.while (%[[ARG2:.+]] = %[[C0]], %[[ARG3:.+]] = %[[INIT]])
+// CHECK-SAME:          : (i32, tensor<13x13x8x8xf32>) -> (i32, tensor<13x13x8x8xf32>) {
+// CHECK:             %[[ADD:.+]] = arith.addf %[[ARG3]], %[[PACK]] : tensor<13x13x8x8xf32>
+// CHECK:             %[[NEXT:.+]] = arith.addi %[[ARG2]], %[[C1]] : i32
+// CHECK:             %[[COND:.+]] = arith.cmpi slt, %[[NEXT]], %[[BOUND]] : i32
+// CHECK:             scf.condition(%[[COND]]) %[[NEXT]], %[[ADD]] : i32, tensor<13x13x8x8xf32>
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[ARG4:.+]]: i32, %[[ARG5:.+]]: tensor<13x13x8x8xf32>):
+// CHECK:             scf.yield %[[ARG4]], %[[ARG5]] : i32, tensor<13x13x8x8xf32>
+// CHECK:           }
+// CHECK:           scf.yield %[[LOOP]]#0, %[[LOOP]]#1 : i32, tensor<13x13x8x8xf32>
+// CHECK:         } else {
+// CHECK:           scf.yield %[[C0]], %[[INIT]] : i32, tensor<13x13x8x8xf32>
+// CHECK:         }
+// CHECK:         return %[[RES]]#1 : tensor<13x13x8x8xf32>
+
+// -----
+
+func.func @hoist_pack_op_from_do_while(%bound : i32, %src : tensor<100x100xf32>) -> tensor<13x13x8x8xf32> {
+  %cst0 = arith.constant 0 : i32
+  %cst1 = arith.constant 1 : i32
+  %pad0 = arith.constant 0.0 : f32
+  %init = arith.constant dense<0.0> : tensor<13x13x8x8xf32>
+  %res:2 = scf.while (%iter = %cst0, %val = %init) : (i32, tensor<13x13x8x8xf32>) -> (i32, tensor<13x13x8x8xf32>) {
+    %dest = tensor.empty() : tensor<13x13x8x8xf32>
+    %pack = tensor.pack %src padding_value(%pad0 : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %dest : tensor<100x100xf32> -> tensor<13x13x8x8xf32>
+    %add = arith.addf %val, %pack : tensor<13x13x8x8xf32>
+    %next = arith.addi %iter, %cst1 : i32
+    %cond = arith.cmpi slt, %next, %bound : i32
+    scf.condition(%cond) %next, %add : i32, tensor<13x13x8x8xf32>
+  } do {
+  ^bb0(%arg1: i32, %arg2: tensor<13x13x8x8xf32>):
+    scf.yield %arg1, %arg2 : i32, tensor<13x13x8x8xf32>
+  }
+  return %res#1 : tensor<13x13x8x8xf32>
+}
+
+// CHECK-LABEL: func.func @hoist_pack_op_from_do_while
+// CHECK-SAME:      (%[[BOUND:.+]]: i32, %[[SRC:.+]]: tensor<100x100xf32>)
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : i32
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-DAG:     %[[PAD:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:     %[[INIT:.+]] = arith.constant dense<0.000000e+00> : tensor<13x13x8x8xf32>
+// CHECK-NOT:     scf.if
+// CHECK:         %[[DEST:.+]] = tensor.empty() : tensor<13x13x8x8xf32>
+// CHECK:         %[[PACK:.+]] = tensor.pack %[[SRC]] padding_value(%[[PAD]] : f32)
+// CHECK:             inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %[[DEST]] : tensor<100x100xf32> -> tensor<13x13x8x8xf32>
+// CHECK:         %[[LOOP:.+]]:2 = scf.while (%[[ARG2:.+]] = %[[C0]], %[[ARG3:.+]] = %[[INIT]])
+// CHECK-SAME:        (i32, tensor<13x13x8x8xf32>) -> (i32, tensor<13x13x8x8xf32>) {
+// CHECK:           %[[ADD:.+]] = arith.addf %[[ARG3]], %[[PACK]] : tensor<13x13x8x8xf32>
+// CHECK:           %[[NEXT:.+]] = arith.addi %[[ARG2]], %[[C1]] : i32
+// CHECK:           %[[COND:.+]] = arith.cmpi slt, %[[NEXT]], %[[BOUND]] : i32
+// CHECK:           scf.condition(%[[COND]]) %[[NEXT]], %[[ADD]] : i32, tensor<13x13x8x8xf32>
+// CHECK:         } do {
+// CHECK:         ^bb0(%[[ARG4:.+]]: i32, %[[ARG5:.+]]: tensor<13x13x8x8xf32>):
+// CHECK:           scf.yield %[[ARG4]], %[[ARG5]] : i32, tensor<13x13x8x8xf32>
+// CHECK:         }
+// CHECK:         return %[[LOOP]]#1 : tensor<13x13x8x8xf32>
+
+// -----
+
+func.func @not_hoist_loop_variant_and_non_leaf_alone(%bound : i32, %src : tensor<100x100xf32>) -> tensor<100x100xf32> {
+  %cst0 = arith.constant 0 : i32
+  %cst1 = arith.constant 1 : i32
+  %pad0 = arith.constant 0.0 : f32
+  %bias = arith.constant dense<1.0> : tensor<13x13x8x8xf32>
+  %res:2 = scf.while (%iter = %cst0, %val = %src) : (i32, tensor<100x100xf32>) -> (i32, tensor<100x100xf32>) {
+    %pack_dest = tensor.empty() : tensor<13x13x8x8xf32>
+    %pack = tensor.pack %val padding_value(%pad0 : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %pack_dest : tensor<100x100xf32> -> tensor<13x13x8x8xf32>
+    %add = arith.addf %pack, %bias : tensor<13x13x8x8xf32>
+    %unpack_dest = tensor.empty() : tensor<100x100xf32>
+    %unpack = tensor.unpack %add inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %unpack_dest : tensor<13x13x8x8xf32> -> tensor<100x100xf32>
+    %next = arith.addi %iter, %cst1 : i32
+    %cond = arith.cmpi slt, %next, %bound : i32
+    scf.condition(%cond) %next, %unpack : i32, tensor<100x100xf32>
+  } do {
+  ^bb0(%arg1: i32, %arg2: tensor<100x100xf32>):
+    scf.yield %arg1, %arg2 : i32, tensor<100x100xf32>
+  }
+  return %res#1 : tensor<100x100xf32>
+}
+
+// CHECK-LABEL: func.func @not_hoist_loop_variant_and_non_leaf_alone
+// CHECK-NOT:     tensor.empty
+// CHECK-NOT:     tensor.pack
+// CHECK-NOT:     tensor.unpack
+// CHECK:         scf.while
+// CHECK:           %[[PACK_DEST:.+]] = tensor.empty
+// CHECK:           tensor.pack {{.*}} into %[[PACK_DEST]]
+// CHECK:           %[[UNPACK_DEST:.+]] = tensor.empty
+// CHECK:           tensor.unpack {{.*}} into %[[UNPACK_DEST]]
+// CHECK:           scf.condition
+// CHECK:         } do {
+// CHECK:           scf.yield
+// CHECK:         }


### PR DESCRIPTION
Add `GlobalLoopInvariantCodeMotionPass` (`--iree-global-opt-loop-invariant-code-motion`) to hoist loop invariants in global optimization stage.

As the first step we only limit the case on constant `tensor.pack %cst` in `scf.while` loop, which is a common case when enabling data-tiling. However the pass can be easily extended to support other ops and loops.