### PR TITLE
[Codegen] Rework global read vector distribution to use new layout

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -149,6 +149,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:AMDGPUUtils",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineToStandard",
+        "@llvm-project//mlir:AffineTransforms",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithToAMDGPU",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -111,6 +111,7 @@ iree_cc_library(
     MLIRAMDGPUUtils
     MLIRAffineDialect
     MLIRAffineToStandard
+    MLIRAffineTransforms
     MLIRAnalysis
     MLIRArithDialect
     MLIRArithToAMDGPU

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Conversion/VectorToGPU/VectorToGPU.h"
+#include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -719,6 +720,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool forROCDL) {
   pm.addPass(memref::createFoldMemRefAliasOpsPass());
   pm.addPass(memref::createExpandStridedMetadataPass());
   pm.addPass(createEmulateNarrowTypePass());
+  pm.addPass(affine::createAffineExpandIndexOpsPass());
   pm.addPass(createLowerAffinePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute.mlir
@@ -40,10 +40,66 @@ builtin.module attributes { hal.executable.target = #hal.executable.target<"rocm
 //       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
 //       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x4xf32>)
-//       CHECK:     %[[RLOAD:.+]] = vector.load %{{.*}} : memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<8xf16>
-//       CHECK:     %[[LLOAD:.+]] = vector.load %{{.*}} : memref<256x16xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<8xf16>
-//       CHECK:     vector.store %[[RLOAD]], %[[LHS_ALLOC]]{{.*}} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<8xf16>
-//       CHECK:     vector.store %[[LLOAD]], %[[RHS_ALLOC]]{{.*}} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<8xf16>
+//       CHECK:     %[[LLOAD:.+]] = vector.transfer_read {{.*}} : memref<16x256xf16, {{.*}}>, vector<1x8xf16>
+//       CHECK:     %[[RLOAD:.+]] = vector.transfer_read {{.*}} : memref<256x16xf16, {{.*}}>, vector<1x8xf16>
+//       CHECK:     vector.transfer_write %[[LLOAD]], %[[LHS_ALLOC]]{{.*}} : vector<1x8xf16>, memref<16x32xf16, #gpu.address_space<workgroup>>
+//       CHECK:     vector.transfer_write %[[RLOAD]], %[[RHS_ALLOC]]{{.*}} : vector<1x8xf16>, memref<32x16xf16, #gpu.address_space<workgroup>>
+//       CHECK:     gpu.barrier
+// CHECK-COUNT-2:   vector.load %[[LHS_ALLOC]]{{.*}} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<4xf16>
+// CHECK-COUNT-8:   vector.load %[[RHS_ALLOC]]{{.*}} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<1xf16>
+// CHECK-COUNT-2:   amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32> 
+//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<4xf32> to vector<1x1x4xf32>
+//       CHECK:     scf.yield %[[BCAST]] : vector<1x1x4xf32>
+// CHECK-COUNT-4: vector.store {{.*}} : memref<16x16xf32{{.*}}>, vector<1xf32>
+
+// -----
+
+builtin.module attributes { hal.executable.target = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
+  mma_intrinsics = [#iree_gpu.mfma_layout<F16_16x16x16_F32>,
+                    #iree_gpu.mfma_layout<F16_32x32x8_F32>],
+  target_arch = "gfx940",
+  ukernels = "none"}>} {
+  func.func @matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>,
+                                %rhs: memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>,
+                                %out: memref<16x16xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
+                                attributes {subgroup_size = 64, workgroup_size = [64, 1, 1]} {
+    %alloc = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
+    %alloc_0 = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
+    %cst = arith.constant 0.000000e+00 : f16 
+    %cst_1 = arith.constant dense<0.000000e+00> : vector<16x16xf32>
+    %c32 = arith.constant 32 : index 
+    %c256 = arith.constant 256 : index 
+    %c0 = arith.constant 0 : index 
+    %5 = scf.for %arg0 = %c0 to %c256 step %c32 iter_args(%arg1 = %cst_1) -> (vector<16x16xf32>) {
+      %6 = vector.transfer_read %lhs[%c0, %arg0], %cst {in_bounds = [true, true]} : memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<16x32xf16>
+      %7 = vector.transfer_read %rhs[%arg0, %c0], %cst {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d1, d0)>} : memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<32x16xf16>
+      vector.transfer_write %6, %alloc_0[%c0, %c0] {in_bounds = [true, true]} : vector<16x32xf16>, memref<16x32xf16, #gpu.address_space<workgroup>>
+      gpu.barrier
+      vector.transfer_write %7, %alloc[%c0, %c0] {in_bounds = [true, true]} : vector<32x16xf16>, memref<32x16xf16, #gpu.address_space<workgroup>>
+      gpu.barrier
+      %8 = vector.transfer_read %alloc_0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<16x32xf16>
+      %9 = vector.transfer_read %alloc[%c0, %c0], %cst {in_bounds = [true, true]} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<32x16xf16>
+      %10 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %8, %9, %arg1 : vector<16x32xf16>, vector<32x16xf16> into vector<16x16xf32> 
+      scf.yield %10 : vector<16x16xf32>
+    }
+    vector.transfer_write %5, %out[%c0, %c0] {in_bounds = [true, true]} : vector<16x16xf32>, memref<16x16xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+    memref.dealloc %alloc_0 : memref<16x32xf16, #gpu.address_space<workgroup>>
+    memref.dealloc %alloc : memref<32x16xf16, #gpu.address_space<workgroup>>
+    return
+  }
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1) -> (d1, d0)>
+
+// CHECK-LABEL: func.func @matmul_256x256x256
+//       CHECK:   %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x4xf32>
+//       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
+//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x4xf32>)
+//       CHECK:     %[[LLOAD:.+]] = vector.transfer_read {{.*}} : memref<16x256xf16, {{.*}}>, vector<1x8xf16>
+//       CHECK:     %[[RLOAD:.+]] = vector.transfer_read {{.*}} permutation_map = #[[$MAP]]} : memref<16x256xf16, {{.*}}>, vector<8x1xf16>
+//       CHECK:     vector.transfer_write %[[LLOAD]], %[[LHS_ALLOC]]{{.*}} : vector<1x8xf16>, memref<16x32xf16, #gpu.address_space<workgroup>>
+//       CHECK:     vector.transfer_write %[[RLOAD]], %[[RHS_ALLOC]]{{.*}} : vector<8x1xf16>, memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:     gpu.barrier
 // CHECK-COUNT-2:   vector.load %[[LHS_ALLOC]]{{.*}} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<4xf16>
 // CHECK-COUNT-8:   vector.load %[[RHS_ALLOC]]{{.*}} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<1xf16>


### PR DESCRIPTION
Contraction distribution is still using the previous layout. This now supports arbitrary read
ranks. It still does not do any verification that the read layouts will actually resolve, and only
really applies to simple matmul cases.