### PR TITLE
[Codegen][GPU] Fix multi-dim warp reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -269,13 +269,11 @@ public:
         auto vecType = llvm::dyn_cast<VectorType>(val.getType());
         if (!vecType)
           return AffineMap::get(val.getContext());
-        // Create a map (d0, d1) -> (d1) to distribute along the inner
-        // dimension. Once we support n-d distribution we can add more
-        // complex cases.
+        // Create an identity dim map of rank |vecRank|. This greedily divides
+        // threads along the outermost vector dimensions to the innermost ones.
         int64_t vecRank = vecType.getRank();
         OpBuilder builder(val.getContext());
-        return AffineMap::get(vecRank, 0,
-                              builder.getAffineDimExpr(vecRank - 1));
+        return builder.getMultiDimIdentityMap(vecRank);
       };
 
       RewritePatternSet patterns(ctx);


### PR DESCRIPTION
The way warp reduce works today cannot distribute transfers in any way other than some contiguous grouping of threads (innermost or outermost).

This chooses to divide the vector across threads from outermost to innermost vector dimension to be consistent with the current state.