### PR TITLE
Update 'iree-samples' -> 'iree-experimental' after rename.

### DIFF
--- a/build_tools/python/e2e_test_framework/models/torch_models.py
+++ b/build_tools/python/e2e_test_framework/models/torch_models.py
@@ -12,10 +12,10 @@ from e2e_test_framework.definitions import common_definitions
 import e2e_test_framework.models.utils as model_utils
 
 # Implementations of the models listed below can be found in
-# https://github.com/iree-org/iree-samples/tree/main/iree-torch/importer.
+# https://github.com/iree-org/iree-experimental/tree/main/iree-torch/library/models.
 # We import the PyTorch models offline and make the .mlir available here for benchmarking.
 # If the mlir artifacts need to be updated, please run
-# https://github.com/iree-org/iree-samples/blob/main/iree-torch/importer/update_torch_models.sh
+# https://github.com/iree-org/iree-experimental/blob/main/iree-torch/library/import_torch_models.sh
 # Then update the `source_url` below with the new paths.
 
 # `ClipTextModel` encodes text into an embedding.

--- a/docs/website/docs/community/index.md
+++ b/docs/website/docs/community/index.md
@@ -2,10 +2,12 @@
 
 Projects built by community members:
 
-* The [SHARK](https://github.com/nod-ai/SHARK) project from
-  [nod.ai](https://nod.ai/) uses a forked version of IREE
-  ([SHARK-Runtime](https://github.com/nod-ai/SHARK-Runtime)), offering
-  highly tuned performance on a large corpus of machine learning programs.
+* The [SHARK](https://github.com/nod-ai/SHARK) and
+  [SRT](https://github.com/nod-ai/SRT) projects offer highly tuned performance
+  and user interfaces for running a large corpus of machine learning programs.
+
+* The [SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine) project provides
+  tools for bridging between PyTorch and IREE.
 
 * The [IREE Bare-Metal Arm Sample](https://github.com/iml130/iree-bare-metal-arm)
   shows how to build IREE with the
@@ -20,13 +22,9 @@ Projects built by community members:
 Official repositories:
 
 * [iree-jax](https://github.com/iree-org/iree-jax) is home to
-  IREE's support for [JAX](https://github.com/google/jax) programs.
+  IREE's AOT support for [JAX](https://github.com/google/jax) programs.
 
-* [iree-torch](https://github.com/iree-org/iree-torch) contains
-  IREE's [PyTorch](https://pytorch.org/) frontend, leveraging the
-  [torch-mlir](https://github.com/llvm/torch-mlir) project.
-
-* [iree-samples](https://github.com/iree-org/iree-samples)
+* [iree-experimental](https://github.com/iree-org/iree-experimental)
   includes various samples and prototypes built with IREE.
 
 * [iree-llvm-sandbox](https://github.com/iree-org/iree-llvm-sandbox)

--- a/docs/website/docs/developers/debugging/integration-tests.md
+++ b/docs/website/docs/developers/debugging/integration-tests.md
@@ -27,20 +27,21 @@ arguments, and replace `flow.dispatch.tensor.store` with `return` op.
 
 Note: This only works when dispatch formation logics are identical between runs.
 
-## iree-samples repository tests
+## iree-experimental repository tests
 
-Follow [README](https://github.com/iree-org/iree-samples#readme) to run the model.
-The MLIR files will be generated. You'll find the saved file from log. E.g.,
+Follow [README](https://github.com/iree-org/iree-experimental#readme) to run the
+model. The MLIR files will be generated. You'll find the saved file from log.
+E.g.,
 
 ``` shell
 [ RUN      ] MobilenetV2Int8Test.test_compile_tflite
 I0401 17:27:04.084272 140182373025024 test_util.py:119] Setting up for IREE
 I0401 17:27:04.085064 140182373025024 binaries.py:218] Invoke IREE Pipeline:
-  /tmp/iree-samples/iree-samples.venv/lib/python3.9/site-packages/iree/tools/tflite/iree-import-tflite
-    /tmp/iree-samples/tflitehub/tmp/mobilenet_v2_int8_test.py/model.tflite
+  /tmp/iree-experimental/iree-experimental.venv/lib/python3.9/site-packages/iree/tools/tflite/iree-import-tflite
+    /tmp/iree-experimental/tflitehub/tmp/mobilenet_v2_int8_test.py/model.tflite
     --mlir-print-debuginfo
-    --save-temp-tfl-input=/tmp/iree-samples/tflitehub/tmp/mobilenet_v2_int8_test.py/tflite.mlir
-    --save-temp-iree-input=/tmp/iree-samples/tflitehub/tmp/mobilenet_v2_int8_test.py/tosa.mlir
+    --save-temp-tfl-input=/tmp/iree-experimental/tflitehub/tmp/mobilenet_v2_int8_test.py/tflite.mlir
+    --save-temp-iree-input=/tmp/iree-experimental/tflitehub/tmp/mobilenet_v2_int8_test.py/tosa.mlir
 ```
 
 Unfortunately, the artifacts are not dumped in the runs. There is an

--- a/docs/website/docs/developers/general/developer-overview.md
+++ b/docs/website/docs/developers/general/developer-overview.md
@@ -24,7 +24,7 @@ developers.
 * [/tools/](https://github.com/openxla/iree/blob/main/tools/):
   Developer tools (`iree-compile`, `iree-run-module`, etc.)
 * [/samples/](https://github.com/openxla/iree/blob/main/samples/): Also see the
-  separate <https://github.com/iree-org/iree-samples> repository
+  separate <https://github.com/iree-org/iree-experimental> repository
 
 ## IREE compiler code layout
 

--- a/docs/website/docs/guides/ml-frameworks/index.md
+++ b/docs/website/docs/guides/ml-frameworks/index.md
@@ -39,7 +39,7 @@ Importing from other frameworks is planned - stay tuned!
 Check out the samples in IREE's
 [`samples/` directory](https://github.com/openxla/iree/tree/main/samples),
 as well as the
-[iree-samples repository](https://github.com/iree-org/iree-samples).
+[iree-experimental repository](https://github.com/iree-org/iree-experimental).
 
 ## :octicons-package-dependents-16: Export/Import
 

--- a/docs/website/docs/guides/ml-frameworks/tflite.md
+++ b/docs/website/docs/guides/ml-frameworks/tflite.md
@@ -200,8 +200,9 @@ print(iree_results)
 ## :octicons-code-16: Samples
 
 * The
-[tflitehub folder](https://github.com/iree-org/iree-samples/tree/main/tflitehub)
-in the [iree-samples repository](https://github.com/iree-org/iree-samples)
+[tflitehub folder](https://github.com/iree-org/iree-experimental/tree/main/tflitehub)
+in the
+[iree-experimental repository](https://github.com/iree-org/iree-experimental)
 contains test scripts to compile, run, and compare various TensorFlow Lite
 models sourced from [TensorFlow Hub](https://tfhub.dev/).
 

--- a/docs/website/docs/reference/bindings/c-api.md
+++ b/docs/website/docs/reference/bindings/c-api.md
@@ -485,7 +485,7 @@ hardware devices like CPUs, GPUs and other accelerators.
 [iree-org/iree-template-runtime-cmake](https://github.com/iree-org/iree-template-runtime-cmake/) | [`hello_world.c`](https://github.com/iree-org/iree-template-runtime-cmake/blob/main/hello_world.c) | Runtime application template
 [openxla/iree](https://github.com/openxla/iree/) | [`runtime/demo/`](https://github.com/openxla/iree/blob/main/runtime/src/iree/runtime/demo/) | In-tree demos of the high level runtime API
 [openxla/iree](https://github.com/openxla/iree/) | [`samples/`](https://github.com/openxla/iree/tree/main/samples) | In-tree sample applications
-[iree-org/iree-samples](https://github.com/iree-org/iree-samples/) | [`runtime-library/`](https://github.com/iree-org/iree-samples/tree/main/runtime-library) | Shared runtime library builder<br>Builds `libireert.so` to aid development
+[iree-org/iree-experimental](https://github.com/iree-org/iree-experimental/) | [`runtime-library/`](https://github.com/iree-org/iree-experimental/tree/main/runtime-library) | Shared runtime library builder<br>Builds `libireert.so` to aid development
 [iml130/iree-template-cpp](https://github.com/iml130/iree-template-cpp) | [`simple_embedding.c`](https://github.com/iml130/iree-template-cpp/blob/main/iree_simple_embedding/simple_embedding.c) | Demo integration into a project
 
 ## Compiler + Runtime = JIT

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -153,8 +153,9 @@ print("Results:", results)
 
 Check out the samples in IREE's
 [samples/colab/ directory](https://github.com/openxla/iree/tree/main/samples/colab)
-and the [iree-samples repository](https://github.com/iree-org/iree-samples) for
-examples using the Python APIs.
+and the
+[iree-experimental repository](https://github.com/iree-org/iree-experimental)
+for examples using the Python APIs.
 
 ### :material-console: Console scripts
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,3 +1,4 @@
 # IREE Samples
 
-Also see the [iree-samples](https://github.com/iree-org/iree-samples) repository.
+Also see the [iree-experimental](https://github.com/iree-org/iree-experimental)
+repository.

--- a/samples/vision_inference/README.md
+++ b/samples/vision_inference/README.md
@@ -3,8 +3,8 @@
 This sample demonstrates how to run a MNIST handwritten digit detection vision
 model on an image using IREE's command line tools.
 
-A similar sample is implemented in C code over in the iree-samples repository
-at https://github.com/iree-org/iree-samples/tree/main/cpp/vision_inference
+A similar sample is implemented in C code over in the iree-experimental repository
+at https://github.com/iree-org/iree-experimental/tree/main/cpp/vision_inference
 
 * This version of the sample uses a Python script to convert an image into the
   expected format then runs the compiled MNIST program through IREE's command


### PR DESCRIPTION
The repo was renamed: https://github.com/iree-org/iree-experimental

Also updated a few docs:
* Dropped reference to iree-torch in favor of SHARK-Turbine
* Fixed a few dead links

skip-ci: comment/doc only change