### PR TITLE
[CPU] Centralize pipeline lowering options and apply them consistently.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -128,13 +128,14 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   }
 
   ModuleOp moduleOp = variantOp.getInnerModule();
-  LLVMCPUPipelineOptions options;
+  LLVMCPUPipelineOptions pipelineOpts;
   auto target = variantOp.getTarget();
-  options.lowerToAVX2 = hasAVX2Feature(target);
-  options.enableVectorMasking = isX86(target) || isRISCV(target) ||
-                                (isAArch64(target) && hasAnySVEFeature(target));
-  options.enableUkernels = hasUkernel(target);
-  options.enableAArch64SSVE =
+  pipelineOpts.lowerToAVX2 = hasAVX2Feature(target);
+  pipelineOpts.enableVectorMasking =
+      isX86(target) || isRISCV(target) ||
+      (isAArch64(target) && hasAnySVEFeature(target));
+  pipelineOpts.enableUkernels = hasUkernel(target);
+  pipelineOpts.enableAArch64SSVE =
       isAArch64(target) && hasAnySVEFeature(target) && hasSMEFeature(target);
   switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
   // No pipleline specified, nothing to do.
@@ -146,41 +147,44 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUBufferOpsTileAndVectorize: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
-    addCPUBufferOpsTileAndVectorizePipeline(pipeline, tilingConfig, options);
+    addCPUBufferOpsTileAndVectorizePipeline(pipeline, tilingConfig,
+                                            pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDoubleTilingExpert: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
-    addMultiTilingExpertPassPipeline(pipeline, tilingConfig, options);
+    addMultiTilingExpertPassPipeline(pipeline, tilingConfig, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUDoubleTilingPeelingExpert: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
-    options.enablePeeling = true;
-    addMultiTilingExpertPassPipeline(pipeline, tilingConfig, options);
+    pipelineOpts.enablePeeling = true;
+    addMultiTilingExpertPassPipeline(pipeline, tilingConfig, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUConvTileAndDecomposeExpert: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
-    addConvTileAndDecomposeExpertPassPipeline(pipeline, tilingConfig, options);
+    addConvTileAndDecomposeExpertPassPipeline(pipeline, tilingConfig,
+                                              pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::Mmt4dTilingExpert: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
-    addMmt4dTilingExpertPassPipeline(pipeline, tilingConfig, options);
+    addMmt4dTilingExpertPassPipeline(pipeline, tilingConfig, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDataTiling: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
-    addCPUDataTilingPipeline(pipeline, tilingConfig, options);
+    addCPUDataTilingPipeline(pipeline, tilingConfig, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPULinalgExtTileAndVectorize: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(moduleOp);
-    addCPULinalgExtTileAndVectorizePipeline(pipeline, tilingConfig, options);
+    addCPULinalgExtTileAndVectorizePipeline(pipeline, tilingConfig,
+                                            pipelineOpts);
     break;
   }
   // Transform-dialect pipelines.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -131,42 +131,48 @@ void populateVectorContractCustomKernelsPatterns(
 // LLVMCPU backend Pass Pipelines.
 //----------------------------------------------------------------------------//
 
+struct LLVMCPUPipelineOptions {
+  bool enablePeeling = false;
+  bool enableVectorMasking = false;
+  bool enableAArch64SSVE = false;
+  bool enableUkernels = false;
+  bool lowerToAVX2 = false;
+};
+
 /// Populates the passes to lower linalg ops on buffers. Currenly this
 /// pipeline is only used for dispatches that just copy data from input
 /// interfaces to output interface.
-void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager,
-                                             TilingConfig &tilingConfig,
-                                             bool enableVectorMasking,
-                                             bool enableAArch64SSVE = false);
+void addCPUBufferOpsTileAndVectorizePipeline(
+    OpPassManager &passManager, TilingConfig &tilingConfig,
+    LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes to lower ops through data tiling transformations.
 void addCPUDataTilingPipeline(OpPassManager &passManager,
                               TilingConfig &tilingConfig,
-                              bool enableVectorMasking);
+                              LLVMCPUPipelineOptions &pipelineOpt);
 
-void addCPULinalgExtTileAndVectorizePipeline(OpPassManager &passManager,
-                                             TilingConfig &tilingConfig);
+void addCPULinalgExtTileAndVectorizePipeline(
+    OpPassManager &passManager, TilingConfig &tilingConfig,
+    LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes to lower to scalars operations for linalg based
 /// code-generation. This pipeline does not vectorize, but instead just
 /// converts to memrefs
 void addCPUDefaultPassPipeline(OpPassManager &passManager);
 
-void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager,
-                                               TilingConfig &tilingConfig,
-                                               bool enableVectorMasking,
-                                               bool enableAArch64SSVE = false);
+void addConvTileAndDecomposeExpertPassPipeline(
+    OpPassManager &passManager, TilingConfig &tilingConfig,
+    LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes needed to multi level tile, fuse and vectorize
 /// lowering of linalg ops on tensors to vectors operations.
 void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager,
                                       TilingConfig &tilingConfig,
-                                      bool enableMicrokernels,
-                                      bool lowerToAVX2);
+                                      LLVMCPUPipelineOptions &pipelineOpt);
 
-void addMultiTilingExpertPassPipeline(
-    OpPassManager &passManager, TilingConfig &tilingConfig, bool enablePeeling,
-    bool enableVectorMasking, bool lowerToAVX2, bool enableAArch64SSVE = false);
+void addMultiTilingExpertPassPipeline(OpPassManager &passManager,
+                                      TilingConfig &tilingConfig,
+                                      LLVMCPUPipelineOptions &pipelineOpt);
 
 void addTensorToVectorsPassPipeline(OpPassManager &passManager,
                                     bool lowerToVectors = true);


### PR DESCRIPTION
The revision creates a struct to hold all the lowering options; uses the options all the pipeline. It prevents that the options are set at the entry but not propagated to the pipelines.