### PR TITLE
[Flow] Avoid fusion of dequantization-like ops with producers

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -101,6 +101,12 @@ static bool areFusableOps(MLIRContext *context, OpOperand *fusedOperand,
     return true;
   }
 
+  // Do no fuse dequantization-like operations with producers as we want to keep
+  // the smallest bitwidths at the dispatch boundaries.
+  if (isDequantizationLikeOp(consumerOp)) {
+    return false;
+  }
+
   // If producer does not have a single user, dont fuse.
   if (!producerOp->hasOneUse())
     return false;
@@ -225,6 +231,12 @@ static FailureOr<unsigned> fuseMultiUseProducers(Operation *funcOp,
           return;
         }
 
+        // Dequantization-like operations should be fused with consumers to keep
+        // the smaller bit width on the dispatch boundary.
+        if (isDequantizationLikeOp(genericOp)) {
+          return;
+        }
+
         Operation *fusableProducer = nullptr;
         for (OpOperand &operand : genericOp->getOpOperands()) {
           // 2. Only fuse with `linalg.generic` producers that arent
@@ -259,7 +271,13 @@ static FailureOr<unsigned> fuseMultiUseProducers(Operation *funcOp,
             continue;
           }
 
-          // 7. All uses from `producer` -> `consumer` need to be fusable.
+          // 7. Skip dequantization-like `producer` ops as we would rather fuse
+          // by cloning the producer instead of multi-use fusion.
+          if (isDequantizationLikeOp(producer)) {
+            return;
+          }
+
+          // 8. All uses from `producer` -> `consumer` need to be fusable.
           //    Without this the `producer` is still live, and there is no
           //    advantage to do the fusion.
           if (llvm::any_of(getAllUsesInConsumer(producer, genericOp),


### PR DESCRIPTION
Dequantization-like operations (e.g. arith.extf/extui/extsi) are generally best to aggressively fuse/rematerialize with consumers because this minimizes the amount of memory on the boundaries of dispatches.

This patch changes the heuristics in FusionOfTensorOps to avoid fusion of a dequant-like consumer with its producer. Additionally it disables multi-use fusion of a multi-use dequant-like producer for the same reason, namely we would rather fuse by cloning the dequant-like op instead of typical multi-use fusion.