### PR TITLE
[Util] Do not hoist tensor.extract_slice if it is a reshape

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
@@ -25,7 +25,7 @@ iree_lit_test_suite(
             "fold_globals.mlir",
             "fuse_globals.mlir",
             "hoist_into_globals.mlir",
-            "hoist_into_globals_linalg.mlir",
+            "hoist_into_globals_external.mlir",
             "import_resources.mlir",
             "ipo.mlir",
             "outline_constants.mlir",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
@@ -23,7 +23,7 @@ iree_lit_test_suite(
     "fold_globals.mlir"
     "fuse_globals.mlir"
     "hoist_into_globals.mlir"
-    "hoist_into_globals_linalg.mlir"
+    "hoist_into_globals_external.mlir"
     "import_resources.mlir"
     "ipo.mlir"
     "outline_constants.mlir"

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_external.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_external.mlir
@@ -57,3 +57,23 @@ module @broadcast_treated_as_leaf {
   }
   // CHECK-NOT: util.initializer
 }
+
+// -----
+
+// Verifies that extract_slice ops that are just reshapes are not materialized
+// as a leaf.
+// CHECK-LABEL: @extract_slice_treated_as_leaf
+#map0 = affine_map<(d0, d1) -> ()>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+module @extract_slice_treated_as_leaf {
+  // CHECK-NOT: util.global
+  // CHECK: util.func public @main
+  util.func public @main() -> (tensor<2xf32>) {
+    %cst_0 = arith.constant dense<[[0.0, 1.0]]> : tensor<1x2xf32>
+    // CHECK: tensor.extract_slice
+    %0 = tensor.extract_slice %cst_0[0, 0][1, 2][1, 1] : tensor<1x2xf32> to tensor<2xf32>
+    // CHECK: util.return
+    util.return %0 : tensor<2xf32>
+  }
+  // CHECK-NOT: util.initializer
+}


### PR DESCRIPTION
extract_slice ops that only reduce rank should not be hoisted into an
initializer for the same reason as a reshape as it is just a metadata
change.