### PR TITLE
Add optional attribute to set MFMA read layout

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -750,12 +750,16 @@ def SetContractionLayoutAttributes :
      DeclareOpInterfaceMethods<TransformOpInterface>]> {
   let description = [{
     Infers and sets the layout of the target contraction op based on the given
-    MFMA attribute.
+    MFMA attribute. The optional read_layout_indices attribute determines whether
+    to apply a modified version of the MFMA layout to the operands of
+    the contracts that enables loading a greater number of elements from LDS.
+    If empty, the read layout is not applied to any operand. 0 specifies
+    LHS and 1 RHS.
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-                       TransformParamTypeInterface:$mma_type);
-
+                       TransformParamTypeInterface:$mma_type,
+                       DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$read_layout_indices);
   let assemblyFormat = "$target `,` $mma_type attr-dict `:` type($target) `,` type($mma_type)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma.mlir
@@ -14,7 +14,9 @@ hal.executable private @attention {
         // CHECK-NOT: vector.contract
         // CHECK-NOT: iree_vector_ext.to_simd
         // CHECK-NOT: iree_vector_ext.to_simt
+        // CHECK-COUNT-8: vector.load {{.*}} : memref<16x16384x128xf16, #hal.descriptor_type<storage_buffer>>, vector<8xf16>
         // CHECK: scf.for {{.*}} = %c0 to %c16384 step %c64 {{.*}} -> (vector<2xf32>, vector<2xf32>, vector<8x2x4xf32>)
+        // CHECK-COUNT-16: vector.load {{.*}} : memref<64x128xf16, #gpu.address_space<workgroup>>, vector<8xf16>
         // CHECK-COUNT-128: amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32}
         %c0 = arith.constant 0 : index
         %scale = arith.constant 0.08838834764 : f16

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma_transform_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma_transform_spec.mlir
@@ -166,7 +166,7 @@ module attributes { transform.with_named_sequence } {
     %contract1, %contract2 = transform.split_handle %contracts : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
     %layout16x16x16 = transform.param.constant #layout -> !transform.any_param
-    transform.iree.set_contraction_layout_attributes %contract1, %layout16x16x16 : !transform.any_op, !transform.any_param
+    transform.iree.set_contraction_layout_attributes %contract1, %layout16x16x16 { read_layout_indices = array<i64: 0, 1> } : !transform.any_op, !transform.any_param
     transform.iree.set_contraction_layout_attributes %contract2, %layout16x16x16 : !transform.any_op, !transform.any_param
 
     %distribute_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op


### PR DESCRIPTION
This PR adds an optional attribute to set_contraction_layouts that sets another anchor to the defining op of the LHS and/or RHS operands of the contraction. The layout anchor is a modified version of the MFMA layout that reads double the number of elements as the MFMA layout but halves the batch. The user can specify whether to set it on the LHS(0), RHS(1) or both.