### PR TITLE
Prefer broadcasting RHS over LHS in AVX-512 multiply-accumulate instructions

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -39,7 +39,7 @@ iree_uk_mmt4d_tile_f32f32f32_1x16x1_to_16x16x1_x86_64_avx512_base(
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
     IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
-      acc[i] = _mm512_fmadd_ps(_mm512_set1_ps(lhs_ptr[i]), rhs, acc[i]);
+      acc[i] = _mm512_fmadd_ps(rhs, _mm512_set1_ps(lhs_ptr[i]), acc[i]);
     }
     _mm_prefetch((const char*)(lhs_ptr + 128), _MM_HINT_T0);
     lhs_ptr += M0;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
@@ -32,10 +32,9 @@ iree_uk_mmt4d_tile_s8s8s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     rhs_ptr += 32;
     IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
-      acc[i] = _mm512_dpwssd_epi32(acc[i],
+      acc[i] = _mm512_dpwssd_epi32(acc[i], rhs,
                                    _mm512_cvtepi8_epi16(_mm256_set1_epi16(
-                                       *(const iree_uk_int16_t*)(lhs_ptr))),
-                                   rhs);
+                                       *(const iree_uk_int16_t*)(lhs_ptr))));
       lhs_ptr += 2;
     }
   }
@@ -160,7 +159,7 @@ iree_uk_mmt4d_tile_s16s16s32_1x16x2_to_16x16x2_x86_64_avx512_vnni(
     rhs_ptr += 32;
     IREE_UK_UNROLL for (int i = 0; i < M0; ++i) {
       acc[i] = _mm512_dpwssd_epi32(
-          acc[i], _mm512_set1_epi32(*(const iree_uk_int32_t*)lhs_ptr), rhs);
+          acc[i], rhs, _mm512_set1_epi32(*(const iree_uk_int32_t*)lhs_ptr));
       lhs_ptr += 2;
     }
   }


### PR DESCRIPTION
Some AVX-512 multiply-accumulate instructions have variants where the RHS is a `m32bcst`, which is, a 32-bit memory operand with implicit broadcast semantics. These save having to use a separate broadcast instruction so they are preferable.

Depending on each compiler version and each intrinsic, it may or may not make a difference which operand is passed as LHS/RHS, that is, some compilers are able to swap LHS<->RHS as needed to make this happen.

Compiler Explorer: https://godbolt.org/z/eh81x5qT8

Summary:

Compiler | `vfmadd231ps_broadcast_rhs` | `vfmadd231ps_broadcast_lhs` | `vpdpwssd_broadcast_rhs` | `vpdpwssd_broadcast_lhs`
--- | --- | --- | --- | ---
Clang trunk | ✅ | ✅ | ✅ | ✅
Clang 17 | ✅ | ✅ | ✅ | ❌
GCC trunk | ✅ | ✅ | ❌ | ❌
MSVC latest | ❌ | ❌ | ❌ | ❌

So... this PR helps at least on some Clang versions (which happen to include my native Clang-16 toolchain here on Ubuntu).

