### PR TITLE
Revert "[LinalgExt] Do not decompose attention op with manual analysis."

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -100,8 +100,9 @@ static void addTileAndDistributePasses(OpPassManager &pm) {
       createFuseTensorPadWithConsumerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createConcretizePadResultShapePass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      IREE::LinalgExt::createTileAndDecomposeAttentionPass());
+  // TODO(#16421): Disable decomposition due to failure in bufferization.
+  // nestedModulePM.addNestedPass<func::FuncOp>(
+  //     IREE::LinalgExt::createTileAndDecomposeAttentionPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       IREE::LinalgExt::createTileAndDecomposeWinogradTransformPass());
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -113,8 +113,9 @@ tileAndDistributeToWorkgroup(OpPassManager &pm,
   nestedModulePM.addNestedPass<func::FuncOp>(
       createConvertToDestinationPassingStylePass(
           useWARForCooperativeMatrixCodegen));
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      IREE::LinalgExt::createTileAndDecomposeAttentionPass());
+  // TODO(#16421): Disable decomposition due to failure in bufferization.
+  // nestedModulePM.addNestedPass<func::FuncOp>(
+  //     IREE::LinalgExt::createTileAndDecomposeAttentionPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention.mlir
@@ -132,10 +132,7 @@ hal.executable @_attention_dispatch_0 {
 // CHECK:          %[[D18:.+]] = vector.transpose %[[D17]], [1, 0] : vector<128x32xf32> to vector<32x128xf32>
 // CHECK:          %[[D19:.+]] = arith.subf %[[D15]], %[[D18]] : vector<32x128xf32>
 // CHECK:          %[[D20:.+]] = math.exp2 %[[D19]] : vector<32x128xf32>
-// CHECK:          %[[ALLOC_12:.+]] = memref.alloc() {alignment = 64 : i64} : memref<32xf32,
-// CHECK-SAME:       #[[GPU]].address_space<workgroup>>
-// CHECK:          %[[READ_ALLOC_12:.+]] = vector.transfer_read %[[ALLOC_12]]
-// CHECK:          %[[D21:.+]] = arith.subf %[[READ_ALLOC_12]], %[[D16]] : vector<32xf32>
+// CHECK:          %[[D21:.+]] = arith.subf %[[ARG1]], %[[D16]] : vector<32xf32>
 // CHECK:          %[[D22:.+]] = math.exp2 %[[D21]] : vector<32xf32>
 // CHECK:          %[[D23:.+]] = arith.mulf %[[D22]], %[[ARG2]] : vector<32xf32>
 // CHECK:          %[[D24:.+]] = vector.multi_reduction <add>, %[[D20]], %[[D23]] [1] : vector<32x128xf32> to

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tile_and_decompose_attention.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tile_and_decompose_attention.mlir
@@ -53,7 +53,7 @@ func.func @attention(%query: tensor<1x1024x64xf32>, %key: tensor<1x1024x64xf32>,
 // TILESIZE:            linalg.yield %[[D19]] : f32
 // TILESIZE:          } -> tensor<1024x32xf32>
 // TILESIZE:          %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]]], iterator_types = ["parallel"]}
-// TILESIZE-SAME:       ins(%[[D11]] : tensor<1024xf32>) outs(%[[D3]] : tensor<1024xf32>) {
+// TILESIZE-SAME:       ins(%[[D11]] : tensor<1024xf32>) outs(%[[ARG5]] : tensor<1024xf32>) {
 // TILESIZE:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
 // TILESIZE:            %[[D18]] = arith.subf %[[OUT]], %[[IN]] : f32
 // TILESIZE:            %[[D19]] = math.exp2 %[[D18]] : f32
@@ -183,7 +183,7 @@ func.func @attention(%query: tensor<1x1024x64xf32>, %key: tensor<1x1024x64xf32>,
 // CHECK:            linalg.yield %[[D19]] : f32
 // CHECK:          } -> tensor<1024x1024xf32>
 // CHECK:          %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]]], iterator_types = ["parallel"]}
-// CHECK-SAME:       ins(%[[D11]] : tensor<1024xf32>) outs(%[[D3]] : tensor<1024xf32>) {
+// CHECK-SAME:       ins(%[[D11]] : tensor<1024xf32>) outs(%[[ARG5]] : tensor<1024xf32>) {
 // CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
 // CHECK:            %[[D18:.+]] = arith.subf %[[OUT]], %[[IN]] : f32
 // CHECK:            %[[D19:.+]] = math.exp2 %[[D18]] : f32
@@ -280,10 +280,8 @@ func.func @attention(%query: tensor<?x?x?xf32>, %key: tensor<?x?x?xf32>, %value:
 // TILESIZE:            %[[D19:.+]] = math.exp2 %[[D18]] : f32
 // TILESIZE:            linalg.yield %[[D19]] : f32
 // TILESIZE:          } -> tensor<?x32xf32>
-// TILESIZE:          %[[DIM6:.+]] = tensor.dim %[[D11]], %[[C0]]
-// TILESIZE:          %[[INIT:.+]] = tensor.empty(%[[DIM6]])
 // TILESIZE:          %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]]], iterator_types = ["parallel"]}
-// TILESIZE-SAME:       ins(%[[D11]] : tensor<?xf32>) outs(%[[INIT]] : tensor<?xf32>) {
+// TILESIZE-SAME:       ins(%[[D11]] : tensor<?xf32>) outs(%[[ARG8]] : tensor<?xf32>) {
 // TILESIZE:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
 // TILESIZE:            %[[D18]] = arith.subf %[[OUT]], %[[IN]] : f32
 // TILESIZE:            %[[D19]] = math.exp2 %[[D18]] : f32
@@ -415,10 +413,8 @@ func.func @attention(%query: tensor<?x?x?xf32>, %key: tensor<?x?x?xf32>, %value:
 // CHECK:            %[[D19:.+]] = math.exp2 %[[D18]] : f32
 // CHECK:            linalg.yield %[[D19]] : f32
 // CHECK:          } -> tensor<?x?xf32>
-// CHECK:          %[[DIM6:.+]] = tensor.dim %[[D11]], %[[C0]]
-// CHECK:          %[[INIT:.+]] = tensor.empty(%[[DIM6]])
 // CHECK:          %[[D13:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]]], iterator_types = ["parallel"]}
-// CHECK-SAME:       ins(%[[D10]] : tensor<?xf32>) outs(%[[INIT]] : tensor<?xf32>) {
+// CHECK-SAME:       ins(%[[D10]] : tensor<?xf32>) outs(%[[ARG8]] : tensor<?xf32>) {
 // CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
 // CHECK:            %[[D18]] = arith.subf %[[OUT]], %[[IN]] : f32
 // CHECK:            %[[D19]] = math.exp2 %[[D18]] : f32
@@ -515,7 +511,7 @@ func.func @attention(%query: tensor<1x1024x64xf16>, %key: tensor<1x1024x64xf16>,
 // TILESIZE:            linalg.yield %[[D22]] : f32
 // TILESIZE:          } -> tensor<1024x32xf32>
 // TILESIZE:          %[[D14:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]]], iterator_types = ["parallel"]}
-// TILESIZE-SAME:       ins(%[[D12]] : tensor<1024xf32>) outs(%[[D3]] : tensor<1024xf32>) {
+// TILESIZE-SAME:       ins(%[[D12]] : tensor<1024xf32>) outs(%[[ARG5]] : tensor<1024xf32>) {
 // TILESIZE:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
 // TILESIZE:            %[[D21]] = arith.subf %[[OUT]], %[[IN]] : f32
 // TILESIZE:            %[[D22]] = math.exp2 %[[D21]] : f32
@@ -667,7 +663,7 @@ func.func @attention(%query: tensor<1x1024x64xf16>, %key: tensor<1x1024x64xf16>,
 // CHECK:            linalg.yield %[[D22]] : f32
 // CHECK:          } -> tensor<1024x1024xf32>
 // CHECK:          %[[D14:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]]], iterator_types = ["parallel"]}
-// CHECK-SAME:       ins(%[[D12]] : tensor<1024xf32>) outs(%[[D3]] : tensor<1024xf32>) {
+// CHECK-SAME:       ins(%[[D12]] : tensor<1024xf32>) outs(%[[ARG5]] : tensor<1024xf32>) {
 // CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
 // CHECK:            %[[D21]] = arith.subf %[[OUT]], %[[IN]] : f32
 // CHECK:            %[[D22]] = math.exp2 %[[D21]] : f32
@@ -778,7 +774,7 @@ func.func @attention_transpose_v(%query: tensor<1x1024x64xf16>, %key: tensor<1x1
 // TILESIZE:            linalg.yield %[[D22]] : f32
 // TILESIZE:          } -> tensor<1024x32xf32>
 // TILESIZE:          %[[D14:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]]], iterator_types = ["parallel"]}
-// TILESIZE-SAME:       ins(%[[D12]] : tensor<1024xf32>) outs(%[[D3]] : tensor<1024xf32>) {
+// TILESIZE-SAME:       ins(%[[D12]] : tensor<1024xf32>) outs(%[[ARG5]] : tensor<1024xf32>) {
 // TILESIZE:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
 // TILESIZE:            %[[D21]] = arith.subf %[[OUT]], %[[IN]] : f32
 // TILESIZE:            %[[D22]] = math.exp2 %[[D21]] : f32
@@ -930,7 +926,7 @@ func.func @attention_transpose_v(%query: tensor<1x1024x64xf16>, %key: tensor<1x1
 // CHECK:            linalg.yield %[[D22]] : f32
 // CHECK:          } -> tensor<1024x1024xf32>
 // CHECK:          %[[D14:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP2]]], iterator_types = ["parallel"]}
-// CHECK-SAME:       ins(%[[D12]] : tensor<1024xf32>) outs(%[[D3]] : tensor<1024xf32>) {
+// CHECK-SAME:       ins(%[[D12]] : tensor<1024xf32>) outs(%[[ARG5]] : tensor<1024xf32>) {
 // CHECK:          ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
 // CHECK:            %[[D21]] = arith.subf %[[OUT]], %[[IN]] : f32
 // CHECK:            %[[D22]] = math.exp2 %[[D21]] : f32


### PR DESCRIPTION
It is a wrong fix. We should pass `arg4` as inputs because of `%29 = arith.subf %out, %in : f32`. It used the previous result to update the value.

```mlir
      %22 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%20 : tensor<128xf32>) outs(%arg4 : tensor<128xf32>) {
      ^bb0(%in: f32, %out: f32):
        %29 = arith.subf %out, %in : f32
        %30 = math.exp2 %29 : f32
        linalg.yield %30 : f32
      } -> tensor<128xf32>
```

E.g,

```mlir
        %25 = tensor.empty() : tensor<64xf32>
        %26 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%23, %arg4 : tensor<64xf32>, tensor<64xf32>) outs(%25 : tensor<64xf32>) {
        ^bb0(%in: f32, %in_7: f32, %out: f32):
          %31 = arith.subf %in_7, %in : f32
          %32 = math.exp2 %31 : f32
          linalg.yield %32 : f32
        } -> tensor<64xf32>
```