### PR TITLE
[python] Enable building of 3.12 wheels on Linux.

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -65,7 +65,7 @@ this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
 manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/nod-ai/manylinux_x86_64:main" }')}"
-python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311}"
+python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-runtime iree-compiler}"
 package_suffix="${package_suffix:-}"

--- a/runtime/bindings/python/tests/benchmark_test.py
+++ b/runtime/bindings/python/tests/benchmark_test.py
@@ -84,7 +84,7 @@ class BenchmarkTest(unittest.TestCase):
             inputs=[arg0, arg1],
         )
 
-        self.assertEquals(len(benchmark_results), 1)
+        self.assertEqual(len(benchmark_results), 1)
         benchmark_time = float(benchmark_results[0].time.split(" ")[0])
         self.assertGreater(benchmark_time, 0)
 
@@ -100,7 +100,7 @@ class BenchmarkTest(unittest.TestCase):
             device=iree.compiler.core.DEFAULT_TESTING_DRIVER,
             inputs=[arg1],
         )
-        self.assertEquals(len(benchmark_results_1), 1)
+        self.assertEqual(len(benchmark_results_1), 1)
 
         benchmark_results_2 = benchmark_module(
             vm_module,
@@ -108,7 +108,7 @@ class BenchmarkTest(unittest.TestCase):
             device=iree.compiler.core.DEFAULT_TESTING_DRIVER,
             inputs=[arg2],
         )
-        self.assertEquals(len(benchmark_results_2), 1)
+        self.assertEqual(len(benchmark_results_2), 1)
 
     def testBenchmarkModuleTimeout(self):
         ctx = iree.runtime.SystemContext()


### PR DESCRIPTION
I've manually built and tested on 3.12. Included a small test change to not use a long deprecated and now removed method.

Fixes #15856