### PR TITLE
Reworking HAL executable lookup/ordinal resolution.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
@@ -87,9 +87,15 @@ func.func @basic_linking() -> () attributes {
     testing.op.c = @dispatch_0::@spirv::@dispatch_0
   }
   %c1 = arith.constant 1 : index
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@spirv::@dispatch_0) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@spirv::@dispatch_1) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@spirv::@dispatch_2) workgroups([%c1, %c1, %c1])
+  %dispatch_0_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_0) : !hal.executable
+  %dispatch_1_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_1) : !hal.executable
+  %dispatch_2_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_2) : !hal.executable
+  %dispatch_0_ordinal = hal.executable.export.ordinal target(@dispatch_0::@spirv::@dispatch_0) : index
+  %dispatch_1_ordinal = hal.executable.export.ordinal target(@dispatch_1::@spirv::@dispatch_1) : index
+  %dispatch_2_ordinal = hal.executable.export.ordinal target(@dispatch_2::@spirv::@dispatch_2) : index
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_0_exe : !hal.executable)[%dispatch_0_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_1_exe : !hal.executable)[%dispatch_1_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_2_exe : !hal.executable)[%dispatch_2_ordinal] workgroups([%c1, %c1, %c1])
   return
 }
 util.initializer {
@@ -97,9 +103,15 @@ util.initializer {
   %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
   %c1 = arith.constant 1 : index
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@spirv::@dispatch_0) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@spirv::@dispatch_1) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@spirv::@dispatch_2) workgroups([%c1, %c1, %c1])
+  %dispatch_0_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_0) : !hal.executable
+  %dispatch_1_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_1) : !hal.executable
+  %dispatch_2_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_2) : !hal.executable
+  %dispatch_0_ordinal = hal.executable.export.ordinal target(@dispatch_0::@spirv::@dispatch_0) : index
+  %dispatch_1_ordinal = hal.executable.export.ordinal target(@dispatch_1::@spirv::@dispatch_1) : index
+  %dispatch_2_ordinal = hal.executable.export.ordinal target(@dispatch_2::@spirv::@dispatch_2) : index
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_0_exe : !hal.executable)[%dispatch_0_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_1_exe : !hal.executable)[%dispatch_1_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_2_exe : !hal.executable)[%dispatch_2_ordinal] workgroups([%c1, %c1, %c1])
   util.return
 }
 
@@ -144,14 +156,26 @@ util.initializer {
 // CHECK:           testing.op.a = @link_executables_linked_spirv
 // CHECK-SAME:      testing.op.b = @link_executables_linked_spirv::@vulkan_spirv_fb
 // CHECK-SAME:      testing.op.c = @link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0
-// CHECK:         hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_1) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_2) workgroups([%c1, %c1, %c1])
+// CHECK-DAG:     %[[DISPATCH_0_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_1_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_2_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_0_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0)
+// CHECK-DAG:     %[[DISPATCH_1_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_1)
+// CHECK-DAG:     %[[DISPATCH_2_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_2)
+// CHECK:         hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_0_EXE]] : !hal.executable)[%[[DISPATCH_0_ORDINAL]]] workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_1_EXE]] : !hal.executable)[%[[DISPATCH_1_ORDINAL]]] workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_2_EXE]] : !hal.executable)[%[[DISPATCH_2_ORDINAL]]] workgroups([%c1, %c1, %c1])
 //
 // CHECK:       util.initializer
-// CHECK:         hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_1) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_2) workgroups([%c1, %c1, %c1])
+// CHECK-DAG:     %[[DISPATCH_0_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_1_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_2_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_0_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_0)
+// CHECK-DAG:     %[[DISPATCH_1_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_1)
+// CHECK-DAG:     %[[DISPATCH_2_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv::@vulkan_spirv_fb::@dispatch_2)
+// CHECK:         hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_0_EXE]] : !hal.executable)[%[[DISPATCH_0_ORDINAL]]] workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_1_EXE]] : !hal.executable)[%[[DISPATCH_1_ORDINAL]]] workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_2_EXE]] : !hal.executable)[%[[DISPATCH_2_ORDINAL]]] workgroups([%c1, %c1, %c1])
 
 // -----
 
@@ -269,10 +293,18 @@ func.func @two_target_environments() -> () {
   %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
   %c1 = arith.constant 1 : index
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@spirv::@dispatch_0) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@spirv::@dispatch_1) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@spirv::@dispatch_2) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_3::@spirv::@dispatch_3) workgroups([%c1, %c1, %c1])
+  %dispatch_0_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_0) : !hal.executable
+  %dispatch_1_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_1) : !hal.executable
+  %dispatch_2_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_2) : !hal.executable
+  %dispatch_3_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_3) : !hal.executable
+  %dispatch_0_ordinal = hal.executable.export.ordinal target(@dispatch_0::@spirv::@dispatch_0) : index
+  %dispatch_1_ordinal = hal.executable.export.ordinal target(@dispatch_1::@spirv::@dispatch_1) : index
+  %dispatch_2_ordinal = hal.executable.export.ordinal target(@dispatch_2::@spirv::@dispatch_2) : index
+  %dispatch_3_ordinal = hal.executable.export.ordinal target(@dispatch_3::@spirv::@dispatch_3) : index
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_0_exe : !hal.executable)[%dispatch_0_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_1_exe : !hal.executable)[%dispatch_1_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_2_exe : !hal.executable)[%dispatch_2_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_3_exe : !hal.executable)[%dispatch_3_ordinal] workgroups([%c1, %c1, %c1])
   return
 }
 
@@ -323,10 +355,18 @@ func.func @two_target_environments() -> () {
 //      CHECK: }
 
 //      CHECK: func.func @two_target_environments()
-//      CHECK:   hal.command_buffer.dispatch.symbol{{.+}} target(@link_executables_linked_spirv_0::@vulkan_spirv_fb::@dispatch_0)
-//      CHECK:   hal.command_buffer.dispatch.symbol{{.+}} target(@link_executables_linked_spirv_1::@vulkan_spirv_fb::@dispatch_1)
-//      CHECK:   hal.command_buffer.dispatch.symbol{{.+}} target(@link_executables_linked_spirv_0::@vulkan_spirv_fb::@dispatch_2)
-//      CHECK:   hal.command_buffer.dispatch.symbol{{.+}} target(@link_executables_linked_spirv_1::@vulkan_spirv_fb::@dispatch_3)
+//  CHECK-DAG:   %[[DISPATCH_0_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv_0) : !hal.executable
+//  CHECK-DAG:   %[[DISPATCH_1_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv_1) : !hal.executable
+//  CHECK-DAG:   %[[DISPATCH_2_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv_0) : !hal.executable
+//  CHECK-DAG:   %[[DISPATCH_3_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_spirv_1) : !hal.executable
+//  CHECK-DAG:   %[[DISPATCH_0_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv_0::@vulkan_spirv_fb::@dispatch_0)
+//  CHECK-DAG:   %[[DISPATCH_1_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv_1::@vulkan_spirv_fb::@dispatch_1)
+//  CHECK-DAG:   %[[DISPATCH_2_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv_0::@vulkan_spirv_fb::@dispatch_2)
+//  CHECK-DAG:   %[[DISPATCH_3_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_spirv_1::@vulkan_spirv_fb::@dispatch_3)
+//      CHECK:   hal.command_buffer.dispatch{{.+}} target(%[[DISPATCH_0_EXE]] : !hal.executable)[%[[DISPATCH_0_ORDINAL]]]
+//      CHECK:   hal.command_buffer.dispatch{{.+}} target(%[[DISPATCH_1_EXE]] : !hal.executable)[%[[DISPATCH_1_ORDINAL]]]
+//      CHECK:   hal.command_buffer.dispatch{{.+}} target(%[[DISPATCH_2_EXE]] : !hal.executable)[%[[DISPATCH_2_ORDINAL]]]
+//      CHECK:   hal.command_buffer.dispatch{{.+}} target(%[[DISPATCH_3_EXE]] : !hal.executable)[%[[DISPATCH_3_ORDINAL]]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
@@ -80,9 +80,15 @@ func.func @basic_linking() -> () attributes {
     testing.op.c = @dispatch_0::@vmvx::@dispatch_0
   }
   %c1 = arith.constant 1 : index
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@vmvx::@dispatch_0) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@vmvx::@dispatch_1) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@vmvx::@dispatch_2) workgroups([%c1, %c1, %c1])
+  %dispatch_0_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_0) : !hal.executable
+  %dispatch_1_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_1) : !hal.executable
+  %dispatch_2_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_2) : !hal.executable
+  %dispatch_0_ordinal = hal.executable.export.ordinal target(@dispatch_0::@vmvx::@dispatch_0) : index
+  %dispatch_1_ordinal = hal.executable.export.ordinal target(@dispatch_1::@vmvx::@dispatch_1) : index
+  %dispatch_2_ordinal = hal.executable.export.ordinal target(@dispatch_2::@vmvx::@dispatch_2) : index
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_0_exe : !hal.executable)[%dispatch_0_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_1_exe : !hal.executable)[%dispatch_1_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_2_exe : !hal.executable)[%dispatch_2_ordinal] workgroups([%c1, %c1, %c1])
   return
 }
 util.initializer {
@@ -90,9 +96,15 @@ util.initializer {
   %device = hal.devices.get %c0 : !hal.device
   %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
   %c1 = arith.constant 1 : index
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@vmvx::@dispatch_0) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@vmvx::@dispatch_1) workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_2::@vmvx::@dispatch_2) workgroups([%c1, %c1, %c1])
+  %dispatch_0_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_0) : !hal.executable
+  %dispatch_1_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_1) : !hal.executable
+  %dispatch_2_exe = hal.executable.lookup device(%device : !hal.device) executable(@dispatch_2) : !hal.executable
+  %dispatch_0_ordinal = hal.executable.export.ordinal target(@dispatch_0::@vmvx::@dispatch_0) : index
+  %dispatch_1_ordinal = hal.executable.export.ordinal target(@dispatch_1::@vmvx::@dispatch_1) : index
+  %dispatch_2_ordinal = hal.executable.export.ordinal target(@dispatch_2::@vmvx::@dispatch_2) : index
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_0_exe : !hal.executable)[%dispatch_0_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_1_exe : !hal.executable)[%dispatch_1_ordinal] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%dispatch_2_exe : !hal.executable)[%dispatch_2_ordinal] workgroups([%c1, %c1, %c1])
   util.return
 }
 
@@ -137,14 +149,26 @@ util.initializer {
 // CHECK:           testing.op.a = @link_executables_linked_vmvx
 // CHECK-SAME:      testing.op.b = @link_executables_linked_vmvx::@vmvx_bytecode_fb
 // CHECK-SAME:      testing.op.c = @link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_0
-// CHECK:         hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_0) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_1) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_2) workgroups([%c1, %c1, %c1])
+// CHECK-DAG:     %[[DISPATCH_0_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_vmvx) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_1_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_vmvx) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_2_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_vmvx) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_0_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_0)
+// CHECK-DAG:     %[[DISPATCH_1_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_1)
+// CHECK-DAG:     %[[DISPATCH_2_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_2)
+// CHECK:         hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_0_EXE]] : !hal.executable)[%[[DISPATCH_0_ORDINAL]]] workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_1_EXE]] : !hal.executable)[%[[DISPATCH_1_ORDINAL]]] workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_2_EXE]] : !hal.executable)[%[[DISPATCH_2_ORDINAL]]] workgroups([%c1, %c1, %c1])
 //
 // CHECK:       util.initializer
-// CHECK:         hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_0) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_1) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:    hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_2) workgroups([%c1, %c1, %c1])
+// CHECK-DAG:     %[[DISPATCH_0_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_vmvx) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_1_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_vmvx) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_2_EXE:.+]] = hal.executable.lookup device(%{{.+}}) executable(@link_executables_linked_vmvx) : !hal.executable
+// CHECK-DAG:     %[[DISPATCH_0_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_0)
+// CHECK-DAG:     %[[DISPATCH_1_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_1)
+// CHECK-DAG:     %[[DISPATCH_2_ORDINAL:.+]] = hal.executable.export.ordinal target(@link_executables_linked_vmvx::@vmvx_bytecode_fb::@dispatch_2)
+// CHECK:         hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_0_EXE]] : !hal.executable)[%[[DISPATCH_0_ORDINAL]]] workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_1_EXE]] : !hal.executable)[%[[DISPATCH_1_ORDINAL]]] workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:    hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%[[DISPATCH_2_EXE]] : !hal.executable)[%[[DISPATCH_2_ORDINAL]]] workgroups([%c1, %c1, %c1])
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
@@ -224,12 +224,14 @@ util.func public @command_buffer_dispatch(
   %arg0: !hal.command_buffer,
   %arg1: !hal.executable
 ) {
+  // CHECK: %[[ORDINAL:.+]] = vm.const.i32 123
+  %ordinal = arith.constant 123 : index
   %c100 = arith.constant 100 : index
   %c200 = arith.constant 200 : index
   %c300 = arith.constant 300 : index
-  // CHECK: vm.call @hal.command_buffer.dispatch(%arg0, %arg1, %zero, %c100, %c200, %c300) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.executable>, i32, i32, i32, i32) -> ()
+  // CHECK: vm.call @hal.command_buffer.dispatch(%arg0, %arg1, %[[ORDINAL]], %c100, %c200, %c300) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.executable>, i32, i32, i32, i32) -> ()
   hal.command_buffer.dispatch<%arg0 : !hal.command_buffer>
-      target(%arg1 : !hal.executable)[0]
+      target(%arg1 : !hal.executable)[%ordinal]
       workgroups([%c100, %c200, %c300])
   util.return
 }
@@ -242,10 +244,12 @@ util.func public @command_buffer_dispatch_indirect(
   %arg1: !hal.executable,
   %arg2: !hal.buffer
 ) {
+  // CHECK: %[[ORDINAL:.+]] = vm.const.i32 123
+  %ordinal = arith.constant 123 : index
   %c100 = arith.constant 100 : index
-  // CHECK: vm.call @hal.command_buffer.dispatch.indirect(%arg0, %arg1, %zero, %arg2, %c100) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.executable>, i32, !vm.ref<!hal.buffer>, i64) -> ()
+  // CHECK: vm.call @hal.command_buffer.dispatch.indirect(%arg0, %arg1, %[[ORDINAL]], %arg2, %c100) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.executable>, i32, !vm.ref<!hal.buffer>, i64) -> ()
   hal.command_buffer.dispatch.indirect<%arg0 : !hal.command_buffer>
-      target(%arg1 : !hal.executable)[0]
+      target(%arg1 : !hal.executable)[%ordinal]
       workgroups(%arg2 : !hal.buffer)[%c100]
   util.return
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
@@ -256,15 +256,23 @@ util.func public @cmdDispatch(%arg0: !stream.resource<transient>, %arg1: index, 
     // CHECK: %[[YZ:.+]] = arith.constant 1 : index
     // CHECK-NEXT: %[[X:.+]] = affine.apply #map()[%c1]
 
+    // Target executable/export:
+    //  CHECK-DAG: %[[EXECUTABLE_0:.+]] = hal.executable.lookup
+    // CHECK-SAME:     device(%[[DEVICE]] : !hal.device)
+    // CHECK-SAME:     executable(@ex) : !hal.executable
+    //  CHECK-DAG: %[[ORDINAL_0:.+]] = hal.executable.export.ordinal
+    // CHECK-SAME:     target(@ex::@aarch64::@dispatch) : index
+
     // Dispatch:
-    // CHECK: hal.command_buffer.dispatch.symbol<%[[CMD]]
-    // CHECK-SAME: target(@ex::@aarch64::@dispatch)
+    // CHECK: hal.command_buffer.dispatch<%[[CMD]]
+    // CHECK-SAME: target(%[[EXECUTABLE_0]] : !hal.executable)[%[[ORDINAL_0]]]
     // CHECK-SAME: workgroups([%[[X]], %[[YZ]], %[[YZ]]])
 
     // Other variant, when selected:
     // CHECK: case 1 {
-    // CHECK: hal.command_buffer.dispatch.symbol<%[[CMD]]
-    // CHECK-SAME: target(@ex::@x86_64::@dispatch)
+    // CHECK-DAG: %[[ORDINAL_1:.+]] = hal.executable.export.ordinal target(@ex::@x86_64::@dispatch)
+    // CHECK: hal.command_buffer.dispatch<%[[CMD]]
+    // CHECK-SAME: target({{.+}})[%[[ORDINAL_1]]]
     stream.cmd.dispatch {@ex::@aarch64::@dispatch, @ex::@x86_64::@dispatch}[%c1, %c2, %c3](%c4_i32, %c5_i32 : i32, i32) {
       ro %arg4[%c0 for %c128] : !stream.resource<transient>{%arg1},
       wo %arg5[%c0 for %c128] : !stream.resource<external>{%arg3}

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -168,6 +168,7 @@ def HAL_BufferType : AnyTypeOf<[
   HAL_Buffer,
 ]>;
 
+def HAL_Ordinal : TypeAlias<Index>;
 def HAL_OrdinalAttr : Util_IndexAttrBase<"size_t">;
 def HAL_OrdinalArrayAttr : TypedArrayAttrBase<HAL_OrdinalAttr, "Array of index ordinal attributes">;
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -717,7 +717,7 @@ Value BufferSubspanOp::getResultSize(unsigned idx) { return getLength(); }
 
 void BufferLengthOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
-  setNameFn(getResult(), "len");
+  setNameFn(getResult(), "length");
 }
 
 //===----------------------------------------------------------------------===//
@@ -1597,6 +1597,7 @@ void ExecutableBinaryOp::build(OpBuilder &builder, OperationState &state,
 
 void ExecutableCreateOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
+  // TODO(benvanik): name after sanitized symbol.
   setNameFn(getResult(), StringRef("exe"));
 }
 
@@ -1606,7 +1607,18 @@ void ExecutableCreateOp::getAsmResultNames(
 
 void ExecutableLookupOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
+  // TODO(benvanik): name after sanitized symbol.
   setNameFn(getResult(), "exe");
+}
+
+//===----------------------------------------------------------------------===//
+// hal.executable.export.ordinal
+//===----------------------------------------------------------------------===//
+
+void ExecutableExportOrdinalOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  // TODO(benvanik): name after sanitized symbol.
+  setNameFn(getResult(), "ordinal");
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -39,8 +39,8 @@ def OpGroupExperimentalOps : OpDocGroup {
 let opDocGroup = OpGroupExperimentalOps in {
 
 def HAL_ExFileFromMemoryOp : HAL_Op<"ex.file.from_memory", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{creates a file mapped into a byte range of a host buffer}];
   let description = [{
     Returns a file handle that is backed by the given `buffer` contents.
@@ -449,9 +449,9 @@ def OpGroupAllocatorOps : OpDocGroup {
 let opDocGroup = OpGroupAllocatorOps in {
 
 def HAL_AllocatorAllocateOp : HAL_Op<"allocator.allocate", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-    DeclareOpInterfaceMethods<Util_SizeAwareOp>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  DeclareOpInterfaceMethods<Util_SizeAwareOp>,
+]> {
   let summary = [{empty buffer allocation operation}];
   let description = [{
     Allocates a buffer of the given size from the allocator.
@@ -482,9 +482,9 @@ def HAL_AllocatorAllocateOp : HAL_Op<"allocator.allocate", [
 }
 
 def HAL_AllocatorImportOp : HAL_Op<"allocator.import", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-    DeclareOpInterfaceMethods<Util_SizeAwareOp>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  DeclareOpInterfaceMethods<Util_SizeAwareOp>,
+]> {
   let summary = [{allocator-supported host buffer import operation}];
   let description = [{
     Tries importing host memory backed by the given byte buffer into a
@@ -573,9 +573,9 @@ def HAL_BufferAssertOp : HAL_Op<"buffer.assert", []> {
 }
 
 def HAL_BufferSubspanOp : HAL_PureOp<"buffer.subspan", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-    DeclareOpInterfaceMethods<Util_SizeAwareOp>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  DeclareOpInterfaceMethods<Util_SizeAwareOp>,
+]> {
   let summary = [{buffer subspan operation}];
   let description = [{
     Returns a reference to a subspan of the buffer.
@@ -599,8 +599,8 @@ def HAL_BufferSubspanOp : HAL_PureOp<"buffer.subspan", [
 }
 
 def HAL_BufferLengthOp : HAL_PureOp<"buffer.length", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{buffer byte length accessor}];
   let description = [{
     Returns the allocated size of a buffer in bytes.
@@ -752,8 +752,8 @@ def HAL_EncodingTypeOp : HAL_PureOp<"encoding_type", [
 }
 
 def HAL_BufferViewCreateOp : HAL_PureOp<"buffer_view.create", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{buffer view reference initializer}];
   let description = [{
     Creates a reference to a buffer with a particular shape and element type.
@@ -807,7 +807,7 @@ def HAL_BufferViewCreateOp : HAL_PureOp<"buffer_view.create", [
   let hasCanonicalizer = 1;
 }
 
-def HAL_BufferViewAssertOp : HAL_Op<"buffer_view.assert", []> {
+def HAL_BufferViewAssertOp : HAL_Op<"buffer_view.assert"> {
   let summary = [{buffer view contents assertion}];
   let description = [{
     Asserts that the buffer view contains a data compatible tensor with the
@@ -838,8 +838,8 @@ def HAL_BufferViewAssertOp : HAL_Op<"buffer_view.assert", []> {
 }
 
 def HAL_BufferViewBufferOp : HAL_PureOp<"buffer_view.buffer", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{buffer view buffer accessor}];
   let description = [{
     Returns the buffer backing this view's contents.
@@ -975,8 +975,8 @@ def OpGroupChannelOps : OpDocGroup {
 let opDocGroup = OpGroupChannelOps in {
 
 def HAL_ChannelCreateOp : HAL_Op<"channel.create", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{creates a new channel for collective communication}];
   let description = [{
     Returns a new channel with the given rank associated with the given device
@@ -1017,8 +1017,8 @@ def HAL_ChannelCreateOp : HAL_Op<"channel.create", [
 }
 
 def HAL_ChannelSplitOp : HAL_Op<"channel.split", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{splits a collective communication channel}];
   let description = [{
     Partitions the group associated with the given channel into disjoint
@@ -1053,8 +1053,8 @@ def HAL_ChannelSplitOp : HAL_Op<"channel.split", [
 }
 
 def HAL_ChannelRankAndCountOp : HAL_PureOp<"channel.rank_and_count", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{returns the rank of the local participant in the group}];
   let description = [{
     Returns the rank the channel represents as a participant in a collective
@@ -1090,8 +1090,8 @@ def OpGroupCommandBufferOps : OpDocGroup {
 let opDocGroup = OpGroupCommandBufferOps in {
 
 def HAL_CommandBufferCreateOp : HAL_Op<"command_buffer.create", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{command buffer allocation operation}];
   let description = [{
     Returns a command buffer from the device pool ready to begin recording.
@@ -1274,10 +1274,9 @@ def HAL_CommandBufferCopyBufferOp : HAL_Op<"command_buffer.copy_buffer"> {
   let hasCanonicalizer = 1;
 }
 
-def HAL_CommandBufferCollectiveOp :
-  HAL_Op<"command_buffer.collective", [
-    AttrSizedOperandSegments,
-  ]> {
+def HAL_CommandBufferCollectiveOp : HAL_Op<"command_buffer.collective", [
+  AttrSizedOperandSegments,
+]> {
   let summary = [{command buffer collective dispatch recording operation}];
   let description = [{
     Dispatches a collective operation defined by op using the given buffers.
@@ -1313,8 +1312,7 @@ def HAL_CommandBufferCollectiveOp :
   }];
 }
 
-def HAL_CommandBufferPushConstantsOp :
-    HAL_Op<"command_buffer.push_constants"> {
+def HAL_CommandBufferPushConstantsOp : HAL_Op<"command_buffer.push_constants"> {
   let summary = [{command buffer push constants operation}];
   let description = [{
     Pushes an inline set of constants that can be accessed by subsequent
@@ -1341,10 +1339,9 @@ def HAL_CommandBufferPushConstantsOp :
   }];
 }
 
-def HAL_CommandBufferPushDescriptorSetOp :
-    HAL_Op<"command_buffer.push_descriptor_set", [
-      SameVariadicOperandSize,
-    ]> {
+def HAL_CommandBufferPushDescriptorSetOp : HAL_Op<"command_buffer.push_descriptor_set", [
+  SameVariadicOperandSize,
+]> {
   let summary = [{command buffer descriptor set push binding operation}];
   let description = [{
     Pushes an inline-defined descriptor set to the command buffer.
@@ -1387,32 +1384,6 @@ def HAL_CommandBufferPushDescriptorSetOp :
   let hasCanonicalizer = 1;
 }
 
-def HAL_CommandBufferDispatchSymbolOp : HAL_Op<"command_buffer.dispatch.symbol"> {
-  let summary = [{command buffer dispatch recording operation, using symbolref}];
-  let description = [{
-    Dispatches an execution request, using a nested symbol reference to the entry point.
-  }];
-
-  let arguments = (ins
-    HAL_CommandBuffer:$command_buffer,
-    SymbolRefAttr:$entry_point,
-    HAL_Dim:$workgroup_x,
-    HAL_Dim:$workgroup_y,
-    HAL_Dim:$workgroup_z
-  );
-
-  let assemblyFormat = [{
-    `<` $command_buffer `:` type($command_buffer) `>`
-    `target` `(` $entry_point `)`
-    `workgroups` `(` `[`
-        $workgroup_x `,`
-        $workgroup_y `,`
-        $workgroup_z
-    `]` `)`
-    attr-dict-with-keyword
-  }];
-}
-
 def HAL_CommandBufferDispatchOp : HAL_Op<"command_buffer.dispatch"> {
   let summary = [{command buffer dispatch recording operation}];
   let description = [{
@@ -1422,7 +1393,7 @@ def HAL_CommandBufferDispatchOp : HAL_Op<"command_buffer.dispatch"> {
   let arguments = (ins
     HAL_CommandBuffer:$command_buffer,
     HAL_Executable:$executable,
-    HAL_OrdinalAttr:$entry_point,
+    HAL_Ordinal:$entry_point,
     HAL_Dim:$workgroup_x,
     HAL_Dim:$workgroup_y,
     HAL_Dim:$workgroup_z
@@ -1441,34 +1412,6 @@ def HAL_CommandBufferDispatchOp : HAL_Op<"command_buffer.dispatch"> {
   }];
 }
 
-def HAL_CommandBufferDispatchIndirectSymbolOp : HAL_Op<"command_buffer.dispatch.indirect.symbol"> {
-  let summary = [{command buffer indirect dispatch recording operation, using symbolref}];
-  let description = [{
-    Dispatches an execution request with the dispatch parameters loaded from the
-    given buffer, using using a nested symbol reference to the entry point.
-
-    ```mlir
-    hal.command_buffer.dispatch.indirect.symbol %cmd, @executable::@target::@entry,
-                                                workgroups = %buffer[%offset]
-    ```
-  }];
-
-  let arguments = (ins
-    HAL_CommandBuffer:$command_buffer,
-    SymbolRefAttr:$entry_point,
-    HAL_BufferType:$workgroups_buffer,
-    HAL_DeviceSize:$workgroups_offset
-  );
-
-  let assemblyFormat = [{
-    `<` $command_buffer `:` type($command_buffer) `>`
-    `target` `(` $entry_point `)`
-    `workgroups` `(` $workgroups_buffer `:` type($workgroups_buffer) `)`
-    `` `[` $workgroups_offset `]`
-    attr-dict-with-keyword
-  }];
-}
-
 def HAL_CommandBufferDispatchIndirectOp : HAL_Op<"command_buffer.dispatch.indirect"> {
   let summary = [{command buffer indirect dispatch recording operation}];
   let description = [{
@@ -1479,7 +1422,7 @@ def HAL_CommandBufferDispatchIndirectOp : HAL_Op<"command_buffer.dispatch.indire
   let arguments = (ins
     HAL_CommandBuffer:$command_buffer,
     HAL_Executable:$executable,
-    HAL_OrdinalAttr:$entry_point,
+    HAL_Ordinal:$entry_point,
     HAL_BufferType:$workgroups_buffer,
     HAL_DeviceSize:$workgroups_offset
   );
@@ -1509,10 +1452,9 @@ def OpGroupDescriptorSetLayoutOps : OpDocGroup {
 
 let opDocGroup = OpGroupDescriptorSetLayoutOps in {
 
-def HAL_DescriptorSetLayoutCreateOp :
-  HAL_PureOp<"descriptor_set_layout.create", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+def HAL_DescriptorSetLayoutCreateOp : HAL_PureOp<"descriptor_set_layout.create", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{creates a descriptor set layout}];
   let description = [{
     Creates a descriptor set layout that defines the bindings used within a set.
@@ -1553,8 +1495,8 @@ def OpGroupDeviceOps : OpDocGroup {
 let opDocGroup = OpGroupDeviceOps in {
 
 def HAL_DeviceAllocatorOp : HAL_PureOp<"device.allocator", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{device allocator accessor operation}];
   let description = [{
     Returns the allocator that can be used to allocate buffers compatible with
@@ -1582,7 +1524,9 @@ def HAL_DeviceAllocatorOp : HAL_PureOp<"device.allocator", [
   ];
 }
 
-def HAL_ReturnOp : HAL_Op<"return", [Terminator]> {
+def HAL_ReturnOp : HAL_Op<"return", [
+  Terminator,
+]> {
   let summary = [{return from a hal.* region}];
   let description = [{
     Returns the given values from the region and back to the host code.
@@ -1606,8 +1550,7 @@ def HAL_ReturnOp : HAL_Op<"return", [Terminator]> {
   let hasVerifier = 1;
 }
 
-def HAL_DeviceQueryOp :
-    HAL_PureOp<"device.query", []> {
+def HAL_DeviceQueryOp : HAL_PureOp<"device.query"> {
   let summary = [{returns a runtime configuration parameter from the device}];
   let description = [{
     Queries a device configuration parameter with the given key.
@@ -1677,9 +1620,9 @@ def HAL_DeviceQueryOp :
 }
 
 def HAL_DeviceQueueAllocaOp : HAL_Op<"device.queue.alloca", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-    DeclareOpInterfaceMethods<Util_SizeAwareOp>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  DeclareOpInterfaceMethods<Util_SizeAwareOp>,
+]> {
   let summary = [{allocates a queue-ordered transient buffer}];
   let description = [{
     Returns a queue-ordered transient buffer that will be available for use when
@@ -1963,11 +1906,11 @@ def OpGroupExecutableOps : OpDocGroup {
 let opDocGroup = OpGroupExecutableOps in {
 
 def HAL_ExecutableSourceOp : HAL_Op<"executable.source", [
-    IsolatedFromAbove,
-    SingleBlockImplicitTerminator<"IREE::HAL::ExecutableSourceEndOp">,
-    Symbol,
-    SymbolTable,
-  ]> {
+  IsolatedFromAbove,
+  SingleBlockImplicitTerminator<"IREE::HAL::ExecutableSourceEndOp">,
+  Symbol,
+  SymbolTable,
+]> {
   let summary = [{generic source contents of an executable op}];
   let description = [{
     This is an unspecialized source representation of an executable
@@ -2024,20 +1967,20 @@ def HAL_ExecutableSourceOp : HAL_Op<"executable.source", [
 }
 
 def HAL_ExecutableSourceEndOp : HAL_Op<"executable.source_end", [
-    HasParent<"IREE::HAL::ExecutableSourceOp">,
-    Terminator,
-  ]> {
+  HasParent<"IREE::HAL::ExecutableSourceOp">,
+  Terminator,
+]> {
   let summary = [{terminator pseudo-op for the executable source op}];
   let assemblyFormat = "attr-dict";
 }
 
 def HAL_ExecutableOp : HAL_Op<"executable", [
-    IsolatedFromAbove,
-    SingleBlockImplicitTerminator<"IREE::HAL::ExecutableEndOp">,
-    Symbol,
-    SymbolTable,
-    Util_ObjectLike,
-  ]> {
+  IsolatedFromAbove,
+  SingleBlockImplicitTerminator<"IREE::HAL::ExecutableEndOp">,
+  Symbol,
+  SymbolTable,
+  Util_ObjectLike,
+]> {
   let summary = [{target-specific executable module}];
   let description = [{
     An executable module representing a target-specific compiled
@@ -2072,21 +2015,21 @@ def HAL_ExecutableOp : HAL_Op<"executable", [
 }
 
 def HAL_ExecutableEndOp : HAL_Op<"executable_end", [
-    HasParent<"IREE::HAL::ExecutableOp">,
-    Terminator,
-  ]> {
+  HasParent<"IREE::HAL::ExecutableOp">,
+  Terminator,
+]> {
   let summary = [{terminator pseudo-op for the executable op}];
   let assemblyFormat = "attr-dict";
 }
 
 def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
-    Symbol,
-    ParentOneOf<[
-      "IREE::HAL::ExecutableSourceOp",
-      "IREE::HAL::ExecutableVariantOp",
-    ]>,
-    IsolatedFromAbove,
-  ]> {
+  Symbol,
+  ParentOneOf<[
+    "IREE::HAL::ExecutableSourceOp",
+    "IREE::HAL::ExecutableVariantOp",
+  ]>,
+  IsolatedFromAbove,
+]> {
   let summary = [{executable entry point declaration}];
   let description = [{
     An entry point exported by the executable with statically-available
@@ -2148,12 +2091,12 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
 }
 
 def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
-    IsolatedFromAbove,
-    HasParent<"IREE::HAL::ExecutableOp">,
-    SingleBlockImplicitTerminator<"IREE::HAL::ExecutableVariantEndOp">,
-    Symbol,
-    SymbolTable,
-  ]> {
+  IsolatedFromAbove,
+  HasParent<"IREE::HAL::ExecutableOp">,
+  SingleBlockImplicitTerminator<"IREE::HAL::ExecutableVariantEndOp">,
+  Symbol,
+  SymbolTable,
+]> {
   let summary = [{target-specific variant of an executable op}];
   let description = [{
     The target IR for the executable. This can be preserved for debugging but
@@ -2235,18 +2178,18 @@ def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
 }
 
 def HAL_ExecutableVariantEndOp : HAL_Op<"executable.variant_end", [
-    HasParent<"IREE::HAL::ExecutableVariantOp">,
-    Terminator,
-  ]> {
+  HasParent<"IREE::HAL::ExecutableVariantOp">,
+  Terminator,
+]> {
   let summary = [{terminator pseudo-op for the executable variant op}];
   let assemblyFormat = "attr-dict";
 }
 
 def HAL_ExecutableConditionOp : HAL_Op<"executable.condition", [
-    IsolatedFromAbove,
-    FunctionOpInterface,
-    CallableOpInterface,
-  ]> {
+  IsolatedFromAbove,
+  FunctionOpInterface,
+  CallableOpInterface,
+]> {
   let summary = [{host code to determine if the executable is enabled}];
   let description = [{
     Variants are selected based on their target and this optional condition
@@ -2295,16 +2238,15 @@ def HAL_ExecutableConditionOp : HAL_Op<"executable.condition", [
   let hasVerifier = 1;
 }
 
-def HAL_ExecutableConstantBlockOp :
-  HAL_Op<"executable.constant.block", [
-    ParentOneOf<[
-      "IREE::HAL::ExecutableSourceOp",
-      "IREE::HAL::ExecutableVariantOp",
-    ]>,
-    IsolatedFromAbove,
-    CallableOpInterface,
-    FunctionOpInterface,
-  ]> {
+def HAL_ExecutableConstantBlockOp : HAL_Op<"executable.constant.block", [
+  ParentOneOf<[
+    "IREE::HAL::ExecutableSourceOp",
+    "IREE::HAL::ExecutableVariantOp",
+  ]>,
+  IsolatedFromAbove,
+  CallableOpInterface,
+  FunctionOpInterface,
+]> {
   let summary = [{executable constant block initializer}];
   let description = [{
     Initializes one or more constants in the executable constant block by
@@ -2422,9 +2364,9 @@ def HAL_ExecutableConstantLoadOp : HAL_PureOp<"executable.constant.load"> {
 }
 
 def HAL_ExecutableBinaryOp : HAL_Op<"executable.binary", [
-    HasParent<"IREE::HAL::ExecutableOp">,
-    Symbol,
-  ]> {
+  HasParent<"IREE::HAL::ExecutableOp">,
+  Symbol,
+]> {
   let summary = [{compiled executable binary data}];
   let description = [{
     A compiled executable binary with an optional nested module containing the
@@ -2462,9 +2404,9 @@ def HAL_ExecutableBinaryOp : HAL_Op<"executable.binary", [
 }
 
 def HAL_ExecutableCreateOp : HAL_PureOp<"executable.create", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-    AttrSizedOperandSegments,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  AttrSizedOperandSegments,
+]> {
   let summary = [{creates an executable}];
   let description = [{
     Creates a target-dependent executable cached on the provided device. Entry
@@ -2501,8 +2443,8 @@ def HAL_ExecutableCreateOp : HAL_PureOp<"executable.create", [
 }
 
 def HAL_ExecutableLookupOp : HAL_PureOp<"executable.lookup", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{executable cache lookup pseudo-op}];
   let description = [{
     Used during conversion to provide a placeholder for a globally cached and
@@ -2523,16 +2465,29 @@ def HAL_ExecutableLookupOp : HAL_PureOp<"executable.lookup", [
     `:` type($result)
     attr-dict-with-keyword
   }];
+}
 
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "Value":$device, "StringRef":$executable),
-    [{
-      $_state.addOperands({device});
-      $_state.addAttribute("executable", mlir::SymbolRefAttr::get($_builder.getContext(), executable));
-      $_state.addTypes({ExecutableType::get($_builder.getContext())});
-    }]>,
-  ];
+def HAL_ExecutableExportOrdinalOp : HAL_PureOp<"executable.export.ordinal", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
+  let summary = [{executable export ordinal lookup pseudo-op}];
+  let description = [{
+    Resolves an executable export ordinal to a value once ordinals have been
+    assigned.
+  }];
+
+  let arguments = (ins
+    SymbolRefAttr:$entry_point
+  );
+  let results = (outs
+    Index:$result
+  );
+
+  let assemblyFormat = [{
+    `target` `(` $entry_point `)`
+    `:` type($result)
+    attr-dict-with-keyword
+  }];
 }
 
 def HAL_ExecutableCalculateWorkgroupsOp : HAL_PureOp<"executable.calculate_workgroups"> {
@@ -2983,8 +2938,8 @@ def HAL_PipelineLayoutCreateOp : HAL_PureOp<"pipeline_layout.create", [
 }
 
 def HAL_PipelineLayoutLookupOp : HAL_PureOp<"pipeline_layout.lookup", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{pipeline layout cache lookup pseudo-op}];
   let description = [{
     Used during conversion to provide a placeholder for a globally cached and
@@ -3021,9 +2976,9 @@ def OpGroupFenceOps : OpDocGroup {
 let opDocGroup = OpGroupFenceOps in {
 
 def HAL_FenceCreateOp : HAL_Op<"fence.create", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-    MemoryEffects<[MemAlloc]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  MemoryEffects<[MemAlloc]>,
+]> {
   let summary = [{creates an unsignaled fence}];
   let description = [{
     Returns a fence that defines a point in time. By default fences will remain
@@ -3051,8 +3006,8 @@ def HAL_FenceCreateOp : HAL_Op<"fence.create", [
 }
 
 def HAL_FenceJoinOp : HAL_Op<"fence.join", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{creates a fence from the given timepoints}];
   let description = [{
     Returns a fence that joins the input fences as a wait-all operation.
@@ -3137,9 +3092,9 @@ def HAL_FenceFailOp : HAL_Op<"fence.fail"> {
 }
 
 def HAL_FenceAwaitOp : HAL_Op<"fence.await", [
-    Util_YieldPoint,
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  ]> {
+  Util_YieldPoint,
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = [{asynchronous fence wait operation}];
   let description = [{
     Yields the caller until all fences is reached. Returns the `status` of the

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -203,17 +203,17 @@ hal.executable @ex {
 
 // CHECK-LABEL: @command_buffer_dispatch
 //  CHECK-SAME: (%[[CMD:.+]]: !hal.command_buffer,
-//  CHECK-SAME: %[[X:.+]]: index, %[[Y:.+]]: index, %[[Z:.+]]: index)
+//  CHECK-SAME:  %[[EXECUTABLE:.+]]: !hal.executable, %[[ORDINAL:[a-z0-9]+]]: index,
+//  CHECK-SAME:  %[[X:[a-z0-9]+]]: index, %[[Y:[a-z0-9]+]]: index, %[[Z:[a-z0-9]+]]: index)
 util.func public @command_buffer_dispatch(
     %cmd: !hal.command_buffer,
-    %x: index,
-    %y: index,
-    %z: index) {
-  //      CHECK: hal.command_buffer.dispatch.symbol<%[[CMD]] : !hal.command_buffer>
-  // CHECK-SAME:   target(@ex::@backend::@entry0)
+    %executable: !hal.executable, %ordinal: index,
+    %x: index, %y: index, %z: index) {
+  //      CHECK: hal.command_buffer.dispatch<%[[CMD]] : !hal.command_buffer>
+  // CHECK-SAME:   target(%[[EXECUTABLE]] : !hal.executable)[%[[ORDINAL]]
   // CHECK-SAME:   workgroups([%[[X]], %[[Y]], %[[Z]]])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer>
-      target(@ex::@backend::@entry0)
+  hal.command_buffer.dispatch<%cmd : !hal.command_buffer>
+      target(%executable: !hal.executable)[%ordinal]
       workgroups([%x, %y, %z])
   util.return
 }
@@ -233,17 +233,17 @@ hal.executable @ex {
 
 // CHECK-LABEL: @command_buffer_dispatch_indirect
 //  CHECK-SAME: (%[[CMD:.+]]: !hal.command_buffer,
-//  CHECK-SAME:  %[[BUFFER:.+]]: !hal.buffer,
-//  CHECK-SAME:  %[[OFFSET:.+]]: index)
+//  CHECK-SAME:  %[[EXECUTABLE:.+]]: !hal.executable, %[[ORDINAL:.+]]: index,
+//  CHECK-SAME:  %[[BUFFER:.+]]: !hal.buffer, %[[OFFSET:.+]]: index)
 util.func public @command_buffer_dispatch_indirect(
     %cmd: !hal.command_buffer,
-    %buffer: !hal.buffer,
-    %offset: index) {
-  //      CHECK: hal.command_buffer.dispatch.indirect.symbol<%[[CMD]] : !hal.command_buffer>
-  // CHECK-SAME:   target(@ex::@backend::@entry0)
+    %executable: !hal.executable, %ordinal: index,
+    %buffer: !hal.buffer, %offset: index) {
+  //      CHECK: hal.command_buffer.dispatch.indirect<%[[CMD]] : !hal.command_buffer>
+  // CHECK-SAME:   target(%[[EXECUTABLE]] : !hal.executable)[%[[ORDINAL]]
   // CHECK-SAME:   workgroups(%[[BUFFER]] : !hal.buffer)[%[[OFFSET]]]
-  hal.command_buffer.dispatch.indirect.symbol<%cmd : !hal.command_buffer>
-      target(@ex::@backend::@entry0)
+  hal.command_buffer.dispatch.indirect<%cmd : !hal.command_buffer>
+      target(%executable: !hal.executable)[%ordinal]
       workgroups(%buffer : !hal.buffer)[%offset]
   util.return
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -49,6 +49,9 @@ struct Binding {
 struct DispatchParams {
   // All locations that dispatch with these parameters.
   SmallVector<Location> locs;
+  // All affinities that dispatch with these parameters.
+  // Empty if no affinities were specified.
+  SetVector<IREE::Stream::AffinityAttr> affinities;
   // Workload used as input to the workgroup count calculation function.
   SmallVector<unsigned> workload;
   // Analyzed minimum binding sizes.
@@ -58,7 +61,7 @@ struct DispatchParams {
 };
 
 using DispatchParamsMap =
-    llvm::DenseMap<SymbolRefAttr, llvm::SmallVector<DispatchParams>>;
+    llvm::DenseMap<SymbolRefAttr, std::vector<DispatchParams>>;
 
 // Walk |moduleOp| and gather all of the dispatches to each executable.
 // Dispatch parameters are deduplicated by workload so that there's only ever
@@ -70,6 +73,8 @@ static DispatchParamsMap gatherDispatchParams(mlir::ModuleOp moduleOp) {
 
   for (auto funcOp : moduleOp.getOps<mlir::FunctionOpInterface>()) {
     funcOp.walk([&](IREE::Stream::CmdDispatchOp dispatchOp) {
+      auto affinityAttr = IREE::Stream::AffinityAttr::lookup(dispatchOp);
+
       // TODO(benvanik): typed accessors for bindings.
       auto bindingAttrs = llvm::dyn_cast_if_present<ArrayAttr>(
           dispatchOp->getAttr("hal.interface.bindings"));
@@ -143,6 +148,7 @@ static DispatchParamsMap gatherDispatchParams(mlir::ModuleOp moduleOp) {
           dispatchParams = &dispatchParamsSet.back();
         }
         dispatchParams->locs.push_back(dispatchOp.getLoc());
+        dispatchParams->affinities.insert(affinityAttr);
         dispatchParams->workload = workload;
         dispatchParams->bindings = std::move(bindings);
         dispatchParams->uniformOperands = std::move(uniformOperands);
@@ -203,7 +209,8 @@ appendGlobalBuffer(Location loc, StringRef baseName,
 //
 // Expects the runner to pass an i32 value indicating the number of dispatches
 // to be made in one submission.
-static void appendDispatchBenchmark(IREE::HAL::ExecutableOp executableOp,
+static void appendDispatchBenchmark(IREE::Stream::AffinityAttr affinityAttr,
+                                    IREE::HAL::ExecutableOp executableOp,
                                     IREE::HAL::ExecutableVariantOp variantOp,
                                     IREE::HAL::ExecutableExportOp exportOp,
                                     DispatchParams dispatchParams,
@@ -249,6 +256,7 @@ static void appendDispatchBenchmark(IREE::HAL::ExecutableOp executableOp,
       loc, funcBuilder.getIndexType(), entryBlock->getArgument(0));
 
   // TODO(multi-device): support multiple devices in benchmark generation.
+  // For now we should just use the affinityAttr to resolve the device.
   Value device = IREE::HAL::DeviceType::resolveAny(loc, funcBuilder);
 
   // Create and begin command buffer.
@@ -331,6 +339,13 @@ static void appendDispatchBenchmark(IREE::HAL::ExecutableOp executableOp,
           loc, funcBuilder.getIndexType(), funcBuilder.getIndexType(),
           funcBuilder.getIndexType(), device, exportRefAttr, workload);
 
+  // Get the executable/entry point ordinal used to dispatch.
+  Value executable = funcBuilder.create<IREE::HAL::ExecutableLookupOp>(
+      loc, funcBuilder.getType<IREE::HAL::ExecutableType>(), device,
+      exportRefAttr.getRootReference().getValue());
+  Value ordinal = funcBuilder.create<IREE::HAL::ExecutableExportOrdinalOp>(
+      loc, funcBuilder.getIndexType(), exportRefAttr);
+
   // Loop around dispatches based on batch size.
   // Note that we insert a barrier between each dispatch - we could make this
   // optional so that concurrent utilization is measured.
@@ -338,9 +353,10 @@ static void appendDispatchBenchmark(IREE::HAL::ExecutableOp executableOp,
       loc, indexSet.get(0), batchSizeArg, indexSet.get(1), ValueRange{},
       [&](OpBuilder &forBuilder, Location loc, Value iv, ValueRange iters) {
         // Dispatch.
-        forBuilder.create<IREE::HAL::CommandBufferDispatchSymbolOp>(
-            loc, commandBuffer, exportRefAttr, workgroupCountOp.getWorkgroupX(),
-            workgroupCountOp.getWorkgroupY(), workgroupCountOp.getWorkgroupZ());
+        forBuilder.create<IREE::HAL::CommandBufferDispatchOp>(
+            loc, commandBuffer, executable, ordinal,
+            workgroupCountOp.getWorkgroupX(), workgroupCountOp.getWorkgroupY(),
+            workgroupCountOp.getWorkgroupZ());
 
         // Barrier following the dispatch to block the next dispatch.
         auto sourceStage = IREE::HAL::ExecutionStageBitfield::CommandRetire |
@@ -420,8 +436,15 @@ buildBenchmarkModule(IREE::HAL::ExecutableOp sourceExecutableOp,
     auto dispatchParamsSet = dispatchParamsMap.find(symbolRefAttr);
     if (dispatchParamsSet != dispatchParamsMap.end()) {
       for (auto &dispatchParams : dispatchParamsSet->second) {
-        appendDispatchBenchmark(executableOp, variantOp, exportOp,
-                                dispatchParams, moduleBuilder);
+        if (dispatchParams.affinities.empty()) {
+          appendDispatchBenchmark({}, executableOp, variantOp, exportOp,
+                                  dispatchParams, moduleBuilder);
+        } else {
+          for (auto affinityAttr : dispatchParams.affinities) {
+            appendDispatchBenchmark(affinityAttr, executableOp, variantOp,
+                                    exportOp, dispatchParams, moduleBuilder);
+          }
+        }
         hasAnyBenchmarks = true;
       }
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ElideRedundantCommands.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ElideRedundantCommands.cpp
@@ -258,9 +258,7 @@ struct ElideRedundantCommandsPass
                     IREE::HAL::CommandBufferEndDebugGroupOp,
                     IREE::HAL::CommandBufferFillBufferOp,
                     IREE::HAL::CommandBufferCopyBufferOp,
-                    IREE::HAL::CommandBufferDispatchSymbolOp,
                     IREE::HAL::CommandBufferDispatchOp,
-                    IREE::HAL::CommandBufferDispatchIndirectSymbolOp,
                     IREE::HAL::CommandBufferDispatchIndirectOp>(
                   [&](Operation *op) {
                     // Ok - don't impact state.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
@@ -319,6 +319,7 @@ def ResolveExportOrdinalsPass :
     subsequent passes to collapse the executables into opaque blobs.
   }];
   let dependentDialects = [
+    "arith::ArithDialect",
     "IREE::HAL::HALDialect",
   ];
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveExportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveExportOrdinals.cpp
@@ -7,8 +7,8 @@
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::iree_compiler::IREE::HAL {
 
@@ -16,62 +16,6 @@ namespace mlir::iree_compiler::IREE::HAL {
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h.inc"
 
 namespace {
-
-struct ResolveCommandBufferDispatchOrdinals
-    : public OpRewritePattern<IREE::HAL::CommandBufferDispatchSymbolOp> {
-  using OpRewritePattern<
-      IREE::HAL::CommandBufferDispatchSymbolOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(IREE::HAL::CommandBufferDispatchSymbolOp op,
-                                PatternRewriter &rewriter) const override {
-    auto symbol = SymbolTable::lookupNearestSymbolFrom(op, op.getEntryPoint());
-    assert(symbol && "missing ExecutableEntryPoint symbol");
-    auto exportOp = cast<IREE::HAL::ExecutableExportOp>(symbol);
-
-    // Lookup the device for our command buffer, then the executable from the
-    // exports nested reference.
-    auto device = rewriter.createOrFold<IREE::HAL::CommandBufferDeviceOp>(
-        op.getLoc(), IREE::HAL::DeviceType::get(rewriter.getContext()),
-        op.getCommandBuffer());
-    auto executableOp = dyn_cast<IREE::HAL::ExecutableOp>(
-        exportOp->getParentOp()->getParentOp());
-    auto executable = rewriter.createOrFold<IREE::HAL::ExecutableLookupOp>(
-        op.getLoc(), device, executableOp.getSymName());
-
-    rewriter.replaceOpWithNewOp<IREE::HAL::CommandBufferDispatchOp>(
-        op, op.getCommandBuffer(), executable, exportOp.getOrdinalAttr(),
-        op.getWorkgroupX(), op.getWorkgroupY(), op.getWorkgroupZ());
-    return success();
-  }
-};
-
-struct ResolveCommandBufferDispatchIndirectOrdinals
-    : public OpRewritePattern<
-          IREE::HAL::CommandBufferDispatchIndirectSymbolOp> {
-  using OpRewritePattern<
-      IREE::HAL::CommandBufferDispatchIndirectSymbolOp>::OpRewritePattern;
-  LogicalResult
-  matchAndRewrite(IREE::HAL::CommandBufferDispatchIndirectSymbolOp op,
-                  PatternRewriter &rewriter) const override {
-    auto symbol = SymbolTable::lookupNearestSymbolFrom(op, op.getEntryPoint());
-    assert(symbol && "missing ExecutableEntryPoint symbol");
-    auto exportOp = cast<IREE::HAL::ExecutableExportOp>(symbol);
-
-    // Lookup the device for our command buffer, then the executable from the
-    // exports nested reference.
-    auto device = rewriter.createOrFold<IREE::HAL::CommandBufferDeviceOp>(
-        op.getLoc(), IREE::HAL::DeviceType::get(rewriter.getContext()),
-        op.getCommandBuffer());
-    auto executableOp = dyn_cast<IREE::HAL::ExecutableOp>(
-        exportOp->getParentOp()->getParentOp());
-    auto executable = rewriter.createOrFold<IREE::HAL::ExecutableLookupOp>(
-        op.getLoc(), device, executableOp.getSymName());
-
-    rewriter.replaceOpWithNewOp<IREE::HAL::CommandBufferDispatchIndirectOp>(
-        op, op.getCommandBuffer(), executable, exportOp.getOrdinalAttr(),
-        op.getWorkgroupsBuffer(), op.getWorkgroupsOffset());
-    return success();
-  }
-};
 
 //===----------------------------------------------------------------------===//
 // --iree-hal-resolve-export-ordinals
@@ -81,13 +25,18 @@ struct ResolveExportOrdinalsPass
     : public IREE::HAL::impl::ResolveExportOrdinalsPassBase<
           ResolveExportOrdinalsPass> {
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
-    RewritePatternSet patterns(&getContext());
-    patterns.insert<ResolveCommandBufferDispatchOrdinals>(context);
-    patterns.insert<ResolveCommandBufferDispatchIndirectOrdinals>(context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
-      return signalPassFailure();
+    auto moduleOp = getOperation();
+    SymbolTable symbolTable(moduleOp);
+    for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
+      funcOp.walk([&](IREE::HAL::ExecutableExportOrdinalOp ordinalOp) {
+        auto exportOp =
+            symbolTable.lookupNearestSymbolFrom<IREE::HAL::ExecutableExportOp>(
+                ordinalOp, ordinalOp.getEntryPointAttr());
+        Value value = OpBuilder(ordinalOp).create<arith::ConstantIndexOp>(
+            ordinalOp.getLoc(), exportOp.getOrdinalAttr().getInt());
+        ordinalOp.replaceAllUsesWith(value);
+        ordinalOp.erase();
+      });
     }
   }
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -104,17 +104,24 @@ util.func public @simpleDispatch(%arg0: !hal.buffer_view, %arg1: !hal.buffer_vie
     // CHECK:     %c1 = (%[[ARG1_BUFFER]] : !hal.buffer)[%c0, %c16],
     // CHECK:     %c2 = (%[[RESULT_BUFFER]] : !hal.buffer)[%c0, %c16]
     // CHECK:   ])
-    // CHECK:   hal.command_buffer.dispatch.symbol<%[[CMD]] : !hal.command_buffer>
-    // CHECK-SAME: target(@ex::@embedded_elf_aarch64::@dispatch)
+    // CHECK-DAG: %[[EXECUTABLE_0:.+]] = hal.executable.lookup device(%[[DEVICE]] : !hal.device) executable(@ex) : !hal.executable
+    // CHECK-DAG: %[[ORDINAL_0:.+]] = hal.executable.export.ordinal target(@ex::@embedded_elf_aarch64::@dispatch) : index
+    // CHECK:   hal.command_buffer.dispatch<%[[CMD]] : !hal.command_buffer>
+    // CHECK-SAME: target(%[[EXECUTABLE_0]] : !hal.executable)[%[[ORDINAL_0]]]
     // CHECK-SAME: workgroups([%c1, %c1, %c1])
     // CHECK:   scf.yield
     // CHECK: }
     // CHECK: case 1 {
-    // CHECK:   hal.command_buffer.dispatch.symbol<%[[CMD]] : !hal.command_buffer>
-    // CHECK-SAME: target(@ex::@embedded_elf_x86_64::@dispatch)
+    // CHECK-DAG: %[[EXECUTABLE_1:.+]] = hal.executable.lookup device(%[[DEVICE]] : !hal.device) executable(@ex) : !hal.executable
+    // CHECK-DAG: %[[ORDINAL_1:.+]] = hal.executable.export.ordinal target(@ex::@embedded_elf_x86_64::@dispatch) : index
+    // CHECK:   hal.command_buffer.dispatch<%[[CMD]] : !hal.command_buffer>
+    // CHECK-SAME: target(%[[EXECUTABLE_1]] : !hal.executable)[%[[ORDINAL_1]]]
     // CHECK:   scf.yield
     // CHECK: }
-    stream.cmd.dispatch {@ex::@embedded_elf_aarch64::@dispatch, @ex::@embedded_elf_x86_64::@dispatch}[%c4, %c1, %c1] {
+    stream.cmd.dispatch {
+      @ex::@embedded_elf_aarch64::@dispatch,
+      @ex::@embedded_elf_x86_64::@dispatch
+    }[%c4, %c1, %c1] {
       ro %arg0_capture[%c0 for %c16] : !stream.resource<external>{%c16},
       ro %arg1_capture[%c0 for %c16] : !stream.resource<external>{%c16},
       wo %result_capture[%c0 for %c16] : !stream.resource<external>{%c16}

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -89,9 +89,13 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   // CHECK-SAME:     target(@ex0::@embedded_elf_x86_64::@dispatch0)
   // CHECK-SAME:     workload([%c512])
 
+  // Get executable and target ordinal (outside of the loop).
+  // CHECK-DAG: %[[EXECUTABLE:.+]] = hal.executable.lookup device({{.+}}) executable(@ex0) : !hal.executable
+  // CHECK-DAG: %[[ORDINAL_0:.+]] = hal.executable.export.ordinal target(@ex0::@embedded_elf_x86_64::@dispatch0) : index
+
   // Dispatch up to batch size dispatches:
   // CHECK: scf.for %{{.+}} = %c0 to %[[BATCH_SIZE]] step %c1 {
-  // CHECK-NEXT: hal.command_buffer.dispatch.symbol<%[[CMD]] : !hal.command_buffer> target(@ex0::@embedded_elf_x86_64::@dispatch0) workgroups([%[[WORKGROUP_X]], %[[WORKGROUP_Y]], %[[WORKGROUP_Z]]])
+  // CHECK-NEXT: hal.command_buffer.dispatch<%[[CMD]] : !hal.command_buffer> target(%[[EXECUTABLE:.+]] : !hal.executable)[%[[ORDINAL_0]]] workgroups([%[[WORKGROUP_X]], %[[WORKGROUP_Y]], %[[WORKGROUP_Z]]])
   // CHECK-NEXT: hal.command_buffer.execution_barrier
   // CHECK-NEXT: }
 
@@ -105,11 +109,13 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
 
   // CHECK: util.global private mutable @ex0_embedded_elf_x86_64_dispatch1_512x1_buffer : !hal.buffer
   // CHECK: util.func public @ex0_embedded_elf_x86_64_dispatch1_512x1(%arg0: i32)
-  // CHECK:   hal.command_buffer.dispatch.symbol<%{{.+}} : !hal.command_buffer> target(@ex0::@embedded_elf_x86_64::@dispatch1)
+  // CHECK:   %[[ORDINAL_1A:.+]] = hal.executable.export.ordinal target(@ex0::@embedded_elf_x86_64::@dispatch1) : index
+  // CHECK:   hal.command_buffer.dispatch<%{{.+}} : !hal.command_buffer> target({{.+}})[%[[ORDINAL_1A]]]
 
   // CHECK: util.global private mutable @ex0_embedded_elf_x86_64_dispatch1_128x32_buffer : !hal.buffer
   // CHECK: util.func public @ex0_embedded_elf_x86_64_dispatch1_128x32(%arg0: i32)
-  // CHECK:   hal.command_buffer.dispatch.symbol<%{{.+}} : !hal.command_buffer> target(@ex0::@embedded_elf_x86_64::@dispatch1)
+  // CHECK:   %[[ORDINAL_1B:.+]] = hal.executable.export.ordinal target(@ex0::@embedded_elf_x86_64::@dispatch1) : index
+  // CHECK:   hal.command_buffer.dispatch<%{{.+}} : !hal.command_buffer> target({{.+}})[%[[ORDINAL_1B]]]
 
   util.func public @main(%dynamic_arg: i32) -> !stream.timepoint {
     %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/repeat_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/repeat_dispatches.mlir
@@ -9,37 +9,39 @@ util.func public @duplicate_dispatches(%cmd1 : !hal.command_buffer, %cmd2 : !hal
   // CHECK: %[[EXE:.+]] = util.global.load @_executable
   %exe = util.global.load @_executable : !hal.executable
 
+  %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
-  hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+  %c3 = arith.constant 3 : index
+  hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[%c0] workgroups([%c1, %c1, %c1])
   hal.command_buffer.execution_barrier<%cmd1 : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
-  hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[1] workgroups([%c2, %c2, %c2])
+  hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[%c1] workgroups([%c2, %c2, %c2])
 
-  hal.command_buffer.dispatch<%cmd2 : !hal.command_buffer> target(%exe : !hal.executable)[2] workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch<%cmd2 : !hal.command_buffer> target(%exe : !hal.executable)[3] workgroups([%c2, %c2, %c2])
+  hal.command_buffer.dispatch<%cmd2 : !hal.command_buffer> target(%exe : !hal.executable)[%c2] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd2 : !hal.command_buffer> target(%exe : !hal.executable)[%c3] workgroups([%c2, %c2, %c2])
   hal.command_buffer.execution_barrier<%cmd2 : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
 
   util.return
 }
 
-// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c0] workgroups([%c1, %c1, %c1])
 // CHECK: hal.command_buffer.execution_barrier<%[[CMD1]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
-// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c0] workgroups([%c1, %c1, %c1])
 // CHECK: hal.command_buffer.execution_barrier<%[[CMD1]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
 
-// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[1] workgroups([%c2, %c2, %c2])
+// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c1] workgroups([%c2, %c2, %c2])
 // CHECK: hal.command_buffer.execution_barrier<%[[CMD1]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
-// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[1] workgroups([%c2, %c2, %c2])
+// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c1] workgroups([%c2, %c2, %c2])
 // CHECK-NOT: hal.command_buffer.execution_barrier
 
-// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[2] workgroups([%c1, %c1, %c1])
+// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c2] workgroups([%c1, %c1, %c1])
 // CHECK: hal.command_buffer.execution_barrier<%[[CMD2]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
-// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[2] workgroups([%c1, %c1, %c1])
+// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c2] workgroups([%c1, %c1, %c1])
 // CHECK-NOT: hal.command_buffer.execution_barrier
 
-// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[3] workgroups([%c2, %c2, %c2])
+// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c3] workgroups([%c2, %c2, %c2])
 // CHECK: hal.command_buffer.execution_barrier<%[[CMD2]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
-// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[3] workgroups([%c2, %c2, %c2])
+// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c3] workgroups([%c2, %c2, %c2])
 // CHECK: hal.command_buffer.execution_barrier<%[[CMD2]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
 
 // -----
@@ -53,10 +55,11 @@ util.func public @nested_dispatch(%cmd1 : !hal.command_buffer, %idx : index) {
   // CHECK: %[[EXE:.+]] = util.global.load @_executable
   %exe = util.global.load @_executable : !hal.executable
 
+  %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   scf.index_switch %idx
   case 0 {
-    hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+    hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[%c0] workgroups([%c1, %c1, %c1])
     scf.yield
   }
   default {
@@ -67,6 +70,6 @@ util.func public @nested_dispatch(%cmd1 : !hal.command_buffer, %idx : index) {
 
 // CHECK: scf.index_switch
 // CHECK: case 0 {
-// CHECK:   hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+// CHECK:   hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c0] workgroups([%c1, %c1, %c1])
 // CHECK:   hal.command_buffer.execution_barrier<%[[CMD1]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
-// CHECK:   hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+// CHECK:   hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[%c0] workgroups([%c1, %c1, %c1])

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_export_ordinals.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_export_ordinals.mlir
@@ -1,109 +1,30 @@
 // RUN: iree-opt --split-input-file --iree-hal-resolve-export-ordinals %s | FileCheck %s
 
-hal.executable @exe {
+hal.executable @exe0 {
   hal.executable.variant @target target(<"vmvx", "vmvx-bytecode-fb">) {
-    hal.executable.export @entry ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [
+    hal.executable.export @entry123 ordinal(123) layout(#hal.pipeline.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
-        #hal.descriptor_set.binding<0, storage_buffer>,
-        #hal.descriptor_set.binding<1, storage_buffer>
+        #hal.descriptor_set.binding<0, storage_buffer>
       ]>
-    ]>) attributes {
-      workgroup_size = [32 : index, 1 : index, 1 : index]
-    }
+    ]>)
+  }
+}
+hal.executable @exe1 {
+  hal.executable.variant @target target(<"vmvx", "vmvx-bytecode-fb">) {
+    hal.executable.export @entry456 ordinal(456) layout(#hal.pipeline.layout<push_constants = 0, sets = [
+      #hal.descriptor_set.layout<0, bindings = [
+        #hal.descriptor_set.binding<0, storage_buffer>
+      ]>
+    ]>)
   }
 }
 
-// CHECK-LABEL: @dispatch_with_nested_references
-// CHECK-SAME: %[[CMD:.+]]: !hal.command_buffer
-util.func public @dispatch_with_nested_references(%cmd : !hal.command_buffer) {
-  %c10 = arith.constant 10 : index
-  %c11 = arith.constant 11 : index
-  %c12 = arith.constant 12 : index
-  //      CHECK: %[[DEVICE:.+]] = hal.command_buffer.device<%[[CMD]]
-  //      CHECK: %[[EXE:.+]] = hal.executable.lookup
-  // CHECK-SAME:   device(%[[DEVICE]] : !hal.device)
-  // CHECK-SAME:   executable(@exe) : !hal.executable
-  //      CHECK: hal.command_buffer.dispatch<%[[CMD]]
-  // CHECK-SAME:   target(%[[EXE]] : !hal.executable)[0]
-  // CHECK-SAME:   workgroups([%c10, %c11, %c12])
-  hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer>
-      target(@exe::@target::@entry)
-      workgroups([%c10, %c11, %c12])
-  util.return
-}
-
-// -----
-
-// CHECK-LABEL: @dispatch_already_using_ordinals
-util.func public @dispatch_already_using_ordinals(
-  // CHECK-SAME: %[[CMD:.+]]: !hal.command_buffer
-  %cmd: !hal.command_buffer,
-  // CHECK-SAME: %[[EXE:.+]]: !hal.executable
-  %exe: !hal.executable
-) {
-  %c10 = arith.constant 10 : index
-  %c11 = arith.constant 11 : index
-  %c12 = arith.constant 12 : index
-  //      CHECK: hal.command_buffer.dispatch<%[[CMD]] : !hal.command_buffer>
-  // CHECK-SAME:   target(%[[EXE]] : !hal.executable)[2]
-  // CHECK-SAME:   workgroups([%c10, %c11, %c12])
-  hal.command_buffer.dispatch<%cmd : !hal.command_buffer>
-      target(%exe : !hal.executable)[2]
-      workgroups([%c10, %c11, %c12])
-  util.return
-}
-
-// -----
-
-hal.executable @exe {
-  hal.executable.variant @target target(<"vmvx", "vmvx-bytecode-fb">) {
-    hal.executable.export @entry ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [
-      #hal.descriptor_set.layout<0, bindings = [
-        #hal.descriptor_set.binding<0, storage_buffer>,
-        #hal.descriptor_set.binding<1, storage_buffer>
-      ]>
-    ]>) attributes {
-      workgroup_size = [32 : index, 1 : index, 1 : index]
-    }
-  }
-}
-
-// CHECK-LABEL: @dispatch_indirect_with_nested_references
-util.func public @dispatch_indirect_with_nested_references(
-  // CHECK-SAME: %[[CMD:.+]]: !hal.command_buffer
-  %cmd: !hal.command_buffer,
-  // CHECK-SAME: %[[BUF:.+]]: !hal.buffer
-  %buf: !hal.buffer
-) {
-  %c10 = arith.constant 10 : index
-  // CHECK: %[[DEVICE:.+]] = hal.command_buffer.device<%[[CMD]]
-  // CHECK: %[[EXE:.+]] = hal.executable.lookup device(%[[DEVICE]] : !hal.device) executable(@exe)
-  // CHECK: hal.command_buffer.dispatch.indirect<%[[CMD]] : !hal.command_buffer>
-  // CHECK-SAME:   target(%[[EXE]] : !hal.executable)[0]
-  // CHECK-SAME:   workgroups(%[[BUF]] : !hal.buffer)[%c10]
-  hal.command_buffer.dispatch.indirect.symbol<%cmd : !hal.command_buffer>
-      target(@exe::@target::@entry)
-      workgroups(%buf : !hal.buffer)[%c10]
-  util.return
-}
-
-// -----
-
-// CHECK-LABEL: @dispatch_indirect_already_using_ordinals
-util.func public @dispatch_indirect_already_using_ordinals(
-  // CHECK-SAME: %[[CMD:.+]]: !hal.command_buffer
-  %cmd: !hal.command_buffer,
-  // CHECK-SAME: %[[EXE:.+]]: !hal.executable
-  %exe: !hal.executable,
-  // CHECK-SAME: %[[BUF:.+]]: !hal.buffer
-  %buf: !hal.buffer
-) {
-  %c10 = arith.constant 10 : index
-  // CHECK: hal.command_buffer.dispatch.indirect<%[[CMD]] : !hal.command_buffer>
-  // CHECK-SAME:   target(%[[EXE]] : !hal.executable)[0]
-  // CHECK-SAME:   workgroups(%[[BUF]] : !hal.buffer)[%c10]
-  hal.command_buffer.dispatch.indirect<%cmd : !hal.command_buffer>
-      target(%exe : !hal.executable)[0]
-      workgroups(%buf : !hal.buffer)[%c10]
-  util.return
+// CHECK-LABEL: @resolve
+util.func public @resolve() -> (index, index) {
+  // CHECK: %[[ENTRY123:.+]] = arith.constant 123
+  %entry123 = hal.executable.export.ordinal target(@exe0::@target::@entry123) : index
+  // CHECK: %[[ENTRY465:.+]] = arith.constant 456
+  %entry456 = hal.executable.export.ordinal target(@exe1::@target::@entry456) : index
+  // CHECK: util.return %[[ENTRY123]], %[[ENTRY465]]
+  util.return %entry123, %entry456 : index, index
 }

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/Patterns.cpp
@@ -82,12 +82,9 @@ struct ExecutableDispatchOpConversion
   matchAndRewrite(IREE::HAL::Loader::ExecutableDispatchOp dispatchOp,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto entryPoint = rewriter.create<IREE::VM::ConstI32Op>(
-        dispatchOp.getLoc(),
-        static_cast<int32_t>(adaptor.getEntryPoint().getZExtValue()));
     SmallVector<Value, 8> callOperands = {
         adaptor.getExecutable(),
-        entryPoint,
+        castToI32(adaptor.getEntryPoint(), rewriter),
         castToI32(adaptor.getWorkgroupX(), rewriter),
         castToI32(adaptor.getWorkgroupY(), rewriter),
         castToI32(adaptor.getWorkgroupZ(), rewriter),

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/test/executable_ops.mlir
@@ -18,6 +18,8 @@ util.func public @executableLoad(%executable_data: !util.buffer) -> !hal.executa
 // CHECK-SAME: (%[[EXECUTABLE:.+]]: !vm.ref<!hal.executable>,
 // CHECK-SAME:  %[[BUFFER0:.+]]: !vm.buffer, %[[BUFFER1:.+]]: !vm.buffer)
 util.func public @executableDispatch(%executable: !hal.executable, %buffer0: !util.buffer, %buffer1: !util.buffer) {
+  // CHECK-DAG: %[[ORDINAL:.+]] = vm.const.i32 16
+  %ordinal = arith.constant 16 : index
   // CHECK-DAG: %[[COUNT_X:.+]] = vm.const.i32 1000
   %count_x = arith.constant 1000 : index
   // CHECK-DAG: %[[COUNT_Y:.+]] = vm.const.i32 1001
@@ -38,8 +40,8 @@ util.func public @executableDispatch(%executable: !hal.executable, %buffer0: !ut
   %length1 = arith.constant 256 : index
   // CHECK: vm.call.variadic @hal_loader.executable.dispatch
   hal_loader.executable.dispatch
-    // CHECK-SAME: %[[EXECUTABLE]], %c16
-    executable(%executable : !hal.executable)[16]
+    // CHECK-SAME: %[[EXECUTABLE]], %[[ORDINAL]]
+    executable(%executable : !hal.executable)[%ordinal]
     // CHECK-SAME: %[[COUNT_X]], %[[COUNT_Y]], %[[COUNT_Z]]
     workgroups([%count_x, %count_y, %count_z])
     // CHECK-SAME: [%[[CONSTANT0]], %[[CONSTANT1]]]

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
@@ -124,15 +124,19 @@ struct CmdDispatchOpPattern
       bindingLengths.push_back(adaptor.getResourceLengths()[i]);
     }
 
-    // Dispatch with a target-specific workgroup count.
-    auto exportSymRef =
+    auto entryPointAttr =
         SymbolRefAttr::get(builder.getContext(), executableOp.getName(),
                            {SymbolRefAttr::get(exportOp->getParentOp()),
                             SymbolRefAttr::get(exportOp)});
+    Value ordinal =
+        builder.create<IREE::HAL::Loader::ExecutableExportOrdinalOp>(
+            loc, builder.getIndexType(), entryPointAttr);
+
+    // Dispatch with a target-specific workgroup count.
     auto workgroupCount = exportOp.calculateWorkgroupCount(
         loc, /*device=*/nullptr, adaptor.getWorkload(), builder);
-    builder.create<IREE::HAL::Loader::ExecutableDispatchSymbolOp>(
-        loc, executable, exportSymRef, workgroupCount[0], workgroupCount[1],
+    builder.create<IREE::HAL::Loader::ExecutableDispatchOp>(
+        loc, executable, ordinal, workgroupCount[0], workgroupCount[1],
         workgroupCount[2], pushConstants, bindingBuffers, bindingOffsets,
         bindingLengths);
   }

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
@@ -67,9 +67,10 @@ util.func public @cmdDispatch(%buffer0: !stream.resource<transient>, %buffer0_si
     // CHECK-DAG: %[[COUNT_Y:.+]] = arith.constant 251
     // CHECK-DAG: %[[COUNT_Z:.+]] = arith.constant 1
 
+    // CHECK-DAG: %[[ORDINAL:.+]] = hal_loader.executable.export.ordinal target(@ex::@variant::@dispatch) : index
+
     //      CHECK: hal_loader.executable.dispatch
-    // CHECK-SAME:   executable(%[[EXECUTABLE]] : !hal.executable)
-    // CHECK-SAME:   target(@ex::@variant::@dispatch)
+    // CHECK-SAME:   executable(%[[EXECUTABLE]] : !hal.executable)[%[[ORDINAL]]]
     // CHECK-SAME:   workgroups([%[[COUNT_X]], %[[COUNT_Y]], %[[COUNT_Z]]])
     // CHECK-SAME:   constants([%[[CONSTANT0]], %[[CONSTANT1]]])
     // CHECK-SAME:   bindings([

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.td
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.td
@@ -29,10 +29,9 @@ def OpGroupExecutableOps : OpDocGroup {
 
 let opDocGroup = OpGroupExecutableOps in {
 
-def HALLoader_ExecutableQuerySupportOp :
-    HALLoader_PureOp<"executable.query_support", [
-      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-    ]> {
+def HALLoader_ExecutableQuerySupportOp : HALLoader_PureOp<"executable.query_support", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = "queries whether an executable format is supported";
   let description = [{
     Returns true if the given format is supported by the device loader. This
@@ -54,10 +53,9 @@ def HALLoader_ExecutableQuerySupportOp :
   }];
 }
 
-def HALLoader_ExecutableLoadOp :
-    HALLoader_PureOp<"executable.load", [
-      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-    ]> {
+def HALLoader_ExecutableLoadOp : HALLoader_PureOp<"executable.load", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
   let summary = "dynamically loads an executable";
   let description = [{
     Creates, loads, and dynamically links an executable.
@@ -84,11 +82,10 @@ def HALLoader_ExecutableLoadOp :
   }];
 }
 
-def HALLoader_ExecutableLookupOp :
-    HALLoader_PureOp<"executable.lookup", [
-      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-      DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-    ]> {
+def HALLoader_ExecutableLookupOp : HALLoader_PureOp<"executable.lookup", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+]> {
   let summary = [{executable cache lookup pseudo-op}];
   let description = [{
     Used during conversion to provide a placeholder for a globally cached and
@@ -109,50 +106,33 @@ def HALLoader_ExecutableLookupOp :
   }];
 }
 
-def HALLoader_ExecutableDispatchSymbolOp :
-    HALLoader_Op<"executable.dispatch.symbol", [
-      AttrSizedOperandSegments,
-      DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-    ]> {
-  let summary = [{inline executable dispatch operation}];
+def HALLoader_ExecutableExportOrdinalOp : HALLoader_PureOp<"executable.export.ordinal", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+]> {
+  let summary = [{executable export ordinal lookup pseudo-op}];
   let description = [{
-    Dispatches execution to an executable entry point with the given parameters.
-    The entry point is a symbolic reference to an exported entry point.
+    Resolves an executable export ordinal to a value once ordinals have been
+    assigned.
   }];
 
   let arguments = (ins
-    HAL_Executable:$executable,
-    SymbolRefAttr:$entry_point,
-    HAL_Dim:$workgroup_x,
-    HAL_Dim:$workgroup_y,
-    HAL_Dim:$workgroup_z,
-    Variadic<I32>:$push_constants,
-    Variadic<Util_BufferType>:$binding_buffers,
-    Variadic<HAL_DeviceSize>:$binding_offsets,
-    Variadic<HAL_DeviceSize>:$binding_lengths
+    SymbolRefAttr:$entry_point
+  );
+  let results = (outs
+    Index:$result
   );
 
   let assemblyFormat = [{
-    `executable` `(` $executable `:` type($executable) `)`
     `target` `(` $entry_point `)`
-    `workgroups` `(` `[`
-        $workgroup_x `,`
-        $workgroup_y `,`
-        $workgroup_z
-    `]` `)`
-    (`constants` `(` `[` $push_constants^ `]` `)`)?
-    `bindings` `(` `[`
-    custom<DispatchBindings>($binding_buffers,
-                             type($binding_buffers),
-                             $binding_offsets,
-                             $binding_lengths)
-    `]` `)`
+    `:` type($result)
     attr-dict-with-keyword
   }];
 }
 
-def HALLoader_ExecutableDispatchOp :
-    HALLoader_Op<"executable.dispatch", [AttrSizedOperandSegments]> {
+def HALLoader_ExecutableDispatchOp : HALLoader_Op<"executable.dispatch", [
+  AttrSizedOperandSegments,
+]> {
   let summary = [{inline executable dispatch operation}];
   let description = [{
     Dispatches execution to an executable entry point with the given parameters.
@@ -160,7 +140,7 @@ def HALLoader_ExecutableDispatchOp :
 
   let arguments = (ins
     HAL_Executable:$executable,
-    HAL_OrdinalAttr:$entry_point,
+    HAL_Ordinal:$entry_point,
     HAL_Dim:$workgroup_x,
     HAL_Dim:$workgroup_y,
     HAL_Dim:$workgroup_z,

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/IR/test/dispatch_folding.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/IR/test/dispatch_folding.mlir
@@ -7,6 +7,7 @@ util.func public @fold_binding_subspans_into_dispatch(
     // CHECK-SAME: %[[BUFFER:.+]]: !util.buffer, %[[SUBSPAN_OFFSET:.+]]: index, %[[SUBSPAN_LENGTH:.+]]: index
     %buffer: !util.buffer, %subspan_offset: index, %subspan_length: index) {
   %c1 = arith.constant 1 : index
+  %c16 = arith.constant 16 : index
 
   %buffer_size = util.buffer.size %buffer : !util.buffer
   %subspan = util.buffer.subspan %buffer[%subspan_offset] : !util.buffer{%buffer_size} -> !util.buffer{%subspan_length}
@@ -20,7 +21,7 @@ util.func public @fold_binding_subspans_into_dispatch(
 
   // CHECK: hal_loader.executable.dispatch
   hal_loader.executable.dispatch
-    executable(%executable : !hal.executable)[16]
+    executable(%executable : !hal.executable)[%c16]
     workgroups([%c1, %c1, %c1])
     bindings([
       // CHECK: (%[[BUFFER]] : !util.buffer)[%[[ABSOLUTE_OFFSET]], %[[BINDING_LENGTH]]]

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/ResolveExportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/ResolveExportOrdinals.cpp
@@ -8,42 +8,32 @@
 #include "iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.h"
 #include "iree/compiler/Modules/HAL/Loader/Transforms/PassDetail.h"
 #include "iree/compiler/Modules/HAL/Loader/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::iree_compiler::IREE::HAL::Loader {
-
-struct ResolveExecutableDispatchSymbolOp
-    : public OpRewritePattern<IREE::HAL::Loader::ExecutableDispatchSymbolOp> {
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult
-  matchAndRewrite(IREE::HAL::Loader::ExecutableDispatchSymbolOp op,
-                  PatternRewriter &rewriter) const override {
-    auto symbol = SymbolTable::lookupNearestSymbolFrom(op, op.getEntryPoint());
-    assert(symbol && "missing ExecutableEntryPoint symbol");
-    auto exportOp = cast<IREE::HAL::ExecutableExportOp>(symbol);
-    rewriter.replaceOpWithNewOp<IREE::HAL::Loader::ExecutableDispatchOp>(
-        op, op.getExecutable(), exportOp.getOrdinalAttr(), op.getWorkgroupX(),
-        op.getWorkgroupY(), op.getWorkgroupZ(), op.getPushConstants(),
-        op.getBindingBuffers(), op.getBindingOffsets(), op.getBindingLengths());
-    return success();
-  }
-};
 
 class ResolveExportOrdinalsPass
     : public ResolveExportOrdinalsBase<ResolveExportOrdinalsPass> {
 public:
   void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect>();
     registry.insert<IREE::HAL::Loader::HALLoaderDialect>();
   }
 
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
-    RewritePatternSet patterns(&getContext());
-    patterns.insert<ResolveExecutableDispatchSymbolOp>(context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
-      return signalPassFailure();
+    auto moduleOp = getOperation();
+    SymbolTable symbolTable(moduleOp);
+    for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
+      funcOp.walk([&](IREE::HAL::Loader::ExecutableExportOrdinalOp ordinalOp) {
+        auto exportOp =
+            symbolTable.lookupNearestSymbolFrom<IREE::HAL::ExecutableExportOp>(
+                ordinalOp, ordinalOp.getEntryPointAttr());
+        Value value = OpBuilder(ordinalOp).create<arith::ConstantIndexOp>(
+            ordinalOp.getLoc(), exportOp.getOrdinalAttr().getInt());
+        ordinalOp.replaceAllUsesWith(value);
+        ordinalOp.erase();
+      });
     }
   }
 };


### PR DESCRIPTION
This removes the crufty `hal.command_buffer.dispatch.symbol` op and simplifies the ordinal resolution process by not requiring a device SSA value during resolution.

Now only executable and pipeline layout lookup is device-specific which in future changes makes it easier to support multiple devices.