### PR TITLE
[LinalgExt] Delete ForallOpToAsyncRewriter declaration.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
@@ -17,20 +17,6 @@
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
-/// Pattern to rewrite a scf::ForallOp to the async dialect.
-struct ForallOpToAsyncRewriter : public OpRewritePattern<scf::ForallOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  FailureOr<Operation *>
-  returningMatchAndRewrite(scf::ForallOp forallOp,
-                           PatternRewriter &rewriter) const;
-
-  LogicalResult matchAndRewrite(scf::ForallOp forallOp,
-                                PatternRewriter &rewriter) const override {
-    return returningMatchAndRewrite(forallOp, rewriter);
-  }
-};
-
 //===----------------------------------------------------------------------===//
 // Transformations exposed as patterns, moved from upstream MLIR as IREE still
 // heavily relies on patterns that compose through filters.


### PR DESCRIPTION
It's supposed to be deleted with https://github.com/openxla/iree/commit/8b477dc09bd963c7c06ab1c4909b0cb5cfc24acd, but I missed it in the previous PR.