### PR TITLE
Add a knob to disable workgroup reordering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -584,6 +584,8 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
         if (!transInfo)
           return failure();
         DictionaryAttr config = transInfo.getConfiguration();
+        if (config.contains("no_reorder_workgroups"))
+          return failure();
         if (config.contains("mma_schedule"))
           return success();
         return failure();


### PR DESCRIPTION
Add `no_reorder_workgroups` to translation info to opt out of workgroup reordering.