### PR TITLE
[rocm] Fix crash when executable source information is missing

### DIFF
--- a/experimental/rocm/direct_command_buffer.c
+++ b/experimental/rocm/direct_command_buffer.c
@@ -419,14 +419,17 @@ static iree_status_t iree_hal_rocm_direct_command_buffer_dispatch(
       iree_hal_rocm_native_executable_entry_point_kernel_params(
           executable, entry_point, &kernel_params));
 
-  IREE_ROCM_TRACE_ZONE_BEGIN_EXTERNAL(
-      command_buffer->tracing_context, 0,
-      kernel_params.source_location.file_name.data,
-      kernel_params.source_location.file_name.size,
-      kernel_params.source_location.line,
-      kernel_params.source_location.func_name.data,
-      kernel_params.source_location.func_name.size,
-      /*name=*/NULL, 0);
+  IREE_TRACE({
+    iree_hal_rocm_source_location_t source_location;
+    iree_hal_rocm_native_executable_entry_point_source_location(
+        executable, entry_point, &source_location);
+    IREE_ROCM_TRACE_ZONE_BEGIN_EXTERNAL(
+        command_buffer->tracing_context, /*stream=*/0,
+        source_location.file_name.data, source_location.file_name.size,
+        source_location.line, source_location.func_name.data,
+        source_location.func_name.size,
+        /*name=*/NULL, 0);
+  });
 
   // Patch the push constants in the kernel arguments.
   iree_host_size_t num_constants =

--- a/experimental/rocm/native_executable.h
+++ b/experimental/rocm/native_executable.h
@@ -14,9 +14,6 @@
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 
-// flatcc schemas:
-#include "iree/schemas/rocm_executable_def_reader.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -30,11 +27,8 @@ typedef struct iree_hal_rocm_source_location_t {
 typedef struct iree_hal_rocm_kernel_params_t {
   iree_hal_pipeline_layout_t* layout;
   hipFunction_t function;
-  iree_string_view_t name;
   uint32_t block_size[3];
   uint32_t shared_memory_size;
-  IREE_TRACE(iree_hal_rocm_FileLineLocDef_table_t source_location;)
-  IREE_TRACE(iree_hal_rocm_StageLocationDef_vec_t stage_locations;)
 } iree_hal_rocm_kernel_params_t;
 
 // Creates an executable from a HSACO module. The module may contain several

--- a/experimental/rocm/native_executable.h
+++ b/experimental/rocm/native_executable.h
@@ -14,6 +14,9 @@
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 
+// flatcc schemas:
+#include "iree/schemas/rocm_executable_def_reader.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -27,9 +30,11 @@ typedef struct iree_hal_rocm_source_location_t {
 typedef struct iree_hal_rocm_kernel_params_t {
   iree_hal_pipeline_layout_t* layout;
   hipFunction_t function;
+  iree_string_view_t name;
   uint32_t block_size[3];
   uint32_t shared_memory_size;
-  IREE_TRACE(iree_hal_rocm_source_location_t source_location;)
+  IREE_TRACE(iree_hal_rocm_FileLineLocDef_table_t source_location;)
+  IREE_TRACE(iree_hal_rocm_StageLocationDef_vec_t stage_locations;)
 } iree_hal_rocm_kernel_params_t;
 
 // Creates an executable from a HSACO module. The module may contain several
@@ -46,6 +51,12 @@ iree_status_t iree_hal_rocm_native_executable_entry_point_kernel_params(
 
 hipFunction_t iree_hal_rocm_native_executable_for_entry_point(
     iree_hal_executable_t* executable, int32_t entry_point);
+
+// Returns the source location for the given entry point. May be empty if not
+// available.
+void iree_hal_rocm_native_executable_entry_point_source_location(
+    iree_hal_executable_t* base_executable, iree_host_size_t entry_ordinal,
+    iree_hal_rocm_source_location_t* out_source_location);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
This commit fixes crashes when optional executable
source stage locations and/or files are not present:

```
runtime/src/iree/schemas/rocm_executable_def_reader.h:167:
iree_hal_rocm_StageLocationsDef_table_t iree_hal_rocm_StageLocationsDef_vec_at
(iree_hal_rocm_StageLocationsDef_vec_t, size_t):
Assertion `flatbuffers_vec_len(vec) > (i) && "index out of range"' failed.
```

 Now we more closely mirror how Vulkan side is done for it.