### PR TITLE
[GlobalOpt] Add pass with basic global data layout propagation analysis

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -46,6 +46,7 @@ iree_compiler_cc_library(
     srcs = [
         "CleanupNumericNarrowing.cpp",
         "Convert1X1FilterConv2DToMatmul.cpp",
+        "DataLayoutUtils.cpp",
         "DecomposeConcat.cpp",
         "DemoteContractionInputsToBF16.cpp",
         "DetachElementwiseFromNamedOps.cpp",
@@ -59,6 +60,7 @@ iree_compiler_cc_library(
         "MaterializeHomogeneousEncodings.cpp",
         "OptimizeNumerics.cpp",
         "Passes.cpp",
+        "PropagateDataLayout.cpp",
         "PropagateLinalgTranspose.cpp",
         "RaiseSpecialOps.cpp",
         "RemoveZeroExtentTensors.cpp",
@@ -67,6 +69,7 @@ iree_compiler_cc_library(
         "Utils.cpp",
     ],
     hdrs = [
+        "DataLayoutUtils.h",
         "Passes.h",
         "Utils.h",
     ],

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -37,11 +37,13 @@ iree_cc_library(
   NAME
     GlobalOptimization
   HDRS
+    "DataLayoutUtils.h"
     "Passes.h"
     "Utils.h"
   SRCS
     "CleanupNumericNarrowing.cpp"
     "Convert1X1FilterConv2DToMatmul.cpp"
+    "DataLayoutUtils.cpp"
     "DecomposeConcat.cpp"
     "DemoteContractionInputsToBF16.cpp"
     "DetachElementwiseFromNamedOps.cpp"
@@ -55,6 +57,7 @@ iree_cc_library(
     "MaterializeHomogeneousEncodings.cpp"
     "OptimizeNumerics.cpp"
     "Passes.cpp"
+    "PropagateDataLayout.cpp"
     "PropagateLinalgTranspose.cpp"
     "RaiseSpecialOps.cpp"
     "RemoveZeroExtentTensors.cpp"

--- a/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.cpp
@@ -114,7 +114,7 @@ ArrayAttr DataLayoutTransformation::makeTransformArrayAttr(MLIRContext *ctx) {
 }
 
 /// TODO: Replace this trivially conservative placeholder implementation.
-bool DataLayoutTransformation::isIntersecting(DataLayoutTransformation other) {
+bool DataLayoutTransformation::isIntersecting(DataLayoutTransformation &other) {
   return true;
 }
 
@@ -220,7 +220,7 @@ bool DataLayoutTransformation::transform(Operation *op, Value currentValue,
 
 /// The only information to combine for now is correspondingTransformedIndices.
 /// TODO: Check that the transformations are compatible and fail if they aren't.
-bool DataLayoutTransformation::combineLayout(DataLayoutTransformation other) {
+bool DataLayoutTransformation::combineLayout(DataLayoutTransformation &other) {
   assert(correspondingTransformedIndices.size() ==
          other.correspondingTransformedIndices.size());
   bool changed = false;
@@ -240,7 +240,6 @@ bool DataLayoutTransformation::combineLayout(DataLayoutTransformation other) {
 /// Terminal nodes are just GlobalLoadOp and GlobalStoreOp for now.
 SmallVector<StringRef> getTerminalNodeIDs(Value value) {
   SmallVector<StringRef> IDs;
-  DataLayoutTransformation newLayout(cast<ShapedType>(value.getType()));
   if (auto loadOp = value.getDefiningOp<IREE::Util::GlobalLoadOp>()) {
     IDs.push_back(loadOp.getGlobal());
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.cpp
@@ -1,0 +1,480 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/GlobalOptimization/DataLayoutUtils.h"
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <type_traits>
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+
+#define DEBUG_TYPE "iree-global-opt-propagate-data-layout"
+
+static const char kDataLayoutNodeTypeAttr[] = "__node_type__";
+static const char kFoldablePackUnPack[] = "__foldable_pack_unpack__";
+
+namespace mlir::iree_compiler::GlobalOptimization {
+using iree_compiler::IREE::Util::GlobalOp;
+
+template <typename T>
+static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const llvm::SmallVectorImpl<T> &vector) {
+  os << "[ ";
+  for (T element : vector) {
+    os << element << " ";
+  }
+  os << "]";
+
+  return os;
+}
+
+template <typename T>
+static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const llvm::ArrayRef<T> &vector) {
+  os << "[ ";
+  for (T element : vector) {
+    os << element << " ";
+  }
+  os << "]";
+
+  return os;
+}
+
+static llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os, const DataLayoutTransformation &transform) {
+  os << "originalType: " << transform.getOriginalType() << "\n";
+  os << "transformedType: " << transform.getTransformedType() << "\n";
+  os << "innerDimsPos: " << transform.getInnerDimsPos() << "\n";
+  os << "innerTileSizes: " << transform.getInnerTileSizes() << "\n";
+  os << "outerDimsPerm: " << transform.getOuterDimsPerm() << "\n";
+  os << "constantPadValue: " << transform.getConstantPadValue() << "\n";
+  os << "correspondingTransformedIndices: "
+     << transform.getCorrespondingTransformedIndices() << "\n";
+  return os;
+}
+
+//===----------------------------------------------------------------------===//
+// DataLayoutTransformation
+//===----------------------------------------------------------------------===//
+
+/// TODO: Replace this with a more meaningful check for transform validity.
+const bool DataLayoutTransformation::hasValidTransform() {
+  return llvm::detail::isPresent(originalType) &&
+         llvm::detail::isPresent(transformedType);
+}
+
+bool DataLayoutTransformation::transformLayout(Value currentValue,
+                                               Value newValue) {
+  auto curDefiningOp = currentValue.getDefiningOp();
+  auto newDefiningOp = newValue.getDefiningOp();
+  auto isInitOperand = [](Operation *op, Value val) -> bool {
+    if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op)) {
+      return llvm::any_of(dpsOp.getDpsInits(),
+                          [&](Value v) { return v == val; });
+    }
+    return false;
+  };
+  auto valueConsumedByOp = [](Operation *op, Value val) -> bool {
+    return op &&
+           llvm::any_of(op->getOperands(), [&](Value v) { return v == val; });
+  };
+  // currentValue is a producer of newValue
+  if (valueConsumedByOp(newDefiningOp, currentValue)) {
+    // If currentValue is an init operand, then no transform needed.
+    if (isInitOperand(newDefiningOp, currentValue)) {
+      return true;
+    }
+    // Otherwise, perform transformation down through `newDefiningOp`.
+    if (auto newType = dyn_cast<ShapedType>(newValue.getType())) {
+      return transform(newDefiningOp, currentValue, newValue);
+    }
+    // currentValue is a consumer of newValue
+  } else if (valueConsumedByOp(curDefiningOp, newValue)) {
+    // If newValue is an init operand, then no transform needed.
+    if (isInitOperand(curDefiningOp, newValue)) {
+      return true;
+    }
+    // Otherwise, perform transformation up through `curDefiningOp`.
+    if (auto newType = dyn_cast<ShapedType>(newValue.getType())) {
+      return transform(curDefiningOp, currentValue, newValue);
+    }
+  }
+  // Fail if no connecting op
+  return false;
+}
+
+ArrayAttr DataLayoutTransformation::makeTransformArrayAttr(MLIRContext *ctx) {
+  SmallVector<Attribute> attrs;
+  attrs.push_back(TypeAttr::get(originalType));
+  attrs.push_back(TypeAttr::get(transformedType));
+  return ArrayAttr::get(ctx, attrs);
+}
+
+/// TODO: Replace this trivially conservative placeholder implementation.
+bool DataLayoutTransformation::isIntersecting(DataLayoutTransformation other) {
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// DataLayoutTransformation transform implementations
+//===----------------------------------------------------------------------===//
+
+/// Compute the transformation through a tensor::PackOp. Currently the only
+/// supported case is for `currentValue` as the source and `newValue` as the
+/// result of the pack. The `transform` must not have any innerTileSizes,
+/// innerDimsPos, or outerDimsPerm.
+/// TODO: Support cases where transform has outerDimsPerm.
+bool transformThroughOperation(tensor::PackOp packOp,
+                               DataLayoutTransformation &transform,
+                               Value currentValue, Value newValue) {
+  if (!transform.getInnerTileSizes().empty() ||
+      !transform.getInnerDimsPos().empty() ||
+      !transform.getOuterDimsPerm().empty()) {
+    return false;
+  }
+  // Only supporting source->dest transforms for now.
+  if (currentValue != packOp.getSource() || newValue != packOp.getResult()) {
+    return false;
+  }
+  auto padValue = packOp.getPaddingValue();
+  std::optional<TypedAttr> constPadVal = std::nullopt;
+  // Padding values must be the same accross all connected transforms.
+  if (padValue) {
+    auto padConst = padValue.getDefiningOp<arith::ConstantOp>();
+    if (!padConst) {
+      return false;
+    }
+    auto tfConstPadVal = transform.getConstantPadValue();
+    if (tfConstPadVal.has_value() &&
+        tfConstPadVal.value() != padConst.getValue()) {
+      return false;
+    }
+    constPadVal = padConst.getValue();
+  }
+  auto origType = dyn_cast<RankedTensorType>(transform.getOriginalType());
+  if (!origType) {
+    return false;
+  }
+  // If any correspondingTransformedIndices are `-1`, then there is not enough
+  // information to do the packing transformation, so bail and wait to try again
+  // after the transform holds more information.
+  auto cTfInds = transform.getCorrespondingTransformedIndices();
+  if (llvm::any_of(cTfInds, [](int64_t ind) { return ind == -1; })) {
+    return false;
+  }
+
+  auto getPermOrIdentity = [origType](SmallVector<int64_t> perm) {
+    if (perm.empty()) {
+      return llvm::to_vector(llvm::seq<int64_t>(0, origType.getRank()));
+    }
+    return perm;
+  };
+  SmallVector<int64_t> currentOuterDimsPerm =
+      getPermOrIdentity(transform.getOuterDimsPerm());
+  auto packOuterDimsPerm =
+      getPermOrIdentity(SmallVector<int64_t>(packOp.getOuterDimsPerm()));
+  SmallVector<int64_t> newOuterDimsPerm(currentOuterDimsPerm);
+  for (auto [idx, permIdx] : llvm::enumerate(packOuterDimsPerm)) {
+    newOuterDimsPerm[cTfInds[idx]] = cTfInds[permIdx];
+  }
+
+  // The transform does not have any permutations yet, so just correct for the
+  // correspondingTransformedIndices.
+  SmallVector<int64_t> packInnerDimsPos(packOp.getInnerDimsPos());
+  SmallVector<int64_t> newInnerDimsPos;
+  auto inverseOuterDimsPos = invertPermutationVector(currentOuterDimsPerm);
+  for (auto innerPos : packInnerDimsPos) {
+    newInnerDimsPos.push_back(inverseOuterDimsPos[cTfInds[innerPos]]);
+  }
+
+  transform.setOuterDimsPerm(newOuterDimsPerm);
+  transform.setInnerDimsPos(newInnerDimsPos);
+  SmallVector<int64_t> innerTiles(packOp.getStaticInnerTiles());
+  transform.setInnerTileSizes(innerTiles);
+
+  auto newTransformedType = tensor::PackOp::inferPackedType(
+      origType, transform.getInnerTileSizes(), transform.getInnerDimsPos(),
+      transform.getOuterDimsPerm());
+  transform.setTransformedType(newTransformedType);
+  transform.setConstantPadValue(constPadVal);
+  return true;
+}
+
+/// Switch case function for different op types.
+bool DataLayoutTransformation::transform(Operation *op, Value currentValue,
+                                         Value newValue) {
+  return TypeSwitch<Operation *, bool>(op)
+      .Case<tensor::PackOp>([&](tensor::PackOp packOp) {
+        return transformThroughOperation(packOp, *this, currentValue, newValue);
+      })
+      .Default([](Operation *op) { return false; });
+}
+
+/// The only information to combine for now is correspondingTransformedIndices.
+/// TODO: Check that the transformations are compatible and fail if they aren't.
+bool DataLayoutTransformation::combineLayout(DataLayoutTransformation other) {
+  assert(correspondingTransformedIndices.size() ==
+         other.correspondingTransformedIndices.size());
+  bool changed = false;
+  for (auto [idx, cTfInd] : llvm::enumerate(correspondingTransformedIndices)) {
+    if (cTfInd == -1 && other.correspondingTransformedIndices[idx] != -1) {
+      cTfInd = other.correspondingTransformedIndices[idx];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+//===----------------------------------------------------------------------===//
+// Analysis helpers
+//===----------------------------------------------------------------------===//
+
+/// Terminal nodes are just GlobalLoadOp and GlobalStoreOp for now.
+SmallVector<StringRef> getTerminalNodeIDs(Value value) {
+  SmallVector<StringRef> IDs;
+  DataLayoutTransformation newLayout(cast<ShapedType>(value.getType()));
+  if (auto loadOp = value.getDefiningOp<IREE::Util::GlobalLoadOp>()) {
+    IDs.push_back(loadOp.getGlobal());
+  }
+  for (Operation *op : value.getUsers()) {
+    if (auto storeOp = dyn_cast<IREE::Util::GlobalStoreOp>(op)) {
+      IDs.push_back(storeOp.getGlobal());
+    }
+  }
+  return IDs;
+}
+
+/// Return true if the op can assume any possible DataLayoutTransformation.
+static bool isLayoutFlexibleOp(Operation *op) {
+  // return isa<tensor::InsertSliceOp, tensor::ExtractSliceOp,
+  return isa<IREE::Util::GlobalStoreOp, IREE::Util::GlobalLoadOp>(op);
+}
+
+/// Return true if the op defines a DataLayoutTransformation.
+static bool isLayoutDefiningOp(Operation *op) {
+  return isa<tensor::PackOp>(op);
+}
+
+/// Return true if a value is an intermediate node. Intermediate nodes can be
+/// propagated through by some layout, and a node is intermediate if:
+///  - The node has a defining op that can assume any layout and does not define
+///    a layout.
+///  - All of the node's users can assume any layout or define a layout.
+static bool isIntermediateNode(Value value) {
+  if (auto definingOp = value.getDefiningOp()) {
+    if (!isLayoutFlexibleOp(definingOp) || isLayoutDefiningOp(definingOp)) {
+      return false;
+    }
+  } else {
+    return false;
+  }
+  for (auto op : value.getUsers()) {
+    if (!isLayoutFlexibleOp(op) && !isLayoutDefiningOp(op))
+      return false;
+  }
+  return true;
+}
+
+DataLayoutNodeType getNodeTypeForValue(Value value) {
+  if (isIntermediateNode(value))
+    return DataLayoutNodeType::INTERMEDIATE;
+  return DataLayoutNodeType::BARRIER;
+}
+
+//===----------------------------------------------------------------------===//
+// Pass helpers
+//===----------------------------------------------------------------------===//
+
+LogicalResult transformGlobalsToNewLayout(IRRewriter &rewriter,
+                                          SmallVector<Value> edgeNodes,
+                                          DataLayoutTransformation *transform,
+                                          GlobalOp global,
+                                          SymbolTable moduleSymbols) {
+  // Create a new transformed GlobalOp.
+  std::string newGlobalName(global.getGlobalName().str());
+  newGlobalName.append(".packed");
+  auto transformedType = transform->getTransformedType();
+  auto originalType = transform->getOriginalType();
+  std::optional<TypedAttr> transformedInitialValue = std::nullopt;
+  if (auto initialValue = global.getInitialValue()) {
+    if (auto uninitializedAttr =
+            dyn_cast<IREE::Util::UninitializedAttr>(initialValue.value())) {
+      transformedInitialValue = IREE::Util::UninitializedAttr::get(
+          rewriter.getContext(), transformedType);
+    } else {
+      return failure();
+    }
+  }
+  rewriter.setInsertionPoint(global);
+  auto newGlobal = rewriter.create<GlobalOp>(
+      global->getLoc(), StringRef(newGlobalName), global.getIsMutable(),
+      transformedType, transformedInitialValue);
+  newGlobal.setInliningPolicyAttr(global.getInliningPolicyAttr());
+  moduleSymbols.insert(newGlobal);
+  SymbolTable::setSymbolVisibility(newGlobal,
+                                   SymbolTable::getSymbolVisibility(global));
+
+  // Create an initializer to initialize the new global to the padding
+  // value of the pack. This is necessary because we have folded the pack
+  // op into the new global. Additional analysis could tell us whether the
+  // padding is actually needed, but for now we always pad.
+  Location globalLoc = newGlobal->getLoc();
+  auto initializerOp = rewriter.create<IREE::Util::InitializerOp>(globalLoc);
+  auto initializerBuilder =
+      OpBuilder::atBlockBegin(initializerOp.addEntryBlock());
+  // If the transform has no padding value, then use a zero padding value, since
+  // the global may need a pad value even if the layout found in the analysis
+  // did not have a padding value.
+  auto transformPadVal = transform->getConstantPadValue();
+  TypedAttr constPadAttr =
+      transformPadVal.has_value()
+          ? transformPadVal.value()
+          : rewriter.getZeroAttr(transformedType.getElementType());
+  Value padValue =
+      initializerBuilder.create<arith::ConstantOp>(globalLoc, constPadAttr);
+  auto splatOp = initializerBuilder.create<IREE::Flow::TensorSplatOp>(
+      globalLoc, transformedType, padValue, /*result_dims=*/ValueRange{});
+  initializerBuilder.create<IREE::Util::GlobalStoreOp>(
+      globalLoc, splatOp.getResult(), newGlobal.getName());
+  initializerBuilder.create<IREE::Util::ReturnOp>(globalLoc);
+
+  // Rewrite loads and stores to use the new global.
+  SmallVector<OpFoldResult> innerTilesOfr;
+  for (auto tile : transform->getInnerTileSizes()) {
+    innerTilesOfr.push_back(rewriter.getIndexAttr(tile));
+  }
+  for (auto node : edgeNodes) {
+    if (llvm::any_of(node.getUsers(), [](Operation *user) {
+          return isa<IREE::Util::GlobalStoreOp>(user);
+        })) {
+      rewriter.setInsertionPointAfterValue(node);
+      auto dest = rewriter.create<tensor::EmptyOp>(
+          node.getLoc(), transformedType.getShape(),
+          transformedType.getElementType());
+      Value nodePadValue =
+          rewriter.create<arith::ConstantOp>(node.getLoc(), constPadAttr);
+      auto pack = rewriter.create<tensor::PackOp>(
+          node.getLoc(), node, dest, transform->getInnerDimsPos(),
+          innerTilesOfr, /*padding_value=*/nodePadValue,
+          transform->getOuterDimsPerm());
+      setFoldablePackUnPackAttribute(pack);
+      for (auto user : node.getUsers()) {
+        if (isa<IREE::Util::GlobalStoreOp>(user)) {
+          rewriter.create<IREE::Util::GlobalStoreOp>(
+              user->getLoc(), pack.getResult(), newGlobal);
+          rewriter.eraseOp(user);
+        }
+      }
+    }
+    if (auto loadOp = node.getDefiningOp<IREE::Util::GlobalLoadOp>()) {
+      rewriter.setInsertionPoint(loadOp);
+      auto newLoad = rewriter.create<IREE::Util::GlobalLoadOp>(loadOp->getLoc(),
+                                                               newGlobal);
+      auto dest = rewriter.create<tensor::EmptyOp>(
+          loadOp->getLoc(), originalType.getShape(),
+          originalType.getElementType());
+      auto unpack = rewriter.create<tensor::UnPackOp>(
+          loadOp.getLoc(), newLoad, dest, transform->getInnerDimsPos(),
+          innerTilesOfr, transform->getOuterDimsPerm());
+      setFoldablePackUnPackAttribute(unpack);
+      rewriter.replaceOp(loadOp, unpack.getResult());
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Attribute helpers
+//===----------------------------------------------------------------------===//
+
+static StringAttr getNodeTypeStringAttr(MLIRContext *ctx,
+                                        DataLayoutNodeType type) {
+  switch (type) {
+  case DataLayoutNodeType::UNINITIALIZED:
+    return StringAttr::get(ctx, "UNINITIALIZED");
+  case DataLayoutNodeType::INTERMEDIATE:
+    return StringAttr::get(ctx, "INTERMEDIATE");
+  case DataLayoutNodeType::BARRIER:
+    return StringAttr::get(ctx, "BARRIER");
+  default:
+    assert(false && "invalid DataLayoutNodeType");
+  }
+}
+
+static DataLayoutNodeType getNodeTypeFromStringAttr(StringAttr attr) {
+  if (attr.getValue().equals(StringRef("UNINITIALIZED")))
+    return DataLayoutNodeType::UNINITIALIZED;
+  if (attr.getValue().equals(StringRef("INTERMEDIATE")))
+    return DataLayoutNodeType::INTERMEDIATE;
+  return DataLayoutNodeType::BARRIER;
+}
+
+void setNodeTypeAttribute(Operation *op, DataLayoutNodeType nodeType) {
+  op->setAttr(kDataLayoutNodeTypeAttr,
+              getNodeTypeStringAttr(op->getContext(), nodeType));
+  return;
+}
+
+void setFoldablePackUnPackAttribute(Operation *op) {
+  op->setAttr(kFoldablePackUnPack, UnitAttr::get(op->getContext()));
+  return;
+}
+
+bool hasFoldablePackUnPackAttribute(Operation *op) {
+  return static_cast<bool>(op->getAttrOfType<UnitAttr>(kFoldablePackUnPack));
+}
+
+std::optional<DataLayoutNodeType> getNodeTypeFromAttr(Operation *op) {
+  if (auto attr = op->getAttrOfType<StringAttr>(kDataLayoutNodeTypeAttr)) {
+    return getNodeTypeFromStringAttr(attr);
+  }
+  return std::nullopt;
+}
+
+void setDataLayoutTransformationAttributes(Operation *op,
+                                           DataLayoutTransformation *transform,
+                                           StringRef transformID) {
+  op->setAttr(transformID, transform->makeTransformArrayAttr(op->getContext()));
+  return;
+}
+
+} // namespace mlir::iree_compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.h
@@ -34,14 +34,6 @@ public:
   DataLayoutTransformation(ShapedType orig, ShapedType transformed)
       : originalType(orig), transformedType(transformed){};
   DataLayoutTransformation(ShapedType orig) : originalType(orig){};
-  DataLayoutTransformation(DataLayoutTransformation &other) {
-    originalType = other.originalType;
-    transformedType = other.transformedType;
-    innerDimsPos = other.innerDimsPos;
-    innerTileSizes = other.innerTileSizes;
-    outerDimsPerm = other.outerDimsPerm;
-    correspondingTransformedIndices = other.correspondingTransformedIndices;
-  };
   DataLayoutTransformation(){};
 
   ShapedType getOriginalType() const { return originalType; };
@@ -76,7 +68,7 @@ public:
 
   /// Combine the information from this transform with another transform, and
   /// return whether or not information was gained.
-  bool combineLayout(DataLayoutTransformation other);
+  bool combineLayout(DataLayoutTransformation &other);
 
   /// Return whether this transform is valid. For now, only check that there is
   /// an originalType and a transformedType.
@@ -84,7 +76,7 @@ public:
 
   /// Return true if the transformed indices in this transformation overlap with
   /// the transformed indices of the other transformation.
-  bool isIntersecting(DataLayoutTransformation other);
+  bool isIntersecting(DataLayoutTransformation &other);
 
   /// Return true if this transform is an identity transformation.
   bool isIdentity();

--- a/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.h
@@ -6,22 +6,7 @@
 #ifndef IREE_GLOBALOPTIMIZATION_DATALAYOUTUTILS_H_
 #define IREE_GLOBALOPTIMIZATION_DATALAYOUTUTILS_H_
 
-#include <optional>
 #include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
-#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
-#include "llvm/ADT/StringRef.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
-#include "mlir/Dialect/Utils/StaticValueUtils.h"
-#include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/BuiltinTypeInterfaces.h"
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/PatternMatch.h"
-#include "mlir/IR/Visitors.h"
-#include "mlir/Interfaces/DataLayoutInterfaces.h"
-#include "mlir/Support/LogicalResult.h"
 
 namespace mlir {
 class Location;
@@ -101,6 +86,9 @@ public:
   /// the transformed indices of the other transformation.
   bool isIntersecting(DataLayoutTransformation other);
 
+  /// Return true if this transform is an identity transformation.
+  bool isIdentity();
+
   /// Create an ArrayAttr containing transformation information for debugging.
   ArrayAttr makeTransformArrayAttr(MLIRContext *ctx);
 
@@ -155,11 +143,11 @@ SmallVector<StringRef> getTerminalNodeIDs(Value value);
 /// of the `global`, passed in `edgeNodes` as the results or inputs to the
 /// load/store ops. Also, create an initializer to fill the new packed global
 /// with the padding value of the pack in the `transform`.
-LogicalResult transformGlobalsToNewLayout(IRRewriter &rewriter,
-                                          SmallVector<Value> edgeNodes,
-                                          DataLayoutTransformation *transform,
-                                          IREE::Util::GlobalOp global,
-                                          SymbolTable moduleSymbols);
+LogicalResult
+transformGlobalsToNewLayout(IRRewriter &rewriter, SmallVector<Value> edgeNodes,
+                            DataLayoutTransformation *transform,
+                            const Explorer::GlobalInfo *globalInfo,
+                            SymbolTable moduleSymbols);
 
 //===----------------------------------------------------------------------===//
 // Attribute helpers

--- a/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/DataLayoutUtils.h
@@ -1,0 +1,191 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#ifndef IREE_GLOBALOPTIMIZATION_DATALAYOUTUTILS_H_
+#define IREE_GLOBALOPTIMIZATION_DATALAYOUTUTILS_H_
+
+#include <optional>
+#include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "llvm/ADT/StringRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+class Location;
+class OpBuilder;
+class Operation;
+class RewriterBase;
+class Value;
+} // namespace mlir
+
+namespace mlir::iree_compiler::GlobalOptimization {
+
+/// UNINITIALIZED: This node has not been initialized.
+/// INTERMEDIATE: It is possible to propagate a layout through this node.
+/// BARRIER: It is not possible to propagate a layout through this node.
+enum class DataLayoutNodeType {
+  UNINITIALIZED,
+  INTERMEDIATE,
+  BARRIER,
+};
+
+/// TODO: Abstractify DataLayoutTransformation to decouple from specific types
+/// of transformations.
+class DataLayoutTransformation {
+public:
+  DataLayoutTransformation(ShapedType orig, ShapedType transformed)
+      : originalType(orig), transformedType(transformed){};
+  DataLayoutTransformation(ShapedType orig) : originalType(orig){};
+  DataLayoutTransformation(DataLayoutTransformation &other) {
+    originalType = other.originalType;
+    transformedType = other.transformedType;
+    innerDimsPos = other.innerDimsPos;
+    innerTileSizes = other.innerTileSizes;
+    outerDimsPerm = other.outerDimsPerm;
+    correspondingTransformedIndices = other.correspondingTransformedIndices;
+  };
+  DataLayoutTransformation(){};
+
+  ShapedType getOriginalType() const { return originalType; };
+  ShapedType getTransformedType() const { return transformedType; };
+  SmallVector<int64_t> getInnerDimsPos() const { return innerDimsPos; };
+  SmallVector<int64_t> getInnerTileSizes() const { return innerTileSizes; };
+  SmallVector<int64_t> getOuterDimsPerm() const { return outerDimsPerm; };
+  std::optional<TypedAttr> getConstantPadValue() const {
+    return constantPadValue;
+  };
+  SmallVector<int64_t> getCorrespondingTransformedIndices() const {
+    return correspondingTransformedIndices;
+  };
+  void setOriginalType(ShapedType type) { originalType = type; };
+  void setTransformedType(ShapedType type) { transformedType = type; };
+  void setInnerDimsPos(SmallVector<int64_t> pos) { innerDimsPos = pos; };
+  void setInnerTileSizes(SmallVector<int64_t> tiles) {
+    innerTileSizes = tiles;
+  };
+  void setOuterDimsPerm(SmallVector<int64_t> perm) { outerDimsPerm = perm; };
+  void setConstantPadValue(std::optional<TypedAttr> attr) {
+    constantPadValue = attr;
+  };
+  void setCorrespondingTransformedIndices(SmallVector<int64_t> inds) {
+    correspondingTransformedIndices = inds;
+  };
+
+  /// Get the transformed layout at the `newValue`, given the `currentValue`
+  /// with `this` layout. Return true for a successful transformation, and
+  /// return false if the transformation is not supported.
+  bool transformLayout(Value currentValue, Value newValue);
+
+  /// Combine the information from this transform with another transform, and
+  /// return whether or not information was gained.
+  bool combineLayout(DataLayoutTransformation other);
+
+  /// Return whether this transform is valid. For now, only check that there is
+  /// an originalType and a transformedType.
+  const bool hasValidTransform();
+
+  /// Return true if the transformed indices in this transformation overlap with
+  /// the transformed indices of the other transformation.
+  bool isIntersecting(DataLayoutTransformation other);
+
+  /// Create an ArrayAttr containing transformation information for debugging.
+  ArrayAttr makeTransformArrayAttr(MLIRContext *ctx);
+
+  /// Return a new identity transformation.
+  static DataLayoutTransformation *getIdentityTransformation(ShapedType type) {
+    auto *tf = new DataLayoutTransformation(type, type);
+    tf->setCorrespondingTransformedIndices(
+        llvm::to_vector(llvm::seq<int64_t>(0, type.getRank())));
+    return tf;
+  }
+
+private:
+  /// Transform the layout as if propagating through an operation, from the
+  /// `currentValue` to `newValue`, and return the new layout.
+  bool transform(Operation *op, Value currentValue, Value newValue);
+
+  /// The original type corresponding to the source of this layout.
+  ShapedType originalType;
+  /// The type of the layout source after the transformation is applied.
+  ShapedType transformedType;
+  /// Transformation metadate from `originalType`->`transformedType, represented
+  /// as pack metadata (innerDimsPos, innerTileSizes, outerDimsPerm) for now.
+  SmallVector<int64_t> innerDimsPos;
+  SmallVector<int64_t> innerTileSizes;
+  SmallVector<int64_t> outerDimsPerm;
+  /// Optional padding value for packed layouts.
+  std::optional<TypedAttr> constantPadValue = std::nullopt;
+  /// Indices in the `originalType` corresponding to each index of the value
+  /// associated with this DataLayoutTransformation.
+  SmallVector<int64_t> correspondingTransformedIndices;
+};
+
+//===----------------------------------------------------------------------===//
+// Analysis helpers
+//===----------------------------------------------------------------------===//
+
+/// Analyze the producer and users of this value, and return the node type for
+/// the given value.
+DataLayoutNodeType getNodeTypeForValue(Value value);
+
+/// If the node is a terminal node (e.g., the source of a layout, like a value
+/// next to a global load or store), then return the layoutIDs corresponding to
+/// that terminal node.
+SmallVector<StringRef> getTerminalNodeIDs(Value value);
+
+//===----------------------------------------------------------------------===//
+// Pass helpers
+//===----------------------------------------------------------------------===//
+
+/// Rewrite a Util::GlobalOp into the new layout indicated by the given
+/// DataLayoutTransformation, and rewrite all GlobalLoadOps or GlobalStoreOps
+/// of the `global`, passed in `edgeNodes` as the results or inputs to the
+/// load/store ops. Also, create an initializer to fill the new packed global
+/// with the padding value of the pack in the `transform`.
+LogicalResult transformGlobalsToNewLayout(IRRewriter &rewriter,
+                                          SmallVector<Value> edgeNodes,
+                                          DataLayoutTransformation *transform,
+                                          IREE::Util::GlobalOp global,
+                                          SymbolTable moduleSymbols);
+
+//===----------------------------------------------------------------------===//
+// Attribute helpers
+//===----------------------------------------------------------------------===//
+
+/// Padding values can get in the way of unpack(pack(x)) foldings, so this sets
+/// a `__foldable_pack_unpack__` attribute, which indicates that the op came
+/// from a given data layout, and can be folded with the inverse of the op as
+/// long as it also has the same attribute.
+void setFoldablePackUnPackAttribute(Operation *op);
+
+/// Return whether the op has the `__foldable_pack_unpack__` attribute.
+bool hasFoldablePackUnPackAttribute(Operation *op);
+
+/// Get the DataLayoutNodeType of an annotated op.
+std::optional<DataLayoutNodeType> getNodeTypeFromAttr(Operation *op);
+
+/// Set the `__node_type__` attribute for the op.
+void setNodeTypeAttribute(Operation *op, DataLayoutNodeType nodeType);
+
+/// Annotate an op for debugging with the layoutID and original + transformed
+/// type for a transformation.
+void setDataLayoutTransformationAttributes(Operation *op,
+                                           DataLayoutTransformation *transform,
+                                           StringRef transformID);
+
+} // namespace mlir::iree_compiler::GlobalOptimization
+
+#endif // IREE_GLOBALOPTIMIZATION_DATALAYOUTUTILS_H_

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -144,6 +144,10 @@ void buildGlobalOptimizationPassPipeline(
     mainPassManager.addPass(createCanonicalizerPass());
     mainPassManager.addPass(createCSEPass());
     mainPassManager.addPass(createSimplifyPackUnpackPass());
+    if (transformOptions.options.propagateGlobalLayout) {
+      mainPassManager.addPass(createPropagateDataLayoutPass());
+      mainPassManager.addPass(createCSEPass());
+    }
   }
   // Generalize transposes and any other remaining named linalg ops that can
   // now be represented as generics.

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -92,6 +92,9 @@ createMaterializeHomogeneousEncodingsPass();
 /// iree-global-opt-infer-numeric-narrowing.
 std::unique_ptr<Pass> createOptimizeNumericsPass();
 
+/// Propagates data layouts up to globals.
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createPropagateDataLayoutPass();
+
 /// Propagates linalg.transpose ops to a restricted set of operations.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createPropagateLinalgTransposePass(bool enableAggressivePropagation = false);

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -96,6 +96,12 @@ def OptimizeNumerics :
   let constructor = "mlir::iree_compiler::GlobalOptimization::createOptimizeNumericsPass()";
 }
 
+def PropagateDataLayout :
+    Pass<"iree-global-opt-propagate-data-layout", "mlir::ModuleOp"> {
+  let summary = "Propagates data layouts up to globals";
+  let constructor = "mlir::iree_compiler::GlobalOptimization::createPropagateDataLayoutPass()";
+}
+
 def PropagateLinalgTranspose :
     InterfacePass<"iree-global-opt-propagate-linalg-transpose", "mlir::FunctionOpInterface"> {
   let summary = "Propagates linalg.transpose through a restricted set of ops";

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateDataLayout.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateDataLayout.cpp
@@ -1,0 +1,748 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- PropagateDataLayout.cpp - Pass to propagate data layout to globals -===//
+//
+// The pass is to propagate data layout operations like tensor.pack all the
+// way to global loads/stores, and update the layout of globals
+//
+//===----------------------------------------------------------------------===//
+
+#include <optional>
+#include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/Dialect/Util/Analysis/DFX/DepGraph.h"
+#include "iree/compiler/Dialect/Util/Analysis/DFX/Element.h"
+#include "iree/compiler/Dialect/Util/Analysis/DFX/Solver.h"
+#include "iree/compiler/Dialect/Util/Analysis/DFX/State.h"
+#include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
+#include "iree/compiler/Dialect/Util/Analysis/Position.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/GlobalOptimization/DataLayoutUtils.h"
+#include "iree/compiler/GlobalOptimization/PassDetail.h"
+#include "iree/compiler/GlobalOptimization/Passes.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/SuffixTreeNode.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Threading.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-global-opt-propagate-data-layout"
+
+namespace mlir::iree_compiler::GlobalOptimization {
+
+template <typename T>
+static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const llvm::SmallVectorImpl<T> &vector) {
+  os << "[ ";
+  for (T element : vector) {
+    os << element << " ";
+  }
+  os << "]";
+
+  return os;
+}
+
+template <typename T>
+static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const llvm::ArrayRef<T> &vector) {
+  os << "[ ";
+  for (T element : vector) {
+    os << element << " ";
+  }
+  os << "]";
+
+  return os;
+}
+
+static llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os, const DataLayoutTransformation &transform) {
+  os << "originalType: " << transform.getOriginalType() << "\n";
+  os << "transformedType: " << transform.getTransformedType() << "\n";
+  os << "innerDimsPos: " << transform.getInnerDimsPos() << "\n";
+  os << "innerTileSizes: " << transform.getInnerTileSizes() << "\n";
+  os << "outerDimsPerm: " << transform.getOuterDimsPerm() << "\n";
+  os << "constantPadValue: " << transform.getConstantPadValue() << "\n";
+  os << "correspondingTransformedIndices: "
+     << transform.getCorrespondingTransformedIndices() << "\n";
+  return os;
+}
+
+class GlobalDataLayoutState : public DFX::AbstractState {
+public:
+  bool isValidState() const override { return true; }
+  /// TODO: There are cases where the `correspondingTransformedIndices` of a
+  /// transformation may not have maximal information when transforms are
+  /// propagated from the first neighbor that has a valid transform. To fix
+  /// this, the Fixpoint state should be based on how many unknown indices there
+  /// are in `correspondingTransformedIndices`, and states need to be allowed to
+  /// propagate `correspondingTransformedIndices` information after they already
+  /// have a valid transform.
+  bool isAtFixpoint() const override {
+    return false;
+    return getLayoutIDs().size() && all_of(getLayoutIDs(), [&](StringRef id) {
+             return layoutMap.lookup(id)->hasValidTransform();
+           });
+  }
+
+  ChangeStatus indicateOptimisticFixpoint() override {
+    return ChangeStatus::UNCHANGED;
+  }
+
+  ChangeStatus indicatePessimisticFixpoint() override {
+    return ChangeStatus::CHANGED;
+  }
+
+  SmallVector<StringRef> getLayoutIDs() const {
+    SetVector<StringRef> ids;
+    for (auto it : layoutMap) {
+      ids.insert(it.first);
+    }
+    return ids.takeVector();
+  };
+  bool hasLayoutID(StringRef id) { return layoutMap.contains(id); };
+  DataLayoutTransformation *getDataLayoutTransformation(StringRef id) {
+    if (layoutMap.contains(id))
+      return layoutMap[id];
+    return nullptr;
+  };
+  DataLayoutNodeType getNodeType() const { return nodeType; };
+  bool addDataLayoutTransformation(StringRef id,
+                                   DataLayoutTransformation *newLayout) {
+    return layoutMap.insert(std::make_pair(id, newLayout)).second;
+  };
+  void setDataLayoutTransformation(StringRef id,
+                                   DataLayoutTransformation *newLayout) {
+    if (layoutMap.count(id)) {
+      layoutMap.erase(id);
+    }
+    layoutMap.insert(std::make_pair(id, newLayout));
+  };
+
+  bool initializeTerminalNodeIDs(Value value) {
+    DataLayoutTransformation *newLayout =
+        new DataLayoutTransformation(cast<ShapedType>(value.getType()));
+    SmallVector<StringRef> IDs = getTerminalNodeIDs(value);
+    bool addedID = false;
+    for (auto id : IDs) {
+      addedID |= addDataLayoutTransformation(id, newLayout);
+    }
+    return addedID;
+  }
+
+  bool initializeTerminalNodeLayouts(Value value) {
+    bool changed = false;
+    auto layoutType = cast<ShapedType>(value.getType());
+    DataLayoutTransformation *newLayout =
+        DataLayoutTransformation::getIdentityTransformation(layoutType);
+    SmallVector<StringRef> IDs = getTerminalNodeIDs(value);
+    for (auto id : IDs) {
+      if (getDataLayoutTransformation(id) &&
+          !getDataLayoutTransformation(id)->hasValidTransform()) {
+        changed = true;
+      }
+      setDataLayoutTransformation(id, newLayout);
+    }
+    return changed;
+  }
+
+  void setNodeType(DataLayoutNodeType newNodeType) { nodeType = newNodeType; };
+
+private:
+  DenseMap<StringRef, DataLayoutTransformation *> layoutMap;
+  DataLayoutNodeType nodeType = DataLayoutNodeType::UNINITIALIZED;
+};
+
+class GlobalDataLayoutValueElement
+    : public DFX::StateWrapper<GlobalDataLayoutState, DFX::ValueElement> {
+public:
+  using BaseType = DFX::StateWrapper<GlobalDataLayoutState, DFX::ValueElement>;
+  using BaseType::BaseType;
+
+  static GlobalDataLayoutValueElement &createForPosition(const Position &pos,
+                                                         DFX::Solver &solver) {
+    return *(new (solver.getAllocator()) GlobalDataLayoutValueElement(pos));
+  }
+
+  // Identity definitions.
+  static const char ID;
+  const std::string getName() const override {
+    return "GlobalDataLayoutValueElement";
+  }
+  const void *getID() const override { return &ID; }
+  static bool classof(const DFX::AbstractElement *element) {
+    return (element->getID() == &ID);
+  }
+  const std::string getAsStr(AsmState &asmState) const override;
+
+  /// TODO: Restrict BFS search to not search through barriers.
+  static SetVector<Value> getTensorValueNeighbors(Value value) {
+    SetVector<Value> connectedValues;
+    auto appendOpValues = [&](Operation *op) {
+      for (Value v : op->getOperands()) {
+        if (isa<ShapedType>(v.getType())) {
+          connectedValues.insert(v);
+        }
+      }
+      for (Value v : op->getResults()) {
+        if (isa<ShapedType>(v.getType())) {
+          connectedValues.insert(v);
+        }
+      }
+    };
+    // Get defining op values
+    if (Operation *definingOp = value.getDefiningOp()) {
+      appendOpValues(definingOp);
+    }
+    // Get user op values
+    for (Operation *user : value.getUsers()) {
+      appendOpValues(user);
+    }
+    connectedValues.remove(value);
+    return connectedValues;
+  }
+
+  void walkAllConnectedTensorValues(std::function<void(Value &)> fn) {
+    DenseSet<Value> visitedValues;
+    recursivelyWalkAllConnectedTensorValues(getValue(), fn, visitedValues);
+  }
+
+private:
+  static void
+  recursivelyWalkAllConnectedTensorValues(Value value,
+                                          std::function<void(Value &)> fn,
+                                          DenseSet<Value> &visitedValues) {
+    if (visitedValues.contains(value)) {
+      return;
+    }
+    visitedValues.insert(value);
+    fn(value);
+    if (getNodeTypeForValue(value) == DataLayoutNodeType::BARRIER) {
+      return;
+    }
+    for (Value v : getTensorValueNeighbors(value)) {
+      recursivelyWalkAllConnectedTensorValues(v, fn, visitedValues);
+    }
+  }
+  void initializeValue(Value value, DFX::Solver &solver) override;
+  ChangeStatus updateValue(Value value, DFX::Solver &solver) override;
+};
+const char GlobalDataLayoutValueElement::ID = 0;
+
+const std::string
+GlobalDataLayoutValueElement::getAsStr(AsmState &asmState) const {
+  std::string s("getAsStr unimplemented");
+  return s;
+}
+
+class GlobalDataLayoutAnalysis {
+public:
+  GlobalDataLayoutAnalysis(ModuleOp rootOp)
+      : explorer(rootOp, TraversalAction::SHALLOW),
+        solver(explorer, allocator) {
+    explorer.setOpAction<IREE::Util::FuncOp>(TraversalAction::RECURSE);
+    explorer.setOpAction<IREE::Util::InitializerOp>(TraversalAction::RECURSE);
+    explorer.initialize();
+
+    for (auto globalOp : rootOp.getOps<IREE::Util::GlobalOp>()) {
+      auto initialVal = globalOp.getInitialValue();
+      bool isUninitialized =
+          (!initialVal.has_value() ||
+           isa<IREE::Util::UninitializedAttr>(initialVal.value()));
+      if (globalOp.getIsMutable() && isa<ShapedType>(globalOp.getType()) &&
+          isUninitialized) {
+        LLVM_DEBUG({ llvm::dbgs() << "adding global: " << globalOp << "\n"; });
+        globals.insert(std::make_pair(globalOp.getGlobalName(), globalOp));
+      }
+    }
+  }
+
+  SmallVector<Value> getGlobalLayoutEndpoints() {
+    SmallVector<Value> endpoints;
+    auto walkFn = [&](Operation *op) -> WalkResult {
+      if (auto loadOp = dyn_cast<IREE::Util::GlobalLoadOp>(op)) {
+        if (globals.contains(loadOp.getGlobal())) {
+          endpoints.push_back(op->getResult(0));
+        }
+      } else if (auto storeOp = dyn_cast<IREE::Util::GlobalStoreOp>(op)) {
+        if (globals.contains(storeOp.getGlobal())) {
+          endpoints.push_back(op->getOperand(0));
+        }
+      }
+      return WalkResult::advance();
+    };
+    explorer.walk(walkFn);
+    return endpoints;
+  }
+
+  LogicalResult run() {
+    SmallVector<Value> endpoints = getGlobalLayoutEndpoints();
+    for (auto endpoint : endpoints) {
+      solver.getOrCreateElementFor<GlobalDataLayoutValueElement>(
+          Position::forValue(endpoint));
+    }
+    return solver.run();
+  }
+
+  /// Returns a list of all tensor values that may incur an element-wise cost
+  /// when transformed with the given transformation.
+  SetVector<Value>
+  getTransformedValues(DataLayoutTransformation *tf,
+                       SmallVector<GlobalDataLayoutValueElement *> costNodes,
+                       StringRef layoutID) {
+    SetVector<Value> transformedVals;
+    for (auto node : costNodes) {
+      auto definingOp = node->getValue().getDefiningOp();
+      if (llvm::isa_and_nonnull<tensor::EmptyOp>(definingOp)) {
+        continue;
+      }
+      if (auto loadOp =
+              llvm::dyn_cast_or_null<IREE::Util::GlobalLoadOpInterface>(
+                  definingOp)) {
+        if (loadOp.getGlobalName().equals(layoutID))
+          continue;
+      }
+      DataLayoutTransformation *costNodeTf =
+          node->getState().getDataLayoutTransformation(layoutID);
+      // If the transformation does not intersect the value's dimensions, then
+      // the value does not actually need to be transformed.
+      if (tf->isIntersecting(*costNodeTf)) {
+        transformedVals.insert(node->getValue());
+      }
+    }
+    return transformedVals;
+  }
+
+  /// Return true if `a` can be known to have a greater or equal number of
+  /// elements than `b`, assuming dynamic dims must be at least equal to 1.
+  bool hasMoreTotalElements(SetVector<Value> a, SetVector<Value> b) {
+    int64_t staticCountA = 0, staticCountB = 0;
+    bool hasDynamicA = false, hasDynamicB = false;
+    auto countElements = [](SetVector<Value> set, SetVector<Value> other,
+                            int64_t &staticCount, bool &hasDynamicSizes) {
+      for (Value v : set) {
+        // Ignore values that are in both sets
+        if (!other.count(v)) {
+          auto shape = cast<ShapedType>(v.getType()).getShape();
+          int64_t count = 1;
+          for (auto size : shape) {
+            if (size == ShapedType::kDynamic) {
+              hasDynamicSizes = true;
+              continue;
+            }
+            count *= size;
+          }
+          // Always add to staticCount, even if there were dynamic sizes.
+          // Dynamic sizes must be at least 1, so we can know statically
+          // that there are at least [product of static dims] elements.
+          staticCount += count;
+        }
+      }
+    };
+    countElements(a, b, staticCountA, hasDynamicA);
+    countElements(b, a, staticCountB, hasDynamicB);
+    // If B is not dynamic, and the static count of A is greater than B,
+    // then we can know that A has at least as many total elements as B.
+    if (!hasDynamicB && staticCountA >= staticCountB) {
+      return true;
+    }
+    // Otherwise, B has a greater static count, or B is dynamic and we
+    // cannot know statically if there are more elements in B.
+    return false;
+  }
+
+  LogicalResult getSubgraphEdgeNodesAndBestLayoutTransformation(
+      SetVector<GlobalDataLayoutValueElement *> subgraph,
+      SmallVector<Value> &edgeNodes, DataLayoutTransformation *&transform,
+      StringRef layoutID) {
+    assert(edgeNodes.empty() && "edgeNodes expected to be empty");
+    SmallVector<DataLayoutTransformation *> barrierTransforms;
+    SmallVector<GlobalDataLayoutValueElement *> costNodes;
+    DataLayoutTransformation *bestTf;
+    for (auto node : subgraph) {
+      GlobalDataLayoutState state = node->getState();
+      if (state.getNodeType() == DataLayoutNodeType::BARRIER) {
+        costNodes.push_back(node);
+        barrierTransforms.push_back(
+            state.getDataLayoutTransformation(layoutID));
+      }
+      if (!getTerminalNodeIDs(node->getValue()).empty()) {
+        edgeNodes.push_back(node->getValue());
+        // Initialize the "bestTf" as the identity transformation at edge nodes.
+        bestTf = state.getDataLayoutTransformation(layoutID);
+      }
+    }
+    if (barrierTransforms.empty() || edgeNodes.empty()) {
+      return failure();
+    }
+
+    SetVector<Value> bestTransformedValues;
+    for (auto tf : barrierTransforms) {
+      SetVector<Value> transformedValues =
+          getTransformedValues(tf, costNodes, layoutID);
+      // Assume the cost of layout transformations are simple element-wise
+      // operations, so the cost of the transformations are proportional to the
+      // combined total number of elements in the set of transformed tensors.
+      if (!bestTf ||
+          hasMoreTotalElements(transformedValues, bestTransformedValues)) {
+        bestTf = tf;
+        bestTransformedValues = transformedValues;
+      }
+    }
+    transform = bestTf;
+    LLVM_DEBUG({
+      llvm::dbgs() << "layoutID: " << layoutID << "\n";
+      llvm::dbgs() << "best tf: " << *bestTf << "\n\n";
+    });
+    return success();
+  }
+
+  LogicalResult getEdgeNodesAndBestLayoutTransformations(
+      SmallVector<SmallVector<Value>> &edgeNodes,
+      SmallVector<DataLayoutTransformation *> &transforms,
+      SmallVector<StringRef> &layoutIDs) {
+    DenseMap<StringRef, SetVector<GlobalDataLayoutValueElement *>> subgraphMap;
+    auto walkFn = [&](Value val) -> WalkResult {
+      if (auto *elementPtr =
+              solver.lookupElementFor<GlobalDataLayoutValueElement>(
+                  Position::forValue(val),
+                  /*queryingElement=*/nullptr, DFX::Resolution::NONE,
+                  /*allowInvalidState=*/false)) {
+        GlobalDataLayoutState state = elementPtr->getState();
+        // Only support subgraphs with a single layout ID for now
+        auto stateLayoutIDs = state.getLayoutIDs();
+        if (stateLayoutIDs.size() == 1) {
+          if (subgraphMap.count(stateLayoutIDs[0])) {
+            subgraphMap[stateLayoutIDs[0]].insert(elementPtr);
+          } else {
+            SetVector<GlobalDataLayoutValueElement *> s;
+            s.insert(elementPtr);
+            subgraphMap.insert(std::make_pair(stateLayoutIDs[0], s));
+          }
+        }
+      }
+      return WalkResult::advance();
+    };
+    explorer.walkValues(walkFn);
+
+    // For each subgraph, compute the optimal layout and endpoint nodes
+    for (auto [layoutID, valueElems] : subgraphMap) {
+      SmallVector<Value> subgraphEdgeNodes;
+      DataLayoutTransformation *subgraphTransform;
+      if (!failed(getSubgraphEdgeNodesAndBestLayoutTransformation(
+              valueElems, subgraphEdgeNodes, subgraphTransform, layoutID))) {
+        edgeNodes.push_back(subgraphEdgeNodes);
+        transforms.push_back(subgraphTransform);
+        layoutIDs.push_back(layoutID);
+      }
+    }
+    if (edgeNodes.empty()) {
+      return failure();
+    }
+    return success();
+  }
+
+  void annotateDataLayoutNodes() {
+    auto walkFn = [&](Value val) -> WalkResult {
+      if (auto definingOp = val.getDefiningOp()) {
+        if (auto *elementPtr =
+                solver.lookupElementFor<GlobalDataLayoutValueElement>(
+                    Position::forValue(val),
+                    /*queryingElement=*/nullptr, DFX::Resolution::NONE,
+                    /*allowInvalidState=*/false)) {
+          GlobalDataLayoutState state = elementPtr->getState();
+          setNodeTypeAttribute(definingOp, state.getNodeType());
+          for (StringRef id : state.getLayoutIDs()) {
+            setDataLayoutTransformationAttributes(
+                definingOp, state.getDataLayoutTransformation(id), id);
+          }
+        }
+      }
+      return WalkResult::advance();
+    };
+    explorer.walkValues(walkFn);
+  }
+
+  DenseMap<StringRef, IREE::Util::GlobalOp> getGlobals() { return globals; }
+
+private:
+  Explorer explorer;
+  llvm::BumpPtrAllocator allocator;
+  DFX::Solver solver;
+  DenseMap<StringRef, IREE::Util::GlobalOp> globals;
+};
+
+void GlobalDataLayoutValueElement::initializeValue(Value value,
+                                                   DFX::Solver &solver) {
+  GlobalDataLayoutState &newState = getState();
+  if (newState.getNodeType() == DataLayoutNodeType::UNINITIALIZED) {
+    DataLayoutNodeType newNodeType = getNodeTypeForValue(value);
+    newState.setNodeType(newNodeType);
+  }
+  return;
+}
+
+ChangeStatus GlobalDataLayoutValueElement::updateValue(Value value,
+                                                       DFX::Solver &solver) {
+  GlobalDataLayoutState &newState = getState();
+  ChangeStatus status = ChangeStatus::UNCHANGED;
+
+  // Compute the DataLayoutTransformation transformation to the current value.
+  SetVector<Value> valueNeighbors = getTensorValueNeighbors(value);
+  for (Value neighbor : valueNeighbors) {
+    // Find neighbors that are part of the layout graph
+    auto *neighborVE = solver.lookupElementFor<GlobalDataLayoutValueElement>(
+        Position::forValue(neighbor), /*queryingElement=*/nullptr,
+        DFX::Resolution::NONE, /*allowInvalidState=*/false);
+    if (!neighborVE) {
+      continue;
+    }
+    GlobalDataLayoutState neighborState = neighborVE->getState();
+    for (StringRef id : neighborState.getLayoutIDs()) {
+      auto *newLayout = new DataLayoutTransformation(
+          *neighborState.getDataLayoutTransformation(id));
+      // Start by initializing the current newState with an empty transformation
+      // if it does not already have one for this ID.
+      if (newState.addDataLayoutTransformation(
+              id, new DataLayoutTransformation(newLayout->getOriginalType()))) {
+        status = ChangeStatus::CHANGED;
+      }
+      // Try to infer the transformation to the current value using the
+      // transformation from the neighboring value.
+      if (!newLayout->hasValidTransform()) {
+        continue;
+      }
+      if (newLayout->transformLayout(neighbor, value)) {
+        // If there is already a known transformation to the current node, then
+        // try to combine the information from the new inferred layout with the
+        // known transformation, since not all transformations will carry the
+        // maximal information for a given value.
+        auto currentTf = newState.getDataLayoutTransformation(id);
+        if (currentTf && currentTf->hasValidTransform()) {
+          if (currentTf->combineLayout(*newLayout)) {
+            status = ChangeStatus::CHANGED;
+          }
+          continue;
+        }
+        // Otherwise, take the inferred transformation.
+        newState.setDataLayoutTransformation(id, newLayout);
+        status = ChangeStatus::CHANGED;
+      }
+    }
+  }
+
+  // If the newState did not pick up any layoutIDs from its neighbors, then
+  // this is the first node to be initialized with layoutIDs, and we need to
+  // walk the graph to find all reachable layouts from this node. These layouts
+  // will propagate through the neighboring nodes when the neighbors do a state
+  // update, so this should only happen once per connected graph.
+  if (newState.getLayoutIDs().size() == 0) {
+    newState.initializeTerminalNodeIDs(value);
+    walkAllConnectedTensorValues(
+        [&newState](Value v) { newState.initializeTerminalNodeIDs(v); });
+    if (newState.getLayoutIDs().size() > 0) {
+      status = ChangeStatus::CHANGED;
+    }
+  }
+  // Terminal nodes (sources of the layouts) initialize their corresponding
+  // layoutID with the identity transformation.
+  if (newState.initializeTerminalNodeLayouts(value)) {
+    status = ChangeStatus::CHANGED;
+  }
+
+  // Intermediate nodes add ValueElements for all neighboring tensor values.
+  if (newState.getNodeType() == DataLayoutNodeType::INTERMEDIATE) {
+    for (Value val : valueNeighbors) {
+      if (val != value) {
+        if (val.getDefiningOp<tensor::EmptyOp>()) {
+          continue;
+        }
+        auto &newNode = solver.getElementFor<GlobalDataLayoutValueElement>(
+            *this, Position::forValue(val), DFX::Resolution::REQUIRED);
+        solver.recordDependence(*this, newNode, DFX::Resolution::REQUIRED);
+      }
+    }
+  }
+
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// Propagation pattern definitions
+//===----------------------------------------------------------------------===//
+
+class FoldCancellingUnPackPackOps final
+    : public OpRewritePattern<tensor::UnPackOp> {
+public:
+  using OpRewritePattern<tensor::UnPackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::UnPackOp unpackOp,
+                                PatternRewriter &rewriter) const override {
+    return tensor::UnPackOp::canonicalize(unpackOp, rewriter);
+  }
+};
+
+static bool haveSameTiles(tensor::PackOp packOp, tensor::UnPackOp unPackOp) {
+  auto packTiles = packOp.getMixedTiles();
+  auto unPackTiles = unPackOp.getMixedTiles();
+  if (packTiles.size() != unPackTiles.size())
+    return false;
+  for (size_t i = 0, e = packTiles.size(); i < e; i++) {
+    if (!isEqualConstantIntOrValue(packTiles[i], unPackTiles[i]))
+      return false;
+  }
+  return true;
+}
+
+class FoldCancellingPackUnPackOps final
+    : public OpRewritePattern<tensor::PackOp> {
+public:
+  using OpRewritePattern<tensor::PackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::PackOp packOp,
+                                PatternRewriter &rewriter) const override {
+    // Fold an unpack(pack(x)) to x, ignoring padding_value if explicitly.
+    // labeled as a foldable unpack.
+    if (auto unPackOp = packOp.getSource().getDefiningOp<tensor::UnPackOp>()) {
+      if (!hasFoldablePackUnPackAttribute(unPackOp)) {
+        return failure();
+      }
+      if (unPackOp.getSourceType() != packOp.getDestType())
+        return failure();
+      if (packOp.getInnerDimsPos() != unPackOp.getInnerDimsPos() ||
+          packOp.getOuterDimsPerm() != unPackOp.getOuterDimsPerm() ||
+          !haveSameTiles(packOp, unPackOp))
+        return failure();
+      rewriter.replaceOp(packOp, unPackOp.getSource());
+      return success();
+    }
+    return failure();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass definition
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct PropagateDataLayoutPass
+    : public PropagateDataLayoutBase<PropagateDataLayoutPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, tensor::TensorDialect,
+                    IREE::Flow::FlowDialect>();
+  }
+
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void PropagateDataLayoutPass::runOnOperation() {
+  auto moduleOp = getOperation();
+
+  // Do data layout analysis and rewrite globals
+  {
+
+    GlobalDataLayoutAnalysis analysis(moduleOp);
+    if (failed(analysis.run())) {
+      LLVM_DEBUG({ llvm::dbgs() << "analysis failed\n"; });
+      return signalPassFailure();
+    }
+
+    analysis.annotateDataLayoutNodes();
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "\n--- After annotating DAG with start/end points ---\n";
+      moduleOp->print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+
+    // Compute optimal layout for each global
+    SmallVector<SmallVector<Value>> edgeNodes;
+    SmallVector<DataLayoutTransformation *> transforms;
+    SmallVector<StringRef> layoutIDs;
+    if (failed(analysis.getEdgeNodesAndBestLayoutTransformations(
+            edgeNodes, transforms, layoutIDs))) {
+      LLVM_DEBUG({ llvm::dbgs() << "Could not compute optimal layouts\n"; });
+      return;
+    }
+
+    {
+      SymbolTable moduleSymbols(moduleOp);
+      IRRewriter rewriter(&getContext());
+      DenseMap<StringRef, IREE::Util::GlobalOp> globals = analysis.getGlobals();
+      for (auto [idx, layoutID] : llvm::enumerate(layoutIDs)) {
+        if (globals.count(layoutID)) {
+          if (failed(transformGlobalsToNewLayout(
+                  rewriter, edgeNodes[idx], transforms[idx], globals[layoutID],
+                  moduleSymbols))) {
+            return signalPassFailure();
+          }
+        }
+      }
+    }
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n--- After rewriting globals into new layout ---\n";
+    moduleOp->print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+
+  // Propagate data layout transformation to start/end nodes
+  {
+    MLIRContext *context = &getContext();
+    RewritePatternSet propagationPatterns(context);
+    propagationPatterns.insert<FoldCancellingPackUnPackOps>(context);
+    propagationPatterns.insert<FoldCancellingUnPackPackOps>(context);
+
+    if (failed(applyPatternsAndFoldGreedily(moduleOp,
+                                            std::move(propagationPatterns)))) {
+      return signalPassFailure();
+    }
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n--- After propagating data layout through DAGs ---\n";
+    moduleOp->print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+}
+
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createPropagateDataLayoutPass() {
+  return std::make_unique<PropagateDataLayoutPass>();
+}
+
+} // namespace mlir::iree_compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -29,6 +29,7 @@ iree_lit_test_suite(
             "infer_numeric_narrowing.mlir",
             "materialize_homogeneous_encodings.mlir",
             "optimize_numerics.mlir",
+            "propagate_data_layout.mlir",
             "propagate_linalg_transpose.mlir",
             "raise_special_ops.mlir",
             "remove_zero_extent_tensors.mlir",

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_lit_test_suite(
     "infer_numeric_narrowing.mlir"
     "materialize_homogeneous_encodings.mlir"
     "optimize_numerics.mlir"
+    "propagate_data_layout.mlir"
     "propagate_linalg_transpose.mlir"
     "raise_special_ops.mlir"
     "remove_zero_extent_tensors.mlir"

--- a/compiler/src/iree/compiler/GlobalOptimization/test/propagate_data_layout.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/propagate_data_layout.mlir
@@ -1,0 +1,29 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-global-opt-propagate-data-layout,cse)" --split-input-file %s | FileCheck %s
+
+module @pack_propagation {
+  util.global private mutable @_global_state.global = #util.uninitialized : tensor<256x32x128xf32>
+  util.func public @pack_across_globals(%arg0: tensor<32x1x64x1x2xf32>) -> tensor<32x1x16x1x16xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %_global_state.global = util.global.load @_global_state.global : tensor<256x32x128xf32>
+    %0 = tensor.empty() : tensor<32x16x64x16x2xf32>
+    %pack = tensor.pack %_global_state.global outer_dims_perm = [1, 0, 2] inner_dims_pos = [0, 2] inner_tiles = [16, 2] into %0 : tensor<256x32x128xf32> -> tensor<32x16x64x16x2xf32>
+    %1 = tensor.empty() : tensor<32x1x16x1x16xf32>
+    %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<32x1x16x1x16xf32>) -> tensor<32x1x16x1x16xf32>
+    %3 = linalg.batch_mmt4d ins(%arg0, %pack : tensor<32x1x64x1x2xf32>, tensor<32x16x64x16x2xf32>) outs(%2 : tensor<32x1x16x1x16xf32>) -> tensor<32x1x16x1x16xf32>
+    util.return %3 : tensor<32x1x16x1x16xf32>
+  }
+}
+
+// //       CHECK: module @pack_propagation
+// //       CHECK:   private mutable @[[PACKED_GLOBAL:.+]] = #util.uninitialized : tensor<32x16x64x16x2xf32>
+// //       CHECK:   util.initializer {
+// //       CHECK:     %[[SPLAT:.+]] = flow.tensor.splat {{.+}} tensor<32x16x64x16x2xf32>
+// //       CHECK:     util.global.store %[[SPLAT]], @[[PACKED_GLOBAL]] : tensor<32x16x64x16x2xf32>
+// //       CHECK:   util.func public @pack_across_globals
+// //  CHECK-SAME:     %[[ARG0:.+]]: tensor<32x1x64x1x2xf32>
+// //   CHECK-DAG:     %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// //       CHECK:     %[[PACKED_STATE:.+]] = util.global.load @[[PACKED_GLOBAL]] : tensor<32x16x64x16x2xf32>
+// //       CHECK:     %[[EMPTY:.+]] = tensor.empty() : tensor<32x1x16x1x16xf32>
+// //       CHECK:     %[[MMT4D_DST:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<32x1x16x1x16xf32>) -> tensor<32x1x16x1x16xf32>
+// //       CHECK:     %[[MMT4D:.+]] = linalg.batch_mmt4d ins(%[[ARG0]], %[[PACKED_STATE]] : tensor<32x1x64x1x2xf32>, tensor<32x16x64x16x2xf32>) outs(%[[MMT4D_DST]] : tensor<32x1x16x1x16xf32>) -> tensor<32x1x16x1x16xf32>
+// //       CHECK:     util.return %[[MMT4D]] : tensor<32x1x16x1x16xf32>

--- a/compiler/src/iree/compiler/GlobalOptimization/test/propagate_data_layout.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/propagate_data_layout.mlir
@@ -22,7 +22,7 @@ module @pack_propagation {
 // //       CHECK:   util.func public @pack_across_globals
 // //  CHECK-SAME:     %[[ARG0:.+]]: tensor<32x1x64x1x2xf32>
 // //   CHECK-DAG:     %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-// //       CHECK:     %[[PACKED_STATE:.+]] = util.global.load @[[PACKED_GLOBAL]] : tensor<32x16x64x16x2xf32>
+// //       CHECK:     %[[PACKED_STATE:.+]] = util.global.load @[[PACKED_GLOBAL]]{{.+}} : tensor<32x16x64x16x2xf32>
 // //       CHECK:     %[[EMPTY:.+]] = tensor.empty() : tensor<32x1x16x1x16xf32>
 // //       CHECK:     %[[MMT4D_DST:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<32x1x16x1x16xf32>) -> tensor<32x1x16x1x16xf32>
 // //       CHECK:     %[[MMT4D:.+]] = linalg.batch_mmt4d ins(%[[ARG0]], %[[PACKED_STATE]] : tensor<32x1x64x1x2xf32>, tensor<32x16x64x16x2xf32>) outs(%[[MMT4D_DST]] : tensor<32x1x16x1x16xf32>) -> tensor<32x1x16x1x16xf32>

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -114,6 +114,10 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
                    llvm::cl::desc("Enables data tiling path."),
                    llvm::cl::cat(category));
   binder.opt<bool>(
+      "iree-opt-propagate-global-layout", propagateGlobalLayout,
+      llvm::cl::desc("Enables propagation of packed global data layouts."),
+      llvm::cl::cat(category));
+  binder.opt<bool>(
       "iree-opt-const-eval", constEval,
       llvm::cl::desc("Enables eager evaluation of constants using the full "
                      "compiler and runtime (on by default)."),

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -74,6 +74,8 @@ struct GlobalOptimizationOptions {
   // Enables transposing all concatenations to the outer most dimension.
   bool outerDimConcat = false;
 
+  bool propagateGlobalLayout = false;
+
   // Enables data tiling.
   bool dataTiling = true;
 


### PR DESCRIPTION
This adds a new pass to do propagation of data layouts all the way to mutable GlobalOps. This is just the basic analysis flow for now, only capable of handling some trivial cases, but this will be extended.

The pass does an analysis of the full program, and finds subgraphs of values that can all have the same layout. The subgraphs are seeded on loads and stores to GlobalOps, and then transformations are computed from the source layout to the layout at propagation barriers. Then, if one of the barrier layouts is better than the original source layout, the globals are rewritten to the barrier layout, and the layout is propagated through the subgraph.

This PR sets in place the full program analysis, but does not implement any propagations or transformation logic for ops other than PackOp. Future PRs will extend this by adding propagation patterns and logic for computing transformations through different ops.