### PR TITLE
[Codegen][GPU] Add support for transpose distribution with nested layouts

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -614,7 +614,8 @@ struct DistributeTranspose final : OpDistributionPattern<vector::TransposeOp> {
                                 DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
     VectorValue value = transposeOp.getVector();
-    LayoutAttr layout = dyn_cast<LayoutAttr>(signature[value]);
+    VectorLayoutInterface layout =
+        dyn_cast<VectorLayoutInterface>(signature[value]);
     if (!layout) {
       return failure();
     }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -304,7 +304,32 @@ NestedLayoutAttr::project(ArrayRef<bool> droppedDims) const {
 
 VectorLayoutInterface
 NestedLayoutAttr::permute(ArrayRef<int64_t> permutation) const {
-  llvm_unreachable("Not yet implemented");
+  SmallVector<int64_t> subgroupCount =
+      applyPermutation(getSubgroupsPerWorkgroup(), permutation);
+  SmallVector<int64_t> subgroupOrder =
+      applyPermutation(getSubgroupOrder(), permutation);
+  SmallVector<int64_t> batchCount =
+      applyPermutation(getBatchesPerSubgroup(), permutation);
+  SmallVector<int64_t> batchOrder =
+      applyPermutation(getBatchOrder(), permutation);
+  SmallVector<int64_t> outerCount =
+      applyPermutation(getOutersPerBatch(), permutation);
+  SmallVector<int64_t> outerOrder =
+      applyPermutation(getOuterOrder(), permutation);
+  SmallVector<int64_t> threadCount =
+      applyPermutation(getThreadsPerOuter(), permutation);
+  SmallVector<int64_t> threadOrder =
+      applyPermutation(getThreadOrder(), permutation);
+  SmallVector<int64_t> elementCount =
+      applyPermutation(getElementsPerThread(), permutation);
+  SmallVector<int64_t> elementOrder =
+      applyPermutation(getElementOrder(), permutation);
+
+  return NestedLayoutAttr::get(
+      getContext(), subgroupCount, subgroupOrder, batchCount, batchOrder,
+      outerCount, outerOrder, threadCount, threadOrder, elementCount,
+      elementOrder, getSubgroupBasis(), getSubgroupActiveIds(),
+      getThreadBasis(), getThreadActiveIds());
 }
 
 /// We distribute to:


### PR DESCRIPTION
Transposition of a nested layout simply involves transposing all non-basis entries by the permutation of the transpose. If required, the transpose is materialized as a layout conflict at the site of conflict, rather than during the distribution of the transpose (i.e. the pattern for distributing a transpose is a no-op).