### PR TITLE
Add AMDGPU pattern for chained matmuls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPatterns.cpp
@@ -1,0 +1,101 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMGPU/PassDetail.h"
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+struct AMDGPUChainedMatmulPass
+    : public AMDGPUChainedMatmulBase<AMDGPUChainedMatmulPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
+  }
+
+  bool
+  isChainedMatmul(SmallVector<vector::ContractionOp> &chainedMatmuls) const {
+    SetVector<Operation *> forwardSlice;
+    getForwardSlice(chainedMatmuls[0].getOperation(), &forwardSlice);
+    for (auto *sliceOp : llvm::reverse(forwardSlice)) {
+      auto candidateContract = dyn_cast<vector::ContractionOp>(sliceOp);
+      if (!candidateContract)
+        continue;
+      if (candidateContract == chainedMatmuls[1])
+        return true;
+    }
+    return false;
+  }
+
+  void swapOperandsAndTranspose(RewriterBase &rewriter,
+                                vector::ContractionOp contractOp) const {
+    Value lhs = contractOp.getLhs();
+    Value rhs = contractOp.getRhs();
+    Value acc = contractOp.getAcc();
+    rewriter.setInsertionPoint(contractOp);
+    Value transposed = rewriter.create<vector::TransposeOp>(
+        contractOp.getLoc(), acc, SmallVector<int64_t>{1, 0});
+    AffineExpr m, n, k;
+    bindDims(rewriter.getContext(), m, n, k);
+    using MapList = ArrayRef<ArrayRef<AffineExpr>>;
+    auto infer = [](MapList m) { return AffineMap::inferFromExprList(m); };
+    SmallVector<AffineMap> newIndexingMaps = infer({{n, k}, {m, k}, {n, m}});
+    vector::ContractionOp swappedOp = rewriter.create<vector::ContractionOp>(
+        contractOp.getLoc(), rhs, lhs, transposed,
+        rewriter.getAffineMapArrayAttr(newIndexingMaps),
+        contractOp.getIteratorTypesAttr());
+    Value newResult = swappedOp.getResult();
+    transposed = rewriter.create<vector::TransposeOp>(
+        contractOp.getLoc(), newResult, SmallVector<int64_t>{1, 0});
+    rewriter.replaceAllUsesWith(contractOp.getResult(), transposed);
+  }
+
+  bool isCompatibleIndexingMap(vector::ContractionOp contractOp,
+                               MLIRContext *ctx) {
+    AffineExpr m, n, k;
+    bindDims(ctx, m, n, k);
+    using MapList = ArrayRef<ArrayRef<AffineExpr>>;
+    auto infer = [](MapList m) { return AffineMap::inferFromExprList(m); };
+    SmallVector<AffineMap> newIndexingMaps = infer({{m, k}, {n, k}, {m, n}});
+    return newIndexingMaps == contractOp.getIndexingMapsArray();
+  }
+
+  // Given a contraction: D = A x B.T + C, this pattern
+  // modifies the contraction to: D.T = B x A.T + C.T
+  // where .T computes the transpose. Applying this pattern
+  // can remove layout conflicts in certain scenarios
+  // (such as flash attention on CDNA GPUs).
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    SmallVector<vector::ContractionOp> chainedMatmuls;
+    funcOp.walk([&](vector::ContractionOp contractOp) {
+      if (!isCompatibleIndexingMap(contractOp, funcOp.getContext()))
+        return WalkResult::advance();
+      chainedMatmuls.push_back(contractOp);
+      return WalkResult::advance();
+    });
+    if (chainedMatmuls.size() != 2)
+      return;
+    if (!isChainedMatmul(chainedMatmuls))
+      return;
+    IRRewriter rewriter(funcOp.getContext());
+    for (vector::ContractionOp op : chainedMatmuls) {
+      swapOperandsAndTranspose(rewriter, op);
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createAMDGPUChainedMatmulPass() {
+  return std::make_unique<AMDGPUChainedMatmulPass>();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -87,7 +87,7 @@ iree_compiler_cc_library(
 iree_compiler_cc_library(
     name = "LLVMGPU",
     srcs = [
-        "AMDGPUChainedMatmulPatterns.cpp",
+        "AMDGPUChainedMatmulPass.cpp",
         "ConvertToLLVM.cpp",
         "ConvertToNVVM.cpp",
         "ConvertToROCDL.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -87,6 +87,7 @@ iree_compiler_cc_library(
 iree_compiler_cc_library(
     name = "LLVMGPU",
     srcs = [
+        "AMDGPUChainedMatmulPatterns.cpp",
         "ConvertToLLVM.cpp",
         "ConvertToNVVM.cpp",
         "ConvertToROCDL.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -72,7 +72,7 @@ iree_cc_library(
     "ROCDLKernelConfig.h"
     "ROCDLPasses.h"
   SRCS
-    "AMDGPUChainedMatmulPatterns.cpp"
+    "AMDGPUChainedMatmulPass.cpp"
     "ConvertToLLVM.cpp"
     "ConvertToNVVM.cpp"
     "ConvertToROCDL.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -72,6 +72,7 @@ iree_cc_library(
     "ROCDLKernelConfig.h"
     "ROCDLPasses.h"
   SRCS
+    "AMDGPUChainedMatmulPatterns.cpp"
     "ConvertToLLVM.cpp"
     "ConvertToNVVM.cpp"
     "ConvertToROCDL.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -130,6 +130,10 @@ verifyGPUMatmulPipeline(Operation *op,
                         IREE::Codegen::TranslationInfoAttr translationInfo,
                         ArrayRef<int64_t> workgroupSize);
 
+/// Swaps contract operands and transposes results and accumulator.
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createAMDGPUChainedMatmulPass();
+
 //----------------------------------------------------------------------------//
 // Register LLVMGPU Passes
 //----------------------------------------------------------------------------//

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -13,6 +13,12 @@ include "mlir/Pass/PassBase.td"
 // LLVMGPU Passes (keep alphabetical)
 //------------------------------------------------------------------------------
 
+def AMDGPUChainedMatmul :
+    InterfacePass<"iree-amdgpu-chained-matmul", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to swap operands and transpose accumulator and result";
+  let constructor = "mlir::iree_compiler::createAMDGPUChainedMatmulPass()";
+}
+
 // TODO: Bring the argument in line with the names used elsewhere.
 def ConvertToNVVM :
     Pass<"iree-convert-to-nvvm", "ModuleOp"> {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -13,10 +13,10 @@ include "mlir/Pass/PassBase.td"
 // LLVMGPU Passes (keep alphabetical)
 //------------------------------------------------------------------------------
 
-def AMDGPUChainedMatmul :
-    InterfacePass<"iree-amdgpu-chained-matmul", "mlir::FunctionOpInterface"> {
+def AMDGPUPrepareForChainedMatmul :
+    InterfacePass<"iree-amdgpu-prepare-chained-matmul", "mlir::FunctionOpInterface"> {
   let summary = "Pass to swap operands and transpose accumulator and result";
-  let constructor = "mlir::iree_compiler::createAMDGPUChainedMatmulPass()";
+  let constructor = "mlir::iree_compiler::createAMDGPUPrepareForChainedMatmulPass()";
 }
 
 // TODO: Bring the argument in line with the names used elsewhere.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "amdgpu_chained_matmul.mlir",
             "amdgpu_contraction_distribution.mlir",
             "attention.mlir",
             "conv_pipeline_test.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "amdgpu_chained_matmul.mlir"
     "amdgpu_contraction_distribution.mlir"
     "attention.mlir"
     "cast_address_space_function.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_chained_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_chained_matmul.mlir
@@ -1,0 +1,63 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdgpu-chained-matmul),canonicalize,cse)" %s | FileCheck %s
+
+#accesses0 = [
+  affine_map<(m, n, k) -> (m, k)>,
+  affine_map<(m, n, k) -> (n, k)>,
+  affine_map<(m, n, k) -> (m, n)>
+]
+
+#trait0 = {
+  indexing_maps = #accesses0,
+  iterator_types = ["parallel", "parallel", "reduction"]
+}
+
+builtin.module {
+  // CHECK-DAG: #[[MAP:.*]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+  // CHECK-DAG: #[[MAP1:.*]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+  // CHECK-DAG: #[[MAP2:.*]] = affine_map<(d0, d1, d2) -> (d1, d0)>
+  func.func @chained_matmul(%lhs : vector<32x8xf16>, %rhs : vector<16x8xf16>, %acc : vector<32x16xf16>,
+    // CHECK: func.func @chained_matmul(%[[LHS:.*]]: vector<32x8xf16>, %[[RHS:.*]]: vector<16x8xf16>, %[[ACC:.*]]: vector<32x16xf16>
+    // CHECK-SAME: %[[RHS2:.*]]: vector<8x16xf16>, %[[ACC2:.*]]: vector<32x8xf16>
+    %rhs2 : vector<8x16xf16>, %acc2 : vector<32x8xf16>) -> vector<32x8xf16> {
+    // CHECK: %[[TRANS_ACC:.*]] = vector.transpose %[[ACC]], [1, 0] : vector<32x16xf16> to vector<16x32xf16>
+    // CHECK: %[[TRANS_RES:.*]] = vector.contract {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+    // CHECK-SAME: %[[RHS]], %[[LHS]], %[[TRANS_ACC]] : vector<16x8xf16>, vector<32x8xf16> into vector<16x32xf16>
+    // CHECK: %[[RES:.*]] = vector.transpose %[[TRANS_RES]], [1, 0] : vector<16x32xf16> to vector<32x16xf16>
+    %result = vector.contract #trait0 %lhs, %rhs, %acc
+      : vector<32x8xf16>, vector<16x8xf16> into vector<32x16xf16>
+    // CHECK: %[[EXP:.*]] = math.exp2 %[[RES]] : vector<32x16xf16>
+    %exp = math.exp2 %result : vector<32x16xf16>
+    // CHECK: %[[TRANS_ACC2:.*]] = vector.transpose %[[ACC2]], [1, 0] : vector<32x8xf16> to vector<8x32xf16>
+    // CHECK: %[[TRANS_RES2:.*]] = vector.contract {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+    // CHECK-SAME: %[[RHS2]], %[[EXP]], %[[TRANS_ACC2]] : vector<8x16xf16>, vector<32x16xf16> into vector<8x32xf16>
+    // CHECK: %[[RES2:.*]] = vector.transpose %[[TRANS_RES2]], [1, 0] : vector<8x32xf16> to vector<32x8xf16>
+    %result2 = vector.contract #trait0 %exp, %rhs2, %acc2
+      : vector<32x16xf16>, vector<8x16xf16> into vector<32x8xf16>
+    func.return %result2 : vector<32x8xf16>
+  }
+}
+
+// -----
+
+#accesses0 = [
+  affine_map<(m, n, k) -> (m, k)>,
+  affine_map<(m, n, k) -> (n, k)>,
+  affine_map<(m, n, k) -> (m, n)>
+]
+
+#trait0 = {
+  indexing_maps = #accesses0,
+  iterator_types = ["parallel", "parallel", "reduction"]
+}
+
+builtin.module {
+  func.func @non_chained_matmul(%lhs : vector<32x8xf16>, %rhs : vector<16x8xf16>, %acc : vector<32x16xf16>
+    // CHECK: func.func @non_chained_matmul(%[[LHS:.*]]: vector<32x8xf16>, %[[RHS:.*]]: vector<16x8xf16>, %[[ACC:.*]]: vector<32x16xf16>
+    ) -> vector<32x16xf16> {
+    // CHECK-NOT: vector.transpose
+    %result = vector.contract #trait0 %lhs, %rhs, %acc
+      : vector<32x8xf16>, vector<16x8xf16> into vector<32x16xf16>
+    %exp = math.exp2 %result : vector<32x16xf16>
+    func.return %exp : vector<32x16xf16>
+  }
+}


### PR DESCRIPTION
This PR adds a pattern for chained matmuls operators like Flash Attention where by swapping the operands of the sequential matmuls, one can keep the data in registers and avoid a trip to shared memory and/or additional shuffle instructions.

The pattern swaps the operands of the contract op, and inserts transposes for the accumulator and result, if the contracts are chained and satisfy the MMT
indexing maps.