### PR TITLE
Add timeouts to pytest cases in pkgci/iree_tests.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -71,4 +71,4 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
-          pytest SHARK-TestSuite/iree_tests -n 4 -rpfE
+          pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=60

--- a/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
@@ -69,4 +69,4 @@ jobs:
           IREE_TEST_CONFIG_FILES: experimental/regression_suite/external_test_suite/config_gpu_vulkan.json
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest SHARK-TestSuite/iree_tests -n 4 -rpfE
+          pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=60

--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -74,4 +74,4 @@ jobs:
           IREE_TEST_CONFIG_FILES: experimental/regression_suite/external_test_suite/config_cpu_llvm_sync.json
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest SHARK-TestSuite/iree_tests -n auto -rpfE
+          pytest SHARK-TestSuite/iree_tests -n auto -rpfE --timeout=60


### PR DESCRIPTION
When a test times out the error messages are basically useless (for the entire run, not just the specific test cases), since https://pypi.org/project/pytest-timeout/ terminates the test rather forcefully... but timing out is still better than running forever. For the test cases in https://github.com/openxla/iree/issues/16666 that timed out, I just excluded them from the test job configs.