### PR TITLE
[VectorDistribution] Add pattern to distribute layout resolutions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -836,8 +836,14 @@ void populateGPUDistributionLayoutAttrPatterns(Value laneId,
   patterns
       .add<DistributeTransferReadLayoutAttr, DistributeTransferWriteLayoutAttr>(
           patterns.getContext(), laneId);
-  patterns.add<DistributeBroadcastLayoutAttr, DistributeTranspose,
-               DistributeLayoutConflictResolutions>(patterns.getContext());
+  patterns.add<DistributeBroadcastLayoutAttr, DistributeTranspose>(
+      patterns.getContext());
+}
+
+// TODO: Need a new op/analysis to determine when this pattern is safe to use.
+void populateGPULayoutResolutionDistributionPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add<DistributeLayoutConflictResolutions>(patterns.getContext());
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <numeric>
 #include "iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
@@ -702,6 +703,90 @@ struct DistributeBroadcastLayoutAttr final
     });
 
     replaceOpWithDistributedValues(rewriter, broadcastOp, accumulator);
+  }
+};
+
+struct DistributeLayoutConflictResolutions final
+    : OpDistributionPattern<IREE::VectorExt::LayoutConflictResolutionOp> {
+  using OpDistributionPattern::OpDistributionPattern;
+
+  VectorValue reshapeVector(Location loc, RewriterBase &rewriter,
+                            VectorValue src, LayoutAttr &currentLayout,
+                            LayoutAttr &targetLayout, Type elementType) const {
+
+    SmallVector<int64_t> targetShape = targetLayout.getDistributedShape();
+    SmallVector<int64_t> currentShape = currentLayout.getDistributedShape();
+
+    auto newVectorType = VectorType::get(targetShape, elementType);
+    auto constantOp = rewriter.create<arith::ConstantOp>(
+        loc, newVectorType, rewriter.getZeroAttr(newVectorType));
+    auto newVector = dyn_cast<VectorValue>(constantOp.getResult());
+
+    int64_t innermostDim = targetShape.size() - 1;
+    int64_t step =
+        std::min(targetShape[innermostDim], currentShape[innermostDim]);
+    DenseMap<LayoutDimension, int64_t> steps;
+    LayoutDimension vecDim = LayoutDimension::VECTORX;
+    steps[vecDim] = step;
+    LayoutIterator srcIterator(currentLayout, steps);
+    LayoutIterator targetIterator(targetLayout, steps);
+
+    for (; !srcIterator.iterationComplete() &&
+           !targetIterator.iterationComplete();
+         ++srcIterator, ++targetIterator) {
+      SmallVector<int64_t> srcOffset =
+          srcIterator.getState().computeSIMTIndex();
+      SmallVector<int64_t> targetOffset =
+          targetIterator.getState().computeSIMTIndex();
+      SmallVector<int64_t> sliceSize(srcOffset.size(), 1);
+      sliceSize[sliceSize.size() - 1] = step;
+      SmallVector<int64_t> sliceStride(srcOffset.size(), 1);
+      Value slice = rewriter.create<vector::ExtractStridedSliceOp>(
+          loc, src, srcOffset, sliceSize, sliceStride);
+      newVector = rewriter.create<vector::InsertStridedSliceOp>(
+          loc, slice, newVector, targetOffset, sliceStride);
+    }
+    return newVector;
+  }
+
+  LogicalResult
+  matchAndRewrite(IREE::VectorExt::LayoutConflictResolutionOp resolutionOp,
+                  DistributionSignature &signature,
+                  PatternRewriter &rewriter) const override {
+    VectorValue vector = resolutionOp.getInput();
+    VectorValue result = resolutionOp.getOutput();
+    LayoutAttr currentLayout = dyn_cast<LayoutAttr>(signature[vector]);
+    if (!currentLayout)
+      return failure();
+    LayoutAttr targetLayout = dyn_cast<LayoutAttr>(signature[result]);
+    if (!targetLayout)
+      return failure();
+
+    SmallVector<int64_t> currentVecShape = currentLayout.getDistributedShape();
+    SmallVector<int64_t> targetVecShape = targetLayout.getDistributedShape();
+    if (currentVecShape.size() != targetVecShape.size())
+      return failure();
+
+    auto numElements = [](ArrayRef<int64_t> vector) {
+      return std::accumulate(vector.begin(), vector.end(), 1,
+                             std::multiplies<int64_t>());
+    };
+    if (numElements(currentVecShape) != numElements(targetVecShape))
+      return failure();
+
+    // TODO: Support lane conflicts by doing a trip to shared memory or using
+    // shuffles.
+    if (currentLayout.hasLaneConflictWith(targetLayout)) {
+      return failure();
+    }
+
+    Type elementType =
+        llvm::cast<VectorType>(result.getType()).getElementType();
+    Value newVector =
+        reshapeVector(resolutionOp.getLoc(), rewriter,
+                      getDistributed(rewriter, vector, targetLayout),
+                      currentLayout, targetLayout, elementType);
+    replaceOpWithDistributedValues(rewriter, resolutionOp, newVector);
     return success();
   }
 };
@@ -729,6 +814,8 @@ void populateGPUDistributionLayoutAttrPatterns(Value laneId,
           patterns.getContext(), laneId);
   patterns.add<DistributeBroadcastLayoutAttr, DistributeTranspose>(
       patterns.getContext());
+  patterns.add<DistributeTranspose>(patterns.getContext());
+  patterns.add<DistributeLayoutConflictResolutions>(patterns.getContext());
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
@@ -40,6 +40,9 @@ void populateGPUReductionDistributionPatterns(RewritePatternSet &patterns,
 void populateGPUDistributeNestedLayoutAttrPatterns(Value threadId,
                                                    RewritePatternSet &patterns);
 
+void populateGPULayoutResolutionDistributionPatterns(
+    RewritePatternSet &patterns);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_GPUPATTERNS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -417,7 +417,7 @@ func.func @distribute_transpose(%mem: memref<32x32xf16>, %mem1: memref<32x32xf16
 func.func @distribute_broadcast_row_col(%source: vector<32xf32>) -> vector<32x32xf32> {
   %result = vector.broadcast %source {
           "__vector_layout_test_anchor_operand_0" = #layout_broadcast_1d_t,
-          "__vector_layout_test_anchor_result_0" = #layout_broadcast_2d} 
+          "__vector_layout_test_anchor_result_0" = #layout_broadcast_2d}
           : vector<32xf32> to vector<32x32xf32>
   // CHECK-DAG: %[[S00:.*]] = vector.extract %[[SOURCE:.*]][0, 0]
   // CHECK-DAG: vector.insert %[[S00]], %{{.*}} [0, 0, 0]
@@ -450,7 +450,7 @@ func.func @distribute_broadcast_row_col(%source: vector<32xf32>) -> vector<32x32
 func.func @distribute_broadcast_col_row(%source: vector<32xf32>) -> vector<32x32xf32> {
   %result = vector.broadcast %source {
           "__vector_layout_test_anchor_operand_0" = #layout_broadcast_1d,
-          "__vector_layout_test_anchor_result_0" = #layout_broadcast_2d_t} 
+          "__vector_layout_test_anchor_result_0" = #layout_broadcast_2d_t}
           : vector<32xf32> to vector<32x32xf32>
   // CHECK-DAG: %[[S0:.*]] = vector.extract %[[SOURCE:.*]][0]
   // CHECK-DAG: vector.insert %[[S0]], %{{.*}} [0, 0, 0]
@@ -530,7 +530,7 @@ func.func @unresolved_layout_conflict(%a : memref<32x16xf16>, %b : memref<32x16x
 builtin.module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func {experimental = true} : !transform.any_op
     transform.yield
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -967,6 +967,8 @@ transform_dialect::TestGpuVectorDistribution::applyToOne(
   populateGPUDistributionLayoutAttrPatterns(laneId, patterns);
   populateGPUReductionDistributionPatterns(patterns);
   populateGPUDistributeNestedLayoutAttrPatterns(laneId, patterns);
+  if (getExperimental())
+    populateGPULayoutResolutionDistributionPatterns(patterns);
   distributeVectorOps(target, patterns, options);
   return DiagnosedSilenceableFailure::success();
 }

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -563,14 +563,16 @@ def TestGpuVectorDistribution :
     number.
 
     The distribution is done for a single warp using gpu.thread x as the lane
-    ID.
+    ID. The optional experimental attribute enabled experimental distribution
+    patterns.
 
     #### Return modes
 
     This transform does not consume the target handle and always return success.
     }];
 
-    let arguments = (ins TransformHandleTypeInterface:$target);
+    let arguments = (ins TransformHandleTypeInterface:$target,
+                         DefaultValuedOptionalAttr<BoolAttr, "false">:$experimental);
     let results = (outs);
 
     let assemblyFormat = [{ $target attr-dict `:` type($target)}];

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -77,7 +77,7 @@ def LayoutAttr : IREEVectorExt_Attr<"Layout",
   let genVerifyDecl = 0;
   let extraClassDeclaration = [{
     // Get the shape for a given layout dimension.
-    std::optional<int64_t> getShape(const LayoutDimension &dim);
+    std::optional<int64_t> getShape(const LayoutDimension &dim) const;
     std::optional<int64_t> getBatchDim(int64_t dim);
     // Get the lane dimension shape for a provided simd tensor dim.
     std::optional<int64_t> getLaneDim(int64_t dim);
@@ -96,6 +96,12 @@ def LayoutAttr : IREEVectorExt_Attr<"Layout",
     // which is that for lane k, the shuffle op returns the
     // value from lane k ^ offset.
     uint64_t getShuffleOffset(int64_t reductionDim);
+
+    // Determines whether the other layout has a lane
+    // dimension that the current layout does not have OR whether
+    // the shape of the two layouts for a common lane dimension
+    // is not the same.
+    bool hasLaneConflictWith(const LayoutAttr &other);
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h
@@ -107,12 +107,12 @@ public:
   State getState() const { return state; }
   void erase(LayoutDimension dim);
   LayoutIterator getBatchIterator() const;
+  bool iterationComplete();
 
 private:
   void initialize(const PerDimLayoutAttr &attr,
                   DenseMap<LayoutDimension, int64_t> strides,
                   std::optional<int64_t> simdIndex);
-  bool iterationComplete();
   State state;
   DenseSet<LayoutDimension> frozenDimensions;
   int64_t iterations{0};


### PR DESCRIPTION
This PR adds a pattern that can resolve batch-vector layout conflict resolutions. Lane conflicts require either trips to shared memory or shuffles are not handled by the current patch.

The resolution happens through a reshape process where we emit the appropriate insert/extract strided slice ops to convert the vector to the desired shape.