### PR TITLE
Adding `iree-hal-prune-executables` pass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -30,6 +30,7 @@ iree_compiler_cc_library(
         "Passes.cpp",
         "Passes.h.inc",
         "PreprocessExecutables.cpp",
+        "PruneExecutables.cpp",
         "RepeatDispatches.cpp",
         "ResolveExportOrdinals.cpp",
         "SerializeExecutables.cpp",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_cc_library(
     "Passes.cpp"
     "Passes.h.inc"
     "PreprocessExecutables.cpp"
+    "PruneExecutables.cpp"
     "RepeatDispatches.cpp"
     "ResolveExportOrdinals.cpp"
     "SerializeExecutables.cpp"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -223,6 +223,9 @@ void buildHALConfigurationPassPipeline(
   // device communicate across the ABI boundary.
   passManager.addPass(IREE::HAL::createMaterializeInterfacesPass());
 
+  // Prune unused executables and their contents.
+  passManager.addPass(IREE::HAL::createPruneExecutablesPass());
+
   // Dump a source listing of each hal.executable and update the source
   // locations in the IR. This will allow us to easily inspect each executable
   // and give downstream tools that can display source information something
@@ -355,6 +358,9 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   // make all async operations blocking.
   passManager.addPass(IREE::HAL::createFixupLegacySyncPass());
 
+  // Prune unused executables and their contents.
+  passManager.addPass(IREE::HAL::createPruneExecutablesPass());
+
   addCleanupPatterns(passManager);
 
   //----------------------------------------------------------------------------
@@ -437,6 +443,7 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
 
     // NOTE: symbol DCE will destroy executable target contents, so only run
     // it if we serialized things.
+    passManager.addPass(IREE::HAL::createPruneExecutablesPass());
     passManager.addPass(mlir::createSymbolDCEPass());
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
@@ -64,7 +64,7 @@ def AssignTargetDevicesPass :
     Pass<"iree-hal-assign-target-devices", "mlir::ModuleOp"> {
   let summary = "Assigns the HAL devices the module will target to the given list of targets.";
   let description = [{
-    DO NOT SUBMIT
+    Assigns target HAL devices to the module based on the given list.
   }];
   let options = [
     Option<
@@ -206,7 +206,8 @@ def ConfigureExecutablesPass :
     Pass<"iree-hal-configure-executables", "IREE::HAL::ExecutableOp"> {
   let summary = "Configures hal.executable ops via a nested translation pipeline.";
   let description = [{
-    DO NOT SUBMIT
+    Runs a nested pipeline on each executable to attach target-specific
+    configuration information to variants.
   }];
   let options = [
     Option<
@@ -221,7 +222,8 @@ def ConfigureTargetExecutableVariantsPass :
     Pass<"iree-hal-configure-target-executable-variants", "IREE::HAL::ExecutableVariantOp"> {
   let summary = "Configures hal.executable.variant ops for the specified target backend.";
   let description = [{
-    DO NOT SUBMIT
+    Attaches target-specific configuration information to a variant controlling
+    how code generation operates.
   }];
   let options = [
     Option<
@@ -241,7 +243,9 @@ def TranslateExecutablesPass :
     Pass<"iree-hal-translate-executables", "IREE::HAL::ExecutableOp"> {
   let summary = "Translates hal.executable ops via a nested translation pipeline.";
   let description = [{
-    DO NOT SUBMIT
+    Runs a nested pipeline on each executable to translate its variants from
+    their generic MLIR dialects (such as `linalg`) to their target-specific
+    dialects (`llvm`, `spirv`, etc).
   }];
   let options = [
     Option<
@@ -256,7 +260,9 @@ def TranslateTargetExecutableVariantsPass :
     Pass<"iree-hal-translate-target-executable-variants", "IREE::HAL::ExecutableVariantOp"> {
   let summary = "Translates hal.executable.variant ops for the specified target backend.";
   let description = [{
-    DO NOT SUBMIT
+    Translates an executable variant for a specific target from its generic
+    MLIR dialects (such as `linalg`) to the target-specific dialects (`llvm`,
+    `spirv`, etc).
   }];
   let options = [
     Option<
@@ -272,14 +278,23 @@ def TranslateTargetExecutableVariantsPass :
   ];
 }
 
+def PruneExecutablesPass :
+    Pass<"iree-hal-prune-executables", "mlir::ModuleOp"> {
+  let summary = "Prunes executable variants and exports that are not referenced.";
+  let description = [{
+    Prunes executable variants and exports that are not referenced in the
+    module. This is intended to be run late in the pipeline where no new
+    dispatches will be inserted that may require the variants or exports that it
+    removes.
+  }];
+}
+
 def LinkExecutablesPass :
     Pass<"iree-hal-link-executables", "mlir::ModuleOp"> {
   let summary = "Links hal.executable ops into one or more hal.executable ops.";
   let description = [{
-    Calls into each target backend to have it link multiple `hal.executable` ops
-    together (if the backend desires).
-
-    DO NOT SUBMIT
+    Runs a nested pipeline to link multiple `hal.executable` ops together if the
+    target backend the executables are used with desires.
   }];
   let options = [
     Option<
@@ -294,7 +309,10 @@ def LinkTargetExecutablesPass :
     Pass<"iree-hal-link-target-executables", "mlir::ModuleOp"> {
   let summary = "Links executables for the specified target backend.";
   let description = [{
-    DO NOT SUBMIT
+    Links together multiple `hal.executable` ops for the given target backend if
+    desired. Linking allows for intra-module deduplication and amortization of
+    startup time, code size, and runtime overheads that come from managing
+    multiple hundreds/thousands of executables.
   }];
   let options = [
     Option<
@@ -328,7 +346,9 @@ def SerializeExecutablesPass :
     Pass<"iree-hal-serialize-executables", "IREE::HAL::ExecutableOp"> {
   let summary = "Converts hal.executable.variants to one or more hal.executable.binary ops.";
   let description = [{
-    DO NOT SUBMIT
+    Runs a nested pipeline on each executable to serialize its variants from
+    their low-level MLIR dialects (such as `llvm`, `spirv`, etc) to their
+    target-specific object format (static/shared libraries, SPIR-V, etc).
   }];
   let options = [
     Option<
@@ -358,7 +378,9 @@ def SerializeTargetExecutablesPass :
     Pass<"iree-hal-serialize-target-executables", "IREE::HAL::ExecutableOp"> {
   let summary = "Serializes executables for the specified target backend.";
   let description = [{
-    DO NOT SUBMIT
+    Serializes variants for the target backend from their low-level MLIR
+    dialects (such as `llvm`, `spirv`, etc) to their target-specific object
+    format (static/shared libraries, SPIR-V, etc).
   }];
   let options = [
     Option<

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/PruneExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/PruneExecutables.cpp
@@ -1,0 +1,143 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::HAL {
+
+#define GEN_PASS_DEF_PRUNEEXECUTABLESPASS
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h.inc"
+
+namespace {
+
+struct SymbolReferences {
+  Operation *symbolOp;
+  unsigned count = 0;
+};
+using SymbolReferenceMap = DenseMap<Attribute, SymbolReferences>;
+
+static void markReferenced(SymbolRefAttr symbolRefAttr,
+                           SymbolReferenceMap &referenceMap) {
+  auto markReferencedNested = [&](StringAttr rootRefAttr,
+                                  ArrayRef<FlatSymbolRefAttr> nestedRefAttrs) {
+    auto nestedRefAttr = nestedRefAttrs.empty()
+                             ? SymbolRefAttr::get(rootRefAttr)
+                             : SymbolRefAttr::get(rootRefAttr, nestedRefAttrs);
+    auto it = referenceMap.find(nestedRefAttr);
+    if (it != referenceMap.end())
+      ++it->second.count;
+  };
+  auto rootRefAttr = symbolRefAttr.getRootReference();
+  auto nestedRefAttrs = symbolRefAttr.getNestedReferences();
+  for (size_t i = 0; i <= nestedRefAttrs.size(); ++i) {
+    markReferencedNested(rootRefAttr, nestedRefAttrs.slice(0, i));
+  }
+}
+
+static void processOp(Operation *op, SymbolReferenceMap &referenceMap) {
+  SmallVector<Attribute> worklist;
+  for (auto namedAttr : op->getAttrs())
+    worklist.push_back(namedAttr.getValue());
+  while (!worklist.empty()) {
+    auto attr = worklist.pop_back_val();
+    if (auto symbolRefAttr = dyn_cast<SymbolRefAttr>(attr)) {
+      markReferenced(symbolRefAttr, referenceMap);
+    } else {
+      attr.walkImmediateSubElements(
+          [&](Attribute attr) { worklist.push_back(attr); }, [](Type) {});
+    }
+  }
+}
+
+static void eraseOps(ArrayRef<Attribute> symbolRefAttrs,
+                     SymbolReferenceMap &referenceMap) {
+  for (auto symbolRefAttr : symbolRefAttrs) {
+    auto &symbolRefs = referenceMap[symbolRefAttr];
+    if (symbolRefs.count == 0)
+      symbolRefs.symbolOp->erase();
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// --iree-hal-prune-executables
+//===----------------------------------------------------------------------===//
+
+struct PruneExecutablesPass
+    : public IREE::HAL::impl::PruneExecutablesPassBase<PruneExecutablesPass> {
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    // Gather all executable op symbols into a map that we can quickly check
+    // while walking ops.
+    DenseSet<Operation *> ignoredOps;
+    SymbolReferenceMap referenceMap;
+    SmallVector<Attribute> executableRefAttrs;
+    SmallVector<Attribute> variantRefAttrs;
+    SmallVector<Attribute> exportRefAttrs;
+    for (auto executableOp : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
+      ignoredOps.insert(executableOp);
+      if (!executableOp.isPrivate())
+        continue;
+      auto executableRefAttr =
+          FlatSymbolRefAttr::get(executableOp.getSymNameAttr());
+      referenceMap[executableRefAttr].symbolOp = executableOp;
+      executableRefAttrs.push_back(executableRefAttr);
+      for (auto variantOp :
+           executableOp.getOps<IREE::HAL::ExecutableVariantOp>()) {
+        ignoredOps.insert(variantOp);
+        auto variantRefAttr = SymbolRefAttr::get(
+            executableOp.getSymNameAttr(),
+            {
+                FlatSymbolRefAttr::get(variantOp.getSymNameAttr()),
+            });
+        referenceMap[variantRefAttr].symbolOp = variantOp;
+        variantRefAttrs.push_back(variantRefAttr);
+        for (auto exportOp :
+             variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+          ignoredOps.insert(exportOp);
+          auto exportRefAttr = SymbolRefAttr::get(
+              executableOp.getSymNameAttr(),
+              {
+                  FlatSymbolRefAttr::get(variantOp.getSymNameAttr()),
+                  FlatSymbolRefAttr::get(exportOp.getSymNameAttr()),
+              });
+          referenceMap[exportRefAttr].symbolOp = exportOp;
+          exportRefAttrs.push_back(exportRefAttr);
+        }
+      }
+    }
+
+    // Walk all ops in the module that can reference executable symbols and
+    // accumulate the usage counts.
+    SymbolTable symbolTable(moduleOp);
+    moduleOp.walk([&](Operation *op) -> WalkResult {
+      if (ignoredOps.contains(op))
+        return WalkResult::skip();
+      processOp(op, referenceMap);
+      return op->hasTrait<OpTrait::IsIsolatedFromAbove>()
+                 ? WalkResult::skip()
+                 : WalkResult::advance();
+    });
+
+    // Erase any executable-related op with no references.
+    // We have to start with exports > variants > executables so that we don't
+    // erase a container before the nested ops.
+    eraseOps(exportRefAttrs, referenceMap);
+    eraseOps(variantRefAttrs, referenceMap);
+    eraseOps(executableRefAttrs, referenceMap);
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "materialize_resource_caches.mlir",
             "memoize_device_queries.mlir",
             "preprocess_executables.mlir",
+            "prune_executables.mlir",
             "repeat_dispatches.mlir",
             "resolve_export_ordinals.mlir",
             "strip_executable_contents.mlir",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "materialize_resource_caches.mlir"
     "memoize_device_queries.mlir"
     "preprocess_executables.mlir"
+    "prune_executables.mlir"
     "repeat_dispatches.mlir"
     "resolve_export_ordinals.mlir"
     "strip_executable_contents.mlir"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/prune_executables.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/prune_executables.mlir
@@ -1,0 +1,75 @@
+// RUN: iree-opt --split-input-file --iree-hal-prune-executables %s | FileCheck %s
+
+// Tests that an executable with no references is dropped.
+// The MLIR SymbolDCE pass will do this for us but it makes more sense to do it
+// as part of this pass for consistency (after running no executables/variants/
+// exports that are unused exist).
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>
+  ]>
+]>
+
+// Should be removed as there are no uses.
+// CHECK-NOT: hal.executable private @unused_exe
+hal.executable private @unused_exe {
+  hal.executable.variant public @unused_variant target(<"backend", "format">) {
+    hal.executable.export public @unused_export layout(#pipeline_layout)
+  }
+}
+
+// Should not be removed as it's public.
+// CHECK: hal.executable public @unused_public_exe
+hal.executable public @unused_public_exe {}
+
+// Should not be removed as there's a use.
+// CHECK: hal.executable private @used_exe
+hal.executable private @used_exe {}
+
+util.func private @user(%cond: i1) {
+  scf.if %cond {
+    // Ensure we do full walks to find nested ops.
+    util.optimization_barrier {some.ref = @used_exe} %cond : i1
+    scf.yield
+  }
+  util.return
+}
+
+// -----
+
+// Tests that a variant with no references is dropped.
+
+hal.executable private @exe {
+  // CHECK-NOT: hal.executable.variant public @unused_variant
+  hal.executable.variant public @unused_variant target(<"backend", "format">) {}
+  // CHECK: hal.executable.variant public @used_variant
+  hal.executable.variant public @used_variant target(<"backend", "format">) {}
+}
+util.func private @user() attributes {
+  // Ensure we walk into nested attrs.
+  some.ref = {
+    key = [@exe::@used_variant]
+  }
+}
+
+// -----
+
+// Tests that an export with no references is dropped.
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>
+  ]>
+]>
+hal.executable private @exe {
+  hal.executable.variant public @variant target(<"backend", "format">) {
+    // CHECK-NOT: hal.executable.export public @unused_export
+    hal.executable.export public @unused_export layout(#pipeline_layout)
+    // CHECK: hal.executable.export public @used_export
+    hal.executable.export public @used_export layout(#pipeline_layout)
+  }
+}
+util.func private @user() attributes {
+  some.ref = @exe::@variant::@used_export
+}


### PR DESCRIPTION
This is like SymbolDCE but supports dropping variants and exports. We run it a few times during HAL lowering to catch things users may provide as executable source ops or external executables on input, anything we decide we don't need after HAL conversion based on what devices are dispatching certain exports, and after linking/translation where we may end up with some leftovers from the backends.