### PR TITLE
Update git-clang-format ref and clang-format version.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,7 +106,7 @@ jobs:
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
       - name: Running clang-format on changed source files
         run: |
-          /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-18 --style=file
+          /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-18 --style=file || true
           git diff --exit-code
 
   tabs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,7 +93,7 @@ jobs:
         run: ./build_tools/pytype/check_diff.sh "${GITHUB_BASE_REF?}"
 
   clang-format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Installing dependencies
         run: |
@@ -106,7 +106,7 @@ jobs:
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
       - name: Running clang-format on changed source files
         run: |
-          /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-15 --style=file
+          /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-18 --style=file
           git diff --exit-code
 
   tabs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -104,8 +104,11 @@ jobs:
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
+      # See which versions are available for the GitHub-hosted runner here:
+      # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#language-and-runtime
       - name: Running clang-format on changed source files
         run: |
+          clang-format-18 --version
           /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-18 --style=file || true
           git diff --exit-code
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,11 +93,11 @@ jobs:
         run: ./build_tools/pytype/check_diff.sh "${GITHUB_BASE_REF?}"
 
   clang-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Installing dependencies
         run: |
-          wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
+          wget https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -106,7 +106,7 @@ jobs:
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
       - name: Running clang-format on changed source files
         run: |
-          /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-12 --style=file
+          /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-15 --style=file
           git diff --exit-code
 
   tabs:

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -142,9 +142,8 @@ struct AddOpCanon final : OpRewritePattern<mlir::stablehlo::AddOp> {
 
     // The canonical form has the constant operand as the RHS.
     if (isa<IntegerType>(type.getElementType()) && lhsAttr && !rhsAttr) {
-      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
-        op->setOperands(ValueRange{rhs, lhs});
-      });
+      rewriter.modifyOpInPlace(
+          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
       return success();
     }
 
@@ -239,9 +238,8 @@ struct MulOpCanon final : OpRewritePattern<mlir::stablehlo::MulOp> {
 
     // The canonical form has the constant operand as the RHS.
     if (isa<IntegerType>(type.getElementType()) && lhsAttr && !rhsAttr) {
-      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
-        op->setOperands(ValueRange{rhs, lhs});
-      });
+      rewriter.modifyOpInPlace(
+          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
       return success();
     }
 

--- a/compiler/plugins/target/ROCM/builtins/ukernel/argmax_ukernel.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/argmax_ukernel.c
@@ -9,10 +9,10 @@
 #include <hip/hip_runtime.h>
 
 extern "C" __device__ __attribute__((const)) half __ockl_wfred_max_f16(half);
-extern "C" __device__ __attribute__((const))
-int64_t __ockl_wfred_min_i64(int64_t);
-extern "C" __device__ __attribute__((const))
-int32_t __ockl_wfred_min_i32(int32_t);
+extern "C" __device__
+    __attribute__((const)) int64_t __ockl_wfred_min_i64(int64_t);
+extern "C" __device__
+    __attribute__((const)) int32_t __ockl_wfred_min_i32(int32_t);
 
 /*
 Constraint/Tiling note:

--- a/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp
@@ -96,8 +96,9 @@ TEST_F(TileSizeSelectionDeathTest, getLevel_out_of_bounds) {
   // 2. Create TilingConfig and verify that the "vector-inner-parallel" tiling
   // level does not exist (it's out of bounds).
   TilingConfig tilingConfig(loweringConfig);
-  ASSERT_DEATH_IF_SUPPORTED({ tilingConfig.getVectorInnerParallelLevel(); },
-                            "Searching for unavailable tiling level");
+  ASSERT_DEATH_IF_SUPPORTED(
+      { tilingConfig.getVectorInnerParallelLevel(); },
+      "Searching for unavailable tiling level");
 }
 
 #endif

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -69,7 +69,7 @@ public:
 
   LLVMGPULowerExecutableTargetPass() = default;
   LLVMGPULowerExecutableTargetPass(
-      const LLVMGPULowerExecutableTargetPass &pass){};
+      const LLVMGPULowerExecutableTargetPass &pass) {};
 
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -69,7 +69,7 @@ public:
 
   LLVMGPULowerExecutableTargetPass() = default;
   LLVMGPULowerExecutableTargetPass(
-      const LLVMGPULowerExecutableTargetPass &pass) {};
+      const LLVMGPULowerExecutableTargetPass &pass) {}
 
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
@@ -57,7 +57,7 @@ public:
 
   LLVMGPUSelectLoweringStrategyPass() = default;
   LLVMGPUSelectLoweringStrategyPass(
-      const LLVMGPUSelectLoweringStrategyPass &pass) {};
+      const LLVMGPUSelectLoweringStrategyPass &pass) {}
 
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
@@ -57,7 +57,7 @@ public:
 
   LLVMGPUSelectLoweringStrategyPass() = default;
   LLVMGPUSelectLoweringStrategyPass(
-      const LLVMGPUSelectLoweringStrategyPass &pass){};
+      const LLVMGPUSelectLoweringStrategyPass &pass) {};
 
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -77,8 +77,7 @@ static llvm::cl::opt<bool> clLLVMGPUEnablePrefetch(
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const LLVMGPUPipelineOptions &options) {
-  return os << "{"
-            << "enableReduceSharedMemoryBankConflicts = "
+  return os << "{" << "enableReduceSharedMemoryBankConflicts = "
             << options.enableReduceSharedMemoryBankConflicts
             << ", enableReorderWorkgroups = " << options.enableReorderWorkgroups
             << ", enableUkernels = " << options.enableUkernels << "}";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -80,9 +80,8 @@ getLoopRangesImpl(ReifyRankedShapedTypeOpInterface shapedOp, Location loc,
   LogicalResult status = shapedOp.reifyResultShapes(builder, resultDims);
   (void)status;
   assert(succeeded(status) && "reifyResultShapes failed");
-  return llvm::map_to_vector(resultDims[0], [&](OpFoldResult v) {
-    return Range{zero, v, one};
-  });
+  return llvm::map_to_vector(
+      resultDims[0], [&](OpFoldResult v) { return Range{zero, v, one}; });
 }
 
 /// For a given operation returns the loop ranges needed to compute the op.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/TransformExtensions/LinalgExtExtensionsOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/TransformExtensions/LinalgExtExtensionsOps.cpp
@@ -21,8 +21,7 @@ LinalgExt::LinalgExtTransformOpsExtension::LinalgExtTransformOpsExtension() {
       >();
 }
 
-void LinalgExt::LinalgExtTransformOpsExtension::init() {
-}
+void LinalgExt::LinalgExtTransformOpsExtension::init() {}
 
 //===---------------------------------------------------------------------===//
 // TileAndDecomposeAttention

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -83,8 +83,7 @@ struct FuncAnalysis {
 
   void print(llvm::raw_ostream &os, AsmState &asmState) {
     os << "FuncAnalysis: " << (isIncomplete ? "INCOMPLETE! " : "") << "@"
-       << funcOp.getName() << funcOp.getFunctionType() << " "
-       << "\n";
+       << funcOp.getName() << funcOp.getFunctionType() << " " << "\n";
     auto argTypes = funcOp.getArgumentTypes();
     os << "  args: " << argTypes.size() << "\n";
     for (unsigned i = 0; i < argTypes.size(); ++i) {

--- a/compiler/src/iree/compiler/Reducer/Framework/ChunkManager.h
+++ b/compiler/src/iree/compiler/Reducer/Framework/ChunkManager.h
@@ -16,8 +16,8 @@ namespace mlir::iree_compiler::Reducer {
 /// Represents the range: [begin, end).
 class Chunk {
 public:
-  Chunk(unsigned begin, unsigned end) : range({begin, end}) {};
-  Chunk(unsigned numTargets) : Chunk(0, numTargets) {};
+  Chunk(unsigned begin, unsigned end) : range({begin, end}) {}
+  Chunk(unsigned numTargets) : Chunk(0, numTargets) {}
 
   unsigned getBegin() const { return range.first; }
   unsigned getEnd() const { return range.second; }
@@ -40,7 +40,7 @@ bool operator<(const Chunk &C1, const Chunk &C2);
 class ChunkManager {
 public:
   explicit ChunkManager(ArrayRef<Chunk> chunksToKeep)
-      : chunksToKeep(chunksToKeep) {};
+      : chunksToKeep(chunksToKeep) {}
 
   /// Should be called for each feature being processed. Returns true if the
   /// feature should be preserved.

--- a/compiler/src/iree/compiler/Reducer/Framework/ChunkManager.h
+++ b/compiler/src/iree/compiler/Reducer/Framework/ChunkManager.h
@@ -16,8 +16,8 @@ namespace mlir::iree_compiler::Reducer {
 /// Represents the range: [begin, end).
 class Chunk {
 public:
-  Chunk(unsigned begin, unsigned end) : range({begin, end}){};
-  Chunk(unsigned numTargets) : Chunk(0, numTargets){};
+  Chunk(unsigned begin, unsigned end) : range({begin, end}) {};
+  Chunk(unsigned numTargets) : Chunk(0, numTargets) {};
 
   unsigned getBegin() const { return range.first; }
   unsigned getEnd() const { return range.second; }
@@ -40,7 +40,7 @@ bool operator<(const Chunk &C1, const Chunk &C2);
 class ChunkManager {
 public:
   explicit ChunkManager(ArrayRef<Chunk> chunksToKeep)
-      : chunksToKeep(chunksToKeep){};
+      : chunksToKeep(chunksToKeep) {};
 
   /// Should be called for each feature being processed. Returns true if the
   /// feature should be preserved.

--- a/experimental/rocm/rocm_driver.c
+++ b/experimental/rocm/rocm_driver.c
@@ -32,7 +32,7 @@ typedef struct iree_hal_rocm_driver_t {
 
 // Utility macros to convert between HIPDevice and iree_hal_device_id_t.
 #define IREE_HIPDEVICE_TO_DEVICE_ID(device) (iree_hal_device_id_t)((device) + 1)
-#define IREE_DEVICE_ID_TO_HIPDEVICE(device_id) (hipDevice_t)((device_id)-1)
+#define IREE_DEVICE_ID_TO_HIPDEVICE(device_id) (hipDevice_t)((device_id) - 1)
 
 static const iree_hal_driver_vtable_t iree_hal_rocm_driver_vtable;
 

--- a/runtime/bindings/tflite/java/org/tensorflow/lite/native/tensor_jni.cc
+++ b/runtime/bindings/tflite/java/org/tensorflow/lite/native/tensor_jni.cc
@@ -89,7 +89,7 @@ JNI_FUNC jint JNI_PREFIX(nativeBytesSize)(JNIEnv* env, jobject thiz) {
   TfLiteTensor* tensor = GetTensor(env, thiz);
   if (!tensor) {
     return kTfLiteError;  // Failed get handle. Returning to error in Java.
-  }                       // size_t is an unsigned int. This may roll over;
+  }  // size_t is an unsigned int. This may roll over;
   return (jint)TfLiteTensorByteSize(tensor);
 }
 

--- a/runtime/src/iree/base/internal/atomics_msvc.h
+++ b/runtime/src/iree/base/internal/atomics_msvc.h
@@ -29,8 +29,7 @@ typedef enum iree_memory_order_e {
   iree_memory_order_seq_cst,
 } iree_memory_order_t;
 
-#define IREE_ATOMIC_VAR_INIT(value) \
-  { (value) }
+#define IREE_ATOMIC_VAR_INIT(value) {(value)}
 
 typedef struct {
   int32_t __val;

--- a/runtime/src/iree/base/internal/atomics_msvc.h
+++ b/runtime/src/iree/base/internal/atomics_msvc.h
@@ -29,7 +29,8 @@ typedef enum iree_memory_order_e {
   iree_memory_order_seq_cst,
 } iree_memory_order_t;
 
-#define IREE_ATOMIC_VAR_INIT(value) {(value)}
+#define IREE_ATOMIC_VAR_INIT(value) \
+  { (value) }
 
 typedef struct {
   int32_t __val;

--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -194,8 +194,8 @@ static iree_cpuid_regs_t iree_cpuid_raw(uint32_t eax, uint32_t ecx) {
 // The noinline is a tentative work-around for what might be a MSVC miscompile.
 // The symptom is that MSVC builds incorrectly report some CPU features as
 // supported. This only happens for CPU feature bits in the EDX output register.
-__declspec(noinline) static iree_cpuid_regs_t
-    iree_cpuid_raw(uint32_t eax, uint32_t ecx) {
+__declspec(noinline) static iree_cpuid_regs_t iree_cpuid_raw(uint32_t eax,
+                                                             uint32_t ecx) {
   int eax_int;
   int ecx_int;
   memcpy(&eax_int, &eax, sizeof eax);

--- a/runtime/src/iree/base/internal/synchronization.h
+++ b/runtime/src/iree/base/internal/synchronization.h
@@ -366,12 +366,14 @@ typedef struct iree_notification_t {
 } iree_notification_t;
 
 #if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
-#define IREE_NOTIFICATION_INIT {IREE_ATOMIC_VAR_INIT(0)}
+#define IREE_NOTIFICATION_INIT \
+  { IREE_ATOMIC_VAR_INIT(0) }
 #elif !defined(IREE_RUNTIME_USE_FUTEX)
 #define IREE_NOTIFICATION_INIT \
-  {PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0, 0}
+  { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0, 0 }
 #else
-#define IREE_NOTIFICATION_INIT {IREE_ATOMIC_VAR_INIT(0)}
+#define IREE_NOTIFICATION_INIT \
+  { IREE_ATOMIC_VAR_INIT(0) }
 #endif  // notification type
 
 // Initializes a notification to no waiters and an initial epoch of 0.

--- a/runtime/src/iree/base/internal/synchronization.h
+++ b/runtime/src/iree/base/internal/synchronization.h
@@ -366,14 +366,12 @@ typedef struct iree_notification_t {
 } iree_notification_t;
 
 #if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
-#define IREE_NOTIFICATION_INIT \
-  { IREE_ATOMIC_VAR_INIT(0) }
+#define IREE_NOTIFICATION_INIT {IREE_ATOMIC_VAR_INIT(0)}
 #elif !defined(IREE_RUNTIME_USE_FUTEX)
 #define IREE_NOTIFICATION_INIT \
-  { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0, 0 }
+  {PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0, 0}
 #else
-#define IREE_NOTIFICATION_INIT \
-  { IREE_ATOMIC_VAR_INIT(0) }
+#define IREE_NOTIFICATION_INIT {IREE_ATOMIC_VAR_INIT(0)}
 #endif  // notification type
 
 // Initializes a notification to no waiters and an initial epoch of 0.

--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -299,7 +299,7 @@ typedef struct iree_status_handle_t* iree_status_t;
 // We cut out all status storage code when not used.
 #if IREE_STATUS_FEATURES == 0
 #define IREE_STATUS_IMPL_MAKE_(code, ...) \
-  (iree_status_t)(uintptr_t)((code)&IREE_STATUS_CODE_MASK)
+  (iree_status_t)(uintptr_t)((code) & IREE_STATUS_CODE_MASK)
 #define IREE_STATUS_IMPL_MAKE_LOC_(file, line, code, ...) \
   IREE_STATUS_IMPL_MAKE_(code)
 #undef IREE_STATUS_IMPL_RETURN_IF_API_ERROR_

--- a/runtime/src/iree/base/string_view.h
+++ b/runtime/src/iree/base/string_view.h
@@ -90,7 +90,7 @@ static inline iree_string_pair_t iree_make_cstring_pair(const char* first,
 }
 
 #define iree_string_view_literal(str) \
-  {.data = (str), .size = IREE_ARRAYSIZE(str) - 1}
+  { .data = (str), .size = IREE_ARRAYSIZE(str) - 1 }
 
 // Returns a string view initialized with the given cstring.
 #define IREE_SV(cstr) iree_make_cstring_view(cstr)

--- a/runtime/src/iree/base/string_view.h
+++ b/runtime/src/iree/base/string_view.h
@@ -90,7 +90,7 @@ static inline iree_string_pair_t iree_make_cstring_pair(const char* first,
 }
 
 #define iree_string_view_literal(str) \
-  { .data = (str), .size = IREE_ARRAYSIZE(str) - 1 }
+  {.data = (str), .size = IREE_ARRAYSIZE(str) - 1}
 
 // Returns a string view initialized with the given cstring.
 #define IREE_SV(cstr) iree_make_cstring_view(cstr)

--- a/runtime/src/iree/hal/buffer_view.h
+++ b/runtime/src/iree/hal/buffer_view.h
@@ -91,7 +91,7 @@ typedef uint8_t iree_hal_numerical_type_t;
 // TODO(#8193): split out logical and physical bit widths.
 // Returns the bit width of each element.
 #define iree_hal_element_bit_count(element_type) \
-  (iree_host_size_t)((element_type)&0xFF)
+  (iree_host_size_t)((element_type) & 0xFF)
 
 // Returns true if the element is byte-aligned.
 // Sub-byte aligned types such as i4 require user handling of the packing.

--- a/runtime/src/iree/hal/channel.h
+++ b/runtime/src/iree/hal/channel.h
@@ -30,11 +30,11 @@ enum iree_hal_channel_flag_bits_t {
 typedef uint32_t iree_hal_channel_flags_t;
 
 // Specifies that the channel should use environment settings if available.
-#define IREE_HAL_CHANNEL_RANK_DEFAULT ((int32_t)-1)
-#define IREE_HAL_CHANNEL_COUNT_DEFAULT ((int32_t)-1)
+#define IREE_HAL_CHANNEL_RANK_DEFAULT ((int32_t) - 1)
+#define IREE_HAL_CHANNEL_COUNT_DEFAULT ((int32_t) - 1)
 
 // Indicates that the rank will not be part of any group.
-#define IREE_HAL_CHANNEL_NO_COLOR ((int32_t)-1)
+#define IREE_HAL_CHANNEL_NO_COLOR ((int32_t) - 1)
 
 // Parameters defining how a channel should be configured.
 typedef struct {

--- a/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
@@ -21,7 +21,7 @@
 
 // Utility macros to convert between CUDevice and iree_hal_device_id_t.
 #define IREE_CUDEVICE_TO_DEVICE_ID(device) (iree_hal_device_id_t)((device) + 1)
-#define IREE_DEVICE_ID_TO_CUDEVICE(device_id) (CUdevice)((device_id)-1)
+#define IREE_DEVICE_ID_TO_CUDEVICE(device_id) (CUdevice)((device_id) - 1)
 
 typedef struct iree_hal_cuda_driver_t {
   // Abstract resource used for injecting reference counting and vtable;

--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -21,7 +21,7 @@
 
 // Utility macros to convert between hipDevice_t and iree_hal_device_id_t.
 #define IREE_HIPDEVICE_TO_DEVICE_ID(device) (iree_hal_device_id_t)((device) + 1)
-#define IREE_DEVICE_ID_TO_HIPDEVICE(device_id) (hipDevice_t)((device_id)-1)
+#define IREE_DEVICE_ID_TO_HIPDEVICE(device_id) (hipDevice_t)((device_id) - 1)
 
 typedef struct iree_hal_hip_driver_t {
   // Abstract resource used for injecting reference counting and vtable;

--- a/runtime/src/iree/hal/local/elf/elf_types.h
+++ b/runtime/src/iree/hal/local/elf/elf_types.h
@@ -230,9 +230,9 @@ typedef struct {
   iree_elf64_word_t n_type;
 } iree_elf64_nhdr_t;
 
-#define IREE_ELF_ST_INFO(bind, type) (((bind) << 4) + ((type)&0xF))
+#define IREE_ELF_ST_INFO(bind, type) (((bind) << 4) + ((type) & 0xF))
 
-#define IREE_ELF_ST_TYPE(info) ((info)&0xF)
+#define IREE_ELF_ST_TYPE(info) ((info) & 0xF)
 enum {
   IREE_ELF_STT_NOTYPE = 0,
   IREE_ELF_STT_OBJECT = 1,
@@ -249,7 +249,7 @@ enum {
   IREE_ELF_STB_WEAK = 2,    // Weak symbol (somewhat like global).
 };
 
-#define IREE_ELF_ST_VISIBILITY(o) ((o)&0x3)
+#define IREE_ELF_ST_VISIBILITY(o) ((o) & 0x3)
 enum {
   IREE_ELF_STV_DEFAULT = 0,
   IREE_ELF_STV_INTERNAL = 1,
@@ -392,7 +392,7 @@ typedef iree_elf32_shdr_t iree_elf_shdr_t;
 typedef iree_elf32_nhdr_t iree_elf_nhdr_t;
 
 #define IREE_ELF_R_SYM(x) ((x) >> 8)
-#define IREE_ELF_R_TYPE(x) ((x)&0xFF)
+#define IREE_ELF_R_TYPE(x) ((x) & 0xFF)
 
 #elif defined(IREE_PTR_SIZE_64)
 
@@ -416,7 +416,7 @@ typedef iree_elf64_shdr_t iree_elf_shdr_t;
 typedef iree_elf64_nhdr_t iree_elf_nhdr_t;
 
 #define IREE_ELF_R_SYM(i) ((i) >> 32)
-#define IREE_ELF_R_TYPE(i) ((i)&0xFFFFFFFF)
+#define IREE_ELF_R_TYPE(i) ((i) & 0xFFFFFFFF)
 
 #else
 #error "unsupported ELF N size (only 32/64-bits are defined)"

--- a/runtime/src/iree/hal/utils/libmpi.c
+++ b/runtime/src/iree/hal/utils/libmpi.c
@@ -34,9 +34,9 @@ iree_status_t iree_hal_mpi_library_load(
 
   static const char* kMPILoaderSearchNames[] = {
 #if defined(IREE_PLATFORM_WINDOWS)
-    "msmpi.dll",
+      "msmpi.dll",
 #else
-    "libmpi.so",
+      "libmpi.so",
 #endif  // IREE_PLATFORM_WINDOWS
   };
 

--- a/runtime/src/iree/hal/utils/libmpi_test.cc
+++ b/runtime/src/iree/hal/utils/libmpi_test.cc
@@ -70,8 +70,8 @@ iree_hal_mpi_dynamic_symbols_t LibmpiTest::symbols = {0};
 
 // An MPI "hello world" program to test library loading.
 TEST_F(LibmpiTest, HelloWorld) {
-  std::cout << "Hello world! "
-            << "I'm " << rank << " of " << world_size << std::endl;
+  std::cout << "Hello world! " << "I'm " << rank << " of " << world_size
+            << std::endl;
 }
 
 TEST_F(LibmpiTest, MPIErrorToIREEStatus) {

--- a/runtime/src/iree/io/vec_stream.c
+++ b/runtime/src/iree/io/vec_stream.c
@@ -36,7 +36,7 @@ typedef struct iree_io_vec_block_t {
 } iree_io_vec_block_t;
 
 #define IREE_IO_VEC_BLOCK_STORAGE_CAPACITY(block_size) \
-  ((block_size)-offsetof(iree_io_vec_block_t, contents))
+  ((block_size) - offsetof(iree_io_vec_block_t, contents))
 
 typedef struct iree_io_vec_stream_t {
   iree_io_stream_t base;

--- a/runtime/src/iree/task/topology.h
+++ b/runtime/src/iree/task/topology.h
@@ -27,7 +27,7 @@ extern "C" {
 typedef uint32_t iree_task_topology_node_id_t;
 
 // Use any NUMA node (usually the first).
-#define IREE_TASK_TOPOLOGY_NODE_ID_ANY ((iree_task_topology_node_id_t)-1)
+#define IREE_TASK_TOPOLOGY_NODE_ID_ANY ((iree_task_topology_node_id_t) - 1)
 
 // Returns the total number of NUMA nodes in the system or 1 if the query is
 // not available on the platform.

--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -101,27 +101,27 @@
   pc += IREE_REGISTER_ORDINAL_SIZE;
 #define VM_ParseVariadicResults(name) VM_ParseVariadicOperands(name)
 
-#define EMIT_REG_NAME(reg)                \
-  if ((reg)&IREE_REF_REGISTER_TYPE_BIT) { \
-    EMIT_REF_REG_NAME(reg);               \
-  } else {                                \
-    EMIT_I32_REG_NAME(reg);               \
+#define EMIT_REG_NAME(reg)                  \
+  if ((reg) & IREE_REF_REGISTER_TYPE_BIT) { \
+    EMIT_REF_REG_NAME(reg);                 \
+  } else {                                  \
+    EMIT_I32_REG_NAME(reg);                 \
   }
 #define EMIT_I32_REG_NAME(reg)                            \
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format( \
-      b, "%%i%u", ((reg)&IREE_I32_REGISTER_MASK)));
+      b, "%%i%u", ((reg) & IREE_I32_REGISTER_MASK)));
 #define EMIT_I64_REG_NAME(reg)                            \
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format( \
-      b, "%%i%u:%u", ((reg)&IREE_I32_REGISTER_MASK),      \
-      ((reg)&IREE_I32_REGISTER_MASK) + 1));
+      b, "%%i%u:%u", ((reg) & IREE_I32_REGISTER_MASK),    \
+      ((reg) & IREE_I32_REGISTER_MASK) + 1));
 #define EMIT_F32_REG_NAME(reg) EMIT_I32_REG_NAME(reg)
 #define EMIT_REF_REG_NAME(reg)                            \
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format( \
-      b, "%%r%u", ((reg)&IREE_REF_REGISTER_MASK)));
+      b, "%%r%u", ((reg) & IREE_REF_REGISTER_MASK)));
 
 #define EMIT_REG_VALUE(regs, reg)                                           \
-  if ((reg)&IREE_REF_REGISTER_TYPE_BIT) {                                   \
-    iree_vm_ref_t* ref = &(regs)->ref[(reg)&IREE_REF_REGISTER_MASK];        \
+  if ((reg) & IREE_REF_REGISTER_TYPE_BIT) {                                 \
+    iree_vm_ref_t* ref = &(regs)->ref[(reg) & IREE_REF_REGISTER_MASK];      \
     if (iree_vm_ref_is_null(ref)) {                                         \
       IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "null"));  \
     } else {                                                                \
@@ -131,7 +131,7 @@
     }                                                                       \
   } else {                                                                  \
     IREE_RETURN_IF_ERROR(iree_string_builder_append_format(                 \
-        b, "%u", ((regs)->i32[(reg)&IREE_I32_REGISTER_MASK])));             \
+        b, "%u", ((regs)->i32[(reg) & IREE_I32_REGISTER_MASK])));           \
   }
 
 static iree_status_t iree_vm_bytecode_disassembler_emit_type_name(

--- a/runtime/src/iree/vm/bytecode/dispatch_util.h
+++ b/runtime/src/iree/vm/bytecode/dispatch_util.h
@@ -296,7 +296,7 @@ static inline const iree_vm_register_list_t* VM_DecVariadicOperandsImpl(
   }
 
 #define DISPATCH_OP(ext, op_name, body)                               \
-  _dispatch_##ext##_##op_name:;                                       \
+  _dispatch_##ext##_##op_name :;                                      \
   IREE_DISPATCH_TRACE_INSTRUCTION(IREE_VM_PC_OFFSET_##ext, #op_name); \
   body;                                                               \
   goto* kDispatchTable_CORE[bytecode_data[pc++]];

--- a/runtime/src/iree/vm/bytecode/utils/isa.h
+++ b/runtime/src/iree/vm/bytecode/utils/isa.h
@@ -24,7 +24,7 @@
 #define VMMIN(a, b) (((a) < (b)) ? (a) : (b))
 
 #define VM_AlignPC(pc, alignment) \
-  (pc) = ((pc) + ((alignment)-1)) & ~((alignment)-1)
+  (pc) = ((pc) + ((alignment) - 1)) & ~((alignment) - 1)
 
 //===----------------------------------------------------------------------===//
 // Bytecode versioning

--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -460,7 +460,7 @@ iree_status_t iree_vm_bytecode_function_verify(
   IREE_VM_VERIFY_PC_RANGE(pc + IREE_REGISTER_ORDINAL_SIZE, max_pc); \
   const uint32_t name = OP_I16(0);
 #define IREE_VM_VERIFY_REG_ORDINAL_X32(ordinal, category)                      \
-  if (IREE_UNLIKELY(((ordinal)&IREE_REF_REGISTER_TYPE_BIT) != 0)) {            \
+  if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_TYPE_BIT) != 0)) {          \
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                      \
                             category                                           \
                             " register required but ref register %u provided", \
@@ -471,7 +471,7 @@ iree_status_t iree_vm_bytecode_function_verify(
                             (ordinal), verify_state->i32_register_count);      \
   }
 #define IREE_VM_VERIFY_REG_ORDINAL_X64(ordinal, category)                      \
-  if (IREE_UNLIKELY(((ordinal)&IREE_REF_REGISTER_TYPE_BIT) != 0)) {            \
+  if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_TYPE_BIT) != 0)) {          \
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                      \
                             category                                           \
                             " register required but ref register %u provided", \
@@ -496,19 +496,19 @@ iree_status_t iree_vm_bytecode_function_verify(
 #define IREE_VM_VERIFY_REG_F64(ordinal) \
   IREE_VM_VERIFY_REG_ORDINAL_X64(ordinal, "f64");
 #define IREE_VM_VERIFY_REG_REF(ordinal)                                      \
-  if (IREE_UNLIKELY(((ordinal)&IREE_REF_REGISTER_TYPE_BIT) == 0)) {          \
+  if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_TYPE_BIT) == 0)) {        \
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                    \
                             "ref register required but non-ref %u provided", \
                             (ordinal));                                      \
-  } else if (IREE_UNLIKELY(((ordinal)&IREE_REF_REGISTER_MASK) >=             \
+  } else if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_MASK) >=           \
                            verify_state->ref_register_count)) {              \
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,                        \
                             "ref register ordinal %u out of range %u",       \
                             (ordinal), verify_state->ref_register_count);    \
   }
-#define IREE_VM_VERIFY_REG_ANY(ordinal)                             \
-  if (IREE_UNLIKELY(((ordinal)&IREE_REF_REGISTER_TYPE_BIT) == 0)) { \
-  } else {                                                          \
+#define IREE_VM_VERIFY_REG_ANY(ordinal)                               \
+  if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_TYPE_BIT) == 0)) { \
+  } else {                                                            \
   }
 
 #define VM_VerifyConstI8(name)             \
@@ -543,7 +543,7 @@ iree_status_t iree_vm_bytecode_function_verify(
   pc += 8;
 
 #define VM_VerifyFuncAttr(name) VM_VerifyConstI32(name)
-#define VM_IsImportOrdinal(name) (((name)&0x80000000u) != 0)
+#define VM_IsImportOrdinal(name) (((name) & 0x80000000u) != 0)
 #define VM_UnmaskImportOrdinal(name) name &= ~0x80000000u
 #define VM_VerifyImportOrdinal(name)                                          \
   if (IREE_UNLIKELY((name) >= iree_vm_ImportFunctionDef_vec_len(              \

--- a/runtime/src/iree/vm/native_module_packing.h
+++ b/runtime/src/iree/vm/native_module_packing.h
@@ -701,7 +701,7 @@ constexpr NativeFunction<Owner> MakeNativeFunction(
   using dispatch_functor_t = packing::DispatchFunctor<Owner, Result, Params...>;
   return {iree_make_cstring_view(name),
           packing::cconv_storage<Result, sizeof...(Params), Params...>::value(),
-          (void (Owner::*)())fn, &dispatch_functor_t::Call};
+          (void(Owner::*)())fn, &dispatch_functor_t::Call};
 }
 
 template <typename Owner, typename... Params>
@@ -710,7 +710,7 @@ constexpr NativeFunction<Owner> MakeNativeFunction(
   using dispatch_functor_t = packing::DispatchFunctorVoid<Owner, Params...>;
   return {iree_make_cstring_view(name),
           packing::cconv_storage_void<sizeof...(Params), Params...>::value(),
-          (void (Owner::*)())fn, &dispatch_functor_t::Call};
+          (void(Owner::*)())fn, &dispatch_functor_t::Call};
 }
 
 }  // namespace vm

--- a/tools/iree-cpuinfo.c
+++ b/tools/iree-cpuinfo.c
@@ -9,7 +9,7 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/cpu.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   iree_cpu_initialize(iree_allocator_system());
   const uint64_t* cpu_data = iree_cpu_data_fields();
 


### PR DESCRIPTION
This upgrades to clang-format 18 (specifically 18.1.3, or whatever version is in https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#language-and-runtime).

Note that this lint check only runs on changed files, so I ran the script at https://github.com/eklitzke/clang-format-all/ on the IREE directories to update existing files.