### PR TITLE
faster narrow mmt4d ukernels on x86

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -4,8 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <immintrin.h>
-
 #include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
 #include "iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_internal.h"
 
@@ -182,13 +180,61 @@ IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
     iree_uk_mmt4d_tile_f16f16f16_1x16x1_to_16x16x1_x86_64_avx512_base,
     iree_uk_mmt4d_tile_f16f16f16_16x16x1_x86_64_avx512_base, 16)
 
-IREE_UK_ATTRIBUTE_ALWAYS_INLINE
-static inline void
-iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
+iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_8x16x2_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
   IREE_UK_ASSERT(M0 >= 1 && M0 <= 16 && iree_uk_is_po2_u32(M0));
+  iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
+  const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
+  const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
+  __m512i acc[16];
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_loadu_si512((__m512i*)(out_ptr + i * 16));
+    }
+  } else {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_setzero_si512();
+    }
+  }
+
+  for (int k = 0; k < params->K; ++k) {
+    __m512i rhs =
+        _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
+    rhs_ptr += 32;
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_add_epi32(
+          acc[i], _mm512_madd_epi16(_mm512_cvtepi8_epi16(_mm256_set1_epi16(
+                                        *(const iree_uk_int16_t*)(lhs_ptr))),
+                                    rhs));
+      lhs_ptr += 2;
+    }
+  }
+
+  IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+    _mm512_storeu_si512((__m512i*)(out_ptr + i * 16), acc[i]);
+  }
+}
+
+IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_8x16x2_x86_64_avx512_base,
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_x86_64_avx512_base, 1)
+IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_8x16x2_x86_64_avx512_base,
+    iree_uk_mmt4d_tile_s8s8s32_2x16x2_x86_64_avx512_base, 2)
+IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_8x16x2_x86_64_avx512_base,
+    iree_uk_mmt4d_tile_s8s8s32_4x16x2_x86_64_avx512_base, 4)
+IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_8x16x2_x86_64_avx512_base,
+    iree_uk_mmt4d_tile_s8s8s32_8x16x2_x86_64_avx512_base, 8)
+
+void iree_uk_mmt4d_tile_s8s8s32_16x16x2_x86_64_avx512_base(
+    void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -198,25 +244,12 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
   // This unusual layout is chosen so that the inner arithmetic loop only needs
   // to perform cheap shuffles within 128bit groups of lanes.
   __m512i acc[4][4];
-  const int imax = M0 <= 4 ? M0 : 4;
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
       IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-        if (M0 <= 8) {
-          acc[i][j] = _mm512_castsi128_si512(
-              _mm_loadu_si128((__m128i*)(out_ptr + i * 16 + j * 4)));
-          if (M0 > 4) {
-            acc[i][j] = _mm512_inserti32x4(
-                acc[i][j],
-                _mm_loadu_si128(
-                    (__m128i*)(out_ptr + (i + 4) * 16 + ((5 - j) % 4) * 4)),
-                1);
-          }
-        } else {
-          acc[i][j] = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-              out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
-              4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4));
-        }
+        acc[i][j] = iree_uk_avx512_loadu_4x128_from_16x16xi32(
+            out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
+            4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4));
       }
     }
   } else {
@@ -248,36 +281,17 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
     rhs_i16_perm[3] =
         _mm512_permutexvar_epi32(idx_CDEF89AB45670123, rhs_i16_perm[0]);
     // lhs_i16 is the lhs tile (M0x2), sign-extended to i16.
-    __m512i lhs_i16;
-    if (M0 == 1) {
-      lhs_i16 =
-          _mm512_castsi256_si512(_mm256_cvtepi8_epi16(_mm_loadu_si16(lhs_ptr)));
-      lhs_ptr += 2;
-    } else if (M0 == 2) {
-      lhs_i16 =
-          _mm512_castsi256_si512(_mm256_cvtepi8_epi16(_mm_loadu_si32(lhs_ptr)));
-      lhs_ptr += 4;
-    } else if (M0 == 4) {
-      lhs_i16 =
-          _mm512_castsi256_si512(_mm256_cvtepi8_epi16(_mm_loadu_si64(lhs_ptr)));
-      lhs_ptr += 8;
-    } else if (M0 == 8) {
-      lhs_i16 = _mm512_castsi256_si512(
-          _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)lhs_ptr)));
-      lhs_ptr += 16;
-    } else {
-      lhs_i16 =
-          _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)lhs_ptr));
-      lhs_ptr += 32;
-    }
+    __m512i lhs_i16 =
+        _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)lhs_ptr));
+    lhs_ptr += 32;
     // lhs_i16_dup4[i] is lanes of lhs_i16 shuffled as:
     // (i, i, i, i, i+4, i+4, i+4, i+4, i+8, i+8, i+8, i+C, i+C, i+C, i+C).
     __m512i lhs_i16_dup4[4];
-    if (M0 >= 1) lhs_i16_dup4[0] = _mm512_shuffle_epi32(lhs_i16, 0 * 0x55);
-    if (M0 >= 2) lhs_i16_dup4[1] = _mm512_shuffle_epi32(lhs_i16, 1 * 0x55);
-    if (M0 >= 4) lhs_i16_dup4[2] = _mm512_shuffle_epi32(lhs_i16, 2 * 0x55);
-    if (M0 >= 4) lhs_i16_dup4[3] = _mm512_shuffle_epi32(lhs_i16, 3 * 0x55);
-    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+    lhs_i16_dup4[0] = _mm512_shuffle_epi32(lhs_i16, 0 * 0x55);
+    lhs_i16_dup4[1] = _mm512_shuffle_epi32(lhs_i16, 1 * 0x55);
+    lhs_i16_dup4[2] = _mm512_shuffle_epi32(lhs_i16, 2 * 0x55);
+    lhs_i16_dup4[3] = _mm512_shuffle_epi32(lhs_i16, 3 * 0x55);
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
       IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] = _mm512_add_epi32(
             acc[i][j], _mm512_madd_epi16(lhs_i16_dup4[i], rhs_i16_perm[j]));
@@ -285,43 +299,16 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base(
     }
   }
 
-  IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
     IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-      if (M0 <= 8) {
-        _mm_storeu_si128((__m128i*)(out_ptr + i * 16 + j * 4),
-                         _mm512_extracti32x4_epi32(acc[i][j], 0));
-        if (M0 > 4) {
-          _mm_storeu_si128(
-              (__m128i*)(out_ptr + (i + 4) * 16 + ((5 - j) % 4) * 4),
-              _mm512_extracti32x4_epi32(acc[i][j], 1));
-        }
-      } else {
-        iree_uk_avx512_storeu_4x128_to_16x16xi32(
-            out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
-            4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4), acc[i][j]);
-      }
+      iree_uk_avx512_storeu_4x128_to_16x16xi32(
+          out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8, 4 * ((j + 2) % 4),
+          i + 12, 4 * ((7 - j) % 4), acc[i][j]);
     }
   }
 }
 
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base,
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_x86_64_avx512_base, 1)
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base,
-    iree_uk_mmt4d_tile_s8s8s32_2x16x2_x86_64_avx512_base, 2)
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base,
-    iree_uk_mmt4d_tile_s8s8s32_4x16x2_x86_64_avx512_base, 4)
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base,
-    iree_uk_mmt4d_tile_s8s8s32_8x16x2_x86_64_avx512_base, 8)
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_base,
-    iree_uk_mmt4d_tile_s8s8s32_16x16x2_x86_64_avx512_base, 16)
-
-IREE_UK_ATTRIBUTE_ALWAYS_INLINE
-static inline void
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
 iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
@@ -330,106 +317,31 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_base(
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  // acc[i][0] contains the 1st 128bits of row i, the 2nd 128bits of row (i+4),
-  //           the 3rd 128bits of row (i+8), the 4th 128bits of row (i+C).
-  // The other acc[i][j] are permutations of these 128bits groups.
-  // This unusual layout is chosen so that the inner arithmetic loop only needs
-  // to perform cheap shuffles within 128bit groups of lanes.
-  __m512i acc[4][4];
-  const int imax = M0 <= 4 ? M0 : 4;
+  __m512i acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
-      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-        if (M0 <= 8) {
-          acc[i][j] = _mm512_castsi128_si512(
-              _mm_loadu_si128((__m128i*)(out_ptr + i * 16 + j * 4)));
-          if (M0 > 4) {
-            acc[i][j] = _mm512_inserti32x4(
-                acc[i][j],
-                _mm_loadu_si128(
-                    (__m128i*)(out_ptr + (i + 4) * 16 + ((5 - j) % 4) * 4)),
-                1);
-          }
-        } else {
-          acc[i][j] = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-              out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
-              4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4));
-        }
-      }
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_loadu_si512((__m512i*)(out_ptr + i * 16));
     }
   } else {
-    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
-      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-        acc[i][j] = _mm512_setzero_si512();
-      }
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_setzero_si512();
     }
   }
-
-  __m512i idx_45670123CDEF89AB =
-      _mm512_setr_epi32(4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11);
-  __m512i idx_89ABCDEF01234567 =
-      _mm512_setr_epi32(8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7);
-  __m512i idx_CDEF89AB45670123 =
-      _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
   for (int k = 0; k < params->K; ++k) {
-    __m512i rhs_perm[4];
-    // rhs_perm[0] is the rhs tile (2x8).
-    rhs_perm[0] = _mm512_loadu_si512((const __m512i*)rhs_ptr);
+    __m512i rhs = _mm512_loadu_si512((const __m512i*)rhs_ptr);
     rhs_ptr += 32;
-    // The other 3 rhs_perm[i] are permutations of 128-bit groups of that.
-    rhs_perm[1] = _mm512_permutexvar_epi32(idx_45670123CDEF89AB, rhs_perm[0]);
-    rhs_perm[2] = _mm512_permutexvar_epi32(idx_89ABCDEF01234567, rhs_perm[0]);
-    rhs_perm[3] = _mm512_permutexvar_epi32(idx_CDEF89AB45670123, rhs_perm[0]);
-    // lhs is the lhs tile (M0x2).
-    __m512i lhs;
-    if (M0 == 1) {
-      lhs = _mm512_castsi128_si512(_mm_loadu_si32(lhs_ptr));
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_add_epi32(
+          acc[i],
+          _mm512_madd_epi16(_mm512_set1_epi32(*(const iree_uk_int32_t*)lhs_ptr),
+                            rhs));
       lhs_ptr += 2;
-    } else if (M0 == 2) {
-      lhs = _mm512_castsi128_si512(_mm_loadu_si64(lhs_ptr));
-      lhs_ptr += 4;
-    } else if (M0 == 4) {
-      lhs = _mm512_castsi128_si512(_mm_loadu_si128((const __m128i*)lhs_ptr));
-      lhs_ptr += 8;
-    } else if (M0 == 8) {
-      lhs = _mm512_castsi256_si512(_mm256_loadu_si256((const __m256i*)lhs_ptr));
-      lhs_ptr += 16;
-    } else {
-      lhs = _mm512_loadu_si512((const __m512i*)lhs_ptr);
-      lhs_ptr += 32;
-    }
-    // lhs_dup4[i] is lanes of lhs shuffled as:
-    // (i, i, i, i, i+4, i+4, i+4, i+4, i+8, i+8, i+8, i+C, i+C, i+C, i+C).
-    __m512i lhs_dup4[4];
-    if (M0 >= 1) lhs_dup4[0] = _mm512_shuffle_epi32(lhs, 0 * 0x55);
-    if (M0 >= 2) lhs_dup4[1] = _mm512_shuffle_epi32(lhs, 1 * 0x55);
-    if (M0 >= 4) lhs_dup4[2] = _mm512_shuffle_epi32(lhs, 2 * 0x55);
-    if (M0 >= 4) lhs_dup4[3] = _mm512_shuffle_epi32(lhs, 3 * 0x55);
-    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
-      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-        acc[i][j] = _mm512_add_epi32(
-            acc[i][j], _mm512_madd_epi16(lhs_dup4[i], rhs_perm[j]));
-      }
     }
   }
 
-  IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
-    IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-      if (M0 <= 8) {
-        _mm_storeu_si128((__m128i*)(out_ptr + i * 16 + j * 4),
-                         _mm512_extracti32x4_epi32(acc[i][j], 0));
-        if (M0 > 4) {
-          _mm_storeu_si128(
-              (__m128i*)(out_ptr + (i + 4) * 16 + ((5 - j) % 4) * 4),
-              _mm512_extracti32x4_epi32(acc[i][j], 1));
-        }
-      } else {
-        iree_uk_avx512_storeu_4x128_to_16x16xi32(
-            out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
-            4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4), acc[i][j]);
-      }
-    }
+  IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+    _mm512_storeu_si512((__m512i*)(out_ptr + i * 16), acc[i]);
   }
 }
 

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
@@ -7,12 +7,61 @@
 #include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
 #include "iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_internal.h"
 
-static inline void
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
 iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
     const iree_uk_mmt4d_params_t* params, int M0) {
   IREE_UK_ASSERT(M0 >= 1 && M0 <= 16 && iree_uk_is_po2_u32(M0));
+  iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
+  const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
+  const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
+  __m512i acc[16];
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_loadu_si512((__m512i*)(out_ptr + i * 16));
+    }
+  } else {
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_setzero_si512();
+    }
+  }
+
+  for (int k = 0; k < params->K; ++k) {
+    __m512i rhs =
+        _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
+    rhs_ptr += 32;
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_dpwssd_epi32(acc[i],
+                                   _mm512_cvtepi8_epi16(_mm256_set1_epi16(
+                                       *(const iree_uk_int16_t*)(lhs_ptr))),
+                                   rhs);
+      lhs_ptr += 2;
+    }
+  }
+
+  IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+    _mm512_storeu_si512((__m512i*)(out_ptr + i * 16), acc[i]);
+  }
+}
+
+IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_x86_64_avx512_vnni, 1)
+IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
+    iree_uk_mmt4d_tile_s8s8s32_2x16x2_x86_64_avx512_vnni, 2)
+IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
+    iree_uk_mmt4d_tile_s8s8s32_4x16x2_x86_64_avx512_vnni, 4)
+IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
+    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
+    iree_uk_mmt4d_tile_s8s8s32_8x16x2_x86_64_avx512_vnni, 8)
+
+void iree_uk_mmt4d_tile_s8s8s32_16x16x2_x86_64_avx512_vnni(
+    void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -22,25 +71,12 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
   // This unusual layout is chosen so that the inner arithmetic loop only needs
   // to perform cheap shuffles within 128bit groups of lanes.
   __m512i acc[4][4];
-  const int imax = M0 <= 4 ? M0 : 4;
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
       IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-        if (M0 <= 8) {
-          acc[i][j] = _mm512_castsi128_si512(
-              _mm_loadu_si128((__m128i*)(out_ptr + i * 16 + j * 4)));
-          if (M0 > 4) {
-            acc[i][j] = _mm512_inserti32x4(
-                acc[i][j],
-                _mm_loadu_si128(
-                    (__m128i*)(out_ptr + (i + 4) * 16 + ((5 - j) % 4) * 4)),
-                1);
-          }
-        } else {
-          acc[i][j] = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-              out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
-              4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4));
-        }
+        acc[i][j] = iree_uk_avx512_loadu_4x128_from_16x16xi32(
+            out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
+            4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4));
       }
     }
   } else {
@@ -72,36 +108,17 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
     rhs_i16_perm[3] =
         _mm512_permutexvar_epi32(idx_CDEF89AB45670123, rhs_i16_perm[0]);
     // lhs_i16 is the lhs tile (M0x2), sign-extended to i16.
-    __m512i lhs_i16;
-    if (M0 == 1) {
-      lhs_i16 =
-          _mm512_castsi256_si512(_mm256_cvtepi8_epi16(_mm_loadu_si16(lhs_ptr)));
-      lhs_ptr += 2;
-    } else if (M0 == 2) {
-      lhs_i16 =
-          _mm512_castsi256_si512(_mm256_cvtepi8_epi16(_mm_loadu_si32(lhs_ptr)));
-      lhs_ptr += 4;
-    } else if (M0 == 4) {
-      lhs_i16 =
-          _mm512_castsi256_si512(_mm256_cvtepi8_epi16(_mm_loadu_si64(lhs_ptr)));
-      lhs_ptr += 8;
-    } else if (M0 == 8) {
-      lhs_i16 = _mm512_castsi256_si512(
-          _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)lhs_ptr)));
-      lhs_ptr += 16;
-    } else {
-      lhs_i16 =
-          _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)lhs_ptr));
-      lhs_ptr += 32;
-    }
+    __m512i lhs_i16 =
+        _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)lhs_ptr));
+    lhs_ptr += 32;
     // lhs_i16_dup4[i] is lanes of lhs_i16 shuffled as:
     // (i, i, i, i, i+4, i+4, i+4, i+4, i+8, i+8, i+8, i+C, i+C, i+C, i+C).
     __m512i lhs_i16_dup4[4];
-    if (M0 >= 1) lhs_i16_dup4[0] = _mm512_shuffle_epi32(lhs_i16, 0 * 0x55);
-    if (M0 >= 2) lhs_i16_dup4[1] = _mm512_shuffle_epi32(lhs_i16, 1 * 0x55);
-    if (M0 >= 4) lhs_i16_dup4[2] = _mm512_shuffle_epi32(lhs_i16, 2 * 0x55);
-    if (M0 >= 4) lhs_i16_dup4[3] = _mm512_shuffle_epi32(lhs_i16, 3 * 0x55);
-    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+    lhs_i16_dup4[0] = _mm512_shuffle_epi32(lhs_i16, 0 * 0x55);
+    lhs_i16_dup4[1] = _mm512_shuffle_epi32(lhs_i16, 1 * 0x55);
+    lhs_i16_dup4[2] = _mm512_shuffle_epi32(lhs_i16, 2 * 0x55);
+    lhs_i16_dup4[3] = _mm512_shuffle_epi32(lhs_i16, 3 * 0x55);
+    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
       IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
         acc[i][j] =
             _mm512_dpwssd_epi32(acc[i][j], lhs_i16_dup4[i], rhs_i16_perm[j]);
@@ -109,42 +126,16 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
     }
   }
 
-  IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
+  IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
     IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-      if (M0 <= 8) {
-        _mm_storeu_si128((__m128i*)(out_ptr + i * 16 + j * 4),
-                         _mm512_extracti32x4_epi32(acc[i][j], 0));
-        if (M0 > 4) {
-          _mm_storeu_si128(
-              (__m128i*)(out_ptr + (i + 4) * 16 + ((5 - j) % 4) * 4),
-              _mm512_extracti32x4_epi32(acc[i][j], 1));
-        }
-      } else {
-        iree_uk_avx512_storeu_4x128_to_16x16xi32(
-            out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
-            4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4), acc[i][j]);
-      }
+      iree_uk_avx512_storeu_4x128_to_16x16xi32(
+          out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8, 4 * ((j + 2) % 4),
+          i + 12, 4 * ((7 - j) % 4), acc[i][j]);
     }
   }
 }
 
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_x86_64_avx512_vnni, 1)
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
-    iree_uk_mmt4d_tile_s8s8s32_2x16x2_x86_64_avx512_vnni, 2)
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
-    iree_uk_mmt4d_tile_s8s8s32_4x16x2_x86_64_avx512_vnni, 4)
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
-    iree_uk_mmt4d_tile_s8s8s32_8x16x2_x86_64_avx512_vnni, 8)
-IREE_UK_MMT4D_TILE_FUNC_IMPL_FOR_M0(
-    iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni,
-    iree_uk_mmt4d_tile_s8s8s32_16x16x2_x86_64_avx512_vnni, 16)
-
-static inline void
+IREE_UK_ATTRIBUTE_ALWAYS_INLINE static inline void
 iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
     const void* IREE_UK_RESTRICT rhs_panel,
@@ -153,105 +144,29 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
-  // acc[i][0] contains the 1st 128bits of row i, the 2nd 128bits of row (i+4),
-  //           the 3rd 128bits of row (i+8), the 4th 128bits of row (i+C).
-  // The other acc[i][j] are permutations of these 128bits groups.
-  // This unusual layout is chosen so that the inner arithmetic loop only needs
-  // to perform cheap shuffles within 128bit groups of lanes.
-  __m512i acc[4][4];
-  const int imax = M0 <= 4 ? M0 : 4;
+  __m512i acc[16];
   if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
-    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
-      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-        if (M0 <= 8) {
-          acc[i][j] = _mm512_castsi128_si512(
-              _mm_loadu_si128((__m128i*)(out_ptr + i * 16 + j * 4)));
-          if (M0 > 4) {
-            acc[i][j] = _mm512_inserti32x4(
-                acc[i][j],
-                _mm_loadu_si128(
-                    (__m128i*)(out_ptr + (i + 4) * 16 + ((5 - j) % 4) * 4)),
-                1);
-          }
-        } else {
-          acc[i][j] = iree_uk_avx512_loadu_4x128_from_16x16xi32(
-              out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
-              4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4));
-        }
-      }
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_loadu_si512((__m512i*)(out_ptr + i * 16));
     }
   } else {
-    IREE_UK_UNROLL for (int i = 0; i < 4; ++i) {
-      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-        acc[i][j] = _mm512_setzero_si512();
-      }
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_setzero_si512();
     }
   }
-
-  __m512i idx_45670123CDEF89AB =
-      _mm512_setr_epi32(4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11);
-  __m512i idx_89ABCDEF01234567 =
-      _mm512_setr_epi32(8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7);
-  __m512i idx_CDEF89AB45670123 =
-      _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
   for (int k = 0; k < params->K; ++k) {
-    __m512i rhs_perm[4];
-    // rhs_perm[0] is the rhs tile (2x8).
-    rhs_perm[0] = _mm512_loadu_si512((const __m512i*)rhs_ptr);
+    __m512i rhs = _mm512_loadu_si512((const __m512i*)rhs_ptr);
     rhs_ptr += 32;
-    // The other 3 rhs_perm[i] are permutations of 128-bit groups of that.
-    rhs_perm[1] = _mm512_permutexvar_epi32(idx_45670123CDEF89AB, rhs_perm[0]);
-    rhs_perm[2] = _mm512_permutexvar_epi32(idx_89ABCDEF01234567, rhs_perm[0]);
-    rhs_perm[3] = _mm512_permutexvar_epi32(idx_CDEF89AB45670123, rhs_perm[0]);
-    // lhs is the lhs tile (M0x2).
-    __m512i lhs;
-    if (M0 == 1) {
-      lhs = _mm512_castsi128_si512(_mm_loadu_si32(lhs_ptr));
+    IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+      acc[i] = _mm512_dpwssd_epi32(
+          acc[i], _mm512_set1_epi32(*(const iree_uk_int32_t*)lhs_ptr), rhs);
       lhs_ptr += 2;
-    } else if (M0 == 2) {
-      lhs = _mm512_castsi128_si512(_mm_loadu_si64(lhs_ptr));
-      lhs_ptr += 4;
-    } else if (M0 == 4) {
-      lhs = _mm512_castsi128_si512(_mm_loadu_si128((const __m128i*)lhs_ptr));
-      lhs_ptr += 8;
-    } else if (M0 == 8) {
-      lhs = _mm512_castsi256_si512(_mm256_loadu_si256((const __m256i*)lhs_ptr));
-      lhs_ptr += 16;
-    } else {
-      lhs = _mm512_loadu_si512((const __m512i*)lhs_ptr);
-      lhs_ptr += 32;
-    }
-    // lhs_dup4[i] is lanes of lhs shuffled as:
-    // (i, i, i, i, i+4, i+4, i+4, i+4, i+8, i+8, i+8, i+C, i+C, i+C, i+C).
-    __m512i lhs_dup4[4];
-    if (M0 >= 1) lhs_dup4[0] = _mm512_shuffle_epi32(lhs, 0 * 0x55);
-    if (M0 >= 2) lhs_dup4[1] = _mm512_shuffle_epi32(lhs, 1 * 0x55);
-    if (M0 >= 4) lhs_dup4[2] = _mm512_shuffle_epi32(lhs, 2 * 0x55);
-    if (M0 >= 4) lhs_dup4[3] = _mm512_shuffle_epi32(lhs, 3 * 0x55);
-    IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
-      IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-        acc[i][j] = _mm512_dpwssd_epi32(acc[i][j], lhs_dup4[i], rhs_perm[j]);
-      }
     }
   }
 
-  IREE_UK_UNROLL for (int i = 0; i < imax; ++i) {
-    IREE_UK_UNROLL for (int j = 0; j < 4; ++j) {
-      if (M0 <= 8) {
-        _mm_storeu_si128((__m128i*)(out_ptr + i * 16 + j * 4),
-                         _mm512_extracti32x4_epi32(acc[i][j], 0));
-        if (M0 > 4) {
-          _mm_storeu_si128(
-              (__m128i*)(out_ptr + (i + 4) * 16 + ((5 - j) % 4) * 4),
-              _mm512_extracti32x4_epi32(acc[i][j], 1));
-        }
-      } else {
-        iree_uk_avx512_storeu_4x128_to_16x16xi32(
-            out_ptr, i, 4 * j, i + 4, 4 * ((5 - j) % 4), i + 8,
-            4 * ((j + 2) % 4), i + 12, 4 * ((7 - j) % 4), acc[i][j]);
-      }
-    }
+  IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
+    _mm512_storeu_si512((__m512i*)(out_ptr + i * 16), acc[i]);
   }
 }
 


### PR DESCRIPTION
A "narrow" matmul case is one where either the M dimension is small (e.g. vecmat) or the N dimensions is small (e.g. matvec). In the context of our ukernels, it always refers to the M dimension as reduction from narrow-N to narrow-M is meant to have been performed already (see #16399).

So far, narrow mmt4d ukernel tile functions had mostly just been added as naive truncations of the general matmul kernel case. This was often fine (mostly in floating-point cases, and outside of x86) but in some cases was quite inefficient (integer-arithmetic cases on x86).  In one instance that we particularly cared about for Llama2 on x86, we had a one-off doing something more clever (s16u4s32 case) but other than that, our narrow matmul kernels on x86 were pretty bad. This makes them better; this is also a net code shrink as part of the badness was from trying to shoehorn a complicated general matmul kernel design onto all M0 cases, and now it's much simpler with the narrow cases doing something simpler, and the full-width case now relieved from having to be generic.

Benchmark results on my AMD 7950X3D CPU (with Turbo disabled):

|name                                       |Gop/s before|Gop/s after|Speedup (x)|
|-------------------------------------------|------------|-----------|-----------|
|BM_mmt4d_s8s8s32_tile_1x8x2_avx2_fma       |56.0        |99.0       |1.77       |
|BM_mmt4d_s8s8s32_tile_2x8x2_avx2_fma       |78.4        |132.7      |1.69       |
|BM_mmt4d_s8s8s32_tile_4x8x2_avx2_fma       |92.2        |149.3      |1.62       |
|BM_mmt4d_s8s8s32_tile_8x8x2_avx2_fma       |187.3       |188.5      |1.01       |
|BM_mmt4d_s8s8s32_tile_1x16x2_avx512_base   |40.3        |119.4      |2.96       |
|BM_mmt4d_s8s8s32_tile_2x16x2_avx512_base   |52.6        |156.1      |2.97       |
|BM_mmt4d_s8s8s32_tile_4x16x2_avx512_base   |60.7        |169.8      |2.80       |
|BM_mmt4d_s8s8s32_tile_8x16x2_avx512_base   |119.4       |178.9      |1.50       |
|BM_mmt4d_s8s8s32_tile_16x16x2_avx512_base  |236.7       |235.0      |0.99       |
|BM_mmt4d_s8s8s32_tile_1x16x2_avx512_vnni   |52.5        |87.9       |1.67       |
|BM_mmt4d_s8s8s32_tile_2x16x2_avx512_vnni   |74.8        |162.2      |2.17       |
|BM_mmt4d_s8s8s32_tile_4x16x2_avx512_vnni   |79.1        |196.5      |2.49       |
|BM_mmt4d_s8s8s32_tile_8x16x2_avx512_vnni   |157.5       |214.2      |1.36       |
|BM_mmt4d_s8s8s32_tile_16x16x2_avx512_vnni  |312.5       |325.8      |1.04       |
|BM_mmt4d_s16s16s32_tile_1x8x2_avx2_fma     |75.5        |111.3      |1.47       |
|BM_mmt4d_s16s16s32_tile_2x8x2_avx2_fma     |75.2        |170.5      |2.27       |
|BM_mmt4d_s16s16s32_tile_4x8x2_avx2_fma     |124.0       |230.4      |1.86       |
|BM_mmt4d_s16s16s32_tile_8x8x2_avx2_fma     |230.8       |253.5      |1.10       |
|BM_mmt4d_s16s16s32_tile_1x16x2_avx512_base |46.4        |187.9      |4.05       |
|BM_mmt4d_s16s16s32_tile_2x16x2_avx512_base |53.4        |229.4      |4.29       |
|BM_mmt4d_s16s16s32_tile_4x16x2_avx512_base |60.4        |228.8      |3.79       |
|BM_mmt4d_s16s16s32_tile_8x16x2_avx512_base |128.5       |246.7      |1.92       |
|BM_mmt4d_s16s16s32_tile_16x16x2_avx512_base|249.9       |251.6      |1.01       |
|BM_mmt4d_s16s16s32_tile_1x16x2_avx512_vnni |69.0        |102.3      |1.48       |
|BM_mmt4d_s16s16s32_tile_2x16x2_avx512_vnni |86.1        |173.1      |2.01       |
|BM_mmt4d_s16s16s32_tile_4x16x2_avx512_vnni |82.9        |320.6      |3.87       |
|BM_mmt4d_s16s16s32_tile_8x16x2_avx512_vnni |173.7       |341.0      |1.96       |
|BM_mmt4d_s16s16s32_tile_16x16x2_avx512_vnni|308.0       |343.9      |1.12       |
