### PR TITLE
[LLVMGPU] Fix fused elementwise broadcasts in mfma pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -154,7 +154,7 @@ static void populateWarpAndThreadIndices(RewriterBase &rewriter, Value threadId,
                                          NestedLayoutAttr vectorLayout,
                                          SmallVector<Value> &warpIndices,
                                          SmallVector<Value> &threadIndices) {
-  int64_t rank = vectorLayout.getSubgroupBasis().size();
+  int64_t subgroupRank = vectorLayout.getSubgroupBasis().size();
   // The delinearized thread IDs are returned from outer most to inner most,
   // i.e. before applying the layout described dimensions ordering.
   SmallVector<Value> threadIds =
@@ -167,9 +167,8 @@ static void populateWarpAndThreadIndices(RewriterBase &rewriter, Value threadId,
       filteredSubgroupIds.push_back(id);
   }
   SmallVector<Value> filteredThreadIds;
-  for (auto [id, active] :
-       llvm::zip(ArrayRef<Value>(threadIds).drop_front(rank),
-                 vectorLayout.getThreadActiveIds())) {
+  for (auto [id, active] : llvm::zip(llvm::drop_begin(threadIds, subgroupRank),
+                                     vectorLayout.getThreadActiveIds())) {
     if (active)
       filteredThreadIds.push_back(id);
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -371,7 +371,7 @@ builtin.module attributes { transform.with_named_sequence } {
   elements_per_thread     = [4],
 
   subgroup_basis          = [2, 2],
-  subgroup_active_ids       = [false, true],
+  subgroup_active_ids     = [false, true],
   thread_basis            = [4, 16],
   thread_active_ids       = [false, true]
 >


### PR DESCRIPTION
Previously the id helper for transfer reads wasn't correctly selecting the active ids from the delinearized ids.