### PR TITLE
fix build errors when tracing mode = 1

### DIFF
--- a/runtime/src/iree/base/tracing/console.h
+++ b/runtime/src/iree/base/tracing/console.h
@@ -126,7 +126,11 @@ void iree_tracing_memory_free(const char* name, size_t name_length, void* ptr);
 #define IREE_TRACE_SET_THREAD_NAME(name) iree_tracing_set_thread_name(name)
 
 #define IREE_TRACE_PUBLISH_SOURCE_FILE(filename, filename_length, content, \
-                                       content_length)
+                                       content_length)                     \
+  (void)filename;                                                          \
+  (void)filename_length;                                                   \
+  (void)content;                                                           \
+  (void)content_length;
 
 #if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_FIBERS
 // TODO(benvanik): console tracing fiber markers.

--- a/runtime/src/iree/base/tracing/tracy.cc
+++ b/runtime/src/iree/base/tracing/tracy.cc
@@ -434,7 +434,9 @@ void iree_tracing_gpu_zone_notify(uint8_t context_id, uint16_t query_id,
 
 #endif  // IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
 
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_ALLOCATION_TRACKING
 void* iree_tracing_obscure_ptr(void* ptr) { return ptr; }
+#endif  // IREE_TRACING_FEATURE_ALLOCATION_TRACKING
 
 #endif  // IREE_TRACING_FEATURES
 

--- a/runtime/src/iree/base/tracing/tracy.h
+++ b/runtime/src/iree/base/tracing/tracy.h
@@ -177,7 +177,9 @@ void iree_tracing_gpu_zone_notify(uint8_t context_id, uint16_t query_id,
 
 #endif  // IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
 
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_ALLOCATION_TRACKING
 void* iree_tracing_obscure_ptr(void* ptr);
+#endif  // IREE_TRACING_FEATURE_ALLOCATION_TRACKING
 
 #endif  // IREE_TRACING_FEATURES
 

--- a/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
+++ b/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
@@ -547,22 +547,22 @@ iree_status_t iree_hal_cuda_nccl_submit_batch(
   IREE_ASSERT_ARGUMENT(batch);
   IREE_ASSERT_ARGUMENT(stream);
 
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
   // Begin one zone for each entry in the batch. Each entry will show stacked on
   // top of each other and unfortunately use independent CUDA events. We could
   // optimize this by changing the tracing context to expose an API with event
   // reservation and then zone commit using an existing event.
-  IREE_TRACE({
-    iree_bitfield_string_temp_t string_temp;
-    for (iree_host_size_t i = 0; i < batch->count; ++i) {
-      iree_hal_collective_batch_entry_t* entry = &batch->entries[i];
-      iree_string_view_t collective_str =
-          iree_hal_collective_op_format(&entry->op, &string_temp);
-      IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(
-          tracing_context, stream, __FILE__, strlen(__FILE__),
-          (uint32_t)__LINE__, __FUNCTION__, strlen(__FUNCTION__),
-          collective_str.data, collective_str.size);
-    }
-  });
+  iree_bitfield_string_temp_t string_temp;
+  for (iree_host_size_t i = 0; i < batch->count; ++i) {
+    iree_hal_collective_batch_entry_t* entry = &batch->entries[i];
+    iree_string_view_t collective_str =
+        iree_hal_collective_op_format(&entry->op, &string_temp);
+    IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(
+        tracing_context, stream, __FILE__, strlen(__FILE__), (uint32_t)__LINE__,
+        __FUNCTION__, strlen(__FUNCTION__), collective_str.data,
+        collective_str.size);
+  }
+#endif  // IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
 
   // Issue all collective operations in the batch as part of a group.
   // NCCL may be able to fuse or reduce overheads by issuing like this.

--- a/runtime/src/iree/hal/drivers/cuda/tracing.c
+++ b/runtime/src/iree/hal/drivers/cuda/tracing.c
@@ -6,7 +6,7 @@
 
 #include "iree/hal/drivers/cuda/tracing.h"
 
-#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
 
 #include "iree/hal/drivers/cuda/cuda_dynamic_symbols.h"
 #include "iree/hal/drivers/cuda/cuda_status_util.h"

--- a/runtime/src/iree/hal/drivers/cuda/tracing.h
+++ b/runtime/src/iree/hal/drivers/cuda/tracing.h
@@ -63,7 +63,7 @@ void iree_hal_cuda_tracing_context_free(
 void iree_hal_cuda_tracing_context_collect(
     iree_hal_cuda_tracing_context_t* context);
 
-#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
 
 // Begins a normal zone derived on the calling |src_loc|.
 // Must be perfectly nested and paired with a corresponding zone end.


### PR DESCRIPTION
This fixes the compilation error when the tracing mode is set to 1.