### PR TITLE
[rocm][hip] Make shared object init error understandable

### DIFF
--- a/experimental/hip/native_executable.c
+++ b/experimental/hip/native_executable.c
@@ -184,6 +184,11 @@ iree_status_t iree_hal_hip_native_executable_create(
   iree_status_t status = IREE_HIP_RESULT_TO_STATUS(
       symbols, hipModuleLoadDataEx(&module, hsaco_image, 0, NULL, NULL),
       "hipModuleLoadDataEx");
+  if (!iree_status_is_ok(status)) {
+    status = iree_status_annotate(
+        status,
+        IREE_SV("mismatched target chip? missing/wrong bitcode directory?"));
+  }
 
   // Query max optin shared memory per block - we'll use it to compare with
   // kernel usages.

--- a/experimental/rocm/native_executable.c
+++ b/experimental/rocm/native_executable.c
@@ -80,20 +80,25 @@ iree_status_t iree_hal_rocm_native_executable_create(
   iree_host_size_t total_size =
       sizeof(*executable) + entry_count * sizeof(executable->entry_points[0]) +
       total_entry_point_name_chars;
-  iree_status_t status = iree_allocator_malloc(context->host_allocator,
-                                               total_size, (void**)&executable);
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(context->host_allocator, total_size,
+                                (void**)&executable));
   IREE_TRACE(char* string_table_buffer =
                  (char*)((char*)executable + sizeof(*executable) +
                          entry_count * sizeof(executable->entry_points[0])));
+
+  iree_hal_resource_initialize(&iree_hal_rocm_native_executable_vtable,
+                               &executable->resource);
+
   executable->context = context;
-  if (iree_status_is_ok(status)) {
-    iree_hal_resource_initialize(&iree_hal_rocm_native_executable_vtable,
-                                 &executable->resource);
-    executable->context = context;
-    status = ROCM_RESULT_TO_STATUS(
-        context->syms,
-        hipModuleLoadDataEx(&executable->module, hsaco_image, 0, NULL, NULL),
-        "hipModuleLoadDataEx");
+  iree_status_t status = ROCM_RESULT_TO_STATUS(
+      context->syms,
+      hipModuleLoadDataEx(&executable->module, hsaco_image, 0, NULL, NULL),
+      "hipModuleLoadDataEx");
+  if (!iree_status_is_ok(status)) {
+    status = iree_status_annotate(
+        status,
+        IREE_SV("mismatched target chip? missing/wrong bitcode directory?"));
   }
 
   // Query allowed max shared memory.


### PR DESCRIPTION
Provide hints to the "driver error 'hipErrorSharedObjectInitFailed' (303): shared object initialization failed" error.