### PR TITLE
[CPU][ArmSME] Update tiling to use all SME accumulators

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -108,7 +108,7 @@ module {
 //       SSVE-WITHOUT-SME: linalg.matmul
 //  SSVE-WITHOUT-SME-SAME:     lowering_config = #[[CONFIG]]
 
-//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], {{\[}}[4], [4], 0], [0, 0, 1], [0, 0, 0]]>
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], {{\[}}[8], [8], 0], [0, 0, 1], [0, 0, 0]]>
 //   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //       WITH-SME: func.func @matmul_tensors()
 //  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
Previously, we only tiled for a single SME accumulator. This patch updates the lowering_config to make use of all SME accumulators.

This is done by increasing the tile size to [8]x[8] for f32 and to [4]x[8] for f64. This lowers to four [4]x[4] 32-bit accumulators and eight [2]x[2] 64-bit accumulators respectively.

Signed-off-by: Benjamin Maxwell <benjamin.maxwell@arm.com>

ci-extra: build_test_all_arm64