### PR TITLE
[GlobalOpt] Propagate transposes through unary elementwise ops

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/PatternMatch.h"
@@ -42,8 +43,8 @@ static bool isIdentityPermutation(ArrayRef<int64_t> perm) {
 }
 
 // Constructs a transpose of the given tensor and permutation.
-static Value createTranspose(OpBuilder &builder, Value source,
-                             ArrayRef<int64_t> perm) {
+static Value createTransposeInit(OpBuilder &builder, Value source,
+                                 ArrayRef<int64_t> perm) {
   SmallVector<OpFoldResult> mixedSizes =
       tensor::getMixedSizes(builder, source.getLoc(), source);
   applyPermutationToVector(mixedSizes, perm);
@@ -51,6 +52,13 @@ static Value createTranspose(OpBuilder &builder, Value source,
   Value empty =
       builder.create<tensor::EmptyOp>(source.getLoc(), mixedSizes, elemType)
           .getResult();
+  return empty;
+}
+
+// Constructs a transpose of the given tensor and permutation.
+static Value createTranspose(OpBuilder &builder, Value source,
+                             ArrayRef<int64_t> perm) {
+  Value empty = createTransposeInit(builder, source, perm);
   return builder
       .create<linalg::TransposeOp>(source.getLoc(), source, empty, perm)
       ->getResult(0);
@@ -377,6 +385,63 @@ public:
   }
 };
 
+// Propagates a transpose through the input of a unary elementwise operation.
+class PropagateTransposeThroughUnaryElementwiseInput
+    : public OpRewritePattern<linalg::GenericOp> {
+public:
+  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
+                                PatternRewriter &rewriter) const override {
+    if (!IREE::Flow::isNonNullAndOutsideDispatch(genericOp)) {
+      return failure();
+    }
+
+    if (genericOp.getNumDpsInputs() != 1 || genericOp.getNumDpsInputs() != 1 ||
+        !linalg::isElementwise(genericOp)) {
+      return rewriter.notifyMatchFailure(genericOp, "not unary elementwise");
+    }
+
+    OpOperand *input = genericOp.getDpsInputOperand(0);
+    OpOperand *init = genericOp.getDpsInitOperand(0);
+
+    // Skip transposes and broadcasts. Transposes make more sense to fuse
+    // rather than propagate through, and broadcasts are cheaper to transpose
+    // before broadcasting.
+    if (genericOp.getMatchingIndexingMap(input) !=
+        genericOp.getMatchingIndexingMap(init)) {
+      return failure();
+    }
+
+    linalg::TransposeOp transposeOp =
+        input->get().getDefiningOp<linalg::TransposeOp>();
+    if (!transposeOp) {
+      return rewriter.notifyMatchFailure(genericOp, "no transpose operand");
+    }
+
+    ArrayRef<int64_t> perm = transposeOp.getPermutation();
+    auto invPerm = invertPermutationVector(perm);
+
+    // Create a new empty init for the transposed generic.
+    Value newInit = createTransposeInit(rewriter, init->get(), invPerm);
+
+    // We do not need to update indexing maps because this is a unary
+    // elementwise op where the input and output maps are the same. Just
+    // replace the operands with transposed variants.
+    auto newGenericOp = rewriter.create<linalg::GenericOp>(
+        genericOp.getLoc(), newInit.getType(), transposeOp.getInput(), newInit,
+        genericOp.getIndexingMapsArray(), genericOp.getIteratorTypesArray(),
+        /*bodyBuild=*/nullptr, linalg::getPrunedAttributeList(genericOp));
+    rewriter.cloneRegionBefore(genericOp.getRegion(), newGenericOp.getRegion(),
+                               newGenericOp.getRegion().begin());
+
+    Value newResult =
+        createTranspose(rewriter, newGenericOp->getResult(0), perm);
+    rewriter.replaceOp(genericOp, newResult);
+    return success();
+  }
+};
+
 // Sinks a transpose to the input of a linalg named op. The conditions for the
 // rewrite are
 //   1) One of the input producers to the named op is a linalg.transpose
@@ -563,6 +628,8 @@ void PropagateLinalgTransposePass::runOnOperation() {
     sinkingPatterns.insert<SinkTransposeThroughExtractSlice>(context);
     sinkingPatterns.insert<SinkTransposeThroughExpandShape>(context);
     sinkingPatterns.insert<FuseTransposeWithGenericConsumer>(context);
+    sinkingPatterns.add<PropagateTransposeThroughUnaryElementwiseInput>(
+        context, /*benefit=*/2);
     if (enableAggressivePropagation) {
       sinkingPatterns.insert<GeneralizeInputTransposedNamedOp>(context);
     }

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -20,7 +20,6 @@
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Tensor/TransformOps/TensorTransformOps.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"

--- a/compiler/src/iree/compiler/GlobalOptimization/test/propagate_linalg_transpose.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/propagate_linalg_transpose.mlir
@@ -290,3 +290,96 @@ util.func public @propagate_transpose_through_unary_elementwise(%arg0 : tensor<2
 //  SINK-SAME:                    outs({{.*}} : tensor<3x4x2xf32>)
 //  SINK-SAME:                    permutation = [1, 2, 0]
 //       SINK:   util.return %[[RES]] : tensor<3x4x2xf32>
+
+// -----
+
+util.func public @sink_transpose_to_unary_transpose(%arg0 : tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+  %empty = tensor.empty(): tensor<3x4x2xf32>
+  %transposed = linalg.transpose ins(%arg0 : tensor<2x3x4xf32>)
+      outs(%empty : tensor<3x4x2xf32>) permutation = [1, 2, 0]
+  %empty2 = tensor.empty(): tensor<2x3x4xf32>
+  %0 = linalg.generic {indexing_maps = [
+                    affine_map<(d0, d1, d2) -> (d1, d2, d0)>,
+                    affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+                iterator_types = ["parallel", "parallel", "parallel"]}
+                ins(%transposed : tensor<3x4x2xf32>)
+                outs(%empty2 : tensor<2x3x4xf32>) {
+                  ^bb0(%in: f32, %out: f32):
+                    %sqrt = math.rsqrt %in : f32
+                    linalg.yield %sqrt : f32
+                  } -> tensor<2x3x4xf32>
+  util.return %0 : tensor<2x3x4xf32>
+}
+// SINK-LABEL: util.func public @sink_transpose_to_unary_transpose
+//  SINK-SAME:   %[[ARG0:[A-Za-z0-9]+]]: tensor<2x3x4xf32>
+//       SINK:   %[[ELEM:.+]] = linalg.generic
+//  SINK-SAME:     ins(%[[ARG0]] : tensor<2x3x4xf32>
+//  SINK-SAME:     outs(%{{.*}} : tensor<2x3x4xf32>
+//       SINK:     math.rsqrt
+//       SINK:   util.return %[[ELEM]] : tensor<2x3x4xf32>
+
+// -----
+
+util.func public @do_not_sink_multi_use(%arg0 : tensor<2x3x4xf32>) -> (tensor<3x4x2xf32>, tensor<3x4x2xf32>) {
+  %empty = tensor.empty(): tensor<3x4x2xf32>
+  %transposed = linalg.transpose ins(%arg0 : tensor<2x3x4xf32>)
+      outs(%empty : tensor<3x4x2xf32>) permutation = [1, 2, 0]
+  %0 = linalg.generic {indexing_maps = [
+                    affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                    affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+                iterator_types = ["parallel", "parallel", "parallel"]}
+                ins(%transposed : tensor<3x4x2xf32>)
+                outs(%empty : tensor<3x4x2xf32>) {
+                  ^bb0(%in: f32, %out: f32):
+                    %sqrt = math.rsqrt %in : f32
+                    linalg.yield %sqrt : f32
+                  } -> tensor<3x4x2xf32>
+  %1 = linalg.generic {indexing_maps = [
+                    affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                    affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+                iterator_types = ["parallel", "parallel", "parallel"]}
+                ins(%transposed : tensor<3x4x2xf32>)
+                outs(%empty : tensor<3x4x2xf32>) {
+                  ^bb0(%in: f32, %out: f32):
+                    %sqrt = math.exp %in : f32
+                    linalg.yield %sqrt : f32
+                  } -> tensor<3x4x2xf32>
+  util.return %0, %1 : tensor<3x4x2xf32>, tensor<3x4x2xf32>
+}
+// SINK-LABEL: util.func public @do_not_sink_multi_use
+//  SINK-SAME:   %[[ARG0:[A-Za-z0-9]+]]: tensor<2x3x4xf32>
+//       SINK:   %[[T:.+]] = linalg.transpose ins(%[[ARG0]] : tensor<2x3x4xf32>
+//  SINK-SAME:                    outs({{.*}} : tensor<3x4x2xf32>)
+//  SINK-SAME:                    permutation = [1, 2, 0]
+//       SINK:   %[[ELEM0:.+]] = linalg.generic {{.*}} ins(%[[T]]
+//       SINK:     math.rsqrt
+//       SINK:   %[[ELEM1:.+]] = linalg.generic {{.*}} ins(%[[T]]
+//       SINK:     math.exp
+//       SINK:   util.return %[[ELEM0]], %[[ELEM1]]
+
+// -----
+
+util.func public @do_not_sink_unary_multi_use(%arg0 : tensor<2x3x4xf32>) -> (tensor<3x4x2xf32>, tensor<3x4x2xf32>) {
+  %empty = tensor.empty(): tensor<3x4x2xf32>
+  %transposed = linalg.transpose ins(%arg0 : tensor<2x3x4xf32>)
+      outs(%empty : tensor<3x4x2xf32>) permutation = [1, 2, 0]
+  %0 = linalg.generic {indexing_maps = [
+                    affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                    affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+                iterator_types = ["parallel", "parallel", "parallel"]}
+                ins(%transposed : tensor<3x4x2xf32>)
+                outs(%empty : tensor<3x4x2xf32>) {
+                  ^bb0(%in: f32, %out: f32):
+                    %sqrt = math.rsqrt %in : f32
+                    linalg.yield %sqrt : f32
+                  } -> tensor<3x4x2xf32>
+  util.return %0, %transposed : tensor<3x4x2xf32>, tensor<3x4x2xf32>
+}
+// SINK-LABEL: util.func public @do_not_sink_unary_multi_use
+//  SINK-SAME:   %[[ARG0:[A-Za-z0-9]+]]: tensor<2x3x4xf32>
+//       SINK:   %[[T:.+]] = linalg.transpose ins(%[[ARG0]] : tensor<2x3x4xf32>
+//  SINK-SAME:                    outs({{.*}} : tensor<3x4x2xf32>)
+//  SINK-SAME:                    permutation = [1, 2, 0]
+//       SINK:   %[[ELEM:.+]] = linalg.generic {{.*}} ins(%[[T]]
+//       SINK:     math.rsqrt
+//       SINK:   util.return %[[ELEM]], %[[T]]


### PR DESCRIPTION
Fusing a transpose with a unary elementwise operation ends propagation of that transpose, so for unary elementwise ops it makes more sense to instead try to propagate it instead of fusing it to look for clearer fusion opportunities. Instead this patch sinks transposes through elementwise ops in hopes of finding a better destination.