### PR TITLE
[LLVMGPU] Force de-cse all transfer reads with multiple users

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1743,6 +1743,10 @@ setConvolutionIGemmConfig(mlir::FunctionOpInterface entryPoint,
     return failure();
   }
 
+  if (!linalg::isaConvolutionOpInterface(op)) {
+    return failure();
+  }
+
   // This pipeline needs to know the subgroup size for distributing to virtual
   // lane IDs.
   if (targetInfo.supportedSubgroupSizes.empty()) {


### PR DESCRIPTION
When a single transfer_read has multiple users, it can often end up introducing a layout conflict. This clones the read for each user to avoid this.