### PR TITLE
[hip] Introduce options to control load of libamdhip64.so.

### DIFF
--- a/runtime/src/iree/base/internal/dynamic_library.h
+++ b/runtime/src/iree/base/internal/dynamic_library.h
@@ -73,6 +73,13 @@ iree_status_t iree_dynamic_library_attach_symbols_from_file(
 iree_status_t iree_dynamic_library_attach_symbols_from_memory(
     iree_dynamic_library_t* library, iree_const_byte_span_t buffer);
 
+// Queries the operating system for the for the full path of the dynamic
+// library in which |for_symbol| is located. For symbols not in a dynamic
+// library, the behavior is implementation dependent (i.e. it may return
+// a failure status or it may return a path to an executable, etc).
+iree_status_t iree_dynamic_library_get_symbol_path(
+    void* for_symbol, iree_string_builder_t* out_path);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/runtime/src/iree/base/internal/dynamic_library.h
+++ b/runtime/src/iree/base/internal/dynamic_library.h
@@ -78,7 +78,7 @@ iree_status_t iree_dynamic_library_attach_symbols_from_memory(
 // library, the behavior is implementation dependent (i.e. it may return
 // a failure status or it may return a path to an executable, etc).
 iree_status_t iree_dynamic_library_get_symbol_path(
-    void* for_symbol, iree_string_builder_t* out_path);
+    void* for_symbol, iree_string_builder_t* builder);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/base/internal/dynamic_library.h
+++ b/runtime/src/iree/base/internal/dynamic_library.h
@@ -77,7 +77,7 @@ iree_status_t iree_dynamic_library_attach_symbols_from_memory(
 // library in which |for_symbol| is located. For symbols not in a dynamic
 // library, the behavior is implementation dependent (i.e. it may return
 // a failure status or it may return a path to an executable, etc).
-iree_status_t iree_dynamic_library_get_symbol_path(
+iree_status_t iree_dynamic_library_append_symbol_path_to_builder(
     void* for_symbol, iree_string_builder_t* builder);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/base/internal/dynamic_library_posix.c
+++ b/runtime/src/iree/base/internal/dynamic_library_posix.c
@@ -331,7 +331,7 @@ iree_status_t iree_dynamic_library_attach_symbols_from_memory(
   return iree_ok_status();
 }
 
-iree_status_t iree_dynamic_library_get_symbol_path(
+iree_status_t iree_dynamic_library_append_symbol_path_to_builder(
     void* symbol, iree_string_builder_t* builder) {
   Dl_info dl_info;
   if (dladdr((void*)symbol, &dl_info) == 0) {

--- a/runtime/src/iree/base/internal/dynamic_library_posix.c
+++ b/runtime/src/iree/base/internal/dynamic_library_posix.c
@@ -337,7 +337,6 @@ iree_status_t iree_dynamic_library_get_symbol_path(
   if (dladdr((void*)symbol, &dl_info) == 0) {
     return iree_make_status(IREE_STATUS_NOT_FOUND);
   }
-  iree_string_builder_reset(out_path);
   return iree_string_builder_append_cstring(out_path, dl_info.dli_fname);
 }
 

--- a/runtime/src/iree/base/internal/dynamic_library_posix.c
+++ b/runtime/src/iree/base/internal/dynamic_library_posix.c
@@ -332,12 +332,12 @@ iree_status_t iree_dynamic_library_attach_symbols_from_memory(
 }
 
 iree_status_t iree_dynamic_library_get_symbol_path(
-    void* symbol, iree_string_builder_t* out_path) {
+    void* symbol, iree_string_builder_t* builder) {
   Dl_info dl_info;
   if (dladdr((void*)symbol, &dl_info) == 0) {
     return iree_make_status(IREE_STATUS_NOT_FOUND);
   }
-  return iree_string_builder_append_cstring(out_path, dl_info.dli_fname);
+  return iree_string_builder_append_cstring(builder, dl_info.dli_fname);
 }
 
 #endif  // IREE_PLATFORM_*

--- a/runtime/src/iree/base/internal/dynamic_library_posix.c
+++ b/runtime/src/iree/base/internal/dynamic_library_posix.c
@@ -4,6 +4,10 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// Needed to access dladdr on Linux. On MacOS, does nothing (available by
+// default).
+#define _GNU_SOURCE
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -325,6 +329,16 @@ iree_status_t iree_dynamic_library_attach_symbols_from_file(
 iree_status_t iree_dynamic_library_attach_symbols_from_memory(
     iree_dynamic_library_t* library, iree_const_byte_span_t buffer) {
   return iree_ok_status();
+}
+
+iree_status_t iree_dynamic_library_get_symbol_path(
+    void* symbol, iree_string_builder_t* out_path) {
+  Dl_info dl_info;
+  if (dladdr((void*)symbol, &dl_info) == 0) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND);
+  }
+  iree_string_builder_reset(out_path);
+  return iree_string_builder_append_cstring(out_path, dl_info.dli_fname);
 }
 
 #endif  // IREE_PLATFORM_*

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -319,7 +319,7 @@ iree_status_t iree_dynamic_library_lookup_symbol(
   return iree_ok_status();
 }
 
-iree_status_t iree_dynamic_library_get_symbol_path(
+iree_status_t iree_dynamic_library_append_symbol_path_to_builder(
     void* symbol, iree_string_builder_t* builder) {
   HMODULE hm = NULL;
   if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -332,7 +332,7 @@ iree_status_t iree_dynamic_library_get_symbol_path(
   IREE_RETURN_IF_ERROR(iree_string_builder_reserve(out_path, 64));
   while (1) {
     out_path->size =
-        ::GetModuleFileNameA(hm, out_path->buffer, out_path->capacity);
+        GetModuleFileNameA(hm, out_path->buffer, out_path->capacity);
     if (out_path->size == 0) {
       return iree_make_status(IREE_STATUS_NOT_FOUND);
     }

--- a/runtime/src/iree/base/string_builder.c
+++ b/runtime/src/iree/base/string_builder.c
@@ -248,10 +248,12 @@ IREE_API_EXPORT iree_status_t iree_string_pair_builder_emplace_string(
   if (builder->temp_strings_size == builder->temp_strings_capacity) {
     // Resize.
     builder->temp_strings_capacity = iree_max(8, builder->pairs_capacity * 2);
+    char** realloced = builder->temp_strings;
     IREE_RETURN_IF_ERROR(iree_allocator_realloc(
         builder->allocator,
         builder->temp_strings_capacity * sizeof(builder->temp_strings[0]),
-        (void**)&builder->temp_strings));
+        (void**)&realloced));
+    builder->temp_strings = realloced;
   }
 
   char* alloced = NULL;

--- a/runtime/src/iree/base/string_builder.c
+++ b/runtime/src/iree/base/string_builder.c
@@ -247,12 +247,13 @@ IREE_API_EXPORT iree_status_t iree_string_pair_builder_emplace_string(
     iree_string_pair_builder_t* builder, iree_string_view_t* inout_string) {
   if (builder->temp_strings_size == builder->temp_strings_capacity) {
     // Resize.
-    builder->temp_strings_capacity = iree_max(8, builder->pairs_capacity * 2);
+    iree_host_size_t new_capacity =
+        iree_max(8, builder->temp_strings_capacity * 2);
     char** realloced = builder->temp_strings;
     IREE_RETURN_IF_ERROR(iree_allocator_realloc(
-        builder->allocator,
-        builder->temp_strings_capacity * sizeof(builder->temp_strings[0]),
+        builder->allocator, new_capacity * sizeof(builder->temp_strings[0]),
         (void**)&realloced));
+    builder->temp_strings_capacity = new_capacity;
     builder->temp_strings = realloced;
   }
 

--- a/runtime/src/iree/base/string_builder.h
+++ b/runtime/src/iree/base/string_builder.h
@@ -131,6 +131,46 @@ IREE_API_EXPORT IREE_PRINTF_ATTRIBUTE(2, 3) iree_status_t
     iree_string_builder_append_format(iree_string_builder_t* builder,
                                       const char* format, ...);
 
+// Lightweight builder for lists of iree_string_pair_t.
+// Includes a side pool for keeping dynamically allocated strings, since it is
+// common to need to create backed, temporary strings when constructing lists
+// of views.
+typedef struct iree_string_pair_builder_t {
+  // Allocator used for buffer storage.
+  iree_allocator_t allocator;
+
+  // Pairs being assembled.
+  iree_string_pair_t* pairs;
+  iree_host_size_t pairs_size;
+  iree_host_size_t pairs_capacity;
+
+  char** temp_strings;
+  iree_host_size_t temp_strings_size;
+  iree_host_size_t temp_strings_capacity;
+} iree_string_pair_builder_t;
+
+// Initializes a string pair builder in |out_builder| with the given
+// |allocator|.
+IREE_API_EXPORT void iree_string_pair_builder_initialize(
+    iree_allocator_t allocator, iree_string_pair_builder_t* out_builder);
+
+// Deinitializes |builder| and releases allocated storage.
+IREE_API_EXPORT void iree_string_pair_builder_deinitialize(
+    iree_string_pair_builder_t* builder);
+
+// Adds a string pair to |builder|.
+IREE_API_EXPORT iree_status_t iree_string_pair_builder_add(
+    iree_string_pair_builder_t* builder, iree_string_pair_t pair);
+
+// Adds a string/int pair to |builder|.
+IREE_API_EXPORT iree_status_t iree_string_pair_builder_add_int(
+    iree_string_pair_builder_t* builder, iree_string_view_t key, int value);
+
+// Adds a string to the list of temporary allocated strings, updating the
+// |inout_string| to be the allocated version.
+IREE_API_EXPORT iree_status_t iree_string_pair_builder_alloc_string(
+    iree_string_pair_builder_t* builder, iree_string_view_t* inout_string);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/base/string_builder.h
+++ b/runtime/src/iree/base/string_builder.h
@@ -106,6 +106,33 @@ IREE_API_EXPORT IREE_MUST_USE_RESULT char* iree_string_builder_take_storage(
 IREE_API_EXPORT iree_status_t iree_string_builder_reserve(
     iree_string_builder_t* builder, iree_host_size_t minimum_capacity);
 
+// Reserves storage for at least |minimum_additional_capacity| beyond the
+// current size. Return a pointer in |out_buffer| that can have up to
+// |out_capacity| characters written to it. Generally, any contents added
+// in this way should be committed upon success via
+// |iree_string_builder_commit_append|.
+// Always reserves one extra char than requested for a NUL, to be added by
+// a subsequent call to |iree_string_builder_commit_append|.
+// This function is not recommended for general use (prefer
+// |iree_string_builder_append_inline|) but is provided to ease interop with OS
+// functions that return strings/capacities in loops until given a big enough
+// buffer.
+IREE_API_EXPORT iree_status_t iree_string_builder_reserve_for_append(
+    iree_string_builder_t* builder,
+    iree_host_size_t minimum_additional_capacity, char** out_buffer,
+    iree_host_size_t* out_capacity);
+
+// Resizes the string builder after direct modification of the backing buffer
+// has been performed (i.e. via |iree_string_builder_reserve_for_append| or
+// equivalent). It is illegal to resize the builder to a size greater than has
+// been reserved.
+// This function is not recommended for general use (prefer
+// |iree_string_builder_append_inline|) but is provided to ease interop with OS
+// functions that return strings/capacities in loops until given a big enough
+// buffer.
+IREE_API_EXPORT void iree_string_builder_commit_append(
+    iree_string_builder_t* builder, iree_host_size_t append_size);
+
 // Resets the string builder length to 0 without releasing storage.
 IREE_API_EXPORT void iree_string_builder_reset(iree_string_builder_t* builder);
 
@@ -158,17 +185,30 @@ IREE_API_EXPORT void iree_string_pair_builder_initialize(
 IREE_API_EXPORT void iree_string_pair_builder_deinitialize(
     iree_string_pair_builder_t* builder);
 
+// Gets the array of pairs under construction, which is guaranteed to be
+// valid until the builder is modified. This will be NULL if empty.
+static inline iree_string_pair_t* iree_string_pair_builder_pairs(
+    iree_string_pair_builder_t* builder) {
+  return builder->pairs;
+}
+
+// Gets the size of the pairs under construction.
+static inline iree_host_size_t iree_string_pair_builder_size(
+    iree_string_pair_builder_t* builder) {
+  return builder->pairs_size;
+}
+
 // Adds a string pair to |builder|.
 IREE_API_EXPORT iree_status_t iree_string_pair_builder_add(
     iree_string_pair_builder_t* builder, iree_string_pair_t pair);
 
 // Adds a string/int pair to |builder|.
-IREE_API_EXPORT iree_status_t iree_string_pair_builder_add_int(
-    iree_string_pair_builder_t* builder, iree_string_view_t key, int value);
+IREE_API_EXPORT iree_status_t iree_string_pair_builder_add_int32(
+    iree_string_pair_builder_t* builder, iree_string_view_t key, int32_t value);
 
 // Adds a string to the list of temporary allocated strings, updating the
 // |inout_string| to be the allocated version.
-IREE_API_EXPORT iree_status_t iree_string_pair_builder_alloc_string(
+IREE_API_EXPORT iree_status_t iree_string_pair_builder_emplace_string(
     iree_string_pair_builder_t* builder, iree_string_view_t* inout_string);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/drivers/hip/api.h
+++ b/runtime/src/iree/hal/drivers/hip/api.h
@@ -102,6 +102,20 @@ typedef struct iree_hal_hip_driver_options_t {
   // The index of the default HIP device to use within the list of available
   // devices.
   int default_device_index;
+
+  // List of paths to guide searching for the dynamic libamdhip64.so (or
+  // amdhip64.dll), which contains the backing HIP runtime library. If this
+  // is present, it overrides any other mechanism for finding the HIP runtime
+  // library. Default search heuristics are used (i.e. ask the system to find an
+  // appropriately named library) if there are zero entries.
+  // Each entry can be:
+  //
+  // * Directory in which to find a platform specific runtime library
+  //   name.
+  // * Specific fully qualified path to a file that will be loaded with no
+  //   further interpretation if the entry starts with "file:".
+  iree_string_view_t* hip_lib_search_paths;
+  iree_host_size_t hip_lib_search_path_count;
 } iree_hal_hip_driver_options_t;
 
 // Initializes the given |out_options| with default driver creation options.

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
@@ -155,7 +155,7 @@ iree_status_t iree_hal_hip_dynamic_symbols_initialize(
       status = iree_make_status(
           IREE_STATUS_UNAVAILABLE,
           "HIP runtime library 'amdhip64.dll'/'libamdhip64.so' not available: "
-          "please ensure installed and in dynamic library search path:%*.s",
+          "please ensure installed and in dynamic library search path:%.*s",
           (int)error_detail.size, error_detail.data);
     }
   }

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
@@ -65,7 +65,7 @@ static bool iree_hal_hip_try_load_dylib(const char* file_path,
   iree_host_size_t length = 0;
   if (iree_status_to_string(status, &allocator, &buffer, &length)) {
     iree_status_ignore(iree_string_builder_append_format(
-        error_builder, "\n  Tried: %s\n    %s", file_path, buffer));
+        error_builder, "\n  Tried: %s\n    %.*s", file_path, length, buffer));
     iree_allocator_free(allocator, buffer);
   }
 
@@ -145,18 +145,16 @@ iree_status_t iree_hal_hip_dynamic_symbols_initialize(
     iree_string_builder_deinitialize(&path_builder);
   }
 
-  iree_status_t pending_fail_status = iree_make_status(
-      IREE_STATUS_UNAVAILABLE,
-      "HIP runtime library 'amdhip64.dll'/'libamdhip64.so' not available: "
-      "please ensure installed and in dynamic library search path");
-
   if (iree_status_is_ok(status)) {
     if (loaded_one) {
       status = iree_hal_hip_dynamic_symbols_resolve_all(out_syms);
-      iree_status_ignore(pending_fail_status);
     } else {
       iree_string_view_t error_detail =
           iree_string_builder_view(&error_builder);
+      fprintf(stderr, "BUILDER: %.*s\n",
+              iree_string_builder_size(&error_builder),
+              iree_string_builder_buffer(&error_builder));
+      fprintf(stderr, "BUILDER: %.*s\n", error_detail.size, error_detail.data);
       status = iree_make_status(
           IREE_STATUS_UNAVAILABLE,
           "HIP runtime library 'amdhip64.dll'/'libamdhip64.so' not available: "

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
@@ -65,7 +65,8 @@ static bool iree_hal_hip_try_load_dylib(const char* file_path,
   iree_host_size_t length = 0;
   if (iree_status_to_string(status, &allocator, &buffer, &length)) {
     iree_status_ignore(iree_string_builder_append_format(
-        error_builder, "\n  Tried: %s\n    %.*s", file_path, length, buffer));
+        error_builder, "\n  Tried: %s\n    %.*s", file_path, (int)length,
+        buffer));
     iree_allocator_free(allocator, buffer);
   }
 
@@ -151,10 +152,6 @@ iree_status_t iree_hal_hip_dynamic_symbols_initialize(
     } else {
       iree_string_view_t error_detail =
           iree_string_builder_view(&error_builder);
-      fprintf(stderr, "BUILDER: %.*s\n",
-              iree_string_builder_size(&error_builder),
-              iree_string_builder_buffer(&error_builder));
-      fprintf(stderr, "BUILDER: %.*s\n", error_detail.size, error_detail.data);
       status = iree_make_status(
           IREE_STATUS_UNAVAILABLE,
           "HIP runtime library 'amdhip64.dll'/'libamdhip64.so' not available: "

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
@@ -155,7 +155,7 @@ iree_status_t iree_hal_hip_dynamic_symbols_initialize(
       status = iree_make_status(
           IREE_STATUS_UNAVAILABLE,
           "HIP runtime library 'amdhip64.dll'/'libamdhip64.so' not available: "
-          "please ensure installed and in dynamic library search path:%.*s",
+          "please ensure installed and in dynamic library search path: %.*s",
           (int)error_detail.size, error_detail.data);
     }
   }
@@ -183,5 +183,6 @@ iree_status_t iree_hal_hip_dynamic_symbols_append_path_to_builder(
     return iree_make_status(IREE_STATUS_NOT_FOUND);
   }
   // Specific choice of symbol is not important.
-  return iree_dynamic_library_get_symbol_path(syms->hipDeviceGet, out_path);
+  return iree_dynamic_library_append_symbol_path_to_builder(syms->hipDeviceGet,
+                                                            out_path);
 }

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.h
@@ -45,14 +45,36 @@ typedef struct iree_hal_hip_dynamic_symbols_t {
 // Initializes |out_syms| in-place with dynamically loaded HIP symbols.
 // iree_hal_hip_dynamic_symbols_deinitialize must be used to release the
 // library resources.
+//
+// If |hip_lib_search_path_count| is non zero, then |hip_lib_search_paths|
+// is a list of paths to guide searching for the dynamic libamdhip64.so (or
+// amdhip64.dll), which contains the backing HIP runtime library. If this
+// is present, it overrides any other mechanism for finding the HIP runtime
+// library. Default search heuristics are used (i.e. ask the system to find an
+// appropriately named library) if there are zero entries.
+// Each entry can be:
+//
+// * Directory in which to find a platform specific runtime library
+//   name.
+// * Specific fully qualified path to a file that will be loaded with no
+//   further interpretation if the entry starts with "file:".
 iree_status_t iree_hal_hip_dynamic_symbols_initialize(
-    iree_allocator_t host_allocator, iree_hal_hip_dynamic_symbols_t* out_syms);
+    iree_allocator_t host_allocator, iree_host_size_t hip_lib_search_path_count,
+    const iree_string_view_t* hip_lib_search_paths,
+    iree_hal_hip_dynamic_symbols_t* out_syms);
 
 // Deinitializes |syms| by unloading the backing library. All function pointers
 // will be invalidated. They _may_ still work if there are other reasons the
 // library remains loaded so be careful.
 void iree_hal_hip_dynamic_symbols_deinitialize(
     iree_hal_hip_dynamic_symbols_t* syms);
+
+// Gets the absolute path of the shared library or DLL providing the dynamic
+// symbols. If not loaded from a shared library, the exact behavior is
+// implementation dependent (i.e. it may return a failure status or it may
+// return a path to an executable, etc).
+iree_status_t iree_hal_hip_dynamic_symbols_get_path(
+    iree_hal_hip_dynamic_symbols_t* syms, iree_string_builder_t* out_path);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.h
@@ -73,7 +73,7 @@ void iree_hal_hip_dynamic_symbols_deinitialize(
 // symbols. If not loaded from a shared library, the exact behavior is
 // implementation dependent (i.e. it may return a failure status or it may
 // return a path to an executable, etc).
-iree_status_t iree_hal_hip_dynamic_symbols_get_path(
+iree_status_t iree_hal_hip_dynamic_symbols_append_path_to_builder(
     iree_hal_hip_dynamic_symbols_t* syms, iree_string_builder_t* out_path);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
@@ -46,9 +46,9 @@ TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
 }
 
 static const iree_string_view_t non_existing_search_paths[] = {
-    iree_string_view_literal("/path/that/does/not/exist"),
-    iree_string_view_literal("file:nowhere/libamdhip64.so"),
-    iree_string_view_literal("filename_that_does_not_exist.dll"),
+    iree_make_cstring_view("/path/that/does/not/exist"),
+    iree_make_cstring_view("file:nowhere/libamdhip64.so"),
+    iree_make_cstring_view("filename_that_does_not_exist.dll"),
 };
 
 TEST(DynamicSymbolsTest, SearchPathsFail) {

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
@@ -25,7 +25,8 @@ namespace {
 TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   iree_hal_hip_dynamic_symbols_t symbols;
   iree_status_t status = iree_hal_hip_dynamic_symbols_initialize(
-      iree_allocator_system(), &symbols);
+      iree_allocator_system(), /*hip_lib_search_path_count=*/0,
+      /*hip_lib_search_paths=*/NULL, &symbols);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
@@ -42,6 +43,22 @@ TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   }
 
   iree_hal_hip_dynamic_symbols_deinitialize(&symbols);
+}
+
+static const iree_string_view_t non_existing_search_paths[] = {
+    iree_string_view_literal("/path/that/does/not/exist"),
+    iree_string_view_literal("file:nowhere/libamdhip64.so"),
+    iree_string_view_literal("filename_that_does_not_exist.dll"),
+};
+
+TEST(DynamicSymbolsTest, SearchPathsFail) {
+  iree_hal_hip_dynamic_symbols_t symbols;
+  iree_status_t status = iree_hal_hip_dynamic_symbols_initialize(
+      iree_allocator_system(),
+      /*hip_lib_search_path_count=*/IREE_ARRAYSIZE(non_existing_search_paths),
+      non_existing_search_paths, &symbols);
+
+  ASSERT_TRUE(iree_status_is_unavailable(status));
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -237,7 +237,7 @@ static iree_status_t iree_hal_hip_driver_dump_device_info(
   // Report path to the runtime library.
   iree_string_builder_t path_builder;
   iree_string_builder_initialize(builder->allocator, &path_builder);
-  iree_status_t status = iree_hal_hip_dynamic_symbols_get_path(
+  iree_status_t status = iree_hal_hip_dynamic_symbols_append_path_to_builder(
       &driver->hip_symbols, &path_builder);
   if (iree_status_is_ok(status)) {
     status = iree_string_builder_append_format(

--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -74,7 +74,8 @@ static iree_status_t iree_hal_hip_driver_create_internal(
   driver->default_device_index = options->default_device_index;
 
   iree_status_t status = iree_hal_hip_dynamic_symbols_initialize(
-      host_allocator, &driver->hip_symbols);
+      host_allocator, options->hip_lib_search_path_count,
+      options->hip_lib_search_paths, &driver->hip_symbols);
 
   memcpy(&driver->device_params, device_params, sizeof(driver->device_params));
 
@@ -232,6 +233,20 @@ static iree_status_t iree_hal_hip_driver_dump_device_info(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_string_builder_t* builder) {
   iree_hal_hip_driver_t* driver = iree_hal_hip_driver_cast(base_driver);
+
+  // Report path to the runtime library.
+  iree_string_builder_t path_builder;
+  iree_string_builder_initialize(builder->allocator, &path_builder);
+  iree_status_t status = iree_hal_hip_dynamic_symbols_get_path(
+      &driver->hip_symbols, &path_builder);
+  if (iree_status_is_ok(status)) {
+    status = iree_string_builder_append_format(
+        builder, "\n- amdhip64_dylib_path: %s", path_builder.buffer);
+    iree_string_builder_deinitialize(&path_builder);
+    IREE_RETURN_IF_ERROR(status);
+  }
+
+  // Report driver properties.
   if (!driver->hip_symbols.hipGetDevicePropertiesR0600) {
     // ROCm 6.0 release changes the hipDeviceProp_t struct and would need to use
     // the matching hipGetDevicePropertiesR0600() API to query it. This symbol

--- a/runtime/src/iree/hal/drivers/hip/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/hip/registration/driver_module.c
@@ -83,13 +83,13 @@ static iree_status_t iree_hal_hip_driver_parse_flags(
   }
 
   // bool and int flags
-  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int(
+  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int32(
       builder, key_hip_use_streams, FLAG_hip_use_streams));
-  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int(
+  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int32(
       builder, key_hip_async_allocations, FLAG_hip_async_allocations));
-  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int(
+  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int32(
       builder, key_hip_tracing, FLAG_hip_tracing));
-  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int(
+  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int32(
       builder, key_hip_default_index, FLAG_hip_default_index));
 
   // If there were no flag-based dylib paths, consult the environment
@@ -102,7 +102,7 @@ static iree_status_t iree_hal_hip_driver_parse_flags(
       iree_string_view_t dylib_path_env =
           iree_make_cstring_view(raw_dylib_path_env);
       IREE_RETURN_IF_ERROR(
-          iree_string_pair_builder_alloc_string(builder, &dylib_path_env));
+          iree_string_pair_builder_emplace_string(builder, &dylib_path_env));
       while (true) {
         iree_string_view_t first, rest;
         intptr_t index =
@@ -228,7 +228,8 @@ static iree_status_t iree_hal_hip_driver_factory_try_create(
   if (iree_status_is_ok(status)) {
     status = iree_hal_hip_driver_populate_options(
         host_allocator, &driver_options, &device_params,
-        flag_option_builder.pairs_size, flag_option_builder.pairs);
+        iree_string_pair_builder_size(&flag_option_builder),
+        iree_string_pair_builder_pairs(&flag_option_builder));
   }
 
   if (iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/hip/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/hip/registration/driver_module.c
@@ -15,6 +15,14 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/hip/api.h"
 
+IREE_FLAG_LIST(
+    string, hip_dylib_path,
+    "Path to search for an appropriate libamdhip64.so / amdhip64.dll. If any \n"
+    "paths are provided, then only the given paths are searched. Otherwise, \n"
+    "system heuristics are used to find the dylib. By default, each path is \n"
+    "treated as a directory name, but a distinct file can be given which \n"
+    "must match exactly by prefixing with 'file:'.")
+
 IREE_FLAG(bool, hip_use_streams, true,
           "Use HIP streams (instead of graphs) for executing command buffers.");
 
@@ -49,6 +57,119 @@ static iree_status_t iree_hal_hip_driver_factory_enumerate(
   return iree_ok_status();
 }
 
+// Option key constants.
+static const iree_string_view_t key_hip_dylib_path =
+    iree_string_view_literal("hip_dylib_path");
+static const iree_string_view_t key_hip_use_streams =
+    iree_string_view_literal("hip_use_streams");
+static const iree_string_view_t key_hip_async_allocations =
+    iree_string_view_literal("hip_async_allocations");
+static const iree_string_view_t key_hip_tracing =
+    iree_string_view_literal("hip_tracing");
+static const iree_string_view_t key_hip_default_index =
+    iree_string_view_literal("hip_default_index");
+
+// Parses flags and environment variables into a string pair builder.
+static iree_status_t iree_hal_hip_driver_parse_flags(
+    iree_string_pair_builder_t* builder) {
+  const iree_flag_string_list_t dylib_path_list = FLAG_hip_dylib_path_list();
+
+  // hip_dylib_path
+  for (iree_host_size_t i = 0; i < dylib_path_list.count; ++i) {
+    IREE_RETURN_IF_ERROR(iree_string_pair_builder_add(
+        builder,
+        iree_make_string_pair(key_hip_dylib_path, dylib_path_list.values[i])));
+  }
+
+  // bool and int flags
+  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int(
+      builder, key_hip_use_streams, FLAG_hip_use_streams));
+  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int(
+      builder, key_hip_async_allocations, FLAG_hip_async_allocations));
+  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int(
+      builder, key_hip_tracing, FLAG_hip_tracing));
+  IREE_RETURN_IF_ERROR(iree_string_pair_builder_add_int(
+      builder, key_hip_default_index, FLAG_hip_default_index));
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_hip_driver_populate_options(
+    iree_allocator_t host_allocator,
+    iree_hal_hip_driver_options_t* driver_options,
+    iree_hal_hip_device_params_t* device_params, iree_host_size_t pairs_size,
+    iree_string_pair_t* pairs) {
+  // On the first loop, we just count dynamic sized values.
+  int dylib_path_count = 0;
+  for (iree_host_size_t i = 0; i < pairs_size; ++i) {
+    iree_string_view_t key = pairs[i].key;
+    iree_string_view_t value = pairs[i].value;
+    int32_t ivalue;
+
+    if (iree_string_view_equal(key, key_hip_dylib_path)) {
+      ++dylib_path_count;
+    } else if (iree_string_view_equal(key, key_hip_use_streams)) {
+      if (!iree_string_view_atoi_int32(value, &ivalue)) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "Option 'hip_use_streams' expected to be int. Got: '%.*s'",
+            (int)value.size, value.data);
+      }
+      if (ivalue) {
+        device_params->command_buffer_mode =
+            IREE_HAL_HIP_COMMAND_BUFFER_MODE_STREAM;
+      }
+    } else if (iree_string_view_equal(key, key_hip_async_allocations)) {
+      if (!iree_string_view_atoi_int32(value, &ivalue)) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "Option 'hip_async_allocations' expected to be int Got: '%.*s'",
+            (int)value.size, value.data);
+      }
+      device_params->async_allocations = ivalue ? true : false;
+    } else if (iree_string_view_equal(key, key_hip_tracing)) {
+      if (!iree_string_view_atoi_int32(value, &ivalue)) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "Option 'hip_tracing' expected to be int. Got: '%.*s'",
+            (int)value.size, value.data);
+      }
+      device_params->stream_tracing = ivalue ? true : false;
+    } else if (iree_string_view_equal(key, key_hip_default_index)) {
+      if (!iree_string_view_atoi_int32(value, &ivalue)) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "Option 'hip_default_index' expected to be int. Got: '%.*s'",
+            (int)value.size, value.data);
+        ;
+      }
+      driver_options->default_device_index = ivalue;
+    } else {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "Unrecognized options: %.*s", (int)key.size,
+                              key.data);
+    }
+  }
+
+  // Populate dynamic sized values.
+  if (dylib_path_count > 0) {
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+        host_allocator,
+        dylib_path_count * sizeof(driver_options->hip_lib_search_paths[0]),
+        (void**)&driver_options->hip_lib_search_paths));
+    for (iree_host_size_t i = 0; i < pairs_size; ++i) {
+      iree_string_view_t key = pairs[i].key;
+      iree_string_view_t value = pairs[i].value;
+      if (iree_string_view_equal(key, key_hip_dylib_path)) {
+        driver_options->hip_lib_search_paths
+            [driver_options->hip_lib_search_path_count++] = value;
+      }
+    }
+  }
+
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_hip_driver_factory_try_create(
     void* self, iree_string_view_t driver_name, iree_allocator_t host_allocator,
     iree_hal_driver_t** out_driver) {
@@ -62,21 +183,34 @@ static iree_status_t iree_hal_hip_driver_factory_try_create(
 
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  // Option structs.
   iree_hal_hip_driver_options_t driver_options;
   iree_hal_hip_driver_options_initialize(&driver_options);
-
   iree_hal_hip_device_params_t device_params;
   iree_hal_hip_device_params_initialize(&device_params);
-  if (FLAG_hip_use_streams) {
-    device_params.command_buffer_mode = IREE_HAL_HIP_COMMAND_BUFFER_MODE_STREAM;
+
+  // Parse flags.
+  // TODO: In the future, we will only do this step if not given explicit
+  // options.
+  iree_string_pair_builder_t flag_option_builder;
+  iree_string_pair_builder_initialize(host_allocator, &flag_option_builder);
+  iree_status_t status = iree_hal_hip_driver_parse_flags(&flag_option_builder);
+
+  // Parse key/values into option structs.
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_hip_driver_populate_options(
+        host_allocator, &driver_options, &device_params,
+        flag_option_builder.pairs_size, flag_option_builder.pairs);
   }
-  device_params.stream_tracing = FLAG_hip_tracing;
-  device_params.async_allocations = FLAG_hip_async_allocations;
 
-  driver_options.default_device_index = FLAG_hip_default_index;
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_hal_hip_driver_create(driver_name, &driver_options, &device_params,
+                                   host_allocator, out_driver);
+  }
 
-  iree_status_t status = iree_hal_hip_driver_create(
-      driver_name, &driver_options, &device_params, host_allocator, out_driver);
+  iree_allocator_free(host_allocator, driver_options.hip_lib_search_paths);
+  iree_string_pair_builder_deinitialize(&flag_option_builder);
 
   IREE_TRACE_ZONE_END(z0);
 


### PR DESCRIPTION
* Adds a multi-valued flag `--hip_dylib_path`, which if present, overrides default library search behavior:
  * If just a path, it is interpreted as a directory.
  * If prefixed with `file:` it is a specific library file and will not be expanded to anything else.
* If a `--hip_dylib_path` flag is not set, then the `IREE_HIP_DYLIB_PATH` environment variable is consulted/used.
* Library loading code is now much more verbose on error, adding an annotation for each combination tried/failed. Even though this adds some error message accumulation to the success path, I deem it worth it after experiencing all of the failure modes myself and needing to printf for more information: There is much more in the dlopen errors beyond whether the file could be found or not, and if we get reports from the field of issues, I want all context.
* Adds a stanza to dump device info that displays the path the the OS actually resolved for the HIP runtime library.
* Followups will expose this to Python and add environment variables to control it uniformly as well.

This necessitated a bit of an upgrade to how we handle options, and I decided to align it with what I need next (the ability to create a driver with key/value pair options from Python) and unify the flag/option handling.

I free-handed the Windows DLL handling code. Will verify on my Windows machine.