### PR TITLE
[hip] Add missing source locations and fix parsing

### DIFF
--- a/experimental/hip/native_executable.c
+++ b/experimental/hip/native_executable.c
@@ -259,13 +259,13 @@ iree_status_t iree_hal_hip_native_executable_create(
       IREE_TRACE({
         if (iree_hal_rocm_ExecutableDef_source_locations_is_present(
                 executable_def)) {
-          iree_hal_hip_FileLineLocDef_vec_t source_locs_vec =
+          iree_hal_rocm_FileLineLocDef_vec_t source_locs_vec =
               iree_hal_rocm_ExecutableDef_source_locations_get(executable_def);
-          iree_hal_hip_FileLineLocDef_table_t source_loc =
-              iree_hal_hip_FileLineLocDef_vec_at(source_locs_vec, i);
+          iree_hal_rocm_FileLineLocDef_table_t source_loc =
+              iree_hal_rocm_FileLineLocDef_vec_at(source_locs_vec, i);
           flatbuffers_string_t filename =
-              iree_hal_hip_FileLineLocDef_filename_get(source_loc);
-          uint32_t line = iree_hal_hip_FileLineLocDef_line_get(source_loc);
+              iree_hal_rocm_FileLineLocDef_filename_get(source_loc);
+          uint32_t line = iree_hal_rocm_FileLineLocDef_line_get(source_loc);
           kernel_info->source_filename =
               iree_make_string_view(filename, flatbuffers_string_len(filename));
           kernel_info->source_line = line;

--- a/runtime/src/iree/schemas/rocm_executable_def.fbs
+++ b/runtime/src/iree/schemas/rocm_executable_def.fbs
@@ -17,6 +17,13 @@ struct BlockSizeDef {
   z:uint32;
 }
 
+// A struct for a source code location that consists of a file name and
+// a line number within that file.
+table FileLineLocDef {
+  filename:string;
+  line:int32;
+}
+
 table ExecutableDef {
   // A map of entry point ordinals to string names as used in the shader
   // library.
@@ -32,6 +39,11 @@ table ExecutableDef {
 
   // HSACO string of the module.
   hsaco_image:string;
+
+  // A map of entry point ordinals to source locations.
+  // This information is optional and may be used by debuggers and profilers to
+  // associate executable entry points with the source that generated them.
+  source_locations:[FileLineLocDef];
 }
 
 root_type ExecutableDef;


### PR DESCRIPTION
This makes the hip HAL driver to compile when turning on runtime tracing.