### PR TITLE
Set token permissions

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -17,6 +17,9 @@ on:
       # Short term feature branches:
       - sdxl
 
+permissions:
+  contents: read
+
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit

--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -39,24 +39,32 @@ jobs:
 
   regression_test_cpu:
     name: Regression Test CPU
+    permissions:
+      actions: read
     needs: [setup, build_packages]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_cpu')
     uses: ./.github/workflows/pkgci_regression_test_cpu.yml
 
   regression_test_amdgpu_vulkan:
     name: Regression Test AMDGPU-Vulkan
+    permissions:
+      actions: read
     needs: [setup, build_packages]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_vulkan')
     uses: ./.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
 
   regression_test_amdgpu_rocm:
     name: Regression Test AMDGPU-ROCm
+    permissions:
+      actions: read
     needs: [setup, build_packages]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_amdgpu_rocm')
     uses: ./.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
 
   test_tensorflow_cpu:
     name: Test TensorFlow CPU
+    permissions:
+      actions: read
     needs: [setup, build_packages]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_tensorflow_cpu')
     uses: ./.github/workflows/pkgci_test_tensorflow_cpu.yml

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -12,6 +12,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   linux_x86_64_release_packages:
     name: Linux Release (x86_64)

--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -17,10 +17,15 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   linux_x86_64:
     name: Linux (x86_64)
     runs-on: nodai-amdgpu-w7900-x86-64
+    permissions:
+      actions: read
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts

--- a/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
@@ -17,10 +17,15 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   linux_x86_64:
     name: Linux (x86_64)
     runs-on: nodai-amdgpu-w7900-x86-64
+    permissions:
+      actions: read
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts

--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -17,6 +17,9 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   linux_x86_64:
     name: Linux (x86_64)
@@ -26,6 +29,8 @@ jobs:
       - environment=prod
       - cpu
       - os-family=Linux
+    permissions:
+      actions: read
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts

--- a/.github/workflows/pkgci_test_tensorflow_cpu.yml
+++ b/.github/workflows/pkgci_test_tensorflow_cpu.yml
@@ -17,10 +17,15 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   linux_x86_64:
     name: Linux (x86_64)
     runs-on: ubuntu-20.04
+    permissions:
+      actions: read
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts


### PR DESCRIPTION
Sets the top level token permissions to `contents: write`. Furthermore,
`actions: read` is added to download artifacts, see [1].

[1] https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#get-an-artifact