### PR TITLE
[RFC] Option to not vectorize linalg.copy 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -162,6 +162,7 @@ struct GenericVectorizationPassOptions {
   // to specify the masked vector sizes.
   bool useConfiguredVectorSizes = true;
   bool vectorizePadding = false;
+  bool vectorizeCopy = true;
   bool vectorizeGatherAccesses = false;
   // The flag controls whether it touches the structure generated from tiling,
   // which affects later steps like bufferization and vector hoisting.

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -276,6 +276,8 @@ def GenericVectorization :
       "Control whether the op lowering config represents a set of masked vector sizes">,
     Option<"vectorizePadding", "vectorize-padding", "bool", /*default=*/"false",
       "Rewrite all tensor.pad ops in the function to vector form.">,
+    Option<"vectorizeCopy", "vectorize-copy", "bool", /*default=*/"true",
+      "Rewrite all linalg.copy ops in the function to vector form.">,
     Option<"vectorizeGatherAccesses", "vectorize-gather-accesses", "bool", /*default=*/"false",
       "Enable vectorizaiton of operations that may generate vector.gather operations.">,
     Option<"enableCleanup", "enable-cleanup", "bool",/*default=*/"true",


### PR DESCRIPTION
linalg.copy ops in amd-aie lowering represent copies between memory spaces, and so we don't want them to be vectorized to vector.transfer_read and vector.transfer_write ops. This option allows us to leave linalg.copy ops untouched by iree's generic vectorization. 