### PR TITLE
[rocm] Port optional symbols support for hipGetDeviceProperties

### DIFF
--- a/experimental/rocm/dynamic_symbol_tables.h
+++ b/experimental/rocm/dynamic_symbol_tables.h
@@ -4,62 +4,83 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RC_PFN_DECL(hipCtxCreate, hipCtx_t *, unsigned int, hipDevice_t)
-RC_PFN_DECL(hipCtxDestroy, hipCtx_t)
-RC_PFN_DECL(hipDeviceGet, hipDevice_t *, int)  // No direct, need to modify
-RC_PFN_DECL(hipGetDeviceCount, int *)
-RC_PFN_DECL(hipGetDevicePropertiesR0600, hipDeviceProp_t *, int)
-RC_PFN_DECL(hipDeviceGetName, char *, int,
-            hipDevice_t)  // No direct, need to modify
-RC_PFN_STR_DECL(
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipCtxCreate, hipCtx_t *, unsigned int,
+                                hipDevice_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipCtxDestroy, hipCtx_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipDeviceGet, hipDevice_t *,
+                                int)  // No direct, need to modify
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipGetDeviceCount, int *)
+IREE_HAL_ROCM_OPTIONAL_PFN_DECL(hipGetDevicePropertiesR0600, hipDeviceProp_t *,
+                                int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipDeviceGetName, char *, int,
+                                hipDevice_t)  // No direct, need to modify
+IREE_HAL_ROCM_REQUIRED_PFN_STR_DECL(
     hipGetErrorName,
     hipError_t)  // Unlike other functions hipGetErrorName(hipError_t) return
                  // const char* instead of hipError_t so it uses a different
                  // macro
-RC_PFN_STR_DECL(
+IREE_HAL_ROCM_REQUIRED_PFN_STR_DECL(
     hipGetErrorString,
     hipError_t)  // Unlike other functions hipGetErrorName(hipError_t) return
                  // const char* instead of hipError_t so it uses a different
                  // macro
-RC_PFN_DECL(hipInit, unsigned int)
-RC_PFN_DECL(hipModuleLaunchKernel, hipFunction_t, unsigned int, unsigned int,
-            unsigned int, unsigned int, unsigned int, unsigned int,
-            unsigned int, hipStream_t, void **, void **)
-RC_PFN_DECL(hipMemset, void *, int, size_t)
-RC_PFN_DECL(hipMemsetAsync, void *, int, size_t, hipStream_t)
-RC_PFN_DECL(hipMemsetD32Async, void *, int, size_t, hipStream_t)
-RC_PFN_DECL(hipMemsetD16Async, void *, short, size_t, hipStream_t)
-RC_PFN_DECL(hipMemsetD8Async, void *, char, size_t, hipStream_t)
-RC_PFN_DECL(hipMemcpy, void *, const void *, size_t, hipMemcpyKind)
-RC_PFN_DECL(hipMemcpyAsync, void *, const void *, size_t, hipMemcpyKind,
-            hipStream_t)
-RC_PFN_DECL(hipMalloc, void **, size_t)
-RC_PFN_DECL(hipMallocManaged, hipDeviceptr_t *, size_t, unsigned int)
-RC_PFN_DECL(hipFree, void *)
-RC_PFN_DECL(hipHostFree, void *)
-RC_PFN_DECL(hipMemAllocHost, void **, size_t, unsigned int)
-RC_PFN_DECL(hipHostGetDevicePointer, void **, void *, unsigned int)
-RC_PFN_DECL(hipModuleGetFunction, hipFunction_t *, hipModule_t, const char *)
-RC_PFN_DECL(hipModuleLoadDataEx, hipModule_t *, const void *, unsigned int,
-            hipJitOption *, void **)
-RC_PFN_DECL(hipModuleLoadData, hipModule_t *, const void *)
-RC_PFN_DECL(hipModuleUnload, hipModule_t)
-RC_PFN_DECL(hipStreamCreateWithFlags, hipStream_t *, unsigned int)
-RC_PFN_DECL(hipStreamDestroy, hipStream_t)
-RC_PFN_DECL(hipStreamSynchronize, hipStream_t)
-RC_PFN_DECL(hipStreamWaitEvent, hipStream_t, hipEvent_t, unsigned int)
-RC_PFN_DECL(hipEventCreate, hipEvent_t *)
-RC_PFN_DECL(hipEventDestroy, hipEvent_t)
-RC_PFN_DECL(hipEventElapsedTime, float *, hipEvent_t, hipEvent_t)
-RC_PFN_DECL(hipEventQuery, hipEvent_t)
-RC_PFN_DECL(hipEventRecord, hipEvent_t, hipStream_t)
-RC_PFN_DECL(hipEventSynchronize, hipEvent_t)
-RC_PFN_DECL(hipDeviceGetAttribute, int *, hipDeviceAttribute_t, int)
-RC_PFN_DECL(hipFuncSetAttribute, const void *, hipFuncAttribute, int)
-RC_PFN_DECL(hipDeviceGetUuid, hipUUID *, hipDevice_t)
-RC_PFN_DECL(hipDevicePrimaryCtxRetain, hipCtx_t *, hipDevice_t)
-RC_PFN_DECL(hipCtxGetDevice, hipDevice_t *)
-RC_PFN_DECL(hipCtxSetCurrent, hipCtx_t)
-RC_PFN_DECL(hipDevicePrimaryCtxRelease, hipDevice_t)
-RC_PFN_DECL(hipMemPrefetchAsync, const void *, size_t, int, hipStream_t)
-RC_PFN_DECL(hipMemcpyHtoDAsync, hipDeviceptr_t, void *, size_t, hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipInit, unsigned int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipModuleLaunchKernel, hipFunction_t,
+                                unsigned int, unsigned int, unsigned int,
+                                unsigned int, unsigned int, unsigned int,
+                                unsigned int, hipStream_t, void **, void **)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemset, void *, int, size_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemsetAsync, void *, int, size_t,
+                                hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemsetD32Async, void *, int, size_t,
+                                hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemsetD16Async, void *, short, size_t,
+                                hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemsetD8Async, void *, char, size_t,
+                                hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemcpy, void *, const void *, size_t,
+                                hipMemcpyKind)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemcpyAsync, void *, const void *, size_t,
+                                hipMemcpyKind, hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMalloc, void **, size_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMallocManaged, hipDeviceptr_t *, size_t,
+                                unsigned int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipFree, void *)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipHostFree, void *)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemAllocHost, void **, size_t, unsigned int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipHostGetDevicePointer, void **, void *,
+                                unsigned int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipModuleGetFunction, hipFunction_t *,
+                                hipModule_t, const char *)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipModuleLoadDataEx, hipModule_t *,
+                                const void *, unsigned int, hipJitOption *,
+                                void **)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipModuleLoadData, hipModule_t *, const void *)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipModuleUnload, hipModule_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipStreamCreateWithFlags, hipStream_t *,
+                                unsigned int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipStreamDestroy, hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipStreamSynchronize, hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipStreamWaitEvent, hipStream_t, hipEvent_t,
+                                unsigned int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipEventCreate, hipEvent_t *)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipEventDestroy, hipEvent_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipEventElapsedTime, float *, hipEvent_t,
+                                hipEvent_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipEventQuery, hipEvent_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipEventRecord, hipEvent_t, hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipEventSynchronize, hipEvent_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipDeviceGetAttribute, int *,
+                                hipDeviceAttribute_t, int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipFuncSetAttribute, const void *,
+                                hipFuncAttribute, int)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipDeviceGetUuid, hipUUID *, hipDevice_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipDevicePrimaryCtxRetain, hipCtx_t *,
+                                hipDevice_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipCtxGetDevice, hipDevice_t *)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipCtxSetCurrent, hipCtx_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipDevicePrimaryCtxRelease, hipDevice_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemPrefetchAsync, const void *, size_t, int,
+                                hipStream_t)
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipMemcpyHtoDAsync, hipDeviceptr_t, void *,
+                                size_t, hipStream_t)

--- a/experimental/rocm/dynamic_symbols.c
+++ b/experimental/rocm/dynamic_symbols.c
@@ -21,16 +21,24 @@ static const char* kROCMLoaderSearchNames[] = {
 
 static iree_status_t iree_hal_rocm_dynamic_symbols_resolve_all(
     iree_hal_rocm_dynamic_symbols_t* syms) {
-#define RC_PFN_DECL(rocmSymbolName, ...)                              \
+#define IREE_HAL_ROCM_REQUIRED_PFN_DECL(rocmSymbolName, ...)          \
   {                                                                   \
     static const char* kName = #rocmSymbolName;                       \
     IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(          \
         syms->loader_library, kName, (void**)&syms->rocmSymbolName)); \
   }
-#define RC_PFN_STR_DECL(rocmSymbolName, ...) RC_PFN_DECL(rocmSymbolName, ...)
+#define IREE_HAL_ROCM_REQUIRED_PFN_STR_DECL(rocmSymbolName, ...) \
+  IREE_HAL_ROCM_REQUIRED_PFN_DECL(rocmSymbolName, ...)
+#define IREE_HAL_ROCM_OPTIONAL_PFN_DECL(rocmSymbolName, ...)          \
+  {                                                                   \
+    static const char* kName = #rocmSymbolName;                       \
+    IREE_IGNORE_ERROR(iree_dynamic_library_lookup_symbol(             \
+        syms->loader_library, kName, (void**)&syms->rocmSymbolName)); \
+  }
 #include "experimental/rocm/dynamic_symbol_tables.h"  // IWYU pragma: keep
-#undef RC_PFN_DECL
-#undef RC_PFN_STR_DECL
+#undef IREE_HAL_ROCM_REQUIRED_PFN_DECL
+#undef IREE_HAL_ROCM_REQUIRED_PFN_STR_DECL
+#undef IREE_HAL_ROCM_OPTIONAL_PFN_DECL
   return iree_ok_status();
 }
 

--- a/experimental/rocm/dynamic_symbols.h
+++ b/experimental/rocm/dynamic_symbols.h
@@ -22,13 +22,16 @@ extern "C" {
 typedef struct iree_hal_rocm_dynamic_symbols_t {
   iree_dynamic_library_t* loader_library;
 
-#define RC_PFN_DECL(rocmSymbolName, ...) \
+#define IREE_HAL_ROCM_REQUIRED_PFN_DECL(rocmSymbolName, ...) \
   hipError_t (*rocmSymbolName)(__VA_ARGS__);
-#define RC_PFN_STR_DECL(rocmSymbolName, ...) \
+#define IREE_HAL_ROCM_REQUIRED_PFN_STR_DECL(rocmSymbolName, ...) \
   const char* (*rocmSymbolName)(__VA_ARGS__);
+#define IREE_HAL_ROCM_OPTIONAL_PFN_DECL(rocmSymbolName, ...) \
+  hipError_t (*rocmSymbolName)(__VA_ARGS__);
 #include "experimental/rocm/dynamic_symbol_tables.h"  // IWYU pragma: export
-#undef RC_PFN_DECL
-#undef RC_PFN_STR_DECL
+#undef IREE_HAL_ROCM_REQUIRED_PFN_DECL
+#undef IREE_HAL_ROCM_REQUIRED_PFN_STR_DECL
+#undef IREE_HAL_ROCM_OPTIONAL_PFN_DECL
 } iree_hal_rocm_dynamic_symbols_t;
 
 // Initializes |out_syms| in-place with dynamically loaded ROCM symbols.

--- a/experimental/rocm/rocm_driver.c
+++ b/experimental/rocm/rocm_driver.c
@@ -191,6 +191,12 @@ static iree_status_t iree_hal_rocm_driver_dump_device_info(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_string_builder_t* builder) {
   iree_hal_rocm_driver_t* driver = iree_hal_rocm_driver_cast(base_driver);
+  if (!driver->syms.hipGetDevicePropertiesR0600) {
+    // ROCm 6.0 release changes the hipDeviceProp_t struct and would need to use
+    // the matching hipGetDevicePropertiesR0600() API to query it. This symbol
+    // is not available in earlier versions.
+    return iree_ok_status();
+  }
   hipDevice_t device = IREE_DEVICE_ID_TO_HIPDEVICE(device_id);
 
   hipDeviceProp_t prop;


### PR DESCRIPTION
This commit ports over changes made in the hip HAL driver to support optional symbols to fix hipGetDeviceProperties for releases before 6.0.

ci-extra: regression_test_amdgpu_rocm,build_packages