### PR TITLE
Limit release index API requests to the first 1000 releases.

### DIFF
--- a/build_tools/scripts/generate_release_index.py
+++ b/build_tools/scripts/generate_release_index.py
@@ -44,7 +44,8 @@ class ReleaseFetcher:
         url = f"https://api.github.com/repos/{self._repo}/releases"
         page = 1
 
-        while True:
+        # GitHub limits API responses to the first 1000 results.
+        while page * self._per_page < 1000:
             response = self._session.get(
                 url,
                 params={


### PR DESCRIPTION
This is a GitHub-imposed limit. We could try to work around it, but we don't really need a release index dating back three years. (If we do, we should move it off of GitHub releases - they don't scale this well anyways)

This should fix the publish website action.

skip-ci: no presubmit coverage for this