### PR TITLE
Register LinalgExt dialect in the torch pipeline

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/PluginAPI/Client.h"
 #include "mlir/Dialect/MLProgram/IR/MLProgram.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -49,6 +50,7 @@ struct TorchSession
     registry.insert<torch::TorchConversion::TorchConversionDialect>();
     registry.insert<mlir::torch::TMTensor::TMTensorDialect>();
     registry.insert<mlir::ml_program::MLProgramDialect>();
+    registry.insert<IREE::LinalgExt::IREELinalgExtDialect>();
   }
 
   bool extendCustomInputConversionPassPipeline(


### PR DESCRIPTION
We can now generate iree_linalg_ext.attention ops in this pipeline, so need to register the dialect.