### PR TITLE
[CPU] Register a bufferization pipeline.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -768,6 +768,11 @@ void registerCodegenLLVMCPUPasses() {
         buildLLVMCPUCodegenConfigurationPassPipeline(passManager);
       });
 
+  static PassPipelineRegistration<> LLVMCPUBufferizationPipeline(
+      "iree-codegen-llvmcpu-bufferization-pipeline",
+      "Runs the bufferization pipeline for CPU",
+      [](OpPassManager &passManager) { addCPUBufferizePasses(passManager); });
+
   static PassPipelineRegistration<> LLVMCPUVectorLoweringPipeline(
       "iree-codegen-llvmcpu-vector-lowering-pipeline",
       "Runs the translation strategy configuration pipeline on Linalg for CPU",


### PR DESCRIPTION
This is a convenience pipeline for a set of bufferization passes. It explicitly uses CPU allocation and CPU copy functions.