### PR TITLE
Enable MLP plugin only for x86_64 builds.

### DIFF
--- a/samples/custom_dispatch/cpu/mlp_plugin/CMakeLists.txt
+++ b/samples/custom_dispatch/cpu/mlp_plugin/CMakeLists.txt
@@ -10,9 +10,14 @@ if(NOT IREE_TARGET_BACKEND_LLVM_CPU OR
   return()
 endif()
 
+## Current support is only for x86.
+iree_compiler_targeting_iree_arch(MLP_PLUGIN_BUILD_X86_64 "x86_64")
+if (NOT MLP_PLUGIN_BUILD_X86_64)
+  return()
+endif()
+
 # system-library plugin mechanism using the system dynamic library loader.
 if(IREE_HAL_EXECUTABLE_PLUGIN_SYSTEM_LIBRARY)
-
   
 add_library(iree_samples_custom_dispatch_cpu_mlp_plugin SHARED
   mlp_plugin.c

--- a/samples/custom_dispatch/cpu/mlp_plugin/CMakeLists.txt
+++ b/samples/custom_dispatch/cpu/mlp_plugin/CMakeLists.txt
@@ -11,8 +11,8 @@ if(NOT IREE_TARGET_BACKEND_LLVM_CPU OR
 endif()
 
 ## Current support is only for x86.
-iree_compiler_targeting_iree_arch(MLP_PLUGIN_BUILD_X86_64 "x86_64")
-if (NOT MLP_PLUGIN_BUILD_X86_64)
+if(NOT IREE_ARCH STREQUAL "x86_64")
+  message(STATUS "IREE mlp_pluging sample ignored -- only builds for x86_64 (today)")
   return()
 endif()
 


### PR DESCRIPTION
Fixes breakage introduced at #16356

ci-extra: build_test_all_macos_arm64,build_test_all_macos_x86_64