### PR TITLE
[gpu] Improve vector distribution error reporting

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -231,7 +231,8 @@ LogicalResult distributeVectorOps(Operation *root,
   // Run the analysis and determine the layouts.
   LLVM_DEBUG(llvm::dbgs() << "Running Layout Analysis\n");
   VectorLayoutAnalysis analysis(root);
-  options.setAnchorOps(analysis);
+  if (failed(options.setAnchorOps(analysis)))
+    return failure();
   if (failed(analysis.run()))
     return failure();
   LLVM_DEBUG(llvm::dbgs() << "Layout Analysis Succeded\n");

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
@@ -98,7 +98,7 @@ public:
   virtual ~VectorLayoutOptions() = default;
 
   /// Set the anchor ops in the analysis rooted on the root operation.
-  virtual void setAnchorOps(VectorLayoutAnalysis &analysis) = 0;
+  virtual LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) = 0;
 
   bool verifyConversion() const { return fullConversion; }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -941,8 +941,9 @@ public:
   TestVectorLayoutOptions(Operation *root)
       : VectorLayoutOptions(root, /*fullConversion=*/false) {}
 
-  void setAnchorOps(VectorLayoutAnalysis &analysis) override {
+  LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
     setAnchorOpsFromAttributes(analysis, root);
+    return success();
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -1505,8 +1505,9 @@ public:
   TransformVectorLayoutOptions(Operation *root, bool fullConversion)
       : VectorLayoutOptions(root, fullConversion) {}
 
-  void setAnchorOps(VectorLayoutAnalysis &analysis) override {
+  LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
     setAnchorOpsFromAttributes(analysis, root);
+    return success();
   }
 };
 


### PR DESCRIPTION
Instead of using asserts in Debug build mode, make errors as proper errors and make it easy to diagnose.