### PR TITLE
[ROCM] Use translation info to store waves-per-eu

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -285,7 +285,7 @@ public:
           getTranslationInfo(exportOp);
       if (auto translationConfig = translationInfo.getConfiguration()) {
         if (auto attr = dyn_cast_or_null<IntegerAttr>(
-                translationConfig.get("waves-per-eu"))) {
+                translationConfig.get("amdgpu-waves-per-eu"))) {
           wavesPerEu = attr.getValue().getSExtValue();
         }
       }


### PR DESCRIPTION
This allows setting per-kernel waves-per-eu values. For now there are no configs that take advantage of this on default paths, but we do use this in custom transform dialect scripts by annotating the translation info config with this attribute.