### PR TITLE
[Winograd] Improve thread distribution of winograd transform ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -974,7 +974,7 @@ static LogicalResult setWinogradOpConfig(mlir::FunctionOpInterface entryPoint,
   // sizes found in the StableDiffusion model.
   auto pipeline =
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUWinogradVectorize;
-  std::array<int64_t, 3> workgroupSize = {64, 4, 4};
+  std::array<int64_t, 3> workgroupSize = {1024, 1, 1};
   TileSizesListType tileSizes = {{1, 32}};
   return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
                                                pipeline, workgroupSize);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAndDecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAndDecomposeWinogradPass.cpp
@@ -236,7 +236,7 @@ static void computeForallAndForUpperBounds(OpBuilder &builder, Location loc,
 static gpu::GPUThreadMappingAttr getThreadMapping(MLIRContext *context,
                                                   int64_t dim) {
   auto mappingIdInt =
-      std::min<int64_t>(dim + static_cast<uint64_t>(gpu::MappingId::LinearDim0),
+      std::min<int64_t>(dim + static_cast<uint64_t>(gpu::MappingId::DimX),
                         gpu::getMaxEnumValForMappingId());
   return mlir::gpu::GPUThreadMappingAttr::get(
       context, gpu::symbolizeMappingId(mappingIdInt).value());
@@ -249,11 +249,6 @@ static FailureOr<scf::ForallOp> tileWithForall(
     std::optional<scf::ForallOp> &peeledForall, SmallVector<Value> &peeledIvs) {
   SmallVector<Value> lbs, ubs, steps;
   computeLoopParams(lbs, ubs, steps, boundValue, numImageDims, loc, rewriter);
-
-  SmallVector<int64_t> forallInds, forInds;
-  SmallVector<Value> forallUbs, forUbs;
-  computeForallAndForUpperBounds(rewriter, loc, ubs, workgroupSize, forallUbs,
-                                 forUbs, forallInds, forInds);
 
   SmallVector<int64_t> constUbs;
   for (auto ub : ubs) {


### PR DESCRIPTION
This changes the tiling approach of winograd transform ops to fill all the workgroup threads, and peel the extra iterations into a separate scf.forall.