### PR TITLE
Turn on SLPVectorizer for ROCM backend

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -177,7 +177,7 @@ public:
     fam.registerPass([&] { return targetMachine.getTargetIRAnalysis(); });
 
     llvm::PipelineTuningOptions pto;
-    pto.SLPVectorization = false;
+    pto.SLPVectorization = true;
 
     llvm::PassInstrumentationCallbacks pic;
 


### PR DESCRIPTION
While the SLPVectorizer will not help for tensor core type instructions, it can still be helpful for combining scalar elementwise instructions into vector instructions. We turn this on for specifically this use-case when generating AMDGCN ISA.