### PR TITLE
Splitting stack trace support out of status.c.

### DIFF
--- a/runtime/src/iree/base/BUILD.bazel
+++ b/runtime/src/iree/base/BUILD.bazel
@@ -33,6 +33,8 @@ iree_runtime_cc_library(
         "status.c",
         "status.h",
         "status_cc.h",
+        "status_payload.h",
+        "status_stack_trace.c",
         "string_builder.c",
         "string_builder.h",
         "string_view.c",

--- a/runtime/src/iree/base/CMakeLists.txt
+++ b/runtime/src/iree/base/CMakeLists.txt
@@ -24,6 +24,8 @@ iree_cc_library(
     "status.c"
     "status.h"
     "status_cc.h"
+    "status_payload.h"
+    "status_stack_trace.c"
     "string_builder.c"
     "string_builder.h"
     "string_view.c"

--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -6,26 +6,6 @@
 
 #include "iree/base/status.h"
 
-#include "iree/base/attributes.h"
-
-#if defined(IREE_PLATFORM_APPLE)
-#include <dlfcn.h>
-#include <execinfo.h>
-#define IREE_HAVE_BACKTRACE 1
-#define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
-#elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
-// Currently disabled because we can't get meaningful stacks on Linux.
-// #define _GNU_SOURCE 1
-// #include <dlfcn.h>
-// #include <execinfo.h>
-// #define IREE_HAVE_BACKTRACE 1
-// #define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
-#elif defined(IREE_PLATFORM_WINDOWS)
-#pragma warning(disable : 4091)
-#include <dbghelp.h>
-#define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
-#endif  // IREE_PLATFORM_*
-
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
@@ -39,7 +19,8 @@
 #include "iree/base/alignment.h"
 #include "iree/base/allocator.h"
 #include "iree/base/assert.h"
-#include "iree/base/tracing.h"
+#include "iree/base/attributes.h"
+#include "iree/base/status_payload.h"
 
 //===----------------------------------------------------------------------===//
 // C11 aligned_alloc compatibility shim
@@ -311,65 +292,10 @@ struct iree_status_handle_t {
   uintptr_t value;
 };
 
-// Defines the type of an iree_status_payload_t.
-typedef enum iree_status_payload_type_e {
-  // Opaque; payload may still be formatted by a formatter but is not possible
-  // to retrieve by the programmatic APIs.
-  IREE_STATUS_PAYLOAD_TYPE_OPAQUE = 0,
-  // A string message annotation of type iree_status_payload_message_t.
-  IREE_STATUS_PAYLOAD_TYPE_MESSAGE = 1,
-  // Platform-dependent stack trace in iree_status_payload_stack_trace_t.
-  IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE = 2,
-  // Starting type ID for user payloads. IREE reserves all payloads with types
-  // less than this.
-  IREE_STATUS_PAYLOAD_TYPE_MIN_USER = 0x70000000u,
-} iree_status_payload_type_t;
-
-typedef struct iree_status_payload_t iree_status_payload_t;
-
-// Function that formats a payload into a human-readable string form for logs.
-typedef void(IREE_API_PTR* iree_status_payload_formatter_t)(
-    const iree_status_payload_t* payload, iree_host_size_t buffer_capacity,
-    char* buffer, iree_host_size_t* out_buffer_length);
-
-// Header for optional status payloads.
-// Each status may have zero or more payloads associated with it that can later
-// be used to produce more detailed logging or programmatically query
-// information about an error.
-struct iree_status_payload_t {
-  // Next payload in the status payload linked list.
-  struct iree_status_payload_t* next;
-  // Payload type identifier used for programmatic access to payloads. May be
-  // IREE_STATUS_PAYLOAD_TYPE_OPAQUE if the payload cannot be accessed directly.
-  iree_status_payload_type_t type;
-  // Allocator used for the payload and associated resources.
-  iree_allocator_t allocator;
-  // String formatter callback used to write the payload into a string buffer.
-  // If not present then the payload will be mentioned but not dumped when the
-  // status is logged.
-  iree_status_payload_formatter_t formatter;
-};
-
-// A string message (IREE_STATUS_PAYLOAD_TYPE_MESSAGE).
-typedef struct iree_status_payload_message_t {
-  iree_status_payload_t header;
-  // String data reference. May point to an address immediately following this
-  // struct (if copied) or a constant string reference in rodata.
-  iree_string_view_t message;
-} iree_status_payload_message_t;
-
-// A platform-dependent stack trace (IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE).
-typedef struct iree_status_payload_stack_trace_t {
-  iree_status_payload_t header;
-  uint16_t skip_frames;
-  uint16_t frame_count;
-  uintptr_t addresses[];
-} iree_status_payload_stack_trace_t;
-
 // Allocated storage for an iree_status_t.
 // Only statuses that have either source information or payloads will have
 // storage allocated for them.
-typedef struct iree_status_storage_t {
+struct iree_status_storage_t {
   // Optional doubly-linked list of payloads associated with the status.
   // Head = first added, tail = last added.
   iree_status_payload_t* payload_head;
@@ -387,15 +313,15 @@ typedef struct iree_status_storage_t {
   // present as a suffix on the storage.
   iree_string_view_t message;
 #endif  // has IREE_STATUS_FEATURE_ANNOTATIONS
-} iree_status_storage_t;
+};
 
 #define iree_status_storage(status) \
   ((iree_status_storage_t*)(((uintptr_t)(status) & ~IREE_STATUS_CODE_MASK)))
 
 // Appends a payload to the storage doubly-linked list.
-static iree_status_t iree_status_append_payload(
-    iree_status_t status, iree_status_storage_t* storage,
-    iree_status_payload_t* payload) {
+iree_status_t iree_status_append_payload(iree_status_t status,
+                                         iree_status_storage_t* storage,
+                                         iree_status_payload_t* payload) {
   if (!storage->payload_tail) {
     storage->payload_head = payload;
   } else {
@@ -427,345 +353,15 @@ static void iree_status_payload_message_formatter(
   *out_buffer_length = n;
 }
 
-#if defined(IREE_STATUS_HAVE_STACK_TRACE_SUPPORT) && \
-    ((IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_STACK_TRACE) != 0)
-
-// TODO(benvanik): make a string_view utility to share with console tracing.
-static iree_string_view_t iree_status_trim_file_path(const char* file_name) {
-  size_t file_name_length = strlen(file_name);
-  for (int i = (int)file_name_length - 1; i >= 0; --i) {
-    char c = file_name[i];
-    if (c == '/' || c == '\\') {
-      return iree_make_string_view(file_name + i + 1, file_name_length - i - 1);
-    }
-  }
-  return iree_make_string_view(file_name, file_name_length);
-}
-
-static iree_host_size_t iree_string_buffer_append_cstr(
-    iree_host_size_t buffer_capacity, char* buffer,
-    iree_host_size_t buffer_length, const char* str) {
-  iree_host_size_t n =
-      snprintf(buffer ? buffer + buffer_length : NULL,
-               buffer ? buffer_capacity - buffer_length : 0, "%s", str);
-  return IREE_UNLIKELY(n < 0) ? 0 : buffer_length + n;
-}
-
-static iree_host_size_t IREE_PRINTF_ATTRIBUTE(4, 5)
-    iree_string_buffer_append_format(iree_host_size_t buffer_capacity,
-                                     char* buffer,
-                                     iree_host_size_t buffer_length,
-                                     const char* format, ...) {
-  va_list varargs;
-  va_start(varargs, format);
-  iree_host_size_t n =
-      vsnprintf(buffer ? buffer + buffer_length : NULL,
-                buffer ? buffer_capacity - buffer_length : 0, format, varargs);
-  va_end(varargs);
-  return IREE_UNLIKELY(n < 0) ? 0 : buffer_length + n;
-}
-
-#if defined(IREE_PLATFORM_WINDOWS)
-
-typedef BOOL(WINAPI* PFN_SymInitialize)(HANDLE, PCSTR, BOOL);
-typedef BOOL(WINAPI* PFN_SymCleanup)(HANDLE);
-typedef BOOL(WINAPI* PFN_SymGetModuleInfo64)(HANDLE, DWORD64,
-                                             PIMAGEHLP_MODULE64);
-typedef BOOL(WINAPI* PFN_SymFromAddr)(HANDLE, DWORD64, PDWORD64, PSYMBOL_INFO);
-typedef BOOL(WINAPI* PFN_SymGetLineFromAddr64)(HANDLE, DWORD64, PDWORD,
-                                               PIMAGEHLP_LINE);
-typedef struct iree_symbol_resolver_t {
-  SRWLOCK mutex;
-  HMODULE library;
-  PFN_SymInitialize SymInitialize;
-  PFN_SymCleanup SymCleanup;
-  PFN_SymGetModuleInfo64 SymGetModuleInfo64;
-  PFN_SymFromAddr SymFromAddr;
-  PFN_SymGetLineFromAddr64 SymGetLineFromAddr64;
-} iree_symbol_resolver_t;
-
-// If tracy is enabled then it has its own dbghelp lock we need to use.
-// If not enabled then we
-#if defined(TRACY_ENABLE)
-void IREEDbgHelpInit(void);
-void IREEDbgHelpLock(void);
-void IREEDbgHelpUnlock(void);
-static void iree_symbol_resolver_initialize_mutex(
-    iree_symbol_resolver_t* resolver) {
-  IREEDbgHelpInit();
-}
-static void iree_symbol_resolver_lock(iree_symbol_resolver_t* resolver) {
-  IREEDbgHelpLock();
-}
-static void iree_symbol_resolver_unlock(iree_symbol_resolver_t* resolver) {
-  IREEDbgHelpUnlock();
-}
-#else
-static void iree_symbol_resolver_initialize_mutex(
-    iree_symbol_resolver_t* resolver) {
-  InitializeSRWLock(&resolver->mutex);
-}
-static void iree_symbol_resolver_lock(iree_symbol_resolver_t* resolver) {
-  AcquireSRWLockExclusive(&resolver->mutex);
-}
-static void iree_symbol_resolver_unlock(iree_symbol_resolver_t* resolver) {
-  ReleaseSRWLockExclusive(&resolver->mutex);
-}
-#endif  // TRACY_ENABLE
-
-static void iree_symbol_resolver_initialize(
-    iree_symbol_resolver_t* out_resolver) {
-  memset(out_resolver, 0, sizeof(*out_resolver));
-  iree_symbol_resolver_initialize_mutex(out_resolver);
-  out_resolver->library = LoadLibraryA("dbghelp.dll");
-  if (!out_resolver->library) return;
-  out_resolver->SymInitialize =
-      (PFN_SymInitialize)GetProcAddress(out_resolver->library, "SymInitialize");
-  out_resolver->SymCleanup =
-      (PFN_SymCleanup)GetProcAddress(out_resolver->library, "SymCleanup");
-  out_resolver->SymGetModuleInfo64 = (PFN_SymGetModuleInfo64)GetProcAddress(
-      out_resolver->library, "SymGetModuleInfo64");
-  out_resolver->SymFromAddr =
-      (PFN_SymFromAddr)GetProcAddress(out_resolver->library, "SymFromAddr");
-  out_resolver->SymGetLineFromAddr64 = (PFN_SymGetLineFromAddr64)GetProcAddress(
-      out_resolver->library, "SymGetLineFromAddr64");
-  if (!out_resolver->SymInitialize || !out_resolver->SymCleanup ||
-      !out_resolver->SymGetModuleInfo64 || !out_resolver->SymFromAddr ||
-      !out_resolver->SymGetLineFromAddr64) {
-    FreeLibrary(out_resolver->library);
-    memset(out_resolver, 0, sizeof(*out_resolver));
-    return;
-  }
-  out_resolver->SymInitialize(GetCurrentProcess(), /*UserSearchPath=*/NULL,
-                              /*fInvadeProcess=*/TRUE);
-}
-
-static void iree_symbol_resolver_deinitialize(
-    iree_symbol_resolver_t* resolver) {
-  if (resolver->SymCleanup) {
-    resolver->SymCleanup(GetCurrentProcess());
-  }
-  if (resolver->library) {
-    FreeLibrary(resolver->library);
-    resolver->library = NULL;
-  }
-  memset(resolver, 0, sizeof(*resolver));
-}
-
-static BOOL CALLBACK iree_symbol_resolver_setup(PINIT_ONCE InitOnce,
-                                                PVOID Parameter,
-                                                PVOID* Context) {
-  ((void)InitOnce);
-  ((void)Context);
-  iree_symbol_resolver_initialize((iree_symbol_resolver_t*)Parameter);
-  return TRUE;
-}
-
-static INIT_ONCE instance_flag = INIT_ONCE_STATIC_INIT;
-static iree_symbol_resolver_t instance;
-static iree_symbol_resolver_t* iree_symbol_resolver_get(void) {
-  InitOnceExecuteOnce(&instance_flag, iree_symbol_resolver_setup,
-                      (PVOID)&instance, NULL);
-  return &instance;
-}
-
-static bool iree_symbol_resolver_format_frame(iree_symbol_resolver_t* resolver,
-                                              void* address,
-                                              iree_host_size_t buffer_capacity,
-                                              char* buffer,
-                                              iree_host_size_t* buffer_length) {
-  if (IREE_UNLIKELY(!resolver->library)) return false;
-
-  HANDLE process = GetCurrentProcess();
-
-  // Query generic information like what module the address is located in and
-  // what the offset of the address is within its parent symbol.
-  char symbol_buffer[512];
-  SYMBOL_INFO* symbol_info = (SYMBOL_INFO*)symbol_buffer;
-  symbol_info->SizeOfStruct = sizeof(*symbol_info);
-  symbol_info->MaxNameLen = sizeof(symbol_buffer) - sizeof(*symbol_info);
-  DWORD64 displacement64 = 0;
-  iree_symbol_resolver_lock(resolver);
-  BOOL result = resolver->SymFromAddr(process, (DWORD64)address,
-                                      &displacement64, symbol_info);
-  iree_symbol_resolver_unlock(resolver);
-  if (!result) {
-    // Failed to get any information; bail.
-    return false;
-  }
-
-  IMAGEHLP_MODULE64 module;
-  module.SizeOfStruct = sizeof(module);
-  if (resolver->SymGetModuleInfo64(process, symbol_info->ModBase, &module)) {
-    *buffer_length = iree_string_buffer_append_cstr(
-        buffer_capacity, buffer, *buffer_length, module.ModuleName);
-  } else {
-    *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                    *buffer_length, "???");
-  }
-
-  *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                  *buffer_length, " <");
-  if (symbol_info->NameLen > 0) {
-    *buffer_length = iree_string_buffer_append_format(
-        buffer_capacity, buffer, *buffer_length, "%.*s",
-        (int)symbol_info->NameLen, symbol_info->Name);
-  } else {
-    *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                    *buffer_length, "???");
-  }
-  if (displacement64) {
-    *buffer_length = iree_string_buffer_append_format(
-        buffer_capacity, buffer, *buffer_length, "+0x%0" PRIx64,
-        displacement64);
-  }
-  *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                  *buffer_length, ">");
-
-  // Note that the returned name pointer is only valid while the lock is held.
-  IMAGEHLP_LINE64 line;
-  line.SizeOfStruct = sizeof(line);
-  DWORD displacement32 = 0;
-  iree_symbol_resolver_lock(resolver);
-  if (resolver->SymGetLineFromAddr64(process, (DWORD64)address, &displacement32,
-                                     &line)) {
-    *buffer_length = iree_string_buffer_append_format(
-        buffer_capacity, buffer, *buffer_length, " (%s:%" PRIu32 ")",
-        line.FileName, (uint32_t)line.LineNumber);
-  }
-  iree_symbol_resolver_unlock(resolver);
-
-  return true;
-}
-
-#endif  // IREE_PLATFORM_WINDOWS
-
-static iree_host_size_t iree_status_payload_stack_trace_format_frame(
-    void* address, iree_host_size_t buffer_capacity, char* buffer) {
-  iree_host_size_t buffer_length = iree_string_buffer_append_format(
-      buffer_capacity, buffer, 0, "  0x%016" PRIx64 " ",
-      (uint64_t)(uintptr_t)address);
-#if defined(IREE_HAVE_BACKTRACE)
-  Dl_info info;
-  if (dladdr(address, &info) != 0) {
-    if (info.dli_fname) {
-      iree_string_view_t fname = iree_status_trim_file_path(info.dli_fname);
-      buffer_length = iree_string_buffer_append_format(
-          buffer_capacity, buffer, buffer_length, "%.*s", (int)fname.size,
-          fname.data);
-    } else {
-      buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                     buffer_length, "???");
-    }
-    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                   buffer_length, " <");
-    if (info.dli_sname) {
-      iree_string_view_t sname = iree_make_cstring_view(info.dli_sname);
-      buffer_length = iree_string_buffer_append_format(
-          buffer_capacity, buffer, buffer_length, "%.*s", (int)sname.size,
-          sname.data);
-    } else {
-      buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                     buffer_length, "???");
-    }
-    void* saddr = info.dli_saddr ? info.dli_saddr : address;
-    ptrdiff_t diff = (ptrdiff_t)address - (ptrdiff_t)saddr;
-    if (diff) {
-      buffer_length = iree_string_buffer_append_format(
-          buffer_capacity, buffer, buffer_length, "+0x%0" PRIx32,
-          (int32_t)diff);
-    }
-    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                   buffer_length, ">");
-  } else {
-    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                   buffer_length, "???");
-  }
-#elif defined(IREE_PLATFORM_WINDOWS)
-  if (!iree_symbol_resolver_format_frame(iree_symbol_resolver_get(), address,
-                                         buffer_capacity, buffer,
-                                         &buffer_length)) {
-    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                   buffer_length, "???");
-  }
-#else
-  // Symbol resolution not implemented on the platform.
-  buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
-                                                 buffer_length, "???");
-#endif
-  return iree_string_buffer_append_cstr(buffer_capacity, buffer, buffer_length,
-                                        "\n");
-}
-
-static void iree_status_payload_stack_trace_formatter(
-    const iree_status_payload_t* base_payload, iree_host_size_t buffer_capacity,
-    char* buffer, iree_host_size_t* out_buffer_length) {
-  iree_status_payload_stack_trace_t* payload =
-      (iree_status_payload_stack_trace_t*)base_payload;
-  if (payload->frame_count - payload->skip_frames == 0) return;
-  iree_host_size_t buffer_length =
-      iree_string_buffer_append_cstr(buffer_capacity, buffer, 0, "stack:\n");
-  for (iree_host_size_t i = payload->skip_frames + 1; i < payload->frame_count;
-       ++i) {
-    buffer_length += iree_status_payload_stack_trace_format_frame(
-        (void*)payload->addresses[i],
-        buffer ? buffer_capacity - buffer_length : 0,
-        buffer ? buffer + buffer_length : NULL);
-    if (buffer_length > buffer_capacity) buffer = NULL;
-  }
-  *out_buffer_length = buffer_length;
-}
-
 // Captures the current stack and attaches it to the status storage.
 // A count of |skip_frames| will be skipped from the top of the stack.
 // Setting |skip_frames|=0 will include the caller in the stack while
 // |skip_frames|=1 will exclude it.
-static iree_status_t iree_status_attach_stack_trace(
-    iree_status_t status, iree_status_storage_t* storage, int skip_frames) {
-  // Reserve storage for the number of stack frames so we can capture directly
-  // into the storage even if we don't need them all. At the point we are
-  // mallocing the exact size doesn't really matter.
-  iree_status_payload_stack_trace_t* payload = NULL;
-  iree_host_size_t total_size =
-      sizeof(*payload) +
-      sizeof(payload->addresses[0]) * IREE_STATUS_MAX_STACK_TRACE_FRAMES;
-
-  iree_allocator_t allocator = iree_allocator_system();
-  iree_status_ignore(
-      iree_allocator_malloc(allocator, total_size, (void**)&payload));
-  if (IREE_UNLIKELY(!payload)) return status;
-  memset(payload, 0, sizeof(*payload));
-  payload->header.type = IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE;
-  payload->header.allocator = allocator;
-  payload->header.formatter = iree_status_payload_stack_trace_formatter;
-
-#if defined(IREE_HAVE_BACKTRACE)
-  // Capture up to the max frame count and skip some frames when formatting -
-  // this means that our actual backtrace() max frame count is smaller than the
-  // defined value. We could instead overallocate by skip_frames to waste a bit
-  // of memory but keep the processing simpler.
-  payload->skip_frames = skip_frames;
-  payload->frame_count = backtrace((void**)&payload->addresses,
-                                   IREE_STATUS_MAX_STACK_TRACE_FRAMES);
-#elif defined(IREE_PLATFORM_WINDOWS)
-  // NOTE: Win32 supports skip frames by default so we don't lose any storage.
-  payload->frame_count =
-      CaptureStackBackTrace(skip_frames, IREE_STATUS_MAX_STACK_TRACE_FRAMES,
-                            (void**)&payload->addresses, NULL);
-#endif
-
-  return iree_status_append_payload(status, storage,
-                                    (iree_status_payload_t*)payload);
-}
-
-#else
-
-static iree_status_t iree_status_attach_stack_trace(
-    iree_status_t status, iree_status_storage_t* storage, int skip_frames) {
-  return status;
-}
-
-#endif  // has IREE_STATUS_FEATURE_STACK_TRACE
+//
+// Defined in status_stack_trace.c.
+iree_status_t iree_status_attach_stack_trace(iree_status_t status,
+                                             iree_status_storage_t* storage,
+                                             int skip_frames);
 
 IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t
 iree_status_allocate(iree_status_code_t code, const char* file, uint32_t line,

--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -398,6 +398,9 @@ typedef struct iree_status_handle_t* iree_status_t;
 #define IREE_CHECK_OK(expr)                                                    \
   IREE_STATUS_IMPL_CHECK_OK_(IREE_STATUS_IMPL_CONCAT_(__status_, __COUNTER__), \
                              (expr))
+//===----------------------------------------------------------------------===//
+// Status code utilities
+//===----------------------------------------------------------------------===//
 
 // Returns the canonical status code for the given errno value.
 // https://en.cppreference.com/w/cpp/error/errno_macros
@@ -415,6 +418,10 @@ iree_status_code_from_win32_error(uint32_t error);
 // IREE_STATUS_UNAVAILABLE = "UNAVAILABLE". Do not rely on string-matching the
 // result as the exact text may change.
 IREE_API_EXPORT const char* iree_status_code_string(iree_status_code_t code);
+
+//===----------------------------------------------------------------------===//
+// Status management
+//===----------------------------------------------------------------------===//
 
 // Allocates a new status instance for a failing error |code|.
 // |file| and |line| should be populated with __FILE__ and __LINE__ at the call
@@ -493,6 +500,10 @@ IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t IREE_PRINTF_ATTRIBUTE(2, 3)
 #define iree_status_annotate(base_status, ...) (base_status)
 #define iree_status_annotate_f(base_status, ...) (base_status)
 #endif  // has IREE_STATUS_FEATURE_ANNOTATIONS
+
+//===----------------------------------------------------------------------===//
+// Status string conversion and printing
+//===----------------------------------------------------------------------===//
 
 // Formats the status as a multi-line string containing all associated payloads.
 // Note that this may contain PII such as file paths and must only be used for

--- a/runtime/src/iree/base/status_payload.h
+++ b/runtime/src/iree/base/status_payload.h
@@ -1,0 +1,88 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_STATUS_PAYLOAD_H_
+#define IREE_BASE_STATUS_PAYLOAD_H_
+
+#include "iree/base/allocator.h"
+#include "iree/base/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Status payload API
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_status_storage_t iree_status_storage_t;
+
+// Defines the type of an iree_status_payload_t.
+typedef enum iree_status_payload_type_e {
+  // Opaque; payload may still be formatted by a formatter but is not possible
+  // to retrieve by the programmatic APIs.
+  IREE_STATUS_PAYLOAD_TYPE_OPAQUE = 0,
+  // A string message annotation of type iree_status_payload_message_t.
+  IREE_STATUS_PAYLOAD_TYPE_MESSAGE = 1,
+  // Platform-dependent stack trace in iree_status_payload_stack_trace_t.
+  IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE = 2,
+  // Starting type ID for user payloads. IREE reserves all payloads with types
+  // less than this.
+  IREE_STATUS_PAYLOAD_TYPE_MIN_USER = 0x70000000u,
+} iree_status_payload_type_t;
+
+typedef struct iree_status_payload_t iree_status_payload_t;
+
+// Function that formats a payload into a human-readable string form for logs.
+typedef void(IREE_API_PTR* iree_status_payload_formatter_t)(
+    const iree_status_payload_t* payload, iree_host_size_t buffer_capacity,
+    char* buffer, iree_host_size_t* out_buffer_length);
+
+// Header for optional status payloads.
+// Each status may have zero or more payloads associated with it that can later
+// be used to produce more detailed logging or programmatically query
+// information about an error.
+struct iree_status_payload_t {
+  // Next payload in the status payload linked list.
+  struct iree_status_payload_t* next;
+  // Payload type identifier used for programmatic access to payloads. May be
+  // IREE_STATUS_PAYLOAD_TYPE_OPAQUE if the payload cannot be accessed directly.
+  iree_status_payload_type_t type;
+  // Allocator used for the payload and associated resources.
+  iree_allocator_t allocator;
+  // String formatter callback used to write the payload into a string buffer.
+  // If not present then the payload will be mentioned but not dumped when the
+  // status is logged.
+  iree_status_payload_formatter_t formatter;
+};
+
+// A string message (IREE_STATUS_PAYLOAD_TYPE_MESSAGE).
+typedef struct iree_status_payload_message_t {
+  iree_status_payload_t header;
+  // String data reference. May point to an address immediately following this
+  // struct (if copied) or a constant string reference in rodata.
+  iree_string_view_t message;
+} iree_status_payload_message_t;
+
+// A platform-dependent stack trace (IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE).
+typedef struct iree_status_payload_stack_trace_t {
+  iree_status_payload_t header;
+  uint16_t skip_frames;
+  uint16_t frame_count;
+  uintptr_t addresses[];
+} iree_status_payload_stack_trace_t;
+
+// TODO(benvanik): expose API for appending/enumerating payloads.
+// Currently this is an implementation detail.
+iree_status_t iree_status_append_payload(iree_status_t status,
+                                         iree_status_storage_t* storage,
+                                         iree_status_payload_t* payload);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_STATUS_PAYLOAD_H_

--- a/runtime/src/iree/base/status_stack_trace.c
+++ b/runtime/src/iree/base/status_stack_trace.c
@@ -1,0 +1,380 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/target_platform.h"
+
+#if defined(IREE_PLATFORM_APPLE)
+#include <dlfcn.h>
+#include <execinfo.h>
+#define IREE_HAVE_BACKTRACE 1
+#define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
+#elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
+// Currently disabled because we can't get meaningful stacks on Linux.
+// #define _GNU_SOURCE 1
+// #include <dlfcn.h>
+// #include <execinfo.h>
+// #define IREE_HAVE_BACKTRACE 1
+// #define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
+#elif defined(IREE_PLATFORM_WINDOWS)
+#pragma warning(disable : 4091)
+#include <dbghelp.h>
+#define IREE_STATUS_HAVE_STACK_TRACE_SUPPORT 1
+#endif  // IREE_PLATFORM_*
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "iree/base/alignment.h"
+#include "iree/base/allocator.h"
+#include "iree/base/assert.h"
+#include "iree/base/config.h"
+#include "iree/base/status.h"
+#include "iree/base/status_payload.h"
+#include "iree/base/tracing.h"
+
+#if defined(IREE_STATUS_HAVE_STACK_TRACE_SUPPORT) && \
+    ((IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_STACK_TRACE) != 0)
+
+// TODO(benvanik): make a string_view utility to share with console tracing.
+static iree_string_view_t iree_status_trim_file_path(const char* file_name) {
+  size_t file_name_length = strlen(file_name);
+  for (int i = (int)file_name_length - 1; i >= 0; --i) {
+    char c = file_name[i];
+    if (c == '/' || c == '\\') {
+      return iree_make_string_view(file_name + i + 1, file_name_length - i - 1);
+    }
+  }
+  return iree_make_string_view(file_name, file_name_length);
+}
+
+static iree_host_size_t iree_string_buffer_append_cstr(
+    iree_host_size_t buffer_capacity, char* buffer,
+    iree_host_size_t buffer_length, const char* str) {
+  iree_host_size_t n =
+      snprintf(buffer ? buffer + buffer_length : NULL,
+               buffer ? buffer_capacity - buffer_length : 0, "%s", str);
+  return IREE_UNLIKELY(n < 0) ? 0 : buffer_length + n;
+}
+
+static iree_host_size_t IREE_PRINTF_ATTRIBUTE(4, 5)
+    iree_string_buffer_append_format(iree_host_size_t buffer_capacity,
+                                     char* buffer,
+                                     iree_host_size_t buffer_length,
+                                     const char* format, ...) {
+  va_list varargs;
+  va_start(varargs, format);
+  iree_host_size_t n =
+      vsnprintf(buffer ? buffer + buffer_length : NULL,
+                buffer ? buffer_capacity - buffer_length : 0, format, varargs);
+  va_end(varargs);
+  return IREE_UNLIKELY(n < 0) ? 0 : buffer_length + n;
+}
+
+#if defined(IREE_PLATFORM_WINDOWS)
+
+typedef BOOL(WINAPI* PFN_SymInitialize)(HANDLE, PCSTR, BOOL);
+typedef BOOL(WINAPI* PFN_SymCleanup)(HANDLE);
+typedef BOOL(WINAPI* PFN_SymGetModuleInfo64)(HANDLE, DWORD64,
+                                             PIMAGEHLP_MODULE64);
+typedef BOOL(WINAPI* PFN_SymFromAddr)(HANDLE, DWORD64, PDWORD64, PSYMBOL_INFO);
+typedef BOOL(WINAPI* PFN_SymGetLineFromAddr64)(HANDLE, DWORD64, PDWORD,
+                                               PIMAGEHLP_LINE);
+typedef struct iree_symbol_resolver_t {
+  SRWLOCK mutex;
+  HMODULE library;
+  PFN_SymInitialize SymInitialize;
+  PFN_SymCleanup SymCleanup;
+  PFN_SymGetModuleInfo64 SymGetModuleInfo64;
+  PFN_SymFromAddr SymFromAddr;
+  PFN_SymGetLineFromAddr64 SymGetLineFromAddr64;
+} iree_symbol_resolver_t;
+
+// If tracy is enabled then it has its own dbghelp lock we need to use.
+// If not enabled then we
+#if defined(TRACY_ENABLE)
+void IREEDbgHelpInit(void);
+void IREEDbgHelpLock(void);
+void IREEDbgHelpUnlock(void);
+static void iree_symbol_resolver_initialize_mutex(
+    iree_symbol_resolver_t* resolver) {
+  IREEDbgHelpInit();
+}
+static void iree_symbol_resolver_lock(iree_symbol_resolver_t* resolver) {
+  IREEDbgHelpLock();
+}
+static void iree_symbol_resolver_unlock(iree_symbol_resolver_t* resolver) {
+  IREEDbgHelpUnlock();
+}
+#else
+static void iree_symbol_resolver_initialize_mutex(
+    iree_symbol_resolver_t* resolver) {
+  InitializeSRWLock(&resolver->mutex);
+}
+static void iree_symbol_resolver_lock(iree_symbol_resolver_t* resolver) {
+  AcquireSRWLockExclusive(&resolver->mutex);
+}
+static void iree_symbol_resolver_unlock(iree_symbol_resolver_t* resolver) {
+  ReleaseSRWLockExclusive(&resolver->mutex);
+}
+#endif  // TRACY_ENABLE
+
+static void iree_symbol_resolver_initialize(
+    iree_symbol_resolver_t* out_resolver) {
+  memset(out_resolver, 0, sizeof(*out_resolver));
+  iree_symbol_resolver_initialize_mutex(out_resolver);
+  out_resolver->library = LoadLibraryA("dbghelp.dll");
+  if (!out_resolver->library) return;
+  out_resolver->SymInitialize =
+      (PFN_SymInitialize)GetProcAddress(out_resolver->library, "SymInitialize");
+  out_resolver->SymCleanup =
+      (PFN_SymCleanup)GetProcAddress(out_resolver->library, "SymCleanup");
+  out_resolver->SymGetModuleInfo64 = (PFN_SymGetModuleInfo64)GetProcAddress(
+      out_resolver->library, "SymGetModuleInfo64");
+  out_resolver->SymFromAddr =
+      (PFN_SymFromAddr)GetProcAddress(out_resolver->library, "SymFromAddr");
+  out_resolver->SymGetLineFromAddr64 = (PFN_SymGetLineFromAddr64)GetProcAddress(
+      out_resolver->library, "SymGetLineFromAddr64");
+  if (!out_resolver->SymInitialize || !out_resolver->SymCleanup ||
+      !out_resolver->SymGetModuleInfo64 || !out_resolver->SymFromAddr ||
+      !out_resolver->SymGetLineFromAddr64) {
+    FreeLibrary(out_resolver->library);
+    memset(out_resolver, 0, sizeof(*out_resolver));
+    return;
+  }
+  out_resolver->SymInitialize(GetCurrentProcess(), /*UserSearchPath=*/NULL,
+                              /*fInvadeProcess=*/TRUE);
+}
+
+static void iree_symbol_resolver_deinitialize(
+    iree_symbol_resolver_t* resolver) {
+  if (resolver->SymCleanup) {
+    resolver->SymCleanup(GetCurrentProcess());
+  }
+  if (resolver->library) {
+    FreeLibrary(resolver->library);
+    resolver->library = NULL;
+  }
+  memset(resolver, 0, sizeof(*resolver));
+}
+
+static BOOL CALLBACK iree_symbol_resolver_setup(PINIT_ONCE InitOnce,
+                                                PVOID Parameter,
+                                                PVOID* Context) {
+  ((void)InitOnce);
+  ((void)Context);
+  iree_symbol_resolver_initialize((iree_symbol_resolver_t*)Parameter);
+  return TRUE;
+}
+
+static INIT_ONCE instance_flag = INIT_ONCE_STATIC_INIT;
+static iree_symbol_resolver_t instance;
+static iree_symbol_resolver_t* iree_symbol_resolver_get(void) {
+  InitOnceExecuteOnce(&instance_flag, iree_symbol_resolver_setup,
+                      (PVOID)&instance, NULL);
+  return &instance;
+}
+
+static bool iree_symbol_resolver_format_frame(iree_symbol_resolver_t* resolver,
+                                              void* address,
+                                              iree_host_size_t buffer_capacity,
+                                              char* buffer,
+                                              iree_host_size_t* buffer_length) {
+  if (IREE_UNLIKELY(!resolver->library)) return false;
+
+  HANDLE process = GetCurrentProcess();
+
+  // Query generic information like what module the address is located in and
+  // what the offset of the address is within its parent symbol.
+  char symbol_buffer[512];
+  SYMBOL_INFO* symbol_info = (SYMBOL_INFO*)symbol_buffer;
+  symbol_info->SizeOfStruct = sizeof(*symbol_info);
+  symbol_info->MaxNameLen = sizeof(symbol_buffer) - sizeof(*symbol_info);
+  DWORD64 displacement64 = 0;
+  iree_symbol_resolver_lock(resolver);
+  BOOL result = resolver->SymFromAddr(process, (DWORD64)address,
+                                      &displacement64, symbol_info);
+  iree_symbol_resolver_unlock(resolver);
+  if (!result) {
+    // Failed to get any information; bail.
+    return false;
+  }
+
+  IMAGEHLP_MODULE64 module;
+  module.SizeOfStruct = sizeof(module);
+  if (resolver->SymGetModuleInfo64(process, symbol_info->ModBase, &module)) {
+    *buffer_length = iree_string_buffer_append_cstr(
+        buffer_capacity, buffer, *buffer_length, module.ModuleName);
+  } else {
+    *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                    *buffer_length, "???");
+  }
+
+  *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                  *buffer_length, " <");
+  if (symbol_info->NameLen > 0) {
+    *buffer_length = iree_string_buffer_append_format(
+        buffer_capacity, buffer, *buffer_length, "%.*s",
+        (int)symbol_info->NameLen, symbol_info->Name);
+  } else {
+    *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                    *buffer_length, "???");
+  }
+  if (displacement64) {
+    *buffer_length = iree_string_buffer_append_format(
+        buffer_capacity, buffer, *buffer_length, "+0x%0" PRIx64,
+        displacement64);
+  }
+  *buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                  *buffer_length, ">");
+
+  // Note that the returned name pointer is only valid while the lock is held.
+  IMAGEHLP_LINE64 line;
+  line.SizeOfStruct = sizeof(line);
+  DWORD displacement32 = 0;
+  iree_symbol_resolver_lock(resolver);
+  if (resolver->SymGetLineFromAddr64(process, (DWORD64)address, &displacement32,
+                                     &line)) {
+    *buffer_length = iree_string_buffer_append_format(
+        buffer_capacity, buffer, *buffer_length, " (%s:%" PRIu32 ")",
+        line.FileName, (uint32_t)line.LineNumber);
+  }
+  iree_symbol_resolver_unlock(resolver);
+
+  return true;
+}
+
+#endif  // IREE_PLATFORM_WINDOWS
+
+static iree_host_size_t iree_status_payload_stack_trace_format_frame(
+    void* address, iree_host_size_t buffer_capacity, char* buffer) {
+  iree_host_size_t buffer_length = iree_string_buffer_append_format(
+      buffer_capacity, buffer, 0, "  0x%016" PRIx64 " ",
+      (uint64_t)(uintptr_t)address);
+#if defined(IREE_HAVE_BACKTRACE)
+  Dl_info info;
+  if (dladdr(address, &info) != 0) {
+    if (info.dli_fname) {
+      iree_string_view_t fname = iree_status_trim_file_path(info.dli_fname);
+      buffer_length = iree_string_buffer_append_format(
+          buffer_capacity, buffer, buffer_length, "%.*s", (int)fname.size,
+          fname.data);
+    } else {
+      buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                     buffer_length, "???");
+    }
+    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                   buffer_length, " <");
+    if (info.dli_sname) {
+      iree_string_view_t sname = iree_make_cstring_view(info.dli_sname);
+      buffer_length = iree_string_buffer_append_format(
+          buffer_capacity, buffer, buffer_length, "%.*s", (int)sname.size,
+          sname.data);
+    } else {
+      buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                     buffer_length, "???");
+    }
+    void* saddr = info.dli_saddr ? info.dli_saddr : address;
+    ptrdiff_t diff = (ptrdiff_t)address - (ptrdiff_t)saddr;
+    if (diff) {
+      buffer_length = iree_string_buffer_append_format(
+          buffer_capacity, buffer, buffer_length, "+0x%0" PRIx32,
+          (int32_t)diff);
+    }
+    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                   buffer_length, ">");
+  } else {
+    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                   buffer_length, "???");
+  }
+#elif defined(IREE_PLATFORM_WINDOWS)
+  if (!iree_symbol_resolver_format_frame(iree_symbol_resolver_get(), address,
+                                         buffer_capacity, buffer,
+                                         &buffer_length)) {
+    buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                   buffer_length, "???");
+  }
+#else
+  // Symbol resolution not implemented on the platform.
+  buffer_length = iree_string_buffer_append_cstr(buffer_capacity, buffer,
+                                                 buffer_length, "???");
+#endif
+  return iree_string_buffer_append_cstr(buffer_capacity, buffer, buffer_length,
+                                        "\n");
+}
+
+static void iree_status_payload_stack_trace_formatter(
+    const iree_status_payload_t* base_payload, iree_host_size_t buffer_capacity,
+    char* buffer, iree_host_size_t* out_buffer_length) {
+  iree_status_payload_stack_trace_t* payload =
+      (iree_status_payload_stack_trace_t*)base_payload;
+  if (payload->frame_count - payload->skip_frames == 0) return;
+  iree_host_size_t buffer_length =
+      iree_string_buffer_append_cstr(buffer_capacity, buffer, 0, "stack:\n");
+  for (iree_host_size_t i = payload->skip_frames + 1; i < payload->frame_count;
+       ++i) {
+    buffer_length += iree_status_payload_stack_trace_format_frame(
+        (void*)payload->addresses[i],
+        buffer ? buffer_capacity - buffer_length : 0,
+        buffer ? buffer + buffer_length : NULL);
+    if (buffer_length > buffer_capacity) buffer = NULL;
+  }
+  *out_buffer_length = buffer_length;
+}
+
+// Captures the current stack and attaches it to the status storage.
+// A count of |skip_frames| will be skipped from the top of the stack.
+// Setting |skip_frames|=0 will include the caller in the stack while
+// |skip_frames|=1 will exclude it.
+iree_status_t iree_status_attach_stack_trace(iree_status_t status,
+                                             iree_status_storage_t* storage,
+                                             int skip_frames) {
+  // Reserve storage for the number of stack frames so we can capture directly
+  // into the storage even if we don't need them all. At the point we are
+  // mallocing the exact size doesn't really matter.
+  iree_status_payload_stack_trace_t* payload = NULL;
+  iree_host_size_t total_size =
+      sizeof(*payload) +
+      sizeof(payload->addresses[0]) * IREE_STATUS_MAX_STACK_TRACE_FRAMES;
+
+  iree_allocator_t allocator = iree_allocator_system();
+  iree_status_ignore(
+      iree_allocator_malloc(allocator, total_size, (void**)&payload));
+  if (IREE_UNLIKELY(!payload)) return status;
+  memset(payload, 0, sizeof(*payload));
+  payload->header.type = IREE_STATUS_PAYLOAD_TYPE_STACK_TRACE;
+  payload->header.allocator = allocator;
+  payload->header.formatter = iree_status_payload_stack_trace_formatter;
+
+#if defined(IREE_HAVE_BACKTRACE)
+  // Capture up to the max frame count and skip some frames when formatting -
+  // this means that our actual backtrace() max frame count is smaller than the
+  // defined value. We could instead overallocate by skip_frames to waste a bit
+  // of memory but keep the processing simpler.
+  payload->skip_frames = skip_frames;
+  payload->frame_count = backtrace((void**)&payload->addresses,
+                                   IREE_STATUS_MAX_STACK_TRACE_FRAMES);
+#elif defined(IREE_PLATFORM_WINDOWS)
+  // NOTE: Win32 supports skip frames by default so we don't lose any storage.
+  payload->frame_count =
+      CaptureStackBackTrace(skip_frames, IREE_STATUS_MAX_STACK_TRACE_FRAMES,
+                            (void**)&payload->addresses, NULL);
+#endif
+
+  return iree_status_append_payload(status, storage,
+                                    (iree_status_payload_t*)payload);
+}
+
+#else
+
+iree_status_t iree_status_attach_stack_trace(iree_status_t status,
+                                             iree_status_storage_t* storage,
+                                             int skip_frames) {
+  return status;
+}
+
+#endif  // has IREE_STATUS_FEATURE_STACK_TRACE


### PR DESCRIPTION
This makes it clearer where to add more stack trace capture implementations and will let us keep the platform-specific goo in a single place that's easy to globally toggle off.