### PR TITLE
[VectorExt] Add support for projecting nested layouts

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -243,13 +243,13 @@ builtin.module attributes { transform.with_named_sequence } {
     %c0 = arith.constant 0 : index
     %cst_0 = arith.constant 0.0 : f16
     %cst0_1 = arith.constant dense<0.0> : vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true], "__vector_layout_test_anchor_result_0" = #layout} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{thread_basis = [4, 16]}}
     %root_red = vector.multi_reduction<add>, %root, %cst0_1 [0]  : vector<16x16xf16> to vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
     %c = arith.mulf %root_red, %a : vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
     func.return %c : vector<16xf16>
   }
 
@@ -281,13 +281,13 @@ builtin.module attributes { transform.with_named_sequence } {
     %c0 = arith.constant 0 : index
     %cst_0 = arith.constant 0.0 : f16
     %cst0_1 = arith.constant dense<0.0> : vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true], "__vector_layout_test_anchor_result_0" = #layout} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{thread_basis = [4, 16]}}
     %root_red = vector.multi_reduction<add>, %root, %cst0_1 [1]  : vector<16x16xf16> to vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
     %c = arith.mulf %root_red, %a : vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
     func.return %c : vector<16xf16>
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Common/VectorLayoutAnalysis.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
@@ -435,10 +436,11 @@ NestedLayoutAttr permuteAndCreateNestedLayout(
     applyPermutationToVector(elementOrder, permute);
   }
 
-  return NestedLayoutAttr::get(context, subgroupCount, subgroupOrder,
-                               batchCount, batchOrder, outerCount, outerOrder,
-                               threadCount, threadOrder, elementCount,
-                               elementOrder, subgroupBasis, threadBasis);
+  return NestedLayoutAttr::get(
+      context, subgroupCount, subgroupOrder, batchCount, batchOrder, outerCount,
+      outerOrder, threadCount, threadOrder, elementCount, elementOrder,
+      subgroupBasis, SmallVector<bool>(subgroupBasis.size(), true), threadBasis,
+      SmallVector<bool>(threadBasis.size(), true));
 }
 
 std::optional<std::tuple<VectorExt::VectorLayoutInterface,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -285,7 +285,9 @@ private:
 
     auto layout = IREE::VectorExt::NestedLayoutAttr::get(
         context, subgroupCounts, order, batchSizes, order, outerSizes, order,
-        threadCounts, order, elementSizes, order, subgroupBasis, threadBasis);
+        threadCounts, order, elementSizes, order, subgroupBasis,
+        SmallVector<bool>(subgroupBasis.size(), true), threadBasis,
+        SmallVector<bool>(threadBasis.size(), true));
     analysis.setAnchor(transfer.getResult(), layout);
     if (printLayout) {
       llvm::outs() << "transfer '" << transfer << "' vector layout: " << layout

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -282,7 +282,10 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     ArrayRefParameter<"int64_t", "element_order">:$elementOrder,
 
     ArrayRefParameter<"int64_t", "subgroup_basis">:$subgroupBasis,
-    ArrayRefParameter<"int64_t", "thread_basis">:$threadBasis
+    ArrayRefParameter<"bool", "subgroup_active_ids">:$subgroupActiveIds,
+
+    ArrayRefParameter<"int64_t", "thread_basis">:$threadBasis,
+    ArrayRefParameter<"bool", "thread_active_ids">:$threadActiveIds
   );
 
   // By default, identity orderings are elided when parsing/printing.
@@ -300,8 +303,8 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
         custom<Permutation>("\"thread_order\"", ref($threadsPerOuter), "true", $threadOrder) ``
         custom<Permutation>("\"element_order\"", ref($elementsPerThread), "true", $elementOrder) ``
 
-        `subgroup_basis`          `=` `[` $subgroupBasis `]` `,`
-        `thread_basis`            `=` `[` $threadBasis `]`
+        custom<Basis>("\"subgroup_basis\"", "\"subgroup_active_ids\"", "true", $subgroupBasis, $subgroupActiveIds) ``
+        custom<Basis>("\"thread_basis\"", "\"thread_active_ids\"", "false", $threadBasis, $threadActiveIds) ``
     `>`
   }];
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtInterfaces.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtInterfaces.td
@@ -33,7 +33,7 @@ def VectorLayoutInterface : AttrInterface<"VectorLayoutInterface"> {
       /*description=*/"Projects the given layout.",
       /*retTy=*/"VectorLayoutInterface",
       /*methodName=*/"project",
-      /*args=*/(ins "::llvm::ArrayRef<bool>":$projectedDims)
+      /*args=*/(ins "::llvm::ArrayRef<bool>":$droppedDims)
     >,
     InterfaceMethod<
       /*description=*/"Get the distributed shape for the given vector type.",

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -14,7 +14,6 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -300,8 +299,8 @@ NestedLayoutAttr::project(ArrayRef<bool> projectedDims) const {
   return NestedLayoutAttr::get(getContext(), subgroupCount, subgroupOrder,
                                batchCount, batchOrder, outerCount, outerOrder,
                                threadCount, threadOrder, elementCount,
-                               elementOrder, getSubgroupBasis(), projectedDims,
-                               getThreadBasis(), projectedDims);
+                               elementOrder, getSubgroupBasis(), subgroupMask,
+                               getThreadBasis(), threadMask);
 }
 
 VectorLayoutInterface
@@ -428,7 +427,6 @@ NestedLayoutAttr::computeThreadIds(Value threadId,
 
   // Modulo the delinearized subgroup/thread ids by the number of unique
   // elements distributed to those ids.
-  int64_t tileIdx = 0;
   for (auto [delinearized, basis, isActive] :
        llvm::zip_equal(delinearized, basisSizes, activeIdFilter)) {
     if (!isActive) {

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -386,7 +386,7 @@ LogicalResult NestedLayoutAttr::verify(
 /// Given a single flat thread ID, compute the indices of the distributed
 /// dimensions (subgroup and thread ids). The only difference between subgroup
 /// and thread dimensions is the order in which they are "divided out" of the
-/// underlying vector (i.e. vector_shape /= subgroups -> batches -> orders ->
+/// underlying vector (i.e. vector_shape /= subgroups -> batches -> outers ->
 /// threads -> elements). There is no requirement that a subgroup id only
 /// spans subgroups.
 SmallVector<Value>
@@ -431,7 +431,7 @@ NestedLayoutAttr::computeThreadIds(Value threadId,
   // Modulo the active delinearized subgroup/thread ids by the number of unique
   // elements distributed to those ids. The only difference between subgroup
   // and thread dimensions is the order in which they are "divided out" of the
-  // underlying vector (i.e. vector_shape /= subgroups -> batches -> orders ->
+  // underlying vector (i.e. vector_shape /= subgroups -> batches -> outers ->
   // threads -> elements). There is no requirement that a subgroup id only
   // spans subgroups.
   //

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
@@ -43,3 +43,18 @@ func.func @invalid_to_simt_vector_element_type(%simt : vector<64xf32>) -> vector
   %simd = iree_vector_ext.to_simt %simt : vector<64xf32> -> vector<2x2xf16>
   func.return %simd : vector<2x2xf16>
 }
+
+// -----
+
+// expected-error @+1 {{number of active basis ids must be equal to the layout rank}}
+#layout = #iree_vector_ext.nested_layout<
+  subgroups_per_workgroup = [1],
+  batches_per_subgroup = [1],
+  outers_per_batch = [1],
+  threads_per_outer = [1],
+  elements_per_thread = [1],
+
+  subgroup_basis = [2],
+  subgroup_active_ids = [false],
+  thread_basis   = [2]
+>

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
@@ -89,6 +89,24 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   thread_active_ids = [false, true, true]
 >
 
+#nested_5 = #iree_vector_ext.nested_layout<
+  subgroups_per_workgroup = [1, 1],
+  batches_per_subgroup = [4, 2],
+  outers_per_batch = [1, 4],
+  threads_per_outer = [2, 4],
+  elements_per_thread = [4, 1],
+
+  subgroup_order = [1, 0],
+  batch_order = [1, 0],
+  thread_order = [1, 0],
+  element_order = [1, 0],
+
+  subgroup_basis = [2, 4],
+  subgroup_active_ids = [true, true],
+  thread_basis   = [4, 2],
+  thread_active_ids = [true, true]
+>
+
 func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   %cst_0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
@@ -97,7 +115,8 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
     sourceLayout = #nested_1,
     desiredLayout = #nested_2,
     otherLayout0 = #nested_3,
-    otherLayout1 = #nested_4
+    otherLayout1 = #nested_4,
+    otherLayout2 = #nested_5
   } : vector<32x32xf16> -> vector<32x32xf16>
   return %2 : vector<32x32xf16>
 }
@@ -106,11 +125,13 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-DAG: #[[LAYOUT1:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 4], outers_per_batch = [4, 1], threads_per_outer = [4, 2], elements_per_thread = [1, 4], outer_order = [1, 0], subgroup_basis = [1, 1], thread_basis = [4, 2]>
 // CHECK-DAG: #[[LAYOUT2:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [2, 4, 8], subgroup_active_ids= [true, true, false], thread_basis = [2, 4]>
 // CHECK-DAG: #[[LAYOUT3:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [2, 4, 8], subgroup_active_ids= [true, true, false], thread_basis = [2, 4, 2], thread_active_ids= [false, true, true]>
+// CHECK-DAG: #[[LAYOUT4:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [2, 4], thread_basis = [4, 2]>
 // CHECK-LABEL: func.func @specify_nested
 // CHECK:      iree_vector_ext.layout_conflict_resolution
 // CHECK-SAME:         desiredLayout = #[[LAYOUT0]]
 // CHECK-SAME:         otherLayout0 = #[[LAYOUT2]]
 // CHECK-SAME:         otherLayout1 = #[[LAYOUT3]]
+// CHECK-SAME:         otherLayout2 = #[[LAYOUT4]]
 // CHECK-SAME:         sourceLayout = #[[LAYOUT1]]
 
 // -----

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
@@ -54,19 +54,63 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   thread_basis   = [2, 4]
 >
 
+#nested_3 = #iree_vector_ext.nested_layout<
+  subgroups_per_workgroup = [1, 1],
+  batches_per_subgroup = [4, 2],
+  outers_per_batch = [1, 4],
+  threads_per_outer = [2, 4],
+  elements_per_thread = [4, 1],
+
+  subgroup_order = [1, 0],
+  batch_order = [1, 0],
+  thread_order = [1, 0],
+  element_order = [1, 0],
+
+  subgroup_basis = [2, 4, 8],
+  subgroup_active_ids = [true, true, false],
+  thread_basis   = [2, 4]
+>
+
+#nested_4 = #iree_vector_ext.nested_layout<
+  subgroups_per_workgroup = [1, 1],
+  batches_per_subgroup = [4, 2],
+  outers_per_batch = [1, 4],
+  threads_per_outer = [2, 4],
+  elements_per_thread = [4, 1],
+
+  subgroup_order = [1, 0],
+  batch_order = [1, 0],
+  thread_order = [1, 0],
+  element_order = [1, 0],
+
+  subgroup_basis = [2, 4, 8],
+  subgroup_active_ids = [true, true, false],
+  thread_basis   = [2, 4, 2],
+  thread_active_ids = [false, true, true]
+>
+
 func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   %cst_0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
   %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<32x32xf16>, vector<32x32xf16>
-  %2 = iree_vector_ext.layout_conflict_resolution %result {sourceLayout = #nested_1, desiredLayout = #nested_2} : vector<32x32xf16> -> vector<32x32xf16>
+  %2 = iree_vector_ext.layout_conflict_resolution %result {
+    sourceLayout = #nested_1,
+    desiredLayout = #nested_2,
+    otherLayout0 = #nested_3,
+    otherLayout1 = #nested_4
+  } : vector<32x32xf16> -> vector<32x32xf16>
   return %2 : vector<32x32xf16>
 }
 
 // CHECK-DAG: #[[LAYOUT0:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [1, 1], thread_basis = [2, 4]>
 // CHECK-DAG: #[[LAYOUT1:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 4], outers_per_batch = [4, 1], threads_per_outer = [4, 2], elements_per_thread = [1, 4], outer_order = [1, 0], subgroup_basis = [1, 1], thread_basis = [4, 2]>
+// CHECK-DAG: #[[LAYOUT2:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [2, 4, 8], subgroup_active_ids= [true, true, false], thread_basis = [2, 4]>
+// CHECK-DAG: #[[LAYOUT3:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [2, 4, 8], subgroup_active_ids= [true, true, false], thread_basis = [2, 4, 2], thread_active_ids= [false, true, true]>
 // CHECK-LABEL: func.func @specify_nested
 // CHECK:      iree_vector_ext.layout_conflict_resolution
 // CHECK-SAME:         desiredLayout = #[[LAYOUT0]]
+// CHECK-SAME:         otherLayout0 = #[[LAYOUT2]]
+// CHECK-SAME:         otherLayout1 = #[[LAYOUT3]]
 // CHECK-SAME:         sourceLayout = #[[LAYOUT1]]
 
 // -----


### PR DESCRIPTION
This adds two new fields to the layout to track which ids in the basis are correspond to the subgroups_per_workgroup and threads_per_outer. The reason these masks are required is because when performing a rank-reducing projection, we lose necessary degrees of freedom (dimensions) that can indicate how the data in the underlying vector is replicated across threads. The simplest example is reducing a 2x2 vector with a grid of 2x2 threads. In this case there are two ways the reduced data can be replicated across threads.

```
vector<2> = s0, s1, s0, s1
vector<2> = s0, s0, s1, s1
```

however we only have one valid layout based on the constraints on the thread basis/thread counts. Assuming all other dimensions are 1, it is required that thread_count == vector size == 2. Similarly, the total number of threads in the basis must be equal to the flat total number of threads (in this case 4). Since there is only one valid layout, there is no way to differentiate between these two distributed cases.

The active_id masks fix this by further decoupling the thread basis (i.e. how to delinearize the flat thread id to a set of ids used by the layout) from the actual vector shape. Handling projections then is simply a matter of masking off the ids of the basis according to the projected dims.