### PR TITLE
mmt4d ukernel: simplification in generic tile funcs: stop using a stack array

### DIFF
--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -44,11 +44,6 @@ static void iree_uk_mmt4d_validate(const iree_uk_mmt4d_params_t* params) {
   // - Ensure that {LHS,RHS} strides are multiples of 8 bits.
   IREE_UK_ASSERT(!((params->lhs_stride0 * lhs_bits) % 8));
   IREE_UK_ASSERT(!((params->rhs_stride0 * rhs_bits) % 8));
-
-  // Ensure iree_uk_mmt4d_tile_generic_max_bytes large enough for this tile.
-  IREE_UK_ASSERT(params->M0 * params->N0 *
-                     iree_uk_type_size(iree_uk_mmt4d_out_type(mmt4d_type)) <=
-                 iree_uk_mmt4d_tile_generic_max_bytes);
 #endif  // IREE_UK_ENABLE_ASSERTS
 }
 

--- a/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
@@ -150,24 +150,6 @@ typedef void (*iree_uk_mmt4d_tile_func_t)(
   IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0_1_2_4_8(G, F1, F2, F4, F8)               \
   IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(G, F16, 16)
 
-// In order to be helpful as a reference for future architecture-specific
-// kernels, the generic kernels are structured like an actual optimized kernel,
-// using an "accumulator tile" that in this case is a stack array (which would
-// become a group of SIMD registers in an actual optimized kernel). The downside
-// of this approach is that we have to set a fixed max size for the accumulator
-// tile, but for now all known cases are comfortably far below where trouble
-// would happen. For reference:
-// - On ARM NEON, the entire register space is 512 bytes, so the accumulator
-//   tile is less than that, typically 256 to 384 bytes.
-// - On ARM SME, we will be working with an accumulator tile as large as 4096
-//   bytes (IIUC).
-// - The smallest stack frame size limit that we know we may have to deal with
-//   on certain targets is 16 kilobytes.
-// The size or architecture-specific tiles is relevant here because this
-// generic code is what will be run as a fallback if the device is found not to
-// support the CPU feature that the tile sizes were picked to target.
-enum { iree_uk_mmt4d_tile_generic_max_bytes = 4096 };
-
 // Architecture-specific implementation, or generic fallback returning null.
 iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
     const iree_uk_mmt4d_params_t* params);

--- a/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/builtins/ukernel/exported_bits.h"
 #include "iree/builtins/ukernel/mmt4d_internal.h"
 
 // Generic implementation of matmul tile, s8*s4->s32 case.
@@ -19,24 +20,20 @@ static void iree_uk_mmt4d_tile_s8s4s32_generic(
   // K0 must be even.
   IREE_UK_ASSERT(!(K0 % 2));
   iree_uk_int16_t K0half = K0 / 2;
-  // Initialize the local accumulator tile.
-  iree_uk_int32_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      iree_uk_int32_t acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                                ? out_tile[i0 * N0 + j0]
+                                : 0;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         // As K0 must be even, we 2x-unroll the K0 loop, writing a 2D dot
         // product.
         for (iree_uk_index_t k0h = 0; k0h < K0half; ++k0h) {
-          iree_uk_int32_t lhs_0 = lhs_panel[i0 * K0 + 2 * k0h];
-          iree_uk_int32_t lhs_1 = lhs_panel[i0 * K0 + 2 * k0h + 1];
-          iree_uk_int8_t rhs_byte = rhs_panel[j0 * K0half + k0h];
-
+          iree_uk_int32_t lhs_0 = lhs_panel[k * M0 * K0 + i0 * K0 + 2 * k0h];
+          iree_uk_int32_t lhs_1 =
+              lhs_panel[k * M0 * K0 + i0 * K0 + 2 * k0h + 1];
+          iree_uk_int8_t rhs_byte =
+              rhs_panel[k * N0 * K0half + j0 * K0half + k0h];
           iree_uk_int8_t rhs_0 = rhs_byte & 0x0F;
           if (rhs_0 & 0x08) {
             rhs_0 |= 0xF0;
@@ -45,16 +42,12 @@ static void iree_uk_mmt4d_tile_s8s4s32_generic(
           if (rhs_1 & 0x08) {
             rhs_1 |= 0xF0;
           }
-
-          acc[i0 * N0 + j0] += lhs_0 * rhs_0 + lhs_1 * rhs_1;
+          acc += lhs_0 * rhs_0 + lhs_1 * rhs_1;
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0half;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, s8*s8->s32 case.
@@ -67,29 +60,21 @@ static void iree_uk_mmt4d_tile_s8s8s32_generic(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  iree_uk_int32_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      iree_uk_int32_t acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                                ? out_tile[i0 * N0 + j0]
+                                : 0;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          iree_uk_int32_t lhs_i32 = lhs_panel[i0 * K0 + k0];
-          iree_uk_int32_t rhs_i32 = rhs_panel[j0 * K0 + k0];
-          acc[i0 * N0 + j0] += lhs_i32 * rhs_i32;
+          iree_uk_int32_t lhs_i32 = lhs_panel[k * M0 * K0 + i0 * K0 + k0];
+          iree_uk_int32_t rhs_i32 = rhs_panel[k * N0 * K0 + j0 * K0 + k0];
+          acc += lhs_i32 * rhs_i32;
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, s16*s16->s32 case.
@@ -102,29 +87,21 @@ static void iree_uk_mmt4d_tile_s16s16s32_generic(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  iree_uk_int32_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      iree_uk_int32_t acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                                ? out_tile[i0 * N0 + j0]
+                                : 0;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          iree_uk_int32_t lhs_i32 = lhs_panel[i0 * K0 + k0];
-          iree_uk_int32_t rhs_i32 = rhs_panel[j0 * K0 + k0];
-          acc[i0 * N0 + j0] += lhs_i32 * rhs_i32;
+          iree_uk_int32_t lhs_i32 = lhs_panel[k * M0 * K0 + i0 * K0 + k0];
+          iree_uk_int32_t rhs_i32 = rhs_panel[k * N0 * K0 + j0 * K0 + k0];
+          acc += lhs_i32 * rhs_i32;
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, s16*u4->s32 case.
@@ -140,34 +117,28 @@ static void iree_uk_mmt4d_tile_s16u4s32_generic(
   // K0 must be even.
   IREE_UK_ASSERT(!(K0 % 2));
   iree_uk_int16_t K0half = K0 / 2;
-  // Initialize the local accumulator tile.
-  iree_uk_int32_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      iree_uk_int32_t acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                                ? out_tile[i0 * N0 + j0]
+                                : 0;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         // As K0 must be even, we 2x-unroll the K0 loop, writing a 2D dot
         // product.
         for (iree_uk_index_t k0h = 0; k0h < K0half; ++k0h) {
-          iree_uk_int32_t lhs_0 = lhs_panel[i0 * K0 + 2 * k0h];
-          iree_uk_int32_t lhs_1 = lhs_panel[i0 * K0 + 2 * k0h + 1];
-          iree_uk_uint8_t rhs_byte = rhs_panel[j0 * K0half + k0h];
+          iree_uk_int32_t lhs_0 = lhs_panel[k * M0 * K0 + i0 * K0 + 2 * k0h];
+          iree_uk_int32_t lhs_1 =
+              lhs_panel[k * M0 * K0 + i0 * K0 + 2 * k0h + 1];
+          iree_uk_uint8_t rhs_byte =
+              rhs_panel[k * N0 * K0half + j0 * K0half + k0h];
           iree_uk_int32_t rhs_0 = rhs_byte & 0xf;
           iree_uk_int32_t rhs_1 = rhs_byte >> 4;
-          acc[i0 * N0 + j0] += lhs_0 * rhs_0 + lhs_1 * rhs_1;
+          acc += lhs_0 * rhs_0 + lhs_1 * rhs_1;
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0half;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, s16*s8->s32 case.
@@ -180,29 +151,21 @@ static void iree_uk_mmt4d_tile_s16s8s32_generic(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  iree_uk_int32_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      iree_uk_int32_t acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                                ? out_tile[i0 * N0 + j0]
+                                : 0;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          iree_uk_int32_t lhs_i32 = lhs_panel[i0 * K0 + k0];
-          iree_uk_int32_t rhs_i32 = rhs_panel[j0 * K0 + k0];
-          acc[i0 * N0 + j0] += lhs_i32 * rhs_i32;
+          iree_uk_int32_t lhs_i32 = lhs_panel[k * M0 * K0 + i0 * K0 + k0];
+          iree_uk_int32_t rhs_i32 = rhs_panel[k * N0 * K0 + j0 * K0 + k0];
+          acc += lhs_i32 * rhs_i32;
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, f32*f32->f32 case.
@@ -215,29 +178,21 @@ static void iree_uk_mmt4d_tile_f32f32f32_generic(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      float acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                      ? out_tile[i0 * N0 + j0]
+                      : 0.f;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          float lhs_f32 = lhs_panel[i0 * K0 + k0];
-          float rhs_f32 = rhs_panel[j0 * K0 + k0];
-          acc[i0 * N0 + j0] += lhs_f32 * rhs_f32;
+          float lhs_f32 = lhs_panel[k * M0 * K0 + i0 * K0 + k0];
+          float rhs_f32 = rhs_panel[k * N0 * K0 + j0 * K0 + k0];
+          acc += lhs_f32 * rhs_f32;
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, f16*f16->f32 case.
@@ -250,29 +205,23 @@ static void iree_uk_mmt4d_tile_f16f16f32_generic(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      float acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                      ? out_tile[i0 * N0 + j0]
+                      : 0.f;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          float lhs_f32 = iree_uk_f16_to_f32(lhs_panel[i0 * K0 + k0]);
-          float rhs_f32 = iree_uk_f16_to_f32(rhs_panel[j0 * K0 + k0]);
-          acc[i0 * N0 + j0] += lhs_f32 * rhs_f32;
+          float lhs_f32 =
+              iree_uk_f16_to_f32(lhs_panel[k * M0 * K0 + i0 * K0 + k0]);
+          float rhs_f32 =
+              iree_uk_f16_to_f32(rhs_panel[k * N0 * K0 + j0 * K0 + k0]);
+          acc += lhs_f32 * rhs_f32;
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, f16*f16->f16 case.
@@ -286,31 +235,24 @@ static void iree_uk_mmt4d_tile_f16f16f16_generic_noskipround(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  iree_uk_int16_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      iree_uk_int16_t acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                                ? out_tile[i0 * N0 + j0]
+                                : 0;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          float lhs_f32 = iree_uk_f16_to_f32(lhs_panel[i0 * K0 + k0]);
-          float rhs_f32 = iree_uk_f16_to_f32(rhs_panel[j0 * K0 + k0]);
-          iree_uk_int16_t* acc_ptr = &acc[i0 * N0 + j0];
-          float acc_f32 = iree_uk_f16_to_f32(*acc_ptr);
-          *acc_ptr = iree_uk_f32_to_f16(acc_f32 + lhs_f32 * rhs_f32);
+          float lhs_f32 =
+              iree_uk_f16_to_f32(lhs_panel[k * M0 * K0 + i0 * K0 + k0]);
+          float rhs_f32 =
+              iree_uk_f16_to_f32(rhs_panel[k * N0 * K0 + j0 * K0 + k0]);
+          float acc_f32 = iree_uk_f16_to_f32(acc);
+          acc = iree_uk_f32_to_f16(acc_f32 + lhs_f32 * rhs_f32);
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, f16*f16->f16 case.
@@ -324,31 +266,23 @@ static void iree_uk_mmt4d_tile_f16f16f16_generic_skipround(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  float acc_f32[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i)
-      acc_f32[i] = iree_uk_f16_to_f32(out_tile[i]);
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc_f32[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      float acc_f32 = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                          ? iree_uk_f16_to_f32(out_tile[i0 * N0 + j0])
+                          : 0.f;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          float lhs_f32 = iree_uk_f16_to_f32(lhs_panel[i0 * K0 + k0]);
-          float rhs_f32 = iree_uk_f16_to_f32(rhs_panel[j0 * K0 + k0]);
-          acc_f32[i0 * N0 + j0] += lhs_f32 * rhs_f32;
+          float lhs_f32 =
+              iree_uk_f16_to_f32(lhs_panel[k * M0 * K0 + i0 * K0 + k0]);
+          float rhs_f32 =
+              iree_uk_f16_to_f32(rhs_panel[k * N0 * K0 + j0 * K0 + k0]);
+          acc_f32 += lhs_f32 * rhs_f32;
         }
       }
+      out_tile[i0 * N0 + j0] = iree_uk_f32_to_f16(acc_f32);
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i)
-    out_tile[i] = iree_uk_f32_to_f16(acc_f32[i]);
 }
 
 // Generic implementation of matmul tile, bf16*bf16->f32 case.
@@ -361,29 +295,23 @@ static void iree_uk_mmt4d_tile_bf16bf16f32_generic(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      float acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                      ? out_tile[i0 * N0 + j0]
+                      : 0.f;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          float lhs_f32 = iree_uk_bf16_to_f32(lhs_panel[i0 * K0 + k0]);
-          float rhs_f32 = iree_uk_bf16_to_f32(rhs_panel[j0 * K0 + k0]);
-          acc[i0 * N0 + j0] += lhs_f32 * rhs_f32;
+          float lhs_f32 =
+              iree_uk_bf16_to_f32(lhs_panel[k * M0 * K0 + i0 * K0 + k0]);
+          float rhs_f32 =
+              iree_uk_bf16_to_f32(rhs_panel[k * N0 * K0 + j0 * K0 + k0]);
+          acc += lhs_f32 * rhs_f32;
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, bf16*bf16->bf16 case.
@@ -397,31 +325,24 @@ static void iree_uk_mmt4d_tile_bf16bf16bf16_generic_noskipround(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  iree_uk_int16_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      iree_uk_int16_t acc = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                                ? out_tile[i0 * N0 + j0]
+                                : 0;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          float lhs_f32 = iree_uk_bf16_to_f32(lhs_panel[i0 * K0 + k0]);
-          float rhs_f32 = iree_uk_bf16_to_f32(rhs_panel[j0 * K0 + k0]);
-          iree_uk_int16_t* acc_ptr = &acc[i0 * N0 + j0];
-          float acc_f32 = iree_uk_bf16_to_f32(*acc_ptr);
-          *acc_ptr = iree_uk_f32_to_bf16(acc_f32 + lhs_f32 * rhs_f32);
+          float lhs_f32 =
+              iree_uk_bf16_to_f32(lhs_panel[k * M0 * K0 + i0 * K0 + k0]);
+          float rhs_f32 =
+              iree_uk_bf16_to_f32(rhs_panel[k * N0 * K0 + j0 * K0 + k0]);
+          float acc_f32 = iree_uk_bf16_to_f32(acc);
+          acc = iree_uk_f32_to_bf16(acc_f32 + lhs_f32 * rhs_f32);
         }
       }
+      out_tile[i0 * N0 + j0] = acc;
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i) out_tile[i] = acc[i];
 }
 
 // Generic implementation of matmul tile, bf16*bf16->bf16 case.
@@ -435,31 +356,23 @@ static void iree_uk_mmt4d_tile_bf16bf16bf16_generic_skipround(
   iree_uk_int16_t M0 = params->M0;
   iree_uk_int16_t N0 = params->N0;
   iree_uk_int16_t K0 = params->K0;
-  // Initialize the local accumulator tile.
-  float acc_f32[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    for (int i = 0; i < M0 * N0; ++i)
-      acc_f32[i] = iree_uk_bf16_to_f32(out_tile[i]);
-  } else {
-    for (int i = 0; i < M0 * N0; ++i) acc_f32[i] = 0;
-  }
-  // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < params->K; ++k) {
-    for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+  for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
+    for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
+      float acc_f32 = (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE)
+                          ? iree_uk_bf16_to_f32(out_tile[i0 * N0 + j0])
+                          : 0.f;
+      for (iree_uk_index_t k = 0; k < params->K; ++k) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
-          float lhs_f32 = iree_uk_bf16_to_f32(lhs_panel[i0 * K0 + k0]);
-          float rhs_f32 = iree_uk_bf16_to_f32(rhs_panel[j0 * K0 + k0]);
-          acc_f32[i0 * N0 + j0] += lhs_f32 * rhs_f32;
+          float lhs_f32 =
+              iree_uk_bf16_to_f32(lhs_panel[k * M0 * K0 + i0 * K0 + k0]);
+          float rhs_f32 =
+              iree_uk_bf16_to_f32(rhs_panel[k * N0 * K0 + j0 * K0 + k0]);
+          acc_f32 += lhs_f32 * rhs_f32;
         }
       }
+      out_tile[i0 * N0 + j0] = iree_uk_f32_to_bf16(acc_f32);
     }
-    lhs_panel += M0 * K0;
-    rhs_panel += N0 * K0;
   }
-  // Store the local accumulator tile to the destination.
-  for (int i = 0; i < M0 * N0; ++i)
-    out_tile[i] = iree_uk_f32_to_bf16(acc_f32[i]);
 }
 
 iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(


### PR DESCRIPTION
In the mmt4d ukernel, the generic fallback tile-functions have used a stack array to represent the accumulator in an attempt to mimic what a real optimized tile-func would do with registers. That had an initial purpose of providing some starting point to help guide the design of optimized tile-funcs, but by now there are enough optimized tile-funcs that the existing ones are the starting point for new ones. And that led to more lines of code per generic tile-funcs, and some complication with the sizing of the stack arrays, requiring a lengthy comment and some validation code.