### PR TITLE
Making MaterializeInterfaces anchor on dispatch site device targets.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -5,12 +5,11 @@
 module attributes {hal.device.targets = [
   #hal.device.target<"llvm-cpu", {
     executable_targets = [
-      #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64">,
-      #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
+      #hal.executable.target<"llvm-cpu", "arm_64">,
+      #hal.executable.target<"llvm-cpu", "x86_64">
     ]
   }>
 ]} {
-
   // CHECK: #pipeline_layout = #hal.pipeline.layout<
   // CHECK-SAME: push_constants = 1
   // CHECK-SAME: sets = [
@@ -19,8 +18,8 @@ module attributes {hal.device.targets = [
   // CHECK-SAME:     <1, storage_buffer, ReadOnly>
   // CHECK-SAME:     <2, storage_buffer>
 
-  // CHECK: hal.executable private @ex_workgroups
-  // CHECK:   hal.executable.variant public @embedded_elf_arm_64 target(#executable_target_embedded_elf_arm_64
+  // CHECK: hal.executable private @ex
+  // CHECK:   hal.executable.variant public @arm_64 target(#executable_target_arm_64
   // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout)
   // CHECK-SAME:   hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]
   // CHECK-NEXT: ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
@@ -29,7 +28,7 @@ module attributes {hal.device.targets = [
   // CHECK:     builtin.module
   // CHECK-NEXT:  func.func private @extern_func()
   // CHECK-NEXT:  func.func @entry
-  // CHECK:   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64
+  // CHECK:   hal.executable.variant public @x86_64 target(#executable_target_x86_64
   // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout)
   // CHECK-SAME:   hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]
   // CHECK-NEXT: ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
@@ -37,9 +36,9 @@ module attributes {hal.device.targets = [
   // CHECK-NEXT: }
   // CHECK:     builtin.module
   // CHECK-NEXT:  func.func private @extern_func()
-  // CHECK-NEXT:  func.func @entry
 
-  stream.executable private @ex_workgroups {
+  // CHECK-NEXT:  func.func @entry
+  stream.executable private @ex {
     stream.executable.export public @entry workgroups(%arg0: index, %arg1: index) -> (index, index, index) {
       stream.return %arg0, %arg1, %arg0 : index, index, index
     }
@@ -56,8 +55,10 @@ module attributes {hal.device.targets = [
     %c2 = arith.constant 2 : index
     %0 = stream.resource.alloc uninitialized : !stream.resource<transient>{%arg2}
     %1 = stream.cmd.execute with(%arg0 as %arg4: !stream.resource<constant>{%arg2}, %arg1 as %arg5: !stream.resource<transient>{%arg2}, %0 as %arg6: !stream.resource<transient>{%arg2}) {
-      // CHECK: stream.cmd.dispatch {@ex_workgroups::@embedded_elf_arm_64::@entry, @ex_workgroups::@embedded_elf_x86_64::@entry}
-      stream.cmd.dispatch @ex_workgroups::@entry[%c1, %c2](%arg3 : i32) {
+      // CHECK: stream.cmd.dispatch
+      // CHECK-SAME: @ex::@arm_64::@entry
+      // CHECK-SAME: @ex::@x86_64::@entry
+      stream.cmd.dispatch @ex::@entry[%c1, %c2](%arg3 : i32) {
         ro %arg4[%c0 for %arg2] : !stream.resource<constant>{%arg2},
         ro %arg5[%c0 for %arg2] : !stream.resource<transient>{%arg2},
         wo %arg6[%c0 for %arg2] : !stream.resource<transient>{%arg2}
@@ -70,56 +71,204 @@ module attributes {hal.device.targets = [
 
 // -----
 
+// Tests that executable variants are expanded based on what devices they are
+// dispatched on.
+
+module attributes {
+  // The default device when none is specified.
+  // Functions and scopes can override the target device.
+  hal.device.targets = [
+    #hal.device.target<"cpu", {
+      executable_targets = [
+        #hal.executable.target<"llvm-cpu", "arm_64">,
+        #hal.executable.target<"llvm-cpu", "x86_64">
+      ]
+    }>
+  ]
+} {
+  // CHECK: hal.executable private @ex
+  // CHECK:   hal.executable.variant public @arm_64
+  // CHECK:   hal.executable.variant public @riscv_32
+  // CHECK:   hal.executable.variant public @x86_64
+  stream.executable private @ex {
+    stream.executable.export public @entry workgroups() -> (index, index, index) {
+      %c1 = arith.constant 1 : index
+      stream.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      func.func @entry(%arg0: !stream.binding {stream.alignment = 64 : index}) {
+        return
+      }
+    }
+  }
+  // This function uses the default HAL device targeting arm_64 and x86_64.
+  // CHECK-LABEL: @using_default
+  util.func public @using_default(%arg0: !stream.resource<transient>, %arg1: index) -> !stream.timepoint {
+    %c0 = arith.constant 0 : index
+    %0 = stream.cmd.execute with(%arg0 as %arg2: !stream.resource<transient>{%arg1}) {
+      // CHECK: stream.cmd.dispatch
+      // CHECK-SAME: @ex::@arm_64::@entry
+      // CHECK-NOT: @ex::@riscv_32::@entry
+      // CHECK-SAME: @ex::@x86_64::@entry
+      stream.cmd.dispatch @ex::@entry {
+        rw %arg2[%c0 for %arg1] : !stream.resource<transient>{%arg1}
+      }
+    } => !stream.timepoint
+    util.return %0 : !stream.timepoint
+  }
+  // This function is specialized to only run on only riscv_32 and should
+  // not get assigned the arm_64/x86_64 variant entry points.
+  // CHECK-LABEL: @using_specialized
+  util.func public @using_specialized(%arg0: !stream.resource<transient>, %arg1: index) -> !stream.timepoint attributes {
+    hal.device.targets = [
+      #hal.device.target<"cpu", {
+        executable_targets = [
+          #hal.executable.target<"llvm-cpu", "riscv_32">
+        ]
+      }>
+    ]
+  } {
+    %c0 = arith.constant 0 : index
+    %0 = stream.cmd.execute with(%arg0 as %arg2: !stream.resource<transient>{%arg1}) {
+      // CHECK: stream.cmd.dispatch
+      // CHECK-NOT: @ex::@arm_64::@entry
+      // CHECK-SAME: @ex::@riscv_32::@entry
+      // CHECK-NOT: @ex::@x86_64::@entry
+      stream.cmd.dispatch @ex::@entry {
+        rw %arg2[%c0 for %arg1] : !stream.resource<transient>{%arg1}
+      }
+    } => !stream.timepoint
+    util.return %0 : !stream.timepoint
+  }
+}
+
+// -----
+
 // Tests an already-specified executable source op is expanded into the variants
 // specified by the target configuration. These source executables may come from
 // hand-authored code or other dialects that perform interface assignment
 // themselves.
 
-module attributes {hal.device.targets = [
-  #hal.device.target<"llvm-cpu", {
-    executable_targets = [
-      #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64">,
-      #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
-    ]
-  }>
-]} {
-
-hal.executable.source public @ex {
-  hal.executable.export public @entry layout(#hal.pipeline.layout<push_constants = 1, sets = [
-    #hal.descriptor_set.layout<0, bindings = [
-      #hal.descriptor_set.binding<0, storage_buffer>
-    ]>,
-    #hal.descriptor_set.layout<1, bindings = [
-      #hal.descriptor_set.binding<0, storage_buffer>,
-      #hal.descriptor_set.binding<1, storage_buffer>
-    ]>
-  ]>)
-  builtin.module {
-    func.func @entry() {
-      %const0 = hal.interface.constant.load[0] : index
-      %const1 = hal.interface.constant.load[1] : index
-      %s0b0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32) offset(%const0) : !flow.dispatch.tensor<readonly:tensor<4xf32>>
-      %s1b0 = hal.interface.binding.subspan set(1) binding(0) type(storage_buffer) alignment(32) offset(%const1) : !flow.dispatch.tensor<readonly:tensor<4xf32>>
-      %s1b1 = hal.interface.binding.subspan set(1) binding(1) type(storage_buffer) alignment(16) : !flow.dispatch.tensor<writeonly:tensor<4xf32>>
-      %workgroup_size_x = hal.interface.workgroup.size[0] : index
-      %workgroup_id_x = hal.interface.workgroup.id[0] : index
-      %workgroup_count_x = hal.interface.workgroup.count[0] : index
-      return
+module attributes {
+  // The default device when none is specified.
+  // Functions and scopes can override the target device.
+  hal.device.targets = [
+    #hal.device.target<"cpu", {
+      executable_targets = [
+        #hal.executable.target<"llvm-cpu", "arm_64">,
+        #hal.executable.target<"llvm-cpu", "x86_64">
+      ]
+    }>
+  ]
+} {
+  // CHECK: hal.executable private @ex
+  // CHECK:   hal.executable.variant public @arm_64
+  // CHECK:   hal.executable.variant public @riscv_32
+  // CHECK:   hal.executable.variant public @x86_64
+  hal.executable.source private @ex {
+    hal.executable.export public @entry layout(#hal.pipeline.layout<push_constants = 0, sets = [
+      #hal.descriptor_set.layout<0, bindings = [
+        #hal.descriptor_set.binding<0, storage_buffer>
+      ]>
+    ]>)
+    builtin.module {
+      func.func @entry() {
+        return
+      }
     }
+  }
+  // This function uses the default HAL device targeting arm_64 and x86_64.
+  // CHECK-LABEL: @using_default
+  util.func public @using_default(%arg0: !stream.resource<transient>, %arg1: index) -> !stream.timepoint {
+    %c0 = arith.constant 0 : index
+    %0 = stream.cmd.execute with(%arg0 as %arg2: !stream.resource<transient>{%arg1}) {
+      // CHECK: stream.cmd.dispatch
+      // CHECK-SAME: @ex::@arm_64::@entry
+      // CHECK-NOT: @ex::@riscv_32::@entry
+      // CHECK-SAME: @ex::@x86_64::@entry
+      stream.cmd.dispatch @ex::@entry {
+        rw %arg2[%c0 for %arg1] : !stream.resource<transient>{%arg1}
+      }
+    } => !stream.timepoint
+    util.return %0 : !stream.timepoint
+  }
+  // This function is specialized to only run on only riscv_32 and should
+  // not get assigned the arm_64/x86_64 variant entry points.
+  // CHECK-LABEL: @using_specialized
+  util.func public @using_specialized(%arg0: !stream.resource<transient>, %arg1: index) -> !stream.timepoint attributes {
+    hal.device.targets = [
+      #hal.device.target<"cpu", {
+        executable_targets = [
+          #hal.executable.target<"llvm-cpu", "riscv_32">
+        ]
+      }>
+    ]
+  } {
+    %c0 = arith.constant 0 : index
+    %0 = stream.cmd.execute with(%arg0 as %arg2: !stream.resource<transient>{%arg1}) {
+      // CHECK: stream.cmd.dispatch
+      // CHECK-NOT: @ex::@arm_64::@entry
+      // CHECK-SAME: @ex::@riscv_32::@entry
+      // CHECK-NOT: @ex::@x86_64::@entry
+      stream.cmd.dispatch @ex::@entry {
+        rw %arg2[%c0 for %arg1] : !stream.resource<transient>{%arg1}
+      }
+    } => !stream.timepoint
+    util.return %0 : !stream.timepoint
   }
 }
 
-// CHECK: hal.executable public @ex
-// CHECK:   hal.executable.variant public @embedded_elf_arm_64 target(#executable_target_embedded_elf_arm_64
-// CHECK:     hal.executable.export public @entry layout(#pipeline_layout)
-// CHECK:     builtin.module
-// CHECK-NEXT:  func.func @entry()
-// CHECK:   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64
-// CHECK:     hal.executable.export public @entry layout(#pipeline_layout)
-// CHECK:     builtin.module
-// CHECK-NEXT:  func.func @entry()
+// -----
 
-// TODO(benvanik): test fixup of stream ops when attrs to specify the
-// layout bindings are implemented.
+// Tests that a hal.executable.source op gets expanded to all default targets
+// when it's public in addition to any ones from dispatch sites.
 
+module attributes {
+  hal.device.targets = [
+    #hal.device.target<"cpu", {
+      executable_targets = [
+        #hal.executable.target<"llvm-cpu", "arm_64">,
+        #hal.executable.target<"llvm-cpu", "x86_64">
+      ]
+    }>
+  ]
+} {
+  // CHECK: hal.executable public @ex
+  // CHECK:   hal.executable.variant public @arm_64
+  // CHECK:   hal.executable.variant public @riscv_32
+  // CHECK:   hal.executable.variant public @x86_64
+  hal.executable.source public @ex {
+    hal.executable.export public @entry layout(#hal.pipeline.layout<push_constants = 0, sets = [
+      #hal.descriptor_set.layout<0, bindings = [
+        #hal.descriptor_set.binding<0, storage_buffer>
+      ]>
+    ]>)
+    builtin.module {
+      func.func @entry() {
+        return
+      }
+    }
+  }
+  // CHECK-LABEL: @using_specialized
+  util.func public @using_specialized(%arg0: !stream.resource<transient>, %arg1: index) -> !stream.timepoint attributes {
+    hal.device.targets = [
+      #hal.device.target<"cpu", {
+        executable_targets = [
+          #hal.executable.target<"llvm-cpu", "riscv_32">
+        ]
+      }>
+    ]
+  } {
+    %c0 = arith.constant 0 : index
+    %0 = stream.cmd.execute with(%arg0 as %arg2: !stream.resource<transient>{%arg1}) {
+      // CHECK: stream.cmd.dispatch
+      // CHECK-NOT: @ex::@arm_64::@entry
+      // CHECK-SAME: @ex::@riscv_32::@entry
+      // CHECK-NOT: @ex::@x86_64::@entry
+      stream.cmd.dispatch @ex::@entry {
+        rw %arg2[%c0 for %arg1] : !stream.resource<transient>{%arg1}
+      }
+    } => !stream.timepoint
+    util.return %0 : !stream.timepoint
+  }
 }


### PR DESCRIPTION
Now which executable targets are selected for materialization is derived from the dispatch sites for exports in the source executables. This allows us to join all required targets for a particular export for compilation while keeping each dispatch site referencing only the targets it may dispatch.

To support easier testing and direct HAL executable compilation any `hal.executable.source` or `stream.executable` that is public will take all targets specified on the module in addition to any from dispatch sites. In all normal programs the executables should be private and only use the dispatch sites to determine their targets.