### PR TITLE
[runtime][hip] Fix missing CMake vars for tests

### DIFF
--- a/experimental/hip/CMakeLists.txt
+++ b/experimental/hip/CMakeLists.txt
@@ -8,6 +8,19 @@
 set(IREE_PACKAGE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(IREE_PACKAGE_ROOT_PREFIX "iree/experimental/hip")
 
+# TODO: maybe merge these variables with the equivalent in the ROCm driver.
+# The obstacle is that they are now experimental and should probably not polute
+# the main CMake file.
+set(IREE_HIP_DRIVER_TARGET_CHIP_DEFAULT "gfx908")
+set(IREE_HIP_DRIVER_TARGET_CHIP "${IREE_HIP_DRIVER_TARGET_CHIP_DEFAULT}" CACHE STRING
+  "Target chip for the HIP driver. This influences conformance tests that need to compile device code. Defaults to \"${IREE_HIP_DRIVER_TARGET_CHIP_DEFAULT}\".")
+set(IREE_HIP_DRIVER_LINK_BC_DEFAULT OFF)
+set(IREE_HIP_DRIVER_LINK_BC ${IREE_HIP_DRIVER_LINK_BC_DEFAULT} CACHE BOOL
+  "Whether to try Linking to AMD Bitcodes. This influences conformance tests that need to compile device code. Defaults to ${IREE_HIP_DRIVER_LINK_BC}.")
+set(IREE_HIP_DRIVER_BC_DIR_DEFAULT "/opt/rocm/amdgcn/bitcode")
+set(IREE_HIP_DRIVER_BC_DIR "${IREE_HIP_DRIVER_BC_DIR_DEFAULT}" CACHE STRING
+  "Directory of ROCM Bitcode. This influences conformance tests that need to compile device code. Defaults to \"${IREE_HIP_DRIVER_TARGET_CHIP_DEFAULT}\".")
+
 iree_add_all_subdirs()
 
 if(NOT DEFINED HIP_API_HEADERS_ROOT)

--- a/experimental/hip/cts/CMakeLists.txt
+++ b/experimental/hip/cts/CMakeLists.txt
@@ -5,14 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
-if(IREE_ROCM_LINK_BC)
+if(IREE_HIP_DRIVER_LINK_BC)
   list(APPEND IREE_HIP_TEST_COMPILER_FLAGS "--iree-rocm-link-bc=true")
 else()
   list(APPEND IREE_HIP_TEST_COMPILER_FLAGS "--iree-rocm-link-bc=false")
 endif()
 list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
-  "--iree-rocm-target-chip=${IREE_ROCM_TARGET_CHIP}"
-  "--iree-rocm-bc-dir=${IREE_ROCM_BC_DIR}")
+  "--iree-rocm-target-chip=${IREE_HIP_DRIVER_TARGET_CHIP}"
+  "--iree-rocm-bc-dir=${IREE_HIP_DRIVER_BC_DIR}")
 
 iree_hal_cts_test_suite(
   DRIVER_NAME

--- a/experimental/hip/tests/stablehlo_ops/CMakeLists.txt
+++ b/experimental/hip/tests/stablehlo_ops/CMakeLists.txt
@@ -5,14 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
-if(IREE_ROCM_LINK_BC)
+if(IREE_HIP_DRIVER_LINK_BC)
   list(APPEND IREE_HIP_TEST_COMPILER_FLAGS "--iree-rocm-link-bc=true")
 else()
   list(APPEND IREE_HIP_TEST_COMPILER_FLAGS "--iree-rocm-link-bc=false")
 endif()
 list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
-  "--iree-rocm-target-chip=${IREE_ROCM_TARGET_CHIP}"
-  "--iree-rocm-bc-dir=${IREE_ROCM_BC_DIR}")
+  "--iree-rocm-target-chip=${IREE_HIP_DRIVER_TARGET_CHIP}"
+  "--iree-rocm-bc-dir=${IREE_HIP_DRIVER_BC_DIR}")
 
 iree_check_single_backend_test_suite(
   NAME

--- a/experimental/hip/tests/tosa_ops/CMakeLists.txt
+++ b/experimental/hip/tests/tosa_ops/CMakeLists.txt
@@ -5,14 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
-if(IREE_ROCM_LINK_BC)
+if(IREE_HIP_DRIVER_LINK_BC)
   list(APPEND IREE_HIP_TEST_COMPILER_FLAGS "--iree-rocm-link-bc=true")
 else()
   list(APPEND IREE_HIP_TEST_COMPILER_FLAGS "--iree-rocm-link-bc=false")
 endif()
 list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
-  "--iree-rocm-target-chip=${IREE_ROCM_TARGET_CHIP}"
-  "--iree-rocm-bc-dir=${IREE_ROCM_BC_DIR}")
+  "--iree-rocm-target-chip=${IREE_HIP_DRIVER_TARGET_CHIP}"
+  "--iree-rocm-bc-dir=${IREE_HIP_DRIVER_BC_DIR}")
 
 iree_check_single_backend_test_suite(
   NAME

--- a/experimental/rocm/CMakeLists.txt
+++ b/experimental/rocm/CMakeLists.txt
@@ -12,15 +12,16 @@ cmake_path(ABSOLUTE_PATH IREE_PACKAGE_ROOT_DIR
   OUTPUT_VARIABLE IREE_PACKAGE_ROOT_DIR)
 set(IREE_PACKAGE_ROOT_PREFIX iree)
 
-set(IREE_ROCM_TARGET_CHIP_DEFAULT "gfx908")
-set(IREE_ROCM_TARGET_CHIP "${IREE_ROCM_TARGET_CHIP_DEFAULT}" CACHE STRING
-  "Target chip for ROCm. This influences conformance tests that need to compile device code. Defaults to \"${IREE_ROCM_TARGET_CHIP_DEFAULT}\".")
-set(IREE_ROCM_LINK_BC_DEFAULT OFF)
-set(IREE_ROCM_LINK_BC ${IREE_ROCM_LINK_BC_DEFAULT} CACHE BOOL
-  "Whether to try Linking to AMD Bitcodes. This influences conformance tests that need to compile device code. Defaults to ${IREE_ROCM_LINK_BC}.")
-set(IREE_ROCM_BC_DIR_DEFAULT "/opt/rocm/amdgcn/bitcode")
-set(IREE_ROCM_BC_DIR "${IREE_ROCM_BC_DIR_DEFAULT}" CACHE STRING
-  "Directory of ROCM Bitcode. This influences conformance tests that need to compile device code. Defaults to \"${IREE_ROCM_TARGET_CHIP_DEFAULT}\".")
+# TODO: maybe merge these variables with the equivalent in the HIP driver.
+set(IREE_ROCM_DRIVER_TARGET_CHIP_DEFAULT "gfx908")
+set(IREE_ROCM_DRIVER_TARGET_CHIP "${IREE_ROCM_DRIVER_TARGET_CHIP_DEFAULT}" CACHE STRING
+  "Target chip for the ROCm driver. This influences conformance tests that need to compile device code. Defaults to \"${IREE_ROCM_DRIVER_TARGET_CHIP_DEFAULT}\".")
+set(IREE_ROCM_DRIVER_LINK_BC_DEFAULT OFF)
+set(IREE_ROCM_DRIVER_LINK_BC ${IREE_ROCM_DRIVER_LINK_BC_DEFAULT} CACHE BOOL
+  "Whether to try Linking to AMD Bitcodes. This influences conformance tests that need to compile device code. Defaults to ${IREE_ROCM_DRIVER_LINK_BC}.")
+set(IREE_ROCM_DRIVER_BC_DIR_DEFAULT "/opt/rocm/amdgcn/bitcode")
+set(IREE_ROCM_DRIVER_BC_DIR "${IREE_ROCM_DRIVER_BC_DIR_DEFAULT}" CACHE STRING
+  "Directory of ROCM Bitcode. This influences conformance tests that need to compile device code. Defaults to \"${IREE_ROCM_DRIVER_TARGET_CHIP_DEFAULT}\".")
 
 iree_add_all_subdirs()
 

--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -5,14 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 unset(COMPILER_FLAGS)
-if(IREE_ROCM_LINK_BC)
+if(IREE_ROCM_DRIVER_LINK_BC)
   list(APPEND COMPILER_FLAGS "--iree-rocm-link-bc=true")
 else()
   list(APPEND COMPILER_FLAGS "--iree-rocm-link-bc=false")
 endif()
 list(APPEND COMPILER_FLAGS
-  "--iree-rocm-target-chip=${IREE_ROCM_TARGET_CHIP}"
-  "--iree-rocm-bc-dir=${IREE_ROCM_BC_DIR}")
+  "--iree-rocm-target-chip=${IREE_ROCM_DRIVER_TARGET_CHIP}"
+  "--iree-rocm-bc-dir=${IREE_ROCM_DRIVER_BC_DIR}")
 
 iree_hal_cts_test_suite(
   DRIVER_NAME


### PR DESCRIPTION
The CMake test code from the HIP driver was copied from the ROCm driver. Some vars were defined in the ROCm driver and used in the HIP driver, but since the drivers are still experimental this introduced an order dependency of configuration.

Now the HIP driver gets its own vars.