### PR TITLE
Change ukernels calling convention to default

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
@@ -27,11 +27,11 @@ func.func @mmt4d_f32f32f32(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -110,11 +110,11 @@ func.func @mmt4d_fill(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>, 
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -144,11 +144,11 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -178,11 +178,11 @@ func.func @mmt4d_i16i16i32(%arg0 : tensor<?x?x?x?xi16>, %arg1 : tensor<?x?x?x?xi
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -212,11 +212,11 @@ func.func @mmt4d_i16i8i32(%arg0 : tensor<?x?x?x?xi16>, %arg1 : tensor<?x?x?x?xi8
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -246,11 +246,11 @@ func.func @mmt4d_f16f16f32(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -280,11 +280,11 @@ func.func @mmt4d_f16f16f16(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 //      NOSKIPROUND: func @mmt4d_f16f16f16(
 // NOSKIPROUND-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
@@ -304,11 +304,11 @@ func.func @mmt4d_f16f16f16(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 //  NOSKIPROUND-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  NOSKIPROUND-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  NOSKIPROUND-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      NOSKIPROUND:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      NOSKIPROUND:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // NOSKIPROUND-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // NOSKIPROUND-SAME:       outs(%[[ARG2]] :
 // NOSKIPROUND-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      NOSKIPROUND:   return %[[MICRO_KERNEL]]
+//      NOSKIPROUND:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -338,11 +338,11 @@ func.func @mmt4d_bf16bf16f32(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?x
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -372,11 +372,11 @@ func.func @mmt4d_bf16bf16bf16(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -699,11 +699,11 @@ func.func @mmt4d_i8i8i32_extend_producers(%arg0: tensor<?x?x?x?xi8>, %arg1: tens
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0
 
 // -----
 
@@ -761,8 +761,8 @@ func.func @mmt4d_i16u4i32_extend_producers(%arg0: tensor<?x?x?x?xi16>, %arg1: te
 //  CHECK-DAG:   %[[N0:.+]] = arith.index_cast %[[N0_index]] : index to i32
 //  CHECK-DAG:   %[[K0_index:.+]] = tensor.dim %[[ARG1]], %[[C3]]
 //  CHECK-DAG:   %[[K0:.+]] = arith.index_cast %[[K0_index]] : index to i32
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "iree_uk_mmt4d"
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_mmt4d"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[M]], %[[N]], %[[K]], %[[M0]], %[[N0]], %[[K0]], %[[FLAGS]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+//      CHECK:   return %[[MICRO_KERNEL]]#0

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -115,17 +115,44 @@ static bool iree_uk_mmt4d_early(const iree_uk_mmt4d_params_t* params) {
   return false;
 }
 
-IREE_UK_EXPORT int iree_uk_mmt4d(const iree_uk_mmt4d_params_t* params) {
+void iree_uk_mmt4d_p(const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_validate(params);
 
   // Maybe handle this mmt4d "early", without needing to select a tile_func.
   // Typical cases include trivial cases (e.g. when params->K == 0) and hardware
   // targets that want to handle the entire loop nest in target-specific code.
-  if (iree_uk_mmt4d_early(params)) return 0;
+  if (iree_uk_mmt4d_early(params)) return;
 
   // Select a target-specific tile_func (inner loop on K, computing one M0xN0
   // tile) and use that with generic outer loops.
   iree_uk_mmt4d_tile_func_t tile_func = iree_uk_mmt4d_select_tile_func(params);
   iree_uk_mmt4d_using_tile_func(params, tile_func);
-  return 0;
+}
+
+IREE_UK_EXPORT void iree_uk_mmt4d(
+    const void* lhs_buffer, iree_uk_index_t lhs_offset,
+    iree_uk_index_t lhs_stride0, const void* rhs_buffer,
+    iree_uk_index_t rhs_offset, iree_uk_index_t rhs_stride0, void* out_buffer,
+    iree_uk_index_t out_offset, iree_uk_index_t out_stride0, iree_uk_index_t M,
+    iree_uk_index_t N, iree_uk_index_t K, iree_uk_int32_t M0,
+    iree_uk_int32_t N0, iree_uk_int32_t K0, iree_uk_uint32_t flags,
+    const iree_uk_uint64_t* cpu_data) {
+  iree_uk_mmt4d_params_t params = {.lhs_buffer = lhs_buffer,
+                                   .lhs_offset = lhs_offset,
+                                   .lhs_stride0 = lhs_stride0,
+                                   .rhs_buffer = rhs_buffer,
+                                   .rhs_offset = rhs_offset,
+                                   .rhs_stride0 = rhs_stride0,
+                                   .out_buffer = out_buffer,
+                                   .out_offset = out_offset,
+                                   .out_stride0 = out_stride0,
+                                   .M = M,
+                                   .N = N,
+                                   .K = K,
+                                   .M0 = M0,
+                                   .N0 = N0,
+                                   .K0 = K0,
+                                   .flags = flags,
+                                   .cpu_data = cpu_data};
+  iree_uk_mmt4d_p(&params);
 }

--- a/runtime/src/iree/builtins/ukernel/mmt4d.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.h
@@ -11,27 +11,13 @@
 
 // `mmt4d` microkernel. Used on LLVMCPU (as well as VMVX), due to difficulty of
 // code generation of matrix multiplications kernels.
-
-typedef struct iree_uk_mmt4d_params_t {
-  const void* lhs_buffer;
-  iree_uk_index_t lhs_offset;
-  iree_uk_index_t lhs_stride0;
-  const void* rhs_buffer;
-  iree_uk_index_t rhs_offset;
-  iree_uk_index_t rhs_stride0;
-  void* out_buffer;
-  iree_uk_index_t out_offset;
-  iree_uk_index_t out_stride0;
-  iree_uk_index_t M;
-  iree_uk_index_t N;
-  iree_uk_index_t K;
-  iree_uk_int32_t M0;
-  iree_uk_int32_t N0;
-  iree_uk_int32_t K0;
-  iree_uk_uint32_t flags;
-  const iree_uk_uint64_t* cpu_data;
-} iree_uk_mmt4d_params_t;
-
-IREE_UK_EXPORT int iree_uk_mmt4d(const iree_uk_mmt4d_params_t* params);
+IREE_UK_EXPORT void iree_uk_mmt4d(
+    const void* lhs_buffer, iree_uk_index_t lhs_offset,
+    iree_uk_index_t lhs_stride0, const void* rhs_buffer,
+    iree_uk_index_t rhs_offset, iree_uk_index_t rhs_stride0, void* out_buffer,
+    iree_uk_index_t out_offset, iree_uk_index_t out_stride0, iree_uk_index_t M,
+    iree_uk_index_t N, iree_uk_index_t K, iree_uk_int32_t M0,
+    iree_uk_int32_t N0, iree_uk_int32_t K0, iree_uk_uint32_t flags,
+    const iree_uk_uint64_t* cpu_data);
 
 #endif  // IREE_BUILTINS_UKERNEL_MMT4D_H_

--- a/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
@@ -9,6 +9,31 @@
 
 #include "iree/builtins/ukernel/mmt4d.h"
 
+// While the iree_uk_mmt4d public entry point takes separate parameters,
+// internally the implementation functions pass parameters as this struct.
+typedef struct iree_uk_mmt4d_params_t {
+  const void* lhs_buffer;
+  iree_uk_index_t lhs_offset;
+  iree_uk_index_t lhs_stride0;
+  const void* rhs_buffer;
+  iree_uk_index_t rhs_offset;
+  iree_uk_index_t rhs_stride0;
+  void* out_buffer;
+  iree_uk_index_t out_offset;
+  iree_uk_index_t out_stride0;
+  iree_uk_index_t M;
+  iree_uk_index_t N;
+  iree_uk_index_t K;
+  iree_uk_int32_t M0;
+  iree_uk_int32_t N0;
+  iree_uk_int32_t K0;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_mmt4d_params_t;
+
+// Same as the iree_uk_mmt4d public entry point, but taking the struct.
+void iree_uk_mmt4d_p(const iree_uk_mmt4d_params_t* params);
+
 typedef enum iree_uk_mmt4d_type_t {
   iree_uk_mmt4d_type_f32f32f32 =
       IREE_UK_TIE_3_TYPES_LITERAL(FLOAT_32, FLOAT_32, FLOAT_32),

--- a/runtime/src/iree/builtins/ukernel/pack.c
+++ b/runtime/src/iree/builtins/ukernel/pack.c
@@ -252,13 +252,38 @@ static void iree_uk_pack_using_tile_func(const iree_uk_pack_params_t* params,
   }
 }
 
-IREE_UK_EXPORT int iree_uk_pack(const iree_uk_pack_params_t* params) {
+void iree_uk_pack_p(const iree_uk_pack_params_t* params) {
   iree_uk_pack_validate(params);
 
-  if (iree_uk_pack_early(params)) return 0;
+  if (iree_uk_pack_early(params)) return;
 
   // Select a target-specific tile_func and use that with generic outer loops.
   iree_uk_pack_tile_func_t tile_func = iree_uk_pack_select_tile_func(params);
   iree_uk_pack_using_tile_func(params, tile_func);
-  return 0;
+}
+
+IREE_UK_EXPORT void iree_uk_pack(
+    const void* in_buffer, iree_uk_index_t in_offset,
+    iree_uk_index_t in_stride0, void* out_buffer, iree_uk_index_t out_offset,
+    iree_uk_index_t out_stride0, iree_uk_index_t in_size0,
+    iree_uk_index_t in_size1, iree_uk_index_t out_size0,
+    iree_uk_index_t out_size1, iree_uk_index_t out_size2,
+    iree_uk_index_t out_size3, iree_uk_uint64_t padding_value,
+    iree_uk_uint32_t flags, const iree_uk_uint64_t* cpu_data) {
+  iree_uk_pack_params_t params = {.in_buffer = in_buffer,
+                                  .in_offset = in_offset,
+                                  .in_stride0 = in_stride0,
+                                  .out_buffer = out_buffer,
+                                  .out_offset = out_offset,
+                                  .out_stride0 = out_stride0,
+                                  .in_size0 = in_size0,
+                                  .in_size1 = in_size1,
+                                  .out_size0 = out_size0,
+                                  .out_size1 = out_size1,
+                                  .out_size2 = out_size2,
+                                  .out_size3 = out_size3,
+                                  .padding_value = padding_value,
+                                  .flags = flags,
+                                  .cpu_data = cpu_data};
+  iree_uk_pack_p(&params);
 }

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -13,34 +13,23 @@
 // LLVMCPU backend, because codegen is thought to be good enough and because
 // fusions really matter here.
 
-typedef struct iree_uk_pack_params_t {
-  const void* in_buffer;
-  iree_uk_index_t in_offset;
-  iree_uk_index_t in_stride0;
-  void* out_buffer;
-  iree_uk_index_t out_offset;
-  iree_uk_index_t out_stride0;
-  iree_uk_index_t in_size0;
-  iree_uk_index_t in_size1;
-  iree_uk_index_t out_size0;
-  iree_uk_index_t out_size1;
-  iree_uk_index_t out_size2;
-  iree_uk_index_t out_size3;
-  // The least significant bits of `padding_value`, up to element size, are used
-  // for padding. As this is based solely on bit-significance and not on byte
-  // addresses, this is independent of endianness.
-  //
-  // If the element size is less than 64 bits then the most significant bits
-  // (above element size) are unused.
-  //
-  // If the element size is more than 64 bits then only repeating 64-bit
-  // patterns are supported for padding. This covers most cases as floating
-  // point types encode zero as zero bits.
-  iree_uk_uint64_t padding_value;
-  iree_uk_uint32_t flags;
-  const iree_uk_uint64_t* cpu_data;
-} iree_uk_pack_params_t;
-
-IREE_UK_EXPORT int iree_uk_pack(const iree_uk_pack_params_t* params);
+// The least significant bits of `padding_value`, up to element size, are used
+// for padding. As this is based solely on bit-significance and not on byte
+// addresses, this is independent of endianness.
+//
+// If the element size is less than 64 bits then the most significant bits
+// (above element size) are unused.
+//
+// If the element size is more than 64 bits then only repeating 64-bit
+// patterns are supported for padding. This covers most cases as floating
+// point types encode zero as zero bits.
+IREE_UK_EXPORT void iree_uk_pack(
+    const void* in_buffer, iree_uk_index_t in_offset,
+    iree_uk_index_t in_stride0, void* out_buffer, iree_uk_index_t out_offset,
+    iree_uk_index_t out_stride0, iree_uk_index_t in_size0,
+    iree_uk_index_t in_size1, iree_uk_index_t out_size0,
+    iree_uk_index_t out_size1, iree_uk_index_t out_size2,
+    iree_uk_index_t out_size3, iree_uk_uint64_t padding_value,
+    iree_uk_uint32_t flags, const iree_uk_uint64_t* cpu_data);
 
 #endif  // IREE_BUILTINS_UKERNEL_PACK_H_

--- a/runtime/src/iree/builtins/ukernel/pack_internal.h
+++ b/runtime/src/iree/builtins/ukernel/pack_internal.h
@@ -9,6 +9,26 @@
 
 #include "iree/builtins/ukernel/pack.h"
 
+typedef struct iree_uk_pack_params_t {
+  const void* in_buffer;
+  iree_uk_index_t in_offset;
+  iree_uk_index_t in_stride0;
+  void* out_buffer;
+  iree_uk_index_t out_offset;
+  iree_uk_index_t out_stride0;
+  iree_uk_index_t in_size0;
+  iree_uk_index_t in_size1;
+  iree_uk_index_t out_size0;
+  iree_uk_index_t out_size1;
+  iree_uk_index_t out_size2;
+  iree_uk_index_t out_size3;
+  iree_uk_uint64_t padding_value;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_pack_params_t;
+
+void iree_uk_pack_p(const iree_uk_pack_params_t* params);
+
 typedef enum iree_uk_pack_type_t {
   iree_uk_pack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
   iree_uk_pack_type_i8i8 = IREE_UK_TIE_2_TYPES_LITERAL(INT_8, INT_8),

--- a/runtime/src/iree/builtins/ukernel/query_tile_sizes.c
+++ b/runtime/src/iree/builtins/ukernel/query_tile_sizes.c
@@ -62,7 +62,7 @@ static void iree_uk_query_tile_sizes_2d_matmul(
   }
 }
 
-IREE_UK_EXPORT int iree_uk_query_tile_sizes_2d(
+IREE_UK_EXPORT void iree_uk_query_tile_sizes_2d(
     const iree_uk_query_tile_sizes_2d_params_t* params,
     iree_uk_query_tile_sizes_2d_out_params_t* out_params) {
   iree_uk_query_tile_sizes_2d_validate(params);
@@ -72,5 +72,4 @@ IREE_UK_EXPORT int iree_uk_query_tile_sizes_2d(
   } else {
     // Shouldn't happen, validated earlier.
   }
-  return 0;
 }

--- a/runtime/src/iree/builtins/ukernel/query_tile_sizes.h
+++ b/runtime/src/iree/builtins/ukernel/query_tile_sizes.h
@@ -26,7 +26,7 @@ typedef struct iree_uk_query_tile_sizes_2d_out_params_t {
   iree_uk_index_t tile_size1;
 } iree_uk_query_tile_sizes_2d_out_params_t;
 
-IREE_UK_EXPORT int iree_uk_query_tile_sizes_2d(
+IREE_UK_EXPORT void iree_uk_query_tile_sizes_2d(
     const iree_uk_query_tile_sizes_2d_params_t* params,
     iree_uk_query_tile_sizes_2d_out_params_t* out_params);
 

--- a/runtime/src/iree/builtins/ukernel/tools/e2e_matmul_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/e2e_matmul_benchmark.c
@@ -10,8 +10,10 @@
 #include "iree/base/internal/flags.h"
 #include "iree/builtins/ukernel/api.h"
 #include "iree/builtins/ukernel/mmt4d_internal.h"
+#include "iree/builtins/ukernel/pack_internal.h"
 #include "iree/builtins/ukernel/tools/benchmark.h"
 #include "iree/builtins/ukernel/tools/util.h"
+#include "iree/builtins/ukernel/unpack_internal.h"
 
 IREE_FLAG(string, type, "f32f32f32",
           "Element types triple (LHS, RHS, OUT). Valid values include: "
@@ -174,13 +176,13 @@ static void iree_uk_e2e_matmul(
     const iree_uk_pack_params_t* pack_out_params,
     const iree_uk_mmt4d_params_t* mmt4d_params,
     const iree_uk_unpack_params_t* unpack_out_params) {
-  iree_uk_pack(pack_lhs_params);
-  iree_uk_pack(pack_rhs_params);
+  iree_uk_pack_p(pack_lhs_params);
+  iree_uk_pack_p(pack_rhs_params);
   if (mmt4d_params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    iree_uk_pack(pack_out_params);
+    iree_uk_pack_p(pack_out_params);
   }
-  iree_uk_mmt4d(mmt4d_params);
-  iree_uk_unpack(unpack_out_params);
+  iree_uk_mmt4d_p(mmt4d_params);
+  iree_uk_unpack_p(unpack_out_params);
 }
 
 static iree_status_t iree_uk_benchmark_e2e_matmul(

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -71,7 +71,7 @@ static iree_status_t iree_uk_benchmark_mmt4d(
   int64_t batch_count = 1;
   while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
     for (int i = 0; i < batch_count; ++i) {
-      iree_uk_mmt4d(&params);
+      iree_uk_mmt4d_p(&params);
     }
     total_iterations += batch_count;
     batch_count *= 2;

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.c
@@ -426,7 +426,7 @@ static void iree_uk_test_mmt4d_for_shape_params(
                                   << iree_uk_type_bit_count_log2(out_type));
 
   iree_mmt4d_reference(&reference_params);
-  iree_uk_mmt4d(&actual_params);
+  iree_uk_mmt4d_p(&actual_params);
 
   // For now we use exact comparisons, even for float, even though the reference
   // code accumulates in a different order compared to the actual code. This

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -85,7 +85,7 @@ static iree_status_t iree_uk_benchmark_pack(
   int64_t batch_count = 1;
   while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
     for (int i = 0; i < batch_count; ++i) {
-      iree_uk_pack(&params);
+      iree_uk_pack_p(&params);
     }
     total_iterations += batch_count;
     batch_count *= 2;

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.c
@@ -110,7 +110,7 @@ static void iree_uk_test_pack_for_shape_params(
                              (params.out_offset * iree_uk_type_size(out_type));
 
   iree_pack_reference(&reference_params);
-  iree_uk_pack(&actual_params);
+  iree_uk_pack_p(&actual_params);
 
   if (memcmp(actual_out_buffer, reference_out_buffer, out_buffer_size)) {
     IREE_UK_TEST_FAIL(test);

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -84,7 +84,7 @@ static iree_status_t iree_uk_benchmark_unpack(
   int64_t batch_count = 1;
   while (iree_benchmark_keep_running(benchmark_state, batch_count)) {
     for (int i = 0; i < batch_count; ++i) {
-      iree_uk_unpack(&params);
+      iree_uk_unpack_p(&params);
     }
     total_iterations += batch_count;
     batch_count *= 2;

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.c
@@ -98,7 +98,7 @@ static void iree_uk_test_unpack_for_shape_params(
                              (params.out_offset * iree_uk_type_size(out_type));
 
   iree_unpack_reference(&reference_params);
-  iree_uk_unpack(&actual_params);
+  iree_uk_unpack_p(&actual_params);
 
   if (!iree_uk_2d_buffers_equal(actual_out_buffer, reference_out_buffer,
                                 out_type, params.out_size0, params.out_size1,

--- a/runtime/src/iree/builtins/ukernel/unpack.c
+++ b/runtime/src/iree/builtins/ukernel/unpack.c
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/builtins/ukernel/unpack.h"
+
 #include "iree/builtins/ukernel/unpack_internal.h"
 
 enum { iree_uk_unpack_tmp_buf_size = 4096 };
@@ -192,13 +194,37 @@ static void iree_uk_unpack_using_tile_func(
   }
 }
 
-IREE_UK_EXPORT int iree_uk_unpack(const iree_uk_unpack_params_t* params) {
+void iree_uk_unpack_p(const iree_uk_unpack_params_t* params) {
   iree_uk_unpack_validate(params);
 
-  if (iree_uk_unpack_early(params)) return 0;
+  if (iree_uk_unpack_early(params)) return;
 
   // Select a target-specific tile_func and use that with generic outer loops.
   iree_uk_unpack_tile_func_t func = iree_uk_unpack_select_tile_func(params);
   iree_uk_unpack_using_tile_func(params, func);
-  return 0;
+}
+
+IREE_UK_EXPORT void iree_uk_unpack(
+    const void* in_buffer, iree_uk_index_t in_offset,
+    iree_uk_index_t in_stride0, void* out_buffer, iree_uk_index_t out_offset,
+    iree_uk_index_t out_stride0, iree_uk_index_t in_size0,
+    iree_uk_index_t in_size1, iree_uk_index_t in_size2,
+    iree_uk_index_t in_size3, iree_uk_index_t out_size0,
+    iree_uk_index_t out_size1, iree_uk_uint32_t flags,
+    const iree_uk_uint64_t* cpu_data) {
+  iree_uk_unpack_params_t params = {.in_buffer = in_buffer,
+                                    .in_offset = in_offset,
+                                    .in_stride0 = in_stride0,
+                                    .out_buffer = out_buffer,
+                                    .out_offset = out_offset,
+                                    .out_stride0 = out_stride0,
+                                    .in_size0 = in_size0,
+                                    .in_size1 = in_size1,
+                                    .in_size2 = in_size2,
+                                    .in_size3 = in_size3,
+                                    .out_size0 = out_size0,
+                                    .out_size1 = out_size1,
+                                    .flags = flags,
+                                    .cpu_data = cpu_data};
+  iree_uk_unpack_p(&params);
 }

--- a/runtime/src/iree/builtins/ukernel/unpack.h
+++ b/runtime/src/iree/builtins/ukernel/unpack.h
@@ -14,23 +14,13 @@
 // pack ops tend to get fused with many other ops, with substantial performance
 // benefit outweighing the microkernel advantage.
 
-typedef struct iree_uk_unpack_params_t {
-  const void* in_buffer;
-  iree_uk_index_t in_offset;
-  iree_uk_index_t in_stride0;
-  void* out_buffer;
-  iree_uk_index_t out_offset;
-  iree_uk_index_t out_stride0;
-  iree_uk_index_t in_size0;
-  iree_uk_index_t in_size1;
-  iree_uk_index_t in_size2;
-  iree_uk_index_t in_size3;
-  iree_uk_index_t out_size0;
-  iree_uk_index_t out_size1;
-  iree_uk_uint32_t flags;
-  const iree_uk_uint64_t* cpu_data;
-} iree_uk_unpack_params_t;
-
-IREE_UK_EXPORT int iree_uk_unpack(const iree_uk_unpack_params_t* params);
+IREE_UK_EXPORT void iree_uk_unpack(
+    const void* in_buffer, iree_uk_index_t in_offset,
+    iree_uk_index_t in_stride0, void* out_buffer, iree_uk_index_t out_offset,
+    iree_uk_index_t out_stride0, iree_uk_index_t in_size0,
+    iree_uk_index_t in_size1, iree_uk_index_t in_size2,
+    iree_uk_index_t in_size3, iree_uk_index_t out_size0,
+    iree_uk_index_t out_size1, iree_uk_uint32_t flags,
+    const iree_uk_uint64_t* cpu_data);
 
 #endif  // IREE_BUILTINS_UKERNEL_UNPACK_H_

--- a/runtime/src/iree/builtins/ukernel/unpack_internal.h
+++ b/runtime/src/iree/builtins/ukernel/unpack_internal.h
@@ -9,6 +9,25 @@
 
 #include "iree/builtins/ukernel/unpack.h"
 
+typedef struct iree_uk_unpack_params_t {
+  const void* in_buffer;
+  iree_uk_index_t in_offset;
+  iree_uk_index_t in_stride0;
+  void* out_buffer;
+  iree_uk_index_t out_offset;
+  iree_uk_index_t out_stride0;
+  iree_uk_index_t in_size0;
+  iree_uk_index_t in_size1;
+  iree_uk_index_t in_size2;
+  iree_uk_index_t in_size3;
+  iree_uk_index_t out_size0;
+  iree_uk_index_t out_size1;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_uk_unpack_params_t;
+
+void iree_uk_unpack_p(const iree_uk_unpack_params_t* params);
+
 typedef enum iree_uk_unpack_type_t {
   iree_uk_unpack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
   iree_uk_unpack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -577,23 +577,9 @@ IREE_VMVX_ABI_EXPORT(iree_vmvx_mmt4d, mmt4d, v) {
                            /*stride1=*/1,
                            /*size0=*/M,
                            /*size1=*/N * out_tile_size);
-  iree_uk_mmt4d_params_t ukernel_params = {
-      .flags = args->flags,
-      .lhs_buffer = lhs,
-      .rhs_buffer = rhs,
-      .out_buffer = out,
-      .lhs_stride0 = lhs_stride0,
-      .rhs_stride0 = rhs_stride0,
-      .out_stride0 = out_stride0,
-      .M = M,
-      .N = N,
-      .K = K,
-      .M0 = M0,
-      .N0 = N0,
-      .K0 = K0,
-      .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
-  };
-  iree_uk_mmt4d(&ukernel_params);
+  iree_uk_mmt4d(lhs, 0 /*offsets already accounted for*/, lhs_stride0, rhs, 0,
+                rhs_stride0, out, 0, out_stride0, M, N, K, M0, N0, K0,
+                args->flags, (const iree_uk_uint64_t*)iree_cpu_data_fields());
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
@@ -650,22 +636,10 @@ IREE_VMVX_ABI_EXPORT(iree_vmvx_pack, pack, v) {
                            /*stride1=*/1,
                            /*size0=*/args->out_size0,
                            /*size1=*/args->out_size1 * out_tile_size);
-  iree_uk_pack_params_t ukernel_params = {
-      .in_buffer = in,
-      .out_buffer = out,
-      .in_stride0 = args->in_stride0,
-      .out_stride0 = args->out_stride0,
-      .in_size0 = args->in_size0,
-      .in_size1 = args->in_size1,
-      .out_size0 = args->out_size0,
-      .out_size1 = args->out_size1,
-      .out_size2 = args->out_size2,
-      .out_size3 = args->out_size3,
-      .padding_value = args->padding_value,
-      .flags = args->flags,
-      .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
-  };
-  iree_uk_pack(&ukernel_params);
+  iree_uk_pack(in, 0, args->in_stride0, out, 0, args->out_stride0,
+               args->in_size0, args->in_size1, args->out_size0, args->out_size1,
+               args->out_size2, args->out_size3, args->padding_value,
+               args->flags, (const iree_uk_uint64_t*)iree_cpu_data_fields());
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
@@ -718,21 +692,10 @@ IREE_VMVX_ABI_EXPORT(iree_vmvx_unpack, unpack, v) {
                            /*stride1=*/1,
                            /*size0=*/args->out_size0,
                            /*size1=*/args->out_size1);
-  iree_uk_unpack_params_t ukernel_params = {
-      .in_buffer = in,
-      .out_buffer = out,
-      .in_stride0 = args->in_stride0,
-      .out_stride0 = args->out_stride0,
-      .in_size0 = args->in_size0,
-      .in_size1 = args->in_size1,
-      .in_size2 = args->in_size2,
-      .in_size3 = args->in_size3,
-      .out_size0 = args->out_size0,
-      .out_size1 = args->out_size1,
-      .flags = args->flags,
-      .cpu_data = (const iree_uk_uint64_t*)iree_cpu_data_fields(),
-  };
-  iree_uk_unpack(&ukernel_params);
+  iree_uk_unpack(in, 0, args->in_stride0, out, 0, args->out_stride0,
+                 args->in_size0, args->in_size1, args->in_size2, args->in_size3,
+                 args->out_size0, args->out_size1, args->flags,
+                 (const iree_uk_uint64_t*)iree_cpu_data_fields());
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }


### PR DESCRIPTION
This will be useful to introduce the mmt4d-query ukernel for #15784, as the default calling convention allows for scalar return values. This is also a cleanup in its own right: at this point, ukernels only use ParameterStruct calling convention for historical reasons.