### PR TITLE
Make use of `tileAndDistributeToWorkgroups` pass.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -721,32 +721,39 @@ void addGPUBaseLoweringPassPipeline(OpPassManager &pm) {
 }
 
 void addGPUImplicitGEMMPassPipeline(OpPassManager &pm) {
-  auto &nestedModulePM = pm.nest<ModuleOp>();
-  nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUIm2ColPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(createTileUsingForallPass(0));
-  nestedModulePM.addPass(createCanonicalizerPass());
-  nestedModulePM.addPass(createCSEPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createLLVMGPUTileMatmulAndFuseImg2ColPass(1));
-  nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUPadIGemmPass());
-  nestedModulePM.addPass(createCanonicalizerPass());
-  nestedModulePM.addPass(createCSEPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createLLVMGPURewritePadInDestinationPassingStylePass());
+  {
+    auto &nestedModulePM = pm.nest<ModuleOp>();
+    nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUIm2ColPass());
+    tileAndDistributeToWorkgroup(pm);
+  }
 
-  // TODO: Add distribution on threads
-  // TODO: Add vectorization.
-  // TODO: Check if it works with existing bufferization passes.
+  {
+    auto &nestedModulePM = pm.nest<ModuleOp>();
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createLLVMGPUTileMatmulAndFuseImg2ColPass(1));
+    nestedModulePM.addPass(createCanonicalizerPass());
+    nestedModulePM.addPass(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUPadIGemmPass());
+    nestedModulePM.addPass(createCanonicalizerPass());
+    nestedModulePM.addPass(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createLLVMGPURewritePadInDestinationPassingStylePass());
 
-  addBufferizePasses(nestedModulePM);
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      IREE::LinalgExt::createLinalgExtToLoopsPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createRemoveSingleIterationLoopPass());
-  nestedModulePM.addPass(createCanonicalizerPass());
-  nestedModulePM.addPass(createCSEPass());
+    // TODO: Add distribution on threads
+    // TODO: Add vectorization.
+    // TODO: Check if it works with existing bufferization passes.
+
+    addBufferizePasses(nestedModulePM);
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        IREE::LinalgExt::createLinalgExtToLoopsPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createConvertLinalgToLoopsPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createRemoveSingleIterationLoopPass());
+    nestedModulePM.addPass(createCanonicalizerPass());
+    nestedModulePM.addPass(createCSEPass());
+  }
 }
 
 // Add passes to make the address computation more explicit and optimize them.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLowerExecutableTarget.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -17,6 +18,8 @@
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+
+#define DEBUG_TYPE "iree-rocdl-lower-executable-target"
 
 namespace mlir::iree_compiler {
 
@@ -65,6 +68,11 @@ public:
       variantOp.emitOpError("unsupported pipeline on ROCDL target");
       return signalPassFailure();
     }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Running pipeline : ";
+      pipeline.dump();
+    });
 
     if (failed(runPipeline(pipeline, variantOp))) {
       return signalPassFailure();


### PR DESCRIPTION
This avoids using custom fusion passes.