### PR TITLE
Adding magic kernel launch parameter mapping to ROCM.

### DIFF
--- a/experimental/rocm/native_executable.c
+++ b/experimental/rocm/native_executable.c
@@ -18,6 +18,10 @@
 #include "iree/schemas/rocm_executable_def_reader.h"
 #include "iree/schemas/rocm_executable_def_verifier.h"
 
+static_assert(sizeof(iree_hal_rocm_parameter_mapping_op_t) ==
+                  sizeof(iree_hal_rocm_ParameterMappingOp_t),
+              "struct size mismatch");
+
 typedef struct iree_hal_rocm_entry_point_t {
   iree_hal_rocm_kernel_params_t kernel_params;
   iree_string_view_t name;
@@ -44,6 +48,74 @@ static iree_hal_rocm_native_executable_t* iree_hal_rocm_native_executable_cast(
   return (iree_hal_rocm_native_executable_t*)base_value;
 }
 
+static iree_status_t iree_hal_rocm_validate_parameter_mapping(
+    iree_hal_rocm_ParameterMappingDef_table_t mapping_def) {
+  uint16_t total_length =
+      iree_hal_rocm_ParameterMappingDef_total_length_get(mapping_def);
+  // We could pull this limit from a device attribute, probably.
+  if (total_length >= IREE_HAL_ROCM_MAX_PARAMETER_BUFFER_SIZE) {
+    return iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "parameter buffer size is limited to 4KB; requested %u", total_length);
+  }
+  iree_hal_rocm_ParameterMappingOp_vec_t ops =
+      iree_hal_rocm_ParameterMappingDef_ops_get(mapping_def);
+  size_t op_count = ops ? iree_hal_rocm_ParameterMappingOp_vec_len(ops) : 0;
+  size_t push_constant_capacity =
+      IREE_HAL_ROCM_MAX_PUSH_CONSTANT_COUNT * sizeof(uint32_t);
+  for (size_t i = 0; i < op_count; ++i) {
+    const iree_hal_rocm_ParameterMappingOp_t* op =
+        iree_hal_rocm_ParameterMappingOp_vec_at(ops, i);
+    switch (op->type) {
+      case IREE_HAL_ROCM_PARAMETER_MAPPING_TYPE_CONSTANT:
+        switch (op->size) {
+          case 1:
+          case 2:
+          case 4:
+          case 8:
+            break;
+          default:
+            return iree_make_status(
+                IREE_STATUS_INVALID_ARGUMENT,
+                "only 1, 2, 4, and 8-byte parameters are supported (got %u)",
+                op->size);
+        }
+        if (op->source + op->size > push_constant_capacity) {
+          return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                  "source constant offset out of bounds");
+        }
+        break;
+      case IREE_HAL_ROCM_PARAMETER_MAPPING_TYPE_BUFFER:
+        // Only 64-bit supported right now.
+        if (op->size != sizeof(hipDeviceptr_t)) {
+          return iree_make_status(
+              IREE_STATUS_INVALID_ARGUMENT,
+              "buffer parameters must match hipDeviceptr_t");
+        }
+        uint8_t set = (uint8_t)(op->source >> 8);
+        uint8_t binding = (uint8_t)(op->source & 0xFF);
+        if (set >= IREE_HAL_ROCM_MAX_DESCRIPTOR_SET_COUNT) {
+          return iree_make_status(
+              IREE_STATUS_INVALID_ARGUMENT,
+              "descriptor set ordinal out of bounds (%u >= %u)", set,
+              IREE_HAL_ROCM_MAX_DESCRIPTOR_SET_COUNT);
+        }
+        if (binding >= IREE_HAL_ROCM_MAX_DESCRIPTOR_SET_BINDING_COUNT) {
+          return iree_make_status(
+              IREE_STATUS_INVALID_ARGUMENT,
+              "descriptor binding ordinal out of bounds (%u >= %u)", binding,
+              IREE_HAL_ROCM_MAX_DESCRIPTOR_SET_BINDING_COUNT);
+        }
+        break;
+    }
+    if (op->target + op->size > total_length) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "target parameter out of range");
+    }
+  }
+  return iree_ok_status();
+}
+
 iree_status_t iree_hal_rocm_native_executable_create(
     iree_hal_rocm_context_wrapper_t* context,
     const iree_hal_executable_params_t* executable_params,
@@ -66,6 +138,8 @@ iree_status_t iree_hal_rocm_native_executable_create(
       iree_hal_rocm_ExecutableDef_hsaco_image_get(executable_def);
   flatbuffers_string_vec_t entry_points_vec =
       iree_hal_rocm_ExecutableDef_entry_points_get(executable_def);
+  iree_hal_rocm_ParameterMappingDef_vec_t mappings_vec =
+      iree_hal_rocm_ExecutableDef_mappings_get(executable_def);
   iree_hal_rocm_BlockSizeDef_vec_t block_sizes_vec =
       iree_hal_rocm_ExecutableDef_block_sizes_get(executable_def);
   flatbuffers_uint32_vec_t shared_memory_sizes =
@@ -138,6 +212,7 @@ iree_status_t iree_hal_rocm_native_executable_create(
                   shared_memory_sizes[i]),
               "hipFuncSetAttribute");
         }
+        if (!iree_status_is_ok(status)) break;
         // Package required parameters for kernel launches for each entry point.
         iree_hal_rocm_entry_point_t* entry_point_info =
             &executable->entry_points[i];
@@ -150,6 +225,30 @@ iree_status_t iree_hal_rocm_native_executable_create(
         params->block_size[1] = block_sizes_vec[i].y;
         params->block_size[2] = block_sizes_vec[i].z;
         params->shared_memory_size = shared_memory_sizes[i];
+
+        // Optional parameter repacking mapping.
+        // We alias the data directly from the flatbuffer here.
+        if (mappings_vec &&
+            i < iree_hal_rocm_ParameterMappingDef_vec_len(mappings_vec)) {
+          iree_hal_rocm_ParameterMappingDef_table_t mapping_def =
+              iree_hal_rocm_ParameterMappingDef_vec_at(mappings_vec, i);
+          if (mapping_def) {
+            status = iree_hal_rocm_validate_parameter_mapping(mapping_def);
+            if (!iree_status_is_ok(status)) break;
+            params->parameter_size =
+                iree_hal_rocm_ParameterMappingDef_total_length_get(mapping_def);
+            iree_hal_rocm_ParameterMappingOp_vec_t ops =
+                iree_hal_rocm_ParameterMappingDef_ops_get(mapping_def);
+            params->mapping_count =
+                (uint32_t)iree_hal_rocm_ParameterMappingOp_vec_len(ops);
+            params->mappings =
+                params->mapping_count
+                    ? (const iree_hal_rocm_parameter_mapping_op_t*)
+                          iree_hal_rocm_ParameterMappingOp_vec_at(ops, 0)
+                    : NULL;
+          }
+        }
+
         entry_point_info->name = iree_make_string_view(
             entry_name, flatbuffers_string_len(entry_name));
       }

--- a/experimental/rocm/native_executable.h
+++ b/experimental/rocm/native_executable.h
@@ -24,11 +24,27 @@ typedef struct iree_hal_rocm_source_location_t {
   iree_string_view_t func_name;
 } iree_hal_rocm_source_location_t;
 
+typedef enum iree_hal_rocm_parameter_mapping_type_e {
+  IREE_HAL_ROCM_PARAMETER_MAPPING_TYPE_CONSTANT = 0,
+  IREE_HAL_ROCM_PARAMETER_MAPPING_TYPE_BUFFER = 1,
+} iree_hal_rocm_parameter_mapping_type_t;
+
+typedef struct iree_hal_rocm_parameter_mapping_op_t {
+  uint8_t type;  // iree_hal_rocm_parameter_mapping_type_t
+  uint8_t size;
+  uint16_t source;
+  uint16_t target;
+} iree_hal_rocm_parameter_mapping_op_t;
+
 typedef struct iree_hal_rocm_kernel_params_t {
   iree_hal_pipeline_layout_t* layout;
   hipFunction_t function;
   uint32_t block_size[3];
   uint32_t shared_memory_size;
+  // Only used with parameter mapping:
+  uint32_t parameter_size;                               // optional
+  uint32_t mapping_count;                                // optional
+  const iree_hal_rocm_parameter_mapping_op_t* mappings;  // optional
 } iree_hal_rocm_kernel_params_t;
 
 // Creates an executable from a HSACO module. The module may contain several

--- a/experimental/rocm/pipeline_layout.h
+++ b/experimental/rocm/pipeline_layout.h
@@ -17,6 +17,15 @@ extern "C" {
 
 #define IREE_HAL_ROCM_MAX_PUSH_CONSTANT_COUNT 64
 
+// The max number of bindings per descriptor set allowed in the HIP HAL
+// implementation.
+#define IREE_HAL_ROCM_MAX_DESCRIPTOR_SET_BINDING_COUNT 16
+
+// The max number of descriptor sets allowed in the HIP HAL implementation.
+#define IREE_HAL_ROCM_MAX_DESCRIPTOR_SET_COUNT 4
+
+#define IREE_HAL_ROCM_MAX_PARAMETER_BUFFER_SIZE 4096
+
 //===----------------------------------------------------------------------===//
 // iree_hal_rocm_descriptor_set_layout_t
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/schemas/rocm_executable_def.fbs
+++ b/runtime/src/iree/schemas/rocm_executable_def.fbs
@@ -17,6 +17,36 @@ struct BlockSizeDef {
   z:uint32;
 }
 
+enum ParameterMappingType:uint8 {
+  CONSTANT = 0,
+  BUFFER = 1,
+}
+
+// Specifies the source and target of a parameter mapping operation.
+struct ParameterMappingOp {
+  // Type of the mapping.
+  type:ParameterMappingType;
+  // Size of the parameter (constant value or pointer width) in bytes.
+  size:uint8;
+  // For buffers: uint8 set, uint8 binding.
+  // For push constants: source byte offset in the push constant data.
+  source:uint16;
+  // Target byte offset in the parameter buffer.
+  target:uint16;
+}
+
+// Describes a parameter packing specification.
+table ParameterMappingDef {
+  // Total size of the target parameter buffer in bytes.
+  total_length:uint16;
+  // Mappings from a parameter source of a specific type to a target byte offset
+  // in the parameter buffer. Multiple mappings may source from the same
+  // parameter but it is expected that each target is only set once. Ideally
+  // mappings should be sorted by target offset but need not be and may be
+  // sparse.
+  ops:[ParameterMappingOp];
+}
+
 // A struct for a source code location that consists of a file name and
 // a line number within that file.
 table FileLineLocDef {
@@ -45,6 +75,10 @@ table ExecutableDef {
   // A map of entry point ordinals to string names as used in the shader
   // library.
   entry_points:[string];
+
+  // Optional list of mappings per entry point. If either the list or an
+  // individual mapping is omitted the default behavior is used.
+  mappings:[ParameterMappingDef];
 
   // Block sizes for each entry point.
   // This list has the same size as the entry_points list.

--- a/samples/custom_dispatch/hip/kernels/kernels.cu
+++ b/samples/custom_dispatch/hip/kernels/kernels.cu
@@ -72,3 +72,26 @@ extern "C" __global__ void simple_mul_inplace(
     binding1[tid] *= binding0[tid];
   }
 }
+
+// `value += %arg0 + %arg1 * %arg2`
+//
+// Custom explicit ABI:
+//  +0  arg2
+//  +4  arg1
+//  +8  binding0
+// +16  arg0
+// +20  dim
+//
+// Matching parameter mapping specification:
+//   rocm.parameter_mapping = "c4:0:20,c4:4:16,c4:8:4,c4:12:0,b8:0:0:8"
+//
+// From the source:
+//   (dim, arg0, arg1, arg2, binding0)
+extern "C" __global__ void packed_parameters(int arg2, int arg1,
+                                             float* __restrict__ binding0,
+                                             int arg0, int dim) {
+  int tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < dim) {
+    binding0[tid] += arg0 + arg1 * arg2;
+  }
+}


### PR DESCRIPTION
This is an experimental feature and not exposed in HIP. I'm not sure I like anything about it, but it does seem to work. The string expressing the mapping is a compiler-only thing and something we can change (pull off arg/result attrs, etc).

To use, an external executable export can be annotated with a `rocm.parameter_mapping` string attr that defines the type of each parameter and how it's mapped from IREE's ABI to the kernel ABI. The string is composed of comma-delimited operations that define the parameter type (`b` for buffer, `c` for constant), byte size, a source specifier, and a target specifier.

For buffers: `b8:1:2:56` means a 64-bit buffer in set 1 binding 2 gets stored in the parameter buffer at byte offset 56.
For constants: `c4:32:40` means a 32-bit constant at push constant byte offset 32 gets stored in the parameter buffer at byte offset 40.