### PR TITLE
[Codegen][ROCDL] Extend mfma pipeline to support a few more matmul variants

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -463,15 +463,17 @@ setMatmulVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
       mlir::linalg::inferContractionDims(op);
   assert(succeeded(contractionDims) && "Could not infer contraction dims");
 
-  // TODO: Relax this condition to strictly alignment requirements.
-  if (contractionDims->k.size() != 1 || contractionDims->m.size() != 1 ||
-      contractionDims->n.size() != 1) {
+  if (contractionDims->k.size() < 1 || contractionDims->m.size() < 1 ||
+      contractionDims->n.size() < 1) {
     return failure();
   }
 
-  int64_t mDim = contractionDims->m[0];
-  int64_t nDim = contractionDims->n[0];
-  int64_t kDim = contractionDims->k[0];
+  // For now we are not being smart and trying to reshape dimensions to allow
+  // for better usage of intrinsics, and instead are tiling all dimensions
+  // except the inner most m, n, and k dimensions to 1.
+  int64_t mDim = contractionDims->m.back();
+  int64_t nDim = contractionDims->n.back();
+  int64_t kDim = contractionDims->k.back();
 
   Value lhs = op.getDpsInputOperand(0)->get();
   Value rhs = op.getDpsInputOperand(1)->get();
@@ -520,6 +522,19 @@ setMatmulVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
   for (int64_t batch : contractionDims->batch) {
     workgroupTileSizes[batch] = 1;
   }
+
+  // Tile all m, n, and k dimensions to 1 except the inner most. Unit dims
+  // from this tiling are folded before vectorization.
+  for (int64_t m : ArrayRef<unsigned int>(contractionDims->m).drop_back()) {
+    workgroupTileSizes[m] = 1;
+  }
+  for (int64_t n : ArrayRef<unsigned int>(contractionDims->n).drop_back()) {
+    workgroupTileSizes[n] = 1;
+  }
+  for (int64_t k : ArrayRef<unsigned int>(contractionDims->k).drop_back()) {
+    workgroupTileSizes[k] = 1;
+  }
+
   // Compute the M/N dimension tile size by multiply subgroup information.
   workgroupTileSizes[mDim] =
       schedule->mWarpCount * schedule->mTileCount * schedule->mSize;
@@ -555,7 +570,7 @@ static LogicalResult
 setVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
                             linalg::LinalgOp linalgOp,
                             const TargetInfo &targetInfo) {
-  if (isMatmulOrBatchMatmul(linalgOp)) {
+  if (linalg::isaContractionOpInterface(linalgOp)) {
     return setMatmulVectorDistributionConfig(entryPoint, linalgOp, targetInfo);
   }
   if (isa<linalg::ConvolutionOpInterface>(*linalgOp)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -111,9 +111,78 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
 //          CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<2x4x1x1x1x4xf16>)
 //          CHECK:     arith.extf %[[ARG]] : vector<2x4x1x1x1x4xf16> to vector<2x4x1x1x1x4xf32>
 // CHECK-COUNT-16:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//          CHECK:     %[[TRUNC:.+]] = arith.truncf %157 : vector<2x4x1x1x1x4xf32> to vector<2x4x1x1x1x4xf16>
+//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<2x4x1x1x1x4xf32> to vector<2x4x1x1x1x4xf16>
 //          CHECK:     scf.yield %[[TRUNC]] : vector<2x4x1x1x1x4xf16>
 //  CHECK-COUNT-8:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable @expanded_matmul_transpose_b_executable {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
+      target_arch = "gfx940",
+      mma_intrinsics = [#iree_gpu.mfma_layout<F16_16x16x16_F32>,
+                        #iree_gpu.mfma_layout<F16_32x32x8_F32>]
+  }>) {
+  hal.executable.export @expanded_matmul_transpose_b layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @expanded_matmul_transpose_b() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0)
+          : !flow.dispatch.tensor<readonly:tensor<2x64x2048xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0)
+          : !flow.dispatch.tensor<readonly:tensor<10x64x2048xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0)
+          : !flow.dispatch.tensor<writeonly:tensor<2x10x64x64xf16>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 64, 2048], strides = [1, 1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<2x64x2048xf16>> -> tensor<2x64x2048xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [10, 64, 2048], strides = [1, 1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<10x64x2048xf16>> -> tensor<10x64x2048xf16>
+
+        %5 = tensor.empty() : tensor<2x10x64x64xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2x10x64x64xf16>) -> tensor<2x10x64x64xf16>
+        %7 = linalg.generic {
+          indexing_maps = [
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+          ],
+          iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+        } ins(%3, %4 : tensor<2x64x2048xf16>, tensor<10x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf16>) {
+        ^bb0(%lhs: f16, %rhs: f16, %out: f16):
+          %mul = arith.mulf %lhs, %rhs : f16
+          %add = arith.addf %mul, %out : f16
+          linalg.yield %add : f16
+        } -> tensor<2x10x64x64xf16>
+
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1]
+          : tensor<2x10x64x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x10x64x64xf16>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable.export public @expanded_matmul_transpose_b
+//  CHECK-SAME:    workgroup_size = [256 : index, 1 : index, 1 : index]
+
+//    CHECK-LABEL: func @expanded_matmul_transpose_b
+//          CHECK:   scf.for {{.*}} = %c0 to %c2048 step %c32 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<4x1x1x1x1x4xf16>)
+//          CHECK:     arith.extf %[[ARG]] : vector<4x1x1x1x1x4xf16> to vector<4x1x1x1x1x4xf32>
+// CHECK-COUNT-8:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
+//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<4x1x1x1x1x4xf32> to vector<4x1x1x1x1x4xf16>
+//          CHECK:     scf.yield %[[TRUNC]] : vector<4x1x1x1x1x4xf16>
+//  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<2x10x64x64xf16, #hal.descriptor_type<storage_buffer>>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -179,7 +179,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
 //    CHECK-LABEL: func @expanded_matmul_transpose_b
 //          CHECK:   scf.for {{.*}} = %c0 to %c2048 step %c32 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<4x1x1x1x1x4xf16>)
 //          CHECK:     arith.extf %[[ARG]] : vector<4x1x1x1x1x4xf16> to vector<4x1x1x1x1x4xf32>
-// CHECK-COUNT-8:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
+// CHECK-COUNT-8:      amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 //          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<4x1x1x1x1x4xf32> to vector<4x1x1x1x1x4xf16>
 //          CHECK:     scf.yield %[[TRUNC]] : vector<4x1x1x1x1x4xf16>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<2x10x64x64xf16, #hal.descriptor_type<storage_buffer>>


### PR DESCRIPTION
Similar to convolution, we just tile all MNK dimensions to 1 except the inner most. This is in preparation for some fusion experiments.