### PR TITLE
[rocdl] NFC: Move mfma intrinsic details to the MFMAAttr impl

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -234,10 +234,10 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
   }
 
   struct MFMAParameters {
-    uint32_t m;
-    uint32_t n;
-    uint32_t k;
-    uint32_t blocks;
+    uint32_t m = 0;
+    uint32_t n = 0;
+    uint32_t k = 0;
+    uint32_t blocks = 0;
   };
 
   // Generates amdgpu.mfma operation on the given inputs for the given MFMA

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -178,9 +178,8 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
             rewriter.create<vector::ExtractOp>(loc, lhs, lhsBatchOffsets);
         Value rhsSlice =
             rewriter.create<vector::ExtractOp>(loc, rhs, rhsBatchOffsets);
-        accSlice =
-            computeMMA(rewriter, loc, lhsSlice, rhsSlice, accSlice, aVectorType,
-                       bVectorType, cVectorType, mfmaParams);
+        accSlice = computeMMA(rewriter, loc, mfmaParams, lhsSlice, rhsSlice,
+                              accSlice, aVectorType, bVectorType, cVectorType);
       }
       finalTile = rewriter.create<vector::InsertOp>(loc, accSlice, finalTile,
                                                     resultBatchOffsets);
@@ -243,9 +242,9 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
 
   // Generates amdgpu.mfma operation on the given inputs for the given MFMA
   // |intrinsic|.
-  Value computeMMA(OpBuilder &builder, Location loc, Value a, Value b, Value c,
-                   VectorType aType, VectorType bType, VectorType cType,
-                   const MFMAParameters &mfmaParams) const {
+  Value computeMMA(OpBuilder &builder, Location loc,
+                   const MFMAParameters &mfmaParams, Value a, Value b, Value c,
+                   VectorType aType, VectorType bType, VectorType cType) const {
     Value aCast = builder.create<vector::ShapeCastOp>(a.getLoc(), aType, a);
     Value bCast = builder.create<vector::ShapeCastOp>(b.getLoc(), bType, b);
     Value cCast = builder.create<vector::ShapeCastOp>(c.getLoc(), cType, c);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -316,6 +316,7 @@ MFMAAttr::getABCVectorTypes() const {
     return std::make_tuple(aType, bType, cType);
   }
   }
+  // This should not happen but just to make GCC happy.
   return std::make_tuple(VectorType{}, VectorType{}, VectorType{});
 }
 
@@ -325,6 +326,19 @@ MFMAAttr::getContractionLayout(vector::ContractionOp contract) const {
   ConcreteMmaLayout layout =
       getConcreteMFMALayout(contract->getContext(), getIntrinsic().getValue());
   return IREE::GPU::getContractionLayout(contract, layout);
+}
+
+int64_t MFMAAttr::getBlockSize() {
+  switch (getIntrinsic().getValue()) {
+  case MFMAIntrinsic::F16_16x16x16_F32: {
+    return 1;
+  }
+  case MFMAIntrinsic::F16_32x32x8_F32: {
+    return 1;
+  }
+  }
+  // This should not happen but just to make GCC happy.
+  return 0;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -60,7 +60,7 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
     "::mlir::Type":$cType
   );
 
-  let extraClassDeclaration = [{
+  string baseExtraClassDeclaration = [{
     ::std::tuple<Type, Type, Type> getABCElementTypes() {
       return ::std::make_tuple(getAType(), getBType(), getCType());
     }
@@ -117,6 +117,10 @@ def IREEGPU_MFMA : IREEGPU_MmaVectorLayoutAttr<"MFMA", "MFMAIntrinsicAttr"> {
   let builders = [
     AttrBuilder<(ins "MFMAIntrinsic":$intrinsic)>
   ];
+
+  let extraClassDeclaration = !strconcat(baseExtraClassDeclaration, [{
+    int64_t getBlockSize();
+  }]);
 }
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS


### PR DESCRIPTION
This makes sure that we have a clear and central place for getting intrinsic related details.