### PR TITLE
[spirv] Add explicit layout to the top-level buffer

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -203,7 +203,13 @@ getGlobalVarTypeForIndirectBinding(MLIRContext *ctx, uint32_t set,
   auto memberPtr = spirv::PointerType::get(
       placeholderResourceType, spirv::StorageClass::PhysicalStorageBuffer);
   SmallVector<Type> members(maxBinding + 1, memberPtr);
-  auto structType = spirv::StructType::get(members);
+  // We are creating a top-level Block decorated interface type here, it needs
+  // explicit layout per SPIR-V requirements.
+  SmallVector<uint32_t> offsets(maxBinding + 1);
+  for (int i = 0; i < offsets.size(); ++i) {
+    offsets[i] = 8 * i; // Each pointer takes 8 bytes.
+  }
+  auto structType = spirv::StructType::get(members, offsets);
 
   return spirv::PointerType::get(structType,
                                  spirv::StorageClass::StorageBuffer);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/physical_storage_buffer_addresses.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/physical_storage_buffer_addresses.mlir
@@ -42,7 +42,7 @@ hal.executable private @interface_binding {
 
 // CHECK-LABEL: spirv.module PhysicalStorageBuffer64
 //       CHECK:   spirv.GlobalVariable [[GLOBAL:@.+]] bind(3, 0) :
-//  CHECK-SAME:     !spirv.ptr<!spirv.struct<(!spirv.ptr<i32, PhysicalStorageBuffer>, !spirv.ptr<i32, PhysicalStorageBuffer>, !spirv.ptr<i32, PhysicalStorageBuffer>)>, StorageBuffer>
+//  CHECK-SAME:     !spirv.ptr<!spirv.struct<(!spirv.ptr<i32, PhysicalStorageBuffer> [0], !spirv.ptr<i32, PhysicalStorageBuffer> [8], !spirv.ptr<i32, PhysicalStorageBuffer> [16])>, StorageBuffer>
 //       CHECK:   spirv.func
 //       CHECK:   %[[addr0:.+]] = spirv.mlir.addressof [[GLOBAL]]
 //  CHECK-NEXT:   %[[cst0:.+]] = spirv.Constant 0 : i32


### PR DESCRIPTION
Per SPIR-V requirements, `Block`-decorated interface variables should have explicit layout.

Related to https://github.com/openxla/iree/issues/13945