### PR TITLE
TRY: defer CPUMaterializeUpperBoundTileSizePass.

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/MaterializeHomogeneousEncodings.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/MaterializeHomogeneousEncodings.cpp
@@ -65,9 +65,9 @@ public:
     }
 
     OpPassManager passManager(moduleOp.getOperationName());
-    FunctionLikeNest(passManager).addPass([&]() {
-      return createCPUMaterializeUpperBoundTileSizePass(executableTargets);
-    });
+    // FunctionLikeNest(passManager).addPass([&]() {
+    //   return createCPUMaterializeUpperBoundTileSizePass(executableTargets);
+    // });
     FunctionLikeNest(passManager).addPass([&]() {
       return createCPUMaterializeEncodingPass(executableTarget);
     });


### PR DESCRIPTION
VMVX already defers it and LLVM CPU seems to compile with it deferred but it's not clear if this is required for performance.