### PR TITLE
[Codegen][GPU] Fix multi-dim warp reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -274,8 +274,7 @@ public:
         // complex cases.
         int64_t vecRank = vecType.getRank();
         OpBuilder builder(val.getContext());
-        return AffineMap::get(vecRank, 0,
-                              builder.getAffineDimExpr(vecRank - 1));
+        return builder.getMultiDimIdentityMap(vecRank);
       };
 
       RewritePatternSet patterns(ctx);


### PR DESCRIPTION
The way warp reduce works today cannot distribute transfers in any way other than some contiguous grouping of threads (innermost or outermost).

This chooses to divide the vector across threads from outermost to innermost to be consistent with the current state.