### PR TITLE
Adding --task_abort_on_failure flag/API.

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/registration/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_task/registration/BUILD.bazel
@@ -21,6 +21,7 @@ iree_runtime_cc_library(
     ],
     deps = [
         "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:flags",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/local_task:task_driver",
         "//runtime/src/iree/hal/local/loaders/registration",

--- a/runtime/src/iree/hal/drivers/local_task/registration/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/registration/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     "driver_module.c"
   DEPS
     iree::base
+    iree::base::internal::flags
     iree::hal
     iree::hal::drivers::local_task::task_driver
     iree::hal::local::loaders::registration

--- a/runtime/src/iree/hal/drivers/local_task/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/local_task/registration/driver_module.c
@@ -10,10 +10,15 @@
 #include <stddef.h>
 
 #include "iree/base/api.h"
+#include "iree/base/internal/flags.h"
 #include "iree/hal/drivers/local_task/task_driver.h"
 #include "iree/hal/local/loaders/registration/init.h"
 #include "iree/hal/local/plugins/registration/init.h"
 #include "iree/task/api.h"
+
+IREE_FLAG(
+    bool, task_abort_on_failure, false,
+    "Aborts the program on the first failure within a task system queue.");
 
 static iree_status_t iree_hal_local_task_driver_factory_enumerate(
     void* self, iree_host_size_t* out_driver_info_count,
@@ -41,6 +46,9 @@ static iree_status_t iree_hal_local_task_driver_factory_try_create(
 
   iree_hal_task_device_params_t default_params;
   iree_hal_task_device_params_initialize(&default_params);
+  if (FLAG_task_abort_on_failure) {
+    default_params.queue_scope_flags |= IREE_TASK_SCOPE_FLAG_ABORT_ON_FAILURE;
+  }
 
   // Create executors for each topology specified by flags.
   // Stack allocated storage today but we can query for the total count and

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -57,6 +57,7 @@ static iree_hal_task_device_t* iree_hal_task_device_cast(
 void iree_hal_task_device_params_initialize(
     iree_hal_task_device_params_t* out_params) {
   out_params->arena_block_size = 32 * 1024;
+  out_params->queue_scope_flags = IREE_TASK_SCOPE_FLAG_NONE;
 }
 
 static iree_status_t iree_hal_task_device_check_params(
@@ -131,9 +132,9 @@ iree_status_t iree_hal_task_device_create(
     device->queue_count = queue_count;
     for (iree_host_size_t i = 0; i < device->queue_count; ++i) {
       // TODO(benvanik): add a number to each queue ID.
-      iree_hal_task_queue_initialize(device->identifier, queue_executors[i],
-                                     &device->small_block_pool,
-                                     &device->queues[i]);
+      iree_hal_task_queue_initialize(
+          device->identifier, params->queue_scope_flags, queue_executors[i],
+          &device->small_block_pool, &device->queues[i]);
     }
   }
 

--- a/runtime/src/iree/hal/drivers/local_task/task_device.h
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.h
@@ -23,6 +23,8 @@ typedef struct iree_hal_task_device_params_t {
   // Larger sizes will lower overhead and ensure the heap isn't hit for
   // transient allocations while also increasing memory consumption.
   iree_host_size_t arena_block_size;
+  // Default flags for the iree_task_scope_t used for each queue.
+  iree_task_scope_flags_t queue_scope_flags;
 } iree_hal_task_device_params_t;
 
 // Initializes |out_params| to default values.

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -421,6 +421,7 @@ static iree_status_t iree_hal_task_queue_retire_cmd_allocate(
 //===----------------------------------------------------------------------===//
 
 void iree_hal_task_queue_initialize(iree_string_view_t identifier,
+                                    iree_task_scope_flags_t scope_flags,
                                     iree_task_executor_t* executor,
                                     iree_arena_block_pool_t* block_pool,
                                     iree_hal_task_queue_t* out_queue) {
@@ -433,7 +434,7 @@ void iree_hal_task_queue_initialize(iree_string_view_t identifier,
   iree_task_executor_retain(out_queue->executor);
   out_queue->block_pool = block_pool;
 
-  iree_task_scope_initialize(identifier, &out_queue->scope);
+  iree_task_scope_initialize(identifier, scope_flags, &out_queue->scope);
 
   iree_hal_task_queue_state_initialize(&out_queue->state);
 

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.h
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.h
@@ -40,6 +40,7 @@ typedef struct iree_hal_task_queue_t {
 } iree_hal_task_queue_t;
 
 void iree_hal_task_queue_initialize(iree_string_view_t identifier,
+                                    iree_task_scope_flags_t scope_flags,
                                     iree_task_executor_t* executor,
                                     iree_arena_block_pool_t* block_pool,
                                     iree_hal_task_queue_t* out_queue);

--- a/runtime/src/iree/task/executor_demo.cc
+++ b/runtime/src/iree/task/executor_demo.cc
@@ -62,7 +62,8 @@ extern "C" int main(int argc, char* argv[]) {
 
   //
   iree_task_scope_t scope_a;
-  iree_task_scope_initialize(iree_make_cstring_view("a"), &scope_a);
+  iree_task_scope_initialize(iree_make_cstring_view("a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope_a);
 
   //
   iree_task_call_t call0;

--- a/runtime/src/iree/task/executor_test.cc
+++ b/runtime/src/iree/task/executor_test.cc
@@ -49,7 +49,8 @@ TEST(ExecutorTest, LifetimeStress) {
     IREE_ASSERT_OK(iree_task_executor_create(
         options, &topology, iree_allocator_system(), &executor));
     iree_task_scope_t scope;
-    iree_task_scope_initialize(iree_make_cstring_view("scope"), &scope);
+    iree_task_scope_initialize(iree_make_cstring_view("scope"),
+                               IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
     static std::atomic<int> received_value = {0};
     iree_task_call_t call;
@@ -97,7 +98,8 @@ TEST(ExecutorTest, SubmissionStress) {
   IREE_ASSERT_OK(iree_task_executor_create(options, &topology,
                                            iree_allocator_system(), &executor));
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
   for (int i = 0; i < 1000; ++i) {
     static std::atomic<int> received_value = {0};

--- a/runtime/src/iree/task/scope.h
+++ b/runtime/src/iree/task/scope.h
@@ -19,6 +19,15 @@
 extern "C" {
 #endif  // __cplusplus
 
+enum iree_task_scope_flag_bits_e {
+  IREE_TASK_SCOPE_FLAG_NONE = 0u,
+  // Calls iree_status_abort on the first failure within the scope.
+  // Hosting applications should properly handle the errors by retrieving the
+  // failure status from the appropriate query or wait primitive.
+  IREE_TASK_SCOPE_FLAG_ABORT_ON_FAILURE = 1u << 0,
+};
+typedef uint32_t iree_task_scope_flags_t;
+
 // iree_task_scope_t is an atomic reference-counting helper posting a
 // notification when the reference count is decremended to 0.
 //
@@ -47,6 +56,9 @@ extern "C" {
 typedef struct iree_task_scope_t {
   // Name used for logging and tracing.
   char name[16];
+
+  // Flags controlling optional scope behavior.
+  iree_task_scope_flags_t flags;
 
   // Base color used for tasks in this scope.
   // The color will be modulated based on task type.
@@ -78,6 +90,7 @@ typedef struct iree_task_scope_t {
 // Callers must ensure the scope remains live for as long as there are any
 // tasks that may reference it.
 void iree_task_scope_initialize(iree_string_view_t name,
+                                iree_task_scope_flags_t flags,
                                 iree_task_scope_t* out_scope);
 
 // Deinitializes an task scope.

--- a/runtime/src/iree/task/scope_test.cc
+++ b/runtime/src/iree/task/scope_test.cc
@@ -17,7 +17,8 @@ namespace {
 
 TEST(ScopeTest, Lifetime) {
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope_a"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope_a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
   EXPECT_TRUE(iree_task_scope_is_idle(&scope));
   iree_task_scope_deinitialize(&scope);
 }
@@ -27,7 +28,7 @@ TEST(ScopeTest, Lifetime) {
 TEST(ScopeTest, LongNameTruncation) {
   iree_task_scope_t scope;
   iree_task_scope_initialize(iree_make_cstring_view("01234567890123456789"),
-                             &scope);
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
   EXPECT_TRUE(iree_string_view_equal(iree_make_cstring_view("012345678901234"),
                                      iree_task_scope_name(&scope)));
   iree_task_scope_deinitialize(&scope);
@@ -35,7 +36,8 @@ TEST(ScopeTest, LongNameTruncation) {
 
 TEST(ScopeTest, AbortEmpty) {
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope_a"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope_a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
   // Current state is OK.
   EXPECT_TRUE(iree_task_scope_is_idle(&scope));
@@ -55,7 +57,8 @@ TEST(ScopeTest, AbortEmpty) {
 
 TEST(ScopeTest, FailEmpty) {
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope_a"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope_a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
   // Current state is OK.
   EXPECT_TRUE(iree_task_scope_is_idle(&scope));
@@ -80,7 +83,8 @@ TEST(ScopeTest, FailEmpty) {
 // calls are ignored.
 TEST(ScopeTest, FailAgain) {
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope_a"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope_a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
   // Current state is OK.
   EXPECT_TRUE(iree_task_scope_is_idle(&scope));
@@ -116,7 +120,8 @@ TEST(ScopeTest, FailAgain) {
 
 TEST(ScopeTest, WaitIdleWhenIdle) {
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope_a"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope_a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
   // Current state is OK and idle.
   EXPECT_TRUE(iree_task_scope_is_idle(&scope));
@@ -132,7 +137,8 @@ TEST(ScopeTest, WaitIdleWhenIdle) {
 
 TEST(ScopeTest, WaitIdleDeadlineExceeded) {
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope_a"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope_a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
   // Current state is OK and idle.
   EXPECT_TRUE(iree_task_scope_is_idle(&scope));
@@ -161,7 +167,8 @@ TEST(ScopeTest, WaitIdleDeadlineExceeded) {
 
 TEST(ScopeTest, WaitIdleSuccess) {
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope_a"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope_a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
   // Current state is OK and idle.
   EXPECT_TRUE(iree_task_scope_is_idle(&scope));
@@ -200,7 +207,8 @@ TEST(ScopeTest, WaitIdleSuccess) {
 
 TEST(ScopeTest, WaitIdleFailure) {
   iree_task_scope_t scope;
-  iree_task_scope_initialize(iree_make_cstring_view("scope_a"), &scope);
+  iree_task_scope_initialize(iree_make_cstring_view("scope_a"),
+                             IREE_TASK_SCOPE_FLAG_NONE, &scope);
 
   // Current state is OK and idle.
   EXPECT_TRUE(iree_task_scope_is_idle(&scope));

--- a/runtime/src/iree/task/testing/task_test.h
+++ b/runtime/src/iree/task/testing/task_test.h
@@ -31,7 +31,8 @@ class TaskTest : public ::testing::Test {
         options, &topology, iree_allocator_system(), &executor_));
     iree_task_topology_deinitialize(&topology);
 
-    iree_task_scope_initialize(iree_make_cstring_view("scope"), &scope_);
+    iree_task_scope_initialize(iree_make_cstring_view("scope"),
+                               IREE_TASK_SCOPE_FLAG_NONE, &scope_);
   }
 
   virtual void TearDown() {

--- a/runtime/src/iree/task/testing/test_util.h
+++ b/runtime/src/iree/task/testing/test_util.h
@@ -34,7 +34,8 @@ using TaskScopePtr =
     std::unique_ptr<iree_task_scope_t, void (*)(iree_task_scope_t*)>;
 static inline TaskScopePtr AllocateScope(const char* name) {
   iree_task_scope_t* scope = new iree_task_scope_t();
-  iree_task_scope_initialize(iree_make_cstring_view(name), scope);
+  iree_task_scope_initialize(iree_make_cstring_view(name),
+                             IREE_TASK_SCOPE_FLAG_NONE, scope);
   return {scope, [](iree_task_scope_t* scope) {
             iree_task_scope_deinitialize(scope);
             delete scope;


### PR DESCRIPTION
This issues an `iree_status_abort` on the first failure within a queue scope to make it easier to debug queue issues. Hosting applications not using the driver module can set the flag on the local-task device parameters when creating one.