### PR TITLE
Integrate llvm/llvm-project@80cff273906b

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,9 +242,10 @@ jobs:
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
+  # Disabled until Bazel build is fixed (seems to need Bazel version 6.0+)
   build_test_all_bazel:
     needs: setup
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_bazel')
+    if: false && contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_bazel')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}


### PR DESCRIPTION
Jumps past the cherry-pick from the previous integrate.

The upstream LLVM Bazel build now requires Bazel 6 (as of https://github.com/llvm/llvm-project/commit/5f2097dbeda0dfb21bc9dec27f4c8ff2ad42cef2). Until we can update the version of Bazel we include in our Docker images, this disables the Bazel build across the project. (ETA 1-2 days - just need someone with the right access to rebuild and verify it is working again)
Discussion here: https://discord.com/channels/689900678990135345/1080178290188374049/1212435654265544715