### PR TITLE
[hip][rocm] Fix hipGetDeviceProperties usage after ROCm 6.0

### DIFF
--- a/experimental/hip/dynamic_symbol_tables.h
+++ b/experimental/hip/dynamic_symbol_tables.h
@@ -34,7 +34,8 @@ IREE_HAL_HIP_REQUIRED_PFN_DECL(hipFreeAsync, void *, hipStream_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipFuncSetAttribute, const void *,
                                hipFuncAttribute, int)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGetDeviceCount, int *)
-IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGetDeviceProperties, hipDeviceProp_t *, int)
+IREE_HAL_HIP_OPTIONAL_PFN_DECL(hipGetDevicePropertiesR0600, hipDeviceProp_t *,
+                               int)
 // hipGetErrorName(hipError_t) and hipGetErrorString(hipError_t) return
 // const char* instead of hipError_t so it uses a different macro.
 IREE_HAL_HIP_REQUIRED_PFN_STR_DECL(hipGetErrorName, hipError_t)

--- a/experimental/hip/hip_driver.c
+++ b/experimental/hip/hip_driver.c
@@ -232,12 +232,19 @@ static iree_status_t iree_hal_hip_driver_dump_device_info(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_string_builder_t* builder) {
   iree_hal_hip_driver_t* driver = iree_hal_hip_driver_cast(base_driver);
+  if (!driver->hip_symbols.hipGetDevicePropertiesR0600) {
+    // ROCm 6.0 release changes the hipDeviceProp_t struct and would need to use
+    // the matching hipGetDevicePropertiesR0600() API to query it. This symbol
+    // is not available in earlier versions.
+    return iree_ok_status();
+  }
+
   hipDevice_t device = IREE_DEVICE_ID_TO_HIPDEVICE(device_id);
 
   hipDeviceProp_t prop;
   IREE_HIP_RETURN_IF_ERROR(&driver->hip_symbols,
-                           hipGetDeviceProperties(&prop, device),
-                           "hipGetDeviceProperties");
+                           hipGetDevicePropertiesR0600(&prop, device),
+                           "hipGetDevicePropertiesR0600");
 
   // GPU capabilities and architecture.
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format(

--- a/experimental/rocm/dynamic_symbol_tables.h
+++ b/experimental/rocm/dynamic_symbol_tables.h
@@ -8,7 +8,7 @@ RC_PFN_DECL(hipCtxCreate, hipCtx_t *, unsigned int, hipDevice_t)
 RC_PFN_DECL(hipCtxDestroy, hipCtx_t)
 RC_PFN_DECL(hipDeviceGet, hipDevice_t *, int)  // No direct, need to modify
 RC_PFN_DECL(hipGetDeviceCount, int *)
-RC_PFN_DECL(hipGetDeviceProperties, hipDeviceProp_t *, int)
+RC_PFN_DECL(hipGetDevicePropertiesR0600, hipDeviceProp_t *, int)
 RC_PFN_DECL(hipDeviceGetName, char *, int,
             hipDevice_t)  // No direct, need to modify
 RC_PFN_STR_DECL(

--- a/experimental/rocm/rocm_driver.c
+++ b/experimental/rocm/rocm_driver.c
@@ -185,8 +185,9 @@ static iree_status_t iree_hal_rocm_driver_dump_device_info(
   hipDevice_t device = IREE_DEVICE_ID_TO_HIPDEVICE(device_id);
 
   hipDeviceProp_t prop;
-  ROCM_RETURN_IF_ERROR(&driver->syms, hipGetDeviceProperties(&prop, device),
-                       "hipGetDeviceProperties");
+  ROCM_RETURN_IF_ERROR(&driver->syms,
+                       hipGetDevicePropertiesR0600(&prop, device),
+                       "hipGetDevicePropertiesR0600");
 
   // GPU capabilities and architecture.
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format(


### PR DESCRIPTION
ROCm 6.0 changes the `hipDeviceProp_t` struct, so we would need the new `hipGetDevicePropertiesR0600()` API to query it--the existing `hipGetDeviceProperties()`l API won't work for our case with dynamic libraries.

Related to https://github.com/ROCm/ROCm/issues/2728