### PR TITLE
Reduce lowering_config.conv test & enable it in test_riscv.sh

### DIFF
--- a/build_tools/cmake/test_riscv.sh
+++ b/build_tools/cmake/test_riscv.sh
@@ -42,9 +42,8 @@ declare -a label_exclude_args=(
   "^noriscv$"
 )
 
-# TODO(#10462): Investigate the lowering_config test issue.
 declare -a test_exclude_args=(
-  "regression_llvm-cpu_lowering_config"
+  " "
 )
 
 if [[ "${BUILD_PRESET}" == "benchmark-suite-test" ]]; then

--- a/tests/e2e/regression/lowering_config.mlir
+++ b/tests/e2e/regression/lowering_config.mlir
@@ -31,8 +31,8 @@ func.func @lowering_config_test() {
     lowering_config = <tile_sizes = [[0, 7, 7, 64, 0, 0, 0], [6, 7, 1, 32, 0, 0, 0], [0, 0, 0, 0, 3, 1, 4], [0, 0, 0, 0, 0, 0, 0]]>,
     translation_info = <CPUConvTileAndDecomposeExpert>>
 func.func @conv() {
-  %input = util.unfoldable_constant dense<1.0> : tensor<36x7x7x512xf32>
-  %filter = util.unfoldable_constant dense<1.0> : tensor<3x3x512x512xf32>
+  %input = util.unfoldable_constant dense<1.0> : tensor<12x7x7x512xf32>
+  %filter = util.unfoldable_constant dense<1.0> : tensor<3x3x512x128xf32>
   %0 = "stablehlo.convolution"(%input, %filter) {
     compilation_info = #conv_compilation0,
     batch_group_count = 1 : i64,
@@ -41,7 +41,7 @@ func.func @conv() {
     padding = dense<1> : tensor<2x2xi64>,
     rhs_dilation = dense<1> : tensor<2xi64>,
     window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<36x7x7x512xf32>, tensor<3x3x512x512xf32>) -> tensor<36x7x7x512xf32>
+  } : (tensor<12x7x7x512xf32>, tensor<3x3x512x128xf32>) -> tensor<12x7x7x128xf32>
   %1 = "stablehlo.convolution"(%input, %filter) {
     compilation_info = #conv_compilation1,
     batch_group_count = 1 : i64,
@@ -50,7 +50,7 @@ func.func @conv() {
     padding = dense<1> : tensor<2x2xi64>,
     rhs_dilation = dense<1> : tensor<2xi64>,
     window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<36x7x7x512xf32>, tensor<3x3x512x512xf32>) -> tensor<36x7x7x512xf32>
-  check.expect_almost_eq(%0, %1) : tensor<36x7x7x512xf32>
+  } : (tensor<12x7x7x512xf32>, tensor<3x3x512x128xf32>) -> tensor<12x7x7x128xf32>
+  check.expect_almost_eq(%0, %1) : tensor<12x7x7x128xf32>
   return
 }


### PR DESCRIPTION
`check_regression_llvm-cpu_lowering_config.mlir` can run correctly in riscv now, but fails in 60 seconds timeout.

As discussed in https://github.com/openxla/iree/issues/10462, this PR reduces the test case.

Time reduction in my machine:
252 -> 30 sec
![image](https://github.com/openxla/iree/assets/55973122/603104bf-edd2-4730-beae-aad75727e545)

Related issue: https://github.com/openxla/iree/issues/10462
FYI. @rednoah91 
