### PR TITLE
Add a matmul pipeline which uses pad to model shared memcpy.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -78,7 +78,7 @@ std::optional<GPUMMASchedule>
 deduceMMASchedule(const GPUMatmulShapeType &problem,
                   ArrayRef<GPUMatmulShapeType> intrinsics,
                   const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimit,
-                  bool canUpcastAcc) {
+                  bool canUpcastAcc, bool mustBeAligned) {
   for (auto [index, intrinsic] : llvm::enumerate(intrinsics)) {
     if (problem.aType != intrinsic.aType || problem.bType != intrinsic.bType) {
       continue; // Cannot use this intrinsic for mismatched types
@@ -93,9 +93,9 @@ deduceMMASchedule(const GPUMatmulShapeType &problem,
       }
     }
 
-    if (problem.mSize % intrinsic.mSize != 0 ||
-        problem.nSize % intrinsic.nSize != 0 ||
-        problem.kSize % intrinsic.kSize != 0) {
+    if (mustBeAligned && (problem.mSize % intrinsic.mSize != 0 ||
+                          problem.nSize % intrinsic.nSize != 0 ||
+                          problem.kSize % intrinsic.kSize != 0)) {
       continue; // Cannot use this intrinsic for misaligned cases
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -50,6 +50,6 @@ std::optional<GPUMMASchedule>
 deduceMMASchedule(const GPUMatmulShapeType &problem,
                   ArrayRef<GPUMatmulShapeType> intrinsics,
                   const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimit,
-                  bool canUpcastAcc = false);
+                  bool canUpcastAcc = false, bool mustBeAligned = true);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -54,8 +54,10 @@ def LLVMGPU_ImplicitGEMM
     : I32EnumAttrCase<"LLVMGPUImplicitGEMM", 111>;
 def LLVMGPU_ConvVectorDistribute
     : I32EnumAttrCase<"LLVMGPUConvVectorDistribute", 112>;
+def LLVMGPU_MatmulVectorDistribute
+    : I32EnumAttrCase<"LLVMGPUMatmulVectorDistribute", 113>;
 def LLVMGPU_WinogradVectorize
-    : I32EnumAttrCase<"LLVMGPUWinogradVectorize", 113>;
+    : I32EnumAttrCase<"LLVMGPUWinogradVectorize", 114>;
 
 def SPIRV_BaseLowering
     : I32EnumAttrCase<"SPIRVBaseLowering", 200>;
@@ -97,7 +99,7 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     LLVMGPU_TransposeSharedMem, LLVMGPU_WarpReduction, LLVMGPU_PackUnPack,
     LLVMGPU_MatmulTensorCoreMmaSync, LLVMGPU_VectorDistribute,
     LLVMGPU_ImplicitGEMM, LLVMGPU_ConvVectorDistribute,
-    LLVMGPU_WinogradVectorize,
+    LLVMGPU_MatmulVectorDistribute, LLVMGPU_WinogradVectorize,
 
     // SPIR-V CodeGen pipelines
     SPIRV_BaseLowering, SPIRV_BaseDistribute, SPIRV_BaseVectorize,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -54,8 +54,8 @@ def LLVMGPU_ImplicitGEMM
     : I32EnumAttrCase<"LLVMGPUImplicitGEMM", 111>;
 def LLVMGPU_ConvVectorDistribute
     : I32EnumAttrCase<"LLVMGPUConvVectorDistribute", 112>;
-def LLVMGPU_MatmulVectorDistribute
-    : I32EnumAttrCase<"LLVMGPUMatmulVectorDistribute", 113>;
+def LLVMGPU_PadAndVectorDistribute
+    : I32EnumAttrCase<"LLVMGPUPadAndVectorDistribute", 113>;
 def LLVMGPU_WinogradVectorize
     : I32EnumAttrCase<"LLVMGPUWinogradVectorize", 114>;
 
@@ -99,7 +99,7 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     LLVMGPU_TransposeSharedMem, LLVMGPU_WarpReduction, LLVMGPU_PackUnPack,
     LLVMGPU_MatmulTensorCoreMmaSync, LLVMGPU_VectorDistribute,
     LLVMGPU_ImplicitGEMM, LLVMGPU_ConvVectorDistribute,
-    LLVMGPU_MatmulVectorDistribute, LLVMGPU_WinogradVectorize,
+    LLVMGPU_PadAndVectorDistribute, LLVMGPU_WinogradVectorize,
 
     // SPIR-V CodeGen pipelines
     SPIRV_BaseLowering, SPIRV_BaseDistribute, SPIRV_BaseVectorize,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -104,6 +104,7 @@ iree_compiler_cc_library(
         "LLVMGPUPrefetching.cpp",
         "LLVMGPUPromoteConvImgAndTileFilter.cpp",
         "LLVMGPUPromoteDenseCstToTensor.cpp",
+        "LLVMGPUPromoteMatmulToFitMMA.cpp",
         "LLVMGPURewritePadInDestinationPassingStyle.cpp",
         "LLVMGPUSelectLoweringStrategy.cpp",
         "LLVMGPUTensorCoreVectorization.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -96,6 +96,7 @@ iree_compiler_cc_library(
         "LLVMGPUCastAddressSpaceFunction.cpp",
         "LLVMGPUCastTypeToFitMMA.cpp",
         "LLVMGPUDistributeSharedMemcpyV2.cpp",
+        "LLVMGPUFoldExtractSliceIntoXferWrite.cpp",
         "LLVMGPUIm2ColPass.cpp",
         "LLVMGPULowerExecutableTarget.cpp",
         "LLVMGPUNormalizeContractMaps.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -81,6 +81,7 @@ iree_cc_library(
     "LLVMGPUCastAddressSpaceFunction.cpp"
     "LLVMGPUCastTypeToFitMMA.cpp"
     "LLVMGPUDistributeSharedMemcpyV2.cpp"
+    "LLVMGPUFoldExtractSliceIntoXferWrite.cpp"
     "LLVMGPUIm2ColPass.cpp"
     "LLVMGPULowerExecutableTarget.cpp"
     "LLVMGPUNormalizeContractMaps.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -89,6 +89,7 @@ iree_cc_library(
     "LLVMGPUPrefetching.cpp"
     "LLVMGPUPromoteConvImgAndTileFilter.cpp"
     "LLVMGPUPromoteDenseCstToTensor.cpp"
+    "LLVMGPUPromoteMatmulToFitMMA.cpp"
     "LLVMGPURewritePadInDestinationPassingStyle.cpp"
     "LLVMGPUSelectLoweringStrategy.cpp"
     "LLVMGPUTensorCoreVectorization.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -45,11 +45,6 @@ llvm::cl::opt<bool> clGPUEnableVectorDistribution(
     llvm::cl::desc("enable the usage of the vector distribution pipeline"),
     llvm::cl::init(false));
 
-llvm::cl::opt<bool> clGPUUsePadToModelMemcpy(
-    "iree-codegen-llvmgpu-use-pad-to-model-memcpy",
-    llvm::cl::desc("enable the usage of the vector distribution pipeline"),
-    llvm::cl::init(false));
-
 llvm::cl::opt<bool> clGPUUseConvVectorDistributePipeline(
     "iree-codegen-llvmgpu-use-conv-vector-distribute-pipeline",
     llvm::cl::desc("enable the usage of the conv vector distribution pipeline"),
@@ -658,12 +653,11 @@ setMatmulVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
                                  /*canUpcastAcc=*/true);
   }
 
-  // Only batch_matmul is supported in the LLVMGPUMatmulVectorDistribute
+  // Only batch_matmul is supported in the LLVMGPUPadAndVectorDistribute
   // pipeline.
-  if (!schedule && clGPUUsePadToModelMemcpy &&
-      !contractionDims->batch.empty()) {
+  if (!schedule && !contractionDims->batch.empty()) {
     pipeline = IREE::Codegen::DispatchLoweringPassPipeline::
-        LLVMGPUMatmulVectorDistribute;
+        LLVMGPUPadAndVectorDistribute;
     bool mustBeAligned = false;
     schedule = deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimit,
                                  /*canUpcastAcc=*/false, mustBeAligned);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUFoldExtractSliceIntoXferWrite.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUFoldExtractSliceIntoXferWrite.cpp
@@ -1,0 +1,103 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMGPU/PassDetail.h"
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+namespace {
+
+class FoldExtractSliceIntoXferWrite final
+    : public OpRewritePattern<tensor::ExtractSliceOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractSliceOp,
+                                PatternRewriter &rewriter) const override {
+    if (extractSliceOp.getDroppedDims().any()) {
+      return failure();
+    }
+
+    auto result = dyn_cast<OpResult>(extractSliceOp.getSource());
+    if (!result) {
+      return failure();
+    }
+    if (!result.hasOneUse()) {
+      return failure();
+    }
+
+    auto xferOp =
+        extractSliceOp.getSource().getDefiningOp<vector::TransferWriteOp>();
+    if (!xferOp) {
+      return failure();
+    }
+    if (!xferOp.getSource().getDefiningOp<tensor::EmptyOp>()) {
+      return failure();
+    }
+    if (xferOp.getMask()) {
+      return failure();
+    }
+    if (!xferOp.getInBounds()) {
+      return failure();
+    }
+
+    Location loc = extractSliceOp.getLoc();
+    SmallVector<OpFoldResult> mixedSizes = extractSliceOp.getMixedSizes();
+    auto init = rewriter.create<tensor::EmptyOp>(
+        loc, mixedSizes, extractSliceOp.getType().getElementType());
+
+    SmallVector<bool> inBounds;
+    inBounds.resize(mixedSizes.size());
+    for (auto [idx, vecSize, destSize] :
+         llvm::zip_equal(llvm::seq<int64_t>(0, inBounds.size()),
+                         xferOp.getVectorType().getShape(), mixedSizes)) {
+      auto maybeCst = getConstantIntValue(destSize);
+      if (!maybeCst) {
+        inBounds[idx] = false;
+        continue;
+      }
+      if (*maybeCst == vecSize) {
+        inBounds[idx] = false;
+      } else {
+        inBounds[idx] = true;
+      }
+    }
+
+    rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
+        extractSliceOp, xferOp.getVector(), init, xferOp.getIndices(),
+        xferOp.getPermutationMap(), inBounds);
+
+    return success();
+  }
+};
+
+struct LLVMGPUFoldExtractSliceIntoXferWritePass
+    : public LLVMGPUFoldExtractSliceIntoXferWriteBase<
+          LLVMGPUFoldExtractSliceIntoXferWritePass> {
+  void getDependentDialects(DialectRegistry &registry) const override {}
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    auto funcOp = getOperation();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<FoldExtractSliceIntoXferWrite>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createLLVMGPUFoldExtractSliceIntoXferWritePass() {
+  return std::make_unique<LLVMGPUFoldExtractSliceIntoXferWritePass>();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -123,7 +123,13 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
     addGPUTransposePassPipeline(pipeline);
     break;
   case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorDistribute:
-    addGPUVectorDistributePassPipeline(pipeline);
+    addGPUVectorDistributePassPipeline(pipeline,
+                                       /*usePadToModelSharedMemcpy=*/false);
+    break;
+  case IREE::Codegen::DispatchLoweringPassPipeline::
+      LLVMGPUMatmulVectorDistribute:
+    addGPUVectorDistributePassPipeline(pipeline,
+                                       /*usePadToModelSharedMemcpy=*/true);
     break;
   case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUConvVectorDistribute:
     addGPUConvVectorDistributePassPipeline(pipeline);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -127,7 +127,7 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
                                        /*usePadToModelSharedMemcpy=*/false);
     break;
   case IREE::Codegen::DispatchLoweringPassPipeline::
-      LLVMGPUMatmulVectorDistribute:
+      LLVMGPUPadAndVectorDistribute:
     addGPUVectorDistributePassPipeline(pipeline,
                                        /*usePadToModelSharedMemcpy=*/true);
     break;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPromoteMatmulToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPromoteMatmulToFitMMA.cpp
@@ -1,0 +1,213 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMGPU/PassDetail.h"
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-llvmgpu-promote-matmul-to-fit-mma"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+/// Fold `tensor.pad(cst, tensor.extract*(linalg.fill(cst)))` into
+/// `linalg.fill(cst, empty)` when the padding constant and the fill constant
+/// are the same.
+/// This seems generally desirable as a folding but may be too intrusive, so we
+/// only apply it selectively for now.
+// TODO: atm hardcoded on linalg.fill but we could take any result of any
+// generic that yields a constant in that result.
+// TODO(hanchung): Refactor it to a common place. This is copied from
+// Codegen/Common/TransformExtensions/CommonExtensions.cpp
+struct FoldFillIntoPad : public OpRewritePattern<tensor::PadOp> {
+  using OpRewritePattern<tensor::PadOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(tensor::PadOp padOp,
+                                PatternRewriter &rewriter) const final {
+    Operation *currentOp = padOp.getSource().getDefiningOp();
+    auto maybeExtractSlice =
+        dyn_cast_or_null<tensor::ExtractSliceOp>(currentOp);
+    while (currentOp && maybeExtractSlice) {
+      currentOp = maybeExtractSlice.getSource().getDefiningOp();
+      maybeExtractSlice = dyn_cast_or_null<tensor::ExtractSliceOp>(currentOp);
+    }
+    auto fillOp = dyn_cast_or_null<linalg::FillOp>(currentOp);
+    if (!fillOp) {
+      return rewriter.notifyMatchFailure(
+          padOp, "not coming from a linalg.fill op via tensor.extract_slice*");
+    }
+
+    Value padValue = padOp.getConstantPaddingValue();
+    RankedTensorType resultType = padOp.getResultType();
+    if (!padValue ||
+        getAsOpFoldResult(padValue) !=
+            getAsOpFoldResult(fillOp.getDpsInputOperand(0)->get())) {
+      return rewriter.notifyMatchFailure(
+          padOp, "not a constant value matching the fill value");
+    }
+
+    Location loc = padOp.getLoc();
+    auto emptyOp = rewriter.create<tensor::EmptyOp>(
+        loc, tensor::getMixedSizes(rewriter, loc, padOp),
+        resultType.getElementType());
+    rewriter.replaceOpWithNewOp<linalg::FillOp>(padOp, padValue,
+                                                emptyOp.getResult());
+
+    return success();
+  }
+};
+
+class LLVMGPUPromoteMatmulToFitMMAPass
+    : public LLVMGPUPromoteMatmulToFitMMABase<
+          LLVMGPUPromoteMatmulToFitMMAPass> {
+private:
+  LLVMGPUMatmulPadOption option = LLVMGPUMatmulPadOption::ParallelDims;
+
+public:
+  explicit LLVMGPUPromoteMatmulToFitMMAPass(LLVMGPUMatmulPadOption option)
+      : option(option) {}
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<tensor::TensorDialect, linalg::LinalgDialect>();
+  }
+
+  void pad(RewriterBase &rewriter, linalg::LinalgOp op,
+           utils::IteratorType targetIterType, bool nofold) const {
+    LLVM_DEBUG(llvm::dbgs() << "candidate: " << op << "\n");
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointAfter(op);
+
+    SmallVector<int64_t> paddingDims;
+    for (auto [index, iterType] : llvm::enumerate(op.getIteratorTypesArray())) {
+      if (iterType == targetIterType) {
+        paddingDims.push_back(index);
+      }
+    }
+
+    SmallVector<bool> packPaddings(op.getNumDpsInputs(), nofold);
+
+    // One is enough because they will essentially be padded to corresponding
+    // tile sizes, which should be multiple of MMA shapes.
+    SmallVector<int64_t> padToMultipleOf(paddingDims.size(), 1);
+    SmallVector<Attribute> paddingValueAttributes;
+    for (auto &operand : op->getOpOperands()) {
+      auto elemType = getElementTypeOrSelf(operand.get().getType());
+      paddingValueAttributes.push_back(rewriter.getZeroAttr(elemType));
+    }
+
+    auto options =
+        linalg::LinalgPaddingOptions()
+            .setPaddingDimensions(paddingDims)
+            .setPaddingValues(paddingValueAttributes)
+            .setPadToMultipleOf(padToMultipleOf)
+            .setPackPaddings(packPaddings)
+            .setCopyBackOp(linalg::LinalgPaddingOptions::CopyBackOp::None);
+
+    FailureOr<IREE::Codegen::LoweringConfigAttr> loweringConfig =
+        getLoweringConfig(op);
+    if (succeeded(loweringConfig)) {
+      options =
+          options.setSmallestStaticBounds(loweringConfig->getTileSizeVals(0));
+    }
+
+    FailureOr<linalg::LinalgOp> result =
+        linalg::padAndHoistLinalgOp(rewriter, op, options);
+    if (failed(result)) {
+      LLVM_DEBUG(llvm::dbgs() << "failed to pad op " << op << "\n");
+    }
+  }
+
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    auto funcOp = getOperation();
+
+    // Preserve the innermost tensor.pad ops (i.e., pad for reduction dims), so
+    // we can kick canonicalization patterns to fold outer tensor.pad ops away.
+    bool nofold = false;
+    utils::IteratorType targetIterType = utils::IteratorType::parallel;
+    switch (option) {
+    case LLVMGPUMatmulPadOption::ParallelDims:
+      LLVM_DEBUG(llvm::dbgs() << "padding parallel dims\n");
+      targetIterType = utils::IteratorType::parallel;
+      nofold = false;
+      break;
+    case LLVMGPUMatmulPadOption::ReductionDims:
+      LLVM_DEBUG(llvm::dbgs() << "padding reduction dims\n");
+      targetIterType = utils::IteratorType::reduction;
+      nofold = true;
+      break;
+    default: // Unreachable.
+      assert(false);
+      break;
+    };
+
+    SmallVector<linalg::LinalgOp> candidates;
+    funcOp->walk([&](linalg::LinalgOp op) {
+      if (linalg::isaContractionOpInterface(op)) {
+        candidates.push_back(op);
+      }
+    });
+
+    IRRewriter rewriter(ctx);
+    for (auto op : candidates) {
+      pad(rewriter, op, targetIterType, nofold);
+    }
+
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.insert<FoldFillIntoPad>(ctx);
+      memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
+      ctx->getLoadedDialect<tensor::TensorDialect>()
+          ->getCanonicalizationPatterns(patterns);
+      tensor::PadOp::getCanonicalizationPatterns(patterns, ctx);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
+        return signalPassFailure();
+      }
+    }
+
+    // XXX(hanchung): This is needed for pad op fusion, which will remove
+    // outer pad ops. I.e., it mainly wants to remove first pad op in the
+    // pad->extract_slice->pad chain, while the canonicalization pattern can
+    // only recognize slice->pad->slice->pad.
+    {
+      SmallVector<tensor::PadOp> padOps;
+      funcOp.walk([&](tensor::PadOp op) { padOps.push_back(op); });
+      for (auto op : padOps) {
+        auto src =
+            op.getSource().getDefiningOp<IREE::Flow::DispatchTensorLoadOp>();
+        if (!src) {
+          continue;
+        }
+
+        rewriter.setInsertionPointAfter(src);
+        SmallVector<OpFoldResult> sizes =
+            tensor::getMixedSizes(rewriter, op.getLoc(), src);
+        SmallVector<OpFoldResult> offsets(sizes.size(),
+                                          rewriter.getIndexAttr(0));
+        SmallVector<OpFoldResult> strides(sizes.size(),
+                                          rewriter.getIndexAttr(1));
+        auto extractSliceOp = rewriter.create<tensor::ExtractSliceOp>(
+            op.getLoc(), src.getResult(), offsets, sizes, strides);
+        rewriter.startOpModification(op);
+        op.getSourceMutable().assign(extractSliceOp.getResult());
+        rewriter.finalizeOpModification(op);
+      }
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createLLVMGPUPromoteMatmulToFitMMAPass(LLVMGPUMatmulPadOption option) {
+  return std::make_unique<LLVMGPUPromoteMatmulToFitMMAPass>(option);
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPromoteMatmulToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPromoteMatmulToFitMMA.cpp
@@ -206,20 +206,6 @@ public:
       if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
-
-      // Rely on GPUVectorAlloc to model aligned cases.
-      funcOp.walk([&](tensor::PadOp padOp) {
-        if (!padOp.getNofoldAttr()) {
-          return;
-        }
-        if (!llvm::all_of(padOp.getMixedLowPad(), isZeroIndex) ||
-            !llvm::all_of(padOp.getMixedHighPad(), isZeroIndex)) {
-          return;
-        }
-        rewriter.startOpModification(padOp);
-        padOp.setNofold(false);
-        rewriter.finalizeOpModification(padOp);
-      });
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -77,6 +77,10 @@ public:
                 setTransferReadAnchor(context, analysis, transfer);
                 return success();
               })
+              .Case([&](vector::TransferWriteOp transfer) {
+                setTransferWriteAnchor(context, analysis, transfer);
+                return success();
+              })
               .Default([](Operation *) { return success(); });
       return failed(setResult) ? WalkResult::interrupt()
                                : WalkResult::advance();
@@ -197,100 +201,36 @@ private:
     return success();
   }
 
-  // Sets a layout anchor for reads from global memory.
-  // The layout this generates is approximately the following:
-  //
-  // #layout = #iree_vector_ext.nested_layout<
-  //    subgroups_per_workgroup = [1, ..., 1]
-  //    batches_per_subgroup =    [<remaining undistributed elements>]
-  //    outers_per_batch =        [1, ..., 1]
-  //    threads_per_outer =       [<greedy from innermost memref dim>]
-  //    elements_per_thread =     [1, ..., 128/element_bitwidth, ..., 1]
-  //            innermost_memref_dimension ^^^^^^
-  //
-  // (All orders are the same)
-  //    *_order = [<broadcasted_dims>, <transfer_permutation>]>
-  //
-  // So for the following transfer_read with 64 threads:
-  //  vector.transfer_read ... : memref<16x256xf16>, vector<16x32xf16>
-  //
-  // We use the following layout:
-  // #layout = #iree_vector_ext.nested_layout<
-  //    subgroups_per_workgroup = [1, 1]
-  //    batches_per_subgroup =    [1, 1]
-  //    outers_per_batch =        [1, 1]
-  //    threads_per_outer =       [16, 4]
-  //    elements_per_thread =     [1, 8]
-  //
-  //    *_order = [0, 1]>
-  void setTransferReadAnchor(MLIRContext *context,
-                             VectorLayoutAnalysis &analysis,
-                             vector::TransferReadOp transfer) {
-
-    // Get the forward slice of the transfer to approximate whether it will take
-    // the layout of a contraction instead. Transfer_read ops used directly by a
-    // contraction (i.e. without a copy to shared memory in between) should take
-    // the layout of the contraction op. This is common for cases where the
-    // initial values of the accumulator in a linalg.matmul is read from memory
-    // instead of just being a zerofill.
-    ForwardSliceOptions forwardOptions;
-    forwardOptions.filter = [&](Operation *op) -> bool {
-      return llvm::any_of(op->getResultTypes(),
-                          [](Type t) { return isa<VectorType>(t); });
-    };
-    BackwardSliceOptions backwardOptions;
-    backwardOptions.filter = [&](Operation *op) -> bool {
-      return llvm::any_of(op->getOperandTypes(),
-                          [](Type t) { return isa<VectorType>(t); });
-    };
-    SetVector<Operation *> slice =
-        getSlice(transfer, backwardOptions, forwardOptions);
-
-    if (llvm::any_of(slice, [](Operation *op) {
-          return llvm::isa<vector::ContractionOp>(op);
-        })) {
-      return;
-    }
-
-    // TODO: Support masking.
-    if (transfer.getMask()) {
-      return;
-    }
-    // Shared memory loads are expected to take the layout of the contraction.
-    auto sourceMemRefType =
-        dyn_cast<MemRefType>(transfer.getSource().getType());
-    if (!sourceMemRefType || hasSharedMemoryAddressSpace(sourceMemRefType)) {
-      return;
-    }
-
-    int64_t bitWidth = IREE::Util::getTypeBitWidth(
-        getElementTypeOrSelf(transfer.getVectorType()));
+  VectorLayoutInterface getMemoryTransferLayout(MLIRContext *context,
+                                                VectorValue vector,
+                                                AffineMap transferMap) {
+    VectorType vectorType = vector.getType();
+    int64_t bitWidth =
+        IREE::Util::getTypeBitWidth(getElementTypeOrSelf(vectorType));
     if (!llvm::isPowerOf2_64(bitWidth) || bitWidth > 128) {
-      return;
+      return nullptr;
     }
     int64_t numElementsPerThread = 128 / bitWidth;
-    int64_t flatNumElements =
-        ShapedType::getNumElements(transfer.getVectorType().getShape());
+    int64_t flatNumElements = ShapedType::getNumElements(vectorType.getShape());
     int64_t flatNumThreads = ShapedType::getNumElements(workgroupSize);
     if (flatNumElements % flatNumThreads != 0) {
-      return;
+      return nullptr;
     }
     numElementsPerThread =
         std::min(numElementsPerThread, flatNumElements / flatNumThreads);
 
-    AffineMap transferMap = transfer.getPermutationMap();
     if (transferMap.getNumDims() == 0) {
-      return;
+      return nullptr;
     }
 
     // Select the innermost dim of the memref as the contiguous dim to load
     // from.
-    int64_t transferRank = transfer.getVectorType().getRank();
+    int64_t transferRank = vectorType.getRank();
     std::optional<unsigned> maybeDim = transferMap.getResultPosition(
         getAffineDimExpr(transferMap.getNumDims() - 1, context));
     int64_t distXDim = maybeDim ? *maybeDim : transferRank - 1;
 
-    ArrayRef<int64_t> vectorShape = transfer.getVectorType().getShape();
+    ArrayRef<int64_t> vectorShape = vectorType.getShape();
 
     // Limit the maximum inner vector read width to the innermost contiguous
     // dimension. We could try to be clever and extend this to adjacent
@@ -373,7 +313,122 @@ private:
         threadCounts, order, elementSizes, order, subgroupBasis,
         SmallVector<bool>(subgroupBasis.size(), true), threadBasis,
         SmallVector<bool>(threadBasis.size(), true));
-    analysis.setAnchor(transfer.getResult(), layout);
+    return layout;
+  }
+
+  // Sets a layout anchor for reads from global memory.
+  // The layout this generates is approximately the following:
+  //
+  // #layout = #iree_vector_ext.nested_layout<
+  //    subgroups_per_workgroup = [1, ..., 1]
+  //    batches_per_subgroup =    [<remaining undistributed elements>]
+  //    outers_per_batch =        [1, ..., 1]
+  //    threads_per_outer =       [<greedy from innermost memref dim>]
+  //    elements_per_thread =     [1, ..., 128/element_bitwidth, ..., 1]
+  //            innermost_memref_dimension ^^^^^^
+  //
+  // (All orders are the same)
+  //    *_order = [<broadcasted_dims>, <transfer_permutation>]>
+  //
+  // So for the following transfer_read with 64 threads:
+  //  vector.transfer_read ... : memref<16x256xf16>, vector<16x32xf16>
+  //
+  // We use the following layout:
+  // #layout = #iree_vector_ext.nested_layout<
+  //    subgroups_per_workgroup = [1, 1]
+  //    batches_per_subgroup =    [1, 1]
+  //    outers_per_batch =        [1, 1]
+  //    threads_per_outer =       [16, 4]
+  //    elements_per_thread =     [1, 8]
+  //
+  //    *_order = [0, 1]>
+  void setTransferReadAnchor(MLIRContext *context,
+                             VectorLayoutAnalysis &analysis,
+                             vector::TransferReadOp transfer) {
+
+    // Get the forward slice of the transfer to approximate whether it will take
+    // the layout of a contraction instead. Transfer_read ops used directly by a
+    // contraction (i.e. without a copy to shared memory in between) should take
+    // the layout of the contraction op. This is common for cases where the
+    // initial values of the accumulator in a linalg.matmul is read from memory
+    // instead of just being a zerofill.
+    ForwardSliceOptions forwardOptions;
+    forwardOptions.filter = [&](Operation *op) -> bool {
+      return llvm::any_of(op->getResultTypes(),
+                          [](Type t) { return isa<VectorType>(t); });
+    };
+    BackwardSliceOptions backwardOptions;
+    backwardOptions.filter = [&](Operation *op) -> bool {
+      return llvm::any_of(op->getOperandTypes(),
+                          [](Type t) { return isa<VectorType>(t); });
+    };
+    SetVector<Operation *> slice =
+        getSlice(transfer, backwardOptions, forwardOptions);
+
+    if (llvm::any_of(slice, [](Operation *op) {
+          return llvm::isa<vector::ContractionOp>(op);
+        })) {
+      return;
+    }
+
+    // TODO: Support masking.
+    if (transfer.getMask()) {
+      return;
+    }
+    // Shared memory loads are expected to take the layout of the contraction.
+    auto sourceMemRefType =
+        dyn_cast<MemRefType>(transfer.getSource().getType());
+    if (!sourceMemRefType || hasSharedMemoryAddressSpace(sourceMemRefType)) {
+      return;
+    }
+
+    VectorLayoutInterface layout = getMemoryTransferLayout(
+        context, transfer.getVector(), transfer.getPermutationMap());
+
+    analysis.setAnchor(transfer.getVector(), layout);
+
+    if (printLayout) {
+      llvm::outs() << "transfer '" << transfer << "' vector layout: " << layout
+                   << "\n";
+    }
+  }
+
+  void setTransferWriteAnchor(MLIRContext *context,
+                              VectorLayoutAnalysis &analysis,
+                              vector::TransferWriteOp transfer) {
+
+    // Get the backward slice of the transfer to approximate whether it will
+    // take the layout of a contraction or transfer_read instead.
+    ForwardSliceOptions forwardOptions;
+    forwardOptions.filter = [&](Operation *op) -> bool {
+      return llvm::any_of(op->getResultTypes(),
+                          [](Type t) { return isa<VectorType>(t); });
+    };
+    BackwardSliceOptions backwardOptions;
+    backwardOptions.filter = [&](Operation *op) -> bool {
+      return llvm::any_of(op->getOperandTypes(),
+                          [](Type t) { return isa<VectorType>(t); });
+    };
+    SetVector<Operation *> slice =
+        getSlice(transfer, backwardOptions, forwardOptions);
+
+    if (llvm::any_of(slice, [](Operation *op) {
+          return llvm::isa<vector::ContractionOp>(op) ||
+                 llvm::isa<vector::TransferReadOp>(op);
+        })) {
+      return;
+    }
+
+    // TODO: Support masking.
+    if (transfer.getMask()) {
+      return;
+    }
+
+    VectorLayoutInterface layout = getMemoryTransferLayout(
+        context, transfer.getVector(), transfer.getPermutationMap());
+
+    analysis.setAnchor(transfer.getVector(), layout);
+
     if (printLayout) {
       llvm::outs() << "transfer '" << transfer << "' vector layout: " << layout
                    << "\n";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -577,7 +577,8 @@ static void addVectorBufferizePasses(OpPassManager &passManager) {
   passManager.addPass(createCSEPass());
 }
 
-void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
+void addGPUVectorDistributePassPipeline(OpPassManager &pm,
+                                        bool usePadToModelSharedMemcpy) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
@@ -599,9 +600,25 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
+  if (usePadToModelSharedMemcpy) {
+    LLVMGPUMatmulPadOption option = LLVMGPUMatmulPadOption::ParallelDims;
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createLLVMGPUPromoteMatmulToFitMMAPass(option));
+  }
+
   // Problem specific (reduction) tiling.
   nestedModulePM.addNestedPass<func::FuncOp>(
       createGPUTensorTileToSerialLoops(true));
+
+  if (usePadToModelSharedMemcpy) {
+    LLVMGPUMatmulPadOption option = LLVMGPUMatmulPadOption::ReductionDims;
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createLLVMGPUPromoteMatmulToFitMMAPass(option));
+    nestedModulePM.addPass(createCanonicalizerPass());
+    nestedModulePM.addPass(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createLLVMGPURewritePadInDestinationPassingStylePass());
+  }
 
   // Generalize all named ops so that we can fold away unit extent dims. By this
   // point, all tiling is finished so the tiling configurations on those ops can
@@ -624,7 +641,9 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
   addGPUVectorizationPasses(nestedModulePM);
 
   // Allocate tensors for copies to shared memory.
-  nestedModulePM.addNestedPass<func::FuncOp>(createGPUVectorAlloc());
+  if (!usePadToModelSharedMemcpy) {
+    nestedModulePM.addNestedPass<func::FuncOp>(createGPUVectorAlloc());
+  }
 
   // Tensor -> Memref
   addVectorBufferizePasses(nestedModulePM);
@@ -641,6 +660,24 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUVectorDistribute());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
+
+  if (usePadToModelSharedMemcpy) {
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        memref::createFoldMemRefAliasOpsPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createGPUDistributeSharedMemoryCopy());
+
+    {
+      GenericVectorizationPassOptions options;
+      nestedModulePM.addNestedPass<func::FuncOp>(
+          createGenericVectorizationPass(options));
+      nestedModulePM.addNestedPass<func::FuncOp>(
+          createOptimizeTensorInsertExtractSlicesPass());
+      nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+      nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
+    }
+  }
 
   nestedModulePM.addNestedPass<func::FuncOp>(
       createGPUReduceSharedMemoryBankConflicts());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -639,6 +639,10 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm,
 
   // Linalg -> Vector
   addGPUVectorizationPasses(nestedModulePM);
+  if (usePadToModelSharedMemcpy) {
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createLLVMGPUFoldExtractSliceIntoXferWritePass());
+  }
 
   // Allocate tensors for copies to shared memory.
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUVectorAlloc());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -641,7 +641,10 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm,
   addGPUVectorizationPasses(nestedModulePM);
 
   // Allocate tensors for copies to shared memory.
-  if (!usePadToModelSharedMemcpy) {
+  if (usePadToModelSharedMemcpy) {
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createGPUVectorAlloc(/*promoteLHS=*/false));
+  } else {
     nestedModulePM.addNestedPass<func::FuncOp>(createGPUVectorAlloc());
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -52,7 +52,8 @@ void addGPUTransposePassPipeline(OpPassManager &pm);
 void addGPUVectorizationPassPipeline(OpPassManager &pm);
 
 /// Lowering based on vector distribution patterns.
-void addGPUVectorDistributePassPipeline(OpPassManager &pm);
+void addGPUVectorDistributePassPipeline(OpPassManager &pm,
+                                        bool usePadToModelSharedMemcpy);
 void addGPUConvVectorDistributePassPipeline(OpPassManager &pm);
 
 /// Lowering reductions to warp reductions.
@@ -186,6 +187,12 @@ verifyGPUMatmulPipeline(Operation *op,
 /// on operators like Flash Attention.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createAMDGPUPrepareForChainedMatmulPass();
+
+/// Pass to pad operations on tensors in top-down order.
+enum class LLVMGPUMatmulPadOption { ParallelDims, ReductionDims };
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createLLVMGPUPromoteMatmulToFitMMAPass(
+    LLVMGPUMatmulPadOption option = LLVMGPUMatmulPadOption::ParallelDims);
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMGPUPromoteConvImgAndTileFilterPass();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -122,6 +122,9 @@ enum class GPUTensorCoreType {
   MMA_SYNC = 1,
 };
 
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createLLVMGPUFoldExtractSliceIntoXferWritePass();
+
 /// Convert Linalg ops to Vector and prepare converstion to GPU MMA ops.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMGPUTensorCoreVectorizationPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -89,6 +89,12 @@ def LLVMGPUPrefetchSharedMemory :
   let constructor = "mlir::iree_compiler::createLLVMGPUPrefetchSharedMemoryPass()";
 }
 
+def LLVMGPUPromoteMatmulToFitMMA :
+    InterfacePass<"iree-llvmgpu-promote-matmul-to-fit-mma", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to promote contraction ops to fit mma shapes";
+  let constructor = "mlir::iree_compiler::createLLVMGPUPromoteMatmulToFitMMAPass()";
+}
+
 def LLVMGPUPromoteConvImgAndTileFilter :
     InterfacePass<"iree-llvmgpu-promote-conv-img-and-tile-filter", "mlir::FunctionOpInterface"> {
   let summary = "Pass promote convolution image operand and tile filter with tilingLevel=1.";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -60,6 +60,12 @@ def LLVMGPUCastTypeToFitMMA : InterfacePass<"iree-llvmgpu-cast-type-to-fit-mma",
   let constructor = "mlir::iree_compiler::createLLVMGPUCastTypeToFitMMAPass()";
 }
 
+def LLVMGPUFoldExtractSliceIntoXferWrite :
+    InterfacePass<"iree-llvmgpu-fold-extract-slice-into-xfer-write", "mlir::FunctionOpInterface"> {
+  let summary = "Perform a pass that folds extract_slice(xfer_write) into a single xfer_write";
+  let constructor = "mlir::iree_compiler::createLLVMGPUFoldExtractSliceIntoXferWritePass()";
+}
+
 def LLVMGPUIm2Col : InterfacePass<"iree-llvmgpu-im2col", "mlir::FunctionOpInterface"> {
   let summary = "Perform Im2Col conversion for convolution operations";
   let constructor = "mlir::iree_compiler::createLLVMGPUIm2ColPass()";

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
@@ -264,9 +264,9 @@ public:
       TypeSwitch<Operation *, void>(linalgOp.getOperation())
           .Case<linalg::Conv2DNhwcHwcfOp>(
               [&](auto convOp) { padConvOp(rewriter, linalgOp, intrinsics); })
-          .Case<linalg::BatchMatmulOp>([&](auto matmulOp) {
-            padBatchGemmOp(rewriter, linalgOp, intrinsics);
-          })
+          //.Case<linalg::BatchMatmulOp>([&](auto matmulOp) {
+            //padBatchGemmOp(rewriter, linalgOp, intrinsics);
+          //})
           .Default([&](Operation *op) {});
     }
   }


### PR DESCRIPTION
The new strategy is compiling until shared memory copy distribution. Mahesh is looking at the issue.

The smallest bounding box inference could fail while the op is really bounded by tile sizes. We provide an option for smallest bounding values as fallback: https://github.com/shark-infra/llvm-project/commit/55ff42c87b39d67f0fefbb4b0c6d6a02e3af3db0

To enable the new pipeline, we add `--iree-codegen-llvmgpu-use-vector-distribution` to the `iree-compile` tool.

Full IR dump: https://gist.github.com/hanhanW/8dca0f932a97a723a4189c68d906710a
