### PR TITLE
[VectorDistribution] Enable layout resolution lowering for LayoutAttr

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -1528,6 +1528,7 @@ transform_dialect::AMDGPUDistributeVectorsOp::applyToOne(
   populateGPUReductionDistributionPatterns(patterns);
   populateGPUDistributeNestedLayoutAttrPatterns(laneId, patterns);
   populateAMDGPUDistributionPatterns(patterns);
+  populateGPULayoutResolutionDistributionPatterns(patterns);
   if (failed(distributeVectorOps(target, patterns, options))) {
     return emitDefaultSilenceableFailure(target);
   }


### PR DESCRIPTION
This patch adds the layout conflict resolution patterns (which in specific cases, lowers a layout conflict to a transpose if possible).

This pattern simply enables the pattern, the pattern is already tested in another test pass.