### PR TITLE
Fix a bug in the fastpath of iree_hal_task_semaphore_multi_wait which was doing a spurious wait.

### DIFF
--- a/runtime/bindings/python/tests/hal_device_loop_test.py
+++ b/runtime/bindings/python/tests/hal_device_loop_test.py
@@ -71,9 +71,7 @@ class HalDeviceLoopBridgeTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        # TODO: Switch to local-task (experiencing some wait deadlocking
-        # that needs triage).
-        self.device = get_device("local-sync")
+        self.device = get_device("local-task")
         self.allocator = self.device.allocator
 
 


### PR DESCRIPTION
When in an ANY wait mode, the first known-signaled semaphore is sufficient to skip the wait and any further timepoint creation.