### PR TITLE
[Preprocessing] Change nesting of FoldUnitExtentDims

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -92,8 +92,8 @@ buildTransposeConvolutionPassPipeline(OpPassManager &passManager,
       .addPass(GlobalOptimization::createDetachElementwiseFromNamedOpsPass)
       .addPass(mlir::createLinalgNamedOpConversionPass)
       .addPass(GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass)
-      .addPass(createConvertConvToChannelsLastPass)
-      .addPass(IREE::Flow::createFoldUnitExtentDimsPass);
+      .addPass(createConvertConvToChannelsLastPass);
+  passManager.addPass(IREE::Flow::createFoldUnitExtentDimsPass());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 }


### PR DESCRIPTION
The nesting was changed for FoldUnitExtentDims, and the nesting was not changed in the preprocessing registration. This fixes the bug.