### PR TITLE
Refining emplace allocations to handle dynamic shapes.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -88,16 +88,15 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp) {
         // TODO(#14566): continue if sparse emplacement on multiple results.
         break;
       }
-      if (!IREE::Util::isValueUsableForOp(updateOp.getTargetSize(), dispatchOp))
-        break;
-      if (!IREE::Util::isValueUsableForOp(updateOp.getTargetOffset(),
-                                          dispatchOp))
-        break;
-      if (!IREE::Util::isValueUsableForOp(updateOp.getTargetEnd(), dispatchOp))
-        break;
-      if (!IREE::Util::isValueUsableForOp(updateOp.getUpdateSize(), dispatchOp))
-        break;
-      if (!IREE::Util::tryMoveProducerBefore(updateOp.getTarget(),
+      if (!IREE::Util::tryMoveProducerBefore(updateOp.getUpdateSize(),
+                                             dispatchOp) ||
+          !IREE::Util::tryMoveProducerBefore(updateOp.getTargetSize(),
+                                             dispatchOp) ||
+          !IREE::Util::tryMoveProducerBefore(updateOp.getTargetOffset(),
+                                             dispatchOp) ||
+          !IREE::Util::tryMoveProducerBefore(updateOp.getTargetEnd(),
+                                             dispatchOp) ||
+          !IREE::Util::tryMoveProducerBefore(updateOp.getTarget(),
                                              dispatchOp)) {
         // Failed to move while keeping valid SSA dominance.
         // TODO(#14566): continue if sparse emplacement on multiple results.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -136,7 +136,8 @@ void buildStreamAsyncPassPipeline(OpPassManager &passManager,
   // required for correct execution while copy elision is for performance only
   // (though it's critical enough that it is not optional).
   FunctionLikeNest(passManager)
-      .addPass(IREE::Stream::createMaterializeCopyOnWritePass);
+      .addPass(IREE::Stream::createMaterializeCopyOnWritePass)
+      .addPass(mlir::createCanonicalizerPass);
   passManager.addPass(IREE::Stream::createElideAsyncCopiesPass());
   FunctionLikeNest(passManager)
       .addPass(mlir::createCanonicalizerPass)

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
@@ -11,11 +11,12 @@ util.func public @emplaceDispatch(
     // CHECK-SAME: %[[TARGET:arg[0-9]+]]: !stream.resource<*>, %[[TARGET_SIZE:arg[0-9]+]]: index
     %target: !stream.resource<*>, %target_size: index) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index
-  // CHECK-DAG: %[[UPDATE_END:.+]] = arith.addi %[[UPDATE_OFFSET]], %[[UPDATE_SIZE]]
-  %update_end = arith.addi %update_offset, %update_size : index
+  // CHECK: %[[UPDATE_END:.+]] = arith.addi %[[UPDATE_OFFSET]], %[[UPDATE_SIZE]]
   // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@dispatch(%[[INPUT]][{{.+}}], %[[TARGET]][%[[UPDATE_OFFSET]] to %[[UPDATE_END]] for %[[UPDATE_SIZE]]]) :
   // CHECK-SAME: (!stream.resource<*>{%[[INPUT_SIZE]]}, !stream.resource<*>{%[[TARGET_SIZE]]}) -> %[[TARGET]]{%[[TARGET_SIZE]]}
   %update = stream.async.dispatch @ex::@dispatch(%input[%c0 to %input_size for %input_size]) : (!stream.resource<*>{%input_size}) -> !stream.resource<*>{%update_size}
+  // NOTE: this gets hoisted above the dispatch.
+  %update_end = arith.addi %update_offset, %update_size : index
   // CHECK-NOT: stream.async.update
   %result = stream.async.update %update, %target[%update_offset to %update_end] : !stream.resource<*>{%update_size} -> %target as !stream.resource<*>{%target_size}
   // CHECK: util.return %[[RESULT]]


### PR DESCRIPTION
#15261 was aggressive in disabling the pass for any offset/size SSA values computed as part of updates. In most programs the offset arith ops would end up after the dispatches we would want to emplace and this pass wouldn't touch them. Now we try to move the arith ops up before the dispatch so we can do the placement.

Progress on #16647. This allows us to emplace llama2 variable updates with dynamic offsets.