### PR TITLE
[DO NOT SUBMIT] Initial i8mm lowering implementation scratch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/google/googletest.git
 [submodule "third_party/llvm-project"]
 	path = third_party/llvm-project
-	url = https://github.com/shark-infra/llvm-project.git
+	url = https://github.com/KoolJBlack/llvm-project.git
 [submodule "third_party/vulkan_headers"]
 	path = third_party/vulkan_headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -122,6 +122,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithTransforms",
         "@llvm-project//mlir:ArmNeon2dToIntr",
         "@llvm-project//mlir:ArmNeonDialect",
+        "@llvm-project//mlir:ArmNeonTransforms",
         "@llvm-project//mlir:ArmSMEToLLVM",
         "@llvm-project//mlir:ArmSMEToLLVMIRTranslation",
         "@llvm-project//mlir:ArmSMEToSCF",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -96,6 +96,7 @@ iree_cc_library(
     MLIRArithTransforms
     MLIRArmNeon2dToIntr
     MLIRArmNeonDialect
+    MLIRArmNeonTransforms
     MLIRArmSMEToLLVM
     MLIRArmSMEToLLVMIRTranslation
     MLIRArmSMEToSCF

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
@@ -96,12 +96,12 @@ void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
   if (enableVectorContractCustomKernels) {
     // Special-case vector.contract codegen paths. This needs to happen
     // just before the generic vector ops lowerings.
-    RewritePatternSet patterns(context);
-    auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
-    populateVectorContractCustomKernelsPatterns(target, patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-      return signalPassFailure();
-    }
+    // RewritePatternSet patterns(context);
+    // auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
+    // populateVectorContractCustomKernelsPatterns(target, patterns);
+    // if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    //   return signalPassFailure();
+    // }
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
@@ -96,12 +96,12 @@ void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
   if (enableVectorContractCustomKernels) {
     // Special-case vector.contract codegen paths. This needs to happen
     // just before the generic vector ops lowerings.
-    // RewritePatternSet patterns(context);
-    // auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
-    // populateVectorContractCustomKernelsPatterns(target, patterns);
-    // if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-    //   return signalPassFailure();
-    // }
+    RewritePatternSet patterns(context);
+    auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
+    populateVectorContractCustomKernelsPatterns(target, patterns);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -6,6 +6,8 @@
 
 #include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "mlir/Dialect/ArmNeon/ArmNeonDialect.h"
+#include "mlir/Dialect/ArmNeon/Transforms.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
@@ -26,7 +28,8 @@ public:
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<linalg::LinalgDialect, vector::VectorDialect>();
+    registry.insert<linalg::LinalgDialect, vector::VectorDialect,
+                    arm_neon::ArmNeonDialect>();
   }
   void runOnOperation() override;
 };
@@ -53,6 +56,8 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
           .setVectorTransferSplit(vectorTransferSplit);
 
   RewritePatternSet patterns(ctx);
+  arm_neon::populateLowerContractionToSMMLAPatternPatterns(patterns);
+
   vector::populateVectorToVectorCanonicalizationPatterns(patterns);
   vector::populateVectorGatherLoweringPatterns(patterns);
   vector::populateVectorContractLoweringPatterns(


### PR DESCRIPTION
Inserts `populateLowerVectorToArmNeonPatterns()` to trigger on [2,2,8] tile sizes. 