### PR TITLE
Fix enablement of mmt4d ukernel test cases based on ISA code paths built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_all')
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
     runs-on: windows-2022-64core
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_all')
     runs-on: windows-2022-64core
     defaults:
       run:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -138,7 +138,10 @@ DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
 # The file paths should be specified using Unix shell-style wildcards.
 PRESUBMIT_TOUCH_ONLY_JOBS = [
     ("build_test_all_macos_arm64", ["runtime/src/iree/hal/drivers/metal/*"]),
-    ("build_test_all_windows", ["*win32*", "*windows*", "*msvc*"]),
+    (
+        "build_test_all_windows",
+        ["*win32*", "*windows*", "*msvc*", "runtime/src/iree/builtins/ukernel/*"]
+    ),
 ]
 
 # Default presets enabled in CI.

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -140,7 +140,7 @@ PRESUBMIT_TOUCH_ONLY_JOBS = [
     ("build_test_all_macos_arm64", ["runtime/src/iree/hal/drivers/metal/*"]),
     (
         "build_test_all_windows",
-        ["*win32*", "*windows*", "*msvc*", "runtime/src/iree/builtins/ukernel/*"]
+        ["*win32*", "*windows*", "*msvc*", "runtime/src/iree/builtins/ukernel/*"],
     ),
 ]
 

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_entry_point.c
@@ -306,5 +306,3 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
       return 0;
   }
 }
-
-const bool iree_uk_mmt4d_linked_arch_code = true;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_entry_point.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_entry_point.c
@@ -415,5 +415,3 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
       return 0;
   }
 }
-
-const bool iree_uk_mmt4d_linked_arch_code = true;

--- a/runtime/src/iree/builtins/ukernel/fallback.c
+++ b/runtime/src/iree/builtins/ukernel/fallback.c
@@ -14,8 +14,6 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
   return 0;
 }
 
-const bool iree_uk_mmt4d_linked_arch_code = false;
-
 iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_arch(
     const iree_uk_pack_params_t* params) {
   return 0;

--- a/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
@@ -172,9 +172,6 @@ enum { iree_uk_mmt4d_tile_generic_max_bytes = 4096 };
 iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arch(
     const iree_uk_mmt4d_params_t* params);
 
-// Indicator of architecture-specific implementation.
-extern const bool iree_uk_mmt4d_linked_arch_code;
-
 // Generic fallback.
 iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(
     const iree_uk_mmt4d_params_t* params);


### PR DESCRIPTION
This fixes `build_test_all_windows` CI and adds CI configuration to trigger it on all ukernel code changes going forward.

There is an unresolved mystery as to what exactly went wrong on `build_test_all_windows` CI job, as its MSVC compiler failed the `check_cxx_compile_flags` for `/arch:AVX2` while the exact same MSVC version succeeded in the `build_test_runtime_windows` CI job.

But regardless, there was something not well thought out in how I did the testcase enablement. I had added a global constant bool indicating whether we had linked architecture-specific code, but that was only per-architecture, not accounting for the fact that, depending on `check_cxx_compile_flags`, some sub-architecture code paths could be individually disabled.

This new PR redoes that: the global constant bools are dropped, and instead, the problem is tackled differently in `mmt4d_test` vs `mmt4d_benchmark`:
* In `mmt4d_test`, as we really want to avoid testcases silently testing nothing, we keep running *without fallback*, but we now condition testcases on `IREE_UK_BUILD_*` cmake-defined variables.
* In `mmt4d_benchmark`, we just enable the fallback, so in the worst case if a code path is disabled, the outcome is a poor benchmark result. `mmt4d_benchmark` doesn't need to catch enablement, that's already done by `mmt4d_test`.