### PR TITLE
[Preprocessing] Add pre-configured pass pipeline for conv transpose

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/BUILD.bazel
@@ -30,7 +30,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:LinalgTransforms",
-        "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
     ],
 )

--- a/compiler/src/iree/compiler/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/BUILD.bazel
@@ -21,11 +21,16 @@ iree_compiler_cc_library(
         "Passes.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
+        "//compiler/src/iree/compiler/GlobalOptimization",
         "//compiler/src/iree/compiler/Pipelines:Options",
         "//compiler/src/iree/compiler/PluginAPI",
         "//compiler/src/iree/compiler/Preprocessing/Common:Transforms",
+        "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:Pass",
     ],
 )

--- a/compiler/src/iree/compiler/Preprocessing/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/CMakeLists.txt
@@ -20,10 +20,15 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRArithDialect
+    MLIRLinalgTransforms
     MLIRPass
+    MLIRTransforms
+    iree::compiler::Dialect::Flow::Transforms
+    iree::compiler::GlobalOptimization
     iree::compiler::Pipelines::Options
     iree::compiler::PluginAPI
     iree::compiler::Preprocessing::Common::Transforms
+    iree::compiler::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -5,13 +5,22 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "iree/compiler/Preprocessing/Passes.h"
 
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/GlobalOptimization/Passes.h"
 #include "iree/compiler/Preprocessing/Common/Passes.h"
+#include "iree/compiler/Utils/PassUtils.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/Passes.h"
 
 #define DEBUG_TYPE "iree-preprocessing-pass-pipeline"
 
 namespace mlir::iree_compiler::Preprocessing {
+
+using FunctionLikeNest =
+    MultiOpNest<IREE::Util::InitializerOp, IREE::Util::FuncOp>;
 
 namespace {
 
@@ -77,6 +86,32 @@ void buildPreprocessingPassPipeline(
   }
 }
 
-void registerPreprocessingPasses() { registerCommonPreprocessingPasses(); }
+static void
+buildTransposeConvolutionPassPipeline(OpPassManager &passManager,
+                                      const TransformOptions &options) {
+  FunctionLikeNest(passManager)
+      .addPass(GlobalOptimization::createDetachElementwiseFromNamedOpsPass)
+      .addPass(mlir::createLinalgNamedOpConversionPass)
+      .addPass(GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass)
+      .addPass(createConvertConvToChannelsLastPass)
+      .addPass(IREE::Flow::createFoldUnitExtentDimsPass);
+  passManager.addPass(createCanonicalizerPass());
+  passManager.addPass(createCSEPass());
+}
+
+void registerPreprocessingPasses() {
+  registerCommonPreprocessingPasses();
+
+  PassPipelineRegistration<TransformOptions>
+      globalOptimizationTransformPassPipeline(
+          "iree-preprocessing-transpose-convolution-pipeline",
+          "Runs a pass pipeline for transposing and canonicalizing "
+          "convolutions",
+          [](OpPassManager &passManager,
+             const TransformOptions &transformOptions) {
+            buildTransposeConvolutionPassPipeline(passManager,
+                                                  transformOptions);
+          });
+}
 
 } // namespace mlir::iree_compiler::Preprocessing

--- a/compiler/src/iree/compiler/Preprocessing/Passes.h
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.h
@@ -12,8 +12,12 @@
 #include "iree/compiler/Pipelines/Options.h"
 #include "iree/compiler/PluginAPI/Client.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassOptions.h"
 
 namespace mlir::iree_compiler::Preprocessing {
+
+/// Placeholder struct for preprocessing pass pipeline options.
+struct TransformOptions : public PassPipelineOptions<TransformOptions> {};
 
 /// Adds a set of passes to the given pass manager that run preprocessing
 /// passes specified in textual pass-pipeline format using


### PR DESCRIPTION
This is a convenience pipeline for a set of preprocessing passes that work well with transposing convolution ops.