### PR TITLE
Drop double print from translate executables pipeline failures.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -103,7 +103,7 @@ struct TranslateExecutablesPass
     IREE_COMPILER_TRACE_MESSAGE_DYNAMIC(INFO, executableOp.getSymName().str());
 
     if (failed(runPipeline(passManager, executableOp))) {
-      executableOp.emitError() << "failed to translate executables";
+      llvm::errs() << "failed to translate executables\n";
       return signalPassFailure();
     }
   }


### PR DESCRIPTION
Translation pipeline failures already print the op context, so this resulted in double printing (e.g. https://gist.github.com/ScottTodd/5ad27d31f8f3f30a590a86bb97a0885b). See also `--mlir-print-op-on-diagnostic`.