### PR TITLE
[Codegen] Add op for setting contraction layouts based on mfma attribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -219,6 +219,7 @@ iree_compiler_cc_library(
         ":PassesIncGen",
         # Dialects
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransformOps",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -238,6 +238,7 @@ iree_cc_library(
     MLIRVectorTransforms
     iree::compiler::Codegen::Common::TransformExtensions::CommonExtensions
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::LLVMCPU::TransformExtensions::LLVMCPUExtensions
     iree::compiler::Codegen::LLVMGPU::TransformExtensions::LLVMGPUExtensions
     iree::compiler::Codegen::TransformStrategies::Common::TransformStrategies

--- a/compiler/src/iree/compiler/Codegen/Common/CommonDialectRegistration.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CommonDialectRegistration.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/LLVMCPU/TransformExtensions/LLVMCPUExtensions.h"
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
@@ -65,6 +66,7 @@ void registerTransformDialectTranslationDependentDialects(
                   mlir::iree_compiler::IREE::VectorExt::IREEVectorExtDialect,
                   mlir::iree_compiler::IREE::Flow::FlowDialect,
                   mlir::iree_compiler::IREE::Codegen::IREECodegenDialect,
+                  mlir::iree_compiler::IREE::GPU::IREEGPUDialect,
                   arith::ArithDialect,
                   affine::AffineDialect,
                   bufferization::BufferizationDialect,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD.bazel
@@ -59,6 +59,7 @@ iree_compiler_cc_library(
         ":LLVMGPUExtensionsOpGen",
         "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Common/GPU:CommonGPUPasses",
+        "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/LLVMGPU/Utils",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_cc_library(
     MLIRViewLikeInterface
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::GPU::CommonGPUPasses
+    iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::LLVMGPU::Utils
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::HAL::IR

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -11,7 +11,6 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
-#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -36,7 +36,7 @@ def MapNestedForallToGpuThreadsOp :
     If necessary, scf.forall that do not use the whole thread range
     result in predicated computations.
 
-    Barriers are inserted after each scf.forall op 
+    Barriers are inserted after each scf.forall op
     if `sync_after_distribution` is true.
 
     Return modes:
@@ -721,7 +721,6 @@ def AMDGPUDistributeVectorsOp :
     }];
 }
 
-
 def CreateMatmulMfmaTileSizesOp :
   Op<Transform_Dialect, "iree.create_matmul_mfma_tile_sizes",
     [MemoryEffectsOpInterface,
@@ -738,6 +737,22 @@ def CreateMatmulMfmaTileSizesOp :
                       TransformParamTypeInterface:$problem_specific_sizes);
 
   let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
+def SetContractionLayoutAttributes :
+  Op<Transform_Dialect, "iree.set_contraction_layout_attributes",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let description = [{
+    Infers and sets the layout of the target contraction op based on the given
+    MFMA attribute.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target,
+                       TransformParamTypeInterface:$mma_type);
+
+  let assemblyFormat = "$target `,` $mma_type attr-dict `:` type($target) `,` type($mma_type)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma.mlir
@@ -15,7 +15,7 @@ hal.executable private @attention {
         // CHECK-NOT: iree_vector_ext.to_simd
         // CHECK-NOT: iree_vector_ext.to_simt
         // CHECK: scf.for {{.*}} = %c0 to %c16384 step %c64 {{.*}} -> (vector<2xf32>, vector<2xf32>, vector<8x2x4xf32>)
-        // CHECK-COUNT-128: amdgu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32}
+        // CHECK-COUNT-128: amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32}
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x16384x128xf16>>
         %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x16384x128xf16>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma.mlir
@@ -6,7 +6,7 @@ hal.executable private @attention {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
     hal.executable.export public @attention_dispatch_0_attention_16x16384x128xf16 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer, ReadOnly>, <3, storage_buffer>]>]>) {
     ^bb0(%arg0: !hal.device):
-      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -15,7 +15,7 @@ hal.executable private @attention {
         // CHECK-NOT: iree_vector_ext.to_simd
         // CHECK-NOT: iree_vector_ext.to_simt
         // CHECK: scf.for {{.*}} = %c0 to %c16384 step %c64 {{.*}} -> (vector<2xf32>, vector<2xf32>, vector<8x2x4xf32>)
-        // CHECK-COUNT-128: amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32}
+        // CHECK-COUNT-128: amdgu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32}
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x16384x128xf16>>
         %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x16384x128xf16>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma_transform_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma_transform_spec.mlir
@@ -153,11 +153,9 @@ module attributes { transform.with_named_sequence } {
 
     // Get the vector.contract ops.
     %contracts = transform.structured.match ops{["vector.contract"]} in %variant_op_3 :  (!transform.any_op) -> !transform.any_op
-    %contract1, %contract2 = transform.split_handle %contracts : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
     %layout16x16x16 = transform.param.constant #layout -> !transform.any_param
-    transform.iree.set_contraction_layout_attributes %contract1, %layout16x16x16 : !transform.any_op, !transform.any_param
-    transform.iree.set_contraction_layout_attributes %contract2, %layout16x16x16 : !transform.any_op, !transform.any_param
+    transform.iree.set_contraction_layout_attributes %contracts, %layout16x16x16 : !transform.any_op, !transform.any_param
 
     %distribute_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
     transform.iree.amdgpu_distribute_vectors %distribute_func : !transform.any_op

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma_transform_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma_transform_spec.mlir
@@ -1,36 +1,4 @@
-// First Matmul
-// A: 64x128
-// B: 32x128 MMT
-// C: 64x32
-#layout_a1 = #iree_vector_ext.layout<
-  <[BATCHX, LANEX], [4, 16]>,
-  <[BATCHY, LANEY, VECTORX], [8, 4, 4]>
->
-#layout_b1 = #iree_vector_ext.layout<
-  <[BATCHX, LANEX], [2, 16]>,
-  <[BATCHY, LANEY, VECTORX], [8, 4, 4]>
->
-#layout_c1 = #iree_vector_ext.layout<
-  <[BATCHX, LANEY, VECTORX], [4, 4, 4]>,
-  <[BATCHY, LANEX], [2, 16]>
->
- 
-// Second Matmul
-// A: 128x64
-// B: 64x32  MM
-// C: 128x32
-#layout_a2 = #iree_vector_ext.layout<
-  <[BATCHX, LANEX], [8, 16]>,
-  <[BATCHY, LANEY, VECTORX], [4, 4, 4]>
->
-#layout_b2 = #iree_vector_ext.layout<
-  <[BATCHX, LANEY, VECTORX], [4, 4, 4]>,
-  <[BATCHY, LANEX], [2, 16]>
->
-#layout_c2 = #iree_vector_ext.layout<
-  <[BATCHX, LANEY, VECTORX], [8, 4, 4]>,
-  <[BATCHY, LANEX], [2, 16]>
->
+#layout = #iree_gpu.mfma_layout<F16_16x16x16_F32>
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.consumed}) {
@@ -187,21 +155,9 @@ module attributes { transform.with_named_sequence } {
     %contracts = transform.structured.match ops{["vector.contract"]} in %variant_op_3 :  (!transform.any_op) -> !transform.any_op
     %contract1, %contract2 = transform.split_handle %contracts : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    %layoutA1 = transform.param.constant #layout_a1 -> !transform.any_param
-    %layoutB1 = transform.param.constant #layout_b1 -> !transform.any_param
-    %layoutC1 = transform.param.constant #layout_c1 -> !transform.any_param
-
-    %layoutA2 = transform.param.constant #layout_a2 -> !transform.any_param
-    %layoutB2 = transform.param.constant #layout_b2 -> !transform.any_param
-    %layoutC2 = transform.param.constant #layout_c2 -> !transform.any_param
-
-    transform.annotate %contract1 "__vector_layout_test_anchor_operand_0" = %layoutA1 : !transform.any_op, !transform.any_param
-    transform.annotate %contract1 "__vector_layout_test_anchor_operand_1" = %layoutB1 : !transform.any_op, !transform.any_param
-    transform.annotate %contract1 "__vector_layout_test_anchor_operand_2" = %layoutC1 : !transform.any_op, !transform.any_param
-
-    transform.annotate %contract2 "__vector_layout_test_anchor_operand_0" = %layoutA2 : !transform.any_op, !transform.any_param
-    transform.annotate %contract2 "__vector_layout_test_anchor_operand_1" = %layoutB2 : !transform.any_op, !transform.any_param
-    transform.annotate %contract2 "__vector_layout_test_anchor_operand_2" = %layoutC2 : !transform.any_op, !transform.any_param
+    %layout16x16x16 = transform.param.constant #layout -> !transform.any_param
+    transform.iree.set_contraction_layout_attributes %contract1, %layout16x16x16 : !transform.any_op, !transform.any_param
+    transform.iree.set_contraction_layout_attributes %contract2, %layout16x16x16 : !transform.any_op, !transform.any_param
 
     %distribute_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
     transform.iree.amdgpu_distribute_vectors %distribute_func : !transform.any_op


### PR DESCRIPTION
Instead of having to hard code layouts, infers the layout from an mfma fragment. Verified to generate bitwise identical IR to the previous script.