### PR TITLE
Don't link `opencl.bc` when compiling for ROCm. 

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -53,22 +53,24 @@ jobs:
             -rA -s -m "plat_rdna3_rocm and presubmit" \
             experimental/regression_suite
 
-      # Out of tree tests
-      - name: Checking out external TestSuite repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-        with:
-          repository: nod-ai/SHARK-TestSuite
-          ref: 46ab63b271fddd78e071c0590e9a073f6282b005
-          path: SHARK-TestSuite
-          submodules: false
-      - name: Installing external TestSuite Python requirements
-        run: |
-          source ${VENV_DIR}/bin/activate
-          python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
-      - name: Run external TestSuite tests
-        env:
-          IREE_TEST_CONFIG_FILES: experimental/regression_suite/external_test_suite/config_gpu_rocm_rdna3.json
-        run: |
-          source ${VENV_DIR}/bin/activate
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
-          pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=30 --retries=2
+      # Disabled while flaky. Might be replaced with HIP tests instead?
+
+      # # Out of tree tests
+      # - name: Checking out external TestSuite repository
+      #   uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      #   with:
+      #     repository: nod-ai/SHARK-TestSuite
+      #     ref: 46ab63b271fddd78e071c0590e9a073f6282b005
+      #     path: SHARK-TestSuite
+      #     submodules: false
+      # - name: Installing external TestSuite Python requirements
+      #   run: |
+      #     source ${VENV_DIR}/bin/activate
+      #     python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
+      # - name: Run external TestSuite tests
+      #   env:
+      #     IREE_TEST_CONFIG_FILES: experimental/regression_suite/external_test_suite/config_gpu_rocm_rdna3.json
+      #   run: |
+      #     source ${VENV_DIR}/bin/activate
+      #     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
+      #     pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=30 --retries=2

--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -53,24 +53,22 @@ jobs:
             -rA -s -m "plat_rdna3_rocm and presubmit" \
             experimental/regression_suite
 
-      # Disabled while flaky. Might be replaced with HIP tests instead?
-
-      # # Out of tree tests
-      # - name: Checking out external TestSuite repository
-      #   uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-      #   with:
-      #     repository: nod-ai/SHARK-TestSuite
-      #     ref: 46ab63b271fddd78e071c0590e9a073f6282b005
-      #     path: SHARK-TestSuite
-      #     submodules: false
-      # - name: Installing external TestSuite Python requirements
-      #   run: |
-      #     source ${VENV_DIR}/bin/activate
-      #     python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
-      # - name: Run external TestSuite tests
-      #   env:
-      #     IREE_TEST_CONFIG_FILES: experimental/regression_suite/external_test_suite/config_gpu_rocm_rdna3.json
-      #   run: |
-      #     source ${VENV_DIR}/bin/activate
-      #     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
-      #     pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=30 --retries=2
+      # Out of tree tests
+      - name: Checking out external TestSuite repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          repository: nod-ai/SHARK-TestSuite
+          ref: 46ab63b271fddd78e071c0590e9a073f6282b005
+          path: SHARK-TestSuite
+          submodules: false
+      - name: Installing external TestSuite Python requirements
+        run: |
+          source ${VENV_DIR}/bin/activate
+          python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
+      - name: Run external TestSuite tests
+        env:
+          IREE_TEST_CONFIG_FILES: experimental/regression_suite/external_test_suite/config_gpu_rocm_rdna3.json
+        run: |
+          source ${VENV_DIR}/bin/activate
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
+          pytest SHARK-TestSuite/iree_tests -n 4 -rpfE --timeout=30 --retries=2

--- a/compiler/plugins/target/ROCM/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/CMakeLists.txt
@@ -73,7 +73,7 @@ iree_cc_library(
 # there. We default to downloading as it is a better use experience
 # by default.
 # See: https://github.com/shark-infra/amdgpu-device-libs
-set(_amd_required_libs "ocml.bc" "ockl.bc" "opencl.bc")
+set(_amd_required_libs "ocml.bc" "ockl.bc")
 set(_amd_device_bc_url
     "https://github.com/shark-infra/amdgpu-device-libs/releases/download/v20231101/amdgpu-device-libs-llvm-6086c272a3a59eb0b6b79dcbe00486bf4461856a.tgz")
 set(_amd_device_bc_sha256 "336362416c68fdd8bb80328f65ca7ebaa0c119ea19c95df6df30c832a4df39b9")

--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
@@ -139,8 +139,7 @@ LogicalResult linkPathBitcodeFiles(Location loc, llvm::Linker &linker,
 static std::vector<std::string> getROCDLPaths(std::string targetChip,
                                               std::string bitCodeDir) {
   // AMDGPU bitcodes.
-  static const std::vector<std::string> rocdlFilenames(
-      {"opencl.bc", "ocml.bc", "ockl.bc"});
+  static const std::vector<std::string> rocdlFilenames({"ocml.bc", "ockl.bc"});
 
   // Construct full path to ROCDL bitcode libraries.
   std::vector<std::string> result;


### PR DESCRIPTION
We shouldn't be using it, and linking it in to every executable adds ~20 seconds wall time for large programs like unet:

![image](https://github.com/openxla/iree/assets/4010439/260c420f-11ec-4a20-af6e-055a0599f582)


~~Also enable the external tests (ONNX ops) on ROCm again to confirm that this doesn't regress anything there.~~ (Need to update the XFAIL sets there after newly passing tests, in a separate PR)