### PR TITLE
Update CODEOWNERS for LinalgExt dialect.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,8 +50,6 @@
 # llvm-external-projects
 /llvm-external-projects/ @stellaraccident
 /llvm-external-projects/iree-dialects/ @MaheshRavishankar
-/llvm-external-projects/iree-dialects/**/Dialect/LinalgExt/ @hanhanW @MaheshRavishankar
-/llvm-external-projects/iree-dialects/test/iree_linalgext @hanhanW @MaheshRavishankar
 
 # Other Top-Level Directories
 /docs/ @ScottTodd
@@ -69,6 +67,7 @@
 /compiler/src/iree/compiler/Codegen/TransformStrategies/ @qedawkins @MaheshRavishankar
 /compiler/src/iree/compiler/ConstEval/ @hanhanW @stellaraccident
 /compiler/src/iree/compiler/Dialect/Flow/ @hanhanW @MaheshRavishankar
+/compiler/src/iree/compiler/Dialect/LinalgExt/ @hanhanW @MaheshRavishankar
 /compiler/src/iree/compiler/Dialect/Vulkan/ @antiagainst
 /compiler/src/iree/compiler/GlobalOptimization/ @hanhanW
 /compiler/src/iree/compiler/InputConversion/ @MaheshRavishankar @stellaraccident


### PR DESCRIPTION
The LinalgExt dialect is collapsed into the IREE main source tree, so we need to update the path in CODEOWNERS as well.