### PR TITLE
[LLVMGPU] Add initial workgroup reodering pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -53,7 +53,8 @@ LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
                                          bool collapseLoops = false);
 
 LogicalResult swizzleWorkgroupsInFunc(mlir::FunctionOpInterface funcOp,
-                                      unsigned swizzleLogTile);
+                                      unsigned swizzleLogTile,
+                                      ArrayRef<int64_t> workgroupCount);
 
 // Lowers workgroup memory copies to distributed transfer_read/transfer_write
 // ops. Expects the memory copy to be marked with copy_to_workgroup_memory

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -145,9 +145,11 @@ createConvertVectorReductionToGPUPass(
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createWorkgroupSpecializationPass();
 
-/// Converts vector ops to gpu dialect.
+/// Reorders workgroup IDs.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createWorkGroupSwizzle(unsigned swizzleLogTile = 0);
+createReorderWorkgroups(
+    unsigned swizzleLogTile = 0,
+    std::function<LogicalResult(mlir::FunctionOpInterface)> filterFn = nullptr);
 
 // This pass generalizes named Linalg ops that are better off as generics.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -132,10 +132,10 @@ def WorkgroupSpecialization :
   let constructor = "mlir::iree_compiler::createWorkgroupSpecializationPass()";
 }
 
-def WorkGroupSwizzle :
-    InterfacePass<"iree-workgroup-swizzle", "mlir::FunctionOpInterface"> {
-  let summary = "swizzle the workgroup ids for better cache reuse";
-  let constructor = "mlir::iree_compiler::createWorkGroupSwizzle()";
+def ReorderWorkgroups :
+    InterfacePass<"iree-codegen-reorder-workgroups", "mlir::FunctionOpInterface"> {
+  let summary = "Reorder workgroup ids for better cache reuse";
+  let constructor = "mlir::iree_compiler::createReorderWorkgroups()";
   let options = [
     Option<"logTile", "logTile", "unsigned",
             /*default=*/"0",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
@@ -4,10 +4,18 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cassert>
 #include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+#define DEBUG_TYPE "iree-codegen-reorder-workgroups"
 
 namespace mlir::iree_compiler {
 
@@ -24,10 +32,14 @@ namespace mlir::iree_compiler {
 /// }
 // TODO: Make this a callback and the core functionality in the pass a utility
 // function.
-static void makeSwizzledId(Location loc, OpBuilder b, Value workgroupIdX,
-                           Value workgroupIdY, Value gridSizeX, Value gridSizeY,
-                           Value &SwizzledIdX, Value &SwizzledIdY,
-                           unsigned swizzleTile) {
+static std::pair<Value, Value> makeSwizzledId(Location loc, OpBuilder b,
+                                              Value workgroupIdX,
+                                              Value workgroupIdY,
+                                              ArrayRef<int64_t> workgroupCount,
+                                              unsigned swizzleTile) {
+  Value gridSizeX = b.create<arith::ConstantIndexOp>(loc, workgroupCount[0]);
+  Value gridSizeY = b.create<arith::ConstantIndexOp>(loc, workgroupCount[1]);
+
   Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
   Value tile = b.create<arith::ConstantIndexOp>(loc, swizzleTile);
   Value yModTile = b.create<arith::RemUIOp>(loc, workgroupIdY, tile);
@@ -48,52 +60,74 @@ static void makeSwizzledId(Location loc, OpBuilder b, Value workgroupIdX,
   Value condition2 = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ugt,
                                              gyAddTile, gridSizeY);
   Value condition3 = b.create<arith::AndIOp>(loc, condition1, condition2);
-  SwizzledIdX = b.create<arith::SelectOp>(loc, condition3, workgroupIdX,
-                                          unboundedSwizzledIdX);
-  SwizzledIdY = b.create<arith::SelectOp>(loc, condition3, workgroupIdY,
-                                          unboundedSwizzledIdY);
+  Value swizzledIdX = b.create<arith::SelectOp>(loc, condition3, workgroupIdX,
+                                                unboundedSwizzledIdX);
+  Value swizzledIdY = b.create<arith::SelectOp>(loc, condition3, workgroupIdY,
+                                                unboundedSwizzledIdY);
+  return {swizzledIdX, swizzledIdY};
+
+  /*
+  Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
+  Value one = b.create<arith::ConstantIndexOp>(loc, 1);
+  Value two = b.create<arith::ConstantIndexOp>(loc, 2);
+  Value last = b.create<arith::SubIOp>(loc, gridSizeX, one);
+  Value reversedX = b.create<arith::SubIOp>(loc, last, workgroupIdX);
+  Value yMod2 = b.create<arith::RemSIOp>(loc, workgroupIdY, two);
+  Value isYEven = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, yMod2, zero);
+  Value newX = b.create<arith::SelectOp>(loc, isYEven, workgroupIdX, reversedX);
+  SwizzledIdX = newX;
+  SwizzledIdY = workgroupIdY; */
 }
 
 LogicalResult swizzleWorkgroupsInFunc(mlir::FunctionOpInterface funcOp,
-                                      unsigned swizzleLogTile) {
+                                      unsigned swizzleLogTile, ArrayRef<int64_t> workgroupCount) {
+  assert(workgroupCount.size() == 3 && "Expected a 3D grid");
   if (swizzleLogTile == 0)
     return success();
-  unsigned swizzleTile = pow(2, swizzleLogTile);
-  std::array<IREE::HAL::InterfaceWorkgroupIDOp, 2> oldWorkgroupIds;
-  bool xFound = false, yFound = false;
+
+  unsigned swizzleTile = 1u << swizzleLogTile;
+  IREE::HAL::InterfaceWorkgroupIDOp oldXId;
+  IREE::HAL::InterfaceWorkgroupIDOp oldYId;
+  unsigned numXIdOps = 0;
+  unsigned numYIdOps = 0;
   funcOp.walk([&](IREE::HAL::InterfaceWorkgroupIDOp idOp) {
     unsigned index = idOp.getDimension().getZExtValue();
     if (index == 0) {
-      oldWorkgroupIds[index] = idOp;
-      xFound = true;
+      oldXId = idOp;
+      ++numXIdOps;
     } else if (index == 1) {
-      oldWorkgroupIds[index] = idOp;
-      yFound = true;
+      oldYId = idOp;
+      ++numYIdOps;
     }
   });
-  if (xFound == false || yFound == false)
+
+  if (numXIdOps != 1 || numYIdOps != 1) {
+    LLVM_DEBUG(llvm::dbgs() << "Could not find X or Y\n");
     return failure();
+  }
+
   OpBuilder builder(funcOp);
-  builder.setInsertionPoint(&funcOp.front(), funcOp.front().begin());
+  builder.setInsertionPointToStart(&funcOp.front());
+  // We create two new workgroup ID ops at the very top of the function and use
+  // that to RAUW the old ones. This way we don't have to worry about the
+  // picking the exact insertion points that do not violate dominance between
+  // their defs and users.
   Value workgroupIdX =
       builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(funcOp.getLoc(), 0);
   Value workgroupIdY =
       builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(funcOp.getLoc(), 1);
-  Value gridSizeX =
-      builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(funcOp.getLoc(), 0);
-  Value gridSizeY =
-      builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(funcOp.getLoc(), 1);
-  Value SwizzledIdX, SwizzledIdY;
-  makeSwizzledId(funcOp.getLoc(), builder, workgroupIdX, workgroupIdY,
-                 gridSizeX, gridSizeY, SwizzledIdX, SwizzledIdY, swizzleTile);
-  oldWorkgroupIds[0].replaceAllUsesWith(SwizzledIdX);
-  oldWorkgroupIds[1].replaceAllUsesWith(SwizzledIdY);
+  auto [newX, newY] = makeSwizzledId(funcOp.getLoc(), builder, workgroupIdX,
+                                     workgroupIdY, workgroupCount, swizzleTile);
+  oldXId.replaceAllUsesWith(newX);
+  oldYId.replaceAllUsesWith(newY);
+  oldXId->erase();
+  oldYId->erase();
   return success();
 }
 
 namespace {
-struct WorkGroupSwizzlePass
-    : public WorkGroupSwizzleBase<WorkGroupSwizzlePass> {
+struct WorkGroupSwizzlePass final
+    : WorkGroupSwizzleBase<WorkGroupSwizzlePass> {
   WorkGroupSwizzlePass(unsigned swizzleLogTile)
       : swizzleLogTile(swizzleLogTile) {}
 
@@ -108,8 +142,36 @@ struct WorkGroupSwizzlePass
     return success();
   }
   void runOnOperation() override {
-    auto funcOp = getOperation();
-    (void)swizzleWorkgroupsInFunc(funcOp, swizzleLogTile);
+    if (swizzleLogTile == 0)
+      return;
+
+    FunctionOpInterface funcOp = getOperation();
+    SmallVector<int64_t> workgroupCount = getStaticNumWorkgroups(funcOp);
+    if (workgroupCount.size() != 3) {
+      LLVM_DEBUG(llvm::dbgs() << "Reorder Workgroups: failed to find static "
+                                 "workgroup counts. Bailing out.");
+      return;
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- Before reorder workgroups with workgroup counts: [";
+      llvm::interleaveComma(workgroupCount, llvm::dbgs());
+      llvm::dbgs() << "] ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+
+    if (failed(
+            swizzleWorkgroupsInFunc(funcOp, swizzleLogTile, workgroupCount))) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed to reorder workgroups\n");
+      return;
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After reorder workgroups ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
   }
 
 private:

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -875,7 +875,11 @@ DiagnosedSilenceableFailure transform_dialect::WorkgroupSwizzleOp::applyToOne(
     transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
     transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
-  (void)swizzleWorkgroupsInFunc(target, getLogTile());
+  SmallVector<int64_t> workgroupCount = getStaticNumWorkgroups(target);
+  if (workgroupCount.size() != 3) {
+    return DiagnosedSilenceableFailure::success();
+  }
+  (void)swizzleWorkgroupsInFunc(target, getLogTile(), workgroupCount);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -522,6 +522,8 @@ static void addVectorBufferizePasses(OpPassManager &passManager) {
 void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createWorkGroupSwizzle(logSwizzleTile));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -11,10 +11,12 @@
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/ComplexToStandard/ComplexToStandard.h"
@@ -31,9 +33,11 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassOptions.h"
 #include "mlir/Pass/PassRegistry.h"
+#include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/Passes.h"
 
 #define DEBUG_TYPE "iree-llvm-gpu-lowering-pass-pipeline"
@@ -42,9 +46,10 @@ namespace mlir::iree_compiler {
 
 constexpr int64_t kDefaultSubgroupSize = 32;
 
-static llvm::cl::opt<unsigned>
-    logSwizzleTile("iree-codegen-log-swizzle-tile",
-                   llvm::cl::desc("log swizzle tile value"), llvm::cl::init(0));
+llvm::cl::opt<unsigned> clLogSwizzleTile(
+    "iree-codegen-log-swizzle-tile",
+    llvm::cl::desc("Reorder workgroup using strategy: log swizzle tile value"),
+    llvm::cl::init(0));
 
 llvm::cl::opt<int64_t> clLLVMGPUSharedMemoryLimit(
     "iree-llvmgpu-shared-memory-limit",
@@ -249,8 +254,8 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
 
   nestedModulePM.addNestedPass<func::FuncOp>(
       createGPUReduceSharedMemoryBankConflicts());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createWorkGroupSwizzle(logSwizzleTile));
+  // nestedModulePM.addNestedPass<func::FuncOp>(
+  //    createWorkGroupSwizzle(logSwizzleTile));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
@@ -297,8 +302,8 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
 
   nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createWorkGroupSwizzle(logSwizzleTile));
+  // nestedModulePM.addNestedPass<func::FuncOp>(
+  //    createWorkGroupSwizzle(logSwizzleTile));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
@@ -365,8 +370,8 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
 
   nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createWorkGroupSwizzle(logSwizzleTile));
+  // nestedModulePM.addNestedPass<func::FuncOp>(
+  //    createWorkGroupSwizzle(logSwizzleTile));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
@@ -523,7 +528,19 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createWorkGroupSwizzle(logSwizzleTile));
+      createReorderWorkgroups(clLogSwizzleTile, [](FunctionOpInterface funcOp) {
+        auto entryPoint = getEntryPoint(funcOp);
+        if (failed(entryPoint))
+          return failure();
+        IREE::Codegen::TranslationInfoAttr transInfo =
+            getTranslationInfo(*entryPoint);
+        if (!transInfo)
+          return failure();
+        DictionaryAttr config = transInfo.getConfiguration();
+        if (config.contains("mma_schedule"))
+          return success();
+        return failure();
+      }));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 


### PR DESCRIPTION
Repurpose the workgroup swizzling pass to do more general workgroup reordering.
Add filter function to run in mma pipelines only. Do not use workgroup counts from the runtime as these don't currently work on rocm.