### PR TITLE
Qualify include paths in compiler target plugins.

### DIFF
--- a/compiler/plugins/target/CUDA/SetBlockIdsRangePass.cpp
+++ b/compiler/plugins/target/CUDA/SetBlockIdsRangePass.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "./SetBlockIdsRangePass.h"
+#include "compiler/plugins/target/CUDA/SetBlockIdsRangePass.h"
 
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/InstIterator.h"

--- a/compiler/plugins/target/MetalSPIRV/MSLToMetalLib.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MSLToMetalLib.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "./MSLToMetalLib.h"
+#include "compiler/plugins/target/MetalSPIRV/MSLToMetalLib.h"
 
 #include <stdlib.h>
 

--- a/compiler/plugins/target/MetalSPIRV/MSLToMetalLib.h
+++ b/compiler/plugins/target/MetalSPIRV/MSLToMetalLib.h
@@ -7,7 +7,7 @@
 #ifndef IREE_COMPILER_PLUGINS_TARGET_METALSPIRV_MSLTOMETALLIB_H_
 #define IREE_COMPILER_PLUGINS_TARGET_METALSPIRV_MSLTOMETALLIB_H_
 
-#include "./MetalTargetPlatform.h"
+#include "compiler/plugins/target/MetalSPIRV/MetalTargetPlatform.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
 

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -4,9 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "./MSLToMetalLib.h"
-#include "./MetalTargetPlatform.h"
-#include "./SPIRVToMSL.h"
+#include "compiler/plugins/target/MetalSPIRV/MSLToMetalLib.h"
+#include "compiler/plugins/target/MetalSPIRV/MetalTargetPlatform.h"
+#include "compiler/plugins/target/MetalSPIRV/SPIRVToMSL.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"

--- a/compiler/plugins/target/MetalSPIRV/SPIRVToMSL.cpp
+++ b/compiler/plugins/target/MetalSPIRV/SPIRVToMSL.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "./SPIRVToMSL.h"
+#include "compiler/plugins/target/MetalSPIRV/SPIRVToMSL.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"

--- a/compiler/plugins/target/ROCM/ROCMTargetFeatures.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTargetFeatures.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "./ROCMTargetFeatures.h"
+#include "compiler/plugins/target/ROCM/ROCMTargetFeatures.h"
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "llvm/ADT/StringSwitch.h"

--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "./ROCMTargetUtils.h"
+#include "compiler/plugins/target/ROCM/ROCMTargetUtils.h"
 
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/HAL/Target/LLVMLinkerUtils.h"

--- a/compiler/plugins/target/WebGPUSPIRV/SPIRVToWGSL.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/SPIRVToWGSL.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "./SPIRVToWGSL.h"
+#include "compiler/plugins/target/WebGPUSPIRV/SPIRVToWGSL.h"
 
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "./SPIRVToWGSL.h"
+#include "compiler/plugins/target/WebGPUSPIRV/SPIRVToWGSL.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
 #include "iree/compiler/Codegen/WGSL/Passes.h"


### PR DESCRIPTION
Progress on https://github.com/openxla/iree/issues/15468

Bikeshedding time, before I pull [`HAL/Target/LLVMCPU/`](https://github.com/openxla/iree/tree/main/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU) (with its multiple files) across.

* The main source tree at `compiler/src/iree/compiler` uses defs to drop the leading `compiler/src/` from include paths: https://github.com/openxla/iree/blob/3bdb45bf788d490d3fec154593706d9f2283b2a8/compiler/src/CMakeLists.txt#L7-L11
* The _input_ plugins use a slightly different technique to use their own prefixes: https://github.com/openxla/iree/blob/3bdb45bf788d490d3fec154593706d9f2283b2a8/compiler/plugins/input/Torch/CMakeLists.txt#L8-L17 https://github.com/openxla/iree/blob/3bdb45bf788d490d3fec154593706d9f2283b2a8/compiler/plugins/input/Torch/torch-iree/InputConversion/SetStrictSymbolicShapes.cpp#L16-L17

These _target_ plugins had been avoiding that by just using relative includes... but we can also use includes anchored on the repository root, or we can apply a similar include trick if there is a specific name we want.