### PR TITLE
[LLVMGPU] Add support for KM_NK_MN contractions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -96,6 +96,7 @@ iree_compiler_cc_library(
         "LLVMGPUCastAddressSpaceFunction.cpp",
         "LLVMGPUCastTypeToFitMMA.cpp",
         "LLVMGPULowerExecutableTarget.cpp",
+        "LLVMGPUNormalizeContractMaps.cpp",
         "LLVMGPUPackSharedMemoryAlloc.cpp",
         "LLVMGPUPrefetching.cpp",
         "LLVMGPUSelectLoweringStrategy.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -81,6 +81,7 @@ iree_cc_library(
     "LLVMGPUCastAddressSpaceFunction.cpp"
     "LLVMGPUCastTypeToFitMMA.cpp"
     "LLVMGPULowerExecutableTarget.cpp"
+    "LLVMGPUNormalizeContractMaps.cpp"
     "LLVMGPUPackSharedMemoryAlloc.cpp"
     "LLVMGPUPrefetching.cpp"
     "LLVMGPUSelectLoweringStrategy.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUNormalizeContractMaps.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUNormalizeContractMaps.cpp
@@ -1,0 +1,113 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
+#include "iree/compiler/Codegen/LLVMGPU/PassDetail.h"
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+struct NormalizeContractionMaps : OpRewritePattern<vector::ContractionOp> {
+  NormalizeContractionMaps(MLIRContext *context, IREE::GPU::MmaAttr intrinsic,
+                           PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit), intrinsic(intrinsic) {}
+
+  LogicalResult matchAndRewrite(vector::ContractionOp contractOp,
+                                PatternRewriter &rewriter) const override {
+    VectorContractOpInfo opInfo(contractOp);
+    if (opInfo.getOpKind() != VectorContractOpInfo::OpKind::KM_NK_MN) {
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "already normalized contract kind");
+    }
+
+    auto srcCType = dyn_cast<VectorType>(contractOp.getAccType());
+    if (!srcCType) {
+      return rewriter.notifyMatchFailure(contractOp, "unhandled scalar case");
+    }
+
+    SmallVector<int64_t> perm = {1, 0};
+
+    MLIRContext *context = rewriter.getContext();
+    AffineExpr m, n, k;
+    bindDims(context, m, n, k);
+
+    using MapList = ArrayRef<ArrayRef<AffineExpr>>;
+    SmallVector<AffineMap> indexingMaps =
+        AffineMap::inferFromExprList(MapList{{m, k}, {k, n}, {m, n}}, context);
+
+    Location loc = contractOp.getLoc();
+    auto transposeAcc =
+        rewriter.create<vector::TransposeOp>(loc, contractOp.getAcc(), perm);
+    auto newContractOp = rewriter.create<vector::ContractionOp>(
+        loc, contractOp.getRhs(), contractOp.getLhs(), transposeAcc,
+        rewriter.getAffineMapArrayAttr(indexingMaps),
+        contractOp.getIteratorTypes());
+
+    rewriter.replaceOpWithNewOp<vector::TransposeOp>(contractOp, newContractOp,
+                                                     perm);
+    return success();
+  }
+
+private:
+  IREE::GPU::MmaAttr intrinsic;
+};
+
+struct LLVMGPUNormalizeContractMapsPass
+    : public LLVMGPUNormalizeContractMapsBase<
+          LLVMGPUNormalizeContractMapsPass> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
+    registry.insert<arith::ArithDialect>();
+  }
+
+  void runOnOperation() override {
+    auto func = getOperation();
+
+    llvm::StringLiteral scheduleAttrName =
+        IREE::GPU::MMAScheduleAttr::getMnemonic();
+    auto scheduleAttr =
+        func->getAttrOfType<IREE::GPU::MMAScheduleAttr>(scheduleAttrName);
+    if (!scheduleAttr) {
+      DictionaryAttr configDict = getTranslationInfo(func).getConfiguration();
+      scheduleAttr = dyn_cast_or_null<IREE::GPU::MMAScheduleAttr>(
+          configDict.get(scheduleAttrName));
+    }
+    if (!scheduleAttr) {
+      func.emitError() << "missing mma_schedule\n";
+      return signalPassFailure();
+    }
+
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<NormalizeContractionMaps>(context,
+                                           scheduleAttr.getIntrinsic());
+
+    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+std::unique_ptr<InterfacePass<FunctionOpInterface>>
+createLLVMGPUNormalizeContractMapsPass() {
+  return std::make_unique<LLVMGPUNormalizeContractMapsPass>();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -561,6 +561,8 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
 
   // Vector SIMD -> Vector SIMT
   nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMGPUNormalizeContractMapsPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createLLVMGPUCastTypeToFitMMAPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUVectorDistribute());
   nestedModulePM.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -95,6 +95,10 @@ createLLVMGPUSelectLoweringStrategyPass();
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createLLVMGPULowerExecutableTargetPass();
 
+/// Normalizes the indexing maps of contraction operaions.
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createLLVMGPUNormalizeContractMapsPass();
+
 // Pass to pack shared memory allocations in order to reduce shared memory
 // usage.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -95,7 +95,7 @@ createLLVMGPUSelectLoweringStrategyPass();
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createLLVMGPULowerExecutableTargetPass();
 
-/// Normalizes the indexing maps of contraction operaions.
+/// Normalizes the indexing maps of contraction operations.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMGPUNormalizeContractMapsPass();
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -66,8 +66,8 @@ def LLVMGPULowerExecutableTarget :
   let constructor = "mlir::iree_compiler::createLLVMGPULowerExecutableTargetPass()";
 }
 
-def LLVMGPUNormalizeContractMaps : InterfacePass<"iree-llvmgpu-normalize-contract-maps",
-                                            "mlir::FunctionOpInterface"> {
+def LLVMGPUNormalizeContractMaps :
+    InterfacePass<"iree-llvmgpu-normalize-contract-maps", "mlir::FunctionOpInterface"> {
   let summary = "Normalizes the indexing maps of contraction operations";
   let constructor = "mlir::iree_compiler::createLLVMGPUNormalizeContractMapsPass()";
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -66,6 +66,12 @@ def LLVMGPULowerExecutableTarget :
   let constructor = "mlir::iree_compiler::createLLVMGPULowerExecutableTargetPass()";
 }
 
+def LLVMGPUNormalizeContractMaps : InterfacePass<"iree-llvmgpu-normalize-contract-maps",
+                                            "mlir::FunctionOpInterface"> {
+  let summary = "Normalizes the indexing maps of contraction operations";
+  let constructor = "mlir::iree_compiler::createLLVMGPUNormalizeContractMapsPass()";
+}
+
 def LLVMGPUPackSharedMemoryAlloc :
     InterfacePass<"iree-llvmgpu-pack-shared-memory-alloc", "mlir::FunctionOpInterface"> {
   let summary = "Pass pack shared memory allocation in order to reduce memory usage.";

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
@@ -18,6 +18,8 @@ VectorContractOpInfo::getOperandMNIndex() const {
     return std::make_pair(0, 1);
   case OpKind::MK_NK_MN:
     return std::make_pair(0, 0);
+  case OpKind::KM_NK_MN:
+    return std::make_pair(1, 0);
   case OpKind::UNKNOWN:
     break;
   }
@@ -32,6 +34,8 @@ VectorContractOpInfo::getOperandKIndex() const {
     return std::make_pair(1, 0);
   case OpKind::MK_NK_MN:
     return std::make_pair(1, 1);
+  case OpKind::KM_NK_MN:
+    return std::make_pair(0, 1);
   case OpKind::UNKNOWN:
     break;
   }
@@ -62,6 +66,8 @@ VectorContractOpInfo::inferOpKind(MLIRContext *ctx,
     return OpKind::MK_KN_MN;
   if (maps == infer({{m, k}, {n, k}, {m, n}}))
     return OpKind::MK_NK_MN;
+  if (maps == infer({{k, m}, {n, k}, {m, n}}))
+    return OpKind::KM_NK_MN;
   return OpKind::UNKNOWN;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
@@ -48,6 +48,7 @@ VectorContractOpInfo::getResultMNIndex() const {
   switch (opKind) {
   case OpKind::MK_KN_MN:
   case OpKind::MK_NK_MN:
+  case OpKind::KM_NK_MN:
     return std::make_pair(0, 1);
   default:
     break;

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
@@ -11,7 +11,7 @@ namespace mlir::iree_compiler {
 /// A class for querying information about a contract op.
 class VectorContractOpInfo {
 public:
-  enum class OpKind { MK_KN_MN, MK_NK_MN, UNKNOWN };
+  enum class OpKind { MK_KN_MN, MK_NK_MN, KM_NK_MN, UNKNOWN };
 
   explicit VectorContractOpInfo(vector::ContractionOp op) {
     opKind = inferOpKind(op.getContext(), op.getIndexingMapsArray());


### PR DESCRIPTION
Enables certain transpose fusions. Handles this case by swapping the operands of the contraction and transposing the result. Does not change any default behavior for SDXL because this path is not yet exercised.