### PR TITLE
[torch] Implement async and mutability programming model.

### DIFF
--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_cc_library(
   SRCS
     "BitCastQuantTensor.cpp"
     "ConvertTMTensorToLinalgExt.cpp"
+    "FuncConversion.cpp"
     "SetStrictSymbolicShapes.cpp"
     "Passes.cpp"
   DEPS

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/FuncConversion.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/FuncConversion.cpp
@@ -263,6 +263,7 @@ class FuncFuncOpPattern : public OpConversionPattern<func::FuncOp> {
     // TODO(multi-device): emit get with derived ordinal or lookup with attr. We
     // could always say device 0 for now but could instead look for an
     // iree.abi.affinity/iree.abi.device/etc.
+    Value timeoutMillis = rewriter.create<arith::ConstantIntOp>(loc, -1, 32);
     Value device = IREE::HAL::DeviceType::resolveAny(loc, rewriter);
     Value waitFence = rewriter.create<IREE::Util::NullOp>(
         loc, rewriter.getType<IREE::HAL::FenceType>());
@@ -278,7 +279,6 @@ class FuncFuncOpPattern : public OpConversionPattern<func::FuncOp> {
             .getResults();
 
     // Wait forever for signal.
-    auto timeoutMillis = rewriter.create<arith::ConstantIntOp>(loc, -1, 32);
     rewriter.create<IREE::HAL::FenceAwaitOp>(loc, rewriter.getI32Type(),
                                              timeoutMillis, signalFence);
 

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/FuncConversion.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/FuncConversion.cpp
@@ -1,0 +1,504 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "torch-iree/InputConversion/Passes.h"
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "torch-iree/InputConversion/PassDetail.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+
+namespace Torch = mlir::torch::Torch;
+namespace TorchConversion = mlir::torch::TorchConversion;
+
+namespace mlir::iree_compiler::TorchInput {
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Func dialect -> Util patterns
+//===----------------------------------------------------------------------===//
+
+class FuncFuncOpPattern : public OpConversionPattern<func::FuncOp> {
+  using OpConversionPattern<func::FuncOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(func::FuncOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    FunctionType srcFuncType = srcOp.getFunctionType();
+    TypeConverter::SignatureConversion signatureConversion(
+        srcOp.getNumArguments());
+
+    // Convert function arguments.
+    for (unsigned i = 0, e = srcFuncType.getNumInputs(); i < e; ++i) {
+      if (failed(getTypeConverter()->convertSignatureArg(
+              i, srcFuncType.getInput(i), signatureConversion))) {
+        return rewriter.notifyMatchFailure(srcOp, "argument failed to convert");
+      }
+    }
+
+    // To support async, we add two fences (wait and signal) to the converted
+    // function arguments. Conversion patterns in this file access them with
+    // helper functions that know this.
+    Type fenceType = rewriter.getType<IREE::HAL::FenceType>();
+    signatureConversion.addInputs(ArrayRef<Type>{fenceType, fenceType});
+
+    // Convert function results.
+    SmallVector<Type, 1> convertedResultTypes;
+    if (failed(getTypeConverter()->convertTypes(srcFuncType.getResults(),
+                                                convertedResultTypes))) {
+      return rewriter.notifyMatchFailure(srcOp, "results failed to convert");
+    }
+
+    // // Build tied operands index mapping results back to operands.
+    // SmallVector<int64_t> tiedOperands;
+    // bool anyTiedOperands = false;
+    // for (unsigned i = 0; i < srcFuncType.getNumResults(); ++i) {
+    //   auto tiedAttr =
+    //       srcOp.getResultAttrOfType<IntegerAttr>(i, "iree.abi.tied");
+    //   if (tiedAttr) {
+    //     tiedOperands.push_back(tiedAttr.getInt());
+    //   } else {
+    //     tiedOperands.push_back(-1);
+    //   }
+    // }
+    // auto tiedOperandsAttr = anyTiedOperands
+    //                             ? rewriter.getIndexArrayAttr(tiedOperands)
+    //                             : ArrayAttr{};
+
+    // Create new function with converted argument and result types.
+    // Note that attributes are dropped. Consider preserving some if needed.
+    auto newFuncType = mlir::FunctionType::get(
+        srcOp.getContext(), signatureConversion.getConvertedTypes(),
+        convertedResultTypes);
+    auto newFuncOp = rewriter.create<IREE::Util::FuncOp>(
+        srcOp.getLoc(), srcOp.getName(), newFuncType,
+        /*tiedOperandsAttr=*/ArrayAttr{});
+    newFuncOp.setSymVisibilityAttr(srcOp.getSymVisibilityAttr());
+    rewriter.inlineRegionBefore(srcOp.getBody(), newFuncOp.getFunctionBody(),
+                                newFuncOp.end());
+
+    // Handle defacto attrs to specialized ones.
+    if (srcOp->hasAttr("noinline")) {
+      newFuncOp.setInliningPolicyAttr(
+          rewriter.getAttr<IREE::Util::InlineNeverAttr>());
+    }
+
+    // Allowlist of function attributes to retain when importing funcs.
+    constexpr const char *kRetainedAttributes[] = {
+        "iree.reflection",
+        "vm.fallback",
+        "vm.signature",
+        "vm.version",
+    };
+    auto retainedAttributes = ArrayRef<const char *>(
+        kRetainedAttributes,
+        sizeof(kRetainedAttributes) / sizeof(kRetainedAttributes[0]));
+    for (auto retainAttrName : retainedAttributes) {
+      StringRef attrName(retainAttrName);
+      Attribute attr = srcOp->getAttr(attrName);
+      if (attr)
+        newFuncOp->setAttr(attrName, attr);
+    }
+
+    // Copy all arg/result attrs. We could filter these.
+    if (auto argAttrs = srcOp.getAllArgAttrs()) {
+      newFuncOp.setAllArgAttrs(argAttrs);
+    }
+    if (auto resultAttrs = srcOp.getAllResultAttrs()) {
+      newFuncOp.setAllResultAttrs(resultAttrs);
+    }
+
+    // Tell the rewriter to convert the region signature.
+    const TypeConverter &typeConverter = *getTypeConverter();
+    if (failed(rewriter.convertRegionTypes(&newFuncOp.getFunctionBody(),
+                                           typeConverter,
+                                           &signatureConversion))) {
+      return failure();
+    }
+
+    rewriter.eraseOp(srcOp);
+    return success();
+  }
+};
+
+class FuncCallOpPattern : public OpConversionPattern<func::CallOp> {
+  using OpConversionPattern<func::CallOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(func::CallOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type, 1> resultTypes;
+    if (failed(getTypeConverter()->convertTypes(srcOp.getResultTypes(),
+                                                resultTypes))) {
+      return rewriter.notifyMatchFailure(srcOp, "results failed to convert");
+    }
+    auto tiedOperandsAttr =
+        srcOp->getAttrOfType<ArrayAttr>("iree.abi.tied_operands");
+    rewriter.replaceOpWithNewOp<IREE::Util::CallOp>(
+        srcOp, resultTypes, srcOp.getCallee(), adaptor.getOperands(),
+        tiedOperandsAttr);
+    return success();
+  }
+};
+
+class FuncReturnOpPattern : public OpConversionPattern<func::ReturnOp> {
+  using OpConversionPattern<func::ReturnOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(func::ReturnOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<IREE::Util::ReturnOp>(srcOp,
+                                                      adaptor.getOperands());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Mutable tensor type conversion.
+// Here we rely on the characteristic that at the torch level, conversion to
+// and from the value domain is only legal at certain well defined points in
+// the program (currently at graph edges but potentially in the future at
+// various control flow points). These conversions are modeled by:
+//   * torch.copy.to_vtensor: Copy from a mutable tensor (torch.tensor) to
+//     an immutable value (torch.vtensor).
+//   * torch.copy.to_tensor: Allocates a new mutable tensor and initializes it
+//     with the value of the given immutable tensor.
+//   * torch.overwrite.tensor.contents: Updates the contents of a mutable
+//     tensor from a given immutable tensor.
+//
+// Note that when importing from Torch, these ops cannot just be added at will,
+// and they are only created as a result of structural conversions. Therefore,
+// we can rely on these invariants and assume that usage outside of this is an
+// invalid program.
+//
+// Conversion Mechanic:
+// --------------------
+//   * torch.copy.to_vtensor is handled directly as a conversion pattern because
+//     it is pure (with the only constraint that it has to happen after the
+//     function level wait fence).
+//   * The mutation ops are not handled during conversion, but we emit an
+//     unrealized_conversion_cast from the block-arg !hal.buffer_view to
+//     unhandled ops.
+//   * Function level post processing is performed to clean up sub-graphs of
+//     mutation. The cast op has an attribute `torch.coarse_signal_mutation`
+//     added to make it easy to perform post-processing.
+//
+// Post Processing:
+// ----------------
+// At the function level, all mutable argument mutations must be coellesced
+// into a single barrier to signal the signal fence (as a default, this is
+// conservatively safe, but for more complicated programs, we may want to
+// enable explicit tieing of the mutation to a signal fence in order to
+// enable more pipelining).
+//
+// We structurally have a very narrow definition of how such mutable arguments
+// can be used:
+//   * Consumed by a `torch.overwrite.tensor.contents`.
+//   * Returned from the function.
+//
+// This results in a small number of subgraphs that can exist for users of
+// a mutable argument. We detect all such subgraphs by walking the module for
+// unrealized_conversion_cast operators with the
+// `torch.coarse_signal_mutation` attribute, added during type
+// materialization for any unrecognized (presumed mutation) ops operating on
+// the argument. If no such casts are present, then the function does not
+// actually mutate its argument and no action is needed.
+//===----------------------------------------------------------------------===//
+
+class CopyEntryArgToValueTensorPattern
+    : public OpConversionPattern<Torch::CopyToValueTensorOp> {
+  using OpConversionPattern<Torch::CopyToValueTensorOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(Torch::CopyToValueTensorOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Access the type converted buffer view.
+    auto bufferView = dyn_cast<BlockArgument>(adaptor.getOperand());
+    if (!bufferView) {
+      return rewriter.notifyMatchFailure(srcOp,
+                                         "not produced by a BlockArgument");
+    }
+    Block *producerBlock = bufferView.getOwner();
+    if (!isa<IREE::Util::FuncOp>(producerBlock->getParentOp())) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "not produced directly by parent function");
+    }
+    if (!producerBlock->isEntryBlock()) {
+      return rewriter.notifyMatchFailure(srcOp, "not produced by entry block");
+    }
+
+    auto resultVTensorType =
+        cast<Torch::ValueTensorType>(srcOp.getResult().getType());
+    auto ireeTensorType = resultVTensorType.toBuiltinTensor();
+
+    // The producer block will always end in {wait_fence, signal_fence}.
+    Value waitFence =
+        producerBlock->getArgument(producerBlock->getNumArguments() - 2);
+    Value imported = rewriter.create<IREE::HAL::TensorImportOp>(
+        srcOp.getLoc(), ireeTensorType, bufferView,
+        /*target_encoding=*/TypeAttr::get(ireeTensorType),
+        /*wait_fence*/ waitFence,
+        /*name=*/StringAttr());
+
+    rewriter.replaceOpWithNewOp<TorchConversion::FromBuiltinTensorOp>(
+        srcOp, resultVTensorType, imported);
+    return success();
+  }
+};
+
+Value convertToBuiltinTensor(OpBuilder &builder, Value possibleTorchTensor) {
+  Type ty = possibleTorchTensor.getType();
+  if (isa<TensorType>(ty))
+    return possibleTorchTensor;
+
+  Torch::ValueTensorType vtensorType = cast<Torch::ValueTensorType>(ty);
+  TensorType builtinTy = vtensorType.toBuiltinTensor();
+  return builder.create<TorchConversion::ToBuiltinTensorOp>(
+      possibleTorchTensor.getLoc(), builtinTy, possibleTorchTensor);
+}
+
+void setupMutableTensorConversion(ConversionTarget &target,
+                                  RewritePatternSet &patterns,
+                                  TypeConverter &typeConverter) {
+  target.addIllegalOp<Torch::CopyToValueTensorOp>();
+  // target.addIllegalOp<Torch::CopyToNonValueTensorOp>();
+  // target.addIllegalOp<Torch::OverwriteTensorContentsOp>();
+  patterns.insert<CopyEntryArgToValueTensorPattern>(typeConverter,
+                                                    patterns.getContext());
+
+  typeConverter.addConversion(
+      [](Torch::NonValueTensorType type) -> std::optional<Type> {
+        return IREE::HAL::BufferViewType::get(type.getContext());
+      });
+  auto materialization = [](OpBuilder &builder, Torch::NonValueTensorType type,
+                            ValueRange inputs, Location loc) -> Value {
+    auto castOp = builder.create<UnrealizedConversionCastOp>(loc, type, inputs);
+    castOp->setAttr("torch.coarse_signal_mutation", builder.getUnitAttr());
+    return castOp.getResult(0);
+  };
+  typeConverter.addSourceMaterialization(materialization);
+  typeConverter.addArgumentMaterialization(materialization);
+}
+
+LogicalResult postProcessFunctionMutation(IREE::Util::FuncOp funcOp) {
+  // Walk to find arguments subject to some mutation.
+  SmallPtrSet<Value, 4> coarseSignalArgs;
+  SmallVector<IREE::Util::ReturnOp> returnOps;
+  funcOp.walk([&](Operation *op) {
+    if (auto castOp = dyn_cast<UnrealizedConversionCastOp>(op)) {
+      if (castOp->hasAttr("torch.coarse_signal_mutation")) {
+        Value source = castOp.getOperand(0);
+        Value target = castOp.getResult(0);
+        coarseSignalArgs.insert(source);
+
+        // Makes the IR invalid for any consumers, but that is fine. If we do
+        // not transform the consumers, we will fail anyway, and eliminating the
+        // cast here makes everything simpler.
+        target.replaceAllUsesWith(source);
+        castOp->erase();
+      }
+    } else if (auto returnOp = dyn_cast<IREE::Util::ReturnOp>(op)) {
+      returnOps.push_back(returnOp);
+    }
+  });
+
+  bool hasCoarseSignalMutation = !coarseSignalArgs.empty();
+  Block *entryBlock = &funcOp.front();
+  Value coarseSignalFence =
+      entryBlock->getArgument(entryBlock->getNumArguments() - 1);
+
+  // Enforce some structural conditions. We presently have no way to generate
+  // programs that violate these, but maybe someday. Then a more advanced
+  // algorithm will be needed.
+  if (hasCoarseSignalMutation && returnOps.size() > 1) {
+    auto diag =
+        emitError(funcOp.getLoc())
+        << "functions with coarse signal mutation must only have a single exit";
+    for (auto returnOp : returnOps) {
+      diag.attachNote(returnOp.getLoc()) << "illegal multiple return";
+    }
+    return diag;
+  }
+
+  // Assemble the postamble, consisting of a signaling barrier and mutating
+  // exports.
+  IREE::Util::ReturnOp returnOp = returnOps.front();
+  OpBuilder builder(returnOp);
+  IRMapping returnMapping;
+  SmallVector<Operation *> eraseOps;
+  // Tensors that need to be joined in a barrier on the coarse signal fence
+  // and exported.
+  SmallVector<Value> barrierSources;
+  SmallVector<Value> exportBuffers;
+  SmallVector<bool> exportIsMutation;
+
+  // Process each arg that participates in coarse signaling.
+  for (Value bufferArg : coarseSignalArgs) {
+    Value overwriteTensor;
+    for (OpOperand &use : bufferArg.getUses()) {
+      Operation *useOp = use.getOwner();
+
+      // Legal uses that require no further action.
+      if (isa<IREE::HAL::TensorImportOp>(useOp))
+        continue;
+
+      // Other uses.
+      if (auto overwrite = dyn_cast<Torch::OverwriteTensorContentsOp>(useOp)) {
+        if (overwriteTensor) {
+          return emitError(useOp->getLoc())
+                 << "unsupported multiple updates on coarse signaling mutable "
+                    "tensor";
+        }
+        overwriteTensor = convertToBuiltinTensor(builder, overwrite.getValue());
+        barrierSources.push_back(overwriteTensor);
+        exportIsMutation.push_back(true);
+        exportBuffers.push_back(bufferArg);
+        eraseOps.push_back(overwrite);
+      } else {
+        return emitError(useOp->getLoc())
+               << "unsupported operation on coarse signaling mutable tensor";
+      }
+    }
+  }
+
+  // Generate barriers and exports.
+  auto barrierOp = builder.create<IREE::HAL::TensorBarrierOp>(
+      funcOp.getLoc(), barrierSources, coarseSignalFence);
+  for (auto [sourceTensor, isMutation, barrierTensor] : llvm::zip_equal(
+           barrierSources, exportIsMutation, barrierOp.getResults())) {
+    Value exportedValue = builder.create<IREE::HAL::TensorExportOp>(
+        sourceTensor.getLoc(), builder.getType<IREE::HAL::BufferViewType>(),
+        barrierTensor, TypeAttr::get(sourceTensor.getType()), StringAttr());
+    if (isMutation) {
+      // We must not drop exports of mutation, so hold on to it.
+      builder.create<IREE::Util::OptimizationBarrierOp>(sourceTensor.getLoc(),
+                                                        exportedValue);
+    }
+    returnMapping.map(sourceTensor, barrierTensor);
+  }
+
+  // Clean up.
+  for (Operation *op : eraseOps) {
+    op->erase();
+  }
+
+  return success();
+}
+
+// class OverwriteEntryArgTensorContents
+//     : public OpConversionPattern<Torch::OverwriteTensorContentsOp> {
+//   using OpConversionPattern<
+//       Torch::OverwriteTensorContentsOp>::OpConversionPattern;
+//   LogicalResult
+//   matchAndRewrite(Torch::OverwriteTensorContentsOp srcOp, OpAdaptor adaptor,
+//                   ConversionPatternRewriter &rewriter) const override {
+//     // Access the type converted buffer view.
+//     auto bufferView = dyn_cast<BlockArgument>(adaptor.getOverwritten());
+//     if (!bufferView) {
+//       return rewriter.notifyMatchFailure(
+//           srcOp, "not overwriting into a BlockArgument");
+//     }
+//     Block *producerBlock = bufferView.getOwner();
+//     if (!isa<IREE::Util::FuncOp>(producerBlock->getParentOp())) {
+//       return rewriter.notifyMatchFailure(
+//           srcOp, "not produced directly by parent function");
+//     }
+//     if (!producerBlock->isEntryBlock()) {
+//       return rewriter.notifyMatchFailure(srcOp, "not produced by entry
+//       block");
+//     }
+//     if (!isa<IREE::Util::FuncOp>(srcOp->getParentOp())) {
+//       return rewriter.notifyMatchFailure(srcOp, "not a direct child of a
+//       func");
+//     }
+
+//     // The producer block will always end in {wait_fence, signal_fence}.
+//     Value signalFence =
+//         producerBlock->getArgument(producerBlock->getNumArguments() - 1);
+//     auto barrierOp = rewriter.create<IREE::HAL::TensorBarrierOp>(
+//         srcOp.getLoc(), ValueRange{adaptor.getValue()}, signalFence);
+//     // Signals that the overall pass should post-process combine these into a
+//     // single barrier.
+//     barrierOp->setAttr("torch.combine_func_barrier_signal",
+//                        rewriter.getUnitAttr());
+
+//     rewriter.eraseOp(srcOp);
+//     return success();
+//   }
+// };
+
+} // namespace
+
+struct FuncConversionPass : public FuncConversionBase<FuncConversionPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::HAL::HALDialect>();
+    registry.insert<IREE::Util::UtilDialect>();
+    registry.insert<TorchConversion::TorchConversionDialect>();
+  }
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    auto *context = &getContext();
+
+    ConversionTarget target(*context);
+    target.addLegalOp<ModuleOp>();
+    target.addLegalDialect<IREE::Util::UtilDialect>();
+    target.markUnknownOpDynamicallyLegal([&](Operation *op) { return true; });
+
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    TorchConversion::setupBackendTypeConversion(target, typeConverter);
+
+    RewritePatternSet patterns(context);
+
+    // Func conversion.
+    target.addDynamicallyLegalDialect<func::FuncDialect>(
+        [&](Operation *op) -> std::optional<bool> {
+          // Allow the func dialect within nested modules but not in the
+          // top-level one that represents the host program.
+          return op->getParentOfType<mlir::ModuleOp>() != getOperation();
+        });
+
+    patterns.insert<FuncFuncOpPattern>(typeConverter, context);
+    patterns.insert<FuncCallOpPattern>(typeConverter, context);
+    patterns.insert<FuncReturnOpPattern>(typeConverter, context);
+
+    // Mutable tensor at the graph edges conversion.
+    setupMutableTensorConversion(target, patterns, typeConverter);
+    // patterns.insert<CopyEntryArgToValueTensorPattern>(typeConverter,
+    // context); patterns.insert<OverwriteEntryArgTensorContents>(typeConverter,
+    // context);
+
+    if (failed(applyFullConversion(module, target, std::move(patterns)))) {
+      signalPassFailure();
+    }
+
+    // Post-process functions.
+    for (auto funcOp : module.getOps<IREE::Util::FuncOp>()) {
+      if (funcOp.isExternal())
+        continue;
+      if (failed(postProcessFunctionMutation(funcOp))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createFuncConversionPass() {
+  return std::make_unique<FuncConversionPass>();
+}
+
+} // namespace mlir::iree_compiler::TorchInput

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/PassDetail.h
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/PassDetail.h
@@ -7,6 +7,7 @@
 #ifndef TORCH_IREE_INPUTCONVERSION_PASSDETAIL_H_
 #define TORCH_IREE_INPUTCONVERSION_PASSDETAIL_H_
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
@@ -68,6 +68,11 @@ void createTorchToIREEPipeline(
   // The resolution of `dim` ops tends to create identical ops. CSE them.
   pm.addNestedPass<func::FuncOp>(createCSEPass());
 
+  // Regular function calls in torch have to be inlined presently. In the
+  // future, we would like to support async invocation, which will operate
+  // differently and would not be subject to inlining.
+  pm.addPass(mlir::createInlinerPass());
+
   pm.addPass(createFuncConversionPass());
   pm.addNestedPass<IREE::Util::FuncOp>(createCanonicalizerPass());
   pm.addPass(createSymbolDCEPass());

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
@@ -51,7 +51,7 @@ void createTorchToIREEPipeline(
       torch::Torch::createDecomposeComplexOpsPass(emptyArrayRef));
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTMTensorPass());
   pm.addNestedPass<func::FuncOp>(
-          TorchInput::createConvertTMTensorToLinalgExtPass());
+      TorchInput::createConvertTMTensorToLinalgExtPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTensorPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToLinalgPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToSCFPass());

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
@@ -50,6 +50,8 @@ void createTorchToIREEPipeline(
   pm.addNestedPass<func::FuncOp>(
       torch::Torch::createDecomposeComplexOpsPass(emptyArrayRef));
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTMTensorPass());
+  pm.addNestedPass<func::FuncOp>(
+          TorchInput::createConvertTMTensorToLinalgExtPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTensorPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToLinalgPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToSCFPass());

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
@@ -74,13 +74,8 @@ void createTorchToIREEPipeline(
 
   // Finish the type conversion from `torch` types to the types of the
   // linalg-on-tensors backend contract.
-  //   pm.addPass(torch::TorchConversion::createFuncBackendTypeConversionPass());
-  //   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<IREE::Util::FuncOp>(
       torch::TorchConversion::createFinalizingBackendTypeConversionPass());
-
-  // TODO: Add validation pass.
-  // pm.addPass(createSymbolDCEPass());
 }
 
 void registerTMTensorConversionPasses() {

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.cpp
@@ -6,6 +6,7 @@
 
 #include "torch-iree/InputConversion/Passes.h"
 
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -65,15 +66,19 @@ void createTorchToIREEPipeline(
   // The resolution of `dim` ops tends to create identical ops. CSE them.
   pm.addNestedPass<func::FuncOp>(createCSEPass());
 
+  pm.addPass(createFuncConversionPass());
+  pm.addNestedPass<IREE::Util::FuncOp>(createCanonicalizerPass());
+  pm.addPass(createSymbolDCEPass());
+
   // Finish the type conversion from `torch` types to the types of the
   // linalg-on-tensors backend contract.
-  pm.addPass(torch::TorchConversion::createFuncBackendTypeConversionPass());
-  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<func::FuncOp>(
+  //   pm.addPass(torch::TorchConversion::createFuncBackendTypeConversionPass());
+  //   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<IREE::Util::FuncOp>(
       torch::TorchConversion::createFinalizingBackendTypeConversionPass());
 
   // TODO: Add validation pass.
-  pm.addPass(createSymbolDCEPass());
+  // pm.addPass(createSymbolDCEPass());
 }
 
 void registerTMTensorConversionPasses() {

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.h
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.h
@@ -7,6 +7,7 @@
 #ifndef TORCH_IREE_INPUTCONVERSION_PASSES_H_
 #define TORCH_IREE_INPUTCONVERSION_PASSES_H_
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 
@@ -27,6 +28,8 @@ createConvertTMTensorToLinalgExtPass();
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createSetStrictSymbolicShapesPass();
+
+std::unique_ptr<OperationPass<ModuleOp>> createFuncConversionPass();
 
 // Creates a pipeline that lowers from the torch backend contract to IREE.
 // This is based on the torch-backend-to-linalg-on-tensors-backend-pipeline

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.td
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/Passes.td
@@ -27,4 +27,14 @@ def SetStrictSymbolicShapesPass :
   let constructor = "mlir::iree_compiler::TorchInput::createSetStrictSymbolicShapesPass()";
 }
 
+def FuncConversion :
+    Pass<"torch-iree-func-conversion", "ModuleOp"> {
+  let summary = "Finalizes conversion from torch to IREE";
+  let constructor = "mlir::iree_compiler::TorchInput::createFuncConversionPass()";
+  let description = [{
+    Conversion pass for finalizing functions and ABI. Replaces the generic 
+    torch-func-backend-type-conversion pass.
+  }];
+}
+
 #endif // TORCH_IREE_INPUTCONVERSION_PASSES

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/CMakeLists.txt
@@ -7,6 +7,7 @@ iree_lit_test_suite(
     "attention.mlir"
     "bitcast_quant_tensor.mlir"
     "func_conversion.mlir"
+    "func_conversion_invalid.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/CMakeLists.txt
@@ -6,6 +6,7 @@ iree_lit_test_suite(
     "auto_input_conversion.mlir"
     "attention.mlir"
     "bitcast_quant_tensor.mlir"
+    "func_conversion.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
@@ -75,7 +75,7 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
 //   CHECK-DAG: %[[EXPORT_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0 into(%arg1 : !hal.buffer_view)
 //   CHECK-DAG: %[[UNUSED:.+]] = util.optimization_barrier %[[EXPORT_RESULT1]]
 //   CHECK-DAG: %[[EXPORT_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1 :
-// util.return %[[EXPORT_RESULT0]]
+//       CHECK: util.return %[[EXPORT_RESULT0]]
 builtin.module @mutable_input_overwrite_no_return {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.tensor<[5,4],f32>) 
     -> (!torch.vtensor<[4,5],si32>) {
@@ -88,6 +88,10 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.tensor<[5,4],f3
 }
 
 // -----
+// This isn't a great program to write but is legal. It verifies that if the
+// function returns an intermediate vtensor just before it was noted as mutated
+// that we export it properly. This would be a hard program to write in PyTorch
+// but possible to end up this way so testing the corner.
 // Not a good idea to do but legal. This verifies that if returning a mutated
 // tensor's intermediate value, you will get two exports, indicating a copy.
 // CHECK-LABEL: @mutable_input_overwrite_return_alias_copies

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
@@ -1,0 +1,50 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(torch-iree-func-conversion)" %s | FileCheck %s
+
+// CHECK-LABEL: @immutable_import_export
+//       CHECK: util.func public @main$async(
+//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view, 
+//  CHECK-SAME:     %arg2: !hal.fence, %arg3: !hal.fence) -> 
+//  CHECK-SAME:     (!hal.buffer_view, !hal.buffer_view) 
+//  CHECK-SAME:     attributes {iree.abi.model = "coarse-fences", iree.abi.stub} 
+//   CHECK-DAG:   %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%arg2) => %arg0 : !hal.buffer_view -> tensor<4x5xi32>
+//   CHECK-DAG:   %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%arg2) => %arg1 : !hal.buffer_view -> tensor<5x4xf32>
+//   CHECK-DAG:   %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]] : tensor<4x5xi32> -> !torch.vtensor<[4,5],si32>
+//   CHECK-DAG:   %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]] : tensor<5x4xf32> -> !torch.vtensor<[5,4],f32>
+//   CHECK-DAG:   %[[TORCH_RESULT0:.+]] = torch.operator "foobar0"(%[[TORCH_ARG0]])
+//   CHECK-DAG:   %[[TORCH_RESULT1:.+]] = torch.operator "foobar1"(%[[TORCH_ARG1]])
+//   CHECK-DAG:   %[[TENSOR_RESULT0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
+//   CHECK-DAG:   %[[TENSOR_RESULT1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
+//       CHECK:   %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TENSOR_RESULT0]], %[[TENSOR_RESULT1]] : tensor<4x5xi32>, tensor<5x4xf32>) => %arg3
+//   CHECK-DAG:   %[[FUNC_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0
+//   CHECK-DAG:   %[[FUNC_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1
+//       CHECK:   util.return %[[FUNC_RESULT0]], %[[FUNC_RESULT1]]
+//
+//       CHECK: util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view) 
+//  CHECK-SAME:     -> (!hal.buffer_view, !hal.buffer_view) attributes {iree.abi.stub}
+//   CHECK-DAG:   %[[CONSTANT0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[CONSTANT1:.+]] = arith.constant -1 : i32
+//   CHECK-DAG:   %[[DEVICE0:.+]] = hal.devices.get %[[CONSTANT0]] : !hal.device
+//   CHECK-DAG:   %[[NULL_FENCE:.+]] = util.null : !hal.fence
+//       CHECK:   %[[NEW_FENCE:.+]] = hal.fence.create device(%[[DEVICE0]] : !hal.device) flags("None")
+//       CHECK:   %[[CALL_RESULTS:.+]]:2 = util.call @main$async(%arg0, %arg1, %[[NULL_FENCE]], %[[NEW_FENCE]])
+//       CHECK:   %[[AWAIT_STATUS:.+]] = hal.fence.await until([%[[NEW_FENCE]]]) timeout_millis(%[[CONSTANT1]])
+//       CHECK:   util.return %[[CALL_RESULTS]]#0, %[[CALL_RESULTS]]#1 : !hal.buffer_view, !hal.buffer_view
+builtin.module @immutable_import_export {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.vtensor<[5,4],f32>) 
+    -> (!torch.vtensor<[4,5],si32>, !torch.vtensor<[5,4],f32>) {
+  %0 = torch.operator "foobar0"(%arg0) : (!torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
+  %1 = torch.operator "foobar1"(%arg1) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
+  return %0, %1 : !torch.vtensor<[4,5],si32>, !torch.vtensor<[5,4],f32>
+}
+}
+
+// -----
+// CHECK-LABEL: @return_immutable_arg
+// CHECK: util.func public @main$async
+// CHECK: hal.tensor.barrier join( : ) => %arg2
+// CHECK: util.return %arg0
+builtin.module @return_immutable_arg {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>  {
+  return %arg0 : !torch.vtensor<[4,5],si32>
+}
+}

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
@@ -1,5 +1,8 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(torch-iree-func-conversion)" %s | FileCheck %s
 
+// Canonical test of the immutable input->compute->return case. This is
+// exhaustively verified for both the async and sync wrapper function.
+// There shouldn't be much need to further verify the sync wrapper function.
 // CHECK-LABEL: @immutable_import_export
 //       CHECK: util.func public @main$async(
 //  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view, 
@@ -45,6 +48,129 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.vtensor<[5,4],f
 // CHECK: util.return %arg0
 builtin.module @return_immutable_arg {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>  {
+  return %arg0 : !torch.vtensor<[4,5],si32>
+}
+}
+
+// -----
+// Tests the immutable + mutable argument case where the mutable argument is
+// overwritten as part of the function cleanup and the argument is not returned.
+// This exhaustively verifies the async function.
+// Note that the order of the barrier operands and successors is implementation
+// dependent, and the current implementation processes mutable before
+// immutable.
+// CHECK-LABEL: @mutable_input_overwrite_no_return
+//       CHECK: util.func public @main$async(
+//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view, 
+//  CHECK-SAME:     %arg2: !hal.fence, %arg3: !hal.fence) -> !hal.buffer_view
+//   CHECK-DAG: %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%arg2) => %arg0
+//   CHECK-DAG: %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]]
+//   CHECK-DAG: %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%arg2) => %arg1
+//   CHECK-DAG: %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]]
+//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_ARG0]])
+//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_ARG1]])
+//   CHECK-DAG: %[[TENSOR_ARG0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
+//   CHECK-DAG: %[[TENSOR_ARG1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
+//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TENSOR_ARG1]], %[[TENSOR_ARG0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %arg3 : !hal.fence
+//   CHECK-DAG: %[[EXPORT_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0 into(%arg1 : !hal.buffer_view)
+//   CHECK-DAG: %[[UNUSED:.+]] = util.optimization_barrier %[[EXPORT_RESULT1]]
+//   CHECK-DAG: %[[EXPORT_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1 :
+// util.return %[[EXPORT_RESULT0]]
+builtin.module @mutable_input_overwrite_no_return {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.tensor<[5,4],f32>) 
+    -> (!torch.vtensor<[4,5],si32>) {
+  %0 = torch.copy.to_vtensor %arg1 : !torch.vtensor<[5,4],f32>
+  %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
+  %2 = torch.operator "other_calc"(%arg0) : (!torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
+  torch.overwrite.tensor.contents %1 overwrites %arg1 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
+  return %2 : !torch.vtensor<[4,5],si32>
+}
+}
+
+// -----
+// Not a good idea to do but legal. This verifies that if returning a mutated
+// tensor's intermediate value, you will get two exports, indicating a copy.
+// CHECK-LABEL: @mutable_input_overwrite_return_alias_copies
+//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%{{.*}}, %{{.*}} : tensor<5x4xf32>, tensor<5x4xf32>) 
+//   CHECK-DAG: = hal.tensor.export %[[BARRIER_RESULTS]]#0 into(%arg0 : !hal.buffer_view)
+//   CHECK-DAG: = hal.tensor.export %[[BARRIER_RESULTS]]#1 :
+builtin.module @mutable_input_overwrite_return_alias_copies {
+func.func @main(%arg0: !torch.tensor<[5,4],f32>) -> (!torch.vtensor<[5,4],f32>) {
+  %0 = torch.copy.to_vtensor %arg0 : !torch.vtensor<[5,4],f32>
+  %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
+  torch.overwrite.tensor.contents %1 overwrites %arg0 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
+  return %1 : !torch.vtensor<[5,4],f32>
+}
+}
+
+// -----
+// CHECK-LABEL: @retained_attribute_reflection
+//      CHECK: util.func public @main$async(
+// CHECK-SAME:   iree.reflection = {some.attr = 4 : index}
+//      CHECK: util.func public @main(
+// CHECK-SAME:   iree.reflection = {some.attr = 4 : index}
+builtin.module @retained_attribute_reflection {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32> 
+  attributes {
+    iree.reflection = {
+      some.attr = 4 : index
+    }    
+  }
+{
+  return %arg0 : !torch.vtensor<[4,5],si32>
+}
+}
+
+// -----
+// CHECK-LABEL: @retained_attribute_ignored
+//      CHECK: util.func public @main$async(
+//  CHECK-NOT: iree.nonretained
+builtin.module @retained_attribute_ignored {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32> 
+  attributes {
+    iree.nonretained = "dummy"
+  }
+{
+  return %arg0 : !torch.vtensor<[4,5],si32>
+}
+}
+
+// -----
+// CHECK-LABEL: @retained_attribute_noinline
+//      CHECK: util.func public @main$async(
+// CHECK-SAME:   inlining_policy = #util.inline.never
+//      CHECK: util.func public @main(
+// CHECK-NOT:    inlining_policy
+builtin.module @retained_attribute_noinline {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32> 
+  attributes {
+    noinline
+  }
+{
+  return %arg0 : !torch.vtensor<[4,5],si32>
+}
+}
+
+// -----
+// CHECK-LABEL: @private_visibility
+// CHECK: util.func private @main$async
+// CHECK: util.func private @main
+builtin.module @private_visibility {
+func.func private @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32> 
+{
+  return %arg0 : !torch.vtensor<[4,5],si32>
+}
+}
+
+// -----
+// CHECK-LABEL: @tied_operand
+// CHECK: util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> %arg0
+// CHECK: util.func public @main(%arg0: !hal.buffer_view) -> !hal.buffer_view
+// CHECK: = util.call @main$async{{.*}} -> %arg0
+builtin.module @tied_operand {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> 
+  (!torch.vtensor<[4,5],si32> {iree.abi.tied = 0})
+{
   return %arg0 : !torch.vtensor<[4,5],si32>
 }
 }

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
@@ -44,7 +44,7 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.vtensor<[5,4],f
 // -----
 // CHECK-LABEL: @return_immutable_arg
 // CHECK: util.func public @main$async
-// CHECK: hal.tensor.barrier join( : ) => %arg2
+// CHECK: hal.fence.signal<%arg2 : !hal.fence>
 // CHECK: util.return %arg0
 builtin.module @return_immutable_arg {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>  {

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion.mlir
@@ -178,3 +178,92 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>) ->
   return %arg0 : !torch.vtensor<[4,5],si32>
 }
 }
+
+// -----
+// Verify that dynamic dimensions verify.
+// CHECK-LABEL: @immutable_import_export
+// CHECK: hal.buffer_view.dim<%arg0
+// CHECK: hal.buffer_view.dim<%arg1
+builtin.module @immutable_import_export {
+func.func @main(%arg0: !torch.vtensor<[4,?],si32>, %arg1: !torch.vtensor<[?,4],f32>) 
+    -> (!torch.vtensor<[4,?],si32>, !torch.vtensor<[?,4],f32>) {
+  %0 = torch.operator "foobar0"(%arg0) : (!torch.vtensor<[4,?],si32>) -> !torch.vtensor<[4,?],si32>
+  %1 = torch.operator "foobar1"(%arg1) : (!torch.vtensor<[?,4],f32>) -> !torch.vtensor<[?,4],f32>
+  return %0, %1 : !torch.vtensor<[4,?],si32>, !torch.vtensor<[?,4],f32>
+}
+}
+
+// -----
+// CHECK-LABEL: @torch_bool_return
+// CHECK: torch_c.to_i1
+// CHECK: util.return {{.*}} : i1
+module @torch_bool_return {
+  func.func @main() -> !torch.bool {
+    %0 = torch.operator "some.primitive"() : () -> !torch.bool
+    return %0 : !torch.bool
+  }
+}
+
+// -----
+// CHECK-LABEL: @torch_int_return
+// CHECK: torch_c.to_i64
+// CHECK: util.return {{.*}} : i64
+module @torch_int_return {
+  func.func @main() -> !torch.int {
+    %0 = torch.operator "some.primitive"() : () -> !torch.int
+    return %0 : !torch.int
+  }
+}
+
+// -----
+// CHECK-LABEL: @torch_float_return
+// CHECK: torch_c.to_f64
+// CHECK: util.return {{.*}} : f64
+module @torch_float_return {
+  func.func @main() -> !torch.float {
+    %0 = torch.operator "some.primitive"() : () -> !torch.float
+    return %0 : !torch.float
+  }
+}
+
+// -----
+// CHECK-LABEL: @torch_generator_return
+// CHECK: torch_c.generator_to_i64
+// CHECK: util.return {{.*}} : i64
+module @torch_generator_return {
+  func.func @main() -> !torch.Generator {
+    %0 = torch.operator "some.primitive"() : () -> !torch.Generator
+    return %0 : !torch.Generator
+  }
+}
+
+// -----
+// CHECK-LABEL: @torch_bool_arg
+// CHECK: torch_c.from_i1 %arg0
+module @torch_bool_arg {
+  func.func @main(%arg0 : !torch.bool) -> (!torch.vtensor<[1],f32>) {
+    %0 = torch.operator "some.primitive"(%arg0) : (!torch.bool) ->  (!torch.vtensor<[1],f32>)
+    return %0 : !torch.vtensor<[1],f32>
+  }
+}
+
+// -----
+// CHECK-LABEL: @torch_int_arg
+// CHECK: torch_c.from_i64 %arg0
+module @torch_int_arg {
+  func.func @main(%arg0 : !torch.int) -> (!torch.vtensor<[1],f32>) {
+    %0 = torch.operator "some.primitive"(%arg0) : (!torch.int) ->  (!torch.vtensor<[1],f32>)
+    return %0 : !torch.vtensor<[1],f32>
+  }
+}
+
+// -----
+// CHECK-LABEL: @torch_float_arg
+// CHECK: torch_c.from_f64 %arg0
+module @torch_float_arg {
+  func.func @main(%arg0 : !torch.float) -> (!torch.vtensor<[1],f32>) {
+    %0 = torch.operator "some.primitive"(%arg0) : (!torch.float) ->  (!torch.vtensor<[1],f32>)
+    return %0 : !torch.vtensor<[1],f32>
+  }
+}
+

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion_invalid.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/func_conversion_invalid.mlir
@@ -1,0 +1,14 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(torch-iree-func-conversion)" --verify-diagnostics %s
+
+// We do not support returning a mutable tensor from a function.
+// It is unclear if these can be generated from current torch tooling. If it
+// ever becomes a problem, something can be implemented.
+builtin.module @mutable_input_overwrite_return {
+func.func @main(%arg0: !torch.tensor<[5,4],f32>) -> (!torch.tensor<[5,4],f32>) {
+  %0 = torch.copy.to_vtensor %arg0 : !torch.vtensor<[5,4],f32>
+  %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
+  torch.overwrite.tensor.contents %1 overwrites %arg0 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
+  // expected-error @+1 {{unsupported operation on coarse signaling mutable tensor}}
+  return %arg0 : !torch.tensor<[5,4],f32>
+}
+}

--- a/compiler/plugins/input/Torch/torch-iree/InputConversion/test/torch_to_iree.mlir
+++ b/compiler/plugins/input/Torch/torch-iree/InputConversion/test/torch_to_iree.mlir
@@ -4,7 +4,7 @@
 
 // Verify that we can have IREE ops in the input and the types convert
 // properly.
-// CHECK: func @forward(%arg0: tensor<128x20xf32>) -> tensor<128x30xf32>
+// CHECK-LABEL: util.func public @forward$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> !hal.buffer_view
 // CHECK: linalg.matmul
 module {
   func.func @forward(%arg0: !torch.vtensor<[128,20],f32>) -> !torch.vtensor<[128,30],f32> {
@@ -31,7 +31,7 @@ module {
 // -----
 
 // Verify we can decompose complex ops
-// CHECK: func @main(%arg0: tensor<2x3x4xf32>) -> (tensor<2x3x4xf32>, tensor<2x3x4xf32>)
+// CHECK-LABEL: util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> (!hal.buffer_view, !hal.buffer_view)
 // CHECK: tensor.empty
 module {
   func.func @main(%arg0: !torch.vtensor<[2,3,4],f32>) -> (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>) {
@@ -44,7 +44,8 @@ module {
     %int1 = torch.constant.int 1
     %1 = torch.prim.ListConstruct %int12, %int4_0, %int1 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
     %none = torch.constant.none
-    %none_1 = torch.constant.none    %cpu = torch.constant.device "cpu"
+    %none_1 = torch.constant.none    
+    %cpu = torch.constant.device "cpu"
     %false = torch.constant.bool false
     %2 = torch.aten.empty_strided %0, %1, %none, %none_1, %cpu, %false : !torch.list<int>, !torch.list<int>, !torch.none, !torch.none, !torch.Device, !torch.bool -> !torch.vtensor<[2,3,4],f32>
     %false_2 = torch.constant.bool false

--- a/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/torch-iree/PluginRegistration.cpp
@@ -65,8 +65,6 @@ struct TorchSession
       TorchInput::TorchToIREELoweringPipelineOptions torchOptions;
       torchOptions.strictSymbolicShapes = options.strictSymbolicShapes;
       TorchInput::createTorchToIREEPipeline(passManager, torchOptions);
-      passManager.addNestedPass<func::FuncOp>(
-          TorchInput::createConvertTMTensorToLinalgExtPass());
       return true;
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -474,10 +474,18 @@ LogicalResult TensorImportOp::verify() {
 void TensorExportOp::build(OpBuilder &builder, OperationState &result,
                            Type resultType, Value source,
                            TypeAttr sourceEncoding, StringAttr name) {
+  build(builder, result, resultType, source, sourceEncoding,
+        /*targetStorage=*/nullptr, name);
+}
+
+void TensorExportOp::build(OpBuilder &builder, OperationState &result,
+                           Type resultType, Value source,
+                           TypeAttr sourceEncoding, Value targetStorage,
+                           StringAttr name) {
   auto dynamicDims =
       IREE::Util::buildDynamicDimsForValue(result.location, source, builder);
   build(builder, result, resultType, source, sourceEncoding, dynamicDims,
-        /*target_storage=*/nullptr, name);
+        targetStorage, name);
 }
 
 Value TensorExportOp::getTiedResult(unsigned resultIndex) {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -221,6 +221,13 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
       "TypeAttr":$sourceEncoding,
       "StringAttr":$name
     )>,
+    OpBuilder<(ins
+      "Type":$resultType,
+      "Value":$source,
+      "TypeAttr":$sourceEncoding,
+      "Value":$targetStorage,
+      "StringAttr":$name
+    )>,
   ];
 
   let extraClassDeclaration = [{


### PR DESCRIPTION
This patch removes the reference torch-mlir `FuncBackendTypeConversionPass` and implements a new `FuncConversionPass` which directly targets IREE functions. This centralizes in one place the conversions that let us get to a high fidelity between torch->iree, whereas they were spread across half a dozen places. Centralizing lets us implement both mutability and the corresponding impact that has to synchronization policy at the ABI. This relies on knowledge of actual Torch semantics and is unsuitable for the generic input conversion pipelines.

Also move the conversion from tm_tensor to linalg_ext up to where we convert into tm_tensor vs being after all conversions are done. The forcing function was that such op level conversions should not be done once we commit the ABI.

A key difference vs the previous state: At the end of `--torch-to-iree`, all functions are defined on BufferView (vs tensor) and have appropriate import/export/synchronization in place. This was being done in different stages before. Attributes have been added to converted functions to disable those default bufferization/wrapping stages when coming in from Torch in this way, since it has already been fully converted to IREE semantics.

The effect to all of this is that if you compile a Torch program that performs an inplace update of a tensor argument or a containing nn.Module buffer, then the FX importer will note the arrangement, and IREE will properly set up those arguments to be mutable and tie them so that they can operate in place on device (subject to certain fusion and other heuristics which can force a copy). Only tensor content replacement is supported right now. This may be expanded as Torch moves forward on these points.