### PR TITLE
Moving CPUMaterializeUpperBoundTileSizePass out of HAL.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
@@ -554,8 +554,7 @@ void CPUMaterializeUpperBoundTileSizePass::runOnOperation() {
   MLIRContext *context = &getContext();
   auto operation = getOperation();
   if (targetAttrs.empty()) {
-    targetAttrs =
-        IREE::HAL::DeviceTargetAttr::lookupExecutableTargets(operation);
+    targetAttrs = {IREE::HAL::ExecutableTargetAttr::lookup(operation)};
   }
   RewritePatternSet patterns(context);
   MaterializeEncodingFn materializeEncodingFn =

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -88,6 +88,8 @@ static llvm::cl::opt<bool> clUseSoftmaxInterFusion(
     llvm::cl::init(true));
 
 static void addTileAndDistributePasses(OpPassManager &pm) {
+  pm.nest<ModuleOp>().nest<func::FuncOp>().addPass(
+      createCPUMaterializeUpperBoundTileSizePass());
   pm.addPass(createTileAndDistributeToWorkgroupsPass());
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
@@ -36,6 +36,8 @@ static llvm::cl::opt<bool> clEnableUKernelsDecomposeLinalgGeneric(
     llvm::cl::init(true));
 
 static void addTileAndDistributePasses(OpPassManager &pm) {
+  pm.nest<ModuleOp>().nest<func::FuncOp>().addPass(
+      createCPUMaterializeUpperBoundTileSizePass());
   pm.addPass(createTileAndDistributeToWorkgroupsPass());
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -44,7 +44,6 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":PassesIncGen",
-        "//compiler/src/iree/compiler/Codegen/Common/CPU:CommonCPUPasses",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/Analysis",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -57,7 +57,6 @@ iree_cc_library(
     MLIRSupport
     MLIRTensorDialect
     MLIRTransforms
-    iree::compiler::Codegen::Common::CPU::CommonCPUPasses
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::Analysis

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -8,7 +8,6 @@
 
 #include <memory>
 
-#include "iree/compiler/Codegen/Common/CPU/Passes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
@@ -261,10 +260,6 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   if (compileFrom < PipelinePhase::ExecutableSources) {
     buildHALConfigurationPassPipeline(passManager, targetRegistry,
                                       targetOptions);
-
-    FunctionLikeNest(passManager).addPass([]() {
-      return createCPUMaterializeUpperBoundTileSizePass();
-    });
 
     // Preprocess executables using an external tool. The tool may mutate one or
     // more variants and even insert or remove variants.


### PR DESCRIPTION
This is codegen specific to LLVM-CPU and VMVX and now runs at the head of those pipelines to match it having run before translation previously. The pass itself is doing some of the right things but needs to be changed to handle non-CPU targets for it to work in the new world.

This is required (besides for decoupling the CPU codegen specific pass dependency from the generic HAL pipeline) to remove IREE::HAL::DeviceTargetAttr::lookupExecutableTargets as any whole-program activity must instead look at the targets assigned to hal.executables as part of MaterializeInterfaces or at the device target of each dispatch into an executable - there is no longer the concept of a global device.