### PR TITLE
[rocdl] Deduce and plumb MMA schedule in vector distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -12,7 +12,7 @@
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 
-#define DEBUG_TYPE "iree-amdgpu-distribute-contract"
+#define DEBUG_TYPE "iree-codegen-amdgpu-distribute-contract"
 
 namespace mlir::iree_compiler {
 namespace {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -23,15 +23,16 @@ struct GPUMatmulShapeType {
 
 /// Struct containing seed tile sizes for GPU MMA heuristics deduction logic.
 struct GPUMMAHeuristicSeeds {
-  // The default number of subgroups to use per workgroup
-  int64_t numSubgroupsPerWorkgroup;
-  // The default number of tiles along M/N dimension to use per workgroup
-  int64_t numMNTilesPerSubgroup;
-  // The default number of tiles along K dimension to use per subgroup
-  int64_t numKTilesPerSubgroup;
+  // The best number of subgroups to use per workgroup
+  int64_t bestSubgroupCountPerWorkgroup;
+  // The best number of total tiles along M*N dimensions per subgroup
+  int64_t bestMNTileCountPerSubgroup;
+  // The best number of tiles along K dimension per subgroup
+  int64_t bestKTileCountPerSubgroup;
 };
 
 struct GPUMMASchedule {
+  uint64_t index;     // Index of the chosen intrinsic
   int64_t mSize;      // Native MMA size along M dimension
   int64_t nSize;      // Native MMA size along N dimension
   int64_t kSize;      // Native MMA size along K dimension

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -32,7 +32,8 @@ struct GPUMMAHeuristicSeeds {
 };
 
 struct GPUMMASchedule {
-  uint64_t index;     // Index of the chosen intrinsic
+  // Index of the chosen intrinsic into the list of given MMA intrinsics
+  uint64_t index;
   int64_t mSize;      // Native MMA size along M dimension
   int64_t nSize;      // Native MMA size along N dimension
   int64_t kSize;      // Native MMA size along K dimension

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         ":IREEGPUInterfaces",
         "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Utils",
+        "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//llvm-external-projects/iree-dialects:IREEVectorExtDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:DialectUtils",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
     MLIRVectorDialect
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Utils
+    iree::compiler::Codegen::Utils::VectorOpUtils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -432,6 +432,9 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
 
   auto mfmaAttr = llvm::cast<MFMAAttr>(getIntrinsic());
 
+  // TODO: revisit the handling of subgroup/thread basis
+  SmallVector<int64_t, 2> subgroupBasis = {getSubgroupMCount(), getSubgroupNCount()};
+
   // C matrix layout
   MFMAAttr::OuterThreadElement cCounts = mfmaAttr.getCOuterThreadElementCount();
   MFMAAttr::OuterThreadElement cOrders = mfmaAttr.getCOuterThreadElementOrder();
@@ -442,13 +445,12 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
                                                  getSubgroupNTileCount()};
   SmallVector<int64_t, 2> cSubgroupOrder = {0, 1};
   SmallVector<int64_t, 2> cBatchOrder = {0, 1};
-  SmallVector<int64_t, 2> cSubgroupBasis = cSubgroupPerWorkgroup;
   SmallVector<int64_t, 2> cThreadBasis = cCounts.thread;
 
   auto cLayout = NestedLayoutAttr::get(
       getContext(), cSubgroupPerWorkgroup, cSubgroupOrder, cBatchesPerSubgroup,
       cBatchOrder, cCounts.outer, cOrders.outer, cCounts.thread, cOrders.thread,
-      cCounts.element, cOrders.element, cSubgroupBasis, cThreadBasis);
+      cCounts.element, cOrders.element, subgroupBasis, cThreadBasis);
 
   // A matrix layout
   MFMAAttr::OuterThreadElement aCounts = mfmaAttr.getAOuterThreadElementCount();
@@ -459,13 +461,12 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
                                                  getSubgroupKTileCount()};
   SmallVector<int64_t, 2> aSubgroupOrder = {0, 1};
   SmallVector<int64_t, 2> aBatchOrder = {0, 1};
-  SmallVector<int64_t, 2> aSubgroupBasis = aSubgroupPerWorkgroup;
   SmallVector<int64_t, 2> aThreadBasis = aCounts.thread;
 
   auto aLayout = NestedLayoutAttr::get(
       getContext(), aSubgroupPerWorkgroup, aSubgroupOrder, aBatchesPerSubgroup,
       aBatchOrder, aCounts.outer, aOrders.outer, aCounts.thread, aOrders.thread,
-      aCounts.element, aOrders.element, aSubgroupBasis, aThreadBasis);
+      aCounts.element, aOrders.element, subgroupBasis, aThreadBasis);
 
   // B matrix layout
   MFMAAttr::OuterThreadElement bCounts = mfmaAttr.getBOuterThreadElementCount();
@@ -476,13 +477,12 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
                                                  getSubgroupNTileCount()};
   SmallVector<int64_t, 2> bSubgroupOrder = {0, 1};
   SmallVector<int64_t, 2> bBatchOrder = {0, 1};
-  SmallVector<int64_t, 2> bSubgroupBasis = bSubgroupPerWorkgroup;
   SmallVector<int64_t, 2> bThreadBasis = bCounts.thread;
 
   auto bLayout = NestedLayoutAttr::get(
       getContext(), bSubgroupPerWorkgroup, bSubgroupOrder, bBatchesPerSubgroup,
       bBatchOrder, bCounts.outer, bOrders.outer, bCounts.thread, bOrders.thread,
-      bCounts.element, bOrders.element, bSubgroupBasis, bThreadBasis);
+      bCounts.element, bOrders.element, subgroupBasis, bThreadBasis);
 
   return std::make_tuple(aLayout, bLayout, cLayout);
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -433,7 +433,8 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
   auto mfmaAttr = llvm::cast<MFMAAttr>(getIntrinsic());
 
   // TODO: revisit the handling of subgroup/thread basis
-  SmallVector<int64_t, 2> subgroupBasis = {getSubgroupMCount(), getSubgroupNCount()};
+  SmallVector<int64_t, 2> subgroupBasis = {getSubgroupMCount(),
+                                           getSubgroupNCount()};
 
   // C matrix layout
   MFMAAttr::OuterThreadElement cCounts = mfmaAttr.getCOuterThreadElementCount();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -6,10 +6,13 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 
+#include "iree-dialects/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Common/VectorLayoutAnalysis.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -27,6 +30,7 @@ using VectorLayoutInterface =
     mlir::iree_compiler::IREE::VectorExt::VectorLayoutInterface;
 using PerDimLayoutAttr = mlir::iree_compiler::IREE::VectorExt::PerDimLayoutAttr;
 using LayoutAttr = mlir::iree_compiler::IREE::VectorExt::LayoutAttr;
+using NestedLayoutAttr = mlir::iree_compiler::IREE::VectorExt::NestedLayoutAttr;
 
 namespace mlir::iree_compiler::IREE::GPU {
 
@@ -324,7 +328,7 @@ MFMAAttr::getContractionLayout(vector::ContractionOp contract) const {
   return IREE::GPU::getContractionLayout(contract, layout);
 }
 
-int64_t MFMAAttr::getBlockSize() {
+int64_t MFMAAttr::getBlockSize() const {
   switch (getIntrinsic().getValue()) {
   case MFMAIntrinsic::F16_16x16x16_F32: {
     return 1;
@@ -337,8 +341,155 @@ int64_t MFMAAttr::getBlockSize() {
   return 0;
 }
 
+MFMAAttr::OuterThreadElement MFMAAttr::getAOuterThreadElementCount() const {
+  switch (getIntrinsic().getValue()) {
+  case MFMAIntrinsic::F16_16x16x16_F32: {
+    return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*element=*/{1, 4}};
+  }
+  case MFMAIntrinsic::F16_32x32x8_F32: {
+    return {/*outer=*/{1, 1}, /*thread=*/{32, 2}, /*element=*/{1, 4}};
+  }
+  }
+  return {};
+}
+
+MFMAAttr::OuterThreadElement MFMAAttr::getBOuterThreadElementCount() const {
+  switch (getIntrinsic().getValue()) {
+  case MFMAIntrinsic::F16_16x16x16_F32: {
+    return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*element=*/{4, 1}};
+  }
+  case MFMAIntrinsic::F16_32x32x8_F32: {
+    return {/*outer=*/{1, 1}, /*thread=*/{2, 32}, /*element=*/{4, 1}};
+  }
+  }
+  return {};
+}
+
+MFMAAttr::OuterThreadElement MFMAAttr::getCOuterThreadElementCount() const {
+  switch (getIntrinsic().getValue()) {
+  case MFMAIntrinsic::F16_16x16x16_F32: {
+    return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*element=*/{4, 1}};
+  }
+  case MFMAIntrinsic::F16_32x32x8_F32: {
+    return {/*outer=*/{4, 1}, /*thread=*/{2, 32}, /*element=*/{4, 1}};
+  }
+  }
+  return {};
+}
+
+MFMAAttr::OuterThreadElement MFMAAttr::getAOuterThreadElementOrder() const {
+  switch (getIntrinsic().getValue()) {
+  case MFMAIntrinsic::F16_16x16x16_F32:
+  case MFMAIntrinsic::F16_32x32x8_F32: {
+    return {/*outer=*/{0, 1}, /*thread=*/{1, 0}, /*element=*/{0, 1}};
+  }
+  }
+  return {};
+}
+
+MFMAAttr::OuterThreadElement MFMAAttr::getBOuterThreadElementOrder() const {
+  switch (getIntrinsic().getValue()) {
+  case MFMAIntrinsic::F16_16x16x16_F32:
+  case MFMAIntrinsic::F16_32x32x8_F32: {
+    return {/*outer=*/{0, 1}, /*thread=*/{0, 1}, /*element=*/{1, 0}};
+  }
+  }
+  return {};
+}
+
+MFMAAttr::OuterThreadElement MFMAAttr::getCOuterThreadElementOrder() const {
+  switch (getIntrinsic().getValue()) {
+  case MFMAIntrinsic::F16_16x16x16_F32:
+  case MFMAIntrinsic::F16_32x32x8_F32: {
+    return {/*outer=*/{0, 1}, /*thread=*/{0, 1}, /*element=*/{1, 0}};
+  }
+  }
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
-// Initialize attributes
+// MMA Schedule Attributes
+//===----------------------------------------------------------------------===//
+
+std::optional<std::tuple<VectorExt::VectorLayoutInterface,
+                         VectorExt::VectorLayoutInterface,
+                         VectorExt::VectorLayoutInterface>>
+MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
+  VectorContractOpInfo opInfo(contractOp);
+  if (opInfo.getOpKind() == VectorContractOpInfo::OpKind::UNKNOWN)
+    return std::nullopt;
+
+  auto [aM, bN] = *opInfo.getOperandMNIndex();
+  auto [aK, bK] = *opInfo.getOperandKIndex();
+  auto [cM, cN] = *opInfo.getResultMNIndex();
+  SmallVector<int64_t, 2> aPermute = {aM, aK};
+  SmallVector<int64_t, 2> bPermute = {bK, bN};
+  SmallVector<int64_t, 2> cPermute = {cM, cN};
+
+  // TODO: drop this and permute the following fields
+  if (!isIdentityPermutation(aPermute) || !isIdentityPermutation(bPermute) ||
+      !isIdentityPermutation(cPermute))
+    return std::nullopt;
+
+  auto mfmaAttr = llvm::cast<MFMAAttr>(getIntrinsic());
+
+  // C matrix layout
+  MFMAAttr::OuterThreadElement cCounts = mfmaAttr.getCOuterThreadElementCount();
+  MFMAAttr::OuterThreadElement cOrders = mfmaAttr.getCOuterThreadElementOrder();
+
+  SmallVector<int64_t, 2> cSubgroupPerWorkgroup = {getSubgroupMCount(),
+                                                   getSubgroupNCount()};
+  SmallVector<int64_t, 2> cBatchesPerSubgroup = {getSubgroupMTileCount(),
+                                                 getSubgroupNTileCount()};
+  SmallVector<int64_t, 2> cSubgroupOrder = {0, 1};
+  SmallVector<int64_t, 2> cBatchOrder = {0, 1};
+  SmallVector<int64_t, 2> cSubgroupBasis = cSubgroupPerWorkgroup;
+  SmallVector<int64_t, 2> cThreadBasis = cCounts.thread;
+
+  auto cLayout = NestedLayoutAttr::get(
+      getContext(), cSubgroupPerWorkgroup, cSubgroupOrder, cBatchesPerSubgroup,
+      cBatchOrder, cCounts.outer, cOrders.outer, cCounts.thread, cOrders.thread,
+      cCounts.element, cOrders.element, cSubgroupBasis, cThreadBasis);
+
+  // A matrix layout
+  MFMAAttr::OuterThreadElement aCounts = mfmaAttr.getAOuterThreadElementCount();
+  MFMAAttr::OuterThreadElement aOrders = mfmaAttr.getAOuterThreadElementOrder();
+
+  SmallVector<int64_t, 2> aSubgroupPerWorkgroup = {getSubgroupMCount(), 1};
+  SmallVector<int64_t, 2> aBatchesPerSubgroup = {getSubgroupMTileCount(),
+                                                 getSubgroupKTileCount()};
+  SmallVector<int64_t, 2> aSubgroupOrder = {0, 1};
+  SmallVector<int64_t, 2> aBatchOrder = {0, 1};
+  SmallVector<int64_t, 2> aSubgroupBasis = aSubgroupPerWorkgroup;
+  SmallVector<int64_t, 2> aThreadBasis = aCounts.thread;
+
+  auto aLayout = NestedLayoutAttr::get(
+      getContext(), aSubgroupPerWorkgroup, aSubgroupOrder, aBatchesPerSubgroup,
+      aBatchOrder, aCounts.outer, aOrders.outer, aCounts.thread, aOrders.thread,
+      aCounts.element, aOrders.element, aSubgroupBasis, aThreadBasis);
+
+  // B matrix layout
+  MFMAAttr::OuterThreadElement bCounts = mfmaAttr.getBOuterThreadElementCount();
+  MFMAAttr::OuterThreadElement bOrders = mfmaAttr.getBOuterThreadElementOrder();
+
+  SmallVector<int64_t, 2> bSubgroupPerWorkgroup = {1, getSubgroupNCount()};
+  SmallVector<int64_t, 2> bBatchesPerSubgroup = {getSubgroupKTileCount(),
+                                                 getSubgroupNTileCount()};
+  SmallVector<int64_t, 2> bSubgroupOrder = {0, 1};
+  SmallVector<int64_t, 2> bBatchOrder = {0, 1};
+  SmallVector<int64_t, 2> bSubgroupBasis = bSubgroupPerWorkgroup;
+  SmallVector<int64_t, 2> bThreadBasis = bCounts.thread;
+
+  auto bLayout = NestedLayoutAttr::get(
+      getContext(), bSubgroupPerWorkgroup, bSubgroupOrder, bBatchesPerSubgroup,
+      bBatchOrder, bCounts.outer, bOrders.outer, bCounts.thread, bOrders.thread,
+      bCounts.element, bOrders.element, bSubgroupBasis, bThreadBasis);
+
+  return std::make_tuple(aLayout, bLayout, cLayout);
+}
+
+//===----------------------------------------------------------------------===//
+// Attribute Registration
 //===----------------------------------------------------------------------===//
 
 void IREEGPUDialect::registerAttributes() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -4,9 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-//===- IREEGPUAttrs.h - Codegen GPU dialect attributes --------------------===//
-//===----------------------------------------------------------------------===//
-
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS_H_
 
@@ -23,31 +20,5 @@
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h.inc"
 // clang-format on
-
-namespace mlir::linalg {
-class LinalgOp;
-} // namespace mlir::linalg
-
-namespace mlir::iree_compiler {
-
-// Returns an MmaAttr from the array of mmaKinds compatible with the given
-// structured operation description. The conditions for compatibility are
-//
-// 1. The iteration bounds are aligned on the shape of the mma operation.
-// 2. The element types of |inputTypes| match with `[aType, bType, cType]`
-//
-// Returns the first successful match.
-std::optional<IREE::GPU::MmaAttr>
-getCompatibleMmaAttr(ArrayAttr mmaKinds, ArrayRef<AffineMap> indexingMaps,
-                     ArrayRef<int64_t> iterationBounds, TypeRange inputTypes);
-// Helper for contractions.
-std::optional<IREE::GPU::MmaAttr> getCompatibleMmaAttr(ArrayAttr mmaKinds,
-                                                       vector::ContractionOp);
-// Helper for linalg ops. Fails if the linalg op is not inferrable as a
-// contraction op.
-std::optional<IREE::GPU::MmaAttr> getCompatibleMmaAttr(ArrayAttr mmaKinds,
-                                                       linalg::LinalgOp);
-
-} // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -13,8 +13,9 @@ include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
 
-def IREEGPU_MmaArrayAttr : TypedArrayAttrBase<IREEGPU_MmaAttr,
-    "Descriptor array of a list of supported mma operations">;
+//===----------------------------------------------------------------------===//
+// Base MMA Vector Layout Attributes
+//===----------------------------------------------------------------------===//
 
 class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
     AttrDef<IREEGPU_Dialect, attrname, [
@@ -96,7 +97,7 @@ def IREEGPU_MFMAIntrinsic : IREEGPU_I32MmaEnumAttr<"MFMAIntrinsic",
 def IREEGPU_MFMAIntrinsicAttr
   : IREEGPU_MmaEnumAttr<IREEGPU_MFMAIntrinsic, "mfma_intrinsic">;
 
-def IREEGPU_MFMA : IREEGPU_MmaVectorLayoutAttr<"MFMA", "MFMAIntrinsicAttr"> {
+def IREEGPU_MFMAAttr : IREEGPU_MmaVectorLayoutAttr<"MFMA", "MFMAIntrinsicAttr"> {
   let mnemonic = "mfma_layout";
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
 
@@ -119,8 +120,57 @@ def IREEGPU_MFMA : IREEGPU_MmaVectorLayoutAttr<"MFMA", "MFMAIntrinsicAttr"> {
   ];
 
   let extraClassDeclaration = !strconcat(baseExtraClassDeclaration, [{
-    int64_t getBlockSize();
+    int64_t getBlockSize() const;
+
+    struct OuterThreadElement {
+      SmallVector<int64_t, 2> outer;
+      SmallVector<int64_t, 2> thread;
+      SmallVector<int64_t, 2> element;
+    };
+
+    OuterThreadElement getAOuterThreadElementCount() const;
+    OuterThreadElement getBOuterThreadElementCount() const;
+    OuterThreadElement getCOuterThreadElementCount() const;
+
+    OuterThreadElement getAOuterThreadElementOrder() const;
+    OuterThreadElement getBOuterThreadElementOrder() const;
+    OuterThreadElement getCOuterThreadElementOrder() const;
   }]);
 }
+
+//===----------------------------------------------------------------------===//
+// MMA schedule Attributes
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_MmaScheduleAttr : AttrDef<IREEGPU_Dialect, "MMASchedule"> {
+  let mnemonic = "mma_schedule";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+
+  string description = [{
+    A schedule of MMA intrinsic instruction and various levels of tile sizes
+    to solve a specific contraction problem.
+  }];
+
+
+  let parameters = (ins
+    "::mlir::iree_compiler::IREE::GPU::MmaAttr":$intrinsic,
+    "int64_t":$subgroup_m_count,
+    "int64_t":$subgroup_n_count,
+    "int64_t":$subgroup_m_tile_count,
+    "int64_t":$subgroup_n_tile_count,
+    "int64_t":$subgroup_k_tile_count
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let extraClassDeclaration = [{
+    // Returns the A/B/C matrix concrete layout targeting |contractOp|.
+    ::std::optional<::std::tuple<VectorExt::VectorLayoutInterface,
+                                 VectorExt::VectorLayoutInterface,
+                                 VectorExt::VectorLayoutInterface>>
+      getContractionLayout(::mlir::vector::ContractionOp contractOp) const;
+  }];
+}
+
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -122,19 +122,32 @@ def IREEGPU_MFMAAttr : IREEGPU_MmaVectorLayoutAttr<"MFMA", "MFMAIntrinsicAttr"> 
   let extraClassDeclaration = !strconcat(baseExtraClassDeclaration, [{
     int64_t getBlockSize() const;
 
-    struct OuterThreadElement {
+    // Partial nested layout for an MMA intrinsic's matrix input/output inside
+    // a single subgroup.
+    //
+    // Note that this is just a container used by the following methods; it can
+    // contain both the shape and the order.
+    struct SingleSubgroupLayout {
       SmallVector<int64_t, 2> outer;
       SmallVector<int64_t, 2> thread;
       SmallVector<int64_t, 2> element;
     };
 
-    OuterThreadElement getAOuterThreadElementCount() const;
-    OuterThreadElement getBOuterThreadElementCount() const;
-    OuterThreadElement getCOuterThreadElementCount() const;
+    // Returns the A/B/C matrix's partial nested layout shape inside a single
+    // subgroup. Shape at each outer/thread/element level is a 2-D value,
+    // following canonical matmul order--(M, K) for A, (K, N) for B, and
+    // (M, N) for C.
+    SingleSubgroupLayout getASingleSubgroupLayoutCount() const;
+    SingleSubgroupLayout getBSingleSubgroupLayoutCount() const;
+    SingleSubgroupLayout getCSingleSubgroupLayoutCount() const;
 
-    OuterThreadElement getAOuterThreadElementOrder() const;
-    OuterThreadElement getBOuterThreadElementOrder() const;
-    OuterThreadElement getCOuterThreadElementOrder() const;
+    // Returns the A/B/C matrix's partial nested layout order inside a single
+    // subgroup. Order at each outer/thread/element level is a 2-value
+    // permuation vector, following canonical matmul order--(M, K) for A,
+    // (K, N) for B, and (M, N) for C.
+    SingleSubgroupLayout getASingleSubgroupLayoutOrder() const;
+    SingleSubgroupLayout getBSingleSubgroupLayoutOrder() const;
+    SingleSubgroupLayout getCSingleSubgroupLayoutOrder() const;
   }]);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -124,6 +124,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Common:TransformDialectInterpreterPass",
         "//compiler/src/iree/compiler/Codegen/Common/GPU:CommonGPUPasses",
+        "//compiler/src/iree/compiler/Codegen/Common/GPU:GPUHeuristics",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -167,6 +167,7 @@ iree_cc_library(
     MLIRVectorTransforms
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::GPU::CommonGPUPasses
+    iree::compiler::Codegen::Common::GPU::GPUHeuristics
     iree::compiler::Codegen::Common::TransformDialectInterpreterPass
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -374,14 +374,14 @@ setVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
   // for later access in the pipeline.
   MLIRContext *context = op.getContext();
   auto scheduleAttr = IREE::GPU::MMAScheduleAttr::get(
-      op.getContext(), mmaAttrs[schedule->index], schedule->mWarpCount,
+      context, mmaAttrs[schedule->index], schedule->mWarpCount,
       schedule->nWarpCount, schedule->mTileCount, schedule->nTileCount,
       schedule->kTileCount);
   SmallVector<NamedAttribute, 1> attrs;
   attrs.emplace_back(
       StringAttr::get(context, IREE::GPU::MMAScheduleAttr::getMnemonic()),
       scheduleAttr);
-  auto configDict = DictionaryAttr::get(op.getContext(), attrs);
+  auto configDict = DictionaryAttr::get(context, attrs);
 
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, tileSizes,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -24,7 +24,6 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
-#include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -134,7 +134,6 @@ static void addGPUVectorizationPasses(OpPassManager &pm) {
   options.vectorizeGatherAccesses = true;
   options.enableCleanup = false;
   options.foldCastIntoContract = true;
-  options.maxVectorSize = 4096;
   pm.addNestedPass<func::FuncOp>(createGenericVectorizationPass(options));
   pm.addNestedPass<func::FuncOp>(createOptimizeTensorInsertExtractSlicesPass());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute.mlir
@@ -1,21 +1,22 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-llvmgpu-vector-distribute, canonicalize, cse))' -split-input-file %s | FileCheck %s
 
 builtin.module attributes { hal.executable.target = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
-  mma_intrinsics = [#iree_gpu.mfma_layout<F16_16x16x16_F32>,
-                    #iree_gpu.mfma_layout<F16_32x32x8_F32>],
   target_arch = "gfx940",
   ukernels = "none"}>} {
   func.func @matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>,
                                 %rhs: memref<256x16xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>,
                                 %out: memref<16x16xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
-                                attributes {subgroup_size = 64, workgroup_size = [64, 1, 1]} {
+    attributes {
+      mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mfma_layout<F16_16x16x16_F32>,
+                       subgroup_m_count = 1, subgroup_n_count = 1, subgroup_m_tile_count = 1, subgroup_n_tile_count = 1, subgroup_k_tile_count = 2>,
+      subgroup_size = 64, workgroup_size = [64, 1, 1]} {
     %alloc = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
     %alloc_0 = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-    %cst = arith.constant 0.000000e+00 : f16 
+    %cst = arith.constant 0.000000e+00 : f16
     %cst_1 = arith.constant dense<0.000000e+00> : vector<16x16xf32>
-    %c32 = arith.constant 32 : index 
-    %c256 = arith.constant 256 : index 
-    %c0 = arith.constant 0 : index 
+    %c32 = arith.constant 32 : index
+    %c256 = arith.constant 256 : index
+    %c0 = arith.constant 0 : index
     %5 = scf.for %arg0 = %c0 to %c256 step %c32 iter_args(%arg1 = %cst_1) -> (vector<16x16xf32>) {
       %6 = vector.transfer_read %lhs[%c0, %arg0], %cst {in_bounds = [true, true]} : memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<16x32xf16>
       %7 = vector.transfer_read %rhs[%arg0, %c0], %cst {in_bounds = [true, true]} : memref<256x16xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<32x16xf16>
@@ -25,7 +26,10 @@ builtin.module attributes { hal.executable.target = #hal.executable.target<"rocm
       gpu.barrier
       %8 = vector.transfer_read %alloc_0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<16x32xf16>
       %9 = vector.transfer_read %alloc[%c0, %c0], %cst {in_bounds = [true, true]} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<32x16xf16>
-      %10 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %8, %9, %arg1 : vector<16x32xf16>, vector<32x16xf16> into vector<16x16xf32> 
+      %10 = vector.contract {
+        indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+        %8, %9, %arg1 : vector<16x32xf16>, vector<32x16xf16> into vector<16x16xf32>
       scf.yield %10 : vector<16x16xf32>
     }
     vector.transfer_write %5, %out[%c0, %c0] {in_bounds = [true, true]} : vector<16x16xf32>, memref<16x16xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
@@ -36,40 +40,41 @@ builtin.module attributes { hal.executable.target = #hal.executable.target<"rocm
 }
 
 // CHECK-LABEL: func.func @matmul_256x256x256
-//       CHECK:   %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x4xf32>
+//       CHECK:   %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x1x4xf32>
 //       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x4xf32>)
+//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x1x1x1x4xf32>)
 //       CHECK:     %[[LLOAD:.+]] = vector.transfer_read {{.*}} : memref<16x256xf16, {{.*}}>, vector<1x8xf16>
 //       CHECK:     %[[RLOAD:.+]] = vector.transfer_read {{.*}} : memref<256x16xf16, {{.*}}>, vector<1x8xf16>
 //       CHECK:     vector.transfer_write %[[LLOAD]], %[[LHS_ALLOC]]{{.*}} : vector<1x8xf16>, memref<16x32xf16, #gpu.address_space<workgroup>>
 //       CHECK:     vector.transfer_write %[[RLOAD]], %[[RHS_ALLOC]]{{.*}} : vector<1x8xf16>, memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:     gpu.barrier
-// CHECK-COUNT-2:   vector.load %[[LHS_ALLOC]]{{.*}} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<4xf16>
-// CHECK-COUNT-8:   vector.load %[[RHS_ALLOC]]{{.*}} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<1xf16>
-// CHECK-COUNT-2:   amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32> 
-//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<4xf32> to vector<1x1x4xf32>
-//       CHECK:     scf.yield %[[BCAST]] : vector<1x1x4xf32>
-// CHECK-COUNT-4: vector.store {{.*}} : memref<16x16xf32{{.*}}>, vector<1xf32>
+// CHECK-COUNT-2:   vector.transfer_read %[[LHS_ALLOC]][{{.+}}], %{{.+}} {in_bounds = [true, true]} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<1x4xf16>
+// CHECK-COUNT-2:   vector.transfer_read %[[RHS_ALLOC]][{{.+}}], %{{.+}} {in_bounds = [true, true]} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+// CHECK-COUNT-2:   amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
+//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<1x1x1x4xf32> to vector<1x1x1x1x1x4xf32>
+//       CHECK:     scf.yield %[[BCAST]] : vector<1x1x1x1x1x4xf32>
+//       CHECK:  vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<16x16xf32{{.*}}>
 
 // -----
 
 builtin.module attributes { hal.executable.target = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
-  mma_intrinsics = [#iree_gpu.mfma_layout<F16_16x16x16_F32>,
-                    #iree_gpu.mfma_layout<F16_32x32x8_F32>],
   target_arch = "gfx940",
   ukernels = "none"}>} {
   func.func @matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>,
                                 %rhs: memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>,
                                 %out: memref<16x16xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
-                                attributes {subgroup_size = 64, workgroup_size = [64, 1, 1]} {
+    attributes {
+      mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mfma_layout<F16_16x16x16_F32>,
+                       subgroup_m_count = 1, subgroup_n_count = 1, subgroup_m_tile_count = 1, subgroup_n_tile_count = 1, subgroup_k_tile_count = 2>,
+      subgroup_size = 64, workgroup_size = [64, 1, 1]} {
     %alloc = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
     %alloc_0 = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-    %cst = arith.constant 0.000000e+00 : f16 
+    %cst = arith.constant 0.000000e+00 : f16
     %cst_1 = arith.constant dense<0.000000e+00> : vector<16x16xf32>
-    %c32 = arith.constant 32 : index 
-    %c256 = arith.constant 256 : index 
-    %c0 = arith.constant 0 : index 
+    %c32 = arith.constant 32 : index
+    %c256 = arith.constant 256 : index
+    %c0 = arith.constant 0 : index
     %5 = scf.for %arg0 = %c0 to %c256 step %c32 iter_args(%arg1 = %cst_1) -> (vector<16x16xf32>) {
       %6 = vector.transfer_read %lhs[%c0, %arg0], %cst {in_bounds = [true, true]} : memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<16x32xf16>
       %7 = vector.transfer_read %rhs[%arg0, %c0], %cst {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d1, d0)>} : memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<32x16xf16>
@@ -79,7 +84,10 @@ builtin.module attributes { hal.executable.target = #hal.executable.target<"rocm
       gpu.barrier
       %8 = vector.transfer_read %alloc_0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<16x32xf16>
       %9 = vector.transfer_read %alloc[%c0, %c0], %cst {in_bounds = [true, true]} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<32x16xf16>
-      %10 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %8, %9, %arg1 : vector<16x32xf16>, vector<32x16xf16> into vector<16x16xf32> 
+      %10 = vector.contract {
+        indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+        %8, %9, %arg1 : vector<16x32xf16>, vector<32x16xf16> into vector<16x16xf32>
       scf.yield %10 : vector<16x16xf32>
     }
     vector.transfer_write %5, %out[%c0, %c0] {in_bounds = [true, true]} : vector<16x16xf32>, memref<16x16xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
@@ -92,18 +100,18 @@ builtin.module attributes { hal.executable.target = #hal.executable.target<"rocm
 // CHECK: #[[$MAP:.+]] = affine_map<(d0, d1) -> (d1, d0)>
 
 // CHECK-LABEL: func.func @matmul_256x256x256
-//       CHECK:   %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x4xf32>
+//       CHECK:   %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x1x4xf32>
 //       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x4xf32>)
+//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x1x1x1x4xf32>)
 //       CHECK:     %[[LLOAD:.+]] = vector.transfer_read {{.*}} : memref<16x256xf16, {{.*}}>, vector<1x8xf16>
 //       CHECK:     %[[RLOAD:.+]] = vector.transfer_read {{.*}} permutation_map = #[[$MAP]]} : memref<16x256xf16, {{.*}}>, vector<8x1xf16>
 //       CHECK:     vector.transfer_write %[[LLOAD]], %[[LHS_ALLOC]]{{.*}} : vector<1x8xf16>, memref<16x32xf16, #gpu.address_space<workgroup>>
 //       CHECK:     vector.transfer_write %[[RLOAD]], %[[RHS_ALLOC]]{{.*}} : vector<8x1xf16>, memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:     gpu.barrier
-// CHECK-COUNT-2:   vector.load %[[LHS_ALLOC]]{{.*}} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<4xf16>
-// CHECK-COUNT-8:   vector.load %[[RHS_ALLOC]]{{.*}} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<1xf16>
-// CHECK-COUNT-2:   amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32> 
-//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<4xf32> to vector<1x1x4xf32>
-//       CHECK:     scf.yield %[[BCAST]] : vector<1x1x4xf32>
-// CHECK-COUNT-4: vector.store {{.*}} : memref<16x16xf32{{.*}}>, vector<1xf32>
+// CHECK-COUNT-2:   vector.transfer_read %[[LHS_ALLOC]][{{.+}}], %{{.+}} {in_bounds = [true, true]} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<1x4xf16>
+// CHECK-COUNT-2:   vector.transfer_read %[[RHS_ALLOC]][{{.+}}], %{{.+}} {in_bounds = [true, true]} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+// CHECK-COUNT-2:   amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
+//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<1x1x1x4xf32> to vector<1x1x1x1x1x4xf32>
+//       CHECK:     scf.yield %[[BCAST]] : vector<1x1x1x1x1x4xf32>
+//       CHECK:  vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<16x16xf32{{.*}}>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_rocm.mlir
@@ -39,9 +39,11 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
 
 // Basic pipeline test to make sure it generates the instructions we expect.
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute>
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute
+//  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mfma_layout<F16_16x16x16_F32>,
+//  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2, subgroup_m_tile_count = 2, subgroup_n_tile_count = 4, subgroup_k_tile_count = 2>
+
 // CHECK-LABEL: hal.executable.export public @matmul_256x256x256
-//  CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mfma_layout<F16_16x16x16_F32>, subgroup_m_count = 2, subgroup_n_count = 2, subgroup_m_tile_count = 2, subgroup_n_tile_count = 4, subgroup_k_tile_count = 2>
 //  CHECK-SAME:    subgroup_size = 64
 //  CHECK-SAME:    translation_info = #[[$TRANSLATION]]
 //  CHECK-SAME:    workgroup_size = [128 : index, 2 : index, 1 : index]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_rocm.mlir
@@ -20,8 +20,8 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
     }
   builtin.module {
     func.func @matmul_256x256x256() {
-      %cst = arith.constant 0.000000e+00 : f32 
-      %c0 = arith.constant 0 : index 
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
       %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x256xf16>>
       %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x256xf16>>
       %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<256x256xf32>>
@@ -39,13 +39,17 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
 
 // Basic pipeline test to make sure it generates the instructions we expect.
 
-// CHECK:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute>
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute>
 // CHECK-LABEL: hal.executable.export public @matmul_256x256x256
-// CHECK-SAME:    subgroup_size = 64
-// CHECK-SAME:    translation_info = #[[$TRANSLATION]]
-// CHECK-SAME:    workgroup_size = [64 : index, 1 : index, 1 : index]
-// CHECK-LABEL:     func.func @matmul_256x256x256
-// CHECK-COUNT:       scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}}) -> (vector<1x1x4xf32>)
-// CHECK-COUNT-2:       amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-// CHECK:               scf.yield %{{.*}} : vector<1x1x4xf32>
-// CHECK-COUNT-4:     vector.store {{.*}} : memref<256x256xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
+//  CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mfma_layout<F16_16x16x16_F32>, subgroup_m_count = 2, subgroup_n_count = 2, subgroup_m_tile_count = 2, subgroup_n_tile_count = 4, subgroup_k_tile_count = 2>
+//  CHECK-SAME:    subgroup_size = 64
+//  CHECK-SAME:    translation_info = #[[$TRANSLATION]]
+//  CHECK-SAME:    workgroup_size = [128 : index, 2 : index, 1 : index]
+
+//    CHECK-LABEL: func.func @matmul_256x256x256
+//          CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}}) -> (vector<2x4x1x1x1x4xf32>)
+// Each subgroup handles 2 * 4 tiles, and for each tile we accumulate 2 times
+// along the K dimension. So in total 16 mfma ops.
+// CHECK-COUNT-16:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
+//          CHECK:     scf.yield %{{.+}} : vector<2x4x1x1x1x4xf32>
+//  CHECK-COUNT-8:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #hal.descriptor_type<storage_buffer>>

--- a/compiler/src/iree/compiler/Codegen/Utils/LinalgOpInfo.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinalgOpInfo.h
@@ -6,22 +6,17 @@
 
 #ifndef IREE_COMPILER_CODEGEN_COMMON_LINALGOPINFO_H_
 #define IREE_COMPILER_CODEGEN_COMMON_LINALGOPINFO_H_
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/Types.h"
-#include "mlir/IR/Value.h"
 
-namespace mlir::linalg {
-class LinalgOp;
-} // namespace mlir::linalg
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/IR/AffineMap.h"
 
 namespace mlir::iree_compiler {
 
-/// Returns true if a map represents the appropriate transpose. Pass this into
-/// the LinalgOpInfo for additional transpose granularity.
-using TransposeMapFilter = std::function<bool(AffineMap map)>;
-
 class LinalgOpInfo {
 public:
+  /// Returns true if a map represents a chosen transpose granularity.
+  using TransposeMapFilter = std::function<bool(AffineMap map)>;
+
   LinalgOpInfo(linalg::LinalgOp linalgOp);
   LinalgOpInfo(linalg::LinalgOp linalgOp,
                TransposeMapFilter transposeMapFilter);
@@ -42,6 +37,10 @@ private:
   bool dynamicTrait;
   SmallVector<OpOperand *> transposeOperands;
 };
+
+// Returns true if the given |linalgOp| is a matmul or batch matmul.
+// This also looks into the shape to filter out cases like matvec.
+bool isMatmulOrBatchMatmul(linalg::LinalgOp linalgOp);
 
 } // namespace mlir::iree_compiler
 


### PR DESCRIPTION
This commit reuses the basic heuristics for deducing cooperative matrix configuration in SPIR-V for ROCDL. We deduce a full tiling schedule and attach it as a newly introduced `iree_gpu.mma_schedule` attribute for the vector distribution pipeline to pick up and convert into concrete `iree_gpu.mfma_layout` to drive contraction vector distribution.