### PR TITLE
[VectorDistribution] Fix layout iteration when VECTORX is frozen

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -474,6 +474,47 @@ func.func @distribute_broadcast_col_row(%source: vector<32xf32>) -> vector<32x32
   func.return %result : vector<32x32xf32>
 }
 
+#layout_broadcast_vectory_1d = #iree_vector_ext.layout<
+  <[BATCHY, VECTORX], [1, 4]>
+>
+
+#layout_broadcast_vectory_2d = #iree_vector_ext.layout<
+  <[BATCHX, VECTORY], [1, 4]>,
+  <[BATCHY, VECTORX], [1, 4]>
+>
+
+// This test case checks if we distribute correct when we have vectorx frozen
+// and we iterate on vectory.
+// This previously caused a bug, since calculating SIMT index for broadcast
+// needs to know the range of vectorx.
+func.func @distribute_broadcast_vectory(%source: vector<4xf32>) -> vector<4x4xf32> {
+  %result = vector.broadcast %source {
+          "__vector_layout_test_anchor_operand_0" = #layout_broadcast_vectory_1d,
+          "__vector_layout_test_anchor_result_0" = #layout_broadcast_vectory_2d}
+          : vector<4xf32> to vector<4x4xf32>
+  // CHECK-DAG: %[[S00:.*]] = vector.extract %[[SOURCE:.*]][0, 0] : f32 from vector<1x4xf32>
+  // CHECK-DAG: %[[S01:.*]] = vector.extract %[[SOURCE:.*]][0, 1] : f32 from vector<1x4xf32>
+  // CHECK-DAG: %[[S02:.*]] = vector.extract %[[SOURCE:.*]][0, 2] : f32 from vector<1x4xf32>
+  // CHECK-DAG: %[[S02:.*]] = vector.extract %[[SOURCE:.*]][0, 3] : f32 from vector<1x4xf32>
+  // CHECK-DAG: vector.insert %[[S00:.*]] %{{.*}} [0, 0, 0] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S00:.*]] %{{.*}} [0, 0, 4] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S00:.*]] %{{.*}} [0, 0, 8] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S00:.*]] %{{.*}} [0, 0, 12] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S01:.*]] %{{.*}} [0, 0, 1] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S01:.*]] %{{.*}} [0, 0, 5] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S01:.*]] %{{.*}} [0, 0, 9] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S01:.*]] %{{.*}} [0, 0, 13] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S02:.*]] %{{.*}} [0, 0, 2] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S02:.*]] %{{.*}} [0, 0, 6] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S02:.*]] %{{.*}} [0, 0, 10] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S02:.*]] %{{.*}} [0, 0, 14] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S03:.*]] %{{.*}} [0, 0, 3] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S03:.*]] %{{.*}} [0, 0, 7] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S03:.*]] %{{.*}} [0, 0, 11] : f32 into vector<1x1x16xf32>
+  // CHECK-DAG: vector.insert %[[S03:.*]] %{{.*}} [0, 0, 15] : f32 into vector<1x1x16xf32>
+  func.return %result : vector<4x4xf32>
+}
+
 builtin.module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
@@ -481,7 +522,7 @@ builtin.module attributes { transform.with_named_sequence } {
     transform.yield
   }
 }
-
+ 
 // -----
 
 #row_layout = #iree_vector_ext.per_dim_layout<[BATCHX, LANEY, VECTORX], [2, 4, 4]>

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -58,6 +58,7 @@ void LayoutIterator::maybeFreezeAndConcatenate(
     if (!state.contains(frozenDim)) {
       frozenDimensions.insert(frozenDim);
       state[frozenDim] = frozenIt;
+      state.ranges[frozenDim] = frozenState.ranges.lookup(frozenDim);
     }
   }
 }


### PR DESCRIPTION
Previously, the iterator was not keeping track of ranges, which led to crashes when iterating on VECTORY dimension.