### PR TITLE
Retry failed pytest cases to try limiting flakes.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -60,7 +60,7 @@ jobs:
       #   uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       #   with:
       #     repository: nod-ai/SHARK-TestSuite
-      #     ref: 00053290a576ae39aecb6fb2757b58fcd3b143f2
+      #     ref: 46ab63b271fddd78e071c0590e9a073f6282b005
       #     path: SHARK-TestSuite
       #     submodules: false
       # - name: Installing external TestSuite Python requirements
@@ -73,4 +73,4 @@ jobs:
       #   run: |
       #     source ${VENV_DIR}/bin/activate
       #     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
-      #     pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=60
+      #     pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=30 --retries=2

--- a/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 00053290a576ae39aecb6fb2757b58fcd3b143f2
+          ref: 46ab63b271fddd78e071c0590e9a073f6282b005
           path: SHARK-TestSuite
           submodules: false
       - name: Installing external TestSuite Python requirements
@@ -69,4 +69,4 @@ jobs:
           IREE_TEST_CONFIG_FILES: experimental/regression_suite/external_test_suite/config_gpu_vulkan.json
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=60
+          pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=30 --retries=2

--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 00053290a576ae39aecb6fb2757b58fcd3b143f2
+          ref: 46ab63b271fddd78e071c0590e9a073f6282b005
           path: SHARK-TestSuite
           submodules: false
       - name: Installing external TestSuite Python requirements
@@ -74,4 +74,4 @@ jobs:
           IREE_TEST_CONFIG_FILES: experimental/regression_suite/external_test_suite/config_cpu_llvm_sync.json
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest SHARK-TestSuite/iree_tests -n auto -rpfE --timeout=60
+          pytest SHARK-TestSuite/iree_tests -n auto -rpfE --timeout=30 --retries=2


### PR DESCRIPTION
This uses https://pypi.org/project/pytest-retry/ to retry failed tests. When we have 1000+ test cases running on real hardware with GPUs / accelerators, some runs are likely to have flakes. Hopefully failures like https://github.com/openxla/iree/actions/runs/8206978856/job/22447547947?pr=16706#step:9:54 will be quieter this way.

~~Unfortunately, that doesn't seem to compose well with https://pypi.org/project/pytest-timeout/ (a test that times out will not be retried, from what I can tell).~~ (maybe this isn't the case... can't quite tell from a few local and CI runs)

Bumped the commit ref to https://github.com/nod-ai/SHARK-TestSuite/commit/46ab63b271fddd78e071c0590e9a073f6282b005 to include the dep in requirements.txt and a small patch to be more compatible with pytest-retry.