### PR TITLE
Use subgroup size when doing shuffles

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -377,13 +377,14 @@ struct DistributeReductions final
                                 vector::CombiningKind combiningKind,
                                 int64_t entriesPerVector, Value mEmpty,
                                 OpBuilder &rewriter, Location loc) const {
-    uint32_t size = maxBitsPerShuffle;
+    // TODO: Get subgroup size from translation info.
+    uint32_t subgroupSize = 64;
     Value mask;
     assert(llvm::isPowerOf2_64(laneSize));
     for (uint64_t i = shuffleOffset; i < shuffleOffset * laneSize; i <<= 1) {
       Value packed = packVectorToSupportedWidth(loc, rewriter, result);
-      auto shuffleOp = rewriter.create<gpu::ShuffleOp>(loc, packed, i, size,
-                                                       gpu::ShuffleMode::XOR);
+      auto shuffleOp = rewriter.create<gpu::ShuffleOp>(
+          loc, packed, i, subgroupSize, gpu::ShuffleMode::XOR);
       Value unpacked =
           unpackToVector(loc, rewriter, shuffleOp.getShuffleResult(),
                          result.getType().cast<VectorType>());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -305,94 +305,127 @@ builtin.module attributes { transform.with_named_sequence } {
 #col_layout = #iree_vector_ext.per_dim_layout<[BATCHY, LANEX], [1, 16]>
 #layout2d = #iree_vector_ext.layout<#row_layout, #col_layout>
 #layout1d = #iree_vector_ext.layout<#col_layout>
-
-func.func @distribute_reduction_f16(%source: vector<16x16xf16>, %init: vector<16xf16>) -> vector<16xf16> {
-  // CHECK:      func.func @distribute_reduction_f16(%[[ARG0:[a-zA-Z0-9_]+]]: vector<16x16xf16>, %[[ARG1:[a-zA-Z0-9_]+]]:
-  // CHECK-SAME:   vector<16xf16>) -> vector<16xf16> {
-  // CHECK-DAG:    %[[C32_I32:.+]] = arith.constant 32 : i32
-  // CHECK-DAG:    %[[C16_I32:.+]] = arith.constant 16 : i32
-  // CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<2xf16>
-  // CHECK-DAG:    %[[CST_0:.+]] = arith.constant dense<0.000000e+00> : vector<1xf16>
-  // CHECK:        %[[D0:.+]] = iree_vector_ext.to_simt %[[ARG1]] : vector<16xf16> -> vector<1xf16>
-  // CHECK:        %[[D1:.+]] = vector.extract %[[D0]][0] : f16 from vector<1xf16>
-  // CHECK:        %[[D2:.+]] = iree_vector_ext.to_simt %[[ARG0]] : vector<16x16xf16> -> vector<1x1x4xf16>
-  // CHECK:        %[[D3:.+]] = vector.extract %[[D2]][0, 0, 0] : f16 from vector<1x1x4xf16>
-  // CHECK:        %[[D4:.+]] = vector.insert %[[D3]], %[[CST]] [0] : f16 into vector<2xf16>
-  // CHECK:        %[[D5:.+]] = vector.extract %[[D2]][0, 0, 1] : f16 from vector<1x1x4xf16>
-  // CHECK:        %[[D6:.+]] = vector.insert %[[D5]], %[[D4]] [1] : f16 into vector<2xf16>
-  // CHECK:        %[[D7:.+]] = vector.extract %[[D2]][0, 0, 2] : f16 from vector<1x1x4xf16>
-  // CHECK:        %[[D8:.+]] = vector.insert %[[D7]], %[[D6]] [0] : f16 into vector<2xf16>
-  // CHECK:        %[[D9:.+]] = vector.extract %[[D2]][0, 0, 3] : f16 from vector<1x1x4xf16>
-  // CHECK:        %[[D10:.+]] = vector.insert %[[D9]], %[[D8]] [1] : f16 into vector<2xf16>
-  // CHECK:        %[[D11:.+]] = arith.maximumf %[[D6]], %[[D10]] : vector<2xf16>
-  // CHECK:        %[[D12:.+]] = vector.bitcast %[[D11]] : vector<2xf16> to vector<1xi32>
-  // CHECK:        %[[D13:.+]] = vector.extract %[[D12]][0] : i32 from vector<1xi32>
-  // CHECK:        %[[SHUFFLERESULT:.+]], %[[VALID:.+]] = gpu.shuffle  xor %[[D13]], %[[C16_I32]], %[[C32_I32]] : i32
-  // CHECK:        %[[D14:.+]] = vector.broadcast %[[SHUFFLERESULT]] : i32 to vector<1xi32>
-  // CHECK:        %[[D15:.+]] = vector.bitcast %[[D14]] : vector<1xi32> to vector<2xf16>
-  // CHECK:        %[[D16:.+]] = arith.maximumf %[[D15]], %[[D11]] : vector<2xf16>
-  // CHECK:        %[[D17:.+]] = vector.bitcast %[[D16]] : vector<2xf16> to vector<1xi32>
-  // CHECK:        %[[D18:.+]] = vector.extract %[[D17]][0] : i32 from vector<1xi32>
-  // CHECK:        %[[SHUFFLERESULT_1:.+]], %[[VALID_2:.+]] = gpu.shuffle  xor %[[D18]], %[[C32_I32]], %[[C32_I32]] : i32
-  // CHECK:        %[[D19:.+]] = vector.broadcast %[[SHUFFLERESULT_1]] : i32 to vector<1xi32>
-  // CHECK:        %[[D20:.+]] = vector.bitcast %[[D19]] : vector<1xi32> to vector<2xf16>
-  // CHECK:        %[[D21:.+]] = arith.maximumf %[[D20]], %[[D16]] : vector<2xf16>
-  // CHECK:        %[[D22:.+]] = vector.extract %[[D21]][0] : f16 from vector<2xf16>
-  // CHECK:        %[[D23:.+]] = vector.extract %[[D21]][1] : f16 from vector<2xf16>
-  // CHECK:        %[[D24:.+]] = arith.maximumf %[[D22]], %[[D23]] : f16
-  // CHECK:        %[[D25:.+]] = arith.maximumf %[[D24]], %[[D1]] : f16
-  // CHECK:        %[[D26:.+]] = vector.insert %[[D25]], %[[CST_0]] [0] : f16 into vector<1xf16>
-  // CHECK:        %[[D27:.+]] = iree_vector_ext.to_simd %[[D26]] : vector<1xf16> -> vector<16xf16>
-  %result = vector.multi_reduction <maximumf>, %source, %init {
-                "__vector_layout_test_anchor_operand_0" = #layout2d,
-                "__vector_layout_test_anchor_operand_1" = #layout1d,
-                "__vector_layout_test_anchor_result_0" = #layout1d
-              } [0] : vector<16x16xf16> to vector<16xf16>
-  func.return %result : vector<16xf16>
+// Dummy hal executable ops to set the subgroup size which is required for distributing reductions.
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {}>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>]>]>
+hal.executable private @reduction_dispatch {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+    hal.executable.export public @distribute_reduction_f16 ordinal(0) layout(#pipeline_layout) attributes {subgroup_size = 64 : index} {
+      ^bb0(%arg0: !hal.device):
+        %c2 = arith.constant 2 : index
+        %c32 = arith.constant 32 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c2, %c32, %c1 : index, index, index
+    }
+    builtin.module {
+      func.func @distribute_reduction_f16(%source: vector<16x16xf16>, %init: vector<16xf16>) -> vector<16xf16> {
+        // CHECK:      func.func @distribute_reduction_f16(%[[ARG0:[a-zA-Z0-9_]+]]: vector<16x16xf16>, %[[ARG1:[a-zA-Z0-9_]+]]:
+        // CHECK-SAME:   vector<16xf16>) -> vector<16xf16> {
+        // CHECK-DAG:    %[[C32_I32:.+]] = arith.constant 32 : i32
+        // CHECK-DAG:    %[[C64_I32:.+]] = arith.constant 64 : i32
+        // CHECK-DAG:    %[[C16_I32:.+]] = arith.constant 16 : i32
+        // CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<2xf16>
+        // CHECK-DAG:    %[[CST_0:.+]] = arith.constant dense<0.000000e+00> : vector<1xf16>
+        // CHECK:        %[[D0:.+]] = iree_vector_ext.to_simt %[[ARG1]] : vector<16xf16> -> vector<1xf16>
+        // CHECK:        %[[D1:.+]] = vector.extract %[[D0]][0] : f16 from vector<1xf16>
+        // CHECK:        %[[D2:.+]] = iree_vector_ext.to_simt %[[ARG0]] : vector<16x16xf16> -> vector<1x1x4xf16>
+        // CHECK:        %[[D3:.+]] = vector.extract %[[D2]][0, 0, 0] : f16 from vector<1x1x4xf16>
+        // CHECK:        %[[D4:.+]] = vector.insert %[[D3]], %[[CST]] [0] : f16 into vector<2xf16>
+        // CHECK:        %[[D5:.+]] = vector.extract %[[D2]][0, 0, 1] : f16 from vector<1x1x4xf16>
+        // CHECK:        %[[D6:.+]] = vector.insert %[[D5]], %[[D4]] [1] : f16 into vector<2xf16>
+        // CHECK:        %[[D7:.+]] = vector.extract %[[D2]][0, 0, 2] : f16 from vector<1x1x4xf16>
+        // CHECK:        %[[D8:.+]] = vector.insert %[[D7]], %[[D6]] [0] : f16 into vector<2xf16>
+        // CHECK:        %[[D9:.+]] = vector.extract %[[D2]][0, 0, 3] : f16 from vector<1x1x4xf16>
+        // CHECK:        %[[D10:.+]] = vector.insert %[[D9]], %[[D8]] [1] : f16 into vector<2xf16>
+        // CHECK:        %[[D11:.+]] = arith.maximumf %[[D6]], %[[D10]] : vector<2xf16>
+        // CHECK:        %[[D12:.+]] = vector.bitcast %[[D11]] : vector<2xf16> to vector<1xi32>
+        // CHECK:        %[[D13:.+]] = vector.extract %[[D12]][0] : i32 from vector<1xi32>
+        // CHECK:        %[[SHUFFLERESULT:.+]], %[[VALID:.+]] = gpu.shuffle  xor %[[D13]], %[[C16_I32]], %[[C64_I32]] : i32
+        // CHECK:        %[[D14:.+]] = vector.broadcast %[[SHUFFLERESULT]] : i32 to vector<1xi32>
+        // CHECK:        %[[D15:.+]] = vector.bitcast %[[D14]] : vector<1xi32> to vector<2xf16>
+        // CHECK:        %[[D16:.+]] = arith.maximumf %[[D15]], %[[D11]] : vector<2xf16>
+        // CHECK:        %[[D17:.+]] = vector.bitcast %[[D16]] : vector<2xf16> to vector<1xi32>
+        // CHECK:        %[[D18:.+]] = vector.extract %[[D17]][0] : i32 from vector<1xi32>
+        // CHECK:        %[[SHUFFLERESULT_1:.+]], %[[VALID_2:.+]] = gpu.shuffle  xor %[[D18]], %[[C32_I32]], %[[C64_I32]] : i32
+        // CHECK:        %[[D19:.+]] = vector.broadcast %[[SHUFFLERESULT_1]] : i32 to vector<1xi32>
+        // CHECK:        %[[D20:.+]] = vector.bitcast %[[D19]] : vector<1xi32> to vector<2xf16>
+        // CHECK:        %[[D21:.+]] = arith.maximumf %[[D20]], %[[D16]] : vector<2xf16>
+        // CHECK:        %[[D22:.+]] = vector.extract %[[D21]][0] : f16 from vector<2xf16>
+        // CHECK:        %[[D23:.+]] = vector.extract %[[D21]][1] : f16 from vector<2xf16>
+        // CHECK:        %[[D24:.+]] = arith.maximumf %[[D22]], %[[D23]] : f16
+        // CHECK:        %[[D25:.+]] = arith.maximumf %[[D24]], %[[D1]] : f16
+        // CHECK:        %[[D26:.+]] = vector.insert %[[D25]], %[[CST_0]] [0] : f16 into vector<1xf16>
+        // CHECK:        %[[D27:.+]] = iree_vector_ext.to_simd %[[D26]] : vector<1xf16> -> vector<16xf16>
+        %result = vector.multi_reduction <maximumf>, %source, %init {
+                      "__vector_layout_test_anchor_operand_0" = #layout2d,
+                      "__vector_layout_test_anchor_operand_1" = #layout1d,
+                      "__vector_layout_test_anchor_result_0" = #layout1d
+                    } [0] : vector<16x16xf16> to vector<16xf16>
+        func.return %result : vector<16xf16>
+      }
+    }
+  }
 }
 
-func.func @distribute_reduction_f32(%source: vector<16x16xf32>, %init: vector<16xf32>) -> vector<16xf32> {
-  // CHECK:      func.func @distribute_reduction_f32(%[[ARG0:[a-zA-Z0-9_]+]]: vector<16x16xf32>, %[[ARG1:[a-zA-Z0-9_]+]]:
-  // CHECK-SAME:   vector<16xf32>) -> vector<16xf32> {
-  // CHECK-DAG:    %[[C32_I32:.+]] = arith.constant 32 : i32
-  // CHECK-DAG:    %[[C16_I32:.+]] = arith.constant 16 : i32
-  // CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1xf32>
-  // CHECK:        %[[D0:.+]] = iree_vector_ext.to_simt %[[ARG1]] : vector<16xf32> -> vector<1xf32>
-  // CHECK:        %[[D1:.+]] = vector.extract %[[D0]][0] : f32 from vector<1xf32>
-  // CHECK:        %[[D2:.+]] = iree_vector_ext.to_simt %[[ARG0]] : vector<16x16xf32> -> vector<1x1x4xf32>
-  // CHECK:        %[[D3:.+]] = vector.extract %[[D2]][0, 0, 0] : f32 from vector<1x1x4xf32>
-  // CHECK:        %[[D4:.+]] = vector.insert %[[D3]], %[[CST]] [0] : f32 into vector<1xf32>
-  // CHECK:        %[[D5:.+]] = vector.extract %[[D2]][0, 0, 1] : f32 from vector<1x1x4xf32>
-  // CHECK:        %[[D6:.+]] = vector.insert %[[D5]], %[[D4]] [0] : f32 into vector<1xf32>
-  // CHECK:        %[[D7:.+]] = arith.maximumf %[[D4]], %[[D6]] : vector<1xf32>
-  // CHECK:        %[[D8:.+]] = vector.extract %[[D2]][0, 0, 2] : f32 from vector<1x1x4xf32>
-  // CHECK:        %[[D9:.+]] = vector.insert %[[D8]], %[[D6]] [0] : f32 into vector<1xf32>
-  // CHECK:        %[[D10:.+]] = arith.maximumf %[[D7]], %[[D9]] : vector<1xf32>
-  // CHECK:        %[[D11:.+]] = vector.extract %[[D2]][0, 0, 3] : f32 from vector<1x1x4xf32>
-  // CHECK:        %[[D12:.+]] = vector.insert %[[D11]], %[[D9]] [0] : f32 into vector<1xf32>
-  // CHECK:        %[[D13:.+]] = arith.maximumf %[[D10]], %[[D12]] : vector<1xf32>
-  // CHECK:        %[[D14:.+]] = vector.bitcast %[[D13]] : vector<1xf32> to vector<1xi32>
-  // CHECK:        %[[D15:.+]] = vector.extract %[[D14]][0] : i32 from vector<1xi32>
-  // CHECK:        %[[SHUFFLERESULT:.+]], %[[VALID:.+]] = gpu.shuffle  xor %[[D15]], %[[C16_I32]], %[[C32_I32]] : i32
-  // CHECK:        %[[D16:.+]] = vector.broadcast %[[SHUFFLERESULT]] : i32 to vector<1xi32>
-  // CHECK:        %[[D17:.+]] = vector.bitcast %[[D16]] : vector<1xi32> to vector<1xf32>
-  // CHECK:        %[[D18:.+]] = arith.maximumf %[[D17]], %[[D13]] : vector<1xf32>
-  // CHECK:        %[[D19:.+]] = vector.bitcast %[[D18]] : vector<1xf32> to vector<1xi32>
-  // CHECK:        %[[D20:.+]] = vector.extract %[[D19]][0] : i32 from vector<1xi32>
-  // CHECK:        %[[SHUFFLERESULT_0:.+]], %[[VALID_1:.+]] = gpu.shuffle  xor %[[D20]], %[[C32_I32]], %[[C32_I32]] : i32
-  // CHECK:        %[[D21:.+]] = vector.broadcast %[[SHUFFLERESULT_0]] : i32 to vector<1xi32>
-  // CHECK:        %[[D22:.+]] = vector.bitcast %[[D21]] : vector<1xi32> to vector<1xf32>
-  // CHECK:        %[[D23:.+]] = arith.maximumf %[[D22]], %[[D18]] : vector<1xf32>
-  // CHECK:        %[[D24:.+]] = vector.extract %[[D23]][0] : f32 from vector<1xf32>
-  // CHECK:        %[[D25:.+]] = arith.maximumf %[[D24]], %[[D1]] : f32
-  // CHECK:        %[[D26:.+]] = vector.insert %[[D25]], %[[CST]] [0] : f32 into vector<1xf32>
-  // CHECK:        %[[D27:.+]] = iree_vector_ext.to_simd %[[D26]] : vector<1xf32> -> vector<16xf32>
-  %result = vector.multi_reduction <maximumf>, %source, %init {
-                "__vector_layout_test_anchor_operand_0" = #layout2d,
-                "__vector_layout_test_anchor_operand_1" = #layout1d,
-                "__vector_layout_test_anchor_result_0" = #layout1d
-              } [0] : vector<16x16xf32> to vector<16xf32>
-  func.return %result : vector<16xf32>
+// Dummy hal executable ops to set the subgroup size which is required for distributing reductions.
+#executable_target_rocm_hsaco_fb2 = #hal.executable.target<"rocm", "rocm-hsaco-fb", {}>
+#pipeline_layout2 = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>]>]>
+hal.executable private @reduction_dispatch2 {
+  hal.executable.variant public @rocm_hsaco_fb2 target(#executable_target_rocm_hsaco_fb2) {
+    hal.executable.export public @distribute_reduction_f32 ordinal(0) layout(#pipeline_layout2) attributes {subgroup_size = 64 : index} {
+      ^bb0(%arg0: !hal.device):
+        %c2 = arith.constant 2 : index
+        %c32 = arith.constant 32 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c2, %c32, %c1 : index, index, index
+    }
+    builtin.module {
+      func.func @distribute_reduction_f32(%source: vector<16x16xf32>, %init: vector<16xf32>) -> vector<16xf32> {
+        // CHECK:      func.func @distribute_reduction_f32(%[[ARG0:[a-zA-Z0-9_]+]]: vector<16x16xf32>, %[[ARG1:[a-zA-Z0-9_]+]]:
+        // CHECK-SAME:   vector<16xf32>) -> vector<16xf32> {
+        // CHECK-DAG:    %[[C32_I32:.+]] = arith.constant 32 : i32
+        // CHECK-DAG:    %[[C64_I32:.+]] = arith.constant 64 : i32
+        // CHECK-DAG:    %[[C16_I32:.+]] = arith.constant 16 : i32
+        // CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1xf32>
+        // CHECK:        %[[D0:.+]] = iree_vector_ext.to_simt %[[ARG1]] : vector<16xf32> -> vector<1xf32>
+        // CHECK:        %[[D1:.+]] = vector.extract %[[D0]][0] : f32 from vector<1xf32>
+        // CHECK:        %[[D2:.+]] = iree_vector_ext.to_simt %[[ARG0]] : vector<16x16xf32> -> vector<1x1x4xf32>
+        // CHECK:        %[[D3:.+]] = vector.extract %[[D2]][0, 0, 0] : f32 from vector<1x1x4xf32>
+        // CHECK:        %[[D4:.+]] = vector.insert %[[D3]], %[[CST]] [0] : f32 into vector<1xf32>
+        // CHECK:        %[[D5:.+]] = vector.extract %[[D2]][0, 0, 1] : f32 from vector<1x1x4xf32>
+        // CHECK:        %[[D6:.+]] = vector.insert %[[D5]], %[[D4]] [0] : f32 into vector<1xf32>
+        // CHECK:        %[[D7:.+]] = arith.maximumf %[[D4]], %[[D6]] : vector<1xf32>
+        // CHECK:        %[[D8:.+]] = vector.extract %[[D2]][0, 0, 2] : f32 from vector<1x1x4xf32>
+        // CHECK:        %[[D9:.+]] = vector.insert %[[D8]], %[[D6]] [0] : f32 into vector<1xf32>
+        // CHECK:        %[[D10:.+]] = arith.maximumf %[[D7]], %[[D9]] : vector<1xf32>
+        // CHECK:        %[[D11:.+]] = vector.extract %[[D2]][0, 0, 3] : f32 from vector<1x1x4xf32>
+        // CHECK:        %[[D12:.+]] = vector.insert %[[D11]], %[[D9]] [0] : f32 into vector<1xf32>
+        // CHECK:        %[[D13:.+]] = arith.maximumf %[[D10]], %[[D12]] : vector<1xf32>
+        // CHECK:        %[[D14:.+]] = vector.bitcast %[[D13]] : vector<1xf32> to vector<1xi32>
+        // CHECK:        %[[D15:.+]] = vector.extract %[[D14]][0] : i32 from vector<1xi32>
+        // CHECK:        %[[SHUFFLERESULT:.+]], %[[VALID:.+]] = gpu.shuffle  xor %[[D15]], %[[C16_I32]], %[[C64_I32]] : i32
+        // CHECK:        %[[D16:.+]] = vector.broadcast %[[SHUFFLERESULT]] : i32 to vector<1xi32>
+        // CHECK:        %[[D17:.+]] = vector.bitcast %[[D16]] : vector<1xi32> to vector<1xf32>
+        // CHECK:        %[[D18:.+]] = arith.maximumf %[[D17]], %[[D13]] : vector<1xf32>
+        // CHECK:        %[[D19:.+]] = vector.bitcast %[[D18]] : vector<1xf32> to vector<1xi32>
+        // CHECK:        %[[D20:.+]] = vector.extract %[[D19]][0] : i32 from vector<1xi32>
+        // CHECK:        %[[SHUFFLERESULT_0:.+]], %[[VALID_1:.+]] = gpu.shuffle  xor %[[D20]], %[[C32_I32]], %[[C64_I32]] : i32
+        // CHECK:        %[[D21:.+]] = vector.broadcast %[[SHUFFLERESULT_0]] : i32 to vector<1xi32>
+        // CHECK:        %[[D22:.+]] = vector.bitcast %[[D21]] : vector<1xi32> to vector<1xf32>
+        // CHECK:        %[[D23:.+]] = arith.maximumf %[[D22]], %[[D18]] : vector<1xf32>
+        // CHECK:        %[[D24:.+]] = vector.extract %[[D23]][0] : f32 from vector<1xf32>
+        // CHECK:        %[[D25:.+]] = arith.maximumf %[[D24]], %[[D1]] : f32
+        // CHECK:        %[[D26:.+]] = vector.insert %[[D25]], %[[CST]] [0] : f32 into vector<1xf32>
+        // CHECK:        %[[D27:.+]] = iree_vector_ext.to_simd %[[D26]] : vector<1xf32> -> vector<16xf32>
+        %result = vector.multi_reduction <maximumf>, %source, %init {
+                      "__vector_layout_test_anchor_operand_0" = #layout2d,
+                      "__vector_layout_test_anchor_operand_1" = #layout1d,
+                      "__vector_layout_test_anchor_result_0" = #layout1d
+                    } [0] : vector<16x16xf32> to vector<16xf32>
+        func.return %result : vector<16xf32>
+      }
+    }
+  }
 }
 
 #transpose_test_layout = #iree_vector_ext.layout<<[LANEY], [32]>, <[LANEX, VECTORX], [4, 4]>>
@@ -528,7 +561,7 @@ builtin.module attributes { transform.with_named_sequence } {
     transform.yield
   }
 }
- 
+
 // -----
 
 #row_layout = #iree_vector_ext.per_dim_layout<[BATCHX, LANEY, VECTORX], [2, 4, 4]>


### PR DESCRIPTION
The subgroup size for CDNA architectures is 64 whereas previous the shuffle was being done with 32 lanes
participating. This PR fixes that.

In the future, this information should be queried from the translation info.