### PR TITLE
Run all CI jobs on LLVM integrate PRs.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -403,6 +403,7 @@ def get_enabled_jobs(
     all_jobs: Set[str],
     *,
     is_pr: bool,
+    is_llvm_integrate_pr: bool,
     modified_paths: Optional[Iterable[str]],
 ) -> Set[str]:
     """Returns the CI jobs to run.
@@ -411,6 +412,7 @@ def get_enabled_jobs(
       trailers: trailers from PR description.
       all_jobs: all known supported jobs.
       is_pr: whether this is for pull requests or not.
+      is_llvm_integrate_pr:  whether this is for an LLVM integrate PR or not.
       modified_paths: the paths of the files changed. These paths are
         relative to the repo root directory.
 
@@ -419,8 +421,13 @@ def get_enabled_jobs(
     """
     if not is_pr:
         print(
-            "Running all jobs because run was not triggered by a pull request"
-            " event.",
+            "Running all jobs because run was not triggered by a pull request event.",
+            file=sys.stderr,
+        )
+        return all_jobs
+    if is_llvm_integrate_pr:
+        print(
+            "Running all jobs because run was triggered by an LLVM integrate pull request event.",
             file=sys.stderr,
         )
         return all_jobs
@@ -578,6 +585,7 @@ def main():
             all_jobs,
             modified_paths=get_modified_paths(base_ref),
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
     except ValueError as e:
         print(e)

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -145,12 +145,14 @@ class ConfigureCITest(unittest.TestCase):
         trailers = {}
         all_jobs = {"job1", "job2", "job3"}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         self.assertCountEqual(jobs, all_jobs)
 
@@ -160,12 +162,14 @@ class ConfigureCITest(unittest.TestCase):
         postsubmit_job = next(iter(configure_ci.DEFAULT_POSTSUBMIT_ONLY_JOBS))
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = False
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         self.assertCountEqual(jobs, all_jobs)
 
@@ -175,14 +179,33 @@ class ConfigureCITest(unittest.TestCase):
         postsubmit_job = next(iter(configure_ci.DEFAULT_POSTSUBMIT_ONLY_JOBS))
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         self.assertCountEqual(jobs, default_jobs)
+
+    def test_get_enabled_jobs_llvm_integrate(self):
+        trailers = {}
+        default_jobs = {"job1", "job2", "job3"}
+        postsubmit_job = next(iter(configure_ci.DEFAULT_POSTSUBMIT_ONLY_JOBS))
+        all_jobs = default_jobs | {postsubmit_job}
+        is_pr = True
+        is_llvm_integrate_pr = True
+        modified_paths = ["runtime/file"]
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modified_paths=modified_paths,
+            is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
+        )
+        self.assertCountEqual(jobs, all_jobs)
 
     def test_get_enabled_jobs_no_modifies(self):
         trailers = {}
@@ -190,12 +213,14 @@ class ConfigureCITest(unittest.TestCase):
         postsubmit_job = next(iter(configure_ci.DEFAULT_POSTSUBMIT_ONLY_JOBS))
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["experimental/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         self.assertCountEqual(jobs, {})
 
@@ -205,12 +230,14 @@ class ConfigureCITest(unittest.TestCase):
         postsubmit_job = next(iter(configure_ci.DEFAULT_POSTSUBMIT_ONLY_JOBS))
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         self.assertCountEqual(jobs, {"job3"})
 
@@ -220,12 +247,14 @@ class ConfigureCITest(unittest.TestCase):
         postsubmit_job = next(iter(configure_ci.DEFAULT_POSTSUBMIT_ONLY_JOBS))
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         self.assertCountEqual(jobs, {})
 
@@ -235,12 +264,14 @@ class ConfigureCITest(unittest.TestCase):
         default_jobs = {"job1", "job2", "job3"}
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         self.assertCountEqual(jobs, all_jobs)
 
@@ -250,12 +281,14 @@ class ConfigureCITest(unittest.TestCase):
         default_jobs = {"job1", "job2", "job3"}
         all_jobs = default_jobs | {postsubmit_job}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         self.assertCountEqual(jobs, {postsubmit_job})
 
@@ -263,12 +296,14 @@ class ConfigureCITest(unittest.TestCase):
         trailers = {}
         all_jobs = {"job1"}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/src/iree/hal/drivers/metal/file"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         expected_jobs = {"job1", "build_test_all_macos_arm64"}
         self.assertCountEqual(jobs, expected_jobs)
@@ -277,12 +312,14 @@ class ConfigureCITest(unittest.TestCase):
         trailers = {}
         all_jobs = {"job1"}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["runtime/src/iree/base/internal/threading_win32.c"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         expected_jobs = {"job1", "build_test_all_windows"}
         self.assertCountEqual(jobs, expected_jobs)
@@ -292,12 +329,14 @@ class ConfigureCITest(unittest.TestCase):
         trailers = {}
         all_jobs = {"job1"}
         is_pr = True
+        is_llvm_integrate_pr = False
         modified_paths = ["docs/windows.md"]
         jobs = configure_ci.get_enabled_jobs(
             trailers,
             all_jobs,
             modified_paths=modified_paths,
             is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
         )
         expected_jobs = {}
         self.assertCountEqual(jobs, expected_jobs)


### PR DESCRIPTION
These jobs currently run on postsubmit and are opt-in for presubmit:

Job name | Time taken
-- | --
build_test_all_arm64 | 1h20m
build_test_all_windows | 22m
build_test_all_macos_arm64 | 42m
build_test_all_macos_x86_64 | 1h34m
test_a100 | 7m

Now they will always run on PRs identified as LLVM integrate PRs, matching the behavior of the benchmark jobs.