### PR TITLE
Update excluded test names for Windows failures.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -109,8 +109,8 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
   # These tests are failing on Windows.
   excluded_tests+=(
     # TODO(#11077): INVALID_ARGUMENT: argument/result signature mismatch
-    "iree/tests/e2e/matmul/e2e_matmul_dt_uk_i8_small_vmvx_local-task"
-    "iree/tests/e2e/matmul/e2e_matmul_dt_uk_f32_small_vmvx_local-task"
+    "iree/tests/e2e/matmul/e2e_matmul_vmvx_dt_uk_i8_small_vmvx_local-task"
+    "iree/tests/e2e/matmul/e2e_matmul_vmvx_dt_uk_f32_small_vmvx_local-task"
     # TODO: Regressed when `pack` ukernel gained a uint64_t parameter in #13264.
     "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_pack.mlir"
     "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_pack_dynamic_inner_tiles.mlir"


### PR DESCRIPTION
Fixes CI failures introduced by https://github.com/openxla/iree/pull/16511

ci-exactly: build_test_all_windows