### PR TITLE
[Codegen][LLVMGPU] Fixes for chained matmul pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPass.cpp
@@ -130,7 +130,7 @@ struct AMDGPUPrepareForChainedMatmulPass
     bindDims(contractOp.getContext(), m, n, k);
     using MapList = ArrayRef<ArrayRef<AffineExpr>>;
     auto infer = [&](MapList m) {
-      return AffineMap::inferFromExprList(m, ctx);
+      return AffineMap::inferFromExprList(m, contractOp.getContext());
     };
     SmallVector<AffineMap> newIndexingMaps = infer({{m, k}, {n, k}, {m, n}});
     return newIndexingMaps == contractOp.getIndexingMapsArray();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPass.cpp
@@ -13,6 +13,48 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+/// Let's assume that we only have vector.contract with the standard indexing
+/// maps:
+///    (m, n, k), A: (m, k), B: (k, n), C: (m, n).
+/// We will represent this contract operation by a "@".
+///
+/// Given a matmul:
+///
+/// C = A @ B
+///
+/// This pass decides when to convert this matmul to:
+///
+/// A.T = transpose(A)
+/// B.T = transpose(B)
+/// C.T = A.T @ B.T
+/// C = transpose(C.T)
+///
+/// This is useful when the "@" instruction that the hardware lowers to
+/// has a specific layout (see VectorLayoutInterface for more information)
+/// but the further uses of C expects a transposed layout to the produced
+/// layout.
+///
+/// For example, for "@" lowering to AMDGPU MFMA instructions, the operands
+/// have layout L and L.T and the result has the layout L.T .
+/// So if you have a chain of matmuls:
+///
+/// C (L.T) = A (L) @ B (L.T)
+/// E (L.T) = C (L.T)  @ D (L.T)
+///            ^^^^^^^
+///            Expected layout by instruction is L
+///
+/// To fix this, we can apply this transformation on the first matrix:
+///
+/// C.T (L.T) = A.T (L) @ B (L.T)
+/// C   (L)   = transpose C.T (L.T)
+/// E   (L.T) = C (L)  @ D (L.T)
+///            ^^^^^
+///            Layout matches the instruction!
+///
+/// Note that the mathematical formula
+///   C = A @ B --> C.T = B.T @ A.T
+/// is only defined on standard "@" function, it may be a different
+/// transformation for other indexing maps.
 struct AMDGPUPrepareForChainedMatmulPass
     : public AMDGPUPrepareForChainedMatmulBase<
           AMDGPUPrepareForChainedMatmulPass> {
@@ -20,63 +62,72 @@ struct AMDGPUPrepareForChainedMatmulPass
     registry.insert<vector::VectorDialect>();
   }
 
-  /// A chained matmul is one where the result of the first matmul
-  /// is used as the first operand of another matmul (
-  /// first matmul lies in the backward slice of the
-  /// LHS of the second matmul).
-  bool
-  isChainedMatmul(SmallVector<vector::ContractionOp> &chainedMatmuls) const {
-    SetVector<Operation *> backwardSlice;
-    getBackwardSlice(chainedMatmuls[1].getLhs(), &backwardSlice);
-    for (auto *sliceOp : backwardSlice) {
-      auto candidateContract = dyn_cast<vector::ContractionOp>(sliceOp);
-      if (!candidateContract)
-        continue;
-      if (candidateContract == chainedMatmuls[0])
-        return true;
-    }
-    return false;
-  }
-
   /// Given a vector contract of the form
   /// %output = vector.contract %lhs, %rhs, %acc
   /// this function swaps the operands (%rhs, %lhs),
   /// transposes the accumulator and output and updates
   /// the indexing maps for the new contract op.
+  ///
+  /// Given a contract:
+  ///
+  ///   result = vector.contract lhs, rhs, acc
+  ///
+  /// transform it to
+  ///
+  ///   lhs.T = transpose(lhs)
+  ///   rhs.T = transpose(rhs)
+  ///   acc.T = transpose(acc)
+  ///   result.T = vector.contract rhs.T, lhs.T, acc.T
+  ///   result = transpose(result.T)
+  ///
+  /// This transformation holds for the "@" case we described above. For
+  /// other indexing maps, we need to take into account transposed which are
+  /// fused into the contract. `isOperandSwapInvariant` tells us when we can
+  /// simply swap the operands without transposing them.
   void swapOperandsAndTranspose(RewriterBase &rewriter,
                                 vector::ContractionOp contractOp) const {
     Value lhs = contractOp.getLhs();
     Value rhs = contractOp.getRhs();
     Value acc = contractOp.getAcc();
     rewriter.setInsertionPoint(contractOp);
-    Value transposed = rewriter.create<vector::TransposeOp>(
-        contractOp.getLoc(), acc, SmallVector<int64_t>{1, 0});
-    AffineExpr m, n, k;
-    bindDims(rewriter.getContext(), m, n, k);
-    using MapList = ArrayRef<ArrayRef<AffineExpr>>;
-    auto infer = [&](MapList m) {
-      return AffineMap::inferFromExprList(m, contractOp.getContext());
-    };
-    SmallVector<AffineMap> newIndexingMaps = infer({{n, k}, {m, k}, {n, m}});
+    acc = rewriter.create<vector::TransposeOp>(contractOp.getLoc(), acc,
+                                               SmallVector<int64_t>{1, 0});
+
+    if (!isOperandSwapInvariant(contractOp)) {
+      lhs = rewriter.create<vector::TransposeOp>(contractOp.getLoc(), lhs,
+                                                 SmallVector<int64_t>{1, 0});
+      rhs = rewriter.create<vector::TransposeOp>(contractOp.getLoc(), rhs,
+                                                 SmallVector<int64_t>{1, 0});
+    }
+
     vector::ContractionOp swappedOp = rewriter.create<vector::ContractionOp>(
-        contractOp.getLoc(), rhs, lhs, transposed,
-        rewriter.getAffineMapArrayAttr(newIndexingMaps),
+        contractOp.getLoc(), rhs, lhs, acc, contractOp.getIndexingMaps(),
         contractOp.getIteratorTypesAttr());
-    Value newResult = swappedOp.getResult();
-    transposed = rewriter.create<vector::TransposeOp>(
-        contractOp.getLoc(), newResult, SmallVector<int64_t>{1, 0});
-    rewriter.replaceAllUsesWith(contractOp.getResult(), transposed);
+    rewriter.replaceOpWithNewOp<vector::TransposeOp>(
+        contractOp, swappedOp.getResult(), SmallVector<int64_t>{1, 0});
   }
 
-  /// The only compatible indexing map corresponds to
-  /// the matmul_transpose_b, and is
-  /// (m, n, k) -> (m, k)
-  /// (m, n, k) -> (n, k)
-  /// (m, n, k) -> (m, n)
-  bool isCompatibleIndexingMap(vector::ContractionOp contractOp,
-                               MLIRContext *ctx) {
+  /// For a matmul_transpose_b, this transformation boils down to an operand
+  /// swap and result transpose:
+  ///
+  /// def matmul_transpose_b(A, B):
+  ///   B.T = transpose(B)
+  ///   C = A @ B.T
+  ///   return C
+  ///
+  /// def matmul_transpose_b_swapped(A, B):
+  ///   A.T = transpose(A)
+  ///   C.T = B @ A.T
+  ///   C   = transpose(C.T)
+  ///   return C
+  ///
+  /// matmul_transpose_b(B, A) = matmul_transpose_b_swapped(B, A).T
+  ///
+  /// TODO: This check applies more generally when one of the operands in the
+  /// function is transposed compared to what "@" expects.
+  bool isOperandSwapInvariant(vector::ContractionOp contractOp) const {
     AffineExpr m, n, k;
-    bindDims(ctx, m, n, k);
+    bindDims(contractOp.getContext(), m, n, k);
     using MapList = ArrayRef<ArrayRef<AffineExpr>>;
     auto infer = [&](MapList m) {
       return AffineMap::inferFromExprList(m, ctx);
@@ -85,22 +136,65 @@ struct AMDGPUPrepareForChainedMatmulPass
     return newIndexingMaps == contractOp.getIndexingMapsArray();
   }
 
+  /// Returns a vector.contract operation that this value was transitively
+  /// produced from.
+  ///
+  /// A chained matmul is one where the lhs of the candidate matrix
+  /// is a result of another matmul (a matmul lies in the backward slice of lhs
+  /// of the first matmul).
+  FailureOr<vector::ContractionOp>
+  getTransitiveMatmulParent(vector::ContractionOp contractOp) const {
+    SetVector<Operation *> backwardSlice;
+    getBackwardSlice(contractOp.getLhs(), &backwardSlice);
+    vector::ContractionOp result;
+    for (Operation *sliceOp : backwardSlice) {
+      auto chainParent = dyn_cast<vector::ContractionOp>(sliceOp);
+      if (!chainParent) {
+        continue;
+      }
+
+      // For now, we only support transpose invariant matmuls. This is because
+      // transposing the inputs may have a non-trivial cost which we need
+      // to think about.
+      if (!isOperandSwapInvariant(chainParent)) {
+        continue;
+      }
+
+      // If we have multiple matmul parents, we fail.
+      if (result) {
+        return failure();
+      }
+
+      result = chainParent;
+    }
+
+    if (result) {
+      return result;
+    }
+
+    return failure();
+  }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
-    SmallVector<vector::ContractionOp> chainedMatmuls;
+    SmallVector<vector::ContractionOp> matmulCandidates;
     funcOp.walk([&](vector::ContractionOp contractOp) {
-      if (!isCompatibleIndexingMap(contractOp, funcOp.getContext()))
-        return WalkResult::advance();
-      chainedMatmuls.push_back(contractOp);
-      return WalkResult::advance();
+      matmulCandidates.push_back(contractOp);
     });
-    if (chainedMatmuls.size() != 2)
-      return;
-    if (!isChainedMatmul(chainedMatmuls))
-      return;
+
     IRRewriter rewriter(funcOp.getContext());
-    for (vector::ContractionOp op : chainedMatmuls) {
-      swapOperandsAndTranspose(rewriter, op);
+    for (auto candidate : matmulCandidates) {
+      FailureOr<vector::ContractionOp> maybeChainedParent =
+          getTransitiveMatmulParent(candidate);
+      if (failed(maybeChainedParent)) {
+        continue;
+      }
+      auto chainParent = maybeChainedParent.value();
+      swapOperandsAndTranspose(rewriter, chainParent);
+
+      // TODO: We should be only transposing the second matrix if the
+      // result of the first matmul is used by the second matmul transitively.
+      swapOperandsAndTranspose(rewriter, candidate);
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_chained_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_chained_matmul.mlir
@@ -12,9 +12,9 @@
 }
 
 builtin.module {
-  // CHECK-DAG: #[[MAP:.*]] = affine_map<(d0, d1, d2) -> (d1, d2)>
-  // CHECK-DAG: #[[MAP1:.*]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-  // CHECK-DAG: #[[MAP2:.*]] = affine_map<(d0, d1, d2) -> (d1, d0)>
+  // CHECK-DAG: #[[MAP:.*]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+  // CHECK-DAG: #[[MAP1:.*]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+  // CHECK-DAG: #[[MAP2:.*]] = affine_map<(d0, d1, d2) -> (d0, d1)>
   func.func @chained_matmul(%lhs : vector<32x8xf16>, %rhs : vector<16x8xf16>, %acc : vector<32x16xf16>,
     // CHECK: func.func @chained_matmul(%[[LHS:.*]]: vector<32x8xf16>, %[[RHS:.*]]: vector<16x8xf16>, %[[ACC:.*]]: vector<32x16xf16>
     // CHECK-SAME: %[[RHS2:.*]]: vector<8x16xf16>, %[[ACC2:.*]]: vector<32x8xf16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_chained_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_chained_matmul.mlir
@@ -88,3 +88,56 @@ builtin.module {
     func.return %result2 : vector<32x32xf16>
   }
 }
+
+// -----
+
+#accesses0 = [
+  affine_map<(m, n, k) -> (m, k)>,
+  affine_map<(m, n, k) -> (n, k)>,
+  affine_map<(m, n, k) -> (m, n)>
+]
+
+#accesses1 = [
+  affine_map<(m, n, k) -> (m, k)>,
+  affine_map<(m, n, k) -> (k, n)>,
+  affine_map<(m, n, k) -> (m, n)>
+]
+
+#trait0 = {
+  indexing_maps = #accesses0,
+  iterator_types = ["parallel", "parallel", "reduction"]
+}
+
+#trait1 = {
+  indexing_maps = #accesses1,
+  iterator_types = ["parallel", "parallel", "reduction"]
+}
+
+builtin.module {
+  func.func @chained_matmul_mmt_mm(%lhs : vector<32x8xf16>, %rhs : vector<16x8xf16>, %acc : vector<32x16xf16>,
+    // CHECK-DAG: #[[MAP:.*]]  = affine_map<(d0, d1, d2) -> (d0, d2)>
+    // CHECK-DAG: #[[MAP1:.*]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+    // CHECK-DAG: #[[MAP2:.*]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+    // CHECK-DAG: #[[MAP3:.*]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+    // CHECK: func.func @chained_matmul_mmt_mm(%[[LHS:.*]]: vector<32x8xf16>, %[[RHS:.*]]: vector<16x8xf16>, %[[ACC:.*]]: vector<32x16xf16>
+    // CHECK-SAME: %[[RHS2:.*]]: vector<16x8xf16>, %[[ACC2:.*]]: vector<32x8xf16>
+    %rhs2 : vector<16x8xf16>, %acc2 : vector<32x8xf16>) -> vector<32x8xf16> {
+    // CHECK: %[[TRANS_ACC:.*]] = vector.transpose %[[ACC]], [1, 0] : vector<32x16xf16> to vector<16x32xf16>
+    // CHECK: %[[TRANS_RES:.*]] = vector.contract {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+    // CHECK-SAME: %[[RHS]], %[[LHS]], %[[TRANS_ACC]] : vector<16x8xf16>, vector<32x8xf16> into vector<16x32xf16>
+    // CHECK: %[[RES:.*]] = vector.transpose %[[TRANS_RES]], [1, 0] : vector<16x32xf16> to vector<32x16xf16>
+    %result = vector.contract #trait0 %lhs, %rhs, %acc
+      : vector<32x8xf16>, vector<16x8xf16> into vector<32x16xf16>
+    // CHECK: %[[EXP:.*]] = math.exp2 %[[RES]] : vector<32x16xf16>
+    %exp = math.exp2 %result : vector<32x16xf16>
+    // CHECK: %[[TRANS_ACC2:.*]] = vector.transpose %[[ACC2]], [1, 0] : vector<32x8xf16> to vector<8x32xf16>
+    // CHECK: %[[TRANS_EXP:.*]] = vector.transpose %[[EXP]], [1, 0] : vector<32x16xf16> to vector<16x32xf16>
+    // CHECK: %[[TRANS_RHS2:.*]] = vector.transpose %[[RHS2]], [1, 0] : vector<16x8xf16> to vector<8x16xf16>
+    // CHECK: %[[TRANS_RES2:.*]] = vector.contract {indexing_maps = [#[[MAP]], #[[MAP3]], #[[MAP2]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+    // CHECK-SAME: %[[TRANS_RHS2]], %[[TRANS_EXP]], %[[TRANS_ACC2]] : vector<8x16xf16>, vector<16x32xf16> into vector<8x32xf16>
+    // CHECK: %[[RES2:.*]] = vector.transpose %[[TRANS_RES2]], [1, 0] : vector<8x32xf16> to vector<32x8xf16>
+    %result2 = vector.contract #trait1 %exp, %rhs2, %acc2
+      : vector<32x16xf16>, vector<16x8xf16> into vector<32x8xf16>
+    func.return %result2 : vector<32x8xf16>
+  }
+}


### PR DESCRIPTION
- Previously, the pass was only working for matmul_transpose_b -> matmul_transpose_b. The second matmul can be other types of matmul also.
- Fixes indexing maps.
- Adds more documentation
- Transposes second matmul in chain also (This shouldn't be always done)