### PR TITLE
Fix `iree-import-onnx` operation/module usage.

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
@@ -11,7 +11,7 @@ Typically, when installed from a wheel, this can be invoked as:
   iree-import-onnx some.pb
 
 Or from Python:
-  
+
   python -m iree.compiler.tools.import_onnx ...
 """
 import argparse
@@ -42,7 +42,7 @@ def main(args):
     model_proto = load_onnx_model(args.input_file)
     context = Context()
     model_info = onnx_importer.ModelInfo(model_proto)
-    m = model_info.create_module(context=context)
+    m = model_info.create_module(context=context).operation
     imp = onnx_importer.NodeImporter.define_function(model_info.main_graph, m)
     imp.import_all()
     if not args.no_verify:


### PR DESCRIPTION
This broke when we pulled in https://github.com/llvm/torch-mlir/pull/2795 as part of https://github.com/openxla/iree/pull/16481, with errors like this:
```
Traceback (most recent call last):
  File "/usr/local/bin/iree-import-onnx", line 8, in <module>
    sys.exit(_cli_main())
  File "/usr/local/lib/python3.10/dist-packages/iree/compiler/tools/import_onnx/__main__.py", line 83, in _cli_main
    sys.exit(main(parse_arguments()))
  File "/usr/local/lib/python3.10/dist-packages/iree/compiler/tools/import_onnx/__main__.py", line 46, in main
    imp = onnx_importer.NodeImporter.define_function(model_info.main_graph, m)
  File "/usr/local/lib/python3.10/dist-packages/iree/compiler/extras/onnx_importer.py", line 203, in define_function
    body = module_op.regions[0].blocks[0]
AttributeError: 'iree.compiler._mlir_libs._mlir.ir.Module' object has no attribute 'regions'
```

The type information is also wrong on `create_module` - will send a fix for that to torch-mlir.

The test isn't running on any of our CI jobs since it soft fails if the `onnx` Python package is not installed. I don't see an easy path to turning the test on right now, so just unblocking other work using this.

More discussion here: https://discord.com/channels/689900678990135345/706175572920762449/1212833027630047272