### PR TITLE
Moving MaterializeInterfaces' spooky action at a distance around a little.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchExterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchExterns.cpp
@@ -43,9 +43,6 @@ convertDispatchExternToDispatchOp(IREE::HAL::DispatchExternOp dispatchExternOp,
       dispatchExternOp.getArguments(), dispatchExternOp.getArgumentDims(),
       dispatchExternOp.getResultDims(), dispatchExternOp.getTiedOperandsAttr());
   dispatchOp->setDialectAttrs(dispatchExternOp->getDialectAttrs());
-  if (auto bindingsAttr = dispatchExternOp.getBindingsAttr()) {
-    dispatchOp->setAttr("hal.interface.bindings", bindingsAttr);
-  }
 
   // Replace uses of the existing results with the new results.
   for (int i = 0; i < dispatchExternOp.getNumResults(); ++i) {
@@ -110,6 +107,9 @@ outlineDispatchExternOp(std::string name,
         dispatchExternOp.getSubgroupSizeAttr(),
         dispatchExternOp.getWorkgroupLocalMemoryAttr());
     exportOp->setDialectAttrs(dispatchExternOp->getDialectAttrs());
+    if (auto bindingsAttr = dispatchExternOp.getBindingsAttr()) {
+      exportOp->setAttr("hal.interface.bindings", bindingsAttr);
+    }
     if (!dispatchExternOp.getWorkgroupCount().empty()) {
       IRMapping mapper;
       dispatchExternOp.getWorkgroupCount().cloneInto(

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_externs.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_externs.mlir
@@ -5,6 +5,7 @@
 // CHECK-SAME:       objects([#hal.executable.object<{path = "a.o"}>])
 // CHECK-NEXT:     hal.executable.export public @main ordinal(100)
 // CHECK-SAME:         layout(#hal.pipeline.layout<push_constants = 1, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>)
+// CHECK-SAME:         hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>]
 // CHECK-NEXT:     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
 // CHECK-NEXT:       %ok, %value = hal.device.query<%arg0 : !hal.device> key("some" :: "value") : i1, i32
 // CHECK-NEXT:       %0 = arith.index_cast %value : i32 to index
@@ -16,6 +17,7 @@
 // CHECK-NEXT:       hal.return %ok : i1
 //      CHECK:     hal.executable.export public @main ordinal(200)
 // CHECK-SAME:         layout(#hal.pipeline.layout<push_constants = 1, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>)
+// CHECK-SAME:         hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>]
 // CHECK-NEXT:     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
 
 // Demonstrates the full functionality of an extern dispatch op.
@@ -27,9 +29,7 @@ util.func public @dispatchExtern(%arg0: tensor<4xi32>, %arg1: tensor<8xi32>, %ar
   %y = arith.constant 50 : index
   // Dispatch workgroups to the externally defined function "main" in the
   // referenced object files.
-  // CHECK: %[[RESULT:.+]] = flow.dispatch {@extern_dispatch_0::@a::@main, @extern_dispatch_0::@b::@main}[%c100, %c50](%arg0, %arg1, %arg2) {
-  // CHECK-SAME: hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>]
-  // CHECK-SAME: } : (tensor<4xi32>, tensor<8xi32>, i32) -> %arg1
+  // CHECK: %[[RESULT:.+]] = flow.dispatch {@extern_dispatch_0::@a::@main, @extern_dispatch_0::@b::@main}
   %result = hal.dispatch.extern "main"[%x, %y](%arg0, %arg1, %arg2) : (tensor<4xi32>, tensor<8xi32>, i32) -> %arg1
     // Translates the workload (%x and %y captured above) into an XYZ workgroup
     // count, optionally using device information.

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
@@ -128,7 +128,7 @@ deriveExportLayout(IREE::Stream::ExecutableExportOp exportOp,
   unsigned operandCount = 0;
   unsigned bindingCount = 0;
   for (auto arg : funcOp.getArgumentTypes()) {
-    if (llvm::isa<IREE::Stream::BindingType>(arg)) {
+    if (isa<IREE::Stream::BindingType>(arg)) {
       ++bindingCount;
     } else {
       ++operandCount;
@@ -140,9 +140,8 @@ deriveExportLayout(IREE::Stream::ExecutableExportOp exportOp,
   for (auto dispatchOp : dispatchOps) {
     auto resourceAccessesAttrs = dispatchOp.getResourceAccesses().getValue();
     for (unsigned i = 0; i < bindingCount; ++i) {
-      auto resourceAccessAttr =
-          llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
-              resourceAccessesAttrs[i]);
+      auto resourceAccessAttr = cast<IREE::Stream::ResourceAccessBitfieldAttr>(
+          resourceAccessesAttrs[i]);
       auto resourceAccess = static_cast<IREE::Stream::ResourceAccessBitfield>(
           resourceAccessAttr.getInt());
       if (!bitEnumContainsAll(resourceAccess,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
@@ -184,6 +184,10 @@ hal.executable private @ex {
       hal.return %selected : i1
     }
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
+      hal.interface.bindings = [
+        #hal.interface.binding<0, 4>,
+        #hal.interface.binding<1, 5>
+      ],
       translation_info = #iree_codegen.translation_info<CPUDefault>
     } {
     ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
@@ -197,6 +201,10 @@ hal.executable private @ex {
   }
   hal.executable.variant public @x86_64 target(#executable_target_x86_64) {
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
+      hal.interface.bindings = [
+        #hal.interface.binding<0, 4>,
+        #hal.interface.binding<1, 5>
+      ],
       translation_info = #iree_codegen.translation_info<CPUDefault>
     } {
     ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
@@ -276,11 +284,6 @@ util.func public @cmdDispatch(%arg0: !stream.resource<transient>, %arg1: index, 
     stream.cmd.dispatch {@ex::@aarch64::@dispatch, @ex::@x86_64::@dispatch}[%c1, %c2, %c3](%c4_i32, %c5_i32 : i32, i32) {
       ro %arg4[%c0 for %c128] : !stream.resource<transient>{%arg1},
       wo %arg5[%c0 for %c128] : !stream.resource<external>{%arg3}
-    } attributes {
-      hal.interface.bindings = [
-        #hal.interface.binding<0, 4>,
-        #hal.interface.binding<1, 5>
-      ]
     }
     // CHECK: hal.command_buffer.execution_barrier<%[[CMD]]
   } => !stream.timepoint

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -87,6 +87,30 @@ Value DeviceType::resolveAny(Location loc, OpBuilder &builder) {
 }
 
 //===----------------------------------------------------------------------===//
+// Utilities
+//===----------------------------------------------------------------------===//
+
+SmallVector<IREE::HAL::InterfaceBindingAttr>
+getInterfaceBindingAttrs(Operation *op, size_t resourceCount) {
+  // It'd be nice if we had something typed here but this is just used for
+  // spooky action at a distance or user overrides. If the attribute is not
+  // found (not set by MaterializeInterfaces or the user) we construct one by
+  // convention (dense set 0 bindings for each resource).
+  auto bindingAttrs = op->getAttrOfType<ArrayAttr>("hal.interface.bindings");
+  if (bindingAttrs) {
+    return llvm::to_vector(
+        bindingAttrs.getAsRange<IREE::HAL::InterfaceBindingAttr>());
+  }
+  SmallVector<IREE::HAL::InterfaceBindingAttr> bindings;
+  for (size_t i = 0; i < resourceCount; ++i) {
+    bindings.push_back(IREE::HAL::InterfaceBindingAttr::get(op->getContext(),
+                                                            /*set=*/0,
+                                                            /*binding=*/i));
+  }
+  return bindings;
+}
+
+//===----------------------------------------------------------------------===//
 // Dialect registration
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.h
@@ -278,4 +278,17 @@ operator<<(AsmPrinter &printer,
 #include "iree/compiler/Dialect/HAL/IR/HALAttrs.h.inc" // IWYU pragma: keep
 // clang-format on
 
+//===----------------------------------------------------------------------===//
+// Utilities
+//===----------------------------------------------------------------------===//
+
+namespace mlir::iree_compiler::IREE::HAL {
+
+// Returns the assigned bindings via the `hal.interface.bindings` attribute
+// on the operation or default bindings in set 0 with bindings [0, count).
+SmallVector<IREE::HAL::InterfaceBindingAttr>
+getInterfaceBindingAttrs(Operation *op, size_t resourceCount);
+
+} // namespace mlir::iree_compiler::IREE::HAL
+
 #endif // IREE_COMPILER_DIALECT_HAL_IR_HALTYPES_H_

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
@@ -88,6 +88,17 @@ struct ConvertToHALPass
                                       std::move(patterns)))) {
       return signalPassFailure();
     }
+
+    // Cleanup conversion attributes used for spooky action at a distance.
+    for (auto executableOp : getOperation().getOps<IREE::HAL::ExecutableOp>()) {
+      for (auto variantOp :
+           executableOp.getOps<IREE::HAL::ExecutableVariantOp>()) {
+        for (auto exportOp :
+             variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+          exportOp->removeAttr("hal.interface.bindings");
+        }
+      }
+    }
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -134,46 +134,29 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
         ro %result_capture[%c0 for %c32] : !stream.resource<transient>{%c128},
         rw %result_capture[%c32 for %c32] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
-      } attributes {hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>,
-        #hal.interface.binding<0, 2>
-      ]}
+      }
       // NOTE: today the dynamic args will prevent us from generating
       // benchmarks. We could handle this better by tracking alignment and such.
       stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch0[%c512](%c300_i32, %dynamic_arg : i32, i32) {
         ro %result_capture[%c0 for %c32] : !stream.resource<transient>{%c128},
         rw %result_capture[%c32 for %c32] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
-      } attributes {hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>,
-        #hal.interface.binding<0, 2>
-      ]}
+      }
 
       // Multiple dispatches to a single entry point.
       // Dispatches are deduplicated and the two 128x32x1 should combine.
       stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch1[%c512, %c1] {
         ro %result_capture[%c0 for %c64] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
-      } attributes {hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>
-      ]}
+      }
       stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch1[%c128, %c32] {
         ro %result_capture[%c0 for %c64] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
-      } attributes {hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>
-      ]}
+      }
       stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch1[%c128, %c32] {
         ro %result_capture[%c0 for %c64] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
-      } attributes {hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>
-      ]}
+      }
     } => !stream.timepoint
     %39 = stream.resource.dealloca await(%6) => %result : !stream.resource<transient>{%c128} => !stream.timepoint
     util.return %39 : !stream.timepoint

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -21,7 +21,8 @@ module attributes {hal.device.targets = [
 
   // CHECK: hal.executable private @ex_workgroups
   // CHECK:   hal.executable.variant public @embedded_elf_arm_64 target(#executable_target_embedded_elf_arm_64
-  // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout) {
+  // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout)
+  // CHECK-SAME:   hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]
   // CHECK-NEXT: ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
   // CHECK-NEXT:   hal.return %[[ARG0]], %[[ARG1]], %[[ARG0]] : index, index, index
   // CHECK-NEXT: }
@@ -29,7 +30,8 @@ module attributes {hal.device.targets = [
   // CHECK-NEXT:  func.func private @extern_func()
   // CHECK-NEXT:  func.func @entry
   // CHECK:   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64
-  // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout) {
+  // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout)
+  // CHECK-SAME:   hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]
   // CHECK-NEXT: ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
   // CHECK-NEXT:   hal.return %[[ARG0]], %[[ARG1]], %[[ARG0]] : index, index, index
   // CHECK-NEXT: }
@@ -55,11 +57,6 @@ module attributes {hal.device.targets = [
     %0 = stream.resource.alloc uninitialized : !stream.resource<transient>{%arg2}
     %1 = stream.cmd.execute with(%arg0 as %arg4: !stream.resource<constant>{%arg2}, %arg1 as %arg5: !stream.resource<transient>{%arg2}, %0 as %arg6: !stream.resource<transient>{%arg2}) {
       // CHECK: stream.cmd.dispatch {@ex_workgroups::@embedded_elf_arm_64::@entry, @ex_workgroups::@embedded_elf_x86_64::@entry}
-      // CHECK: attributes {
-      // CHECK-SAME: hal.interface.bindings = [
-      // CHECK-SAME:   #hal.interface.binding<0, 0>,
-      // CHECK-SAME:   #hal.interface.binding<0, 1>,
-      // CHECK-SAME:   #hal.interface.binding<0, 2>
       stream.cmd.dispatch @ex_workgroups::@entry[%c1, %c2](%arg3 : i32) {
         ro %arg4[%c0 for %arg2] : !stream.resource<constant>{%arg2},
         ro %arg5[%c0 for %arg2] : !stream.resource<transient>{%arg2},

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/test/inline_executables.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/test/inline_executables.mlir
@@ -178,12 +178,6 @@ util.func private @dispatch0(%resource0: !stream.resource<constant>, %resource1:
       ro %resource0_inner[%binding0_offset for %binding0_length] : !stream.resource<constant>{%resource_size},
       ro %resource1_inner[%binding1_offset for %binding1_length] : !stream.resource<transient>{%resource_size},
       wo %resource2_inner[%binding2_offset for %binding2_length] : !stream.resource<external>{%resource_size}
-    } attributes {
-      hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>,
-        #hal.interface.binding<0, 2>
-      ]
     }
   } => !stream.timepoint
   util.return

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
@@ -80,11 +80,6 @@ util.func public @cmdDispatch(%buffer0: !stream.resource<transient>, %buffer0_si
     stream.cmd.dispatch @ex::@dispatch[%workload_x, %workload_y](%constant0, %constant1 : i32, i32) {
       ro %buffer0_inner[%buffer0_offset for %buffer0_length] : !stream.resource<transient>{%buffer0_size},
       wo %buffer1_inner[%buffer1_offset for %buffer1_length] : !stream.resource<external>{%buffer1_size}
-    } attributes {
-      hal.interface.bindings = [
-        #hal.interface.binding<0, 4>,
-        #hal.interface.binding<1, 5>
-      ]
     }
   } => !stream.timepoint
   // CHECK: return %c0

--- a/samples/custom_dispatch/cpu/embedded/example_hal.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_hal.mlir
@@ -90,7 +90,19 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
                 <1, storage_buffer, ReadOnly>,
                 <2, storage_buffer>
             ]>
-          ]>) {
+          ]>) attributes {
+            // Bindings are automatically inferred when possible as part of the
+            // ABI but can be overridden if the user wants to use features such
+            // as sparse bindings or multiple descriptor sets. To do so the
+            // `hal.interface.bindings` attribute can be added to a dispatch op
+            // as follows mapping tensor operands/results to the pipeline layout
+            // sets/bindings:
+            hal.interface.bindings = [
+              #hal.interface.binding<0, 0>,
+              #hal.interface.binding<0, 1>,
+              #hal.interface.binding<0, 2>
+            ]
+          } {
       ^bb0(%device: !hal.device, %workload: index):
         // This host function is used to compute the XYZ workgroup count
         // dispatched at runtime. It can query the %device for capabilities
@@ -245,17 +257,6 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
 
     // Dispatch a basic `ret = lhs * rhs` using an external function.
     %0 = flow.dispatch @executable::@x86_64::@simple_mul[%dim](%dim_i32, %arg0, %arg1) {
-      // Bindings are automatically inferred when possible as part of the ABI
-      // but can be overridden if the user wants to use features such as sparse
-      // bindings or multiple descriptor sets. To do so the
-      // `hal.interface.bindings` attribute can be added to a dispatch op as
-      // follows mapping tensor operands/results to the pipeline layout
-      // sets/bindings:
-      hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>,
-        #hal.interface.binding<0, 2>
-      ],
       // HACK: keep the executable live through DCE. Only required when
       // using the automatic variant selection.
       // TODO(benvanik): automatically add this when required.

--- a/samples/custom_dispatch/cpu/embedded/example_transform_spec.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_transform_spec.mlir
@@ -74,13 +74,7 @@ module attributes {transform.with_named_sequence} {
     %dim_i32 = arith.index_cast %dim : index to i32
 
     // Dispatch a basic `ret = -|lhs * rhs|` using an external function.
-    %0 = flow.dispatch @executable::@x86_64::@simple_mul_abs_negate[%dim](%dim_i32, %arg0, %arg1) {
-      hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>,
-        #hal.interface.binding<0, 2>
-      ]
-    } : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
+    %0 = flow.dispatch @executable::@x86_64::@simple_mul_abs_negate[%dim](%dim_i32, %arg0, %arg1) : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
 
     util.return %0 : tensor<?xf32>
   }

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec.mlir
@@ -61,13 +61,7 @@ module attributes {transform.with_named_sequence} {
     %n_i32 = arith.index_cast %n : index to i32
     %k_i32 = arith.index_cast %k : index to i32
 
-    %mlp_result = flow.dispatch @executable::@x86_64::@mlp(%lhs, %rhs, %m_i32, %n_i32, %k_i32) {
-      hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>,
-        #hal.interface.binding<0, 2>
-      ]
-    } : (tensor<?x?xf32>{%m, %k}, tensor<?x?xf32>{%k, %n}, i32, i32, i32) -> tensor<?x?xf32>{%m, %n}
+    %mlp_result = flow.dispatch @executable::@x86_64::@mlp(%lhs, %rhs, %m_i32, %n_i32, %k_i32) : (tensor<?x?xf32>{%m, %k}, tensor<?x?xf32>{%k, %n}, i32, i32, i32) -> tensor<?x?xf32>{%m, %n}
 
     util.return %mlp_result : tensor<?x?xf32>
   }

--- a/samples/custom_dispatch/vulkan/shaders/example.mlir
+++ b/samples/custom_dispatch/vulkan/shaders/example.mlir
@@ -78,7 +78,19 @@ module @example attributes {hal.device.targets = [#vulkan_target]} {
               <1, storage_buffer, ReadOnly>,
               <2, storage_buffer>
           ]>
-        ]>) {
+        ]>) attributes {
+          // Bindings are automatically inferred when possible as part of the
+          // ABI but can be overridden if the user wants to use features such as
+          // sparse bindings or multiple descriptor sets. To do so the
+          // `hal.interface.bindings` attribute can be added to an export op as
+          // follows mapping tensor operands/results to the pipeline layout
+          // sets/bindings:
+          hal.interface.bindings = [
+            #hal.interface.binding<0, 0>,
+            #hal.interface.binding<0, 1>,
+            #hal.interface.binding<0, 2>
+          ]
+        } {
     ^bb0(%device: !hal.device, %workload: index):
       // This host function is used to compute the XYZ workgroup count
       // dispatched at runtime. It can query the %device for capabilities
@@ -136,29 +148,13 @@ module @example attributes {hal.device.targets = [#vulkan_target]} {
     %dim_i32 = arith.index_cast %dim : index to i32
 
     // Dispatch a basic `ret = lhs * rhs` shader.
-    %0 = flow.dispatch @simple_mul::@main[%dim](%dim_i32, %arg0, %arg1) {
-      // Bindings are automatically inferred when possible as part of the ABI
-      // but can be overridden if the user wants to use features such as sparse
-      // bindings or multiple descriptor sets. To do so the
-      // `hal.interface.bindings` attribute can be added to a dispatch op as
-      // follows mapping tensor operands/results to the pipeline layout
-      // sets/bindings:
-      hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>,
-        #hal.interface.binding<0, 2>
-      ]
-    } : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
+    %0 = flow.dispatch @simple_mul::@main[%dim](%dim_i32, %arg0, %arg1) : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
 
     // Code gen some other ops - these will interleave with the hand-authored
     // ones but naturally won't be able to fuse with them.
     %1 = arith.addf %0, %arg1 : tensor<?xf32>
 
     // Dispatch an in-place `rhs *= lhs` shader.
-    //
-    // Note that we don't declare the hal.interface.bindings and let them be
-    // inferred - this only works when either specifying the variant that has
-    // a pipeline layout defined or all variants have the same pipeline layouts.
     %2 = flow.dispatch @simple_mul_inplace::@main[%dim](%dim_i32, %0, %1) : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> %1{%dim}
 
     // CHECK: 8xf32=96 96 96 96 96 96 96 96


### PR DESCRIPTION
The magic `hal.interface.bindings` attribute that allows for `stream.cmd.dispatch` alignment with HAL interfaces during conversion is now moved to the export ops instead of being added on the dispatches. This allows each variant to have its own binding mapping and thus its own pipeline layout in subsequent steps. We still generate the same mapping for everything today but externally-provided executables are now allowed to differ and in the future target backends can specify their own. This will also allow us to potentially perform pruning/linking prior to conversion for cases where some variants are only dispatched on certain devices and we want to optimize layouts to reduce the number of layout changes during execution.

Future changes rework this code even more to reduce the number of full-module walks we perform and allow for scoped device targets. 