### PR TITLE
Use correct 'webgpu-spirv' flag name in samples.

### DIFF
--- a/experimental/web/sample_webgpu/build_sample.sh
+++ b/experimental/web/sample_webgpu/build_sample.sh
@@ -51,7 +51,7 @@ compile_sample() {
   echo "  Compiling '$1' sample for WebGPU..."
   ${COMPILE_TOOL?} $3 \
     --iree-input-type=$2 \
-    --iree-hal-target-backends=webgpu \
+    --iree-hal-target-backends=webgpu-spirv \
     --iree-codegen-gpu-native-math-precision=true \
     --iree-stream-resource-alias-mutable-bindings=true \
     --o ${BINARY_DIR}/$1_webgpu.vmfb

--- a/experimental/web/sample_webgpu/index.html
+++ b/experimental/web/sample_webgpu/index.html
@@ -180,7 +180,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <textarea type="text" readonly spellcheck="false"
     class="form-control" style="width:610px; height:90px; resize:none; font-family: monospace;">
---iree-hal-target-backends=webgpu \
+--iree-hal-target-backends=webgpu-spirv \
 --iree-codegen-gpu-native-math-precision=true \
 --iree-stream-resource-alias-mutable-bindings=true \</textarea>
 

--- a/experimental/web/sample_webgpu/iree_api_webgpu.js
+++ b/experimental/web/sample_webgpu/iree_api_webgpu.js
@@ -24,7 +24,7 @@ async function ireeInitialize() {
 //
 // In order to call functions on the program it must be compiled in a supported
 // configuration, such as with these flags:
-//     --iree-hal-target-backends=webgpu
+//     --iree-hal-target-backends=webgpu-spirv
 //
 // Resolves with an opaque pointer to the program state on success.
 async function ireeLoadProgram(vmfbPathOrBuffer) {


### PR DESCRIPTION
Attempting to fix https://github.com/openxla/iree/actions/workflows/samples.yml, now that stablehlo errors in Colab notebooks have cleared and we're left with just 
```
=== Compiling sample MLIR files to VM FlatBuffer outputs (.vmfb) ===
  Compiling 'simple_abs' sample for WebGPU...
/work/samples/models/simple_abs.mlir:0:0: error: target backend 'webgpu' not registered; registered backends: cuda, llvm-cpu, metal-spirv, rocm, vmvx, vmvx-inline, vulkan-spirv, webgpu-spirv
```

Test run here: https://github.com/openxla/iree/actions/runs/8176913085