### PR TITLE
[Flow] Fix exponential blowup when optimizing dynamic `tensor.dim`s

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -99,14 +99,14 @@ LogicalResult simplifyDimOps(RewriterBase &rewriter,
 
     // Try to simplify dynamic dims.
     SmallVector<Value> dynamicDims;
-    if (failed(IREE::Flow::reifyDynamicResultDims(rewriter, dimOp.getSource(),
-                                                  dynamicDims)))
-      return failure();
-    unsigned ctr = 0;
-    for (int64_t i = 0; i < *dimOp.getConstantIndex(); ++i)
-      if (tensorType.isDynamicDim(i))
-        ++ctr;
-    rewriter.replaceOp(dimOp, dynamicDims[ctr]);
+    if (succeeded(IREE::Flow::getOptimizedDynamicResultDims(
+            rewriter, dimOp.getSource(), dynamicDims))) {
+      unsigned ctr = 0;
+      for (int64_t i = 0; i < *dimOp.getConstantIndex(); ++i)
+        if (tensorType.isDynamicDim(i))
+          ++ctr;
+      rewriter.replaceOp(dimOp, dynamicDims[ctr]);
+    }
   }
 
   return success();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -223,8 +223,10 @@ static bool hasDynamicShape(Type t) {
 }
 
 /// Reify the dynamic dimensions of the given value.
-LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
-                                     SmallVector<Value> &dynamicDims) {
+static LogicalResult
+reifyDynamicResultDimsImpl(OpBuilder &b, Value value,
+                           SmallVectorImpl<Value> &dynamicDims,
+                           bool createTensorDimOps) {
   OpBuilder::InsertionGuard guard(b);
 
   // Case 1: No dynamic result dims.
@@ -246,6 +248,9 @@ LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
 
   // Case 2: Value is a block argument.
   if (auto bbArg = llvm::dyn_cast<BlockArgument>(value)) {
+    if (!createTensorDimOps)
+      return failure();
+
     b.setInsertionPointToStart(bbArg.getOwner());
     emitTensorDimOps();
     return success();
@@ -261,7 +266,8 @@ LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
   if (tiedOp) {
     Value tiedOperand = tiedOp.getTiedResultOperand(value);
     if (tiedOperand && tiedOperand.getType() == value.getType())
-      return reifyDynamicResultDims(b, tiedOperand, dynamicDims);
+      return reifyDynamicResultDimsImpl(b, tiedOperand, dynamicDims,
+                                        createTensorDimOps);
   }
 
   // Case 4: Query ShapeAwareOpInterface.
@@ -285,10 +291,27 @@ LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
     return success();
   }
 
+  if (!createTensorDimOps)
+    return failure();
+
   // None of the above. Insert tensor.dim ops.
   b.setInsertionPointAfter(op);
   emitTensorDimOps();
   return success();
+}
+
+/// Reify the dynamic dimensions of the given value.
+LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
+                                     SmallVectorImpl<Value> &dynamicDims) {
+  return reifyDynamicResultDimsImpl(b, value, dynamicDims,
+                                    /*createTensorDimOps=*/true);
+}
+
+LogicalResult
+getOptimizedDynamicResultDims(OpBuilder &b, Value value,
+                              SmallVectorImpl<Value> &dynamicDims) {
+  return reifyDynamicResultDimsImpl(b, value, dynamicDims,
+                                    /*createTensorDimOps=*/false);
 }
 
 // Append a result to the given DispatchRegionOp. The newly created

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
@@ -31,9 +31,17 @@ bool isNonNullAndOutsideDispatch(ArrayRef<Operation *> operations);
 SmallVector<Range> getLoopRanges(Operation *op, Location loc,
                                  OpBuilder &builder);
 
-/// Reify the dynamic dimensions of the given value.
+/// Reify the dynamic dimensions of the given value, inserting at the back of
+/// 'dynamicDims'.
 LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
-                                     SmallVector<Value> &dynamicDims);
+                                     SmallVectorImpl<Value> &dynamicDims);
+
+/// Attemps to create optimized expressions for computing every dynamic
+/// dimension of 'value'. If successful, 'dynamicDims' contains a value for each
+/// dynamic dimension of 'value'. Returns failure otherwise.
+LogicalResult
+getOptimizedDynamicResultDims(OpBuilder &b, Value value,
+                              SmallVectorImpl<Value> &dynamicDims);
 
 /// Append a result to the given DispatchRegionOp. The newly created
 /// DispatchRegionOp is returned.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -235,11 +235,11 @@ util.func public @always_fuse_cast
 //  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[N1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG0]], %[[C1]]
-//  CHECK-DAG:   %[[N2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
 //      CHECK:   %[[RESULT1:.+]] = flow.dispatch.workgroups[%[[M]], %[[K]], %[[N1]]]
 // CHECK-SAME:     (%[[ARG0]], %[[ARG1]], %[[M]], %[[K]], %[[N1]])
 //      CHECK:     tensor.cast
 //      CHECK:     flow.return
+//  CHECK-DAG:   %[[N2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
 //      CHECK:   %[[RESULT2:.+]] = flow.dispatch.workgroups[%[[M]], %[[K]], %[[N2]]]
 // CHECK-SAME:     (%[[ARG0]], %[[ARG2]], %[[M]], %[[K]], %[[N2]])
 //      CHECK:     tensor.cast

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_dispatch_regions.mlir
@@ -32,6 +32,9 @@ util.func public @pack_elementwise_fusion(%arg0 : tensor<?xf32>,
 // CHECK-LABEL: util.func public @pack_elementwise_fusion(
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?xf32>
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//       CHECK:   tensor.dim
+//       CHECK:   tensor.dim
+//  CHECK-NOT:    tensor.dim
 //       CHECK:   %[[RETURN:.+]] = flow.dispatch.region
 //       CHECK:     %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:         iterator_types = ["parallel", "parallel"]


### PR DESCRIPTION
The `simplifyDimOps` function used `reifyDynamicResultDims` to replace instances of `tensor.dim` in the hopes of it producing more optimized expressions than a plain `tensor.dim`. In the case that `reifyDynamicResultDims` failed to do so, it fell back to also generating `tensor.dim`.

This is problematic for that specific caller as it generates these for every dynamic dimension. In a test-case of mine this leads to generating two `tensor.dim` operations for every initial `tensor.dim` which was then performed for every `linalg.generic` operation, producing roughly 2^20 `tensor.dim` operations.
This could also be seen when running the testcases in `form_dispatch_regions.mlir` where the output contained exponential as many unused `tensor.dim` operations as the input.

This PR fixes that by issue by separating the concept of `reifying` dynamic dimensions and `optimizing` dynamic dimension. The former is used when an expression representing the dynamic dimension is required and retains the current behavior of falling back to generating `tensor.dim` operations. The latter is now used to optimize existing `tensor.dim`, returning failure if unable to do so.