### PR TITLE
If negative tolerance in numerical test, then emit error

### DIFF
--- a/tools/iree-e2e-matmul-test.cc
+++ b/tools/iree-e2e-matmul-test.cc
@@ -583,6 +583,10 @@ static bool matmul_result_elements_agree(iree_e2e_test_value_t expected,
         iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "mismatched types"));
     return false;
   }
+
+  // Negative tolerance is never satisfied: same behavior as numpy.allclose
+  if (FLAG_acceptable_fp_delta < 0.0f) return false;
+
   switch (expected.type) {
     case IREE_E2E_TEST_VALUE_TYPE_I32:
       return actual.i32 == expected.i32;

--- a/tools/iree-e2e-matmul-test.cc
+++ b/tools/iree-e2e-matmul-test.cc
@@ -584,8 +584,13 @@ static bool matmul_result_elements_agree(iree_e2e_test_value_t expected,
     return false;
   }
 
-  // Negative tolerance is never satisfied: same behavior as numpy.allclose
-  if (FLAG_acceptable_fp_delta < 0.0f) return false;
+  if (FLAG_acceptable_fp_delta < 0.0f) {
+    iree_status_abort(
+        iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                         "negative tolerance (acceptable_fp_delta=%.8g)",
+                         FLAG_acceptable_fp_delta));
+    return false;
+  }
 
   switch (expected.type) {
     case IREE_E2E_TEST_VALUE_TYPE_I32:


### PR DESCRIPTION
Numpy:

![image](https://github.com/openxla/iree/assets/4902987/1f60a82d-83d8-4a76-b1fc-ecf011f90c7a)

My sanity check in iree-amd-aie of setting a negative tolerance failed, leaving me unsure if something else in the backend wasn't working. 