### PR TITLE
[GlobalOpt] Add reshape propagation and transpose fusion into linalg results to transpose propagation

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -21,7 +21,6 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -117,6 +117,8 @@ static void specializeGenericTransposeOp(RewriterBase &rewriter,
 // Other pattern helpers
 //===----------------------------------------------------------------------===//
 
+/// If the `op` is a ContractionOpInterface, return the generalized op. If the
+/// `op` is a linalg::GenericOp, then just return the generic op.
 static FailureOr<linalg::GenericOp>
 getGenericOpOrGeneralizeContraction(RewriterBase &rewriter, Operation *op) {
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);


### PR DESCRIPTION
This PR enables fusion of transposes into the DPS init of linalg ops during PropagateLinalgTranspose. This also enables fusion by expansion and collapsing to propagate reshapes up and down during transpose propagation. After this PR, transpose propagation works as follows:
 - First, canonicalize named contractions by fusing nearby transpose operations to create new named ops.
 - Propagate both reshapes and transposes up, and fuse transposes into the DPS inits of linalg ops.
 - Propagate both reshapes and transposes down, and fuse transposes into the inputs of linalg ops.
 - Compose adjacent transpose operations into a single transpose.