### PR TITLE
Simplify workgroup ordering strategy

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cassert>
-#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
@@ -23,7 +23,7 @@ namespace mlir::iree_compiler {
 /// to top -> down then left -> right.
 static std::pair<Value, Value>
 reorderIds(Location loc, OpBuilder b, Value workgroupIdX, Value workgroupIdY,
-           ArrayRef<int64_t> workgroupCount, unsigned swizzleTile) {
+           ArrayRef<int64_t> workgroupCount, unsigned /*swizzleTile*/) {
   Value gridSizeX = b.create<arith::ConstantIndexOp>(loc, workgroupCount[0]);
   Value gridSizeY = b.create<arith::ConstantIndexOp>(loc, workgroupCount[1]);
   Value linearized = b.create<arith::MulIOp>(loc, workgroupIdY, gridSizeX);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cassert>
-#include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -46,9 +46,11 @@ namespace mlir::iree_compiler {
 
 constexpr int64_t kDefaultSubgroupSize = 32;
 
+// TODO: Rename this flag.
 llvm::cl::opt<unsigned> clLogSwizzleTile(
     "iree-codegen-log-swizzle-tile",
-    llvm::cl::desc("Reorder workgroup using strategy: log swizzle tile value"),
+    llvm::cl::desc("Reorder workgroup using strategy: top -> bottom then left "
+                   "-> right. (0: disabled, non-0: enabled)"),
     llvm::cl::init(0));
 
 llvm::cl::opt<int64_t> clLLVMGPUSharedMemoryLimit(


### PR DESCRIPTION
This yields the same performance on the full model but has lower overhead on isolated microbenchmarks.