### PR TITLE
[LLVMGPU] Add flag for maximum shared memory limit

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -701,7 +701,9 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool forROCDL) {
   // Run checks on shared memory usage.
   // TODO: query this from the target.
   int64_t limit = clLLVMGPUSharedMemoryLimit;
-  auto getSharedMemoryLimit = [&](mlir::FunctionOpInterface) { return limit; };
+  auto getSharedMemoryLimit = [limit](mlir::FunctionOpInterface) {
+    return limit;
+  };
   auto getIndexBitwidth = [](mlir::FunctionOpInterface) { return 64; };
   pm.addPass(
       createGPUCheckResourceUsagePass(getSharedMemoryLimit, getIndexBitwidth));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -51,7 +51,7 @@ llvm::cl::opt<int64_t> clLLVMGPUSharedMemoryLimit(
     "iree-llvmgpu-shared-memory-limit",
     llvm::cl::desc("specify the maximum amount of shared memory allowed to be "
                    "allocated for the given target"),
-    llvm::cl::init(65536));
+    llvm::cl::init(163 * 1024));
 
 //===----------------------------------------------------------------------===//
 // Bufferization Configuration

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -47,6 +47,12 @@ static llvm::cl::opt<unsigned>
     logSwizzleTile("iree-codegen-log-swizzle-tile",
                    llvm::cl::desc("log swizzle tile value"), llvm::cl::init(0));
 
+llvm::cl::opt<int64_t> clLLVMGPUSharedMemoryLimit(
+    "iree-llvmgpu-shared-memory-limit",
+    llvm::cl::desc("specify the maximum amount of shared memory allowed to be "
+                   "allocated for the given target"),
+    llvm::cl::init(65536));
+
 //===----------------------------------------------------------------------===//
 // Bufferization Configuration
 //===----------------------------------------------------------------------===//
@@ -694,9 +700,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool forROCDL) {
 
   // Run checks on shared memory usage.
   // TODO: query this from the target.
-  auto getSharedMemoryLimit = [](mlir::FunctionOpInterface) {
-    return 163 * 1024;
-  };
+  int64_t limit = clLLVMGPUSharedMemoryLimit;
+  auto getSharedMemoryLimit = [&](mlir::FunctionOpInterface) { return limit; };
   auto getIndexBitwidth = [](mlir::FunctionOpInterface) { return 64; };
   pm.addPass(
       createGPUCheckResourceUsagePass(getSharedMemoryLimit, getIndexBitwidth));


### PR DESCRIPTION
This is as silly as it looks. A target specific detail like this should not be set by a flag, however the refactor of LLVMGPU -> a more general backend w/ proper target configuration attributes is in progress and there is consensus to not build out the target configuration logic too much on the LLVMGPU side right now.