### PR TITLE
[StableHLO] Add SelectOp to GenericTypeConvert

### DIFF
--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/StableHLOToIREEInputDialects.cpp
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/StableHLOToIREEInputDialects.cpp
@@ -536,7 +536,8 @@ struct ConvertStableHloToIreeInputDialects final
         GenericTypeConvert<tensor::FromElementsOp>,
         GenericTypeConvert<tensor::CollapseShapeOp>,
         GenericTypeConvert<tensor::ExpandShapeOp>,
-        GenericTypeConvert<arith::IndexCastUIOp>>(*typeConverter, context);
+        GenericTypeConvert<arith::IndexCastUIOp>,
+        GenericTypeConvert<arith::SelectOp>>(*typeConverter, context);
 
     ConversionTarget target(*context);
     auto isIllegalType = [&](Type t) { return !typeConverter->isLegal(t); };

--- a/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/test/stablehlo_to_iree_input_dialects.mlir
+++ b/compiler/plugins/input/StableHLO/stablehlo-iree/Conversion/test/stablehlo_to_iree_input_dialects.mlir
@@ -130,3 +130,13 @@ func.func @while_unsigned(%arg0: tensor<ui32>) -> tensor<ui32> {
   }
   return %0 : tensor<ui32>
 }
+
+// -----
+
+// CHECK-LABEL: @select_conversion
+func.func @select_conversion(%arg0: tensor<i1>, %arg1: tensor<?xui16>, %arg2: tensor<?xui16>) -> tensor<?xui16> {
+  %extracted = tensor.extract %arg0[] : tensor<i1>
+  // CHECK: arith.select
+  %0 = arith.select %extracted, %arg1, %arg2 : tensor<?xui16>
+  return %0 : tensor<?xui16>
+}


### PR DESCRIPTION
Several control-flow Ops (stablehlo.if, stablehlo.case, etc) fail because arith::SelectOp is not allowed as a legal op. This patch add SelectOp into GenericTypeConvert.

Fix for #16376