### PR TITLE
Fix generic op to allow fusion of conv + elemwise.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -38,6 +38,12 @@
 
 #define DEBUG_TYPE "iree-flow-form-dispatch-regions"
 
+static llvm::cl::opt<bool> clAssumeAlwaysVectorizedLowering(
+    "iree-flow-assume-always-vectorized-lowering",
+    llvm::cl::desc(
+        "Assume all dispatches will be vectorized to allow aggressive fusion"),
+    llvm::cl::init(true));
+
 static const char kRootOpAttr[] = "__root_op__";
 static const char kFusionGroupsAttr[] = "__fused_op__";
 
@@ -467,6 +473,13 @@ static bool canUseInOperandAsInitOperand(OpOperand *inOperand,
                                          OpOperand *initOperand) {
   assert(inOperand->getOwner() == initOperand->getOwner() &&
          "expected in-operand and init-operand to be owned by same operation");
+
+  // If dispatch is always vectorized we dont need to deal with these
+  // constraints. This is only needed for non-vectorized dispatches to avoid
+  // large stack allocations.
+  if (clAssumeAlwaysVectorizedLowering) {
+    return true;
+  }
 
   // Check that the owner is a `generic` op.
   auto genericOp = dyn_cast<linalg::GenericOp>(inOperand->getOwner());

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InterchangeTransposeGenericOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InterchangeTransposeGenericOps.cpp
@@ -37,8 +37,8 @@ struct TransposeGenericOpPattern : public OpRewritePattern<linalg::GenericOp> {
     std::optional<AffineMap> mapForInterchange;
 
     for (auto operand : genericOp.getDpsInputOperands()) {
-      auto producer = operand->get().getDefiningOp<linalg::LinalgOp>();
-      if (!producer)
+      auto producer = operand->get().getDefiningOp<linalg::Conv2DNhwcHwcfOp>();
+      if (!producer || !llvm::hasSingleElement(producer->getUsers()))
         continue;
 
       // check if the generic op has a non-identity map for the operand.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -92,7 +92,7 @@ static llvm::cl::opt<bool> clDispatchGenerateWorkloadRegion(
 static llvm::cl::opt<bool> clNormalizeInputIndexingMap(
     "iree-flow-normalize-input-indexing-map",
     llvm::cl::desc("Enable normalizing input indexing map to identity."),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 static llvm::cl::opt<bool>
     clDumpDispatchGraph("iree-flow-dump-dispatch-graph",


### PR DESCRIPTION
The transposition from nchw -> nhwc + fusion of the transpose with producers changes the indexing map that messes with the dispatch region formation logic. Fix up the indexing map to allow producer and consumer fusion by allowing the dispatch region formation to better analyse the conformance of iteration spaces.