### PR TITLE
[cuda][hip] Add support for semaphore multi wait

### DIFF
--- a/experimental/hip/CMakeLists.txt
+++ b/experimental/hip/CMakeLists.txt
@@ -64,6 +64,7 @@ iree_cc_library(
     iree::base::internal::event_pool
     iree::base::internal::synchronization
     iree::base::internal::threading
+    iree::base::internal::wait_handle
     iree::base::internal::flatcc::parsing
     iree::hal
     iree::hal::utils::collective_batch

--- a/experimental/hip/event_semaphore.c
+++ b/experimental/hip/event_semaphore.c
@@ -346,7 +346,7 @@ iree_status_t iree_hal_hip_semaphore_multi_wait(
   iree_status_t status = iree_wait_set_allocate(
       semaphore_list.count, iree_arena_allocator(&arena), &wait_set);
 
-  // Acquire a wait handle for each semaphore timepoint we are to wait on.
+  // Acquire a host wait handle for each semaphore timepoint we are to wait on.
   iree_host_size_t timepoint_count = 0;
   iree_hal_hip_timepoint_t** timepoints = NULL;
   iree_host_size_t total_timepoint_size =
@@ -373,9 +373,9 @@ iree_status_t iree_hal_hip_semaphore_multi_wait(
         iree_hal_hip_semaphore_t* semaphore =
             iree_hal_hip_semaphore_cast(semaphore_list.semaphores[i]);
 
-        // Slow path: get a native wait handle for the timepoint. This should
-        // happen outside of the lock given that acquiring has its own internal
-        // locks.
+        // Slow path: get a native host wait handle for the timepoint. This
+        // should happen outside of the lock given that acquiring has its own
+        // internal locks.
         iree_hal_hip_timepoint_t* timepoint = NULL;
         status = iree_hal_hip_semaphore_acquire_timepoint_host_wait(
             semaphore, semaphore_list.payload_values[i], timeout, &timepoint);

--- a/experimental/hip/event_semaphore.h
+++ b/experimental/hip/event_semaphore.h
@@ -49,6 +49,14 @@ iree_status_t iree_hal_hip_event_semaphore_acquire_timepoint_device_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t min_value,
     hipEvent_t* out_event);
 
+// Performs a multi-wait on one or more semaphores.
+// Returns IREE_STATUS_DEADLINE_EXCEEDED if the wait does not complete before
+// |deadline_ns| elapses.
+iree_status_t iree_hal_hip_semaphore_multi_wait(
+    const iree_hal_semaphore_list_t semaphore_list,
+    iree_hal_wait_mode_t wait_mode, iree_timeout_t timeout,
+    iree_arena_block_pool_t* block_pool);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/experimental/hip/event_semaphore.h
+++ b/experimental/hip/event_semaphore.h
@@ -49,9 +49,8 @@ iree_status_t iree_hal_hip_event_semaphore_acquire_timepoint_device_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t min_value,
     hipEvent_t* out_event);
 
-// Performs a multi-wait on one or more semaphores.
-// Returns IREE_STATUS_DEADLINE_EXCEEDED if the wait does not complete before
-// |deadline_ns| elapses.
+// Performs a multi-wait on one or more semaphores. Returns
+// IREE_STATUS_DEADLINE_EXCEEDED if the wait does not complete before |timeout|.
 iree_status_t iree_hal_hip_semaphore_multi_wait(
     const iree_hal_semaphore_list_t semaphore_list,
     iree_hal_wait_mode_t wait_mode, iree_timeout_t timeout,

--- a/experimental/hip/hip_device.c
+++ b/experimental/hip/hip_device.c
@@ -671,8 +671,9 @@ static iree_status_t iree_hal_hip_device_queue_flush(
 static iree_status_t iree_hal_hip_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "waiting multiple semaphores not yet implemented");
+  iree_hal_hip_device_t* device = iree_hal_hip_device_cast(base_device);
+  return iree_hal_hip_semaphore_multi_wait(semaphore_list, wait_mode, timeout,
+                                           &device->block_pool);
 }
 
 static iree_status_t iree_hal_hip_device_profiling_begin(

--- a/runtime/src/iree/hal/cts/semaphore_submission_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_submission_test.h
@@ -8,6 +8,7 @@
 #define IREE_HAL_CTS_SEMAPHORE_SUBMISSION_TEST_H_
 
 #include <cstdint>
+#include <thread>
 
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
@@ -181,6 +182,271 @@ TEST_P(semaphore_submission_test, SubmitWithMultipleSemaphores) {
   iree_hal_semaphore_release(wait_semaphore_2);
   iree_hal_semaphore_release(signal_semaphore_1);
   iree_hal_semaphore_release(signal_semaphore_2);
+}
+
+// Tests we can wait on both host and device semaphore to singal.
+TEST_P(semaphore_submission_test, WaitAllHostAndDeviceSemaphores) {
+  iree_hal_command_buffer_t* command_buffer = NULL;
+  IREE_ASSERT_OK(iree_hal_command_buffer_create(
+      device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+      IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*binding_capacity=*/0, &command_buffer));
+
+  IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
+  IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
+
+  // Create two semaphores, one for the host thread to wait on, and one for the
+  // device to wait on.
+  iree_hal_semaphore_t* host_wait_semaphore = NULL;
+  iree_hal_semaphore_t* device_wait_semaphore = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &host_wait_semaphore));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &device_wait_semaphore));
+
+  // Create two semaphores, one for the host thread to signal, and one for the
+  // device to signal.
+  iree_hal_semaphore_t* host_signal_semaphore = NULL;
+  iree_hal_semaphore_t* device_signal_semaphore = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &host_signal_semaphore));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &device_signal_semaphore));
+
+  // Prepare device wait and signal semaphore lists.
+  uint64_t device_wait_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t device_wait_semaphores = {
+      /*cout=*/1, &device_wait_semaphore, device_wait_payload_values};
+  uint64_t device_signal_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t device_signal_semaphores = {
+      /*count=*/1, &device_signal_semaphore, device_signal_payload_values};
+
+  // Dispatch the device command buffer to have it wait.
+  IREE_ASSERT_OK(iree_hal_device_queue_execute(
+      device_, /*queue_affinity=*/0, device_wait_semaphores,
+      device_signal_semaphores, 1, &command_buffer));
+
+  // Start another thread and have it wait.
+  std::thread thread([&]() {
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_wait(host_wait_semaphore, 1ull,
+                                iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+    IREE_ASSERT_OK(iree_hal_semaphore_signal(host_signal_semaphore, 1ull));
+  });
+
+  // Work shouldn't start until all wait semaphores reach their payload values.
+  uint64_t value;
+  IREE_ASSERT_OK(iree_hal_semaphore_query(host_signal_semaphore, &value));
+  EXPECT_EQ(0ull, value);
+  IREE_ASSERT_OK(iree_hal_semaphore_query(device_signal_semaphore, &value));
+  EXPECT_EQ(0ull, value);
+
+  // Signal the wait semaphores for both host thread and device, work should
+  // begin and complete.
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(host_wait_semaphore, 1ull));
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(device_wait_semaphore, 1ull));
+
+  // Now wait on both to complete.
+  iree_hal_semaphore_t* main_semaphore_ptrs[] = {host_signal_semaphore,
+                                                 device_signal_semaphore};
+  uint64_t main_payload_values[] = {1ull, 1ull};
+  iree_hal_semaphore_list_t main_wait_semaphores = {
+      IREE_ARRAYSIZE(main_semaphore_ptrs), main_semaphore_ptrs,
+      main_payload_values};
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
+      device_, IREE_HAL_WAIT_MODE_ALL, main_wait_semaphores,
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+  thread.join();
+
+  iree_hal_command_buffer_release(command_buffer);
+  iree_hal_semaphore_release(host_wait_semaphore);
+  iree_hal_semaphore_release(device_wait_semaphore);
+  iree_hal_semaphore_release(host_signal_semaphore);
+  iree_hal_semaphore_release(device_signal_semaphore);
+}
+
+// Tests we can wait on any host and device semaphore to singal and device
+// signals.
+TEST_P(semaphore_submission_test,
+       WaitAnyHostAndDeviceSemaphoresAndDeviceSignals) {
+  iree_hal_command_buffer_t* command_buffer = NULL;
+  IREE_ASSERT_OK(iree_hal_command_buffer_create(
+      device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+      IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*binding_capacity=*/0, &command_buffer));
+
+  IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
+  IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
+
+  // Create two semaphores, one for the host thread to wait on, and one for the
+  // device to wait on.
+  iree_hal_semaphore_t* host_wait_semaphore = NULL;
+  iree_hal_semaphore_t* device_wait_semaphore = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &host_wait_semaphore));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &device_wait_semaphore));
+
+  // Create two semaphores, one for the host thread to signal, and one for the
+  // device to signal.
+  iree_hal_semaphore_t* host_signal_semaphore = NULL;
+  iree_hal_semaphore_t* device_signal_semaphore = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &host_signal_semaphore));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &device_signal_semaphore));
+
+  // Prepare device wait and signal semaphore lists.
+  uint64_t device_wait_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t device_wait_semaphores = {
+      /*cout=*/1, &device_wait_semaphore, device_wait_payload_values};
+  uint64_t device_signal_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t device_signal_semaphores = {
+      /*count=*/1, &device_signal_semaphore, device_signal_payload_values};
+
+  // Dispatch the device command buffer to have it wait.
+  IREE_ASSERT_OK(iree_hal_device_queue_execute(
+      device_, /*queue_affinity=*/0, device_wait_semaphores,
+      device_signal_semaphores, 1, &command_buffer));
+
+  // Start another thread and have it wait.
+  std::thread thread([&]() {
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_wait(host_wait_semaphore, 1ull,
+                                iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+    IREE_ASSERT_OK(iree_hal_semaphore_signal(host_signal_semaphore, 1ull));
+  });
+
+  // Work shouldn't start until all wait semaphores reach their payload values.
+  uint64_t value;
+  IREE_ASSERT_OK(iree_hal_semaphore_query(host_signal_semaphore, &value));
+  EXPECT_EQ(0ull, value);
+  IREE_ASSERT_OK(iree_hal_semaphore_query(device_signal_semaphore, &value));
+  EXPECT_EQ(0ull, value);
+
+  // Signal the wait semaphores for the device, work should begin and complete.
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(device_wait_semaphore, 1ull));
+
+  // Now wait on any to complete.
+  iree_hal_semaphore_t* main_semaphore_ptrs[] = {host_signal_semaphore,
+                                                 device_signal_semaphore};
+  uint64_t main_payload_values[] = {1ull, 1ull};
+  iree_hal_semaphore_list_t main_wait_semaphores = {
+      IREE_ARRAYSIZE(main_semaphore_ptrs), main_semaphore_ptrs,
+      main_payload_values};
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
+      device_, IREE_HAL_WAIT_MODE_ANY, main_wait_semaphores,
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+
+  // Check both host and device signal semaphores match our expectation.
+  IREE_ASSERT_OK(iree_hal_semaphore_query(host_signal_semaphore, &value));
+  EXPECT_EQ(0ull, value);
+  IREE_ASSERT_OK(iree_hal_semaphore_query(device_signal_semaphore, &value));
+  EXPECT_EQ(1ull, value);
+
+  // Now let the host thread to complete.
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(host_wait_semaphore, 1ull));
+  thread.join();
+
+  iree_hal_command_buffer_release(command_buffer);
+  iree_hal_semaphore_release(host_wait_semaphore);
+  iree_hal_semaphore_release(device_wait_semaphore);
+  iree_hal_semaphore_release(host_signal_semaphore);
+  iree_hal_semaphore_release(device_signal_semaphore);
+}
+
+// Tests we can wait on any host and device semaphore to singal and host
+// signals.
+TEST_P(semaphore_submission_test,
+       WaitAnyHostAndDeviceSemaphoresAndHostSignals) {
+  iree_hal_command_buffer_t* command_buffer = NULL;
+  IREE_ASSERT_OK(iree_hal_command_buffer_create(
+      device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+      IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*binding_capacity=*/0, &command_buffer));
+
+  IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
+  IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
+
+  // Create two semaphores, one for the host thread to wait on, and one for the
+  // device to wait on.
+  iree_hal_semaphore_t* host_wait_semaphore = NULL;
+  iree_hal_semaphore_t* device_wait_semaphore = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &host_wait_semaphore));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &device_wait_semaphore));
+
+  // Create two semaphores, one for the host thread to signal, and one for the
+  // device to signal.
+  iree_hal_semaphore_t* host_signal_semaphore = NULL;
+  iree_hal_semaphore_t* device_signal_semaphore = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &host_signal_semaphore));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, 0ull, &device_signal_semaphore));
+
+  // Prepare device wait and signal semaphore lists.
+  uint64_t device_wait_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t device_wait_semaphores = {
+      /*cout=*/1, &device_wait_semaphore, device_wait_payload_values};
+  uint64_t device_signal_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t device_signal_semaphores = {
+      /*count=*/1, &device_signal_semaphore, device_signal_payload_values};
+
+  // Dispatch the device command buffer to have it wait.
+  IREE_ASSERT_OK(iree_hal_device_queue_execute(
+      device_, /*queue_affinity=*/0, device_wait_semaphores,
+      device_signal_semaphores, 1, &command_buffer));
+
+  // Start another thread and have it wait.
+  std::thread thread([&]() {
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_wait(host_wait_semaphore, 1ull,
+                                iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+    IREE_ASSERT_OK(iree_hal_semaphore_signal(host_signal_semaphore, 1ull));
+  });
+
+  // Work shouldn't start until all wait semaphores reach their payload values.
+  uint64_t value;
+  IREE_ASSERT_OK(iree_hal_semaphore_query(host_signal_semaphore, &value));
+  EXPECT_EQ(0ull, value);
+  IREE_ASSERT_OK(iree_hal_semaphore_query(device_signal_semaphore, &value));
+  EXPECT_EQ(0ull, value);
+
+  // Signal the wait semaphores for the host thread, work should begin and
+  // complete.
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(host_wait_semaphore, 1ull));
+
+  // Now wait on both to complete.
+  iree_hal_semaphore_t* main_semaphore_ptrs[] = {host_signal_semaphore,
+                                                 device_signal_semaphore};
+  uint64_t main_payload_values[] = {1ull, 1ull};
+  iree_hal_semaphore_list_t main_wait_semaphores = {
+      IREE_ARRAYSIZE(main_semaphore_ptrs), main_semaphore_ptrs,
+      main_payload_values};
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
+      device_, IREE_HAL_WAIT_MODE_ANY, main_wait_semaphores,
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+  thread.join();
+
+  // Check both host and device signal semaphores match our expectation.
+  IREE_ASSERT_OK(iree_hal_semaphore_query(host_signal_semaphore, &value));
+  EXPECT_EQ(1ull, value);
+  IREE_ASSERT_OK(iree_hal_semaphore_query(device_signal_semaphore, &value));
+  EXPECT_EQ(0ull, value);
+
+  // Signal and wait for the device to complete too.
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(device_wait_semaphore, 1ull));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_wait(device_signal_semaphore, 1ull,
+                              iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+
+  iree_hal_command_buffer_release(command_buffer);
+  iree_hal_semaphore_release(host_wait_semaphore);
+  iree_hal_semaphore_release(device_wait_semaphore);
+  iree_hal_semaphore_release(host_signal_semaphore);
+  iree_hal_semaphore_release(device_signal_semaphore);
 }
 
 // TODO: test device -> device synchronization: submit two batches with a

--- a/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
@@ -61,6 +61,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/internal:event_pool",
         "//runtime/src/iree/base/internal:synchronization",
         "//runtime/src/iree/base/internal:threading",
+        "//runtime/src/iree/base/internal:wait_handle",
         "//runtime/src/iree/base/internal/flatcc:parsing",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/utils:collective_batch",

--- a/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
@@ -59,6 +59,7 @@ iree_cc_library(
     iree::base::internal::flatcc::parsing
     iree::base::internal::synchronization
     iree::base::internal::threading
+    iree::base::internal::wait_handle
     iree::hal
     iree::hal::utils::collective_batch
     iree::hal::utils::deferred_command_buffer

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -790,8 +790,9 @@ static iree_status_t iree_hal_cuda_device_queue_flush(
 static iree_status_t iree_hal_cuda_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "waiting multiple semaphores not yet implemented");
+  iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
+  return iree_hal_cuda_semaphore_multi_wait(semaphore_list, wait_mode, timeout,
+                                            &device->block_pool);
 }
 
 static iree_status_t iree_hal_cuda_device_profiling_begin(

--- a/runtime/src/iree/hal/drivers/cuda/event_semaphore.c
+++ b/runtime/src/iree/hal/drivers/cuda/event_semaphore.c
@@ -7,6 +7,7 @@
 #include "iree/hal/drivers/cuda/event_semaphore.h"
 
 #include "iree/base/internal/synchronization.h"
+#include "iree/base/internal/wait_handle.h"
 #include "iree/hal/drivers/cuda/cuda_dynamic_symbols.h"
 #include "iree/hal/drivers/cuda/cuda_status_util.h"
 #include "iree/hal/drivers/cuda/timepoint_pool.h"
@@ -301,7 +302,7 @@ static iree_status_t iree_hal_cuda_semaphore_wait(
     return iree_ok_status();
   }
 
-  // Slow path: acquire a timepoint. This should happen outside of the lock to
+  // Slow path: acquire a timepoint. This should happen outside of the lock too
   // given that acquiring has its own internal locks.
   iree_hal_cuda_timepoint_t* timepoint = NULL;
   iree_status_t status = iree_hal_cuda_semaphore_acquire_timepoint_host_wait(
@@ -320,6 +321,97 @@ static iree_status_t iree_hal_cuda_semaphore_wait(
   }
   iree_hal_cuda_timepoint_pool_release(semaphore->timepoint_pool, 1,
                                        &timepoint);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_hal_cuda_semaphore_multi_wait(
+    const iree_hal_semaphore_list_t semaphore_list,
+    iree_hal_wait_mode_t wait_mode, iree_timeout_t timeout,
+    iree_arena_block_pool_t* block_pool) {
+  if (semaphore_list.count == 0) return iree_ok_status();
+
+  if (semaphore_list.count == 1) {
+    // Fast-path for a single semaphore.
+    return iree_hal_semaphore_wait(semaphore_list.semaphores[0],
+                                   semaphore_list.payload_values[0], timeout);
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
+
+  // Avoid heap allocations by using the device block pool for the wait set.
+  iree_arena_allocator_t arena;
+  iree_arena_initialize(block_pool, &arena);
+  iree_wait_set_t* wait_set = NULL;
+  iree_status_t status = iree_wait_set_allocate(
+      semaphore_list.count, iree_arena_allocator(&arena), &wait_set);
+
+  // Acquire a wait handle for each semaphore timepoint we are to wait on.
+  iree_host_size_t timepoint_count = 0;
+  iree_hal_cuda_timepoint_t** timepoints = NULL;
+  iree_host_size_t total_timepoint_size =
+      semaphore_list.count * sizeof(timepoints[0]);
+  bool needs_wait = true;
+  status =
+      iree_arena_allocate(&arena, total_timepoint_size, (void**)&timepoints);
+  if (iree_status_is_ok(status)) {
+    memset(timepoints, 0, total_timepoint_size);
+    for (iree_host_size_t i = 0; i < semaphore_list.count && needs_wait; ++i) {
+      uint64_t current_value = 0;
+      status = iree_hal_cuda_semaphore_query(semaphore_list.semaphores[i],
+                                             &current_value);
+      if (!iree_status_is_ok(status)) break;
+
+      if (current_value >= semaphore_list.payload_values[i]) {
+        // Fast path: already satisfied.
+        // If in ANY wait mode, this is sufficient and we don't actually need
+        // to wait. This also skips acquiring timepoints for any remaining
+        // semaphores. We still exit normally otherwise so as to cleanup
+        // any timepoints already acquired.
+        if (wait_mode == IREE_HAL_WAIT_MODE_ANY) needs_wait = false;
+      } else {
+        iree_hal_cuda_semaphore_t* semaphore =
+            iree_hal_cuda_semaphore_cast(semaphore_list.semaphores[i]);
+
+        // Slow path: get a native wait handle for the timepoint. This should
+        // happen outside of the lock given that acquiring has its own internal
+        // locks.
+        iree_hal_cuda_timepoint_t* timepoint = NULL;
+        status = iree_hal_cuda_semaphore_acquire_timepoint_host_wait(
+            semaphore, semaphore_list.payload_values[i], timeout, &timepoint);
+        if (iree_status_is_ok(status)) {
+          timepoints[timepoint_count++] = timepoint;
+          status =
+              iree_wait_set_insert(wait_set, timepoint->timepoint.host_wait);
+        }
+        if (!iree_status_is_ok(status)) break;
+      }
+    }
+  }
+
+  // Perform the wait.
+  if (iree_status_is_ok(status) && needs_wait) {
+    if (wait_mode == IREE_HAL_WAIT_MODE_ANY) {
+      status = iree_wait_any(wait_set, deadline_ns, /*out_wake_handle=*/NULL);
+    } else {
+      status = iree_wait_all(wait_set, deadline_ns);
+    }
+  }
+
+  for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
+    iree_hal_cuda_timepoint_t* timepoint = timepoints[i];
+    iree_hal_semaphore_t* semaphore = timepoint->base.semaphore;
+    // Cancel if this is still an unresolved host wait.
+    if (semaphore) {
+      iree_hal_semaphore_cancel_timepoint(semaphore, &timepoint->base);
+    }
+    iree_hal_cuda_timepoint_pool_release(timepoint->pool, 1, &timepoint);
+  }
+  iree_wait_set_free(wait_set);
+  iree_arena_deinitialize(&arena);
+
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/drivers/cuda/event_semaphore.c
+++ b/runtime/src/iree/hal/drivers/cuda/event_semaphore.c
@@ -348,7 +348,7 @@ iree_status_t iree_hal_cuda_semaphore_multi_wait(
   iree_status_t status = iree_wait_set_allocate(
       semaphore_list.count, iree_arena_allocator(&arena), &wait_set);
 
-  // Acquire a wait handle for each semaphore timepoint we are to wait on.
+  // Acquire a host wait handle for each semaphore timepoint we are to wait on.
   iree_host_size_t timepoint_count = 0;
   iree_hal_cuda_timepoint_t** timepoints = NULL;
   iree_host_size_t total_timepoint_size =
@@ -375,9 +375,9 @@ iree_status_t iree_hal_cuda_semaphore_multi_wait(
         iree_hal_cuda_semaphore_t* semaphore =
             iree_hal_cuda_semaphore_cast(semaphore_list.semaphores[i]);
 
-        // Slow path: get a native wait handle for the timepoint. This should
-        // happen outside of the lock given that acquiring has its own internal
-        // locks.
+        // Slow path: get a native host wait handle for the timepoint. This
+        // should happen outside of the lock given that acquiring has its own
+        // internal locks.
         iree_hal_cuda_timepoint_t* timepoint = NULL;
         status = iree_hal_cuda_semaphore_acquire_timepoint_host_wait(
             semaphore, semaphore_list.payload_values[i], timeout, &timepoint);

--- a/runtime/src/iree/hal/drivers/cuda/event_semaphore.h
+++ b/runtime/src/iree/hal/drivers/cuda/event_semaphore.h
@@ -49,9 +49,8 @@ iree_status_t iree_hal_cuda_event_semaphore_acquire_timepoint_device_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t min_value,
     CUevent* out_event);
 
-// Performs a multi-wait on one or more semaphores.
-// Returns IREE_STATUS_DEADLINE_EXCEEDED if the wait does not complete before
-// |deadline_ns| elapses.
+// Performs a multi-wait on one or more semaphores. Returns
+// IREE_STATUS_DEADLINE_EXCEEDED if the wait does not complete before |timeout|.
 iree_status_t iree_hal_cuda_semaphore_multi_wait(
     const iree_hal_semaphore_list_t semaphore_list,
     iree_hal_wait_mode_t wait_mode, iree_timeout_t timeout,

--- a/runtime/src/iree/hal/drivers/cuda/event_semaphore.h
+++ b/runtime/src/iree/hal/drivers/cuda/event_semaphore.h
@@ -49,6 +49,14 @@ iree_status_t iree_hal_cuda_event_semaphore_acquire_timepoint_device_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t min_value,
     CUevent* out_event);
 
+// Performs a multi-wait on one or more semaphores.
+// Returns IREE_STATUS_DEADLINE_EXCEEDED if the wait does not complete before
+// |deadline_ns| elapses.
+iree_status_t iree_hal_cuda_semaphore_multi_wait(
+    const iree_hal_semaphore_list_t semaphore_list,
+    iree_hal_wait_mode_t wait_mode, iree_timeout_t timeout,
+    iree_arena_block_pool_t* block_pool);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
This commit fills out the unimplemented logic for waiting
multiple semaphores in the cuda and hip hal drivers.
A few tests are added to cover various semaphore waiting
and signaling cases.