### PR TITLE
[CPU] remove architecture check for llvm-cpu ordinal passes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignConstantOrdinals.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignConstantOrdinals.cpp
@@ -20,11 +20,6 @@ struct LLVMCPUAssignConstantOrdinalsPass
   void runOnOperation() override {
     auto variantOp = getOperation();
 
-    // Ignore non-LLVMCPU variants.
-    // TODO(benvanik): a way to nest this in the pipeline via dynamic passes.
-    if (variantOp.getTarget().getBackend().getValue() != "llvm-cpu")
-      return;
-
     // Get a constant key -> ordinal mapping.
     auto keyOrdinals = variantOp.gatherConstantOrdinals();
     if (keyOrdinals.empty())

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignImportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignImportOrdinals.cpp
@@ -20,11 +20,6 @@ struct LLVMCPUAssignImportOrdinalsPass
   void runOnOperation() override {
     auto variantOp = getOperation();
 
-    // Ignore non-LLVMCPU variants.
-    // TODO(benvanik): a way to nest this in the pipeline via dynamic passes.
-    if (variantOp.getTarget().getBackend().getValue() != "llvm-cpu")
-      return;
-
     auto *context = variantOp.getContext();
     auto unitAttr = UnitAttr::get(context);
     auto importKeyAttr = StringAttr::get(context, "hal.executable.import.key");


### PR DESCRIPTION
These if-statements are not needed anymore, since the passes are anyway only called in the llvm-cpu pipeline. 

@benvanik fyi, we had a discussion about those statements a few months ago on discord