### PR TITLE
Revert "Fold tensor collapse (#16831)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -291,17 +291,6 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
         "maxWorkgroupParallelDims set to more than allowed MaxParallelDims");
   }
 
-  // Try to cleanup reshapes
-  {
-    RewritePatternSet patterns(context);
-    populateReshapeToInterfaceTensorPatterns(patterns);
-    if (failed(
-            applyPatternsAndFoldGreedily(innerModule, std::move(patterns)))) {
-      innerModule->emitOpError("failed to fold reshapes with stores/loads");
-      return signalPassFailure();
-    }
-  }
-
   for (auto funcOp : innerModule.getOps<mlir::FunctionOpInterface>()) {
     auto exportOp = entryPoints.lookup(funcOp.getName());
     if (!exportOp)


### PR DESCRIPTION
This reverts commit 36377c2337efba98f235f9fde6d0b53256806cd5 because of a numerical regression.