### PR TITLE
NFC: Move ContractOpInfo to a new file in Codegen/Utils/

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -6,7 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
-#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
+#include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
@@ -19,75 +19,6 @@ namespace {
 
 using namespace mlir::iree_compiler::IREE::VectorExt;
 using VectorValue = TypedValue<VectorType>;
-
-/// A class for querying information about a contract op.
-class ContractOpDetail {
-public:
-  enum class OpKind { MK_KN_MN, MK_NK_MN, UNKNOWN };
-
-  explicit ContractOpDetail(vector::ContractionOp op) {
-    opKind = inferOpKind(op.getContext(), op.getIndexingMapsArray());
-  }
-
-  OpKind getOpKind() const { return opKind; }
-
-  // Returns the (LHS M, RHS N) dimension index pair.
-  std::optional<std::pair<int, int>> getOperandMNIndex() const {
-    switch (opKind) {
-    case OpKind::MK_KN_MN:
-      return std::make_pair(0, 1);
-    case OpKind::MK_NK_MN:
-      return std::make_pair(0, 0);
-    case OpKind::UNKNOWN:
-      break;
-    }
-    return std::nullopt;
-  }
-
-  // Returns the (LHS K, RHS K) dimension index pair.
-  std::optional<std::pair<int, int>> getOperandKIndex() const {
-    switch (opKind) {
-    case OpKind::MK_KN_MN:
-      return std::make_pair(1, 0);
-    case OpKind::MK_NK_MN:
-      return std::make_pair(1, 1);
-    case OpKind::UNKNOWN:
-      break;
-    }
-    return std::nullopt;
-  }
-
-  // Returns the result (M, N) dimension index pair.
-  std::optional<std::pair<int, int>> getResultMNIndex() const {
-    switch (opKind) {
-    case OpKind::MK_KN_MN:
-    case OpKind::MK_NK_MN:
-      return std::make_pair(0, 1);
-    default:
-      break;
-    }
-    return std::nullopt;
-  }
-
-private:
-  // Gets the kind of a contract op with the given indexing |maps|.
-  OpKind inferOpKind(MLIRContext *ctx, SmallVector<AffineMap> maps) {
-    using MapList = ArrayRef<ArrayRef<AffineExpr>>;
-    auto infer = [&](MapList m) {
-      return AffineMap::inferFromExprList(m, ctx);
-    };
-    AffineExpr m, n, k;
-    bindDims(ctx, m, n, k);
-    if (maps == infer({{m, k}, {k, n}, {m, n}}))
-      return OpKind::MK_KN_MN;
-    if (maps == infer({{m, k}, {n, k}, {m, n}}))
-      return OpKind::MK_NK_MN;
-    return OpKind::UNKNOWN;
-  }
-
-private:
-  OpKind opKind = OpKind::UNKNOWN;
-};
 
 /// Distributes `vector.contract` ops with nested layouts.
 struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
@@ -140,8 +71,8 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
     mfmaParams.blocks = mfmaAttr.getBlockSize();
 
     // Infer the contract kind so that we know know to correlate M/N/K dims.
-    ContractOpDetail opDetail(contractOp);
-    if (opDetail.getOpKind() == ContractOpDetail::OpKind::UNKNOWN) {
+    VectorContractOpInfo opDetail(contractOp);
+    if (opDetail.getOpKind() == VectorContractOpInfo::OpKind::UNKNOWN) {
       return rewriter.notifyMatchFailure(contractOp, "unknown contract kind");
     }
 
@@ -243,7 +174,7 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
   }
 
   // Gets the batch size for matmul K dimensions.
-  std::optional<int64_t> getKBatchSize(const ContractOpDetail &opDetail,
+  std::optional<int64_t> getKBatchSize(const VectorContractOpInfo &opDetail,
                                        NestedLayoutAttr lhsLayout,
                                        NestedLayoutAttr rhsLayout) const {
     auto [lhsK, rhsK] = *opDetail.getOperandKIndex();
@@ -257,7 +188,7 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
 
   // Given a contract op's batch |resultOffsets|, fills its batch offsets for
   // both LHS and RHS.
-  void fillOperandBatchOffsets(const ContractOpDetail &opDetail,
+  void fillOperandBatchOffsets(const VectorContractOpInfo &opDetail,
                                int64_t kOffset, ArrayRef<int64_t> resultOffsets,
                                NestedLayoutAttr resultLayout,
                                SmallVector<int64_t, 2> &lhsOffsets,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -85,6 +85,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",
+        "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -113,6 +113,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils
+    iree::compiler::Codegen::Utils::VectorOpUtils
     iree::compiler::Dialect::HAL::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -66,3 +66,19 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ViewLikeInterface",
     ],
 )
+
+iree_compiler_cc_library(
+    name = "VectorOpUtils",
+    srcs = [
+        "VectorOpUtils.cpp",
+    ],
+    hdrs = [
+        "VectorOpUtils.h",
+    ],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:VectorDialect",
+    ],
+)

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -62,4 +62,19 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    VectorOpUtils
+  HDRS
+    "VectorOpUtils.h"
+  SRCS
+    "VectorOpUtils.cpp"
+  DEPS
+    LLVMSupport
+    MLIRIR
+    MLIRSupport
+    MLIRVectorDialect
+  PUBLIC
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
@@ -1,0 +1,68 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
+
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+
+namespace mlir::iree_compiler {
+
+std::optional<std::pair<int, int>>
+VectorContractOpInfo::getOperandMNIndex() const {
+  switch (opKind) {
+  case OpKind::MK_KN_MN:
+    return std::make_pair(0, 1);
+  case OpKind::MK_NK_MN:
+    return std::make_pair(0, 0);
+  case OpKind::UNKNOWN:
+    break;
+  }
+  return std::nullopt;
+}
+
+// Returns the (LHS K, RHS K) dimension index pair.
+std::optional<std::pair<int, int>>
+VectorContractOpInfo::getOperandKIndex() const {
+  switch (opKind) {
+  case OpKind::MK_KN_MN:
+    return std::make_pair(1, 0);
+  case OpKind::MK_NK_MN:
+    return std::make_pair(1, 1);
+  case OpKind::UNKNOWN:
+    break;
+  }
+  return std::nullopt;
+}
+
+// Returns the result (M, N) dimension index pair.
+std::optional<std::pair<int, int>>
+VectorContractOpInfo::getResultMNIndex() const {
+  switch (opKind) {
+  case OpKind::MK_KN_MN:
+  case OpKind::MK_NK_MN:
+    return std::make_pair(0, 1);
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
+VectorContractOpInfo::OpKind
+VectorContractOpInfo::inferOpKind(MLIRContext *ctx,
+                                  SmallVector<AffineMap> maps) const {
+  using MapList = ArrayRef<ArrayRef<AffineExpr>>;
+  auto infer = [&](MapList m) { return AffineMap::inferFromExprList(m, ctx); };
+  AffineExpr m, n, k;
+  bindDims(ctx, m, n, k);
+  if (maps == infer({{m, k}, {k, n}, {m, n}}))
+    return OpKind::MK_KN_MN;
+  if (maps == infer({{m, k}, {n, k}, {m, n}}))
+    return OpKind::MK_NK_MN;
+  return OpKind::UNKNOWN;
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
@@ -1,0 +1,38 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+
+namespace mlir::iree_compiler {
+
+/// A class for querying information about a contract op.
+class VectorContractOpInfo {
+public:
+  enum class OpKind { MK_KN_MN, MK_NK_MN, UNKNOWN };
+
+  explicit VectorContractOpInfo(vector::ContractionOp op) {
+    opKind = inferOpKind(op.getContext(), op.getIndexingMapsArray());
+  }
+
+  OpKind getOpKind() const { return opKind; }
+
+  // Returns the (LHS M, RHS N) dimension index pair.
+  std::optional<std::pair<int, int>> getOperandMNIndex() const;
+
+  // Returns the (LHS K, RHS K) dimension index pair.
+  std::optional<std::pair<int, int>> getOperandKIndex() const;
+
+  // Returns the result (M, N) dimension index pair.
+  std::optional<std::pair<int, int>> getResultMNIndex() const;
+
+private:
+  // Gets the kind of a contract op with the given indexing |maps|.
+  OpKind inferOpKind(MLIRContext *ctx, SmallVector<AffineMap> maps) const;
+
+  OpKind opKind = OpKind::UNKNOWN;
+};
+
+} // namespace mlir::iree_compiler


### PR DESCRIPTION
This prepares it to be shared by other parts in the codebase.