### PR TITLE
[Flow] Add pass for exporting executables as individual MLIR functions

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -39,6 +39,7 @@ iree_compiler_cc_library(
         "ConvertRegionToWorkgroups.cpp",
         "ConvertToFlow.cpp",
         "DeduplicateExecutables.cpp",
+        "DumpExecutableFunctions.cpp",
         "DispatchWithTransformDialect.cpp",
         "DumpDispatchGraph.cpp",
         "ExportBenchmarkFuncs.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "DeduplicateExecutables.cpp"
     "DispatchWithTransformDialect.cpp"
     "DumpDispatchGraph.cpp"
+    "DumpExecutableFunctions.cpp"
     "ExportBenchmarkFuncs.cpp"
     "FoldUnitExtentDims.cpp"
     "FormDispatchRegions.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpExecutableFunctions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpExecutableFunctions.cpp
@@ -1,0 +1,258 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+#include <utility>
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/Utils/IndexSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir::iree_compiler::IREE::Flow {
+
+namespace {
+
+// Appends a function calling the given |exportOp| to the module.
+static void buildDispatchExportFunction(IREE::Flow::ExecutableOp executableOp,
+                                        IREE::Flow::ExecutableExportOp exportOp,
+                                        OpBuilder &moduleBuilder) {
+  auto loc = executableOp.getLoc();
+
+  std::string baseName =
+      (executableOp.getName() + "_" + exportOp.getName()).str();
+
+  auto exportedFunc = llvm::dyn_cast_if_present<FunctionOpInterface>(
+      SymbolTable::lookupSymbolIn(executableOp.getInnerModule(),
+                                  exportOp.getName()));
+  if (!exportedFunc || !exportedFunc.getResultTypes().empty()) {
+    return;
+  }
+
+  SmallVector<Type> argumentTypes;
+  for (auto workloadType : exportOp.getWorkgroupCount().getArgumentTypes()) {
+    if (!workloadType.isIndex()) {
+      // Assume 64 bit index to be safe.
+      argumentTypes.push_back(moduleBuilder.getI64Type());
+    } else {
+      argumentTypes.push_back(workloadType);
+    }
+  }
+  SmallVector<Type> resultTypes;
+  SmallVector<Type> resultDimTypes;
+  SmallVector<int64_t> tiedArguments;
+  int64_t numTensorArgs = 0;
+  for (auto argType : exportedFunc.getArgumentTypes()) {
+    if (auto flowTensorType = dyn_cast<Flow::DispatchTensorType>(argType)) {
+      RankedTensorType tensorType = flowTensorType.asRankedTensorType();
+      // TODO: Support generating dynamic dispatches. Properly tying tensor
+      // sizes to workload values is tricky. Alternatively we could require
+      // users to pass values for all dynamic sizes manually, but there is
+      // likely a better solution that doesn't involve trying to dispatch
+      // the executable directly.
+      if (!tensorType.hasStaticShape()) {
+        return;
+      }
+      TensorAccess accessType = flowTensorType.getAccess();
+      if (accessType != TensorAccess::WriteOnly) {
+        argumentTypes.push_back(flowTensorType.asRankedTensorType());
+        numTensorArgs++;
+      }
+      // Infer results as any writeable tensor.
+      if (accessType != TensorAccess::ReadOnly) {
+        resultTypes.push_back(flowTensorType.asRankedTensorType());
+        tiedArguments.push_back(IREE::Util::TiedOpInterface::kUntiedIndex);
+      }
+      if (accessType == TensorAccess::ReadWrite) {
+        tiedArguments.back() = numTensorArgs - 1;
+      }
+      continue;
+    }
+    if (!argType.isIndex()) {
+      // Assume 64 bit index to be safe.
+      argumentTypes.push_back(moduleBuilder.getI64Type());
+    } else {
+      argumentTypes.push_back(argType);
+    }
+  }
+
+  // Create a function that runs the dispatches based on signature of the
+  // exported function.
+  auto funcType = moduleBuilder.getFunctionType(argumentTypes, resultTypes);
+  auto funcOp =
+      moduleBuilder.create<IREE::Util::FuncOp>(loc, baseName, funcType);
+  funcOp.setVisibility(SymbolTable::Visibility::Public);
+
+  // Build the function that runs the dispatch.
+  auto *entryBlock = funcOp.addEntryBlock();
+  OpBuilder funcBuilder = OpBuilder::atBlockBegin(entryBlock);
+  IndexSet indexSet(loc, funcBuilder);
+
+  int64_t numWorkgroupArgs = exportOp.getWorkgroupCount().getNumArguments();
+  auto workloadArgs = entryBlock->getArguments().slice(0, numWorkgroupArgs);
+  SmallVector<Value> workloadIndexArgs;
+  for (auto [workloadType, workloadBlockArg] : llvm::zip_equal(
+           exportOp.getWorkgroupCount().getArgumentTypes(), workloadArgs)) {
+    if (workloadType.isIndex()) {
+      auto workloadIndexArg = funcBuilder.create<arith::IndexCastOp>(
+          loc, funcBuilder.getIndexType(), workloadBlockArg);
+      workloadIndexArgs.push_back(workloadIndexArg);
+    } else {
+      workloadIndexArgs.push_back(workloadBlockArg);
+    }
+  }
+
+  SmallVector<Value> arguments;
+  // Slices off the first |numWorkgroupArgs| block arguments; the remaining
+  // block arguments are the arguments to the dispatch.
+  for (auto blockArg : entryBlock->getArguments().slice(numWorkgroupArgs)) {
+    if (blockArg.getType().isIndex()) {
+      arguments.push_back(funcBuilder.create<arith::IndexCastOp>(
+          loc, funcBuilder.getIndexType(), blockArg));
+      continue;
+    }
+    arguments.push_back(blockArg);
+  }
+
+  SmallVector<Attribute> tiedAttrs =
+      llvm::map_to_vector<8>(tiedArguments, [&](int64_t v) -> Attribute {
+        return IntegerAttr::get(funcBuilder.getIndexType(), v);
+      });
+
+  auto dispatchOp = funcBuilder.create<IREE::Flow::DispatchOp>(
+      loc, exportOp, workloadIndexArgs, resultTypes,
+      /*resultDims=*/SmallVector<Value>{}, arguments,
+      /*argumentDims=*/SmallVector<Value>{},
+      ArrayAttr::get(funcBuilder.getContext(), tiedAttrs));
+
+  funcBuilder.create<IREE::Util::ReturnOp>(loc, dispatchOp.getResults());
+}
+
+// Builds a module exporting one function for each dispatch configuration
+// targeting |sourceExecutableOp|.
+static mlir::OwningOpRef<mlir::ModuleOp>
+buildExecutableModule(IREE::Flow::ExecutableOp sourceExecutableOp) {
+  // Empty module with default name.
+  // We could use the original module name here to make tracking nicer.
+  mlir::OwningOpRef<mlir::ModuleOp> moduleOp =
+      mlir::ModuleOp::create(sourceExecutableOp.getLoc());
+  auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp->getBody());
+
+  // Intentionally ignore the device targets for the current module. The
+  // exported functions should be compilable for any target.
+
+  // Clone the executable into the new module.
+  auto executableOp =
+      cast<IREE::Flow::ExecutableOp>(moduleBuilder.clone(*sourceExecutableOp));
+
+  // Add functions to test each entry point with its various dispatch
+  // parameters.
+  auto exportOps = llvm::to_vector(
+      executableOp.getBody().getOps<IREE::Flow::ExecutableExportOp>());
+  for (auto exportOp :
+       executableOp.getBody().getOps<IREE::Flow::ExecutableExportOp>()) {
+    buildDispatchExportFunction(executableOp, exportOp, moduleBuilder);
+  }
+
+  // Run CSE and the canonicalizer to pretty up the output.
+  PassManager passManager(moduleOp->getContext());
+  passManager.addPass(mlir::createCanonicalizerPass());
+  passManager.addPass(mlir::createCSEPass());
+  if (failed(passManager.run(*moduleOp))) {
+    moduleOp->emitError("failed to run canonicalizer; malformed output");
+    return {};
+  }
+
+  return moduleOp;
+}
+
+static void dumpModuleToStream(mlir::ModuleOp moduleOp, StringRef fileName,
+                               llvm::raw_ostream &os) {
+  OpPrintingFlags flags;
+  flags.useLocalScope(); // could use global scope, but IR gets messy fast
+  moduleOp.print(os, flags);
+  os << "\n"; // newline at end of file
+}
+
+//===----------------------------------------------------------------------===//
+// --iree-flow-dump-executable-functions
+//===----------------------------------------------------------------------===//
+
+/// Pass declaration.
+struct DumpExecutableFunctionsPass
+    : public DumpExecutableFunctionsPassBase<DumpExecutableFunctionsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, IREE::Util::UtilDialect,
+                    tensor::TensorDialect>();
+  }
+  DumpExecutableFunctionsPass(std::string path) { this->path = path; }
+  DumpExecutableFunctionsPass(const DumpExecutableFunctionsPass &pass)
+      : DumpExecutableFunctionsPass(pass.path) {}
+  void runOnOperation() override;
+};
+
+void DumpExecutableFunctionsPass::runOnOperation() {
+  auto moduleOp = getOperation();
+  auto moduleName = moduleOp.getName().value_or("module");
+
+  // Help people out and mkdir if needed.
+  if (!path.empty() && path != "-") {
+    llvm::sys::fs::create_directories(path);
+  }
+
+  // Produce one file per executable containing all exported entry points.
+  for (auto executableOp : moduleOp.getOps<IREE::Flow::ExecutableOp>()) {
+    auto benchmarkModuleOp = buildExecutableModule(executableOp);
+    if (!benchmarkModuleOp)
+      continue;
+    auto fileName =
+        (moduleName + "_" + executableOp.getName() + "_function.mlir").str();
+    if (path.empty() || path == "-") {
+      dumpModuleToStream(*benchmarkModuleOp, fileName, llvm::outs());
+    } else {
+      auto filePath =
+          (path + llvm::sys::path::get_separator() + fileName).str();
+      std::string error;
+      auto file = mlir::openOutputFile(filePath, &error);
+      if (!file) {
+        executableOp.emitError()
+            << "while dumping to " << path << ": " << error;
+        return signalPassFailure();
+      }
+      dumpModuleToStream(*benchmarkModuleOp, fileName, file->os());
+      file->keep();
+    }
+  }
+}
+
+} // namespace
+
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createDumpExecutableFunctionsPass(std::string path) {
+  return std::make_unique<DumpExecutableFunctionsPass>(path);
+}
+
+} // namespace mlir::iree_compiler::IREE::Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -111,6 +111,12 @@ static llvm::cl::opt<bool> clZeroFillEmptyTensors(
         "Zero fill empty tensors instead of leaving them uninitialized."),
     llvm::cl::init(false));
 
+static llvm::cl::opt<std::string> clDumpFlowExecutableFunctions(
+    "iree-flow-dump-executable-functions-to",
+    llvm::cl::desc("directory path to dump individual mlir files for all flow "
+                   "executables."),
+    llvm::cl::init(""));
+
 namespace mlir::iree_compiler::IREE::Flow {
 
 using FunctionLikeNest =
@@ -287,6 +293,11 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
           IREE::Flow::createDumpDispatchGraphPass(dotFile->os()));
       dotFile->keep();
     }
+  }
+
+  if (!clDumpFlowExecutableFunctions.empty()) {
+    std::string path = clDumpFlowExecutableFunctions;
+    passManager.addPass(IREE::Flow::createDumpExecutableFunctionsPass(path));
   }
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -10,6 +10,7 @@
 #include <functional>
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "llvm/ADT/StringMap.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
@@ -207,6 +208,11 @@ std::unique_ptr<Pass> createCollapseDimsPass();
 /// Creates a pass to dump a graph for dispatches
 std::unique_ptr<Pass>
 createDumpDispatchGraphPass(raw_ostream &os = llvm::errs());
+
+// Create a pass to initialize all empty tensors after dispatch formation to
+// zero or uninitialized allocations.
+std::unique_ptr<OperationPass<ModuleOp>>
+createDumpExecutableFunctionsPass(std::string path = "");
 
 //===----------------------------------------------------------------------===//
 // Register all Passes

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -57,6 +57,26 @@ def DeduplicateExecutables :
   let constructor = "mlir::iree_compiler::IREE::Flow::createDeduplicateExecutablesPass()";
 }
 
+def DumpExecutableFunctionsPass :
+    Pass<"iree-flow-dump-executable-functions", "mlir::ModuleOp"> {
+  let summary = "Dumps standalone flow.executables to the provided path.";
+  let description = [{
+    Dumps one MLIR file per flow.executable containing the executable contents
+    and a single function with a flow.dispatch into the single entry point for
+    the executable. This is intended as a part of a developer flow for dumping
+    target agnostic executables and then compiling them in isolation for
+    comparison across backends.
+  }];
+  let constructor = "mlir::iree_compiler::IREE::Flow::createDumpExecutableFunctionsPass()";
+  let options = [
+    Option<
+      "path", "path",
+      "std::string", "",
+      "File system path to write each executable MLIR file."
+    >,
+  ];
+}
+
 def FoldUnitExtentDims :
     InterfacePass<"iree-flow-fold-unit-extent-dims", "mlir::FunctionOpInterface"> {
   let summary = "Fold unit extent dimension of operations";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "convert_region_to_workgroups.mlir",
             "deduplicate_executables.mlir",
             "dispatch_linalg_on_tensors.mlir",
+            "dump_executable_functions.mlir",
             "collapse_linalg_generic_on_tensors.mlir",
             "dispatch_linalg_on_tensors_default.mlir",
             "dispatch_linalg_on_tensors_fusion_with_transpose.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_lit_test_suite(
     "dispatch_linalg_on_tensors_default.mlir"
     "dispatch_linalg_on_tensors_fusion_with_transpose.mlir"
     "dispatch_linalg_transform_dialect.mlir"
+    "dump_executable_functions.mlir"
     "export_benchmark_funcs.mlir"
     "fold_unit_dims.mlir"
     "form_dispatch_regions.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dump_executable_functions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dump_executable_functions.mlir
@@ -1,0 +1,25 @@
+// RUN: iree-opt --split-input-file --iree-flow-dump-executable-functions %s | FileCheck %s
+
+// Test by dumping to stdout.
+
+// CHECK-LABEL: flow.executable public @single_executable_ex_0
+flow.executable public @single_executable_ex_0 {
+  flow.executable.export @forward_dispatch_0
+  builtin.module {
+    func.func @forward_dispatch_0(%arg0: !flow.dispatch.tensor<readonly:tensor<1048576xf32>>, %arg1: !flow.dispatch.tensor<readonly:tensor<1048576xf32>>, %arg2: !flow.dispatch.tensor<writeonly:tensor<1048576xf32>>) {
+      %0 = flow.dispatch.tensor.load %arg0, offsets = [0], sizes = [1048576], strides = [1] : !flow.dispatch.tensor<readonly:tensor<1048576xf32>> -> tensor<1048576xf32>
+      %1 = flow.dispatch.tensor.load %arg1, offsets = [0], sizes = [1048576], strides = [1] : !flow.dispatch.tensor<readonly:tensor<1048576xf32>> -> tensor<1048576xf32>
+      %2 = tensor.empty() : tensor<1048576xf32>
+      %3 = linalg.add ins(%0, %1 : tensor<1048576xf32>, tensor<1048576xf32>) outs(%2 : tensor<1048576xf32>) -> tensor<1048576xf32>
+      flow.dispatch.tensor.store %3, %arg2, offsets = [0], sizes = [1048576], strides = [1] : tensor<1048576xf32> -> !flow.dispatch.tensor<writeonly:tensor<1048576xf32>>
+      return
+    }
+  }
+}
+
+// CHECK-LABEL: util.func public @single_executable_ex_0_forward_dispatch_0
+// CHECK-SAME:      %[[ARG0:[A-Za-z0-9]+]]: tensor<1048576xf32>, %[[ARG1:[A-Za-z0-9]+]]: tensor<1048576xf32>
+// CHECK-SAME:      -> tensor<1048576xf32> {
+// CHECK:         %[[DISPATCH:.+]] = flow.dispatch @single_executable_ex_0::@forward_dispatch_0
+// CHECK-SAME:      %[[ARG0]], %[[ARG1]]) : (tensor<1048576xf32>, tensor<1048576xf32>) -> tensor<1048576xf32>
+// CHECK:         util.return %[[DISPATCH]] : tensor<1048576xf32>


### PR DESCRIPTION
This allows for exporting the set of deduplicated Flow executables for independent testing/comparison across backends. This only supports statically shaped dispatches because tracking tied dimension quickly gets out of hand for what is supposed to be a simple pass. There might be another export point before this for `flow.dispatch.region` so we don't have to track tied result dims.