### PR TITLE
Revert "Turn on SLPVectorizer for ROCM backend (#16412)"

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -177,7 +177,7 @@ public:
     fam.registerPass([&] { return targetMachine.getTargetIRAnalysis(); });
 
     llvm::PipelineTuningOptions pto;
-    pto.SLPVectorization = true;
+    pto.SLPVectorization = false;
 
     llvm::PassInstrumentationCallbacks pic;
 


### PR DESCRIPTION
This reverts commit c066ceb0b9c0de6608d8ac33c4fd960af73d9ee2.