### PR TITLE
[cuda][hip] Remove pool assert during allocator creation

### DIFF
--- a/experimental/hip/hip_allocator.c
+++ b/experimental/hip/hip_allocator.c
@@ -57,7 +57,6 @@ iree_status_t iree_hal_hip_allocator_create(
     hipStream_t stream, iree_hal_hip_memory_pools_t* pools,
     iree_allocator_t host_allocator, iree_hal_allocator_t** out_allocator) {
   IREE_ASSERT_ARGUMENT(hip_symbols);
-  IREE_ASSERT_ARGUMENT(pools);
   IREE_ASSERT_ARGUMENT(out_allocator);
   IREE_TRACE_ZONE_BEGIN(z0);
 

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -59,7 +59,6 @@ iree_status_t iree_hal_cuda_allocator_create(
     CUstream stream, iree_hal_cuda_memory_pools_t* pools,
     iree_allocator_t host_allocator, iree_hal_allocator_t** out_allocator) {
   IREE_ASSERT_ARGUMENT(cuda_symbols);
-  IREE_ASSERT_ARGUMENT(pools);
   IREE_ASSERT_ARGUMENT(out_allocator);
   IREE_TRACE_ZONE_BEGIN(z0);
 


### PR DESCRIPTION
`pools` could be `NULL` when the hardware doesn't support memory pools