### PR TITLE
Remove Convert1X1FilterConv2DToMatmulPass in preprocessing for VAE

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -91,7 +91,6 @@ buildTransposeConvolutionPassPipeline(OpPassManager &passManager,
   FunctionLikeNest(passManager)
       .addPass(GlobalOptimization::createDetachElementwiseFromNamedOpsPass)
       .addPass(mlir::createLinalgNamedOpConversionPass)
-      .addPass(GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass)
       .addPass(createConvertConvToChannelsLastPass)
       .addPass(IREE::Flow::createFoldUnitExtentDimsPass);
   passManager.addPass(createCanonicalizerPass());


### PR DESCRIPTION
 Convert1X1FilterConv2DToMatmulPass in preprocessing is causing numerical regression on VAE.
 Removing brings max error from VAE from 0.11 to 0.010 with little to no e2e perf change
 and unet/clip numerics remain stable