### PR TITLE
Bump numpy dep up to the 2.0 prerelease.

### DIFF
--- a/runtime/bindings/python/iree/runtime/build_requirements.txt
+++ b/runtime/bindings/python/iree/runtime/build_requirements.txt
@@ -6,7 +6,7 @@
 pip>=21.3
 setuptools>=62.4.0
 nanobind>=1.4.0
-numpy>=1.19.4
+numpy>=2.0.0b1
 requests>=2.28.0
 wheel>=0.36.2
 

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "cmake",
     "nanobind>=1.4.0",
     "ninja",
-    "numpy",
+    "numpy>=2.0.0b1",
     "packaging",
     "PyYAML",
 ]


### PR DESCRIPTION
Fixes https://github.com/openxla/iree/issues/16762 and https://github.com/nod-ai/SHARK-Turbine/issues/530

This fixes compatibility issues between the `iree-runtime` Python package and numpy 2.0+ (currently in prerelease). If a user installs a newer numpy version and tries to import IREE, they get an error like this:

> A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0b1 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled against NumPy 2.0.

The official docs (https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice) have some notes about ways to support both numpy 1.xx _and >= 2.0, but some (limited) local testing, I _think_ our usage of numpy isn't complex enough to need anything extra though?

---

Also note: the "base" Dockerfile in IREE (used by some build and test jobs) bundles these Python build requirements, and I'm not updating the images in this PR. Our package CI builds are more flexible - they install frequently changing deps on demand.