### PR TITLE
Make ukernels fallback opt-in and add a `mmt4d_info` ukernel to query the mmt4d implementation.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -222,6 +222,11 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::Mmt4DOp op,
     flags |= IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS;
   }
 
+  // TODO(#15784): drop the fallback flag, instead create a iree_uk_mmt4d_info
+  // ukernel op to query whether the ukernel has fast code for this case, and
+  // preserve the original `linalg.mmt4d` as a fallback in the `else` branch.
+  flags |= IREE_UK_FLAG_MMT4D_ALLOW_GENERIC_FALLBACK_TILE_FUNCTION;
+
   Location loc = op.getLoc();
   Value m = rewriter.create<tensor::DimOp>(loc, lhs, 0);
   Value n = rewriter.create<tensor::DimOp>(loc, rhs, 0);

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
@@ -13,7 +13,7 @@ func.func @mmt4d_f32f32f32(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1281 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -100,7 +100,7 @@ func.func @mmt4d_fill(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>, 
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1025 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG1]], %[[C1]]
@@ -130,7 +130,7 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1282 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -164,7 +164,7 @@ func.func @mmt4d_i16i16i32(%arg0 : tensor<?x?x?x?xi16>, %arg1 : tensor<?x?x?x?xi
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1287 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -198,7 +198,7 @@ func.func @mmt4d_i16i8i32(%arg0 : tensor<?x?x?x?xi16>, %arg1 : tensor<?x?x?x?xi8
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1289 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -232,7 +232,7 @@ func.func @mmt4d_f16f16f32(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1283 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -266,7 +266,7 @@ func.func @mmt4d_f16f16f16(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1284 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -290,7 +290,7 @@ func.func @mmt4d_f16f16f16(%arg0 : tensor<?x?x?x?xf16>, %arg1 : tensor<?x?x?x?xf
 // NOSKIPROUND-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // NOSKIPROUND-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
 // NOSKIPROUND-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf16>
-//  NOSKIPROUND-DAG:   %[[FLAGS:.+]] = arith.constant 260 : i32
+//  NOSKIPROUND-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  NOSKIPROUND-DAG:   %[[C0:.+]] = arith.constant 0
 //  NOSKIPROUND-DAG:   %[[C1:.+]] = arith.constant 1
 //  NOSKIPROUND-DAG:   %[[C2:.+]] = arith.constant 2
@@ -324,7 +324,7 @@ func.func @mmt4d_bf16bf16f32(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?x
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1285 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -358,7 +358,7 @@ func.func @mmt4d_bf16bf16bf16(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1286 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -486,7 +486,7 @@ func.func @pack_bf16bf16(%arg0 : tensor<?x?xbf16>, %arg1 : tensor<?x?x7x8xbf16>,
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 259 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[PAD:.+]] = arith.extui %[[ARG2]] : i32 to i64
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[IN_SIZE1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
@@ -514,7 +514,7 @@ func.func @pack_i32i32_transpose_inner(%arg0 : tensor<?x?xi32>, %arg1 : tensor<?
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: f32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 769 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[BITCAST:.+]] = arith.bitcast %[[ARG2]] : f32 to i32
 //  CHECK-DAG:   %[[PAD:.+]] = arith.extui %[[BITCAST]] : i32 to i64
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
@@ -580,7 +580,7 @@ func.func @unpack_f16f16(%arg0 : tensor<?x?x7x8xf16>, %arg1 : tensor<?x?xf16>) -
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xi32>
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 259 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[IN_SIZE1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
@@ -606,7 +606,7 @@ func.func @unpack_i32i32_transpose_inner(%arg0 : tensor<?x?x7x8xi32>, %arg1 : te
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 769 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[IN_SIZE0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[IN_SIZE1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_SIZE0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
@@ -629,7 +629,7 @@ func.func @unpack_f32f32_transpose_inner_and_outer(%arg0 : tensor<?x?x7x8xf32>, 
 
 //     CHECK: func @query_tile_sizes_2d(
 // CHECK-DAG: %[[DYNAMIC:.+]] = arith.constant -9223372036854775808 : index
-// CHECK-DAG: %[[FLAGS:.+]] = arith.constant 259 : i32
+// CHECK-DAG: %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 // CHECK:     %[[RESULT:.+]]:2 = iree_codegen.ukernel.generic "vmvx.query_tile_sizes.2d"
 // CHECK-SAME: ins(%[[DYNAMIC]], %[[DYNAMIC]], %[[FLAGS]] : index, index, i32)
 // CHECK:     return %[[RESULT]]#0, %[[RESULT]]#1 : index, index
@@ -685,7 +685,7 @@ func.func @mmt4d_i8i8i32_extend_producers(%arg0: tensor<?x?x?x?xi8>, %arg1: tens
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1282 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
@@ -747,7 +747,7 @@ func.func @mmt4d_i16u4i32_extend_producers(%arg0: tensor<?x?x?x?xi16>, %arg1: te
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi4>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
-//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1288 : i32
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant {{[0-9]+}} : i32
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_entry_point.c
@@ -306,3 +306,5 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
       return 0;
   }
 }
+
+const bool iree_uk_mmt4d_linked_arch_code = true;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_entry_point.c
@@ -415,3 +415,5 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
       return 0;
   }
 }
+
+const bool iree_uk_mmt4d_linked_arch_code = true;

--- a/runtime/src/iree/builtins/ukernel/exported_bits.h
+++ b/runtime/src/iree/builtins/ukernel/exported_bits.h
@@ -42,7 +42,11 @@
 
 // bit flags
 #define IREE_UK_FLAG_MMT4D_ACCUMULATE 0x100
+#define IREE_UK_FLAG_MMT4D_ALLOW_GENERIC_FALLBACK_TILE_FUNCTION 0x200
 #define IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS 0x400
+
+// output bit flags for iree_uk_mmt4d_info
+#define IREE_UK_FLAG_MMT4D_INFO_HAVE_ARCHITECTURE_SPECIFIC_TILE_FUNCTION 0x1
 
 //===----------------------------------------------------------------------===//
 // pack

--- a/runtime/src/iree/builtins/ukernel/fallback.c
+++ b/runtime/src/iree/builtins/ukernel/fallback.c
@@ -14,6 +14,8 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
   return 0;
 }
 
+const bool iree_uk_mmt4d_linked_arch_code = false;
+
 iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_arch(
     const iree_uk_pack_params_t* params) {
   return 0;

--- a/runtime/src/iree/builtins/ukernel/mmt4d.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.h
@@ -20,4 +20,10 @@ IREE_UK_EXPORT void iree_uk_mmt4d(
     iree_uk_int32_t N0, iree_uk_int32_t K0, iree_uk_uint32_t flags,
     const iree_uk_uint64_t* cpu_data);
 
+// Returns a bit-field of information about how a mmt4d with the given
+// parameters would run.
+IREE_UK_EXPORT iree_uk_uint32_t
+iree_uk_mmt4d_info(iree_uk_int32_t M0, iree_uk_int32_t N0, iree_uk_int32_t K0,
+                   iree_uk_uint32_t flags, const iree_uk_uint64_t* cpu_data);
+
 #endif  // IREE_BUILTINS_UKERNEL_MMT4D_H_

--- a/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
@@ -34,6 +34,11 @@ typedef struct iree_uk_mmt4d_params_t {
 // Same as the iree_uk_mmt4d public entry point, but taking the struct.
 void iree_uk_mmt4d_p(const iree_uk_mmt4d_params_t* params);
 
+// Same as the iree_uk_mmt4d_info public entry point, but taking the struct.
+// Only the struct fields corresponding to iree_uk_mmt4d_info parameters are
+// used.
+iree_uk_uint32_t iree_uk_mmt4d_info_p(const iree_uk_mmt4d_params_t* params);
+
 typedef enum iree_uk_mmt4d_type_t {
   iree_uk_mmt4d_type_f32f32f32 =
       IREE_UK_TIE_3_TYPES_LITERAL(FLOAT_32, FLOAT_32, FLOAT_32),
@@ -163,12 +168,15 @@ typedef void (*iree_uk_mmt4d_tile_func_t)(
 // support the CPU feature that the tile sizes were picked to target.
 enum { iree_uk_mmt4d_tile_generic_max_bytes = 4096 };
 
-// Returns the tile function to use for the mmt4d op with the given params.
-iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func(
+// Architecture-specific implementation, or generic fallback returning null.
+iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
     const iree_uk_mmt4d_params_t* params);
 
-// Architecture-specific implementation.
-iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
+// Indicator of architecture-specific implementation.
+extern const bool iree_uk_mmt4d_linked_arch_code;
+
+// Generic fallback.
+iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(
     const iree_uk_mmt4d_params_t* params);
 
 #endif  // IREE_BUILTINS_UKERNEL_MMT4D_INTERNAL_H_

--- a/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
@@ -462,7 +462,7 @@ static void iree_uk_mmt4d_tile_bf16bf16bf16_generic_skipround(
     out_tile[i] = iree_uk_f32_to_bf16(acc_f32[i]);
 }
 
-static iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(
+iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(
     const iree_uk_mmt4d_params_t* params) {
   switch (iree_uk_mmt4d_type(params->flags)) {
     case iree_uk_mmt4d_type_f32f32f32:
@@ -493,12 +493,4 @@ static iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(
       // Shouldn't happen, validated earlier.
       return 0;
   }
-}
-
-iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func(
-    const iree_uk_mmt4d_params_t* params) {
-  iree_uk_mmt4d_tile_func_t arch_tile_func =
-      iree_uk_mmt4d_select_tile_func_arch(params);
-  if (arch_tile_func) return arch_tile_func;
-  return iree_uk_mmt4d_select_tile_func_generic(params);
 }

--- a/runtime/src/iree/builtins/ukernel/tools/e2e_matmul_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/e2e_matmul_benchmark.c
@@ -391,6 +391,7 @@ static void iree_uk_benchmark_register_e2e_matmul(const char* type_str, int M,
   char name[128];
   snprintf(name, sizeof name, "e2e_matmul_%s_%dx%dx%d", type_str, M, K, N);
   iree_uk_uint32_t mmt4d_flags = iree_uk_mmt4d_parse_type_into_flag(type_str);
+  mmt4d_flags |= IREE_UK_FLAG_MMT4D_ALLOW_GENERIC_FALLBACK_TILE_FUNCTION;
   if (accumulate) mmt4d_flags |= IREE_UK_FLAG_MMT4D_ACCUMULATE;
   iree_uk_benchmark_e2e_matmul_params_t params = {
       .mmt4d_flags = mmt4d_flags, .M = M, .K = K, .N = N};

--- a/runtime/src/iree/builtins/ukernel/tools/test.c
+++ b/runtime/src/iree/builtins/ukernel/tools/test.c
@@ -126,30 +126,23 @@ void iree_uk_test(const char* name,
       .status = IREE_UK_TEST_STATUS_RUN,
   };
   iree_uk_test_log_status(&test);
-  // First try without any optional CPU feature (test.cpu_data is still zeros).
-  // This matters even when the feature is supported by the CPU because we want
-  // to test the fallback to the architecture-default code path.
-  test_func(&test, params);
-  // Then try with optional CPU features, if specified.
-  if (strlen(cpu_features)) {
-    // Are specified CPU features supported by the CPU?
-    iree_uk_initialize_cpu_once();
-    iree_uk_make_cpu_data_for_features(cpu_features, test.cpu_data);
-    if (iree_uk_cpu_supports(test.cpu_data)) {
-      // CPU supports features. Run this part of the test.
-      iree_uk_test_log_info(&test, "🚀", "CPU supports required features");
-      test_func(&test, params);
-    } else {
-      // CPU does not support features. Skip this part of the test.
-      char msg[128];
-      snprintf(msg, sizeof msg, "CPU does not support required feature %s",
-               iree_uk_cpu_first_unsupported_feature(test.cpu_data));
-      iree_uk_test_log_info(&test, "🦕", msg);
-      // Set test status to SKIPPED if it was still the initial RUN.
-      // Do not overwrite a FAILED from the run without optional CPU features.
-      if (test.status == IREE_UK_TEST_STATUS_RUN) {
-        test.status = IREE_UK_TEST_STATUS_SKIPPED;
-      }
+  // Are specified CPU features supported by the CPU?
+  iree_uk_initialize_cpu_once();
+  iree_uk_make_cpu_data_for_features(cpu_features, test.cpu_data);
+  if (iree_uk_cpu_supports(test.cpu_data)) {
+    // CPU supports features. Run this part of the test.
+    iree_uk_test_log_info(&test, "🚀", "CPU supports required features");
+    test_func(&test, params);
+  } else {
+    // CPU does not support features. Skip this part of the test.
+    char msg[128];
+    snprintf(msg, sizeof msg, "CPU does not support required feature %s",
+             iree_uk_cpu_first_unsupported_feature(test.cpu_data));
+    iree_uk_test_log_info(&test, "🦕", msg);
+    // Set test status to SKIPPED if it was still the initial RUN.
+    // Do not overwrite a FAILED from the run without optional CPU features.
+    if (test.status == IREE_UK_TEST_STATUS_RUN) {
+      test.status = IREE_UK_TEST_STATUS_SKIPPED;
     }
   }
   if (test.status == IREE_UK_TEST_STATUS_FAILED) {


### PR DESCRIPTION
This is a key step towards implementing the ukernels-to-codegen fallback when ukernels would not have fast code (#15784).

Not automatically falling back anymore, revealed that one testcase was actually testing the wrong tile size all along :-)