### PR TITLE
[cuda][hip] Guard against NULL cleanup callbacks

### DIFF
--- a/experimental/hip/pending_queue_actions.c
+++ b/experimental/hip/pending_queue_actions.c
@@ -50,7 +50,7 @@ typedef struct iree_hal_hip_queue_action_t {
   iree_hal_hip_pending_queue_actions_t* owning_actions;
 
   // The callback to run after completing this action and before freeing
-  // all resources.
+  // all resources. Can be NULL.
   iree_hal_hip_pending_action_cleanup_callback_t cleanup_callback;
   // User data to pass into the callback.
   void* callback_user_data;
@@ -612,7 +612,9 @@ static void iree_hal_hip_pending_queue_actions_cleanup_execution(
   iree_allocator_t host_allocator = actions->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  action->cleanup_callback(action->callback_user_data);
+  if (action->cleanup_callback) {
+    action->cleanup_callback(action->callback_user_data);
+  }
 
   iree_hal_resource_set_free(action->resource_set);
   iree_hal_hip_free_semaphore_list(host_allocator,

--- a/experimental/hip/pending_queue_actions.h
+++ b/experimental/hip/pending_queue_actions.h
@@ -54,6 +54,9 @@ typedef void(IREE_API_PTR* iree_hal_hip_pending_action_cleanup_callback_t)(
 
 // Enqueues the given list of |command_buffers| that waits on
 // |wait_semaphore_list| and signals |signal_semaphore_lsit|.
+//
+// |cleanup_callback|, if not NULL, will run after the action completes but
+// before releasing all retained resources.
 iree_status_t iree_hal_hip_pending_queue_actions_enqueue_execution(
     iree_hal_device_t* device, hipStream_t dispatch_stream,
     hipStream_t callback_stream, iree_hal_hip_pending_queue_actions_t* actions,

--- a/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.c
+++ b/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.c
@@ -50,7 +50,7 @@ typedef struct iree_hal_cuda_queue_action_t {
   iree_hal_cuda_pending_queue_actions_t* owning_actions;
 
   // The callback to run after completing this action and before freeing
-  // all resources.
+  // all resources. Can be NULL.
   iree_hal_cuda_pending_action_cleanup_callback_t cleanup_callback;
   // User data to pass into the callback.
   void* callback_user_data;
@@ -614,7 +614,9 @@ static void iree_hal_cuda_pending_queue_actions_cleanup_execution(
   iree_allocator_t host_allocator = actions->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  action->cleanup_callback(action->callback_user_data);
+  if (action->cleanup_callback) {
+    action->cleanup_callback(action->callback_user_data);
+  }
 
   iree_hal_resource_set_free(action->resource_set);
   iree_hal_cuda_free_semaphore_list(host_allocator,

--- a/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.h
+++ b/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.h
@@ -54,6 +54,9 @@ typedef void(IREE_API_PTR* iree_hal_cuda_pending_action_cleanup_callback_t)(
 
 // Enqueues the given list of |command_buffers| that waits on
 // |wait_semaphore_list| and signals |signal_semaphore_lsit|.
+//
+// |cleanup_callback|, if not NULL, will run after the action completes but
+// before releasing all retained resources.
 iree_status_t iree_hal_cuda_pending_queue_actions_enqueue_execution(
     iree_hal_device_t* device, CUstream dispatch_stream,
     CUstream callback_stream, iree_hal_cuda_pending_queue_actions_t* actions,


### PR DESCRIPTION
Not all equeued actions need cleanup. So allow NULL case
and guard against it.