### PR TITLE
[CPU][ArmSME] Add `-arm-sme-vector-legalization` to ArmSME pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -697,6 +697,12 @@ static void addLowerToLLVMPasses(OpPassManager &passManager,
   }
 
   if (enableAArch64SME) {
+    // Decompose large (2D-scalable) vector types to (multiple) SME tiles
+    // + some ArmSME specific vector dialect rewrites.
+    passManager.addPass(mlir::arm_sme::createVectorLegalizationPass());
+    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+
     // (Arith, Vector) -> ArmSME
     passManager.addNestedPass<func::FuncOp>(
         mlir::createArithToArmSMEConversionPass());


### PR DESCRIPTION
This is needed to legalize vector types larger than a single SME tile, and for various small ArmSME-specific rewrites.