### PR TITLE
[hip] Initialize the executable resource after allocation

### DIFF
--- a/experimental/hip/native_executable.c
+++ b/experimental/hip/native_executable.c
@@ -174,6 +174,9 @@ iree_status_t iree_hal_hip_native_executable_create(
           (char*)((char*)executable + sizeof(*executable) +
                   entry_point_count * sizeof(executable->entry_points[0])));
 
+  iree_hal_resource_initialize(&iree_hal_hip_native_executable_vtable,
+                               &executable->resource);
+
   // Load the HSACO image - this will fail if the device cannot handle the
   // contents. We could check this prior to creating
   hipModule_t module = NULL;
@@ -195,8 +198,6 @@ iree_status_t iree_hal_hip_native_executable_create(
   }
 
   if (iree_status_is_ok(status)) {
-    iree_hal_resource_initialize(&iree_hal_hip_native_executable_vtable,
-                                 &executable->resource);
     executable->host_allocator = host_allocator;
     executable->symbols = symbols;
     executable->hip_module = module;


### PR DESCRIPTION
This guarantees that we always have basic bookkeeping structure updated for the resource. So if something goes wrong when creating the native executable and we are relying on the `iree_hal_executable_destroy` to destroy it, we don't crash.

Progress towards https://github.com/openxla/iree/issues/15790