### PR TITLE
Unroll fixed-trip-count loops within mmt4d ukernel tile functions.

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_base.c
@@ -7,7 +7,8 @@
 #include "iree/builtins/ukernel/arch/arm_64/common_arm_64.h"
 #include "iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_internal.h"
 
-static inline void iree_uk_mmt4d_tile_f32f32f32_1x8x1_to_8x8x1_arm_64(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_f32f32f32_1x8x1_to_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
@@ -17,17 +18,15 @@ static inline void iree_uk_mmt4d_tile_f32f32f32_1x8x1_to_8x8x1_arm_64(
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   float32x4_t acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < 2 * M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
       acc[i] = vld1q_f32(out_ptr + 4 * i);
     }
   } else {
-    for (int i = 0; i < 2 * M0; ++i) {
-      acc[i] = vdupq_n_f32(0);
-    }
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) { acc[i] = vdupq_n_f32(0); }
   }
   for (int k = 0; k < params->K; ++k) {
     float32x4_t rhs[2];
-    for (int i = 0; i < 2; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 2; ++i) {
       rhs[i] = vld1q_f32(rhs_ptr + 4 * i);
     }
     rhs_ptr += 8;
@@ -45,7 +44,7 @@ static inline void iree_uk_mmt4d_tile_f32f32f32_1x8x1_to_8x8x1_arm_64(
       acc[3] = vfmaq_lane_f32(acc[3], rhs[1], lhs, 1);
     } else {
       float32x4_t lhs[2];
-      for (int i = 0; i < M0 / 4; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0 / 4; ++i) {
         lhs[i] = vld1q_f32(lhs_ptr + 4 * i);
       }
       lhs_ptr += M0;
@@ -69,7 +68,7 @@ static inline void iree_uk_mmt4d_tile_f32f32f32_1x8x1_to_8x8x1_arm_64(
       }
     }
   }
-  for (int i = 0; i < 2 * M0; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
     vst1q_f32(out_ptr + 4 * i, acc[i]);
   }
 }
@@ -84,7 +83,8 @@ IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0_1_2_4_8(
 // Shared implementation for f16f16f16 and f16f16f32.
 // In the f16f16f16 case, intermediate roundings are skipped. This function
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
-static inline void iree_uk_mmt4d_tile_f16f16fXX_1x8x1_to_8x8x1_arm_64(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_f16f16fXX_1x8x1_to_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type, int M0) {
@@ -95,23 +95,21 @@ static inline void iree_uk_mmt4d_tile_f16f16fXX_1x8x1_to_8x8x1_arm_64(
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
-      for (int i = 0; i < 2 * M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
         acc[i] = vld1q_f32(out_ptr + 4 * i);
       }
     } else {
       float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-      for (int i = 0; i < 2 * M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
         acc[i] = vcvt_f32_f16(vld1_f16(out_ptr + 4 * i));
       }
     }
   } else {
-    for (int i = 0; i < 2 * M0; ++i) {
-      acc[i] = vdupq_n_f32(0);
-    }
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) { acc[i] = vdupq_n_f32(0); }
   }
   for (int k = 0; k < params->K; ++k) {
     float32x4_t rhs[2];
-    for (int i = 0; i < 2; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 2; ++i) {
       rhs[i] = vcvt_f32_f16(vld1_f16(rhs_ptr + 4 * i));
     }
     rhs_ptr += 8;
@@ -131,7 +129,7 @@ static inline void iree_uk_mmt4d_tile_f16f16fXX_1x8x1_to_8x8x1_arm_64(
       acc[3] = vfmaq_lane_f32(acc[3], rhs[1], lhs, 1);
     } else {
       float32x4_t lhs[2];
-      for (int i = 0; i < M0 / 4; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0 / 4; ++i) {
         lhs[i] = vcvt_f32_f16(vld1_f16(lhs_ptr + 4 * i));
       }
       lhs_ptr += M0;
@@ -157,18 +155,19 @@ static inline void iree_uk_mmt4d_tile_f16f16fXX_1x8x1_to_8x8x1_arm_64(
   }
   if (acc_type == IREE_UK_TYPE_FLOAT_32) {
     float* IREE_UK_RESTRICT out_ptr = out_tile;
-    for (int i = 0; i < 2 * M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
       vst1q_f32(out_ptr + 4 * i, acc[i]);
     }
   } else {
     float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-    for (int i = 0; i < 2 * M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
       vst1_f16(out_ptr + 4 * i, vcvt_f16_f32(acc[i]));
     }
   }
 }
 
-static inline void iree_uk_mmt4d_tile_f16f16f16_1x8x1_to_8x8x1_arm_64(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_f16f16f16_1x8x1_to_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
@@ -176,7 +175,8 @@ static inline void iree_uk_mmt4d_tile_f16f16f16_1x8x1_to_8x8x1_arm_64(
       out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_16, M0);
 }
 
-static inline void iree_uk_mmt4d_tile_f16f16f32_1x8x1_to_8x8x1_arm_64(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_f16f16f32_1x8x1_to_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
@@ -198,7 +198,8 @@ IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0_1_2_4_8(
     iree_uk_mmt4d_tile_f16f16f16_4x8x1_arm_64,
     iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64)
 
-static inline void iree_uk_mmt4d_tile_s8s8s32_1x8x1_to_8x8x1_arm_64(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_s8s8s32_1x8x1_to_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
@@ -208,19 +209,17 @@ static inline void iree_uk_mmt4d_tile_s8s8s32_1x8x1_to_8x8x1_arm_64(
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   int32x4_t acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < 2 * M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
       acc[i] = vld1q_s32(out_ptr + 4 * i);
     }
   } else {
-    for (int i = 0; i < 2 * M0; ++i) {
-      acc[i] = vdupq_n_s32(0);
-    }
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) { acc[i] = vdupq_n_s32(0); }
   }
   for (int k = 0; k < params->K; ++k) {
     int16x8_t rhs = vmovl_s8(vld1_s8(rhs_ptr));
     rhs_ptr += 8;
     if (M0 <= 4) {
-      for (int i = 0; i < M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
         int16_t lhs = *lhs_ptr++;
         acc[2 * i + 0] = vmlal_n_s16(acc[2 * i + 0], vget_low_s16(rhs), lhs);
         acc[2 * i + 1] = vmlal_n_s16(acc[2 * i + 1], vget_high_s16(rhs), lhs);
@@ -253,7 +252,7 @@ static inline void iree_uk_mmt4d_tile_s8s8s32_1x8x1_to_8x8x1_arm_64(
           vmlal_lane_s16(acc[15], vget_high_s16(rhs), vget_high_s16(lhs), 3);
     }
   }
-  for (int i = 0; i < 2 * M0; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
     vst1q_s32(out_ptr + 4 * i, acc[i]);
   }
 }
@@ -269,7 +268,8 @@ IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0_1_2_4_8(
 // `qd8-f32-qc4w-gemm-1x16-minmax-neon-mlal-lane.c` in
 // https://github.com/google/XNNPACK. We borrow the int4 conversion trick
 // described within the method body.
-static inline void iree_uk_mmt4d_tile_s8s4s32_1x16x2_to_4x16x2_arm_64(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_s8s4s32_1x16x2_to_4x16x2_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
@@ -282,9 +282,7 @@ static inline void iree_uk_mmt4d_tile_s8s4s32_1x16x2_to_4x16x2_arm_64(
   int32x4_t acc[16];
   // We start with zero accumulators and add the value of *out_ptr later.
   // This is required for the int4 trick described later.
-  for (int i = 0; i < 4 * M0; ++i) {
-    acc[i] = vdupq_n_s32(0);
-  }
+  IREE_UK_UNROLL for (int i = 0; i < 4 * M0; ++i) { acc[i] = vdupq_n_s32(0); }
 
   const int8x16_t vmask = vmovq_n_s8(0xF0);
 
@@ -389,7 +387,7 @@ static inline void iree_uk_mmt4d_tile_s8s4s32_1x16x2_to_4x16x2_arm_64(
     }
   }
 
-  for (int i = 0; i < 4 * M0; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < 4 * M0; ++i) {
     // Divide by 16 since we shifted int4s to the upper 4 bits of int8s.
     acc[i] = vshrq_n_s32(acc[i], 4);
     if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
@@ -31,7 +31,8 @@ static inline float32x4_t iree_uk_neon_uzp2_f32_as_s64(float32x4_t a,
       vuzp2q_s64(vreinterpretq_s64_f32(a), vreinterpretq_s64_f32(b)));
 }
 
-static inline void iree_uk_mmt4d_tile_bf16bf16fXX_1x8x4_to_8x8x4_arm_64_bf16(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_bf16bf16fXX_1x8x4_to_8x8x4_arm_64_bf16(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type, int M0) {
@@ -46,8 +47,8 @@ static inline void iree_uk_mmt4d_tile_bf16bf16fXX_1x8x4_to_8x8x4_arm_64_bf16(
   const int mtiles = M0 == 1 ? 1 : M0 / 2;
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     // Load row-major accumulator and swizzle into 2x2 register tiles.
-    for (int i = 0; i < mtiles; ++i) {
-      for (int j = 0; j < 2; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < mtiles; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 2; ++j) {
         float32x4_t acc_1x4_0, acc_1x4_1;
         if (acc_type == IREE_UK_TYPE_FLOAT_32) {
           const float* IREE_UK_RESTRICT out_ptr = out_tile;
@@ -68,16 +69,14 @@ static inline void iree_uk_mmt4d_tile_bf16bf16fXX_1x8x4_to_8x8x4_arm_64_bf16(
       }
     }
   } else {
-    for (int i = 0; i < mtiles; ++i) {
-      for (int j = 0; j < 4; ++j) {
-        acc[i][j] = vdupq_n_f32(0);
-      }
+    IREE_UK_UNROLL for (int i = 0; i < mtiles; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) { acc[i][j] = vdupq_n_f32(0); }
     }
   }
 
   for (int k = 0; k < params->K; ++k) {
     bfloat16x8_t rhs[4];
-    for (int i = 0; i < 4; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
       rhs[i] = vld1q_bf16(rhs_ptr + 8 * i);
     }
     rhs_ptr += 32;
@@ -87,20 +86,20 @@ static inline void iree_uk_mmt4d_tile_bf16bf16fXX_1x8x4_to_8x8x4_arm_64_bf16(
       lhs[0] = vcombine_bf16(lhs4, lhs4);
       lhs_ptr += 4;
     } else
-      for (int i = 0; i < mtiles; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < mtiles; ++i) {
         lhs[i] = vld1q_bf16(lhs_ptr);
         lhs_ptr += 8;
       }
-    for (int i = 0; i < mtiles; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < mtiles; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = vbfmmlaq_f32(acc[i][j], lhs[i], rhs[j]);
       }
     }
   }
 
   // Swizzle accumulator 2x2 register tiles back to row-major and store.
-  for (int i = 0; i < mtiles; ++i) {
-    for (int j = 0; j < 2; ++j) {
+  IREE_UK_UNROLL for (int i = 0; i < mtiles; ++i) {
+    IREE_UK_UNROLL for (int j = 0; j < 2; ++j) {
       float32x4_t acc_1x4_0 =
           iree_uk_neon_uzp1_f32_as_s64(acc[i][2 * j + 0], acc[i][2 * j + 1]);
       float32x4_t acc_1x4_1 =
@@ -123,7 +122,8 @@ static inline void iree_uk_mmt4d_tile_bf16bf16fXX_1x8x4_to_8x8x4_arm_64_bf16(
   }
 }
 
-static inline void iree_uk_mmt4d_tile_bf16bf16f32_1x8x4_to_8x8x4_arm_64_bf16(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_bf16bf16f32_1x8x4_to_8x8x4_arm_64_bf16(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
@@ -131,7 +131,8 @@ static inline void iree_uk_mmt4d_tile_bf16bf16f32_1x8x4_to_8x8x4_arm_64_bf16(
       out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_32, M0);
 }
 
-static inline void iree_uk_mmt4d_tile_bf16bf16bf16_1x8x4_to_8x8x4_arm_64_bf16(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_bf16bf16bf16_1x8x4_to_8x8x4_arm_64_bf16(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
@@ -17,17 +17,15 @@ static inline void iree_uk_mmt4d_tile_s8s8s32_1x8x4_to_8x8x4_arm_64_dotprod(
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   int32x4_t acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < 2 * M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
       acc[i] = vld1q_s32(out_ptr + 4 * i);
     }
   } else {
-    for (int i = 0; i < 2 * M0; ++i) {
-      acc[i] = vdupq_n_s32(0);
-    }
+    IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) { acc[i] = vdupq_n_s32(0); }
   }
   for (int k = 0; k < params->K; ++k) {
     int8x16_t rhs[2];
-    for (int i = 0; i < 2; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 2; ++i) {
       rhs[i] = vld1q_s8(rhs_ptr + 16 * i);
     }
     rhs_ptr += 32;
@@ -39,7 +37,7 @@ static inline void iree_uk_mmt4d_tile_s8s8s32_1x8x4_to_8x8x4_arm_64_dotprod(
     } else if (M0 == 2) {
       lhs[0] = vcombine_s8(vld1_s8(lhs_ptr), vdup_n_s8(0));
     } else
-      for (int i = 0; i < 2; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < 2; ++i) {
         lhs[i] = vld1q_s8(lhs_ptr + 16 * i);
       }
     lhs_ptr += 4 * M0;
@@ -64,7 +62,7 @@ static inline void iree_uk_mmt4d_tile_s8s8s32_1x8x4_to_8x8x4_arm_64_dotprod(
     acc[15] = vdotq_lane_s32(acc[15], rhs[1], vget_high_s8(lhs[1]), 1);
   }
 
-  for (int i = 0; i < 2 * M0; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < 2 * M0; ++i) {
     vst1q_s32(out_ptr + 4 * i, acc[i]);
   }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fullfp16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fullfp16.c
@@ -7,7 +7,8 @@
 #include "iree/builtins/ukernel/arch/arm_64/common_arm_64.h"
 #include "iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_internal.h"
 
-void iree_uk_mmt4d_tile_f16f16f16_1x8x1_to_8x8x1_arm_64_fullfp16(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_f16f16f16_1x8x1_to_8x8x1_arm_64_fullfp16(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
@@ -17,23 +18,21 @@ void iree_uk_mmt4d_tile_f16f16f16_1x8x1_to_8x8x1_arm_64_fullfp16(
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float16x8_t acc[8];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       acc[i] = vld1q_f16(out_ptr + 8 * i);
     }
   } else {
-    for (int i = 0; i < M0; ++i) {
-      acc[i] = vdupq_n_f16(0);
-    }
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) { acc[i] = vdupq_n_f16(0); }
   }
   for (int k = 0; k < params->K; ++k) {
     float16x8_t rhs = vld1q_f16(rhs_ptr);
     rhs_ptr += 8;
     if (M0 <= 2) {
-      for (int i = 0; i < M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
         acc[i] = vfmaq_n_f16(acc[i], rhs, *lhs_ptr++);
       }
     } else {
-      for (int i = 0; i < M0; i += 4) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; i += 4) {
         float16x4_t lhs = vld1_f16(lhs_ptr);
         lhs_ptr += 4;
         acc[i + 0] = vfmaq_lane_f16(acc[i + 0], rhs, lhs, 0);
@@ -43,7 +42,7 @@ void iree_uk_mmt4d_tile_f16f16f16_1x8x1_to_8x8x1_arm_64_fullfp16(
       }
     }
   }
-  for (int i = 0; i < M0; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
     vst1q_f16(out_ptr + 8 * i, acc[i]);
   }
 }

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -9,7 +9,7 @@
 #include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
 #include "iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_internal.h"
 
-static inline void
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
 iree_uk_mmt4d_tile_f32f32f32_1x16x1_to_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
@@ -27,27 +27,27 @@ iree_uk_mmt4d_tile_f32f32f32_1x16x1_to_16x16x1_x86_64_avx512_base(
   _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
   __m512 acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       acc[i] = _mm512_loadu_ps(out_ptr + i * 16);
     }
   } else {
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       acc[i] = _mm512_setzero_ps();
     }
   }
 
-  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
+  for (int k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_loadu_ps(rhs_ptr);
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       acc[i] = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[i]), rhs, acc[i]);
     }
     _mm_prefetch((const char*)(lhs_ptr + 128), _MM_HINT_T0);
     lhs_ptr += M0;
   }
 
-  for (int i = 0; i < M0; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
     _mm512_storeu_ps(out_ptr + i * 16, acc[i]);
   }
 }
@@ -63,7 +63,7 @@ IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0_1_2_4_8_16(
 // Shared implementation for f16f16f16 and f16f16f32.
 // In the f16f16f16 case, intermediate roundings are skipped. This function
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
-static inline void
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
 iree_uk_mmt4d_tile_f16f16fXX_1x16x1_to_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
@@ -81,23 +81,23 @@ iree_uk_mmt4d_tile_f16f16fXX_1x16x1_to_16x16x1_x86_64_avx512_base(
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
-      for (int i = 0; i < M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
         acc[i] = _mm512_loadu_ps(out_ptr + i * 16);
       }
     } else {
       iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-      for (int i = 0; i < M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
         acc[i] = _mm512_cvtph_ps(
             _mm256_loadu_si256((const __m256i*)(out_ptr + i * 16)));
       }
     }
   } else {
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       acc[i] = _mm512_setzero_ps();
     }
   }
 
-  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
+  for (int k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
@@ -134,18 +134,19 @@ iree_uk_mmt4d_tile_f16f16fXX_1x16x1_to_16x16x1_x86_64_avx512_base(
   }
   if (acc_type == IREE_UK_TYPE_FLOAT_32) {
     float* IREE_UK_RESTRICT out_ptr = out_tile;
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       _mm512_storeu_ps(out_ptr + i * 16, acc[i]);
     }
   } else {
     iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       _mm256_storeu_si256((__m256i*)(out_ptr + i * 16),
                           _mm512_cvtps_ph(acc[i], _MM_FROUND_TO_NEAREST_INT));
     }
   }
 }
 
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE
 static inline void
 iree_uk_mmt4d_tile_f16f16f32_1x16x1_to_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
@@ -155,6 +156,7 @@ iree_uk_mmt4d_tile_f16f16f32_1x16x1_to_16x16x1_x86_64_avx512_base(
       out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_32, M0);
 }
 
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE
 static inline void
 iree_uk_mmt4d_tile_f16f16f16_1x16x1_to_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
@@ -180,6 +182,7 @@ IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0_1_2_4_8_16(
     iree_uk_mmt4d_tile_f16f16f16_8x16x1_x86_64_avx512_base,
     iree_uk_mmt4d_tile_f16f16f16_16x16x1_x86_64_avx512_base)
 
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE
 static inline void
 iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
@@ -197,8 +200,8 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
   __m512i acc[4][4];
   const int imax = M0 <= 4 ? M0 : 4;
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < imax; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         if (M0 <= 8) {
           acc[i][j] = _mm512_castsi128_si512(
               _mm_loadu_si128((__m128i*)(out_ptr + i * 16 + j * 4)));
@@ -217,8 +220,8 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
       }
     }
   } else {
-    for (int i = 0; i < 4; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = _mm512_setzero_si512();
       }
     }
@@ -231,7 +234,7 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
   __m512i idx_CDEF89AB45670123 =
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
-  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
+  for (int k = 0; k < params->K; ++k) {
     __m512i rhs_i16_perm[4];
     // rhs_i16_perm[0] is the rhs tile (2x8), sign-extended to i16.
     rhs_i16_perm[0] =
@@ -274,16 +277,16 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
     if (M0 >= 2) lhs_i16_dup4[1] = _mm512_shuffle_epi32(lhs_i16, 1 * 0x55);
     if (M0 >= 4) lhs_i16_dup4[2] = _mm512_shuffle_epi32(lhs_i16, 2 * 0x55);
     if (M0 >= 4) lhs_i16_dup4[3] = _mm512_shuffle_epi32(lhs_i16, 3 * 0x55);
-    for (int i = 0; i < imax; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = _mm512_add_epi32(
             acc[i][j], _mm512_madd_epi16(lhs_i16_dup4[i], rhs_i16_perm[j]));
       }
     }
   }
 
-  for (int i = 0; i < imax; ++i) {
-    for (int j = 0; j < 4; ++j) {
+  IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+    IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
       if (M0 <= 8) {
         _mm_storeu_si128((__m128i*)(out_ptr + i * 16 + j * 4),
                          _mm512_extracti32x4_epi32(acc[i][j], 0));
@@ -309,6 +312,7 @@ IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0_1_2_4_8_16(
     iree_uk_mmt4d_tile_s8s8s32_8x16x2_x86_64_avx512_base,
     iree_uk_mmt4d_tile_s8s8s32_16x16x2_x86_64_avx512_base)
 
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE
 static inline void
 iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
@@ -326,8 +330,8 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_base(
   __m512i acc[4][4];
   const int imax = M0 <= 4 ? M0 : 4;
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < imax; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         if (M0 <= 8) {
           acc[i][j] = _mm512_castsi128_si512(
               _mm_loadu_si128((__m128i*)(out_ptr + i * 16 + j * 4)));
@@ -346,8 +350,8 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_base(
       }
     }
   } else {
-    for (int i = 0; i < 4; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = _mm512_setzero_si512();
       }
     }
@@ -360,7 +364,7 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_base(
   __m512i idx_CDEF89AB45670123 =
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
-  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
+  for (int k = 0; k < params->K; ++k) {
     __m512i rhs_perm[4];
     // rhs_perm[0] is the rhs tile (2x8).
     rhs_perm[0] = _mm512_loadu_si512((const __m512i*)rhs_ptr);
@@ -394,16 +398,16 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_base(
     if (M0 >= 2) lhs_dup4[1] = _mm512_shuffle_epi32(lhs, 1 * 0x55);
     if (M0 >= 4) lhs_dup4[2] = _mm512_shuffle_epi32(lhs, 2 * 0x55);
     if (M0 >= 4) lhs_dup4[3] = _mm512_shuffle_epi32(lhs, 3 * 0x55);
-    for (int i = 0; i < imax; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = _mm512_add_epi32(
             acc[i][j], _mm512_madd_epi16(lhs_dup4[i], rhs_perm[j]));
       }
     }
   }
 
-  for (int i = 0; i < imax; ++i) {
-    for (int j = 0; j < 4; ++j) {
+  IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+    IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
       if (M0 <= 8) {
         _mm_storeu_si128((__m128i*)(out_ptr + i * 16 + j * 4),
                          _mm512_extracti32x4_epi32(acc[i][j], 0));

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_bf16.c
@@ -54,40 +54,40 @@ iree_uk_mmt4d_tile_bf16bf16fXX_1x16x2_to_16x16x2_x86_64_avx512_bf16(
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
-      for (int i = 0; i < M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
         acc[i] = _mm512_loadu_ps(out_ptr + i * 16);
       }
     } else {
       iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-      for (int i = 0; i < M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
         __m256i loaded = _mm256_loadu_si256((const __m256i*)(out_ptr + i * 16));
         acc[i] = _mm512_cvtpbh_ps(*(const __m256bh*)&loaded);
       }
     }
   } else {
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       acc[i] = _mm512_setzero_ps();
     }
   }
 
-  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
+  for (int k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_loadu_ps(rhs_ptr);
     rhs_ptr += 32;
-    for (int i = 0; i < M0; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       acc[i] = iree_mm512_dpbf16_ps_broadcast_rhs(acc[i], rhs, lhs_ptr + 2 * i);
     }
     lhs_ptr += M0 * 2;
   }
 
-  for (int i = 0; i < M0; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
-      for (int i = 0; i < M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
         _mm512_storeu_ps(out_ptr + i * 16, acc[i]);
       }
     } else {
       iree_uk_uint16_t* IREE_UK_RESTRICT out_ptr = out_tile;
-      for (int i = 0; i < M0; ++i) {
+      IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
         __m256bh converted = _mm512_cvtneps_pbh(acc[i]);
         _mm256_storeu_si256((__m256i*)(out_ptr + i * 16),
                             *(const __m256i*)&converted);

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
@@ -24,8 +24,8 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
   __m512i acc[4][4];
   const int imax = M0 <= 4 ? M0 : 4;
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < imax; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         if (M0 <= 8) {
           acc[i][j] = _mm512_castsi128_si512(
               _mm_loadu_si128((__m128i*)(out_ptr + i * 16 + j * 4)));
@@ -44,8 +44,8 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
       }
     }
   } else {
-    for (int i = 0; i < 4; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = _mm512_setzero_si512();
       }
     }
@@ -58,7 +58,7 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
   __m512i idx_CDEF89AB45670123 =
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
-  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
+  for (int k = 0; k < params->K; ++k) {
     __m512i rhs_i16_perm[4];
     // rhs_i16_perm[0] is the rhs tile (2x8), sign-extended to i16.
     rhs_i16_perm[0] =
@@ -101,16 +101,16 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
     if (M0 >= 2) lhs_i16_dup4[1] = _mm512_shuffle_epi32(lhs_i16, 1 * 0x55);
     if (M0 >= 4) lhs_i16_dup4[2] = _mm512_shuffle_epi32(lhs_i16, 2 * 0x55);
     if (M0 >= 4) lhs_i16_dup4[3] = _mm512_shuffle_epi32(lhs_i16, 3 * 0x55);
-    for (int i = 0; i < imax; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] =
             _mm512_dpwssd_epi32(acc[i][j], lhs_i16_dup4[i], rhs_i16_perm[j]);
       }
     }
   }
 
-  for (int i = 0; i < imax; ++i) {
-    for (int j = 0; j < 4; ++j) {
+  IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+    IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
       if (M0 <= 8) {
         _mm_storeu_si128((__m128i*)(out_ptr + i * 16 + j * 4),
                          _mm512_extracti32x4_epi32(acc[i][j], 0));
@@ -153,8 +153,8 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
   __m512i acc[4][4];
   const int imax = M0 <= 4 ? M0 : 4;
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < imax; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         if (M0 <= 8) {
           acc[i][j] = _mm512_castsi128_si512(
               _mm_loadu_si128((__m128i*)(out_ptr + i * 16 + j * 4)));
@@ -173,8 +173,8 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
       }
     }
   } else {
-    for (int i = 0; i < 4; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = _mm512_setzero_si512();
       }
     }
@@ -187,7 +187,7 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
   __m512i idx_CDEF89AB45670123 =
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
-  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
+  for (int k = 0; k < params->K; ++k) {
     __m512i rhs_perm[4];
     // rhs_perm[0] is the rhs tile (2x8).
     rhs_perm[0] = _mm512_loadu_si512((const __m512i*)rhs_ptr);
@@ -221,15 +221,15 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
     if (M0 >= 2) lhs_dup4[1] = _mm512_shuffle_epi32(lhs, 1 * 0x55);
     if (M0 >= 4) lhs_dup4[2] = _mm512_shuffle_epi32(lhs, 2 * 0x55);
     if (M0 >= 4) lhs_dup4[3] = _mm512_shuffle_epi32(lhs, 3 * 0x55);
-    for (int i = 0; i < imax; ++i) {
-      for (int j = 0; j < 4; ++j) {
+    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = _mm512_dpwssd_epi32(acc[i][j], lhs_dup4[i], rhs_perm[j]);
       }
     }
   }
 
-  for (int i = 0; i < imax; ++i) {
-    for (int j = 0; j < 4; ++j) {
+  IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+    IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
       if (M0 <= 8) {
         _mm_storeu_si128((__m128i*)(out_ptr + i * 16 + j * 4),
                          _mm512_extracti32x4_epi32(acc[i][j], 0));
@@ -274,8 +274,8 @@ IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0_1_2_4_8_16(
 // being less-than-8-bit values (it's not specific beyond that to 4bit).
 // Meanwhile, when we split the LHS s16 values into high and low 8bit components
 // the high 8bits are signed s8 and the low 8bit are unsigned u8. So, for each
-// of the combinations of operands that we have to feed _mm512_dpbusd_epi32,
-// we manage to find an operand order that accomodates the instruction's
+// of the combinations of operands that we have to feed _mm512_dpbusd_epi32, we
+// manage to find an operand order that accomodates the instruction's
 // requirements on signednesses.
 void iree_uk_mmt4d_tile_s16u4s32_1x32x8_x86_64_avx512_vnni(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
@@ -307,7 +307,7 @@ void iree_uk_mmt4d_tile_s16u4s32_1x32x8_x86_64_avx512_vnni(
   const __m128i idx_2_mod_4 = _mm_set1_epi32(0x0e0a0602);
   const __m128i idx_3_mod_4 = _mm_set1_epi32(0x0f0b0703);
   const __m512i mask_0f = _mm512_set1_epi8(0x0f);
-  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
+  for (int k = 0; k < params->K; ++k) {
     // Load 8xs16 LHS data.
     __m128i lhs = _mm_loadu_si128((const __m128i*)lhs_ptr);
     lhs_ptr += 8;

--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -97,6 +97,12 @@
 #define IREE_UK_ATTRIBUTE_NOINLINE
 #endif  // IREE_UK_HAVE_ATTRIBUTE(noinline)
 
+#if IREE_UK_HAVE_ATTRIBUTE(always_inline) || defined(IREE_UK_COMPILER_GCC)
+#define IREE_UK_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define IREE_UK_ATTRIBUTE_ALWAYS_INLINE
+#endif  // IREE_UK_HAVE_ATTRIBUTE(always_inline)
+
 #if defined(IREE_UK_COMPILER_CLANG_OR_GCC)
 #define IREE_UK_LIKELY(x) (__builtin_expect(!!(x), 1))
 #define IREE_UK_UNLIKELY(x) (__builtin_expect(!!(x), 0))
@@ -118,6 +124,17 @@
 #else
 #define IREE_UK_ATTRIBUTE_UNUSED
 #endif  // IREE_UK_HAVE_ATTRIBUTE(maybe_unused / unused)
+
+// IREE_UK_UNROLL: request full unrolling of loops with constant trip count.
+#if defined(IREE_UK_COMPILER_CLANG)
+#define IREE_UK_UNROLL _Pragma("clang loop unroll(full)")
+#elif defined(IREE_UK_COMPILER_GCC)
+// GCC requires passing a max unroll factor. 64 should be enough for anybody.
+#define IREE_UK_UNROLL _Pragma("GCC unroll 64")
+#else
+// MSVC doesn't have a pragma unroll.
+#define IREE_UK_UNROLL
+#endif  // defined(IREE_UK_COMPILER_CLANG)
 
 //===----------------------------------------------------------------------===//
 // Local replacement for stdbool.h


### PR DESCRIPTION
mmt4d ukernels rely on fixed-trip-count for loops to do repetitive work without encumbering source code. This relies on the compiler always unrolling these for loops. We found in #16596 that that isn't always the case.

The actual reason why unrolling failed to happen in the case in #16596 is actually that I forgot a `static inline` on the shared implementation function for that ukernel; inlining it was necessary to reveal the constancy of the trip count and thus the unrollability. So technically, it might be enough to just add the missing `static inline`. But then, when we forget it, that silently degrades performance as it did here. By contrast, adding these `unroll(full)` pragmas causes a clang warning to be generated when the loop can't be unrolled, which is how I realized that I had forgotten the `static inline`. So as some layers of defense-in-depth against suboptimal compilation of ukernel code, this PR adds:
1. The missing `static inline` on those helper functions.
2. The `pragma unroll(full)` on all loops that should always be unrolled.
3. `attribute(always_inline)` on top of `static inline` on those functions that we really know should always be inlined and where failure to inline would lead to failure to unroll.