### PR TITLE
Modify SplitK functionality for SDXL

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
@@ -84,7 +84,8 @@ struct SplitReductionPass : public SplitReductionBase<SplitReductionPass> {
       unsigned reductionDim = dims[0];
       SmallVector<int64_t, 4> loopRanges = op.getStaticLoopRanges();
       int64_t reductionDimSize = loopRanges[reductionDim];
-      if (ShapedType::isDynamic(reductionDimSize) || reductionDimSize < kReductionThresh)
+      if (ShapedType::isDynamic(reductionDimSize) || 
+          reductionDimSize < kReductionThresh)
         return false;
       return true;
     };

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
@@ -41,8 +41,7 @@ static LogicalResult splitReductionOnMatmul(
     linalg::ControlSplitReductionFn controlSplitReductionFn) {
   // Since user information about compilation are passed through attributes we
   // need to make sure to propagate those.
-  SmallVector<NamedAttribute> prunedAttributeList =
-      getPrunedAttributeList(op);
+  SmallVector<NamedAttribute> prunedAttributeList = getPrunedAttributeList(op);
 
   FailureOr<linalg::SplitReductionResult> result =
       linalg::splitReduction(rewriter, op, controlSplitReductionFn);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
@@ -30,7 +30,8 @@ static llvm::cl::list<int64_t> topkSplitReductionRatio(
     llvm::cl::desc("comma separated list of split ratios"),
     llvm::cl::CommaSeparated);
 
-inline static SmallVector<NamedAttribute> getPrunedAttributeList(linalg::LinalgOp op) {
+inline static SmallVector<NamedAttribute>
+getPrunedAttributeList(linalg::LinalgOp op) {
   auto elidedAttrs = llvm::to_vector(linalg::GenericOp::getAttributeNames());
   elidedAttrs.push_back(linalg::LinalgDialect::kMemoizedIndexingMapsAttrName);
   return getPrunedAttributeList(op, elidedAttrs);
@@ -84,7 +85,7 @@ struct SplitReductionPass : public SplitReductionBase<SplitReductionPass> {
       unsigned reductionDim = dims[0];
       SmallVector<int64_t, 4> loopRanges = op.getStaticLoopRanges();
       int64_t reductionDimSize = loopRanges[reductionDim];
-      if (ShapedType::isDynamic(reductionDimSize) || 
+      if (ShapedType::isDynamic(reductionDimSize) ||
           reductionDimSize < kReductionThresh)
         return false;
       return true;


### PR DESCRIPTION
This PR replaces MatmulOp with LinalgOp to apply splitK. It also filters for the reduction dimension to eliminate small ones. 

Co-autored-by: Harsh Menon Harsh.Menon@amd.com
Co-autored-by: Hanhan Wang hanhan0912@gmail.com