### PR TITLE
Revert "Ukernels: enable limited debug information that is useful in profilers like Tracy."

### DIFF
--- a/build_tools/bazel/iree_bitcode_library.bzl
+++ b/build_tools/bazel/iree_bitcode_library.bzl
@@ -85,9 +85,6 @@ def iree_bitcode_library(
         "-fno-ident",
         "-fdiscard-value-names",
 
-        # Limited debug information that is useful in profilers like Tracy.
-        "-gline-tables-only",
-
         # Set the size of wchar_t to 4 bytes (instead of 2 bytes).
         # This must match what the runtime is built with.
         "-fno-short-wchar",

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -38,44 +38,18 @@ function(iree_import_tflite_model)
 
   if(NOT TARGET "${_RULE_TARGET_NAME}")
     cmake_path(GET _RULE_SOURCE FILENAME _MODEL_BASENAME)
-
-    # See PR #15756: PoseNet mysterious errors go away when run through iree-opt.
-    if(_RULE_SOURCE MATCHES PoseNet)
-      set(_PREOPT ON)
-    else()
-      set(_PREOPT OFF)
-    endif()
-
-    if(_PREOPT)
-      set(_PREOPT_SOURCE "${_RULE_OUTPUT_MLIR_FILE}.before-preopt")
-      set(_IMPORT_DESTINATION "${_PREOPT_SOURCE}")
-    else()
-      set(_IMPORT_DESTINATION "${_RULE_OUTPUT_MLIR_FILE}")
-    endif()
-
     add_custom_command(
-      OUTPUT "${_IMPORT_DESTINATION}"
+      OUTPUT "${_RULE_OUTPUT_MLIR_FILE}"
       COMMAND
         "${IREE_IMPORT_TFLITE_PATH}"
         "${_RULE_SOURCE}"
-        "-o=${_IMPORT_DESTINATION}"
+        "-o=${_RULE_OUTPUT_MLIR_FILE}"
         ${_RULE_IMPORT_FLAGS}
       DEPENDS
         "${_RULE_SOURCE}"
       COMMENT "Importing TFLite model ${_MODEL_BASENAME}"
       VERBATIM
     )
-
-    if(_PREOPT)
-      add_custom_command(
-        OUTPUT "${_RULE_OUTPUT_MLIR_FILE}"
-        COMMAND "iree-opt" "${_PREOPT_SOURCE}" "-o" "${_RULE_OUTPUT_MLIR_FILE}"
-        DEPENDS "${_IMPORT_DESTINATION}"
-        COMMENT "Processing TFLite model ${_MODEL_BASENAME} with iree-opt"
-        VERBATIM
-      )
-    endif()
-
     add_custom_target("${_RULE_TARGET_NAME}"
       DEPENDS
         "${_RULE_OUTPUT_MLIR_FILE}"

--- a/build_tools/cmake/iree_bitcode_library.cmake
+++ b/build_tools/cmake/iree_bitcode_library.cmake
@@ -55,9 +55,6 @@ function(iree_bitcode_library)
     "-fno-ident"
     "-fdiscard-value-names"
 
-    # Limited debug information that is useful in profilers like Tracy.
-    "-gline-tables-only"
-
     # Set the size of wchar_t to 4 bytes (instead of 2 bytes).
     # This must match what the runtime is built with.
     "-fno-short-wchar"


### PR DESCRIPTION
Reverts openxla/iree#15756

Reason: more models have the same issue, https://github.com/openxla/iree/actions/runs/8284380403/attempts/1