### PR TITLE
[LinalgExt] Add options to not decompose attention with manual analysis.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -100,11 +100,13 @@ static void addTileAndDistributePasses(OpPassManager &pm) {
       createFuseTensorPadWithConsumerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createConcretizePadResultShapePass());
-  // TODO(#16421): Disable decomposition due to failure in bufferization.
-  // nestedModulePM.addNestedPass<func::FuncOp>(
-  //     IREE::LinalgExt::createTileAndDecomposeAttentionPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createTileAndDecomposeAttentionPass(
+          /*useSCFIterMax=*/false));
   nestedModulePM.addNestedPass<func::FuncOp>(
       IREE::LinalgExt::createTileAndDecomposeWinogradTransformPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -113,9 +113,9 @@ tileAndDistributeToWorkgroup(OpPassManager &pm,
   nestedModulePM.addNestedPass<func::FuncOp>(
       createConvertToDestinationPassingStylePass(
           useWARForCooperativeMatrixCodegen));
-  // TODO(#16421): Disable decomposition due to failure in bufferization.
-  // nestedModulePM.addNestedPass<func::FuncOp>(
-  //     IREE::LinalgExt::createTileAndDecomposeAttentionPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createTileAndDecomposeAttentionPass(
+          /*useSCFIterMax=*/false));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.h
@@ -129,11 +129,13 @@ tileAttention(IREE::LinalgExt::AttentionOp attnOp,
 void decomposeTiledAttention(IREE::LinalgExt::AttentionOp tiledAttnOp,
                              SmallVectorImpl<Operation *> &ops,
                              RewriterBase &rewriter,
-                             std::optional<uint64_t> tileSize = std::nullopt);
+                             std::optional<uint64_t> tileSize = std::nullopt,
+                             bool useSCFIterMax = true);
 
 // Creates a pass to convert the attention op into a sequence of
 // linalg ops.
-std::unique_ptr<Pass> createTileAndDecomposeAttentionPass();
+std::unique_ptr<Pass>
+createTileAndDecomposeAttentionPass(bool useSCFIterMax = true);
 
 // Marker used as attribute the depth of the split reduction transformations.
 const StringLiteral kSplitReductionDepthMarker = "__split_reduction_depth__";

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -78,6 +78,9 @@ def TileAndDecomposeAttention :
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::"
                     "createTileAndDecomposeAttentionPass()";
   let options = [
+    Option<"useSCFIterMax", "useSCFIterMax", "bool", /*default=*/"true",
+           "Choose whether to use SCF iterator to update max value in"
+           "decomposition">,
     Option<"onlyTile", "onlyTile", "bool", /*default=*/"false",
            "Choose whether to only tile or go through till decomposition">,
     Option<"tileSize", "tileSize", "uint64_t", /*default=*/"",

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -127,6 +127,7 @@ iree_check_single_backend_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
+            "attention.mlir",
             "winograd_input.mlir",
             "winograd_output.mlir",
         ],

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -18,6 +18,7 @@ iree_check_single_backend_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
+            "attention.mlir",
             "reverse.mlir",
             "scan.mlir",
             "scatter.mlir",
@@ -91,6 +92,7 @@ iree_check_single_backend_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
+            "attention.mlir",
             "reverse.mlir",
             "scan.mlir",
             "scatter.mlir",
@@ -147,6 +149,7 @@ iree_check_single_backend_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
+            "attention.mlir",
             "reverse.mlir",  #TODO(#12415): disabled due to miscompilation on Pixel 6.
             # TODO(antiagainst): scan fails on Adreno GPUs due to driver bug.
             # Re-enable this once we have new devices with up-to-date drivers.

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_cuda
   SRCS
+    "attention.mlir"
     "reverse.mlir"
     "scan.mlir"
     "scatter.mlir"
@@ -76,6 +77,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_llvm-cpu_local-task
   SRCS
+    "attention.mlir"
     "reverse.mlir"
     "scan.mlir"
     "scatter.mlir"

--- a/tests/e2e/linalg_ext_ops/attention.mlir
+++ b/tests/e2e/linalg_ext_ops/attention.mlir
@@ -1,0 +1,13 @@
+func.func @attention() {
+  %init = tensor.empty() : tensor<1x4x4xf32>
+  %query = util.unfoldable_constant dense<1.0> : tensor<1x4x4xf32>
+  %key = util.unfoldable_constant dense<0.5> : tensor<1x4x4xf32>
+  %value = util.unfoldable_constant dense<2.0> : tensor<1x4x4xf32>
+  %1 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<1x4x4xf32>,
+        tensor<1x4x4xf32>, tensor<1x4x4xf32>) outs(%init : tensor<1x4x4xf32>) -> tensor<1x4x4xf32>
+  check.expect_almost_eq_const(
+      %1,
+      dense<[[[2.0, 2.0, 2.0, 2.0], [2.0, 2.0, 2.0, 2.0], [2.0, 2.0, 2.0, 2.0], [2.0, 2.0, 2.0, 2.0]]]> : tensor<1x4x4xf32>
+  ) : tensor<1x4x4xf32>
+  return
+}


### PR DESCRIPTION
We should rely on the bufferization analysis to eliminate buffers for us, but not pull in the logic manually. It is dangerous especially if the upstream logics change. The revision also adds an e2e test for attention op.

Towards https://github.com/openxla/iree/issues/16421

ci-extra: test_gpu