### PR TITLE
[Flow] Loosen restrictions on body ops of dequant-like ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -218,6 +218,10 @@ static bool isRootOp(Operation *op) {
   if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
     return false;
   }
+  // Dequantization-like ops get cloned into dispatches later.
+  if (isDequantizationLikeOp(op)) {
+    return false;
+  }
   // Any Linalg named op or generic op with reduction iterator types is a root
   // op.
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -556,15 +556,6 @@ bool isDequantizationLikeOp(Operation *op) {
       outputElementType.getIntOrFloatBitWidth()) {
     return false;
   }
-
-  for (auto &bodyOp : genericOp.getBody()->getOperations()) {
-    if (!isa<arith::ExtUIOp, arith::ExtSIOp, arith::MulFOp, arith::MulIOp,
-             arith::AddFOp, arith::AddIOp, arith::SubFOp, arith::SubIOp,
-             arith::SIToFPOp, arith::UIToFPOp, linalg::YieldOp>(bodyOp)) {
-      return false;
-    }
-  }
-
   return true;
 }
 


### PR DESCRIPTION
The restrictions for selecting dequant-like ops were too conservative. It should not matter what the body of the operation is as long as the primary input bitwidth is decreased.